### PR TITLE
ENH: Intersection, Union and Difference methods for Interval and IntervalArray

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -47,6 +47,7 @@ Other enhancements
 - :meth:`Series.cummin` and :meth:`Series.cummax` now supports :class:`CategoricalDtype` (:issue:`52335`)
 - :meth:`Series.plot` now correctly handle the ``ylabel`` parameter for pie charts, allowing for explicit control over the y-axis label (:issue:`58239`)
 - Added :meth:`Interval.intersection` and :meth:`IntervalArray.intersection` to calculate the intersection between interval-like objects (:issue:`21998`)
+- Added :meth:`Interval.union` and :meth:`IntervalArray.union` to calculate the union between interval-like objects (:issue:`21998`)
 - Restore support for reading Stata 104-format and enable reading 103-format dta files (:issue:`58554`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -46,6 +46,7 @@ Other enhancements
 - :meth:`DataFrame.pivot_table` and :func:`pivot_table` now allow the passing of keyword arguments to ``aggfunc`` through ``**kwargs`` (:issue:`57884`)
 - :meth:`Series.cummin` and :meth:`Series.cummax` now supports :class:`CategoricalDtype` (:issue:`52335`)
 - :meth:`Series.plot` now correctly handle the ``ylabel`` parameter for pie charts, allowing for explicit control over the y-axis label (:issue:`58239`)
+- Added :meth:`Interval.difference` and :meth:`IntervalArray.difference` to calculate the difference between interval-like objects (:issue:`21998`)
 - Added :meth:`Interval.intersection` and :meth:`IntervalArray.intersection` to calculate the intersection between interval-like objects (:issue:`21998`)
 - Added :meth:`Interval.union` and :meth:`IntervalArray.union` to calculate the union between interval-like objects (:issue:`21998`)
 - Restore support for reading Stata 104-format and enable reading 103-format dta files (:issue:`58554`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -46,6 +46,7 @@ Other enhancements
 - :meth:`DataFrame.pivot_table` and :func:`pivot_table` now allow the passing of keyword arguments to ``aggfunc`` through ``**kwargs`` (:issue:`57884`)
 - :meth:`Series.cummin` and :meth:`Series.cummax` now supports :class:`CategoricalDtype` (:issue:`52335`)
 - :meth:`Series.plot` now correctly handle the ``ylabel`` parameter for pie charts, allowing for explicit control over the y-axis label (:issue:`58239`)
+- Added :meth:`Interval.intersection` and :meth:`IntervalArray.intersection` to calculate the intersection between interval-like objects (:issue:`21998`)
 - Restore support for reading Stata 104-format and enable reading 103-format dta files (:issue:`58554`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1444,6 +1444,72 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             [interval.intersection(other) for interval in self], dtype=object
         )
 
+    _interval_shared_docs["union"] = textwrap.dedent(
+        """
+    Calculates union between each interval in the %(klass)s and a given
+    Interval.
+
+    The union of two intervals are all the values in both, including
+    closed endpoints.
+
+    Parameters
+    ----------
+    other : Interval
+        Interval to which to calculate the union.
+
+    Returns
+    -------
+    array
+        Array of arrays containing the unions between each interval and other.
+
+    See Also
+    --------
+    Interval.union : Calculate union between two Interval objects.
+
+    Examples
+    --------
+    %(examples)s
+
+    >>> intervals.union(pd.Interval(0, 2, 'right'))
+    array([[Interval(0, 2, closed='right')],
+           [Interval(0, 5, closed='right')],
+           [Interval(0, 4, closed='right')]], dtype=object)
+
+    >>> intervals.union(pd.Interval(5, 8, closed='left'))
+    array([array([Interval(0, 1, closed='right'), Interval(5, 8, closed='left')],
+                 dtype=object)                                                   ,
+           array([Interval(1, 8, closed='neither')], dtype=object),
+           array([Interval(2, 4, closed='right'), Interval(5, 8, closed='left')],
+                 dtype=object)                                                   ],
+          dtype=object)
+    """
+    )
+
+    @Appender(
+        _interval_shared_docs["union"]
+        % {
+            "klass": "IntervalArray",
+            "examples": textwrap.dedent(
+                """\
+        >>> data = [(0, 1), (1, 5), (2, 4)]
+        >>> intervals = pd.arrays.IntervalArray.from_tuples(data)
+        >>> intervals
+        <IntervalArray>
+        [(0, 1], (1, 5], (2, 4]]
+        Length: 3, dtype: interval[int64, right]
+        """
+            ),
+        }
+    )
+    def union(self, other):
+        if isinstance(other, (IntervalArray, ABCIntervalIndex)):
+            raise NotImplementedError
+        if not isinstance(other, Interval):
+            msg = f"`other` must be Interval-like, got {type(other).__name__}"
+            raise TypeError(msg)
+
+        return np.array([interval.union(other) for interval in self], dtype=object)
+
     # ---------------------------------------------------------------------
 
     @property

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1380,6 +1380,70 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         # (simplifying the negation allows this to be done in less operations)
         return op1(self.left, other.right) & op2(other.left, self.right)
 
+    _interval_shared_docs["intersection"] = textwrap.dedent(
+        """
+    Calculates intersection between all intervals in the %(klass)s and a given
+    Interval.
+
+    The intersection of two intervals is the common points shared between both,
+    including closed endpoints. Open endpoints are not included.
+
+    Parameters
+    ----------
+    other : Interval
+        Interval to which to calculate the intersection.
+
+    Returns
+    -------
+    array
+        Array containing the Intersections between each interval and other.
+
+    See Also
+    --------
+    Interval.intersection : Calculate intersection between two Interval objects.
+
+    Examples
+    --------
+    %(examples)s
+
+    >>> intervals.intersection(pd.Interval(0, 2, 'right'))
+    array([Interval(0, 1, closed='right'), Interval(1, 2, closed='right'),
+           None], dtype=object)
+
+    Intersection with a single value:
+
+    >>> intervals.intersection(pd.Interval(5, 8, closed='left'))
+    array([None, Interval(5, 5, closed='both'), None], dtype=object)
+    """
+    )
+
+    @Appender(
+        _interval_shared_docs["intersection"]
+        % {
+            "klass": "IntervalArray",
+            "examples": textwrap.dedent(
+                """\
+        >>> data = [(0, 1), (1, 5), (2, 4)]
+        >>> intervals = pd.arrays.IntervalArray.from_tuples(data)
+        >>> intervals
+        <IntervalArray>
+        [(0, 1], (1, 5], (2, 4]]
+        Length: 3, dtype: interval[int64, right]
+        """
+            ),
+        }
+    )
+    def intersection(self, other):
+        if isinstance(other, (IntervalArray, ABCIntervalIndex)):
+            raise NotImplementedError
+        if not isinstance(other, Interval):
+            msg = f"`other` must be Interval-like, got {type(other).__name__}"
+            raise TypeError(msg)
+
+        return np.array(
+            [interval.intersection(other) for interval in self], dtype=object
+        )
+
     # ---------------------------------------------------------------------
 
     @property

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1510,6 +1510,71 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
         return np.array([interval.union(other) for interval in self], dtype=object)
 
+    _interval_shared_docs["difference"] = textwrap.dedent(
+        """
+    Calculates difference between each Interval in the %(klass)s and a given
+    Interval.
+
+    The difference between two intervals are the points in the first
+    interval that are not shared with the second interval.
+
+    Parameters
+    ----------
+    other : Interval
+        Interval to which to calculate the difference.
+
+    Returns
+    -------
+    array
+        Array of arrays containing the differences between each interval and other.
+
+    See Also
+    --------
+    Interval.difference : Calculate difference between two Interval objects.
+
+    Examples
+    --------
+    %(examples)s
+
+    >>> intervals.difference(pd.Interval(0, 2, 'right'))
+    array([[Interval(0, 0, closed='both')],
+           [Interval(2, 5, closed='right')],
+           [Interval(2, 4, closed='right')]], dtype=object)
+
+    >>> intervals.difference(pd.Interval(2, 3, closed='left'))
+    array([array([Interval(0, 1, closed='right')], dtype=object),
+           array([Interval(1, 2, closed='neither'), Interval(3, 5, closed='both')],
+                 dtype=object)                                                     ,
+           array([Interval(3, 4, closed='right')], dtype=object)],
+          dtype=object)
+    """
+    )
+
+    @Appender(
+        _interval_shared_docs["difference"]
+        % {
+            "klass": "IntervalArray",
+            "examples": textwrap.dedent(
+                """\
+        >>> data = [(0, 1), (1, 5), (2, 4)]
+        >>> intervals = pd.arrays.IntervalArray.from_tuples(data)
+        >>> intervals
+        <IntervalArray>
+        [(0, 1], (1, 5], (2, 4]]
+        Length: 3, dtype: interval[int64, right]
+        """
+            ),
+        }
+    )
+    def difference(self, other):
+        if isinstance(other, (IntervalArray, ABCIntervalIndex)):
+            raise NotImplementedError
+        if not isinstance(other, Interval):
+            msg = f"`other` must be Interval-like, got {type(other).__name__}"
+            raise TypeError(msg)
+
+        return np.array([interval.difference(other) for interval in self], dtype=object)
+
     # ---------------------------------------------------------------------
 
     @property

--- a/pandas/tests/arrays/interval/test_overlaps.py
+++ b/pandas/tests/arrays/interval/test_overlaps.py
@@ -133,3 +133,47 @@ class TestIntersection:
         msg = f"`other` must be Interval-like, got {type(other).__name__}"
         with pytest.raises(TypeError, match=msg):
             interval_container.intersection(other)
+
+
+class TestUnion:
+    def test_union_interval_array(self):
+        interval = Interval(1, 8, "left")
+
+        tuples = [  # Intervals:
+            (1, 8),  # identical
+            (2, 4),  # nested
+            (0, 9),  # spanning
+            (4, 10),  # partial
+            (-5, 1),  # adjacent closed
+            (8, 10),  # adjacent open
+            (10, 15),  # disjoint
+        ]
+        interval_container = IntervalArray.from_tuples(tuples, "both")
+
+        expected = np.array(
+            [
+                np.array([Interval(1, 8, "both")], dtype=object),
+                np.array([Interval(1, 8, "left")], dtype=object),
+                np.array([Interval(0, 9, "both")], dtype=object),
+                np.array([Interval(1, 10, "both")], dtype=object),
+                np.array([Interval(-5, 8, "left")], dtype=object),
+                np.array([Interval(1, 10, "both")], dtype=object),
+                np.array(
+                    [Interval(1, 8, "left"), Interval(10, 15, "both")], dtype=object
+                ),
+            ],
+            dtype=object,
+        )
+        result = interval_container.union(interval)
+        tm.assert_numpy_array_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "other",
+        [10, True, "foo", Timedelta("1 day"), Timestamp("2018-01-01")],
+        ids=lambda x: type(x).__name__,
+    )
+    def test_union_invalid_type(self, other):
+        interval_container = IntervalArray.from_breaks(range(5))
+        msg = f"`other` must be Interval-like, got {type(other).__name__}"
+        with pytest.raises(TypeError, match=msg):
+            interval_container.union(other)

--- a/pandas/tests/arrays/interval/test_overlaps.py
+++ b/pandas/tests/arrays/interval/test_overlaps.py
@@ -92,3 +92,44 @@ class TestOverlaps:
         msg = f"`other` must be Interval-like, got {type(other).__name__}"
         with pytest.raises(TypeError, match=msg):
             interval_container.overlaps(other)
+
+
+class TestIntersection:
+    def test_intersection_interval_array(self):
+        interval = Interval(1, 8, "left")
+
+        tuples = [  # Intervals:
+            (1, 8),  # identical
+            (2, 4),  # nested
+            (0, 9),  # spanning
+            (4, 10),  # partial
+            (-5, 1),  # adjacent closed
+            (8, 10),  # adjacent open
+            (10, 15),  # disjoint
+        ]
+        interval_container = IntervalArray.from_tuples(tuples, "both")
+
+        expected = np.array(
+            [
+                Interval(1, 8, "left"),
+                Interval(2, 4, "both"),
+                Interval(1, 8, "left"),
+                Interval(4, 8, "left"),
+                Interval(1, 1, "both"),
+                None,
+                None,
+            ]
+        )
+        result = interval_container.intersection(interval)
+        tm.assert_numpy_array_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "other",
+        [10, True, "foo", Timedelta("1 day"), Timestamp("2018-01-01")],
+        ids=lambda x: type(x).__name__,
+    )
+    def test_intersection_invalid_type(self, other):
+        interval_container = IntervalArray.from_breaks(range(5))
+        msg = f"`other` must be Interval-like, got {type(other).__name__}"
+        with pytest.raises(TypeError, match=msg):
+            interval_container.intersection(other)

--- a/pandas/tests/scalar/interval/test_overlaps.py
+++ b/pandas/tests/scalar/interval/test_overlaps.py
@@ -166,3 +166,122 @@ class TestIntersection:
         msg = f"`other` must be an Interval, got {type(other).__name__}"
         with pytest.raises(TypeError, match=msg):
             interval.intersection(other)
+
+
+class TestUnion:
+    def test_union_self(self):
+        interval = Interval(1, 8, "left")
+
+        result = interval.union(interval)
+
+        expected = np.array([interval], dtype=object)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_union_include_limits(self):
+        other = Interval(1, 8, "left")
+
+        intervals = np.array(
+            [
+                Interval(7, 9, "left"),  # include left
+                Interval(0, 2, "right"),  # include right
+                Interval(1, 8, "right"),  # open limit
+            ]
+        )
+
+        expected = np.array(
+            [
+                np.array([Interval(1, 9, "left")], dtype=object),
+                np.array([Interval(0, 8, "neither")], dtype=object),
+                np.array([Interval(1, 8, "both")], dtype=object),
+            ],
+            dtype=object,
+        )
+
+        result = np.array([interval.union(other) for interval in intervals])
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_union_overlapping(self):
+        other = Interval(1, 8, "left")
+
+        intervals = np.array(
+            [
+                Interval(2, 4, "both"),  # nested
+                Interval(0, 9, "both"),  # spanning
+                Interval(4, 10, "both"),  # partial
+            ]
+        )
+
+        expected = np.array(
+            [
+                np.array([Interval(1, 8, "left")], dtype=object),
+                np.array([Interval(0, 9, "both")], dtype=object),
+                np.array([Interval(1, 10, "both")], dtype=object),
+            ],
+            dtype=object,
+        )
+
+        result = np.array([interval.union(other) for interval in intervals])
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_union_adjacent(self):
+        other = Interval(1, 8, "left")
+
+        intervals = np.array(
+            [
+                Interval(-5, 1, "both"),  # adjacent closed
+                Interval(8, 10, "both"),  # adjacent open
+                Interval(10, 15, "both"),  # disjoint
+            ]
+        )
+
+        expected = np.array(
+            [
+                np.array([Interval(-5, 8, "left")], dtype=object),
+                np.array([Interval(1, 10, "both")], dtype=object),
+                np.array([other, Interval(10, 15, "both")], dtype=object),
+            ],
+            dtype=object,
+        )
+
+        result = np.array(
+            [interval.union(other) for interval in intervals], dtype=object
+        )
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_union_timestamps(self):
+        year_2020 = Interval(
+            Timestamp("2020-01-01 00:00:00"),
+            Timestamp("2021-01-01 00:00:00"),
+            closed="left",
+        )
+
+        year_2021 = Interval(
+            Timestamp("2021-01-01 00:00:00"),
+            Timestamp("2022-01-01 00:00:00"),
+            closed="left",
+        )
+
+        expected = np.array(
+            [
+                Interval(
+                    Timestamp("2020-01-01 00:00:00"),
+                    Timestamp("2022-01-01 00:00:00"),
+                    closed="left",
+                )
+            ],
+            dtype=object,
+        )
+
+        result = year_2020.union(year_2021)
+        tm.assert_numpy_array_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "other",
+        [10, True, "foo", Timedelta("1 day"), Timestamp("2018-01-01")],
+        ids=lambda x: type(x).__name__,
+    )
+    def test_union_invalid_type(self, other):
+        interval = Interval(0, 1)
+        msg = f"`other` must be an Interval, got {type(other).__name__}"
+        with pytest.raises(TypeError, match=msg):
+            interval.union(other)


### PR DESCRIPTION
- [x] closes #21998
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

### 1) Description
Me and @Leventide have implemented the following methods for Interval and IntervalArray operations:

**1.1) Interval methods**
**-  Intersection**
The 'Intersection' method returns the common points between two intervals in a form of Interval or None if there is no intersection.

**- Union**
The 'Union' method returns all the points present in atleast one of the intervals. It returns this result in a form of an numpy array of Intervals.

**- Difference**
The 'Difference' method returns the points in the first interval that aren't contained in the second interval. It returns this result in a form of an numpy array of Intervals.

**1.2) IntervalArray methods**
The corresponding methods for the IntervalArray apply the operation element by element. In other words, it calculates the result based on each interval in the array with the given interval.

**-  Intersection**
The 'Intersection' method returns an numpy array of Intervals containing the Intersections between each interval and the given one.

**- Union**
The 'Union' method returns an array of arrays of Intervals containing the unions between each interval and the given one.

**- Difference**
The 'Difference' method returns an array of arrays of Intervals containing the differences between each interval and the given one.

### 2) Why didn't we use IntervalArray instead of numpy arrays:
IntervalArray can only contain Intervals that are equally closed. For operations such as union and difference between intervals, since the result can have two intervals that aren't equally closed, using IntervalArray wouldn't return the proper result.

### 3) Are there other implementations of these methods already available?
We saw that https://piso.readthedocs.io/en/latest/reference/interval.html has a implementation for these methods. However, since it uses IntervalArray it can only handle correctly operations between intervals that are equally closed. By using numpy arrays we can apply these methods correctly for any kind of interval.

