### PR TITLE
make dtype to be ignored in constructors if data is Series or DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -705,6 +705,7 @@ class DataFrame(NDFrame, OpsMixin):
         if isinstance(data, DataFrame):
             data = data._mgr
             allow_mgr = True
+            dtype = None
             if not copy:
                 # if not copying data, ensure to still return a shallow copy
                 # to avoid the result sharing the same Manager

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -445,6 +445,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                     "compound dtype.  Use DataFrame instead."
                 )
         elif isinstance(data, Series):
+            dtype = None
             if index is None:
                 index = data.index
                 data = data._mgr.copy(deep=False)


### PR DESCRIPTION
The note in the docs added in #59300 wasn't sufficient: the dtype kwarg was ignored in certain cases. Set it to None if creating Series from another Series and the same for DataFrames. See GH pandas-dev#59060.

Request review from @mroeschke and @jorisvandenbossche

- [x] closes #59060
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
