### PR TITLE
REGR: from_records not initializing subclasses properly

### DIFF
--- a/doc/source/whatsnew/v2.2.2.rst
+++ b/doc/source/whatsnew/v2.2.2.rst
@@ -16,6 +16,7 @@ Fixed regressions
 - :meth:`DataFrame.__dataframe__` was producing incorrect data buffers when the a column's type was a pandas nullable on with missing values (:issue:`56702`)
 - :meth:`DataFrame.__dataframe__` was producing incorrect data buffers when the a column's type was a pyarrow nullable on with missing values (:issue:`57664`)
 - Avoid issuing a spurious ``DeprecationWarning`` when a custom :class:`DataFrame` or :class:`Series` subclass method is called (:issue:`57553`)
+- Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
 - Fixed regression in precision of :func:`to_datetime` with string and ``unit`` input (:issue:`57051`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2302,7 +2302,8 @@ class DataFrame(NDFrame, OpsMixin):
             columns = columns.drop(exclude)
 
         mgr = arrays_to_mgr(arrays, columns, result_index)
-        return cls._from_mgr(mgr, axes=mgr.axes)
+        result = cls._from_mgr(mgr, axes=mgr.axes)
+        return result._constructor_from_mgr(mgr, axes=mgr.axes)
 
     def to_records(
         self, index: bool = True, column_dtypes=None, index_dtypes=None

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -769,6 +769,13 @@ def test_constructor_with_metadata():
     assert isinstance(subset, MySubclassWithMetadata)
 
 
+def test_constructor_with_metadata_from_records():
+    # GH#57008
+    df = MySubclassWithMetadata.from_records([{"a": 1, "b": 2}])
+    assert df.my_metadata is None
+    assert type(df) is MySubclassWithMetadata
+
+
 class SimpleDataFrameSubClass(DataFrame):
     """A subclass of DataFrame that does not define a constructor."""
 


### PR DESCRIPTION
- [ ] closes #57008 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


cc @jbrockmendel would appreciate thoughts, we don't have access to _constructor_from_mgr, so we need a workaround somehow.