### PR TITLE
 BUG: encoding is ignored for read_csv on FileLike objects - FIX - GH#57954 

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -11,6 +11,7 @@ from collections import (
     defaultdict,
 )
 import csv
+from io import TextIOBase
 import sys
 from textwrap import fill
 from typing import (
@@ -654,6 +655,14 @@ def _read(
             )
     else:
         chunksize = validate_integer("chunksize", chunksize, 1)
+
+    encoding = kwds.get("encoding")
+    if (
+        encoding
+        and isinstance(filepath_or_buffer, TextIOBase)
+        and filepath_or_buffer.encoding != encoding
+    ):
+        raise ValueError("File's encoding does not match with given encoding")
 
     nrows = kwds.get("nrows", None)
 


### PR DESCRIPTION
- [x] closes #57954 
- [x] [Tests added and passed
- [x] All [code checks passed]
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
