### PR TITLE
CI: correct error msg in `test_view_index`

### DIFF
--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -312,7 +312,10 @@ class TestNumericInt:
 
     def test_view_index(self, simple_index):
         index = simple_index
-        msg = "Cannot change data-type for array of references."
+        msg = (
+            "Cannot change data-type for array of references.|"
+            "Cannot change data-type for object array.|"
+        )
         with pytest.raises(TypeError, match=msg):
             index.view(Index)
 

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -312,7 +312,7 @@ class TestNumericInt:
 
     def test_view_index(self, simple_index):
         index = simple_index
-        msg = "Cannot change data-type for object array"
+        msg = "Cannot change data-type for array of references."
         with pytest.raises(TypeError, match=msg):
             index.view(Index)
 

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -375,7 +375,7 @@ class TestRangeIndex:
 
     def test_view_index(self, simple_index):
         index = simple_index
-        msg = "Cannot change data-type for object array"
+        msg = "Cannot change data-type for array of references."
         with pytest.raises(TypeError, match=msg):
             index.view(Index)
 

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -375,7 +375,10 @@ class TestRangeIndex:
 
     def test_view_index(self, simple_index):
         index = simple_index
-        msg = "Cannot change data-type for array of references."
+        msg = (
+            "Cannot change data-type for array of references.|"
+            "Cannot change data-type for object array.|"
+        )
         with pytest.raises(TypeError, match=msg):
             index.view(Index)
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -358,7 +358,7 @@ class TestIndex:
             with pytest.raises(NotImplementedError, match="i8"):
                 index.view("i8")
         else:
-            msg = "Cannot change data-type for object array"
+            msg = "Cannot change data-type for array of references."
             with pytest.raises(TypeError, match=msg):
                 index.view("i8")
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -358,7 +358,10 @@ class TestIndex:
             with pytest.raises(NotImplementedError, match="i8"):
                 index.view("i8")
         else:
-            msg = "Cannot change data-type for array of references."
+            msg = (
+                "Cannot change data-type for array of references.|"
+                "Cannot change data-type for object array.|"
+            )
             with pytest.raises(TypeError, match=msg):
                 index.view("i8")
 

--- a/pandas/tests/indexes/test_datetimelike.py
+++ b/pandas/tests/indexes/test_datetimelike.py
@@ -88,7 +88,10 @@ class TestDatetimeLike:
         result = type(simple_index)(idx)
         tm.assert_index_equal(result, idx)
 
-        msg = "Cannot change data-type for array of references."
+        msg = (
+            "Cannot change data-type for array of references.|"
+            "Cannot change data-type for object array.|"
+        )
         with pytest.raises(TypeError, match=msg):
             idx.view(type(simple_index))
 

--- a/pandas/tests/indexes/test_datetimelike.py
+++ b/pandas/tests/indexes/test_datetimelike.py
@@ -88,7 +88,7 @@ class TestDatetimeLike:
         result = type(simple_index)(idx)
         tm.assert_index_equal(result, idx)
 
-        msg = "Cannot change data-type for object array"
+        msg = "Cannot change data-type for array of references."
         with pytest.raises(TypeError, match=msg):
             idx.view(type(simple_index))
 

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -880,7 +880,7 @@ class TestNumericBase:
         idx_view = idx.view(dtype)
         tm.assert_index_equal(idx, index_cls(idx_view, name="Foo"), exact=True)
 
-        msg = "Cannot change data-type for object array"
+        msg = "Cannot change data-type for array of references."
         with pytest.raises(TypeError, match=msg):
             # GH#55709
             idx.view(index_cls)

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -880,7 +880,10 @@ class TestNumericBase:
         idx_view = idx.view(dtype)
         tm.assert_index_equal(idx, index_cls(idx_view, name="Foo"), exact=True)
 
-        msg = "Cannot change data-type for array of references."
+        msg = (
+            "Cannot change data-type for array of references.|"
+            "Cannot change data-type for object array.|"
+        )
         with pytest.raises(TypeError, match=msg):
             # GH#55709
             idx.view(index_cls)


### PR DESCRIPTION
CI failed, the reason: `AssertionError: Regex pattern did not match.`

Replaced error msg `'Cannot change data-type for object array'` with `'Cannot change data-type for array of references.'`