### PR TITLE
BUG: Resampling to "B" frequency with closed="right" and label="right" adds empty bins

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -653,6 +653,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrameGroupby.transform` and :meth:`SeriesGroupby.transform` with a reducer and ``observed=False`` that coerces dtype to float when there are unobserved categories. (:issue:`55326`)
 - Bug in :meth:`Rolling.apply` where the applied function could be called on fewer than ``min_period`` periods if ``method="table"``. (:issue:`58868`)
 - Bug in :meth:`Series.resample` could raise when the the date range ended shortly before a non-existent time. (:issue:`58380`)
+- Bug in :meth:`Series.resample` where bin edges were not correct with closed="right" and label="right" for :class:`~pandas.tseries.offsets.BusinessDay` (:issue:`59495`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2173,7 +2173,11 @@ class TimeGrouper(Grouper):
         if self.closed == "right":
             labels = binner
             if self.label == "right":
-                labels = labels[1:]
+                if binner.freqstr == "B":
+                    labels = labels[1:-1]
+                    bins = bins[0:-1]
+                else:
+                    labels = labels[1:]
         elif self.label == "right":
             labels = labels[1:]
 


### PR DESCRIPTION
- [x] closes #59495
- [x] Tests added and passed
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst`



fixed bug: Resampling to frequency='B' with closed='right'a nd label='right'
