### PR TITLE
BUG/TST: non-numeric EA reductions

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -616,6 +616,7 @@ ExtensionArray
 ^^^^^^^^^^^^^^
 - Bug in :meth:`.arrays.ArrowExtensionArray.__setitem__` which caused wrong behavior when using an integer array with repeated values as a key (:issue:`58530`)
 - Bug in :meth:`api.types.is_datetime64_any_dtype` where a custom :class:`ExtensionDtype` would return ``False`` for array-likes (:issue:`57055`)
+- Bug in various :class:`DataFrame` reductions for pyarrow temporal dtypes returning incorrect dtype when result was null (:issue:`59234`)
 
 Styler
 ^^^^^^

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1706,8 +1706,6 @@ class ArrowExtensionArray(
         if name == "median":
             # GH 52679: Use quantile instead of approximate_median; returns array
             result = result[0]
-        if pc.is_null(result).as_py():
-            return result
 
         if name in ["min", "max", "sum"] and pa.types.is_duration(pa_type):
             result = result.cast(pa_type)

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1986,7 +1986,10 @@ class ExtensionArray:
             )
         result = meth(skipna=skipna, **kwargs)
         if keepdims:
-            result = np.array([result])
+            if name in ["min", "max"]:
+                result = self._from_sequence([result], dtype=self.dtype)
+            else:
+                result = np.array([result])
 
         return result
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2275,6 +2275,19 @@ default 'raise'
     # -----------------------------------------------------------------
     # Reductions
 
+    def _reduce(
+        self, name: str, *, skipna: bool = True, keepdims: bool = False, **kwargs
+    ):
+        result = super()._reduce(name, skipna=skipna, keepdims=keepdims, **kwargs)
+        if keepdims and isinstance(result, np.ndarray):
+            if name == "std":
+                from pandas.core.arrays import TimedeltaArray
+
+                return TimedeltaArray._from_sequence(result)
+            else:
+                return self._from_sequence(result, dtype=self.dtype)
+        return result
+
     def std(
         self,
         axis=None,

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -956,6 +956,17 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         delta = delta.view("i8")
         return lib.item_from_zerodim(delta)
 
+    # ------------------------------------------------------------------
+    # Reductions
+
+    def _reduce(
+        self, name: str, *, skipna: bool = True, keepdims: bool = False, **kwargs
+    ):
+        result = super()._reduce(name, skipna=skipna, keepdims=keepdims, **kwargs)
+        if keepdims and isinstance(result, np.ndarray):
+            return self._from_sequence(result, dtype=self.dtype)
+        return result
+
 
 def raise_on_incompatible(left, right) -> IncompatibleFrequency:
     """

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -522,11 +522,17 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
         return super().astype(dtype, copy)
 
     def _reduce(
-        self, name: str, *, skipna: bool = True, axis: AxisInt | None = 0, **kwargs
+        self,
+        name: str,
+        *,
+        skipna: bool = True,
+        keepdims: bool = False,
+        axis: AxisInt | None = 0,
+        **kwargs,
     ):
         if name in ["min", "max"]:
             result = getattr(self, name)(skipna=skipna, axis=axis)
-            if kwargs.get("keepdims"):
+            if keepdims:
                 return self._from_sequence([result], dtype=self.dtype)
             return result
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -525,7 +525,10 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
         self, name: str, *, skipna: bool = True, axis: AxisInt | None = 0, **kwargs
     ):
         if name in ["min", "max"]:
-            return getattr(self, name)(skipna=skipna, axis=axis)
+            result = getattr(self, name)(skipna=skipna, axis=axis)
+            if kwargs.get("keepdims"):
+                return self._from_sequence([result], dtype=self.dtype)
+            return result
 
         raise TypeError(f"Cannot perform reduction '{name}' with string dtype")
 

--- a/pandas/tests/extension/base/reduce.py
+++ b/pandas/tests/extension/base/reduce.py
@@ -4,7 +4,6 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.api.types import is_numeric_dtype
 
 
 class BaseReduceTests:
@@ -119,8 +118,6 @@ class BaseReduceTests:
     def test_reduce_frame(self, data, all_numeric_reductions, skipna):
         op_name = all_numeric_reductions
         ser = pd.Series(data)
-        if not is_numeric_dtype(ser.dtype):
-            pytest.skip(f"{ser.dtype} is not numeric dtype")
 
         if op_name in ["count", "kurt", "sem"]:
             pytest.skip(f"{op_name} not an array method")

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -95,6 +95,11 @@ class TestDatetimeArray(base.ExtensionTests):
             return None
         return super()._get_expected_exception(op_name, obj, other)
 
+    def _get_expected_reduction_dtype(self, arr, op_name: str, skipna: bool):
+        if op_name == "std":
+            return "timedelta64[ns]"
+        return arr.dtype
+
     def _supports_accumulation(self, ser, op_name: str) -> bool:
         return op_name in ["cummin", "cummax"]
 


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

Fixes a few bugs related to non-numeric EA reductions and expands testing by un-skipping a number of existing tests.

```
> pytest -k test_reduce pandas/tests/extension/

# main branch
2160 passed, 1222 skipped, 154 xfailed

# PR
2507 passed, 886 skipped, 143 xfailed
```


BUG fix example:

```
In [1]: import pandas as pd

In [2]: arr = pd.array([None], dtype="duration[ms][pyarrow]")

In [3]: pd.DataFrame({"a": arr}).min().dtype

# main branch
Out[3]: int64[pyarrow]

# PR
Out[3]: duration[ms][pyarrow]
```