### PR TITLE
DOC: Update DataFrame.sparse methods' docstring to pass docstring validation

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -109,7 +109,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.DataFrame.sem PR01,RT03,SA01" \
         -i "pandas.DataFrame.skew RT03,SA01" \
         -i "pandas.DataFrame.sparse PR01" \
-        -i "pandas.DataFrame.sparse.to_dense SA01" \
         -i "pandas.DataFrame.std PR01,RT03,SA01" \
         -i "pandas.DataFrame.sum RT03" \
         -i "pandas.DataFrame.swaplevel SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -109,8 +109,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.DataFrame.sem PR01,RT03,SA01" \
         -i "pandas.DataFrame.skew RT03,SA01" \
         -i "pandas.DataFrame.sparse PR01" \
-        -i "pandas.DataFrame.sparse.from_spmatrix SA01" \
-        -i "pandas.DataFrame.sparse.to_coo SA01" \
         -i "pandas.DataFrame.sparse.to_dense SA01" \
         -i "pandas.DataFrame.std PR01,RT03,SA01" \
         -i "pandas.DataFrame.sum RT03" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -108,7 +108,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.DataFrame.reorder_levels SA01" \
         -i "pandas.DataFrame.sem PR01,RT03,SA01" \
         -i "pandas.DataFrame.skew RT03,SA01" \
-        -i "pandas.DataFrame.sparse PR01,SA01" \
+        -i "pandas.DataFrame.sparse PR01" \
         -i "pandas.DataFrame.sparse.density SA01" \
         -i "pandas.DataFrame.sparse.from_spmatrix SA01" \
         -i "pandas.DataFrame.sparse.to_coo SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -109,7 +109,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.DataFrame.sem PR01,RT03,SA01" \
         -i "pandas.DataFrame.skew RT03,SA01" \
         -i "pandas.DataFrame.sparse PR01" \
-        -i "pandas.DataFrame.sparse.density SA01" \
         -i "pandas.DataFrame.sparse.from_spmatrix SA01" \
         -i "pandas.DataFrame.sparse.to_coo SA01" \
         -i "pandas.DataFrame.sparse.to_dense SA01" \

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -392,6 +392,11 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
         """
         Ratio of non-sparse points to total (dense) data points.
 
+        See Also
+        --------
+        DataFrame.sparse.from_spmatrix : Create a new DataFrame from a
+        scipy sparse matrix.
+
         Examples
         --------
         >>> df = pd.DataFrame({"A": pd.arrays.SparseArray([0, 1, 0, 1])})

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -367,6 +367,10 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
         float32. By numpy.find_common_type convention, mixing int64 and
         and uint64 will result in a float64 dtype.
 
+        See Also
+        --------
+        DataFrame.sparse.to_dense : Convert a DataFrame with sparse values to dense.
+
         Examples
         --------
         >>> df = pd.DataFrame({"A": pd.arrays.SparseArray([0, 1, 0, 1])})

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -395,7 +395,7 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
         See Also
         --------
         DataFrame.sparse.from_spmatrix : Create a new DataFrame from a
-        scipy sparse matrix.
+            scipy sparse matrix.
 
         Examples
         --------

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -333,7 +333,6 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
         DataFrame.sparse.density : Ratio of non-sparse points to total
             (dense) data points.
 
-
         Examples
         --------
         >>> df = pd.DataFrame({"A": pd.arrays.SparseArray([0, 1, 0])})

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -278,6 +278,11 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
             Each column of the DataFrame is stored as a
             :class:`arrays.SparseArray`.
 
+        See Also
+        --------
+        DataFrame.sparse.to_coo : Return the contents of the frame as a
+            sparse SciPy COO matrix.
+
         Examples
         --------
         >>> import scipy.sparse

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -328,6 +328,12 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
         DataFrame
             A DataFrame with the same values stored as dense arrays.
 
+        See Also
+        --------
+        DataFrame.sparse.density : Ratio of non-sparse points to total
+            (dense) data points.
+
+
         Examples
         --------
         >>> df = pd.DataFrame({"A": pd.arrays.SparseArray([0, 1, 0])})

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -357,6 +357,10 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
             If the caller is heterogeneous and contains booleans or objects,
             the result will be of dtype=object. See Notes.
 
+        See Also
+        --------
+        DataFrame.sparse.to_dense : Convert a DataFrame with sparse values to dense.
+
         Notes
         -----
         The dtype will be the lowest-common-denominator type (implicit
@@ -366,10 +370,6 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
         e.g. If the dtypes are float16 and float32, dtype will be upcast to
         float32. By numpy.find_common_type convention, mixing int64 and
         and uint64 will result in a float64 dtype.
-
-        See Also
-        --------
-        DataFrame.sparse.to_dense : Convert a DataFrame with sparse values to dense.
 
         Examples
         --------

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -243,6 +243,10 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
     """
     DataFrame accessor for sparse data.
 
+    See Also
+    --------
+    DataFrame.sparse.density : Ratio of non-sparse points to total (dense) data points.
+
     Examples
     --------
     >>> df = pd.DataFrame({"a": [1, 2, 0, 0], "b": [3, 0, 0, 4]}, dtype="Sparse[int]")


### PR DESCRIPTION
- [ ] xref #58065

Fixed docstring errors for:

`pandas.DataFrame.sparse`
`pandas.DataFrame.sparse.density`
`pandas.DataFrame.sparse.from_spmatrix`
`pandas.DataFrame.sparse.to_coo`
`pandas.DataFrame.sparse.to_dense`

Fixed functions also removed from code_checks.sh