### PR TITLE
Support construction of a DataFrame from a Mapping

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -44,6 +44,7 @@ Other enhancements
 - :meth:`DataFrame.cummin`, :meth:`DataFrame.cummax`, :meth:`DataFrame.cumprod` and :meth:`DataFrame.cumsum` methods now have a ``numeric_only`` parameter (:issue:`53072`)
 - :meth:`DataFrame.fillna` and :meth:`Series.fillna` can now accept ``value=None``; for non-object dtype the corresponding NA value will be used (:issue:`57723`)
 - :meth:`DataFrame.pivot_table` and :func:`pivot_table` now allow the passing of keyword arguments to ``aggfunc`` through ``**kwargs`` (:issue:`57884`)
+- :meth:`DataFrame` now supports to create a new :class:`DataFrame` from a :py:class:`collections.abc.Mapping` object (:issue:`58803`)
 - :meth:`Series.cummin` and :meth:`Series.cummax` now supports :class:`CategoricalDtype` (:issue:`52335`)
 - :meth:`Series.plot` now correctly handle the ``ylabel`` parameter for pie charts, allowing for explicit control over the y-axis label (:issue:`58239`)
 - Restore support for reading Stata 104-format and enable reading 103-format dta files (:issue:`58554`)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -87,6 +87,7 @@ from pandas.io._util import _arrow_dtype_mapping
 
 if TYPE_CHECKING:
     from collections.abc import (
+        Mapping,
         Sequence,
         Sized,
     )
@@ -860,13 +861,13 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
     return dtype, val
 
 
-def dict_compat(d: dict[Scalar, Scalar]) -> dict[Scalar, Scalar]:
+def dict_compat(d: Mapping[Scalar, Scalar]) -> dict[Scalar, Scalar]:
     """
-    Convert datetimelike-keyed dicts to a Timestamp-keyed dict.
+    Convert datetimelike-keyed Mappings to a Timestamp-keyed dict.
 
     Parameters
     ----------
-    d: dict-like object
+    d: Mapping object
 
     Returns
     -------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -513,12 +513,12 @@ class DataFrame(NDFrame, OpsMixin):
 
     Parameters
     ----------
-    data : ndarray (structured or homogeneous), Iterable, dict, or DataFrame
-        Dict can contain Series, arrays, constants, dataclass or list-like objects. If
-        data is a dict, column order follows insertion-order. If a dict contains Series
-        which have an index defined, it is aligned by its index. This alignment also
-        occurs if data is a Series or a DataFrame itself. Alignment is done on
-        Series/DataFrame inputs.
+    data : ndarray (structured or homogeneous), Iterable, Mapping, or DataFrame
+        Mapping can contain Series, arrays, constants, dataclass or list-like objects.
+        If data is a Mapping, column order follows insertion-order. If a Mapping
+        contains Series which have an index defined, it is aligned by its index. This
+        alignment also occurs if data is a Series or a DataFrame itself. Alignment is
+        done on Series/DataFrame inputs.
 
         If data is a list of dicts, column order follows insertion-order.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1735,7 +1735,7 @@ class DataFrame(NDFrame, OpsMixin):
     @classmethod
     def from_dict(
         cls,
-        data: dict,
+        data: Mapping,
         orient: FromDictOrient = "columns",
         dtype: Dtype | None = None,
         columns: Axes | None = None,
@@ -1748,7 +1748,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         Parameters
         ----------
-        data : dict
+        data : Mapping
             Of the form {field : array-like} or {field : dict}.
         orient : {'columns', 'index', 'tight'}, default 'columns'
             The "orientation" of the data. If the keys of the passed dict

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -735,7 +735,7 @@ class DataFrame(NDFrame, OpsMixin):
             raise ValueError("columns cannot be a set")
 
         if copy is None:
-            if isinstance(data, dict):
+            if isinstance(data, Mapping):
                 # retain pre-GH#38939 default behavior
                 copy = True
             elif not isinstance(data, (Index, DataFrame, Series)):
@@ -754,7 +754,7 @@ class DataFrame(NDFrame, OpsMixin):
                 data, axes={"index": index, "columns": columns}, dtype=dtype, copy=copy
             )
 
-        elif isinstance(data, dict):
+        elif isinstance(data, Mapping):
             # GH#38939 de facto copy defaults to False only in non-dict cases
             mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy)
         elif isinstance(data, ma.MaskedArray):

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -77,6 +77,7 @@ from pandas.core.internals.managers import (
 if TYPE_CHECKING:
     from collections.abc import (
         Hashable,
+        Mapping,
         Sequence,
     )
 
@@ -347,7 +348,7 @@ def _check_values_indices_shape_match(
 
 
 def dict_to_mgr(
-    data: dict,
+    data: Mapping,
     index,
     columns,
     *,

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -77,7 +77,6 @@ from pandas.core.internals.managers import (
 if TYPE_CHECKING:
     from collections.abc import (
         Hashable,
-        Mapping,
         Sequence,
     )
 
@@ -348,7 +347,7 @@ def _check_values_indices_shape_match(
 
 
 def dict_to_mgr(
-    data: Mapping,
+    data: abc.Mapping,
     index,
     columns,
     *,
@@ -537,7 +536,7 @@ def _homogenize(
             refs.append(val._references)
             val = val._values
         else:
-            if isinstance(val, dict):
+            if isinstance(val, abc.Mapping):
                 # GH#41785 this _should_ be equivalent to (but faster than)
                 #  val = Series(val, index=index)._values
                 if oindex is None:
@@ -579,7 +578,7 @@ def _extract_index(data) -> Index:
         if isinstance(val, ABCSeries):
             have_series = True
             indexes.append(val.index)
-        elif isinstance(val, dict):
+        elif isinstance(val, abc.Mapping):
             have_dicts = True
             indexes.append(list(val.keys()))
         elif is_list_like(val) and getattr(val, "ndim", 1) == 1:

--- a/pandas/tests/frame/common.py
+++ b/pandas/tests/frame/common.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import (
+    Mapping,
+    Sequence,
+)
 from typing import TYPE_CHECKING
 
 from pandas import (
@@ -9,6 +13,35 @@ from pandas import (
 
 if TYPE_CHECKING:
     from pandas._typing import AxisInt
+
+
+class DictWrapper(Mapping):
+    _dict: dict
+
+    def __init__(self, d: dict) -> None:
+        self._dict = d
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __iter__(self):
+        return self._dict.__iter__()
+
+    def __len__(self):
+        return self._dict.__len__()
+
+
+class ListWrapper(Sequence):
+    _list: list
+
+    def __init__(self, lst: list) -> None:
+        self._list = lst
+
+    def __getitem__(self, i):
+        return self._list[i]
+
+    def __len__(self):
+        return self._list.__len__()
 
 
 def _check_mixed_float(df, dtype=None):

--- a/pandas/tests/frame/common.py
+++ b/pandas/tests/frame/common.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
 
 class DictWrapper(Mapping):
-    _dict: dict
-
     def __init__(self, d: dict) -> None:
         self._dict = d
 
@@ -32,8 +30,6 @@ class DictWrapper(Mapping):
 
 
 class ListWrapper(Sequence):
-    _list: list
-
     def __init__(self, lst: list) -> None:
         self._list = lst
 

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -11,8 +11,10 @@ from pandas import (
     MultiIndex,
     RangeIndex,
     Series,
+    date_range,
 )
 import pandas._testing as tm
+from pandas.tests.frame.common import DictWrapper
 
 
 class TestFromDict:
@@ -133,6 +135,15 @@ class TestFromDict:
         )
         expected = DataFrame.from_dict(a, orient="columns").T
         result = DataFrame.from_dict(a, orient="index")
+        tm.assert_frame_equal(result, expected)
+
+    def test_constructor_from_mapping(self):
+        idx = Index(date_range("20130101", periods=3, tz="US/Eastern"), name="foo")
+        dr = date_range("20130110", periods=3)
+
+        # construction
+        expected = DataFrame(DictWrapper({"A": idx, "B": dr}))
+        result = DataFrame.from_dict(DictWrapper({"A": idx, "B": dr}))
         tm.assert_frame_equal(result, expected)
 
     def test_from_dict_columns_parameter(self):

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -146,6 +146,18 @@ class TestFromDict:
         result = DataFrame.from_dict(DictWrapper({"A": idx, "B": dr}))
         tm.assert_frame_equal(result, expected)
 
+    def test_constructor_from_mapping_of_mapping(self):
+        data = DictWrapper(
+            {
+                "a": DictWrapper({"x": 1, "y": 2}),
+                "b": DictWrapper({"x": 3, "y": 4}),
+                "c": DictWrapper({"x": 5, "y": 6}),
+            }
+        )
+        expected = DataFrame(data)
+        result = DataFrame.from_dict(data)
+        tm.assert_frame_equal(result, expected)
+
     def test_from_dict_columns_parameter(self):
         # GH#18529
         # Test new columns parameter for from_dict that was added to make

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2932,6 +2932,31 @@ class TestDataFrameConstructorWithDatetimeTZ:
         tm.assert_series_equal(df["A"], Series(idx, name="A"))
         tm.assert_series_equal(df["B"], Series(dr, name="B"))
 
+    def test_from_mapping_of_dict(self):
+        data = {
+            "a": {"x": 1, "y": 2},
+            "b": {"x": 3, "y": 4},
+            "c": {"x": 5, "y": 6},
+        }
+        expected = DataFrame(data)
+
+        # construction
+        result = DataFrame(DictWrapper(data))
+        tm.assert_frame_equal(result, expected)
+
+    def test_from_mapping_of_mapping(self):
+        data = {
+            "a": {"x": 1, "y": 2},
+            "b": {"x": 3, "y": 4},
+            "c": {"x": 5, "y": 6},
+        }
+        expected = DataFrame(data)
+
+        # construction
+        wrapped = DictWrapper({k: DictWrapper(v) for k, v in data.items()})
+        result = DataFrame(wrapped)
+        tm.assert_frame_equal(result, expected)
+
     def test_from_mapping_list(self):
         idx = Index(date_range("20130101", periods=3, tz="US/Eastern"), name="foo")
         dr = date_range("20130110", periods=3)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -5,11 +5,7 @@ from collections import (
     defaultdict,
     namedtuple,
 )
-from collections.abc import (
-    Iterator,
-    Mapping,
-    Sequence,
-)
+from collections.abc import Iterator
 from dataclasses import make_dataclass
 from datetime import (
     date,
@@ -65,6 +61,10 @@ from pandas.arrays import (
     SparseArray,
     TimedeltaArray,
 )
+from pandas.tests.frame.common import (
+    DictWrapper,
+    ListWrapper,
+)
 
 MIXED_FLOAT_DTYPES = ["float16", "float32", "float64"]
 MIXED_INT_DTYPES = [
@@ -77,35 +77,6 @@ MIXED_INT_DTYPES = [
     "int32",
     "int64",
 ]
-
-
-class DictWrapper(Mapping):
-    _dict: dict
-
-    def __init__(self, d: dict) -> None:
-        self._dict = d
-
-    def __getitem__(self, key):
-        return self._dict[key]
-
-    def __iter__(self):
-        return self._dict.__iter__()
-
-    def __len__(self):
-        return self._dict.__len__()
-
-
-class ListWrapper(Sequence):
-    _list: list
-
-    def __init__(self, lst: list) -> None:
-        self._list = lst
-
-    def __getitem__(self, i):
-        return self._list[i]
-
-    def __len__(self):
-        return self._list.__len__()
 
 
 class TestDataFrameConstructors:
@@ -2950,7 +2921,7 @@ class TestDataFrameConstructorWithDatetimeTZ:
         tm.assert_series_equal(df["A"], Series(idx, name="A"))
         tm.assert_series_equal(df["B"], Series(dr, name="B"))
 
-    def test_from_dict_with_mapping(self):
+    def test_from_mapping(self):
         idx = Index(date_range("20130101", periods=3, tz="US/Eastern"), name="foo")
         dr = date_range("20130110", periods=3)
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2961,7 +2961,7 @@ class TestDataFrameConstructorWithDatetimeTZ:
         tm.assert_series_equal(df["A"], Series(idx, name="A"))
         tm.assert_series_equal(df["B"], Series(dr, name="B"))
 
-    def test_from_mappiog_list(self):
+    def test_from_mapping_list(self):
         idx = Index(date_range("20130101", periods=3, tz="US/Eastern"), name="foo")
         dr = date_range("20130110", periods=3)
         data = DataFrame({"A": idx, "B": dr})
@@ -2976,7 +2976,7 @@ class TestDataFrameConstructorWithDatetimeTZ:
         tm.assert_series_equal(df["A"], Series(idx, name="A"))
         tm.assert_series_equal(df["B"], Series(dr, name="B"))
 
-    def test_from_mappiog_sequence(self):
+    def test_from_mapping_sequence(self):
         idx = Index(date_range("20130101", periods=3, tz="US/Eastern"), name="foo")
         dr = date_range("20130110", periods=3)
         data = DataFrame({"A": idx, "B": dr})


### PR DESCRIPTION
This pull-request adds support for using a `Mapping` in the construction of a `DataFrame`.  By applying this change, the following Julia code will work.

```
julia> using PythonCall
julia> pd = pyimport("pandas")
julia> df = pd.DataFrame(Dict("a" => [1, 2, 3], "b" => [4, 5, 6]))
Python:
   b  a
0  4  1
1  5  2
2  6  3
```

I have confirmed that there is no performance degradation when constructing a `DataFrame` from a `dict`.

```
$ asv continuous -E virtualenv -b ^frame_ctor.FromDict origin/main HEAD
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
·· Installing 684a22fb <support_mapping_in_dataframe> into virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter..
· Running 16 total benchmarks (2 commits * 1 environments * 8 benchmarks)
[ 0.00%] · For pandas commit 2aa155ae <main> (round 1/2):
[ 0.00%] ·· Building for virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter..
[ 0.00%] ·· Benchmarking virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
[ 3.12%] ··· Running (frame_ctor.FromDicts.time_dict_of_categoricals--)........
[25.00%] · For pandas commit 684a22fb <support_mapping_in_dataframe> (round 1/2):
[25.00%] ·· Building for virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter..
[25.00%] ·· Benchmarking virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
[28.12%] ··· Running (frame_ctor.FromDicts.time_dict_of_categoricals--)........
[50.00%] · For pandas commit 684a22fb <support_mapping_in_dataframe> (round 2/2):
[50.00%] ·· Benchmarking virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
[53.12%] ··· frame_ctor.FromDicts.time_dict_of_categoricals                                327±8μs
[56.25%] ··· frame_ctor.FromDicts.time_list_of_dict                                    16.8±0.09ms
[59.38%] ··· frame_ctor.FromDicts.time_nested_dict                                      16.1±0.2ms
[62.50%] ··· frame_ctor.FromDicts.time_nested_dict_columns                              16.3±0.3ms
[65.62%] ··· frame_ctor.FromDicts.time_nested_dict_index                                13.2±0.1ms
[68.75%] ··· frame_ctor.FromDicts.time_nested_dict_index_columns                       12.9±0.08ms
[71.88%] ··· frame_ctor.FromDicts.time_nested_dict_int64                                29.1±0.1ms
[75.00%] ··· frame_ctor.FromDictwithTimestamp.time_dict_with_timestamp_offsets                  ok
[75.00%] ··· ======== ============
              offset
             -------- ------------
              <Nano>   7.97±0.1ms
              <Hour>   10.9±0.2ms
             ======== ============

[75.00%] · For pandas commit 2aa155ae <main> (round 2/2):
[75.00%] ·· Building for virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter..
[75.00%] ·· Benchmarking virtualenv-py3.10-Cython3.0-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-python-build-scipy-sqlalchemy-tables-xlrd-xlsxwriter
[78.12%] ··· frame_ctor.FromDicts.time_dict_of_categoricals                                330±2μs
[81.25%] ··· frame_ctor.FromDicts.time_list_of_dict                                     17.2±0.3ms
[84.38%] ··· frame_ctor.FromDicts.time_nested_dict                                     16.2±0.08ms
[87.50%] ··· frame_ctor.FromDicts.time_nested_dict_columns                              16.2±0.1ms
[90.62%] ··· frame_ctor.FromDicts.time_nested_dict_index                                13.2±0.2ms
[93.75%] ··· frame_ctor.FromDicts.time_nested_dict_index_columns                        13.5±0.2ms
[96.88%] ··· frame_ctor.FromDicts.time_nested_dict_int64                                29.7±0.3ms
[100.00%] ··· frame_ctor.FromDictwithTimestamp.time_dict_with_timestamp_offsets                  ok
[100.00%] ··· ======== =============
               offset
              -------- -------------
               <Nano>   8.16±0.07ms
               <Hour>   11.2±0.06ms
              ======== =============


BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```

- [x] partially closes #58803 (only dataframe construction part)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
