### PR TITLE
BUG (string dtype): convert dictionary input to materialized string array in ArrowStringArray constructor

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -130,18 +130,22 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
 
     def __init__(self, values) -> None:
         _chk_pyarrow_available()
-        if isinstance(values, (pa.Array, pa.ChunkedArray)) and pa.types.is_string(
-            values.type
+        if isinstance(values, (pa.Array, pa.ChunkedArray)) and (
+            pa.types.is_string(values.type)
+            or (
+                pa.types.is_dictionary(values.type)
+                and (
+                    pa.types.is_string(values.type.value_type)
+                    or pa.types.is_large_string(values.type.value_type)
+                )
+            )
         ):
             values = pc.cast(values, pa.large_string())
 
         super().__init__(values)
         self._dtype = StringDtype(storage=self._storage, na_value=self._na_value)
 
-        if not pa.types.is_large_string(self._pa_array.type) and not (
-            pa.types.is_dictionary(self._pa_array.type)
-            and pa.types.is_large_string(self._pa_array.type.value_type)
-        ):
+        if not pa.types.is_large_string(self._pa_array.type):
             raise ValueError(
                 "ArrowStringArray requires a PyArrow (chunked) array of "
                 "large_string type"

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -88,19 +88,18 @@ def test_constructor_not_string_type_value_dictionary_raises(chunked):
         ArrowStringArray(arr)
 
 
-@pytest.mark.xfail(
-    reason="dict conversion does not seem to be implemented for large string in arrow"
-)
+@pytest.mark.parametrize("string_type", ["string", "large_string"])
 @pytest.mark.parametrize("chunked", [True, False])
-def test_constructor_valid_string_type_value_dictionary(chunked):
+def test_constructor_valid_string_type_value_dictionary(string_type, chunked):
     pa = pytest.importorskip("pyarrow")
 
-    arr = pa.array(["1", "2", "3"], pa.large_string()).dictionary_encode()
+    arr = pa.array(["1", "2", "3"], getattr(pa, string_type)()).dictionary_encode()
     if chunked:
         arr = pa.chunked_array(arr)
 
     arr = ArrowStringArray(arr)
-    assert pa.types.is_string(arr._pa_array.type.value_type)
+    # dictionary type get converted to dense large string array
+    assert pa.types.is_large_string(arr._pa_array.type)
 
 
 def test_constructor_from_list():


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/pull/54074 allowed to pass dictionary encoded string data in the `ArrowStringArray` constructor, because such values can be passed when reading partitioned datasets (it was fixing https://github.com/pandas-dev/pandas/issues/53951).

However, when you actually have a column with string dtype but backed by a dictionary encoded pyarrow array, our StringArray implemention is not set up for that, so once you call some string specific functionality, you can run into errors. Example:

```
In [2]: arr = pd.core.arrays.ArrowStringArray(pa.array(["a", "b", None, "a"], pa.large_string()).dictionary_encode())

In [3]: arr
Out[3]: 
<ArrowStringArray>
['a', 'b', <NA>, 'a']
Length: 4, dtype: string

In [4]: pd.Series(arr)
Out[4]: 
0       a
1       b
2    <NA>
3       a
dtype: string

In [5]: pd.Series(arr).str.len()
...
ArrowNotImplementedError: Function 'utf8_length' has no kernel matching input types (dictionary<values=large_string, indices=int32, ordered=0>)
```

Maybe we could at some point properly support storing dict encoded string values under the hood. But until then, I think it is better to materialize the dictionary encoded input to a plain pyarrow string array, which is what this PR is doing.

- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
