### PR TITLE
DOC: Update orc.py to say orc instead of parquet

### DIFF
--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -73,7 +73,7 @@ def read_orc(
         .. versionadded:: 2.0
 
     filesystem : fsspec or pyarrow filesystem, default None
-        Filesystem object to use when reading the parquet file.
+        Filesystem object to use when reading the orc file.
 
         .. versionadded:: 2.1.0
 
@@ -99,7 +99,7 @@ def read_orc(
     --------
     >>> result = pd.read_orc("example_pa.orc")  # doctest: +SKIP
     """
-    # we require a newer version of pyarrow than we support for parquet
+    # we require a newer version of pyarrow than we support for orc
 
     orc = import_optional_dependency("pyarrow.orc")
 


### PR DESCRIPTION
Looks like the [filesystem implementation was initially copy pasted](https://github.com/pandas-dev/pandas/pull/51623/files#diff-dcfc078a101eee58a0d665a67ac19730f1e6b68d3bf7760ca8bbede2746a4c39R72) from the parquet one, and a few edits were missed to refer to orc instead.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
