### PR TITLE
BUG: Let check_exact_index default to True for integers

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -152,7 +152,7 @@ Other API changes
 - Updated :meth:`DataFrame.to_excel` so that the output spreadsheet has no styling. Custom styling can still be done using :meth:`Styler.to_excel` (:issue:`54154`)
 - pickle and HDF (``.h5``) files created with Python 2 are no longer explicitly supported (:issue:`57387`)
 - pickled objects from pandas version less than ``1.0.0`` are no longer supported (:issue:`57155`)
-- when comparing the indexes in :func:`testing.assert_series_equal`, the default value for check_exact is decided based on the :class:`Index` dtype, instead of the :class:`Series` dtype. (:issue:`57386`)
+- when comparing the indexes in :func:`testing.assert_series_equal`, check_exact defaults to True if an :class:`Index` is of integer dtypes. (:issue:`57386`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.deprecations:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -152,6 +152,7 @@ Other API changes
 - Updated :meth:`DataFrame.to_excel` so that the output spreadsheet has no styling. Custom styling can still be done using :meth:`Styler.to_excel` (:issue:`54154`)
 - pickle and HDF (``.h5``) files created with Python 2 are no longer explicitly supported (:issue:`57387`)
 - pickled objects from pandas version less than ``1.0.0`` are no longer supported (:issue:`57155`)
+- when comparing the indexes in :func:`testing.assert_series_equal`, the default value for check_exact is decided based on the :class:`Index` dtype, instead of the :class:`Series` dtype. (:issue:`57386`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.deprecations:

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -861,12 +861,19 @@ def assert_series_equal(
     check_names : bool, default True
         Whether to check the Series and Index names attribute.
     check_exact : bool, default False
-        Whether to compare number exactly.
+        Whether to compare number exactly. This also applies when checking
+        Index equivalence.
 
         .. versionchanged:: 2.2.0
 
             Defaults to True for integer dtypes if none of
             ``check_exact``, ``rtol`` and ``atol`` are specified.
+
+        .. versionchanged:: 3.0.0
+
+            When checking Index equivalence, the default value for check_exact
+            is based off the Index dtype, instead of the Series dtype.
+
     check_datetimelike_compat : bool, default False
         Compare datetime-like which is comparable ignoring dtype.
     check_categorical : bool, default True
@@ -913,11 +920,17 @@ def assert_series_equal(
             or is_numeric_dtype(right.dtype)
             and not is_float_dtype(right.dtype)
         )
+        left_index_dtypes = (
+            [left.index.dtype] if left.index.nlevels == 1 else left.index.dtypes
+        )
+        right_index_dtypes = (
+            [right.index.dtype] if right.index.nlevels == 1 else right.index.dtypes
+        )
         check_exact_index = (
-            is_numeric_dtype(left.index.dtype)
-            and not is_float_dtype(left.index.dtype)
-            or is_numeric_dtype(right.index.dtype)
-            and not is_float_dtype(right.index.dtype)
+            all(is_numeric_dtype(dtype) for dtype in left_index_dtypes)
+            and not any(is_float_dtype(dtype) for dtype in left_index_dtypes)
+            or all(is_numeric_dtype(dtype) for dtype in right_index_dtypes)
+            and not any(is_float_dtype(dtype) for dtype in right_index_dtypes)
         )
     elif check_exact is lib.no_default:
         check_exact = False

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -871,8 +871,8 @@ def assert_series_equal(
 
         .. versionchanged:: 3.0.0
 
-            When checking Index equivalence, the default value for check_exact
-            is based off the Index dtype, instead of the Series dtype.
+            check_exact for comparing the Indexes defaults to True by
+            checking if an Index is of integer dtypes.
 
     check_datetimelike_compat : bool, default False
         Compare datetime-like which is comparable ignoring dtype.
@@ -926,12 +926,9 @@ def assert_series_equal(
         right_index_dtypes = (
             [right.index.dtype] if right.index.nlevels == 1 else right.index.dtypes
         )
-        check_exact_index = (
-            all(is_numeric_dtype(dtype) for dtype in left_index_dtypes)
-            and not any(is_float_dtype(dtype) for dtype in left_index_dtypes)
-            or all(is_numeric_dtype(dtype) for dtype in right_index_dtypes)
-            and not any(is_float_dtype(dtype) for dtype in right_index_dtypes)
-        )
+        check_exact_index = all(
+            dtype.kind in "iu" for dtype in left_index_dtypes
+        ) or all(dtype.kind in "iu" for dtype in right_index_dtypes)
     elif check_exact is lib.no_default:
         check_exact = False
         check_exact_index = False

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -902,7 +902,6 @@ def assert_series_equal(
     >>> tm.assert_series_equal(a, b)
     """
     __tracebackhide__ = True
-    check_exact_index = check_exact
     if (
         check_exact is lib.no_default
         and rtol is lib.no_default
@@ -923,6 +922,8 @@ def assert_series_equal(
     elif check_exact is lib.no_default:
         check_exact = False
         check_exact_index = False
+    else:
+        check_exact_index = check_exact
 
     rtol = rtol if rtol is not lib.no_default else 1.0e-5
     atol = atol if atol is not lib.no_default else 1.0e-8

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -902,7 +902,7 @@ def assert_series_equal(
     >>> tm.assert_series_equal(a, b)
     """
     __tracebackhide__ = True
-    check_exact_index = False if check_exact is lib.no_default else check_exact
+    check_exact_index = check_exact
     if (
         check_exact is lib.no_default
         and rtol is lib.no_default
@@ -914,8 +914,15 @@ def assert_series_equal(
             or is_numeric_dtype(right.dtype)
             and not is_float_dtype(right.dtype)
         )
+        check_exact_index = (
+            is_numeric_dtype(left.index.dtype)
+            and not is_float_dtype(left.index.dtype)
+            or is_numeric_dtype(right.index.dtype)
+            and not is_float_dtype(right.index.dtype)
+        )
     elif check_exact is lib.no_default:
         check_exact = False
+        check_exact_index = False
 
     rtol = rtol if rtol is not lib.no_default else 1.0e-5
     atol = atol if atol is not lib.no_default else 1.0e-8

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -500,8 +500,12 @@ def test_assert_series_equal_int_tol():
             marks=pytest.mark.xfail(reason="check_exact_index defaults to True"),
         ),
         pytest.param(
-            pd.MultiIndex.from_arrays([[0, 0, 0, 0, 1, 1], [1, 2, 3, 4, 5, 10000000000001]]),
-            pd.MultiIndex.from_arrays([[0, 0, 0, 0, 1, 1], [1, 2, 3, 4, 5, 10000000000002]]),
+            pd.MultiIndex.from_arrays(
+                [[0, 0, 0, 0, 1, 1], [1, 2, 3, 4, 5, 10000000000001]]
+            ),
+            pd.MultiIndex.from_arrays(
+                [[0, 0, 0, 0, 1, 1], [1, 2, 3, 4, 5, 10000000000002]]
+            ),
             marks=pytest.mark.xfail(reason="check_exact_index defaults to True"),
         ),
     ],

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -475,9 +475,40 @@ def test_assert_series_equal_int_tol():
     )
 
 
-def test_assert_series_equal_index_exact_default():
+@pytest.mark.parametrize(
+    "left_idx, right_idx",
+    [
+        (
+            pd.Index([0, 0.2, 0.4, 0.6, 0.8, 1]),
+            pd.Index(np.linspace(0, 1, 6)),
+        ),
+        (
+            pd.MultiIndex.from_arrays([[0, 0, 0, 0, 1, 1], [0, 0.2, 0.4, 0.6, 0.8, 1]]),
+            pd.MultiIndex.from_arrays([[0, 0, 0, 0, 1, 1], np.linspace(0, 1, 6)]),
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [["a", "a", "a", "b", "b", "b"], [1, 2, 3, 4, 5, 10000000000001]]
+            ),
+            pd.MultiIndex.from_arrays(
+                [["a", "a", "a", "b", "b", "b"], [1, 2, 3, 4, 5, 10000000000002]]
+            ),
+        ),
+        pytest.param(
+            pd.Index([1, 2, 3, 4, 5, 10000000000001]),
+            pd.Index([1, 2, 3, 4, 5, 10000000000002]),
+            marks=pytest.mark.xfail(reason="check_exact_index defaults to True"),
+        ),
+        pytest.param(
+            pd.MultiIndex.from_arrays([[0, 0, 0, 0, 1, 1], [1, 2, 3, 4, 5, 10000000000001]]),
+            pd.MultiIndex.from_arrays([[0, 0, 0, 0, 1, 1], [1, 2, 3, 4, 5, 10000000000002]]),
+            marks=pytest.mark.xfail(reason="check_exact_index defaults to True"),
+        ),
+    ],
+)
+def test_assert_series_equal_check_exact_index_default(left_idx, right_idx):
     # GH#57067
-    ser1 = Series(np.zeros(6, dtype=int), [0, 0.2, 0.4, 0.6, 0.8, 1])
-    ser2 = Series(np.zeros(6, dtype=int), np.linspace(0, 1, 6))
+    ser1 = Series(np.zeros(6, dtype=int), left_idx)
+    ser2 = Series(np.zeros(6, dtype=int), right_idx)
     tm.assert_series_equal(ser1, ser2)
     tm.assert_frame_equal(ser1.to_frame(), ser2.to_frame())


### PR DESCRIPTION
- [ ] closes #57386
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
