### PR TITLE
DOC: Resolve RT03 errors for selected methods

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -614,10 +614,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (RT03)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=RT03 --ignore_functions \
-        pandas.DataFrame.expanding\
-        pandas.DataFrame.filter\
-        pandas.DataFrame.first_valid_index\
-        pandas.DataFrame.get\
         pandas.DataFrame.hist\
         pandas.DataFrame.infer_objects\
         pandas.DataFrame.kurt\

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -618,7 +618,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.DataFrame.infer_objects\
         pandas.DataFrame.kurt\
         pandas.DataFrame.kurtosis\
-        pandas.DataFrame.last_valid_index\
         pandas.DataFrame.mask\
         pandas.DataFrame.max\
         pandas.DataFrame.mean\

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4189,7 +4189,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         ----------
         key : object
             Key for which item should be returned.
-        default : object
+        default : object, default None
             Default value to return if key is not found.
 
         Returns

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5383,7 +5383,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Returns
         -------
         Same type as caller
-            The filtered subset of the DataFrame or Series. 
+            The filtered subset of the DataFrame or Series.
 
         See Also
         --------
@@ -11745,12 +11745,16 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(position="first", klass=_shared_doc_kwargs["klass"])
     def first_valid_index(self) -> Hashable:
         """
-        Return index for {position} non-NA value or None, if no non-NA value is found.
+        Return index for {position} non-missing value or None, if no non-missing value is found.
+
+        See the :ref:`User Guide <missing_data>` for more information on which values are
+        considered missing.
 
         Returns
         -------
         type of index
-
+            Index of {position} non-missing value.
+            
         Examples
         --------
         For Series:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5362,10 +5362,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         axis: Axis | None = None,
     ) -> Self:
         """
-        Subset the dataframe rows or columns according to the specified index labels.
-
-        Note that this routine does not filter a dataframe on its
-        contents. The filter is applied to the labels of the index.
+        Subset the DataFrame or Series according to the specified index labels.
+        For DataFrame, filter rows or columns depending on ``axis`` argument. 
+        Note that this routine does not filter based on content.
+        The filter is applied to the labels of the index.
 
         Parameters
         ----------
@@ -5378,11 +5378,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         axis : {0 or 'index', 1 or 'columns', None}, default None
             The axis to filter on, expressed either as an index (int)
             or axis name (str). By default this is the info axis, 'columns' for
-            DataFrame. For `Series` this parameter is unused and defaults to `None`.
+            `DataFrame`. For `Series` this parameter is unused and defaults to `None`.
 
         Returns
         -------
-        same type as input object
+        Same type as caller
+            The filtered subset of the DataFrame or Series. 
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5383,7 +5383,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         axis : {0 or 'index', 1 or 'columns', None}, default None
             The axis to filter on, expressed either as an index (int)
             or axis name (str). By default this is the info axis, 'columns' for
-            ``DataFrame``. For ``Series`` this parameter is unused and defaults to ``None``.
+            ``DataFrame``. For ``Series`` this parameter is unused and defaults to
+            ``None``.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4182,16 +4182,19 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     def get(self, key, default=None):
         """
         Get item from object for given key (ex: DataFrame column).
-
-        Returns default value if not found.
+        Returns ``default`` value if not found.
 
         Parameters
         ----------
         key : object
+            Key for which item should be returned.
+        default : object
+            Default value to return if key is not found.
 
         Returns
         -------
         same type as items contained in object
+            Item for given key or ``default`` value, if key is not found.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5383,7 +5383,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         axis : {0 or 'index', 1 or 'columns', None}, default None
             The axis to filter on, expressed either as an index (int)
             or axis name (str). By default this is the info axis, 'columns' for
-            `DataFrame`. For `Series` this parameter is unused and defaults to `None`.
+            ``DataFrame``. For ``Series`` this parameter is unused and defaults to ``None``.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4182,6 +4182,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     def get(self, key, default=None):
         """
         Get item from object for given key (ex: DataFrame column).
+
         Returns ``default`` value if not found.
 
         Parameters
@@ -5366,7 +5367,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> Self:
         """
         Subset the DataFrame or Series according to the specified index labels.
-        For DataFrame, filter rows or columns depending on ``axis`` argument. 
+
+        For DataFrame, filter rows or columns depending on ``axis`` argument.
         Note that this routine does not filter based on content.
         The filter is applied to the labels of the index.
 
@@ -11748,16 +11750,16 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     @doc(position="first", klass=_shared_doc_kwargs["klass"])
     def first_valid_index(self) -> Hashable:
         """
-        Return index for {position} non-missing value or None, if no non-missing value is found.
+        Return index for {position} non-missing value or None, if no value is found.
 
-        See the :ref:`User Guide <missing_data>` for more information on which values are
-        considered missing.
+        See the :ref:`User Guide <missing_data>` for more information
+        on which values are considered missing.
 
         Returns
         -------
         type of index
             Index of {position} non-missing value.
-            
+
         Examples
         --------
         For Series:


### PR DESCRIPTION
Resolve all RT03 errors for the following cases:

scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.expanding
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.filter
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.first_valid_index
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.last_valid_index
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.get
- xref DOC: fix RT03 errors in docstrings  #57416
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
