### PR TITLE
Fix part of docstring timedelta #59698

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -104,9 +104,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.sparse.npoints SA01" \
         -i "pandas.Series.sparse.sp_values SA01" \
         -i "pandas.Timedelta.components SA01" \
-        -i "pandas.Timedelta.max PR02" \
-        -i "pandas.Timedelta.min PR02" \
-        -i "pandas.Timedelta.resolution PR02" \
         -i "pandas.Timedelta.to_timedelta64 SA01" \
         -i "pandas.Timedelta.total_seconds SA01" \
         -i "pandas.TimedeltaIndex.to_pytimedelta RT03,SA01" \

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1857,6 +1857,21 @@ class Timedelta(_Timedelta):
         Values for construction in compat with datetime.timedelta.
         Numpy ints and floats will be coerced to python ints and floats.
 
+    **Attributes
+    --------
+    resolution: Timedelta
+        Represents the smallest difference between two time units that can be represented
+        by the Timedelta object. 
+        Fixed at 0 days 00:00:00.000000001 (1 nanosecond).
+    min : Timedelta
+        Returns the minimum Timedelta value that can be created or used in
+        pandas operations.
+        Fixed at -106752 days +00:12:43.145224193
+    max : Timedelta
+        Returns the maximum Timedelta value that can be created or used in
+        pandas operations.
+        Fixed at 106751 days 23:47:16.854775807.
+
     See Also
     --------
     Timestamp : Represents a single timestamp in time.

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1857,11 +1857,11 @@ class Timedelta(_Timedelta):
         Values for construction in compat with datetime.timedelta.
         Numpy ints and floats will be coerced to python ints and floats.
 
-    **Attributes
-    --------
+    Attributes
+    ----------
     resolution: Timedelta
-        Represents the smallest difference between two time units that can be represented
-        by the Timedelta object. 
+        Represents the smallest difference between two time units that can be
+        represented by the Timedelta object.
         Fixed at 0 days 00:00:00.000000001 (1 nanosecond).
     min : Timedelta
         Returns the minimum Timedelta value that can be created or used in


### PR DESCRIPTION
Part of [59698](https://github.com/pandas-dev/pandas/issues/59698)

Addresses:

pandas.Timedelta

Added the missing explanations (PRO2) for min, max, and resolution.

Removed:

-  i "pandas.Timedelta.resolution PR02" \
-  i "pandas.Timedelta.min PR02" \
-  i "pandas.Timedelta.resolution PR02" \

from code_checks.sh

p.s. I'm not 100% confident if this is the appropriate way to document these attributes. That said, they're being defined by a class called `MinMaxReso`, and they don't have their separate definitions per se. So, I found this most appropriate way to document them.