### PR TITLE
DOC: Fix minor grammatical typo in `core/series.py` docstring.

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -294,7 +294,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     z   NaN
     dtype: float64
 
-    Note that the Index is first build with the keys from the dictionary.
+    Note that the Index is first built with the keys from the dictionary.
     After this the Series is reindexed with the given Index values, hence we
     get all NaN as a result.
 


### PR DESCRIPTION
Fix minor grammatical typo in `core/series.py` docstring. 

Minor fix to fix "is build with" -> "is built with".