### PR TITLE
ENH add *args support for numba apply

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -498,6 +498,7 @@ Other
 - Bug in :class:`DataFrame` when passing a ``dict`` with a NA scalar and ``columns`` that would always return ``np.nan`` (:issue:`57205`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
+- Bug in :meth:`DataFrame.apply` where passing ``raw=True`` and ``engine="numba"`` ignored ``args`` passed to the applied function (:issue:`58712`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which caused an exception when using NumPy attributes via ``@`` notation, e.g., ``df.eval("@np.floor(a)")``. (:issue:`58041`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which did not allow to use ``tan`` function. (:issue:`55091`)
 - Bug in :meth:`DataFrame.sort_index` when passing ``axis="columns"`` and ``ignore_index=True`` and ``ascending=False`` not returning a :class:`RangeIndex` columns (:issue:`57293`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -498,7 +498,7 @@ Other
 - Bug in :class:`DataFrame` when passing a ``dict`` with a NA scalar and ``columns`` that would always return ``np.nan`` (:issue:`57205`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
-- Bug in :meth:`DataFrame.apply` where passing ``raw=True`` and ``engine="numba"`` ignored ``args`` passed to the applied function (:issue:`58712`)
+- Bug in :meth:`DataFrame.apply` where passing ``engine="numba"`` ignored ``args`` passed to the applied function (:issue:`58712`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which caused an exception when using NumPy attributes via ``@`` notation, e.g., ``df.eval("@np.floor(a)")``. (:issue:`58041`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which did not allow to use ``tan`` function. (:issue:`55091`)
 - Bug in :meth:`DataFrame.sort_index` when passing ``axis="columns"`` and ``ignore_index=True`` and ``ascending=False`` not returning a :class:`RangeIndex` columns (:issue:`57293`)

--- a/pandas/core/_numba/executor.py
+++ b/pandas/core/_numba/executor.py
@@ -14,6 +14,8 @@ import numpy as np
 
 from pandas.compat._optional import import_optional_dependency
 
+from pandas.core.util.numba_ import jit_user_function
+
 
 @functools.cache
 def generate_apply_looper(func, nopython=True, nogil=True, parallel=False):
@@ -21,7 +23,7 @@ def generate_apply_looper(func, nopython=True, nogil=True, parallel=False):
         import numba
     else:
         numba = import_optional_dependency("numba")
-    nb_compat_func = numba.extending.register_jitable(func)
+    nb_compat_func = jit_user_function(func)
 
     @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
     def nb_looper(values, axis, *args):

--- a/pandas/core/_numba/executor.py
+++ b/pandas/core/_numba/executor.py
@@ -24,7 +24,7 @@ def generate_apply_looper(func, nopython=True, nogil=True, parallel=False):
     nb_compat_func = numba.extending.register_jitable(func)
 
     @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
-    def nb_looper(values, axis):
+    def nb_looper(values, axis, *args):
         # Operate on the first row/col in order to get
         # the output shape
         if axis == 0:
@@ -33,7 +33,7 @@ def generate_apply_looper(func, nopython=True, nogil=True, parallel=False):
         else:
             first_elem = values[0]
             dim0 = values.shape[0]
-        res0 = nb_compat_func(first_elem)
+        res0 = nb_compat_func(first_elem, *args)
         # Use np.asarray to get shape for
         # https://github.com/numba/numba/issues/4202#issuecomment-1185981507
         buf_shape = (dim0,) + np.atleast_1d(np.asarray(res0)).shape
@@ -44,11 +44,11 @@ def generate_apply_looper(func, nopython=True, nogil=True, parallel=False):
         if axis == 1:
             buff[0] = res0
             for i in numba.prange(1, values.shape[0]):
-                buff[i] = nb_compat_func(values[i])
+                buff[i] = nb_compat_func(values[i], *args)
         else:
             buff[:, 0] = res0
             for j in numba.prange(1, values.shape[1]):
-                buff[:, j] = nb_compat_func(values[:, j])
+                buff[:, j] = nb_compat_func(values[:, j], *args)
         return buff
 
     return nb_looper

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
     from pandas.core.resample import Resampler
     from pandas.core.window.rolling import BaseWindow
 
-
 ResType = dict[int, Any]
 
 
@@ -976,7 +975,11 @@ class FrameApply(NDFrameApply):
             return wrapper
 
         if engine == "numba":
-            args, kwargs = prepare_function_arguments(self.func, self.args, self.kwargs)
+            args, kwargs = prepare_function_arguments(
+                self.func,  # type: ignore[arg-type]
+                self.args,
+                self.kwargs,
+            )
             # error: Argument 1 to "__call__" of "_lru_cache_wrapper" has
             # incompatible type "Callable[..., Any] | str | list[Callable
             # [..., Any] | str] | dict[Hashable,Callable[..., Any] | str |
@@ -1139,10 +1142,10 @@ class FrameRowApply(FrameApply):
         return numba_func
 
     def apply_with_numba(self) -> dict[int, Any]:
-        args, kwargs = prepare_function_arguments(self.func, self.args, self.kwargs)
+        func = cast(Callable, self.func)
+        args, kwargs = prepare_function_arguments(func, self.args, self.kwargs)
         nb_func = self.generate_numba_apply_func(
-            cast(Callable, self.func),
-            **get_jit_arguments(self.engine_kwargs, kwargs),
+            func, **get_jit_arguments(self.engine_kwargs, kwargs)
         )
         from pandas.core._numba.extensions import set_numba_data
 
@@ -1284,10 +1287,10 @@ class FrameColumnApply(FrameApply):
         return numba_func
 
     def apply_with_numba(self) -> dict[int, Any]:
-        args, kwargs = prepare_function_arguments(self.func, self.args, self.kwargs)
+        func = cast(Callable, self.func)
+        args, kwargs = prepare_function_arguments(func, self.args, self.kwargs)
         nb_func = self.generate_numba_apply_func(
-            cast(Callable, self.func),
-            **get_jit_arguments(self.engine_kwargs, kwargs),
+            func, **get_jit_arguments(self.engine_kwargs, kwargs)
         )
 
         from pandas.core._numba.extensions import set_numba_data

--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import types
 from typing import (
     TYPE_CHECKING,
@@ -97,3 +98,47 @@ def jit_user_function(func: Callable) -> Callable:
         numba_func = numba.extending.register_jitable(func)
 
     return numba_func
+
+
+_sentinel = object()
+
+
+def prepare_function_arguments(
+    func: Callable, args: tuple, kwargs: dict
+) -> tuple[tuple, dict]:
+    """
+    Prepare arguments for jitted function. As numba functions do not support kwargs,
+    we try to move kwargs into args if possible.
+
+    Parameters
+    ----------
+    func : function
+        user defined function
+    args : tuple
+        user input positional arguments
+    kwargs : dict
+        user input keyword arguments
+
+    Returns
+    -------
+    tuple[tuple, dict]
+        args, kwargs
+
+    """
+    if not kwargs:
+        return args, kwargs
+
+    # the udf should have this pattern: def udf(value, *args, **kwargs):...
+    signature = inspect.signature(func)
+    arguments = signature.bind(_sentinel, *args, **kwargs)
+    arguments.apply_defaults()
+    # Ref: https://peps.python.org/pep-0362/
+    # Arguments which could be passed as part of either *args or **kwargs
+    # will be included only in the BoundArguments.args attribute.
+    args = arguments.args
+    kwargs = arguments.kwargs
+
+    assert args[0] is _sentinel
+    args = args[1:]
+
+    return args, kwargs

--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -55,10 +55,15 @@ def get_jit_arguments(
         engine_kwargs = {}
 
     nopython = engine_kwargs.get("nopython", True)
-    if kwargs and nopython:
+    if kwargs:
+        # Note: in case numba supports keyword-only arguments in
+        # a future version, we should remove this check. But this
+        # seems unlikely to happen soon.
+
         raise NumbaUtilError(
-            "numba does not support kwargs with nopython=True: "
-            "https://github.com/numba/numba/issues/2916"
+            "numba does not support keyword-only arguments"
+            "https://github.com/numba/numba/issues/2916, "
+            "https://github.com/numba/numba/issues/6846"
         )
     nogil = engine_kwargs.get("nogil", False)
     parallel = engine_kwargs.get("parallel", False)

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1724,9 +1724,11 @@ def test_numba_raw_apply_with_args(engine):
     if engine == "numba":
         # GH:58712
         df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        result = df.apply(lambda x, a, b: x + a + b, args=(1, 2), engine=engine, raw=True)
-        # note:
-        # result is always float dtype, see core._numba.executor.py:generate_apply_looper
+        result = df.apply(
+            lambda x, a, b: x + a + b, args=(1, 2), engine=engine, raw=True
+        )
+        # note: result is always float dtype,
+        # see core._numba.executor.py:generate_apply_looper
         expected = df + 3.0
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -64,7 +64,7 @@ def test_apply(float_frame, engine, request):
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("raw", [True, False])
 def test_apply_args(float_frame, axis, raw, engine, request):
-    if engine == "numba":
+    if engine == "numba" and raw is False:
         mark = pytest.mark.xfail(reason="numba engine doesn't support args")
         request.node.add_marker(mark)
     result = float_frame.apply(

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1720,17 +1720,18 @@ def test_agg_dist_like_and_nonunique_columns():
     tm.assert_series_equal(result, expected)
 
 
-def test_numba_raw_apply_with_args():
-    # GH:58712
-    df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    result = df.apply(lambda x, a, b: x + a + b, args=(1, 2), engine="numba", raw=True)
-    # note:
-    # result is always float dtype, see core._numba.executor.py:generate_apply_looper
-    expected = df + 3.0
-    tm.assert_frame_equal(result, expected)
+def test_numba_raw_apply_with_args(engine):
+    if engine == "numba":
+        # GH:58712
+        df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        result = df.apply(lambda x, a, b: x + a + b, args=(1, 2), engine=engine, raw=True)
+        # note:
+        # result is always float dtype, see core._numba.executor.py:generate_apply_looper
+        expected = df + 3.0
+        tm.assert_frame_equal(result, expected)
 
-    with pytest.raises(
-        pd.errors.NumbaUtilError,
-        match="numba does not support kwargs with nopython=True",
-    ):
-        df.apply(lambda x, a, b: x + a + b, args=(1,), b=2, engine="numba", raw=True)
+        with pytest.raises(
+            pd.errors.NumbaUtilError,
+            match="numba does not support kwargs with nopython=True",
+        ):
+            df.apply(lambda x, a, b: x + a + b, args=(1,), b=2, engine=engine, raw=True)

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -63,16 +63,28 @@ def test_apply(float_frame, engine, request):
 
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("raw", [True, False])
-def test_apply_args(float_frame, axis, raw, engine):
+@pytest.mark.parametrize("nopython", [True, False])
+def test_apply_args(float_frame, axis, raw, engine, nopython):
+    engine_kwargs = {"nopython": nopython}
     result = float_frame.apply(
-        lambda x, y: x + y, axis, args=(1,), raw=raw, engine=engine
+        lambda x, y: x + y,
+        axis,
+        args=(1,),
+        raw=raw,
+        engine=engine,
+        engine_kwargs=engine_kwargs,
     )
     expected = float_frame + 1
     tm.assert_frame_equal(result, expected)
 
     # GH:58712
     result = float_frame.apply(
-        lambda x, a, b: x + a + b, args=(1,), b=2, engine=engine, raw=raw
+        lambda x, a, b: x + a + b,
+        args=(1,),
+        b=2,
+        raw=raw,
+        engine=engine,
+        engine_kwargs=engine_kwargs,
     )
     expected = float_frame + 3
     tm.assert_frame_equal(result, expected)
@@ -81,18 +93,28 @@ def test_apply_args(float_frame, axis, raw, engine):
         # keyword-only arguments are not supported in numba
         with pytest.raises(
             pd.errors.NumbaUtilError,
-            match="numba does not support kwargs with nopython=True",
+            match="numba does not support keyword-only arguments",
         ):
             float_frame.apply(
-                lambda x, a, *, b: x + a + b, args=(1,), b=2, engine=engine, raw=raw
+                lambda x, a, *, b: x + a + b,
+                args=(1,),
+                b=2,
+                raw=raw,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
             )
 
         with pytest.raises(
             pd.errors.NumbaUtilError,
-            match="numba does not support kwargs with nopython=True",
+            match="numba does not support keyword-only arguments",
         ):
             float_frame.apply(
-                lambda *x, b: x[0] + x[1] + b, args=(1,), b=2, engine=engine, raw=raw
+                lambda *x, b: x[0] + x[1] + b,
+                args=(1,),
+                b=2,
+                raw=raw,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
             )
 
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1718,3 +1718,19 @@ def test_agg_dist_like_and_nonunique_columns():
     result = df.agg({"A": "count"})
     expected = df["A"].count()
     tm.assert_series_equal(result, expected)
+
+
+def test_numba_raw_apply_with_args():
+    # GH:58712
+    df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    result = df.apply(lambda x, a, b: x + a + b, args=(1, 2), engine="numba", raw=True)
+    # note:
+    # result is always float dtype, see core._numba.executor.py:generate_apply_looper
+    expected = df + 3.0
+    tm.assert_frame_equal(result, expected)
+
+    with pytest.raises(
+        pd.errors.NumbaUtilError,
+        match="numba does not support kwargs with nopython=True",
+    ):
+        df.apply(lambda x, a, b: x + a + b, args=(1,), b=2, engine="numba", raw=True)

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -304,7 +304,9 @@ def test_use_global_config():
 
 @td.skip_if_no("numba")
 def test_invalid_kwargs_nopython():
-    with pytest.raises(NumbaUtilError, match="numba does not support keyword-only arguments"):
+    with pytest.raises(
+        NumbaUtilError, match="numba does not support keyword-only arguments"
+    ):
         Series(range(1)).rolling(1).apply(
             lambda x: x, kwargs={"a": 1}, engine="numba", raw=True
         )

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -304,7 +304,7 @@ def test_use_global_config():
 
 @td.skip_if_no("numba")
 def test_invalid_kwargs_nopython():
-    with pytest.raises(NumbaUtilError, match="numba does not support kwargs with"):
+    with pytest.raises(NumbaUtilError, match="numba does not support keyword-only arguments"):
         Series(range(1)).rolling(1).apply(
             lambda x: x, kwargs={"a": 1}, engine="numba", raw=True
         )


### PR DESCRIPTION
- [ ] closes #58712
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

added `*args` to `nb_looper()`. 
use `get_jit_arguments()` to disallow `**kwargs` in raw + numba engine.