### PR TITLE
TST: Fix CI failures (don't xfail postgresql / don't xfail for pyarrow=16)

### DIFF
--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -24,7 +24,7 @@ pytestmark = [
 ]
 
 
-@xfail_pyarrow  # ValueError: Found non-unique column index
+@pytest.mark.filterwarnings("ignore:Passing a BlockManager:DeprecationWarning")
 def test_multi_thread_string_io_read_csv(all_parsers):
     # see gh-11786
     parser = all_parsers

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -13,6 +13,7 @@ import pytest
 import pandas as pd
 from pandas import DataFrame
 import pandas._testing as tm
+from pandas.util.version import Version
 
 xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
 
@@ -25,9 +26,17 @@ pytestmark = [
 
 
 @pytest.mark.filterwarnings("ignore:Passing a BlockManager:DeprecationWarning")
-def test_multi_thread_string_io_read_csv(all_parsers):
+def test_multi_thread_string_io_read_csv(all_parsers, request):
     # see gh-11786
     parser = all_parsers
+    if parser == "pyarrow":
+        pa = pytest.importorskip("pyarrow")
+        if Version(pa.__version__) < Version("16.0"):
+            request.applymarker(
+                pytest.mark.xfail(
+                    reason="# ValueError: Found non-unique column index", strict=True
+                )
+            )
     max_row_range = 100
     num_files = 10
 

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -33,9 +33,7 @@ def test_multi_thread_string_io_read_csv(all_parsers, request):
         pa = pytest.importorskip("pyarrow")
         if Version(pa.__version__) < Version("16.0"):
             request.applymarker(
-                pytest.mark.xfail(
-                    reason="# ValueError: Found non-unique column index"
-                )
+                pytest.mark.xfail(reason="# ValueError: Found non-unique column index")
             )
     max_row_range = 100
     num_files = 10

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -34,7 +34,7 @@ def test_multi_thread_string_io_read_csv(all_parsers, request):
         if Version(pa.__version__) < Version("16.0"):
             request.applymarker(
                 pytest.mark.xfail(
-                    reason="# ValueError: Found non-unique column index", strict=True
+                    reason="# ValueError: Found non-unique column index"
                 )
             )
     max_row_range = 100

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -29,7 +29,7 @@ pytestmark = [
 def test_multi_thread_string_io_read_csv(all_parsers, request):
     # see gh-11786
     parser = all_parsers
-    if parser == "pyarrow":
+    if parser.engine == "pyarrow":
         pa = pytest.importorskip("pyarrow")
         if Version(pa.__version__) < Version("16.0"):
             request.applymarker(

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2302,7 +2302,7 @@ def test_api_read_sql_duplicate_columns(conn, request):
     if "adbc" in conn:
         pa = pytest.importorskip("pyarrow")
         if not (
-            Version(pa.__version__) >= Version("16.0") and conn == "sqlite_adbc_conn"
+            Version(pa.__version__) >= Version("16.0") and conn in ["sqlite_adbc_conn", "postgresql_adbc_conn"]
         ):
             request.node.add_marker(
                 pytest.mark.xfail(

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2302,7 +2302,8 @@ def test_api_read_sql_duplicate_columns(conn, request):
     if "adbc" in conn:
         pa = pytest.importorskip("pyarrow")
         if not (
-            Version(pa.__version__) >= Version("16.0") and conn in ["sqlite_adbc_conn", "postgresql_adbc_conn"]
+            Version(pa.__version__) >= Version("16.0")
+            and conn in ["sqlite_adbc_conn", "postgresql_adbc_conn"]
         ):
             request.node.add_marker(
                 pytest.mark.xfail(


### PR DESCRIPTION
Using `tm.assert_produces_warning` for the first test gives:
```
AssertionError: Warning not set with correct stacklevel
```
It seems the stacklevel is set incorrectly and should be changed (see #55591), I just temporarily fixed it by using `pytest.mark.filterwarnings`