### PR TITLE
DOC: Fix for excelwriter engine for ods files

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -957,7 +957,7 @@ class ExcelWriter(Generic[_WorkbookT]):
 
     * `xlsxwriter <https://pypi.org/project/XlsxWriter/>`__ for xlsx files if xlsxwriter
       is installed otherwise `openpyxl <https://pypi.org/project/openpyxl/>`__
-    * `odswriter <https://pypi.org/project/odswriter/>`__ for ods files
+    * `odf <https://pypi.org/project/odfpy/>`__ for ods files
 
     See :meth:`DataFrame.to_excel` for typical usage.
 
@@ -1004,7 +1004,7 @@ class ExcelWriter(Generic[_WorkbookT]):
         * xlsxwriter: ``xlsxwriter.Workbook(file, **engine_kwargs)``
         * openpyxl (write mode): ``openpyxl.Workbook(**engine_kwargs)``
         * openpyxl (append mode): ``openpyxl.load_workbook(file, **engine_kwargs)``
-        * odswriter: ``odf.opendocument.OpenDocumentSpreadsheet(**engine_kwargs)``
+        * odf: ``odf.opendocument.OpenDocumentSpreadsheet(**engine_kwargs)``
 
         .. versionadded:: 1.3.0
 


### PR DESCRIPTION
From https://github.com/pandas-dev/pandas/pull/58831#discussion_r1642841812

Changing odswriter references to odfpy

```py
from pandas.io.excel._util import get_writer
get_writer('odswriter') # fails with ValueError: No Excel writer 'odswriter'
get_writer('odf') # works returning pandas.io.excel._odswriter.ODSWriter
```

That said, the library doesn't seem to be maintained. Maybe we should consider deprecating.