### PR TITLE
Prevent conversion to bytes with error message

### DIFF
--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -127,6 +127,10 @@ def _astype_nansafe(
 
     if copy or arr.dtype == object or dtype == object:
         # Explicit copy, or required since NumPy can't view from / to object.
+        if dtype == 'bytes':
+            # If conversion to bytes is not fully supported or may lead to data loss
+            raise ValueError("Conversion to bytes is not fully supported or may lead to data loss.")
+
         return arr.astype(dtype, copy=True)
 
     return arr.astype(dtype, copy=copy)


### PR DESCRIPTION
- [x] closes #58205
- [x] BUG Fix (pop up a error message when dytpe is byte because If conversion to bytes is  supported it may lead to data loss such as truncation of the \00.
.
