### PR TITLE
TST: Added match argument for most uses of tm.assert_produces_warning

### DIFF
--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -557,11 +557,12 @@ is being raised, using ``pytest.raises`` instead.
 Testing a warning
 ^^^^^^^^^^^^^^^^^
 
-Use ``tm.assert_produces_warning`` as a context manager to check that a block of code raises a warning.
+Use ``tm.assert_produces_warning`` as a context manager to check that a block of code raises a warning
+and specify the warning message using the ``match`` argument.
 
 .. code-block:: python
 
-    with tm.assert_produces_warning(DeprecationWarning):
+    with tm.assert_produces_warning(DeprecationWarning, match="the warning message"):
         pd.deprecated_function()
 
 If a warning should specifically not happen in a block of code, pass ``False`` into the context manager.

--- a/pandas/tests/arrays/sparse/test_constructors.py
+++ b/pandas/tests/arrays/sparse/test_constructors.py
@@ -90,13 +90,13 @@ class TestConstructors:
         dti = pd.date_range("2016-01-01", periods=3, tz="US/Pacific")
 
         expected = SparseArray(np.asarray(dti, dtype="datetime64[ns]"))
-
-        with tm.assert_produces_warning(UserWarning, match="loses timezone information"):
+        msg = "loses timezone information"
+        with tm.assert_produces_warning(UserWarning, match=msg):
             result = SparseArray(dti)
 
         tm.assert_sp_array_equal(result, expected)
 
-        with tm.assert_produces_warning(UserWarning, match="loses timezone information"):
+        with tm.assert_produces_warning(UserWarning, match=msg):
             result = SparseArray(pd.Series(dti))
 
         tm.assert_sp_array_equal(result, expected)

--- a/pandas/tests/arrays/sparse/test_constructors.py
+++ b/pandas/tests/arrays/sparse/test_constructors.py
@@ -91,12 +91,12 @@ class TestConstructors:
 
         expected = SparseArray(np.asarray(dti, dtype="datetime64[ns]"))
 
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="loses timezone information"):
             result = SparseArray(dti)
 
         tm.assert_sp_array_equal(result, expected)
 
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="loses timezone information"):
             result = SparseArray(pd.Series(dti))
 
         tm.assert_sp_array_equal(result, expected)

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -778,7 +778,7 @@ class TestDatetimeArray(SharedTests):
         arr2d = arr1d.reshape(1, -1)
 
         warn = None if arr1d.tz is None else UserWarning
-        with tm.assert_produces_warning(warn):
+        with tm.assert_produces_warning(warn, match="will drop timezone information"):
             result = arr2d.to_period("D")
             expected = arr1d.to_period("D").reshape(1, -1)
         tm.assert_period_array_equal(result, expected)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1014,7 +1014,8 @@ class TestAlignment:
         else:
             seen = False
 
-        with tm.assert_produces_warning(seen):
+        msg = "Alignment difference on axis 1 is larger than an order of magnitude"
+        with tm.assert_produces_warning(seen, match=msg):
             pd.eval("df + s", engine=engine, parser=parser)
 
         s = Series(np.random.default_rng(2).standard_normal(1000))
@@ -1036,7 +1037,7 @@ class TestAlignment:
         else:
             wrn = False
 
-        with tm.assert_produces_warning(wrn) as w:
+        with tm.assert_produces_warning(wrn, match=msg) as w:
             pd.eval("df + s", engine=engine, parser=parser)
 
             if not is_python_engine and performance_warning:

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -797,5 +797,5 @@ def test_pandas_dtype_numpy_warning():
 
 def test_pandas_dtype_ea_not_instance():
     # GH 31356 GH 54592
-    with tm.assert_produces_warning(UserWarning):
+    with tm.assert_produces_warning(UserWarning, match="without any arguments"):
         assert pandas_dtype(CategoricalDtype) == CategoricalDtype()

--- a/pandas/tests/dtypes/test_generic.py
+++ b/pandas/tests/dtypes/test_generic.py
@@ -124,7 +124,7 @@ def test_setattr_warnings():
         #  this should not raise a warning
         df.two.not_an_index = [1, 2]
 
-    with tm.assert_produces_warning(UserWarning):
+    with tm.assert_produces_warning(UserWarning, match="doesn't allow columns"):
         #  warn when setting column to nonexistent name
         df.four = df.two + 2
         assert df.four.sum() > df.two.sum()

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -145,7 +145,7 @@ class TestDataFrameIndexing:
         # we are producing a warning that since the passed boolean
         # key is not the same as the given index, we will reindex
         # not sure this is really necessary
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="will be reindexed"):
             indexer_obj = indexer_obj.reindex(datetime_frame.index[::-1])
             subframe_obj = datetime_frame[indexer_obj]
             tm.assert_frame_equal(subframe_obj, subframe)

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -711,7 +711,10 @@ class TestDataFrameSetItem:
         df["np-array"] = a
 
         # Instantiation of `np.matrix` gives PendingDeprecationWarning
-        with tm.assert_produces_warning(PendingDeprecationWarning):
+        with tm.assert_produces_warning(
+            PendingDeprecationWarning,
+            match="the matrix subclass is not the recommended way to represent matrices",
+        ):
             df["np-matrix"] = np.matrix(a)
 
         tm.assert_frame_equal(df, expected)

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -713,7 +713,7 @@ class TestDataFrameSetItem:
         # Instantiation of `np.matrix` gives PendingDeprecationWarning
         with tm.assert_produces_warning(
             PendingDeprecationWarning,
-            match="the matrix subclass is not the recommended way to represent matrices",
+            match="matrix subclass is not the recommended way to represent matrices",
         ):
             df["np-matrix"] = np.matrix(a)
 

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -166,7 +166,7 @@ class TestDataFrameToDict:
         # GH#16927: When converting to a dict, if a column has a non-unique name
         # it will be dropped, throwing a warning.
         df = DataFrame([[1, 2, 3]], columns=["a", "a", "b"])
-        with tm.assert_produces_warning(UserWarning, match="some columns will be omitted"):
+        with tm.assert_produces_warning(UserWarning, match="columns will be omitted"):
             df.to_dict()
 
     @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -166,7 +166,7 @@ class TestDataFrameToDict:
         # GH#16927: When converting to a dict, if a column has a non-unique name
         # it will be dropped, throwing a warning.
         df = DataFrame([[1, 2, 3]], columns=["a", "a", "b"])
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="some columns will be omitted"):
             df.to_dict()
 
     @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1097,7 +1097,7 @@ class TestFrameArithmetic:
                     and expr.USE_NUMEXPR
                     and switch_numexpr_min_elements == 0
                 ):
-                    warn = UserWarning  # "evaluating in Python space because ..."
+                    warn = UserWarning
             else:
                 msg = (
                     f"cannot perform __{op.__name__}__ with this "
@@ -1105,17 +1105,16 @@ class TestFrameArithmetic:
                 )
 
             with pytest.raises(TypeError, match=msg):
-                with tm.assert_produces_warning(warn):
+                with tm.assert_produces_warning(warn, match="evaluating in Python"):
                     op(df, elem.value)
 
         elif (op, dtype) in skip:
             if op in [operator.add, operator.mul]:
                 if expr.USE_NUMEXPR and switch_numexpr_min_elements == 0:
-                    # "evaluating in Python space because ..."
                     warn = UserWarning
                 else:
                     warn = None
-                with tm.assert_produces_warning(warn):
+                with tm.assert_produces_warning(warn, match="evaluating in Python"):
                     op(df, elem.value)
 
             else:

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -699,7 +699,7 @@ class TestDataFrameAnalytics:
         expected = DataFrame({"A": ["a", np.nan]})
 
         warning = None if using_infer_string else UserWarning
-        with tm.assert_produces_warning(warning):
+        with tm.assert_produces_warning(warning, match="Unable to sort modes"):
             result = df.mode(dropna=False)
             result = result.sort_values(by="A").reset_index(drop=True)
 

--- a/pandas/tests/indexes/base_class/test_setops.py
+++ b/pandas/tests/indexes/base_class/test_setops.py
@@ -84,13 +84,13 @@ class TestIndexSetOps:
         # https://github.com/pandas-dev/pandas/issues/24959
         idx = Index([1, pd.Timestamp("2000")])
         # default (sort=None)
-        with tm.assert_produces_warning(RuntimeWarning):
+        with tm.assert_produces_warning(RuntimeWarning, match="not supported between"):
             result = idx.union(idx[:1])
 
         tm.assert_index_equal(result, idx)
 
         # sort=None
-        with tm.assert_produces_warning(RuntimeWarning):
+        with tm.assert_produces_warning(RuntimeWarning, match="not supported between"):
             result = idx.union(idx[:1], sort=None)
         tm.assert_index_equal(result, idx)
 

--- a/pandas/tests/indexes/datetimes/methods/test_to_period.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_period.py
@@ -117,10 +117,10 @@ class TestToPeriod:
             freq="5min",
         )
 
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="drop timezone info"):
             pi1 = rng.to_period("5min")
 
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="drop timezone info"):
             pi2 = rng.to_period()
 
         tm.assert_index_equal(pi1, pi2)
@@ -143,8 +143,7 @@ class TestToPeriod:
             ]
         )
 
-        with tm.assert_produces_warning(UserWarning):
-            # warning that timezone info will be lost
+        with tm.assert_produces_warning(UserWarning, match="drop timezone info"):
             period = index.to_period(freq="ms")
         assert 2 == len(period)
         assert period[0] == Period("2007-01-01 10:11:12.123Z", "ms")
@@ -158,8 +157,7 @@ class TestToPeriod:
             ]
         )
 
-        with tm.assert_produces_warning(UserWarning):
-            # warning that timezone info will be lost
+        with tm.assert_produces_warning(UserWarning, match="drop timezone info"):
             period = index.to_period(freq="us")
         assert 2 == len(period)
         assert period[0] == Period("2007-01-01 10:11:12.123456Z", "us")
@@ -172,10 +170,7 @@ class TestToPeriod:
     def test_to_period_tz(self, tz):
         ts = date_range("1/1/2000", "2/1/2000", tz=tz)
 
-        with tm.assert_produces_warning(UserWarning):
-            # GH#21333 warning that timezone info will be lost
-            # filter warning about freq deprecation
-
+        with tm.assert_produces_warning(UserWarning, match="drop timezone info"):
             result = ts.to_period()[0]
             expected = ts[0].to_period(ts.freq)
 
@@ -183,8 +178,7 @@ class TestToPeriod:
 
         expected = date_range("1/1/2000", "2/1/2000").to_period()
 
-        with tm.assert_produces_warning(UserWarning):
-            # GH#21333 warning that timezone info will be lost
+        with tm.assert_produces_warning(UserWarning, match="drop timezone info"):
             result = ts.to_period(ts.freq)
 
         tm.assert_index_equal(result, expected)
@@ -193,7 +187,7 @@ class TestToPeriod:
     def test_to_period_tz_utc_offset_consistency(self, tz):
         # GH#22905
         ts = date_range("1/1/2000", "2/1/2000", tz="Etc/GMT-1")
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="drop timezone info"):
             result = ts.to_period()[0]
             expected = ts[0].to_period(ts.freq)
             assert result == expected

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -382,7 +382,7 @@ def test_union_sort_other_incomparable():
     idx = MultiIndex.from_product([[1, pd.Timestamp("2000")], ["a", "b"]])
 
     # default, sort=None
-    with tm.assert_produces_warning(RuntimeWarning):
+    with tm.assert_produces_warning(RuntimeWarning, match="are unorderable"):
         result = idx.union(idx[:1])
     tm.assert_index_equal(result, idx)
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1065,10 +1065,10 @@ class TestIndex:
         left_index = Index(np.random.default_rng(2).permutation(15))
         right_index = date_range("2020-01-01", periods=10)
 
-        with tm.assert_produces_warning(RuntimeWarning):
+        with tm.assert_produces_warning(RuntimeWarning, match="not supported between"):
             result = left_index.join(right_index, how="outer")
 
-        with tm.assert_produces_warning(RuntimeWarning):
+        with tm.assert_produces_warning(RuntimeWarning, match="not supported between"):
             expected = left_index.astype(object).union(right_index.astype(object))
 
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -142,25 +142,18 @@ class TestIndexConstructorInference:
         data = [ctor]
         data.insert(pos, nulls_fixture)
 
-        warn = None
         if nulls_fixture is NA:
             expected = Index([NA, NaT])
             mark = pytest.mark.xfail(reason="Broken with np.NaT ctor; see GH 31884")
             request.applymarker(mark)
-            # GH#35942 numpy will emit a DeprecationWarning within the
-            #  assert_index_equal calls.  Since we can't do anything
-            #  about it until GH#31884 is fixed, we suppress that warning.
-            warn = DeprecationWarning
 
         result = Index(data)
 
-        with tm.assert_produces_warning(warn):
-            tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = Index(np.array(data, dtype=object))
 
-        with tm.assert_produces_warning(warn):
-            tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("swap_objs", [True, False])
     def test_constructor_mixed_nat_objs_infers_object(self, swap_objs):

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -882,7 +882,7 @@ class TestSetOpsUnsorted:
         b = Index([2, Timestamp("1999"), 1])
         op = operator.methodcaller(opname, b)
 
-        with tm.assert_produces_warning(RuntimeWarning):
+        with tm.assert_produces_warning(RuntimeWarning, match="not supported between"):
             # sort=None, the default
             result = op(a)
         expected = Index([3, Timestamp("2000"), 2, Timestamp("1999")])

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1280,19 +1280,25 @@ class TestCanHoldElement:
         # `elem` to not have the same length as `arr`
         ii2 = IntervalIndex.from_breaks(arr[:-1], closed="neither")
         elem = element(ii2)
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(
+            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
+        ):
             self.check_series_setitem(elem, ii, False)
         assert not blk._can_hold_element(elem)
 
         ii3 = IntervalIndex.from_breaks([Timestamp(1), Timestamp(3), Timestamp(4)])
         elem = element(ii3)
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(
+            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
+        ):
             self.check_series_setitem(elem, ii, False)
         assert not blk._can_hold_element(elem)
 
         ii4 = IntervalIndex.from_breaks([Timedelta(1), Timedelta(3), Timedelta(4)])
         elem = element(ii4)
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(
+            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
+        ):
             self.check_series_setitem(elem, ii, False)
         assert not blk._can_hold_element(elem)
 
@@ -1312,12 +1318,16 @@ class TestCanHoldElement:
         # `elem` to not have the same length as `arr`
         pi2 = pi.asfreq("D")[:-1]
         elem = element(pi2)
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(
+            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
+        ):
             self.check_series_setitem(elem, pi, False)
 
         dti = pi.to_timestamp("s")[:-1]
         elem = element(dti)
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(
+            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
+        ):
             self.check_series_setitem(elem, pi, False)
 
     def check_can_hold_element(self, obj, elem, inplace: bool):

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1280,25 +1280,20 @@ class TestCanHoldElement:
         # `elem` to not have the same length as `arr`
         ii2 = IntervalIndex.from_breaks(arr[:-1], closed="neither")
         elem = element(ii2)
-        with tm.assert_produces_warning(
-            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
-        ):
+        msg = "Setting an item of incompatible dtype is deprecated"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             self.check_series_setitem(elem, ii, False)
         assert not blk._can_hold_element(elem)
 
         ii3 = IntervalIndex.from_breaks([Timestamp(1), Timestamp(3), Timestamp(4)])
         elem = element(ii3)
-        with tm.assert_produces_warning(
-            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
-        ):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             self.check_series_setitem(elem, ii, False)
         assert not blk._can_hold_element(elem)
 
         ii4 = IntervalIndex.from_breaks([Timedelta(1), Timedelta(3), Timedelta(4)])
         elem = element(ii4)
-        with tm.assert_produces_warning(
-            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
-        ):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             self.check_series_setitem(elem, ii, False)
         assert not blk._can_hold_element(elem)
 
@@ -1318,16 +1313,13 @@ class TestCanHoldElement:
         # `elem` to not have the same length as `arr`
         pi2 = pi.asfreq("D")[:-1]
         elem = element(pi2)
-        with tm.assert_produces_warning(
-            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
-        ):
+        msg = "Setting an item of incompatible dtype is deprecated"
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             self.check_series_setitem(elem, pi, False)
 
         dti = pi.to_timestamp("s")[:-1]
         elem = element(dti)
-        with tm.assert_produces_warning(
-            FutureWarning, match="Setting an item of incompatible dtype is deprecated"
-        ):
+        with tm.assert_produces_warning(FutureWarning, match=msg):
             self.check_series_setitem(elem, pi, False)
 
     def check_can_hold_element(self, obj, elem, inplace: bool):

--- a/pandas/tests/io/formats/test_css.py
+++ b/pandas/tests/io/formats/test_css.py
@@ -38,30 +38,31 @@ def test_css_parse_normalisation(name, norm, abnorm):
 
 
 @pytest.mark.parametrize(
-    "invalid_css,remainder",
+    "invalid_css,remainder,msg",
     [
         # No colon
-        ("hello-world", ""),
-        ("border-style: solid; hello-world", "border-style: solid"),
+        ("hello-world", "", "expected a colon"),
+        ("border-style: solid; hello-world", "border-style: solid", "expected a colon"),
         (
             "border-style: solid; hello-world; font-weight: bold",
             "border-style: solid; font-weight: bold",
+            "expected a colon",
         ),
         # Unclosed string fail
         # Invalid size
-        ("font-size: blah", "font-size: 1em"),
-        ("font-size: 1a2b", "font-size: 1em"),
-        ("font-size: 1e5pt", "font-size: 1em"),
-        ("font-size: 1+6pt", "font-size: 1em"),
-        ("font-size: 1unknownunit", "font-size: 1em"),
-        ("font-size: 10", "font-size: 1em"),
-        ("font-size: 10 pt", "font-size: 1em"),
+        ("font-size: blah", "font-size: 1em", "Unhandled size"),
+        ("font-size: 1a2b", "font-size: 1em", "Unhandled size"),
+        ("font-size: 1e5pt", "font-size: 1em", "Unhandled size"),
+        ("font-size: 1+6pt", "font-size: 1em", "Unhandled size"),
+        ("font-size: 1unknownunit", "font-size: 1em", "Unhandled size"),
+        ("font-size: 10", "font-size: 1em", "Unhandled size"),
+        ("font-size: 10 pt", "font-size: 1em", "Unhandled size"),
         # Too many args
-        ("border-top: 1pt solid red green", "border-top: 1pt solid green"),
+        ("border-top: 1pt solid red green", "border-top: 1pt solid green", "Too many"),
     ],
 )
-def test_css_parse_invalid(invalid_css, remainder):
-    with tm.assert_produces_warning(CSSWarning):
+def test_css_parse_invalid(invalid_css, remainder, msg):
+    with tm.assert_produces_warning(CSSWarning, match=msg):
         assert_same_resolution(invalid_css, remainder)
 
 
@@ -120,7 +121,7 @@ def test_css_side_shorthands(shorthand, expansions):
         {top: "1pt", right: "4pt", bottom: "2pt", left: "0pt"},
     )
 
-    with tm.assert_produces_warning(CSSWarning):
+    with tm.assert_produces_warning(CSSWarning, match="Could not expand"):
         assert_resolves(f"{shorthand}: 1pt 1pt 1pt 1pt 1pt", {})
 
 

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -325,7 +325,7 @@ def test_css_to_excel_bad_colors(input_color):
     if input_color is not None:
         expected["fill"] = {"patternType": "solid"}
 
-    with tm.assert_produces_warning(CSSWarning):
+    with tm.assert_produces_warning(CSSWarning, match="Unhandled color format"):
         convert = CSSToExcelConverter()
         assert expected == convert(css)
 

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -634,7 +634,7 @@ class TestTableOrient:
         # GH 19130
         df = DataFrame(index=idx)
         df.index.name = "index"
-        with tm.assert_produces_warning():
+        with tm.assert_produces_warning(UserWarning, match="not round-trippable"):
             set_default_names(df)
 
     def test_timestamp_in_columns(self):

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -222,7 +222,7 @@ class TestClipboard:
 
     # Separator is ignored when excel=False and should produce a warning
     def test_copy_delim_warning(self, df):
-        with tm.assert_produces_warning():
+        with tm.assert_produces_warning(UserWarning, match="ignores the sep argument"):
             df.to_clipboard(excel=False, sep="\t")
 
     # Tests that the default behavior of to_clipboard is tab

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -463,7 +463,7 @@ class TestMMapWrapper:
             index=pd.Index([f"i-{i}" for i in range(30)], dtype=object),
         )
         with tm.ensure_clean() as path:
-            with tm.assert_produces_warning(UnicodeWarning):
+            with tm.assert_produces_warning(UnicodeWarning, match="byte order mark"):
                 df.to_csv(path, compression=compression_, encoding=encoding)
 
             # reading should fail (otherwise we wouldn't need the warning)

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -133,7 +133,7 @@ def test_compression_warning(compression_only):
     )
     with tm.ensure_clean() as path:
         with icom.get_handle(path, "w", compression=compression_only) as handles:
-            with tm.assert_produces_warning(RuntimeWarning):
+            with tm.assert_produces_warning(RuntimeWarning, match="has no effect"):
                 df.to_csv(handles.handle, compression=compression_only)
 
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2602,7 +2602,7 @@ def test_con_unknown_dbapi2_class_does_not_error_without_sql_alchemy_installed()
             self.conn.close()
 
     with contextlib.closing(MockSqliteConnection(":memory:")) as conn:
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="pandas only supports"):
             sql.read_sql("SELECT 1", conn)
 
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2602,7 +2602,7 @@ def test_con_unknown_dbapi2_class_does_not_error_without_sql_alchemy_installed()
             self.conn.close()
 
     with contextlib.closing(MockSqliteConnection(":memory:")) as conn:
-        with tm.assert_produces_warning(UserWarning, match="pandas only supports"):
+        with tm.assert_produces_warning(UserWarning, match="only supports SQLAlchemy"):
             sql.read_sql("SELECT 1", conn)
 
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -189,11 +189,12 @@ class TestStata:
         path2 = datapath("io", "data", "stata", "stata2_115.dta")
         path3 = datapath("io", "data", "stata", "stata2_117.dta")
 
-        with tm.assert_produces_warning(UserWarning):
+        msg = "Leaving in Stata Internal Format"
+        with tm.assert_produces_warning(UserWarning, match=msg):
             parsed_114 = self.read_dta(path1)
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match=msg):
             parsed_115 = self.read_dta(path2)
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match=msg):
             parsed_117 = self.read_dta(path3)
             # FIXME: don't leave commented-out
             # 113 is buggy due to limits of date format support in Stata
@@ -478,7 +479,8 @@ class TestStata:
         formatted = formatted.astype(np.int32)
 
         path = temp_file
-        with tm.assert_produces_warning(InvalidColumnName):
+        msg = "Not all pandas column names were valid Stata variable names"
+        with tm.assert_produces_warning(InvalidColumnName, match=msg):
             original.to_stata(path, convert_dates=None)
 
         written_and_read_again = self.read_dta(path)
@@ -515,7 +517,8 @@ class TestStata:
         formatted = formatted.astype(np.int32)
 
         path = temp_file
-        with tm.assert_produces_warning(InvalidColumnName):
+        msg = "Not all pandas column names were valid Stata variable names"
+        with tm.assert_produces_warning(InvalidColumnName, match=msg):
             original.to_stata(path, convert_dates=None, version=version)
             # should get a warning for that format.
 
@@ -612,7 +615,8 @@ class TestStata:
         original.index.name = "index"
         path = temp_file
         # should get a warning for that format.
-        with tm.assert_produces_warning(InvalidColumnName):
+        msg = "Not all pandas column names were valid Stata variable names"
+        with tm.assert_produces_warning(InvalidColumnName, match=msg):
             original.to_stata(path)
 
         written_and_read_again = self.read_dta(path)
@@ -672,7 +676,7 @@ class TestStata:
         original = DataFrame({"s0": s0, "s1": s1, "s2": s2, "s3": s3})
         original.index.name = "index"
         path = temp_file
-        with tm.assert_produces_warning(PossiblePrecisionLoss):
+        with tm.assert_produces_warning(PossiblePrecisionLoss, match="from int64 to"):
             original.to_stata(path)
 
         written_and_read_again = self.read_dta(path)
@@ -687,7 +691,8 @@ class TestStata:
         original = DataFrame([datetime(2006, 11, 19, 23, 13, 20)])
         original.index.name = "index"
         path = temp_file
-        with tm.assert_produces_warning(InvalidColumnName):
+        msg = "Not all pandas column names were valid Stata variable names"
+        with tm.assert_produces_warning(InvalidColumnName, match=msg):
             original.to_stata(path, convert_dates={0: "tc"})
 
         written_and_read_again = self.read_dta(path)
@@ -1111,7 +1116,8 @@ class TestStata:
             [["a"], ["b"], ["c"], ["d"], [1]], columns=["Too_long"]
         ).astype("category")
 
-        with tm.assert_produces_warning(ValueLabelTypeMismatch):
+        msg = "data file created has not lost information due to duplicate labels"
+        with tm.assert_produces_warning(ValueLabelTypeMismatch, match=msg):
             original.to_stata(path)
             # should get a warning for mixed content
 
@@ -1732,7 +1738,8 @@ The repeated labels are:\n-+\nwolof
         )
         original.index.name = "index"
 
-        with tm.assert_produces_warning(InvalidColumnName):
+        msg = "Not all pandas column names were valid Stata variable names"
+        with tm.assert_produces_warning(InvalidColumnName, match=msg):
             path = temp_file
             original.to_stata(path, convert_strl=["long", 1], version=117)
             reread = self.read_dta(path)
@@ -2138,8 +2145,9 @@ def test_chunked_categorical(version, temp_file):
 def test_chunked_categorical_partial(datapath):
     dta_file = datapath("io", "data", "stata", "stata-dta-partially-labeled.dta")
     values = ["a", "b", "a", "b", 3.0]
+    msg = "series with value labels are not fully labeled"
     with StataReader(dta_file, chunksize=2) as reader:
-        with tm.assert_produces_warning(CategoricalConversionWarning):
+        with tm.assert_produces_warning(CategoricalConversionWarning, match=msg):
             for i, block in enumerate(reader):
                 assert list(block.cats) == values[2 * i : 2 * (i + 1)]
                 if i < 2:
@@ -2147,7 +2155,7 @@ def test_chunked_categorical_partial(datapath):
                 else:
                     idx = pd.Index([3.0], dtype="float64")
                 tm.assert_index_equal(block.cats.cat.categories, idx)
-    with tm.assert_produces_warning(CategoricalConversionWarning):
+    with tm.assert_produces_warning(CategoricalConversionWarning, match=msg):
         with StataReader(dta_file, chunksize=5) as reader:
             large_chunk = reader.__next__()
     direct = read_stata(dta_file)
@@ -2303,7 +2311,8 @@ def test_non_categorical_value_label_name_conversion(temp_file):
         "_1__2_": {3: "three"},
     }
 
-    with tm.assert_produces_warning(InvalidColumnName):
+    msg = "Not all pandas column names were valid Stata variable names"
+    with tm.assert_produces_warning(InvalidColumnName, match=msg):
         data.to_stata(temp_file, value_labels=value_labels)
 
     with StataReader(temp_file) as reader:

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -2001,7 +2001,7 @@ class TestDataFramePlots:
         plt.close("all")
 
         gs, axes = _generate_4_axes_via_gridspec()
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             axes = df.plot(subplots=True, ax=axes, sharex=True)
         _check(axes)
 
@@ -2065,7 +2065,7 @@ class TestDataFramePlots:
         plt.close("all")
 
         gs, axes = _generate_4_axes_via_gridspec()
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             axes = df.plot(subplots=True, ax=axes, sharey=True)
 
         gs.tight_layout(plt.gcf())
@@ -2186,7 +2186,7 @@ class TestDataFramePlots:
 
         # vertical / subplots / sharex=True / sharey=True
         ax1, ax2 = _get_vertical_grid()
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             axes = df.plot(subplots=True, ax=[ax1, ax2], sharex=True, sharey=True)
         assert len(axes[0].lines) == 1
         assert len(axes[1].lines) == 1
@@ -2202,7 +2202,7 @@ class TestDataFramePlots:
 
         # horizontal / subplots / sharex=True / sharey=True
         ax1, ax2 = _get_horizontal_grid()
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             axes = df.plot(subplots=True, ax=[ax1, ax2], sharex=True, sharey=True)
         assert len(axes[0].lines) == 1
         assert len(axes[1].lines) == 1
@@ -2252,7 +2252,7 @@ class TestDataFramePlots:
 
         # subplots / sharex=True / sharey=True
         axes = _get_boxed_grid()
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             axes = df.plot(subplots=True, ax=axes, sharex=True, sharey=True)
         for ax in axes:
             assert len(ax.lines) == 1

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -335,7 +335,7 @@ class TestDataFramePlotsSubplots:
             np.random.default_rng(2).random((10, 4)),
             index=list(string.ascii_letters[:10]),
         )
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="layout keyword is ignored"):
             returned = df.plot(
                 subplots=True, ax=axes, layout=layout, sharex=False, sharey=False
             )
@@ -501,7 +501,7 @@ class TestDataFramePlotsSubplots:
             columns=list("AB"),
         )
         _, axes = plt.subplots(2, 1)
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             axes = df.plot(subplots=True, ax=axes, sharex=True)
         for ax in axes:
             assert len(ax.lines) == 1

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -129,7 +129,8 @@ class TestDataFramePlots:
         df["Y"] = Series(["A"] * 10)
         # Multiple columns with an ax argument should use same figure
         fig, ax = mpl.pyplot.subplots()
-        with tm.assert_produces_warning(UserWarning):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, match=msg):
             axes = df.boxplot(
                 column=["Col1", "Col2"], by="X", ax=ax, return_type="axes"
             )
@@ -607,7 +608,7 @@ class TestDataFrameGroupByPlots:
         # passes multiple axes to plot, hist or boxplot
         # location should be changed if other test is added
         # which has earlier alphabetical order
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             _, axes = mpl.pyplot.subplots(2, 2)
             df.groupby("category").boxplot(column="height", return_type="axes", ax=axes)
             _check_axes_shape(mpl.pyplot.gcf().axes, axes_num=4, layout=(2, 2))
@@ -617,7 +618,7 @@ class TestDataFrameGroupByPlots:
         # GH 6970, GH 7069
         df = hist_df
         fig, axes = mpl.pyplot.subplots(2, 3)
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             returned = df.boxplot(
                 column=["height", "weight", "category"],
                 by="gender",
@@ -630,7 +631,7 @@ class TestDataFrameGroupByPlots:
         assert returned[0].figure is fig
 
         # draw on second row
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             returned = df.groupby("classroom").boxplot(
                 column=["height", "weight", "category"], return_type="axes", ax=axes[1]
             )
@@ -647,7 +648,7 @@ class TestDataFrameGroupByPlots:
         _, axes = mpl.pyplot.subplots(2, 3)
         with pytest.raises(ValueError, match=msg):
             # pass different number of axes from required
-            with tm.assert_produces_warning(UserWarning):
+            with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
                 axes = df.groupby("classroom").boxplot(ax=axes)
 
     def test_fontsize(self):

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1558,7 +1558,7 @@ class TestSeriesMode:
         expected = Series(["foo", np.nan])
         s = Series([1, "foo", "foo", np.nan, np.nan])
 
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match="Unable to sort modes"):
             result = s.mode(dropna=False)
             result = result.sort_values().reset_index(drop=True)
 

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1567,11 +1567,12 @@ class TestMergeDtypes:
         B = DataFrame({"Y": [1.1, 2.5, 3.0]})
         expected = DataFrame({"X": [3], "Y": [3.0]})
 
-        with tm.assert_produces_warning(UserWarning):
+        msg = "the float values are not equal to their int representation"
+        with tm.assert_produces_warning(UserWarning, match=msg):
             result = A.merge(B, left_on="X", right_on="Y")
             tm.assert_frame_equal(result, expected)
 
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match=msg):
             result = B.merge(A, left_on="Y", right_on="X")
             tm.assert_frame_equal(result, expected[["Y", "X"]])
 

--- a/pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py
+++ b/pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py
@@ -24,7 +24,8 @@ class TestTimestampToPyDatetime:
         ts = Timestamp("2011-01-01 9:00:00.123456789")
 
         # Warn the user of data loss (nanoseconds).
-        with tm.assert_produces_warning(UserWarning):
+        msg = "Discarding nonzero nanoseconds in conversion"
+        with tm.assert_produces_warning(UserWarning, match=msg):
             expected = datetime(2011, 1, 1, 9, 0, 0, 123456)
             result = ts.to_pydatetime()
             assert result == expected

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -501,8 +501,7 @@ class TestTimestampConversion:
         # GH#21333 make sure a warning is issued when timezone
         # info is lost
         ts = Timestamp("2009-04-15 16:17:18", tz="US/Eastern")
-        with tm.assert_produces_warning(UserWarning):
-            # warning that timezone info will be lost
+        with tm.assert_produces_warning(UserWarning, match="drop timezone information"):
             ts.to_period("D")
 
     def test_to_numpy_alias(self):

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -359,12 +359,13 @@ class TestSeriesArithmetic:
             else None
         )
         ser = Series([True, None, False], dtype="boolean")
-        with tm.assert_produces_warning(warning):
+        msg = "operator is not supported by numexpr for the bool dtype"
+        with tm.assert_produces_warning(warning, match=msg):
             result = ser + [True, None, True]
         expected = Series([True, None, True], dtype="boolean")
         tm.assert_series_equal(result, expected)
 
-        with tm.assert_produces_warning(warning):
+        with tm.assert_produces_warning(warning, match=msg):
             result = [True, None, True] + ser
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -339,47 +339,36 @@ class TestExpressions:
             # raises TypeError
             return
 
+        msg = "operator is not supported by numexpr"
         with monkeypatch.context() as m:
             m.setattr(expr, "_MIN_ELEMENTS", 5)
             with option_context("compute.use_numexpr", True):
-                with tm.assert_produces_warning(
-                    UserWarning, match="operator is not supported by numexpr"
-                ):
+                with tm.assert_produces_warning(UserWarning, match=msg):
                     r = f(df, df)
                     e = fe(df, df)
                     tm.assert_frame_equal(r, e)
 
-                with tm.assert_produces_warning(
-                    UserWarning, match="operator is not supported by numexpr"
-                ):
+                with tm.assert_produces_warning(UserWarning, match=msg):
                     r = f(df.a, df.b)
                     e = fe(df.a, df.b)
                     tm.assert_series_equal(r, e)
 
-                with tm.assert_produces_warning(
-                    UserWarning, match="operator is not supported by numexpr"
-                ):
+                with tm.assert_produces_warning(UserWarning, match=msg):
                     r = f(df.a, True)
                     e = fe(df.a, True)
                     tm.assert_series_equal(r, e)
 
-                with tm.assert_produces_warning(
-                    UserWarning, match="operator is not supported by numexpr"
-                ):
+                with tm.assert_produces_warning(UserWarning, match=msg):
                     r = f(False, df.a)
                     e = fe(False, df.a)
                     tm.assert_series_equal(r, e)
 
-                with tm.assert_produces_warning(
-                    UserWarning, match="operator is not supported by numexpr"
-                ):
+                with tm.assert_produces_warning(UserWarning, match=msg):
                     r = f(False, df)
                     e = fe(False, df)
                     tm.assert_frame_equal(r, e)
 
-                with tm.assert_produces_warning(
-                    UserWarning, match="operator is not supported by numexpr"
-                ):
+                with tm.assert_produces_warning(UserWarning, match=msg):
                     r = f(df, True)
                     e = fe(df, True)
                     tm.assert_frame_equal(r, e)

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -342,32 +342,44 @@ class TestExpressions:
         with monkeypatch.context() as m:
             m.setattr(expr, "_MIN_ELEMENTS", 5)
             with option_context("compute.use_numexpr", True):
-                with tm.assert_produces_warning():
+                with tm.assert_produces_warning(
+                    UserWarning, match="operator is not supported by numexpr"
+                ):
                     r = f(df, df)
                     e = fe(df, df)
                     tm.assert_frame_equal(r, e)
 
-                with tm.assert_produces_warning():
+                with tm.assert_produces_warning(
+                    UserWarning, match="operator is not supported by numexpr"
+                ):
                     r = f(df.a, df.b)
                     e = fe(df.a, df.b)
                     tm.assert_series_equal(r, e)
 
-                with tm.assert_produces_warning():
+                with tm.assert_produces_warning(
+                    UserWarning, match="operator is not supported by numexpr"
+                ):
                     r = f(df.a, True)
                     e = fe(df.a, True)
                     tm.assert_series_equal(r, e)
 
-                with tm.assert_produces_warning():
+                with tm.assert_produces_warning(
+                    UserWarning, match="operator is not supported by numexpr"
+                ):
                     r = f(False, df.a)
                     e = fe(False, df.a)
                     tm.assert_series_equal(r, e)
 
-                with tm.assert_produces_warning():
+                with tm.assert_produces_warning(
+                    UserWarning, match="operator is not supported by numexpr"
+                ):
                     r = f(False, df)
                     e = fe(False, df)
                     tm.assert_frame_equal(r, e)
 
-                with tm.assert_produces_warning():
+                with tm.assert_produces_warning(
+                    UserWarning, match="operator is not supported by numexpr"
+                ):
                     r = f(df, True)
                     e = fe(df, True)
                     tm.assert_frame_equal(r, e)

--- a/pandas/tests/test_optional_dependency.py
+++ b/pandas/tests/test_optional_dependency.py
@@ -42,7 +42,7 @@ def test_bad_version(monkeypatch):
     result = import_optional_dependency("fakemodule", min_version="0.8")
     assert result is module
 
-    with tm.assert_produces_warning(UserWarning):
+    with tm.assert_produces_warning(UserWarning, match=match):
         result = import_optional_dependency("fakemodule", errors="warn")
     assert result is None
 
@@ -53,7 +53,7 @@ def test_bad_version(monkeypatch):
     with pytest.raises(ImportError, match="Pandas requires version '1.1.0'"):
         import_optional_dependency("fakemodule", min_version="1.1.0")
 
-    with tm.assert_produces_warning(UserWarning):
+    with tm.assert_produces_warning(UserWarning, match="Pandas requires version"):
         result = import_optional_dependency(
             "fakemodule", errors="warn", min_version="1.1.0"
         )
@@ -81,7 +81,7 @@ def test_submodule(monkeypatch):
     with pytest.raises(ImportError, match=match):
         import_optional_dependency("fakemodule.submodule")
 
-    with tm.assert_produces_warning(UserWarning):
+    with tm.assert_produces_warning(UserWarning, match=match):
         result = import_optional_dependency("fakemodule.submodule", errors="warn")
     assert result is None
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1738,7 +1738,10 @@ class TestToDatetimeUnit:
     def test_unit_str(self, cache):
         # GH 57051
         # Test that strs aren't dropping precision to 32-bit accidentally.
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(
+            FutureWarning,
+            match="The behavior of 'to_datetime' with 'unit' when parsing strings is deprecated",
+        ):
             res = to_datetime(["1704660000"], unit="s", origin="unix")
         expected = to_datetime([1704660000], unit="s", origin="unix")
         tm.assert_index_equal(res, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1740,7 +1740,7 @@ class TestToDatetimeUnit:
         # Test that strs aren't dropping precision to 32-bit accidentally.
         with tm.assert_produces_warning(
             FutureWarning,
-            match="The behavior of 'to_datetime' with 'unit' when parsing strings is deprecated",
+            match="'to_datetime' with 'unit' when parsing strings is deprecated",
         ):
             res = to_datetime(["1704660000"], unit="s", origin="unix")
         expected = to_datetime([1704660000], unit="s", origin="unix")

--- a/pandas/tests/window/test_expanding.py
+++ b/pandas/tests/window/test_expanding.py
@@ -696,5 +696,7 @@ def test_numeric_only_corr_cov_series(kernel, use_arg, numeric_only, dtype):
 def test_keyword_quantile_deprecated():
     # GH #52550
     ser = Series([1, 2, 3, 4])
-    with tm.assert_produces_warning(FutureWarning):
+    with tm.assert_produces_warning(
+        FutureWarning, match="the 'quantile' keyword is deprecated, use 'q' instead"
+    ):
         ser.expanding().quantile(quantile=0.5)

--- a/pandas/tests/window/test_rolling_quantile.py
+++ b/pandas/tests/window/test_rolling_quantile.py
@@ -178,5 +178,7 @@ def test_center_reindex_frame(frame, q):
 def test_keyword_quantile_deprecated():
     # GH #52550
     s = Series([1, 2, 3, 4])
-    with tm.assert_produces_warning(FutureWarning):
+    with tm.assert_produces_warning(
+        FutureWarning, match="the 'quantile' keyword is deprecated, use 'q' instead"
+    ):
         s.rolling(2).quantile(quantile=0.4)


### PR DESCRIPTION
xref #58290
Places where I skipped match argument:
`computation/test_eval.py` and `frame/test_query_eval.py` as I couldn't get the tests to trigger the warning
`plotting/test_datetimelike.py` same reason as above.

The tests for internal things in `util` folder: 
`test_assert_produces_warning.py`, `test_deprecate_kwarg.py`, `test_deprecate_nonkeyword_arguments.py`, `test_deprecate.py`



other places I skipped because it would complicate the logic (I.E. `api/test_api.py`'s `test_depr` method.)
