### PR TITLE
PERF: (partial) fix for np_datetime.c performance regression

### DIFF
--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -754,21 +754,21 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
     const npy_int64 per_day = sec_per_day * per_sec;
     npy_int64 ifrac = td;
     const int sign = td < 0 ? -1 : 1;
-    const int uneven_in_seconds = td % per_sec != 0;
+    const int uneven_in_seconds = td % per_sec != 0 ? 1 : 0;
     // put frac in seconds
-    if (sign < 0 && uneven_in_seconds)
-      td = td / per_sec - 1;
-    else
-      td = td / per_sec;
-
-    if (td < 0) {
-      // even fraction
-      if ((-td % sec_per_day) != 0) {
-        out->days = -td / sec_per_day + 1;
-        td += sec_per_day * out->days;
-      } else {
-        td = -td;
+    if (sign < 0) {
+      td = td / per_sec - uneven_in_seconds;
+      if (td < 0) {
+        // even fraction
+        if ((-td % sec_per_day) != 0) {
+          out->days = -td / sec_per_day + 1;
+          td += sec_per_day * out->days;
+        } else {
+          td = -td;
+        }
       }
+    } else {
+      td = td / per_sec;
     }
 
     if (td >= sec_per_day) {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -756,26 +756,26 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
     const int sign = td < 0 ? -1 : 1;
     const int uneven_in_seconds = td % per_sec != 0 ? 1 : 0;
     // put frac in seconds
+    td = td / per_sec;
     if (sign < 0) {
-      td = td / per_sec - uneven_in_seconds;
+      td -= uneven_in_seconds;
       // even fraction
       if ((-td % sec_per_day) != 0) {
+        // days = td / sec_per_day - is_even_fraction
         out->days = td / sec_per_day - 1;
         td -= sec_per_day * out->days;
       } else {
-        td = -td;
-        if (td >= sec_per_day) {
-          out->days = -td / sec_per_day;
+        if (td <= sec_per_day) {
+          out->days = td / sec_per_day;
+          td = -td;
           td += out->days * sec_per_day;
+        } else {
+          td = -td;
         }
       }
-
-    } else {
-      td = td / per_sec;
-      if (td >= sec_per_day) {
-        out->days = td / sec_per_day;
-        td -= out->days * sec_per_day;
-      }
+    } else if (td >= sec_per_day) {
+      out->days = td / sec_per_day;
+      td -= out->days * sec_per_day;
     }
 
     if (td >= sec_per_hour) {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -754,8 +754,9 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
     const npy_int64 per_day = sec_per_day * per_sec;
     npy_int64 ifrac = td;
     const int sign = td < 0 ? -1 : 1;
+    const int uneven_in_seconds = td % per_sec != 0;
     // put frac in seconds
-    if (sign < 0 && td % per_sec != 0)
+    if (sign < 0 && uneven_in_seconds)
       td = td / per_sec - 1;
     else
       td = td / per_sec;
@@ -774,6 +775,8 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
       out->days += td / sec_per_day;
       td -= out->days * sec_per_day;
     }
+
+    out->days = sign * (out->days);
 
     if (td >= sec_per_hour) {
       out->hrs = (npy_int32)(td / sec_per_hour);

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -761,6 +761,7 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
 
     const int sign = frac < 0 ? -1 : 1;
     if (frac < 0) {
+    npy_int64 ifrac = td;
       // even fraction
       if ((-frac % sec_per_day) != 0) {
         out->days = -frac / sec_per_day + 1;
@@ -794,11 +795,7 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
       out->days = -out->days;
 
     if (base > NPY_FR_s) {
-      const npy_int64 sfrac =
-          (out->hrs * sec_per_hour + out->min * sec_per_min + out->sec) *
-          per_sec;
-
-      npy_int64 ifrac = td - (out->days * per_day + sfrac);
+      ifrac = (ifrac - out->days * per_day) % per_sec;
 
       if (base == NPY_FR_ms) {
         out->ms = (npy_int32)ifrac;

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -788,7 +788,6 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
 
     if (frac >= 0) {
       out->sec = (npy_int32)frac;
-      frac -= out->sec;
     }
 
     if (sign < 0)

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -753,11 +753,12 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
 
     const npy_int64 per_day = sec_per_day * per_sec;
     const int sign = td < 0 ? -1 : 1;
-    const int is_negative = td < 0 ? 1 : 0;
-    const int uneven_in_seconds = td % per_sec != 0 ? 1 : 0;
     // put frac in seconds
-    npy_int64 sfrac = td / per_sec - is_negative * uneven_in_seconds;
+    npy_int64 sfrac = td / per_sec;
     if (sign < 0) {
+      if (td % per_sec != 0)
+        sfrac -= 1;
+
       // even fraction
       if ((-sfrac % sec_per_day) != 0) {
         out->days = sfrac / sec_per_day - 1;

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -765,8 +765,17 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
       } else {
         td = -td;
       }
+      if (td >= sec_per_day) {
+        out->days += out->days + td / sec_per_day;
+        td -= out->days * sec_per_day;
+      }
+      out->days = -out->days;
     } else {
       td = td / per_sec;
+      if (td >= sec_per_day) {
+        out->days += out->days + td / sec_per_day;
+        td -= out->days * sec_per_day;
+      }
     }
 
     if (td >= sec_per_day) {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -801,9 +801,8 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
         out->ms = ifrac / (1000LL * 1000LL);
         ifrac = ifrac % (1000LL * 1000LL);
         out->us = ifrac / 1000LL;
-        out->nanoseconds = ifrac % 1000LL;
+        out->ns = ifrac % 1000LL;
       }
-      out->microseconds = out->ms * 1000 + out->us;
     }
 
   } break;
@@ -815,6 +814,8 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
   }
   out->seconds =
       (npy_int32)(out->hrs * sec_per_hour + out->min * sec_per_min + out->sec);
+  out->microseconds = out->ms * 1000 + out->us;
+  out->nanoseconds = out->ns;
 }
 
 /*

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -797,19 +797,20 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
       ifrac = (ifrac - out->days * per_day) % per_sec;
 
       if (base == NPY_FR_ms) {
-        out->ms = (npy_int32)ifrac;
+        out->ms = ifrac;
       } else if (base == NPY_FR_us) {
         out->ms = (npy_int32)(ifrac / 1000LL);
         ifrac = ifrac % 1000LL;
         out->us = (npy_int32)ifrac;
+        out->ms = (ifrac / 1000LL);
+        out->us = ifrac % 1000LL;
       } else if (base == NPY_FR_ns) {
-        out->ms = (npy_int32)(ifrac / (1000LL * 1000LL));
-        ifrac = ifrac % (1000LL * 1000LL);
-        out->us = (npy_int32)(ifrac / 1000LL);
-        ifrac = ifrac % 1000LL;
-        out->ns = (npy_int32)ifrac;
+        out->ms = (ifrac / (1000LL * 1000LL));
+        out->us = (ifrac / 1000LL);
+        out->nanoseconds = ifrac % 1000LL;
       }
     }
+    out->microseconds = out->ms * 1000 + out->us;
 
   } break;
   default:

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -799,9 +799,6 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
       if (base == NPY_FR_ms) {
         out->ms = ifrac;
       } else if (base == NPY_FR_us) {
-        out->ms = (npy_int32)(ifrac / 1000LL);
-        ifrac = ifrac % 1000LL;
-        out->us = (npy_int32)ifrac;
         out->ms = (ifrac / 1000LL);
         out->us = ifrac % 1000LL;
       } else if (base == NPY_FR_ns) {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -755,36 +755,36 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
     npy_int64 ifrac = td;
     int sign = td >= 0 ? 1 : -1;
     int has_seconds = td % per_sec != 0 ? 1 : 0;
-    frac = td / per_sec;
+    td = td / per_sec;
     if (sign < 0) {
       if (has_seconds == 1) {
-        frac -= 1;
+        td -= 1;
       }
-      frac *= -1;
+      td *= -1;
       // even fraction
-      if ((frac % sec_per_day) != 0) {
-        out->days = -frac / sec_per_day - 1;
-        frac += per_sec * out->days;
+      if ((td % sec_per_day) != 0) {
+        out->days = -td / sec_per_day - 1;
+        td += per_sec * out->days;
       }
     }
 
-    if (frac >= sec_per_day) {
-      out->days += sign * frac / sec_per_day;
-      frac -= sign * out->days * sec_per_day;
+    if (td >= sec_per_day) {
+      out->days += sign * td / sec_per_day;
+      td -= sign * out->days * sec_per_day;
     }
 
-    if (frac >= sec_per_hour) {
-      out->hrs = (npy_int32)(frac / sec_per_hour);
-      frac %= sec_per_hour;
+    if (td >= sec_per_hour) {
+      out->hrs = (npy_int32)(td / sec_per_hour);
+      td %= sec_per_hour;
     }
 
-    if (frac >= sec_per_min) {
-      out->min = (npy_int32)(frac / sec_per_min);
-      frac %= sec_per_min;
+    if (td >= sec_per_min) {
+      out->min = (npy_int32)(td / sec_per_min);
+      td %= sec_per_min;
     }
 
-    if (frac >= 0) {
-      out->sec = (npy_int32)frac;
+    if (td >= 0) {
+      out->sec = (npy_int32)td;
     }
 
     if (base > NPY_FR_s) {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -778,13 +778,6 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
       }
     }
 
-    if (td >= sec_per_day) {
-      out->days += td / sec_per_day;
-      td -= out->days * sec_per_day;
-    }
-
-    out->days = sign * (out->days);
-
     if (td >= sec_per_hour) {
       out->hrs = (npy_int32)(td / sec_per_hour);
       td %= sec_per_hour;
@@ -798,9 +791,6 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
     if (td >= 0) {
       out->sec = (npy_int32)td;
     }
-
-    if (sign < 0)
-      out->days = -out->days;
 
     if (base > NPY_FR_s) {
       ifrac = (ifrac - out->days * per_day) % per_sec;

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -764,16 +764,17 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
         td += sec_per_day * out->days;
       } else {
         td = -td;
-      }
-      if (td >= sec_per_day) {
-        out->days += out->days + td / sec_per_day;
-        td -= out->days * sec_per_day;
+        if (td >= sec_per_day) {
+          out->days = td / sec_per_day;
+          td -= out->days * sec_per_day;
+        }
       }
       out->days = -out->days;
+
     } else {
       td = td / per_sec;
       if (td >= sec_per_day) {
-        out->days += out->days + td / sec_per_day;
+        out->days = td / sec_per_day;
         td -= out->days * sec_per_day;
       }
     }

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -789,6 +789,7 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
     }
 
     if (base > NPY_FR_s) {
+      // there will be at most 1 billion nanoseconds left here
       npy_int32 ifrac = (npy_int32)((td - out->days * per_day) % per_sec);
 
       if (base == NPY_FR_ms) {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -758,14 +758,12 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
     // put frac in seconds
     if (sign < 0) {
       td = td / per_sec - uneven_in_seconds;
-      if (td < 0) {
-        // even fraction
-        if ((-td % sec_per_day) != 0) {
-          out->days = -td / sec_per_day + 1;
-          td += sec_per_day * out->days;
-        } else {
-          td = -td;
-        }
+      // even fraction
+      if ((-td % sec_per_day) != 0) {
+        out->days = -td / sec_per_day + 1;
+        td += sec_per_day * out->days;
+      } else {
+        td = -td;
       }
     } else {
       td = td / per_sec;

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -778,12 +778,12 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
 
     if (frac >= sec_per_hour) {
       out->hrs = (npy_int32)(frac / sec_per_hour);
-      frac -= out->hrs * sec_per_hour;
+      frac %= sec_per_hour;
     }
 
     if (frac >= sec_per_min) {
       out->min = (npy_int32)(frac / sec_per_min);
-      frac -= out->min * sec_per_min;
+      frac %= sec_per_min;
     }
 
     if (frac >= 0) {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -760,16 +760,15 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
       td = td / per_sec - uneven_in_seconds;
       // even fraction
       if ((-td % sec_per_day) != 0) {
-        out->days = -td / sec_per_day + 1;
-        td += sec_per_day * out->days;
+        out->days = td / sec_per_day - 1;
+        td -= sec_per_day * out->days;
       } else {
         td = -td;
         if (td >= sec_per_day) {
-          out->days = td / sec_per_day;
-          td -= out->days * sec_per_day;
+          out->days = -td / sec_per_day;
+          td += out->days * sec_per_day;
         }
       }
-      out->days = -out->days;
 
     } else {
       td = td / per_sec;

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -813,8 +813,6 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
 
   out->seconds =
       (npy_int32)(out->hrs * sec_per_hour + out->min * sec_per_min + out->sec);
-  out->microseconds = out->ms * 1000 + out->us;
-  out->nanoseconds = out->ns;
 }
 
 /*

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -776,37 +776,35 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
     }
 
     if (td >= sec_per_hour) {
-      out->hrs = (td / sec_per_hour);
+      out->hrs = (npy_int32)(td / sec_per_hour);
       td %= sec_per_hour;
     }
 
     if (td >= sec_per_min) {
-      out->min = td / sec_per_min;
+      out->min = (npy_int32)(td / sec_per_min);
       td %= sec_per_min;
     }
 
     if (td >= 0) {
-      out->sec = td;
+      out->sec = (npy_int32)td;
     }
 
     if (sign < 0)
       out->days = -out->days;
 
     if (base > NPY_FR_s) {
-      // the days * per_day removes so many base units that ifrac is within
-      // int32 bounds
       ifrac = (ifrac - out->days * per_day) % per_sec;
 
       if (base == NPY_FR_ms) {
-        out->ms = ifrac;
+        out->ms = (npy_int32)ifrac;
       } else if (base == NPY_FR_us) {
-        out->ms = ifrac / 1000LL;
-        out->us = ifrac % 1000LL;
+        out->ms = (npy_int32)(ifrac / 1000LL);
+        out->us = (npy_int32)(ifrac % 1000LL);
       } else if (base == NPY_FR_ns) {
-        out->ms = ifrac / (1000LL * 1000LL);
+        out->ms = (npy_int32)(ifrac / (1000LL * 1000LL));
         ifrac = ifrac % (1000LL * 1000LL);
-        out->us = ifrac / 1000LL;
-        out->nanoseconds = ifrac % 1000LL;
+        out->us = (npy_int32)(ifrac / 1000LL);
+        out->nanoseconds = (npy_int32)(ifrac % 1000LL);
       }
       out->microseconds = out->ms * 1000 + out->us;
     }


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Fixes (part) of the performance regression seen mentioned in #57951. The main performance improvements are the ~~ ~~refactoring of the "days" parsing logic~~ and the simpler calculation of ifrac.

The days parsing refactoring needed to be reverted. I overlooked an issue that happens for td close to int64 bounds there.