### PR TITLE
REF: Prefer testing and documenting zoneinfo instead of pytz

### DIFF
--- a/asv_bench/benchmarks/tslibs/timestamp.py
+++ b/asv_bench/benchmarks/tslibs/timestamp.py
@@ -1,7 +1,10 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
+import zoneinfo
 
 import numpy as np
-import pytz
 
 from pandas import Timestamp
 
@@ -12,7 +15,7 @@ class TimestampConstruction:
     def setup(self):
         self.npdatetime64 = np.datetime64("2020-01-01 00:00:00")
         self.dttime_unaware = datetime(2020, 1, 1, 0, 0, 0)
-        self.dttime_aware = datetime(2020, 1, 1, 0, 0, 0, 0, pytz.UTC)
+        self.dttime_aware = datetime(2020, 1, 1, 0, 0, 0, 0, timezone.utc)
         self.ts = Timestamp("2020-01-01 00:00:00")
 
     def time_parse_iso8601_no_tz(self):
@@ -113,7 +116,7 @@ class TimestampOps:
         self.ts = Timestamp("2017-08-25 08:16:14", tz=tz)
 
     def time_replace_tz(self, tz):
-        self.ts.replace(tzinfo=pytz.timezone("US/Eastern"))
+        self.ts.replace(tzinfo=zoneinfo.ZoneInfo("US/Eastern"))
 
     def time_replace_None(self, tz):
         self.ts.replace(tzinfo=None)
@@ -144,8 +147,8 @@ class TimestampOps:
 
 class TimestampAcrossDst:
     def setup(self):
-        dt = datetime(2016, 3, 27, 1)
-        self.tzinfo = pytz.timezone("CET").localize(dt, is_dst=False).tzinfo
+        dt = datetime(2016, 3, 27, 1, fold=0)
+        self.tzinfo = dt.astimezone(zoneinfo.ZoneInfo("Europe/Berlin")).tzinfo
         self.ts2 = Timestamp(dt)
 
     def time_replace_across_dst(self):

--- a/asv_bench/benchmarks/tslibs/tslib.py
+++ b/asv_bench/benchmarks/tslibs/tslib.py
@@ -20,13 +20,13 @@ from datetime import (
     timedelta,
     timezone,
 )
+import zoneinfo
 
 from dateutil.tz import (
     gettz,
     tzlocal,
 )
 import numpy as np
-import pytz
 
 try:
     from pandas._libs.tslibs import ints_to_pydatetime
@@ -38,7 +38,7 @@ _tzs = [
     None,
     timezone.utc,
     timezone(timedelta(minutes=60)),
-    pytz.timezone("US/Pacific"),
+    zoneinfo.ZoneInfo("US/Pacific"),
     gettz("Asia/Tokyo"),
     tzlocal_obj,
 ]

--- a/asv_bench/benchmarks/tslibs/tz_convert.py
+++ b/asv_bench/benchmarks/tslibs/tz_convert.py
@@ -1,5 +1,6 @@
+from datetime import timezone
+
 import numpy as np
-from pytz import UTC
 
 from pandas._libs.tslibs.tzconversion import tz_localize_to_utc
 
@@ -41,7 +42,7 @@ class TimeTZConvert:
         #  dti = DatetimeIndex(self.i8data, tz=tz)
         #  dti.tz_localize(None)
         if old_sig:
-            tz_convert_from_utc(self.i8data, UTC, tz)
+            tz_convert_from_utc(self.i8data, timezone.utc, tz)
         else:
             tz_convert_from_utc(self.i8data, tz)
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -4990,7 +4990,7 @@ Caveats
   convenience you can use ``store.flush(fsync=True)`` to do this for you.
 * Once a ``table`` is created columns (DataFrame)
   are fixed; only exactly the same columns can be appended
-* Be aware that timezones (e.g., ``pytz.timezone('US/Eastern')``)
+* Be aware that timezones (e.g., ``zoneinfo.ZoneInfo('US/Eastern')``)
   are not necessarily equal across timezone versions.  So if data is
   localized to a specific timezone in the HDFStore using one version
   of a timezone library and that data is updated with another version, the data
@@ -5169,6 +5169,8 @@ See the `Full Documentation <https://github.com/wesm/feather>`__.
 
 .. ipython:: python
 
+   import pytz
+
    df = pd.DataFrame(
        {
            "a": list("abc"),
@@ -5178,7 +5180,7 @@ See the `Full Documentation <https://github.com/wesm/feather>`__.
            "e": [True, False, True],
            "f": pd.Categorical(list("abc")),
            "g": pd.date_range("20130101", periods=3),
-           "h": pd.date_range("20130101", periods=3, tz="US/Eastern"),
+           "h": pd.date_range("20130101", periods=3, tz=pytz.timezone("US/Eastern")),
            "i": pd.date_range("20130101", periods=3, freq="ns"),
        }
    )

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -2337,7 +2337,7 @@ Time zone handling
 ------------------
 
 pandas provides rich support for working with timestamps in different time
-zones using the ``pytz`` and ``dateutil`` libraries or :class:`datetime.timezone`
+zones using the ``zoneinfo``, ``pytz`` and ``dateutil`` libraries or :class:`datetime.timezone`
 objects from the standard library.
 
 
@@ -2354,14 +2354,14 @@ By default, pandas objects are time zone unaware:
 To localize these dates to a time zone (assign a particular time zone to a naive date),
 you can use the ``tz_localize`` method or the ``tz`` keyword argument in
 :func:`date_range`, :class:`Timestamp`, or :class:`DatetimeIndex`.
-You can either pass ``pytz`` or ``dateutil`` time zone objects or Olson time zone database strings.
+You can either pass ``zoneinfo``, ``pytz`` or ``dateutil`` time zone objects or Olson time zone database strings.
 Olson time zone strings will return ``pytz`` time zone objects by default.
 To return ``dateutil`` time zone objects, append ``dateutil/`` before the string.
 
-* In ``pytz`` you can find a list of common (and less common) time zones using
-  ``from pytz import common_timezones, all_timezones``.
+* For ``zoneinfo``, a list of available timezones are available from :py:func:`zoneinfo.available_timezones`.
+* In ``pytz`` you can find a list of common (and less common) time zones using ``pytz.all_timezones``.
 * ``dateutil`` uses the OS time zones so there isn't a fixed list available. For
-  common zones, the names are the same as ``pytz``.
+  common zones, the names are the same as ``pytz`` and ``zoneinfo``.
 
 .. ipython:: python
 
@@ -2466,7 +2466,7 @@ you can use the ``tz_convert`` method.
 
 .. warning::
 
-    If you are using dates beyond 2038-01-18, due to current deficiencies
+    If you are using dates beyond 2038-01-18 with ``pytz``, due to current deficiencies
     in the underlying libraries caused by the year 2038 problem, daylight saving time (DST) adjustments
     to timezone aware dates will not be applied. If and when the underlying libraries are fixed,
     the DST transitions will be applied.
@@ -2475,9 +2475,11 @@ you can use the ``tz_convert`` method.
 
     .. ipython:: python
 
+      import pytz
+
        d_2037 = "2037-03-31T010101"
        d_2038 = "2038-03-31T010101"
-       DST = "Europe/London"
+       DST = pytz.timezone("Europe/London")
        assert pd.Timestamp(d_2037, tz=DST) != pd.Timestamp(d_2037, tz="GMT")
        assert pd.Timestamp(d_2038, tz=DST) == pd.Timestamp(d_2038, tz="GMT")
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -841,7 +841,7 @@ class NaTType(_NaT):
 
         Parameters
         ----------
-        tz : str, pytz.timezone, dateutil.tz.tzfile or None
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time which Timestamp will be converted to.
             None will remove timezone holding UTC time.
 
@@ -894,7 +894,7 @@ class NaTType(_NaT):
         ----------
         ordinal : int
             Date corresponding to a proleptic Gregorian ordinal.
-        tz : str, pytz.timezone, dateutil.tz.tzfile or None
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for the Timestamp.
 
         Notes
@@ -1301,7 +1301,7 @@ timedelta}, default 'raise'
 
         Parameters
         ----------
-        tz : str, pytz.timezone, dateutil.tz.tzfile or None
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time which Timestamp will be converted to.
             None will remove timezone holding UTC time.
 
@@ -1355,7 +1355,7 @@ timedelta}, default 'raise'
 
         Parameters
         ----------
-        tz : str, pytz.timezone, dateutil.tz.tzfile or None
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time which Timestamp will be converted to.
             None will remove timezone holding local time.
 
@@ -1455,13 +1455,13 @@ default 'raise'
 
         Replace timezone (not a conversion):
 
-        >>> import pytz
-        >>> ts.replace(tzinfo=pytz.timezone('US/Pacific'))
+        >>> import zoneinfo
+        >>> ts.replace(tzinfo=zoneinfo.ZoneInfo('US/Pacific'))
         Timestamp('2020-03-14 15:32:52.192548651-0700', tz='US/Pacific')
 
         Analogous for ``pd.NaT``:
 
-        >>> pd.NaT.replace(tzinfo=pytz.timezone('US/Pacific'))
+        >>> pd.NaT.replace(tzinfo=zoneinfo.ZoneInfo('US/Pacific'))
         NaT
         """,
     )

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1374,7 +1374,7 @@ class Timestamp(_Timestamp):
         Timezone info.
     nanosecond : int, optional, default 0
         Value of nanosecond.
-    tz : str, pytz.timezone, dateutil.tz.tzfile or None
+    tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
         Time zone for time which Timestamp will have.
     unit : str
         Unit used for conversion if ts_input is of type int or float. The
@@ -1441,7 +1441,7 @@ class Timestamp(_Timestamp):
         ----------
         ordinal : int
             Date corresponding to a proleptic Gregorian ordinal.
-        tz : str, pytz.timezone, dateutil.tz.tzfile or None
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for the Timestamp.
 
         Notes
@@ -2382,7 +2382,7 @@ timedelta}, default 'raise'
 
         Parameters
         ----------
-        tz : str, pytz.timezone, dateutil.tz.tzfile or None
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time which Timestamp will be converted to.
             None will remove timezone holding local time.
 
@@ -2489,7 +2489,7 @@ default 'raise'
 
         Parameters
         ----------
-        tz : str, pytz.timezone, dateutil.tz.tzfile or None
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time which Timestamp will be converted to.
             None will remove timezone holding UTC time.
 
@@ -2593,13 +2593,13 @@ default 'raise'
 
         Replace timezone (not a conversion):
 
-        >>> import pytz
-        >>> ts.replace(tzinfo=pytz.timezone('US/Pacific'))
+        >>> import zoneinfo
+        >>> ts.replace(tzinfo=zoneinfo.ZoneInfo('US/Pacific'))
         Timestamp('2020-03-14 15:32:52.192548651-0700', tz='US/Pacific')
 
         Analogous for ``pd.NaT``:
 
-        >>> pd.NaT.replace(tzinfo=pytz.timezone('US/Pacific'))
+        >>> pd.NaT.replace(tzinfo=zoneinfo.ZoneInfo('US/Pacific'))
         NaT
         """
 

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -119,27 +119,26 @@ cpdef inline object get_timezone(tzinfo tz):
         raise TypeError("tz argument cannot be None")
     if is_utc(tz):
         return tz
+    elif is_zoneinfo(tz):
+        return tz.key
+    elif treat_tz_as_pytz(tz):
+        zone = tz.zone
+        if zone is None:
+            return tz
+        return zone
+    elif treat_tz_as_dateutil(tz):
+        if ".tar.gz" in tz._filename:
+            raise ValueError(
+                "Bad tz filename. Dateutil on python 3 on windows has a "
+                "bug which causes tzfile._filename to be the same for all "
+                "timezone files. Please construct dateutil timezones "
+                'implicitly by passing a string like "dateutil/Europe'
+                '/London" when you construct your pandas objects instead '
+                "of passing a timezone object. See "
+                "https://github.com/pandas-dev/pandas/pull/7362")
+        return "dateutil/" + tz._filename
     else:
-        if treat_tz_as_dateutil(tz):
-            if ".tar.gz" in tz._filename:
-                raise ValueError(
-                    "Bad tz filename. Dateutil on python 3 on windows has a "
-                    "bug which causes tzfile._filename to be the same for all "
-                    "timezone files. Please construct dateutil timezones "
-                    'implicitly by passing a string like "dateutil/Europe'
-                    '/London" when you construct your pandas objects instead '
-                    "of passing a timezone object. See "
-                    "https://github.com/pandas-dev/pandas/pull/7362")
-            return "dateutil/" + tz._filename
-        else:
-            # tz is a pytz timezone or unknown.
-            try:
-                zone = tz.zone
-                if zone is None:
-                    return tz
-                return zone
-            except AttributeError:
-                return tz
+        return tz
 
 
 cpdef inline tzinfo maybe_get_tz(object tz):

--- a/pandas/_testing/_hypothesis.py
+++ b/pandas/_testing/_hypothesis.py
@@ -6,7 +6,6 @@ from datetime import datetime
 
 from hypothesis import strategies as st
 from hypothesis.extra.dateutil import timezones as dateutil_timezones
-from hypothesis.extra.pytz import timezones as pytz_timezones
 
 from pandas.compat import is_platform_windows
 
@@ -57,7 +56,7 @@ else:
 DATETIME_JAN_1_1900_OPTIONAL_TZ = st.datetimes(
     min_value=pd.Timestamp(1900, 1, 1).to_pydatetime(),  # pyright: ignore[reportArgumentType]
     max_value=pd.Timestamp(1900, 1, 1).to_pydatetime(),  # pyright: ignore[reportArgumentType]
-    timezones=st.one_of(st.none(), dateutil_timezones(), pytz_timezones()),
+    timezones=st.one_of(st.none(), dateutil_timezones(), st.timezones()),
 )
 
 DATETIME_IN_PD_TIMESTAMP_RANGE_NO_TZ = st.datetimes(

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -594,7 +594,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):  # type: ignore[misc]
 
         Returns
         -------
-        datetime.tzinfo, pytz.tzinfo.BaseTZInfo, dateutil.tz.tz.tzfile, or None
+        zoneinfo.ZoneInfo,, datetime.tzinfo, pytz.tzinfo.BaseTZInfo, dateutil.tz.tz.tzfile, or None
             Returns None when the array is tz-naive.
 
         See Also
@@ -624,7 +624,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):  # type: ignore[misc]
         ... )
         >>> idx.tz
         datetime.timezone.utc
-        """
+        """  # noqa: E501
         # GH 18595
         return getattr(self.dtype, "tz", None)
 
@@ -863,7 +863,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):  # type: ignore[misc]
 
         Parameters
         ----------
-        tz : str, pytz.timezone, dateutil.tz.tzfile, datetime.tzinfo or None
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile, datetime.tzinfo or None
             Time zone for time. Corresponding timestamps would be converted
             to this time zone of the Datetime Array/Index. A `tz` of None will
             convert to UTC and remove the timezone information.
@@ -923,7 +923,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):  # type: ignore[misc]
                        '2014-08-01 08:00:00',
                        '2014-08-01 09:00:00'],
                         dtype='datetime64[ns]', freq='h')
-        """
+        """  # noqa: E501
         tz = timezones.maybe_get_tz(tz)
 
         if self.tz is None:
@@ -955,7 +955,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):  # type: ignore[misc]
 
         Parameters
         ----------
-        tz : str, pytz.timezone, dateutil.tz.tzfile, datetime.tzinfo or None
+        tz : str, zoneinfo.ZoneInfo,, pytz.timezone, dateutil.tz.tzfile, datetime.tzinfo or None
             Time zone to convert timestamps to. Passing ``None`` will
             remove the time zone information preserving local time.
         ambiguous : 'infer', 'NaT', bool array, default 'raise'
@@ -1081,7 +1081,7 @@ default 'raise'
         0   2015-03-29 03:30:00+02:00
         1   2015-03-29 03:30:00+02:00
         dtype: datetime64[ns, Europe/Warsaw]
-        """
+        """  # noqa: E501
         nonexistent_options = ("raise", "NaT", "shift_forward", "shift_backward")
         if nonexistent not in nonexistent_options and not isinstance(
             nonexistent, timedelta

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -147,7 +147,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         One of pandas date offset strings or corresponding objects. The string
         'infer' can be passed in order to set the frequency of the index as the
         inferred frequency upon creation.
-    tz : pytz.timezone or dateutil.tz.tzfile or datetime.tzinfo or str
+    tz : zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile, datetime.tzinfo or str
         Set the Timezone of the data.
     ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
         When clocks moved backward due to DST, ambiguous times may arise.

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -5,6 +5,7 @@ from datetime import (
     datetime,
     time,
     timedelta,
+    timezone,
 )
 from itertools import (
     product,
@@ -14,7 +15,6 @@ import operator
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs.tslibs.conversion import localize_pydatetime
 from pandas._libs.tslibs.offsets import shift_months
@@ -1870,8 +1870,10 @@ class TestTimestampSeriesArithmetic:
 
     def test_sub_datetime_compat(self, unit):
         # see GH#14088
-        ser = Series([datetime(2016, 8, 23, 12, tzinfo=pytz.utc), NaT]).dt.as_unit(unit)
-        dt = datetime(2016, 8, 22, 12, tzinfo=pytz.utc)
+        ser = Series([datetime(2016, 8, 23, 12, tzinfo=timezone.utc), NaT]).dt.as_unit(
+            unit
+        )
+        dt = datetime(2016, 8, 22, 12, tzinfo=timezone.utc)
         # The datetime object has "us" so we upcast lower units
         exp_unit = tm.get_finest_unit(unit, "us")
         exp = Series([Timedelta("1 days"), NaT]).dt.as_unit(exp_unit)

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -1,9 +1,9 @@
 import datetime
 import decimal
+import zoneinfo
 
 import numpy as np
 import pytest
-import pytz
 
 import pandas as pd
 import pandas._testing as tm
@@ -285,9 +285,6 @@ def test_array_copy():
     assert tm.shares_memory(a, b)
 
 
-cet = pytz.timezone("CET")
-
-
 @pytest.mark.parametrize(
     "data, expected",
     [
@@ -326,11 +323,18 @@ cet = pytz.timezone("CET")
         ),
         (
             [
-                datetime.datetime(2000, 1, 1, tzinfo=cet),
-                datetime.datetime(2001, 1, 1, tzinfo=cet),
+                datetime.datetime(
+                    2000, 1, 1, tzinfo=zoneinfo.ZoneInfo("Europe/Berlin")
+                ),
+                datetime.datetime(
+                    2001, 1, 1, tzinfo=zoneinfo.ZoneInfo("Europe/Berlin")
+                ),
             ],
             DatetimeArray._from_sequence(
-                ["2000", "2001"], dtype=pd.DatetimeTZDtype(tz=cet, unit="us")
+                ["2000", "2001"],
+                dtype=pd.DatetimeTZDtype(
+                    tz=zoneinfo.ZoneInfo("Europe/Berlin"), unit="us"
+                ),
             ),
         ),
         # timedelta

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -3,7 +3,6 @@ import weakref
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 
@@ -391,8 +390,9 @@ class TestDatetimeTZDtype(Base):
 
     def test_tz_standardize(self):
         # GH 24713
+        pytz = pytest.importorskip("pytz")
         tz = pytz.timezone("US/Eastern")
-        dr = date_range("2013-01-01", periods=3, tz="US/Eastern")
+        dr = date_range("2013-01-01", periods=3, tz=tz)
         dtype = DatetimeTZDtype("ns", dr.tz)
         assert dtype.tz == tz
         dtype = DatetimeTZDtype("ns", dr[0].tz)

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -12,6 +12,7 @@ from datetime import (
     datetime,
     time,
     timedelta,
+    timezone,
 )
 from decimal import Decimal
 from fractions import Fraction
@@ -27,7 +28,6 @@ from typing import (
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs import (
     lib,
@@ -1022,7 +1022,7 @@ class TestInference:
 
     def test_mixed_dtypes_remain_object_array(self):
         # GH14956
-        arr = np.array([datetime(2015, 1, 1, tzinfo=pytz.utc), 1], dtype=object)
+        arr = np.array([datetime(2015, 1, 1, tzinfo=timezone.utc), 1], dtype=object)
         result = lib.maybe_convert_objects(arr, convert_non_numeric=True)
         tm.assert_numpy_array_equal(result, arr)
 

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -1,10 +1,12 @@
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 from decimal import Decimal
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas._config import using_pyarrow_string_dtype
 
@@ -239,7 +241,7 @@ class TestFromRecords:
         tm.assert_frame_equal(frame, expected)
 
     def test_frame_from_records_utc(self):
-        rec = {"datum": 1.5, "begin_time": datetime(2006, 4, 27, tzinfo=pytz.utc)}
+        rec = {"datum": 1.5, "begin_time": datetime(2006, 4, 27, tzinfo=timezone.utc)}
 
         # it works
         DataFrame.from_records([rec], index="begin_time")

--- a/pandas/tests/frame/methods/test_at_time.py
+++ b/pandas/tests/frame/methods/test_at_time.py
@@ -1,8 +1,11 @@
-from datetime import time
+from datetime import (
+    time,
+    timezone,
+)
+import zoneinfo
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs.tslibs import timezones
 
@@ -65,7 +68,7 @@ class TestAtTime:
         assert len(rs) == 0
 
     @pytest.mark.parametrize(
-        "hour", ["1:00", "1:00AM", time(1), time(1, tzinfo=pytz.UTC)]
+        "hour", ["1:00", "1:00AM", time(1), time(1, tzinfo=timezone.utc)]
     )
     def test_at_time_errors(self, hour):
         # GH#24043
@@ -83,7 +86,7 @@ class TestAtTime:
         # GH#24043
         dti = date_range("2018", periods=3, freq="h", tz="US/Pacific")
         df = DataFrame(list(range(len(dti))), index=dti)
-        result = df.at_time(time(4, tzinfo=pytz.timezone("US/Eastern")))
+        result = df.at_time(time(4, tzinfo=zoneinfo.ZoneInfo("US/Eastern")))
         expected = df.iloc[1:2]
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/methods/test_join.py
+++ b/pandas/tests/frame/methods/test_join.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import zoneinfo
 
 import numpy as np
 import pytest
@@ -543,17 +544,14 @@ class TestDataFrameJoin:
             df1.join(df2, on="a")
 
     def test_frame_join_tzaware(self):
+        tz = zoneinfo.ZoneInfo("US/Central")
         test1 = DataFrame(
             np.zeros((6, 3)),
-            index=date_range(
-                "2012-11-15 00:00:00", periods=6, freq="100ms", tz="US/Central"
-            ),
+            index=date_range("2012-11-15 00:00:00", periods=6, freq="100ms", tz=tz),
         )
         test2 = DataFrame(
             np.zeros((3, 3)),
-            index=date_range(
-                "2012-11-15 00:00:00", periods=3, freq="250ms", tz="US/Central"
-            ),
+            index=date_range("2012-11-15 00:00:00", periods=3, freq="250ms", tz=tz),
             columns=range(3, 6),
         )
 
@@ -561,4 +559,4 @@ class TestDataFrameJoin:
         expected = test1.index.union(test2.index)
 
         tm.assert_index_equal(result.index, expected)
-        assert result.index.tz.zone == "US/Central"
+        assert result.index.tz.key == "US/Central"

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -2,11 +2,13 @@ from collections import (
     OrderedDict,
     defaultdict,
 )
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas import (
     NA,
@@ -209,15 +211,15 @@ class TestDataFrameToDict:
         # GH#18372 When converting to dict with orient='records' columns of
         # datetime that are tz-aware were not converted to required arrays
         data = [
-            (datetime(2017, 11, 18, 21, 53, 0, 219225, tzinfo=pytz.utc),),
-            (datetime(2017, 11, 18, 22, 6, 30, 61810, tzinfo=pytz.utc),),
+            (datetime(2017, 11, 18, 21, 53, 0, 219225, tzinfo=timezone.utc),),
+            (datetime(2017, 11, 18, 22, 6, 30, 61810, tzinfo=timezone.utc),),
         ]
         df = DataFrame(list(data), columns=["d"])
 
         result = df.to_dict(orient="records")
         expected = [
-            {"d": Timestamp("2017-11-18 21:53:00.219225+0000", tz=pytz.utc)},
-            {"d": Timestamp("2017-11-18 22:06:30.061810+0000", tz=pytz.utc)},
+            {"d": Timestamp("2017-11-18 21:53:00.219225+0000", tz=timezone.utc)},
+            {"d": Timestamp("2017-11-18 22:06:30.061810+0000", tz=timezone.utc)},
         ]
         tm.assert_dict_equal(result[0], expected[0])
         tm.assert_dict_equal(result[1], expected[1])

--- a/pandas/tests/frame/methods/test_tz_convert.py
+++ b/pandas/tests/frame/methods/test_tz_convert.py
@@ -1,3 +1,5 @@
+import zoneinfo
+
 import numpy as np
 import pytest
 
@@ -13,28 +15,34 @@ import pandas._testing as tm
 
 class TestTZConvert:
     def test_tz_convert(self, frame_or_series):
-        rng = date_range("1/1/2011", periods=200, freq="D", tz="US/Eastern")
+        rng = date_range(
+            "1/1/2011", periods=200, freq="D", tz=zoneinfo.ZoneInfo("US/Eastern")
+        )
 
         obj = DataFrame({"a": 1}, index=rng)
         obj = tm.get_obj(obj, frame_or_series)
 
-        result = obj.tz_convert("Europe/Berlin")
-        expected = DataFrame({"a": 1}, rng.tz_convert("Europe/Berlin"))
+        berlin = zoneinfo.ZoneInfo("Europe/Berlin")
+        result = obj.tz_convert(berlin)
+        expected = DataFrame({"a": 1}, rng.tz_convert(berlin))
         expected = tm.get_obj(expected, frame_or_series)
 
-        assert result.index.tz.zone == "Europe/Berlin"
+        assert result.index.tz.key == "Europe/Berlin"
         tm.assert_equal(result, expected)
 
     def test_tz_convert_axis1(self):
-        rng = date_range("1/1/2011", periods=200, freq="D", tz="US/Eastern")
+        rng = date_range(
+            "1/1/2011", periods=200, freq="D", tz=zoneinfo.ZoneInfo("US/Eastern")
+        )
 
         obj = DataFrame({"a": 1}, index=rng)
 
         obj = obj.T
-        result = obj.tz_convert("Europe/Berlin", axis=1)
-        assert result.columns.tz.zone == "Europe/Berlin"
+        berlin = zoneinfo.ZoneInfo("Europe/Berlin")
+        result = obj.tz_convert(berlin, axis=1)
+        assert result.columns.tz.key == "Europe/Berlin"
 
-        expected = DataFrame({"a": 1}, rng.tz_convert("Europe/Berlin"))
+        expected = DataFrame({"a": 1}, rng.tz_convert(berlin))
 
         tm.assert_equal(result, expected.T)
 

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -1,6 +1,7 @@
-from datetime import datetime
-
-import pytz
+from datetime import (
+    datetime,
+    timezone,
+)
 
 from pandas import DataFrame
 import pandas._testing as tm
@@ -13,7 +14,7 @@ class TestDataFrameAlterAxes:
         # GH 6785
         # set the index manually
 
-        df = DataFrame([{"ts": datetime(2014, 4, 1, tzinfo=pytz.utc), "foo": 1}])
+        df = DataFrame([{"ts": datetime(2014, 4, 1, tzinfo=timezone.utc), "foo": 1}])
         expected = df.set_index("ts")
         df.index = df["ts"]
         df.pop("ts")

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -14,12 +14,12 @@ from datetime import (
 )
 import functools
 import re
+import zoneinfo
 
 import numpy as np
 from numpy import ma
 from numpy.ma import mrecords
 import pytest
-import pytz
 
 from pandas._config import using_pyarrow_string_dtype
 
@@ -1908,8 +1908,7 @@ class TestDataFrameConstructors:
     def test_constructor_with_datetimes3(self):
         # GH 7594
         # don't coerce tz-aware
-        tz = pytz.timezone("US/Eastern")
-        dt = tz.localize(datetime(2012, 1, 1))
+        dt = datetime(2012, 1, 1, tzinfo=zoneinfo.ZoneInfo("US/Eastern"))
 
         df = DataFrame({"End Date": dt}, index=[0])
         assert df.iat[0, 0] == dt

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -5,11 +5,11 @@ test with the TimeGrouper / grouping with datetimes
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 
 import numpy as np
 import pytest
-import pytz
 
 import pandas as pd
 from pandas import (
@@ -774,12 +774,12 @@ class TestGroupBy:
     def test_timezone_info(self):
         # see gh-11682: Timezone info lost when broadcasting
         # scalar datetime to DataFrame
-
-        df = DataFrame({"a": [1], "b": [datetime.now(pytz.utc)]})
-        assert df["b"][0].tzinfo == pytz.utc
+        utc = timezone.utc
+        df = DataFrame({"a": [1], "b": [datetime.now(utc)]})
+        assert df["b"][0].tzinfo == utc
         df = DataFrame({"a": [1, 2, 3]})
-        df["b"] = datetime.now(pytz.utc)
-        assert df["b"][0].tzinfo == pytz.utc
+        df["b"] = datetime.now(utc)
+        assert df["b"][0].tzinfo == utc
 
     def test_datetime_count(self):
         df = DataFrame(

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import dateutil
 import numpy as np
 import pytest
-import pytz
 
 import pandas as pd
 from pandas import (
@@ -251,6 +250,8 @@ class TestDatetimeIndex:
         _check_rng(rng_utc)
 
     def test_index_convert_to_datetime_array_explicit_pytz(self):
+        pytz = pytest.importorskip("pytz")
+
         def _check_rng(rng):
             converted = rng.to_pydatetime()
             assert isinstance(converted, np.ndarray)

--- a/pandas/tests/indexes/datetimes/methods/test_shift.py
+++ b/pandas/tests/indexes/datetimes/methods/test_shift.py
@@ -1,7 +1,7 @@
 from datetime import datetime
+import zoneinfo
 
 import pytest
-import pytz
 
 from pandas.errors import NullFrequencyError
 
@@ -12,8 +12,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-
-START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 
 class TestDatetimeIndexShift:
@@ -122,24 +120,28 @@ class TestDatetimeIndexShift:
     )
     def test_dti_shift_near_midnight(self, shift, result_time, unit):
         # GH 8616
-        dt = datetime(2014, 11, 14, 0)
-        dt_est = pytz.timezone("EST").localize(dt)
+        tz = zoneinfo.ZoneInfo("US/Eastern")
+        dt_est = datetime(2014, 11, 14, 0, tzinfo=tz)
         idx = DatetimeIndex([dt_est]).as_unit(unit)
         ser = Series(data=[1], index=idx)
         result = ser.shift(shift, freq="h")
-        exp_index = DatetimeIndex([result_time], tz="EST").as_unit(unit)
+        exp_index = DatetimeIndex([result_time], tz=tz).as_unit(unit)
         expected = Series(1, index=exp_index)
         tm.assert_series_equal(result, expected)
 
     def test_shift_periods(self, unit):
         # GH#22458 : argument 'n' was deprecated in favor of 'periods'
-        idx = date_range(start=START, end=END, periods=3, unit=unit)
+        idx = date_range(
+            start=datetime(2009, 1, 1), end=datetime(2010, 1, 1), periods=3, unit=unit
+        )
         tm.assert_index_equal(idx.shift(periods=0), idx)
         tm.assert_index_equal(idx.shift(0), idx)
 
     @pytest.mark.parametrize("freq", ["B", "C"])
     def test_shift_bday(self, freq, unit):
-        rng = date_range(START, END, freq=freq, unit=unit)
+        rng = date_range(
+            datetime(2009, 1, 1), datetime(2010, 1, 1), freq=freq, unit=unit
+        )
         shifted = rng.shift(5)
         assert shifted[0] == rng[5]
         assert shifted.freq == rng.freq
@@ -153,11 +155,21 @@ class TestDatetimeIndexShift:
         assert shifted.freq == rng.freq
 
     def test_shift_bmonth(self, performance_warning, unit):
-        rng = date_range(START, END, freq=pd.offsets.BMonthEnd(), unit=unit)
+        rng = date_range(
+            datetime(2009, 1, 1),
+            datetime(2010, 1, 1),
+            freq=pd.offsets.BMonthEnd(),
+            unit=unit,
+        )
         shifted = rng.shift(1, freq=pd.offsets.BDay())
         assert shifted[0] == rng[0] + pd.offsets.BDay()
 
-        rng = date_range(START, END, freq=pd.offsets.BMonthEnd(), unit=unit)
+        rng = date_range(
+            datetime(2009, 1, 1),
+            datetime(2010, 1, 1),
+            freq=pd.offsets.BMonthEnd(),
+            unit=unit,
+        )
         with tm.assert_produces_warning(performance_warning):
             shifted = rng.shift(1, freq=pd.offsets.CDay())
             assert shifted[0] == rng[0] + pd.offsets.CDay()

--- a/pandas/tests/indexes/datetimes/methods/test_to_period.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_period.py
@@ -1,7 +1,8 @@
+from datetime import timezone
+
 import dateutil.tz
 from dateutil.tz import tzlocal
 import pytest
-import pytz
 
 from pandas._libs.tslibs.ccalendar import MONTHS
 from pandas._libs.tslibs.offsets import MonthEnd
@@ -155,7 +156,13 @@ class TestToPeriod:
 
     @pytest.mark.parametrize(
         "tz",
-        ["US/Eastern", pytz.utc, tzlocal(), "dateutil/US/Eastern", dateutil.tz.tzutc()],
+        [
+            "US/Eastern",
+            timezone.utc,
+            tzlocal(),
+            "dateutil/US/Eastern",
+            dateutil.tz.tzutc(),
+        ],
     )
     def test_to_period_tz(self, tz):
         ts = date_range("1/1/2000", "2/1/2000", tz=tz)

--- a/pandas/tests/indexes/datetimes/methods/test_tz_convert.py
+++ b/pandas/tests/indexes/datetimes/methods/test_tz_convert.py
@@ -4,7 +4,6 @@ import dateutil.tz
 from dateutil.tz import gettz
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs.tslibs import timezones
 
@@ -260,11 +259,14 @@ class TestTZConvert:
         [
             "US/Eastern",
             "dateutil/US/Eastern",
-            pytz.timezone("US/Eastern"),
+            "pytz/US/Eastern",
             gettz("US/Eastern"),
         ],
     )
     def test_dti_tz_convert_utc_to_local_no_modify(self, tz):
+        if isinstance(tz, str) and tz.startswith("pytz/"):
+            pytz = pytest.importorskip("pytz")
+            tz = pytz.timezone(tz.removeprefix("pytz/"))
         rng = date_range("3/11/2012", "3/12/2012", freq="h", tz="utc")
         rng_eastern = rng.tz_convert(tz)
 

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -7,6 +7,7 @@ from datetime import (
 )
 from functools import partial
 from operator import attrgetter
+import zoneinfo
 
 import dateutil
 import dateutil.tz
@@ -152,7 +153,9 @@ class TestDatetimeIndex:
         df = pd.DataFrame(
             {
                 "dt": date_range("20130101", periods=3),
-                "dttz": date_range("20130101", periods=3, tz="US/Eastern"),
+                "dttz": date_range(
+                    "20130101", periods=3, tz=zoneinfo.ZoneInfo("US/Eastern")
+                ),
                 "dt_with_null": [
                     Timestamp("20130101"),
                     pd.NaT,
@@ -161,7 +164,7 @@ class TestDatetimeIndex:
                 "dtns": date_range("20130101", periods=3, freq="ns"),
             }
         )
-        assert df.dttz.dtype.tz.zone == "US/Eastern"
+        assert df.dttz.dtype.tz.key == "US/Eastern"
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -198,7 +201,11 @@ class TestDatetimeIndex:
         # incompat tz/dtype
         msg = "cannot supply both a tz and a dtype with a tz"
         with pytest.raises(ValueError, match=msg):
-            DatetimeIndex(i.tz_localize(None).asi8, dtype=i.dtype, tz="US/Pacific")
+            DatetimeIndex(
+                i.tz_localize(None).asi8,
+                dtype=i.dtype,
+                tz=zoneinfo.ZoneInfo("US/Hawaii"),
+            )
 
     def test_construction_index_with_mixed_timezones(self):
         # gh-11488: no tz results in DatetimeIndex
@@ -736,7 +743,7 @@ class TestDatetimeIndex:
         dti = DatetimeIndex(["2010"], tz="UTC")
         msg = "Cannot directly set timezone"
         with pytest.raises(AttributeError, match=msg):
-            dti.tz = pytz.timezone("US/Pacific")
+            dti.tz = zoneinfo.ZoneInfo("US/Pacific")
 
     @pytest.mark.parametrize(
         "tz",
@@ -764,7 +771,9 @@ class TestDatetimeIndex:
     @pytest.mark.parametrize("tz", ["US/Pacific", "US/Eastern", "Asia/Tokyo"])
     def test_constructor_with_non_normalized_pytz(self, tz):
         # GH 18595
-        non_norm_tz = Timestamp("2010", tz=tz).tz
+        pytz = pytest.importorskip("pytz")
+        tz_in = pytz.timezone(tz)
+        non_norm_tz = Timestamp("2010", tz=tz_in).tz
         result = DatetimeIndex(["2010"], tz=non_norm_tz)
         assert pytz.timezone(tz) is result.tz
 
@@ -914,7 +923,9 @@ class TestDatetimeIndex:
         expected = DatetimeIndex([Timestamp("2019", tz="UTC"), pd.NaT])
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize("tz", [pytz.timezone("US/Eastern"), gettz("US/Eastern")])
+    @pytest.mark.parametrize(
+        "tz", [zoneinfo.ZoneInfo("US/Eastern"), gettz("US/Eastern")]
+    )
     def test_dti_from_tzaware_datetime(self, tz):
         d = [datetime(2012, 8, 19, tzinfo=tz)]
 
@@ -963,7 +974,7 @@ class TestDatetimeIndex:
     @pytest.mark.parametrize(
         "tz",
         [
-            pytz.timezone("US/Eastern"),
+            "pytz/US/Eastern",
             gettz("US/Eastern"),
         ],
     )
@@ -972,6 +983,9 @@ class TestDatetimeIndex:
     def test_dti_ambiguous_matches_timestamp(self, tz, use_str, box_cls, request):
         # GH#47471 check that we get the same raising behavior in the DTI
         # constructor and Timestamp constructor
+        if isinstance(tz, str) and tz.startswith("pytz/"):
+            pytz = pytest.importorskip(tz)
+            tz = pytz.timezone(tz.removeprefix("pytz/"))
         dtstr = "2013-11-03 01:59:59.999999"
         item = dtstr
         if not use_str:

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -984,7 +984,6 @@ class TestDatetimeIndex:
         # GH#47471 check that we get the same raising behavior in the DTI
         # constructor and Timestamp constructor
         if isinstance(tz, str) and tz.startswith("pytz/"):
-            pytz = pytest.importorskip(tz)
             tz = pytz.timezone(tz.removeprefix("pytz/"))
         dtstr = "2013-11-03 01:59:59.999999"
         item = dtstr

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -12,7 +12,6 @@ import re
 import numpy as np
 import pytest
 import pytz
-from pytz import timezone
 
 from pandas._libs.tslibs import timezones
 from pandas._libs.tslibs.offsets import (
@@ -97,6 +96,7 @@ class TestTimestampEquivDateRange:
         assert ts == stamp
 
     def test_date_range_timestamp_equiv_explicit_pytz(self):
+        pytz = pytest.importorskip("pytz")
         rng = date_range("20090415", "20090519", tz=pytz.timezone("US/Eastern"))
         stamp = rng[0]
 
@@ -490,7 +490,8 @@ class TestDateRanges:
 
     def test_range_tz_pytz(self):
         # see gh-2906
-        tz = timezone("US/Eastern")
+        pytz = pytest.importorskip("pytz")
+        tz = pytz.timezone("US/Eastern")
         start = tz.localize(datetime(2011, 1, 1))
         end = tz.localize(datetime(2011, 1, 3))
 
@@ -517,14 +518,16 @@ class TestDateRanges:
         ],
     )
     def test_range_tz_dst_straddle_pytz(self, start, end):
-        start = Timestamp(start, tz="US/Eastern")
-        end = Timestamp(end, tz="US/Eastern")
+        pytz = pytest.importorskip("pytz")
+        tz = pytz.timezone("US/Eastern")
+        start = Timestamp(start, tz=tz)
+        end = Timestamp(end, tz=tz)
         dr = date_range(start, end, freq="D")
         assert dr[0] == start
         assert dr[-1] == end
         assert np.all(dr.hour == 0)
 
-        dr = date_range(start, end, freq="D", tz="US/Eastern")
+        dr = date_range(start, end, freq="D", tz=tz)
         assert dr[0] == start
         assert dr[-1] == end
         assert np.all(dr.hour == 0)
@@ -533,7 +536,7 @@ class TestDateRanges:
             start.replace(tzinfo=None),
             end.replace(tzinfo=None),
             freq="D",
-            tz="US/Eastern",
+            tz=tz,
         )
         assert dr[0] == start
         assert dr[-1] == end

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -1,9 +1,11 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 import dateutil.tz
 import numpy as np
 import pytest
-import pytz
 
 import pandas as pd
 from pandas import (
@@ -276,7 +278,7 @@ class TestDatetimeIndexRendering:
             result = idx._summary()
             assert result == expected
 
-    @pytest.mark.parametrize("tz", [None, pytz.utc, dateutil.tz.tzutc()])
+    @pytest.mark.parametrize("tz", [None, timezone.utc, dateutil.tz.tzutc()])
     @pytest.mark.parametrize("freq", ["B", "C"])
     def test_dti_business_repr_etc_smoke(self, tz, freq):
         # only really care that it works

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -1,11 +1,11 @@
 from datetime import (
     datetime,
+    timedelta,
     timezone,
 )
 
 import numpy as np
 import pytest
-import pytz
 
 import pandas.util._test_decorators as td
 
@@ -560,6 +560,7 @@ class TestBusinessDatetimeIndex:
         tm.assert_index_equal(res, idx)
 
     def test_month_range_union_tz_pytz(self, sort):
+        pytz = pytest.importorskip("pytz")
         tz = pytz.timezone("US/Eastern")
 
         early_start = datetime(2011, 1, 1)
@@ -648,7 +649,7 @@ class TestCustomDatetimeIndex:
         assert result.freq == b.freq
 
     @pytest.mark.parametrize(
-        "tz", [None, "UTC", "Europe/Berlin", pytz.FixedOffset(-60)]
+        "tz", [None, "UTC", "Europe/Berlin", timezone(timedelta(hours=-1))]
     )
     def test_intersection_dst_transition(self, tz):
         # GH 46702: Europe/Berlin has DST transition

--- a/pandas/tests/indexes/multi/test_reshape.py
+++ b/pandas/tests/indexes/multi/test_reshape.py
@@ -1,8 +1,8 @@
 from datetime import datetime
+import zoneinfo
 
 import numpy as np
 import pytest
-import pytz
 
 import pandas as pd
 from pandas import (
@@ -114,11 +114,11 @@ def test_append_index():
     result = idx1.append(midx_lv2)
 
     # see gh-7112
-    tz = pytz.timezone("Asia/Tokyo")
+    tz = zoneinfo.ZoneInfo("Asia/Tokyo")
     expected_tuples = [
-        (1.1, tz.localize(datetime(2011, 1, 1))),
-        (1.2, tz.localize(datetime(2011, 1, 2))),
-        (1.3, tz.localize(datetime(2011, 1, 3))),
+        (1.1, datetime(2011, 1, 1, tzinfo=tz)),
+        (1.2, datetime(2011, 1, 2, tzinfo=tz)),
+        (1.3, datetime(2011, 1, 3, tzinfo=tz)),
     ]
     expected = Index([1.1, 1.2, 1.3] + expected_tuples)
     tm.assert_index_equal(result, expected)
@@ -138,9 +138,9 @@ def test_append_index():
     expected = Index._simple_new(
         np.array(
             [
-                (1.1, tz.localize(datetime(2011, 1, 1)), "A"),
-                (1.2, tz.localize(datetime(2011, 1, 2)), "B"),
-                (1.3, tz.localize(datetime(2011, 1, 3)), "C"),
+                (1.1, datetime(2011, 1, 1, tzinfo=tz), "A"),
+                (1.2, datetime(2011, 1, 2, tzinfo=tz), "B"),
+                (1.3, datetime(2011, 1, 3, tzinfo=tz), "C"),
             ]
             + expected_tuples,
             dtype=object,

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -10,7 +10,6 @@ import time
 import dateutil
 import numpy as np
 import pytest
-import pytz
 
 import pandas._libs.json as ujson
 from pandas.compat import IS64
@@ -370,6 +369,7 @@ class TestUltraJSONTests:
 
     def test_encode_time_conversion_pytz(self):
         # see gh-11473: to_json segfaults with timezone-aware datetimes
+        pytz = pytest.importorskip("pytz")
         test = datetime.time(10, 12, 15, 343243, pytz.utc)
         output = ujson.ujson_dumps(test)
         expected = f'"{test.isoformat()}"'

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -12,7 +12,6 @@ from io import StringIO
 
 import numpy as np
 import pytest
-import pytz
 
 import pandas as pd
 from pandas import (
@@ -217,6 +216,7 @@ def test_parse_tz_aware(all_parsers):
         {"x": [0.5]}, index=Index([Timestamp("2012-06-13 01:39:00+00:00")], name="Date")
     )
     if parser.engine == "pyarrow":
+        pytz = pytest.importorskip("pytz")
         expected_tz = pytz.utc
     else:
         expected_tz = timezone.utc

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -96,7 +96,7 @@ class TestFeather:
         df["timedeltas"] = pd.timedelta_range("1 day", periods=3)
         df["intervals"] = pd.interval_range(0, 3, 3)
 
-        assert df.dttz.dtype.tz.zone == "US/Eastern"
+        assert df.dttz.dtype.tz.key == "US/Eastern"
 
         expected = df.copy()
         expected.loc[1, "bool_with_null"] = None

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -1,5 +1,7 @@
 """test feather-format compat"""
 
+import zoneinfo
+
 import numpy as np
 import pytest
 
@@ -62,6 +64,7 @@ class TestFeather:
             self.check_error_on_write(obj, ValueError, msg)
 
     def test_basic(self):
+        tz = zoneinfo.ZoneInfo("US/Eastern")
         df = pd.DataFrame(
             {
                 "string": list("abc"),
@@ -76,7 +79,7 @@ class TestFeather:
                     list(pd.date_range("20130101", periods=3)), freq=None
                 ),
                 "dttz": pd.DatetimeIndex(
-                    list(pd.date_range("20130101", periods=3, tz="US/Eastern")),
+                    list(pd.date_range("20130101", periods=3, tz=tz)),
                     freq=None,
                 ),
                 "dt_with_null": [

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1129,9 +1129,11 @@ class TestParquetPyArrow(Base):
 class TestParquetFastParquet(Base):
     @pytest.mark.xfail(reason="datetime_with_nat gets incorrect values")
     def test_basic(self, fp, df_full):
+        pytz = pytest.importorskip("pytz")
+        tz = pytz.timezone("US/Eastern")
         df = df_full
 
-        dti = pd.date_range("20130101", periods=3, tz="US/Eastern")
+        dti = pd.date_range("20130101", periods=3, tz=tz)
         dti = dti._with_freq(None)  # freq doesn't round-trip
         df["datetime_tz"] = dti
         df["timedelta"] = pd.timedelta_range("1 day", periods=3)

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -111,6 +111,7 @@ def test_flatten_buffer(data):
 
 
 def test_pickles(datapath):
+    pytest.importorskip("pytz")
     if not is_platform_little_endian():
         pytest.skip("known failure on non-little endian")
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from functools import partial
+import zoneinfo
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs import lib
 from pandas._typing import DatetimeNaTType
@@ -1655,13 +1655,13 @@ def test_resample_dst_anchor2(unit):
 
 def test_downsample_across_dst(unit):
     # GH 8531
-    tz = pytz.timezone("Europe/Berlin")
+    tz = zoneinfo.ZoneInfo("Europe/Berlin")
     dt = datetime(2014, 10, 26)
-    dates = date_range(tz.localize(dt), periods=4, freq="2h").as_unit(unit)
+    dates = date_range(dt.astimezone(tz), periods=4, freq="2h").as_unit(unit)
     result = Series(5, index=dates).resample("h").mean()
     expected = Series(
         [5.0, np.nan] * 3 + [5.0],
-        index=date_range(tz.localize(dt), periods=7, freq="h").as_unit(unit),
+        index=date_range(dt.astimezone(tz), periods=7, freq="h").as_unit(unit),
     )
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -1,11 +1,14 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 import re
 import warnings
+import zoneinfo
 
 import dateutil
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs.tslibs.ccalendar import (
     DAYS,
@@ -304,7 +307,7 @@ class TestPeriodIndex:
     @pytest.mark.parametrize(
         "tz",
         [
-            pytz.timezone("America/Los_Angeles"),
+            zoneinfo.ZoneInfo("America/Los_Angeles"),
             dateutil.tz.gettz("America/Los_Angeles"),
         ],
     )
@@ -312,9 +315,13 @@ class TestPeriodIndex:
         # see gh-5430
         local_timezone = tz
 
-        start = datetime(year=2013, month=11, day=1, hour=0, minute=0, tzinfo=pytz.utc)
+        start = datetime(
+            year=2013, month=11, day=1, hour=0, minute=0, tzinfo=timezone.utc
+        )
         # 1 day later
-        end = datetime(year=2013, month=11, day=2, hour=0, minute=0, tzinfo=pytz.utc)
+        end = datetime(
+            year=2013, month=11, day=2, hour=0, minute=0, tzinfo=timezone.utc
+        )
 
         index = date_range(start, end, freq="h", name="idx")
 
@@ -336,7 +343,7 @@ class TestPeriodIndex:
     @pytest.mark.parametrize(
         "tz",
         [
-            pytz.timezone("America/Los_Angeles"),
+            zoneinfo.ZoneInfo("America/Los_Angeles"),
             dateutil.tz.gettz("America/Los_Angeles"),
         ],
     )
@@ -353,8 +360,6 @@ class TestPeriodIndex:
             index=exp_dti,
         )
         tm.assert_series_equal(result, expected)
-        # Especially assert that the timezone is LMT for pytz
-        assert result.index.tz == tz
 
     def test_resample_nonexistent_time_bin_edge(self):
         # GH 19375

--- a/pandas/tests/reshape/concat/test_append_common.py
+++ b/pandas/tests/reshape/concat/test_append_common.py
@@ -1,3 +1,5 @@
+import zoneinfo
+
 import numpy as np
 import pytest
 
@@ -353,14 +355,15 @@ class TestConcatAppendCommon:
         tm.assert_series_equal(res, Series(exp, index=[0, 1, 0, 1]))
 
         # different tz
-        dti3 = pd.DatetimeIndex(["2012-01-01", "2012-01-02"], tz="US/Pacific")
+        tz_diff = zoneinfo.ZoneInfo("US/Hawaii")
+        dti3 = pd.DatetimeIndex(["2012-01-01", "2012-01-02"], tz=tz_diff)
 
         exp = Index(
             [
                 pd.Timestamp("2011-01-01", tz=tz),
                 pd.Timestamp("2011-01-02", tz=tz),
-                pd.Timestamp("2012-01-01", tz="US/Pacific"),
-                pd.Timestamp("2012-01-02", tz="US/Pacific"),
+                pd.Timestamp("2012-01-01", tz=tz_diff),
+                pd.Timestamp("2012-01-02", tz=tz_diff),
             ],
             dtype=object,
         )

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -2,7 +2,6 @@ import datetime
 
 import numpy as np
 import pytest
-import pytz
 
 import pandas.util._test_decorators as td
 
@@ -2071,7 +2070,7 @@ class TestAsOfMerge:
                     start=to_datetime("2016-01-02"),
                     freq="D",
                     periods=5,
-                    tz=pytz.timezone("UTC"),
+                    tz=datetime.timezone.utc,
                     unit=unit,
                 ),
                 "value1": np.arange(5),
@@ -2083,7 +2082,7 @@ class TestAsOfMerge:
                     start=to_datetime("2016-01-01"),
                     freq="D",
                     periods=5,
-                    tz=pytz.timezone("UTC"),
+                    tz=datetime.timezone.utc,
                     unit=unit,
                 ),
                 "value2": list("ABCDE"),
@@ -2097,7 +2096,7 @@ class TestAsOfMerge:
                     start=to_datetime("2016-01-02"),
                     freq="D",
                     periods=5,
-                    tz=pytz.timezone("UTC"),
+                    tz=datetime.timezone.utc,
                     unit=unit,
                 ),
                 "value1": np.arange(5),

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -3,10 +3,10 @@ from datetime import (
     timedelta,
 )
 import operator
+import zoneinfo
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs.tslibs import iNaT
 from pandas.compat.numpy import np_version_gte1p24p3
@@ -361,7 +361,7 @@ _ops = {
         (Timestamp("2014-01-01"), "timestamp"),
         (Timestamp("2014-01-01", tz="UTC"), "timestamp"),
         (Timestamp("2014-01-01", tz="US/Eastern"), "timestamp"),
-        (pytz.timezone("Asia/Tokyo").localize(datetime(2014, 1, 1)), "timestamp"),
+        (datetime(2014, 1, 1).astimezone(zoneinfo.ZoneInfo("Asia/Tokyo")), "timestamp"),
     ],
 )
 def test_nat_arithmetic_scalar(op_name, value, val_type):

--- a/pandas/tests/scalar/timestamp/methods/test_timestamp_method.py
+++ b/pandas/tests/scalar/timestamp/methods/test_timestamp_method.py
@@ -1,8 +1,8 @@
 # NB: This is for the Timestamp.timestamp *method* specifically, not
 # the Timestamp class in general.
+from datetime import timezone
 
 import pytest
-from pytz import utc
 
 from pandas._libs.tslibs import Timestamp
 from pandas.compat import WASM
@@ -18,7 +18,7 @@ class TestTimestampMethod:
         # GH#17329
         # tz-naive --> treat it as if it were UTC for purposes of timestamp()
         ts = fixed_now_ts
-        uts = ts.replace(tzinfo=utc)
+        uts = ts.replace(tzinfo=timezone.utc)
         assert ts.timestamp() == uts.timestamp()
 
         tsc = Timestamp("2014-10-11 11:00:01.12345678", tz="US/Central")

--- a/pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py
+++ b/pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py
@@ -3,7 +3,7 @@ from datetime import (
     timedelta,
 )
 
-import pytz
+import pytest
 
 from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
 import pandas.util._test_decorators as td
@@ -43,6 +43,7 @@ class TestTimestampToPyDatetime:
         assert stamp.tzinfo == dtval.tzinfo
 
     def test_timestamp_to_pydatetime_explicit_pytz(self):
+        pytz = pytest.importorskip("pytz")
         stamp = Timestamp("20090415", tz=pytz.timezone("US/Eastern"))
         dtval = stamp.to_pydatetime()
         assert stamp == dtval

--- a/pandas/tests/scalar/timestamp/methods/test_tz_localize.py
+++ b/pandas/tests/scalar/timestamp/methods/test_tz_localize.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 import re
+import zoneinfo
 
 from dateutil.tz import gettz
 import pytest
@@ -17,68 +18,57 @@ from pandas import (
     Timestamp,
 )
 
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    # Cannot assign to a type
-    ZoneInfo = None  # type: ignore[misc, assignment]
-
 
 class TestTimestampTZLocalize:
     @pytest.mark.skip_ubsan
     def test_tz_localize_pushes_out_of_bounds(self):
         # GH#12677
         # tz_localize that pushes away from the boundary is OK
+        pytz = pytest.importorskip("pytz")
         msg = (
             f"Converting {Timestamp.min.strftime('%Y-%m-%d %H:%M:%S')} "
             f"underflows past {Timestamp.min}"
         )
-        pac = Timestamp.min.tz_localize("US/Pacific")
+        pac = Timestamp.min.tz_localize(pytz.timezone("US/Pacific"))
         assert pac._value > Timestamp.min._value
         pac.tz_convert("Asia/Tokyo")  # tz_convert doesn't change value
         with pytest.raises(OutOfBoundsDatetime, match=msg):
-            Timestamp.min.tz_localize("Asia/Tokyo")
+            Timestamp.min.tz_localize(pytz.timezone("Asia/Tokyo"))
 
         # tz_localize that pushes away from the boundary is OK
         msg = (
             f"Converting {Timestamp.max.strftime('%Y-%m-%d %H:%M:%S')} "
             f"overflows past {Timestamp.max}"
         )
-        tokyo = Timestamp.max.tz_localize("Asia/Tokyo")
+        tokyo = Timestamp.max.tz_localize(pytz.timezone("Asia/Tokyo"))
         assert tokyo._value < Timestamp.max._value
         tokyo.tz_convert("US/Pacific")  # tz_convert doesn't change value
         with pytest.raises(OutOfBoundsDatetime, match=msg):
-            Timestamp.max.tz_localize("US/Pacific")
+            Timestamp.max.tz_localize(pytz.timezone("US/Pacific"))
 
-    def test_tz_localize_ambiguous_bool(self, unit):
+    @pytest.mark.parametrize(
+        "tz",
+        [zoneinfo.ZoneInfo("US/Central"), "dateutil/US/Central", "pytz/US/Central"],
+    )
+    def test_tz_localize_ambiguous_bool(self, unit, tz):
         # make sure that we are correctly accepting bool values as ambiguous
         # GH#14402
+        if isinstance(tz, str) and tz.startswith("pytz/"):
+            pytz = pytest.importorskip("pytz")
+            tz = pytz.timezone(tz.removeprefix("pytz/"))
         ts = Timestamp("2015-11-01 01:00:03").as_unit(unit)
-        expected0 = Timestamp("2015-11-01 01:00:03-0500", tz="US/Central")
-        expected1 = Timestamp("2015-11-01 01:00:03-0600", tz="US/Central")
+        expected0 = Timestamp("2015-11-01 01:00:03-0500", tz=tz)
+        expected1 = Timestamp("2015-11-01 01:00:03-0600", tz=tz)
 
         msg = "Cannot infer dst time from 2015-11-01 01:00:03"
         with pytest.raises(pytz.AmbiguousTimeError, match=msg):
-            ts.tz_localize("US/Central")
+            ts.tz_localize(tz)
 
-        with pytest.raises(pytz.AmbiguousTimeError, match=msg):
-            ts.tz_localize("dateutil/US/Central")
-
-        if ZoneInfo is not None:
-            try:
-                tz = ZoneInfo("US/Central")
-            except KeyError:
-                # no tzdata
-                pass
-            else:
-                with pytest.raises(pytz.AmbiguousTimeError, match=msg):
-                    ts.tz_localize(tz)
-
-        result = ts.tz_localize("US/Central", ambiguous=True)
+        result = ts.tz_localize(tz, ambiguous=True)
         assert result == expected0
         assert result._creso == getattr(NpyDatetimeUnit, f"NPY_FR_{unit}").value
 
-        result = ts.tz_localize("US/Central", ambiguous=False)
+        result = ts.tz_localize(tz, ambiguous=False)
         assert result == expected1
         assert result._creso == getattr(NpyDatetimeUnit, f"NPY_FR_{unit}").value
 
@@ -205,9 +195,10 @@ class TestTimestampTZLocalize:
     def test_tz_localize_ambiguous_compat(self):
         # validate that pytz and dateutil are compat for dst
         # when the transition happens
+        pytz = pytest.importorskip("pytz")
         naive = Timestamp("2013-10-27 01:00:00")
 
-        pytz_zone = "Europe/London"
+        pytz_zone = pytz.timezone("Europe/London")
         dateutil_zone = "dateutil/Europe/London"
         result_pytz = naive.tz_localize(pytz_zone, ambiguous=False)
         result_dateutil = naive.tz_localize(dateutil_zone, ambiguous=False)
@@ -236,13 +227,16 @@ class TestTimestampTZLocalize:
     @pytest.mark.parametrize(
         "tz",
         [
-            pytz.timezone("US/Eastern"),
+            "pytz/US/Eastern",
             gettz("US/Eastern"),
-            "US/Eastern",
+            zoneinfo.ZoneInfo("US/Eastern"),
             "dateutil/US/Eastern",
         ],
     )
     def test_timestamp_tz_localize(self, tz):
+        if isinstance(tz, str) and tz.startswith("pytz/"):
+            pytz = pytest.importorskip("pytz")
+            tz = pytz.timezone(tz.removeprefix("pytz/"))
         stamp = Timestamp("3/11/2012 04:00")
 
         result = stamp.tz_localize(tz)

--- a/pandas/tests/scalar/timestamp/methods/test_tz_localize.py
+++ b/pandas/tests/scalar/timestamp/methods/test_tz_localize.py
@@ -54,7 +54,6 @@ class TestTimestampTZLocalize:
         # make sure that we are correctly accepting bool values as ambiguous
         # GH#14402
         if isinstance(tz, str) and tz.startswith("pytz/"):
-            pytz = pytest.importorskip("pytz")
             tz = pytz.timezone(tz.removeprefix("pytz/"))
         ts = Timestamp("2015-11-01 01:00:03").as_unit(unit)
         expected0 = Timestamp("2015-11-01 01:00:03-0500", tz=tz)

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -7,7 +7,6 @@ from datetime import (
 from dateutil.tz import gettz
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs.tslibs import (
     OutOfBoundsDatetime,
@@ -294,7 +293,7 @@ class TestTimestampArithmetic:
     @pytest.mark.parametrize(
         "tz",
         [
-            pytz.timezone("US/Eastern"),
+            "pytz/US/Eastern",
             gettz("US/Eastern"),
             "US/Eastern",
             "dateutil/US/Eastern",
@@ -302,7 +301,9 @@ class TestTimestampArithmetic:
     )
     def test_timestamp_add_timedelta_push_over_dst_boundary(self, tz):
         # GH#1389
-
+        if isinstance(tz, str) and tz.startswith("pytz/"):
+            pytz = pytest.importorskip("pytz")
+            tz = pytz.timezone(tz.removeprefix("pytz/"))
         # 4 hours before DST transition
         stamp = Timestamp("3/10/2012 22:00", tz=tz)
 

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -123,6 +123,7 @@ class TestTimestampConstructorFoldKeyword:
         # Test for GH#25057
         # pytz doesn't support fold. Check that we raise
         # if fold is passed with pytz
+        pytz = pytest.importorskip("pytz")
         msg = "pytz timezones do not support fold. Please use dateutil timezones."
         tz = pytz.timezone("Europe/London")
         with pytest.raises(ValueError, match=msg):
@@ -160,15 +161,13 @@ class TestTimestampConstructorFoldKeyword:
         expected = fold
         assert result == expected
 
-    try:
-        _tzs = [
+    @pytest.mark.parametrize(
+        "tz",
+        [
             "dateutil/Europe/London",
             zoneinfo.ZoneInfo("Europe/London"),
-        ]
-    except zoneinfo.ZoneInfoNotFoundError:
-        _tzs = ["dateutil/Europe/London"]
-
-    @pytest.mark.parametrize("tz", _tzs)
+        ],
+    )
     @pytest.mark.parametrize(
         "ts_input,fold_out",
         [
@@ -565,11 +564,11 @@ class TestTimestampConstructors:
         timezones = [
             (None, 0),
             ("UTC", 0),
-            (pytz.utc, 0),
+            (timezone.utc, 0),
             ("Asia/Tokyo", 9),
             ("US/Eastern", -4),
             ("dateutil/US/Pacific", -7),
-            (pytz.FixedOffset(-180), -3),
+            (timezone(timedelta(hours=-3)), -3),
             (dateutil.tz.tzoffset(None, 18000), 5),
         ]
 
@@ -622,11 +621,11 @@ class TestTimestampConstructors:
 
         timezones = [
             ("UTC", 0),
-            (pytz.utc, 0),
+            (timezone.utc, 0),
             ("Asia/Tokyo", 9),
             ("US/Eastern", -4),
             ("dateutil/US/Pacific", -7),
-            (pytz.FixedOffset(-180), -3),
+            (timezone(timedelta(hours=-3)), -3),
             (dateutil.tz.tzoffset(None, 18000), 5),
         ]
 
@@ -706,7 +705,7 @@ class TestTimestampConstructors:
 
         msg = "at most one of"
         with pytest.raises(ValueError, match=msg):
-            Timestamp("2017-10-22", tzinfo=pytz.utc, tz="UTC")
+            Timestamp("2017-10-22", tzinfo=timezone.utc, tz="UTC")
 
         msg = "Cannot pass a date attribute keyword argument when passing a date string"
         with pytest.raises(ValueError, match=msg):
@@ -719,11 +718,11 @@ class TestTimestampConstructors:
         # GH#17943, GH#17690, GH#5168
         stamps = [
             Timestamp(year=2017, month=10, day=22, tz="UTC"),
-            Timestamp(year=2017, month=10, day=22, tzinfo=pytz.utc),
-            Timestamp(year=2017, month=10, day=22, tz=pytz.utc),
-            Timestamp(datetime(2017, 10, 22), tzinfo=pytz.utc),
+            Timestamp(year=2017, month=10, day=22, tzinfo=timezone.utc),
+            Timestamp(year=2017, month=10, day=22, tz=timezone.utc),
+            Timestamp(datetime(2017, 10, 22), tzinfo=timezone.utc),
             Timestamp(datetime(2017, 10, 22), tz="UTC"),
-            Timestamp(datetime(2017, 10, 22), tz=pytz.utc),
+            Timestamp(datetime(2017, 10, 22), tz=timezone.utc),
         ]
         assert all(ts == stamps[0] for ts in stamps)
 
@@ -898,13 +897,13 @@ class TestTimestampConstructors:
     def test_construct_with_different_string_format(self, arg):
         # GH 12064
         result = Timestamp(arg)
-        expected = Timestamp(datetime(2013, 1, 1), tz=pytz.FixedOffset(540))
+        expected = Timestamp(datetime(2013, 1, 1), tz=timezone(timedelta(hours=9)))
         assert result == expected
 
     @pytest.mark.parametrize("box", [datetime, Timestamp])
     def test_raise_tz_and_tzinfo_in_datetime_input(self, box):
         # GH 23579
-        kwargs = {"year": 2018, "month": 1, "day": 1, "tzinfo": pytz.utc}
+        kwargs = {"year": 2018, "month": 1, "day": 1, "tzinfo": timezone.utc}
         msg = "Cannot pass a datetime or Timestamp"
         with pytest.raises(ValueError, match=msg):
             Timestamp(box(**kwargs), tz="US/Pacific")
@@ -912,7 +911,7 @@ class TestTimestampConstructors:
         with pytest.raises(ValueError, match=msg):
             Timestamp(box(**kwargs), tzinfo=pytz.timezone("US/Pacific"))
 
-    def test_dont_convert_dateutil_utc_to_pytz_utc(self):
+    def test_dont_convert_dateutil_utc_to_default_utc(self):
         result = Timestamp(datetime(2018, 1, 1), tz=tzutc())
         expected = Timestamp(datetime(2018, 1, 1)).tz_localize(tzutc())
         assert result == expected
@@ -996,7 +995,7 @@ class TestTimestampConstructors:
     @pytest.mark.parametrize(
         "tz",
         [
-            pytz.timezone("US/Eastern"),
+            "pytz/US/Eastern",
             gettz("US/Eastern"),
             "US/Eastern",
             "dateutil/US/Eastern",
@@ -1005,7 +1004,9 @@ class TestTimestampConstructors:
     def test_timestamp_constructed_by_date_and_tz(self, tz):
         # GH#2993, Timestamp cannot be constructed by datetime.date
         # and tz correctly
-
+        if isinstance(tz, str) and tz.startswith("pytz/"):
+            pytz = pytest.importorskip("pytz")
+            tz = pytz.timezone(tz.removeprefix("pytz/"))
         result = Timestamp(date(2012, 3, 11), tz=tz)
 
         expected = Timestamp("3/11/2012", tz=tz)

--- a/pandas/tests/scalar/timestamp/test_formats.py
+++ b/pandas/tests/scalar/timestamp/test_formats.py
@@ -1,9 +1,11 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 import pprint
 
 import dateutil.tz
 import pytest
-import pytz  # a test below uses pytz but only inside a `eval` call
 
 from pandas.compat import WASM
 
@@ -181,14 +183,14 @@ class TestTimestampRendering:
         ts_nanos_micros = Timestamp(1200)
         assert str(ts_nanos_micros) == "1970-01-01 00:00:00.000001200"
 
-    def test_repr_matches_pydatetime_tz_pytz(self):
-        dt_date = datetime(2013, 1, 2, tzinfo=pytz.utc)
+    def test_repr_matches_pydatetime_tz_stdlib(self):
+        dt_date = datetime(2013, 1, 2, tzinfo=timezone.utc)
         assert str(dt_date) == str(Timestamp(dt_date))
 
-        dt_datetime = datetime(2013, 1, 2, 12, 1, 3, tzinfo=pytz.utc)
+        dt_datetime = datetime(2013, 1, 2, 12, 1, 3, tzinfo=timezone.utc)
         assert str(dt_datetime) == str(Timestamp(dt_datetime))
 
-        dt_datetime_us = datetime(2013, 1, 2, 12, 1, 3, 45, tzinfo=pytz.utc)
+        dt_datetime_us = datetime(2013, 1, 2, 12, 1, 3, 45, tzinfo=timezone.utc)
         assert str(dt_datetime_us) == str(Timestamp(dt_datetime_us))
 
     def test_repr_matches_pydatetime_tz_dateutil(self):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -9,6 +9,7 @@ from datetime import (
 import locale
 import time
 import unicodedata
+import zoneinfo
 
 from dateutil.tz import (
     tzlocal,
@@ -20,8 +21,6 @@ from hypothesis import (
 )
 import numpy as np
 import pytest
-import pytz
-from pytz import utc
 
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 from pandas._libs.tslibs.timezones import (
@@ -259,7 +258,7 @@ class TestTimestampProperties:
 
 
 class TestTimestamp:
-    @pytest.mark.parametrize("tz", [None, pytz.timezone("US/Pacific")])
+    @pytest.mark.parametrize("tz", [None, zoneinfo.ZoneInfo("US/Pacific")])
     def test_disallow_setting_tz(self, tz):
         # GH#3746
         ts = Timestamp("2010")
@@ -311,7 +310,7 @@ class TestTimestamp:
             assert int((Timestamp(x)._value - Timestamp(y)._value) / 1e9) == 0
 
         compare(Timestamp.now(), datetime.now())
-        compare(Timestamp.now("UTC"), datetime.now(pytz.timezone("UTC")))
+        compare(Timestamp.now("UTC"), datetime.now(timezone.utc))
         compare(Timestamp.now("UTC"), datetime.now(tzutc()))
         msg = "Timestamp.utcnow is deprecated"
         with tm.assert_produces_warning(FutureWarning, match=msg):
@@ -329,12 +328,12 @@ class TestTimestamp:
         compare(
             # Support tz kwarg in Timestamp.fromtimestamp
             Timestamp.fromtimestamp(current_time, "UTC"),
-            datetime.fromtimestamp(current_time, utc),
+            datetime.fromtimestamp(current_time, timezone.utc),
         )
         compare(
             # Support tz kwarg in Timestamp.fromtimestamp
             Timestamp.fromtimestamp(current_time, tz="UTC"),
-            datetime.fromtimestamp(current_time, utc),
+            datetime.fromtimestamp(current_time, timezone.utc),
         )
 
         date_component = datetime.now(timezone.utc)
@@ -585,9 +584,9 @@ class TestNonNano:
         assert ts.month_name() == alt.month_name()
 
     def test_tz_convert(self, ts):
-        ts = Timestamp._from_value_and_reso(ts._value, ts._creso, utc)
+        ts = Timestamp._from_value_and_reso(ts._value, ts._creso, timezone.utc)
 
-        tz = pytz.timezone("US/Pacific")
+        tz = zoneinfo.ZoneInfo("US/Pacific")
         result = ts.tz_convert(tz)
 
         assert isinstance(result, Timestamp)

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -14,7 +14,6 @@ from dateutil.tz import (
 )
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs import index as libindex
 
@@ -63,6 +62,7 @@ def test_fancy_setitem():
 @pytest.mark.parametrize("tz_source", ["pytz", "dateutil"])
 def test_getitem_setitem_datetime_tz(tz_source):
     if tz_source == "pytz":
+        pytz = pytest.importorskip(tz_source)
         tzget = pytz.timezone
     else:
         # handle special case for utc in dateutil

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -6,7 +6,6 @@ from datetime import (
 
 import numpy as np
 import pytest
-import pytz
 
 from pandas import (
     Categorical,
@@ -861,7 +860,7 @@ class TestFillnaPad:
 
     def test_ffill_mixed_dtypes_without_missing_data(self):
         # GH#14956
-        series = Series([datetime(2015, 1, 1, tzinfo=pytz.utc), 1])
+        series = Series([datetime(2015, 1, 1, tzinfo=timezone.utc), 1])
         result = series.ffill()
         tm.assert_series_equal(series, result)
 
@@ -923,16 +922,16 @@ class TestFillnaPad:
         # GH#14872
 
         data = Series(
-            [NaT, NaT, datetime(2016, 12, 12, 22, 24, 6, 100001, tzinfo=pytz.utc)]
+            [NaT, NaT, datetime(2016, 12, 12, 22, 24, 6, 100001, tzinfo=timezone.utc)]
         )
 
         filled = data.bfill()
 
         expected = Series(
             [
-                datetime(2016, 12, 12, 22, 24, 6, 100001, tzinfo=pytz.utc),
-                datetime(2016, 12, 12, 22, 24, 6, 100001, tzinfo=pytz.utc),
-                datetime(2016, 12, 12, 22, 24, 6, 100001, tzinfo=pytz.utc),
+                datetime(2016, 12, 12, 22, 24, 6, 100001, tzinfo=timezone.utc),
+                datetime(2016, 12, 12, 22, 24, 6, 100001, tzinfo=timezone.utc),
+                datetime(2016, 12, 12, 22, 24, 6, 100001, tzinfo=timezone.utc),
             ]
         )
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -10,11 +10,11 @@ from datetime import (
 )
 from decimal import Decimal
 import locale
+import zoneinfo
 
 from dateutil.parser import parse
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs import tslib
 from pandas._libs.tslibs import (
@@ -432,9 +432,11 @@ class TestTimeConversionFormats:
                 ["2010-01-01 12:00:00 Z", "2010-01-01 12:00:00 Z"],
                 [
                     Timestamp(
-                        "2010-01-01 12:00:00", tzinfo=pytz.FixedOffset(0)
-                    ),  # pytz coerces to UTC
-                    Timestamp("2010-01-01 12:00:00", tzinfo=pytz.FixedOffset(0)),
+                        "2010-01-01 12:00:00", tzinfo=timezone(timedelta(minutes=0))
+                    ),
+                    Timestamp(
+                        "2010-01-01 12:00:00", tzinfo=timezone(timedelta(minutes=0))
+                    ),
                 ],
             ],
         ],
@@ -1169,6 +1171,7 @@ class TestToDatetime:
 
     def test_to_datetime_tz_pytz(self, cache):
         # see gh-8260
+        pytz = pytest.importorskip("pytz")
         us_eastern = pytz.timezone("US/Eastern")
         arr = np.array(
             [
@@ -1699,7 +1702,9 @@ class TestToDatetime:
             ["2020-10-26 00:00:00+06:00", Timestamp("2018-01-01", tz="US/Pacific")],
             [
                 "2020-10-26 00:00:00+06:00",
-                datetime(2020, 1, 1, 18, tzinfo=pytz.timezone("Australia/Melbourne")),
+                datetime(2020, 1, 1, 18).astimezone(
+                    zoneinfo.ZoneInfo("Australia/Melbourne")
+                ),
             ],
         ],
     )
@@ -2351,7 +2356,7 @@ class TestToDatetimeMisc:
     )
     def test_to_datetime_iso8601_with_timezone_valid(self, input, format):
         # https://github.com/pandas-dev/pandas/issues/12649
-        expected = Timestamp(2020, 1, 1, tzinfo=pytz.UTC)
+        expected = Timestamp(2020, 1, 1, tzinfo=timezone.utc)
         result = to_datetime(input, format=format)
         assert result == expected
 
@@ -2778,7 +2783,7 @@ class TestToDatetimeInferFormat:
         # GH 41047
         ser = Series([ts + zero_tz])
         result = to_datetime(ser)
-        tz = pytz.utc if zero_tz == "Z" else None
+        tz = timezone.utc if zero_tz == "Z" else None
         expected = Series([Timestamp(ts, tz=tz)])
         tm.assert_series_equal(result, expected)
 
@@ -3213,7 +3218,7 @@ class TestOrigin:
     def test_invalid_origins_tzinfo(self):
         # GH16842
         with pytest.raises(ValueError, match="must be tz-naive"):
-            to_datetime(1, unit="D", origin=datetime(2000, 1, 1, tzinfo=pytz.utc))
+            to_datetime(1, unit="D", origin=datetime(2000, 1, 1, tzinfo=timezone.utc))
 
     def test_incorrect_value_exception(self):
         # GH47495

--- a/pandas/tests/tseries/holiday/test_holiday.py
+++ b/pandas/tests/tseries/holiday/test_holiday.py
@@ -1,7 +1,9 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 import pytest
-from pytz import utc
 
 from pandas import (
     DatetimeIndex,
@@ -128,9 +130,9 @@ def test_holiday_dates(holiday, start_date, end_date, expected):
     # Verify that timezone info is preserved.
     assert list(
         holiday.dates(
-            utc.localize(Timestamp(start_date)), utc.localize(Timestamp(end_date))
+            Timestamp(start_date, tz=timezone.utc), Timestamp(end_date, tz=timezone.utc)
         )
-    ) == [utc.localize(dt) for dt in expected]
+    ) == [dt.replace(tzinfo=timezone.utc) for dt in expected]
 
 
 @pytest.mark.parametrize(
@@ -194,8 +196,10 @@ def test_holidays_within_dates(holiday, start, expected):
 
     # Verify that timezone info is preserved.
     assert list(
-        holiday.dates(utc.localize(Timestamp(start)), utc.localize(Timestamp(start)))
-    ) == [utc.localize(dt) for dt in expected]
+        holiday.dates(
+            Timestamp(start, tz=timezone.utc), Timestamp(start, tz=timezone.utc)
+        )
+    ) == [dt.replace(tzinfo=timezone.utc) for dt in expected]
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/tseries/offsets/test_dst.py
+++ b/pandas/tests/tseries/offsets/test_dst.py
@@ -229,12 +229,6 @@ class TestDST:
 @pytest.mark.parametrize(
     "original_dt, target_dt, offset, tz",
     [
-        pytest.param(
-            Timestamp("1900-01-01"),
-            Timestamp("1905-07-01"),
-            MonthBegin(66),
-            "Africa/Lagos",
-        ),
         (
             Timestamp("2021-10-01 01:15"),
             Timestamp("2021-10-31 01:15"),

--- a/pandas/tests/tseries/offsets/test_dst.py
+++ b/pandas/tests/tseries/offsets/test_dst.py
@@ -5,7 +5,6 @@ Tests for DateOffset additions over Daylight Savings Time
 from datetime import timedelta
 
 import pytest
-import pytz
 
 from pandas._libs.tslibs import Timestamp
 from pandas._libs.tslibs.offsets import (
@@ -33,10 +32,8 @@ from pandas._libs.tslibs.offsets import (
 
 from pandas import DatetimeIndex
 import pandas._testing as tm
-from pandas.util.version import Version
 
-# error: Module has no attribute "__version__"
-pytz_version = Version(pytz.__version__)  # type: ignore[attr-defined]
+pytz = pytest.importorskip("pytz")
 
 
 def get_utc_offset_hours(ts):
@@ -52,7 +49,10 @@ class TestDST:
 
     # test both basic names and dateutil timezones
     timezone_utc_offsets = {
-        "US/Eastern": {"utc_offset_daylight": -4, "utc_offset_standard": -5},
+        pytz.timezone("US/Eastern"): {
+            "utc_offset_daylight": -4,
+            "utc_offset_standard": -5,
+        },
         "dateutil/US/Pacific": {"utc_offset_daylight": -7, "utc_offset_standard": -8},
     }
     valid_date_offsets_singular = [
@@ -96,7 +96,10 @@ class TestDST:
         if (
             offset_name in ["hour", "minute", "second", "microsecond"]
             and offset_n == 1
-            and tstart == Timestamp("2013-11-03 01:59:59.999999-0500", tz="US/Eastern")
+            and tstart
+            == Timestamp(
+                "2013-11-03 01:59:59.999999-0500", tz=pytz.timezone("US/Eastern")
+            )
         ):
             # This addition results in an ambiguous wall time
             err_msg = {
@@ -147,7 +150,9 @@ class TestDST:
             assert datepart_offset == offset.kwds[offset_name]
         else:
             # the offset should be the same as if it was done in UTC
-            assert t == (tstart.tz_convert("UTC") + offset).tz_convert("US/Pacific")
+            assert t == (tstart.tz_convert("UTC") + offset).tz_convert(
+                pytz.timezone("US/Pacific")
+            )
 
     def _make_timestamp(self, string, hrs_offset, tz):
         if hrs_offset >= 0:
@@ -229,10 +234,6 @@ class TestDST:
             Timestamp("1905-07-01"),
             MonthBegin(66),
             "Africa/Lagos",
-            marks=pytest.mark.xfail(
-                pytz_version < Version("2020.5") or pytz_version == Version("2022.2"),
-                reason="GH#41906: pytz utc transition dates changed",
-            ),
         ),
         (
             Timestamp("2021-10-01 01:15"),
@@ -263,7 +264,7 @@ class TestDST:
 def test_nontick_offset_with_ambiguous_time_error(original_dt, target_dt, offset, tz):
     # .apply for non-Tick offsets throws AmbiguousTimeError when the target dt
     # is dst-ambiguous
-    localized_dt = original_dt.tz_localize(tz)
+    localized_dt = original_dt.tz_localize(pytz.timezone(tz))
 
     msg = f"Cannot infer dst time from {target_dt}, try using the 'ambiguous' argument"
     with pytest.raises(pytz.AmbiguousTimeError, match=msg):

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -1,8 +1,10 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 import numpy as np
 import pytest
-from pytz import UTC
 
 from pandas._libs.tslibs import (
     OutOfBoundsTimedelta,
@@ -55,7 +57,7 @@ def _compare_local_to_utc(tz_didx, naive_didx):
 def test_tz_localize_to_utc_copies():
     # GH#46460
     arr = np.arange(5, dtype="i8")
-    result = tz_convert_from_utc(arr, tz=UTC)
+    result = tz_convert_from_utc(arr, tz=timezone.utc)
     tm.assert_numpy_array_equal(result, arr)
     assert not np.shares_memory(arr, result)
 
@@ -100,7 +102,7 @@ def test_tz_convert_readonly():
     # GH#35530
     arr = np.array([0], dtype=np.int64)
     arr.setflags(write=False)
-    result = tz_convert_from_utc(arr, UTC)
+    result = tz_convert_from_utc(arr, timezone.utc)
     tm.assert_numpy_array_equal(result, arr)
 
 
@@ -141,14 +143,18 @@ class SubDatetime(datetime):
     "dt, expected",
     [
         pytest.param(
-            Timestamp("2000-01-01"), Timestamp("2000-01-01", tz=UTC), id="timestamp"
+            Timestamp("2000-01-01"),
+            Timestamp("2000-01-01", tz=timezone.utc),
+            id="timestamp",
         ),
         pytest.param(
-            datetime(2000, 1, 1), datetime(2000, 1, 1, tzinfo=UTC), id="datetime"
+            datetime(2000, 1, 1),
+            datetime(2000, 1, 1, tzinfo=timezone.utc),
+            id="datetime",
         ),
         pytest.param(
             SubDatetime(2000, 1, 1),
-            SubDatetime(2000, 1, 1, tzinfo=UTC),
+            SubDatetime(2000, 1, 1, tzinfo=timezone.utc),
             id="subclassed_datetime",
         ),
     ],
@@ -157,5 +163,5 @@ def test_localize_pydatetime_dt_types(dt, expected):
     # GH 25851
     # ensure that subclassed datetime works with
     # localize_pydatetime
-    result = conversion.localize_pydatetime(dt, UTC)
+    result = conversion.localize_pydatetime(dt, timezone.utc)
     assert result == expected

--- a/pandas/tests/tslibs/test_resolution.py
+++ b/pandas/tests/tslibs/test_resolution.py
@@ -1,6 +1,7 @@
+import datetime
+
 import numpy as np
 import pytest
-import pytz
 
 from pandas._libs.tslibs import (
     Resolution,
@@ -23,7 +24,7 @@ def test_get_resolution_non_nano_data():
     res = get_resolution(arr, None, NpyDatetimeUnit.NPY_FR_us.value)
     assert res == Resolution.RESO_US
 
-    res = get_resolution(arr, pytz.UTC, NpyDatetimeUnit.NPY_FR_us.value)
+    res = get_resolution(arr, datetime.timezone.utc, NpyDatetimeUnit.NPY_FR_us.value)
     assert res == Resolution.RESO_US
 
 

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -6,7 +6,6 @@ from datetime import (
 
 import dateutil.tz
 import pytest
-import pytz
 
 from pandas._libs.tslibs import (
     conversion,
@@ -22,10 +21,11 @@ def test_is_utc(utc_fixture):
     assert timezones.is_utc(tz)
 
 
-@pytest.mark.parametrize("tz_name", list(pytz.common_timezones))
 def test_cache_keys_are_distinct_for_pytz_vs_dateutil(tz_name):
-    tz_p = timezones.maybe_get_tz(tz_name)
-    tz_d = timezones.maybe_get_tz("dateutil/" + tz_name)
+    pytz = pytest.importorskip("pytz")
+    for tz_name in pytz.common_timezones:
+        tz_p = timezones.maybe_get_tz(tz_name)
+        tz_d = timezones.maybe_get_tz("dateutil/" + tz_name)
 
     if tz_d is None:
         pytest.skip(tz_name + ": dateutil does not know about this one")
@@ -76,12 +76,15 @@ def test_tz_compare_utc(utc_fixture, utc_fixture2):
 
 @pytest.fixture(
     params=[
-        (pytz.timezone("US/Eastern"), lambda tz, x: tz.localize(x)),
+        ("pytz/US/Eastern", lambda tz, x: tz.localize(x)),
         (dateutil.tz.gettz("US/Eastern"), lambda tz, x: x.replace(tzinfo=tz)),
     ]
 )
 def infer_setup(request):
     eastern, localize = request.param
+    if isinstance(eastern, str) and eastern.startswith("pytz/"):
+        pytz = pytest.importorskip("pytz")
+        eastern = pytz.timezone(eastern.removeprefix("pytz/"))
 
     start_naive = datetime(2001, 1, 1)
     end_naive = datetime(2009, 1, 1)
@@ -111,10 +114,10 @@ def test_infer_tz_compat(infer_setup):
 
 def test_infer_tz_utc_localize(infer_setup):
     _, _, start, end, start_naive, end_naive = infer_setup
-    utc = pytz.utc
+    utc = timezone.utc
 
-    start = utc.localize(start_naive)
-    end = utc.localize(end_naive)
+    start = start_naive.astimezone(utc)
+    end = end_naive.astimezone(utc)
 
     assert timezones.infer_tzinfo(start, end) is utc
 
@@ -124,8 +127,8 @@ def test_infer_tz_mismatch(infer_setup, ordered):
     eastern, _, _, _, start_naive, end_naive = infer_setup
     msg = "Inputs must both have the same timezone"
 
-    utc = pytz.utc
-    start = utc.localize(start_naive)
+    utc = timezone.utc
+    start = start_naive.astimezone(utc)
     end = conversion.localize_pydatetime(end_naive, eastern)
 
     args = (start, end) if ordered else (end, start)
@@ -139,7 +142,7 @@ def test_maybe_get_tz_invalid_types():
         timezones.maybe_get_tz(44.0)
 
     with pytest.raises(TypeError, match="<class 'module'>"):
-        timezones.maybe_get_tz(pytz)
+        timezones.maybe_get_tz(pytest)
 
     msg = "<class 'pandas._libs.tslibs.timestamps.Timestamp'>"
     with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -21,7 +21,7 @@ def test_is_utc(utc_fixture):
     assert timezones.is_utc(tz)
 
 
-def test_cache_keys_are_distinct_for_pytz_vs_dateutil(tz_name):
+def test_cache_keys_are_distinct_for_pytz_vs_dateutil():
     pytz = pytest.importorskip("pytz")
     for tz_name in pytz.common_timezones:
         tz_p = timezones.maybe_get_tz(tz_name)


### PR DESCRIPTION
Split off from https://github.com/pandas-dev/pandas/pull/57045

* Add more documentation about `zoneinfo.ZoneInfo` objects being accepted
* Changed tests/benchmark to prefer stdlib timezone objects instead of pytz objects e.g. `pytz.utc` -> `datetime.timezone.utc`, `pytz.timezone("US/Pacific")` -> `zoneinfo.ZoneInfo("US/Pacific")`