### PR TITLE
DOC: Remove duplicated Series.dt.normalize from docs

### DIFF
--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -335,7 +335,6 @@ Datetime properties
    Series.dt.tz
    Series.dt.freq
    Series.dt.unit
-   Series.dt.normalize
 
 Datetime methods
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
`Series.dt.normalize` is listed both as an attribute and as a method. Removing the attribute instance, since it's a method.
