### PR TITLE
STYLE: Detect unnecessary pylint ignore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
     hooks:
     -   id: pylint
         stages: [manual]
-        args: [--load-plugins=pylint.extensions.redefined_loop_name]
+        args: [--load-plugins=pylint.extensions.redefined_loop_name, --fail-on=I0021]
     -   id: pylint
         alias: redefined-outer-name
         name: Redefining name from outer scope

--- a/pandas/core/groupby/indexing.py
+++ b/pandas/core/groupby/indexing.py
@@ -114,7 +114,6 @@ class GroupByIndexingMixin:
         4  b  5
         """
         if TYPE_CHECKING:
-            # pylint: disable-next=used-before-assignment
             groupby_self = cast(groupby.GroupBy, self)
         else:
             groupby_self = self

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -993,7 +993,6 @@ def to_datetime(
         errors=errors,
         exact=exact,
     )
-    # pylint: disable-next=used-before-assignment
     result: Timestamp | NaTType | Series | Index
 
     if isinstance(arg, Timestamp):

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -1311,7 +1311,6 @@ class TestToLatexMultiindex:
         )
         col_names = [n if (bool(n) and 1 in axes) else "" for n in names]
         observed = df.to_latex(multirow=False)
-        # pylint: disable-next=consider-using-f-string
         expected = r"""\begin{tabular}{llrrrr}
 \toprule
  & %s & \multicolumn{2}{r}{1} & \multicolumn{2}{r}{2} \\

--- a/pandas/tests/series/test_iteration.py
+++ b/pandas/tests/series/test_iteration.py
@@ -4,12 +4,10 @@ class TestIteration:
 
     def test_iter_datetimes(self, datetime_series):
         for i, val in enumerate(datetime_series):
-            # pylint: disable-next=unnecessary-list-index-lookup
             assert val == datetime_series.iloc[i]
 
     def test_iter_strings(self, string_series):
         for i, val in enumerate(string_series):
-            # pylint: disable-next=unnecessary-list-index-lookup
             assert val == string_series.iloc[i]
 
     def test_iteritems_datetimes(self, datetime_series):


### PR DESCRIPTION
Enable `pylint`'s `I0021`/`useless-suppression` ([doc](https://pylint.pycqa.org/en/latest/user_guide/messages/information/useless-suppression.html)) 

This should make it easier to recognize how many `pylint` rules that `ruff` is still missing.