### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.Timestamp.as_unit and pandas.Timedelta.as_unit

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -261,6 +261,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.var PR01,RT03,SA01" \
         -i "pandas.SparseDtype SA01" \
         -i "pandas.Timedelta PR07,SA01" \
+        -i "pandas.Timedelta.as_unit SA01" \
         -i "pandas.Timedelta.asm8 SA01" \
         -i "pandas.Timedelta.ceil SA01" \
         -i "pandas.Timedelta.components SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -265,7 +265,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.var PR01,RT03,SA01" \
         -i "pandas.SparseDtype SA01" \
         -i "pandas.Timedelta PR07,SA01" \
-        -i "pandas.Timedelta.as_unit SA01" \
         -i "pandas.Timedelta.asm8 SA01" \
         -i "pandas.Timedelta.ceil SA01" \
         -i "pandas.Timedelta.components SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -285,7 +285,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.TimedeltaIndex.nanoseconds SA01" \
         -i "pandas.TimedeltaIndex.seconds SA01" \
         -i "pandas.TimedeltaIndex.to_pytimedelta RT03,SA01" \
-        -i "pandas.Timestamp.as_unit SA01" \
         -i "pandas.Timestamp.asm8 SA01" \
         -i "pandas.Timestamp.astimezone SA01" \
         -i "pandas.Timestamp.ceil SA01" \

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -1383,6 +1383,14 @@ default 'raise'
         -------
         Timestamp
 
+        See Also
+        --------
+        Timestamp.asm8 : Return numpy datetime64 format in nanoseconds.
+        Timestamp.to_pydatetime : Convert Timestamp object to a native
+            Python datetime object.
+        to_timedelta : Convert argument into timedelta object,
+            which can represent differences in times.
+
         Examples
         --------
         >>> ts = pd.Timestamp('2023-01-01 00:00:00.01')

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1115,6 +1115,14 @@ cdef class _Timestamp(ABCTimestamp):
         -------
         Timestamp
 
+        See Also
+        --------
+        Timestamp.asm8 : Return numpy datetime64 format in nanoseconds.
+        Timestamp.to_pydatetime : Convert Timestamp object to a native
+            Python datetime object.
+        to_timedelta : Convert argument into timedelta object,
+            which can represent differences in times.
+
         Examples
         --------
         >>> ts = pd.Timestamp('2023-01-01 00:00:00.01')


### PR DESCRIPTION
- [x] xref #58505 

fixes
```
pandas.Timestamp.as_unit SA01
pandas.Timedelta.as_unit SA01
```
