### PR TITLE
TST: Skip test_rolling_var_numerical_issues on riscv64 platforms

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -122,6 +122,18 @@ def is_platform_power() -> bool:
     return platform.machine() in ("ppc64", "ppc64le")
 
 
+def is_platform_riscv64() -> bool:
+    """
+    Checking if the running platform use riscv64 architecture.
+
+    Returns
+    -------
+    bool
+        True if the running platform uses riscv64 architecture.
+    """
+    return platform.machine() == "riscv64"
+
+
 def is_ci_environment() -> bool:
     """
     Checking if running in a continuous integration environment by checking

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -10,6 +10,7 @@ from pandas.compat import (
     IS64,
     is_platform_arm,
     is_platform_power,
+    is_platform_riscv64,
 )
 
 from pandas import (
@@ -1081,7 +1082,7 @@ def test_rolling_sem(frame_or_series):
 
 
 @pytest.mark.xfail(
-    is_platform_arm() or is_platform_power(),
+    is_platform_arm() or is_platform_power() or is_platform_riscv64(),
     reason="GH 38921",
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
The test is failing on riscv64.  The failure is reproducible under qemu and on real hardware (VisionFive 2).

Updates #38921

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
