### PR TITLE
DOC: Reference Excel reader installation in the read and write tabular data tutorial

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -269,6 +269,8 @@ SciPy                     1.10.0             computation     Miscellaneous stati
 xarray                    2022.12.0          computation     pandas-like API for N-dimensional data
 ========================= ================== =============== =============================================================
 
+.. _install.excel_dependencies:
+
 Excel files
 ^^^^^^^^^^^
 

--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -112,9 +112,9 @@ strings (``object``).
 My colleague requested the Titanic data as a spreadsheet.
 
 .. note::
-    If you want to use :func:`~pandas.to_excel` and :func:`~pandas.read_excel`, 
+    If you want to use :func:`~pandas.to_excel` and :func:`~pandas.read_excel`,
     you need to install an Excel reader as outlined in the
-    :ref:`Excel files <install.excel_dependencies>` section of the 
+    :ref:`Excel files <install.excel_dependencies>` section of the
     installation documentation.
 
 .. ipython:: python

--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -114,7 +114,7 @@ My colleague requested the Titanic data as a spreadsheet.
 .. note::
     If you want to use :func:`~pandas.to_excel` and :func:`~pandas.read_excel`, 
     you need to install an Excel reader as outlined in the
-    :ref:`recommended dependencies <install.excel_dependencies>` section of the 
+    :ref:`Excel files <install.excel_dependencies>` section of the 
     installation documentation.
 
 .. ipython:: python

--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -111,6 +111,12 @@ strings (``object``).
 
 My colleague requested the Titanic data as a spreadsheet.
 
+.. note::
+    If you want to use :func:`~pandas.to_excel` and :func:`~pandas.read_excel`, 
+    you need to install an Excel reader as outlined in the 
+    :ref:`recommended dependencies <install.excel_dependencies>` section of the 
+    installation documentation.
+
 .. ipython:: python
 
     titanic.to_excel("titanic.xlsx", sheet_name="passengers", index=False)

--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -113,7 +113,7 @@ My colleague requested the Titanic data as a spreadsheet.
 
 .. note::
     If you want to use :func:`~pandas.to_excel` and :func:`~pandas.read_excel`, 
-    you need to install an Excel reader as outlined in the 
+    you need to install an Excel reader as outlined in the
     :ref:`recommended dependencies <install.excel_dependencies>` section of the 
     installation documentation.
 


### PR DESCRIPTION
Created a link to the Excel file recommended installation section and referenced it in the `How do I read and write tabular data?` tutorial.

- [x] closes #58246 

The below are not applicable because I am just updating documentation. 

- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
