### PR TITLE
Fix docstrings for pandas.Period.year SA01

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -79,7 +79,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Period.ordinal GL08" \
         -i "pandas.Period.strftime PR01,SA01" \
         -i "pandas.Period.to_timestamp SA01" \
-        -i "pandas.Period.year SA01" \
         -i "pandas.PeriodDtype SA01" \
         -i "pandas.PeriodDtype.freq SA01" \
         -i "pandas.PeriodIndex.day SA01" \

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2038,11 +2038,49 @@ cdef class _Period(PeriodMixin):
         """
         Return the year this Period falls on.
 
+        Returns
+        -------
+        int
+            The year (e.g., 2023)
+
+        See Also
+        --------
+        period.month : Get the month of the year on the given Period.
+        period.day : Return the day of the month the Period falls on.
+
+        Notes
+        -----
+        The year is based on the `ordinal` and `base` attributes of the Period.
+
         Examples
         --------
-        >>> period = pd.Period('2022-01', 'M')
+        Create a Period object for January 2023 and get the year:
+
+        >>> period = pd.Period('2023-01', 'M')
         >>> period.year
-        2022
+        2023
+
+        Create a Period object for 01 January 2023 and get the year:
+        >>> period = pd.Period('2023', 'D')
+        >>> period.year
+        2023
+
+        Get the year for a period representing a quarter:
+
+        >>> period = pd.Period('2023Q2', 'Q')
+        >>> period.year
+        2023
+
+        Handle a case where the Period object is empty, which results in `NaN`:
+
+        >>> period = pd.Period('nan', 'M')
+        >>> period.month
+        nan
+
+        Period object with an invalid format:
+
+        >>> period = pd.Period('invalid', 'M')
+            # Will raise an DateParseError
         """
         base = self._dtype._dtype_code
         return pyear(self.ordinal, base)

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2041,7 +2041,6 @@ cdef class _Period(PeriodMixin):
         Returns
         -------
         int
-            The year (e.g., 2023)
 
         See Also
         --------

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2076,11 +2076,6 @@ cdef class _Period(PeriodMixin):
         >>> period = pd.Period('nan', 'M')
         >>> period.year
         nan
-
-        Period object with an invalid format:
-
-        >>> period = pd.Period('invalid', 'M')
-        # Will raise a DateParseError
         """
         base = self._dtype._dtype_code
         return pyear(self.ordinal, base)

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2044,7 +2044,7 @@ cdef class _Period(PeriodMixin):
 
         See Also
         --------
-        period.month : Get the month of the year on the given Period.
+        period.month : Get the month of the year for the given Period.
         period.day : Return the day of the month the Period falls on.
 
         Notes
@@ -2060,9 +2060,10 @@ cdef class _Period(PeriodMixin):
         2023
 
         Create a Period object for 01 January 2023 and get the year:
+
         >>> period = pd.Period('2023', 'D')
-        >>> period.year
-        2023
+        >>> period.year
+        2023
 
         Get the year for a period representing a quarter:
 
@@ -2073,13 +2074,13 @@ cdef class _Period(PeriodMixin):
         Handle a case where the Period object is empty, which results in `NaN`:
 
         >>> period = pd.Period('nan', 'M')
-        >>> period.month
+        >>> period.year
         nan
 
         Period object with an invalid format:
 
         >>> period = pd.Period('invalid', 'M')
-            # Will raise an DateParseError
+        # Will raise a DateParseError
         """
         base = self._dtype._dtype_code
         return pyear(self.ordinal, base)


### PR DESCRIPTION
Part of #59458

Addresses:
pandas.Period.year having SA01

Changes:
Added See Also section .
Added Returns section .
Added extended section .
Added notes section .
Added examples section .
Removed "pandas.Period.year SA01"  from code_checks.sh