### PR TITLE
Doc: fix PR07 errors for pandas.DataFrame get, rolling, to_hdf

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -499,9 +499,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (PR07)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=PR07 --ignore_functions \
-        pandas.DataFrame.get\
-        pandas.DataFrame.rolling\
-        pandas.DataFrame.to_hdf\
         pandas.DatetimeIndex.indexer_between_time\
         pandas.DatetimeIndex.mean\
         pandas.HDFStore.append\

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2646,6 +2646,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             See the errors argument for :func:`open` for a full list
             of options.
         encoding : str, default "UTF-8"
+            Set character encoding.
 
         See Also
         --------

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -925,12 +925,11 @@ class Window(BaseWindow):
         Default ``None`` (``'right'``).
 
     step : int, default None
-
-        .. versionadded:: 1.5.0
-
         Evaluate the window at every ``step`` result, equivalent to slicing as
         ``[::step]``. ``window`` must be an integer. Using a step argument other
         than None or 1 will produce a result with a different shape than the input.
+
+        .. versionadded:: 1.5.0
 
     method : str {'single', 'table'}, default 'single'
 


### PR DESCRIPTION
All PR07 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=PR07 pandas.DataFrame.get
2. scripts/validate_docstrings.py --format=actions --errors=PR07 pandas.DataFrame.rolling
3. scripts/validate_docstrings.py --format=actions --errors=PR07 pandas.DataFrame.to_hdf

- [x] xref #57420
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
