### PR TITLE
CI: fix CI failure for PDEP with status: Draft

### DIFF
--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -280,6 +280,7 @@ class Preprocessors:
         PDEP's in different status from the directory tree and GitHub.
         """
         KNOWN_STATUS = {
+            "Draft",
             "Under discussion",
             "Accepted",
             "Implemented",


### PR DESCRIPTION
cc @WillAyd 

This will only fix the CI failure, but 2 things to note:
1- The PDEP won't be shown in https://pandas.pydata.org/about/roadmap.html
2- If the PR gets the PDEP label, it will be considered as "Under Discussion" in the website roadmap
I want to fix that, but how will we differentiate? Do we check if the PR is marked as Draft? Or do we check if the PR has a certain label? (e.g. make a PDEP: draft label or use the needs discussion label)
