### PR TITLE
Fix typo in `explode` docs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9695,7 +9695,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         Multi-column explode.
 
-        >>> df.explode(list("AC"))
+        >>> df.explode(list("A", "C"))
              A  B    C
         0    0  1    a
         0    1  1    b


### PR DESCRIPTION
I'm assuming this change is correct, because as it was, it didn't look correct.