### PR TITLE
BUG: Handle unit count when converting from `np.datetime64`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -453,6 +453,7 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`Timestamp` constructor failing to raise when ``tz=None`` is explicitly specified in conjunction with timezone-aware ``tzinfo`` or data (:issue:`48688`)
+- Bug in :class:`Timestamp` constructor ignoring the unit multiplier of a ``datetime64`` (:issue:`39977`)
 - Bug in :func:`date_range` where the last valid timestamp would sometimes not be produced (:issue:`56134`)
 - Bug in :func:`date_range` where using a negative frequency value would not include all points between the start and end values (:issue:`56382`)
 - Bug in :func:`tseries.api.guess_datetime_format` would fail to infer time format when "%Y" == "%H%M" (:issue:`57452`)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -45,6 +45,7 @@ from pandas._libs.tslibs.np_datetime cimport (
     dts_to_iso_string,
     get_conversion_factor,
     get_datetime64_unit,
+    get_datetime64_unit_num,
     get_implementation_bounds,
     import_pandas_datetime,
     npy_datetime,
@@ -287,9 +288,10 @@ cdef int64_t get_datetime64_nanos(object val, NPY_DATETIMEUNIT reso) except? -1:
         return NPY_NAT
 
     unit = get_datetime64_unit(val)
+    nums = get_datetime64_unit_num(val)
 
-    if unit != reso:
-        pandas_datetime_to_datetimestruct(ival, unit, &dts)
+    if unit != reso or nums != 1:
+        pandas_datetime_to_datetimestruct(ival * nums, unit, &dts)
         try:
             ival = npy_datetimestruct_to_datetime(reso, &dts)
         except OverflowError as err:

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -81,6 +81,7 @@ cdef int64_t pydate_to_dt64(
 cdef void pydate_to_dtstruct(date val, npy_datetimestruct *dts) noexcept
 
 cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) noexcept nogil
+cdef int get_datetime64_unit_num(object obj) noexcept nogil
 
 cdef int string_to_dts(
     str val,

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -78,6 +78,13 @@ cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) noexcept nogil:
     return <NPY_DATETIMEUNIT>(<PyDatetimeScalarObject*>obj).obmeta.base
 
 
+cdef int get_datetime64_unit_num(object obj) noexcept nogil:
+    """
+    returns the number of units of the dtype for a numpy datetime64 object.
+    """
+    return (<PyDatetimeScalarObject*>obj).obmeta.num
+
+
 cdef NPY_DATETIMEUNIT get_unit_from_dtype(cnp.dtype dtype):
     # NB: caller is responsible for ensuring this is *some* datetime64 or
     #  timedelta64 dtype, otherwise we can segfault

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -633,6 +633,12 @@ class TestNonNano:
         assert ts <= alt
         assert alt <= ts
 
+    def test_datetime64_unit_count(self):
+        # GH 39977
+        ts = Timestamp(np.datetime64("2000-01-01", "10ns"))
+
+        assert ts == Timestamp("2000-01-01")
+
     def test_cmp_cross_reso(self):
         # numpy gets this wrong because of silent overflow
         dt64 = np.datetime64(9223372800, "s")  # won't fit in M8[ns]


### PR DESCRIPTION
- [x] closes #39977
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
