### PR TITLE
CLN: enforce the deprecation of exposing blocks in core.internals 

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -250,6 +250,7 @@ Removal of prior version deprecations/changes
 - Enforced deprecation of :meth:`Series.interpolate` and :meth:`DataFrame.interpolate` for object-dtype (:issue:`57820`)
 - Enforced deprecation of :meth:`offsets.Tick.delta`, use ``pd.Timedelta(obj)`` instead (:issue:`55498`)
 - Enforced deprecation of ``axis=None`` acting the same as ``axis=0`` in the DataFrame reductions ``sum``, ``prod``, ``std``, ``var``, and ``sem``, passing ``axis=None`` will now reduce over both axes; this is particularly the case when doing e.g. ``numpy.sum(df)`` (:issue:`21597`)
+- Enforced deprecation of ``core.internals`` members ``Block``, ``ExtensionBlock``, and ``DatetimeTZBlock`` (:issue:`58467`)
 - Enforced deprecation of non-standard (``np.ndarray``, :class:`ExtensionArray`, :class:`Index`, or :class:`Series`) argument to :func:`api.extensions.take` (:issue:`52981`)
 - Enforced deprecation of parsing system timezone strings to ``tzlocal``, which depended on system timezone, pass the 'tz' keyword instead (:issue:`50791`)
 - Enforced deprecation of passing a dictionary to :meth:`SeriesGroupBy.agg` (:issue:`52268`)

--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -18,46 +18,5 @@ __all__ = [
 
 def __getattr__(name: str):
     # GH#55139
-    import warnings
-
-    if name == "create_block_manager_from_blocks":
-        # GH#33892
-        warnings.warn(
-            f"{name} is deprecated and will be removed in a future version. "
-            "Use public APIs instead.",
-            DeprecationWarning,
-            # https://github.com/pandas-dev/pandas/pull/55139#pullrequestreview-1720690758
-            # on hard-coding stacklevel
-            stacklevel=2,
-        )
-        from pandas.core.internals.managers import create_block_manager_from_blocks
-
-        return create_block_manager_from_blocks
-
-    if name in [
-        "Block",
-        "ExtensionBlock",
-        "DatetimeTZBlock",
-    ]:
-        warnings.warn(
-            f"{name} is deprecated and will be removed in a future version. "
-            "Use public APIs instead.",
-            DeprecationWarning,
-            # https://github.com/pandas-dev/pandas/pull/55139#pullrequestreview-1720690758
-            # on hard-coding stacklevel
-            stacklevel=2,
-        )
-        if name == "DatetimeTZBlock":
-            from pandas.core.internals.blocks import DatetimeTZBlock
-
-            return DatetimeTZBlock
-        elif name == "ExtensionBlock":
-            from pandas.core.internals.blocks import ExtensionBlock
-
-            return ExtensionBlock
-        else:
-            from pandas.core.internals.blocks import Block
-
-            return Block
 
     raise AttributeError(f"module 'pandas.core.internals' has no attribute '{name}'")

--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -6,17 +6,8 @@ from pandas.core.internals.managers import (
 )
 
 __all__ = [
-    "Block",
-    "DatetimeTZBlock",
-    "ExtensionBlock",
     "make_block",
     "BlockManager",
     "SingleBlockManager",
     "concatenate_managers",
 ]
-
-
-def __getattr__(name: str):
-    # GH#55139
-
-    raise AttributeError(f"module 'pandas.core.internals' has no attribute '{name}'")

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -124,7 +124,8 @@ if TYPE_CHECKING:
         npt,
     )
 
-    from pandas.core.internals import Block
+    from pandas.core.internals.blocks import Block
+
 
 # versioning attribute
 _version = "0.15.2"

--- a/pandas/tests/internals/test_api.py
+++ b/pandas/tests/internals/test_api.py
@@ -41,21 +41,6 @@ def test_namespace():
     assert set(result) == set(expected + modules)
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
-        "Block",
-        "ExtensionBlock",
-        "DatetimeTZBlock",
-    ],
-)
-def test_deprecations(name):
-    # GH#55139
-    msg = f"{name} is deprecated.* Use public APIs instead"
-    with tm.assert_produces_warning(DeprecationWarning, match=msg):
-        getattr(internals, name)
-
-
 def test_make_block_2d_with_dti():
     # GH#41168
     dti = pd.date_range("2012", periods=3, tz="UTC")
@@ -63,18 +48,6 @@ def test_make_block_2d_with_dti():
 
     assert blk.shape == (1, 3)
     assert blk.values.shape == (1, 3)
-
-
-def test_create_block_manager_from_blocks_deprecated():
-    # GH#33892
-    # If they must, downstream packages should get this from internals.api,
-    #  not internals.
-    msg = (
-        "create_block_manager_from_blocks is deprecated and will be "
-        "removed in a future version. Use public APIs instead"
-    )
-    with tm.assert_produces_warning(DeprecationWarning, match=msg):
-        internals.create_block_manager_from_blocks
 
 
 def test_create_dataframe_from_blocks(float_frame):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -649,6 +649,12 @@ class TestBasic(Base):
         ],
     )
     def test_read_empty_array(self, pa, dtype):
+        # GH#58467
+        from pandas.compat._optional import VERSIONS
+
+        pa_min_ver = VERSIONS.get("pyarrow")
+        if Version(pyarrow.__version__) == Version(pa_min_ver):
+            pytest.skip("pandas.core.internals' has no attribute 'DatetimeTZBlock")
         # GH #41241
         df = pd.DataFrame(
             {
@@ -938,6 +944,11 @@ class TestParquetPyArrow(Base):
         check_round_trip(df, pa, write_kwargs={"version": ver})
 
     def test_timezone_aware_index(self, request, pa, timezone_aware_date_list):
+        from pandas.compat._optional import VERSIONS
+
+        pa_min_ver = VERSIONS.get("pyarrow")
+        if Version(pyarrow.__version__) == Version(pa_min_ver):
+            pytest.skip("pandas.core.internals' has no attribute 'DatetimeTZBlock")
         if timezone_aware_date_list.tzinfo != datetime.timezone.utc:
             request.applymarker(
                 pytest.mark.xfail(
@@ -1107,6 +1118,11 @@ class TestParquetPyArrow(Base):
 
 class TestParquetFastParquet(Base):
     def test_basic(self, fp, df_full):
+        from pandas.compat._optional import VERSIONS
+
+        pa_min_ver = VERSIONS.get("pyarrow")
+        if Version(pyarrow.__version__) == Version(pa_min_ver):
+            pytest.skip("pandas.core.internals' has no attribute 'DatetimeTZBlock")
         df = df_full
 
         dti = pd.date_range("20130101", periods=3, tz="US/Eastern")

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -655,8 +655,7 @@ class TestBasic(Base):
                 "value": pd.array([], dtype=dtype),
             }
         )
-        if pyarrow.__version__ == "10.0.1":
-            pytest.skip("skip the pyarrow version '10.0.1'")
+        pytest.importorskip("pyarrow", "10.0.1")
         # GH 45694
         expected = None
         if dtype == "float":
@@ -673,9 +672,7 @@ class TestBasic(Base):
 class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
         df = df_full
-
-        if pyarrow.__version__ == "10.0.1":
-            pytest.skip("skip the pyarrow version '10.0.1'")
+        pytest.importorskip("pyarrow", "10.0.1")
 
         # additional supported types for pyarrow
         dti = pd.date_range("20130101", periods=3, tz="Europe/Brussels")
@@ -943,8 +940,8 @@ class TestParquetPyArrow(Base):
         check_round_trip(df, pa, write_kwargs={"version": ver})
 
     def test_timezone_aware_index(self, request, pa, timezone_aware_date_list):
-        if pyarrow.__version__ == "10.0.1":
-            pytest.skip("skip the pyarrow version '10.0.1'")
+        pytest.importorskip("pyarrow", "10.0.1")
+
         if timezone_aware_date_list.tzinfo != datetime.timezone.utc:
             request.applymarker(
                 pytest.mark.xfail(

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -655,7 +655,7 @@ class TestBasic(Base):
                 "value": pd.array([], dtype=dtype),
             }
         )
-        pytest.importorskip("pyarrow", "10.0.1")
+        pytest.importorskip("pyarrow", "11.0.0")
         # GH 45694
         expected = None
         if dtype == "float":
@@ -672,7 +672,7 @@ class TestBasic(Base):
 class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
         df = df_full
-        pytest.importorskip("pyarrow", "10.0.1")
+        pytest.importorskip("pyarrow", "11.0.0")
 
         # additional supported types for pyarrow
         dti = pd.date_range("20130101", periods=3, tz="Europe/Brussels")
@@ -940,7 +940,7 @@ class TestParquetPyArrow(Base):
         check_round_trip(df, pa, write_kwargs={"version": ver})
 
     def test_timezone_aware_index(self, request, pa, timezone_aware_date_list):
-        pytest.importorskip("pyarrow", "10.0.1")
+        pytest.importorskip("pyarrow", "11.0.0")
 
         if timezone_aware_date_list.tzinfo != datetime.timezone.utc:
             request.applymarker(

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -50,6 +50,7 @@ pytestmark = [
     ),
 ]
 
+
 # setup engines & skips
 @pytest.fixture(
     params=[

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -676,9 +676,9 @@ class TestBasic(Base):
 
 class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
-        df = df_full
-        
         from pandas.compat._optional import VERSIONS
+
+        df = df_full
 
         pa_min_ver = VERSIONS.get("pyarrow")
         if Version(pyarrow.__version__) == Version(pa_min_ver):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -655,7 +655,7 @@ class TestBasic(Base):
                 "value": pd.array([], dtype=dtype),
             }
         )
-        if Version(pyarrow.__version__) == "10.0.1":
+        if pyarrow.__version__ == "10.0.1":
             pytest.skip("skip the pyarrow version '10.0.1'")
         # GH 45694
         expected = None
@@ -674,7 +674,7 @@ class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
         df = df_full
 
-        if Version(pyarrow.__version__) == "10.0.1":
+        if pyarrow.__version__ == "10.0.1":
             pytest.skip("skip the pyarrow version '10.0.1'")
 
         # additional supported types for pyarrow
@@ -943,7 +943,7 @@ class TestParquetPyArrow(Base):
         check_round_trip(df, pa, write_kwargs={"version": ver})
 
     def test_timezone_aware_index(self, request, pa, timezone_aware_date_list):
-        if Version(pyarrow.__version__) == "10.0.1":
+        if pyarrow.__version__ == "10.0.1":
             pytest.skip("skip the pyarrow version '10.0.1'")
         if timezone_aware_date_list.tzinfo != datetime.timezone.utc:
             request.applymarker(

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -50,6 +50,7 @@ pytestmark = [
     ),
 ]
 
+pa = pytest.importorskip("pyarrow", minversion="11.0.0")
 
 # setup engines & skips
 @pytest.fixture(
@@ -649,12 +650,6 @@ class TestBasic(Base):
         ],
     )
     def test_read_empty_array(self, pa, dtype):
-        # GH#58467
-        from pandas.compat._optional import VERSIONS
-
-        pa_min_ver = VERSIONS.get("pyarrow")
-        if Version(pyarrow.__version__) == Version(pa_min_ver):
-            pytest.skip("pandas.core.internals' has no attribute 'DatetimeTZBlock")
         # GH #41241
         df = pd.DataFrame(
             {
@@ -676,13 +671,7 @@ class TestBasic(Base):
 
 class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
-        from pandas.compat._optional import VERSIONS
-
         df = df_full
-
-        pa_min_ver = VERSIONS.get("pyarrow")
-        if Version(pyarrow.__version__) == Version(pa_min_ver):
-            pytest.skip("pandas.core.internals' has no attribute 'DatetimeTZBlock")
 
         # additional supported types for pyarrow
         dti = pd.date_range("20130101", periods=3, tz="Europe/Brussels")
@@ -950,11 +939,6 @@ class TestParquetPyArrow(Base):
         check_round_trip(df, pa, write_kwargs={"version": ver})
 
     def test_timezone_aware_index(self, request, pa, timezone_aware_date_list):
-        from pandas.compat._optional import VERSIONS
-
-        pa_min_ver = VERSIONS.get("pyarrow")
-        if Version(pyarrow.__version__) == Version(pa_min_ver):
-            pytest.skip("pandas.core.internals' has no attribute 'DatetimeTZBlock")
         if timezone_aware_date_list.tzinfo != datetime.timezone.utc:
             request.applymarker(
                 pytest.mark.xfail(

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -677,6 +677,12 @@ class TestBasic(Base):
 class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
         df = df_full
+        
+        from pandas.compat._optional import VERSIONS
+
+        pa_min_ver = VERSIONS.get("pyarrow")
+        if Version(pyarrow.__version__) == Version(pa_min_ver):
+            pytest.skip("pandas.core.internals' has no attribute 'DatetimeTZBlock")
 
         # additional supported types for pyarrow
         dti = pd.date_range("20130101", periods=3, tz="Europe/Brussels")
@@ -1118,11 +1124,6 @@ class TestParquetPyArrow(Base):
 
 class TestParquetFastParquet(Base):
     def test_basic(self, fp, df_full):
-        from pandas.compat._optional import VERSIONS
-
-        pa_min_ver = VERSIONS.get("pyarrow")
-        if Version(pyarrow.__version__) == Version(pa_min_ver):
-            pytest.skip("pandas.core.internals' has no attribute 'DatetimeTZBlock")
         df = df_full
 
         dti = pd.date_range("20130101", periods=3, tz="US/Eastern")

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -673,7 +673,7 @@ class TestBasic(Base):
 class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
         df = df_full
-        
+
         if Version(pyarrow.__version__) == "10.0.1":
             pytest.skip("skip the pyarrow version '10.0.1'")
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -50,8 +50,6 @@ pytestmark = [
     ),
 ]
 
-pa = pytest.importorskip("pyarrow", minversion="11.0.0")
-
 # setup engines & skips
 @pytest.fixture(
     params=[
@@ -78,6 +76,9 @@ def engine(request):
 def pa():
     if not _HAVE_PYARROW:
         pytest.skip("pyarrow is not installed")
+
+    if Version(pyarrow.__version__) == "10.0.1":
+        pytest.skip("skip the minimum '10.0.1' pyarrow version")
     return "pyarrow"
 
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -77,9 +77,6 @@ def engine(request):
 def pa():
     if not _HAVE_PYARROW:
         pytest.skip("pyarrow is not installed")
-
-    if Version(pyarrow.__version__) == "10.0.1":
-        pytest.skip("skip the minimum '10.0.1' pyarrow version")
     return "pyarrow"
 
 
@@ -658,6 +655,8 @@ class TestBasic(Base):
                 "value": pd.array([], dtype=dtype),
             }
         )
+        if Version(pyarrow.__version__) == "10.0.1":
+            pytest.skip("skip the pyarrow version '10.0.1'")
         # GH 45694
         expected = None
         if dtype == "float":
@@ -674,6 +673,9 @@ class TestBasic(Base):
 class TestParquetPyArrow(Base):
     def test_basic(self, pa, df_full):
         df = df_full
+        
+        if Version(pyarrow.__version__) == "10.0.1":
+            pytest.skip("skip the pyarrow version '10.0.1'")
 
         # additional supported types for pyarrow
         dti = pd.date_range("20130101", periods=3, tz="Europe/Brussels")
@@ -941,6 +943,8 @@ class TestParquetPyArrow(Base):
         check_round_trip(df, pa, write_kwargs={"version": ver})
 
     def test_timezone_aware_index(self, request, pa, timezone_aware_date_list):
+        if Version(pyarrow.__version__) == "10.0.1":
+            pytest.skip("skip the pyarrow version '10.0.1'")
         if timezone_aware_date_list.tzinfo != datetime.timezone.utc:
             request.applymarker(
                 pytest.mark.xfail(


### PR DESCRIPTION
xref #55355,
enforced the deprecation of `create_block_manager_from_blocks`

xref #55139
enforced the deprecation of exposing `blocks` in `core.internals `
