### PR TITLE
DOC: Fix docstring error for pandas.DataFrame.axes

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -83,7 +83,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.DataFrame.__iter__ SA01" \
         -i "pandas.DataFrame.assign SA01" \
         -i "pandas.DataFrame.at_time PR01" \
-        -i "pandas.DataFrame.axes SA01" \
         -i "pandas.DataFrame.bfill SA01" \
         -i "pandas.DataFrame.columns SA01" \
         -i "pandas.DataFrame.copy SA01" \

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -994,7 +994,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         It has the row axis labels and column axis labels as the only members.
         They are returned in that order.
-        
+
         See Also
         --------
         DataFrame.index: The index (row labels) of the DataFrame.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -994,6 +994,11 @@ class DataFrame(NDFrame, OpsMixin):
 
         It has the row axis labels and column axis labels as the only members.
         They are returned in that order.
+        
+        See Also
+        --------
+        DataFrame.index: The index (row labels) of the DataFrame.
+        DataFrame.columns: The column labels of the DataFrame.
 
         Examples
         --------


### PR DESCRIPTION
- Fixes docstring error for pandas.DataFrame.axes method (https://github.com/pandas-dev/pandas/issues/58065).
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Closed previous PR https://github.com/pandas-dev/pandas/pull/58102 and re-opened here.