### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.Series.mul

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -210,7 +210,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.min RT03" \
         -i "pandas.Series.mod PR07" \
         -i "pandas.Series.mode SA01" \
-        -i "pandas.Series.mul PR07" \
         -i "pandas.Series.ne PR07,SA01" \
         -i "pandas.Series.pad PR01,SA01" \
         -i "pandas.Series.plot PR02,SA01" \

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5984,8 +5984,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Return Multiplication of series and other, element-wise (binary operator `mul`).
 
         Equivalent to ``series * other``, but with support to substitute
-        a fill_value for
-        missing data in either one of the inputs.
+        a fill_value for missing data in either one of the inputs.
 
         Parameters
         ----------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5973,7 +5973,6 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             other, roperator.rsub, level=level, fill_value=fill_value, axis=axis
         )
 
-    @Appender(ops.make_flex_doc("mul", "series"))
     def mul(
         self,
         other,
@@ -5981,6 +5980,71 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         fill_value: float | None = None,
         axis: Axis = 0,
     ) -> Series:
+        """
+        Return Multiplication of series and other, element-wise
+        (binary operator `mul`).
+
+        Equivalent to ``series * other``, but with support to substitute
+        a fill_value for
+        missing data in either one of the inputs.
+
+        Parameters
+        ----------
+        other : Series or scalar value
+            With which to compute the multiplication.
+        level : int or name
+            Broadcast across a level, matching Index values on the
+            passed MultiIndex level.
+        fill_value : None or float value, default None (NaN)
+            Fill existing missing (NaN) values, and any new element needed for
+            successful Series alignment, with this value before computation.
+            If data in both corresponding Series locations is missing
+            the result of filling (at that location) will be missing.
+        axis : {0 or 'index'}
+            Unused. Parameter needed for compatibility with DataFrame.
+
+        Returns
+        -------
+        Series
+            The result of the operation.
+
+        See Also
+        --------
+        Series.rmul : Reverse of the Multiplication operator, see
+            `Python documentation
+            <https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types>`_
+            for more details.
+
+        Examples
+        --------
+        >>> a = pd.Series([1, 1, 1, np.nan], index=["a", "b", "c", "d"])
+        >>> a
+        a    1.0
+        b    1.0
+        c    1.0
+        d    NaN
+        dtype: float64
+        >>> b = pd.Series([1, np.nan, 1, np.nan], index=["a", "b", "d", "e"])
+        >>> b
+        a    1.0
+        b    NaN
+        d    1.0
+        e    NaN
+        dtype: float64
+        >>> a.multiply(b, fill_value=0)
+        a    1.0
+        b    0.0
+        c    0.0
+        d    0.0
+        e    NaN
+        dtype: float64
+        >>> a.mul(5, fill_value=0)
+        a    5.0
+        b    5.0
+        c    5.0
+        d    0.0
+        dtype: float64
+        """
         return self._flex_method(
             other, operator.mul, level=level, fill_value=fill_value, axis=axis
         )

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5981,8 +5981,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         axis: Axis = 0,
     ) -> Series:
         """
-        Return Multiplication of series and other, element-wise
-        (binary operator `mul`).
+        Return Multiplication of series and other, element-wise (binary operator `mul`).
 
         Equivalent to ``series * other``, but with support to substitute
         a fill_value for


### PR DESCRIPTION
- [ ] xref #58504 

fixes
```
-i "pandas.Series.mul PR07" \

```