### PR TITLE
Backport PR #59818 on branch 2.2.x (BUG: Remove np._get_promotion_state usage)

### DIFF
--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -3,10 +3,12 @@ from datetime import (
     datetime,
 )
 from decimal import Decimal
+import os
 
 import numpy as np
 import pytest
 
+from pandas.compat import WASM
 from pandas.compat.numpy import np_version_gte1p24
 from pandas.errors import IndexingError
 
@@ -1443,7 +1445,11 @@ class TestCoercionFloat64(CoercionTest):
             marks=pytest.mark.xfail(
                 (
                     not np_version_gte1p24
-                    or (np_version_gte1p24 and np._get_promotion_state() != "weak")
+                    or (
+                        np_version_gte1p24
+                        and os.environ.get("NPY_PROMOTION_STATE", "weak") != "weak"
+                    )
+                    or WASM
                 ),
                 reason="np.float32(1.1) ends up as 1.100000023841858, so "
                 "np_can_hold_element raises and we cast to float64",


### PR DESCRIPTION
Backport PR #59818 on branch 2.2.x (BUG: Remove np._get_promotion_state usage)

(cherry picked from commit 081dcdee8d754af90e307cf2311b06b3d02fae2a)
