### PR TITLE
BUG: Fix multiplying Timedelta Series with a pandas nullable dtype Series

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -365,6 +365,7 @@ Timedelta
 ^^^^^^^^^
 - Accuracy improvement in :meth:`Timedelta.to_pytimedelta` to round microseconds consistently for large nanosecond based Timedelta (:issue:`57841`)
 - Bug in :meth:`DataFrame.cumsum` which was raising ``IndexError`` if dtype is ``timedelta64[ns]`` (:issue:`57956`)
+- Bug in :meth:`TimedeltaArray._simple_new` which was raising ``AssertionError`` When multiplying a Series with a timedelta64 dtype with another Series that uses any of the pandas nullable dtypes ``('Int8', 'Int16', 'Int32', 'Int64', 'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Float32', 'Float64', or 'boolean')`` (:issue:`58054`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -41,13 +41,13 @@ from pandas.util._validators import validate_endpoints
 
 from pandas.core.dtypes.common import (
     TD64NS_DTYPE,
+    is_bool_dtype,
     is_float_dtype,
     is_integer_dtype,
+    is_numeric_dtype,
     is_object_dtype,
     is_scalar,
     is_string_dtype,
-    is_numeric_dtype,
-    is_bool_dtype,
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import ExtensionDtype
@@ -493,12 +493,13 @@ class TimedeltaArray(dtl.TimelikeOps):
             result = [arr[n] * other[n] for n in range(len(self))]
             result = np.array(result)
             return type(self)._simple_new(result, dtype=result.dtype)
-        
+
         if is_bool_dtype(other.dtype) or is_numeric_dtype(other.dtype):
             # this multiplication will succeed only if all elements of other
-            #  are any of the pandas nullable dtypes ('Int8', 'Int16', 'Int32', 'Int64', 
-            #  'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Float32', 'Float64', or 'boolean'),
-            #  so we will end up with timedelta64[ns]-dtyped result
+            #  are any of the pandas nullable dtypes ('Int8', 'Int16', 'Int32',
+            # 'Int64', 'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Float32',
+            # 'Float64', or 'boolean'), so we will end up with
+            #  timedelta64[ns]-dtyped result
             result = [self._ndarray[n] * other[n] for n in range(len(self))]
             result = np.array(result)
             return type(self)(result)

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -46,6 +46,8 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_scalar,
     is_string_dtype,
+    is_numeric_dtype,
+    is_bool_dtype,
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import ExtensionDtype
@@ -491,6 +493,15 @@ class TimedeltaArray(dtl.TimelikeOps):
             result = [arr[n] * other[n] for n in range(len(self))]
             result = np.array(result)
             return type(self)._simple_new(result, dtype=result.dtype)
+        
+        if is_bool_dtype(other.dtype) or is_numeric_dtype(other.dtype):
+            # this multiplication will succeed only if all elements of other
+            #  are any of the pandas nullable dtypes ('Int8', 'Int16', 'Int32', 'Int64', 
+            #  'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Float32', 'Float64', or 'boolean'),
+            #  so we will end up with timedelta64[ns]-dtyped result
+            result = [self._ndarray[n] * other[n] for n in range(len(self))]
+            result = np.array(result)
+            return type(self)(result)
 
         # numpy will accept float or int dtype, raise TypeError for others
         result = self._ndarray * other

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -368,6 +368,44 @@ class TestSeriesArithmetic:
             result = [True, None, True] + ser
         tm.assert_series_equal(result, expected)
 
+    def test_mul_nullable_dtype(self):
+        # GH#58054. Multiplying a TimeDelta Series with another series containing any of the
+        # Pandas nullable dtypes should work the same as with the Numpy nullable dtypes
+        td_series = pd.Series(np.random.rand(5) * timedelta(hours=1))
+        other = pd.Series(np.random.rand(5) < 0.5)
+
+        pandas_types = [
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Float32",
+            "Float64",
+            "boolean",
+        ]
+        numpy_types = [
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+            "float32",
+            "float64",
+            "bool",
+        ]
+
+        for dtype1, dtype2 in zip(pandas_types, numpy_types):
+            result = td_series * other.astype(dtype1)
+            expected = td_series * other.astype(dtype2)
+            tm.assert_series_equal(result, expected)
+
 
 # ------------------------------------------------------------------
 # Comparisons

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -369,10 +369,11 @@ class TestSeriesArithmetic:
         tm.assert_series_equal(result, expected)
 
     def test_mul_nullable_dtype(self):
-        # GH#58054. Multiplying a TimeDelta Series with another series containing any of the
-        # Pandas nullable dtypes should work the same as with the Numpy nullable dtypes
-        td_series = pd.Series(np.random.rand(5) * timedelta(hours=1))
-        other = pd.Series(np.random.rand(5) < 0.5)
+        # GH#58054. Multiplying a TimeDelta Series with another series containing
+        # any of the Pandas nullable dtypes should work the same as with the
+        # Numpy nullable dtypes
+        td_series = Series([timedelta(hours=1)])
+        other = Series([True])
 
         pandas_types = [
             "Int8",


### PR DESCRIPTION
- [X] closes #58054 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


Tests were added, but raise an error. Does anyone know how to fix it?

<img width="1005" alt="Screenshot 2024-04-22 at 3 01 50 PM" src="https://github.com/pandas-dev/pandas/assets/71472955/6e227d40-cebd-451a-830e-01da815dd52b">

This is my first pull request, please let me know if I need to change anything :)