### PR TITLE
DOC: Resolve RT03 errors in several methods #2 

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -628,14 +628,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.DataFrame.mean\
         pandas.DataFrame.median\
         pandas.DataFrame.min\
-        pandas.DataFrame.nsmallest\
-        pandas.DataFrame.nunique\
-        pandas.DataFrame.pipe\
-        pandas.DataFrame.plot.box\
-        pandas.DataFrame.plot.density\
-        pandas.DataFrame.plot.kde\
-        pandas.DataFrame.plot.scatter\
-        pandas.DataFrame.pop\
         pandas.DataFrame.prod\
         pandas.DataFrame.product\
         pandas.DataFrame.reindex\

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -628,6 +628,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.DataFrame.mean\
         pandas.DataFrame.median\
         pandas.DataFrame.min\
+        pandas.DataFrame.pop\
         pandas.DataFrame.prod\
         pandas.DataFrame.product\
         pandas.DataFrame.reindex\

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7432,6 +7432,7 @@ class DataFrame(NDFrame, OpsMixin):
         Returns
         -------
         DataFrame
+            DataFrame with the first `n` rows ordered by `columns` in ascending order.
 
         See Also
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11899,6 +11899,7 @@ class DataFrame(NDFrame, OpsMixin):
         Returns
         -------
         Series
+            Series with counts of unique values per row or column, depending on `axis`.
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5839,7 +5839,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Returns
         -------
-        the return type of ``func``.
+        The return type of ``func``.
+            The result of applying ``func`` to the Series or DataFrame.
 
         See Also
         --------
@@ -5855,7 +5856,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Examples
         --------
-        Constructing a income DataFrame from a dictionary.
+        Constructing an income DataFrame from a dictionary.
 
         >>> data = [[8000, 1000], [9500, np.nan], [5000, 2000]]
         >>> df = pd.DataFrame(data, columns=["Salary", "Others"])

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1747,6 +1747,7 @@ class PlotAccessor(PandasObject):
         Returns
         -------
         :class:`matplotlib.axes.Axes` or numpy.ndarray of them
+            The matplotlib axes containing the scatter plot.
 
         See Also
         --------

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1467,6 +1467,7 @@ class PlotAccessor(PandasObject):
         Returns
         -------
         matplotlib.axes.Axes or numpy.ndarray of them
+            The matplotlib axes containing the KDE plot.
 
         See Also
         --------

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1335,6 +1335,7 @@ class PlotAccessor(PandasObject):
         Returns
         -------
         :class:`matplotlib.axes.Axes` or numpy.ndarray of them
+            The matplotlib axes containing the box plot.
 
         See Also
         --------


### PR DESCRIPTION
Resolve all RT03 errors for the following cases:
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.nsmallest
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.nunique
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.pipe
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.plot.box
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.plot.density
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.plot.kde
scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.DataFrame.plot.scatter

- xref DOC: fix RT03 errors in docstrings  #57416
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
