### PR TITLE
typo

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3580,7 +3580,7 @@ class Table(Fixed):
 
     @property
     def data_orientation(self) -> tuple[int, ...]:
-        """return a tuple of my permuted axes, non_indexable at the front"""
+        """return a tuple of my permutated axes, non_indexable at the front"""
         return tuple(
             itertools.chain(
                 [int(a[0]) for a in self.non_index_axes],


### PR DESCRIPTION
_cf_: https://github.com/pandas-dev/pandas/pull/59665

@mroeschke, @mattwang44

pandas/io/pytables.py

reverts this change which shouldn't have been implemented

```diff
-         """return a tuple of my permutated axes, non_indexable at the front"""
+         """return a tuple of my permuted axes, non_indexable at the front"""
```

my apologies

@jreback 



`https://github.com/pandas-dev/pandas/pull/2497`

_cf_: ENH: ndim tables in HDFStore