### PR TITLE
CLN: Some unit tests

### DIFF
--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1489,7 +1489,7 @@ def test_apply_dtype(col):
 
 def test_apply_mutating():
     # GH#35462 case where applied func pins a new BlockManager to a row
-    df = DataFrame({"a": range(100), "b": range(100, 200)})
+    df = DataFrame({"a": range(10), "b": range(10, 20)})
     df_orig = df.copy()
 
     def func(row):

--- a/pandas/tests/apply/test_str.py
+++ b/pandas/tests/apply/test_str.py
@@ -28,7 +28,7 @@ from pandas.tests.apply.common import (
     ],
 )
 @pytest.mark.parametrize("how", ["agg", "apply"])
-def test_apply_with_string_funcs(request, float_frame, func, kwds, how):
+def test_apply_with_string_funcs(float_frame, func, kwds, how):
     result = getattr(float_frame, how)(func, **kwds)
     expected = getattr(float_frame, func)(**kwds)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1080,7 +1080,7 @@ class TestDatetime64Arithmetic:
     @pytest.mark.parametrize("freq", ["h", "D", "W", "2ME", "MS", "QE", "B", None])
     @pytest.mark.parametrize("dtype", [None, "uint8"])
     def test_dt64arr_addsub_intlike(
-        self, request, dtype, index_or_series_or_array, freq, tz_naive_fixture
+        self, dtype, index_or_series_or_array, freq, tz_naive_fixture
     ):
         # GH#19959, GH#19123, GH#19012
         # GH#55860 use index_or_series_or_array instead of box_with_array

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -270,7 +270,7 @@ def test_numpy_array_all_dtypes(any_numpy_dtype):
         ),
     ],
 )
-def test_array(arr, attr, index_or_series, request):
+def test_array(arr, attr, index_or_series):
     box = index_or_series
 
     result = box(arr, copy=False).array
@@ -383,7 +383,7 @@ def test_to_numpy_copy(arr, as_series, using_infer_string):
 
 
 @pytest.mark.parametrize("as_series", [True, False])
-def test_to_numpy_dtype(as_series, unit):
+def test_to_numpy_dtype(as_series):
     tz = "US/Eastern"
     obj = pd.DatetimeIndex(["2000", "2001"], tz=tz)
     if as_series:

--- a/pandas/tests/base/test_value_counts.py
+++ b/pandas/tests/base/test_value_counts.py
@@ -47,11 +47,6 @@ def test_value_counts(index_or_series_obj):
             # i.e IntegerDtype
             expected = expected.astype("Int64")
 
-    # TODO(GH#32514): Order of entries with the same count is inconsistent
-    #  on CI (gh-32449)
-    if obj.duplicated().any():
-        result = result.sort_index()
-        expected = expected.sort_index()
     tm.assert_series_equal(result, expected)
 
 
@@ -89,11 +84,6 @@ def test_value_counts_null(null_obj, index_or_series_obj):
     expected.index.name = obj.name
 
     result = obj.value_counts()
-    if obj.duplicated().any():
-        # TODO(GH#32514):
-        #  Order of entries with the same count is inconsistent on CI (gh-32449)
-        expected = expected.sort_index()
-        result = result.sort_index()
 
     if not isinstance(result.dtype, np.dtype):
         if getattr(obj.dtype, "storage", "") == "pyarrow":
@@ -106,11 +96,8 @@ def test_value_counts_null(null_obj, index_or_series_obj):
     expected[null_obj] = 3
 
     result = obj.value_counts(dropna=False)
-    if obj.duplicated().any():
-        # TODO(GH#32514):
-        #  Order of entries with the same count is inconsistent on CI (gh-32449)
-        expected = expected.sort_index()
-        result = result.sort_index()
+    expected = expected.sort_index()
+    result = result.sort_index()
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1984,9 +1984,8 @@ def test_set_inplace():
     tm.assert_series_equal(result_view["A"], expected)
 
 
-class TestValidate:
-    @pytest.mark.parametrize("value", [1, "True", [1, 2, 3], 5.0])
-    def test_validate_bool_args(self, value):
-        msg = 'For argument "inplace" expected type bool, received type'
-        with pytest.raises(ValueError, match=msg):
-            pd.eval("2+2", inplace=value)
+@pytest.mark.parametrize("value", [1, "True", [1, 2, 3], 5.0])
+def test_validate_bool_args(value):
+    msg = 'For argument "inplace" expected type bool, received type'
+    with pytest.raises(ValueError, match=msg):
+        pd.eval("2+2", inplace=value)

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -245,6 +245,7 @@ def test_alignment_deprecation_enforced():
         np.add(s2, df1)
 
 
+@pytest.mark.single_cpu
 def test_alignment_deprecation_many_inputs_enforced():
     # Enforced in 2.0
     # https://github.com/pandas-dev/pandas/issues/39184

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -121,8 +121,7 @@ class TestMultiLevel:
 
         expected = ymd.groupby([k1, k2]).mean()
 
-        # TODO groupby with level_values drops names
-        tm.assert_frame_equal(result, expected, check_names=False)
+        tm.assert_frame_equal(result, expected)
         assert result.index.names == ymd.index.names[:2]
 
         result2 = ymd.groupby(level=ymd.index.names[:2]).mean()

--- a/pandas/tests/window/test_expanding.py
+++ b/pandas/tests/window/test_expanding.py
@@ -550,7 +550,7 @@ def test_expanding_cov_pairwise_diff_length():
     df2a = DataFrame(
         [[5, 6], [2, 1]], index=[0, 2], columns=Index(["X", "Y"], name="foo")
     )
-    # TODO: xref gh-15826
+    # xref gh-15826
     # .loc is not preserving the names
     result1 = df1.expanding().cov(df2, pairwise=True).loc[2]
     result2 = df1.expanding().cov(df2a, pairwise=True).loc[2]


### PR DESCRIPTION
- Reduced some data sizes
- Removed unused fixtures
- Marked a numba test as `single_cpu`
- Addressed to TODOs