### PR TITLE
TST (string dtype): replace string_storage fixture with explicit storage/na_value keyword arguments for dtype creation

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1312,6 +1312,24 @@ def string_storage(request):
 
 @pytest.fixture(
     params=[
+        ("python", pd.NA),
+        pytest.param(("pyarrow", pd.NA), marks=td.skip_if_no("pyarrow")),
+        pytest.param(("pyarrow", np.nan), marks=td.skip_if_no("pyarrow")),
+    ]
+)
+def string_dtype_arguments(request):
+    """
+    Parametrized fixture for StringDtype storage and na_value.
+
+    * 'python' + pd.NA
+    * 'pyarrow' + pd.NA
+    * 'pyarrow' + np.nan
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
         "numpy_nullable",
         pytest.param("pyarrow", marks=td.skip_if_no("pyarrow")),
     ]

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -23,9 +23,10 @@ from pandas.core.arrays.string_arrow import (
 
 
 @pytest.fixture
-def dtype(string_storage):
-    """Fixture giving StringDtype from parametrized 'string_storage'"""
-    return pd.StringDtype(storage=string_storage)
+def dtype(string_dtype_arguments):
+    """Fixture giving StringDtype from parametrized storage and na_value arguments"""
+    storage, na_value = string_dtype_arguments
+    return pd.StringDtype(storage=storage, na_value=na_value)
 
 
 @pytest.fixture

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -59,8 +59,9 @@ def chunked(request):
 
 
 @pytest.fixture
-def dtype(string_storage):
-    return StringDtype(storage=string_storage)
+def dtype(string_dtype_arguments):
+    storage, na_value = string_dtype_arguments
+    return StringDtype(storage=storage, na_value=na_value)
 
 
 @pytest.fixture


### PR DESCRIPTION
The `string_storage` fixture is currently still parametrized as "python", "pyarrow" and "pyarrow_numpy". In light of the PDEP-14 work, we need to get rid of the "pyarrow_numpy" option (since this is replaced by `storage="pyarrrow", na_value=np.nan`). 

This PR introduces a new fixture to replace the current one for a subset of its use cases, where we currently use it to create the different variants of the string dtype. 

(we might also want to have a direct top-level fixture for those string dtype, but: 1) for those tests, the fixture should be named `dtype` and so easier to keep that defined within the file, 2) we already have a top-level `any_string_dtype` fixture, but that also includes `object` dtype)


xref https://github.com/pandas-dev/pandas/issues/54792