### PR TITLE
Fixed `pd.infer_freq` incompatible with `Series["timestamp[s][pyarrow]"]`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -362,6 +362,7 @@ Datetimelike
 - Bug in :class:`Timestamp` constructor failing to raise when ``tz=None`` is explicitly specified in conjunction with timezone-aware ``tzinfo`` or data (:issue:`48688`)
 - Bug in :func:`date_range` where the last valid timestamp would sometimes not be produced (:issue:`56134`)
 - Bug in :func:`date_range` where using a negative frequency value would not include all points between the start and end values (:issue:`56382`)
+- Bug in :func:`infer_freq` prevented application to :class:`Series` of with ``pyarrow`` dtype. (:issue:`58403`)
 - Bug in :func:`tseries.api.guess_datetime_format` would fail to infer time format when "%Y" == "%H%M" (:issue:`57452`)
 - Bug in setting scalar values with mismatched resolution into arrays with non-nanosecond ``datetime64``, ``timedelta64`` or :class:`DatetimeTZDtype` incorrectly truncating those scalars (:issue:`56410`)
 

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -2,6 +2,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+import importlib
 
 import numpy as np
 import pytest
@@ -556,6 +557,9 @@ def test_infer_freq_non_nano_tzaware(tz_aware_fixture):
     assert res == "B"
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("pyarrow") is None, reason="pyarrow not installed"
+)
 @pytest.mark.parametrize(
     ("data", "expected"),
     [

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -2,7 +2,6 @@ from datetime import (
     datetime,
     timedelta,
 )
-import importlib
 
 import numpy as np
 import pytest
@@ -557,9 +556,6 @@ def test_infer_freq_non_nano_tzaware(tz_aware_fixture):
     assert res == "B"
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("pyarrow") is None, reason="pyarrow not installed"
-)
 @pytest.mark.parametrize(
     ("data", "expected"),
     [
@@ -579,5 +575,6 @@ def test_infer_freq_non_nano_tzaware(tz_aware_fixture):
 )
 @pytest.mark.parametrize("cls", [Index, Series])
 def test_infer_freq_pyarrow(data, expected, cls):
+    pytest.importorskip("pyarrow")
     obj = cls(data).astype("timestamp[s][pyarrow]")
     assert frequencies.infer_freq(obj) == expected

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -554,3 +554,26 @@ def test_infer_freq_non_nano_tzaware(tz_aware_fixture):
 
     res = frequencies.infer_freq(dta)
     assert res == "B"
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (["2022-01-01T10:00:00", "2022-01-01T10:00:30", "2022-01-01T10:01:00"], "30s"),
+        (["2022-01-01T10:00:00", "2022-01-01T10:00:37", "2022-01-01T10:01:00"], None),
+        (["2022-01-01T10:00:00", "2022-01-01T10:00:01", "2022-01-01T10:00:02"], "s"),
+        (
+            [
+                "2022-01-01T10:00:00",
+                "2022-01-01T10:00:01",
+                "2022-01-01T10:00:02",
+                "2022-01-01T10:00:04",
+            ],
+            None,
+        ),
+    ],
+)
+@pytest.mark.parametrize("cls", [Index, Series])
+def test_infer_freq_pyarrow(data, expected, cls):
+    obj = cls(data).astype("timestamp[s][pyarrow]")
+    assert frequencies.infer_freq(obj) == expected

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -33,10 +33,7 @@ from pandas._libs.tslibs.parsing import get_rule_month
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import is_numeric_dtype
-from pandas.core.dtypes.dtypes import (
-    DatetimeTZDtype,
-    PeriodDtype,
-)
+from pandas.core.dtypes.dtypes import PeriodDtype
 from pandas.core.dtypes.generic import (
     ABCIndex,
     ABCSeries,
@@ -112,20 +109,16 @@ def infer_freq(
     >>> pd.infer_freq(idx)
     'D'
     """
+    from pandas.api.types import is_datetime64_any_dtype
     from pandas.core.api import DatetimeIndex
 
-    if isinstance(index, ABCSeries):
-        values = index._values
-        if not (
-            lib.is_np_dtype(values.dtype, "mM")
-            or isinstance(values.dtype, DatetimeTZDtype)
-            or values.dtype == object
-        ):
-            raise TypeError(
-                "cannot infer freq from a non-convertible dtype "
-                f"on a Series of {index.dtype}"
-            )
-        index = values
+    if isinstance(index, ABCSeries) and not (
+        is_datetime64_any_dtype(index) or index.dtype == object
+    ):
+        raise TypeError(
+            "cannot infer freq from a non-convertible dtype "
+            f"on a Series of {index.dtype}"
+        )
 
     inferer: _FrequencyInferer
 


### PR DESCRIPTION
- [x] closes #58403
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
