### PR TITLE
DOC: fix typo in `DataFrame.plot.hist` docstring

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1397,7 +1397,7 @@ class PlotAccessor(PandasObject):
 
         Returns
         -------
-        class:`matplotlib.Axes`
+        :class:`matplotlib.axes.Axes`
             Return a histogram plot.
 
         See Also


### PR DESCRIPTION
Spot a rendering issue [here](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.plot.hist.html)
![hist](https://github.com/pandas-dev/pandas/assets/47032563/16f57912-de5d-4d21-aaa5-4d3671d1cb90)
