### PR TITLE
Add Py_mod_gil slot to C extension modules

### DIFF
--- a/pandas/_libs/src/datetime/pd_datetime.c
+++ b/pandas/_libs/src/datetime/pd_datetime.c
@@ -246,7 +246,9 @@ static int pandas_datetime_exec(PyObject *Py_UNUSED(module)) {
 
 static PyModuleDef_Slot pandas_datetime_slots[] = {
     {Py_mod_exec, pandas_datetime_exec},
+#if PY_VERSION_HEX >= 0x030D0000
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
     {0, NULL},
 };
 

--- a/pandas/_libs/src/datetime/pd_datetime.c
+++ b/pandas/_libs/src/datetime/pd_datetime.c
@@ -245,7 +245,10 @@ static int pandas_datetime_exec(PyObject *Py_UNUSED(module)) {
 }
 
 static PyModuleDef_Slot pandas_datetime_slots[] = {
-    {Py_mod_exec, pandas_datetime_exec}, {0, NULL}};
+    {Py_mod_exec, pandas_datetime_exec},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL},
+};
 
 static struct PyModuleDef pandas_datetimemodule = {
     PyModuleDef_HEAD_INIT,

--- a/pandas/_libs/src/parser/pd_parser.c
+++ b/pandas/_libs/src/parser/pd_parser.c
@@ -161,7 +161,10 @@ static int pandas_parser_exec(PyObject *Py_UNUSED(module)) {
 }
 
 static PyModuleDef_Slot pandas_parser_slots[] = {
-    {Py_mod_exec, pandas_parser_exec}, {0, NULL}};
+    {Py_mod_exec, pandas_parser_exec},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL},
+};
 
 static struct PyModuleDef pandas_parsermodule = {
     PyModuleDef_HEAD_INIT,

--- a/pandas/_libs/src/parser/pd_parser.c
+++ b/pandas/_libs/src/parser/pd_parser.c
@@ -162,7 +162,9 @@ static int pandas_parser_exec(PyObject *Py_UNUSED(module)) {
 
 static PyModuleDef_Slot pandas_parser_slots[] = {
     {Py_mod_exec, pandas_parser_exec},
+#if PY_VERSION_HEX >= 0x030D0000
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
     {0, NULL},
 };
 


### PR DESCRIPTION
x-ref #59057.

The `Py_mod_gil` slot is needed so that the GIL is not automatically enabled when these C extension modules get imported.

- I checked `pandas_datetime` for thread-safety and it appears to be okay.
- `pandas_parser` is not thread-safe. A discussion is needed on whether we should care about it though, since the `c` engine to `read_csv` and friends is already documented as being thread-unsafe and the thread-safe `pyarrow` alternative is already there.