### PR TITLE
DOC: update link in benchmarks.md

### DIFF
--- a/web/pandas/community/benchmarks.md
+++ b/web/pandas/community/benchmarks.md
@@ -75,5 +75,5 @@ There is a quick summary here:
 
 The main benchmarks comparing dataframe tools that include pandas are:
 
-- [DuckDB benchmarks](https://duckdblabs.github.io/db-benchmark/)
+- [DuckDB (former H2O.ai) benchmarks](https://duckdblabs.github.io/db-benchmark/)
 - [TPCH benchmarks](https://pola.rs/posts/benchmarks/)

--- a/web/pandas/community/benchmarks.md
+++ b/web/pandas/community/benchmarks.md
@@ -75,5 +75,5 @@ There is a quick summary here:
 
 The main benchmarks comparing dataframe tools that include pandas are:
 
-- [H2O.ai benchmarks](https://h2oai.github.io/db-benchmark/)
+- [DuckDB benchmarks](https://duckdblabs.github.io/db-benchmark/)
 - [TPCH benchmarks](https://pola.rs/posts/benchmarks/)


### PR DESCRIPTION
- [x] closes #57850
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The [H20.ai benchmark link](https://h2oai.github.io/db-benchmark/) in the [benchmarks webpage](https://pandas.pydata.org/community/benchmarks.html) contains the outdated benchmark results (e.g. the last benchmark was performed July 2021 and it used the pandas==1.2.5). DuckDB published a new benchmark results (e.g. the last benchmark was December 2023 with pandas==2.1.1) in the [link](https://duckdblabs.github.io/db-benchmark/) with the same approach described in [their blog](https://duckdb.org/2023/11/03/db-benchmark-update). So it's a good idea to replace the benchmark link. Thank you @rootsmusic for the issue.