### PR TITLE
BUG: hashing read only object categories raises

### DIFF
--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -11,6 +11,7 @@ import numpy as np
 
 from numpy cimport (
     import_array,
+    ndarray,
     uint8_t,
     uint64_t,
 )
@@ -22,7 +23,7 @@ from pandas._libs.util cimport is_nan
 
 @cython.boundscheck(False)
 def hash_object_array(
-    object[:] arr, str key, str encoding="utf8"
+    ndarray[object, ndim=1] arr, str key, str encoding="utf8"
 ) -> np.ndarray[np.uint64]:
     """
     Parameters

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -93,4 +93,4 @@ def test_hash_read_only_categorical():
     idx = pd.Index(pd.Index(["a", "b", "c"], dtype="object").values)
     cat = pd.CategoricalDtype(idx)
     arr = pd.Series(["a", "b"], dtype=cat).values
-    assert hash(arr.dtype) == 1532899084736511412
+    assert hash(arr.dtype) == hash(arr.dtype)

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -86,3 +86,11 @@ def test_diff():
     df = ser.to_frame(name="A")
     with pytest.raises(TypeError, match=msg):
         df.diff()
+
+
+def test_hash_read_only_categorical():
+    # GH#58481
+    idx = pd.Index(pd.Index(["a", "b", "c"], dtype="object").values)
+    cat = pd.CategoricalDtype(idx)
+    arr = pd.Series(["a", "b"], dtype=cat).values
+    assert hash(arr.dtype) == 1532899084736511412


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

CoW related, so no whatsnew needed