### PR TITLE
BUG: Replace on Series/DataFrame stops replacing after first NA

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -296,7 +296,7 @@ Bug fixes
 - Fixed bug in :meth:`DataFrameGroupBy.apply` that was returning a completely empty DataFrame when all return values of ``func`` were ``None`` instead of returning an empty DataFrame with the original columns and dtypes. (:issue:`57775`)
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
 - Fixed bug in :meth:`Series.rank` that doesn't preserve missing values for nullable integers when ``na_option='keep'``. (:issue:`56976`)
-- Fixed bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently replacing matching instances when `regex=True` and missing values are present. (:issue:`56599`)
+- Fixed bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently replacing matching instances when ``regex=True`` and missing values are present. (:issue:`56599`)
 
 Categorical
 ^^^^^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -296,6 +296,7 @@ Bug fixes
 - Fixed bug in :meth:`DataFrameGroupBy.apply` that was returning a completely empty DataFrame when all return values of ``func`` were ``None`` instead of returning an empty DataFrame with the original columns and dtypes. (:issue:`57775`)
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
 - Fixed bug in :meth:`Series.rank` that doesn't preserve missing values for nullable integers when ``na_option='keep'``. (:issue:`56976`)
+- Fixed bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently replacing matching instances when `regex=True` and missing values are present. (:issue:`56599`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/array_algos/replace.py
+++ b/pandas/core/array_algos/replace.py
@@ -93,17 +93,18 @@ def compare_or_regex_search(
         )
 
     # GH#32621 use mask to avoid comparing to NAs
-    if isinstance(a, np.ndarray):
+    if isinstance(a, np.ndarray) and mask is not None:
         a = a[mask]
+        result = op(a)
 
-    result = op(a)
-
-    if isinstance(result, np.ndarray) and mask is not None:
-        # The shape of the mask can differ to that of the result
-        # since we may compare only a subset of a's or b's elements
-        tmp = np.zeros(mask.shape, dtype=np.bool_)
-        np.place(tmp, mask, result)
-        result = tmp
+        if isinstance(result, np.ndarray):
+            # The shape of the mask can differ to that of the result
+            # since we may compare only a subset of a's or b's elements
+            tmp = np.zeros(mask.shape, dtype=np.bool_)
+            np.place(tmp, mask, result)
+            result = tmp
+    else:
+        result = op(a)
 
     _check_comparison_types(result, a, b)
     return result

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -625,7 +625,9 @@ class TestSeriesReplace:
             "CC": "CC-REPL",
         }
         result = ser.replace(regex_mapping, regex=True)
-        exp = pd.Series(["CC", "CC", "CC-REPL", "DD", "CC", "", pd.NA, "CC"], dtype="string")
+        exp = pd.Series(
+            ["CC", "CC", "CC-REPL", "DD", "CC", "", pd.NA, "CC"], dtype="string"
+        )
         tm.assert_series_equal(result, exp)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -616,7 +616,8 @@ class TestSeriesReplace:
 
     def test_pandas_replace_na(self):
         # GH#43344
-        ser = pd.Series(["AA", "BB", "CC", "DD", "EE", "", pd.NA], dtype="string")
+        # GH#56599
+        ser = pd.Series(["AA", "BB", "CC", "DD", "EE", "", pd.NA, "AA"], dtype="string")
         regex_mapping = {
             "AA": "CC",
             "BB": "CC",
@@ -624,7 +625,7 @@ class TestSeriesReplace:
             "CC": "CC-REPL",
         }
         result = ser.replace(regex_mapping, regex=True)
-        exp = pd.Series(["CC", "CC", "CC-REPL", "DD", "CC", "", pd.NA], dtype="string")
+        exp = pd.Series(["CC", "CC", "CC-REPL", "DD", "CC", "", pd.NA, "CC"], dtype="string")
         tm.assert_series_equal(result, exp)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] closes #56599
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The issue was the line `a = a[mask]` was triggered only for `ndarray` and doesn't hit when `dtype='string'`, but the `np.place` logic applied as long as the result was an `ndarray`.

The old behavior had things like (depending on the number and location of NAs)

```py
In [2]: s = pd.Series(['m', 'm', pd.NA, 'm', 'm', 'm'], dtype='string')

In [3]: s.replace({'m': 't'}, regex=True)
Out[3]:
0       t
1       t
2    <NA>
3       m
4       t
5       t
dtype: string

In [4]: s = pd.Series(['m', 'm', pd.NA, pd.NA, 'm', 'm', 'm'], dtype='string')

In [5]: s.replace({'m': 't'}, regex=True)
Out[5]:
0       t
1       t
2    <NA>
3    <NA>
4       m
5       m
6       t
dtype: string

In [6]: s = pd.Series(['m', 'm', pd.NA, 'm', 'm', pd.NA, 'm', 'm'], dtype='string')

In [7]: s.replace({'m': 't'}, regex=True)
Out[7]:
0       t
1       t
2    <NA>
3       m
4       t
5    <NA>
6       t
7       m
dtype: string
```