### PR TITLE
REF/block the implicit cast of datetime.datetime to pa.date32()

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import functools
 import operator
 import re
@@ -13,7 +14,7 @@ from typing import (
     overload,
 )
 import unicodedata
-import datetime
+
 import numpy as np
 
 from pandas._libs import lib

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -13,7 +13,7 @@ from typing import (
     overload,
 )
 import unicodedata
-
+import datetime
 import numpy as np
 
 from pandas._libs import lib
@@ -427,6 +427,8 @@ class ArrowExtensionArray(
             pa_scalar = value
         elif isna(value):
             pa_scalar = pa.scalar(None, type=pa_type)
+        elif pa_type == pa.date32() and isinstance(value, datetime.datetime):
+            raise ValueError("Cannot convert datetime to date32")
         else:
             # Workaround https://github.com/apache/arrow/issues/37291
             if isinstance(value, Timedelta):


### PR DESCRIPTION
- [x] closes #58420
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The change I made probably doesn't change the entire problem because the code continues to cast all other pyarrow types.
