### PR TITLE
BUG: fix for _validate_setitem_value fails to raise for PandasArray and fix tests

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -627,6 +627,7 @@ ExtensionArray
 - Bug in :meth:`.arrays.ArrowExtensionArray.__setitem__` which caused wrong behavior when using an integer array with repeated values as a key (:issue:`58530`)
 - Bug in :meth:`api.types.is_datetime64_any_dtype` where a custom :class:`ExtensionDtype` would return ``False`` for array-likes (:issue:`57055`)
 - Bug in various :class:`DataFrame` reductions for pyarrow temporal dtypes returning incorrect dtype when result was null (:issue:`59234`)
+- Bug in :class:`NumpyExtensionArray` where it did not raise any error if validated value to be inserted did not have the same dtype (:issue:`51044`).
 
 Styler
 ^^^^^^

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -232,7 +232,7 @@ class NumpyExtensionArray(  # type: ignore[misc]
             fill_value = self.dtype.na_value
         return fill_value
 
-    def _validate_setitem_value(self, value):
+    def _validate_setitem_value(self, value) -> type(value) | None:
         """
         Check if we have a scalar that we can cast losslessly.
 

--- a/pandas/tests/arrays/numpy_/test_numpy.py
+++ b/pandas/tests/arrays/numpy_/test_numpy.py
@@ -275,12 +275,15 @@ def test_setitem_object_typecode(dtype):
 def test_setitem_no_coercion():
     # https://github.com/pandas-dev/pandas/issues/28150
     arr = NumpyExtensionArray(np.array([1, 2, 3]))
-    with pytest.raises(ValueError, match="int"):
+    with pytest.raises(TypeError):
         arr[0] = "a"
 
     # With a value that we do coerce, check that we coerce the value
     #  and not the underlying array.
-    arr[0] = 2.5
+    with pytest.raises(TypeError):
+        arr[0] = 2.5
+
+    arr[0] = 9
     assert isinstance(arr[0], (int, np.integer)), type(arr[0])
 
 
@@ -296,7 +299,10 @@ def test_setitem_preserves_views():
     assert view2[0] == 9
     assert view3[0] == 9
 
-    arr[-1] = 2.5
+    with pytest.raises(TypeError):
+        arr[-1] = 2.5
+
+    arr[-1] = 4
     view1[-1] = 5
     assert arr[-1] == 5
 


### PR DESCRIPTION
- [ x] closes #51044. Added _validate_setitem_value method to NumpyExtensionArray class
- [ x] All tests passed. Modified 2 tests as per new expected behavior.
- [ x] All code checks passed(https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ x] Added type annotations(https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to methods.
- [ x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
