### PR TITLE
WEB: update list of (in)active core devs

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -89,7 +89,6 @@ maintainers:
   - phofl
   - attack68
   - fangchenli
-  - twoertwein
   - lithomas1
   - lukemanley
   - noatamir
@@ -108,6 +107,7 @@ maintainers:
   - wesm
   - gfyoung
   - mzeitlin11
+  - twoertwein
 workgroups:
   coc:
     name: Code of Conduct


### PR DESCRIPTION
I am no longer an active core member.  You can still ping me if you want my input, for example, at pandas-stubs (@Dr-Irv), but don't expect me to open PRs :)

When I joined pandas, I was actively using pandas and didn't have enough software development in my life :), now I'm rarely using pandas and have more than enough software development in my life.

@pandas-dev/pandas-core 