### PR TITLE
ENH: Support μs Greek small letter mu

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -372,6 +372,7 @@ Timedelta
 ^^^^^^^^^
 - Accuracy improvement in :meth:`Timedelta.to_pytimedelta` to round microseconds consistently for large nanosecond based Timedelta (:issue:`57841`)
 - Bug in :meth:`DataFrame.cumsum` which was raising ``IndexError`` if dtype is ``timedelta64[ns]`` (:issue:`57956`)
+- Recognize 0x3bc Greek small letter mu as an alias for micro in :class:`Timedelta` (:issue:`58472`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/timedeltas.pyi
+++ b/pandas/_libs/tslibs/timedeltas.pyi
@@ -55,7 +55,8 @@ UnitChoices: TypeAlias = Literal[
     "us",
     "microseconds",
     "microsecond",
-    "µs",
+    "µs",  # 0x0b5 Latin Extended micro sign
+    "μs",  # 0x3bc Greek small letter mu
     "micro",
     "micros",
     "u",

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -136,7 +136,8 @@ cdef dict timedelta_abbrevs = {
     "us": "us",
     "microseconds": "us",
     "microsecond": "us",
-    "µs": "us",
+    "µs": "us",  # 0x0b5 Latin Extended micro sign
+    "μs": "us",  # 0x3bc Greek small letter mu
     "micro": "us",
     "micros": "us",
     "ns": "ns",
@@ -1796,7 +1797,8 @@ class Timedelta(_Timedelta):
         * 'minutes', 'minute', 'min', or 'm'
         * 'seconds', 'second', 'sec', or 's'
         * 'milliseconds', 'millisecond', 'millis', 'milli', or 'ms'
-        * 'microseconds', 'microsecond', 'micros', 'micro', or 'us'
+        * 'microseconds', 'microsecond', 'micros', 'micro',
+          'µs' (Latin Extended micro sign), 'μs' (Greek small letter mu), or 'us'
         * 'nanoseconds', 'nanosecond', 'nanos', 'nano', or 'ns'.
 
         .. deprecated:: 2.2.0

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5027,9 +5027,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         if com.is_bool_indexer(key):
             # if we have list[bools, length=1e5] then doing this check+convert
-            #  takes 166 µs + 2.1 ms and cuts the ndarray.__getitem__
-            #  time below from 3.8 ms to 496 µs
-            # if we already have ndarray[bool], the overhead is 1.4 µs or .25%
+            #  takes 166 μs + 2.1 ms and cuts the ndarray.__getitem__
+            #  time below from 3.8 ms to 496 μs
+            # if we already have ndarray[bool], the overhead is 1.4 μs or .25%
             if isinstance(getattr(key, "dtype", None), ExtensionDtype):
                 key = key.to_numpy(dtype=bool, na_value=False)
             else:

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -58,7 +58,7 @@ def df(request):
     if data_type == "delims":
         return DataFrame({"a": ['"a,\t"b|c', "d\tef`"], "b": ["hi'j", "k''lm"]})
     elif data_type == "utf8":
-        return DataFrame({"a": ["µasd", "Ωœ∑`"], "b": ["øπ∆˚¬", "œ∑`®"]})
+        return DataFrame({"a": ["μasd", "Ωœ∑`"], "b": ["øπ∆˚¬", "œ∑`®"]})
     elif data_type == "utf16":
         return DataFrame(
             {"a": ["\U0001f44d\U0001f44d", "\U0001f44d\U0001f44d"], "b": ["abc", "def"]}

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -293,7 +293,10 @@ def test_construction():
     assert Timedelta("1 milli") == timedelta(milliseconds=1)
     assert Timedelta("1 millisecond") == timedelta(milliseconds=1)
     assert Timedelta("1 us") == timedelta(microseconds=1)
+    # 0x0b5 Latin Extended micro sign
     assert Timedelta("1 µs") == timedelta(microseconds=1)
+    # 0x3bc Greek small letter mu
+    assert Timedelta("1 μs") == timedelta(microseconds=1)
     assert Timedelta("1 micros") == timedelta(microseconds=1)
     assert Timedelta("1 microsecond") == timedelta(microseconds=1)
     assert Timedelta("1.5 microsecond") == Timedelta("00:00:00.000001500")


### PR DESCRIPTION
The abbreviation for microseconds is best represented as μs, using the 0x3bc Greek small letter mu, instead of the 0xb5 Latin Extended micro sign. This aligns with:

* [The International System of Units (SI) brochure](https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf)
* NFKC normalized [Python code](https://peps.python.org/pep-3131/) and [domain names](https://unicode.org/reports/tr36/)
* Section 2.5 Duplicated Characters of [Unicode Technical Report 25](https://www.unicode.org/reports/tr25/)
* The microfarads abbreviation in [Pandas tests](/pandas-dev/pandas/tree/2.2.x/pandas/tests/computation/test_eval.py#L1914)
* Ruff confusable mapping [updates](https://github.com/astral-sh/ruff/pull/4430/files) (currently in the "preview" stage)

Ensure that both Latin Extended and Greek characters are accepted as aliases for microseconds. Prefer the Greek character in a comment. Looking at the UTF8 test data in test_clipboard.py, the degree and registered trademark symbols should sufficiently cover the Latin Extended character block, so prefer the Greek character there too.

- [x] Closes #58472
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
- [ ] [Type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) not applicable
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file

Recommended changes for when the [RUF001](https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-string/) updates graduate from preview to stable (can't be applied yet because of [RUF100](https://docs.astral.sh/ruff/rules/unused-noqa/)):
```diff
diff --git a/pandas/_libs/tslibs/timedeltas.pyi b/pandas/_libs/tslibs/timedeltas.pyi
index 9fcea5e32d..5cbf061859 100644
--- a/pandas/_libs/tslibs/timedeltas.pyi
+++ b/pandas/_libs/tslibs/timedeltas.pyi
@@ -55,7 +55,7 @@ UnitChoices: TypeAlias = Literal[
     "us",
     "microseconds",
     "microsecond",
-    "µs",  # 0x0b5 Latin Extended micro sign
+    "µs",  # noqa: RUF001 # 0x0b5 Latin Extended micro sign
     "μs",  # 0x3bc Greek small letter mu
     "micro",
     "micros",
diff --git a/pandas/tests/scalar/timedelta/test_constructors.py b/pandas/tests/scalar/timedelta/test_constructors.py
index 138546eb07..adeff7b77a 100644
--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -294,7 +294,7 @@ def test_construction():
     assert Timedelta("1 millisecond") == timedelta(milliseconds=1)
     assert Timedelta("1 us") == timedelta(microseconds=1)
     # 0x0b5 Latin Extended micro sign
-    assert Timedelta("1 µs") == timedelta(microseconds=1)
+    assert Timedelta("1 µs") == timedelta(microseconds=1) # noqa: RUF001
     # 0x3bc Greek small letter mu
     assert Timedelta("1 μs") == timedelta(microseconds=1)
     assert Timedelta("1 micros") == timedelta(microseconds=1)
```