### PR TITLE
Add "N / A" to `STR_NA_VALUES`

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1378,6 +1378,7 @@ STR_NA_VALUES = {
     "#N/A N/A",
     "#N/A",
     "N/A",
+    "N / A",
     "n/a",
     "NA",
     "<NA>",

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -119,6 +119,7 @@ def test_default_na_values(all_parsers):
         "-1.#QNAN",
         "#N/A",
         "N/A",
+        "N / A",
         "n/a",
         "NA",
         "<NA>",


### PR DESCRIPTION
This is a value that I just came across in some data that is in the spirit of the other NA value. I don't think this will be a false positive any more so than some of the other values in this list.

- [x] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature. A test here would just be duplicating the implementation.
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. I don't think this deserves an entry?