### PR TITLE
PERF: MultiIndex.memory_usage shouldn't trigger the index engine

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -345,6 +345,7 @@ Performance improvements
 - Performance improvement in ``DataFrameGroupBy.__len__`` and ``SeriesGroupBy.__len__`` (:issue:`57595`)
 - Performance improvement in indexing operations for string dtypes (:issue:`56997`)
 - Performance improvement in unary methods on a :class:`RangeIndex` returning a :class:`RangeIndex` instead of a :class:`Index` when possible. (:issue:`57825`)
+- Performance improvement in :meth:`MultiIndex.memory_usage` to ignore the index engine when it isn't already cached. (:issue:`58385`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.bug_fixes:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -332,6 +332,7 @@ Performance improvements
 - Performance improvement in :meth:`Index.take` when ``indices`` is a full range indexer from zero to length of index (:issue:`56806`)
 - Performance improvement in :meth:`Index.to_frame` returning a :class:`RangeIndex` columns of a :class:`Index` when possible. (:issue:`58018`)
 - Performance improvement in :meth:`MultiIndex.equals` for equal length indexes (:issue:`56990`)
+- Performance improvement in :meth:`MultiIndex.memory_usage` to ignore the index engine when it isn't already cached. (:issue:`58385`)
 - Performance improvement in :meth:`RangeIndex.__getitem__` with a boolean mask or integers returning a :class:`RangeIndex` instead of a :class:`Index` when possible. (:issue:`57588`)
 - Performance improvement in :meth:`RangeIndex.append` when appending the same index (:issue:`57252`)
 - Performance improvement in :meth:`RangeIndex.argmin` and :meth:`RangeIndex.argmax` (:issue:`57823`)
@@ -345,7 +346,6 @@ Performance improvements
 - Performance improvement in ``DataFrameGroupBy.__len__`` and ``SeriesGroupBy.__len__`` (:issue:`57595`)
 - Performance improvement in indexing operations for string dtypes (:issue:`56997`)
 - Performance improvement in unary methods on a :class:`RangeIndex` returning a :class:`RangeIndex` instead of a :class:`Index` when possible. (:issue:`57825`)
-- Performance improvement in :meth:`MultiIndex.memory_usage` to ignore the index engine when it isn't already cached. (:issue:`58385`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.bug_fixes:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4863,8 +4863,9 @@ class Index(IndexOpsMixin, PandasObject):
     def memory_usage(self, deep: bool = False) -> int:
         result = self._memory_usage(deep=deep)
 
-        # include our engine hashtable
-        result += self._engine.sizeof(deep=deep)
+        # include our engine hashtable, only if it's already cached
+        if "_engine" in self._cache:
+            result += self._engine.sizeof(deep=deep)
         return result
 
     @final

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1391,8 +1391,9 @@ class MultiIndex(Index):
         names_nbytes = sum(getsizeof(i, objsize) for i in self.names)
         result = level_nbytes + label_nbytes + names_nbytes
 
-        # include our engine hashtable
-        result += self._engine.sizeof(deep=deep)
+        # include our engine hashtable, only if it's already cached
+        if "_engine" in self._cache:
+            result += self._engine.sizeof(deep=deep)
         return result
 
     # --------------------------------------------------------------------

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -142,31 +142,6 @@ def test_memory_usage_components_narrow_series(any_real_numpy_dtype):
     assert total_usage == non_index_usage + index_usage
 
 
-def test_memory_usage_doesnt_trigger_engine(index):
-    index._cache.clear()
-    assert "_engine" not in index._cache
-
-    res_without_engine = index.memory_usage()
-    assert "_engine" not in index._cache
-
-    # explicitly load and cache the engine
-    _ = index._engine
-    assert "_engine" in index._cache
-
-    res_with_engine = index.memory_usage()
-
-    # the engine doesn't affect the result even when initialized with values, because
-    # index._engine.sizeof() doesn't consider the content of index._engine.values
-    assert res_with_engine == res_without_engine
-
-    if len(index) == 0:
-        assert res_without_engine == 0
-        assert res_with_engine == 0
-    else:
-        assert res_without_engine > 0
-        assert res_with_engine > 0
-
-
 def test_searchsorted(request, index_or_series_obj):
     # numpy.searchsorted calls obj.searchsorted under the hood.
     # See gh-12238

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -142,6 +142,31 @@ def test_memory_usage_components_narrow_series(any_real_numpy_dtype):
     assert total_usage == non_index_usage + index_usage
 
 
+def test_memory_usage_doesnt_trigger_engine(index):
+    index._cache.clear()
+    assert "_engine" not in index._cache
+
+    res_without_engine = index.memory_usage()
+    assert "_engine" not in index._cache
+
+    # explicitly load and cache the engine
+    _ = index._engine
+    assert "_engine" in index._cache
+
+    res_with_engine = index.memory_usage()
+
+    # the engine doesn't affect the result even when initialized with values, because
+    # index._engine.sizeof() doesn't consider the content of index._engine.values
+    assert res_with_engine == res_without_engine
+
+    if len(index) == 0:
+        assert res_without_engine == 0
+        assert res_with_engine == 0
+    else:
+        assert res_without_engine > 0
+        assert res_with_engine > 0
+
+
 def test_searchsorted(request, index_or_series_obj):
     # numpy.searchsorted calls obj.searchsorted under the hood.
     # See gh-12238

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -326,6 +326,30 @@ class TestBase:
         if index.inferred_type == "object":
             assert result3 > result2
 
+    def test_memory_usage_doesnt_trigger_engine(self, index):
+        index._cache.clear()
+        assert "_engine" not in index._cache
+
+        res_without_engine = index.memory_usage()
+        assert "_engine" not in index._cache
+
+        # explicitly load and cache the engine
+        _ = index._engine
+        assert "_engine" in index._cache
+
+        res_with_engine = index.memory_usage()
+
+        # the empty engine doesn't affect the result even when initialized with values,
+        # because engine.sizeof() doesn't consider the content of engine.values
+        assert res_with_engine == res_without_engine
+
+        if len(index) == 0:
+            assert res_without_engine == 0
+            assert res_with_engine == 0
+        else:
+            assert res_without_engine > 0
+            assert res_with_engine > 0
+
     def test_argsort(self, index):
         if isinstance(index, CategoricalIndex):
             pytest.skip(f"{type(self).__name__} separately tested")


### PR DESCRIPTION
Ignore the index engine when it isn't already cached.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

### Reproducible Example

Calling `memory_usage()` can be unexpectedly slow when called on a big MultiIndex.

Using the main branch:
```python
In [3]: %time idx = pd.MultiIndex.from_product([np.arange(1000), np.arange(1000), np.arange(100)], names=["x0", "x1", "x2"])
CPU times: user 247 ms, sys: 170 ms, total: 417 ms
Wall time: 419 ms

In [4]: %time idx.memory_usage()
CPU times: user 2.91 s, sys: 4.09 s, total: 7 s
Wall time: 8.81 s
Out[4]: 500016953
```

Using this PR branch:
```python
In [3]: %time idx = pd.MultiIndex.from_product([np.arange(1000), np.arange(1000), np.arange(100)], names=["x0", "x1", "x2"])
CPU times: user 238 ms, sys: 148 ms, total: 386 ms
Wall time: 385 ms

In [4]: %time idx.memory_usage()
CPU times: user 112 µs, sys: 1e+03 ns, total: 113 µs
Wall time: 118 µs
Out[4]: 500016953
```

Side note: `index._engine.sizeof()` doesn't consider the content of `index._engine.values`. If it should, a separate issue can be opened. In the example above, the additional unreported used memory would be:
```python
In [8]: idx._engine.values
Out[8]: 
array([   262402,    262403,    262404, ..., 131331299, 131331300,
       131331301], dtype=uint64)

In [9]: idx._engine.values.shape
Out[9]: (100000000,)

In [15]: idx._engine.values.nbytes
Out[15]: 800000000

```
