### PR TITLE
BUG:  `df.plot` with a `PeriodIndex` causes a shift to the right when the frequency multiplier is greater than one

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -415,6 +415,7 @@ Period
 Plotting
 ^^^^^^^^
 - Bug in  :meth:`.DataFrameGroupBy.boxplot` failed when there were multiple groupings (:issue:`14701`)
+- Bug in :meth:`DataFrame.plot` that causes a shift to the right when the frequency multiplier is greater than one. (:issue:`57587`)
 -
 
 Groupby/resample/rolling

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -310,7 +310,7 @@ def maybe_convert_index(ax: Axes, data: NDFrameT) -> NDFrameT:
             if isinstance(data.index, ABCDatetimeIndex):
                 data = data.tz_localize(None).to_period(freq=freq_str)
             elif isinstance(data.index, ABCPeriodIndex):
-                data.index = data.index.asfreq(freq=freq_str)
+                data.index = data.index.asfreq(freq=freq_str, how="start")
     return data
 
 

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -2578,6 +2578,21 @@ class TestDataFramePlots:
             _ = df.plot()
             _ = df.T.plot()
 
+    @pytest.mark.parametrize("freq", ["h", "7h", "60min", "120min", "3M"])
+    def test_plot_period_index_makes_no_right_shift(self, freq):
+        # GH#57587
+        idx = pd.period_range("01/01/2000", freq=freq, periods=4)
+        df = DataFrame(
+            np.array([0, 1, 0, 1]),
+            index=idx,
+            columns=["A"],
+        )
+        expected = idx.values
+
+        ax = df.plot()
+        result = ax.get_lines()[0].get_xdata()
+        assert all(str(result[i]) == str(expected[i]) for i in range(4))
+
 
 def _generate_4_axes_via_gridspec():
     import matplotlib.pyplot as plt

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -984,15 +984,3 @@ class TestSeriesPlots:
         # TODO(3.0): this can be removed once Period[B] deprecation is enforced
         with tm.assert_produces_warning(False):
             _ = ts.plot()
-
-    def test_plot_period_index_makes_no_shift(self):
-        idx = period_range("01/01/2000", freq="60min", periods=4)
-        df = DataFrame(
-            np.array([0, 1, 0, 1]),
-            index=idx,
-            columns=["A"],
-        )
-        ax = df.plot()
-        result = idx.values
-        expected = ax.get_lines()[0].get_xdata()
-        assert result == expected

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -984,3 +984,15 @@ class TestSeriesPlots:
         # TODO(3.0): this can be removed once Period[B] deprecation is enforced
         with tm.assert_produces_warning(False):
             _ = ts.plot()
+
+    def test_plot_period_index_makes_no_shift(self):
+        idx = period_range("01/01/2000", freq="60min", periods=4)
+        df = DataFrame(
+            np.array([0, 1, 0, 1]),
+            index=idx,
+            columns=["A"],
+        )
+        ax = df.plot()
+        result = idx.values
+        expected = ax.get_lines()[0].get_xdata()
+        assert result == expected


### PR DESCRIPTION
- [x] #57587
- [x] #57594 

fixed a bug in `DataFrame.plot` that causes a shift to the right when the frequency multiplier is greater than one and index is `PeriodIndex`.
