### PR TITLE
REF (string dtype): rename using_pyarrow_string_dtype to using_string_dtype

### DIFF
--- a/pandas/_config/__init__.py
+++ b/pandas/_config/__init__.py
@@ -30,6 +30,6 @@ from pandas._config.config import (
 from pandas._config.display import detect_console_encoding
 
 
-def using_pyarrow_string_dtype() -> bool:
+def using_string_dtype() -> bool:
     _mode_options = _global_config["future"]
     return _mode_options["infer_string"]

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -37,7 +37,7 @@ from cython cimport (
     floating,
 )
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs.missing import check_na_tuples_nonequal
 
@@ -2699,7 +2699,7 @@ def maybe_convert_objects(ndarray[object] objects,
         seen.object_ = True
 
     elif seen.str_:
-        if using_pyarrow_string_dtype() and is_string_array(objects, skipna=True):
+        if using_string_dtype() and is_string_array(objects, skipna=True):
             from pandas.core.arrays.string_ import StringDtype
 
             dtype = StringDtype(storage="pyarrow_numpy")

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -16,7 +16,7 @@ from typing import (
 import numpy as np
 from numpy import ma
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas._libs.tslibs import (
@@ -571,11 +571,7 @@ def sanitize_array(
     if not is_list_like(data):
         if index is None:
             raise ValueError("index must be specified when data is not list-like")
-        if (
-            isinstance(data, str)
-            and using_pyarrow_string_dtype()
-            and original_dtype is None
-        ):
+        if isinstance(data, str) and using_string_dtype() and original_dtype is None:
             from pandas.core.arrays.string_ import StringDtype
 
             dtype = StringDtype("pyarrow_numpy")
@@ -609,7 +605,7 @@ def sanitize_array(
             subarr = data
             if data.dtype == object and infer_object:
                 subarr = maybe_infer_to_datetimelike(data)
-            elif data.dtype.kind == "U" and using_pyarrow_string_dtype():
+            elif data.dtype.kind == "U" and using_string_dtype():
                 from pandas.core.arrays.string_ import StringDtype
 
                 dtype = StringDtype(storage="pyarrow_numpy")

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -18,7 +18,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import (
     Interval,
@@ -798,7 +798,7 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
         # coming out as np.str_!
 
         dtype = _dtype_obj
-        if using_pyarrow_string_dtype():
+        if using_string_dtype():
             from pandas.core.arrays.string_ import StringDtype
 
             dtype = StringDtype(storage="pyarrow_numpy")

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -14,7 +14,7 @@ from typing import (
 import numpy as np
 from numpy import ma
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 
@@ -301,7 +301,7 @@ def ndarray_to_mgr(
             bp = BlockPlacement(slice(len(columns)))
             nb = new_block_2d(values, placement=bp, refs=refs)
             block_values = [nb]
-    elif dtype is None and values.dtype.kind == "U" and using_pyarrow_string_dtype():
+    elif dtype is None and values.dtype.kind == "U" and using_string_dtype():
         dtype = StringDtype(storage="pyarrow_numpy")
 
         obj_columns = list(values)

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -8,7 +8,7 @@ from typing import (
 )
 import warnings
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
@@ -131,7 +131,7 @@ def read_feather(
     with get_handle(
         path, "rb", storage_options=storage_options, is_text=False
     ) as handles:
-        if dtype_backend is lib.no_default and not using_pyarrow_string_dtype():
+        if dtype_backend is lib.no_default and not using_string_dtype():
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
@@ -155,7 +155,7 @@ def read_feather(
         elif dtype_backend == "pyarrow":
             return pa_table.to_pandas(types_mapper=pd.ArrowDtype)
 
-        elif using_pyarrow_string_dtype():
+        elif using_string_dtype():
             return pa_table.to_pandas(types_mapper=arrow_string_types_mapper())
         else:
             raise NotImplementedError

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -9,7 +9,7 @@ from typing import (
     Literal,
 )
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
@@ -136,7 +136,7 @@ def read_orc(
             df = pa_table.to_pandas(types_mapper=mapping.get)
         return df
     else:
-        if using_pyarrow_string_dtype():
+        if using_string_dtype():
             types_mapper = arrow_string_types_mapper()
         else:
             types_mapper = None

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -15,7 +15,7 @@ from warnings import (
     filterwarnings,
 )
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
@@ -257,7 +257,7 @@ class PyArrowImpl(BaseImpl):
             to_pandas_kwargs["types_mapper"] = mapping.get
         elif dtype_backend == "pyarrow":
             to_pandas_kwargs["types_mapper"] = pd.ArrowDtype  # type: ignore[assignment]
-        elif using_pyarrow_string_dtype():
+        elif using_string_dtype():
             to_pandas_kwargs["types_mapper"] = arrow_string_types_mapper()
 
         path_or_handle, handles, filesystem = _get_path_or_handle(

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import warnings
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
@@ -301,7 +301,7 @@ class ArrowParserWrapper(ParserBase):
                 dtype_mapping = _arrow_dtype_mapping()
                 dtype_mapping[pa.null()] = pd.Int64Dtype()
                 frame = table.to_pandas(types_mapper=dtype_mapping.get)
-            elif using_pyarrow_string_dtype():
+            elif using_string_dtype():
                 frame = table.to_pandas(types_mapper=arrow_string_types_mapper())
 
             else:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -30,7 +30,7 @@ import numpy as np
 from pandas._config import (
     config,
     get_option,
-    using_pyarrow_string_dtype,
+    using_string_dtype,
 )
 
 from pandas._libs import (
@@ -3294,7 +3294,7 @@ class SeriesFixed(GenericFixed):
         index = self.read_index("index", start=start, stop=stop)
         values = self.read_array("values", start=start, stop=stop)
         result = Series(values, index=index, name=self.name, copy=False)
-        if using_pyarrow_string_dtype() and is_string_array(values, skipna=True):
+        if using_string_dtype() and is_string_array(values, skipna=True):
             result = result.astype("string[pyarrow_numpy]")
         return result
 
@@ -3363,7 +3363,7 @@ class BlockManagerFixed(GenericFixed):
 
             columns = items[items.get_indexer(blk_items)]
             df = DataFrame(values.T, columns=columns, index=axes[1], copy=False)
-            if using_pyarrow_string_dtype() and is_string_array(values, skipna=True):
+            if using_string_dtype() and is_string_array(values, skipna=True):
                 df = df.astype("string[pyarrow_numpy]")
             dfs.append(df)
 
@@ -4735,9 +4735,9 @@ class AppendableFrameTable(AppendableTable):
             else:
                 # Categorical
                 df = DataFrame._from_arrays([values], columns=cols_, index=index_)
-            if not (using_pyarrow_string_dtype() and values.dtype.kind == "O"):
+            if not (using_string_dtype() and values.dtype.kind == "O"):
                 assert (df.dtypes == values.dtype).all(), (df.dtypes, values.dtype)
-            if using_pyarrow_string_dtype() and is_string_array(
+            if using_string_dtype() and is_string_array(
                 values,  # type: ignore[arg-type]
                 skipna=True,
             ):

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -31,7 +31,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
@@ -2197,7 +2197,7 @@ class ADBCDatabase(PandasSQL):
             from pandas.io._util import _arrow_dtype_mapping
 
             mapping = _arrow_dtype_mapping().get
-        elif using_pyarrow_string_dtype():
+        elif using_string_dtype():
             from pandas.io._util import arrow_string_types_mapper
 
             arrow_string_types_mapper()

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -8,7 +8,7 @@ import operator
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas.util._test_decorators as td
 
@@ -303,7 +303,7 @@ class TestArithmetic:
         index += "_x"
         assert "a_x" in index
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="add doesn't work")
+    @pytest.mark.xfail(using_string_dtype(), reason="add doesn't work")
     def test_add(self):
         index = pd.Index([str(i) for i in range(10)])
         expected = pd.Index(index.values * 2)

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -6,7 +6,7 @@ from datetime import (
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.core.dtypes.common import (
     is_float_dtype,
@@ -442,7 +442,7 @@ class TestCategoricalConstructors:
         with pytest.raises(ValueError, match="Unknown dtype"):
             Categorical([1, 2], dtype="foo")
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="Can't be NumPy strings")
+    @pytest.mark.xfail(using_string_dtype(), reason="Can't be NumPy strings")
     def test_constructor_np_strs(self):
         # GH#31499 Hashtable.map_locations needs to work on np.str_ objects
         cat = Categorical(["1", "0", "1"], [np.str_("0"), np.str_("1")])

--- a/pandas/tests/arrays/categorical/test_repr.py
+++ b/pandas/tests/arrays/categorical/test_repr.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas import (
     Categorical,
@@ -78,7 +78,7 @@ class TestCategoricalRepr:
             assert exp == repr(a)
 
     @pytest.mark.skipif(
-        using_pyarrow_string_dtype(),
+        using_string_dtype(),
         reason="Change once infer_string is set to True by default",
     )
     def test_unicode_print(self):

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -3,7 +3,7 @@ import sys
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.compat import PYPY
 
@@ -82,7 +82,7 @@ def test_ndarray_compat_properties(index_or_series_obj):
 
 
 @pytest.mark.skipif(
-    PYPY or using_pyarrow_string_dtype(),
+    PYPY or using_string_dtype(),
     reason="not relevant for PyPy doesn't work properly for arrow strings",
 )
 def test_memory_usage(index_or_series_memory_obj):

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas as pd
 import pandas._testing as tm
@@ -100,7 +100,7 @@ def test_nunique_null(null_obj, index_or_series_obj):
 
 
 @pytest.mark.single_cpu
-@pytest.mark.xfail(using_pyarrow_string_dtype(), reason="decoding fails")
+@pytest.mark.xfail(using_string_dtype(), reason="decoding fails")
 def test_unique_bad_unicode(index_or_series):
     # regression test for #34550
     uval = "\ud83d"  # smiley emoji

--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -5,7 +5,7 @@ from typing import final
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.core.dtypes.common import is_string_dtype
 
@@ -37,7 +37,7 @@ class BaseOpsUtil:
         else:
             result = self.frame_scalar_exc
 
-        if using_pyarrow_string_dtype() and result is not None:
+        if using_string_dtype() and result is not None:
             import pyarrow as pa
 
             result = (  # type: ignore[assignment]

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -19,7 +19,7 @@ import string
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas as pd
 from pandas import Categorical
@@ -99,7 +99,7 @@ class TestCategorical(base.ExtensionTests):
                 continue
             assert na_value_obj not in data
             # this section suffers from super method
-            if not using_pyarrow_string_dtype():
+            if not using_string_dtype():
                 assert na_value_obj in data_missing
 
     def test_empty(self, dtype):

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas import (
     DataFrame,
@@ -44,9 +44,7 @@ class TestFromDict:
         )
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.skipif(
-        using_pyarrow_string_dtype(), reason="columns inferring logic broken"
-    )
+    @pytest.mark.skipif(using_string_dtype(), reason="columns inferring logic broken")
     def test_constructor_list_of_series(self):
         data = [
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 4.0]]),

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.compat import is_platform_little_endian
 
@@ -58,7 +58,7 @@ class TestFromRecords:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.skipif(
-        using_pyarrow_string_dtype(), reason="dtype checking logic doesn't work"
+        using_string_dtype(), reason="dtype checking logic doesn't work"
     )
     def test_from_records_sequencelike(self):
         df = DataFrame(

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas import (
     Categorical,
@@ -65,7 +65,7 @@ class TestFillNA:
         with pytest.raises(TypeError, match=msg):
             datetime_frame.fillna()
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="can't fill 0 in string")
+    @pytest.mark.xfail(using_string_dtype(), reason="can't fill 0 in string")
     def test_fillna_mixed_type(self, float_string_frame):
         mf = float_string_frame
         mf.loc[mf.index[5:20], "foo"] = np.nan
@@ -537,7 +537,7 @@ class TestFillNA:
         filled = df.ffill()
         assert df.columns.tolist() == filled.columns.tolist()
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="can't fill 0 in string")
+    @pytest.mark.xfail(using_string_dtype(), reason="can't fill 0 in string")
     def test_fill_corner(self, float_frame, float_string_frame):
         mf = float_string_frame
         mf.loc[mf.index[5:20], "foo"] = np.nan

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas.util._test_decorators as td
 
@@ -65,7 +65,7 @@ class TestDataFrameInterpolate:
         assert orig.squeeze()[1] == 1.5
 
     @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="interpolate doesn't work for string"
+        using_string_dtype(), reason="interpolate doesn't work for string"
     )
     def test_interp_basic(self):
         df = DataFrame(
@@ -90,7 +90,7 @@ class TestDataFrameInterpolate:
         assert np.shares_memory(df["D"]._values, dvalues)
 
     @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="interpolate doesn't work for string"
+        using_string_dtype(), reason="interpolate doesn't work for string"
     )
     def test_interp_basic_with_non_range_index(self, using_infer_string):
         df = DataFrame(

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -6,7 +6,7 @@ import re
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas as pd
 from pandas import (
@@ -30,9 +30,7 @@ def mix_abc() -> dict[str, list[float | str]]:
 
 
 class TestDataFrameReplace:
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_replace_inplace(self, datetime_frame, float_string_frame):
         datetime_frame.loc[datetime_frame.index[:5], "A"] = np.nan
         datetime_frame.loc[datetime_frame.index[-5:], "A"] = np.nan
@@ -293,9 +291,7 @@ class TestDataFrameReplace:
         expected = DataFrame({"first": [".bc", "bc.", "c.b"]}, dtype=dtype)
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_regex_replace_dict_nested_gh4115(self):
         df = DataFrame({"Type": ["Q", "T", "Q", "Q", "T"], "tmp": 2})
         expected = DataFrame(
@@ -304,9 +300,7 @@ class TestDataFrameReplace:
         result = df.replace({"Type": {"Q": 0, "T": 1}})
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_regex_replace_list_to_scalar(self, mix_abc):
         df = DataFrame(mix_abc)
         expec = DataFrame(
@@ -332,9 +326,7 @@ class TestDataFrameReplace:
         tm.assert_frame_equal(res2, expec)
         tm.assert_frame_equal(res3, expec)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_regex_replace_str_to_numeric(self, mix_abc):
         # what happens when you try to replace a numeric value with a regex?
         df = DataFrame(mix_abc)
@@ -350,9 +342,7 @@ class TestDataFrameReplace:
         tm.assert_frame_equal(res2, expec)
         tm.assert_frame_equal(res3, expec)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_regex_replace_regex_list_to_numeric(self, mix_abc):
         df = DataFrame(mix_abc)
         res = df.replace([r"\s*\.\s*", "b"], 0, regex=True)
@@ -545,9 +535,7 @@ class TestDataFrameReplace:
         result = df.replace(s, df.mean())
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_replace_convert(self):
         # gh 3907
         df = DataFrame([["foo", "bar", "bah"], ["bar", "foo", "bah"]])
@@ -557,9 +545,7 @@ class TestDataFrameReplace:
         res = rep.dtypes
         tm.assert_series_equal(expec, res)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_replace_mixed(self, float_string_frame):
         mf = float_string_frame
         mf.iloc[5:20, mf.columns.get_loc("foo")] = np.nan
@@ -902,9 +888,7 @@ class TestDataFrameReplace:
         with pytest.raises(ValueError, match=msg):
             df.replace(to_rep, values[1:])
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_replace_input_formats_scalar(self):
         df = DataFrame(
             {"A": [np.nan, 0, np.inf], "B": [0, 2, 5], "C": ["", "asdf", "fd"]}
@@ -933,9 +917,7 @@ class TestDataFrameReplace:
         # TODO
         pass
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_replace_dict_no_regex(self):
         answer = Series(
             {
@@ -957,9 +939,7 @@ class TestDataFrameReplace:
         result = answer.replace(weights)
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_replace_series_no_regex(self):
         answer = Series(
             {
@@ -1064,9 +1044,7 @@ class TestDataFrameReplace:
         expected = df.replace({"a": dict(zip(astr, bstr))})
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     def test_replace_swapping_bug(self, using_infer_string):
         df = DataFrame({"a": [True, False, True]})
         res = df.replace({"a": {True: "Y", False: "N"}})
@@ -1197,9 +1175,7 @@ class TestDataFrameReplace:
         result = df.replace(to_replace)
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     @pytest.mark.parametrize(
         "replacer",
         [
@@ -1492,9 +1468,7 @@ class TestDataFrameReplaceRegex:
         expected.loc[expected["a"] == ".", "a"] = expected_replace_val
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't set float into string"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set float into string")
     @pytest.mark.parametrize("regex", [False, True])
     def test_replace_regex_dtype_frame(self, regex):
         # GH-48644

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -5,7 +5,7 @@ import pydoc
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 from pandas._config.config import option_context
 
 import pandas as pd
@@ -113,7 +113,7 @@ class TestDataFrameMisc:
         with pytest.raises(TypeError, match=msg):
             hash(empty_frame)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="surrogates not allowed")
+    @pytest.mark.xfail(using_string_dtype(), reason="surrogates not allowed")
     def test_column_name_contains_unicode_surrogate(self):
         # GH 25509
         colname = "\ud83d"

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -11,7 +11,7 @@ import re
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas as pd
 from pandas import (
@@ -251,9 +251,7 @@ class TestFrameComparisons:
             with pytest.raises(TypeError, match=msg):
                 right_f(pd.Timestamp("nat"), df)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't compare string and int"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't compare string and int")
     def test_mixed_comparison(self):
         # GH#13128, GH#22163 != datetime64 vs non-dt64 should be False,
         # not raise TypeError

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -21,7 +21,7 @@ from numpy import ma
 from numpy.ma import mrecords
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas.compat.numpy import np_version_gt2
@@ -299,14 +299,14 @@ class TestDataFrameConstructors:
         df2 = DataFrame(df.values, dtype=df[0].dtype)
         assert df2._mgr.blocks[0].values.flags.c_contiguous
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="conversion copies")
+    @pytest.mark.xfail(using_string_dtype(), reason="conversion copies")
     def test_1d_object_array_does_not_copy(self):
         # https://github.com/pandas-dev/pandas/issues/39272
         arr = np.array(["a", "b"], dtype="object")
         df = DataFrame(arr, copy=False)
         assert np.shares_memory(df.values, arr)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="conversion copies")
+    @pytest.mark.xfail(using_string_dtype(), reason="conversion copies")
     def test_2d_object_array_does_not_copy(self):
         # https://github.com/pandas-dev/pandas/issues/39272
         arr = np.array([["a", "b"], ["c", "d"]], dtype="object")

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -6,7 +6,7 @@ from dateutil.tz import tzlocal
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.compat import (
     IS64,
@@ -465,7 +465,7 @@ class TestDataFrameAnalytics:
                 getattr(df, op)()
 
     @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="sum doesn't work for arrow strings"
+        using_string_dtype(), reason="sum doesn't work for arrow strings"
     )
     def test_reduce_mixed_frame(self):
         # GH 6806
@@ -1930,9 +1930,7 @@ def test_sum_timedelta64_skipna_false():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    using_pyarrow_string_dtype(), reason="sum doesn't work with arrow strings"
-)
+@pytest.mark.xfail(using_string_dtype(), reason="sum doesn't work with arrow strings")
 def test_mixed_frame_with_integer_sum():
     # https://github.com/pandas-dev/pandas/issues/34520
     df = DataFrame([["a", 1]], columns=list("ab"))

--- a/pandas/tests/frame/test_repr.py
+++ b/pandas/tests/frame/test_repr.py
@@ -7,7 +7,7 @@ from io import StringIO
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas import (
     NA,
@@ -176,7 +176,7 @@ NaT   4"""
 
         repr(biggie)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="/r in")
+    @pytest.mark.xfail(using_string_dtype(), reason="/r in")
     def test_repr(self):
         # columns but no index
         no_index = DataFrame(columns=[0, 1, 3])

--- a/pandas/tests/indexes/base_class/test_formats.py
+++ b/pandas/tests/indexes/base_class/test_formats.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 import pandas._config.config as cf
 
 from pandas import Index
@@ -16,7 +16,7 @@ class TestIndexRendering:
         res = eval(repr(idx))
         tm.assert_index_equal(res, idx)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="repr different")
+    @pytest.mark.xfail(using_string_dtype(), reason="repr different")
     @pytest.mark.parametrize(
         "index,expected",
         [
@@ -81,7 +81,7 @@ class TestIndexRendering:
         result = repr(index)
         assert result == expected
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="repr different")
+    @pytest.mark.xfail(using_string_dtype(), reason="repr different")
     @pytest.mark.parametrize(
         "index,expected",
         [

--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import index as libindex
 from pandas._libs.arrays import NDArrayBacked
@@ -199,7 +199,7 @@ class TestCategoricalIndex:
         expected = CategoricalIndex(expected_data, dtype=dtype)
         tm.assert_index_equal(idx.unique(), expected)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="repr doesn't roundtrip")
+    @pytest.mark.xfail(using_string_dtype(), reason="repr doesn't roundtrip")
     def test_repr_roundtrip(self):
         ci = CategoricalIndex(["a", "b"], categories=["a", "b"], ordered=True)
         str(ci)

--- a/pandas/tests/indexes/categorical/test_formats.py
+++ b/pandas/tests/indexes/categorical/test_formats.py
@@ -4,14 +4,14 @@ Tests for CategoricalIndex.__repr__ and related methods.
 
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 import pandas._config.config as cf
 
 from pandas import CategoricalIndex
 
 
 class TestCategoricalIndexRepr:
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="repr different")
+    @pytest.mark.xfail(using_string_dtype(), reason="repr different")
     def test_string_categorical_index_repr(self):
         # short
         idx = CategoricalIndex(["a", "bb", "ccc"])

--- a/pandas/tests/indexes/interval/test_formats.py
+++ b/pandas/tests/indexes/interval/test_formats.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas import (
     DataFrame,
@@ -42,7 +42,7 @@ class TestIntervalIndexRendering:
         result = repr(obj)
         assert result == expected
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="repr different")
+    @pytest.mark.xfail(using_string_dtype(), reason="repr different")
     def test_repr_floats(self):
         # GH 32553
 

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -6,7 +6,7 @@ import weakref
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs.tslibs import Timestamp
 
@@ -438,7 +438,7 @@ class TestBase:
         assert index[0:4].equals(result)
 
     @pytest.mark.skipif(
-        using_pyarrow_string_dtype(),
+        using_string_dtype(),
         reason="completely different behavior, tested elsewher",
     )
     def test_insert_out_of_bounds(self, index):

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -9,7 +9,7 @@ import itertools
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.compat import (
     IS64,
@@ -826,7 +826,7 @@ class TestReplaceSeriesCoercion(CoercionBase):
         return replacer
 
     # Expected needs adjustment for the infer string option, seems to work as expecetd
-    @pytest.mark.skipif(using_pyarrow_string_dtype(), reason="TODO: test is to complex")
+    @pytest.mark.skipif(using_string_dtype(), reason="TODO: test is to complex")
     def test_replace_series(self, how, to_key, from_key, replacer):
         index = pd.Index([3, 4], name="xxx")
         obj = pd.Series(self.rep[from_key], index=index, name="yyy")

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -8,7 +8,7 @@ import weakref
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.errors import IndexingError
 
@@ -426,9 +426,7 @@ class TestFancy:
         )
         tm.assert_frame_equal(result, df)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="can't multiply arrow strings"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="can't multiply arrow strings")
     def test_multi_assign(self):
         # GH 3626, an assignment of a sub-df to a df
         # set float64 to avoid upcast when setting nan
@@ -654,7 +652,7 @@ class TestMisc:
         df.loc[df.index] = df.loc[df.index]
         tm.assert_frame_equal(df, df2)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="can't set int into string")
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set int into string")
     def test_rhs_alignment(self):
         # GH8258, tests that both rows & columns are aligned to what is
         # assigned to. covers both uniform data-type & multi-type cases

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -13,7 +13,7 @@ from dateutil.tz import gettz
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas._libs import index as libindex
 from pandas.errors import IndexingError
@@ -1204,7 +1204,7 @@ class TestLocBaseIndependent:
 
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="can't set int into string")
+    @pytest.mark.xfail(using_string_dtype(), reason="can't set int into string")
     def test_loc_setitem_str_to_small_float_conversion_type(self):
         # GH#20388
 

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -17,7 +17,7 @@ from zipfile import BadZipFile
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas.util._test_decorators as td
 
@@ -691,9 +691,7 @@ class TestReaders:
         )
         tm.assert_frame_equal(result, df)
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="infer_string takes precedence"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="infer_string takes precedence")
     def test_dtype_backend_string(self, read_ext, string_storage, tmp_excel):
         # GH#36712
         if read_ext in (".xlsb", ".xls"):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -11,7 +11,7 @@ from shutil import get_terminal_size
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas as pd
 from pandas import (
@@ -1347,9 +1347,7 @@ class TestSeriesFormatting:
         sf = fmt.SeriesFormatter(s, name="\u05e2\u05d1\u05e8\u05d9\u05ea")
         sf._get_footer()  # should not raise exception
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="Fixup when arrow is default"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="Fixup when arrow is default")
     def test_east_asian_unicode_series(self):
         # not aligned properly because of east asian width
 
@@ -1724,9 +1722,7 @@ class TestSeriesFormatting:
         ncolsizes = len({len(line.strip()) for line in lines})
         assert ncolsizes == 1
 
-    @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="change when arrow is default"
-    )
+    @pytest.mark.xfail(using_string_dtype(), reason="change when arrow is default")
     def test_format_explicit(self):
         test_sers = gen_series_formatting()
         with option_context("display.max_rows", 4, "display.show_dimensions", False):

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas import (
     CategoricalIndex,
@@ -849,7 +849,7 @@ class TestDataFrameToString:
         frame.to_string()
 
     # TODO: split or simplify this test?
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="fix when arrow is default")
+    @pytest.mark.xfail(using_string_dtype(), reason="fix when arrow is default")
     def test_to_string_index_with_nan(self):
         # GH#2850
         df = DataFrame(

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -10,7 +10,7 @@ import time
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.compat import IS64
 import pandas.util._test_decorators as td
@@ -1573,7 +1573,7 @@ class TestPandasContainer:
 
     # TODO: We are casting to string which coerces None to NaN before casting back
     # to object, ending up with incorrect na values
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="incorrect na conversion")
+    @pytest.mark.xfail(using_string_dtype(), reason="incorrect na conversion")
     @pytest.mark.parametrize("orient", ["split", "records", "index", "columns"])
     def test_to_json_from_json_columns_dtypes(self, orient):
         # GH21892 GH33205
@@ -1854,7 +1854,7 @@ class TestPandasContainer:
         assert result == expected
 
     @pytest.mark.skipif(
-        using_pyarrow_string_dtype(),
+        using_string_dtype(),
         reason="Adjust expected when infer_string is default, no bug here, "
         "just a complicated parametrization",
     )

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -9,7 +9,7 @@ import re
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.compat.numpy import np_version_gte1p25
 
@@ -2656,7 +2656,7 @@ class TestPivot:
         with pytest.raises(TypeError, match="missing 1 required keyword-only argument"):
             df.pivot()
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="None is cast to NaN")
+    @pytest.mark.xfail(using_string_dtype(), reason="None is cast to NaN")
     def test_pivot_columns_is_none(self):
         # GH#48293
         df = DataFrame({None: [1], "b": 2, "c": 3})
@@ -2672,7 +2672,7 @@ class TestPivot:
         expected = DataFrame({1: 3}, index=Index([2], name="b"))
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="None is cast to NaN")
+    @pytest.mark.xfail(using_string_dtype(), reason="None is cast to NaN")
     def test_pivot_index_is_none(self):
         # GH#48293
         df = DataFrame({None: [1], "b": 2, "c": 3})
@@ -2686,7 +2686,7 @@ class TestPivot:
         expected = DataFrame(3, index=[1], columns=Index([2], name="b"))
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="None is cast to NaN")
+    @pytest.mark.xfail(using_string_dtype(), reason="None is cast to NaN")
     def test_pivot_values_is_none(self):
         # GH#48293
         df = DataFrame({None: [1], "b": 2, "c": 3})

--- a/pandas/tests/series/indexing/test_where.py
+++ b/pandas/tests/series/indexing/test_where.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas.core.dtypes.common import is_integer
 
@@ -231,7 +231,7 @@ def test_where_ndframe_align():
     tm.assert_series_equal(out, expected)
 
 
-@pytest.mark.xfail(using_pyarrow_string_dtype(), reason="can't set ints into string")
+@pytest.mark.xfail(using_string_dtype(), reason="can't set ints into string")
 def test_where_setitem_invalid():
     # GH 2702
     # make sure correct exceptions are raised on invalid list assignment

--- a/pandas/tests/series/methods/test_reindex.py
+++ b/pandas/tests/series/methods/test_reindex.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 from pandas import (
     NA,
@@ -22,9 +22,7 @@ from pandas import (
 import pandas._testing as tm
 
 
-@pytest.mark.xfail(
-    using_pyarrow_string_dtype(), reason="share memory doesn't work for arrow"
-)
+@pytest.mark.xfail(using_string_dtype(), reason="share memory doesn't work for arrow")
 def test_reindex(datetime_series, string_series):
     identity = string_series.reindex(string_series.index)
 

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -3,7 +3,7 @@ import re
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas as pd
 import pandas._testing as tm
@@ -359,7 +359,7 @@ class TestSeriesReplace:
         expected = pd.Series([1, np.nan, 3, np.nan, 4, 5], dtype=object)
         tm.assert_series_equal(expected, result)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="can't fill 0 in string")
+    @pytest.mark.xfail(using_string_dtype(), reason="can't fill 0 in string")
     @pytest.mark.parametrize(
         "categorical, numeric",
         [
@@ -620,7 +620,7 @@ class TestSeriesReplace:
         with pytest.raises(TypeError, match="Invalid value"):
             ints.replace(1, 9.5)
 
-    @pytest.mark.xfail(using_pyarrow_string_dtype(), reason="can't fill 1 in string")
+    @pytest.mark.xfail(using_string_dtype(), reason="can't fill 1 in string")
     @pytest.mark.parametrize("regex", [False, True])
     def test_replace_regex_dtype_series(self, regex):
         # GH-48644

--- a/pandas/tests/series/test_formats.py
+++ b/pandas/tests/series/test_formats.py
@@ -6,7 +6,7 @@ from datetime import (
 import numpy as np
 import pytest
 
-from pandas._config import using_pyarrow_string_dtype
+from pandas._config import using_string_dtype
 
 import pandas as pd
 from pandas import (
@@ -144,7 +144,7 @@ class TestSeriesRepr:
         assert "Name: 0" in rep_str
 
     @pytest.mark.xfail(
-        using_pyarrow_string_dtype(), reason="TODO: investigate why this is failing"
+        using_string_dtype(), reason="TODO: investigate why this is failing"
     )
     def test_newline(self):
         ser = Series(["a\n\r\tb"], name="a\n\r\td", index=["a\n\r\tf"])


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/54792

This is a plain search-replace of `using_pyarrow_string_dtype` with `using_string_dtype` plus some automated formatting because of the change.

Given the future string dtype will not be strictly backed by pyarrow, this general config helper to check if the future option is enabled can be better renamed (we might need a more specific check if we are using the pyarrow variant in certain cases later, but that can be added when needed), and given there are coming more PRs working on this, better to do this rename first.
