### PR TITLE
DOC: Improve sort parameter doc of DataFrameGroupBy.value_counts

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -746,7 +746,7 @@ class SeriesGroupBy(GroupBy[Series]):
         normalize : bool, default False
             Return proportions rather than frequencies.
         sort : bool, default True
-            Sort by frequencies when True. Sort by DataFrame column values when False.
+            Sort by frequencies when True.
         ascending : bool, default False
             Sort in ascending order.
         bins : int or list of ints, optional

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -2303,7 +2303,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         normalize : bool, default False
             Return proportions rather than frequencies.
         sort : bool, default True
-            Sort by frequencies.
+            Sort by frequencies when True. Sort by DataFrame column values when False.
         ascending : bool, default False
             Sort in ascending order.
         dropna : bool, default True

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -746,7 +746,7 @@ class SeriesGroupBy(GroupBy[Series]):
         normalize : bool, default False
             Return proportions rather than frequencies.
         sort : bool, default True
-            Sort by frequencies when True.
+            Sort by frequencies.
         ascending : bool, default False
             Sort in ascending order.
         bins : int or list of ints, optional

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -746,7 +746,7 @@ class SeriesGroupBy(GroupBy[Series]):
         normalize : bool, default False
             Return proportions rather than frequencies.
         sort : bool, default True
-            Sort by frequencies.
+            Sort by frequencies when True. Sort by DataFrame column values when False.
         ascending : bool, default False
             Sort in ascending order.
         bins : int or list of ints, optional

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -746,7 +746,7 @@ class SeriesGroupBy(GroupBy[Series]):
         normalize : bool, default False
             Return proportions rather than frequencies.
         sort : bool, default True
-            Sort by frequencies when True. Sort by DataFrame column values when False.
+            Sort by frequencies when True. Preserve the order of the data when False.
         ascending : bool, default False
             Sort in ascending order.
         bins : int or list of ints, optional


### PR DESCRIPTION
- [x] closes #59307 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


I just copied the sort docstring of `Dataframe.value_counts` since the latter is mirrored to behaved like it.

![image](https://github.com/user-attachments/assets/26ad12af-e69e-40c1-97e8-c75708af16b8)

