### PR TITLE
TST (string dtype): fix IO dtype_backend tests for storage of str dtype of columns' Index

### DIFF
--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -712,7 +712,9 @@ class TestReaders:
                 "b": Series(["x", None], dtype=pd.StringDtype(string_storage)),
             }
         )
-        tm.assert_frame_equal(result, expected)
+        # the storage of the str columns' Index is also affected by the
+        # string_storage setting -> ignore that for checking the result
+        tm.assert_frame_equal(result, expected, check_column_type=False)
 
     @pytest.mark.parametrize("dtypes, exp_value", [({}, 1), ({"a.1": "int64"}, 1)])
     def test_dtype_mangle_dup_cols(self, read_ext, dtypes, exp_value):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2194,7 +2194,9 @@ class TestPandasContainer:
         if orient == "values":
             expected.columns = list(range(8))
 
-        tm.assert_frame_equal(result, expected)
+        # the storage of the str columns' Index is also affected by the
+        # string_storage setting -> ignore that for checking the result
+        tm.assert_frame_equal(result, expected, check_column_type=False)
 
     @pytest.mark.parametrize("orient", ["split", "records", "index"])
     def test_read_json_nullable_series(self, string_storage, dtype_backend, orient):

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -470,12 +470,12 @@ b,
 """
         result = parser.read_csv(StringIO(data), dtype_backend="numpy_nullable")
 
-    expected = DataFrame(
-        {
-            "a": pd.array(["a", "b"], dtype=pd.StringDtype(string_storage)),
-            "b": pd.array(["x", pd.NA], dtype=pd.StringDtype(string_storage)),
-        }
-    )
+        expected = DataFrame(
+            {
+                "a": pd.array(["a", "b"], dtype=pd.StringDtype(string_storage)),
+                "b": pd.array(["x", pd.NA], dtype=pd.StringDtype(string_storage)),
+            },
+        )
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -974,7 +974,9 @@ def test_dtype_backend(string_storage, dtype_backend):
         )
         expected["i"] = ArrowExtensionArray(pa.array([None, None]))
 
-    tm.assert_frame_equal(result, expected)
+    # the storage of the str columns' Index is also affected by the
+    # string_storage setting -> ignore that for checking the result
+    tm.assert_frame_equal(result, expected, check_column_type=False)
 
 
 def test_invalid_dtype_backend():

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -207,7 +207,9 @@ class TestReadHtml:
                 }
             )
 
-        tm.assert_frame_equal(result, expected)
+        # the storage of the str columns' Index is also affected by the
+        # string_storage setting -> ignore that for checking the result
+        tm.assert_frame_equal(result, expected, check_column_type=False)
 
     @pytest.mark.network
     @pytest.mark.single_cpu

--- a/pandas/tests/io/xml/test_xml.py
+++ b/pandas/tests/io/xml/test_xml.py
@@ -2050,7 +2050,9 @@ def test_read_xml_nullable_dtypes(
         )
         expected["g"] = ArrowExtensionArray(pa.array([None, None]))
 
-    tm.assert_frame_equal(result, expected)
+    # the storage of the str columns' Index is also affected by the
+    # string_storage setting -> ignore that for checking the result
+    tm.assert_frame_equal(result, expected, check_column_type=False)
 
 
 def test_invalid_dtype_backend():


### PR DESCRIPTION
Quick follow-up on https://github.com/pandas-dev/pandas/pull/59481 (I missed that with the last merge of main there was actually one relevant failure, maybe some interaction with one of my other merged PRs)

This was caused because of the merge of https://github.com/pandas-dev/pandas/pull/59488, that changed to honor the `mode.string_storage` option for the future default string dtype. That meant that DataFrames with string column names that were created in a `with pd.option_context("mode.string_storage", string_storage):` context would now also follow the specified storage for the column names.