### PR TITLE
PERF: Only copy in plotting when needed

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1002,7 +1002,7 @@ class PlotAccessor(PandasObject):
                     if is_integer(y) and not holds_integer(data.columns):
                         y = data.columns[y]
                     # converted to series actually. copy to not modify
-                    data = data[y].copy()
+                    data = data[y].copy(deep=False)
                     data.index.name = y
         elif isinstance(data, ABCDataFrame):
             data_cols = data.columns
@@ -1030,9 +1030,6 @@ class PlotAccessor(PandasObject):
                             pass
 
                 data = data[y]
-                if x is None:
-                    # don't overwrite
-                    data = data.copy()
 
                 if isinstance(data, ABCSeries):
                     label_name = label_kw or y

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -982,10 +982,7 @@ class PlotAccessor(PandasObject):
                 f"Valid plot kinds: {self._all_kinds}"
             )
 
-        # The original data structured can be transformed before passed to the
-        # backend. For example, for DataFrame is common to set the index as the
-        # `x` parameter, and return a Series with the parameter `y` as values.
-        data = self._parent.copy()
+        data = self._parent
 
         if isinstance(data, ABCSeries):
             kwargs["reuse_plot"] = True
@@ -1032,8 +1029,10 @@ class PlotAccessor(PandasObject):
                         except (IndexError, KeyError, TypeError):
                             pass
 
-                # don't overwrite
-                data = data[y].copy()
+                data = data[y]
+                if x is None:
+                    # don't overwrite
+                    data = data.copy()
 
                 if isinstance(data, ABCSeries):
                     label_name = label_kw or y

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1120,7 +1120,7 @@ class TestDataFramePlots:
 
     def test_kde_df(self):
         pytest.importorskip("scipy")
-        df = DataFrame(np.random.default_rng(2).standard_normal((100, 4)))
+        df = DataFrame(np.random.default_rng(2).standard_normal((10, 4)))
         ax = _check_plot_works(df.plot, kind="kde")
         expected = [pprint_thing(c) for c in df.columns]
         _check_legend_labels(ax, labels=expected)


### PR DESCRIPTION
It appears there was an unconditional copy before a plot was made. In some paths, the data (the axes or attributes) was not even modified. In other cases, I _think_ with CoW an eager copy is no longer needed. 