### PR TITLE
DEPR: deprecate units 'w', 'd', 'MS', 'US', 'NS' for Timedelta in favor of  'W', 'D', 'ms', 'us', 'ns'

### DIFF
--- a/doc/source/user_guide/timedeltas.rst
+++ b/doc/source/user_guide/timedeltas.rst
@@ -35,7 +35,7 @@ You can construct a ``Timedelta`` scalar through various arguments, including `I
    pd.Timedelta(days=1, seconds=1)
 
    # integers with a unit
-   pd.Timedelta(1, unit="d")
+   pd.Timedelta(1, unit="D")
 
    # from a datetime.timedelta/np.timedelta64
    pd.Timedelta(datetime.timedelta(days=1, seconds=1))
@@ -94,7 +94,7 @@ is numeric:
 .. ipython:: python
 
    pd.to_timedelta(np.arange(5), unit="s")
-   pd.to_timedelta(np.arange(5), unit="d")
+   pd.to_timedelta(np.arange(5), unit="D")
 
 .. warning::
     If a string or array of strings is passed as an input then the ``unit`` keyword

--- a/doc/source/whatsnew/v0.13.0.rst
+++ b/doc/source/whatsnew/v0.13.0.rst
@@ -523,13 +523,25 @@ Enhancements
   Using the new top-level ``to_timedelta``, you can convert a scalar or array from the standard
   timedelta format (produced by ``to_csv``) into a timedelta type (``np.timedelta64`` in ``nanoseconds``).
 
-  .. ipython:: python
+  .. code-block:: ipython
 
-     pd.to_timedelta('1 days 06:05:01.00003')
-     pd.to_timedelta('15.5us')
-     pd.to_timedelta(['1 days 06:05:01.00003', '15.5us', 'nan'])
-     pd.to_timedelta(np.arange(5), unit='s')
-     pd.to_timedelta(np.arange(5), unit='d')
+     In [53]: pd.to_timedelta('1 days 06:05:01.00003')
+     Out[53]: Timedelta('1 days 06:05:01.000030')
+
+     In [54]: pd.to_timedelta('15.5us')
+     Out[54]: Timedelta('0 days 00:00:00.000015500')
+
+     In [55]: pd.to_timedelta(['1 days 06:05:01.00003', '15.5us', 'nan'])
+     Out[55]: TimedeltaIndex(['1 days 06:05:01.000030', '0 days 00:00:00.000015500', NaT], dtype='timedelta64[ns]', freq=None)
+
+     In [56]: pd.to_timedelta(np.arange(5), unit='s')
+     Out[56]:
+     TimedeltaIndex(['0 days 00:00:00', '0 days 00:00:01', '0 days 00:00:02',
+                     '0 days 00:00:03', '0 days 00:00:04'],
+                    dtype='timedelta64[ns]', freq=None)
+
+     In [57]: pd.to_timedelta(np.arange(5), unit='d')
+     Out[57]: TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
 
   A Series of dtype ``timedelta64[ns]`` can now be divided by another
   ``timedelta64[ns]`` object, or astyped to yield a ``float64`` dtyped Series. This

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -273,6 +273,7 @@ Other Deprecations
 - Deprecated allowing non-keyword arguments in :meth:`Series.to_string` except ``buf``. (:issue:`57280`)
 - Deprecated behavior of :meth:`Series.dt.to_pytimedelta`, in a future version this will return a :class:`Series` containing python ``datetime.timedelta`` objects instead of an ``ndarray`` of timedelta; this matches the behavior of other :meth:`Series.dt` properties. (:issue:`57463`)
 - Deprecated parameter ``method`` in :meth:`DataFrame.reindex_like` / :meth:`Series.reindex_like` (:issue:`58667`)
+- Deprecated strings ``w``, ``d``, ``MIN``, ``MS``, ``US`` and ``NS`` denoting units in :class:`Timedelta` in favour of ``W``, ``D``, ``min``, ``ms``, ``us`` and ``ns`` (:issue:`59051`)
 - Deprecated using ``epoch`` date format in :meth:`DataFrame.to_json` and :meth:`Series.to_json`, use ``iso`` instead. (:issue:`57063`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/tslibs/dtypes.pxd
+++ b/pandas/_libs/tslibs/dtypes.pxd
@@ -15,6 +15,7 @@ cdef dict c_OFFSET_TO_PERIOD_FREQSTR
 cdef dict c_PERIOD_TO_OFFSET_FREQSTR
 cdef dict c_OFFSET_RENAMED_FREQSTR
 cdef dict c_DEPR_ABBREVS
+cdef dict c_DEPR_UNITS
 cdef dict c_PERIOD_AND_OFFSET_DEPR_FREQSTR
 cdef dict attrname_to_abbrevs
 cdef dict npy_unit_to_attrname

--- a/pandas/_libs/tslibs/dtypes.pyx
+++ b/pandas/_libs/tslibs/dtypes.pyx
@@ -346,6 +346,17 @@ cdef dict c_DEPR_ABBREVS = {
     "S": "s",
 }
 
+cdef dict c_DEPR_UNITS = {
+    "w": "W",
+    "d": "D",
+    "H": "h",
+    "MIN": "min",
+    "S": "s",
+    "MS": "ms",
+    "US": "us",
+    "NS": "ns",
+}
+
 cdef dict c_PERIOD_AND_OFFSET_DEPR_FREQSTR = {
     "w": "W",
     "MIN": "min",

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -43,7 +43,7 @@ from pandas._libs.tslibs.conversion cimport (
     precision_from_unit,
 )
 from pandas._libs.tslibs.dtypes cimport (
-    c_DEPR_ABBREVS,
+    c_DEPR_UNITS,
     get_supported_reso,
     is_supported_unit,
     npy_unit_to_abbrev,
@@ -719,15 +719,15 @@ cpdef inline str parse_timedelta_unit(str unit):
         return "ns"
     elif unit == "M":
         return unit
-    elif unit in c_DEPR_ABBREVS:
+    elif unit in c_DEPR_UNITS:
         warnings.warn(
             f"\'{unit}\' is deprecated and will be removed in a "
-            f"future version. Please use \'{c_DEPR_ABBREVS.get(unit)}\' "
+            f"future version. Please use \'{c_DEPR_UNITS.get(unit)}\' "
             f"instead of \'{unit}\'.",
             FutureWarning,
             stacklevel=find_stack_level(),
         )
-        unit = c_DEPR_ABBREVS[unit]
+        unit = c_DEPR_UNITS[unit]
     try:
         return timedelta_abbrevs[unit.lower()]
     except KeyError:

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1811,6 +1811,11 @@ class Timedelta(_Timedelta):
             Values `H`, `T`, `S`, `L`, `U`, and `N` are deprecated in favour
             of the values `h`, `min`, `s`, `ms`, `us`, and `ns`.
 
+        .. deprecated:: 3.0.0
+
+            Allowing the values `w`, `d`, `MIN`, `MS`, `US` and `NS` to denote units
+            are deprecated in favour of the values `W`, `D`, `min`, `ms`, `us` and `ns`.
+
     **kwargs
         Available kwargs: {days, seconds, microseconds,
         milliseconds, minutes, hours, weeks}.

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -746,7 +746,7 @@ class TimedeltaArray(dtl.TimelikeOps):
         --------
         **Series**
 
-        >>> s = pd.Series(pd.to_timedelta(np.arange(5), unit="d"))
+        >>> s = pd.Series(pd.to_timedelta(np.arange(5), unit="D"))
         >>> s
         0   0 days
         1   1 days
@@ -765,7 +765,7 @@ class TimedeltaArray(dtl.TimelikeOps):
 
         **TimedeltaIndex**
 
-        >>> idx = pd.to_timedelta(np.arange(5), unit="d")
+        >>> idx = pd.to_timedelta(np.arange(5), unit="D")
         >>> idx
         TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'],
                        dtype='timedelta64[ns]', freq=None)

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -809,7 +809,7 @@ class TimedeltaArray(dtl.TimelikeOps):
     --------
     For Series:
 
-    >>> ser = pd.Series(pd.to_timedelta([1, 2, 3], unit='d'))
+    >>> ser = pd.Series(pd.to_timedelta([1, 2, 3], unit='D'))
     >>> ser
     0   1 days
     1   2 days

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -459,7 +459,7 @@ class TimedeltaProperties(Properties):
 
         Examples
         --------
-        >>> s = pd.Series(pd.to_timedelta(np.arange(5), unit="d"))
+        >>> s = pd.Series(pd.to_timedelta(np.arange(5), unit="D"))
         >>> s
         0   0 days
         1   1 days

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -170,7 +170,7 @@ def to_timedelta(
     TimedeltaIndex(['0 days 00:00:00', '0 days 00:00:01', '0 days 00:00:02',
                     '0 days 00:00:03', '0 days 00:00:04'],
                    dtype='timedelta64[ns]', freq=None)
-    >>> pd.to_timedelta(np.arange(5), unit="d")
+    >>> pd.to_timedelta(np.arange(5), unit="D")
     TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'],
                    dtype='timedelta64[ns]', freq=None)
     """

--- a/pandas/tests/frame/indexing/test_mask.py
+++ b/pandas/tests/frame/indexing/test_mask.py
@@ -122,7 +122,7 @@ def test_mask_stringdtype(frame_or_series):
 
 def test_mask_where_dtype_timedelta():
     # https://github.com/pandas-dev/pandas/issues/39548
-    df = DataFrame([Timedelta(i, unit="d") for i in range(5)])
+    df = DataFrame([Timedelta(i, unit="D") for i in range(5)])
 
     expected = DataFrame(np.full(5, np.nan, dtype="timedelta64[ns]"))
     tm.assert_frame_equal(df.mask(df.notna()), expected)
@@ -130,7 +130,7 @@ def test_mask_where_dtype_timedelta():
     expected = DataFrame(
         [np.nan, np.nan, np.nan, Timedelta("3 day"), Timedelta("4 day")]
     )
-    tm.assert_frame_equal(df.where(df > Timedelta(2, unit="d")), expected)
+    tm.assert_frame_equal(df.where(df > Timedelta(2, unit="D")), expected)
 
 
 def test_mask_return_dtype():

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -149,7 +149,7 @@ class TestAstype:
         # see GH#9757
         a = Series(date_range("2010-01-04", periods=5))
         b = Series(date_range("3/6/2012 00:00", periods=5, tz="US/Eastern"))
-        c = Series([Timedelta(x, unit="d") for x in range(5)])
+        c = Series([Timedelta(x, unit="D") for x in range(5)])
         d = Series(range(5))
         e = Series([0.0, 0.2, 0.4, 0.6, 0.8])
 

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -600,8 +600,8 @@ class TestResetIndex:
                 {"a": [pd.NaT, Timestamp("2020-01-01")], "b": [1, 2], "x": [11, 12]},
             ),
             (
-                [(pd.NaT, 1), (pd.Timedelta(123, "d"), 2)],
-                {"a": [pd.NaT, pd.Timedelta(123, "d")], "b": [1, 2], "x": [11, 12]},
+                [(pd.NaT, 1), (pd.Timedelta(123, "D"), 2)],
+                {"a": [pd.NaT, pd.Timedelta(123, "D")], "b": [1, 2], "x": [11, 12]},
             ),
         ],
     )

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -148,8 +148,8 @@ def test_len_nan_group():
 
 def test_groupby_timedelta_median():
     # issue 57926
-    expected = Series(data=Timedelta("1d"), index=["foo"])
-    df = DataFrame({"label": ["foo", "foo"], "timedelta": [pd.NaT, Timedelta("1d")]})
+    expected = Series(data=Timedelta("1D"), index=["foo"])
+    df = DataFrame({"label": ["foo", "foo"], "timedelta": [pd.NaT, Timedelta("1D")]})
     gb = df.groupby("label")["timedelta"]
     actual = gb.median()
     tm.assert_series_equal(actual, expected, check_names=False)

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -982,7 +982,7 @@ def test_groupby_sum_timedelta_with_nat():
     df = DataFrame(
         {
             "a": [1, 1, 2, 2],
-            "b": [pd.Timedelta("1d"), pd.Timedelta("2d"), pd.Timedelta("3d"), pd.NaT],
+            "b": [pd.Timedelta("1D"), pd.Timedelta("2D"), pd.Timedelta("3D"), pd.NaT],
         }
     )
     td3 = pd.Timedelta(days=3)

--- a/pandas/tests/indexes/timedeltas/methods/test_shift.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_shift.py
@@ -37,7 +37,7 @@ class TestTimedeltaIndexShift:
 
     def test_tdi_shift_int(self):
         # GH#8083
-        tdi = pd.to_timedelta(range(5), unit="d")
+        tdi = pd.to_timedelta(range(5), unit="D")
         trange = tdi._with_freq("infer") + pd.offsets.Hour(1)
         result = trange.shift(1)
         expected = TimedeltaIndex(
@@ -54,7 +54,7 @@ class TestTimedeltaIndexShift:
 
     def test_tdi_shift_nonstandard_freq(self):
         # GH#8083
-        tdi = pd.to_timedelta(range(5), unit="d")
+        tdi = pd.to_timedelta(range(5), unit="D")
         trange = tdi._with_freq("infer") + pd.offsets.Hour(1)
         result = trange.shift(3, freq="2D 1s")
         expected = TimedeltaIndex(

--- a/pandas/tests/indexes/timedeltas/test_constructors.py
+++ b/pandas/tests/indexes/timedeltas/test_constructors.py
@@ -239,3 +239,28 @@ class TestTimedeltaIndex:
         ci = pd.CategoricalIndex(tdi)
         result = TimedeltaIndex(ci)
         tm.assert_index_equal(result, tdi)
+
+    @pytest.mark.parametrize(
+        "unit,unit_depr",
+        [
+            ("W", "w"),
+            ("D", "d"),
+            ("min", "MIN"),
+            ("s", "S"),
+            ("h", "H"),
+            ("ms", "MS"),
+            ("us", "US"),
+        ],
+    )
+    def test_unit_deprecated(self, unit, unit_depr):
+        # GH#52536, GH#59051
+        msg = f"'{unit_depr}' is deprecated and will be removed in a future version."
+
+        expected = TimedeltaIndex([f"1{unit}", f"2{unit}"])
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = TimedeltaIndex([f"1{unit_depr}", f"2{unit_depr}"])
+        tm.assert_index_equal(result, expected)
+
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            tdi = to_timedelta([1, 2], unit=unit_depr)
+        tm.assert_index_equal(tdi, expected)

--- a/pandas/tests/indexes/timedeltas/test_constructors.py
+++ b/pandas/tests/indexes/timedeltas/test_constructors.py
@@ -168,7 +168,7 @@ class TestTimedeltaIndex:
         # NumPy string array
         strings = np.array(["1 days", "2 days", "3 days"])
         result = TimedeltaIndex(strings)
-        expected = to_timedelta([1, 2, 3], unit="d")
+        expected = to_timedelta([1, 2, 3], unit="D")
         tm.assert_index_equal(result, expected)
 
         from_ints = TimedeltaIndex(expected.asi8)

--- a/pandas/tests/indexes/timedeltas/test_delete.py
+++ b/pandas/tests/indexes/timedeltas/test_delete.py
@@ -44,7 +44,7 @@ class TestTimedeltaIndexDelete:
 
         # reset freq to None
         expected_3_5 = TimedeltaIndex(
-            ["1 d", "2 d", "3 d", "7 d", "8 d", "9 d", "10d"], freq=None, name="idx"
+            ["1 D", "2 D", "3 D", "7 D", "8 D", "9 D", "10D"], freq=None, name="idx"
         )
 
         cases = {

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -20,8 +20,10 @@ import pandas._testing as tm
 
 class TestGetItem:
     def test_getitem_slice_keeps_name(self):
-        # GH#4226
-        tdi = timedelta_range("1d", "5d", freq="h", name="timebucket")
+        # GH#4226, GH#59051
+        msg = "'d' is deprecated and will be removed in a future version."
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            tdi = timedelta_range("1d", "5d", freq="h", name="timebucket")
         assert tdi[1:].name == tdi.name
 
     def test_getitem(self):
@@ -230,7 +232,7 @@ class TestTake:
 
     def test_take_equiv_getitem(self):
         tds = ["1day 02:00:00", "1 day 04:00:00", "1 day 10:00:00"]
-        idx = timedelta_range(start="1d", end="2d", freq="h", name="idx")
+        idx = timedelta_range(start="1D", end="2D", freq="h", name="idx")
         expected = TimedeltaIndex(tds, freq=None, name="idx")
 
         taken1 = idx.take([2, 4, 10])
@@ -337,8 +339,10 @@ class TestContains:
 
     def test_contains(self):
         # Checking for any NaT-like objects
-        # GH#13603
-        td = to_timedelta(range(5), unit="d") + offsets.Hour(1)
+        # GH#13603, GH#59051
+        msg = "'d' is deprecated and will be removed in a future version."
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            td = to_timedelta(range(5), unit="d") + offsets.Hour(1)
         for v in [NaT, None, float("nan"), np.nan]:
             assert v not in td
 

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -42,7 +42,10 @@ class TestTimedeltaIndex:
         tm.assert_index_equal(result, expected)
 
     def test_union_coverage(self):
-        idx = TimedeltaIndex(["3d", "1d", "2d"])
+        # GH#59051
+        msg = "'d' is deprecated and will be removed in a future version."
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            idx = TimedeltaIndex(["3d", "1d", "2d"])
         ordered = TimedeltaIndex(idx.sort_values(), freq="infer")
         result = ordered.union(idx)
         tm.assert_index_equal(result, ordered)
@@ -70,7 +73,7 @@ class TestTimedeltaIndex:
         tm.assert_index_equal(result, exp)
 
     def test_union_bug_4564(self):
-        left = timedelta_range("1 day", "30d")
+        left = timedelta_range("1 day", "30D")
         right = left + pd.offsets.Minute(15)
 
         result = left.union(right)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -511,13 +511,13 @@ class TestCategoricalIndex:
             # pandas scalars
             [Interval(1, 4), Interval(4, 6), Interval(6, 9)],
             [Timestamp(2019, 1, 1), Timestamp(2019, 2, 1), Timestamp(2019, 3, 1)],
-            [Timedelta(1, "d"), Timedelta(2, "d"), Timedelta(3, "D")],
+            [Timedelta(1, "D"), Timedelta(2, "D"), Timedelta(3, "D")],
             # pandas Integer arrays
             *(pd.array([1, 2, 3], dtype=dtype) for dtype in tm.ALL_INT_EA_DTYPES),
             # other pandas arrays
             pd.IntervalIndex.from_breaks([1, 4, 6, 9]).array,
             pd.date_range("2019-01-01", periods=3).array,
-            pd.timedelta_range(start="1d", periods=3).array,
+            pd.timedelta_range(start="1D", periods=3).array,
         ],
     )
     def test_loc_getitem_with_non_string_categories(self, idx_values, ordered):

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -30,9 +30,9 @@ def data_test_ix(request, dirpath):
     fname = os.path.join(dirpath, f"test_sas7bdat_{i}.csv")
     df = pd.read_csv(fname)
     epoch = datetime(1960, 1, 1)
-    t1 = pd.to_timedelta(df["Column4"], unit="d")
+    t1 = pd.to_timedelta(df["Column4"], unit="D")
     df["Column4"] = (epoch + t1).astype("M8[s]")
-    t2 = pd.to_timedelta(df["Column12"], unit="d")
+    t2 = pd.to_timedelta(df["Column12"], unit="D")
     df["Column12"] = (epoch + t2).astype("M8[s]")
     for k in range(df.shape[1]):
         col = df.iloc[:, k]

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1367,8 +1367,8 @@ class TestMerge:
                 ),
             ),
             (
-                TimedeltaIndex(["1d", "2d", "3d"]),
-                TimedeltaIndex(["1d", "2d", "3d", pd.NaT, pd.NaT, pd.NaT]),
+                TimedeltaIndex(["1D", "2D", "3D"]),
+                TimedeltaIndex(["1D", "2D", "3D", pd.NaT, pd.NaT, pd.NaT]),
             ),
         ],
     )

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -79,7 +79,7 @@ class TestTimedeltaAdditionSubtraction:
     @pytest.mark.parametrize("op", [operator.add, ops.radd])
     def test_td_add_datetimelike_scalar(self, op):
         # GH#19738
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         result = op(td, datetime(2016, 1, 1))
         if op is operator.add:
@@ -111,7 +111,7 @@ class TestTimedeltaAdditionSubtraction:
 
     @pytest.mark.parametrize("op", [operator.add, ops.radd])
     def test_td_add_td(self, op):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         result = op(td, Timedelta(days=10))
         assert isinstance(result, Timedelta)
@@ -119,35 +119,35 @@ class TestTimedeltaAdditionSubtraction:
 
     @pytest.mark.parametrize("op", [operator.add, ops.radd])
     def test_td_add_pytimedelta(self, op):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         result = op(td, timedelta(days=9))
         assert isinstance(result, Timedelta)
         assert result == Timedelta(days=19)
 
     @pytest.mark.parametrize("op", [operator.add, ops.radd])
     def test_td_add_timedelta64(self, op):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         result = op(td, np.timedelta64(-4, "D"))
         assert isinstance(result, Timedelta)
         assert result == Timedelta(days=6)
 
     @pytest.mark.parametrize("op", [operator.add, ops.radd])
     def test_td_add_offset(self, op):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         result = op(td, offsets.Hour(6))
         assert isinstance(result, Timedelta)
         assert result == Timedelta(days=10, hours=6)
 
     def test_td_sub_td(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         expected = Timedelta(0, unit="ns")
         result = td - td
         assert isinstance(result, Timedelta)
         assert result == expected
 
     def test_td_sub_pytimedelta(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         expected = Timedelta(0, unit="ns")
 
         result = td - td.to_pytimedelta()
@@ -159,7 +159,7 @@ class TestTimedeltaAdditionSubtraction:
         assert result == expected
 
     def test_td_sub_timedelta64(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         expected = Timedelta(0, unit="ns")
 
         result = td - td.to_timedelta64()
@@ -172,12 +172,12 @@ class TestTimedeltaAdditionSubtraction:
 
     def test_td_sub_nat(self):
         # In this context pd.NaT is treated as timedelta-like
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         result = td - NaT
         assert result is NaT
 
     def test_td_sub_td64_nat(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         td_nat = np.timedelta64("NaT")
 
         result = td - td_nat
@@ -187,13 +187,13 @@ class TestTimedeltaAdditionSubtraction:
         assert result is NaT
 
     def test_td_sub_offset(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         result = td - offsets.Hour(1)
         assert isinstance(result, Timedelta)
         assert result == Timedelta(239, unit="h")
 
     def test_td_add_sub_numeric_raises(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         msg = "unsupported operand type"
         for other in [2, 2.0, np.int64(2), np.float64(2)]:
             with pytest.raises(TypeError, match=msg):
@@ -234,7 +234,7 @@ class TestTimedeltaAdditionSubtraction:
             other - td
 
     def test_td_rsub_nat(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         result = NaT - td
         assert result is NaT
 
@@ -242,7 +242,7 @@ class TestTimedeltaAdditionSubtraction:
         assert result is NaT
 
     def test_td_rsub_offset(self):
-        result = offsets.Hour(1) - Timedelta(10, unit="d")
+        result = offsets.Hour(1) - Timedelta(10, unit="D")
         assert isinstance(result, Timedelta)
         assert result == Timedelta(-239, unit="h")
 
@@ -362,7 +362,7 @@ class TestTimedeltaMultiplicationDivision:
     @pytest.mark.parametrize("op", [operator.mul, ops.rmul])
     def test_td_mul_nat(self, op, td_nat):
         # GH#19819
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         typs = "|".join(["numpy.timedelta64", "NaTType", "Timedelta"])
         msg = "|".join(
             [
@@ -377,7 +377,7 @@ class TestTimedeltaMultiplicationDivision:
     @pytest.mark.parametrize("op", [operator.mul, ops.rmul])
     def test_td_mul_nan(self, op, nan):
         # np.float64('NaN') has a 'dtype' attr, avoid treating as array
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         result = op(td, nan)
         assert result is NaT
 
@@ -449,7 +449,7 @@ class TestTimedeltaMultiplicationDivision:
 
     def test_td_div_timedeltalike_scalar(self):
         # GH#19738
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         result = td / offsets.Hour(1)
         assert result == 240
@@ -480,7 +480,7 @@ class TestTimedeltaMultiplicationDivision:
 
     def test_td_div_numeric_scalar(self):
         # GH#19738
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         result = td / 2
         assert isinstance(result, Timedelta)
@@ -500,7 +500,7 @@ class TestTimedeltaMultiplicationDivision:
     )
     def test_td_div_nan(self, nan):
         # np.float64('NaN') has a 'dtype' attr, avoid treating as array
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         result = td / nan
         assert result is NaT
 
@@ -532,7 +532,7 @@ class TestTimedeltaMultiplicationDivision:
 
     def test_td_rdiv_timedeltalike_scalar(self):
         # GH#19738
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         result = offsets.Hour(1) / td
         assert result == 1 / 240.0
 
@@ -540,7 +540,7 @@ class TestTimedeltaMultiplicationDivision:
 
     def test_td_rdiv_na_scalar(self):
         # GH#31869 None gets cast to NaT
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         result = NaT / td
         assert np.isnan(result)
@@ -560,7 +560,7 @@ class TestTimedeltaMultiplicationDivision:
             np.nan / td
 
     def test_td_rdiv_ndarray(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         arr = np.array([td], dtype=object)
         result = arr / td
@@ -583,7 +583,7 @@ class TestTimedeltaMultiplicationDivision:
             arr / td
 
     def test_td_rdiv_ndarray_0d(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         arr = np.array(td.asm8)
 

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -32,20 +32,31 @@ class TestTimedeltaConstructorUnitKeyword:
         with pytest.raises(ValueError, match=msg):
             to_timedelta([1, 2], unit)
 
-    @pytest.mark.parametrize("unit", ["h", "s"])
-    def test_units_H_S_deprecated(self, unit):
+    @pytest.mark.parametrize(
+        "unit,unit_depr",
+        [
+            ("W", "w"),
+            ("D", "d"),
+            ("min", "MIN"),
+            ("s", "S"),
+            ("h", "H"),
+            ("ms", "MS"),
+            ("us", "US"),
+        ],
+    )
+    def test_unit_deprecated(self, unit, unit_depr):
         # GH#52536
-        msg = f"'{unit.upper()}' is deprecated and will be removed in a future version."
+        msg = f"'{unit_depr}' is deprecated and will be removed in a future version."
 
         expected = Timedelta(1, unit=unit)
         with tm.assert_produces_warning(FutureWarning, match=msg):
-            result = Timedelta(1, unit=unit.upper())
+            result = Timedelta(1, unit=unit_depr)
         tm.assert_equal(result, expected)
 
     @pytest.mark.parametrize(
         "unit, np_unit",
-        [(value, "W") for value in ["W", "w"]]
-        + [(value, "D") for value in ["D", "d", "days", "day", "Days", "Day"]]
+        [("W", "W")]
+        + [(value, "D") for value in ["D", "days", "day", "Days", "Day"]]
         + [
             (value, "m")
             for value in [
@@ -78,7 +89,6 @@ class TestTimedeltaConstructorUnitKeyword:
                 "millisecond",
                 "milli",
                 "millis",
-                "MS",
                 "Milliseconds",
                 "Millisecond",
                 "Milli",
@@ -93,7 +103,6 @@ class TestTimedeltaConstructorUnitKeyword:
                 "microsecond",
                 "micro",
                 "micros",
-                "US",
                 "Microseconds",
                 "Microsecond",
                 "Micro",
@@ -108,7 +117,6 @@ class TestTimedeltaConstructorUnitKeyword:
                 "nanosecond",
                 "nano",
                 "nanos",
-                "NS",
                 "Nanoseconds",
                 "Nanosecond",
                 "Nano",
@@ -250,8 +258,8 @@ def test_from_tick_reso():
 
 def test_construction():
     expected = np.timedelta64(10, "D").astype("m8[ns]").view("i8")
-    assert Timedelta(10, unit="d")._value == expected
-    assert Timedelta(10.0, unit="d")._value == expected
+    assert Timedelta(10, unit="D")._value == expected
+    assert Timedelta(10.0, unit="D")._value == expected
     assert Timedelta("10 days")._value == expected
     assert Timedelta(days=10)._value == expected
     assert Timedelta(days=10.0)._value == expected

--- a/pandas/tests/scalar/timedelta/test_formats.py
+++ b/pandas/tests/scalar/timedelta/test_formats.py
@@ -6,7 +6,7 @@ from pandas import Timedelta
 @pytest.mark.parametrize(
     "td, expected_repr",
     [
-        (Timedelta(10, unit="d"), "Timedelta('10 days 00:00:00')"),
+        (Timedelta(10, unit="D"), "Timedelta('10 days 00:00:00')"),
         (Timedelta(10, unit="s"), "Timedelta('0 days 00:00:10')"),
         (Timedelta(10, unit="ms"), "Timedelta('0 days 00:00:00.010000')"),
         (Timedelta(-10, unit="ms"), "Timedelta('-1 days +23:59:59.990000')"),

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -280,7 +280,7 @@ def test_timedelta_class_min_max_resolution():
 
 class TestTimedeltaUnaryOps:
     def test_invert(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         msg = "bad operand type for unary ~"
         with pytest.raises(TypeError, match=msg):
@@ -295,17 +295,17 @@ class TestTimedeltaUnaryOps:
             ~(td.to_timedelta64())
 
     def test_unary_ops(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
 
         # __neg__, __pos__
-        assert -td == Timedelta(-10, unit="d")
-        assert -td == Timedelta("-10d")
-        assert +td == Timedelta(10, unit="d")
+        assert -td == Timedelta(-10, unit="D")
+        assert -td == Timedelta("-10D")
+        assert +td == Timedelta(10, unit="D")
 
         # __abs__, __abs__(__neg__)
         assert abs(td) == td
         assert abs(-td) == td
-        assert abs(-td) == Timedelta("10d")
+        assert abs(-td) == Timedelta("10D")
 
 
 class TestTimedeltas:
@@ -334,7 +334,7 @@ class TestTimedeltas:
         assert np.isnan(rng.total_seconds())
 
     def test_conversion(self):
-        for td in [Timedelta(10, unit="d"), Timedelta("1 days, 10:11:12.012345")]:
+        for td in [Timedelta(10, unit="D"), Timedelta("1 days, 10:11:12.012345")]:
             pydt = td.to_pytimedelta()
             assert td == Timedelta(pydt)
             assert td == pydt
@@ -450,7 +450,7 @@ class TestTimedeltas:
         assert Timedelta(10, unit="us") == np.timedelta64(10, "us")
         assert Timedelta(10, unit="ms") == np.timedelta64(10, "ms")
         assert Timedelta(10, unit="s") == np.timedelta64(10, "s")
-        assert Timedelta(10, unit="d") == np.timedelta64(10, "D")
+        assert Timedelta(10, unit="D") == np.timedelta64(10, "D")
 
     def test_timedelta_conversions(self):
         assert Timedelta(timedelta(seconds=1)) == np.timedelta64(1, "s").astype(
@@ -474,7 +474,7 @@ class TestTimedeltas:
             td.to_numpy(copy=True)
 
     def test_identity(self):
-        td = Timedelta(10, unit="d")
+        td = Timedelta(10, unit="D")
         assert isinstance(td, Timedelta)
         assert isinstance(td, timedelta)
 
@@ -489,7 +489,10 @@ class TestTimedeltas:
 
         assert Timedelta("1000") == np.timedelta64(1000, "ns")
         assert Timedelta("1000ns") == np.timedelta64(1000, "ns")
-        assert Timedelta("1000NS") == np.timedelta64(1000, "ns")
+
+        msg = "'NS' is deprecated and will be removed in a future version."
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            assert Timedelta("1000NS") == np.timedelta64(1000, "ns")
 
         assert Timedelta("10us") == np.timedelta64(10000, "ns")
         assert Timedelta("100us") == np.timedelta64(100000, "ns")
@@ -508,8 +511,10 @@ class TestTimedeltas:
         assert Timedelta("100s") == np.timedelta64(100000000000, "ns")
         assert Timedelta("1000s") == np.timedelta64(1000000000000, "ns")
 
-        assert Timedelta("1d") == conv(np.timedelta64(1, "D"))
-        assert Timedelta("-1d") == -conv(np.timedelta64(1, "D"))
+        msg = "'d' is deprecated and will be removed in a future version."
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            assert Timedelta("1d") == conv(np.timedelta64(1, "D"))
+        assert Timedelta("-1D") == -conv(np.timedelta64(1, "D"))
         assert Timedelta("1D") == conv(np.timedelta64(1, "D"))
         assert Timedelta("10D") == conv(np.timedelta64(10, "D"))
         assert Timedelta("100D") == conv(np.timedelta64(100, "D"))

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -668,6 +668,26 @@ class TestTimedeltas:
         result = Timedelta.resolution
         assert result == Timedelta(nanoseconds=1)
 
+    @pytest.mark.parametrize(
+        "unit,unit_depr",
+        [
+            ("W", "w"),
+            ("D", "d"),
+            ("min", "MIN"),
+            ("s", "S"),
+            ("h", "H"),
+            ("ms", "MS"),
+            ("us", "US"),
+        ],
+    )
+    def test_unit_deprecated(self, unit, unit_depr):
+        # GH#59051
+        msg = f"'{unit_depr}' is deprecated and will be removed in a future version."
+
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = Timedelta(1, unit_depr)
+        assert result == Timedelta(1, unit)
+
 
 @pytest.mark.parametrize(
     "value, expected",

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -298,7 +298,7 @@ class TestAstype:
     def test_astype_str_cast_td64(self):
         # see GH#9757
 
-        td = Series([Timedelta(1, unit="d")])
+        td = Series([Timedelta(1, unit="D")])
         ser = td.astype(str)
 
         expected = Series(["1 days"], dtype=object)

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -92,7 +92,7 @@ class TestSeriesIsIn:
         tm.assert_series_equal(result, expected)
 
         # timedelta64[ns]
-        s = Series(pd.to_timedelta(range(5), unit="d"))
+        s = Series(pd.to_timedelta(range(5), unit="D"))
         result = s.isin(s[0:2])
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/series/methods/test_nlargest.py
+++ b/pandas/tests/series/methods/test_nlargest.py
@@ -46,7 +46,7 @@ class TestSeriesNLargestNSmallest:
         [
             pd.to_datetime(["2003", "2002", "2001", "2002", "2005"]),
             pd.to_datetime(["2003", "2002", "2001", "2002", "2005"], utc=True),
-            pd.to_timedelta(["3d", "2d", "1d", "2d", "5d"]),
+            pd.to_timedelta(["3D", "2D", "1D", "2D", "5D"]),
             np.array([3, 2, 1, 2, 5], dtype="int8"),
             np.array([3, 2, 1, 2, 5], dtype="int16"),
             np.array([3, 2, 1, 2, 5], dtype="int32"),

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -56,7 +56,10 @@ class TestTimedeltas:
     def test_to_timedelta_series(self):
         # Series
         expected = Series([timedelta(days=1), timedelta(days=1, seconds=1)])
-        result = to_timedelta(Series(["1d", "1days 00:00:01"]))
+
+        msg = "'d' is deprecated and will be removed in a future version."
+        with tm.assert_produces_warning(FutureWarning, match=msg):
+            result = to_timedelta(Series(["1d", "1days 00:00:01"]))
         tm.assert_series_equal(result, expected)
 
     def test_to_timedelta_units(self):

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -578,7 +578,7 @@ def test_missing_minp_zero_variable():
         [np.nan] * 4,
         index=DatetimeIndex(["2017-01-01", "2017-01-04", "2017-01-06", "2017-01-07"]),
     )
-    result = x.rolling(Timedelta("2d"), min_periods=0).sum()
+    result = x.rolling(Timedelta("2D"), min_periods=0).sum()
     expected = Series(0.0, index=x.index)
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
xref #58998