### PR TITLE
DOC: Correct typo in pandas.pivot_table doc

### DIFF
--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -90,7 +90,7 @@ def pivot_table(
         hierarchical columns whose top level are the function names
         (inferred from the function objects themselves).
         If a dict is passed, the key is column to aggregate and the value is
-        function or list of functions. If ``margin=True``, aggfunc will be
+        function or list of functions. If ``margins=True``, aggfunc will be
         used to calculate the partial aggregates.
     fill_value : scalar, default None
         Value to replace missing values with (in the resulting pivot table,


### PR DESCRIPTION
Missing 's'

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
