### PR TITLE
A  typo in user guide doc 

### DIFF
--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -484,7 +484,7 @@ either the left or right tables, the values in the joined table will be
    p.plot([left, right], result, labels=["left", "right"], vertical=False);
    plt.close("all");
 
-You can :class:`Series` and a :class:`DataFrame` with a :class:`MultiIndex` if the names of
+You can merge :class:`Series` and a :class:`DataFrame` with a :class:`MultiIndex` if the names of
 the :class:`MultiIndex` correspond to the columns from the :class:`DataFrame`. Transform
 the :class:`Series` to a :class:`DataFrame` using :meth:`Series.reset_index` before merging
 


### PR DESCRIPTION
There was a typo in user guide doc specifically in [Merge, join, concatenate and compare](https://pandas.pydata.org/docs/dev/user_guide/merging.html#) ,after fixing ,it is now making more sense while reading 