### PR TITLE
TST: link to correct downstream fastparquet bug

### DIFF
--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1333,8 +1333,7 @@ class TestParquetFastParquet(Base):
         check_round_trip(df, fp, expected=expected)
 
     @pytest.mark.xfail(
-        reason="fastparquet passed mismatched values/dtype to DatetimeArray "
-        "constructor, see https://github.com/dask/fastparquet/issues/891"
+        reason="fastparquet bug, see https://github.com/dask/fastparquet/issues/929"
     )
     def test_timezone_aware_index(self, fp, timezone_aware_date_list):
         idx = 5 * [timezone_aware_date_list]


### PR DESCRIPTION
Small change, but the current url links to an older already closed/resolved issue (so which is clearly not the cause of the current xfail). Opened a new issue in fastparquet: https://github.com/dask/fastparquet/issues/929, and updated our comment.