### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.Interval.left

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -88,7 +88,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Index.str PR01,SA01" \
         -i "pandas.Interval PR02" \
         -i "pandas.Interval.closed SA01" \
-        -i "pandas.Interval.left SA01" \
         -i "pandas.Interval.mid SA01" \
         -i "pandas.Interval.right SA01" \
         -i "pandas.IntervalIndex.closed SA01" \

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -377,6 +377,12 @@ cdef class Interval(IntervalMixin):
     """
     Left bound for the interval.
 
+    See Also
+    --------
+    Interval.right : Return the right bound for the interval.
+    numpy.ndarray.left : A similar method in numpy for obtaining
+        the left endpoint(s) of intervals.
+
     Examples
     --------
     >>> interval = pd.Interval(left=1, right=2, closed='left')


### PR DESCRIPTION
- [ ] xref #58498

fixes
```
pandas.Interval.left SA01
```
