### PR TITLE
BLD/RLS: build wheels with released numpy/cython for Python 3.13

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,9 +102,7 @@ jobs:
         python: [["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"]]
         include:
         # TODO: Remove this plus installing build deps in cibw_before_build.sh
-        # and test deps in cibw_before_test.sh after pandas can be built with a released NumPy/Cython
-        - python: ["cp313", "3.13"]
-          cibw_build_frontend: 'pip; args: --no-build-isolation'
+        # after pandas can be built with a released NumPy/Cython
         - python: ["cp313t", "3.13"]
           cibw_build_frontend: 'pip; args: --no-build-isolation'
         # Build Pyodide wheels and upload them to Anaconda.org
@@ -187,11 +185,9 @@ jobs:
       - name: Test Windows Wheels
         if: ${{ matrix.buildplat[1] == 'win_amd64' }}
         shell: pwsh
-        # TODO: Remove NumPy nightly install when there's a 3.13 wheel on PyPI
         run: |
           $TST_CMD = @"
           python -m pip install hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0;
-          ${{ matrix.python[1] == '3.13' && 'python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy;' }}
           python -m pip install `$(Get-Item pandas\wheelhouse\*.whl);
           python -c `'import pandas as pd; pd.test(extra_args=[`\"--no-strict-data-files`\", `\"-m not clipboard and not single_cpu and not slow and not network and not db`\"])`';
           "@

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -65,4 +65,3 @@ graft pandas/_libs/include
 
 # Include cibw script in sdist since it's needed for building wheels
 include scripts/cibw_before_build.sh
-include scripts/cibw_before_test.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,6 @@ test-command = """
   """
 free-threaded-support = true
 before-build = "bash {package}/scripts/cibw_before_build.sh"
-before-test = "bash {package}/scripts/cibw_before_test.sh"
 
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel && bash {package}/scripts/cibw_before_build.sh"
@@ -165,7 +164,7 @@ repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-before-test = "apk update && apk add musl-locales && bash {package}/scripts/cibw_before_test.sh"
+before-test = "apk update && apk add musl-locales"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-win*"

--- a/scripts/cibw_before_build.sh
+++ b/scripts/cibw_before_build.sh
@@ -1,8 +1,6 @@
-# TODO: Delete when there's PyPI NumPy/Cython releases the support Python 3.13.
-# If free-threading support is not included in those releases, this script will have
-# to whether this runs for a free-threaded build instead.
-PYTHON_VERSION="$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")"
-if [[ $PYTHON_VERSION == "313" ]]; then
+# TODO: Delete when there's a PyPI Cython release that supports free-threaded Python 3.13.
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+if [[ $FREE_THREADED_BUILD == "True"  ]]; then
     python -m pip install -U pip
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
     python -m pip install ninja meson-python versioneer[toml]

--- a/scripts/cibw_before_test.sh
+++ b/scripts/cibw_before_test.sh
@@ -1,8 +1,0 @@
-# TODO: Delete when there's PyPI NumPy/Cython releases the support Python 3.13.
-# If free-threading support is not included in those releases, this script will have
-# to whether this runs for a free-threaded build instead.
-PYTHON_VERSION="$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")"
-if [[ $PYTHON_VERSION == "313" ]]; then
-    python -m pip install -U pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-fi


### PR DESCRIPTION
Now that there is a released numpy that supports Python 3.13, we can clean up parts of our TODOs related to that (from https://github.com/pandas-dev/pandas/pull/59136) in our wheel building workflow.

It was noted in https://github.com/pandas-dev/pandas/issues/59817 that our wheel builds were failing because of testing with numpy dev instead of released numpy, a problem which itself is being fixed by https://github.com/pandas-dev/pandas/pull/59818