### PR TITLE
CLN/PERF: Simplify argmin/argmax

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -42,6 +42,7 @@
     // followed by the pip installed packages).
     "matrix": {
         "Cython": ["3.0"],
+        "build": [],
         "matplotlib": [],
         "sqlalchemy": [],
         "scipy": [],

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -42,7 +42,6 @@
     // followed by the pip installed packages).
     "matrix": {
         "Cython": ["3.0"],
-        "build": [],
         "matplotlib": [],
         "sqlalchemy": [],
         "scipy": [],

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -210,7 +210,7 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):  # type: ignor
         # override base class by adding axis keyword
         validate_bool_kwarg(skipna, "skipna")
         if not skipna and self._hasna:
-            raise NotImplementedError
+            raise ValueError("Encountered an NA value with skipna=False")
         return nargminmax(self, "argmin", axis=axis)
 
     # Signature of "argmax" incompatible with supertype "ExtensionArray"
@@ -218,7 +218,7 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):  # type: ignor
         # override base class by adding axis keyword
         validate_bool_kwarg(skipna, "skipna")
         if not skipna and self._hasna:
-            raise NotImplementedError
+            raise ValueError("Encountered an NA value with skipna=False")
         return nargminmax(self, "argmax", axis=axis)
 
     def unique(self) -> Self:

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -885,7 +885,7 @@ class ExtensionArray:
         # 2. argmin itself : total control over sorting.
         validate_bool_kwarg(skipna, "skipna")
         if not skipna and self._hasna:
-            raise NotImplementedError
+            raise ValueError("Encountered an NA value with skipna=False")
         return nargminmax(self, "argmin")
 
     def argmax(self, skipna: bool = True) -> int:
@@ -919,7 +919,7 @@ class ExtensionArray:
         # 2. argmax itself : total control over sorting.
         validate_bool_kwarg(skipna, "skipna")
         if not skipna and self._hasna:
-            raise NotImplementedError
+            raise ValueError("Encountered an NA value with skipna=False")
         return nargminmax(self, "argmax")
 
     def interpolate(

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1623,13 +1623,13 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
     def argmax(self, skipna: bool = True) -> int:
         validate_bool_kwarg(skipna, "skipna")
         if not skipna and self._hasna:
-            raise NotImplementedError
+            raise ValueError("Encountered an NA value with skipna=False")
         return self._argmin_argmax("argmax")
 
     def argmin(self, skipna: bool = True) -> int:
         validate_bool_kwarg(skipna, "skipna")
         if not skipna and self._hasna:
-            raise NotImplementedError
+            raise ValueError("Encountered an NA value with skipna=False")
         return self._argmin_argmax("argmin")
 
     # ------------------------------------------------------------------------

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -733,9 +733,10 @@ class IndexOpsMixin(OpsMixin):
         """
         delegate = self._values
         nv.validate_minmax_axis(axis)
+        skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
 
         if isinstance(delegate, ExtensionArray):
-            return delegate.argmax()
+            return delegate.argmax(skipna=skipna)
         else:
             result = nanops.nanargmax(delegate, skipna=skipna)
             # error: Incompatible return value type (got "Union[int, ndarray]", expected
@@ -748,9 +749,10 @@ class IndexOpsMixin(OpsMixin):
     ) -> int:
         delegate = self._values
         nv.validate_minmax_axis(axis)
+        skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
 
         if isinstance(delegate, ExtensionArray):
-            return delegate.argmin()
+            return delegate.argmin(skipna=skipna)
         else:
             result = nanops.nanargmin(delegate, skipna=skipna)
             # error: Incompatible return value type (got "Union[int, ndarray]", expected

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -53,7 +53,6 @@ from pandas.core.dtypes.missing import (
 
 from pandas.core import (
     algorithms,
-    nanops,
     ops,
 )
 from pandas.core.accessor import DirNamesMixin
@@ -731,43 +730,17 @@ class IndexOpsMixin(OpsMixin):
         the minimum cereal calories is the first element,
         since series is zero-indexed.
         """
-        delegate = self._values
         nv.validate_minmax_axis(axis)
         skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
-
-        if skipna and len(delegate) > 0 and isna(delegate).all():
-            raise ValueError("Encountered all NA values")
-        elif not skipna and isna(delegate).any():
-            raise ValueError("Encountered an NA value with skipna=False")
-
-        if isinstance(delegate, ExtensionArray):
-            return delegate.argmax()
-        else:
-            result = nanops.nanargmax(delegate, skipna=skipna)
-            # error: Incompatible return value type (got "Union[int, ndarray]", expected
-            # "int")
-            return result  # type: ignore[return-value]
+        return self.array.argmax(skipna=skipna)
 
     @doc(argmax, op="min", oppose="max", value="smallest")
     def argmin(
         self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs
     ) -> int:
-        delegate = self._values
         nv.validate_minmax_axis(axis)
-        skipna = nv.validate_argmin_with_skipna(skipna, args, kwargs)
-
-        if skipna and len(delegate) > 0 and isna(delegate).all():
-            raise ValueError("Encountered all NA values")
-        elif not skipna and isna(delegate).any():
-            raise ValueError("Encountered an NA value with skipna=False")
-
-        if isinstance(delegate, ExtensionArray):
-            return delegate.argmin()
-        else:
-            result = nanops.nanargmin(delegate, skipna=skipna)
-            # error: Incompatible return value type (got "Union[int, ndarray]", expected
-            # "int")
-            return result  # type: ignore[return-value]
+        skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
+        return self.array.argmin(skipna=skipna)
 
     def tolist(self) -> list:
         """

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -53,6 +53,7 @@ from pandas.core.dtypes.missing import (
 
 from pandas.core import (
     algorithms,
+    nanops,
     ops,
 )
 from pandas.core.accessor import DirNamesMixin
@@ -730,17 +731,31 @@ class IndexOpsMixin(OpsMixin):
         the minimum cereal calories is the first element,
         since series is zero-indexed.
         """
+        delegate = self._values
         nv.validate_minmax_axis(axis)
-        skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
-        return self.array.argmax(skipna=skipna)
+
+        if isinstance(delegate, ExtensionArray):
+            return delegate.argmax()
+        else:
+            result = nanops.nanargmax(delegate, skipna=skipna)
+            # error: Incompatible return value type (got "Union[int, ndarray]", expected
+            # "int")
+            return result  # type: ignore[return-value]
 
     @doc(argmax, op="min", oppose="max", value="smallest")
     def argmin(
         self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs
     ) -> int:
+        delegate = self._values
         nv.validate_minmax_axis(axis)
-        skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
-        return self.array.argmin(skipna=skipna)
+
+        if isinstance(delegate, ExtensionArray):
+            return delegate.argmin()
+        else:
+            result = nanops.nanargmin(delegate, skipna=skipna)
+            # error: Incompatible return value type (got "Union[int, ndarray]", expected
+            # "int")
+            return result  # type: ignore[return-value]
 
     def tolist(self) -> list:
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6976,10 +6976,11 @@ class Index(IndexOpsMixin, PandasObject):
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
-            if self._isnan.all():
-                raise ValueError("Encountered all NA values")
-            elif not skipna:
+            if not skipna:
                 raise ValueError("Encountered an NA value with skipna=False")
+            elif self._isnan.all():
+                raise ValueError("Encountered all NA values")
+
         return super().argmin(skipna=skipna)
 
     @Appender(IndexOpsMixin.argmax.__doc__)
@@ -6989,10 +6990,10 @@ class Index(IndexOpsMixin, PandasObject):
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
-            if self._isnan.all():
-                raise ValueError("Encountered all NA values")
-            elif not skipna:
+            if not skipna:
                 raise ValueError("Encountered an NA value with skipna=False")
+            elif self._isnan.all():
+                raise ValueError("Encountered all NA values")
         return super().argmax(skipna=skipna)
 
     def min(self, axis=None, skipna: bool = True, *args, **kwargs):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6975,7 +6975,6 @@ class Index(IndexOpsMixin, PandasObject):
         nv.validate_minmax_axis(axis)
 
         if not self._is_multi and self.hasnans:
-            # Take advantage of cache
             if not skipna:
                 raise ValueError("Encountered an NA value with skipna=False")
             elif self._isnan.all():
@@ -6989,7 +6988,6 @@ class Index(IndexOpsMixin, PandasObject):
         nv.validate_minmax_axis(axis)
 
         if not self._is_multi and self.hasnans:
-            # Take advantage of cache
             if not skipna:
                 raise ValueError("Encountered an NA value with skipna=False")
             elif self._isnan.all():

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1439,20 +1439,15 @@ def _maybe_arg_null_out(
         return result
 
     if axis is None or not getattr(result, "ndim", False):
-        if skipna:
-            if mask.all():
-                raise ValueError("Encountered all NA values")
-        else:
-            if mask.any():
-                raise ValueError("Encountered an NA value with skipna=False")
-    else:
-        na_mask = mask.all(axis)
-        if skipna and na_mask.any():
+        if skipna and mask.all():
             raise ValueError("Encountered all NA values")
-        elif not skipna:
-            na_mask = mask.any(axis)
-            if na_mask.any():
-                raise ValueError("Encountered an NA value with skipna=False")
+        elif not skipna and mask.any():
+            raise ValueError("Encountered an NA value with skipna=False")
+    else:
+        if skipna and mask.all(axis).any():
+            raise ValueError("Encountered all NA values")
+        elif not skipna and mask.any(axis).any():
+            raise ValueError("Encountered an NA value with skipna=False")
     return result
 
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1447,7 +1447,7 @@ def _maybe_arg_null_out(
                 raise ValueError("Encountered an NA value with skipna=False")
     else:
         na_mask = mask.all(axis)
-        if na_mask.any():
+        if skipna and na_mask.any():
             raise ValueError("Encountered all NA values")
         elif not skipna:
             na_mask = mask.any(axis)

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -191,10 +191,10 @@ class BaseMethodsTests:
         # GH#38733
         data = data_missing_for_sorting
 
-        with pytest.raises(NotImplementedError, match=""):
+        with pytest.raises(ValueError, match="Encountered an NA value"):
             data.argmin(skipna=False)
 
-        with pytest.raises(NotImplementedError, match=""):
+        with pytest.raises(ValueError, match="Encountered an NA value"):
             data.argmax(skipna=False)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1066,7 +1066,7 @@ class TestDataFrameAnalytics:
         frame.iloc[15:20, -2:] = np.nan
         for df in [frame, int_frame]:
             if (not skipna or axis == 1) and df is not int_frame:
-                if axis == 1:
+                if skipna:
                     msg = "Encountered all NA values"
                 else:
                     msg = "Encountered an NA value"
@@ -1116,7 +1116,7 @@ class TestDataFrameAnalytics:
         frame.iloc[15:20, -2:] = np.nan
         for df in [frame, int_frame]:
             if (skipna is False or axis == 1) and df is frame:
-                if axis == 1:
+                if skipna:
                     msg = "Encountered all NA values"
                 else:
                     msg = "Encountered an NA value"

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -889,7 +889,7 @@ class TestSeriesReductions:
 
         # all NaNs
         allna = string_series * np.nan
-        msg = "attempt to get argmin of an empty sequence"
+        msg = "attempt to get argmax of an empty sequence"
         with pytest.raises(ValueError, match=msg):
             allna.idxmax()
 

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -856,7 +856,7 @@ class TestSeriesReductions:
 
         # all NaNs
         allna = string_series * np.nan
-        msg = "attempt to get argmin of an empty sequence"
+        msg = "Encountered all NA values"
         with pytest.raises(ValueError, match=msg):
             allna.idxmin()
 
@@ -889,7 +889,7 @@ class TestSeriesReductions:
 
         # all NaNs
         allna = string_series * np.nan
-        msg = "attempt to get argmax of an empty sequence"
+        msg = "Encountered all NA values"
         with pytest.raises(ValueError, match=msg):
             allna.idxmax()
 
@@ -1145,18 +1145,15 @@ class TestSeriesReductions:
         if not using_infer_string:
             # attempting to compare np.nan with string raises
             ser3 = Series(["foo", "foo", "bar", "bar", None, np.nan, "baz"])
-            result = ser3.idxmax()
-            expected = 0
-            assert result == expected
-
-            with pytest.raises(ValueError, match="Encountered an NA value"):
+            msg = "'>' not supported between instances of 'float' and 'str'"
+            with pytest.raises(TypeError, match=msg):
+                ser3.idxmax()
+            with pytest.raises(TypeError, match=msg):
                 ser3.idxmax(skipna=False)
-
-            result = ser3.idxmin()
-            expected = 2
-            assert result == expected
-
-            with pytest.raises(ValueError, match="Encountered an NA value"):
+            msg = "'<' not supported between instances of 'float' and 'str'"
+            with pytest.raises(TypeError, match=msg):
+                ser3.idxmin()
+            with pytest.raises(TypeError, match=msg):
                 ser3.idxmin(skipna=False)
 
     def test_idxminmax_object_frame(self):

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -171,9 +171,9 @@ class TestReductions:
             obj.argmin()
         with pytest.raises(ValueError, match="Encountered all NA values"):
             obj.argmax()
-        with pytest.raises(ValueError, match="Encountered all NA values"):
+        with pytest.raises(ValueError, match="Encountered an NA value"):
             obj.argmin(skipna=False)
-        with pytest.raises(ValueError, match="Encountered all NA values"):
+        with pytest.raises(ValueError, match="Encountered an NA value"):
             obj.argmax(skipna=False)
 
         obj = Index([NaT, datetime(2011, 11, 1), datetime(2011, 11, 2), NaT])
@@ -189,9 +189,9 @@ class TestReductions:
             obj.argmin()
         with pytest.raises(ValueError, match="Encountered all NA values"):
             obj.argmax()
-        with pytest.raises(ValueError, match="Encountered all NA values"):
+        with pytest.raises(ValueError, match="Encountered an NA value"):
             obj.argmin(skipna=False)
-        with pytest.raises(ValueError, match="Encountered all NA values"):
+        with pytest.raises(ValueError, match="Encountered an NA value"):
             obj.argmax(skipna=False)
 
     @pytest.mark.parametrize("op, expected_col", [["max", "a"], ["min", "b"]])
@@ -856,7 +856,8 @@ class TestSeriesReductions:
 
         # all NaNs
         allna = string_series * np.nan
-        with pytest.raises(ValueError, match="Encountered all NA values"):
+        msg = "attempt to get argmin of an empty sequence"
+        with pytest.raises(ValueError, match=msg):
             allna.idxmin()
 
         # datetime64[ns]
@@ -888,7 +889,8 @@ class TestSeriesReductions:
 
         # all NaNs
         allna = string_series * np.nan
-        with pytest.raises(ValueError, match="Encountered all NA values"):
+        msg = "attempt to get argmin of an empty sequence"
+        with pytest.raises(ValueError, match=msg):
             allna.idxmax()
 
         s = Series(date_range("20130102", periods=6))
@@ -1143,14 +1145,17 @@ class TestSeriesReductions:
         if not using_infer_string:
             # attempting to compare np.nan with string raises
             ser3 = Series(["foo", "foo", "bar", "bar", None, np.nan, "baz"])
-            msg = "'>' not supported between instances of 'float' and 'str'"
-            with pytest.raises(TypeError, match=msg):
-                ser3.idxmax()
+            result = ser3.idxmax()
+            expected = 0
+            assert result == expected
+
             with pytest.raises(ValueError, match="Encountered an NA value"):
                 ser3.idxmax(skipna=False)
-            msg = "'<' not supported between instances of 'float' and 'str'"
-            with pytest.raises(TypeError, match=msg):
-                ser3.idxmin()
+
+            result = ser3.idxmin()
+            expected = 2
+            assert result == expected
+
             with pytest.raises(ValueError, match="Encountered an NA value"):
                 ser3.idxmin(skipna=False)
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ref: https://github.com/pandas-dev/pandas/pull/57971#discussion_r1539849666

ASVs against main:

```
| Change   | Before [b63ae8c7]    | After [46bbd5eb] <cln_argmin_argmax>   |   Ratio | Benchmark (Parameter)                                         |
|----------|----------------------|----------------------------------------|---------|---------------------------------------------------------------|
| -        | 184±1μs              | 138±3μs                                |    0.75 | series_methods.NanOps.time_func('argmax', 1000000, 'int32')   |
| -        | 14.4±0.1μs           | 10.5±0.2μs                             |    0.73 | series_methods.NanOps.time_func('argmax', 1000, 'float64')    |
| -        | 1.23±0.06ms          | 863±20μs                               |    0.7  | series_methods.NanOps.time_func('argmax', 1000000, 'float64') |
| -        | 77.9±0.6μs           | 40.8±0.7μs                             |    0.52 | series_methods.NanOps.time_func('argmax', 1000000, 'int8')    |
| -        | 7.42±0.2μs           | 2.44±0.06μs                            |    0.33 | series_methods.NanOps.time_func('argmax', 1000, 'int64')      |
| -        | 7.18±0.2μs           | 2.29±0.02μs                            |    0.32 | series_methods.NanOps.time_func('argmax', 1000, 'int32')      |
| -        | 7.25±0.1μs           | 2.29±0.03μs                            |    0.32 | series_methods.NanOps.time_func('argmax', 1000, 'int8')       |
```

ASVs against 2.2.x show no perf change.