### PR TITLE
DOC: add pandas-gbq and related db-dtypes packages to ecosystem

### DIFF
--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -360,6 +360,13 @@ Deltalake python package lets you access tables stored in
 JVM. It provides the ``delta_table.to_pyarrow_table().to_pandas()`` method to convert
 any Delta table into Pandas dataframe.
 
+### [pandas-gbq]([https://github.com/yehoshuadimarsky/bcpandas](https://github.com/googleapis/python-bigquery-pandas))
+
+pandas-gbq provides high performance reads and writes to and from
+[Google BigQuery](https://cloud.google.com/bigquery/). Previously (before version 2.2.0),
+these methods were exposed as `pandas.read_gbq` and `DataFrame.to_gbq`.
+Use `pandas_gbq.read_gbq` and `pandas_gbq.to_gbq`, instead.
+
 ## Out-of-core
 
 ### [Bodo](https://bodo.ai/)
@@ -512,6 +519,13 @@ Awkward-pandas provides an extension type for storing [Awkward
 Arrays](https://awkward-array.org/) inside pandas' Series and
 DataFrame. It also provides an accessor for using awkward functions
 on Series that are of awkward type.
+
+### [db-dtypes](https://github.com/googleapis/python-db-dtypes-pandas)
+
+db-dtypes provides an extension types for working with types like
+DATE, TIME, and JSON from database systems. This package is used
+by pandas-gbq to provide natural dtypes for BigQuery data types without
+a natural numpy type.
 
 ### [Pandas-Genomics](https://pandas-genomics.readthedocs.io/en/latest/)
 

--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -360,7 +360,7 @@ Deltalake python package lets you access tables stored in
 JVM. It provides the ``delta_table.to_pyarrow_table().to_pandas()`` method to convert
 any Delta table into Pandas dataframe.
 
-### [pandas-gbq]([https://github.com/yehoshuadimarsky/bcpandas](https://github.com/googleapis/python-bigquery-pandas))
+### [pandas-gbq](https://github.com/googleapis/python-bigquery-pandas)
 
 pandas-gbq provides high performance reads and writes to and from
 [Google BigQuery](https://cloud.google.com/bigquery/). Previously (before version 2.2.0),


### PR DESCRIPTION
As of pandas 2.2.0, pandas-gbq functionality is fully separated, so I think now would be a good time to introduce it as part of the "ecosystem".

db-dtypes was built for use from pandas-gbq but should be applicable more generally.

- [N/A] closes #xxxx (Replace xxxx with the GitHub issue number)
- [N/A] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [N/A] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [N/A] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [N/A] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
