### PR TITLE
BUG: Join with a list of a single element should behave as a join with a single element (#57676)

### DIFF
--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -911,7 +911,7 @@ to join them together on their indexes.
 
 .. ipython:: python
 
-   right2 = pd.DataFrame({"v": [7, 8, 9]}, index=["K1", "K1", "K2"])
+   right2 = pd.DataFrame({"v": [7, 8, 9]}, index=pd.Index(["K1", "K1", "K2"], name="key1"))
    result = left.join([right, right2])
 
 .. ipython:: python

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -501,6 +501,7 @@ Other
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which caused an exception when using NumPy attributes via ``@`` notation, e.g., ``df.eval("@np.floor(a)")``. (:issue:`58041`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which did not allow to use ``tan`` function. (:issue:`55091`)
+- Bug in :meth:`DataFrame.join` on join, when deciding to concat or merge a list containing MultiIndexes check uniqueness of individual indexes (:issue:`57676`)
 - Bug in :meth:`DataFrame.sort_index` when passing ``axis="columns"`` and ``ignore_index=True`` and ``ascending=False`` not returning a :class:`RangeIndex` columns (:issue:`57293`)
 - Bug in :meth:`DataFrame.transform` that was returning the wrong order unless the index was monotonically increasing. (:issue:`57069`)
 - Bug in :meth:`DataFrame.where` where using a non-bool type array in the function would return a ``ValueError`` instead of a ``TypeError`` (:issue:`56330`)

--- a/pandas/tests/frame/methods/test_join.py
+++ b/pandas/tests/frame/methods/test_join.py
@@ -108,8 +108,6 @@ def test_suffix_on_list_join():
     # check proper errors are raised
     msg = "Suffixes not supported when joining multiple DataFrames"
     with pytest.raises(ValueError, match=msg):
-        first.join([second], lsuffix="y")
-    with pytest.raises(ValueError, match=msg):
         first.join([second, third], rsuffix="x")
     with pytest.raises(ValueError, match=msg):
         first.join([second, third], lsuffix="y", rsuffix="x")
@@ -562,3 +560,21 @@ class TestDataFrameJoin:
 
         tm.assert_index_equal(result.index, expected)
         assert result.index.tz.zone == "US/Central"
+
+    def test_join_lists_index_with_multiindex(self):
+        test1 = DataFrame(
+            {"cat": pd.Categorical(["a", "v", "d"])},
+            index=Index(["a", "b", "c"], name="y"),
+        )
+        test2 = DataFrame(
+            {"foo": np.arange(6)},
+            index=MultiIndex.from_tuples(
+                [(0, "a"), (0, "b"), (0, "c"), (1, "a"), (1, "b"), (1, "c")],
+                names=("x", "y"),
+            ),
+        )
+
+        result = test2.join([test1])
+        expected = test2.join(test1)
+
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #57676
- [x] Added a test to pandas/tests/frame/methods/test_join.py 

Even though it does not make much sense, joining a dataframe with a list of a single element should behave as joining the dataframe with that element.


