### PR TITLE
TST: Update IntervalArray min/max test to fail on changed default skipna

### DIFF
--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -222,9 +222,10 @@ class TestReductions:
         res = arr_na.max(skipna=False)
         assert np.isnan(res)
 
-        res = arr_na.min(skipna=True)
-        assert res == MIN
-        assert type(res) == type(MIN)
-        res = arr_na.max(skipna=True)
-        assert res == MAX
-        assert type(res) == type(MAX)
+        for kws in [{"skipna": True}, {}]:
+            res = arr_na.min(**kws)
+            assert res == MIN
+            assert type(res) == type(MIN)
+            res = arr_na.max(**kws)
+            assert res == MAX
+            assert type(res) == type(MAX)


### PR DESCRIPTION
- [x] Part of #58517 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] ~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~ Not applicable
- [x] ~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~ Not applicable

Before, if the line [core/arrays/interval.py:866](https://github.com/pandas-dev/pandas/blob/v2.2.1/pandas/core/arrays/interval.py#L866) is changed from `def min(self, *, axis: AxisInt | None = None, skipna: bool = True) -> IntervalOrNA:` to `def min(self, *, axis: AxisInt | None = None, skipna: bool = False) -> IntervalOrNA:`, all tests still passed. Now they will fail if the default `skipna` param is updated, perhaps mistakenly.

Applies to `max()` method too since they are tested in the same test function.