### PR TITLE
DOCS: Add docstrings to fixture in /indexes/categorical/test_category.py

### DIFF
--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -21,6 +21,9 @@ from pandas.core.indexes.api import (
 class TestCategoricalIndex:
     @pytest.fixture
     def simple_index(self) -> CategoricalIndex:
+        """
+        Fixture that provides a CategoricalIndex.
+        """
         return CategoricalIndex(list("aabbca"), categories=list("cab"), ordered=False)
 
     def test_can_hold_identifiers(self):


### PR DESCRIPTION
Add docstrings to fixture in `/indexes/categorical/test_category.py` file.
Partially addresses https://github.com/pandas-dev/pandas/issues/19159
