### PR TITLE
allow set_index to set a multiindex from a tuple, not just a list

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5913,7 +5913,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         self._check_inplace_and_allows_duplicate_labels(inplace)
-        if not isinstance(keys, list):
+        if not is_list_like(keys):
             keys = [keys]
 
         err_msg = (

--- a/pandas/tests/copy_view/index/test_index.py
+++ b/pandas/tests/copy_view/index/test_index.py
@@ -44,6 +44,21 @@ def test_set_index_series():
     ser.iloc[0] = 100
     tm.assert_index_equal(df.index, expected)
 
+class TestSetMultiIndex:
+    df = DataFrame({"a": [1, 2], "b": 1.5, "c": [3, 4]})
+
+    def test_from_list(self):
+        df = self.df.set_index(["a", "b"])
+        self._assert(df)
+
+    def test_from_tuple(self):
+        df = self.df.set_index(("a", "b"))
+        self._assert(df)
+
+    def _assert(self, df):
+        assert isinstance(df.index, pd.MultiIndex)
+        assert df.index.names == ["a", "b"]
+
 
 def test_assign_index_as_series():
     df = DataFrame({"a": [1, 2], "b": 1.5})


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
