### PR TITLE
BUG: Fix read_parquet not working with data type pyarrow list (#57411)

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1623,6 +1623,8 @@ def pandas_dtype(dtype) -> DtypeObj:
         return dtype.dtype
     elif isinstance(dtype, (np.dtype, ExtensionDtype)):
         return dtype
+    elif "list" in str(dtype) and "pyarrow" in str(dtype):
+        return dtype
 
     # registered extension types
     result = registry.find(dtype)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -348,6 +348,20 @@ def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
         tm.assert_frame_equal(result, df[["a", "d"]])
 
 
+def test_pyarrow_list():
+    pytest.importorskip("fastparquet")
+    import pyarrow as pa
+
+    list_int = pa.list_(pa.int64())
+    s = pd.Series([[1, 1], [2, 2]], dtype=pd.ArrowDtype(list_int))
+
+    df = pd.DataFrame(s, columns=["col"])
+    df.to_parquet("ex.parquet")
+
+    result = read_parquet(path="ex.parquet", dtype_backend="pyarrow")
+    tm.assert_frame_equal(df, result)
+
+
 class Base:
     def check_error_on_write(self, df, engine, exc, err_msg):
         # check that we are raising the exception on writing


### PR DESCRIPTION
- [x] closes #57411
- [x] [Tests added and passed]
- [x] All [code checks passed]
- [ ] Added [type annotations]
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

When writing a DataFrame to a Parquet file, if the data type of the columns of the DataFrame is a PyArrow list, an error is raised when reading it from the Parquet file.

The error occurs because when reading, pandas tries to use NumPy dtypes which do not support PyArrow lists (in the function pandas_dtype in the file ./pandas/core/dtypes/common.py).

To solve this issue, we add an if statement to check if the column's data type is a PyArrow list. If so, we return the data type without converting it into a NumPy dtype (which does not support PyArrow lists).