### PR TITLE
DEPR: replace for Timedelta deprecated unit 'd' with 'D' in benchmarks

### DIFF
--- a/asv_bench/benchmarks/tslibs/timedelta.py
+++ b/asv_bench/benchmarks/tslibs/timedelta.py
@@ -20,7 +20,7 @@ class TimedeltaConstructor:
         Timedelta(123456789)
 
     def time_from_unit(self):
-        Timedelta(1, unit="d")
+        Timedelta(1, unit="D")
 
     def time_from_components(self):
         Timedelta(


### PR DESCRIPTION
xref #59051