### PR TITLE
BUG: Timestamp ignoring explicit tz=None

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -357,6 +357,7 @@ Categorical
 
 Datetimelike
 ^^^^^^^^^^^^
+- Bug in :class:`Timestamp` constructor failing to raise when ``tz=None`` is explicitly specified in conjunction with timezone-aware ``tzinfo`` or data (:issue:`48688`)
 - Bug in :func:`date_range` where the last valid timestamp would sometimes not be produced (:issue:`56134`)
 - Bug in :func:`date_range` where using a negative frequency value would not include all points between the start and end values (:issue:`56382`)
 -

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1897,6 +1897,11 @@ class Timestamp(_Timestamp):
         if ts.value == NPY_NAT:
             return NaT
 
+        if ts.tzinfo is not None and explicit_tz_none:
+            raise ValueError(
+                "Passed data is timezone-aware, incompatible with 'tz=None'."
+            )
+
         return create_timestamp_from_ts(ts.value, ts.dts, ts.tzinfo, ts.fold, ts.creso)
 
     def _round(self, freq, mode, ambiguous="raise", nonexistent="raise"):

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1793,11 +1793,6 @@ class Timestamp(_Timestamp):
             if tz is not None:
                 raise ValueError("Can provide at most one of tz, tzinfo")
 
-            if explicit_tz_none:
-                raise ValueError(
-                    "Passed data is timezone-aware, incompatible with 'tz=None'."
-                )
-
             # User passed tzinfo instead of tz; avoid silently ignoring
             tz, tzinfo = tzinfo, None
 
@@ -1876,14 +1871,9 @@ class Timestamp(_Timestamp):
                                 hour or 0, minute or 0, second or 0, fold=fold or 0)
             unit = None
 
-        if getattr(ts_input, "tzinfo", None) is not None:
-            if tz is not None:
-                raise ValueError("Cannot pass a datetime or Timestamp with tzinfo with "
-                                 "the tz parameter. Use tz_convert instead.")
-            if explicit_tz_none:
-                raise ValueError(
-                    "Passed data is timezone-aware, incompatible with 'tz=None'."
-                )
+        if getattr(ts_input, "tzinfo", None) is not None and tz is not None:
+            raise ValueError("Cannot pass a datetime or Timestamp with tzinfo with "
+                             "the tz parameter. Use tz_convert instead.")
 
         tzobj = maybe_get_tz(tz)
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1879,7 +1879,7 @@ class Timestamp(_Timestamp):
         if getattr(ts_input, "tzinfo", None) is not None:
             if tz is not None:
                 raise ValueError("Cannot pass a datetime or Timestamp with tzinfo with "
-                             "the tz parameter. Use tz_convert instead.")
+                                 "the tz parameter. Use tz_convert instead.")
             if explicit_tz_none:
                 raise ValueError(
                     "Passed data is timezone-aware, incompatible with 'tz=None'."

--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -136,7 +136,11 @@ class TestAtSetItem:
 class TestAtSetItemWithExpansion:
     def test_at_setitem_expansion_series_dt64tz_value(self, tz_naive_fixture):
         # GH#25506
-        ts = Timestamp("2017-08-05 00:00:00+0100", tz=tz_naive_fixture)
+        ts = (
+            Timestamp("2017-08-05 00:00:00+0100", tz=tz_naive_fixture)
+            if tz_naive_fixture is not None
+            else Timestamp("2017-08-05 00:00:00+0100")
+        )
         result = Series(ts)
         result.at[1] = ts
         expected = Series([ts, ts])

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -621,7 +621,6 @@ class TestTimestampConstructors:
         ]
 
         timezones = [
-            (None, 0),
             ("UTC", 0),
             (pytz.utc, 0),
             ("Asia/Tokyo", 9),

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -1013,6 +1013,15 @@ class TestTimestampConstructors:
         assert result.hour == expected.hour
         assert result == expected
 
+    def test_explicit_tz_none(self):
+        # GH#48688
+        msg = "Passed data is timezone-aware, incompatible with 'tz=None'"
+        with pytest.raises(ValueError, match=msg):
+            Timestamp(datetime(2022, 1, 1, tzinfo=timezone.utc), tz=None)
+
+        with pytest.raises(ValueError, match=msg):
+            Timestamp("2022-01-01 00:00:00", tzinfo=timezone.utc, tz=None)
+
 
 def test_constructor_ambiguous_dst():
     # GH 24329

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -1022,6 +1022,9 @@ class TestTimestampConstructors:
         with pytest.raises(ValueError, match=msg):
             Timestamp("2022-01-01 00:00:00", tzinfo=timezone.utc, tz=None)
 
+        with pytest.raises(ValueError, match=msg):
+            Timestamp("2022-01-01 00:00:00-0400", tz=None)
+
 
 def test_constructor_ambiguous_dst():
     # GH 24329

--- a/pandas/tests/scalar/timestamp/test_formats.py
+++ b/pandas/tests/scalar/timestamp/test_formats.py
@@ -118,7 +118,7 @@ class TestTimestampRendering:
     def test_repr_utcoffset(self):
         # This can cause the tz field to be populated, but it's redundant to
         # include this information in the date-string.
-        date_with_utc_offset = Timestamp("2014-03-13 00:00:00-0400", tz=None)
+        date_with_utc_offset = Timestamp("2014-03-13 00:00:00-0400")
         assert "2014-03-13 00:00:00-0400" in repr(date_with_utc_offset)
         assert "tzoffset" not in repr(date_with_utc_offset)
         assert "UTC-04:00" in repr(date_with_utc_offset)


### PR DESCRIPTION
- [x] closes #48688(Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
