### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.tseries copy methods

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -589,7 +589,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.BMonthBegin PR02" \
         -i "pandas.tseries.offsets.BMonthEnd PR02" \
         -i "pandas.tseries.offsets.BQuarterBegin PR02" \
-        -i "pandas.tseries.offsets.BQuarterBegin.copy SA01" \
         -i "pandas.tseries.offsets.BQuarterBegin.freqstr SA01" \
         -i "pandas.tseries.offsets.BQuarterBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BQuarterBegin.kwds SA01" \
@@ -600,7 +599,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.BQuarterBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.BQuarterBegin.startingMonth GL08" \
         -i "pandas.tseries.offsets.BQuarterEnd PR02" \
-        -i "pandas.tseries.offsets.BQuarterEnd.copy SA01" \
         -i "pandas.tseries.offsets.BQuarterEnd.freqstr SA01" \
         -i "pandas.tseries.offsets.BQuarterEnd.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BQuarterEnd.kwds SA01" \
@@ -611,7 +609,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.BQuarterEnd.rule_code GL08" \
         -i "pandas.tseries.offsets.BQuarterEnd.startingMonth GL08" \
         -i "pandas.tseries.offsets.BYearBegin PR02" \
-        -i "pandas.tseries.offsets.BYearBegin.copy SA01" \
         -i "pandas.tseries.offsets.BYearBegin.freqstr SA01" \
         -i "pandas.tseries.offsets.BYearBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BYearBegin.kwds SA01" \
@@ -622,7 +619,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.BYearBegin.normalize GL08" \
         -i "pandas.tseries.offsets.BYearBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.BYearEnd PR02" \
-        -i "pandas.tseries.offsets.BYearEnd.copy SA01" \
         -i "pandas.tseries.offsets.BYearEnd.freqstr SA01" \
         -i "pandas.tseries.offsets.BYearEnd.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BYearEnd.kwds SA01" \
@@ -634,7 +630,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.BYearEnd.rule_code GL08" \
         -i "pandas.tseries.offsets.BusinessDay PR02,SA01" \
         -i "pandas.tseries.offsets.BusinessDay.calendar GL08" \
-        -i "pandas.tseries.offsets.BusinessDay.copy SA01" \
         -i "pandas.tseries.offsets.BusinessDay.freqstr SA01" \
         -i "pandas.tseries.offsets.BusinessDay.holidays GL08" \
         -i "pandas.tseries.offsets.BusinessDay.is_on_offset GL08" \
@@ -647,7 +642,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.BusinessDay.weekmask GL08" \
         -i "pandas.tseries.offsets.BusinessHour PR02,SA01" \
         -i "pandas.tseries.offsets.BusinessHour.calendar GL08" \
-        -i "pandas.tseries.offsets.BusinessHour.copy SA01" \
         -i "pandas.tseries.offsets.BusinessHour.end GL08" \
         -i "pandas.tseries.offsets.BusinessHour.freqstr SA01" \
         -i "pandas.tseries.offsets.BusinessHour.holidays GL08" \
@@ -661,7 +655,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.BusinessHour.start GL08" \
         -i "pandas.tseries.offsets.BusinessHour.weekmask GL08" \
         -i "pandas.tseries.offsets.BusinessMonthBegin PR02" \
-        -i "pandas.tseries.offsets.BusinessMonthBegin.copy SA01" \
         -i "pandas.tseries.offsets.BusinessMonthBegin.freqstr SA01" \
         -i "pandas.tseries.offsets.BusinessMonthBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BusinessMonthBegin.kwds SA01" \
@@ -671,7 +664,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.BusinessMonthBegin.normalize GL08" \
         -i "pandas.tseries.offsets.BusinessMonthBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.BusinessMonthEnd PR02" \
-        -i "pandas.tseries.offsets.BusinessMonthEnd.copy SA01" \
         -i "pandas.tseries.offsets.BusinessMonthEnd.freqstr SA01" \
         -i "pandas.tseries.offsets.BusinessMonthEnd.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BusinessMonthEnd.kwds SA01" \
@@ -685,7 +677,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.CDay PR02,SA01" \
         -i "pandas.tseries.offsets.CustomBusinessDay PR02,SA01" \
         -i "pandas.tseries.offsets.CustomBusinessDay.calendar GL08" \
-        -i "pandas.tseries.offsets.CustomBusinessDay.copy SA01" \
         -i "pandas.tseries.offsets.CustomBusinessDay.freqstr SA01" \
         -i "pandas.tseries.offsets.CustomBusinessDay.holidays GL08" \
         -i "pandas.tseries.offsets.CustomBusinessDay.is_on_offset GL08" \
@@ -698,7 +689,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.CustomBusinessDay.weekmask GL08" \
         -i "pandas.tseries.offsets.CustomBusinessHour PR02,SA01" \
         -i "pandas.tseries.offsets.CustomBusinessHour.calendar GL08" \
-        -i "pandas.tseries.offsets.CustomBusinessHour.copy SA01" \
         -i "pandas.tseries.offsets.CustomBusinessHour.end GL08" \
         -i "pandas.tseries.offsets.CustomBusinessHour.freqstr SA01" \
         -i "pandas.tseries.offsets.CustomBusinessHour.holidays GL08" \
@@ -713,7 +703,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.CustomBusinessHour.weekmask GL08" \
         -i "pandas.tseries.offsets.CustomBusinessMonthBegin PR02" \
         -i "pandas.tseries.offsets.CustomBusinessMonthBegin.calendar GL08" \
-        -i "pandas.tseries.offsets.CustomBusinessMonthBegin.copy SA01" \
         -i "pandas.tseries.offsets.CustomBusinessMonthBegin.freqstr SA01" \
         -i "pandas.tseries.offsets.CustomBusinessMonthBegin.holidays GL08" \
         -i "pandas.tseries.offsets.CustomBusinessMonthBegin.is_on_offset SA01" \
@@ -727,7 +716,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.CustomBusinessMonthBegin.weekmask GL08" \
         -i "pandas.tseries.offsets.CustomBusinessMonthEnd PR02" \
         -i "pandas.tseries.offsets.CustomBusinessMonthEnd.calendar GL08" \
-        -i "pandas.tseries.offsets.CustomBusinessMonthEnd.copy SA01" \
         -i "pandas.tseries.offsets.CustomBusinessMonthEnd.freqstr SA01" \
         -i "pandas.tseries.offsets.CustomBusinessMonthEnd.holidays GL08" \
         -i "pandas.tseries.offsets.CustomBusinessMonthEnd.is_on_offset SA01" \
@@ -740,7 +728,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.CustomBusinessMonthEnd.rule_code GL08" \
         -i "pandas.tseries.offsets.CustomBusinessMonthEnd.weekmask GL08" \
         -i "pandas.tseries.offsets.DateOffset PR02" \
-        -i "pandas.tseries.offsets.DateOffset.copy SA01" \
         -i "pandas.tseries.offsets.DateOffset.freqstr SA01" \
         -i "pandas.tseries.offsets.DateOffset.is_on_offset GL08" \
         -i "pandas.tseries.offsets.DateOffset.kwds SA01" \
@@ -750,7 +737,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.DateOffset.normalize GL08" \
         -i "pandas.tseries.offsets.DateOffset.rule_code GL08" \
         -i "pandas.tseries.offsets.Day PR02" \
-        -i "pandas.tseries.offsets.Day.copy SA01" \
         -i "pandas.tseries.offsets.Day.freqstr SA01" \
         -i "pandas.tseries.offsets.Day.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Day.kwds SA01" \
@@ -760,7 +746,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Day.normalize GL08" \
         -i "pandas.tseries.offsets.Day.rule_code GL08" \
         -i "pandas.tseries.offsets.Easter PR02" \
-        -i "pandas.tseries.offsets.Easter.copy SA01" \
         -i "pandas.tseries.offsets.Easter.freqstr SA01" \
         -i "pandas.tseries.offsets.Easter.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Easter.kwds SA01" \
@@ -770,7 +755,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Easter.normalize GL08" \
         -i "pandas.tseries.offsets.Easter.rule_code GL08" \
         -i "pandas.tseries.offsets.FY5253 PR02" \
-        -i "pandas.tseries.offsets.FY5253.copy SA01" \
         -i "pandas.tseries.offsets.FY5253.freqstr SA01" \
         -i "pandas.tseries.offsets.FY5253.get_rule_code_suffix GL08" \
         -i "pandas.tseries.offsets.FY5253.get_year_end GL08" \
@@ -785,7 +769,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.FY5253.variation GL08" \
         -i "pandas.tseries.offsets.FY5253.weekday GL08" \
         -i "pandas.tseries.offsets.FY5253Quarter PR02" \
-        -i "pandas.tseries.offsets.FY5253Quarter.copy SA01" \
         -i "pandas.tseries.offsets.FY5253Quarter.freqstr SA01" \
         -i "pandas.tseries.offsets.FY5253Quarter.get_rule_code_suffix GL08" \
         -i "pandas.tseries.offsets.FY5253Quarter.get_weeks GL08" \
@@ -802,7 +785,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.FY5253Quarter.weekday GL08" \
         -i "pandas.tseries.offsets.FY5253Quarter.year_has_extra_week GL08" \
         -i "pandas.tseries.offsets.Hour PR02" \
-        -i "pandas.tseries.offsets.Hour.copy SA01" \
         -i "pandas.tseries.offsets.Hour.freqstr SA01" \
         -i "pandas.tseries.offsets.Hour.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Hour.kwds SA01" \
@@ -812,7 +794,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Hour.normalize GL08" \
         -i "pandas.tseries.offsets.Hour.rule_code GL08" \
         -i "pandas.tseries.offsets.LastWeekOfMonth PR02,SA01" \
-        -i "pandas.tseries.offsets.LastWeekOfMonth.copy SA01" \
         -i "pandas.tseries.offsets.LastWeekOfMonth.freqstr SA01" \
         -i "pandas.tseries.offsets.LastWeekOfMonth.is_on_offset GL08" \
         -i "pandas.tseries.offsets.LastWeekOfMonth.kwds SA01" \
@@ -824,7 +805,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.LastWeekOfMonth.week GL08" \
         -i "pandas.tseries.offsets.LastWeekOfMonth.weekday GL08" \
         -i "pandas.tseries.offsets.Micro PR02" \
-        -i "pandas.tseries.offsets.Micro.copy SA01" \
         -i "pandas.tseries.offsets.Micro.freqstr SA01" \
         -i "pandas.tseries.offsets.Micro.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Micro.kwds SA01" \
@@ -834,7 +814,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Micro.normalize GL08" \
         -i "pandas.tseries.offsets.Micro.rule_code GL08" \
         -i "pandas.tseries.offsets.Milli PR02" \
-        -i "pandas.tseries.offsets.Milli.copy SA01" \
         -i "pandas.tseries.offsets.Milli.freqstr SA01" \
         -i "pandas.tseries.offsets.Milli.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Milli.kwds SA01" \
@@ -844,7 +823,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Milli.normalize GL08" \
         -i "pandas.tseries.offsets.Milli.rule_code GL08" \
         -i "pandas.tseries.offsets.Minute PR02" \
-        -i "pandas.tseries.offsets.Minute.copy SA01" \
         -i "pandas.tseries.offsets.Minute.freqstr SA01" \
         -i "pandas.tseries.offsets.Minute.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Minute.kwds SA01" \
@@ -854,7 +832,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Minute.normalize GL08" \
         -i "pandas.tseries.offsets.Minute.rule_code GL08" \
         -i "pandas.tseries.offsets.MonthBegin PR02" \
-        -i "pandas.tseries.offsets.MonthBegin.copy SA01" \
         -i "pandas.tseries.offsets.MonthBegin.freqstr SA01" \
         -i "pandas.tseries.offsets.MonthBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.MonthBegin.kwds SA01" \
@@ -864,7 +841,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.MonthBegin.normalize GL08" \
         -i "pandas.tseries.offsets.MonthBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.MonthEnd PR02" \
-        -i "pandas.tseries.offsets.MonthEnd.copy SA01" \
         -i "pandas.tseries.offsets.MonthEnd.freqstr SA01" \
         -i "pandas.tseries.offsets.MonthEnd.is_on_offset GL08" \
         -i "pandas.tseries.offsets.MonthEnd.kwds SA01" \
@@ -874,7 +850,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.MonthEnd.normalize GL08" \
         -i "pandas.tseries.offsets.MonthEnd.rule_code GL08" \
         -i "pandas.tseries.offsets.Nano PR02" \
-        -i "pandas.tseries.offsets.Nano.copy SA01" \
         -i "pandas.tseries.offsets.Nano.freqstr SA01" \
         -i "pandas.tseries.offsets.Nano.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Nano.kwds SA01" \
@@ -884,7 +859,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Nano.normalize GL08" \
         -i "pandas.tseries.offsets.Nano.rule_code GL08" \
         -i "pandas.tseries.offsets.QuarterBegin PR02" \
-        -i "pandas.tseries.offsets.QuarterBegin.copy SA01" \
         -i "pandas.tseries.offsets.QuarterBegin.freqstr SA01" \
         -i "pandas.tseries.offsets.QuarterBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.QuarterBegin.kwds SA01" \
@@ -895,7 +869,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.QuarterBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.QuarterBegin.startingMonth GL08" \
         -i "pandas.tseries.offsets.QuarterEnd PR02" \
-        -i "pandas.tseries.offsets.QuarterEnd.copy SA01" \
         -i "pandas.tseries.offsets.QuarterEnd.freqstr SA01" \
         -i "pandas.tseries.offsets.QuarterEnd.is_on_offset GL08" \
         -i "pandas.tseries.offsets.QuarterEnd.kwds SA01" \
@@ -906,7 +879,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.QuarterEnd.rule_code GL08" \
         -i "pandas.tseries.offsets.QuarterEnd.startingMonth GL08" \
         -i "pandas.tseries.offsets.Second PR02" \
-        -i "pandas.tseries.offsets.Second.copy SA01" \
         -i "pandas.tseries.offsets.Second.freqstr SA01" \
         -i "pandas.tseries.offsets.Second.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Second.kwds SA01" \
@@ -916,7 +888,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Second.normalize GL08" \
         -i "pandas.tseries.offsets.Second.rule_code GL08" \
         -i "pandas.tseries.offsets.SemiMonthBegin PR02,SA01" \
-        -i "pandas.tseries.offsets.SemiMonthBegin.copy SA01" \
         -i "pandas.tseries.offsets.SemiMonthBegin.day_of_month GL08" \
         -i "pandas.tseries.offsets.SemiMonthBegin.freqstr SA01" \
         -i "pandas.tseries.offsets.SemiMonthBegin.is_on_offset GL08" \
@@ -927,7 +898,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.SemiMonthBegin.normalize GL08" \
         -i "pandas.tseries.offsets.SemiMonthBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.SemiMonthEnd PR02,SA01" \
-        -i "pandas.tseries.offsets.SemiMonthEnd.copy SA01" \
         -i "pandas.tseries.offsets.SemiMonthEnd.day_of_month GL08" \
         -i "pandas.tseries.offsets.SemiMonthEnd.freqstr SA01" \
         -i "pandas.tseries.offsets.SemiMonthEnd.is_on_offset GL08" \
@@ -938,7 +908,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.SemiMonthEnd.normalize GL08" \
         -i "pandas.tseries.offsets.SemiMonthEnd.rule_code GL08" \
         -i "pandas.tseries.offsets.Tick GL08" \
-        -i "pandas.tseries.offsets.Tick.copy SA01" \
         -i "pandas.tseries.offsets.Tick.freqstr SA01" \
         -i "pandas.tseries.offsets.Tick.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Tick.kwds SA01" \
@@ -948,7 +917,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Tick.normalize GL08" \
         -i "pandas.tseries.offsets.Tick.rule_code GL08" \
         -i "pandas.tseries.offsets.Week PR02" \
-        -i "pandas.tseries.offsets.Week.copy SA01" \
         -i "pandas.tseries.offsets.Week.freqstr SA01" \
         -i "pandas.tseries.offsets.Week.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Week.kwds SA01" \
@@ -959,7 +927,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Week.rule_code GL08" \
         -i "pandas.tseries.offsets.Week.weekday GL08" \
         -i "pandas.tseries.offsets.WeekOfMonth PR02,SA01" \
-        -i "pandas.tseries.offsets.WeekOfMonth.copy SA01" \
         -i "pandas.tseries.offsets.WeekOfMonth.freqstr SA01" \
         -i "pandas.tseries.offsets.WeekOfMonth.is_on_offset GL08" \
         -i "pandas.tseries.offsets.WeekOfMonth.kwds SA01" \
@@ -971,7 +938,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.WeekOfMonth.week GL08" \
         -i "pandas.tseries.offsets.WeekOfMonth.weekday GL08" \
         -i "pandas.tseries.offsets.YearBegin PR02" \
-        -i "pandas.tseries.offsets.YearBegin.copy SA01" \
         -i "pandas.tseries.offsets.YearBegin.freqstr SA01" \
         -i "pandas.tseries.offsets.YearBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.YearBegin.kwds SA01" \
@@ -982,7 +948,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.YearBegin.normalize GL08" \
         -i "pandas.tseries.offsets.YearBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.YearEnd PR02" \
-        -i "pandas.tseries.offsets.YearEnd.copy SA01" \
         -i "pandas.tseries.offsets.YearEnd.freqstr SA01" \
         -i "pandas.tseries.offsets.YearEnd.is_on_offset GL08" \
         -i "pandas.tseries.offsets.YearEnd.kwds SA01" \

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -500,6 +500,13 @@ cdef class BaseOffset:
         """
         Return a copy of the frequency.
 
+        See Also
+        --------
+        tseries.offsets.Week.copy : Return a copy of Week offset.
+        tseries.offsets.DateOffset.copy : Return a copy of date offset.
+        tseries.offsets.MonthEnd.copy : Return a copy of MonthEnd offset.
+        tseries.offsets.YearBegin.copy : Return a copy of YearBegin offset.
+
         Examples
         --------
         >>> freq = pd.DateOffset(1)


### PR DESCRIPTION
- [ ] xref #58536 

fixes

```
-i "pandas.tseries.offsets.BQuarterEnd.copy SA01" \
-i "pandas.tseries.offsets.BYearBegin.copy SA01" \
-i "pandas.tseries.offsets.BYearEnd.copy SA01" \
-i "pandas.tseries.offsets.BusinessDay.copy SA01" \
-i "pandas.tseries.offsets.BusinessHour.copy SA01" \
-i "pandas.tseries.offsets.BusinessMonthBegin.copy SA01" \
-i "pandas.tseries.offsets.BusinessMonthEnd.copy SA01" \
-i "pandas.tseries.offsets.CustomBusinessDay.copy SA01" \
-i "pandas.tseries.offsets.CustomBusinessHour.copy SA01" \
-i "pandas.tseries.offsets.CustomBusinessMonthBegin.copy SA01" \
-i "pandas.tseries.offsets.CustomBusinessMonthEnd.copy SA01" \
-i "pandas.tseries.offsets.DateOffset.copy SA01" \
-i "pandas.tseries.offsets.Day.copy SA01" \
-i "pandas.tseries.offsets.Easter.copy SA01" \
-i "pandas.tseries.offsets.FY5253.copy SA01" \
-i "pandas.tseries.offsets.FY5253Quarter.copy SA01" \
-i "pandas.tseries.offsets.Hour.copy SA01" \
-i "pandas.tseries.offsets.LastWeekOfMonth.copy SA01" \
-i "pandas.tseries.offsets.Micro.copy SA01" \
-i "pandas.tseries.offsets.Milli.copy SA01" \
-i "pandas.tseries.offsets.Minute.copy SA01" \
-i "pandas.tseries.offsets.MonthBegin.copy SA01" \
-i "pandas.tseries.offsets.MonthEnd.copy SA01" \
-i "pandas.tseries.offsets.Nano.copy SA01" \
-i "pandas.tseries.offsets.QuarterBegin.copy SA01" \
-i "pandas.tseries.offsets.QuarterEnd.copy SA01" \
-i "pandas.tseries.offsets.Second.copy SA01" \
-i "pandas.tseries.offsets.SemiMonthBegin.copy SA01" \
-i "pandas.tseries.offsets.SemiMonthEnd.copy SA01" \
-i "pandas.tseries.offsets.Tick.copy SA01" \
-i "pandas.tseries.offsets.Week.copy SA01" \
-i "pandas.tseries.offsets.WeekOfMonth.copy SA01" \
-i "pandas.tseries.offsets.YearBegin.copy SA01" \
-i "pandas.tseries.offsets.YearEnd.copy SA01" \
```
