### PR TITLE
CI/DOC: Fix CI failure for Status: Draft PDEPs and don't show them on the roadmap webpage

### DIFF
--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -320,7 +320,7 @@ class Preprocessors:
         github_repo_url = context["main"]["github_repo_url"]
         resp = requests.get(
             "https://api.github.com/search/issues?"
-            f"q=is:pr is:open label:PDEP repo:{github_repo_url}",
+            f"q=is:pr is:open label:PDEP draft:false repo:{github_repo_url}",
             headers=GITHUB_API_HEADERS,
             timeout=5,
         )

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -280,6 +280,7 @@ class Preprocessors:
         PDEP's in different status from the directory tree and GitHub.
         """
         KNOWN_STATUS = {
+            "Draft",
             "Under discussion",
             "Accepted",
             "Implemented",


### PR DESCRIPTION
- [x] closes #59253

This solution will treat any Draft PR as a `Status: Draft` PDEP (and therefore not show it on the roadmap page)
Other solutions will likely complicate the code too much.