### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.Index.str and pandas.Series.str

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -85,7 +85,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Index.join PR07,RT03,SA01" \
         -i "pandas.Index.names GL08" \
         -i "pandas.Index.ravel PR01,RT03" \
-        -i "pandas.Index.str PR01,SA01" \
         -i "pandas.Interval PR02" \
         -i "pandas.Interval.closed SA01" \
         -i "pandas.Interval.left SA01" \
@@ -240,7 +239,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.sparse.sp_values SA01" \
         -i "pandas.Series.sparse.to_coo PR07,RT03,SA01" \
         -i "pandas.Series.std PR01,RT03,SA01" \
-        -i "pandas.Series.str PR01,SA01" \
         -i "pandas.Series.str.capitalize RT03" \
         -i "pandas.Series.str.casefold RT03" \
         -i "pandas.Series.str.center RT03,SA01" \

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -162,6 +162,16 @@ class StringMethods(NoNewAttributesMixin):
     Patterned after Python's string methods, with some inspiration from
     R's stringr package.
 
+    Parameters
+    ----------
+    data : Series or Index
+        The content of the Series or Index.
+
+    See Also
+    --------
+    Series.str : Vectorized string functions for Series.
+    Index.str : Vectorized string functions for Index.
+
     Examples
     --------
     >>> s = pd.Series(["A_Str_Series"])


### PR DESCRIPTION
- [ ] xref #58068 

fixes

```
pandas.Index.str PR01,SA01
pandas.Series.str PR01,SA01
```
