### PR TITLE
DOC: Enforce Numpy Docstring Validation | pandas.api.extensions.ExtensionArray

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -193,7 +193,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.Timestamp.value GL08" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray.dtype SA01" \
         -i "pandas.api.extensions.ExtensionArray.duplicated RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.fillna SA01" \
         -i "pandas.api.extensions.ExtensionArray.insert PR07,RT03,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -193,7 +193,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.Timestamp.value GL08" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray.astype SA01" \
         -i "pandas.api.extensions.ExtensionArray.dropna RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.dtype SA01" \
         -i "pandas.api.extensions.ExtensionArray.duplicated RT03,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -193,7 +193,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.Timestamp.value GL08" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray._values_for_factorize SA01" \
         -i "pandas.api.extensions.ExtensionArray.astype SA01" \
         -i "pandas.api.extensions.ExtensionArray.dropna RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.dtype SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -193,7 +193,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.Timestamp.value GL08" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray._pad_or_backfill PR01,RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray._reduce RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray._values_for_factorize SA01" \
         -i "pandas.api.extensions.ExtensionArray.astype SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -193,7 +193,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.Timestamp.value GL08" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray._reduce RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray._values_for_factorize SA01" \
         -i "pandas.api.extensions.ExtensionArray.astype SA01" \
         -i "pandas.api.extensions.ExtensionArray.dropna RT03,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -193,7 +193,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.Timestamp.value GL08" \
         -i "pandas.Timestamp.year GL08" \
-        -i "pandas.api.extensions.ExtensionArray.dropna RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.dtype SA01" \
         -i "pandas.api.extensions.ExtensionArray.duplicated RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.fillna SA01" \

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -713,6 +713,16 @@ class ExtensionArray:
             An ``ExtensionArray`` if ``dtype`` is ``ExtensionDtype``,
             otherwise a Numpy ndarray with ``dtype`` for its dtype.
 
+        See Also
+        --------
+        Series.astype : Cast a Series to a different dtype.
+        DataFrame.astype : Cast a DataFrame to a different dtype.
+        api.extensions.ExtensionArray : Base class for ExtensionArray objects.
+        core.arrays.DatetimeArray._from_sequence : Create a DatetimeArray from a
+            sequence.
+        core.arrays.TimedeltaArray._from_sequence : Create a TimedeltaArray from
+            a sequence.
+
         Examples
         --------
         >>> arr = pd.array([1, 2, 3])

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -608,6 +608,14 @@ class ExtensionArray:
         """
         An instance of ExtensionDtype.
 
+        See Also
+        --------
+        api.extensions.ExtensionDtype : Base class for extension dtypes.
+        api.extensions.ExtensionArray : Base class for extension array types.
+        api.extensions.ExtensionArray.dtype : The dtype of an ExtensionArray.
+        Series.dtype : The dtype of a Series.
+        DataFrame.dtype : The dtype of a DataFrame.
+
         Examples
         --------
         >>> pd.array([1, 2, 3]).dtype
@@ -2065,10 +2073,6 @@ class ExtensionArray:
         2.0
         >>> pd.array([1, 2, 3])._reduce("median")
         2.0
-        >>> pd.array([1, np.nan, 2, np.nan])._reduce("sum", skipna=False)
-        nan
-        >>> pd.array([1, np.nan, 2, np.nan])._reduce("sum", skipna=True)
-        3
         """
         meth = getattr(self, name, None)
         if meth is None:

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1175,6 +1175,16 @@ class ExtensionArray:
 
         Returns
         -------
+        Self
+            An ExtensionArray of the same type as the original but with all
+            NA values removed.
+
+        See Also
+        --------
+        Series.dropna : Remove missing values from a Series.
+        DataFrame.dropna : Remove missing values from a DataFrame.
+        api.extensions.ExtensionArray.isna : Check for missing values in
+            an ExtensionArray.
 
         Examples
         --------

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1439,6 +1439,10 @@ class ExtensionArray:
             `-1` and not included in `uniques`. By default,
             ``np.nan`` is used.
 
+        See Also
+        --------
+        util.hash_pandas_object : Hash the pandas object.
+
         Notes
         -----
         The values returned by this method are also used in

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -2004,16 +2004,47 @@ class ExtensionArray:
 
         Returns
         -------
-        scalar
+        scalar or ndarray:
+            The result of the reduction operation. The type of the result
+            depends on `keepdims`:
+            - If `keepdims` is `False`, a scalar value is returned.
+            - If `keepdims` is `True`, the result is wrapped in a numpy array with
+            a single element.
 
         Raises
         ------
         TypeError : subclass does not define operations
 
+        See Also
+        --------
+        Series.min : Return the minimum value.
+        Series.max : Return the maximum value.
+        Series.sum : Return the sum of values.
+        Series.mean : Return the mean of values.
+        Series.median : Return the median of values.
+        Series.std : Return the standard deviation.
+        Series.var : Return the variance.
+        Series.prod : Return the product of values.
+        Series.sem : Return the standard error of the mean.
+        Series.kurt : Return the kurtosis.
+        Series.skew : Return the skewness.
+
         Examples
         --------
         >>> pd.array([1, 2, 3])._reduce("min")
         1
+        >>> pd.array([1, 2, 3])._reduce("max")
+        3
+        >>> pd.array([1, 2, 3])._reduce("sum")
+        6
+        >>> pd.array([1, 2, 3])._reduce("mean")
+        2.0
+        >>> pd.array([1, 2, 3])._reduce("median")
+        2.0
+        >>> pd.array([1, np.nan, 2, np.nan])._reduce("sum", skipna=False)
+        nan
+        >>> pd.array([1, np.nan, 2, np.nan])._reduce("sum", skipna=True)
+        3
         """
         meth = getattr(self, name, None)
         if meth is None:

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1032,6 +1032,12 @@ class ExtensionArray:
             maximum number of entries along the entire axis where NaNs will be
             filled.
 
+        limit_area : {'inside', 'outside'} or None, default None
+            Specifies which area to limit filling.
+            - 'inside': Limit the filling to the area within the gaps.
+            - 'outside': Limit the filling to the area outside the gaps.
+            If `None`, no limitation is applied.
+
         copy : bool, default True
             Whether to make a copy of the data before filling. If False, then
             the original should be modified and no new memory should be allocated.
@@ -1043,6 +1049,16 @@ class ExtensionArray:
         Returns
         -------
         Same type as self
+            The filled array with the same type as the original.
+
+        See Also
+        --------
+        Series.ffill : Forward fill missing values.
+        Series.bfill : Backward fill missing values.
+        DataFrame.ffill : Forward fill missing values in DataFrame.
+        DataFrame.bfill : Backward fill missing values in DataFrame.
+        api.types.isna : Check for missing values.
+        api.types.isnull : Check for missing values.
 
         Examples
         --------


### PR DESCRIPTION
- xref https://github.com/pandas-dev/pandas/issues/58539

fixes:
```
pandas.api.extensions.ExtensionArray._pad_or_backfill 
pandas.api.extensions.ExtensionArray._reduce
pandas.api.extensions.ExtensionArray._values_for_factorize
pandas.api.extensions.ExtensionArray.astype
pandas.api.extensions.ExtensionArray.dropna
pandas.api.extensions.ExtensionArray.dtype
```

