### PR TITLE
DOCS: fix docstring validation errors for pandas.Series

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -159,8 +159,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.str.replace SA01" \
         -i "pandas.Series.str.wrap RT03,SA01" \
         -i "pandas.Series.str.zfill RT03" \
-        -i "pandas.Series.struct.dtypes SA01" \
-        -i "pandas.Series.to_markdown SA01" \
         -i "pandas.Timedelta.asm8 SA01" \
         -i "pandas.Timedelta.ceil SA01" \
         -i "pandas.Timedelta.components SA01" \

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -244,6 +244,10 @@ class StructAccessor(ArrowAccessor):
         pandas.Series
             The data type of each child field.
 
+        See Also
+        -------
+        Series.dtype: Return the dtype object of the underlying data.
+
         Examples
         --------
         >>> import pyarrow as pa

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -245,7 +245,7 @@ class StructAccessor(ArrowAccessor):
             The data type of each child field.
 
         See Also
-        -------
+        --------
         Series.dtype: Return the dtype object of the underlying data.
 
         Examples

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1617,6 +1617,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         str
             {klass} in Markdown-friendly format.
 
+        See Also
+        -------
+        Series.to_frame : Rrite a text representation of object to the system clipboard.
+        Series.to_latex : Render Series to LaTeX-formatted table.
+
         Notes
         -----
         Requires the `tabulate <https://pypi.org/project/tabulate>`_ package.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1618,7 +1618,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             {klass} in Markdown-friendly format.
 
         See Also
-        -------
+        --------
         Series.to_frame : Rrite a text representation of object to the system clipboard.
         Series.to_latex : Render Series to LaTeX-formatted table.
 


### PR DESCRIPTION
Partially addresses https://github.com/pandas-dev/pandas/issues/59592

Fixes:
```
-i "pandas.Series.struct.dtypes SA01" \ 
-i "pandas.Series.to_markdown SA01" \ 
```