### PR TITLE
DOC: Enforce Numpy Docstring Validation for pandas.IntervalIndex.right

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -83,7 +83,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.IntervalIndex.left GL08" \
         -i "pandas.IntervalIndex.length GL08" \
         -i "pandas.IntervalIndex.mid GL08" \
-        -i "pandas.IntervalIndex.right GL08" \
         -i "pandas.IntervalIndex.set_closed RT03,SA01" \
         -i "pandas.IntervalIndex.to_tuples RT03,SA01" \
         -i "pandas.MultiIndex PR01" \

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -833,8 +833,7 @@ class IntervalIndex(ExtensionIndex):
     @cache_readonly
     def right(self) -> Index:
         """
-        Return an Index containing the right bounds of the intervals
-        in the IntervalIndex.
+        Return an Index having the right bounds of the intervals in the IntervalIndex.
 
         The right bounds of each interval in the IntervalIndex are
         returned as an Index. The datatype of the right bounds is the

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -832,6 +832,40 @@ class IntervalIndex(ExtensionIndex):
 
     @cache_readonly
     def right(self) -> Index:
+        """
+        Return an Index containing the right bounds of the intervals
+        in the IntervalIndex.
+
+        The right bounds of each interval in the IntervalIndex are
+        returned as an Index. The datatype of the right bounds is the
+        same as the datatype of the endpoints of the intervals.
+
+        Returns
+        -------
+        pandas.Index
+            An Index containing the right bounds of the intervals.
+
+        See Also
+        --------
+        IntervalIndex.left : Return the left bounds of the intervals
+            in the IntervalIndex.
+        IntervalIndex.mid : Return the mid-point of the intervals in
+            the IntervalIndex.
+        IntervalIndex.length : Return the length of the intervals in
+            the IntervalIndex.
+
+        Examples
+        --------
+        >>> iv_idx = pd.IntervalIndex.from_arrays([1, 2, 3], [4, 5, 6], closed="right")
+        >>> iv_idx.right
+        Int64Index([4, 5, 6], dtype='int64')
+
+        >>> iv_idx = pd.IntervalIndex.from_tuples(
+        ...     [(1, 4), (2, 5), (3, 6)], closed="left"
+        ... )
+        >>> iv_idx.right
+        Int64Index([4, 5, 6], dtype='int64')
+        """
         return Index(self._data.right, copy=False)
 
     @cache_readonly

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -842,7 +842,7 @@ class IntervalIndex(ExtensionIndex):
 
         Returns
         -------
-        pandas.Index
+        Index
             An Index containing the right bounds of the intervals.
 
         See Also

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -833,7 +833,7 @@ class IntervalIndex(ExtensionIndex):
     @cache_readonly
     def right(self) -> Index:
         """
-        Return an Index having the right bounds of the intervals in the IntervalIndex.
+        Return right bounds of the intervals in the IntervalIndex.
 
         The right bounds of each interval in the IntervalIndex are
         returned as an Index. The datatype of the right bounds is the


### PR DESCRIPTION
- [ ] xref #58498 

fixes
```
pandas.IntervalIndex.right GL08
```
