### PR TITLE
BUG: Improve error message when casting array of objects to int

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1697,7 +1697,7 @@ def maybe_cast_to_integer_array(arr: list | np.ndarray, dtype: np.dtype) -> np.n
             )
         raise ValueError("Trying to coerce float values to integers")
     if arr.dtype == object:
-        raise ValueError("Trying to coerce float values to integers")
+        raise ValueError("Trying to coerce object values to integers")
 
     if casted.dtype < arr.dtype:
         # TODO: Can this path be hit anymore with numpy > 2

--- a/pandas/tests/indexes/numeric/test_numeric.py
+++ b/pandas/tests/indexes/numeric/test_numeric.py
@@ -397,7 +397,7 @@ class TestIntNumericIndex:
 
         # preventing casting
         arr = np.array([1, "2", 3, "4"], dtype=object)
-        msg = "Trying to coerce float values to integers"
+        msg = "Trying to coerce object values to integers"
         with pytest.raises(ValueError, match=msg):
             index_cls(arr, dtype=dtype)
 


### PR DESCRIPTION
- [x] ref #58586

This doesn't fix the main problem, but it at least improves the error message until it gets fixed