### PR TITLE
fix: type error when exporting file as bytes

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 from collections.abc import (
     Callable,
     Hashable,
@@ -1238,7 +1239,7 @@ class ExcelWriter(Generic[_WorkbookT]):
 
     def __init__(
         self,
-        path: FilePath | WriteExcelBuffer | ExcelWriter,
+        path: FilePath | WriteExcelBuffer | ExcelWriter | io[bytes],
         engine: str | None = None,
         date_format: str | None = None,
         datetime_format: str | None = None,


### PR DESCRIPTION
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
![image](https://github.com/user-attachments/assets/50cb4a49-df23-4673-8d76-9db5dca7cc0a)
[official doc url](https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#writing-excel-files)
"Writing Excel files to memory" part

