### PR TITLE
_may_promote hotfix.

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -625,7 +625,6 @@ def _maybe_promote(dtype: np.dtype, fill_value=np.nan):
         return dtype, fill_value
 
     if is_valid_na_for_dtype(fill_value, dtype) and dtype.kind in "iufcmM":
-        dtype = ensure_dtype_can_hold_na(dtype)
         fv = na_value_for_dtype(dtype)
         return dtype, fv
 


### PR DESCRIPTION
- [x] closes #58428 


If `is_valid_na_for_dtype(fill_value, dtype)` is passing then why is there a need to change `dtype` to accomodate na and call `ensure_dtype_can_hold_na` which unnecessarily promotes dtype from `int64` to `float64`