### PR TITLE
DOC: Add 'See Also' and 'Parameters' for pandas.api.indexers.VariableOffsetWindowIndexer

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -267,7 +267,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.extensions.ExtensionArray.tolist RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.unique RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.view SA01" \
-        -i "pandas.api.indexers.VariableOffsetWindowIndexer PR01,SA01" \
         -i "pandas.api.interchange.from_dataframe RT03,SA01" \
         -i "pandas.api.types.is_any_real_numeric_dtype SA01" \
         -i "pandas.api.types.is_bool PR01,SA01" \

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -167,6 +167,31 @@ class VariableOffsetWindowIndexer(BaseIndexer):
     """
     Calculate window boundaries based on a non-fixed offset such as a BusinessDay.
 
+    Parameters
+    ----------
+    index_array : np.ndarray, default 0
+        Array-like structure specifying the indices for data points.
+        This parameter is currently not used.
+
+    window_size : int, optional, default 0
+        Specifies the number of data points in each window.
+        This parameter is currently not used.
+
+    index : DatetimeIndex, optional
+        ``DatetimeIndex`` of the labels of each observation.
+
+    offset : BaseOffset, optional
+        ``DateOffset`` representing the size of the window.
+
+    **kwargs
+        Additional keyword arguments passed to the parent class ``BaseIndexer``.
+
+    See Also
+    --------
+    api.indexers.BaseIndexer : Base class for all indexers.
+    DataFrame.rolling : Rolling window calculations on DataFrames.
+    offsets : Module providing various time offset classes.
+
     Examples
     --------
     >>> from pandas.api.indexers import VariableOffsetWindowIndexer


### PR DESCRIPTION
Add 'See Also' and 'Parameters' for pandas.api.indexers.VariableOffsetWindowIndexer

- xref https://github.com/pandas-dev/pandas/issues/58577 fixes pandas.api.indexers.VariableOffsetWindowIndexer
