### PR TITLE
BUG: Remove "Mean of empty slice" warning in nanmedian

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -745,6 +745,10 @@ def nanmedian(values, *, axis: AxisInt | None = None, skipna: bool = True, mask=
     >>> s = pd.Series([1, np.nan, 2, 2])
     >>> nanops.nanmedian(s.values)
     2.0
+
+    >>> s = pd.Series([np.nan, np.nan, np.nan])
+    >>> nanops.nanmedian(s.values)
+    nan
     """
     # for floats without mask, the data already uses NaN as missing value
     # indicator, and `mask` will be calculated from that below -> in those
@@ -762,6 +766,9 @@ def nanmedian(values, *, axis: AxisInt | None = None, skipna: bool = True, mask=
             # Suppress RuntimeWarning about All-NaN slice
             warnings.filterwarnings(
                 "ignore", "All-NaN slice encountered", RuntimeWarning
+            )
+            warnings.filterwarnings(
+                "ignore", "Mean of empty slice", RuntimeWarning
             )
             res = np.nanmedian(x[_mask])
         return res

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -767,9 +767,7 @@ def nanmedian(values, *, axis: AxisInt | None = None, skipna: bool = True, mask=
             warnings.filterwarnings(
                 "ignore", "All-NaN slice encountered", RuntimeWarning
             )
-            warnings.filterwarnings(
-                "ignore", "Mean of empty slice", RuntimeWarning
-            )
+            warnings.filterwarnings("ignore", "Mean of empty slice", RuntimeWarning)
             res = np.nanmedian(x[_mask])
         return res
 


### PR DESCRIPTION
This PR supresses a warning when calculating the `median` of a `pd.Series` that is full of `NA`s. The warning is just letting you know that `numpy` got an empty array but correctly returns `np.nan`.

The warning is issued as follows:
1. When the series has `NA`s and you try to calculate the `median`, `nanops.nanmedian` is called.
2. When the array is full of NAs, the `_mask` in `nanops.nanmedian.get_median` is all `False`, so `np.nanmedian(x[_mask])` gets an empty array.
3. `np.nanmedian` calls `numpy.lib.nanfunctions._nanmedian` which has a short-circuit path when the array is empty [[ref](https://github.com/numpy/numpy/blob/1c8b03bf2c87f081eea211a5061e423285c548af/numpy/lib/_nanfunctions_impl.py#L1215-L1216)].
4. This path calls `np.nanmean`. This creates an empty mask [[ref](https://github.com/numpy/numpy/blob/1c8b03bf2c87f081eea211a5061e423285c548af/numpy/lib/_nanfunctions_impl.py#L1033)] because the array is empty.
5. Then, the sum of the negated mask is used as the denominator of the `mean`, which causes the result to be `np.nan` (correct!).
6. The method issues a warning because the array was empty.

Another way to solve this would be to change `get_median` to explicitly return `np.nan` before the call to `np.nanmedian`, but that would involve tampering with the condition in the if, which has no comments so I'm unsure if changing it makes sense.

```python
    def get_median(x, _mask=None):
        if _mask is None:
            _mask = notna(x)
        else:
            _mask = ~_mask
        all_na = _mask.all()
        if (not skipna and not all_na) or all_na:
            return np.nan
        with warnings.catch_warnings():
            # Suppress RuntimeWarning about All-NaN slice
            warnings.filterwarnings(
                        "ignore", "All-NaN slice encountered", RuntimeWarning
            )
            res = np.nanmedian(x[_mask])
        return res
```
which simplifies to `if skipna: return np.nan` I think.

I haven't added tests nor ensured all of the below passed not added comments because I want to ensure this is the preferred solution. Otherwise, I can edit `get_median`. Let me know!

---

- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
