### PR TITLE
String dtype: fix alignment sorting in case of python storage

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9542,6 +9542,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 join_index, lidx, ridx = self.index.join(
                     other.index, how=join, level=level, return_indexers=True
                 )
+
             if is_series:
                 left = self._reindex_indexer(join_index, lidx)
             elif lidx is None or join_index is None:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9542,7 +9542,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 join_index, lidx, ridx = self.index.join(
                     other.index, how=join, level=level, return_indexers=True
                 )
-
             if is_series:
                 left = self._reindex_indexer(join_index, lidx)
             elif lidx is None or join_index is None:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4884,7 +4884,10 @@ class Index(IndexOpsMixin, PandasObject):
             return (
                 isinstance(self.dtype, np.dtype)
                 or isinstance(self._values, (ArrowExtensionArray, BaseMaskedArray))
-                or self.dtype == "string[python]"
+                or (
+                    isinstance(self.dtype, StringDtype)
+                    and self.dtype.storage == "python"
+                )
             )
         # Exclude index types where the conversion to numpy converts to object dtype,
         #  which negates the performance benefit of libjoin

--- a/pandas/tests/series/methods/test_align.py
+++ b/pandas/tests/series/methods/test_align.py
@@ -148,6 +148,19 @@ def test_align_periodindex(join_type):
     ts.align(ts[::2], join=join_type)
 
 
+def test_align_stringindex(any_string_dtype):
+    left = Series(range(3), index=pd.Index(["a", "b", "d"], dtype=any_string_dtype))
+    right = Series(range(3), index=pd.Index(["a", "b", "c"], dtype=any_string_dtype))
+    result_left, result_right = left.align(right)
+
+    expected_idx = pd.Index(["a", "b", "c", "d"], dtype=any_string_dtype)
+    expected_left = Series([0, 1, np.nan, 2], index=expected_idx)
+    expected_right = Series([0, 1, 2, np.nan], index=expected_idx)
+
+    tm.assert_series_equal(result_left, expected_left)
+    tm.assert_series_equal(result_right, expected_right)
+
+
 def test_align_left_fewer_levels():
     # GH#45224
     left = Series([2], index=pd.MultiIndex.from_tuples([(1, 3)], names=["a", "c"]))


### PR DESCRIPTION
Follow-up on the implementation of the object-dtype version of the NaN string dtype in https://github.com/pandas-dev/pandas/pull/58451. From expanding test coverage for this dtype in https://github.com/pandas-dev/pandas/pull/59437, there were a lot of alignment failures:

```
In [1]: pd.options.future.infer_string = True

In [2]: a = Series([1, 1, 1, np.nan], index=["a", "b", "c", "d"])
   ...: b = Series([2, np.nan, 1, np.nan], index=["a", "b", "d", "e"])

In [3]: b.align(a)
Out[3]: 
(a    2.0
 b    NaN
 d    1.0
 e    NaN
 c    NaN
 dtype: float64,
 a    1.0
 b    1.0
 d    NaN
 e    NaN
 c    1.0
 dtype: float64)
```

The above result is not sorted, while normally alignment does sort by default. 

The underlying issue is that `idx1.union(idx2, sort=True)` is not sorting for string dtype (will open a separate issue for that), but the reason we were getting to that code path is because we didn't correctly indicate we can use the faster libjoin for this dtype.

xref https://github.com/pandas-dev/pandas/issues/54792