### PR TITLE
BUG: Added test for setitem using loc not aligning on index

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -3264,3 +3264,14 @@ class TestLocSeries:
             index=Index(np.array(ids).repeat(1000), dtype="Int64"),
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_loc_index_alignment_for_series(self):
+        # GH #56024
+        df = DataFrame({"a": [1, 2], "b": [3, 4]})
+        other = Series([200, 999], index=[1, 0])
+        df.loc[:, "a"] = other
+        expected = DataFrame({"a": [200, 999], "b": [3, 4]})
+        print(expected)
+        print(df)
+        tm.assert_frame_equal(expected, df)
+        # assert expected.equals(df)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -3270,8 +3270,5 @@ class TestLocSeries:
         df = DataFrame({"a": [1, 2], "b": [3, 4]})
         other = Series([200, 999], index=[1, 0])
         df.loc[:, "a"] = other
-        expected = DataFrame({"a": [200, 999], "b": [3, 4]})
-        print(expected)
-        print(df)
+        expected = DataFrame({"a": [999, 200], "b": [3, 4]})
         tm.assert_frame_equal(expected, df)
-        # assert expected.equals(df)


### PR DESCRIPTION
- [x] closes #56024
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
