### PR TITLE
Doc: fix SA01 errors for pandas.BooleanDtype and pandas.StringDtype

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -865,7 +865,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (SA01)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=SA01 --ignore_functions \
-        pandas.BooleanDtype\
         pandas.Categorical.__array__\
         pandas.Categorical.as_ordered\
         pandas.Categorical.as_unordered\
@@ -1177,7 +1176,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.Series.update\
         pandas.Series.var\
         pandas.SparseDtype\
-        pandas.StringDtype\
         pandas.Timedelta\
         pandas.Timedelta.as_unit\
         pandas.Timedelta.asm8\

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -56,6 +56,10 @@ class BooleanDtype(BaseMaskedDtype):
     -------
     None
 
+    See Also
+    --------
+    StringDtype : Extension dtype for string data.
+
     Examples
     --------
     >>> pd.BooleanDtype()

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -92,6 +92,10 @@ class StringDtype(StorageExtensionDtype):
     -------
     None
 
+    See Also
+    --------
+    BooleanDtype : Extension dtype for boolean data.
+
     Examples
     --------
     >>> pd.StringDtype()


### PR DESCRIPTION
All SA01 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.BooleanDtype
2. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.StringDtype

- [x]  xref  #57417
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
