### PR TITLE
DOC: Clarify nrows behavior in read_csv

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -268,6 +268,18 @@ skipfooter : int, default 0
     Number of lines at bottom of file to skip (Unsupported with ``engine='c'``).
 nrows : int, optional
     Number of rows of file to read. Useful for reading pieces of large files.
+    Refers to the number of data rows in the returned DataFrame, excluding:
+
+    * The header row containing column names.
+    * Rows before the header row, if ``header=1`` or larger.
+
+    Example usage:
+    
+    * To read the first 999,999 (non-header) rows:
+      ``read_csv(..., nrows=999999)``
+    
+    * To read rows 1,000,000 through 1,999,999:
+      ``read_csv(..., skiprows=1000000, nrows=999999)``
 na_values : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable}}, optional
     Additional strings to recognize as ``NA``/``NaN``. If ``dict`` passed, specific
     per-column ``NA`` values.  By default the following values are interpreted as

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -274,10 +274,10 @@ nrows : int, optional
     * Rows before the header row, if ``header=1`` or larger.
 
     Example usage:
-    
+
     * To read the first 999,999 (non-header) rows:
       ``read_csv(..., nrows=999999)``
-    
+
     * To read rows 1,000,000 through 1,999,999:
       ``read_csv(..., skiprows=1000000, nrows=999999)``
 na_values : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable}}, optional


### PR DESCRIPTION
- [x] closes #59078
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Here’s the updated summary with a note section included:

Summary:

This pull request updates the `nrows` parameter documentation for `read_csv` to address ambiguity in the previous text. The original documentation was vague and did not clearly specify that `nrows` counts only the data rows returned, excluding the header, and skipped rows. The revised documentation provides a clearer definition of `nrows` and includes practical examples to better illustrate its usage, improving the overall clarity of the documentation.

Note:

Thanks to the suggestions from a previous PR made by the issuer and insights from Stack Overflow (https://stackoverflow.com/questions/23853553/python-pandas-how-to-read-only-first-n-rows-of-csv-files-in), the updated documentation hopefully clarifies that `nrows` excludes rows skipped with `skiprows`, and the header row. Please let me know if any examples should be added, revised, or removed to further enhance clarity. I understand that the example with `skiprows` might seem obvious, but it was included to address potential confusion.
