### PR TITLE
DOC: pyarrow.rst: Add missing IO readers

### DIFF
--- a/doc/source/user_guide/pyarrow.rst
+++ b/doc/source/user_guide/pyarrow.rst
@@ -159,9 +159,11 @@ PyArrow also provides IO reading functionality that has been integrated into sev
 functions provide an ``engine`` keyword that can dispatch to PyArrow to accelerate reading from an IO source.
 
 * :func:`read_csv`
+* :func:`read_feather`
 * :func:`read_json`
 * :func:`read_orc`
-* :func:`read_feather`
+* :func:`read_parquet`
+* :func:`read_table` (experimental)
 
 .. ipython:: python
 


### PR DESCRIPTION
# Changes

* Add `read_parquet` and `read_table` (experimental) to the list of IO readers that support the PyArrow engine.
* Alphabetize list to improve readability.


- [x] (N/A) closes #xxxx
- [x] (N/A) [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] (N/A) All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] (N/A) Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] (N/A) Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
