### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.Interval.mid

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -89,7 +89,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Interval PR02" \
         -i "pandas.Interval.closed SA01" \
         -i "pandas.Interval.left SA01" \
-        -i "pandas.Interval.mid SA01" \
         -i "pandas.Interval.right SA01" \
         -i "pandas.IntervalIndex.closed SA01" \
         -i "pandas.IntervalIndex.contains RT03" \

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -167,6 +167,12 @@ cdef class IntervalMixin:
         """
         Return the midpoint of the Interval.
 
+        See Also
+        --------
+        Interval.left : Return the left bound for the interval.
+        Interval.right : Return the right bound for the interval.
+        Interval.length : Return the length of the interval.
+
         Examples
         --------
         >>> iv = pd.Interval(0, 5)


### PR DESCRIPTION
- [ ] xref #58498

fixes
```
pandas.Interval.mid SA01
```