### PR TITLE
CI/TST: Check for tzset in set_timezone

### DIFF
--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -73,14 +73,15 @@ def set_timezone(tz: str) -> Generator[None, None, None]:
     import time
 
     def setTZ(tz) -> None:
-        if tz is None:
-            try:
-                del os.environ["TZ"]
-            except KeyError:
-                pass
-        else:
-            os.environ["TZ"] = tz
-            time.tzset()
+        if hasattr(time, "tzset"):
+            if tz is None:
+                try:
+                    del os.environ["TZ"]
+                except KeyError:
+                    pass
+            else:
+                os.environ["TZ"] = tz
+                time.tzset()
 
     orig_tz = os.environ.get("TZ")
     setTZ(tz)

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -37,10 +37,13 @@ from pandas._testing._hypothesis import DATETIME_NO_TZ
 )
 def test_parsing_tzlocal_deprecated():
     # GH#50791
-    msg = (
-        r"Parsing 'EST' as tzlocal \(dependent on system timezone\) "
-        r"is no longer supported\. "
-        "Pass the 'tz' keyword or call tz_localize after construction instead"
+    msg = "|".join(
+        [
+            r"Parsing 'EST' as tzlocal \(dependent on system timezone\) "
+            r"is no longer supported\. "
+            "Pass the 'tz' keyword or call tz_localize after construction instead",
+            ".*included an un-recognized timezone",
+        ]
     )
     dtstr = "Jan 15 2004 03:00 EST"
 


### PR DESCRIPTION
Appears the ARM tests are failing because `tzset` is not available. This API is limited to certain platform so we should be checking if we can set a tz in the first place