### PR TITLE
PERF: Remove slower short circut checks in RangeIndex__getitem__

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1153,11 +1153,6 @@ class RangeIndex(Index):
             else:
                 key = np.asarray(key, dtype=bool)
             check_array_indexer(self._range, key)  # type: ignore[arg-type]
-            # Short circuit potential _shallow_copy check
-            if key.all():
-                return self._simple_new(self._range, name=self.name)
-            elif not key.any():
-                return self._simple_new(_empty_range, name=self.name)
             key = np.flatnonzero(key)
         try:
             return self.take(key)


### PR DESCRIPTION
- [ ] closes #57712 (Replace xxxx with the GitHub issue number)

Although the `all()` and `not any()` checks were supposed to be for short-circuiting, I think these cases are not common enough to always check in this if branch. The `not any()` check will get reduced by `np.flatnonzero`. The `all()` check cannot short circuit unlike the check in `_shallow_copy`.

A probably more "common case":

```python
In [1]: from pandas import *; import numpy as np
+ /opt/miniconda3/envs/pandas-dev/bin/ninja
[1/1] Generating write_version_file with a custom command

In [2]: N = 10**6

In [3]: s = Series(date_range("2000-01-01", freq="s", periods=N))

In [4]: s[np.random.randint(1, N, 100)] = NaT

In [6]: %timeit s.dropna()
7.49 ms ± 333 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # main

In [5]: %timeit s.dropna()
7.22 ms ± 239 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # PR
```

The worst case where `if key.all()` would have gotten hit (will be improved by https://github.com/pandas-dev/pandas/pull/57812)

```python
In [1]: import pandas as pd, numpy as np, pyarrow as pa
+ /opt/miniconda3/envs/pandas-dev/bin/ninja
[1/1] Generating write_version_file with a custom command

In [2]: ri = pd.RangeIndex(range(100_000))

In [3]: mask = [True] * 100_000

In [4]: %timeit ri[mask]
2.82 ms ± 31.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # PR

In [4]: %timeit ri[mask]
2.41 ms ± 23.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # main
```
