### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.Interval

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -77,7 +77,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.DataFrame.plot PR02,SA01" \
         -i "pandas.Grouper PR02" \
         -i "pandas.Index PR07" \
-        -i "pandas.Interval PR02" \
         -i "pandas.IntervalIndex.get_loc PR07,RT03,SA01" \
         -i "pandas.IntervalIndex.is_non_overlapping_monotonic SA01" \
         -i "pandas.IntervalIndex.left GL08" \

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -291,7 +291,7 @@ cdef class Interval(IntervalMixin):
     """
     Immutable object implementing an Interval, a bounded slice-like interval.
 
-    Parameters
+    Attributes
     ----------
     left : orderable scalar
         Left bound for the interval.


### PR DESCRIPTION
- [ ] xref #58498 

fixes
```
pandas.Interval PR02
```
