### PR TITLE
DOC: Add DataFrame.median() to the deprecated automatic downcasting list in release notes 2.2.0

### DIFF
--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -638,6 +638,7 @@ These methods are:
 - :meth:`DataFrame.mask`, :meth:`Series.mask`
 - :meth:`DataFrame.where`, :meth:`Series.where`
 - :meth:`DataFrame.clip`, :meth:`Series.clip`
+- :meth:`DataFrame.median`
 
 Explicitly call :meth:`DataFrame.infer_objects` to replicate the current behavior in the future.
 


### PR DESCRIPTION

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
