### PR TITLE
ENH: Processing of .mask() for pd.NA #56844

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -482,6 +482,7 @@ Other
 - Bug in :class:`DataFrame` when passing a ``dict`` with a NA scalar and ``columns`` that would always return ``np.nan`` (:issue:`57205`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
+- Bug in :func:`mask` to handle NaN values in condition of function. (:issue:`56844`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which caused an exception when using NumPy attributes via ``@`` notation, e.g., ``df.eval("@np.floor(a)")``. (:issue:`58041`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which did not allow to use ``tan`` function. (:issue:`55091`)
 - Bug in :meth:`DataFrame.sort_index` when passing ``axis="columns"`` and ``ignore_index=True`` and ``ascending=False`` not returning a :class:`RangeIndex` columns (:issue:`57293`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -329,6 +329,7 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 - Fixed bug in :class:`SparseDtype` for equal comparison with na fill value. (:issue:`54770`)
+- Fixed bug in :func:`mask` to handle NaN values in condition of function. (:issue:`56844`)
 - Fixed bug in :meth:`.DataFrameGroupBy.median` where nat values gave an incorrect result. (:issue:`57926`)
 - Fixed bug in :meth:`DataFrame.cumsum` which was raising ``IndexError`` if dtype is ``timedelta64[ns]`` (:issue:`57956`)
 - Fixed bug in :meth:`DataFrame.join` inconsistently setting result index name (:issue:`55815`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9999,7 +9999,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         cond = common.apply_if_callable(cond, self)
         other = common.apply_if_callable(other, self)
 
-        if isinstance(cond, ABCDataFrame | ABCSeries):
+        if isinstance(cond, (ABCDataFrame, ABCSeries)):
             cond = cond.fillna(False)
 
         # see gh-21891

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9960,7 +9960,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         cond = common.apply_if_callable(cond, self)
         other = common.apply_if_callable(other, self)
 
-        if isinstance(cond, ABCDataFrame | ABCSeries):
+        if isinstance(cond, (ABCDataFrame, ABCSeries)):
             cond = cond.fillna(False)
 
         # see gh-21891

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9999,6 +9999,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         cond = common.apply_if_callable(cond, self)
         other = common.apply_if_callable(other, self)
 
+        if isinstance(cond, ABCDataFrame | ABCSeries):
+            cond = cond.fillna(False)
+
         # see gh-21891
         if not hasattr(cond, "__invert__"):
             cond = np.array(cond)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9960,6 +9960,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         cond = common.apply_if_callable(cond, self)
         other = common.apply_if_callable(other, self)
 
+        if isinstance(cond, ABCDataFrame | ABCSeries):
+            cond = cond.fillna(False)
+
         # see gh-21891
         if not hasattr(cond, "__invert__"):
             cond = np.array(cond)

--- a/pandas/tests/frame/indexing/test_mask.py
+++ b/pandas/tests/frame/indexing/test_mask.py
@@ -150,3 +150,11 @@ def test_mask_inplace_no_other():
     df.mask(cond, inplace=True)
     expected = DataFrame({"a": [np.nan, 2], "b": ["x", np.nan]})
     tm.assert_frame_equal(df, expected)
+
+
+def test_mask_with_NA():
+    df = DataFrame({"A": [0, 1, 2]})
+    cond = Series([-1, 1, None]).convert_dtypes() < 0
+    result = df.mask(cond, other=100)
+    expected = DataFrame({"A": [100, 1, 2]})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/indexing/test_mask.py
+++ b/pandas/tests/frame/indexing/test_mask.py
@@ -154,7 +154,8 @@ def test_mask_inplace_no_other():
 
 def test_mask_with_NA():
     df = DataFrame({"A": [0, 1, 2]})
-    cond = Series([-1, 1, None]).convert_dtypes() < 0
+    cond = Series([True, False, pd.NA], dtype=pd.BooleanDtype())
+
     result = df.mask(cond, other=100)
     expected = DataFrame({"A": [100, 1, 2]})
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #56844
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This commit addresses an issue where using NA in conjunction with the mask() method that resulted in unexpected behavior. The problem arose when comparing a Series containing NA as a condition within mask(), causing inconsistencies in the output. This fix ensures that NA behaves consistently as False in logical operations within mask().
