### PR TITLE
DOC: Clarify allowed values for on_bad_lines in read_csv

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -413,25 +413,27 @@ on_bad_lines : {{'error', 'warn', 'skip'}} or Callable, default 'error'
     - ``'error'``, raise an Exception when a bad line is encountered.
     - ``'warn'``, raise a warning when a bad line is encountered and skip that line.
     - ``'skip'``, skip bad lines without raising or warning when they are encountered.
-
+    - Callable, function that will process a single bad line.
+        - With ``engine='python'``, function with signature
+          ``(bad_line: list[str]) -> list[str] | None``.
+          ``bad_line`` is a list of strings split by the ``sep``.
+          If the function returns ``None``, the bad line will be ignored.
+          If the function returns a new ``list`` of strings with more elements than
+          expected, a ``ParserWarning`` will be emitted while dropping extra elements.
+        - With ``engine='pyarrow'``, function with signature
+          as described in `pyarrow documentation
+          <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html
+          #pyarrow.csv.ParseOptions.invalid_row_handler>`_.
+    
     .. versionadded:: 1.3.0
 
     .. versionadded:: 1.4.0
 
-        - Callable, function with signature
-          ``(bad_line: list[str]) -> list[str] | None`` that will process a single
-          bad line. ``bad_line`` is a list of strings split by the ``sep``.
-          If the function returns ``None``, the bad line will be ignored.
-          If the function returns a new ``list`` of strings with more elements than
-          expected, a ``ParserWarning`` will be emitted while dropping extra elements.
-          Only supported when ``engine='python'``
+        Callable
 
     .. versionchanged:: 2.2.0
 
-        - Callable, function with signature
-          as described in `pyarrow documentation
-          <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html
-          #pyarrow.csv.ParseOptions.invalid_row_handler>`_ when ``engine='pyarrow'``
+        Callable for ``engine='pyarrow'``
 
 delim_whitespace : bool, default False
     Specifies whether or not whitespace (e.g. ``' '`` or ``'\\t'``) will be

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -424,7 +424,7 @@ on_bad_lines : {{'error', 'warn', 'skip'}} or Callable, default 'error'
           as described in `pyarrow documentation
           <https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html
           #pyarrow.csv.ParseOptions.invalid_row_handler>`_.
-    
+
     .. versionadded:: 1.3.0
 
     .. versionadded:: 1.4.0

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -408,7 +408,7 @@ dialect : str or csv.Dialect, optional
     documentation for more details.
 on_bad_lines : {{'error', 'warn', 'skip'}} or Callable, default 'error'
     Specifies what to do upon encountering a bad line (a line with too many fields).
-    Allowed values are :
+    Allowed values are:
 
     - ``'error'``, raise an Exception when a bad line is encountered.
     - ``'warn'``, raise a warning when a bad line is encountered and skip that line.


### PR DESCRIPTION
Move the callable options out of the version added/changed tags and improve the flow.

- ~~[ ] closes #xxxx (Replace xxxx with the GitHub issue number)~~
- ~~[ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~~
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- ~~[ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~~
- ~~[ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~~

Check my work to make sure I got the details right, please. One thing is, I'm not sure if "process" is the right term for the PyArrow `invalid_row_handler` since all it does is say "skip" or "error".

BTW, `invalid_row_handler` isn't mentioned specifically, so at first I thought "signature as described in pyarrow documentation" was referring to the signature of the `ParseOptions` constructor.

Also, the description should probably state explicitly what happens when the function returns a list of strings with the right number of elements (with `engine='python'`). I haven't used it myself, but I'm inferring it gets forwarded to the parser that turns a table of strings into a dataframe.