### PR TITLE
Doc: Fix RT03 errors for  read_orc, read_sas, read_spss, read_stata

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -854,10 +854,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.plotting.parallel_coordinates\
         pandas.plotting.radviz\
         pandas.plotting.table\
-        pandas.read_orc\
-        pandas.read_sas\
-        pandas.read_spss\
-        pandas.read_stata\
         pandas.set_eng_float_format\
         pandas.timedelta_range\
         pandas.util.hash_pandas_object # There should be no backslash in the final line, please keep this comment in the last ignored function

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -83,6 +83,7 @@ def read_orc(
     Returns
     -------
     DataFrame
+        DataFrame based on the ORC file.
 
     Notes
     -----

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -119,8 +119,9 @@ def read_sas(
 
     Returns
     -------
-    DataFrame if iterator=False and chunksize=None, else SAS7BDATReader
-    or XportReader
+    DataFrame, SAS7BDATReader, or XportReader
+        DataFrame if iterator=False and chunksize=None, else SAS7BDATReader
+        or XportReader, file format is inferred from file extension.
 
     Examples
     --------

--- a/pandas/io/spss.py
+++ b/pandas/io/spss.py
@@ -50,6 +50,7 @@ def read_spss(
     Returns
     -------
     DataFrame
+        DataFrame based on the SPSS file.
 
     Examples
     --------

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -161,7 +161,8 @@ filepath_or_buffer : str, path object or file-like object
 
 Returns
 -------
-DataFrame or pandas.api.typing.StataReader
+DataFrame, pandas.api.typing.StataReader
+    If iterator or chunksize, returns StataReader, else DataFrame.
 
 See Also
 --------


### PR DESCRIPTION
All RT03 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.read_orc
2. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.read_sas
3. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.read_spss
4. scripts/validate_docstrings.py --format=actions --errors=RT03 pandas.read_stata

- [x] xref #57416
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
