### PR TITLE
Fix issue #47101

### DIFF
--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -124,14 +124,15 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
                     new_mask = np.zeros(arr.shape, dtype=np.bool_)
                     new_mask[arr_mask] = arr[arr_mask] == x
                 else:
-                    # GH#47101 
-                    # Fix where type bool has no attribute to_numpy() by first 
-                    # attempting to broadcast with np.equal for some cases, and then 
-                    # an explicit type check when checking the mask for any straggling 
+                    # GH#47101
+                    # Fix where type bool has no attribute to_numpy() by first
+                    # attempting to broadcast with np.equal for some cases, and then
+                    # an explicit type check when checking the mask for any straggling
                     # cases. Where a literal comparison would fail np.equal we fall back
                     # to the original equality check.
                     try:
-                        new_mask = np.equal(arr, x)
+                        # In case of an uncastable type, this will emit TypeError
+                        new_mask = np.equal(arr, x) # type: ignore[arg-type]
                     except TypeError:
                         # Old behaviour for uncastable types
                         new_mask = arr == x
@@ -139,7 +140,7 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
                     if not isinstance(new_mask, np.ndarray):
                         # usually BooleanArray
                         if isinstance(new_mask, bool):
-                            new_mask = np.array([new_mask], dtype= bool) 
+                            new_mask = np.array([new_mask], dtype= bool)
                         else: 
                             new_mask = new_mask.to_numpy(dtype=bool, na_value=False)
                 mask |= new_mask

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -141,7 +141,7 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
                         # usually BooleanArray
                         if isinstance(new_mask, bool):
                             new_mask = np.array([new_mask], dtype= bool)
-                        else: 
+                        else:
                             new_mask = new_mask.to_numpy(dtype=bool, na_value=False)
                 mask |= new_mask
 

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -129,7 +129,11 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
                     # attempting to broadcast with np.equal for some cases, and then 
                     # an explicit type check when checking the mask for any straggling 
                     # cases
-                    new_mask = np.equal(arr, x)
+                    try:
+                        new_mask = np.equal(arr, x)
+                    except TypeError:
+                        # Old behaviour for uncastable types
+                        new_mask = arr == x
 
                     if not isinstance(new_mask, np.ndarray):
                         # usually BooleanArray

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -125,10 +125,11 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
                     new_mask[arr_mask] = arr[arr_mask] == x
                 else:
                     # GH#47101 
-                    # Fix where type 'bool' has no attribute 'to_numpy()' by first 
+                    # Fix where type bool has no attribute to_numpy() by first 
                     # attempting to broadcast with np.equal for some cases, and then 
                     # an explicit type check when checking the mask for any straggling 
-                    # cases
+                    # cases. Where a literal comparison would fail np.equal we fall back
+                    # to the original equality check.
                     try:
                         new_mask = np.equal(arr, x)
                     except TypeError:
@@ -138,7 +139,7 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
                     if not isinstance(new_mask, np.ndarray):
                         # usually BooleanArray
                         if isinstance(new_mask, bool):
-                            new_mask = np.array([new_mask]) 
+                            new_mask = np.array([new_mask], dtype= bool) 
                         else: 
                             new_mask = new_mask.to_numpy(dtype=bool, na_value=False)
                 mask |= new_mask

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -124,11 +124,15 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
                     new_mask = np.zeros(arr.shape, dtype=np.bool_)
                     new_mask[arr_mask] = arr[arr_mask] == x
                 else:
-                    new_mask = arr == x
+                    # GH#47101 
+                    # Fix where type 'bool' has no attribute 'to_numpy()' by first attempting to broadcast 
+                    # with np.equal for some cases, and then an explicit type check when checking the mask
+                    # for any straggling cases
+                    new_mask = np.equal(arr, x)
 
                     if not isinstance(new_mask, np.ndarray):
                         # usually BooleanArray
-                        new_mask = new_mask.to_numpy(dtype=bool, na_value=False)
+                        new_mask = np.array([new_mask]) if isinstance(new_mask, bool) else new_mask.to_numpy(dtype=bool, na_value=False)
                 mask |= new_mask
 
     if na_mask.any():

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -125,14 +125,18 @@ def mask_missing(arr: ArrayLike, values_to_mask) -> npt.NDArray[np.bool_]:
                     new_mask[arr_mask] = arr[arr_mask] == x
                 else:
                     # GH#47101 
-                    # Fix where type 'bool' has no attribute 'to_numpy()' by first attempting to broadcast 
-                    # with np.equal for some cases, and then an explicit type check when checking the mask
-                    # for any straggling cases
+                    # Fix where type 'bool' has no attribute 'to_numpy()' by first 
+                    # attempting to broadcast with np.equal for some cases, and then 
+                    # an explicit type check when checking the mask for any straggling 
+                    # cases
                     new_mask = np.equal(arr, x)
 
                     if not isinstance(new_mask, np.ndarray):
                         # usually BooleanArray
-                        new_mask = np.array([new_mask]) if isinstance(new_mask, bool) else new_mask.to_numpy(dtype=bool, na_value=False)
+                        if isinstance(new_mask, bool):
+                            new_mask = np.array([new_mask]) 
+                        else: 
+                            new_mask = new_mask.to_numpy(dtype=bool, na_value=False)
                 mask |= new_mask
 
     if na_mask.any():

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1521,7 +1521,7 @@ class TestDataFrameReplaceRegex:
 
     def test_replace_bool_to_numpy_attributeerror(self):
         # GH#47101
-        pass_pre_patch = pd.DataFrame({"d":[None]})
+        pass_pre_patch = DataFrame({"d":[None]})
         tm.assert_frame_equal(pass_pre_patch, pass_pre_patch.replace('', pd.NA))
-        fail_pre_patch = pd.DataFrame({"d":[pd.NA]})
+        fail_pre_patch = DataFrame({"d":[pd.NA]})
         tm.assert_frame_equal(fail_pre_patch, fail_pre_patch.replace('', pd.NA))

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1518,3 +1518,10 @@ class TestDataFrameReplaceRegex:
             assert len(df._mgr.blocks) == 2
         else:
             assert len(df._mgr.blocks) == 1
+
+    def test_replace_bool_to_numpy_attributeerror(self):
+        # GH#47101
+        pass_pre_patch = pd.DataFrame({"d":[None]})
+        tm.assert_frame_equal(pass_pre_patch, pass_pre_patch.replace('', pd.NA))
+        fail_pre_patch = pd.DataFrame({"d":[pd.NA]})
+        tm.assert_frame_equal(fail_pre_match, fail_pre_patch.replace('', pd.NA))

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1524,4 +1524,4 @@ class TestDataFrameReplaceRegex:
         pass_pre_patch = pd.DataFrame({"d":[None]})
         tm.assert_frame_equal(pass_pre_patch, pass_pre_patch.replace('', pd.NA))
         fail_pre_patch = pd.DataFrame({"d":[pd.NA]})
-        tm.assert_frame_equal(fail_pre_match, fail_pre_patch.replace('', pd.NA))
+        tm.assert_frame_equal(fail_pre_patch, fail_pre_patch.replace('', pd.NA))

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1522,6 +1522,6 @@ class TestDataFrameReplaceRegex:
     def test_replace_bool_to_numpy_attributeerror(self):
         # GH#47101
         pass_pre_patch = DataFrame({"d":[None]})
-        tm.assert_frame_equal(pass_pre_patch, pass_pre_patch.replace('', pd.NA))
+        tm.assert_frame_equal(pass_pre_patch, pass_pre_patch.replace("", pd.NA))
         fail_pre_patch = DataFrame({"d":[pd.NA]})
-        tm.assert_frame_equal(fail_pre_patch, fail_pre_patch.replace('', pd.NA))
+        tm.assert_frame_equal(fail_pre_patch, fail_pre_patch.replace("", pd.NA))


### PR DESCRIPTION
Bisecting two years ago ( https://github.com/pandas-dev/pandas/issues/47101#issuecomment-1139606268 ) shows this regression was introduced in b2d54d9 in 2021. Somehow this hasn't been patched since then.

PR #48313 was supposed to address this, but the PR was closed and never merged and the bug has persisted.

Patch takes two tracks -- it first replaces the `arr == x` with [`np.equals()`](https://numpy.org/doc/1.26/reference/generated/numpy.equal.html) which will handle broadcasting in most cases by itself. For the remainder of cases, an explicit type check is done to return an array for the mask.

- [x] closes #47101
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
