### PR TITLE
Remove extra space in ``resample`` freq deprecation

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -4894,7 +4894,7 @@ cpdef to_offset(freq, bint is_period=False):
                         f"\'{name}\' is deprecated and will be removed "
                         f"in a future version, please use "
                         f"\'{c_PERIOD_AND_OFFSET_DEPR_FREQSTR.get(name)}\' "
-                        f" instead.",
+                        f"instead.",
                         FutureWarning,
                         stacklevel=find_stack_level(),
                         )


### PR DESCRIPTION
While running `dask` tests against the nightly version of `pandas` I noticed there's an extra space in the resample frequency deprecation warning (note the extra space before "instead"):

```
FutureWarning: 'd' is deprecated and will be removed in a future version, please use 'D'  instead.
```

This PR just removes the extra space. 

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
