### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.Timestamp.days_in_month

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -331,8 +331,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.day_of_year SA01" \
         -i "pandas.Timestamp.dayofweek SA01" \
         -i "pandas.Timestamp.dayofyear SA01" \
-        -i "pandas.Timestamp.days_in_month SA01" \
-        -i "pandas.Timestamp.daysinmonth SA01" \
         -i "pandas.Timestamp.dst SA01" \
         -i "pandas.Timestamp.floor SA01" \
         -i "pandas.Timestamp.fold GL08" \

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -904,6 +904,11 @@ cdef class _Timestamp(ABCTimestamp):
         -------
         int
 
+        See Also
+        --------
+        Timestamp.month_name : Return the month name of the Timestamp with
+            specified locale.
+
         Examples
         --------
         >>> ts = pd.Timestamp(2020, 3, 14)


### PR DESCRIPTION
- [ ] xref #58505 

fixes
```
pandas.Timestamp.days_in_month
```
