### PR TITLE
CLN: Remove __nonzero__ in favor of __bool__

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1491,13 +1491,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         return res.__finalize__(self, method="__invert__")
 
     @final
-    def __nonzero__(self) -> NoReturn:
+    def __bool__(self) -> NoReturn:
         raise ValueError(
             f"The truth value of a {type(self).__name__} is ambiguous. "
             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
         )
-
-    __bool__ = __nonzero__
 
     @final
     def abs(self) -> Self:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2907,13 +2907,11 @@ class Index(IndexOpsMixin, PandasObject):
         return self + other
 
     @final
-    def __nonzero__(self) -> NoReturn:
+    def __bool__(self) -> NoReturn:
         raise ValueError(
             f"The truth value of a {type(self).__name__} is ambiguous. "
             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
         )
-
-    __bool__ = __nonzero__
 
     # --------------------------------------------------------------------
     # Set Operation Methods

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -263,11 +263,8 @@ class BaseBlockManager(PandasObject):
             blocks = []
         return type(self).from_blocks(blocks, axes)
 
-    def __nonzero__(self) -> bool:
+    def __bool__(self) -> bool:
         return True
-
-    # Python3 compat
-    __bool__ = __nonzero__
 
     def set_axis(self, axis: AxisInt, new_labels: Index) -> None:
         # Caller is responsible for ensuring we have an Index object.


### PR DESCRIPTION
`__nonzero__` was a Python 2 convention dropped in Python 3: https://docs.python.org/3/whatsnew/3.0.html#operators-and-special-methods