### PR TITLE
CLN: Enforce deprecations for EA.fillna

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -34,7 +34,6 @@ Other enhancements
 - Allow dictionaries to be passed to :meth:`pandas.Series.str.replace` via ``pat`` parameter (:issue:`51748`)
 - Support passing a :class:`Series` input to :func:`json_normalize` that retains the :class:`Series` :class:`Index` (:issue:`51452`)
 - Users can globally disable any ``PerformanceWarning`` by setting the option ``mode.performance_warnings`` to ``False`` (:issue:`56920`)
--
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:
@@ -258,6 +257,7 @@ Removal of prior version deprecations/changes
 - Unrecognized timezones when parsing strings to datetimes now raises a ``ValueError`` (:issue:`51477`)
 - Removed the :class:`Grouper` attributes ``ax``, ``groups``, ``indexer``, and ``obj`` (:issue:`51206`, :issue:`51182`)
 - Removed deprecated keyword ``verbose`` on :func:`read_csv` and :func:`read_table` (:issue:`56556`)
+- Removed the ``method`` keyword in ``ExtensionArray.fillna``, implement ``ExtensionArray._pad_or_backfill`` instead (:issue:`53621`)
 - Removed the attribute ``dtypes`` from :class:`.DataFrameGroupBy` (:issue:`51997`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -29,7 +29,6 @@ from pandas.compat import (
     pa_version_under13p0,
 )
 from pandas.util._decorators import doc
-from pandas.util._validators import validate_fillna_kwargs
 
 from pandas.core.dtypes.cast import (
     can_hold_element,
@@ -1068,6 +1067,7 @@ class ArrowExtensionArray(
                 #   a kernel for duration types.
                 pass
 
+        # TODO: Why do we no longer need the above cases?
         # TODO(3.0): after EA.fillna 'method' deprecation is enforced, we can remove
         #  this method entirely.
         return super()._pad_or_backfill(
@@ -1078,21 +1078,15 @@ class ArrowExtensionArray(
     def fillna(
         self,
         value: object | ArrayLike | None = None,
-        method: FillnaOptions | None = None,
         limit: int | None = None,
         copy: bool = True,
     ) -> Self:
-        value, method = validate_fillna_kwargs(value, method)
-
         if not self._hasna:
             # TODO(CoW): Not necessary anymore when CoW is the default
             return self.copy()
 
         if limit is not None:
-            return super().fillna(value=value, method=method, limit=limit, copy=copy)
-
-        if method is not None:
-            return super().fillna(method=method, limit=limit, copy=copy)
+            return super().fillna(value=value, limit=limit, copy=copy)
 
         if isinstance(value, (np.ndarray, ExtensionArray)):
             # Similar to check_value_size, but we do not mask here since we may
@@ -1118,7 +1112,7 @@ class ArrowExtensionArray(
             #   a kernel for duration types.
             pass
 
-        return super().fillna(value=value, method=method, limit=limit, copy=copy)
+        return super().fillna(value=value, limit=limit, copy=copy)
 
     def isin(self, values: ArrayLike) -> npt.NDArray[np.bool_]:
         # short-circuit to return all False array.

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -29,7 +29,6 @@ from pandas._typing import (
     ArrayLike,
     AxisInt,
     Dtype,
-    FillnaOptions,
     IntervalClosedType,
     NpDtype,
     PositionalIndexer,
@@ -894,23 +893,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         indexer = obj.argsort()[-1]
         return obj[indexer]
 
-    def _pad_or_backfill(  # pylint: disable=useless-parent-delegation
-        self,
-        *,
-        method: FillnaOptions,
-        limit: int | None = None,
-        limit_area: Literal["inside", "outside"] | None = None,
-        copy: bool = True,
-    ) -> Self:
-        # TODO(3.0): after EA.fillna 'method' deprecation is enforced, we can remove
-        #  this method entirely.
-        return super()._pad_or_backfill(
-            method=method, limit=limit, limit_area=limit_area, copy=copy
-        )
-
-    def fillna(
-        self, value=None, method=None, limit: int | None = None, copy: bool = True
-    ) -> Self:
+    def fillna(self, value=None, limit: int | None = None, copy: bool = True) -> Self:
         """
         Fill NA/NaN values using the specified method.
 
@@ -921,9 +904,6 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             Alternatively, a Series or dict can be used to fill in different
             values for each index. The value should not be a list. The
             value(s) passed should be either Interval objects or NA/NaN.
-        method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
-            (Not implemented yet for IntervalArray)
-            Method to use for filling holes in reindexed Series
         limit : int, default None
             (Not implemented yet for IntervalArray)
             If method is specified, this is the maximum number of consecutive
@@ -944,8 +924,6 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         """
         if copy is False:
             raise NotImplementedError
-        if method is not None:
-            return super().fillna(value=value, method=method, limit=limit)
 
         value_left, value_right = self._validate_scalar(value)
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -38,7 +38,6 @@ from pandas.compat import (
 )
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import doc
-from pandas.util._validators import validate_fillna_kwargs
 
 from pandas.core.dtypes.base import ExtensionDtype
 from pandas.core.dtypes.common import (
@@ -237,32 +236,18 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         return new_values
 
     @doc(ExtensionArray.fillna)
-    def fillna(
-        self, value=None, method=None, limit: int | None = None, copy: bool = True
-    ) -> Self:
-        value, method = validate_fillna_kwargs(value, method)
-
+    def fillna(self, value=None, limit: int | None = None, copy: bool = True) -> Self:
         mask = self._mask
 
         value = missing.check_value_size(value, mask, len(self))
 
         if mask.any():
-            if method is not None:
-                func = missing.get_fill_func(method, ndim=self.ndim)
-                npvalues = self._data.T
-                new_mask = mask.T
-                if copy:
-                    npvalues = npvalues.copy()
-                    new_mask = new_mask.copy()
-                func(npvalues, limit=limit, mask=new_mask)
-                return self._simple_new(npvalues.T, new_mask.T)
+            # fill with value
+            if copy:
+                new_values = self.copy()
             else:
-                # fill with value
-                if copy:
-                    new_values = self.copy()
-                else:
-                    new_values = self[:]
-                new_values[mask] = value
+                new_values = self[:]
+            new_values[mask] = value
         else:
             if copy:
                 new_values = self.copy()

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -847,19 +847,6 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         else:
             return self
 
-    def fillna(
-        self, value=None, method=None, limit: int | None = None, copy: bool = True
-    ) -> Self:
-        if method is not None:
-            # view as dt64 so we get treated as timelike in core.missing,
-            #  similar to dtl._period_dispatch
-            dta = self.view("M8[ns]")
-            result = dta.fillna(value=value, method=method, limit=limit, copy=copy)
-            # error: Incompatible return value type (got "Union[ExtensionArray,
-            # ndarray[Any, Any]]", expected "PeriodArray")
-            return result.view(self.dtype)  # type: ignore[return-value]
-        return super().fillna(value=value, method=method, limit=limit, copy=copy)
-
     # ------------------------------------------------------------------
     # Arithmetic Methods
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -98,10 +98,7 @@ if TYPE_CHECKING:
 
     from scipy.sparse import spmatrix
 
-    from pandas._typing import (
-        FillnaOptions,
-        NumpySorter,
-    )
+    from pandas._typing import NumpySorter
 
     SparseIndexKind = Literal["integer", "block"]
 
@@ -717,24 +714,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         mask[self.sp_index.indices] = isna(self.sp_values)
         return type(self)(mask, fill_value=False, dtype=dtype)
 
-    def _pad_or_backfill(  # pylint: disable=useless-parent-delegation
-        self,
-        *,
-        method: FillnaOptions,
-        limit: int | None = None,
-        limit_area: Literal["inside", "outside"] | None = None,
-        copy: bool = True,
-    ) -> Self:
-        # TODO(3.0): We can remove this method once deprecation for fillna method
-        #  keyword is enforced.
-        return super()._pad_or_backfill(
-            method=method, limit=limit, limit_area=limit_area, copy=copy
-        )
-
     def fillna(
         self,
         value=None,
-        method: FillnaOptions | None = None,
         limit: int | None = None,
         copy: bool = True,
     ) -> Self:
@@ -743,17 +725,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         Parameters
         ----------
-        value : scalar, optional
-        method : str, optional
-
-            .. warning::
-
-               Using 'method' will result in high memory use,
-               as all `fill_value` methods will be converted to
-               an in-memory ndarray
-
+        value : scalar
         limit : int, optional
-
         copy: bool, default True
             Ignored for SparseArray.
 
@@ -773,22 +746,15 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         When ``self.fill_value`` is not NA, the result dtype will be
         ``self.dtype``. Again, this preserves the amount of memory used.
         """
-        if (method is None and value is None) or (
-            method is not None and value is not None
-        ):
-            raise ValueError("Must specify one of 'method' or 'value'.")
+        if value is None:
+            raise ValueError("Must specify 'value'.")
+        new_values = np.where(isna(self.sp_values), value, self.sp_values)
 
-        if method is not None:
-            return super().fillna(method=method, limit=limit)
-
+        if self._null_fill_value:
+            # This is essentially just updating the dtype.
+            new_dtype = SparseDtype(self.dtype.subtype, fill_value=value)
         else:
-            new_values = np.where(isna(self.sp_values), value, self.sp_values)
-
-            if self._null_fill_value:
-                # This is essentially just updating the dtype.
-                new_dtype = SparseDtype(self.dtype.subtype, fill_value=value)
-            else:
-                new_dtype = self.dtype
+            new_dtype = self.dtype
 
         return self._simple_new(new_values, self._sparse_index, new_dtype)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -99,7 +99,6 @@ from pandas.util._validators import (
     check_dtype_backend,
     validate_ascending,
     validate_bool_kwarg,
-    validate_fillna_kwargs,
     validate_inclusive,
 )
 
@@ -9578,7 +9577,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         # fill
         fill_na = notna(fill_value)
         if fill_na:
-            fill_value, _ = validate_fillna_kwargs(fill_value, None)
             left = left.fillna(fill_value)
             right = right.fillna(fill_value)
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1873,13 +1873,11 @@ class ExtensionBlock(EABackedBlock):
             copy, refs = self._get_refs_and_copy(inplace)
 
             try:
-                new_values = self.values.fillna(
-                    value=value, method=None, limit=limit, copy=copy
-                )
+                new_values = self.values.fillna(value=value, limit=limit, copy=copy)
             except TypeError:
                 # 3rd party EA that has not implemented copy keyword yet
                 refs = None
-                new_values = self.values.fillna(value=value, method=None, limit=limit)
+                new_values = self.values.fillna(value=value, limit=limit)
                 # issue the warning *after* retrying, in case the TypeError
                 #  was caused by an invalid fill_value
                 warnings.warn(

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -62,34 +62,6 @@ class TestCategoricalMissing:
         exp = Categorical([1, np.nan, 3], categories=[1, 2, 3])
         tm.assert_categorical_equal(cat, exp)
 
-    @pytest.mark.parametrize(
-        "fillna_kwargs, msg",
-        [
-            (
-                {"value": 1, "method": "ffill"},
-                "Cannot specify both 'value' and 'method'.",
-            ),
-            ({}, "Must specify a fill 'value' or 'method'."),
-            ({"method": "bad"}, "Invalid fill method. Expecting .* bad"),
-            (
-                {"value": Series([1, 2, 3, 4, "a"])},
-                "Cannot setitem on a Categorical with a new category",
-            ),
-        ],
-    )
-    def test_fillna_raises(self, fillna_kwargs, msg):
-        # https://github.com/pandas-dev/pandas/issues/19682
-        # https://github.com/pandas-dev/pandas/issues/13628
-        cat = Categorical([1, 2, 3, None, None])
-
-        if len(fillna_kwargs) == 1 and "value" in fillna_kwargs:
-            err = TypeError
-        else:
-            err = ValueError
-
-        with pytest.raises(err, match=msg):
-            cat.fillna(**fillna_kwargs)
-
     @pytest.mark.parametrize("named", [True, False])
     def test_fillna_iterable_category(self, named):
         # https://github.com/pandas-dev/pandas/issues/21097

--- a/pandas/tests/extension/conftest.py
+++ b/pandas/tests/extension/conftest.py
@@ -189,7 +189,7 @@ def use_numpy(request):
 def fillna_method(request):
     """
     Parametrized fixture giving method parameters 'ffill' and 'bfill' for
-    Series.fillna(method=<method>) testing.
+    Series.<method> testing.
     """
     return request.param
 

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -287,17 +287,10 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
         return value_counts(self.to_numpy(), dropna=dropna)
 
     # We override fillna here to simulate a 3rd party EA that has done so. This
-    #  lets us test the deprecation telling authors to implement _pad_or_backfill
-    # Simulate a 3rd-party EA that has not yet updated to include a "copy"
+    #  lets us test a 3rd-party EA that has not yet updated to include a "copy"
     #  keyword in its fillna method.
-    # error: Signature of "fillna" incompatible with supertype "ExtensionArray"
-    def fillna(  # type: ignore[override]
-        self,
-        value=None,
-        method=None,
-        limit: int | None = None,
-    ):
-        return super().fillna(value=value, method=method, limit=limit, copy=True)
+    def fillna(self, value=None, limit=None):
+        return super().fillna(value=value, limit=limit, copy=True)
 
 
 def to_decimal(values, context=None):

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -137,104 +137,12 @@ class TestDecimalArray(base.ExtensionTests):
         ):
             super().test_fillna_frame(data_missing)
 
-    def test_fillna_limit_pad(self, data_missing):
-        msg = "ExtensionArray.fillna 'method' keyword is deprecated"
-        with tm.assert_produces_warning(
-            DeprecationWarning,
-            match=msg,
-            check_stacklevel=False,
-            raise_on_extra_warnings=False,
-        ):
-            super().test_fillna_limit_pad(data_missing)
-
-        msg = "The 'method' keyword in DecimalArray.fillna is deprecated"
-        with tm.assert_produces_warning(
-            FutureWarning,
-            match=msg,
-            check_stacklevel=False,
-            raise_on_extra_warnings=False,
-        ):
-            super().test_fillna_limit_pad(data_missing)
-
-    @pytest.mark.parametrize(
-        "limit_area, input_ilocs, expected_ilocs",
-        [
-            ("outside", [1, 0, 0, 0, 1], [1, 0, 0, 0, 1]),
-            ("outside", [1, 0, 1, 0, 1], [1, 0, 1, 0, 1]),
-            ("outside", [0, 1, 1, 1, 0], [0, 1, 1, 1, 1]),
-            ("outside", [0, 1, 0, 1, 0], [0, 1, 0, 1, 1]),
-            ("inside", [1, 0, 0, 0, 1], [1, 1, 1, 1, 1]),
-            ("inside", [1, 0, 1, 0, 1], [1, 1, 1, 1, 1]),
-            ("inside", [0, 1, 1, 1, 0], [0, 1, 1, 1, 0]),
-            ("inside", [0, 1, 0, 1, 0], [0, 1, 1, 1, 0]),
-        ],
-    )
-    def test_ffill_limit_area(
-        self, data_missing, limit_area, input_ilocs, expected_ilocs
-    ):
-        # GH#56616
-        msg = "ExtensionArray.fillna 'method' keyword is deprecated"
-        with tm.assert_produces_warning(
-            DeprecationWarning,
-            match=msg,
-            check_stacklevel=False,
-            raise_on_extra_warnings=False,
-        ):
-            msg = "DecimalArray does not implement limit_area"
-            with pytest.raises(NotImplementedError, match=msg):
-                super().test_ffill_limit_area(
-                    data_missing, limit_area, input_ilocs, expected_ilocs
-                )
-
-    def test_fillna_limit_backfill(self, data_missing):
-        msg = "ExtensionArray.fillna 'method' keyword is deprecated"
-        with tm.assert_produces_warning(
-            DeprecationWarning,
-            match=msg,
-            check_stacklevel=False,
-            raise_on_extra_warnings=False,
-        ):
-            super().test_fillna_limit_backfill(data_missing)
-
-        msg = "The 'method' keyword in DecimalArray.fillna is deprecated"
-        with tm.assert_produces_warning(
-            FutureWarning,
-            match=msg,
-            check_stacklevel=False,
-            raise_on_extra_warnings=False,
-        ):
-            super().test_fillna_limit_backfill(data_missing)
-
-    def test_fillna_no_op_returns_copy(self, data):
-        msg = "|".join(
-            [
-                "ExtensionArray.fillna 'method' keyword is deprecated",
-                "The 'method' keyword in DecimalArray.fillna is deprecated",
-            ]
-        )
-        with tm.assert_produces_warning(
-            (FutureWarning, DeprecationWarning), match=msg, check_stacklevel=False
-        ):
-            super().test_fillna_no_op_returns_copy(data)
-
     def test_fillna_series(self, data_missing):
         msg = "ExtensionArray.fillna added a 'copy' keyword"
         with tm.assert_produces_warning(
             DeprecationWarning, match=msg, check_stacklevel=False
         ):
             super().test_fillna_series(data_missing)
-
-    def test_fillna_series_method(self, data_missing, fillna_method):
-        msg = "|".join(
-            [
-                "ExtensionArray.fillna 'method' keyword is deprecated",
-                "The 'method' keyword in DecimalArray.fillna is deprecated",
-            ]
-        )
-        with tm.assert_produces_warning(
-            (FutureWarning, DeprecationWarning), match=msg, check_stacklevel=False
-        ):
-            super().test_fillna_series_method(data_missing, fillna_method)
 
     @pytest.mark.parametrize("dropna", [True, False])
     def test_value_counts(self, all_data, dropna):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -706,10 +706,6 @@ class TestArrowArray(base.ExtensionTests):
         assert result is not data
         tm.assert_extension_array_equal(result, data)
 
-        result = data.fillna(method="backfill")
-        assert result is not data
-        tm.assert_extension_array_equal(result, data)
-
     @pytest.mark.xfail(
         reason="GH 45419: pyarrow.ChunkedArray does not support views", run=False
     )

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -136,10 +136,6 @@ class TestStringArray(base.ExtensionTests):
         assert result is not data
         tm.assert_extension_array_equal(result, data)
 
-        result = data.fillna(method="backfill")
-        assert result is not data
-        tm.assert_extension_array_equal(result, data)
-
     def _get_expected_exception(
         self, op_name: str, obj, other
     ) -> type[Exception] | None:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ref: #53621

Ran into a little trouble here - `NDFrame.fillna` has a `limit` argument that wasn't deprecated and works, but `EA.fillna` has this deprecated and is currently ignored. Currently this PR keeps the `limit` argument in `EA.fillna` and removes the deprecation, but the implementation still ignores it. If we want to keep it, I plan on doing a followup implementing `limit` across all EAs (I think this should be straightforward except for maybe Sparse - not sure). 

As an alternative, we could also deprecate `limit` on `NDFrame.fillna` (not my preference), and then I can keep but not enforce the deprecation on `EA.fillna` here.

cc @jbrockmendel 