### PR TITLE
DOC: Fix inconsistent and incomplete documentation of `pandas.eval`

### DIFF
--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -211,8 +211,8 @@ def eval(
         Furthermore, the following mathematical functions are supported:
 
         - Trigonometric: ``sin``, ``cos``, ``tan``, ``arcsin``, ``arccos``, \
-            ``arctan``, ``sinh``, ``cosh``, ``tanh``, ``arcsinh``, ``arccosh`` \
-            and ``arctanh``
+            ``arctan``, ``arctan2``, ``sinh``, ``cosh``, ``tanh``, ``arcsinh``, \
+            ``arccosh`` and ``arctanh``
         - Logarithms: ``log`` natural, ``log10`` base 10, ``log1p`` log(1+x)
         - Absolute Value ``abs``
         - Square root ``sqrt``

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -223,8 +223,8 @@ def eval(
         for further function support details.
 
         Using the ``'python'`` engine allows the use of native Python operators
-        like integer division ``//``, in addition to Python functions,
-        both built-in and user-defined.
+        such as floor division ``//``, in addition to built-in and user-defined
+        Python functions.
 
         Additionally, the ``'pandas'`` parser allows the use of :keyword:`and`,
         :keyword:`or`, and :keyword:`not` with the same semantics as the

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -188,15 +188,6 @@ def eval(
     """
     Evaluate a Python expression as a string using various backends.
 
-    The following arithmetic operations are supported: ``+``, ``-``, ``*``,
-    ``/``, ``**``, ``%``, ``//`` (python engine only) along with the following
-    boolean operations: ``|`` (or), ``&`` (and), and ``~`` (not).
-    Additionally, the ``'pandas'`` parser allows the use of :keyword:`and`,
-    :keyword:`or`, and :keyword:`not` with the same semantics as the
-    corresponding bitwise operators.  :class:`~pandas.Series` and
-    :class:`~pandas.DataFrame` objects are supported and behave as they would
-    with plain ol' Python evaluation.
-
     .. warning::
 
         ``eval`` can run arbitrary code which can make you vulnerable to code
@@ -210,6 +201,34 @@ def eval(
         <https://docs.python.org/3/reference/simple_stmts.html#simple-statements>`__,
         only Python `expressions
         <https://docs.python.org/3/reference/simple_stmts.html#expression-statements>`__.
+
+        By default, with the numexpr engine, the following operations are supported:
+
+        - Arthimetic operations: ``+``, ``-``, ``*``, ``/``, ``**``, ``%``
+        - Boolean operations: ``|`` (or), ``&`` (and), and ``~`` (not)
+        - Comparison operators: ``<``, ``<=``, ``==``, ``!=``, ``>=``, ``>``
+
+        Furthermore, the following mathematical functions are supported:
+
+        - Trigonometric: ``sin``, ``cos``, ``tan``, ``arcsin``, ``arccos``, \
+            ``arctan``, ``sinh``, ``cosh``, ``tanh``, ``arcsinh``, ``arccosh`` \
+            and ``arctanh``
+        - Logarithms: ``log`` natural, ``log10`` base 10, ``log1p`` log(1+x)
+        - Absolute Value ``abs``
+        - Square root ``sqrt``
+        - Exponential ``exp`` and Exponential minus one ``expm1``
+
+        See the numexpr engine `documentation
+        <https://numexpr.readthedocs.io/en/latest/user_guide.html#supported-functions>`__
+        for further function support details.
+
+        Using the ``'python'`` engine allows the use of native Python operators
+        like integer division ``//``, in addition to Python functions,
+        both built-in and user-defined.
+
+        Additionally, the ``'pandas'`` parser allows the use of :keyword:`and`,
+        :keyword:`or`, and :keyword:`not` with the same semantics as the
+        corresponding bitwise operators.
     parser : {'pandas', 'python'}, default 'pandas'
         The parser to use to construct the syntax tree from the expression. The
         default of ``'pandas'`` parses code slightly different than standard

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4479,20 +4479,8 @@ class DataFrame(NDFrame, OpsMixin):
         expr : str
             The query string to evaluate.
 
-            You can refer to variables
-            in the environment by prefixing them with an '@' character like
-            ``@a + b``.
-
-            You can refer to column names that are not valid Python variable names
-            by surrounding them in backticks. Thus, column names containing spaces
-            or punctuation (besides underscores) or starting with digits must be
-            surrounded by backticks. (For example, a column named "Area (cm^2)" would
-            be referenced as ```Area (cm^2)```). Column names which are Python keywords
-            (like "if", "for", "import", etc) cannot be used.
-
-            For example, if one of your columns is called ``a a`` and you want
-            to sum it with ``b``, your query should be ```a a` + b``.
-
+            See the documentation for :meth:`DataFrame.eval` for details on
+            referring to column names and variables.
         inplace : bool
             Whether to modify the DataFrame rather than creating a new one.
         **kwargs
@@ -4651,8 +4639,18 @@ class DataFrame(NDFrame, OpsMixin):
             in the environment by prefixing them with an '@' character like
             ``@a + b``.
 
-            You can refer to column names that are not valid Python variable
-            names by surrounding them with backticks `````.
+            You can refer to column names that are not valid Python variable names
+            by surrounding them in backticks. Thus, column names containing spaces
+            or punctuation (besides underscores) or starting with digits must be
+            surrounded by backticks. (For example, a column named "Area (cm^2)" would
+            be referenced as ```Area (cm^2)```). Column names which are Python keywords
+            (like "if", "for", "import", etc) cannot be used.
+
+            For example, if one of your columns is called ``a a`` and you want
+            to sum it with ``b``, your query should be ```a a` + b``.
+
+            See the documentation for :func:`eval` for full details of
+            supported operations and functions in the expression string.
         inplace : bool, default False
             If the expression contains an assignment, whether to perform the
             operation inplace and mutate the existing DataFrame. Otherwise,
@@ -4660,7 +4658,7 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs
             See the documentation for :func:`eval` for complete details
             on the keyword arguments accepted by
-            :meth:`~pandas.DataFrame.query`.
+            :meth:`~pandas.DataFrame.eval`.
 
         Returns
         -------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4479,8 +4479,11 @@ class DataFrame(NDFrame, OpsMixin):
         expr : str
             The query string to evaluate.
 
+            See the documentation for :func:`eval` for details of
+            supported operations and functions in the query string.
+
             See the documentation for :meth:`DataFrame.eval` for details on
-            referring to column names and variables.
+            referring to column names and variables in the query string.
         inplace : bool
             Whether to modify the DataFrame rather than creating a new one.
         **kwargs


### PR DESCRIPTION
- [x] closes #58338
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

This PR implements the suggested documentation improvements outlined in #58338:
- Covering the supported operators and functions to `pandas.eval`
- Reorganising and adding links to  `pandas.DataFrame.eval` and  `pandas.DataFrame.query` to have a consistent explanation of the `expr` parameters