### PR TITLE
CLN: BaseGrouper

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -682,7 +682,8 @@ class SeriesGroupBy(GroupBy[Series]):
         b    1
         dtype: int64
         """
-        ids, ngroups = self._grouper.group_info
+        ids = self._grouper.ids
+        ngroups = self._grouper.ngroups
         val = self.obj._values
         codes, uniques = algorithms.factorize(val, use_na_sentinel=dropna, sort=False)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1360,7 +1360,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
     @final
     def _numba_prep(self, data: DataFrame):
-        ids, ngroups = self._grouper.group_info
+        ngroups = self._grouper.ngroups
         sorted_index = self._grouper.result_ilocs
         sorted_ids = self._grouper._sorted_ids
 
@@ -1969,7 +1969,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         this is currently implementing sort=False
         (though the default is sort=True) for groupby in general
         """
-        ids, ngroups = self._grouper.group_info
+        ids = self._grouper.ids
+        ngroups = self._grouper.ngroups
         sorter = get_group_index_sorter(ids, ngroups)
         ids, count = ids[sorter], len(ids)
 
@@ -2185,7 +2186,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Freq: MS, dtype: int64
         """
         data = self._get_data_to_aggregate()
-        ids, ngroups = self._grouper.group_info
+        ids = self._grouper.ids
+        ngroups = self._grouper.ngroups
         mask = ids != -1
 
         is_series = data.ndim == 1
@@ -3840,7 +3842,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         if limit is None:
             limit = -1
 
-        ids, ngroups = self._grouper.group_info
+        ids = self._grouper.ids
+        ngroups = self._grouper.ngroups
 
         col_func = partial(
             libgroupby.group_fillna_indexer,
@@ -4361,7 +4364,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             qs = np.array([q], dtype=np.float64)
             pass_qs = None
 
-        ids, ngroups = self._grouper.group_info
+        ids = self._grouper.ids
+        ngroups = self._grouper.ngroups
         if self.dropna:
             # splitter drops NA groups, we need to do the same
             ids = ids[ids >= 0]
@@ -5038,7 +5042,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             else:
                 if fill_value is lib.no_default:
                     fill_value = None
-                ids, ngroups = self._grouper.group_info
+                ids = self._grouper.ids
+                ngroups = self._grouper.ngroups
                 res_indexer = np.zeros(len(ids), dtype=np.int64)
 
                 libgroupby.group_shift_indexer(res_indexer, ids, ngroups, period)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -73,7 +73,6 @@ if TYPE_CHECKING:
         Generator,
         Hashable,
         Iterator,
-        Sequence,
     )
 
     from pandas.core.generic import NDFrame
@@ -581,24 +580,20 @@ class BaseGrouper:
     def __init__(
         self,
         axis: Index,
-        groupings: Sequence[grouper.Grouping],
+        groupings: list[grouper.Grouping],
         sort: bool = True,
         dropna: bool = True,
     ) -> None:
         assert isinstance(axis, Index), axis
 
         self.axis = axis
-        self._groupings: list[grouper.Grouping] = list(groupings)
+        self._groupings = groupings
         self._sort = sort
         self.dropna = dropna
 
     @property
     def groupings(self) -> list[grouper.Grouping]:
         return self._groupings
-
-    @property
-    def shape(self) -> Shape:
-        return tuple(ping.ngroups for ping in self.groupings)
 
     def __iter__(self) -> Iterator[Hashable]:
         return iter(self.indices)
@@ -628,11 +623,15 @@ class BaseGrouper:
         -------
         Generator yielding subsetted objects
         """
-        ids, ngroups = self.group_info
-        return _get_splitter(
+        if isinstance(data, Series):
+            klass: type[DataSplitter] = SeriesSplitter
+        else:
+            # i.e. DataFrame
+            klass = FrameSplitter
+
+        return klass(
             data,
-            ids,
-            ngroups,
+            self.ngroups,
             sorted_ids=self._sorted_ids,
             sort_idx=self.result_ilocs,
         )
@@ -692,7 +691,8 @@ class BaseGrouper:
         """
         Compute group sizes.
         """
-        ids, ngroups = self.group_info
+        ids = self.ids
+        ngroups = self.ngroups
         out: np.ndarray | list
         if ngroups:
             out = np.bincount(ids[ids != -1], minlength=ngroups)
@@ -728,12 +728,6 @@ class BaseGrouper:
         Whether grouper has null value(s) that are dropped.
         """
         return bool((self.ids < 0).any())
-
-    @cache_readonly
-    def group_info(self) -> tuple[npt.NDArray[np.intp], int]:
-        result_index, ids = self.result_index_and_ids
-        ngroups = len(result_index)
-        return ids, ngroups
 
     @cache_readonly
     def codes_info(self) -> npt.NDArray[np.intp]:
@@ -1124,10 +1118,6 @@ class BinGrouper(BaseGrouper):
         return indices
 
     @cache_readonly
-    def group_info(self) -> tuple[npt.NDArray[np.intp], int]:
-        return self.ids, self.ngroups
-
-    @cache_readonly
     def codes(self) -> list[npt.NDArray[np.intp]]:
         return [self.ids]
 
@@ -1191,29 +1181,25 @@ class DataSplitter(Generic[NDFrameT]):
     def __init__(
         self,
         data: NDFrameT,
-        labels: npt.NDArray[np.intp],
         ngroups: int,
         *,
         sort_idx: npt.NDArray[np.intp],
         sorted_ids: npt.NDArray[np.intp],
     ) -> None:
         self.data = data
-        self.labels = ensure_platform_int(labels)  # _should_ already be np.intp
         self.ngroups = ngroups
 
         self._slabels = sorted_ids
         self._sort_idx = sort_idx
 
     def __iter__(self) -> Iterator:
-        sdata = self._sorted_data
-
         if self.ngroups == 0:
             # we are inside a generator, rather than raise StopIteration
             # we merely return signal the end
             return
 
         starts, ends = lib.generate_slices(self._slabels, self.ngroups)
-
+        sdata = self._sorted_data
         for start, end in zip(starts, ends):
             yield self._chop(sdata, slice(start, end))
 
@@ -1241,20 +1227,3 @@ class FrameSplitter(DataSplitter):
         mgr = sdata._mgr.get_slice(slice_obj, axis=1)
         df = sdata._constructor_from_mgr(mgr, axes=mgr.axes)
         return df.__finalize__(sdata, method="groupby")
-
-
-def _get_splitter(
-    data: NDFrame,
-    labels: npt.NDArray[np.intp],
-    ngroups: int,
-    *,
-    sort_idx: npt.NDArray[np.intp],
-    sorted_ids: npt.NDArray[np.intp],
-) -> DataSplitter:
-    if isinstance(data, Series):
-        klass: type[DataSplitter] = SeriesSplitter
-    else:
-        # i.e. DataFrame
-        klass = FrameSplitter
-
-    return klass(data, labels, ngroups, sort_idx=sort_idx, sorted_ids=sorted_ids)

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -104,7 +104,9 @@ class TestSorting:
         gr = df.groupby(list("abcde"))
 
         # verify this is testing what it is supposed to test!
-        assert is_int64_overflow_possible(gr._grouper.shape)
+        assert is_int64_overflow_possible(
+            tuple(ping.ngroups for ping in gr._grouper.groupings)
+        )
 
         mi = MultiIndex.from_arrays(
             [ar.ravel() for ar in np.array_split(np.unique(arr, axis=0), 5, axis=1)],


### PR DESCRIPTION
* `BaseGrouper.group_info` seems wholly redundant with `ids` and `ngroups` which are also already defined properties. Removed `group_info` since usages don't need both components
*  `BaseGrouper.shape` was not used
* `DataSplitter.labels` was not used