### PR TITLE
DOC: Fix typo in indexing.rst

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1730,7 +1730,7 @@ Returning a view versus a copy
 .. warning::
 
     :ref:`Copy-on-Write <copy_on_write>`
-    will become the new default in pandas 3.0. This means than chained indexing will
+    will become the new default in pandas 3.0. This means that chained indexing will
     never work. As a consequence, the ``SettingWithCopyWarning`` won't be necessary
     anymore.
     See :ref:`this section <copy_on_write_chained_assignment>`


### PR DESCRIPTION
Fix typo in "Returning a view versus a copy" section

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
