### PR TITLE
Migrate ruff config to the latest format

### DIFF
--- a/doc/sphinxext/announce.py
+++ b/doc/sphinxext/announce.py
@@ -32,6 +32,7 @@ From the bash command line with $GITHUB token.
     $ ./scripts/announce.py $GITHUB v1.11.0..v1.11.1 > announce.rst
 
 """
+
 import codecs
 import os
 import re

--- a/doc/sphinxext/contributors.py
+++ b/doc/sphinxext/contributors.py
@@ -14,6 +14,7 @@ use::
 While the v0.23.1 tag does not exist, that will use the HEAD of the
 branch as the end of the revision range.
 """
+
 from announce import build_components
 from docutils import nodes
 from docutils.parsers.rst import Directive

--- a/pandas/util/version/__init__.py
+++ b/pandas/util/version/__init__.py
@@ -131,7 +131,7 @@ class InvalidVersion(ValueError):
 
     Examples
     --------
-    >>> pd.util.version.Version('1.')
+    >>> pd.util.version.Version("1.")
     Traceback (most recent call last):
     InvalidVersion: Invalid version: '1.'
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,8 @@ environment = {CFLAGS="-g0"}
 line-length = 88
 target-version = "py310"
 fix = true
+
+[tool.ruff.lint]
 unfixable = []
 typing-modules = ["pandas._typing"]
 
@@ -271,8 +273,8 @@ ignore = [
   "PLW0603",
   # Use `typing.NamedTuple` instead of `collections.namedtuple`
   "PYI024",
-  # No builtin `eval()` allowed
-  "PGH001",
+  # Use of possibly insecure function; consider using ast.literal_eval
+  "S307",
   # while int | float can be shortened to float, the former is more explicit
   "PYI041",
   # incorrect-dict-iterator, flags valid Series.items usage
@@ -345,7 +347,7 @@ exclude = [
 [tool.ruff.lint.flake8-import-conventions.aliases]
 "pandas.core.construction.array" = "pd_array"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # relative imports allowed for asv_bench
 "asv_bench/*" = ["TID", "NPY002"]
 # to be enabled gradually


### PR DESCRIPTION
Resolves these warnings (available if running `ruff` directly) and fix some formatting errors discovered in the new config that's arguably should be equivalent to the old one.

```bash
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'typing-modules' -> 'lint.typing-modules'
  - 'unfixable' -> 'lint.unfixable'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
warning: `PGH001` has been remapped to `S307`.
```