### PR TITLE
REGR: Performance of DataFrame.stack where columns are not a MultiIndex

### DIFF
--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -932,14 +932,18 @@ def stack_v3(frame: DataFrame, level: list[int]) -> Series | DataFrame:
         if len(frame.columns) == 1:
             data = frame.copy()
         else:
-            # Take the data from frame corresponding to this idx value
-            if len(level) == 1:
-                idx = (idx,)
-            gen = iter(idx)
-            column_indexer = tuple(
-                next(gen) if k in set_levels else slice(None)
-                for k in range(frame.columns.nlevels)
-            )
+            if not isinstance(frame.columns, MultiIndex) and not isinstance(idx, tuple):
+                # GH#57750 - if the frame is an Index with tuples, .loc below will fail
+                column_indexer = idx
+            else:
+                # Take the data from frame corresponding to this idx value
+                if len(level) == 1:
+                    idx = (idx,)
+                gen = iter(idx)
+                column_indexer = tuple(
+                    next(gen) if k in set_levels else slice(None)
+                    for k in range(frame.columns.nlevels)
+                )
             data = frame.loc[:, column_indexer]
 
         if len(level) < frame.columns.nlevels:


### PR DESCRIPTION
- [x] closes #57302 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Thanks @DeaMariaLeon for identifying this regression and @jorisvandenbossche for the solution used here.

ASVs

```
| Change   | Before [e51039af] <enh_fillna_allow_none~1>   | After [664c54b8] <regr_perf_stack>   |   Ratio | Benchmark (Parameter)                                                  |
|----------|-----------------------------------------------|--------------------------------------|---------|------------------------------------------------------------------------|
| -        | 304±2ms                                       | 44.2±0.4ms                           |    0.15 | reshape.ReshapeExtensionDtype.time_stack('datetime64[ns, US/Pacific]') |
| -        | 304±2ms                                       | 43.7±0.2ms                           |    0.14 | reshape.ReshapeExtensionDtype.time_stack('Period[s]')                  |
| -        | 294±0.7ms                                     | 40.8±0.3ms                           |    0.14 | reshape.ReshapeMaskedArrayDtype.time_stack('Float64')                  |
| -        | 291±2ms                                       | 40.7±0.2ms                           |    0.14 | reshape.ReshapeMaskedArrayDtype.time_stack('Int64')                    |
```