### PR TITLE
BUG: Fixed DataFrameGroupBy.transform with numba returning the wrong order with non increasing indexes #57069

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -303,6 +303,7 @@ Bug fixes
 - Fixed bug in :class:`SparseDtype` for equal comparison with na fill value. (:issue:`54770`)
 - Fixed bug in :meth:`DataFrame.join` inconsistently setting result index name (:issue:`55815`)
 - Fixed bug in :meth:`DataFrame.to_string` that raised ``StopIteration`` with nested DataFrames. (:issue:`16098`)
+- Fixed bug in :meth:`DataFrame.transform` that was returning the wrong order unless the index was monotonically increasing. (:issue:`57069`)
 - Fixed bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Fixed bug in :meth:`DataFrameGroupBy.apply` that was returning a completely empty DataFrame when all return values of ``func`` were ``None`` instead of returning an empty DataFrame with the original columns and dtypes. (:issue:`57775`)
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1439,6 +1439,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         data and indices into a Numba jitted function.
         """
         data = self._obj_with_exclusions
+        index_sorting = self._grouper.result_ilocs
         df = data if data.ndim == 2 else data.to_frame()
 
         starts, ends, sorted_index, sorted_data = self._numba_prep(df)
@@ -1456,7 +1457,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         )
         # result values needs to be resorted to their original positions since we
         # evaluated the data sorted by group
-        result = result.take(np.argsort(sorted_index), axis=0)
+        result = result.take(np.argsort(index_sorting), axis=0)
         index = data.index
         if data.ndim == 1:
             result_kwargs = {"name": data.name}

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -181,8 +181,22 @@ def test_index_data_correctly_passed():
 
     df = DataFrame({"group": ["A", "A", "B"], "v": [4, 5, 6]}, index=[-1, -2, -3])
     result = df.groupby("group").transform(f, engine="numba")
-    expected = DataFrame([-4.0, -3.0, -2.0], columns=["v"], index=[-1, -2, -3])
+    expected = DataFrame([-2.0, -3.0, -4.0], columns=["v"], index=[-1, -2, -3])
     tm.assert_frame_equal(result, expected)
+
+
+def test_index_order_consistency_preserved():
+    # GH 57069
+    pytest.importorskip("numba")
+
+    def f(values, index):
+        return values
+
+    df = DataFrame({"vals": [0.0, 1.0, 2.0, 3.0], "group": [0, 1, 0, 1]})
+    df.index = df.index.values[::-1]
+    result = df.groupby("group")["vals"].transform(f, engine="numba")
+    expected = Series([0.0, 1.0, 2.0, 3.0], index=[3, 2, 1, 0], name="vals")
+    tm.assert_series_equal(result, expected)
 
 
 def test_engine_kwargs_not_cached():

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -192,7 +192,9 @@ def test_index_order_consistency_preserved():
     def f(values, index):
         return values
 
-    df = DataFrame({"vals": [0.0, 1.0, 2.0, 3.0], "group": [0, 1, 0, 1]}, index=range(3, -1, -1))
+    df = DataFrame(
+        {"vals": [0.0, 1.0, 2.0, 3.0], "group": [0, 1, 0, 1]}, index=range(3, -1, -1)
+    )
     result = df.groupby("group")["vals"].transform(f, engine="numba")
     expected = Series([0.0, 1.0, 2.0, 3.0], index=range(3, -1, -1), name="vals")
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -192,10 +192,9 @@ def test_index_order_consistency_preserved():
     def f(values, index):
         return values
 
-    df = DataFrame({"vals": [0.0, 1.0, 2.0, 3.0], "group": [0, 1, 0, 1]})
-    df.index = df.index.values[::-1]
+    df = DataFrame({"vals": [0.0, 1.0, 2.0, 3.0], "group": [0, 1, 0, 1]}, index=range(3, -1, -1))
     result = df.groupby("group")["vals"].transform(f, engine="numba")
-    expected = Series([0.0, 1.0, 2.0, 3.0], index=[3, 2, 1, 0], name="vals")
+    expected = Series([0.0, 1.0, 2.0, 3.0], index=range(3, -1, -1), name="vals")
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [X] closes #57069
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

DataFrameGroupBy.transform with numba was returning the wrong order unless the index was monotonically increasing due to the transformed results not being correctly reordered. 
Fixed the test "pandas/tests/groupby/transform/test_numba.py::test_index_data_correctly_passed" to expect the correct order in the result.
Added a test "pandas/tests/groupby/transform/test_numba.py::test_index_order_consistency_preserved" to test DataFrameGroupBy.transform with engine='numba' with a decreasing index.