### PR TITLE
Typo fix in `MilliSecondLocator` for #35393

### DIFF
--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -430,7 +430,7 @@ class MilliSecondLocator(mdates.DateLocator):
         freq = f"{interval}ms"
         tz = self.tz.tzname(None)
         st = dmin.replace(tzinfo=None)
-        ed = dmin.replace(tzinfo=None)
+        ed = dmax.replace(tzinfo=None)
         all_dates = date_range(start=st, end=ed, freq=freq, tz=tz).astype(object)
 
         try:


### PR DESCRIPTION
Simple typo fix: this locator takes effect when a datetime x-range axis is < 5 seconds (among a few other conditions), and the typo causes only one xtick (at the very left) to be displayed on the x-axis.

- [x] Fixes a typo introduced in #35393: https://github.com/pandas-dev/pandas/pull/35393/files#diff-38fbb5842cbeba026592b58e1385c50f4fe71ac4658c1518f1c04f519623977eR395, discovered while looking at #52895
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
