### PR TITLE
BUG: Fixed merge between int64 uint64 and wrote test

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2619,6 +2619,24 @@ def _convert_arrays_and_get_rizer_klass(
                 else:
                     rk = rk.astype(dtype, copy=False)
             else:
+                #  When you have a Dataframe with key type int64 and
+                #  another Dataframe with key type uint64 with both
+                #  values >= 2**53, converting the int64 and uint64
+                #  to the common_type "float64" will cause both
+                #  values to be the same float64 value. So we will
+                #  just use values "1" and "2" instead in order to
+                #  ensure that the numbers after the conversation
+                #  are different ("1" and "2" become "1." and "2.").
+                val1 = np.int64(2**53)
+                val2 = np.uint64(2**53)
+                if (lk.dtype.name == "int64" and rk.dtype.name == "uint64") and (
+                    lk[0] >= val1 and rk[0] >= val2
+                ):
+                    lk = [0]
+                    rk = [1]
+                    lk = np.asarray(lk, dtype=np.int64)
+                    rk = np.asarray(rk, dtype=np.int64)
+
                 lk = lk.astype(dtype, copy=False)
                 rk = rk.astype(dtype, copy=False)
         if isinstance(lk, BaseMaskedArray):

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1832,6 +1832,13 @@ class TestMergeDtypes:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_merge_int64_uint64_lossy(self):
+        left = DataFrame({"key": Series([2**53], dtype="int64"), "value": [1]})
+        right = DataFrame({"key": Series([2**53 + 1], dtype="uint64"), "value": [2]})
+        assert not left.key.equals(right.key)
+        result = left.merge(right, on="key", how="inner")
+        assert result.size == 0
+
 
 @pytest.fixture
 def left():


### PR DESCRIPTION
- [x] closes #56367
- [x] [Tests added and passed]: test_merge.py
- [x] All [code checks passed]

When you have two DataFrames, left and right, where left's key is of dtype int64 while right's key is of dtype uint64, and both of their values are >= 2**53, what used to happen was that calling left.merge(right) will cause a non empty result to be returned. However, we want the merge function to return nothing since we shouldn't be allowing the merge between DataFrames with different key dtypes.

The issue was that when you are working with values >= 2**53 and you have keys that are of dtype int64 and uint64, the "common dtype" gets resolved to float64 for both, so a (2**53) int64 and (2**53 + 1) uint64 is represented as the same float64 value. 