### PR TITLE
CLN: enforce deprecation of `interpolate` with object dtype

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -201,6 +201,7 @@ Removal of prior version deprecations/changes
 - Changed the default value of ``observed`` in :meth:`DataFrame.groupby` and :meth:`Series.groupby` to ``True`` (:issue:`51811`)
 - Enforced deprecation disallowing parsing datetimes with mixed time zones unless user passes ``utc=True`` to :func:`to_datetime` (:issue:`57275`)
 - Enforced deprecation of :meth:`.DataFrameGroupBy.get_group` and :meth:`.SeriesGroupBy.get_group` allowing the ``name`` argument to be a non-tuple when grouping by a list of length 1 (:issue:`54155`)
+- Enforced deprecation of :meth:`Series.interpolate` and :meth:`DataFrame.interpolate` for object-dtype (:issue:`57820`)
 - Enforced deprecation of ``axis=None`` acting the same as ``axis=0`` in the DataFrame reductions ``sum``, ``prod``, ``std``, ``var``, and ``sem``, passing ``axis=None`` will now reduce over both axes; this is particularly the case when doing e.g. ``numpy.sum(df)`` (:issue:`21597`)
 - Enforced deprecation of passing a dictionary to :meth:`SeriesGroupBy.agg` (:issue:`52268`)
 - Enforced deprecation of string ``AS`` denoting frequency in :class:`YearBegin` and strings ``AS-DEC``, ``AS-JAN``, etc. denoting annual frequencies with various fiscal year starts (:issue:`57793`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7845,12 +7845,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             obj, should_transpose = self, False
         else:
             obj, should_transpose = (self.T, True) if axis == 1 else (self, False)
-            if np.any(obj.dtypes == object):
-                # GH#53631
-                if not (obj.ndim == 2 and np.all(obj.dtypes == object)):
-                    raise TypeError(
-                        f"{type(self).__name__} cannot interpolate with object dtype."
-                    )
+            # GH#53631
+            if np.any(obj.dtypes == object) and (
+                obj.ndim == 1 or not np.all(obj.dtypes == object)
+            ):
+                raise TypeError(
+                    f"{type(self).__name__} cannot interpolate with object dtype."
+                )
 
         if method in fillna_methods and "fill_value" in kwargs:
             raise ValueError(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7846,21 +7846,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         else:
             obj, should_transpose = (self.T, True) if axis == 1 else (self, False)
             # GH#53631
-            if obj.ndim == 1 and obj.dtype == object:
+            if (obj.ndim == 1 and obj.dtype == object) or (
+                obj.ndim == 2 and np.any(obj.dtypes == object)
+            ):
                 raise TypeError(
                     f"{type(self).__name__} cannot interpolate with object dtype."
                 )
-            if obj.ndim == 2:
-                if np.all(obj.dtypes == object):
-                    raise TypeError(
-                        "Cannot interpolate with all object-dtype columns "
-                        "in the DataFrame. Try setting at least one "
-                        "column to a numeric dtype."
-                    )
-                elif np.any(obj.dtypes == object):
-                    raise TypeError(
-                        f"{type(self).__name__} cannot interpolate with object dtype."
-                    )
 
         if method in fillna_methods and "fill_value" in kwargs:
             raise ValueError(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7848,13 +7848,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             if np.any(obj.dtypes == object):
                 # GH#53631
                 if not (obj.ndim == 2 and np.all(obj.dtypes == object)):
-                    # don't warn in cases that already raise
-                    warnings.warn(
-                        f"{type(self).__name__}.interpolate with object dtype is "
-                        "deprecated and will raise in a future version. Call "
-                        "obj.infer_objects(copy=False) before interpolating instead.",
-                        FutureWarning,
-                        stacklevel=find_stack_level(),
+                    raise TypeError(
+                        f"{type(self).__name__} cannot interpolate with object dtype."
                     )
 
         if method in fillna_methods and "fill_value" in kwargs:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7846,9 +7846,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         else:
             obj, should_transpose = (self.T, True) if axis == 1 else (self, False)
             # GH#53631
-            if (obj.ndim == 1 and obj.dtype == object) or (
-                obj.ndim == 2 and np.any(obj.dtypes == object)
-            ):
+            if np.any(obj.dtypes == object):
                 raise TypeError(
                     f"{type(self).__name__} cannot interpolate with object dtype."
                 )

--- a/pandas/tests/copy_view/test_interp_fillna.py
+++ b/pandas/tests/copy_view/test_interp_fillna.py
@@ -111,20 +111,12 @@ def test_interp_fill_functions_inplace(func, dtype):
     assert view._mgr._has_no_reference(0)
 
 
-def test_interpolate_cleaned_fill_method():
-    # Check that "method is set to None" case works correctly
+def test_interpolate_cannot_with_object_dtype():
     df = DataFrame({"a": ["a", np.nan, "c"], "b": 1})
-    df_orig = df.copy()
 
-    msg = "DataFrame.interpolate with object dtype"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
-        result = df.interpolate(method="linear")
-
-    assert np.shares_memory(get_array(result, "a"), get_array(df, "a"))
-    result.iloc[0, 0] = Timestamp("2021-12-31")
-
-    assert not np.shares_memory(get_array(result, "a"), get_array(df, "a"))
-    tm.assert_frame_equal(df, df_orig)
+    msg = "DataFrame cannot interpolate with object dtype"
+    with pytest.raises(TypeError, match=msg):
+        df.interpolate()
 
 
 def test_interpolate_object_convert_no_op():

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -79,7 +79,7 @@ class TestDataFrameInterpolate:
         msg = "DataFrame cannot interpolate with object dtype"
         with pytest.raises(TypeError, match=msg):
             df.interpolate()
-        
+
         cvalues = df["C"]._values
         dvalues = df["D"].values
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -302,22 +302,14 @@ class TestDataFrameInterpolate:
                 "E": [1, 2, 3, 4],
             }
         )
-        msg = (
-            "Cannot interpolate with all object-dtype columns "
-            "in the DataFrame. Try setting at least one "
-            "column to a numeric dtype."
-        )
+        msg = "DataFrame cannot interpolate with object dtype"
         with pytest.raises(TypeError, match=msg):
             df.astype("object").interpolate(axis=axis)
 
     def test_interp_raise_on_all_object_dtype(self):
         # GH 22985
         df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, dtype="object")
-        msg = (
-            "Cannot interpolate with all object-dtype columns "
-            "in the DataFrame. Try setting at least one "
-            "column to a numeric dtype."
-        )
+        msg = "DataFrame cannot interpolate with object dtype"
         with pytest.raises(TypeError, match=msg):
             df.interpolate()
 

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -846,10 +846,10 @@ class TestSeriesInterpolateData:
 
     def test_interpolate_asfreq_raises(self):
         ser = Series(["a", None, "b"], dtype=object)
-        msg2 = "Series.interpolate with object dtype"
+        msg2 = "Series cannot interpolate with object dtype"
         msg = "Invalid fill method"
-        with pytest.raises(ValueError, match=msg):
-            with tm.assert_produces_warning(FutureWarning, match=msg2):
+        with pytest.raises(TypeError, match=msg2):
+            with pytest.raises(ValueError, match=msg):
                 ser.interpolate(method="asfreq")
 
     def test_interpolate_fill_value(self):


### PR DESCRIPTION
xref #53638

enforced deprecation of `interpolate` with object dtype
