### PR TITLE
BUG: Fix groupby().any() behavior for timedelta columns with all null valuesfix issue #59712

### DIFF
--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -371,19 +371,6 @@ class WrappedCythonOp:
 
         is_datetimelike = dtype.kind in "mM"
 
-        if self.how in ["any", "all"]:
-            if mask is None:
-                mask = isna(values)
-            if dtype == object:
-                if kwargs["skipna"]:
-                    # GH#37501: don't raise on pd.NA when skipna=True
-                    if mask.any():
-                        # mask on original values computed separately
-                        values = values.copy()
-                        values[mask] = True
-            values = values.astype(bool, copy=False).view(np.int8)
-            is_numeric = True
-
         if is_datetimelike:
             values = values.view("int64")
             is_numeric = True
@@ -397,6 +384,19 @@ class WrappedCythonOp:
             mask = mask.T
             if result_mask is not None:
                 result_mask = result_mask.T
+
+        if self.how in ["any", "all"]:
+            if mask is None:
+                mask = isna(values)
+            if dtype == object:
+                if kwargs["skipna"]:
+                    # GH#37501: don't raise on pd.NA when skipna=True
+                    if mask.any():
+                        # mask on original values computed separately
+                        values = values.copy()
+                        values[mask] = True
+            values = values.astype(bool, copy=False).view(np.int8)
+            is_numeric = True
 
         out_shape = self._get_output_shape(ngroups, values)
         func = self._get_cython_function(self.kind, self.how, values.dtype, is_numeric)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -371,14 +371,6 @@ class WrappedCythonOp:
 
         is_datetimelike = dtype.kind in "mM"
 
-        if is_datetimelike:
-            values = values.view("int64")
-            is_numeric = True
-        elif dtype.kind == "b":
-            values = values.view("uint8")
-        if values.dtype == "float16":
-            values = values.astype(np.float32)
-
         if self.how in ["any", "all"]:
             if mask is None:
                 mask = isna(values)
@@ -391,6 +383,14 @@ class WrappedCythonOp:
                         values[mask] = True
             values = values.astype(bool, copy=False).view(np.int8)
             is_numeric = True
+
+        if is_datetimelike:
+            values = values.view("int64")
+            is_numeric = True
+        elif dtype.kind == "b":
+            values = values.view("uint8")
+        if values.dtype == "float16":
+            values = values.astype(np.float32)
 
         values = values.T
         if mask is not None:

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -1180,3 +1180,15 @@ def test_grouping_by_key_is_in_axis():
     result = gb.sum()
     expected = DataFrame({"a": [1, 2], "b": [1, 2], "c": [7, 5]})
     tm.assert_frame_equal(result, expected)
+
+def test_groupby_any_timedelta_with_all_nulls():
+    # Create a DataFrame with timedelta values, including NaT (null timedelta)
+    df = pd.DataFrame({
+        'timedelta': [pd.Timedelta(days=1), pd.NaT],
+        'group': [0, 1]
+    })
+    result = df.groupby('group')['timedelta'].any()
+
+    # Expected behavior: group 1 should return False because it has all null values
+    expected = pd.Series([True, False], index=[0, 1])
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
This pull request addresses a bug in the `groupby().any()` method when applied to DataFrames with `timedelta` columns where all values are null (`NaT`). Previously, the method incorrectly returned `True` for groups with all null values in the `timedelta` column. 

**Changes Made:**
- Updated the `_call_cython_op` method to correctly handle `timedelta` columns when computing the `any()` aggregation.
- Added a new test case to verify that `groupby().any()` returns `False` for groups where all `timedelta` values are null.

**Issue Reference:**
- See issue [#59712](https://github.com/pandas-dev/pandas/issues/59712) for more details about the bug report.

This fix ensures that the `groupby().any()` method behaves consistently for `timedelta` columns, aligning with the behavior observed for other data types.
