### PR TITLE
DEPR: keep_default_dates and convert_dates in read_json

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1926,7 +1926,6 @@ is ``None``. To explicitly force ``Series`` parsing, pass ``typ=series``
 * ``dtype`` : if True, infer dtypes, if a dict of column to dtype, then use those, if ``False``, then don't infer dtypes at all, default is True, apply only to the data.
 * ``convert_axes`` : boolean, try to convert the axes to the proper dtypes, default is ``True``
 * ``convert_dates`` : a list of columns to parse for dates; If ``True``, then try to parse date-like columns, default is ``True``.
-* ``keep_default_dates`` : boolean, default ``True``. If parsing dates, then parse the default date-like columns.
 * ``precise_float`` : boolean, default ``False``. Set to enable usage of higher precision (strtod) function when decoding string to double values. Default (``False``) is to use fast but less precise builtin functionality.
 * ``date_unit`` : string, the timestamp unit to detect if converting dates. Default
   None. By default the timestamp precision will be detected, if this is not desired

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -152,7 +152,7 @@ class TestPandasContainer:
 
         with tm.assert_produces_warning(expected_warning, match=msg):
             result = read_json(
-                StringIO(df.to_json(orient=orient)), orient=orient, convert_dates=["x"]
+                StringIO(df.to_json(orient=orient)), orient=orient
             )
         if orient == "values":
             expected = DataFrame(data)
@@ -840,7 +840,7 @@ class TestPandasContainer:
         with tm.assert_produces_warning(FutureWarning, match=msg):
             json = StringIO(df.to_json(date_unit="ns"))
 
-        result = read_json(json, convert_dates=False)
+        result = read_json(json)
         expected = df.copy()
         expected["date"] = expected["date"].values.view("i8")
         expected["foo"] = expected["foo"].astype("int64")
@@ -1056,7 +1056,7 @@ class TestPandasContainer:
         # TODO: check_dtype/check_index_type should be removable
         # once read_json gets non-nano support
         tm.assert_frame_equal(
-            read_json(buf, convert_dates=["date", "date_obj"]),
+            read_json(buf),
             df,
             check_index_type=False,
             check_dtype=False,
@@ -1125,7 +1125,7 @@ class TestPandasContainer:
     def test_url(self, field, dtype, httpserver):
         data = '{"created_at": ["2023-06-23T18:21:36Z"], "closed_at": ["2023-06-23T18:21:36"], "updated_at": ["2023-06-23T18:21:36Z"]}\n'  # noqa: E501
         httpserver.serve_content(content=data)
-        result = read_json(httpserver.url, convert_dates=True)
+        result = read_json(httpserver.url)
         assert result[field].dtype == dtype
 
     def test_timedelta(self):

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -224,8 +224,6 @@ def test_readjson_chunks_closes(chunksize):
             typ="frame",
             dtype=True,
             convert_axes=True,
-            convert_dates=True,
-            keep_default_dates=True,
             precise_float=False,
             date_unit=None,
             encoding=None,

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -86,7 +86,7 @@ def test_to_read_gcs(gcs_buffer, format, monkeypatch, capsys, request):
         )
         with tm.assert_produces_warning(FutureWarning, match=msg):
             df1.to_json(path)
-        df2 = read_json(path, convert_dates=["dt"])
+        df2 = read_json(path)
     elif format == "parquet":
         pytest.importorskip("pyarrow")
         pa_fs = pytest.importorskip("pyarrow.fs")


### PR DESCRIPTION
Issue #59161

(NOT TOTALLY DONE THIS IS A DRAFT PULL REQUEST ... THE DESCRIPTION WILL BE DONE IN PROFESSIONAL LANGUAGE IF I CAN GET TO THE ACTUAL PULL REQUEST)

New contributor and self-taught non-professional programmer who loves pandas and fixed a few tests here in 2022.

The part not finished yet = refactoring `dtype` conversion to use `infer_dtype` instead of `astype` guessing ... reading the directions closely enough to get the development environment built correctly took a while and then I've made quite a few changes and am a little bit confused about the aforementioned part and was hoping to get the other changes checked in order to make sure that I am on the correct path.

I tried to delete instances of `keep_default_dates` and `convert_dates` in parameters, calls, and corresponding tests of `read_json` and in related functions, so that it will fall back on using `dtype` conversions from the ujson parser, while keeping the functions and tests intact whenever they are not totally dependent on `keep_default_dates` and `convert_dates`.

`convert_dates` also exists in a file for `sas7bdat` and in parts of the code involving `Stata`, but not as part of the `read_json` function in such cases, so I am pretty sure that these are separate but I wanted to check.
