### PR TITLE
TST: Add test for regression in `groupby` with tuples yielding MultiIndex

### DIFF
--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -823,37 +823,37 @@ class TestGrouping:
         tm.assert_frame_equal(result, expected)
 
 
-def test_groupby_tuple_keys_handle_multiindex():
-    # https://github.com/pandas-dev/pandas/issues/21340
-    df = DataFrame(
-        {
-            "num1": [0, 8, 9, 4, 3, 3, 5, 9, 3, 6],
-            "num2": [3, 8, 6, 4, 9, 2, 1, 7, 0, 9],
-            "num3": [6, 5, 7, 8, 5, 1, 1, 10, 7, 8],
-            "category_tuple": [
-                (0, 1),
-                (0, 1),
-                (0, 1),
-                (0, 4),
-                (2, 3),
-                (2, 3),
-                (2, 3),
-                (2, 3),
-                (5,),
-                (6,),
-            ],
-            "category_string": list("aaabbbbcde"),
-        }
-    )
-    df = df[["category_tuple", "category_string", "num1", "num2", "num3"]]
-    expected = df.sort_values(by=["category_tuple", "num1"])
+    def test_groupby_tuple_keys_handle_multiindex(self):
+        # https://github.com/pandas-dev/pandas/issues/21340
+        df = DataFrame(
+            {
+                "num1": [0, 8, 9, 4, 3, 3, 5, 9, 3, 6],
+                "num2": [3, 8, 6, 4, 9, 2, 1, 7, 0, 9],
+                "num3": [6, 5, 7, 8, 5, 1, 1, 10, 7, 8],
+                "category_tuple": [
+                    (0, 1),
+                    (0, 1),
+                    (0, 1),
+                    (0, 4),
+                    (2, 3),
+                    (2, 3),
+                    (2, 3),
+                    (2, 3),
+                    (5,),
+                    (6,),
+                ],
+                "category_string": list("aaabbbbcde"),
+            }
+        )
+        df = df[["category_tuple", "category_string", "num1", "num2", "num3"]]
+        expected = df.sort_values(by=["category_tuple", "num1"])
 
-    msg = "DataFrameGroupBy.apply operated on the grouping columns"
-    with tm.assert_produces_warning(DeprecationWarning, match=msg):
-        result = df.groupby("category_tuple").apply(lambda x: x.sort_values(by="num1"))
-    expected = expected[result.columns]
+        msg = "DataFrameGroupBy.apply operated on the grouping columns"
+        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+            result = df.groupby("category_tuple").apply(lambda x: x.sort_values(by="num1"))
+        expected = expected[result.columns]
 
-    tm.assert_frame_equal(result.reset_index(drop=True), expected)
+        tm.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
 # get_group

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -844,7 +844,6 @@ class TestGrouping:
                 "category_string": list("aaabbbbcde"),
             }
         )
-        df = df[["category_tuple", "category_string", "num1", "num2", "num3"]]
         expected = df.sort_values(by=["category_tuple", "num1"])
 
         msg = "DataFrameGroupBy.apply operated on the grouping columns"

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -846,7 +846,7 @@ class TestGrouping:
         )
         df = df[["category_tuple", "category_string", "num1", "num2", "num3"]]
         expected = df.sort_values(by=["category_tuple", "num1"])
-        
+
         msg = "DataFrameGroupBy.apply operated on the grouping columns"
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
             result = df.groupby("category_tuple").apply(

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -822,7 +822,6 @@ class TestGrouping:
         )
         tm.assert_frame_equal(result, expected)
 
-
     def test_groupby_tuple_keys_handle_multiindex(self):
         # https://github.com/pandas-dev/pandas/issues/21340
         df = DataFrame(
@@ -850,7 +849,9 @@ class TestGrouping:
 
         msg = "DataFrameGroupBy.apply operated on the grouping columns"
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
-            result = df.groupby("category_tuple").apply(lambda x: x.sort_values(by="num1"))
+            result = df.groupby("category_tuple").apply(
+                lambda x: x.sort_values(by="num1")
+            )
         expected = expected[result.columns]
 
         tm.assert_frame_equal(result.reset_index(drop=True), expected)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -845,12 +845,9 @@ class TestGrouping:
             }
         )
         expected = df.sort_values(by=["category_tuple", "num1"])
-
-        msg = "DataFrameGroupBy.apply operated on the grouping columns"
-        with tm.assert_produces_warning(DeprecationWarning, match=msg):
-            result = df.groupby("category_tuple").apply(
-                lambda x: x.sort_values(by="num1")
-            )
+        result = df.groupby("category_tuple").apply(
+            lambda x: x.sort_values(by="num1"), include_groups=False
+        )
         expected = expected[result.columns]
         tm.assert_frame_equal(result.reset_index(drop=True), expected)
 

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -846,14 +846,13 @@ class TestGrouping:
         )
         df = df[["category_tuple", "category_string", "num1", "num2", "num3"]]
         expected = df.sort_values(by=["category_tuple", "num1"])
-
+        
         msg = "DataFrameGroupBy.apply operated on the grouping columns"
         with tm.assert_produces_warning(DeprecationWarning, match=msg):
             result = df.groupby("category_tuple").apply(
                 lambda x: x.sort_values(by="num1")
             )
         expected = expected[result.columns]
-
         tm.assert_frame_equal(result.reset_index(drop=True), expected)
 
 

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -823,6 +823,39 @@ class TestGrouping:
         tm.assert_frame_equal(result, expected)
 
 
+def test_groupby_tuple_keys_handle_multiindex():
+    # https://github.com/pandas-dev/pandas/issues/21340
+    df = DataFrame(
+        {
+            "num1": [0, 8, 9, 4, 3, 3, 5, 9, 3, 6],
+            "num2": [3, 8, 6, 4, 9, 2, 1, 7, 0, 9],
+            "num3": [6, 5, 7, 8, 5, 1, 1, 10, 7, 8],
+            "category_tuple": [
+                (0, 1),
+                (0, 1),
+                (0, 1),
+                (0, 4),
+                (2, 3),
+                (2, 3),
+                (2, 3),
+                (2, 3),
+                (5,),
+                (6,),
+            ],
+            "category_string": list("aaabbbbcde"),
+        }
+    )
+    df = df[["category_tuple", "category_string", "num1", "num2", "num3"]]
+    expected = df.sort_values(by=["category_tuple", "num1"])
+
+    msg = "DataFrameGroupBy.apply operated on the grouping columns"
+    with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        result = df.groupby("category_tuple").apply(lambda x: x.sort_values(by="num1"))
+    expected = expected[result.columns]
+
+    tm.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
 # get_group
 # --------------------------------
 


### PR DESCRIPTION
- [x] closes #21340 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests).
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Added unit test to `pandas/tests/groupby/test_grouping.py` to address GH #21340

