### PR TITLE
DOC: fix SA01,ES01 for pandas.RangeIndex.start

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -76,7 +76,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Period.to_timestamp SA01" \
         -i "pandas.PeriodDtype.freq SA01" \
         -i "pandas.RangeIndex.from_range PR01,SA01" \
-        -i "pandas.RangeIndex.start SA01" \
         -i "pandas.RangeIndex.step SA01" \
         -i "pandas.RangeIndex.stop SA01" \
         -i "pandas.Series.cat.add_categories PR01,PR02" \

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -295,6 +295,22 @@ class RangeIndex(Index):
         """
         The value of the `start` parameter (``0`` if this was not supplied).
 
+        This property returns the starting value of the `RangeIndex`. If the `start`
+        value is not explicitly provided during the creation of the `RangeIndex`,
+        it defaults to 0. The `start` property is part of the `RangeIndex`, which
+        represents a range of integers in a memory-efficient manner. It is typically
+        used when you need to generate a sequence of numbers with minimal memory
+        overhead. The `RangeIndex` is frequently used as the default index for pandas
+        DataFrames and Series when no explicit index is provided. This property allows
+        users to access the starting point of the range, which may be useful for
+        iteration, slicing, or other operations where the starting value is relevant.
+
+        See Also
+        --------
+        RangeIndex : Immutable index implementing a range-based index.
+        RangeIndex.stop : Returns the stop value of the `RangeIndex`.
+        RangeIndex.step : Returns the step value of the `RangeIndex`.
+
         Examples
         --------
         >>> idx = pd.RangeIndex(5)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -297,13 +297,7 @@ class RangeIndex(Index):
 
         This property returns the starting value of the `RangeIndex`. If the `start`
         value is not explicitly provided during the creation of the `RangeIndex`,
-        it defaults to 0. The `start` property is part of the `RangeIndex`, which
-        represents a range of integers in a memory-efficient manner. It is typically
-        used when you need to generate a sequence of numbers with minimal memory
-        overhead. The `RangeIndex` is frequently used as the default index for pandas
-        DataFrames and Series when no explicit index is provided. This property allows
-        users to access the starting point of the range, which may be useful for
-        iteration, slicing, or other operations where the starting value is relevant.
+        it defaults to 0.
 
         See Also
         --------


### PR DESCRIPTION
fixes

```
pandas.RangeIndex.start SA01,ES01
```