### PR TITLE
2.2.x Enhance to_numeric to support hexadecimal, octal, and binary string inputs

### DIFF
--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+from pandas._libs import libmissing
+from pandas.core.dtypes.common import is_string_dtype
+from pandas.core.dtypes.missing import isna
 
 from typing import (
     TYPE_CHECKING,
@@ -41,6 +44,16 @@ if TYPE_CHECKING:
         npt,
     )
 
+def parse_numeric(value):
+    if isinstance(value, str):
+        try:
+            return int(value, 0)  # Automatically detect radix
+        except ValueError:
+            try:
+                return float(value)
+            except ValueError:
+                return libmissing.NA 
+    return value
 
 def to_numeric(
     arg,
@@ -161,6 +174,7 @@ def to_numeric(
     2    3.0
     dtype: Float32
     """
+    
     if downcast not in (None, "integer", "signed", "unsigned", "float"):
         raise ValueError("invalid downcasting method provided")
 
@@ -215,14 +229,25 @@ def to_numeric(
     else:
         values = ensure_object(values)
         coerce_numeric = errors != "raise"
-        values, new_mask = lib.maybe_convert_numeric(  # type: ignore[call-overload]
-            values,
-            set(),
-            coerce_numeric=coerce_numeric,
-            convert_to_masked_nullable=dtype_backend is not lib.no_default
-            or isinstance(values_dtype, StringDtype)
-            and values_dtype.na_value is libmissing.NA,
-        )
+        parsed_values = []
+        new_mask = []
+
+        for idx, x in enumerate(values):
+            parsed_value = parse_numeric(x)
+            if libmissing.checknull(parsed_value):
+                if errors == 'raise':
+                    raise ValueError(f"Unable to parse string '{x}' at position {idx}")
+                elif errors == 'coerce':
+                    parsed_values.append(libmissing.NA)
+                    new_mask.append(True)
+                    continue
+            else:
+                parsed_values.append(parsed_value)
+                new_mask.append(False)
+
+        values = np.array(parsed_values, dtype=object)
+        new_mask = np.array(new_mask, dtype=bool)
+
 
     if new_mask is not None:
         # Remove unnecessary values, is expected later anyway and enables


### PR DESCRIPTION
Added a Helper Function parse_numeric:

Introduced a new internal function parse_numeric that attempts to parse strings with base prefixes:
Uses int(value, 0) to automatically detect the numerical base from the string prefix.
If parsing as an integer fails, it attempts to parse the value as a float.
Returns libmissing.NA if both parsing attempts fail.

Modified the Parsing Logic in to_numeric:

Replaced the call to lib.maybe_convert_numeric with a loop that applies parse_numeric to each element.
Handles errors according to the errors parameter:
Raises a ValueError with informative messaging when errors='raise'.
Sets unparseable values to NaN when errors='coerce'.
Utilizes a mask (new_mask) to track which values could not be parsed.