### PR TITLE
REF: Use `default_index` or preserve original Index type for empty-like results

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -503,8 +503,8 @@ Timezones
 
 Numeric
 ^^^^^^^
+- Bug in :meth:`DataFrame.quantile` where the column type was not preserved when ``numeric_only=True`` with a list-like ``q`` produced an empty result (:issue:`59035`)
 - Bug in ``np.matmul`` with :class:`Index` inputs raising a ``TypeError`` (:issue:`57079`)
-- Bug in :meth:`DataFrame.quantile` where the column type was not preserved when ``numeric_only=True`` with a list-like ``q`` produced an empty result (:issue:`?``)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -504,7 +504,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in ``np.matmul`` with :class:`Index` inputs raising a ``TypeError`` (:issue:`57079`)
--
+- Bug in :meth:`DataFrame.quantile` where the column type was not preserved when ``numeric_only=True`` with a list-like ``q`` produced an empty result (:issue:`?``)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -13078,7 +13078,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         if len(data.columns) == 0:
             # GH#23925 _get_numeric_data may have dropped all columns
-            cols = Index([], name=self.columns.name)
+            cols = self.columns[:0]
 
             dtype = np.float64
             if axis == 1:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -158,7 +158,6 @@ from pandas.core.indexes.api import (
     Index,
     MultiIndex,
     PeriodIndex,
-    RangeIndex,
     default_index,
     ensure_index,
 )
@@ -1852,7 +1851,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 else:
                     # Drop the last level of Index by replacing with
                     # a RangeIndex
-                    dropped.columns = RangeIndex(dropped.columns.size)
+                    dropped.columns = default_index(dropped.columns.size)
 
             # Handle dropping index labels
             if labels_to_drop:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -128,7 +128,6 @@ from pandas.core.groupby.indexing import (
 from pandas.core.indexes.api import (
     Index,
     MultiIndex,
-    RangeIndex,
     default_index,
 )
 from pandas.core.internals.blocks import ensure_block_shape
@@ -1264,7 +1263,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         if self._grouper.has_dropped_na:
             # Add back in any missing rows due to dropna - index here is integral
             # with values referring to the row of the input so can use RangeIndex
-            result = result.reindex(RangeIndex(len(index)), axis=0)
+            result = result.reindex(default_index(len(index)), axis=0)
         result = result.set_axis(index, axis=0)
 
         return result
@@ -1334,7 +1333,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             #   enforced in __init__
             result = self._insert_inaxis_grouper(result, qs=qs)
             result = result._consolidate()
-            result.index = RangeIndex(len(result))
+            result.index = default_index(len(result))
 
         else:
             index = self._grouper.result_index

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -34,6 +34,7 @@ from pandas.core.groupby.categorical import recode_for_groupby
 from pandas.core.indexes.api import (
     Index,
     MultiIndex,
+    default_index,
 )
 from pandas.core.series import Series
 
@@ -901,7 +902,7 @@ def get_grouper(
     if len(groupings) == 0 and len(obj):
         raise ValueError("No group keys passed!")
     if len(groupings) == 0:
-        groupings.append(Grouping(Index([], dtype="int"), np.array([], dtype=np.intp)))
+        groupings.append(Grouping(default_index(0), np.array([], dtype=np.intp)))
 
     # create the internals grouper
     grouper = ops.BaseGrouper(group_axis, groupings, sort=sort, dropna=dropna)

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -130,7 +130,7 @@ def _get_combined_index(
     # TODO: handle index names!
     indexes = _get_distinct_objs(indexes)
     if len(indexes) == 0:
-        index = Index([])
+        index = default_index(0)
     elif len(indexes) == 1:
         index = indexes[0]
     elif intersect:

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -130,7 +130,7 @@ def _get_combined_index(
     # TODO: handle index names!
     indexes = _get_distinct_objs(indexes)
     if len(indexes) == 0:
-        index = default_index(0)
+        index: Index = default_index(0)
     elif len(indexes) == 1:
         index = indexes[0]
     elif intersect:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -249,7 +249,7 @@ class BaseBlockManager(PandasObject):
     def make_empty(self, axes=None) -> Self:
         """return an empty BlockManager with the items axis of len 0"""
         if axes is None:
-            axes = [Index([])] + self.axes[1:]
+            axes = [default_index(0)] + self.axes[1:]
 
         # preserve dtype if possible
         if self.ndim == 1:

--- a/pandas/core/methods/selectn.py
+++ b/pandas/core/methods/selectn.py
@@ -29,6 +29,8 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.dtypes import BaseMaskedDtype
 
+from pandas.core.indexes.api import default_index
+
 if TYPE_CHECKING:
     from pandas._typing import (
         DtypeObj,
@@ -38,6 +40,7 @@ if TYPE_CHECKING:
 
     from pandas import (
         DataFrame,
+        Index,
         Series,
     )
 else:
@@ -199,11 +202,6 @@ class SelectNFrame(SelectN[DataFrame]):
         self.columns = columns
 
     def compute(self, method: str) -> DataFrame:
-        from pandas.core.api import (
-            Index,
-            default_index,
-        )
-
         n = self.n
         frame = self.obj
         columns = self.columns

--- a/pandas/core/methods/selectn.py
+++ b/pandas/core/methods/selectn.py
@@ -228,7 +228,7 @@ class SelectNFrame(SelectN[DataFrame]):
         original_index = frame.index
         cur_frame = frame = frame.reset_index(drop=True)
         cur_n = n
-        indexer = default_index(0)
+        indexer: Index = default_index(0)
 
         for i, column in enumerate(columns):
             # For each column we apply method to cur_frame[column].

--- a/pandas/core/methods/selectn.py
+++ b/pandas/core/methods/selectn.py
@@ -199,7 +199,10 @@ class SelectNFrame(SelectN[DataFrame]):
         self.columns = columns
 
     def compute(self, method: str) -> DataFrame:
-        from pandas.core.api import Index
+        from pandas.core.api import (
+            Index,
+            default_index,
+        )
 
         n = self.n
         frame = self.obj
@@ -227,7 +230,7 @@ class SelectNFrame(SelectN[DataFrame]):
         original_index = frame.index
         cur_frame = frame = frame.reset_index(drop=True)
         cur_n = n
-        indexer = Index([], dtype=np.int64)
+        indexer = default_index(0)
 
         for i, column in enumerate(columns):
             # For each column we apply method to cur_frame[column].

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -42,7 +42,7 @@ from pandas.core.frame import DataFrame
 from pandas.core.indexes.api import (
     Index,
     MultiIndex,
-    RangeIndex,
+    default_index,
 )
 from pandas.core.reshape.concat import concat
 from pandas.core.series import Series
@@ -1047,7 +1047,7 @@ def stack_reshape(
             if data.ndim == 1:
                 data.name = 0
             else:
-                data.columns = RangeIndex(len(data.columns))
+                data.columns = default_index(len(data.columns))
         buf.append(data)
 
     if len(buf) > 0 and not frame.empty:

--- a/pandas/tests/frame/methods/test_quantile.py
+++ b/pandas/tests/frame/methods/test_quantile.py
@@ -926,3 +926,12 @@ class TestQuantileExtensionDtype:
             expected_data, name=0.5, index=Index(expected_index), dtype=np.float64
         )
         tm.assert_series_equal(result, expected)
+
+
+def test_multi_quantile_numeric_only_retains_columns():
+    df = DataFrame(list("abc"))
+    result = df.quantile([0.5, 0.7], numeric_only=True)
+    expected = DataFrame(index=[0.5, 0.7])
+    tm.assert_frame_equal(
+        result, expected, check_index_type=True, check_column_type=True
+    )

--- a/pandas/tests/frame/methods/test_quantile.py
+++ b/pandas/tests/frame/methods/test_quantile.py
@@ -710,14 +710,14 @@ class TestDataFrameQuantile:
         result = df.quantile(
             0.5, numeric_only=True, interpolation=interpolation, method=method
         )
-        expected = Series([], index=[], name=0.5, dtype=np.float64)
+        expected = Series([], name=0.5, dtype=np.float64)
         expected.index.name = "captain tightpants"
         tm.assert_series_equal(result, expected)
 
         result = df.quantile(
             [0.5], numeric_only=True, interpolation=interpolation, method=method
         )
-        expected = DataFrame([], index=[0.5], columns=[])
+        expected = DataFrame([], index=[0.5])
         expected.columns.name = "captain tightpants"
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -93,14 +93,18 @@ class TestGeneric:
         if isinstance(o, DataFrame):
             # preserve columns dtype
             expected.columns = o.columns[:0]
-        # https://github.com/pandas-dev/pandas/issues/50862
-        tm.assert_equal(result.reset_index(drop=True), expected)
+        tm.assert_equal(result, expected)
 
         # get the bool data
         arr = np.array([True, True, False, True])
         o = construct(frame_or_series, n, value=arr, **kwargs)
         result = o._get_numeric_data()
         tm.assert_equal(result, o)
+
+    def test_get_bool_data_empty_preserve_index(self):
+        expected = Series([], dtype="bool")
+        result = expected._get_bool_data()
+        tm.assert_series_equal(result, expected, check_index_type=True)
 
     def test_nonzero(self, frame_or_series):
         # GH 4633

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1558,7 +1558,7 @@ class TestIndexUtils:
 
     def test_get_combined_index(self):
         result = _get_combined_index([])
-        expected = Index([])
+        expected = RangeIndex(0)
         tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/series/methods/test_get_numeric_data.py
+++ b/pandas/tests/series/methods/test_get_numeric_data.py
@@ -1,5 +1,4 @@
 from pandas import (
-    Index,
     Series,
     date_range,
 )
@@ -19,7 +18,7 @@ class TestGetNumericData:
 
         obj = Series([1, "2", 3.0])
         result = obj._get_numeric_data()
-        expected = Series([], dtype=object, index=Index([], dtype=object))
+        expected = Series([], dtype=object)
         tm.assert_series_equal(result, expected)
 
         obj = Series([True, False, True])
@@ -28,5 +27,5 @@ class TestGetNumericData:
 
         obj = Series(date_range("20130101", periods=3))
         result = obj._get_numeric_data()
-        expected = Series([], dtype="M8[ns]", index=Index([], dtype=object))
+        expected = Series([], dtype="M8[ns]")
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #50862 (Replace xxxx with the GitHub issue number)

Since `DataFrame` and `Series` more consistently return `RangeIndex` for empty-like constructors since 2.0, this PR uses 
`default_index(0)` more consistently internally