### PR TITLE
BUG (string): ArrowEA comparisons with mismatched types

### DIFF
--- a/doc/source/whatsnew/v2.2.2.rst
+++ b/doc/source/whatsnew/v2.2.2.rst
@@ -42,6 +42,7 @@ Bug fixes
 - :meth:`DataFrame.__dataframe__` was showing bytemask instead of bitmask for ``'string[pyarrow]'`` validity buffer (:issue:`57762`)
 - :meth:`DataFrame.__dataframe__` was showing non-null validity buffer (instead of ``None``) ``'string[pyarrow]'`` without missing values (:issue:`57761`)
 - :meth:`DataFrame.to_sql` was failing to find the right table when using the schema argument (:issue:`57539`)
+- Bug in comparison between object with :class:`ArrowDtype` and incompatible-dtyped (e.g. string vs bool) incorrectly raising instead of returning all-``False`` (for ``==``) or all-``True`` (for ``!=``) (:issue:`??`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_222.other:

--- a/doc/source/whatsnew/v2.2.2.rst
+++ b/doc/source/whatsnew/v2.2.2.rst
@@ -42,7 +42,6 @@ Bug fixes
 - :meth:`DataFrame.__dataframe__` was showing bytemask instead of bitmask for ``'string[pyarrow]'`` validity buffer (:issue:`57762`)
 - :meth:`DataFrame.__dataframe__` was showing non-null validity buffer (instead of ``None``) ``'string[pyarrow]'`` without missing values (:issue:`57761`)
 - :meth:`DataFrame.to_sql` was failing to find the right table when using the schema argument (:issue:`57539`)
-- Bug in comparison between object with :class:`ArrowDtype` and incompatible-dtyped (e.g. string vs bool) incorrectly raising instead of returning all-``False`` (for ``==``) or all-``True`` (for ``!=``) (:issue:`??`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_222.other:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -667,8 +667,8 @@ ExtensionArray
 ^^^^^^^^^^^^^^
 - Bug in :meth:`.arrays.ArrowExtensionArray.__setitem__` which caused wrong behavior when using an integer array with repeated values as a key (:issue:`58530`)
 - Bug in :meth:`api.types.is_datetime64_any_dtype` where a custom :class:`ExtensionDtype` would return ``False`` for array-likes (:issue:`57055`)
+- Bug in comparison between object with :class:`ArrowDtype` and incompatible-dtyped (e.g. string vs bool) incorrectly raising instead of returning all-``False`` (for ``==``) or all-``True`` (for ``!=``) (:issue:`59505`)
 - Bug in various :class:`DataFrame` reductions for pyarrow temporal dtypes returning incorrect dtype when result was null (:issue:`59234`)
-- Bug in comparison between object with :class:`ArrowDtype` and incompatible-dtyped (e.g. string vs bool) incorrectly raising instead of returning all-``False`` (for ``==``) or all-``True`` (for ``!=``) (:issue:`??`)
 
 Styler
 ^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -668,6 +668,7 @@ ExtensionArray
 - Bug in :meth:`.arrays.ArrowExtensionArray.__setitem__` which caused wrong behavior when using an integer array with repeated values as a key (:issue:`58530`)
 - Bug in :meth:`api.types.is_datetime64_any_dtype` where a custom :class:`ExtensionDtype` would return ``False`` for array-likes (:issue:`57055`)
 - Bug in various :class:`DataFrame` reductions for pyarrow temporal dtypes returning incorrect dtype when result was null (:issue:`59234`)
+- Bug in comparison between object with :class:`ArrowDtype` and incompatible-dtyped (e.g. string vs bool) incorrectly raising instead of returning all-``False`` (for ``==``) or all-``True`` (for ``!=``) (:issue:`??`)
 
 Styler
 ^^^^^^

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -36,7 +36,6 @@ from pandas.core.arrays.string_ import (
     BaseStringArray,
     StringDtype,
 )
-from pandas.core.ops import invalid_comparison
 from pandas.core.strings.object_array import ObjectStringArrayMixin
 
 if not pa_version_under10p1:
@@ -563,10 +562,7 @@ class ArrowStringArrayNumpySemantics(ArrowStringArray):
         return result
 
     def _cmp_method(self, other, op):
-        try:
-            result = super()._cmp_method(other, op)
-        except pa.ArrowNotImplementedError:
-            return invalid_comparison(self, other, op)
+        result = super()._cmp_method(other, op)
         if op == operator.ne:
             return result.to_numpy(np.bool_, na_value=True)
         else:

--- a/pandas/tests/series/test_logical_ops.py
+++ b/pandas/tests/series/test_logical_ops.py
@@ -541,6 +541,7 @@ class TestSeriesLogicalOps:
         with pytest.raises(TypeError, match="Invalid comparison"):
             ser > ser2
 
+        # GH#59505
         ser3 = ser2.astype("string[pyarrow]")
         result3_eq = ser3 == ser
         tm.assert_series_equal(result3_eq, expected_eq.astype("bool[pyarrow]"))

--- a/pandas/tests/series/test_logical_ops.py
+++ b/pandas/tests/series/test_logical_ops.py
@@ -9,6 +9,7 @@ from pandas._config import using_string_dtype
 from pandas.compat import HAS_PYARROW
 
 from pandas import (
+    ArrowDtype,
     DataFrame,
     Index,
     Series,
@@ -523,18 +524,37 @@ class TestSeriesLogicalOps:
         result = ser1 ^ ser2
         tm.assert_series_equal(result, expected)
 
+    # TODO: this belongs in comparison tests
     def test_pyarrow_numpy_string_invalid(self):
         # GH#56008
-        pytest.importorskip("pyarrow")
+        pa = pytest.importorskip("pyarrow")
         ser = Series([False, True])
         ser2 = Series(["a", "b"], dtype="string[pyarrow_numpy]")
         result = ser == ser2
-        expected = Series(False, index=ser.index)
-        tm.assert_series_equal(result, expected)
+        expected_eq = Series(False, index=ser.index)
+        tm.assert_series_equal(result, expected_eq)
 
         result = ser != ser2
-        expected = Series(True, index=ser.index)
-        tm.assert_series_equal(result, expected)
+        expected_ne = Series(True, index=ser.index)
+        tm.assert_series_equal(result, expected_ne)
 
         with pytest.raises(TypeError, match="Invalid comparison"):
             ser > ser2
+
+        ser3 = ser2.astype("string[pyarrow]")
+        result3_eq = ser3 == ser
+        tm.assert_series_equal(result3_eq, expected_eq.astype("bool[pyarrow]"))
+        result3_ne = ser3 != ser
+        tm.assert_series_equal(result3_ne, expected_ne.astype("bool[pyarrow]"))
+
+        with pytest.raises(TypeError, match="Invalid comparison"):
+            ser > ser3
+
+        ser4 = ser2.astype(ArrowDtype(pa.string()))
+        result4_eq = ser4 == ser
+        tm.assert_series_equal(result4_eq, expected_eq.astype("bool[pyarrow]"))
+        result4_ne = ser4 != ser
+        tm.assert_series_equal(result4_ne, expected_ne.astype("bool[pyarrow]"))
+
+        with pytest.raises(TypeError, match="Invalid comparison"):
+            ser > ser4


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

