### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.DataFrame.prod

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -75,7 +75,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.DataFrame.median RT03,SA01" \
         -i "pandas.DataFrame.min RT03" \
         -i "pandas.DataFrame.plot PR02,SA01" \
-        -i "pandas.DataFrame.prod RT03" \
         -i "pandas.DataFrame.product RT03" \
         -i "pandas.DataFrame.sem PR01,RT03,SA01" \
         -i "pandas.DataFrame.skew RT03,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -75,7 +75,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.DataFrame.median RT03,SA01" \
         -i "pandas.DataFrame.min RT03" \
         -i "pandas.DataFrame.plot PR02,SA01" \
-        -i "pandas.DataFrame.product RT03" \
         -i "pandas.DataFrame.sem PR01,RT03,SA01" \
         -i "pandas.DataFrame.skew RT03,SA01" \
         -i "pandas.DataFrame.sparse PR01" \

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11730,7 +11730,6 @@ class DataFrame(NDFrame, OpsMixin):
         return result
 
     @deprecate_nonkeyword_arguments(version="3.0", allowed_args=["self"], name="prod")
-    @doc(make_doc("prod", ndim=2))
     def prod(
         self,
         axis: Axis | None = 0,
@@ -11739,6 +11738,73 @@ class DataFrame(NDFrame, OpsMixin):
         min_count: int = 0,
         **kwargs,
     ) -> Series:
+        """
+        Return the product of the values over the requested axis.
+
+        Parameters
+        ----------
+        axis : {index (0), columns (1)}
+            Axis for the function to be applied on.
+            For `Series` this parameter is unused and defaults to 0.
+
+            .. warning::
+
+                The behavior of DataFrame.prod with ``axis=None`` is deprecated,
+                in a future version this will reduce over both axes and return a scalar
+                To retain the old behavior, pass axis=0 (or do not pass axis).
+
+            .. versionadded:: 2.0.0
+
+        skipna : bool, default True
+            Exclude NA/null values when computing the result.
+        numeric_only : bool, default False
+            Include only float, int, boolean columns. Not implemented for Series.
+
+        min_count : int, default 0
+            The required number of valid values to perform the operation. If fewer than
+            ``min_count`` non-NA values are present the result will be NA.
+        **kwargs
+            Additional keyword arguments to be passed to the function.
+
+        Returns
+        -------
+        Series or scalar
+            The product of the values over the requested axis.
+
+        See Also
+        --------
+        Series.sum : Return the sum.
+        Series.min : Return the minimum.
+        Series.max : Return the maximum.
+        Series.idxmin : Return the index of the minimum.
+        Series.idxmax : Return the index of the maximum.
+        DataFrame.sum : Return the sum over the requested axis.
+        DataFrame.min : Return the minimum over the requested axis.
+        DataFrame.max : Return the maximum over the requested axis.
+        DataFrame.idxmin : Return the index of the minimum over the requested axis.
+        DataFrame.idxmax : Return the index of the maximum over the requested axis.
+
+        Examples
+        --------
+        By default, the product of an empty or all-NA Series is ``1``
+
+        >>> pd.Series([], dtype="float64").prod()
+        1.0
+
+        This can be controlled with the ``min_count`` parameter
+
+        >>> pd.Series([], dtype="float64").prod(min_count=1)
+        nan
+
+        Thanks to the ``skipna`` parameter, ``min_count`` handles all-NA and
+        empty series identically.
+
+        >>> pd.Series([np.nan]).prod()
+        1.0
+
+        >>> pd.Series([np.nan]).prod(min_count=1)
+        nan
+        """
         result = super().prod(
             axis=axis,
             skipna=skipna,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11777,7 +11777,8 @@ numeric_only : bool, default False
 
 Returns
 -------
-{name1} or scalar\
+{name1} or scalar
+    The product of the values over the requested axis.\
 {see_also}\
 {examples}
 """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11777,8 +11777,7 @@ numeric_only : bool, default False
 
 Returns
 -------
-{name1} or scalar
-    The product of the values over the requested axis.\
+{name1} or scalar\
 {see_also}\
 {examples}
 """


### PR DESCRIPTION
- [ ] xref #58065 

fixes
```
-i "pandas.DataFrame.prod RT03" \
-i "pandas.DataFrame.product RT03" \
```
