### PR TITLE
DOC: Fix typo in `StylerRenderer.format` docstring

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1052,7 +1052,7 @@ class StylerRenderer:
         When using a ``formatter`` string the dtypes must be compatible, otherwise a
         `ValueError` will be raised.
 
-        When instantiating a Styler, default formatting can be applied be setting the
+        When instantiating a Styler, default formatting can be applied by setting the
         ``pandas.options``:
 
           - ``styler.format.formatter``: default None.


### PR DESCRIPTION
Fixes a typo in the [Styler.format.html](https://pandas.pydata.org/docs/reference/api/pandas.io.formats.style.Styler.format.html) docs.