### PR TITLE
DOC: Fix Numpy Docstring validation errors in pandas.api.extensions.ExtensionArray

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -224,7 +224,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.extensions.ExtensionArray.insert PR07,RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.interpolate PR01,SA01" \
         -i "pandas.api.extensions.ExtensionArray.isin PR07,RT03,SA01" \
-        -i "pandas.api.extensions.ExtensionArray.take RT03" \
         -i "pandas.api.extensions.ExtensionArray.tolist RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.unique RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.view SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -224,7 +224,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.extensions.ExtensionArray.insert PR07,RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.interpolate PR01,SA01" \
         -i "pandas.api.extensions.ExtensionArray.isin PR07,RT03,SA01" \
-        -i "pandas.api.extensions.ExtensionArray.nbytes SA01" \
         -i "pandas.api.extensions.ExtensionArray.ndim SA01" \
         -i "pandas.api.extensions.ExtensionArray.ravel RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.take RT03" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -224,7 +224,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.extensions.ExtensionArray.insert PR07,RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.interpolate PR01,SA01" \
         -i "pandas.api.extensions.ExtensionArray.isin PR07,RT03,SA01" \
-        -i "pandas.api.extensions.ExtensionArray.ndim SA01" \
         -i "pandas.api.extensions.ExtensionArray.ravel RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.take RT03" \
         -i "pandas.api.extensions.ExtensionArray.tolist RT03,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -224,7 +224,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.extensions.ExtensionArray.insert PR07,RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.interpolate PR01,SA01" \
         -i "pandas.api.extensions.ExtensionArray.isin PR07,RT03,SA01" \
-        -i "pandas.api.extensions.ExtensionArray.isna SA01" \
         -i "pandas.api.extensions.ExtensionArray.nbytes SA01" \
         -i "pandas.api.extensions.ExtensionArray.ndim SA01" \
         -i "pandas.api.extensions.ExtensionArray.ravel RT03,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -224,7 +224,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.extensions.ExtensionArray.insert PR07,RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.interpolate PR01,SA01" \
         -i "pandas.api.extensions.ExtensionArray.isin PR07,RT03,SA01" \
-        -i "pandas.api.extensions.ExtensionArray.ravel RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.take RT03" \
         -i "pandas.api.extensions.ExtensionArray.tolist RT03,SA01" \
         -i "pandas.api.extensions.ExtensionArray.unique RT03,SA01" \

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -649,6 +649,11 @@ class ExtensionArray:
         """
         Extension Arrays are only allowed to be 1-dimensional.
 
+        See Also
+        --------
+        ExtensionArray.shape: Return a tuple of the array dimensions.
+        ExtensionArray.size: The number of elements in the array.
+
         Examples
         --------
         >>> arr = pd.array([1, 2, 3])
@@ -664,8 +669,8 @@ class ExtensionArray:
 
         See Also
         --------
-        ExtensionArray.size: The number of elements in the array.
         ExtensionArray.shape: Return a tuple of the array dimensions.
+        ExtensionArray.size: The number of elements in the array.
 
         Examples
         --------

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1847,6 +1847,11 @@ class ExtensionArray:
         Returns
         -------
         ExtensionArray
+            A flattened view on the array.
+
+        See Also
+        --------
+        ExtensionArray.tolist: Return a list of the values.
 
         Notes
         -----

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -662,6 +662,11 @@ class ExtensionArray:
         """
         The number of bytes needed to store this object in memory.
 
+        See Also
+        --------
+        ExtensionArray.size: The number of elements in the array.
+        ExtensionArray.shape: Return a tuple of the array dimensions.
+
         Examples
         --------
         >>> pd.array([1, 2, 3]).nbytes

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1595,6 +1595,7 @@ class ExtensionArray:
         Returns
         -------
         ExtensionArray
+            An array formed with selected `indices`.
 
         Raises
         ------

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -767,6 +767,11 @@ class ExtensionArray:
             an ndarray would be expensive, an ExtensionArray may be
             returned.
 
+        See Also
+        --------
+        ExtensionArray.dropna: Return ExtensionArray without NA values.
+        ExtensionArray.fillna: Fill NA/NaN values using the specified method.
+
         Notes
         -----
         If returning an ExtensionArray, then

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -546,7 +546,7 @@ class MPLPlot(ABC):
                 new_ax.set_yscale("log")
             elif self.logy == "sym" or self.loglog == "sym":
                 new_ax.set_yscale("symlog")
-            return new_ax  # type: ignore[return-value]
+            return new_ax
 
     @final
     @cache_readonly


### PR DESCRIPTION
- Related to: https://github.com/pandas-dev/pandas/issues/58539

Fixes docstring issues listed below:
```
   -i "pandas.api.extensions.ExtensionArray.isna SA01" \
   -i "pandas.api.extensions.ExtensionArray.nbytes SA01" \
   -i "pandas.api.extensions.ExtensionArray.ndim SA01" \
   -i "pandas.api.extensions.ExtensionArray.ravel RT03,SA01" \
   -i "pandas.api.extensions.ExtensionArray.take RT03" \
```
