### PR TITLE
Doc: fix PR07 errors in DatetimeIndex - indexer_between_time, mean and HDFStore - append, get, put

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -502,11 +502,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         pandas.DataFrame.get\
         pandas.DataFrame.rolling\
         pandas.DataFrame.to_hdf\
-        pandas.DatetimeIndex.indexer_between_time\
-        pandas.DatetimeIndex.mean\
-        pandas.HDFStore.append\
-        pandas.HDFStore.get\
-        pandas.HDFStore.put\
         pandas.Index\
         pandas.Index.append\
         pandas.Index.copy\

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1577,6 +1577,7 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
         skipna : bool, default True
             Whether to ignore any NaT elements.
         axis : int, optional, default 0
+            Axis for the function to be applied on.
 
         Returns
         -------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -774,7 +774,9 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             appropriate format ("%H:%M", "%H%M", "%I:%M%p", "%I%M%p",
             "%H:%M:%S", "%H%M%S", "%I:%M:%S%p","%I%M%S%p").
         include_start : bool, default True
+            Include boundaries; whether to set start bound as closed or open.
         include_end : bool, default True
+            Include boundaries; whether to set end bound as closed or open.
 
         Returns
         -------

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -779,6 +779,7 @@ class HDFStore:
         Parameters
         ----------
         key : str
+            Object to retrieve from file. Raises KeyError if not found.
 
         Returns
         -------
@@ -1110,7 +1111,9 @@ class HDFStore:
         Parameters
         ----------
         key : str
+            Key of object to store in file.
         value : {Series, DataFrame}
+            Value of object to store in file.
         format : 'fixed(f)|table(t)', default is 'fixed'
             Format to use when storing object in HDFStore. Value can be one of:
 
@@ -1248,7 +1251,9 @@ class HDFStore:
         Parameters
         ----------
         key : str
+            Key of object to append.
         value : {Series, DataFrame}
+            Value of object to append.
         format : 'table' is the default
             Format to use when storing object in HDFStore.  Value can be one of:
 
@@ -1265,11 +1270,16 @@ class HDFStore:
             queries, or True to use all columns. By default only the axes
             of the object are indexed. See `here
             <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#query-via-data-columns>`__.
-        min_itemsize : dict of columns that specify minimum str sizes
-        nan_rep : str to use as str nan representation
-        chunksize : size to chunk the writing
-        expectedrows : expected TOTAL row size of this table
-        encoding : default None, provide an encoding for str
+        min_itemsize : int, dict, or None
+            Dict of columns that specify minimum str sizes.
+        nan_rep : str
+            Str to use as str nan representation.
+        chunksize : int or None
+            Size to chunk the writing.
+        expectedrows : int
+            Expected TOTAL row size of this table.
+        encoding : default None
+            Provide an encoding for str.
         dropna : bool, default False, optional
             Do not write an ALL nan row to the store settable
             by the option 'io.hdf.dropna_table'.


### PR DESCRIPTION
All PR07 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=PR07 pandas.DatetimeIndex.indexer_between_time
2. scripts/validate_docstrings.py --format=actions --errors=PR07 pandas.DatetimeIndex.mean
3. scripts/validate_docstrings.py --format=actions --errors=PR07 pandas.HDFStore.append
4. scripts/validate_docstrings.py --format=actions --errors=PR07 pandas.HDFStore.get
5. scripts/validate_docstrings.py --format=actions --errors=PR07 pandas.HDFStore.put

- [x] xref https://github.com/pandas-dev/pandas/issues/57420
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
