### PR TITLE
STY: Add flake8-slots and flake8-raise rules 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,6 @@ repos:
         files: ^pandas
         exclude: ^pandas/tests
         args: [--select, "ANN001,ANN2", --fix-only, --exit-non-zero-on-fix]
-    -   id: ruff
-        name: ruff-use-pd_array-in-core
-        alias: ruff-use-pd_array-in-core
-        files: ^pandas/core/
-        exclude: ^pandas/core/api\.py$
-        args: [--select, "ICN001", --exit-non-zero-on-fix]
     -   id: ruff-format
         exclude: ^scripts
 -   repo: https://github.com/jendrikseipp/vulture

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -41,7 +41,7 @@ from pandas.core.arrays.integer import (
     UInt64Dtype,
 )
 from pandas.core.arrays.string_ import StringDtype
-from pandas.core.construction import array
+from pandas.core.construction import array  # noqa: ICN001
 from pandas.core.flags import Flags
 from pandas.core.groupby import (
     Grouper,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6729,7 +6729,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         if axis == 1:
             if not self._mgr.is_single_block and inplace:
-                raise NotImplementedError()
+                raise NotImplementedError
             # e.g. test_align_fill_method
             result = self.T._pad_or_backfill(
                 method=method, limit=limit, limit_area=limit_area

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1191,13 +1191,13 @@ class _LocationIndexer(NDFrameIndexerBase):
             return self._getitem_axis(maybe_callable, axis=axis)
 
     def _is_scalar_access(self, key: tuple):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _getitem_tuple(self, tup: tuple):
         raise AbstractMethodError(self)
 
     def _getitem_axis(self, key, axis: AxisInt):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _has_valid_setitem_indexer(self, indexer) -> bool:
         raise AbstractMethodError(self)

--- a/pandas/core/interchange/buffer.py
+++ b/pandas/core/interchange/buffer.py
@@ -114,7 +114,7 @@ class PandasBufferPyarrow(Buffer):
         """
         Represent this structure as DLPack interface.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def __dlpack_device__(self) -> tuple[DlpackDeviceType, int | None]:
         """

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1376,7 +1376,7 @@ class StataReader(StataParser, abc.Iterator):
         elif self._format_version > 104:
             return self._decode(self._path_or_buf.read(18))
         else:
-            raise ValueError()
+            raise ValueError
 
     def _get_seek_variable_labels(self) -> int:
         if self._format_version == 117:
@@ -1388,7 +1388,7 @@ class StataReader(StataParser, abc.Iterator):
         elif self._format_version >= 118:
             return self._read_int64() + 17
         else:
-            raise ValueError()
+            raise ValueError
 
     def _read_old_header(self, first_char: bytes) -> None:
         self._format_version = int(first_char[0])

--- a/pandas/tests/config/test_localization.py
+++ b/pandas/tests/config/test_localization.py
@@ -92,7 +92,7 @@ def test_can_set_locale_invalid_get(monkeypatch):
     #  but a subsequent getlocale() raises a ValueError.
 
     def mock_get_locale():
-        raise ValueError()
+        raise ValueError
 
     with monkeypatch.context() as m:
         m.setattr(locale, "getlocale", mock_get_locale)

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -41,7 +41,7 @@ class TestDataFrameSetItem:
     def test_setitem_str_subclass(self):
         # GH#37366
         class mystring(str):
-            pass
+            __slots__ = ()
 
         data = ["2020-10-22 01:21:00+00:00"]
         index = DatetimeIndex(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,8 @@ select = [
   "G",
   # flake8-future-annotations
   "FA",
+  # unconventional-import-alias
+  "ICN001",
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,8 @@ select = [
   "FA",
   # unconventional-import-alias
   "ICN001",
+  # refurb
+  "FURB",
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,8 +236,10 @@ select = [
   "FA",
   # unconventional-import-alias
   "ICN001",
-  # refurb
-  "FURB",
+  # flake8-slots
+  "SLOT",
+  # flake8-raise
+  "RSE"
 ]
 
 ignore = [


### PR DESCRIPTION
Also moves `ICN001` to the main ruff linter