### PR TITLE
read_csv(engine="pyarrow") fails with unknown column count

### DIFF
--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -139,12 +139,14 @@ class ArrowParserWrapper(ParserBase):
             ]
 
         self.read_options = {
-            "autogenerate_column_names": self.header is None,
+            "autogenerate_column_names": self.header is None and self.names is None,
             "skip_rows": self.header
             if self.header is not None
             else self.kwds["skiprows"],
             "encoding": self.encoding,
         }
+        if self.names:
+            self.read_options["column_names"] = self.names
 
     def _finalize_pandas_output(self, frame: DataFrame) -> DataFrame:
         """

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -139,14 +139,15 @@ class ArrowParserWrapper(ParserBase):
             ]
 
         self.read_options = {
-            "autogenerate_column_names": self.header is None and self.names is None,
             "skip_rows": self.header
             if self.header is not None
             else self.kwds["skiprows"],
             "encoding": self.encoding,
         }
-        if self.names:
+        if self.header is None and self.names is not None:
             self.read_options["column_names"] = self.names
+        else:
+            self.read_options["autogenerate_column_names"] = True
 
     def _finalize_pandas_output(self, frame: DataFrame) -> DataFrame:
         """

--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -730,3 +730,11 @@ b,j,y
     )
     expected = DataFrame([["a", "i"], ["b", "j"]], dtype="string[pyarrow]")
     tm.assert_frame_equal(result, expected)
+
+
+def test_names_pyarrow(pyarrow_parser_only):
+    result = pyarrow_parser_only.read_csv(
+        StringIO("1,2"), engine="pyarrow", names=["A", "B"], header=None
+    )
+    expected = DataFrame({"A": [1], "B": [2]})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
```
>>> pd.read_csv(StringIO("1,2"), engine="pyarrow", dtype_backend="pyarrow", names=["A", "B"], header=None)
Traceback (most recent call last):
  File "D:\ps_env_02_20\Lib\site-packages\pandas\io\parsers\arrow_parser_wrapper.py", line 266, in read
    table = pyarrow_csv.read_csv(
            ^^^^^^^^^^^^^^^^^^^^^
  File "pyarrow\_csv.pyx", line 1261, in pyarrow._csv.read_csv
  File "pyarrow\_csv.pyx", line 1270, in pyarrow._csv.read_csv
  File "pyarrow\error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow\error.pxi", line 91, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: CSV parse error: Empty CSV file or block: cannot infer number of columns

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\ps_env_02_20\Lib\site-packages\pandas\io\parsers\readers.py", line 1026, in read_csv
    return _read(filepath_or_buffer, kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ps_env_02_20\Lib\site-packages\pandas\io\parsers\readers.py", line 626, in _read
    return parser.read(nrows)
           ^^^^^^^^^^^^^^^^^^
  File "D:\ps_env_02_20\Lib\site-packages\pandas\io\parsers\readers.py", line 1911, in read
    df = self._engine.read()  # type: ignore[attr-defined]
         ^^^^^^^^^^^^^^^^^^^
  File "D:\ps_env_02_20\Lib\site-packages\pandas\io\parsers\arrow_parser_wrapper.py", line 273, in read
    raise ParserError(e) from e
pandas.errors.ParserError: CSV parse error: Empty CSV file or block: cannot infer number of columns
>>>
```

But I use names parameter to pass number of columns, so error about "cannot infer number of columns" is confusing in this case, becuase I specified exactly number of columns so it doesn't need to be inferred.