### PR TITLE
PERF: cache plotting date locators for DatetimeIndex plotting

### DIFF
--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -556,6 +556,7 @@ def _get_periods_per_ymd(freq: BaseOffset) -> tuple[int, int, int]:
     return ppd, ppm, ppy
 
 
+@functools.cache
 def _daily_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
     # error: "BaseOffset" has no attribute "_period_dtype_code"
     dtype_code = freq._period_dtype_code  # type: ignore[attr-defined]
@@ -755,6 +756,7 @@ def _daily_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
     return info
 
 
+@functools.cache
 def _monthly_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
     _, _, periodsperyear = _get_periods_per_ymd(freq)
 
@@ -826,6 +828,7 @@ def _monthly_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
     return info
 
 
+@functools.cache
 def _quarterly_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
     _, _, periodsperyear = _get_periods_per_ymd(freq)
     vmin_orig = vmin
@@ -873,6 +876,7 @@ def _quarterly_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
     return info
 
 
+@functools.cache
 def _annual_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
     # Note: small difference here vs other finders in adding 1 to vmax
     (vmin, vmax) = (int(vmin), int(vmax + 1))

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -557,7 +557,7 @@ def _get_periods_per_ymd(freq: BaseOffset) -> tuple[int, int, int]:
 
 
 @functools.cache
-def _daily_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
+def _daily_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
     # error: "BaseOffset" has no attribute "_period_dtype_code"
     dtype_code = freq._period_dtype_code  # type: ignore[attr-defined]
 
@@ -757,7 +757,7 @@ def _daily_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
 
 
 @functools.cache
-def _monthly_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
+def _monthly_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
     _, _, periodsperyear = _get_periods_per_ymd(freq)
 
     vmin_orig = vmin
@@ -829,7 +829,7 @@ def _monthly_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
 
 
 @functools.cache
-def _quarterly_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
+def _quarterly_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
     _, _, periodsperyear = _get_periods_per_ymd(freq)
     vmin_orig = vmin
     (vmin, vmax) = (int(vmin), int(vmax))
@@ -877,7 +877,7 @@ def _quarterly_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
 
 
 @functools.cache
-def _annual_finder(vmin, vmax, freq: BaseOffset) -> np.ndarray:
+def _annual_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
     # Note: small difference here vs other finders in adding 1 to vmax
     (vmin, vmax) = (int(vmin), int(vmax + 1))
     span = vmax - vmin + 1


### PR DESCRIPTION
- [x] closes #57035 (Replace xxxx with the GitHub issue number)

Using the last plotting example from the issue

```python
In [1]: import time
   ...: import pandas as pd
   ...: import matplotlib.pyplot as plt

In [2]: ts_index = pd.date_range('2020-01-01 00:00', periods=500_000, freq='10min')
   ...: 
   ...: s_a = pd.Series(data=1, index=ts_index)
   ...: s_b = pd.Series(data=2, index=ts_index)

In [3]: fig, ax = plt.subplots()
   ...: t_s4 = time.time()
   ...: s_a.plot(ax=ax)
   ...: print("Time elapsed Series.plot() on existing plt axis without matplotlib line plot: "
   ...:       f"{(time.time()-t_s4):.2f} seconds")
Time elapsed Series.plot() on existing plt axis without matplotlib line plot: 8.96 seconds  # main
Time elapsed Series.plot() on existing plt axis without matplotlib line plot: 1.34 seconds  # PR
```
