### PR TITLE
DOC: Minor fix to docstring formatting for `head()` and `tail()`

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5527,7 +5527,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         it returns an empty object. When ``n`` is negative, it returns
         all rows except the last ``|n|`` rows, mirroring the behavior of ``df[:n]``.
 
-        If n is larger than the number of rows, this function returns all rows.
+        If ``n`` is larger than the number of rows, this function returns all rows.
 
         Parameters
         ----------
@@ -5615,7 +5615,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         For negative values of `n`, this function returns all rows except
         the first `|n|` rows, equivalent to ``df[|n|:]``.
 
-        If n is larger than the number of rows, this function returns all rows.
+        If `n` is larger than the number of rows, this function returns all rows.
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5615,7 +5615,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         For negative values of `n`, this function returns all rows except
         the first `|n|` rows, equivalent to ``df[|n|:]``.
 
-        If `n` is larger than the number of rows, this function returns all rows.
+        If ``n`` is larger than the number of rows, this function returns all rows.
 
         Parameters
         ----------


### PR DESCRIPTION
Fix minor inconsistency in docstring formatting for `head()` and `tail()`.

Fix the code formatting for the `n` variable appearing in the docstrings of `head()` and `tail()` so that it is consistent with surrounding uses of the variable.