### PR TITLE
DOC: Added a missing docstring to pandas/conftest.py.

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -951,6 +951,9 @@ def rand_series_with_duplicate_datetimeindex() -> Series:
     ]
 )
 def ea_scalar_and_dtype(request):
+    """
+    Fixture that tests each scalar and datetime type.
+    """
     return request.param
 
 


### PR DESCRIPTION
It came up in the pytest output. See function ea_scalar_and_dtype line number 953.
Issue Number #19159 