### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.api.extensions.register_extension_dtype

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -370,7 +370,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.extensions.ExtensionArray.tolist RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.unique RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.view SA01" \
-        -i "pandas.api.extensions.register_extension_dtype SA01" \
         -i "pandas.api.indexers.BaseIndexer PR01,SA01" \
         -i "pandas.api.indexers.FixedForwardWindowIndexer PR01,SA01" \
         -i "pandas.api.indexers.VariableOffsetWindowIndexer PR01,SA01" \

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -488,8 +488,8 @@ def register_extension_dtype(cls: type_t[ExtensionDtypeT]) -> type_t[ExtensionDt
 
     See Also
     --------
-    api.extensions.ExtensionDtype : The base class for creating custom
-        pandas data types.
+    api.extensions.ExtensionDtype : The base class for creating custom pandas
+        data types.
     Series : One-dimensional array with axis labels.
     DataFrame : Two-dimensional, size-mutable, potentially heterogeneous
         tabular data.

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -486,6 +486,14 @@ def register_extension_dtype(cls: type_t[ExtensionDtypeT]) -> type_t[ExtensionDt
     callable
         A class decorator.
 
+    See Also
+    --------
+    api.extensions.ExtensionDtype : The base class for creating custom
+        pandas data types.
+    Series : One-dimensional array with axis labels.
+    DataFrame : Two-dimensional, size-mutable, potentially heterogeneous
+        tabular data.
+
     Examples
     --------
     >>> from pandas.api.extensions import register_extension_dtype, ExtensionDtype


### PR DESCRIPTION
- [ ] xref #58539 

fixes
```
pandas.api.extensions.register_extension_dtype SA01
```
