### PR TITLE
REF (string): de-duplicate str_endswith, startswith

### DIFF
--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -25,10 +25,6 @@ if TYPE_CHECKING:
 
 
 class ArrowStringArrayMixin:
-    # _object_compat specifies whether we should 1) attempt to match behaviors
-    #  of the object-backed StringDtype and 2) fall back to object-based
-    #  computation for cases that pyarrow does not support natively.
-    _object_compat = False
     _pa_array: Sized
 
     def __init__(self, *args, **kwargs) -> None:
@@ -114,17 +110,9 @@ class ArrowStringArrayMixin:
             result = pc.starts_with(self._pa_array, pattern=pat)
         else:
             if len(pat) == 0:
-                if self._object_compat:
-                    # mimic existing behaviour of string extension array
-                    # and python string method
-                    result = pa.array(
-                        np.zeros(len(self._pa_array), dtype=np.bool_),
-                        mask=isna(self._pa_array),
-                    )
-                else:
-                    # For empty tuple, pd.StringDtype() returns null for missing values
-                    # and false for valid values.
-                    result = pc.if_else(pc.is_null(self._pa_array), None, False)
+                # For empty tuple we return null for missing values and False
+                #  for valid values.
+                result = pc.if_else(pc.is_null(self._pa_array), None, False)
             else:
                 result = pc.starts_with(self._pa_array, pattern=pat[0])
 
@@ -139,17 +127,9 @@ class ArrowStringArrayMixin:
             result = pc.ends_with(self._pa_array, pattern=pat)
         else:
             if len(pat) == 0:
-                if self._object_compat:
-                    # mimic existing behaviour of string extension array
-                    # and python string method
-                    result = pa.array(
-                        np.zeros(len(self._pa_array), dtype=np.bool_),
-                        mask=isna(self._pa_array),
-                    )
-                else:
-                    # For empty tuple, pd.StringDtype() returns null for missing values
-                    # and false for valid values.
-                    result = pc.if_else(pc.is_null(self._pa_array), None, False)
+                # For empty tuple we return null for missing values and False
+                #  for valid values.
+                result = pc.if_else(pc.is_null(self._pa_array), None, False)
             else:
                 result = pc.ends_with(self._pa_array, pattern=pat[0])
 

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -118,7 +118,7 @@ class ArrowStringArrayMixin:
 
                 for p in pat[1:]:
                     result = pc.or_(result, pc.starts_with(self._pa_array, pattern=p))
-        if not isna(na):
+        if not isna(na):  # pyright: ignore [reportGeneralTypeIssues]
             result = result.fill_null(na)
         return self._convert_bool_result(result)
 
@@ -135,6 +135,6 @@ class ArrowStringArrayMixin:
 
                 for p in pat[1:]:
                     result = pc.or_(result, pc.ends_with(self._pa_array, pattern=p))
-        if not isna(na):
+        if not isna(na):  # pyright: ignore [reportGeneralTypeIssues]
             result = result.fill_null(na)
         return self._convert_bool_result(result)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2337,38 +2337,7 @@ class ArrowExtensionArray(
             result = result.fill_null(na)
         return type(self)(result)
 
-    def _str_startswith(self, pat: str | tuple[str, ...], na=None) -> Self:
-        if isinstance(pat, str):
-            result = pc.starts_with(self._pa_array, pattern=pat)
-        else:
-            if len(pat) == 0:
-                # For empty tuple, pd.StringDtype() returns null for missing values
-                # and false for valid values.
-                result = pc.if_else(pc.is_null(self._pa_array), None, False)
-            else:
-                result = pc.starts_with(self._pa_array, pattern=pat[0])
-
-                for p in pat[1:]:
-                    result = pc.or_(result, pc.starts_with(self._pa_array, pattern=p))
-        if not isna(na):
-            result = result.fill_null(na)
-        return type(self)(result)
-
-    def _str_endswith(self, pat: str | tuple[str, ...], na=None) -> Self:
-        if isinstance(pat, str):
-            result = pc.ends_with(self._pa_array, pattern=pat)
-        else:
-            if len(pat) == 0:
-                # For empty tuple, pd.StringDtype() returns null for missing values
-                # and false for valid values.
-                result = pc.if_else(pc.is_null(self._pa_array), None, False)
-            else:
-                result = pc.ends_with(self._pa_array, pattern=pat[0])
-
-                for p in pat[1:]:
-                    result = pc.or_(result, pc.ends_with(self._pa_array, pattern=p))
-        if not isna(na):
-            result = result.fill_null(na)
+    def _result_converter(self, result):
         return type(self)(result)
 
     def _str_replace(

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -278,7 +278,6 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
 
     # ------------------------------------------------------------------------
     # String methods interface
-    _object_compat = True
 
     _str_map = BaseStringArray._str_map
     _str_startswith = ArrowStringArrayMixin._str_startswith

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -281,6 +281,8 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
     _object_compat = True
 
     _str_map = BaseStringArray._str_map
+    _str_startswith = ArrowStringArrayMixin._str_startswith
+    _str_endswith = ArrowStringArrayMixin._str_endswith
 
     def _str_contains(
         self, pat, case: bool = True, flags: int = 0, na=np.nan, regex: bool = True

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -278,6 +278,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
 
     # ------------------------------------------------------------------------
     # String methods interface
+    _object_compat = True
 
     _str_map = BaseStringArray._str_map
 
@@ -297,44 +298,6 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
         if not isna(na):
             result[isna(result)] = bool(na)
         return result
-
-    def _str_startswith(self, pat: str | tuple[str, ...], na: Scalar | None = None):
-        if isinstance(pat, str):
-            result = pc.starts_with(self._pa_array, pattern=pat)
-        else:
-            if len(pat) == 0:
-                # mimic existing behaviour of string extension array
-                # and python string method
-                result = pa.array(
-                    np.zeros(len(self._pa_array), dtype=bool), mask=isna(self._pa_array)
-                )
-            else:
-                result = pc.starts_with(self._pa_array, pattern=pat[0])
-
-                for p in pat[1:]:
-                    result = pc.or_(result, pc.starts_with(self._pa_array, pattern=p))
-        if not isna(na):
-            result = result.fill_null(na)
-        return self._convert_bool_result(result)
-
-    def _str_endswith(self, pat: str | tuple[str, ...], na: Scalar | None = None):
-        if isinstance(pat, str):
-            result = pc.ends_with(self._pa_array, pattern=pat)
-        else:
-            if len(pat) == 0:
-                # mimic existing behaviour of string extension array
-                # and python string method
-                result = pa.array(
-                    np.zeros(len(self._pa_array), dtype=bool), mask=isna(self._pa_array)
-                )
-            else:
-                result = pc.ends_with(self._pa_array, pattern=pat[0])
-
-                for p in pat[1:]:
-                    result = pc.or_(result, pc.ends_with(self._pa_array, pattern=p))
-        if not isna(na):
-            result = result.fill_null(na)
-        return self._convert_bool_result(result)
 
     def _str_replace(
         self,


### PR DESCRIPTION
<s>This adds a _object_compat attribute to govern whether the subclass uses object-dtype semantics in cases where they differ.</s><b>update</b>_object_compat turned out to be unnecessary.

