### PR TITLE
DOC: fix list indentation in pandas.DataFrame.stack

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9288,10 +9288,9 @@ class DataFrame(NDFrame, OpsMixin):
         DataFrame. The new inner-most levels are created by pivoting the
         columns of the current dataframe:
 
-          - if the columns have a single level, the output is a Series;
-          - if the columns have multiple levels, the new index
-            level(s) is (are) taken from the prescribed level(s) and
-            the output is a DataFrame.
+        - if the columns have a single level, the output is a Series;
+        - if the columns have multiple levels, the new index level(s) is (are)
+          taken from the prescribed level(s) and the output is a DataFrame.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixed the grey-out box around the list of options for multiple levels of columns.