### PR TITLE
ENH: Globally enable Cython free-threading directive

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -388,8 +388,6 @@ jobs:
 
       - name: Run Tests
         uses: ./.github/actions/run-tests
-        env:
-          PYTHON_GIL: 0
 
   # NOTE: this job must be kept in sync with the Pyodide build job in wheels.yml
   emscripten:

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,11 @@ else
     meson.add_dist_script(py, versioneer, '-o', '_version_meson.py')
 endif
 
+cy = meson.get_compiler('cython')
+if cy.version().version_compare('>=3.1.0')
+  add_global_arguments('-Xfreethreading_compatible=true', language : 'cython')
+endif
+
 # Needed by pandas.test() when it looks for the pytest ini options
 py.install_sources(
     'pyproject.toml',

--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,7 @@ endif
 
 cy = meson.get_compiler('cython')
 if cy.version().version_compare('>=3.1.0')
-  add_global_arguments('-Xfreethreading_compatible=true', language : 'cython')
+  add_project_arguments('-Xfreethreading_compatible=true', language : 'cython')
 endif
 
 # Needed by pandas.test() when it looks for the pytest ini options

--- a/pandas/_libs/src/vendored/ujson/python/ujson.c
+++ b/pandas/_libs/src/vendored/ujson/python/ujson.c
@@ -384,6 +384,10 @@ PyMODINIT_FUNC PyInit_json(void) {
     return NULL;
   }
 
+#ifdef Py_GIL_DISABLED
+  PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
 #ifndef PYPY_VERSION
   PyObject *mod_decimal = PyImport_ImportModule("decimal");
   if (mod_decimal) {


### PR DESCRIPTION
This is the Cython equivalent of adding a `Py_mod_gil` slot with `Py_MOD_GIL_NOT_USED` like we did in #59135.

x-ref #59057.