### PR TITLE
Clean up more Cython warning

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1603,7 +1603,7 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
 
 # -> ndarray[f'|S{width}']
 cdef _to_fw_string(parser_t *parser, int64_t col, int64_t line_start,
-                   int64_t line_end, int64_t width) noexcept:
+                   int64_t line_end, int64_t width):
     cdef:
         char *data
         ndarray result


### PR DESCRIPTION
Overlooked this in the recent PR. I think this is the last of Cython warnings.

`(warning: /home/pandas/pandas/_libs/parsers.pyx:1605:26: noexcept clause is ignored for function returning Python object)`