### PR TITLE
CLN: enforce deprecation `resample` with `PeriodIndex`

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8614,7 +8614,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         rule,
         closed: Literal["right", "left"] | None = None,
         label: Literal["right", "left"] | None = None,
-        convention: Literal["start", "end", "s", "e"] | lib.NoDefault = lib.no_default,
         kind: Literal["timestamp", "period"] | None | lib.NoDefault = lib.no_default,
         on: Level | None = None,
         level: Level | None = None,
@@ -8642,12 +8641,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Which bin edge label to label bucket with. The default is 'left'
             for all frequency offsets except for 'ME', 'YE', 'QE', 'BME',
             'BA', 'BQE', and 'W' which all have a default of 'right'.
-        convention : {{'start', 'end', 's', 'e'}}, default 'start'
-            For `PeriodIndex` only, controls whether to use the start or
-            end of `rule`.
-
-            .. deprecated:: 2.2.0
-                Convert PeriodIndex to DatetimeIndex before resampling instead.
         kind : {{'timestamp', 'period'}}, optional, default None
             Pass 'timestamp' to convert the resulting index to a
             `DateTimeIndex` or 'period' to convert it to a `PeriodIndex`.
@@ -8959,25 +8952,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         else:
             kind = None
 
-        if convention is not lib.no_default:
-            warnings.warn(
-                f"The 'convention' keyword in {type(self).__name__}.resample is "
-                "deprecated and will be removed in a future version. "
-                "Explicitly cast PeriodIndex to DatetimeIndex before resampling "
-                "instead.",
-                FutureWarning,
-                stacklevel=find_stack_level(),
-            )
-        else:
-            convention = "start"
-
         return get_resampler(
             cast("Series | DataFrame", self),
             freq=rule,
             label=label,
             closed=closed,
             kind=kind,
-            convention=convention,
+            convention="start",
             key=on,
             level=level,
             origin=origin,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8954,7 +8954,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         return get_resampler(
             cast("Series | DataFrame", self),
-            freq=rule,
+            freq=rule, 
             label=label,
             closed=closed,
             kind=kind,

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -11,7 +11,6 @@ from typing import (
     no_type_check,
     overload,
 )
-import warnings
 
 import numpy as np
 
@@ -32,10 +31,7 @@ from pandas.util._decorators import (
     Substitution,
     doc,
 )
-from pandas.util._exceptions import (
-    find_stack_level,
-    rewrite_warning,
-)
+from pandas.util._exceptions import rewrite_warning
 
 from pandas.core.dtypes.dtypes import (
     ArrowDtype,
@@ -1711,13 +1707,7 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
     @property
     def _resampler_for_grouping(self):
-        warnings.warn(
-            "Resampling a groupby with a PeriodIndex is deprecated. "
-            "Cast to DatetimeIndex before resampling instead.",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
-        return PeriodIndexResamplerGroupby
+        raise TypeError("Resampling with a PeriodIndex is not supported.")
 
     def _get_binner_for_time(self):
         if self.kind == "timestamp":
@@ -2054,28 +2044,8 @@ class TimeGrouper(Grouper):
                 gpr_index=ax,
             )
         elif isinstance(ax, PeriodIndex) or kind == "period":
-            if isinstance(ax, PeriodIndex):
-                # GH#53481
-                warnings.warn(
-                    "Resampling with a PeriodIndex is deprecated. "
-                    "Cast index to DatetimeIndex before resampling instead.",
-                    FutureWarning,
-                    stacklevel=find_stack_level(),
-                )
-            else:
-                warnings.warn(
-                    "Resampling with kind='period' is deprecated.  "
-                    "Use datetime paths instead.",
-                    FutureWarning,
-                    stacklevel=find_stack_level(),
-                )
-            return PeriodIndexResampler(
-                obj,
-                timegrouper=self,
-                kind=kind,
-                group_keys=self.group_keys,
-                gpr_index=ax,
-            )
+            # GH#53481
+            raise TypeError("Resampling with a PeriodIndex is not supported.")
         elif isinstance(ax, TimedeltaIndex):
             return TimedeltaIndexResampler(
                 obj,
@@ -2086,7 +2056,7 @@ class TimeGrouper(Grouper):
 
         raise TypeError(
             "Only valid with DatetimeIndex, "
-            "TimedeltaIndex or PeriodIndex, "
+            "TimedeltaIndex, "
             f"but got an instance of '{type(ax).__name__}'"
         )
 

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -75,19 +75,13 @@ def test_asfreq_fill_value(index):
     [
         timedelta_range("1 day", "10 day", freq="D"),
         date_range(datetime(2005, 1, 1), datetime(2005, 1, 10), freq="D"),
-        period_range(datetime(2005, 1, 1), datetime(2005, 1, 10), freq="D"),
     ],
 )
 def test_resample_interpolate(index):
     # GH#12925
     df = DataFrame(range(len(index)), index=index)
-    warn = None
-    if isinstance(df.index, PeriodIndex):
-        warn = FutureWarning
-    msg = "Resampling with a PeriodIndex is deprecated"
-    with tm.assert_produces_warning(warn, match=msg):
-        result = df.resample("1min").asfreq().interpolate()
-        expected = df.resample("1min").interpolate()
+    result = df.resample("1min").asfreq().interpolate()
+    expected = df.resample("1min").interpolate()
     tm.assert_frame_equal(result, expected)
 
 
@@ -105,7 +99,6 @@ def test_raises_on_non_datetimelike_index():
 @pytest.mark.parametrize(
     "index",
     [
-        PeriodIndex([], freq="D", name="a"),
         DatetimeIndex([], name="a"),
         TimedeltaIndex([], name="a"),
     ],
@@ -127,12 +120,7 @@ def test_resample_empty_series(freq, index, resample_method):
         # index is PeriodIndex, so convert to corresponding Period freq
         freq = "M"
 
-    warn = None
-    if isinstance(ser.index, PeriodIndex):
-        warn = FutureWarning
-    msg = "Resampling with a PeriodIndex is deprecated"
-    with tm.assert_produces_warning(warn, match=msg):
-        rs = ser.resample(freq)
+    rs = ser.resample(freq)
     result = getattr(rs, resample_method)()
 
     if resample_method == "ohlc":
@@ -183,7 +171,6 @@ def test_resample_nat_index_series(freq, resample_method):
 @pytest.mark.parametrize(
     "index",
     [
-        PeriodIndex([], freq="D", name="a"),
         DatetimeIndex([], name="a"),
         TimedeltaIndex([], name="a"),
     ],
@@ -205,12 +192,7 @@ def test_resample_count_empty_series(freq, index, resample_method):
         # index is PeriodIndex, so convert to corresponding Period freq
         freq = "M"
 
-    warn = None
-    if isinstance(ser.index, PeriodIndex):
-        warn = FutureWarning
-    msg = "Resampling with a PeriodIndex is deprecated"
-    with tm.assert_produces_warning(warn, match=msg):
-        rs = ser.resample(freq)
+    rs = ser.resample(freq)
 
     result = getattr(rs, resample_method)()
 
@@ -221,9 +203,7 @@ def test_resample_count_empty_series(freq, index, resample_method):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "index", [DatetimeIndex([]), TimedeltaIndex([]), PeriodIndex([], freq="D")]
-)
+@pytest.mark.parametrize("index", [DatetimeIndex([]), TimedeltaIndex([])])
 @pytest.mark.parametrize("freq", ["ME", "D", "h"])
 def test_resample_empty_dataframe(index, freq, resample_method):
     # GH13212
@@ -241,12 +221,7 @@ def test_resample_empty_dataframe(index, freq, resample_method):
         # index is PeriodIndex, so convert to corresponding Period freq
         freq = "M"
 
-    warn = None
-    if isinstance(df.index, PeriodIndex):
-        warn = FutureWarning
-    msg = "Resampling with a PeriodIndex is deprecated"
-    with tm.assert_produces_warning(warn, match=msg):
-        rs = df.resample(freq, group_keys=False)
+    rs = df.resample(freq, group_keys=False)
     result = getattr(rs, resample_method)()
     if resample_method == "ohlc":
         # TODO: no tests with len(df.columns) > 0
@@ -269,9 +244,7 @@ def test_resample_empty_dataframe(index, freq, resample_method):
     # test size for GH13212 (currently stays as df)
 
 
-@pytest.mark.parametrize(
-    "index", [DatetimeIndex([]), TimedeltaIndex([]), PeriodIndex([], freq="D")]
-)
+@pytest.mark.parametrize("index", [DatetimeIndex([]), TimedeltaIndex([])])
 @pytest.mark.parametrize("freq", ["ME", "D", "h"])
 def test_resample_count_empty_dataframe(freq, index):
     # GH28427
@@ -289,12 +262,7 @@ def test_resample_count_empty_dataframe(freq, index):
         # index is PeriodIndex, so convert to corresponding Period freq
         freq = "M"
 
-    warn = None
-    if isinstance(empty_frame_dti.index, PeriodIndex):
-        warn = FutureWarning
-    msg = "Resampling with a PeriodIndex is deprecated"
-    with tm.assert_produces_warning(warn, match=msg):
-        rs = empty_frame_dti.resample(freq)
+    rs = empty_frame_dti.resample(freq)
     result = rs.count()
 
     index = _asfreq_compat(empty_frame_dti.index, freq)
@@ -343,7 +311,6 @@ def test_resample_size_empty_dataframe(freq, index):
 @pytest.mark.parametrize(
     "index",
     [
-        PeriodIndex([], freq="M", name="a"),
         DatetimeIndex([], name="a"),
         TimedeltaIndex([], name="a"),
     ],
@@ -354,16 +321,9 @@ def test_resample_empty_dtypes(index, dtype, resample_method):
     # Empty series were sometimes causing a segfault (for the functions
     # with Cython bounds-checking disabled) or an IndexError.  We just run
     # them to ensure they no longer do.  (GH #10228)
-    warn = None
-    if isinstance(index, PeriodIndex):
-        # GH#53511
-        index = PeriodIndex([], freq="B", name=index.name)
-        warn = FutureWarning
-    msg = "Resampling with a PeriodIndex is deprecated"
-
     empty_series_dti = Series([], index, dtype)
-    with tm.assert_produces_warning(warn, match=msg):
-        rs = empty_series_dti.resample("d", group_keys=False)
+
+    rs = empty_series_dti.resample("d", group_keys=False)
     try:
         getattr(rs, resample_method)()
     except DataError:

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -674,7 +674,7 @@ def test_selection_api_validation():
 
     # non DatetimeIndex
     msg = (
-        "Only valid with DatetimeIndex, TimedeltaIndex or PeriodIndex, "
+        "Only valid with DatetimeIndex, TimedeltaIndex, "
         "but got an instance of 'Index'"
     )
     with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -96,8 +96,8 @@ def test_fails_on_no_datetime_index(index):
     df = DataFrame({"a": range(len(index))}, index=index)
 
     msg = (
-        "Only valid with DatetimeIndex, TimedeltaIndex "
-        f"or PeriodIndex, but got an instance of '{name}'"
+        "Only valid with DatetimeIndex, TimedeltaIndex, "
+        f"but got an instance of '{name}'"
     )
     with pytest.raises(TypeError, match=msg):
         df.groupby(Grouper(freq="D"))


### PR DESCRIPTION
enforced deprecation of `resample` with `PeriodIndex`

