### PR TITLE
PERF: Skip _shallow_copy for RangeIndex._join_empty where other is RangeIndex

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -943,7 +943,7 @@ class RangeIndex(Index):
     def _join_empty(
         self, other: Index, how: JoinHow, sort: bool
     ) -> tuple[Index, npt.NDArray[np.intp] | None, npt.NDArray[np.intp] | None]:
-        if other.dtype.kind == "i":
+        if not isinstance(other, RangeIndex) and other.dtype.kind == "i":
             other = self._shallow_copy(other._values, name=other.name)
         return super()._join_empty(other, how=how, sort=sort)
 


### PR DESCRIPTION
- [ ] closes #57852 (Replace xxxx with the GitHub issue number)


```python
In [1]: from pandas import *; import numpy as np
+ /opt/miniconda3/envs/pandas-dev/bin/ninja
[1/1] Generating write_version_file with a custom command

In [2]: df = DataFrame({"A": np.arange(100_000)})

In [3]: df_empty = DataFrame(columns=["B", "C"], dtype="int64")

In [4]: %timeit df_empty.join(df, how="inner")
369 µs ± 4.17 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  # main

In [4]: %timeit df_empty.join(df, how="inner")
126 µs ± 1.74 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)  # PR
```
