### PR TITLE
Fix link to JSON TAB standard in pdeps

### DIFF
--- a/web/pandas/pdeps/0012-compact-and-reversible-JSON-interface.md
+++ b/web/pandas/pdeps/0012-compact-and-reversible-JSON-interface.md
@@ -291,7 +291,7 @@ Note:
 
 The JSON format for the TableSchema interface is the existing.
 
-The JSON format for the Global interface is defined in [JSON-TAB](https://github.com/loco-philippe/NTV/blob/main/documentation/JSON-TAB-standard.pdf) specification.
+The JSON format for the Global interface is defined in [JSON-TAB](https://github.com/loco-philippe/NTV/blob/v1.1.0/documentation/JSON-TAB-standard.pdf) specification.
 It includes the naming rules originally defined in the [JSON-ND project](https://github.com/glenkleidon/JSON-ND) and support for categorical data.
 The specification have to be updated to include sparse data.
 


### PR DESCRIPTION
Hi, i found that the backlink to the PDF was not working, i linked it to the version where it was still there. I did not create any issue as its a simple fix to a link in the docs.