### PR TITLE
DOC: Add notes section to .isin() docs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -13330,7 +13330,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         Notes
         -----
-            We use `__iter__` (and not `__contains__`) to iterate over values
+            ``__iter__`` is used (and not ``__contains__``) to iterate over values
             when checking if it contains the elements in DataFrame.
 
         Examples

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -13328,6 +13328,11 @@ class DataFrame(NDFrame, OpsMixin):
         Series.str.contains: Test if pattern or regex is contained within a
             string of a Series or Index.
 
+        Notes
+        -----
+            We use `__iter__` (and not `__contains__`) to iterate over values
+            when checking if it contains the elements in DataFrame.
+
         Examples
         --------
         >>> df = pd.DataFrame(


### PR DESCRIPTION
Add a Notes section to the .isin() method docs to clarify that we use __iter__ over __contains__ when checking each element in the `values` collection passed as argument. This clarification was requested because `values` can be a dict, which suggests that under the hood isin() uses __contains__ rather than __iter__, which is not the case and might confuse some users.

- [x] closes #59041 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)

Output of the docs checker script, same as before adding the doc change:
```
1 Errors found for `pandas.DataFrame.isin`:
	ES01	No extended summary found
```

![image](https://github.com/pandas-dev/pandas/assets/24620565/81d3d626-b2bf-4bee-b542-3c6147572d6d)
