### PR TITLE
header, update in basic.rst M #59130

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -158,7 +158,7 @@ a set of specialized cython routines that are especially fast when dealing with 
 Here is a sample (using 100 column x 100,000 row ``DataFrames``):
 
 .. csv-table::
-    :header: "Operation", "0.11.0 (ms)", "Prior Version (ms)", "Ratio to Prior"
+   :header: "Operation", "With speedup (ms)", "Without speedup (ms)", "Ratio"  
     :widths: 25, 25, 25, 25
 
     ``df1 > df2``, 13.32, 125.35,  0.1063


### PR DESCRIPTION
closes #59130
![Screenshot 2024-07-01 220007](https://github.com/pandas-dev/pandas/assets/170221536/3f95dbd5-2ac2-4cf8-9a51-80ba62d536f6)
By changing the header to "With speedup (ms)" and "Without speedup (ms)", the documentation will directly highlight the performance improvements. This makes it easier for users to understand the value of these libraries without needing to know about older versions.

.. csv-table::
    :header: "Operation", "With speedup (ms)", "Without speedup (ms)", "Ratio"
    :widths: 25, 25, 25, 25

    ``df1 > df2``, 13.32, 125.35,  0.1063
    ``df1 * df2``, 21.71,  36.63,  0.5928
    ``df1 + df2``, 22.04,  36.50,  0.6039
