### PR TITLE
DOC: Add RT03,SA01 for pandas.api.types.union_categoricals

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -307,7 +307,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.types.is_string_dtype SA01" \
         -i "pandas.api.types.is_timedelta64_ns_dtype SA01" \
         -i "pandas.api.types.pandas_dtype PR07,RT03,SA01" \
-        -i "pandas.api.types.union_categoricals RT03,SA01" \
         -i "pandas.arrays.ArrowExtensionArray PR07,SA01" \
         -i "pandas.arrays.BooleanArray SA01" \
         -i "pandas.arrays.DatetimeArray SA01" \

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -190,7 +190,7 @@ def union_categoricals(
     Returns
     -------
     Categorical
-        The union of categories being combined
+        The union of categories being combined.
 
     Raises
     ------
@@ -202,15 +202,15 @@ def union_categoricals(
     ValueError
         Empty list of categoricals passed
 
-    Notes
-    -----
-    To learn more about categories, see `link
-    <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html#unioning>`__
-
     See Also
     --------
     CategoricalDtype : Type for categorical data with the categories and orderedness.
     Categorical : Represent a categorical variable in classic R / S-plus fashion.
+
+    Notes
+    -----
+    To learn more about categories, see `link
+    <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html#unioning>`__
 
     Examples
     --------

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -190,6 +190,7 @@ def union_categoricals(
     Returns
     -------
     Categorical
+        The union of categories being combined
 
     Raises
     ------
@@ -205,6 +206,11 @@ def union_categoricals(
     -----
     To learn more about categories, see `link
     <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html#unioning>`__
+
+    See Also
+    --------
+    CategoricalDtype : Type for categorical data with the categories and orderedness.
+    Categorical : Represent a categorical variable in classic R / S-plus fashion.
 
     Examples
     --------


### PR DESCRIPTION
- [x] xref #58577 
fixes `-i "pandas.api.types.union_categoricals RT03,SA01"`

```
Docstring for "pandas.api.types.union_categoricals" correct. :)
```