### PR TITLE
DEPR: 'epoch' date format in to_json

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1952,6 +1952,7 @@ Writing in ISO date format, with microseconds:
 Writing to a file, with a date index and a date column:
 
 .. ipython:: python
+   :okwarning:
 
    dfj2 = dfj.copy()
    dfj2["date"] = pd.Timestamp("20130101")
@@ -2131,6 +2132,7 @@ Preserve string indices:
 Dates written in nanoseconds need to be read back in nanoseconds:
 
 .. ipython:: python
+   :okwarning:
 
    from io import StringIO
    json = dfj2.to_json(date_unit="ns")
@@ -2268,6 +2270,7 @@ other attributes. You can use the orient ``table`` to build
 a JSON string with two fields, ``schema`` and ``data``.
 
 .. ipython:: python
+   :okwarning:
 
    df = pd.DataFrame(
        {
@@ -2377,6 +2380,7 @@ the preservation of metadata such as dtypes and index names in a
 round-trippable manner.
 
 .. ipython:: python
+   :okwarning:
 
    df = pd.DataFrame(
        {

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1952,14 +1952,13 @@ Writing in ISO date format, with microseconds:
 Writing to a file, with a date index and a date column:
 
 .. ipython:: python
-   :okwarning:
 
    dfj2 = dfj.copy()
    dfj2["date"] = pd.Timestamp("20130101")
    dfj2["ints"] = list(range(5))
    dfj2["bools"] = True
    dfj2.index = pd.date_range("20130101", periods=5)
-   dfj2.to_json("test.json")
+   dfj2.to_json("test.json", date_format="iso")
 
    with open("test.json") as fh:
        print(fh.read())
@@ -2132,10 +2131,9 @@ Preserve string indices:
 Dates written in nanoseconds need to be read back in nanoseconds:
 
 .. ipython:: python
-   :okwarning:
 
    from io import StringIO
-   json = dfj2.to_json(date_unit="ns")
+   json = dfj2.to_json(date_format="iso", date_unit="ns")
 
    # Try to parse timestamps as milliseconds -> Won't Work
    dfju = pd.read_json(StringIO(json), date_unit="ms")
@@ -2270,7 +2268,6 @@ other attributes. You can use the orient ``table`` to build
 a JSON string with two fields, ``schema`` and ``data``.
 
 .. ipython:: python
-   :okwarning:
 
    df = pd.DataFrame(
        {
@@ -2380,7 +2377,6 @@ the preservation of metadata such as dtypes and index names in a
 round-trippable manner.
 
 .. ipython:: python
-   :okwarning:
 
    df = pd.DataFrame(
        {

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1949,13 +1949,6 @@ Writing in ISO date format, with microseconds:
    json = dfd.to_json(date_format="iso", date_unit="us")
    json
 
-Epoch timestamps, in seconds:
-
-.. ipython:: python
-
-   json = dfd.to_json(date_format="epoch", date_unit="s")
-   json
-
 Writing to a file, with a date index and a date column:
 
 .. ipython:: python

--- a/doc/source/whatsnew/v2.2.2.rst
+++ b/doc/source/whatsnew/v2.2.2.rst
@@ -30,7 +30,7 @@ Bug fixes
 
 Other
 ~~~~~
--
+- Deprecated using ``epoch`` date format in :meth:`DataFrame.to_json` and :meth:`Series.to_json`, use ``iso`` instead.
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_222.contributors:

--- a/doc/source/whatsnew/v2.2.2.rst
+++ b/doc/source/whatsnew/v2.2.2.rst
@@ -30,7 +30,7 @@ Bug fixes
 
 Other
 ~~~~~
-- Deprecated using ``epoch`` date format in :meth:`DataFrame.to_json` and :meth:`Series.to_json`, use ``iso`` instead.
+-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_222.contributors:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -182,7 +182,7 @@ Other Deprecations
 - Deprecated :meth:`Timestamp.utcnow`, use ``Timestamp.now("UTC")`` instead (:issue:`56680`)
 - Deprecated allowing non-keyword arguments in :meth:`Series.to_markdown` except ``buf``. (:issue:`57280`)
 - Deprecated allowing non-keyword arguments in :meth:`Series.to_string` except ``buf``. (:issue:`57280`)
-- Deprecated using ``epoch`` date format in :meth:`DataFrame.to_json` and :meth:`Series.to_json`, use ``iso`` instead.
+- Deprecated using ``epoch`` date format in :meth:`DataFrame.to_json` and :meth:`Series.to_json`, use ``iso`` instead. (:issue:`57063`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -182,6 +182,7 @@ Other Deprecations
 - Deprecated :meth:`Timestamp.utcnow`, use ``Timestamp.now("UTC")`` instead (:issue:`56680`)
 - Deprecated allowing non-keyword arguments in :meth:`Series.to_markdown` except ``buf``. (:issue:`57280`)
 - Deprecated allowing non-keyword arguments in :meth:`Series.to_string` except ``buf``. (:issue:`57280`)
+- Deprecated using ``epoch`` date format in :meth:`DataFrame.to_json` and :meth:`Series.to_json`, use ``iso`` instead.
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2535,11 +2535,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             date_format = "iso"
         elif date_format is None:
             date_format = "epoch"
-            dtypes = (
-                self.dtypes
-                if self.ndim == 2
-                else [self.dtype]
-            )
+            dtypes = self.dtypes if self.ndim == 2 else [self.dtype]
             if any(lib.is_np_dtype(dtype, "mM") for dtype in dtypes):
                 warnings.warn(
                     "The default 'epoch' date format is deprecated and will be removed "

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2536,9 +2536,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         elif date_format is None:
             date_format = "epoch"
             dtypes = (
-                self.dtypes.values
+                self.dtypes
                 if self.ndim == 2
-                else np.array([self.dtype], dtype=object)
+                else [self.dtype]
             )
             if any(lib.is_np_dtype(dtype, "mM") for dtype in dtypes):
                 warnings.warn(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2542,7 +2542,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             )
             if any(lib.is_np_dtype(dtype, "mM") for dtype in dtypes):
                 warnings.warn(
-                    "The default 'Epoch' date format is deprecated and will be removed "
+                    "The default 'epoch' date format is deprecated and will be removed "
                     "in a future version, please use 'iso' date format instead.",
                     FutureWarning,
                     stacklevel=find_stack_level(),
@@ -2550,7 +2550,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         elif date_format == "epoch":
             # GH#57063
             warnings.warn(
-                "'Epoch' date format is deprecated and will be removed in a future "
+                "'epoch' date format is deprecated and will be removed in a future "
                 "version, please use 'iso' date format instead.",
                 FutureWarning,
                 stacklevel=find_stack_level(),

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2535,8 +2535,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             date_format = "iso"
         elif date_format is None:
             date_format = "epoch"
-            dtypes = getattr(self.dtypes, "values", [self.dtypes])
-            if "m8[ns]" in dtypes or "M8[ns]" in dtypes:
+            dtypes = (
+                self.dtypes.values
+                if self.ndim == 2
+                else np.array([self.dtype], dtype=object)
+            )
+            if any(lib.is_np_dtype(dtype, "mM") for dtype in dtypes):
                 warnings.warn(
                     "The default 'Epoch' date format is deprecated and will be removed "
                     "in a future version, please use 'iso' date format instead.",

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2365,6 +2365,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Accepted args are 'w' (writing) and 'a' (append) only.
             mode='a' is only supported when lines is True and orient is 'records'.
 
+        .. deprecated:: 2.2.2
+            'epoch' date format is deprecated and will be removed in a future version,
+            please use 'iso' instead.
+
         Returns
         -------
         None or str
@@ -2530,6 +2534,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             date_format = "iso"
         elif date_format is None:
             date_format = "epoch"
+        elif date_format == "epoch":
+            # GH#57063
+            warnings.warn(
+                "'Epoch' date format is deprecated and will be removed in a future "
+                "version, please use 'iso' date format instead.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
 
         config.is_nonnegative_int(indent)
         indent = indent or 0

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2535,7 +2535,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             date_format = "iso"
         elif date_format is None:
             date_format = "epoch"
-            if "m8[ns]" in self.dtypes.values or "M8[ns]" in self.dtypes.values:
+            dtypes = getattr(self.dtypes, "values", [self.dtypes])
+            if "m8[ns]" in dtypes or "M8[ns]" in dtypes:
                 warnings.warn(
                     "The default 'Epoch' date format is deprecated and will be removed "
                     "in a future version, please use 'iso' date format instead.",

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2329,7 +2329,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             ``orient='table'``, the default is 'iso'. For all other orients,
             the default is 'epoch'.
 
-            .. deprecated:: 2.2.2
+            .. deprecated:: 3.0.0
                 'epoch' date format is deprecated and will be removed in a future
                 version, please use 'iso' instead.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2328,6 +2328,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             'iso' = ISO8601. The default depends on the `orient`. For
             ``orient='table'``, the default is 'iso'. For all other orients,
             the default is 'epoch'.
+
+            .. deprecated:: 2.2.2
+                'epoch' date format is deprecated and will be removed in a future
+                version, please use 'iso' instead.
+
         double_precision : int, default 10
             The number of decimal places to use when encoding
             floating point values. The possible maximal value is 15.
@@ -2364,10 +2369,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Specify the IO mode for output when supplying a path_or_buf.
             Accepted args are 'w' (writing) and 'a' (append) only.
             mode='a' is only supported when lines is True and orient is 'records'.
-
-        .. deprecated:: 2.2.2
-            'epoch' date format is deprecated and will be removed in a future version,
-            please use 'iso' instead.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2535,6 +2535,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             date_format = "iso"
         elif date_format is None:
             date_format = "epoch"
+            if "m8[ns]" in self.dtypes.values or "M8[ns]" in self.dtypes.values:
+                warnings.warn(
+                    "The default 'Epoch' date format is deprecated and will be removed "
+                    "in a future version, please use 'iso' date format instead.",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
         elif date_format == "epoch":
             # GH#57063
             warnings.warn(

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -456,7 +456,7 @@ class TestTableOrient:
             "Schema requires dates to be formatted with `date_format='iso'`"
         )
         warning_msg = (
-            "'Epoch' date format is deprecated and will be removed in a future "
+            "'epoch' date format is deprecated and will be removed in a future "
             "version, please use 'iso' date format instead."
         )
         with pytest.raises(ValueError, match=error_msg):

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -451,12 +451,17 @@ class TestTableOrient:
         assert result == expected
 
     def test_date_format_raises(self, df_table):
-        msg = (
+        error_msg = (
             "Trying to write with `orient='table'` and `date_format='epoch'`. Table "
             "Schema requires dates to be formatted with `date_format='iso'`"
         )
-        with pytest.raises(ValueError, match=msg):
-            df_table.to_json(orient="table", date_format="epoch")
+        warning_msg = (
+            "'Epoch' date format is deprecated and will be removed in a future "
+            "version, please use 'iso' date format instead."
+        )
+        with pytest.raises(ValueError, match=error_msg):
+            with tm.assert_produces_warning(FutureWarning, match=warning_msg):
+                df_table.to_json(orient="table", date_format="epoch")
 
         # others work
         df_table.to_json(orient="table", date_format="iso")

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -763,7 +763,7 @@ class TestPandasContainer:
     def test_series_with_dtype_datetime(self, dtype, expected):
         s = Series(["2000-01-01"], dtype="datetime64[ns]")
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -814,7 +814,7 @@ class TestPandasContainer:
         df["date"] = Timestamp("20130101").as_unit("ns")
 
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -859,7 +859,7 @@ class TestPandasContainer:
             )
 
         msg = (
-            "'Epoch' date format is deprecated and will be removed in a future "
+            "'epoch' date format is deprecated and will be removed in a future "
             "version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(expected_warning, match=msg):
@@ -962,7 +962,7 @@ class TestPandasContainer:
         df.iloc[4, dl] = pd.NaT
 
         msg = (
-            "'Epoch' date format is deprecated and will be removed in a future "
+            "'epoch' date format is deprecated and will be removed in a future "
             "version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -998,7 +998,7 @@ class TestPandasContainer:
     def test_default_epoch_date_format_deprecated(self, df, warn):
         # GH 57063
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(warn, match=msg):
@@ -1074,7 +1074,7 @@ class TestPandasContainer:
         dfj2.index = date_range("20130101", periods=5)
 
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -1116,7 +1116,7 @@ class TestPandasContainer:
         assert ser.dtype == "timedelta64[ns]"
 
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -1145,7 +1145,7 @@ class TestPandasContainer:
             }
         )
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -1190,7 +1190,7 @@ class TestPandasContainer:
             expected = expected.replace("}", ',"a":"a"}')
 
         msg = (
-            "'Epoch' date format is deprecated and will be removed in a future "
+            "'epoch' date format is deprecated and will be removed in a future "
             "version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(expected_warning, match=msg):
@@ -1208,7 +1208,7 @@ class TestPandasContainer:
             warn = None
 
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(warn, match=msg):
@@ -1295,7 +1295,7 @@ class TestPandasContainer:
         df_naive = df.copy()
         df_naive["A"] = tz_naive
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -1571,7 +1571,7 @@ class TestPandasContainer:
             }
         )
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -1771,7 +1771,7 @@ class TestPandasContainer:
             expected_warning = FutureWarning
 
         msg = (
-            "'Epoch' date format is deprecated and will be removed in a future "
+            "'epoch' date format is deprecated and will be removed in a future "
             "version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(expected_warning, match=msg):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -974,6 +974,33 @@ class TestPandasContainer:
         result = read_json(StringIO(json), date_unit=None)
         tm.assert_frame_equal(result, df)
 
+    @pytest.mark.parametrize(
+        "df, warn",
+        [
+            (DataFrame({"A": ["a", "b", "c"], "B": np.arange(3)}), None),
+            (DataFrame({"A": [True, False, False]}), None),
+            (
+                DataFrame(
+                    {"A": ["a", "b", "c"], "B": pd.to_timedelta(np.arange(3), unit="D")}
+                ),
+                FutureWarning,
+            ),
+            (
+                DataFrame(
+                    {"A": pd.to_datetime(["2020-01-01", "2020-02-01", "2020-03-01"])}
+                ),
+                FutureWarning,
+            ),
+        ],
+    )
+    def test_default_epoch_date_format_deprecated(self, df, warn):
+        msg = (
+            "The default 'Epoch' date format is deprecated and will be removed "
+            "in a future version, please use 'iso' date format instead."
+        )
+        with tm.assert_produces_warning(warn, match=msg):
+            df.to_json()
+
     @pytest.mark.parametrize("unit", ["s", "ms", "us"])
     def test_iso_non_nano_datetimes(self, unit):
         # Test that numpy datetimes

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -940,7 +940,12 @@ class TestPandasContainer:
         df.iloc[2, dl] = Timestamp("21460101 20:43:42")
         df.iloc[4, dl] = pd.NaT
 
-        json = df.to_json(date_format="epoch", date_unit=unit)
+        msg = (
+            "'Epoch' date format is deprecated and will be removed in a future "
+            "version, please use 'iso' date format instead."
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            json = df.to_json(date_format="epoch", date_unit=unit)
 
         # force date unit
         result = read_json(StringIO(json), date_unit=unit)
@@ -1669,7 +1674,17 @@ class TestPandasContainer:
     def test_timedelta_as_label(self, date_format, key):
         df = DataFrame([[1]], columns=[pd.Timedelta("1D")])
         expected = f'{{"{key}":{{"0":1}}}}'
-        result = df.to_json(date_format=date_format)
+
+        expected_warning = None
+        if date_format == "epoch":
+            expected_warning = FutureWarning
+
+        msg = (
+            "'Epoch' date format is deprecated and will be removed in a future "
+            "version, please use 'iso' date format instead."
+        )
+        with tm.assert_produces_warning(expected_warning, match=msg):
+            result = df.to_json(date_format=date_format)
 
         assert result == expected
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -835,14 +835,22 @@ class TestPandasContainer:
             data.append("a")
 
         ser = Series(data, index=data)
-        result = ser.to_json(date_format=date_format)
 
+        expected_warning = None
         if date_format == "epoch":
             expected = '{"1577836800000":1577836800000,"null":null}'
+            expected_warning = FutureWarning
         else:
             expected = (
                 '{"2020-01-01T00:00:00.000":"2020-01-01T00:00:00.000","null":null}'
             )
+
+        msg = (
+            "'Epoch' date format is deprecated and will be removed in a future "
+            "version, please use 'iso' date format instead."
+        )
+        with tm.assert_produces_warning(expected_warning, match=msg):
+            result = ser.to_json(date_format=date_format)
 
         if as_object:
             expected = expected.replace("}", ',"a":"a"}')
@@ -1111,17 +1119,24 @@ class TestPandasContainer:
             data.append("a")
 
         ser = Series(data, index=data)
+        expected_warning = None
         if date_format == "iso":
             expected = (
                 '{"P1DT0H0M0S":"P1DT0H0M0S","P2DT0H0M0S":"P2DT0H0M0S","null":null}'
             )
         else:
+            expected_warning = FutureWarning
             expected = '{"86400000":86400000,"172800000":172800000,"null":null}'
 
         if as_object:
             expected = expected.replace("}", ',"a":"a"}')
 
-        result = ser.to_json(date_format=date_format)
+        msg = (
+            "'Epoch' date format is deprecated and will be removed in a future "
+            "version, please use 'iso' date format instead."
+        )
+        with tm.assert_produces_warning(expected_warning, match=msg):
+            result = ser.to_json(date_format=date_format)
         assert result == expected
 
     @pytest.mark.parametrize("as_object", [True, False])

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -79,7 +79,7 @@ def test_to_read_gcs(gcs_buffer, format, monkeypatch, capsys):
         df2 = read_excel(path, parse_dates=["dt"], index_col=0)
     elif format == "json":
         msg = (
-            "The default 'Epoch' date format is deprecated and will be removed "
+            "The default 'epoch' date format is deprecated and will be removed "
             "in a future version, please use 'iso' date format instead."
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -78,7 +78,12 @@ def test_to_read_gcs(gcs_buffer, format, monkeypatch, capsys):
         df1.to_excel(path)
         df2 = read_excel(path, parse_dates=["dt"], index_col=0)
     elif format == "json":
-        df1.to_json(path, date_format="iso")
+        msg = (
+            "The default 'Epoch' date format is deprecated and will be removed "
+            "in a future version, please use 'iso' date format instead."
+        )
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            df1.to_json(path)
         df2 = read_json(path, convert_dates=["dt"])
     elif format == "parquet":
         pytest.importorskip("pyarrow")

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -78,7 +78,7 @@ def test_to_read_gcs(gcs_buffer, format, monkeypatch, capsys):
         df1.to_excel(path)
         df2 = read_excel(path, parse_dates=["dt"], index_col=0)
     elif format == "json":
-        df1.to_json(path)
+        df1.to_json(path, date_format="iso")
         df2 = read_json(path, convert_dates=["dt"])
     elif format == "parquet":
         pytest.importorskip("pyarrow")


### PR DESCRIPTION
- [x] closes #57063 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
