### PR TITLE
DOC: add examples to clarify the behavior of `is_year_start` for business offsets

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2144,7 +2144,7 @@ default 'raise'
                       dtype='datetime64[ns]', freq='BYS-JAN')
 
         >>> idx.is_year_start
-        array([True, True,  True, True]
+        array([True, True,  True, True])
         """,
     )
     is_year_end = _field_accessor(

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2144,7 +2144,7 @@ default 'raise'
                       dtype='datetime64[ns]', freq='BYS-JAN')
 
         >>> idx.is_year_start
-        array([True, True,  True, True])
+        array([ True,  True,  True,  True])
         """,
     )
     is_year_end = _field_accessor(

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2144,7 +2144,7 @@ default 'raise'
                       dtype='datetime64[ns]', freq='BYS-JAN')
 
         >>> idx.is_year_start
-        array([ True,  True,  True,  True]
+        array([True, True,  True, True]
         """,
     )
     is_year_end = _field_accessor(

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2119,6 +2119,32 @@ default 'raise'
 
         >>> idx.is_year_start
         array([False, False,  True])
+
+        This method, when applied to Series with datetime values under
+        the ``.dt`` accessor, will lose information about Business offsets.
+
+        >>> dates = pd.Series(pd.date_range("2020-10-30", periods=4, freq="BYS"))
+        >>> dates
+        0   2021-01-01
+        1   2022-01-03
+        2   2023-01-02
+        3   2024-01-01
+        dtype: datetime64[ns]
+
+        >>> dates.dt.is_year_start
+        0    True
+        1    False
+        2    False
+        3    True
+        dtype: bool
+
+        >>> idx = pd.date_range("2020-10-30", periods=4, freq="BYS")
+        >>> idx
+        DatetimeIndex(['2021-01-01', '2022-01-03', '2023-01-02', '2024-01-01'],
+                      dtype='datetime64[ns]', freq='BYS-JAN')
+
+        >>> idx.is_year_start
+        array([True, True, True, True]
         """,
     )
     is_year_end = _field_accessor(

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2144,7 +2144,7 @@ default 'raise'
                       dtype='datetime64[ns]', freq='BYS-JAN')
 
         >>> idx.is_year_start
-        array([True, True, True, True]
+        array([ True,  True,  True,  True]
         """,
     )
     is_year_end = _field_accessor(


### PR DESCRIPTION
xref #58691
added examples to clarify the behavior of `is_year_start` for business offsets.