### PR TITLE
BUG: fixed to_numeric loss in precision when converting decimal type to integer

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -332,6 +332,7 @@ Bug fixes
 - Fixed bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
 - Fixed bug in :meth:`Series.rank` that doesn't preserve missing values for nullable integers when ``na_option='keep'``. (:issue:`56976`)
 - Fixed bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently replacing matching instances when ``regex=True`` and missing values are present. (:issue:`56599`)
+- Fixed bug in :func:`to_numeric` that resulted in precision loss when converting decimal type to integer. (:issue:`57213`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -10,7 +10,6 @@ import numpy as np
 from pandas._libs import lib
 from pandas.util._validators import check_dtype_backend
 
-from pandas.core.dtypes.cast import maybe_downcast_numeric
 from pandas.core.dtypes.common import (
     ensure_object,
     is_bool_dtype,
@@ -209,6 +208,7 @@ def to_numeric(
         values = values.view(np.int64)
     else:
         values = ensure_object(values)
+        old_values = values
         coerce_numeric = errors != "raise"
         values, new_mask = lib.maybe_convert_numeric(  # type: ignore[call-overload]
             values,
@@ -254,8 +254,8 @@ def to_numeric(
             # from smallest to largest
             for typecode in typecodes:
                 dtype = np.dtype(typecode)
-                if dtype.itemsize <= values.dtype.itemsize:
-                    values = maybe_downcast_numeric(values, dtype)
+                if dtype.itemsize == values.dtype.itemsize:
+                    values = np.array(old_values, dtype=dtype)
 
                     # successful conversion
                     if values.dtype == dtype:

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -1,4 +1,5 @@
 import decimal
+from decimal import Decimal
 
 import numpy as np
 from numpy import iinfo
@@ -903,4 +904,11 @@ def test_coerce_pyarrow_backend():
     ser = Series(list("12x"), dtype=ArrowDtype(pa.string()))
     result = to_numeric(ser, errors="coerce", dtype_backend="pyarrow")
     expected = Series([1, 2, None], dtype=ArrowDtype(pa.int64()))
+    tm.assert_series_equal(result, expected)
+
+
+def test_decimal_precision():
+    df = DataFrame({"column1": [Decimal("1" * 19)]})
+    result = to_numeric(df["column1"], downcast="integer")
+    expected = df["column1"].astype("int64")
     tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [X] closes #57213
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. _(Not applicable)_
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.