### PR TITLE
CLN: enforce `any/all` deprecation with `datetime64`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -212,6 +212,7 @@ Removal of prior version deprecations/changes
 - All arguments in :meth:`Series.to_dict` are now keyword only (:issue:`56493`)
 - Changed the default value of ``observed`` in :meth:`DataFrame.groupby` and :meth:`Series.groupby` to ``True`` (:issue:`51811`)
 - Enforce deprecation in :func:`testing.assert_series_equal` and :func:`testing.assert_frame_equal` with object dtype and mismatched null-like values, which are now considered not-equal (:issue:`18463`)
+- Enforced deprecation ``all`` and ``any`` reductions with ``datetime64`` and :class:`DatetimeTZDtype` dtypes (:issue:`58029`)
 - Enforced deprecation disallowing parsing datetimes with mixed time zones unless user passes ``utc=True`` to :func:`to_datetime` (:issue:`57275`)
 - Enforced deprecation in :meth:`Series.value_counts` and :meth:`Index.value_counts` with object dtype performing dtype inference on the ``.index`` of the result (:issue:`56161`)
 - Enforced deprecation of :meth:`.DataFrameGroupBy.get_group` and :meth:`.SeriesGroupBy.get_group` allowing the ``name`` argument to be a non-tuple when grouping by a list of length 1 (:issue:`54155`)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1661,11 +1661,8 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
         dtype = self.dtype
         if dtype.kind == "M":
             # Adding/multiplying datetimes is not valid
-            if how in ["sum", "prod", "cumsum", "cumprod", "var", "skew"]:
+            if how in ["any", "all", "sum", "prod", "cumsum", "cumprod", "var", "skew"]:
                 raise TypeError(f"datetime64 type does not support {how} operations")
-            if how in ["any", "all"]:
-                # GH#34479
-                raise TypeError(f"'{how}' with datetime64 dtypes is not supported")
 
         elif isinstance(dtype, PeriodDtype):
             # Adding/multiplying Periods is not valid

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1662,7 +1662,7 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
         if dtype.kind == "M":
             # Adding/multiplying datetimes is not valid
             if how in ["any", "all", "sum", "prod", "cumsum", "cumprod", "var", "skew"]:
-                raise TypeError(f"datetime64 type does not support {how} operations")
+                raise TypeError(f"datetime64 type does not support operation: '{how}'")
 
         elif isinstance(dtype, PeriodDtype):
             # Adding/multiplying Periods is not valid

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2217,11 +2217,11 @@ class TimelikeOps(DatetimeLikeArrayMixin):
     # Reductions
 
     def any(self, *, axis: AxisInt | None = None, skipna: bool = True) -> bool:
-        # GH#34479 the nanops call will issue a FutureWarning for non-td64 dtype
+        # GH#34479 the nanops call will raise a TypeError for non-td64 dtype
         return nanops.nanany(self._ndarray, axis=axis, skipna=skipna, mask=self.isna())
 
     def all(self, *, axis: AxisInt | None = None, skipna: bool = True) -> bool:
-        # GH#34479 the nanops call will issue a FutureWarning for non-td64 dtype
+        # GH#34479 the nanops call will raise a TypeError for non-td64 dtype
 
         return nanops.nanall(self._ndarray, axis=axis, skipna=skipna, mask=self.isna())
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1665,12 +1665,7 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
                 raise TypeError(f"datetime64 type does not support {how} operations")
             if how in ["any", "all"]:
                 # GH#34479
-                warnings.warn(
-                    f"'{how}' with datetime64 dtypes is deprecated and will raise in a "
-                    f"future version. Use (obj != pd.Timestamp(0)).{how}() instead.",
-                    FutureWarning,
-                    stacklevel=find_stack_level(),
-                )
+                raise TypeError(f"'{how}' with datetime64 dtypes is not supported")
 
         elif isinstance(dtype, PeriodDtype):
             # Adding/multiplying Periods is not valid

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -31,7 +31,6 @@ from pandas._typing import (
     npt,
 )
 from pandas.compat._optional import import_optional_dependency
-from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_complex,
@@ -521,12 +520,7 @@ def nanany(
 
     if values.dtype.kind == "M":
         # GH#34479
-        warnings.warn(
-            "'any' with datetime64 dtypes is deprecated and will raise in a "
-            "future version. Use (obj != pd.Timestamp(0)).any() instead.",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
+        raise TypeError("'any' with datetime64 dtypes is not supported")
 
     values, _ = _get_values(values, skipna, fill_value=False, mask=mask)
 
@@ -582,12 +576,7 @@ def nanall(
 
     if values.dtype.kind == "M":
         # GH#34479
-        warnings.warn(
-            "'all' with datetime64 dtypes is deprecated and will raise in a "
-            "future version. Use (obj != pd.Timestamp(0)).all() instead.",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
+        raise TypeError("'all' with datetime64 dtypes is not supported")
 
     values, _ = _get_values(values, skipna, fill_value=True, mask=mask)
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -520,7 +520,7 @@ def nanany(
 
     if values.dtype.kind == "M":
         # GH#34479
-        raise TypeError("'any' with datetime64 dtypes is not supported")
+        raise TypeError("datetime64 type does not support any operations")
 
     values, _ = _get_values(values, skipna, fill_value=False, mask=mask)
 
@@ -576,7 +576,7 @@ def nanall(
 
     if values.dtype.kind == "M":
         # GH#34479
-        raise TypeError("'all' with datetime64 dtypes is not supported")
+        raise TypeError("datetime64 type does not support all operations")
 
     values, _ = _get_values(values, skipna, fill_value=True, mask=mask)
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -520,7 +520,7 @@ def nanany(
 
     if values.dtype.kind == "M":
         # GH#34479
-        raise TypeError("datetime64 type does not support any operations")
+        raise TypeError("datetime64 type does not support operation: 'any'")
 
     values, _ = _get_values(values, skipna, fill_value=False, mask=mask)
 
@@ -576,7 +576,7 @@ def nanall(
 
     if values.dtype.kind == "M":
         # GH#34479
-        raise TypeError("datetime64 type does not support all operations")
+        raise TypeError("datetime64 type does not support operation: 'all'")
 
     values, _ = _get_values(values, skipna, fill_value=True, mask=mask)
 

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -163,7 +163,7 @@ class BaseGroupbyTests:
             msg = "|".join(
                 [
                     # period/datetime
-                    "does not support sum operations",
+                    "does not support operation: 'sum'",
                     # all others
                     re.escape(f"agg function failed [how->sum,dtype->{dtype}"),
                 ]

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -162,7 +162,9 @@ class BaseGroupbyTests:
 
             msg = "|".join(
                 [
-                    # period/datetime
+                    # period
+                    "does not support sum operations",
+                    # datetime
                     "does not support operation: 'sum'",
                     # all others
                     re.escape(f"agg function failed [how->sum,dtype->{dtype}"),

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -104,10 +104,8 @@ class TestDatetimeArray(base.ExtensionTests):
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_boolean(self, data, all_boolean_reductions, skipna):
         meth = all_boolean_reductions
-        msg = f"'{meth}' with datetime64 dtypes is deprecated and will raise in"
-        with tm.assert_produces_warning(
-            FutureWarning, match=msg, check_stacklevel=False
-        ):
+        msg = f"'{meth}' with datetime64 dtypes is not supported"
+        with pytest.raises(TypeError, match=msg):
             super().test_reduce_series_boolean(data, all_boolean_reductions, skipna)
 
     def test_series_constructor(self, data):

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -104,7 +104,7 @@ class TestDatetimeArray(base.ExtensionTests):
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_boolean(self, data, all_boolean_reductions, skipna):
         meth = all_boolean_reductions
-        msg = f"datetime64 type does not support {meth} operations"
+        msg = f"datetime64 type does not support operation: '{meth}'"
         with pytest.raises(TypeError, match=msg):
             super().test_reduce_series_boolean(data, all_boolean_reductions, skipna)
 

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -104,7 +104,7 @@ class TestDatetimeArray(base.ExtensionTests):
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_boolean(self, data, all_boolean_reductions, skipna):
         meth = all_boolean_reductions
-        msg = f"'{meth}' with datetime64 dtypes is not supported"
+        msg = f"datetime64 type does not support {meth} operations"
         with pytest.raises(TypeError, match=msg):
             super().test_reduce_series_boolean(data, all_boolean_reductions, skipna)
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1371,10 +1371,6 @@ class TestDataFrameAnalytics:
         expected = Series([True, True, val, True])
         tm.assert_series_equal(result, expected)
 
-    # GH#50947 deprecates this but it is not emitting a warning in some builds.
-    @pytest.mark.filterwarnings(
-        "ignore:'any' with datetime64 dtypes is deprecated.*:FutureWarning"
-    )
     def test_any_datetime(self):
         # GH 23070
         float_data = [1, np.nan, 3, np.nan]
@@ -1386,10 +1382,9 @@ class TestDataFrameAnalytics:
         ]
         df = DataFrame({"A": float_data, "B": datetime_data})
 
-        result = df.any(axis=1)
-
-        expected = Series([True, True, True, False])
-        tm.assert_series_equal(result, expected)
+        msg = "'any' with datetime64 dtypes is not supported"
+        with pytest.raises(TypeError, match=msg):
+            df.any(axis=1)
 
     def test_any_all_bool_only(self):
         # GH 25101
@@ -1481,23 +1476,23 @@ class TestDataFrameAnalytics:
                 TypeError, match="dtype category does not support reduction"
             ):
                 getattr(DataFrame(data), func.__name__)(axis=None)
-        else:
-            msg = "'(any|all)' with datetime64 dtypes is deprecated"
-            if data.dtypes.apply(lambda x: x.kind == "M").any():
-                warn = FutureWarning
-            else:
-                warn = None
+        if data.dtypes.apply(lambda x: x.kind == "M").any():
+            # GH#34479
+            msg = "'(any|all)' with datetime64 dtypes is not supported"
+            with pytest.raises(TypeError, match=msg):
+                func(data)
 
-            with tm.assert_produces_warning(warn, match=msg, check_stacklevel=False):
-                # GH#34479
-                result = func(data)
+            # method version
+            with pytest.raises(TypeError, match=msg):
+                getattr(DataFrame(data), func.__name__)(axis=None)
+
+        elif data.dtypes.apply(lambda x: x != "category").any():
+            result = func(data)
             assert isinstance(result, np.bool_)
             assert result.item() is expected
 
             # method version
-            with tm.assert_produces_warning(warn, match=msg):
-                # GH#34479
-                result = getattr(DataFrame(data), func.__name__)(axis=None)
+            result = getattr(DataFrame(data), func.__name__)(axis=None)
             assert isinstance(result, np.bool_)
             assert result.item() is expected
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1382,7 +1382,7 @@ class TestDataFrameAnalytics:
         ]
         df = DataFrame({"A": float_data, "B": datetime_data})
 
-        msg = "'any' with datetime64 dtypes is not supported"
+        msg = "datetime64 type does not support any operations"
         with pytest.raises(TypeError, match=msg):
             df.any(axis=1)
 
@@ -1478,7 +1478,7 @@ class TestDataFrameAnalytics:
                 getattr(DataFrame(data), func.__name__)(axis=None)
         if data.dtypes.apply(lambda x: x.kind == "M").any():
             # GH#34479
-            msg = "'(any|all)' with datetime64 dtypes is not supported"
+            msg = "datetime64 type does not support (any|all) operations"
             with pytest.raises(TypeError, match=msg):
                 func(data)
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1382,7 +1382,7 @@ class TestDataFrameAnalytics:
         ]
         df = DataFrame({"A": float_data, "B": datetime_data})
 
-        msg = "datetime64 type does not support any operations"
+        msg = "datetime64 type does not support operation: 'any'"
         with pytest.raises(TypeError, match=msg):
             df.any(axis=1)
 
@@ -1478,7 +1478,7 @@ class TestDataFrameAnalytics:
                 getattr(DataFrame(data), func.__name__)(axis=None)
         if data.dtypes.apply(lambda x: x.kind == "M").any():
             # GH#34479
-            msg = "datetime64 type does not support (any|all) operations"
+            msg = "datetime64 type does not support operation: '(any|all)'"
             with pytest.raises(TypeError, match=msg):
                 func(data)
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -674,7 +674,7 @@ def test_raises_on_nuisance(df):
     df = df.loc[:, ["A", "C", "D"]]
     df["E"] = datetime.now()
     grouped = df.groupby("A")
-    msg = "datetime64 type does not support sum operations"
+    msg = "datetime64 type does not support operation: 'sum'"
     with pytest.raises(TypeError, match=msg):
         grouped.agg("sum")
     with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/groupby/test_raises.py
+++ b/pandas/tests/groupby/test_raises.py
@@ -241,16 +241,16 @@ def test_groupby_raises_datetime(
             return
 
     klass, msg = {
-        "all": (TypeError, "datetime64 type does not support all operations"),
-        "any": (TypeError, "datetime64 type does not support any operations"),
+        "all": (TypeError, "datetime64 type does not support operation: 'all'"),
+        "any": (TypeError, "datetime64 type does not support operation: 'any'"),
         "bfill": (None, ""),
         "corrwith": (TypeError, "cannot perform __mul__ with this index type"),
         "count": (None, ""),
         "cumcount": (None, ""),
         "cummax": (None, ""),
         "cummin": (None, ""),
-        "cumprod": (TypeError, "datetime64 type does not support cumprod operations"),
-        "cumsum": (TypeError, "datetime64 type does not support cumsum operations"),
+        "cumprod": (TypeError, "datetime64 type does not support operation: 'cumprod'"),
+        "cumsum": (TypeError, "datetime64 type does not support operation: 'cumsum'"),
         "diff": (None, ""),
         "ffill": (None, ""),
         "fillna": (None, ""),
@@ -265,7 +265,7 @@ def test_groupby_raises_datetime(
         "ngroup": (None, ""),
         "nunique": (None, ""),
         "pct_change": (TypeError, "cannot perform __truediv__ with this index type"),
-        "prod": (TypeError, "datetime64 type does not support prod"),
+        "prod": (TypeError, "datetime64 type does not support operation: 'prod'"),
         "quantile": (None, ""),
         "rank": (None, ""),
         "sem": (None, ""),
@@ -276,13 +276,13 @@ def test_groupby_raises_datetime(
             "|".join(
                 [
                     r"dtype datetime64\[ns\] does not support reduction",
-                    "datetime64 type does not support skew operations",
+                    "datetime64 type does not support operation: 'skew'",
                 ]
             ),
         ),
         "std": (None, ""),
-        "sum": (TypeError, "datetime64 type does not support sum operations"),
-        "var": (TypeError, "datetime64 type does not support var operations"),
+        "sum": (TypeError, "datetime64 type does not support operation: 'sum"),
+        "var": (TypeError, "datetime64 type does not support operation: 'var'"),
     }[groupby_func]
 
     if groupby_func == "fillna":

--- a/pandas/tests/groupby/test_raises.py
+++ b/pandas/tests/groupby/test_raises.py
@@ -241,8 +241,8 @@ def test_groupby_raises_datetime(
             return
 
     klass, msg = {
-        "all": (TypeError, "'all' with datetime64 dtypes is not supported"),
-        "any": (TypeError, "'any' with datetime64 dtypes is not supported"),
+        "all": (TypeError, "datetime64 type does not support all operations"),
+        "any": (TypeError, "datetime64 type does not support any operations"),
         "bfill": (None, ""),
         "corrwith": (TypeError, "cannot perform __mul__ with this index type"),
         "count": (None, ""),

--- a/pandas/tests/groupby/test_raises.py
+++ b/pandas/tests/groupby/test_raises.py
@@ -241,8 +241,8 @@ def test_groupby_raises_datetime(
             return
 
     klass, msg = {
-        "all": (None, ""),
-        "any": (None, ""),
+        "all": (TypeError, "'all' with datetime64 dtypes is not supported"),
+        "any": (TypeError, "'any' with datetime64 dtypes is not supported"),
         "bfill": (None, ""),
         "corrwith": (TypeError, "cannot perform __mul__ with this index type"),
         "count": (None, ""),
@@ -285,9 +285,7 @@ def test_groupby_raises_datetime(
         "var": (TypeError, "datetime64 type does not support var operations"),
     }[groupby_func]
 
-    if groupby_func in ["any", "all"]:
-        warn_msg = f"'{groupby_func}' with datetime64 dtypes is deprecated"
-    elif groupby_func == "fillna":
+    if groupby_func == "fillna":
         kind = "Series" if groupby_series else "DataFrame"
         warn_msg = f"{kind}GroupBy.fillna is deprecated"
     else:

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -749,6 +749,7 @@ def test_cython_transform_frame_column(
         msg = "|".join(
             [
                 "does not support .* operations",
+                "does not support operation",
                 ".* is not supported for object dtype",
                 "is not implemented for this dtype",
             ]

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1009,32 +1009,41 @@ class TestSeriesReductions:
         ser = Series(dta)
         df = DataFrame(ser)
 
-        msg = "'(any|all)' with datetime64 dtypes is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            # GH#34479
-            assert dta.all()
-            assert dta.any()
+        # GH#34479
+        msg = "'(any|all)' with datetime64 dtypes is not supported"
+        with pytest.raises(TypeError, match=msg):
+            dta.all()
+        with pytest.raises(TypeError, match=msg):
+            dta.any()
 
-            assert ser.all()
-            assert ser.any()
+        with pytest.raises(TypeError, match=msg):
+            ser.all()
+        with pytest.raises(TypeError, match=msg):
+            ser.any()
 
-            assert df.any().all()
-            assert df.all().all()
+        with pytest.raises(TypeError, match=msg):
+            df.any().all()
+        with pytest.raises(TypeError, match=msg):
+            df.all().all()
 
         dta = dta.tz_localize("UTC")
         ser = Series(dta)
         df = DataFrame(ser)
+        # GH#34479
+        with pytest.raises(TypeError, match=msg):
+            dta.all()
+        with pytest.raises(TypeError, match=msg):
+            dta.any()
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            # GH#34479
-            assert dta.all()
-            assert dta.any()
+        with pytest.raises(TypeError, match=msg):
+            ser.all()
+        with pytest.raises(TypeError, match=msg):
+            ser.any()
 
-            assert ser.all()
-            assert ser.any()
-
-            assert df.any().all()
-            assert df.all().all()
+        with pytest.raises(TypeError, match=msg):
+            df.any().all()
+        with pytest.raises(TypeError, match=msg):
+            df.all().all()
 
         tda = dta - dta[0]
         ser = Series(tda)

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1010,7 +1010,7 @@ class TestSeriesReductions:
         df = DataFrame(ser)
 
         # GH#34479
-        msg = "datetime64 type does not support (any|all) operations"
+        msg = "datetime64 type does not support operation: '(any|all)'"
         with pytest.raises(TypeError, match=msg):
             dta.all()
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1010,7 +1010,7 @@ class TestSeriesReductions:
         df = DataFrame(ser)
 
         # GH#34479
-        msg = "'(any|all)' with datetime64 dtypes is not supported"
+        msg = "datetime64 type does not support (any|all) operations"
         with pytest.raises(TypeError, match=msg):
             dta.all()
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -708,7 +708,9 @@ def test_selection_api_validation():
     tm.assert_frame_equal(exp, result)
 
     exp.index.name = "d"
-    with pytest.raises(TypeError, match="datetime64 type does not support sum"):
+    with pytest.raises(
+        TypeError, match="datetime64 type does not support operation: 'sum'"
+    ):
         df.resample("2D", level="d").sum()
     result = df.resample("2D", level="d").sum(numeric_only=True)
     tm.assert_frame_equal(exp, result)


### PR DESCRIPTION
xref #50947, xref #58006

enforced deprecation of `any/all` with `datetime64`