### PR TITLE
Doc: Fix GL08 error for pandas.ExcelFile.book

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -144,7 +144,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Partially validate docstrings (GL08)' ;  echo $MSG
     $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=GL08 --ignore_functions \
-        pandas.ExcelFile.book\
         pandas.Index.empty\
         pandas.Index.names\
         pandas.Index.view\

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1631,6 +1631,32 @@ class ExcelFile:
 
     @property
     def book(self):
+        """
+        Gets the Excel workbook.
+
+        Workbook is the top-level container for all document information.
+
+        Returns
+        -------
+        Excel Workbook
+            The workbook object of the type defined by the engine being used.
+
+        See Also
+        --------
+        read_excel : Read an Excel file into a pandas DataFrame.
+
+        Examples
+        --------
+        >>> file = pd.ExcelFile("myfile.xlsx")  # doctest: +SKIP
+        >>> file.book
+        <openpyxl.workbook.workbook.Workbook object at 0x13055ab90>
+        >>> file.book.path
+        '/xl/workbook.xml'
+        >>> file.book.active
+        <openpyxl.worksheet._read_only.ReadOnlyWorksheet object at 0x13055b040>
+        >>> file.book.sheetnames
+        ['Sheet1', 'Sheet2']
+        """
         return self._reader.book
 
     @property

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1647,13 +1647,13 @@ class ExcelFile:
 
         Examples
         --------
-        >>> file = pd.ExcelFile("myfile.xlsx")  # doctest: +SKIP
+        >>> file = pd.ExcelFile("MyWorkbook.xlsx")
         >>> file.book
-        <openpyxl.workbook.workbook.Workbook object at 0x13055ab90>
+        <openpyxl.workbook.workbook.Workbook object at 0x11eb5ad70>
         >>> file.book.path
         '/xl/workbook.xml'
         >>> file.book.active
-        <openpyxl.worksheet._read_only.ReadOnlyWorksheet object at 0x13055b040>
+        <openpyxl.worksheet._read_only.ReadOnlyWorksheet object at 0x11eb5b370>
         >>> file.book.sheetnames
         ['Sheet1', 'Sheet2']
         """

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1647,14 +1647,14 @@ class ExcelFile:
 
         Examples
         --------
-        >>> file = pd.ExcelFile("MyWorkbook.xlsx")
-        >>> file.book
+        >>> file = pd.ExcelFile("myfile.xlsx")  # doctest: +SKIP
+        >>> file.book  # doctest: +SKIP
         <openpyxl.workbook.workbook.Workbook object at 0x11eb5ad70>
-        >>> file.book.path
+        >>> file.book.path  # doctest: +SKIP
         '/xl/workbook.xml'
-        >>> file.book.active
+        >>> file.book.active  # doctest: +SKIP
         <openpyxl.worksheet._read_only.ReadOnlyWorksheet object at 0x11eb5b370>
-        >>> file.book.sheetnames
+        >>> file.book.sheetnames  # doctest: +SKIP
         ['Sheet1', 'Sheet2']
         """
         return self._reader.book


### PR DESCRIPTION
All GL08 Errors resolved in the following cases:

1. scripts/validate_docstrings.py --format=actions --errors=GL08 pandas.ExcelFile.book

- [x] xref #57443
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
