### PR TITLE
DOCS: fix docstring validation errors for pandas.Series

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -134,9 +134,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.dt.tz_localize PR01,PR02" \
         -i "pandas.Series.dt.unit GL08" \
         -i "pandas.Series.gt SA01" \
-        -i "pandas.Series.list.__getitem__ SA01" \
-        -i "pandas.Series.list.flatten SA01" \
-        -i "pandas.Series.list.len SA01" \
         -i "pandas.Series.lt SA01" \
         -i "pandas.Series.ne SA01" \
         -i "pandas.Series.pad PR01,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -141,8 +141,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.ne SA01" \
         -i "pandas.Series.pad PR01,SA01" \
         -i "pandas.Series.pop SA01" \
-        -i "pandas.Series.prod RT03" \
-        -i "pandas.Series.product RT03" \
         -i "pandas.Series.reorder_levels RT03,SA01" \
         -i "pandas.Series.sem PR01,RT03,SA01" \
         -i "pandas.Series.sparse PR01,SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -140,8 +140,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.lt SA01" \
         -i "pandas.Series.ne SA01" \
         -i "pandas.Series.pad PR01,SA01" \
-        -i "pandas.Series.pop SA01" \
-        -i "pandas.Series.reorder_levels RT03,SA01" \
         -i "pandas.Series.sem PR01,RT03,SA01" \
         -i "pandas.Series.sparse PR01,SA01" \
         -i "pandas.Series.sparse.density SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -139,7 +139,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.pad PR01,SA01" \
         -i "pandas.Series.sem PR01,RT03,SA01" \
         -i "pandas.Series.sparse PR01,SA01" \
-        -i "pandas.Series.sparse.density SA01" \
         -i "pandas.Series.sparse.fill_value SA01" \
         -i "pandas.Series.sparse.from_coo PR07,SA01" \
         -i "pandas.Series.sparse.npoints SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -133,9 +133,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.dt.tz_convert PR01,PR02" \
         -i "pandas.Series.dt.tz_localize PR01,PR02" \
         -i "pandas.Series.dt.unit GL08" \
-        -i "pandas.Series.gt SA01" \
-        -i "pandas.Series.lt SA01" \
-        -i "pandas.Series.ne SA01" \
         -i "pandas.Series.pad PR01,SA01" \
         -i "pandas.Series.sem PR01,RT03,SA01" \
         -i "pandas.Series.sparse PR01,SA01" \

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -97,7 +97,7 @@ class ListAccessor(ArrowAccessor):
         str.len : Python built-in function returning the length of an object.
         Series.size : Returns the length of the Series.
         StringMethods.len : Compute the length of each element in the Series/Index.
-            
+
         Examples
         --------
         >>> import pyarrow as pa
@@ -137,7 +137,7 @@ class ListAccessor(ArrowAccessor):
         See Also
         --------
         ListAccessor.flatten : Flatten list values.
-            
+
         Examples
         --------
         >>> import pyarrow as pa

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -92,6 +92,12 @@ class ListAccessor(ArrowAccessor):
         pandas.Series
             The length of each list.
 
+        See Also
+        --------
+        str.len : Python built-in function returning the length of an object.
+        Series.size : Returns the length of the Series.
+        StringMethods.len : Compute the length of each element in the Series/Index.
+            
         Examples
         --------
         >>> import pyarrow as pa
@@ -128,6 +134,10 @@ class ListAccessor(ArrowAccessor):
         pandas.Series
             The list at requested index.
 
+        See Also
+        --------
+        ListAccessor.flatten : Flatten list values.
+            
         Examples
         --------
         >>> import pyarrow as pa
@@ -186,6 +196,10 @@ class ListAccessor(ArrowAccessor):
         -------
         pandas.Series
             The data from all lists in the series flattened.
+
+        See Also
+        --------
+        ListAccessor.__getitem__ : Index or slice values in the Series.
 
         Examples
         --------

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -671,6 +671,11 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         """
         The percent of non- ``fill_value`` points, as decimal.
 
+        See Also
+        --------
+        DataFrame.sparse.from_spmatrix : Create a new DataFrame from a
+            scipy sparse matrix.
+        
         Examples
         --------
         >>> from pandas.arrays import SparseArray

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -675,7 +675,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         --------
         DataFrame.sparse.from_spmatrix : Create a new DataFrame from a
             scipy sparse matrix.
-        
+
         Examples
         --------
         >>> from pandas.arrays import SparseArray

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11815,6 +11815,8 @@ numeric_only : bool, default False
 Returns
 -------
 {name1} or scalar\
+
+    Value containing the calculation referenced in the description.\
 {see_also}\
 {examples}
 """

--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -376,7 +376,7 @@ _op_descriptions: dict[str, dict[str, str | None]] = {
     "ne": {
         "op": "!=",
         "desc": "Not equal to",
-        "reverse": None,
+        "reverse": "eq",
         "series_examples": _ne_example_SERIES,
         "series_returns": _returns_series,
     },
@@ -397,14 +397,14 @@ _op_descriptions: dict[str, dict[str, str | None]] = {
     "gt": {
         "op": ">",
         "desc": "Greater than",
-        "reverse": None,
+        "reverse": "lt",
         "series_examples": _gt_example_SERIES,
         "series_returns": _returns_series,
     },
     "ge": {
         "op": ">=",
         "desc": "Greater than or equal to",
-        "reverse": None,
+        "reverse": "le",
         "series_examples": _ge_example_SERIES,
         "series_returns": _returns_series,
     },

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4098,7 +4098,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         See Also
         --------
-        DataFrame.reorder_levels : Rearrange index or column levels using input ``order``.
+        DataFrame.reorder_levels : Rearrange index or column levels using
+            input ``order``.
 
         Examples
         --------
@@ -5057,7 +5058,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         --------
         Series.drop: Drop specified values from Series.
         Series.drop_duplicates: Return Series with duplicate values removed.
-            
+
         Examples
         --------
         >>> ser = pd.Series([1, 2, 3])

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4093,7 +4093,12 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        type of caller (new object)
+        Series
+            Type of caller with index as MultiIndex (new object).
+
+        See Also
+        --------
+        DataFrame.reorder_levels : Rearrange index or column levels using input ``order``.
 
         Examples
         --------
@@ -5048,6 +5053,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         scalar
             Value that is popped from series.
 
+        See Also
+        --------
+        Series.drop: Drop specified values from Series.
+        Series.drop_duplicates: Return Series with duplicate values removed.
+            
         Examples
         --------
         >>> ser = pd.Series([1, 2, 3])


### PR DESCRIPTION
Partially addresses #59592 

Fixes:
```
 -i "pandas.Series.pop SA01" \
 -i "pandas.Series.list.__getitem__ SA01" \
 -i "pandas.Series.list.flatten SA01" \
 -i "pandas.Series.list.len SA01" \
 -i "pandas.Series.reorder_levels RT03,SA01" \
 -i "pandas.Series.sparse.density SA01" \
 -i "pandas.Series.gt SA01" \
 -i "pandas.Series.lt SA01" \
 -i "pandas.Series.ne SA01" \
 -i "pandas.Series.prod RT03" \
 -i "pandas.Series.product RT03" \
```