### PR TITLE
API/TST: expand tests for string any/all reduction + fix pyarrow-based implementation

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -697,9 +697,9 @@ class ArrowStringArrayNumpySemantics(ArrowStringArray):
         self, name: str, *, skipna: bool = True, keepdims: bool = False, **kwargs
     ):
         if name in ["any", "all"]:
-            if not skipna and name == "all":
-                nas = pc.invert(pc.is_null(self._pa_array))
-                arr = pc.and_kleene(nas, pc.not_equal(self._pa_array, ""))
+            if not skipna:
+                nas = pc.is_null(self._pa_array)
+                arr = pc.or_kleene(nas, pc.not_equal(self._pa_array, ""))
             else:
                 arr = pc.not_equal(self._pa_array, "")
             return ArrowExtensionArray(arr)._reduce(


### PR DESCRIPTION
While working on adding any/all support for the object-dtype version of the StringDtype in https://github.com/pandas-dev/pandas/pull/58451, I bumped into some issues with the current testing and implementation.

It seemed that our current testing is a bit limited, so I expanded the existing test to cover more cases and to be parametrized over all string dtype variants (including plain object dtype).

But that uncovered some issues with the current implementation of the pyarrow-backed version:

- `any` could return `pd.NA` in case of `skipna=False`, while for this version of the string dtype (not using Kleene logic), the result should always be True or False. This is an easy fix (we currently were only filling missing values in case of `all`, also do this for `any`)
- **How to treat missing values?** As truthy or falsey? The current pyarrow-based implementation explicitly filled the missing values with False, but the [documentation](https://pandas.pydata.org/docs/reference/api/pandas.Series.any.html) says _"If skipna is False, then NA are treated as True, because these are not equal to zero."_ 
  I find that a bit strange (my first expectation would be to treat missing values as False), but it _is_ explicitly documented, and follows the behaviour of current object dtype (eg  `pd.Series(["a". np.nan], dtype=object).all(skipna=False)` gives True, not False.

So for now this PR updated the pyarrow implementation to follow the documented behaviour.

- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
