### PR TITLE
Use bash as default shell in Dockerfile

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -8,7 +8,6 @@
 	// Use 'settings' to set *default* container specific settings.json values on container create.
 	// You can edit these settings after create using File > Preferences > Settings > Remote.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/usr/local/bin/python",
 		"python.formatting.provider": "black",
 		"python.linting.enabled": true,

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,7 @@ tasks:
       cp gitpod/settings.json .vscode/settings.json
       git fetch --tags
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
-      pre-commit install
+      pre-commit install --install-hooks
     command: |
       python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
       echo "✨ Pre-build complete! You can close this terminal ✨ "

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN python -m pip install --upgrade pip
 COPY requirements-dev.txt /tmp
 RUN python -m pip install -r /tmp/requirements-dev.txt
 RUN git config --global --add safe.directory /home/pandas
+
+ENV SHELL "/bin/bash"
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10.8
 WORKDIR /home/pandas
 
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y build-essential
+RUN apt-get install -y build-essential bash-completion
 
 # hdf5 needed for pytables installation
 # libgles2-mesa needed for pytest-qt


### PR DESCRIPTION
GitPod's VSCode in browser (and probably others?) defaults to use `$SHELL` in integrated terminal, which is `sh`.
This change is just confort to have it open `bash` without having to change the settings or open the right one manually.

Note that the `.devcontainer` setting should not be necessary anymore, as the algorithm to chose the right shell should be the same for GitPod and VSCode remote.

From the [relevant VSCode doc](https://code.visualstudio.com/docs/terminal/profiles):
> The default terminal profile shell defaults to `$SHELL` on Linux and macOS and PowerShell on Windows. VS Code will automatically detect most standard shells that can then be configured as the default.


**EDIT**
Added a couple of bonus points:
- `--install-hooks` in pre-commit. This will configure everything immediately. Otherwise, the first commit will be very slow (pre-commit creates the environments on-demand, this will force the creation at the first start)
- `bash-completion`. So to <TAB> everything (git completion works out of the box, for example)