### PR TITLE
DOC: Using np.histogram_bin_edges with pd.cut

### DIFF
--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -142,7 +142,7 @@ def cut(
         fixed set of values.
     Series : One-dimensional array with axis labels (including time series).
     IntervalIndex : Immutable Index implementing an ordered, sliceable set.
-    np.histogram_bin_edges: Function to calculate only the edges of the bins
+    numpy.histogram_bin_edges: Function to calculate only the edges of the bins
         used by the histogram function.
 
     Notes

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -142,11 +142,16 @@ def cut(
         fixed set of values.
     Series : One-dimensional array with axis labels (including time series).
     IntervalIndex : Immutable Index implementing an ordered, sliceable set.
+    np.histogram_bin_edges: Function to calculate only the edges of the bins
+        used by the histogram function.
 
     Notes
     -----
     Any NA values will be NA in the result. Out of bounds values will be NA in
     the resulting Series or Categorical object.
+
+    np.histogram_bin_edges can be used along with cut to calculate bins according
+    to some predefined methods.
 
     Reference :ref:`the user guide <reshaping.tile.cut>` for more examples.
 
@@ -239,6 +244,16 @@ def cut(
     >>> pd.cut([0, 0.5, 1.5, 2.5, 4.5], bins)
     [NaN, (0.0, 1.0], NaN, (2.0, 3.0], (4.0, 5.0]]
     Categories (3, interval[int64, right]): [(0, 1] < (2, 3] < (4, 5]]
+
+    Using np.histogram_bin_edges with cut
+
+    >>> pd.cut(
+    ...     np.array([1, 7, 5, 4]),
+    ...     bins=np.histogram_bin_edges(np.array([1, 7, 5, 4]), bins="auto"),
+    ... )
+    ... # doctest: +ELLIPSIS
+    [NaN, (5.0, 7.0], (3.0, 5.0], (3.0, 5.0]]
+    Categories (3, interval[float64, right]): [(1.0, 3.0] < (3.0, 5.0] < (5.0, 7.0]]
     """
     # NOTE: this binning code is changed a bit from histogram for var(x) == 0
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -150,7 +150,7 @@ def cut(
     Any NA values will be NA in the result. Out of bounds values will be NA in
     the resulting Series or Categorical object.
 
-    np.histogram_bin_edges can be used along with cut to calculate bins according
+    ``numpy.histogram_bin_edges`` can be used along with cut to calculate bins according
     to some predefined methods.
 
     Reference :ref:`the user guide <reshaping.tile.cut>` for more examples.


### PR DESCRIPTION
- [x] closes #59165 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

As per reviews on #https://github.com/pandas-dev/pandas/pull/59241, adding documentation support for using np.histogram_bin_edges with pd.cut to allow bins calculation with strings. 