### PR TITLE
DOC: Update the usage of rtol and atol arguments

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1159,9 +1159,9 @@ def assert_frame_equal(
         If True, compare by blocks.
     check_exact : bool, default False
         Whether to compare number exactly. If False, the comparison uses the
-        relative tolerance (`rtol`) and absolute tolerance (`atol`)
+        relative tolerance (``rtol``) and absolute tolerance (``atol``)
         parameters to determine if two values are considered close,
-        according to the formula: `|a - b| <= (atol + rtol * |b|)`.
+        according to the formula: ``|a - b| <= (atol + rtol * |b|)``.
 
         .. versionchanged:: 2.2.0
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1158,7 +1158,10 @@ def assert_frame_equal(
         Specify how to compare internal data. If False, compare by columns.
         If True, compare by blocks.
     check_exact : bool, default False
-        Whether to compare number exactly.
+        Whether to compare number exactly. If False, the comparison uses the
+        relative tolerance (`rtol`) and absolute tolerance (`atol`)
+        parameters to determine if two values are considered close,
+        according to the formula: `|a - b| <= (atol + rtol * |b|)`.
 
         .. versionchanged:: 2.2.0
 


### PR DESCRIPTION
 Update the usage of `rtol` and `atol` arguments in `pd.testing.assert_frame_equal`

- [x] closes #59344
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).