### PR TITLE
DOC: Fix docstrings for Timestamp: unit, utcoffset, utctimetuple

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -221,9 +221,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.today SA01" \
         -i "pandas.Timestamp.toordinal SA01" \
         -i "pandas.Timestamp.tzinfo GL08" \
-        -i "pandas.Timestamp.unit SA01" \
-        -i "pandas.Timestamp.utcoffset SA01" \
-        -i "pandas.Timestamp.utctimetuple SA01" \
         -i "pandas.Timestamp.value GL08" \
         -i "pandas.Timestamp.year GL08" \
         -i "pandas.api.extensions.ExtensionArray._pad_or_backfill PR01,RT03,SA01" \

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -595,7 +595,23 @@ class NaTType(_NaT):
     utctimetuple = _make_error_func(
         "utctimetuple",
         """
-        Return UTC time tuple, compatible with time.localtime().
+        Return UTC time tuple, compatible with `time.localtime()`.
+
+        This method converts the Timestamp to UTC and returns a time tuple
+        containing 9 components: year, month, day, hour, minute, second,
+        weekday, day of year, and DST flag. This is particularly useful for
+        converting a Timestamp to a format compatible with time module functions.
+
+        Returns
+        -------
+        time.struct_time
+            A time.struct_time object representing the UTC time.
+
+        See Also
+        --------
+        datetime.datetime.utctimetuple : Return UTC time tuple, compatible with time.localtime().
+        Timestamp.timetuple : Return time tuple of local time.
+        time.struct_time : Time tuple structure used by time functions.
 
         Examples
         --------
@@ -611,6 +627,21 @@ class NaTType(_NaT):
         "utcoffset",
         """
         Return utc offset.
+
+        This method returns the difference between UTC and the local time
+        as a `timedelta` object. It is useful for understanding the time
+        difference between the current timezone and UTC.
+
+        Returns
+        --------
+        timedelta
+            The difference between UTC and the local time as a `timedelta` object.
+
+        See Also
+        --------
+        datetime.datetime.utcoffset : Standard library method to get the UTC offset of a datetime object.
+        Timestamp.tzname : Return the name of the timezone.
+        Timestamp.dst : Return the daylight saving time (DST) adjustment.
 
         Examples
         --------

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -609,7 +609,8 @@ class NaTType(_NaT):
 
         See Also
         --------
-        datetime.datetime.utctimetuple : Return UTC time tuple, compatible with time.localtime().
+        datetime.datetime.utctimetuple :
+            Return UTC time tuple, compatible with time.localtime().
         Timestamp.timetuple : Return time tuple of local time.
         time.struct_time : Time tuple structure used by time functions.
 
@@ -639,7 +640,8 @@ class NaTType(_NaT):
 
         See Also
         --------
-        datetime.datetime.utcoffset : Standard library method to get the UTC offset of a datetime object.
+        datetime.datetime.utcoffset :
+            Standard library method to get the UTC offset of a datetime object.
         Timestamp.tzname : Return the name of the timezone.
         Timestamp.dst : Return the daylight saving time (DST) adjustment.
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -256,14 +256,20 @@ cdef class _Timestamp(ABCTimestamp):
 
         This property returns a string representing the time unit of the Timestamp's
         resolution. It corresponds to the smallest time unit that can be represented
-        by this Timestamp object. The possible values are 's' (second), 'ms' (millisecond),
-        'us' (microsecond), and 'ns' (nanosecond).
+        by this Timestamp object. The possible values are:
+        - 's' (second)
+        - 'ms' (millisecond)
+        - 'us' (microsecond)
+        - 'ns' (nanosecond)
 
         Returns
         -------
         str
             A string abbreviation of the Timestamp's resolution unit:
-            's' for second, 'ms' for millisecond, 'us' for microsecond, or 'ns' for nanosecond.
+            - 's' for second
+            - 'ms' for millisecond
+            - 'us' for microsecond
+            - 'ns' for nanosecond
 
         See Also
         --------
@@ -1798,7 +1804,8 @@ class Timestamp(_Timestamp):
 
         See Also
         --------
-        datetime.datetime.utcoffset : Standard library method to get the UTC offset of a datetime object.
+        datetime.datetime.utcoffset :
+            Standard library method to get the UTC offset of a datetime object.
         Timestamp.tzname : Return the name of the timezone.
         Timestamp.dst : Return the daylight saving time (DST) adjustment.
 
@@ -1828,7 +1835,8 @@ class Timestamp(_Timestamp):
 
         See Also
         --------
-        datetime.datetime.utctimetuple : Return UTC time tuple, compatible with time.localtime().
+        datetime.datetime.utctimetuple :
+            Return UTC time tuple, compatible with time.localtime().
         Timestamp.timetuple : Return time tuple of local time.
         time.struct_time : Time tuple structure used by time functions.
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -254,6 +254,22 @@ cdef class _Timestamp(ABCTimestamp):
         """
         The abbreviation associated with self._creso.
 
+        This property returns a string representing the time unit of the Timestamp's
+        resolution. It corresponds to the smallest time unit that can be represented
+        by this Timestamp object. The possible values are 's' (second), 'ms' (millisecond),
+        'us' (microsecond), and 'ns' (nanosecond).
+
+        Returns
+        -------
+        str
+            A string abbreviation of the Timestamp's resolution unit:
+            's' for second, 'ms' for millisecond, 'us' for microsecond, or 'ns' for nanosecond.
+
+        See Also
+        --------
+        Timestamp.resolution : Return resolution of the Timestamp.
+        Timedelta : A duration expressing the difference between two dates or times.
+
         Examples
         --------
         >>> pd.Timestamp("2020-01-01 12:34:56").unit
@@ -1771,6 +1787,21 @@ class Timestamp(_Timestamp):
         """
         Return utc offset.
 
+        This method returns the difference between UTC and the local time
+        as a `timedelta` object. It is useful for understanding the time
+        difference between the current timezone and UTC.
+
+        Returns
+        --------
+        timedelta
+            The difference between UTC and the local time as a `timedelta` object.
+
+        See Also
+        --------
+        datetime.datetime.utcoffset : Standard library method to get the UTC offset of a datetime object.
+        Timestamp.tzname : Return the name of the timezone.
+        Timestamp.dst : Return the daylight saving time (DST) adjustment.
+
         Examples
         --------
         >>> ts = pd.Timestamp('2023-01-01 10:00:00', tz='Europe/Brussels')
@@ -1783,7 +1814,23 @@ class Timestamp(_Timestamp):
 
     def utctimetuple(self):
         """
-        Return UTC time tuple, compatible with time.localtime().
+        Return UTC time tuple, compatible with `time.localtime()`.
+
+        This method converts the Timestamp to UTC and returns a time tuple
+        containing 9 components: year, month, day, hour, minute, second,
+        weekday, day of year, and DST flag. This is particularly useful for
+        converting a Timestamp to a format compatible with time module functions.
+
+        Returns
+        -------
+        time.struct_time
+            A time.struct_time object representing the UTC time.
+
+        See Also
+        --------
+        datetime.datetime.utctimetuple : Return UTC time tuple, compatible with time.localtime().
+        Timestamp.timetuple : Return time tuple of local time.
+        time.struct_time : Time tuple structure used by time functions.
 
         Examples
         --------


### PR DESCRIPTION
Part of https://github.com/pandas-dev/pandas/issues/59458

Addresses:

pandas.Timestamp.unit having SA01
pandas.Timestamp.utcoffset having SA01
pandas.Timestamp.utctimetuple having SA01

Changes:
Added See Also section for all 3.
Added Returns section for all 3.
Added extended section for all 3
Removed all 3 from code_checks.sh