### PR TITLE
Fix : #58748 BUG: eval fails for ExtensionArray

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -593,6 +593,7 @@ Styler
 Other
 ^^^^^
 - Bug in :class:`DataFrame` when passing a ``dict`` with a NA scalar and ``columns`` that would always return ``np.nan`` (:issue:`57205`)
+- Bug in :func:`eval` including division ``\`` failed with a ``TypeError``. (:issue:`58748`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which caused an exception when using NumPy attributes via ``@`` notation, e.g., ``df.eval("@np.floor(a)")``. (:issue:`58041`)
@@ -606,7 +607,6 @@ Other
 - Bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently replacing matching instances when ``regex=True`` and missing values are present. (:issue:`56599`)
 - Bug in Dataframe Interchange Protocol implementation was returning incorrect results for data buffers' associated dtype, for string and datetime columns (:issue:`54781`)
 - Bug in ``Series.list`` methods not preserving the original :class:`Index`. (:issue:`58425`)
-- Bug in :func:`eval` including division ``\`` failed with a ``TypeError``. (:issue:`58748`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -606,7 +606,7 @@ Other
 - Bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently replacing matching instances when ``regex=True`` and missing values are present. (:issue:`56599`)
 - Bug in Dataframe Interchange Protocol implementation was returning incorrect results for data buffers' associated dtype, for string and datetime columns (:issue:`54781`)
 - Bug in ``Series.list`` methods not preserving the original :class:`Index`. (:issue:`58425`)
-- Bug in :func:`eval` including division ``\`` failed with a ``TypeError`` (:issue:`58748`)
+- Bug in :func:`eval` including division ``\`` failed with a ``TypeError``. (:issue:`58748`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -606,6 +606,7 @@ Other
 - Bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently replacing matching instances when ``regex=True`` and missing values are present. (:issue:`56599`)
 - Bug in Dataframe Interchange Protocol implementation was returning incorrect results for data buffers' associated dtype, for string and datetime columns (:issue:`54781`)
 - Bug in ``Series.list`` methods not preserving the original :class:`Index`. (:issue:`58425`)
+- Bug in :func:`eval` including division ``\`` failed with a ``TypeError`` (:issue:`58748`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -593,7 +593,7 @@ Styler
 Other
 ^^^^^
 - Bug in :class:`DataFrame` when passing a ``dict`` with a NA scalar and ``columns`` that would always return ``np.nan`` (:issue:`57205`)
-- Bug in :func:`eval` including division ``\`` failed with a ``TypeError``. (:issue:`58748`)
+- Bug in :func:`eval` on :class:`ExtensionArray` on including division ``/`` failed with a ``TypeError``. (:issue:`58748`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which caused an exception when using NumPy attributes via ``@`` notation, e.g., ``df.eval("@np.floor(a)")``. (:issue:`58041`)

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -509,7 +509,7 @@ class BinOp(Op):
 
 
 def isnumeric(dtype) -> bool:
-    return issubclass(np.dtype(dtype).type, np.number)
+    return getattr(dtype, '_is_numeric', False) or issubclass(np.dtype(dtype).type, np.number)
 
 
 class Div(BinOp):

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -19,6 +19,7 @@ from pandas._libs.tslibs import Timestamp
 
 from pandas.core.dtypes.common import (
     is_list_like,
+    is_numeric_dtype,
     is_scalar,
 )
 
@@ -508,12 +509,6 @@ class BinOp(Op):
             raise NotImplementedError("cannot evaluate scalar only bool ops")
 
 
-def isnumeric(dtype) -> bool:
-    return getattr(dtype, "_is_numeric", False) or issubclass(
-        np.dtype(dtype).type, np.number
-    )
-
-
 class Div(BinOp):
     """
     Div operator to special case casting.
@@ -527,7 +522,9 @@ class Div(BinOp):
     def __init__(self, lhs, rhs) -> None:
         super().__init__("/", lhs, rhs)
 
-        if not isnumeric(lhs.return_type) or not isnumeric(rhs.return_type):
+        if not is_numeric_dtype(lhs.return_type) or not is_numeric_dtype(
+            rhs.return_type
+        ):
             raise TypeError(
                 f"unsupported operand type(s) for {self.op}: "
                 f"'{lhs.return_type}' and '{rhs.return_type}'"

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -509,7 +509,9 @@ class BinOp(Op):
 
 
 def isnumeric(dtype) -> bool:
-    return getattr(dtype, '_is_numeric', False) or issubclass(np.dtype(dtype).type, np.number)
+    return getattr(dtype, "_is_numeric", False) or issubclass(
+        np.dtype(dtype).type, np.number
+    )
 
 
 class Div(BinOp):

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -88,13 +88,6 @@ def na_cmp():
     return cmp
 
 
-@pytest.fixture
-def isnumeric(dtype):
-    return getattr(dtype, "is_numeric", False) or issubclass(
-        np.dtype(dtype).type, np.number
-    )
-
-
 # ----------------------------------------------------------------------------
 class TestDatetimeArray(base.ExtensionTests):
     def _get_expected_exception(self, op_name, obj, other):

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -88,6 +88,13 @@ def na_cmp():
     return cmp
 
 
+@pytest.fixture
+def isnumeric(dtype):
+    return getattr(dtype, "is_numeric", False) or issubclass(
+        np.dtype(dtype).type, np.number
+    )
+
+
 # ----------------------------------------------------------------------------
 class TestDatetimeArray(base.ExtensionTests):
     def _get_expected_exception(self, op_name, obj, other):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -202,10 +202,12 @@ class TestDataFrameEval:
         expected = df["a"]
         tm.assert_series_equal(expected, res)
 
-    def test_extension_array_eval():
+
+class TestDataFrameEvalWithMultiIndex:
+    def test_extension_array_eval(self, engine, parser):
         # GH#58748
         df = DataFrame({"a": pd.array([1, 2, 3]), "b": pd.array([4, 5, 6])})
-        result = df.eval("a / b")
+        result = df.eval("a / b", engine=engine, parser=parser)
         expected = Series([0.25, 0.40, 0.50])
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -202,6 +202,13 @@ class TestDataFrameEval:
         expected = df["a"]
         tm.assert_series_equal(expected, res)
 
+    def test_extension_array_eval():
+        # GH#58748
+        df = DataFrame({"a": pd.array([1, 2, 3]), "b": pd.array([4, 5, 6])})
+        result = df.eval("a / b")
+        expected = Series([0.25, 0.40, 0.50])
+        tm.assert_series_equal(result, expected)
+
 
 class TestDataFrameQueryWithMultiIndex:
     def test_query_with_named_multiindex(self, parser, engine):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -202,8 +202,6 @@ class TestDataFrameEval:
         expected = df["a"]
         tm.assert_series_equal(expected, res)
 
-
-class TestDataFrameEvalWithMultiIndex:
     def test_extension_array_eval(self, engine, parser):
         # GH#58748
         df = DataFrame({"a": pd.array([1, 2, 3]), "b": pd.array([4, 5, 6])})


### PR DESCRIPTION
- [x] closes #58748  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
