### PR TITLE
Doc: fix SA01 errors for as_ordered and as_unordered

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -867,16 +867,12 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=SA01 --ignore_functions \
         pandas.BooleanDtype\
         pandas.Categorical.__array__\
-        pandas.Categorical.as_ordered\
-        pandas.Categorical.as_unordered\
         pandas.Categorical.codes\
         pandas.Categorical.dtype\
         pandas.Categorical.from_codes\
         pandas.Categorical.ordered\
         pandas.CategoricalDtype.categories\
         pandas.CategoricalDtype.ordered\
-        pandas.CategoricalIndex.as_ordered\
-        pandas.CategoricalIndex.as_unordered\
         pandas.CategoricalIndex.codes\
         pandas.CategoricalIndex.ordered\
         pandas.DataFrame.__dataframe__\
@@ -1073,8 +1069,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.Series.backfill\
         pandas.Series.bfill\
         pandas.Series.cat\
-        pandas.Series.cat.as_ordered\
-        pandas.Series.cat.as_unordered\
         pandas.Series.cat.codes\
         pandas.Series.cat.ordered\
         pandas.Series.copy\

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -988,6 +988,10 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         Categorical
             Ordered Categorical.
 
+        See Also
+        --------
+        as_unordered : Set the Categorical to be unordered.
+
         Examples
         --------
         For :class:`pandas.Series`:
@@ -1018,6 +1022,10 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         -------
         Categorical
             Unordered Categorical.
+
+        See Also
+        --------
+        as_ordered : Set the Categorical to be ordered.
 
         Examples
         --------


### PR DESCRIPTION
All SA01 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.Categorical.as_ordered
2. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.Categorical.as_unordered
3. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.CategoricalIndex.as_ordered
4. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.CategoricalIndex.as_unordered
5. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.Series.cat.as_ordered
6. scripts/validate_docstrings.py --format=actions --errors=SA01 pandas.Series.cat.as_unordered

- [x] xref #57417
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
