### PR TITLE
DOC: add SA01 for pandas.tseries.api.guess_datetime_format

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -527,7 +527,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.testing.assert_index_equal PR07,SA01" \
         -i "pandas.testing.assert_series_equal PR07,SA01" \
         -i "pandas.timedelta_range SA01" \
-        -i "pandas.tseries.api.guess_datetime_format SA01" \
         -i "pandas.tseries.offsets.BDay PR02,SA01" \
         -i "pandas.tseries.offsets.BMonthBegin PR02" \
         -i "pandas.tseries.offsets.BQuarterBegin PR02" \

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -859,6 +859,11 @@ def guess_datetime_format(dt_str: str, bint dayfirst=False) -> str | None:
     """
     Guess the datetime format of a given datetime string.
 
+    This function attempts to deduce the format of a given datetime string. It is
+    useful for situations where the datetime format is unknown and needs to be
+    determined for proper parsing. The function handles various datetime components
+    including year, month, day, hour, minute, second, and timezone information.
+
     Parameters
     ----------
     dt_str : str
@@ -875,6 +880,12 @@ def guess_datetime_format(dt_str: str, bint dayfirst=False) -> str | None:
     str or None : ret
         datetime format string (for `strftime` or `strptime`),
         or None if it can't be guessed.
+
+    See Also
+    --------
+    to_datetime : Convert argument to datetime.
+    Timestamp : Pandas replacement for python datetime.datetime object.
+    DatetimeIndex : Immutable ndarray-like of datetime64 data.
 
     Examples
     --------

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -861,8 +861,7 @@ def guess_datetime_format(dt_str: str, bint dayfirst=False) -> str | None:
 
     This function attempts to deduce the format of a given datetime string. It is
     useful for situations where the datetime format is unknown and needs to be
-    determined for proper parsing. The function handles various datetime components
-    including year, month, day, hour, minute, second, and timezone information.
+    determined for proper parsing. The function is not guaranteed to return a format.
 
     Parameters
     ----------


### PR DESCRIPTION
- [ ] xref #58536

fixes
```
pandas.tseries.api.guess_datetime_format SA01
```