### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.IntervalDtype

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -91,7 +91,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Interval.left SA01" \
         -i "pandas.Interval.mid SA01" \
         -i "pandas.Interval.right SA01" \
-        -i "pandas.IntervalDtype PR01,SA01" \
         -i "pandas.IntervalDtype.subtype SA01" \
         -i "pandas.IntervalIndex.closed SA01" \
         -i "pandas.IntervalIndex.contains RT03" \

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1195,6 +1195,9 @@ class IntervalDtype(PandasExtensionDtype):
     ----------
     subtype : str, np.dtype
         The dtype of the Interval bounds.
+    closed : {'right', 'left', 'both', 'neither'}, default 'right'
+        Whether the interval is closed on the left-side, right-side, both or
+        neither. See the Notes for more detailed explanation.
 
     Attributes
     ----------
@@ -1203,6 +1206,10 @@ class IntervalDtype(PandasExtensionDtype):
     Methods
     -------
     None
+
+    See Also
+    --------
+    PeriodDtype : An ExtensionDtype for Period data.
 
     Examples
     --------


### PR DESCRIPTION
- [ ] xref #58498 

fixes

```
-i "pandas.IntervalDtype PR01,SA01" \ 
```
