### PR TITLE
Fix ASV with virtualenv

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -41,6 +41,7 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     "matrix": {
+        "pip+build": [],
         "Cython": ["3.0"],
         "matplotlib": [],
         "sqlalchemy": [],


### PR DESCRIPTION
The default remains conda, but this is needed if you ever change the default locally. Otherwise you get

   STDERR -------->
   /home/willayd/clones/pandas/asv_bench/env/7e437c4d615a12609229592196e74215/bin/python: No module named build