### PR TITLE
Use shorthand notation for pip config-settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             if pip show pandas 1>/dev/null; then
                 pip uninstall -y pandas
             fi
-            python -m pip install --no-build-isolation -ve . --config-settings=setup-args="--werror"
+            python -m pip install --no-build-isolation -ve . -Csetup-args="--werror"
             PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH
             sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
             ci/run_tests.sh
@@ -57,7 +57,7 @@ jobs:
             . ~/virtualenvs/pandas-dev/bin/activate
             python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.13.1 meson[ninja]==1.2.1
             python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
-            python -m pip install --no-cache-dir --no-build-isolation -e . --config-settings=setup-args="--werror"
+            python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
             python -m pip list --no-cache-dir
             export PANDAS_CI=1
             python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml

--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -33,9 +33,9 @@ runs:
       run: |
         if [[ ${{ inputs.editable }} == "true" ]]; then
           pip install -e . --no-build-isolation -v --no-deps \
-            --config-settings=setup-args="--werror"
+            -Csetup-args="--werror"
         else
           pip install . --no-build-isolation -v --no-deps \
-            --config-settings=setup-args="--werror"
+            -Csetup-args="--werror"
         fi
       shell: bash -el {0}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -235,9 +235,9 @@ jobs:
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja]==1.2.1 meson-python==0.13.1
-          python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
+          python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
-          python -m pip install --no-cache-dir --no-build-isolation -e . --config-settings=setup-args="--werror"
+          python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
           export PANDAS_CI=1
           python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
@@ -275,7 +275,7 @@ jobs:
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.13.1 meson[ninja]==1.2.1
           python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
-          python -m pip install --no-cache-dir --no-build-isolation -e . --config-settings=setup-args="--werror"
+          python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
 
       - name: Run Tests
@@ -349,7 +349,7 @@ jobs:
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil tzdata cython hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
-          python -m pip install -ve . --no-build-isolation --no-index --no-deps --config-settings=setup-args="--werror"
+          python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
           python -m pip list
 
       - name: Run Tests
@@ -392,7 +392,7 @@ jobs:
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil pytz tzdata hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
-          python -m pip install -ve . --no-build-isolation --no-index --no-deps --config-settings=setup-args="--werror"
+          python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
           python -m pip list
 
       - name: Run Tests

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,10 +13,10 @@ tasks:
       mkdir -p .vscode
       cp gitpod/settings.json .vscode/settings.json
       git fetch --tags
-      python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
+      python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true
       pre-commit install --install-hooks
     command: |
-      python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
+      python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true
       echo "✨ Pre-build complete! You can close this terminal ✨ "
 
 # --------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ or for installing in [development mode](https://pip.pypa.io/en/latest/cli/pip_in
 
 
 ```sh
-python -m pip install -ve . --no-build-isolation --config-settings=editable-verbose=true
+python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true
 ```
 
 See the full instructions for [installing from source](https://pandas.pydata.org/docs/dev/development/contributing_environment.html).

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -227,7 +227,7 @@ To compile pandas with meson, run::
    # By default, this will print verbose output
    # showing the "rebuild" taking place on import (see section below for explanation)
    # If you do not want to see this, omit everything after --no-build-isolation
-   python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
+   python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true
 
 .. note::
    The version number is pulled from the latest repository tag. Be sure to fetch the latest tags from upstream
@@ -242,15 +242,15 @@ To compile pandas with meson, run::
 It is possible to pass options from the pip frontend to the meson backend if you would like to configure your
 install. Occasionally, you'll want to use this to adjust the build directory, and/or toggle debug/optimization levels.
 
-You can pass a build directory to pandas by appending ``--config-settings builddir="your builddir here"`` to your pip command.
+You can pass a build directory to pandas by appending ``-Cbuilddir="your builddir here"`` to your pip command.
 This option allows you to configure where meson stores your built C extensions, and allows for fast rebuilds.
 
 Sometimes, it might be useful to compile pandas with debugging symbols, when debugging C extensions.
-Appending ``--config-settings setup-args="-Ddebug=true"`` will do the trick.
+Appending ``-Csetup-args="-Ddebug=true"`` will do the trick.
 
 With pip, it is possible to chain together multiple config settings (for example specifying both a build directory
 and building with debug symbols would look like
-``--config-settings builddir="your builddir here" --config-settings=setup-args="-Dbuildtype=debug"``.
+``-Cbuilddir="your builddir here" -Csetup-args="-Dbuildtype=debug"``.
 
 **Compiling pandas with setup.py**
 
@@ -302,7 +302,7 @@ output when importing pandas, you can set the environment variable ``MESONPY_EDT
 
 If you would like to see this verbose output every time, you can set the ``editable-verbose`` config setting to ``true`` like so::
 
-   python -m pip install -ve . --config-settings editable-verbose=true
+   python -m pip install -ve . -Ceditable-verbose=true
 
 .. tip::
    If you ever find yourself wondering whether setuptools or meson was used to build your pandas,

--- a/doc/source/development/debugging_extensions.rst
+++ b/doc/source/development/debugging_extensions.rst
@@ -19,7 +19,7 @@ Debugging locally
 
 By default building pandas from source will generate a release build. To generate a development build you can type::
 
-    pip install -ve . --no-build-isolation --config-settings=builddir="debug" --config-settings=setup-args="-Dbuildtype=debug"
+    pip install -ve . --no-build-isolation -Cbuilddir="debug" -Csetup-args="-Dbuildtype=debug"
 
 .. note::
 
@@ -42,7 +42,7 @@ Inside the image, you can use meson to build/install pandas and place the build 
 
 .. code-block:: sh
 
-    python -m pip install -ve . --no-build-isolation --config-settings=builddir="debug" --config-settings=setup-args="-Dbuildtype=debug"
+    python -m pip install -ve . --no-build-isolation -Cbuilddir="debug" -Csetup-args="-Dbuildtype=debug"
 
 If planning to use cygdb, the files required by that application are placed within the build folder. So you have to first ``cd`` to the build folder, then start that application.
 

--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -157,7 +157,7 @@ and then run::
     git bisect start
     git bisect good v1.4.0
     git bisect bad v1.5.0
-    git bisect run bash -c "python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true; python t.py"
+    git bisect run bash -c "python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true; python t.py"
 
 This finds the first commit that changed the behavior. The C extensions have to be
 rebuilt at every step, so the search can take a while.
@@ -165,7 +165,7 @@ rebuilt at every step, so the search can take a while.
 Exit bisect and rebuild the current version::
 
     git bisect reset
-    python -m pip install -ve . --no-build-isolation --config-settings editable-verbose=true
+    python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true
 
 Report your findings under the corresponding issue and ping the commit author to get
 their input.

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -28,8 +28,8 @@ except ImportError as _err:  # pragma: no cover
     raise ImportError(
         f"C extension: {_module} not built. If you want to import "
         "pandas from the source directory, you may need to run "
-        "'python -m pip install -ve . --no-build-isolation --config-settings "
-        "editable-verbose=true' to build the C extensions first."
+        "'python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true' "
+        "to build the C extensions first."
     ) from _err
 
 from pandas._config import (


### PR DESCRIPTION
Just a minor usability enhancement to cut down on the verbosity of passing arguments to the build backend