### PR TITLE
DOC: Fix docstrings for Timestamp: fromordinal, fromtimestamp

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -206,8 +206,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.date SA01" \
         -i "pandas.Timestamp.day GL08" \
         -i "pandas.Timestamp.fold GL08" \
-        -i "pandas.Timestamp.fromordinal SA01" \
-        -i "pandas.Timestamp.fromtimestamp PR01,SA01" \
         -i "pandas.Timestamp.hour GL08" \
         -i "pandas.Timestamp.max PR02" \
         -i "pandas.Timestamp.microsecond GL08" \

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -783,6 +783,18 @@ class NaTType(_NaT):
 
         Transform timestamp[, tz] to tz's local time from POSIX timestamp.
 
+        Parameters
+        ----------
+        ts : float
+            The POSIX timestamp to convert.
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile, default None
+            Time zone for time which Timestamp will be converted to.
+            If None, uses the system's local timezone.
+
+        See Also
+        --------
+        datetime.datetime.fromtimestamp : Standard library function to convert a timestamp to a datetime object.
+
         Examples
         --------
         >>> pd.Timestamp.fromtimestamp(1584199972)  # doctest: +SKIP
@@ -913,6 +925,12 @@ class NaTType(_NaT):
             Date corresponding to a proleptic Gregorian ordinal.
         tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for the Timestamp.
+
+        See Also
+        --------
+        Timestamp.fromtimestamp : Create a Timestamp from a POSIX timestamp.
+        Timestamp.toordinal: Return proleptic Gregorian ordinal.
+        datetime.datetime.fromordinal : Standard library function to convert an ordinal to a datetime.
 
         Notes
         -----

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1593,6 +1593,15 @@ class Timestamp(_Timestamp):
 
         Transform timestamp[, tz] to tz's local time from POSIX timestamp.
 
+        Parameters
+        ----------
+        ts : float
+            The POSIX timestamp to convert.
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile, default None
+            Time zone for time which Timestamp will be converted to.
+            If None, uses the system's local timezone.
+
+
         Examples
         --------
         >>> pd.Timestamp.fromtimestamp(1584199972)  # doctest: +SKIP

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1449,6 +1449,11 @@ class Timestamp(_Timestamp):
         tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for the Timestamp.
 
+        See Also
+        --------
+        Timestamp.fromtimestamp : Create a Timestamp from a POSIX timestamp.
+        Timestamp.toordinal: Return proleptic Gregorian ordinal.
+
         Notes
         -----
         By definition there cannot be any tz info on the ordinal itself.

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1601,6 +1601,9 @@ class Timestamp(_Timestamp):
             Time zone for time which Timestamp will be converted to.
             If None, uses the system's local timezone.
 
+        See Also
+        --------
+        datetime.datetime.fromtimestamp : Standard library function to convert a timestamp to a datetime object.
 
         Examples
         --------

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1453,6 +1453,7 @@ class Timestamp(_Timestamp):
         --------
         Timestamp.fromtimestamp : Create a Timestamp from a POSIX timestamp.
         Timestamp.toordinal: Return proleptic Gregorian ordinal.
+        datetime.datetime.fromordinal : Standard library function to convert an ordinal to a datetime.
 
         Notes
         -----


### PR DESCRIPTION
Part of #59458

Addresses:

- `pandas.Timestamp.fromordinal` having SA01
- `pandas.Timestamp.fromtimestamp` having PR01, SA01

Changes: 
- Added **See Also** section for both, and a **Parameters** section for `Timestamp.fromtimestamp`.
- Removed both from `code_checks.sh`