### PR TITLE
DOCS: Add docstrings to fixture in /indexing/interval/test_interval_new.py

### DIFF
--- a/pandas/tests/indexing/interval/test_interval_new.py
+++ b/pandas/tests/indexing/interval/test_interval_new.py
@@ -17,6 +17,9 @@ import pandas._testing as tm
 class TestIntervalIndex:
     @pytest.fixture
     def series_with_interval_index(self):
+        """
+        Fixture providing a Series with an IntervalIndex.
+        """
         return Series(np.arange(5), IntervalIndex.from_breaks(np.arange(6)))
 
     def test_loc_with_interval(self, series_with_interval_index, indexer_sl):


### PR DESCRIPTION
Add docstrings to fixture in `/indexing/interval/test_interval_new.py` file.
Partially addresses https://github.com/pandas-dev/pandas/issues/19159
