### PR TITLE
WEB: Updating active/inactive core devs

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -123,11 +123,10 @@ workgroups:
     contact: finance@pandas.pydata.org
     responsibilities: "Approve the project expenses."
     members:
-    - Wes McKinney
+    - Matthew Roeschke
     - Jeff Reback
     - Joris Van den Bossche
     - Tom Augspurger
-    - Matthew Roeschke
   infrastructure:
     name: Infrastructure
     contact: infrastructure@pandas.pydata.org

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -121,11 +121,12 @@ workgroups:
   finance:
     name: Finance
     contact: finance@pandas.pydata.org
-    responsibilities: "Approve the project expenses."
+    responsibilities: "Manage the funding. Coordinate the request of grants. Approve the project expenses."
     members:
     - Matthew Roeschke
     - Jeff Reback
     - Joris Van den Bossche
+    - Patrick Hoefler
   infrastructure:
     name: Infrastructure
     contact: infrastructure@pandas.pydata.org

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -72,11 +72,9 @@ blog:
   - https://phofl.github.io/feeds/pandas.atom.xml
 maintainers:
   active:
-  - wesm
   - jorisvandenbossche
   - TomAugspurger
   - jreback
-  - gfyoung
   - WillAyd
   - mroeschke
   - jbrockmendel
@@ -84,7 +82,6 @@ maintainers:
   - simonjayhawkins
   - topper-123
   - alimcmaster1
-  - bashtage
   - Dr-Irv
   - MarcoGorelli
   - rhshadrach
@@ -93,7 +90,6 @@ maintainers:
   - fangchenli
   - twoertwein
   - lithomas1
-  - mzeitlin11
   - lukemanley
   - noatamir
   inactive:
@@ -108,6 +104,10 @@ maintainers:
   - jschendel
   - charlesdong1991
   - dsaxton
+  - wesm
+  - gfyoung
+  - mzeitlin11
+  - bashtage
 workgroups:
   coc:
     name: Code of Conduct

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -82,6 +82,7 @@ maintainers:
   - simonjayhawkins
   - topper-123
   - alimcmaster1
+  - bashtage
   - Dr-Irv
   - MarcoGorelli
   - rhshadrach
@@ -107,7 +108,6 @@ maintainers:
   - wesm
   - gfyoung
   - mzeitlin11
-  - bashtage
 workgroups:
   coc:
     name: Code of Conduct
@@ -126,7 +126,6 @@ workgroups:
     - Matthew Roeschke
     - Jeff Reback
     - Joris Van den Bossche
-    - Tom Augspurger
   infrastructure:
     name: Infrastructure
     contact: infrastructure@pandas.pydata.org


### PR DESCRIPTION
I've checked with the devs who weren't active in pandas recently to see if they wished to become inactive, and few were happy to become inactive.

Besides to manage expectations of other core devs and the community, this is relevant for the decision making proposed in [PDEP-1](https://github.com/pandas-dev/pandas/pull/53576/files). With the current proposal, the number of maintainers to have a quorum is lowered from 12 to 11 after this PR, and it'll have an impact if more people become a maintainer.

@bashtage I couldn't get an answer from you via email (I sent two emails). If you'd like to remain active that's totally fine, just let me know.