### PR TITLE
Doc: fix RT03 pandas.timedelta_range and pandas.util.hash_pandas_object

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -858,9 +858,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.read_sas\
         pandas.read_spss\
         pandas.read_stata\
-        pandas.set_eng_float_format\
-        pandas.timedelta_range\
-        pandas.util.hash_pandas_object # There should be no backslash in the final line, please keep this comment in the last ignored function
+        pandas.set_eng_float_format # There should be no backslash in the final line, please keep this comment in the last ignored function
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Partially validate docstrings (SA01)' ;  echo $MSG

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -304,6 +304,7 @@ def timedelta_range(
     Returns
     -------
     TimedeltaIndex
+        Fixed frequency, with day as the default.
 
     Notes
     -----

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -106,7 +106,8 @@ def hash_pandas_object(
 
     Returns
     -------
-    Series of uint64, same length as the object
+    Series of uint64
+        Same length as the object.
 
     Examples
     --------


### PR DESCRIPTION
All RT03 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.timedelta_range
2. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.util.hash_pandas_object

- [x] xref #57416
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
