### PR TITLE
Remove 'Not implemented for Series' from _num_doc in generic.py

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11712,7 +11712,7 @@ axis : {axis_descr}
 skipna : bool, default True
     Exclude NA/null values when computing the result.
 numeric_only : bool, default False
-    Include only float, int, boolean columns. Not implemented for Series.
+    Include only float, int, boolean columns.
 
 {min_count}\
 **kwargs


### PR DESCRIPTION
Documentation fix in `generic.py`
line 11715: Removed 'Not implemented for Series' in _num_doc given that `numeric_only` is now implemented for Series in all the methods min, max, mean, median, skew, kurt

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
