### PR TITLE
DOC: Fix link to Conda package in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The source code is currently hosted on GitHub at:
 https://github.com/pandas-dev/pandas
 
 Binary installers for the latest released version are available at the [Python
-Package Index (PyPI)](https://pypi.org/project/pandas) and on [Conda](https://docs.conda.io/en/latest/).
+Package Index (PyPI)](https://pypi.org/project/pandas) and on [Conda](https://anaconda.org/conda-forge/pandas).
 
 ```sh
 # conda


### PR DESCRIPTION
Corrected the Conda link in the `README.md` file to point directly to the pandas package page on Conda Forge instead of the general Conda documentation.