### PR TITLE
Infer extensiondtype from scalar

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1695,7 +1695,6 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
         if is_interval_array(values):
             return "interval"
 
-    print("infer_dtype")
     reg_dtype = _registry.match_scalar(val)
     if reg_dtype:
         return str(reg_dtype)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -107,6 +107,8 @@ from pandas._libs.tslibs.period cimport is_period_object
 from pandas._libs.tslibs.timedeltas cimport convert_to_timedelta64
 from pandas._libs.tslibs.timezones cimport tz_compare
 
+from pandas.core.dtypes.base import _registry
+
 # constants that will be compared to potentially arbitrarily large
 # python int
 cdef:
@@ -1692,6 +1694,11 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
     elif isinstance(val, Interval):
         if is_interval_array(values):
             return "interval"
+
+    print("infer_dtype")
+    reg_dtype = _registry.match_scalar(val)
+    if reg_dtype:
+        return str(reg_dtype)
 
     cnp.PyArray_ITER_RESET(it)
     for i in range(n):

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -370,6 +370,10 @@ def array(
 
         elif data.dtype.kind == "b":
             return BooleanArray._from_sequence(data, dtype="boolean", copy=copy)
+        # elif inferred_dtype != "mixed":
+        #     dtype = pandas_dtype(inferred_dtype)
+        #     cls = dtype.construct_array_type()
+        #     return cls._from_sequence(data, dtype=dtype, copy=copy)
         else:
             # e.g. complex
             return NumpyExtensionArray._from_sequence(data, dtype=data.dtype, copy=copy)

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -370,10 +370,6 @@ def array(
 
         elif data.dtype.kind == "b":
             return BooleanArray._from_sequence(data, dtype="boolean", copy=copy)
-        # elif inferred_dtype != "mixed":
-        #     dtype = pandas_dtype(inferred_dtype)
-        #     cls = dtype.construct_array_type()
-        #     return cls._from_sequence(data, dtype=dtype, copy=copy)
         else:
             # e.g. complex
             return NumpyExtensionArray._from_sequence(data, dtype=data.dtype, copy=copy)

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -444,12 +444,17 @@ class ExtensionDtype:
         """
         return False
 
-    def is_unambiguous_scalar(self):
+    @classmethod
+    def is_unambiguous_scalar(cls, scalar):
         return False
 
     @classmethod
     def construct_from_scalar(cls, scalar):
         return cls()
+    
+    @property
+    def is_external_dtype(self) -> bool:
+        return not self.__module__.split(".")[0] == "pandas"
 
 
 class StorageExtensionDtype(ExtensionDtype):

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -444,6 +444,13 @@ class ExtensionDtype:
         """
         return False
 
+    def is_unambiguous_scalar(self):
+        return False
+
+    @classmethod
+    def construct_from_scalar(cls, scalar):
+        return cls()
+
 
 class StorageExtensionDtype(ExtensionDtype):
     """ExtensionDtype that may be backed by more than one implementation."""
@@ -580,6 +587,14 @@ class Registry:
             except TypeError:
                 pass
 
+        return None
+
+    def match_scalar(
+        self, scalar: Any
+    ) -> type_t[ExtensionDtype] | ExtensionDtype | None:
+        for dtype in self.dtypes:
+            if dtype.is_unambiguous_scalar(scalar):
+                return dtype.construct_from_scalar(scalar)
         return None
 
 

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -454,7 +454,7 @@ class ExtensionDtype:
     
     @property
     def is_external_dtype(self) -> bool:
-        return not self.__module__.split(".")[0] == "pandas"
+        return self.__module__[:8] == "pandas.c"
 
 
 class StorageExtensionDtype(ExtensionDtype):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -918,6 +918,8 @@ def infer_dtype_from_array(arr) -> tuple[DtypeObj, ArrayLike]:
     inferred = lib.infer_dtype(arr, skipna=False)
     if inferred in ["string", "bytes", "mixed", "mixed-integer"]:
         return (np.dtype(np.object_), arr)
+    elif inferred in ["empty", "integer", "floating", "integer-na", "mixed-integer-float", "datetime", "period", "timedelta", "time", "date"]:
+        pass
     else:
         arr_dtype = pandas_dtype_func(inferred)
         if isinstance(arr_dtype, ExtensionDtype):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -44,6 +44,7 @@ from pandas.errors import (
     LossySetitemError,
 )
 
+from pandas.core.dtypes.base import _registry
 from pandas.core.dtypes.common import (
     ensure_int8,
     ensure_int16,
@@ -857,6 +858,10 @@ def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
         subtype = infer_dtype_from_scalar(val.left)[0]
         dtype = IntervalDtype(subtype=subtype, closed=val.closed)
 
+    reg_dtype = _registry.match_scalar(val)
+    if reg_dtype:
+        dtype = reg_dtype
+
     return dtype, val
 
 
@@ -913,6 +918,10 @@ def infer_dtype_from_array(arr) -> tuple[DtypeObj, ArrayLike]:
     inferred = lib.infer_dtype(arr, skipna=False)
     if inferred in ["string", "bytes", "mixed", "mixed-integer"]:
         return (np.dtype(np.object_), arr)
+    else:
+        arr_dtype = pandas_dtype_func(inferred)
+        if isinstance(arr_dtype, ExtensionDtype):
+            return arr_dtype, arr
 
     arr = np.asarray(arr)
     return arr.dtype, arr

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -502,7 +502,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                 data = data.copy()
         else:
             if dtype is None:
-                dtype = infer_dtype_from(data)[0]
+                inferred_dtype = infer_dtype_from(data)[0]
+                if isinstance(inferred_dtype, ExtensionDtype) and inferred_dtype.is_external_dtype:
+                    dtype = inferred_dtype
+                    # import pdb; pdb.set_trace()
             data = sanitize_array(data, index, dtype, copy)
             data = SingleBlockManager.from_array(data, index, refs=refs)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -501,6 +501,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             elif copy:
                 data = data.copy()
         else:
+            if dtype is None:
+                dtype = infer_dtype_from(data)[0]
             data = sanitize_array(data, index, dtype, copy)
             data = SingleBlockManager.from_array(data, index, refs=refs)
 

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -75,9 +75,8 @@ from pandas.core.arrays import (
     FloatingArray,
     IntegerArray,
 )
-from pandas.core.dtypes.dtypes import ExtensionDtype
+from pandas.core.dtypes.dtypes import ExtensionDtype, register_extension_dtype
 
-from pandas.core
 
 @pytest.fixture(params=[True, False], ids=str)
 def coerce(request):
@@ -2032,6 +2031,7 @@ def test_infer_dtype_extensiondtype():
     class MockScalar:
         pass
 
+    @register_extension_dtype
     class MockDtype(ExtensionDtype):
         @property
         def name(self):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -81,6 +81,13 @@ from pandas.core.arrays import (
 def coerce(request):
     return request.param
 
+class MockScalar:
+    pass
+
+class MockDtype(pd.api.extensions.ExtensionDtype):
+    
+
+
 
 class MockNumpyLikeArray:
     """

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -75,18 +75,13 @@ from pandas.core.arrays import (
     FloatingArray,
     IntegerArray,
 )
+from pandas.core.dtypes.dtypes import ExtensionDtype
 
+from pandas.core
 
 @pytest.fixture(params=[True, False], ids=str)
 def coerce(request):
     return request.param
-
-class MockScalar:
-    pass
-
-class MockDtype(pd.api.extensions.ExtensionDtype):
-    
-
 
 
 class MockNumpyLikeArray:
@@ -2032,3 +2027,18 @@ def test_find_result_type_int_int(right, result):
 def test_find_result_type_floats(right, result):
     left_dtype = np.dtype("float16")
     assert find_result_type(left_dtype, right) == result
+
+def test_infer_dtype_extensiondtype():
+    class MockScalar:
+        pass
+
+    class MockDtype(ExtensionDtype):
+        @property
+        def name(self):
+            return "MockDtype"
+        def is_unambiguous_scalar(scalar):
+            if isinstance(scalar, MockScalar):
+                return True
+            return False
+    arr = [MockScalar()]
+    assert lib.infer_dtype(arr, skipna=True) == "MockDtype"

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -205,25 +205,11 @@ class TestSeriesConstructors:
         tm.assert_series_equal(ser, expected)
 
 
-    def test_scalar_extension_dtype2(self):
-        # GH 28401
-        from pandas.core.dtypes.cast import (
-            LossySetitemError,
-            construct_1d_arraylike_from_scalar,
-            find_common_type,
-            infer_dtype_from,
-            maybe_box_native,
-            maybe_cast_pointwise_result,
-        )
+    def test_unambiguous_scalar(self):
         ea_scalar, ea_dtype = MockScalar(), MockDtype()
 
-        # import pdb; pdb.set_trace()
-        infer_dtype_from(MockScalar())
         ser = Series(ea_scalar, index=range(3))
-        expected = Series([ea_scalar] * 3, dtype=ea_dtype)
-
         assert ser.dtype == ea_dtype
-        # tm.assert_series_equal(ser, expected)
 
     def test_constructor(self, datetime_series, using_infer_string):
         empty_series = Series()

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -44,9 +44,61 @@ import pandas._testing as tm
 from pandas.core.arrays import (
     IntegerArray,
     IntervalArray,
-    period_array,
+    period_array,ExtensionArray
 )
 from pandas.core.internals.blocks import NumpyBlock
+
+from pandas.core.dtypes.dtypes import ExtensionDtype,  register_extension_dtype
+
+class MockScalar:
+    pass
+
+@register_extension_dtype
+class MockDtype(ExtensionDtype):
+    type = MockScalar
+    @property
+    def name(self):
+        return "MockDtype"
+    def is_unambiguous_scalar(scalar):
+        if isinstance(scalar, MockScalar):
+            return True
+        return False
+
+    @classmethod
+    def construct_from_string(cls, string: str):
+        if not isinstance(string, str):
+            raise TypeError(
+                f"'construct_from_string' expects a string, got {type(string)}"
+            )
+
+        if string == cls.__name__:
+            return cls()
+        else:
+            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
+
+    @classmethod
+    def construct_array_type(cls):
+        """
+        Return the array type associated with this dtype.
+
+        Returns
+        -------
+        type
+        """
+        return MockArray
+    
+    @property
+    def is_external_dtype(self):
+        return True
+
+
+from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
+class MockArray(NDArrayBackedExtensionArray):
+    dtype = MockDtype()
+    @classmethod
+    def _from_sequence(cls, scalars, *, dtype=None, copy=False):
+        scalars = np.ndarray([0 for i in scalars])
+        return cls(scalars, "O")
 
 
 class TestSeriesConstructors:
@@ -151,6 +203,27 @@ class TestSeriesConstructors:
 
         assert ser.dtype == ea_dtype
         tm.assert_series_equal(ser, expected)
+
+
+    def test_scalar_extension_dtype2(self):
+        # GH 28401
+        from pandas.core.dtypes.cast import (
+            LossySetitemError,
+            construct_1d_arraylike_from_scalar,
+            find_common_type,
+            infer_dtype_from,
+            maybe_box_native,
+            maybe_cast_pointwise_result,
+        )
+        ea_scalar, ea_dtype = MockScalar(), MockDtype()
+
+        # import pdb; pdb.set_trace()
+        infer_dtype_from(MockScalar())
+        ser = Series(ea_scalar, index=range(3))
+        expected = Series([ea_scalar] * 3, dtype=ea_dtype)
+
+        assert ser.dtype == ea_dtype
+        # tm.assert_series_equal(ser, expected)
 
     def test_constructor(self, datetime_series, using_infer_string):
         empty_series = Series()


### PR DESCRIPTION
- [ ] closes #41848
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This adds an `is_unambiguous_scalar` (as suggested) method to `ExtensionDtype` that can be used to infer the dtype when it isn't passed into `Series` or `DataFrame` constructors.  

With these changes `Series()` can recognise `pint.Quantity`s and construct a `PintArray`. Is this a good approch? I've not done any inference in sanitize_array as its docstring doesn't mention inference. However it looks like it'd be easier to do so in there than do so in the various constructor methods.