### PR TITLE
DOC: Fix Docstring Errors for pandas.api.extensions.ExtensionArray

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -375,7 +375,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.weekday SA01" \
         -i "pandas.Timestamp.weekofyear SA01" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray SA01" \
         -i "pandas.api.extensions.ExtensionArray._accumulate RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray._concat_same_type PR07,SA01" \
         -i "pandas.api.extensions.ExtensionArray._formatter SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -375,7 +375,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.weekday SA01" \
         -i "pandas.Timestamp.weekofyear SA01" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray._concat_same_type PR07,SA01" \
+        -i "pandas.api.extensions.ExtensionArray._concat_same_type PR07" \
         -i "pandas.api.extensions.ExtensionArray._formatter SA01" \
         -i "pandas.api.extensions.ExtensionArray._from_sequence SA01" \
         -i "pandas.api.extensions.ExtensionArray._from_sequence_of_strings SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -375,7 +375,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.weekday SA01" \
         -i "pandas.Timestamp.weekofyear SA01" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray._from_sequence SA01" \
         -i "pandas.api.extensions.ExtensionArray._from_sequence_of_strings SA01" \
         -i "pandas.api.extensions.ExtensionArray._hash_pandas_object RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray._pad_or_backfill PR01,RT03,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -375,7 +375,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.weekday SA01" \
         -i "pandas.Timestamp.weekofyear SA01" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray._formatter SA01" \
         -i "pandas.api.extensions.ExtensionArray._from_sequence SA01" \
         -i "pandas.api.extensions.ExtensionArray._from_sequence_of_strings SA01" \
         -i "pandas.api.extensions.ExtensionArray._hash_pandas_object RT03,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -375,7 +375,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.weekday SA01" \
         -i "pandas.Timestamp.weekofyear SA01" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray._concat_same_type PR07" \
         -i "pandas.api.extensions.ExtensionArray._formatter SA01" \
         -i "pandas.api.extensions.ExtensionArray._from_sequence SA01" \
         -i "pandas.api.extensions.ExtensionArray._from_sequence_of_strings SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -375,7 +375,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.weekday SA01" \
         -i "pandas.Timestamp.weekofyear SA01" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray._accumulate RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray._concat_same_type PR07,SA01" \
         -i "pandas.api.extensions.ExtensionArray._formatter SA01" \
         -i "pandas.api.extensions.ExtensionArray._from_sequence SA01" \

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1844,10 +1844,19 @@ class ExtensionArray:
         Returns
         -------
         array
+            An array performing the accumulation operation.
 
         Raises
         ------
         NotImplementedError : subclass does not define accumulations
+
+        See Also
+        --------
+        api.extensions.ExtensionArray._concat_same_type : Concatenate multiple
+            array of this dtype.
+        api.extensions.ExtensionArray.view : Return a view on the array.
+        api.extensions.ExtensionArray._explode : Transform each element of
+            list-like to a row.
 
         Examples
         --------

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1713,6 +1713,9 @@ class ExtensionArray:
             when ``boxed=False`` and :func:`str` is used when
             ``boxed=True``.
 
+        See Also
+        --------
+
         Examples
         --------
         >>> class MyExtensionArray(pd.arrays.NumpyExtensionArray):
@@ -1789,6 +1792,7 @@ class ExtensionArray:
         Parameters
         ----------
         to_concat : sequence of this type
+            An array of the same dtype to concatenate.
 
         Returns
         -------

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1794,6 +1794,15 @@ class ExtensionArray:
         -------
         ExtensionArray
 
+        See Also
+        --------
+        api.extensions.ExtensionArray._explode : Transform each element of
+            list-like to a row.
+        api.extensions.ExtensionArray._formatter : Formatting function for
+            scalar values.
+        api.extensions.ExtensionArray._from_factorized : Reconstruct an
+            ExtensionArray after factorization.
+
         Examples
         --------
         >>> arr1 = pd.array([1, 2, 3])

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1724,9 +1724,6 @@ class ExtensionArray:
         api.extensions.ExtensionArray._from_sequence : Construct a new
             ExtensionArray from a sequence of scalars.
 
-
-
-
         Examples
         --------
         >>> class MyExtensionArray(pd.arrays.NumpyExtensionArray):

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1715,6 +1715,17 @@ class ExtensionArray:
 
         See Also
         --------
+        api.extensions.ExtensionArray._concat_same_type : Concatenate multiple
+            array of this dtype.
+        api.extensions.ExtensionArray._explode : Transform each element of
+            list-like to a row.
+        api.extensions.ExtensionArray._from_factorized : Reconstruct an
+            ExtensionArray after factorization.
+        api.extensions.ExtensionArray._from_sequence : Construct a new
+            ExtensionArray from a sequence of scalars.
+
+
+
 
         Examples
         --------

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -158,6 +158,12 @@ class ExtensionArray:
     _values_for_argsort
     _values_for_factorize
 
+    See Also
+    --------
+    api.extensions.ExtensionDtype : A custom data type, to be paired with an
+        ExtensionArray.
+    api.extensions.ExtensionArray.dtype : An instance of ExtensionDtype.
+
     Notes
     -----
     The interface includes the following abstract methods that must be

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -295,6 +295,13 @@ class ExtensionArray:
         -------
         ExtensionArray
 
+        See Also
+        --------
+        api.extensions.ExtensionArray._from_sequence_of_strings : Construct a new
+            ExtensionArray from a sequence of strings.
+        api.extensions.ExtensionArray._hash_pandas_object : Hook for
+            hash_pandas_object.
+
         Examples
         --------
         >>> pd.arrays.IntegerArray._from_sequence([4, 5])


### PR DESCRIPTION
- [ ] xref #58539

Fixed SA01 issues for the following methods:

```
 -i "pandas.api.extensions.ExtensionArray SA01" \ 
 -i "pandas.api.extensions.ExtensionArray._accumulate RT03,SA01" \ 
 -i "pandas.api.extensions.ExtensionArray._concat_same_type PR07,SA01" \ 
 -i "pandas.api.extensions.ExtensionArray._formatter SA01" \ 
 -i "pandas.api.extensions.ExtensionArray._from_sequence SA01" \ 
```
Fixed functions also removed from code_checks.sh


