### PR TITLE
DOC: add SA01 for pandas.Timestamp.isocalendar

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -256,7 +256,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.fromordinal SA01" \
         -i "pandas.Timestamp.fromtimestamp PR01,SA01" \
         -i "pandas.Timestamp.hour GL08" \
-        -i "pandas.Timestamp.isocalendar SA01" \
         -i "pandas.Timestamp.isoweekday SA01" \
         -i "pandas.Timestamp.max PR02" \
         -i "pandas.Timestamp.microsecond GL08" \

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -528,6 +528,12 @@ class NaTType(_NaT):
         """
         Return a named tuple containing ISO year, week number, and weekday.
 
+        See Also
+        --------
+        DatetimeIndex.isocalendar : Return a 3-tuple containing ISO year,
+            week number, and weekday for the given DatetimeIndex object.
+        datetime.date.isocalendar : The equivalent method for `datetime.date` objects.
+
         Examples
         --------
         >>> ts = pd.Timestamp('2023-01-01 10:00:00')

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1691,6 +1691,12 @@ class Timestamp(_Timestamp):
         """
         Return a named tuple containing ISO year, week number, and weekday.
 
+        See Also
+        --------
+        DatetimeIndex.isocalendar : Return a 3-tuple containing ISO year,
+            week number, and weekday for the given DatetimeIndex object.
+        datetime.date.isocalendar : The equivalent method for `datetime.date` objects.
+
         Examples
         --------
         >>> ts = pd.Timestamp('2023-01-01 10:00:00')


### PR DESCRIPTION
- [ ] xref #58505 

fixes
```
pandas.Timestamp.isocalendar SA01```
