### PR TITLE
Support writing/reading notes to/from excel files 

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -40,6 +40,7 @@ Other enhancements
 - :meth:`Styler.format_index_names` can now be used to format the index and column names (:issue:`48936` and :issue:`47489`)
 - :class:`.errors.DtypeWarning` improved to include column names when mixed data types are detected (:issue:`58174`)
 - :func:`DataFrame.to_excel` argument ``merge_cells`` now accepts a value of ``"columns"`` to only merge :class:`MultiIndex` column header header cells (:issue:`35384`)
+- :func:`DataFrame.to_excel` now supports writing notes to an excel files via :meth:`Styler.set_tooltips` (:issue:`58070`)
 - :meth:`DataFrame.corrwith` now accepts ``min_periods`` as optional arguments, as in :meth:`DataFrame.corr` and :meth:`Series.corr` (:issue:`9490`)
 - :meth:`DataFrame.cummin`, :meth:`DataFrame.cummax`, :meth:`DataFrame.cumprod` and :meth:`DataFrame.cumsum` methods now have a ``numeric_only`` parameter (:issue:`53072`)
 - :meth:`DataFrame.ewm` now allows ``adjust=False`` when ``times`` is provided (:issue:`54328`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2126,10 +2126,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         storage_options_versionadded="1.2.0",
         extra_parameters=textwrap.dedent(
             """\
-        engine_kwargs : dict, optional
-            Arbitrary keyword arguments passed to excel engine.
-    """
+            engine_kwargs : dict, optional
+                Arbitrary keyword arguments passed to excel engine.
+            """
         ),
+        extra_examples="",
     )
     def to_excel(
         self,
@@ -2261,6 +2262,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         automatically chosen depending on the file extension):
 
         >>> df1.to_excel("output1.xlsx", engine="xlsxwriter")  # doctest: +SKIP
+        {extra_examples}
+        End of examples.
         """
         if engine_kwargs is None:
             engine_kwargs = {}

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1212,6 +1212,7 @@ class ExcelWriter(Generic[_WorkbookT]):
         startrow: int = 0,
         startcol: int = 0,
         freeze_panes: tuple[int, int] | None = None,
+        notes: DataFrame | None = None,
     ) -> None:
         """
         Write given formatted cells into Excel an excel sheet
@@ -1220,6 +1221,8 @@ class ExcelWriter(Generic[_WorkbookT]):
         ----------
         cells : generator
             cell of formatted data to save to Excel sheet
+        notes: DataFrame
+            DataFrame containing notes to be written to the Excel sheet
         sheet_name : str, default None
             Name of Excel sheet, if None, then use self.cur_sheet
         startrow : upper left cell row to dump data frame

--- a/pandas/io/excel/_odswriter.py
+++ b/pandas/io/excel/_odswriter.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
         WriteExcelBuffer,
     )
 
+    from pandas.core.frame import DataFrame
+
     from pandas.io.formats.excel import ExcelCell
 
 
@@ -99,6 +101,7 @@ class ODSWriter(ExcelWriter):
         startrow: int = 0,
         startcol: int = 0,
         freeze_panes: tuple[int, int] | None = None,
+        notes: DataFrame | None = None,
     ) -> None:
         """
         Write the frame cells using odf
@@ -109,6 +112,14 @@ class ODSWriter(ExcelWriter):
             TableRow,
         )
         from odf.text import P
+
+        if notes is not None:
+            raise NotImplementedError(
+                """
+                Notes are not supported by the odswriter engine,
+                see https://github.com/eea/odfpy
+                """
+            )
 
         sheet_name = self._get_sheet_name(sheet_name)
         assert sheet_name is not None

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -557,7 +557,10 @@ class ExcelFormatter:
     ) -> None:
         self.rowcounter = 0
         self.na_rep = na_rep
+        self.notes = None
         if not isinstance(df, DataFrame):
+            if df.tooltips is not None:
+                self.notes = df.tooltips.tt_data
             self.styler = df
             self.styler._compute()  # calculate applied styles
             df = df.data
@@ -954,6 +957,7 @@ class ExcelFormatter:
                 startrow=startrow,
                 startcol=startcol,
                 freeze_panes=freeze_panes,
+                notes=self.notes,
             )
         finally:
             # make sure to close opened file handles

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
 
     from pandas import ExcelWriter
 
+import textwrap
 
 ####
 # Shared Doc Strings
@@ -538,6 +539,19 @@ class Styler(StylerRenderer):
         storage_options=_shared_docs["storage_options"],
         storage_options_versionadded="1.5.0",
         extra_parameters="",
+        extra_examples=textwrap.dedent(
+            """\
+            If you wish to write excel notes to the workbook, you can do so by
+            passing a DataFrame to ``set_tooltips``. This process is independent
+            from writing data to the workbook, therefore both DataFrames can have
+            different dimensions.
+
+            >>> notes = pd.DataFrame(
+            ...     [["cell 1", "cell 2"], ["cell 3", "cell 4"]],
+            ... )  # doctest: +SKIP
+            >>> df1.style.set_tooltips(notes).to_excel("output.xlsx")  # doctest: +SKIP
+            """
+        ),
     )
     def to_excel(
         self,


### PR DESCRIPTION
- [x] closes #58070
- [x] [Tests added and passed]
- [x] All [code checks passed]
- [x] Added [type annotations]
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

Me and my colleague @Dacops developed this feature with the use case issued in mind.
We believe the solution can be better understood when looking at the examples we provide in the documentation but also in the tests we made.

Unfortunately, not every engine supported by pandas had the capability to handle notes (calamine, odfreader, pyxlsb, odswriter), on the remaining ones we took the liberty to not only add writing capability as requested in #58070 but also add the complementary operation of reading notes.

In summary, now  you can write notes to an excel (using either openpyxl or xlswriter) by doing:
 ```
 df = pandas.DataFrame(...) # DataFrame holding cell content
 df_notes = pandas.DataFrame(...)  # DataFrame holding notes
 df.style.set_tooltips(df_notes).to_excel(excel_file.xlsx)
```
 The complementary of this (reading using either xlrd or openpyxl) would look something like:
 ```
df_notes = pandas.DataFrame() # empty DataFrame
pandas.read_excel(path, engine="xlrd", notes=df_notes) # df_notes now hold the notes as they were in the excel
```

We will be available and ready to answer any doubts related to the pr.

Hope everything is to your liking.