### PR TITLE
Fix tagging within Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN apt-get install -y libhdf5-dev libgles2-mesa-dev
 RUN python -m pip install --upgrade pip
 COPY requirements-dev.txt /tmp
 RUN python -m pip install -r /tmp/requirements-dev.txt
+RUN git config --global --add safe.directory /home/pandas
 CMD ["/bin/bash"]


### PR DESCRIPTION
When the user within a docker container does not match the user on the host machine (this is the case by default on Linux, not sure of all OSes) you cannot use git to inspect the worktree:

```sh
root@6de0debf3870:/home/pandas# git log
fatal: detected dubious ownership in repository at '/home/pandas'
To add an exception for this directory, call:

	git config --global --add safe.directory /home/pandas
```

This prevents builds within docker from being tagged with the appropriate git revision