### PR TITLE
DOC: Fix Docstring Validation for pandas.Series.str.translate

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -229,7 +229,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.str.strip RT03" \
         -i "pandas.Series.str.swapcase RT03" \
         -i "pandas.Series.str.title RT03" \
-        -i "pandas.Series.str.translate RT03,SA01" \
         -i "pandas.Series.str.upper RT03" \
         -i "pandas.Series.str.wrap RT03,SA01" \
         -i "pandas.Series.str.zfill RT03" \

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2408,7 +2408,11 @@ class StringMethods(NoNewAttributesMixin):
         """
         Map all characters in the string through the given mapping table.
 
-        Equivalent to standard :meth:`str.translate`.
+        This method is equivalent to the standard :meth:`str.translate`
+        method for strings. It maps each character in the string to a new
+        character according to the translation table provided. Unmapped
+        characters are left unchanged, while characters mapped to None
+        are removed.
 
         Parameters
         ----------
@@ -2421,6 +2425,14 @@ class StringMethods(NoNewAttributesMixin):
         Returns
         -------
         Series or Index
+            A new Series or Index with translated strings.
+
+        See Also
+        --------
+        Series.str.replace : Replace occurrences of pattern/regex in the
+            Series with some other string.
+        Index.str.replace : Replace occurrences of pattern/regex in the
+            Index with some other string.
 
         Examples
         --------


### PR DESCRIPTION
- [x] xref #58504

fixes
```
pandas.Series.str.translate RT03,SA01
```
