### PR TITLE
BUG: Fix Index.sort_values with natsort_key raises

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -448,7 +448,7 @@ Other
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
 - Bug in :meth:`DataFrame.sort_index` when passing ``axis="columns"`` and ``ignore_index=True`` and ``ascending=False`` not returning a :class:`RangeIndex` columns (:issue:`57293`)
 - Bug in :meth:`DataFrame.where` where using a non-bool type array in the function would return a ``ValueError`` instead of a ``TypeError`` (:issue:`56330`)
-- Bug in :meth:`Index.sort_values` when passing ``key=natsort.natsort_key`` raising ``TypeError`` (:issue:`56081`)
+- Bug in :meth:`Index.sort_values` when passing a key function that turns values into tuples, e.g. ``key=natsort.natsort_key``, would raise ``TypeError`` (:issue:`56081`)
 - Bug in Dataframe Interchange Protocol implementation was returning incorrect results for data buffers' associated dtype, for string and datetime columns (:issue:`54781`)
 
 .. ***DO NOT USE THIS SECTION***

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -448,6 +448,7 @@ Other
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
 - Bug in :meth:`DataFrame.sort_index` when passing ``axis="columns"`` and ``ignore_index=True`` and ``ascending=False`` not returning a :class:`RangeIndex` columns (:issue:`57293`)
 - Bug in :meth:`DataFrame.where` where using a non-bool type array in the function would return a ``ValueError`` instead of a ``TypeError`` (:issue:`56330`)
+- Bug in :meth:`Index.sort_values` when passing ``key=natsort.natsort_key`` raising ``TypeError`` (:issue:`56081`)
 - Bug in Dataframe Interchange Protocol implementation was returning incorrect results for data buffers' associated dtype, for string and datetime columns (:issue:`54781`)
 
 .. ***DO NOT USE THIS SECTION***

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -577,7 +577,7 @@ def ensure_key_mapped(
         if isinstance(
             values, Index
         ):  # convert to a new Index subclass, not necessarily the same
-            result = Index(result)
+            result = Index(result, tupleize_cols=False)
         else:
             # try to revert to original type otherwise
             type_of_values = type(values)

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -481,10 +481,12 @@ def test_sort_values_with_missing(index_with_missing, na_position, request):
 
 def test_sort_values_natsort_key():
     # GH#56081
-    natsort = pytest.importorskip("natsort")
-    idx = pd.Index(["0hr", "128hr", "72hr", "48hr", "96hr"])
-    expected = pd.Index(["0hr", "48hr", "72hr", "96hr", "128hr"])
-    result = idx.sort_values(key=natsort.natsort_key)
+    def split_convert(s):
+        return tuple(int(x) for x in s.split("."))
+
+    idx = pd.Index(["1.9", "2.0", "1.11", "1.10"])
+    expected = pd.Index(["1.9", "1.10", "1.11", "2.0"])
+    result = idx.sort_values(key=lambda x: tuple(map(split_convert, x)))
     tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -479,6 +479,15 @@ def test_sort_values_with_missing(index_with_missing, na_position, request):
     tm.assert_index_equal(result, expected)
 
 
+def test_sort_values_natsort_key():
+    # GH#56081
+    natsort = pytest.importorskip("natsort")
+    idx = pd.Index(["0hr", "128hr", "72hr", "48hr", "96hr"])
+    expected = pd.Index(["0hr", "48hr", "72hr", "96hr", "128hr"])
+    result = idx.sort_values(key=natsort.natsort_key)
+    tm.assert_index_equal(result, expected)
+
+
 def test_ndarray_compat_properties(index):
     if isinstance(index, PeriodIndex) and not IS64:
         pytest.skip("Overflow")


### PR DESCRIPTION
- [x] closes #56081 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
