### PR TITLE
REF: Allow Index._with_infer to also return RangeIndex

### DIFF
--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -794,3 +794,8 @@ class TestCategoricalConstructors:
         result = Categorical(values=values, categories=categories).categories
         expected = RangeIndex(range(5))
         tm.assert_index_equal(result, expected, exact=True)
+
+    def test_categoricaldtype_numeric_object_to_rangeindex_categories(self):
+        result = CategoricalDtype(np.array([1, 2], dtype=object)).categories
+        expected = RangeIndex(1, 3)
+        tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -46,9 +46,7 @@ def test_groupby_nonobject_dtype(multiindex_dataframe_random_data):
     result = grouped.sum()
 
     expected = multiindex_dataframe_random_data.groupby(key.astype("O")).sum()
-    assert result.index.dtype == np.int8
-    assert expected.index.dtype == np.int64
-    tm.assert_frame_equal(result, expected, check_index_type=False)
+    tm.assert_frame_equal(result, expected, check_index_type=True)
 
 
 def test_groupby_nonobject_dtype_mixed():
@@ -2955,3 +2953,12 @@ def test_groupby_dropna_with_nunique_unique():
     )
 
     tm.assert_frame_equal(result, expected)
+
+
+def test_groupby_groups_returns_rangeindex():
+    df = DataFrame({"group": [1, 1, 2], "value": [1, 2, 3]})
+    result = df.groupby("group").max()
+    expected = DataFrame(
+        [2, 3], index=RangeIndex(1, 3, name="group"), columns=["value"]
+    )
+    tm.assert_frame_equal(result, expected, check_index_type=True)

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -13,6 +13,7 @@ from pandas import (
     DataFrame,
     Index,
     MultiIndex,
+    RangeIndex,
     Series,
     Timestamp,
     concat,
@@ -290,7 +291,7 @@ def test_transform_casting():
             ),
             "DATETIME": pd.to_datetime([f"2014-10-08 {time}" for time in times]),
         },
-        index=pd.RangeIndex(11, name="idx"),
+        index=RangeIndex(11, name="idx"),
     )
 
     result = df.groupby("ID3")["DATETIME"].transform(lambda x: x.diff())
@@ -1535,3 +1536,10 @@ def test_transform_sum_one_column_with_matching_labels_and_missing_labels():
     result = df.groupby(series, as_index=False).transform("sum")
     expected = DataFrame({"X": [-93203.0, -93203.0, np.nan]})
     tm.assert_frame_equal(result, expected)
+
+
+def test_transform_groups_returns_rangeindex():
+    df = DataFrame({"group": [1, 1, 2], "value": [1, 2, 3]})
+    result = df.groupby("group").transform(lambda x: x + 1)
+    expected = DataFrame([2, 3, 4], index=RangeIndex(0, 3), columns=["value"])
+    tm.assert_frame_equal(result, expected, check_index_type=True)


### PR DESCRIPTION
Would supersede https://github.com/pandas-dev/pandas/pull/58117

I see 8 usages of `Index._with_infer` in the codebase. There are some ops like `groupby` and `CategoricalDtype` that would nicely return a `RangeIndex` result if possible