### PR TITLE
DOC: Update Python version support

### DIFF
--- a/doc/source/development/policies.rst
+++ b/doc/source/development/policies.rst
@@ -46,6 +46,8 @@ deprecation removed in the next major release (2.0.0).
 These policies do not apply to features marked as **experimental** in the documentation.
 pandas may change the behavior of experimental features at any time.
 
+.. _policies.python_support:
+
 Python support
 ~~~~~~~~~~~~~~
 

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -21,7 +21,7 @@ Instructions for installing :ref:`from source <install.source>`,
 Python version support
 ----------------------
 
-See :ref:`python support policy <policies.python_support>`.
+See :ref:`Python support policy <policies.python_support>`.
 
 Installing pandas
 -----------------

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -21,7 +21,7 @@ Instructions for installing :ref:`from source <install.source>`,
 Python version support
 ----------------------
 
-Officially Python 3.9, 3.10, 3.11 and 3.12.
+pandas mirrors the `NumPy guidelines for Python support <https://numpy.org/neps/nep-0029-deprecation_policy.html#implementation>`__.
 
 Installing pandas
 -----------------

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -21,7 +21,7 @@ Instructions for installing :ref:`from source <install.source>`,
 Python version support
 ----------------------
 
-pandas mirrors the `NumPy guidelines for Python support <https://numpy.org/neps/nep-0029-deprecation_policy.html#implementation>`__.
+See :ref:`python support policy <policies.python_support>`.
 
 Installing pandas
 -----------------


### PR DESCRIPTION
The supported versions in https://pandas.pydata.org/docs/getting_started/install.html#python-version-support are hard-coded and the reasoning/criteria behind that is ambiguous.

The policy in the [version policy](https://pandas.pydata.org/docs/development/policies.html#python-support) document is clearer, so I just copied it.