### PR TITLE
RT03 fix in pandas.Series.pop docstring.

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -162,7 +162,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.ne SA01" \
         -i "pandas.Series.pad PR01,SA01" \
         -i "pandas.Series.plot PR02" \
-        -i "pandas.Series.pop RT03,SA01" \
+        -i "pandas.Series.pop SA01" \
         -i "pandas.Series.prod RT03" \
         -i "pandas.Series.product RT03" \
         -i "pandas.Series.reorder_levels RT03,SA01" \

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5020,7 +5020,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        Value that is popped from series.
+        scalar
+            Value that is popped from series.
 
         Examples
         --------


### PR DESCRIPTION
Minor RT03 fix in `pandas.core.series.py`, `Series.pop` docstring from `ci/code_checks.sh`.

@phofl 