### PR TITLE
Update resample.py

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1617,6 +1617,24 @@ class DatetimeIndexResampler(Resampler):
     def _resampler_for_grouping(self) -> type[DatetimeIndexResamplerGroupby]:
         return DatetimeIndexResamplerGroupby
 
+    def _get_resampler_for_grouping(self, groupby, how, fill_method, limit, kind):
+        """
+        Return a resampler for groupby object.
+        """
+        self.groupby = groupby
+        self._on = getattr(groupby, 'on', None)
+        if self._on is not None:
+            groupby._selected_obj = groupby._selected_obj.reset_index(drop=True).set_index(self._on)
+        return self._get_resampler(how, fill_method, limit, kind)
+
+    def _get_resampler(self, how, fill_method, limit, kind):
+        """
+        Return a resampler for non-groupby object.
+        """
+        if self._on is not None:
+            self._selected_obj = self._selected_obj.reset_index(drop=True).set_index(self._on)
+        return super()._get_resampler(how, fill_method, limit, kind)
+
     def _get_binner_for_time(self):
         # this is how we are actually creating the bins
         if isinstance(self.ax, PeriodIndex):


### PR DESCRIPTION
Update to solve :-

BUG: groupby then resample on column gives incorrect results if the index is out of order #59350

- [x] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
