### PR TITLE
BUG: pretty print all Mappings, not just dicts

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -357,6 +357,7 @@ MultiIndex
 I/O
 ^^^
 - Bug in :meth:`DataFrame.to_excel` when writing empty :class:`DataFrame` with :class:`MultiIndex` on both axes (:issue:`57696`)
+- Now all ``Mapping`` s are pretty printed correctly. Before only literal ``dict`` s were. (:issue:`57915`)
 -
 -
 

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -187,8 +187,8 @@ def pprint_thing(
     _nest_lvl : internal use only. pprint_thing() is mutually-recursive
         with pprint_sequence, this argument is used to keep track of the
         current nesting level, and limit it.
-    escape_chars : list or dict, optional
-        Characters to escape. If a dict is passed the values are the
+    escape_chars : list[str] or Mapping[str, str], optional
+        Characters to escape. If a Mapping is passed the values are the
         replacements
     default_escapes : bool, default False
         Whether the input escape characters replaces or adds to the defaults
@@ -204,11 +204,11 @@ def pprint_thing(
         thing: Any, escape_chars: EscapeChars | None = escape_chars
     ) -> str:
         translate = {"\t": r"\t", "\n": r"\n", "\r": r"\r"}
-        if isinstance(escape_chars, dict):
+        if isinstance(escape_chars, Mapping):
             if default_escapes:
                 translate.update(escape_chars)
             else:
-                translate = escape_chars
+                translate = escape_chars  # type: ignore[assignment]
             escape_chars = list(escape_chars.keys())
         else:
             escape_chars = escape_chars or ()
@@ -220,7 +220,7 @@ def pprint_thing(
 
     if hasattr(thing, "__next__"):
         return str(thing)
-    elif isinstance(thing, dict) and _nest_lvl < get_option(
+    elif isinstance(thing, Mapping) and _nest_lvl < get_option(
         "display.pprint_nest_depth"
     ):
         result = _pprint_dict(

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -1,5 +1,6 @@
 # Note! This file is aimed specifically at pandas.io.formats.printing utility
 # functions, not the general printing of pandas objects.
+from collections.abc import Mapping
 import string
 
 import pandas._config.config as cf
@@ -14,6 +15,17 @@ def test_adjoin():
     adjoined = printing.adjoin(2, *data)
 
     assert adjoined == expected
+
+
+class MyMapping(Mapping):
+    def __getitem__(self, key):
+        return 4
+
+    def __iter__(self):
+        return iter(["a", "b"])
+
+    def __len__(self):
+        return 2
 
 
 class TestPPrintThing:
@@ -41,6 +53,12 @@ class TestPPrintThing:
 
     def test_repr_set(self):
         assert printing.pprint_thing({1}) == "{1}"
+
+    def test_repr_dict(self):
+        assert printing.pprint_thing({"a": 4, "b": 4}) == "{'a': 4, 'b': 4}"
+
+    def test_repr_mapping(self):
+        assert printing.pprint_thing(MyMapping()) == "{'a': 4, 'b': 4}"
 
 
 class TestFormatBase:


### PR DESCRIPTION
This was discovered in https://github.com/ibis-project/ibis/issues/8687

Due to a strict `isinstance(x, dict)` check, custom mapping types would instead get treated as mere iterables, so only the keys would get printed as a tuple:

```python
import pandas as pd
from ibis.common.collections import frozendict
pd.Series([frozendict({"a": 5, "b": 6})])
# 0    (a, b)
# dtype: object
```

- [x] NA: closes #xxxx
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] NA Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
