### PR TITLE
BUG: DatetimeIndex.union with non-nano

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -489,6 +489,7 @@ Datetimelike
 - Bug in :meth:`Dataframe.agg` with df with missing values resulting in IndexError (:issue:`58810`)
 - Bug in :meth:`DatetimeIndex.is_year_start` and :meth:`DatetimeIndex.is_quarter_start` does not raise on Custom business days frequencies bigger then "1C" (:issue:`58664`)
 - Bug in :meth:`DatetimeIndex.is_year_start` and :meth:`DatetimeIndex.is_quarter_start` returning ``False`` on double-digit frequencies (:issue:`58523`)
+- Bug in :meth:`DatetimeIndex.union` when ``unit`` was non-nanosecond (:issue:`59036`)
 - Bug in setting scalar values with mismatched resolution into arrays with non-nanosecond ``datetime64``, ``timedelta64`` or :class:`DatetimeTZDtype` incorrectly truncating those scalars (:issue:`56410`)
 
 Timedelta

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -523,7 +523,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         # Convert our i8 representations to RangeIndex
         # Caller is responsible for checking isinstance(self.freq, Tick)
         freq = cast(Tick, self.freq)
-        tick = Timedelta(freq).as_unit("ns")._value
+        tick = Timedelta(freq).as_unit(self.unit)._value
         rng = range(self[0]._value, self[-1]._value + tick, tick)
         return RangeIndex(rng)
 
@@ -536,7 +536,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             # RangeIndex defaults to step=1, which we don't want.
             new_freq = self.freq
         elif isinstance(res_i8, RangeIndex):
-            new_freq = to_offset(Timedelta(res_i8.step))
+            new_freq = to_offset(Timedelta(res_i8.step, unit=self.unit))
 
         # TODO(GH#41493): we cannot just do
         #  type(self._data)(res_i8.values, dtype=self.dtype, freq=new_freq)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -536,7 +536,9 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             # RangeIndex defaults to step=1, which we don't want.
             new_freq = self.freq
         elif isinstance(res_i8, RangeIndex):
-            new_freq = to_offset(Timedelta(res_i8.step, unit=self.unit))
+            new_freq = to_offset(
+                Timedelta(res_i8.step, unit=self.unit).as_unit(self.unit)
+            )
 
         # TODO(GH#41493): we cannot just do
         #  type(self._data)(res_i8.values, dtype=self.dtype, freq=new_freq)

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -664,3 +664,19 @@ class TestCustomDatetimeIndex:
         result = index1.union(index2)
         expected = date_range("2021-10-28", periods=6, freq="D", tz="Europe/London")
         tm.assert_index_equal(result, expected)
+
+
+def test_union_non_nano_rangelike():
+    # GH 59036
+    l1 = DatetimeIndex(
+        ["2024-05-11", "2024-05-12"], dtype="datetime64[us]", name="Date", freq="D"
+    )
+    l2 = DatetimeIndex(["2024-05-13"], dtype="datetime64[us]", name="Date", freq="D")
+    result = l1.union(l2)
+    expected = DatetimeIndex(
+        ["2024-05-11", "2024-05-12", "2024-05-13"],
+        dtype="datetime64[us]",
+        name="Date",
+        freq="D",
+    )
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] closes #59036 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
