### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.IntervalDtype.subtype

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -92,7 +92,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Interval.mid SA01" \
         -i "pandas.Interval.right SA01" \
         -i "pandas.IntervalDtype PR01,SA01" \
-        -i "pandas.IntervalDtype.subtype SA01" \
         -i "pandas.IntervalIndex.closed SA01" \
         -i "pandas.IntervalIndex.contains RT03" \
         -i "pandas.IntervalIndex.get_loc PR07,RT03,SA01" \

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1304,6 +1304,10 @@ class IntervalDtype(PandasExtensionDtype):
         """
         The dtype of the Interval bounds.
 
+        See Also
+        --------
+        IntervalDtype: An ExtensionDtype for Interval data.
+
         Examples
         --------
         >>> dtype = pd.IntervalDtype(subtype="int64", closed="both")


### PR DESCRIPTION
- [ ] xref #58498 

fixes
```
 -i "pandas.IntervalDtype.subtype SA01" \ 

```
