### PR TITLE
API: add numeric_only support to groupby agg

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -219,6 +219,25 @@ class SelectionMixin(Generic[NDFrameT]):
         else:
             return self.obj
 
+    @final
+    @cache_readonly
+    def _obj_numeric_only_with_exclusions(self):
+        if isinstance(self.obj, ABCSeries):
+            return self.obj.select_dtypes("number")
+
+        if self._selection is not None:
+            return self.obj[self._selection_list].select_dtypes("number")
+
+        if len(self.exclusions) > 0:
+            # equivalent to `self.obj.drop(self.exclusions, axis=1)
+            #  but this avoids consolidating and making a copy
+            # TODO: following GH#45287 can we now use .drop directly without
+            #  making a copy?
+            obj = self.obj._drop_axis(self.exclusions, axis=1, only_slice=True)
+            return obj.select_dtypes("number")
+        else:
+            return self.obj.select_dtypes("number")
+
     def __getitem__(self, key):
         if self._selection is not None:
             raise IndexError(f"Column(s) {self._selection} already selected")

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1663,3 +1663,53 @@ def test_groupby_aggregation_empty_group():
     msg = "length must not be 0"
     with pytest.raises(ValueError, match=msg):
         df.groupby("A", observed=False).agg(func)
+
+
+@pytest.mark.parametrize(
+    "aggfunc",
+    [
+        "mean",
+        np.mean,
+        ["sum", "mean"],
+        [np.sum, np.mean],
+        ["sum", np.mean],
+        lambda x: x.mean(),
+        {"A": "mean"},
+        {"A": "mean", "B": "sum"},
+        {"A": np.mean},
+    ],
+    ids=[
+        " string_mean ",
+        " numpy_mean ",
+        " list_of_str_and_str ",
+        " list_of_numpy_and_numpy ",
+        " list_of_str_and_numpy ",
+        " lambda ",
+        " dict_with_str ",
+        " dict with 2 vars ",
+        " dict with numpy",
+    ],
+)
+@pytest.mark.parametrize(
+    "groupers",
+    ["groupby1", "groupby2", ["groupby1", "groupby2"]],
+    ids=[" 1_grouper_str ", " 1_grouper_int ", " 2_groupers_str_and_int "],
+)
+@pytest.mark.parametrize(
+    "numeric_only", [True, None], ids=[" numeric_only True ", " no_numeric_only_arg "]
+)  # need to add other kwargs
+def test_different_combinations_of_groupby_agg(aggfunc, groupers, numeric_only):
+    df = DataFrame(
+        {
+            "A": [1, 2, 3, 4, 5],
+            "B": [10, 20, 30, 40, 50],
+            "groupby1": ["diamond", "diamond", "spade", "spade", "spade"],
+            "groupby2": [1, 1, 1, 2, 2],
+            "attr": ["a", "b", "c", "d", "e"],
+        }
+    )
+    if numeric_only or isinstance(aggfunc, dict):
+        df.groupby(by=groupers).agg(func=aggfunc, numeric_only=numeric_only)
+    else:
+        with pytest.raises(TypeError):
+            df.groupby(by=groupers).agg(func=aggfunc)


### PR DESCRIPTION
Currently in early phase seeking prelim feedback.

- [x] partially addresses #56946, relevant to #50538
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
