### PR TITLE
PERF: Performance Improvement on `DataFrame.to_csv()` when `index=False`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -504,6 +504,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.join` for sorted but non-unique indexes (:issue:`56941`)
 - Performance improvement in :meth:`DataFrame.join` when left and/or right are non-unique and ``how`` is ``"left"``, ``"right"``, or ``"inner"`` (:issue:`56817`)
 - Performance improvement in :meth:`DataFrame.join` with ``how="left"`` or ``how="right"`` and ``sort=True`` (:issue:`56919`)
+- Performance improvement in :meth:`DataFrame.to_csv` when ``index=False`` (:issue:`59312`)
 - Performance improvement in :meth:`DataFrameGroupBy.ffill`, :meth:`DataFrameGroupBy.bfill`, :meth:`SeriesGroupBy.ffill`, and :meth:`SeriesGroupBy.bfill` (:issue:`56902`)
 - Performance improvement in :meth:`Index.join` by propagating cached attributes in cases where the result matches one of the inputs (:issue:`57023`)
 - Performance improvement in :meth:`Index.take` when ``indices`` is a full range indexer from zero to length of index (:issue:`56806`)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -320,7 +320,11 @@ class CSVFormatter:
         res = df._get_values_for_csv(**self._number_format)
         data = list(res._iter_column_arrays())
 
-        ix = self.data_index[slicer]._get_values_for_csv(**self._number_format)
+        ix = (
+            self.data_index[slicer]._get_values_for_csv(**self._number_format)
+            if self.nlevels != 0
+            else np.full(end_i - start_i, None)
+        )
         libwriters.write_csv_rows(
             data,
             ix,

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -323,7 +323,7 @@ class CSVFormatter:
         ix = (
             self.data_index[slicer]._get_values_for_csv(**self._number_format)
             if self.nlevels != 0
-            else np.full(end_i - start_i, None)
+            else np.empty(end_i - start_i)
         )
         libwriters.write_csv_rows(
             data,


### PR DESCRIPTION
- [x] closes #59312 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


I added an alternative `ndarray` with the same length on `_get_values_for_csv`'s output, used on `write_csv_rows` crude testing
https://github.com/pandas-dev/pandas/blob/642d2446060afb11f9860c79a7339eb6ec96fea7/pandas/_libs/writers.pyx#L42

# Tests
Using the same code as the referenced issue:
```python
import pandas as pd
import pyarrow as pa
import pyarrow.csv as csv
import time

NUM_ROWS = 10000000
NUM_COLS = 20

# Example Multi-Index DataFrame
df = pd.DataFrame(
    {
        f"col_{col_idx}": range(col_idx * NUM_ROWS, (col_idx + 1) * NUM_ROWS)
        for col_idx in range(NUM_COLS)
    }
)
df = df.set_index(["col_0", "col_1"], drop=False)

# Timing Operation A
start_time = time.time()
df.to_csv("file_A.csv", index=False)
end_time = time.time()
print(f"Operation A time: {end_time - start_time} seconds")

# Timing Operation B
start_time = time.time()
df_reset = df.reset_index(drop=True)
df_reset.to_csv("file_B.csv", index=False)
end_time = time.time()
print(f"Operation B time: {end_time - start_time} seconds")
```

Output before performance improvement
```
Operation A time: 869.2354643344879 seconds
Operation B time: 42.1906418800354 seconds
```

Output after performance improvement
```
Operation A time: 51.408071756362915 seconds
Operation B time: 45.78637385368347 seconds
```

**Operation B** is used for time comparison when resetting index, the change improves the performance on **Operation A**