### PR TITLE
DOCS: Add docstrings to fixtures in /indexes/datetimelike_/test_equals.py

### DIFF
--- a/pandas/tests/indexes/datetimelike_/test_equals.py
+++ b/pandas/tests/indexes/datetimelike_/test_equals.py
@@ -52,6 +52,7 @@ class EqualsTests:
 class TestPeriodIndexEquals(EqualsTests):
     @pytest.fixture
     def index(self):
+        """Fixture for creating a PeriodIndex for use in equality tests."""
         return period_range("2013-01-01", periods=5, freq="D")
 
     # TODO: de-duplicate with other test_equals2 methods
@@ -91,6 +92,7 @@ class TestPeriodIndexEquals(EqualsTests):
 class TestDatetimeIndexEquals(EqualsTests):
     @pytest.fixture
     def index(self):
+        """Fixture for creating a DatetimeIndex for use in equality tests."""
         return date_range("2013-01-01", periods=5)
 
     def test_equals2(self):
@@ -143,6 +145,7 @@ class TestDatetimeIndexEquals(EqualsTests):
 class TestTimedeltaIndexEquals(EqualsTests):
     @pytest.fixture
     def index(self):
+        """Fixture for creating a TimedeltaIndex for use in equality tests."""
         return timedelta_range("1 day", periods=10)
 
     def test_equals2(self):


### PR DESCRIPTION
Add docstrings to fixtures in `/indexes/datetimelike_/test_equals.py` file.

Partially addresses https://github.com/pandas-dev/pandas/issues/19159
