### PR TITLE
CLN: Enforce the deprecation of `delim_whitespace` kwd in `read_csv`

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -783,7 +783,6 @@ def read_csv(
     # Error Handling
     on_bad_lines: str = "error",
     # Internal
-    delim_whitespace: bool | lib.NoDefault = lib.no_default,
     low_memory: bool = _c_parser_defaults["low_memory"],
     memory_map: bool = False,
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
@@ -833,17 +832,6 @@ def read_csv(
             stacklevel=find_stack_level(),
         )
 
-    if delim_whitespace is not lib.no_default:
-        # GH#55569
-        warnings.warn(
-            "The 'delim_whitespace' keyword in pd.read_csv is deprecated and "
-            "will be removed in a future version. Use ``sep='\\s+'`` instead",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
-    else:
-        delim_whitespace = False
-
     # locals() should never be modified
     kwds = locals().copy()
     del kwds["filepath_or_buffer"]
@@ -852,12 +840,11 @@ def read_csv(
     kwds_defaults = _refine_defaults_read(
         dialect,
         delimiter,
-        delim_whitespace,
         engine,
         sep,
         on_bad_lines,
         names,
-        defaults={"delimiter": ","},
+        defaults={"delimiter": ",", "delim_whitespace": False},
         dtype_backend=dtype_backend,
     )
     kwds.update(kwds_defaults)
@@ -974,7 +961,6 @@ def read_table(
     # Error Handling
     on_bad_lines: str = "error",
     # Internal
-    delim_whitespace: bool | lib.NoDefault = lib.no_default,
     low_memory: bool = _c_parser_defaults["low_memory"],
     memory_map: bool = False,
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
@@ -1015,17 +1001,6 @@ def read_table(
             stacklevel=find_stack_level(),
         )
 
-    if delim_whitespace is not lib.no_default:
-        # GH#55569
-        warnings.warn(
-            "The 'delim_whitespace' keyword in pd.read_table is deprecated and "
-            "will be removed in a future version. Use ``sep='\\s+'`` instead",
-            FutureWarning,
-            stacklevel=find_stack_level(),
-        )
-    else:
-        delim_whitespace = False
-
     # locals() should never be modified
     kwds = locals().copy()
     del kwds["filepath_or_buffer"]
@@ -1034,12 +1009,11 @@ def read_table(
     kwds_defaults = _refine_defaults_read(
         dialect,
         delimiter,
-        delim_whitespace,
         engine,
         sep,
         on_bad_lines,
         names,
-        defaults={"delimiter": "\t"},
+        defaults={"delimiter": "\t", "delim_whitespace": False},
         dtype_backend=dtype_backend,
     )
     kwds.update(kwds_defaults)

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1826,12 +1826,6 @@ def _refine_defaults_read(
     if delimiter is None:
         delimiter = sep
 
-    # if delim_whitespace and (delimiter is not lib.no_default):
-    #     raise ValueError(
-    #         "Specified a delimiter with both sep and "
-    #         "delim_whitespace=True; you can only specify one."
-    #     )
-
     if delimiter == "\n":
         raise ValueError(
             r"Specified \n as separator or delimiter. This forces the python engine "

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -480,7 +480,7 @@ def test_read_empty_with_usecols(all_parsers, data, kwargs, expected):
         (
             {
                 "header": None,
-                "delim_whitespace": True,
+                "sep": r"\s+",
                 "skiprows": [0, 1, 2, 3, 5, 6],
                 "skip_blank_lines": True,
             },
@@ -489,7 +489,7 @@ def test_read_empty_with_usecols(all_parsers, data, kwargs, expected):
         # gh-8983: test skipping set of rows after a row with trailing spaces.
         (
             {
-                "delim_whitespace": True,
+                "sep": r"\s+",
                 "skiprows": [1, 2, 3, 5, 6],
                 "skip_blank_lines": True,
             },
@@ -501,22 +501,11 @@ def test_trailing_spaces(all_parsers, kwargs, expected):
     data = "A B C  \nrandom line with trailing spaces    \nskip\n1,2,3\n1,2.,4.\nrandom line with trailing tabs\t\t\t\n   \n5.1,NaN,10.0\n"  # noqa: E501
     parser = all_parsers
 
-    depr_msg = "The 'delim_whitespace' keyword in pd.read_csv is deprecated"
-
     if parser.engine == "pyarrow":
-        msg = "The 'delim_whitespace' option is not supported with the 'pyarrow' engine"
-        with pytest.raises(ValueError, match=msg):
-            with tm.assert_produces_warning(
-                FutureWarning, match=depr_msg, check_stacklevel=False
-            ):
-                parser.read_csv(StringIO(data.replace(",", "  ")), **kwargs)
-        return
+        parser.read_csv(StringIO(data.replace(",", "  ")), **kwargs)
 
-    with tm.assert_produces_warning(
-        FutureWarning, match=depr_msg, check_stacklevel=False
-    ):
-        result = parser.read_csv(StringIO(data.replace(",", "  ")), **kwargs)
-    tm.assert_frame_equal(result, expected)
+    # result = parser.read_csv(StringIO(data.replace(",", "  ")), **kwargs)
+    # tm.assert_frame_equal(result, expected)
 
 
 def test_raise_on_sep_with_delim_whitespace(all_parsers):
@@ -815,25 +804,13 @@ def test_read_csv_names_not_accepting_sets(all_parsers):
         parser.read_csv(StringIO(data), names=set("QAZ"))
 
 
+@xfail_pyarrow
 def test_read_table_delim_whitespace_default_sep(all_parsers):
     # GH: 35958
     f = StringIO("a  b  c\n1 -2 -3\n4  5   6")
     parser = all_parsers
 
-    depr_msg = "The 'delim_whitespace' keyword in pd.read_table is deprecated"
-
-    if parser.engine == "pyarrow":
-        msg = "The 'delim_whitespace' option is not supported with the 'pyarrow' engine"
-        with pytest.raises(ValueError, match=msg):
-            with tm.assert_produces_warning(
-                FutureWarning, match=depr_msg, check_stacklevel=False
-            ):
-                parser.read_table(f, delim_whitespace=True)
-        return
-    with tm.assert_produces_warning(
-        FutureWarning, match=depr_msg, check_stacklevel=False
-    ):
-        result = parser.read_table(f, delim_whitespace=True)
+    result = parser.read_table(f, sep=r"\s+")
     expected = DataFrame({"a": [1, 4], "b": [-2, 5], "c": [-3, 6]})
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -504,8 +504,8 @@ def test_trailing_spaces(all_parsers, kwargs, expected):
     if parser.engine == "pyarrow":
         parser.read_csv(StringIO(data.replace(",", "  ")), **kwargs)
 
-    # result = parser.read_csv(StringIO(data.replace(",", "  ")), **kwargs)
-    # tm.assert_frame_equal(result, expected)
+    result = parser.read_csv(StringIO(data.replace(",", "  ")), **kwargs)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_raise_on_sep_with_delim_whitespace(all_parsers):

--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -682,7 +682,6 @@ def test_header_missing_rows(all_parsers):
         parser.read_csv(StringIO(data), header=[0, 1, 2])
 
 
-# ValueError: The 'delim_whitespace' option is not supported with the 'pyarrow' engine
 @xfail_pyarrow
 def test_header_multiple_whitespaces(all_parsers):
     # GH#54931
@@ -695,7 +694,6 @@ def test_header_multiple_whitespaces(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-# ValueError: The 'delim_whitespace' option is not supported with the 'pyarrow' engine
 @xfail_pyarrow
 def test_header_delim_whitespace(all_parsers):
     # GH#54918
@@ -705,11 +703,7 @@ def test_header_delim_whitespace(all_parsers):
 3,4
     """
 
-    depr_msg = "The 'delim_whitespace' keyword in pd.read_csv is deprecated"
-    with tm.assert_produces_warning(
-        FutureWarning, match=depr_msg, check_stacklevel=False
-    ):
-        result = parser.read_csv(StringIO(data), delim_whitespace=True)
+    result = parser.read_csv(StringIO(data), sep=r"\s+")
     expected = DataFrame({"a,b": ["1,2", "3,4"]})
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -593,9 +593,7 @@ DataCol1   DataCol2
 """.strip()
     skiprows = 2
 
-    depr_msg = "The 'delim_whitespace' keyword in pd.read_csv is deprecated"
-    with tm.assert_produces_warning(FutureWarning, match=depr_msg):
-        expected = read_csv(StringIO(data), skiprows=skiprows, delim_whitespace=True)
+    expected = read_csv(StringIO(data), skiprows=skiprows, sep=r"\s+")
 
     result = read_fwf(StringIO(data), skiprows=skiprows)
     tm.assert_frame_equal(result, expected)
@@ -611,9 +609,7 @@ Once more to be skipped
 """.strip()
     skiprows = [0, 2]
 
-    depr_msg = "The 'delim_whitespace' keyword in pd.read_csv is deprecated"
-    with tm.assert_produces_warning(FutureWarning, match=depr_msg):
-        expected = read_csv(StringIO(data), skiprows=skiprows, delim_whitespace=True)
+    expected = read_csv(StringIO(data), skiprows=skiprows, sep=r"\s+")
 
     result = read_fwf(StringIO(data), skiprows=skiprows)
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/usecols/test_usecols_basic.py
+++ b/pandas/tests/io/parser/usecols/test_usecols_basic.py
@@ -254,30 +254,14 @@ def test_usecols_regex_sep(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
+@xfail_pyarrow
 def test_usecols_with_whitespace(all_parsers):
     parser = all_parsers
     data = "a  b  c\n4  apple  bat  5.7\n8  orange  cow  10"
 
-    depr_msg = "The 'delim_whitespace' keyword in pd.read_csv is deprecated"
-
-    if parser.engine == "pyarrow":
-        msg = "The 'delim_whitespace' option is not supported with the 'pyarrow' engine"
-        with pytest.raises(ValueError, match=msg):
-            with tm.assert_produces_warning(
-                FutureWarning, match=depr_msg, check_stacklevel=False
-            ):
-                parser.read_csv(
-                    StringIO(data), delim_whitespace=True, usecols=("a", "b")
-                )
-        return
-
-    with tm.assert_produces_warning(
-        FutureWarning, match=depr_msg, check_stacklevel=False
-    ):
-        result = parser.read_csv(
-            StringIO(data), delim_whitespace=True, usecols=("a", "b")
-        )
+    result = parser.read_csv(StringIO(data), sep=r"\s+", usecols=("a", "b"))
     expected = DataFrame({"a": ["apple", "orange"], "b": ["bat", "cow"]}, index=[4, 8])
+    print(result)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/parser/usecols/test_usecols_basic.py
+++ b/pandas/tests/io/parser/usecols/test_usecols_basic.py
@@ -261,7 +261,6 @@ def test_usecols_with_whitespace(all_parsers):
 
     result = parser.read_csv(StringIO(data), sep=r"\s+", usecols=("a", "b"))
     expected = DataFrame({"a": ["apple", "orange"], "b": ["bat", "cow"]}, index=[4, 8])
-    print(result)
     tm.assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
removed kwd `delim_whitespace` from `read_table`, `read_csv`
