### PR TITLE
TST: unskip EA reduction tests

### DIFF
--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1198,7 +1198,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         mask = np.ones(mask_size, dtype=bool)
 
         float_dtyp = "float32" if self.dtype == "Float32" else "float64"
-        if name in ["mean", "median", "var", "std", "skew", "kurt"]:
+        if name in ["mean", "median", "var", "std", "skew", "kurt", "sem"]:
             np_dtype = float_dtyp
         elif name in ["min", "max"] or self.dtype.itemsize == 8:
             np_dtype = self.dtype.numpy_dtype.name

--- a/pandas/tests/extension/base/reduce.py
+++ b/pandas/tests/extension/base/reduce.py
@@ -56,7 +56,7 @@ class BaseReduceTests:
         arr = ser.array
         df = pd.DataFrame({"a": arr})
 
-        kwargs = {"ddof": 1} if op_name in ["var", "std"] else {}
+        kwargs = {"ddof": 1} if op_name in ["var", "std", "sem"] else {}
 
         cmp_dtype = self._get_expected_reduction_dtype(arr, op_name, skipna)
 
@@ -119,7 +119,7 @@ class BaseReduceTests:
         op_name = all_numeric_reductions
         ser = pd.Series(data)
 
-        if op_name in ["count", "kurt", "sem"]:
+        if op_name == "count":
             pytest.skip(f"{op_name} not an array method")
 
         if not self._supports_reduction(ser, op_name):

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -72,6 +72,8 @@ class TestDecimalArray(base.ExtensionTests):
         return None
 
     def _supports_reduction(self, ser: pd.Series, op_name: str) -> bool:
+        if op_name in ["kurt", "sem"]:
+            return False
         return True
 
     def check_reduce(self, ser: pd.Series, op_name: str, skipna: bool):

--- a/pandas/tests/extension/test_masked.py
+++ b/pandas/tests/extension/test_masked.py
@@ -301,7 +301,7 @@ class TestMaskedArrays(base.ExtensionTests):
     def _get_expected_reduction_dtype(self, arr, op_name: str, skipna: bool):
         if is_float_dtype(arr.dtype):
             cmp_dtype = arr.dtype.name
-        elif op_name in ["mean", "median", "var", "std", "skew"]:
+        elif op_name in ["mean", "median", "var", "std", "skew", "kurt", "sem"]:
             cmp_dtype = "Float64"
         elif op_name in ["max", "min"]:
             cmp_dtype = arr.dtype.name
@@ -323,9 +323,7 @@ class TestMaskedArrays(base.ExtensionTests):
                 else "UInt64"
             )
         elif arr.dtype.kind == "b":
-            if op_name in ["mean", "median", "var", "std", "skew"]:
-                cmp_dtype = "Float64"
-            elif op_name in ["min", "max"]:
+            if op_name in ["min", "max"]:
                 cmp_dtype = "boolean"
             elif op_name in ["sum", "prod"]:
                 cmp_dtype = (


### PR DESCRIPTION
```
> pytest -k reduce pandas/tests/extension/

# main
3055 passed, 886 skipped, 143 xfailed

# PR
3216 passed, 782 skipped, 86 xfailed 
```