### PR TITLE
TST: Add test for duplicate `by` columns in `groupby.agg` using `pd.namedAgg` and  `asIndex=False`

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2954,3 +2954,38 @@ def test_groupby_dropna_with_nunique_unique():
     )
 
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("as_index_flag", [False])
+def test_groupby_agg_namedagg_with_duplicate_columns(as_index_flag):
+    # GH #58446
+    df = DataFrame(
+        {
+            "col1": [2, 1, 1, 0, 2, 0],
+            "col2": [4, 5, 36, 7, 4, 5],
+            "col3": [3.1, 8.0, 12, 10, 4, 1.1],
+            "col4": [17, 3, 16, 15, 5, 6],
+            "col5": [-1, 3, -1, 3, -2, -1],
+        }
+    )
+
+    result = df.groupby(by=["col1", "col1", "col2"], as_index=as_index_flag).agg(
+        new_col=pd.NamedAgg(column="col1", aggfunc="min"),
+        new_col1=pd.NamedAgg(column="col1", aggfunc="max"),
+        new_col2=pd.NamedAgg(column="col2", aggfunc="count"),
+    )
+
+    expected = DataFrame(
+        {
+            "col1": [0, 0, 1, 1, 2],
+            "col2": [5, 7, 5, 36, 4],
+            "new_col": [0, 0, 1, 1, 2],
+            "new_col1": [0, 0, 1, 1, 2],
+            "new_col2": [1, 1, 1, 1, 2],
+        }
+    )
+
+    if not as_index_flag:
+        expected.reset_index(drop=True, inplace=True)
+
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2956,8 +2956,7 @@ def test_groupby_dropna_with_nunique_unique():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("as_index_flag", [False])
-def test_groupby_agg_namedagg_with_duplicate_columns(as_index_flag):
+def test_groupby_agg_namedagg_with_duplicate_columns():
     # GH#58446
     df = DataFrame(
         {
@@ -2969,7 +2968,7 @@ def test_groupby_agg_namedagg_with_duplicate_columns(as_index_flag):
         }
     )
 
-    result = df.groupby(by=["col1", "col1", "col2"], as_index=as_index_flag).agg(
+    result = df.groupby(by=["col1", "col1", "col2"], as_index=False).agg(
         new_col=pd.NamedAgg(column="col1", aggfunc="min"),
         new_col1=pd.NamedAgg(column="col1", aggfunc="max"),
         new_col2=pd.NamedAgg(column="col2", aggfunc="count"),
@@ -2984,8 +2983,5 @@ def test_groupby_agg_namedagg_with_duplicate_columns(as_index_flag):
             "new_col2": [1, 1, 1, 1, 2],
         }
     )
-
-    if not as_index_flag:
-        expected.reset_index(drop=True, inplace=True)
 
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2958,7 +2958,7 @@ def test_groupby_dropna_with_nunique_unique():
 
 @pytest.mark.parametrize("as_index_flag", [False])
 def test_groupby_agg_namedagg_with_duplicate_columns(as_index_flag):
-    # GH #58446
+    # GH#58446
     df = DataFrame(
         {
             "col1": [2, 1, 1, 0, 2, 0],


### PR DESCRIPTION
- [x] closes #58446  
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)


This PR adds a unit test to `pandas/tests/groupby/test_groupby.py` to verify the correct functionality of `groupby.agg` when passed in `pd.NamedAgg` objects with duplicate columns in the `by` argument, and with `asIndex=False`. Addresses GH #58446.