### PR TITLE
Update ExtensionArray.interpolate to remove outdated method of pad

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1010,7 +1010,6 @@ class ExtensionArray:
             * 'time': Works on daily and higher resolution data to interpolate
             given length of interval.
             * 'index', 'values': use the actual numerical values of the index.
-            * 'pad': Fill in NaNs using existing values.
             * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic', 'barycentric',
             'polynomial': Passed to scipy.interpolate.interp1d, whereas 'spline'
             is passed to scipy.interpolate.UnivariateSpline. These methods use


### PR DESCRIPTION
Removed the outdated method of `pad` from ExtensionArray.interpolate.

Reason:

- Found in #59749 that `pad` raises a ValueError whatever value you pass. 
- #57092) says that `pad` has been removed from DataFrame.Interpolate, which is the origin of ExtensionArray. 
