### PR TITLE
Backport PR #59893 (CI/TST: Check for tzset in set_timezone)

### DIFF
--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -78,14 +78,15 @@ def set_timezone(tz: str) -> Generator[None, None, None]:
     import time
 
     def setTZ(tz) -> None:
-        if tz is None:
-            try:
-                del os.environ["TZ"]
-            except KeyError:
-                pass
-        else:
-            os.environ["TZ"] = tz
-            time.tzset()
+        if hasattr(time, "tzset"):
+            if tz is None:
+                try:
+                    del os.environ["TZ"]
+                except KeyError:
+                    pass
+            else:
+                os.environ["TZ"] = tz
+                time.tzset()
 
     orig_tz = os.environ.get("TZ")
     setTZ(tz)

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -34,6 +34,7 @@ def test_parsing_tzlocal_deprecated():
     msg = (
         "Parsing 'EST' as tzlocal.*"
         "Pass the 'tz' keyword or call tz_localize after construction instead"
+        "|Parsed string"
     )
     dtstr = "Jan 15 2004 03:00 EST"
 

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -17,6 +17,7 @@ from pandas._libs.tslibs import (
 from pandas._libs.tslibs.parsing import parse_datetime_string_with_reso
 from pandas.compat import (
     ISMUSL,
+    is_platform_arm,
     is_platform_windows,
 )
 import pandas.util._test_decorators as td
@@ -26,7 +27,7 @@ from pandas._testing._hypothesis import DATETIME_NO_TZ
 
 
 @pytest.mark.skipif(
-    is_platform_windows() or ISMUSL,
+    is_platform_windows() or ISMUSL or is_platform_arm(),
     reason="TZ setting incorrect on Windows and MUSL Linux",
 )
 def test_parsing_tzlocal_deprecated():
@@ -34,7 +35,6 @@ def test_parsing_tzlocal_deprecated():
     msg = (
         "Parsing 'EST' as tzlocal.*"
         "Pass the 'tz' keyword or call tz_localize after construction instead"
-        "|Parsed string"
     )
     dtstr = "Jan 15 2004 03:00 EST"
 

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -31,13 +31,9 @@ from pandas._testing._hypothesis import DATETIME_NO_TZ
 )
 def test_parsing_tzlocal_deprecated():
     # GH#50791
-    msg = "|".join(
-        [
-            r"Parsing 'EST' as tzlocal \(dependent on system timezone\) "
-            r"is no longer supported\. "
-            "Pass the 'tz' keyword or call tz_localize after construction instead",
-            ".*included an un-recognized timezone",
-        ]
+    msg = (
+        "Parsing 'EST' as tzlocal.*"
+        "Pass the 'tz' keyword or call tz_localize after construction instead"
     )
     dtstr = "Jan 15 2004 03:00 EST"
 

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -31,9 +31,13 @@ from pandas._testing._hypothesis import DATETIME_NO_TZ
 )
 def test_parsing_tzlocal_deprecated():
     # GH#50791
-    msg = (
-        "Parsing 'EST' as tzlocal.*"
-        "Pass the 'tz' keyword or call tz_localize after construction instead"
+    msg = "|".join(
+        [
+            r"Parsing 'EST' as tzlocal \(dependent on system timezone\) "
+            r"is no longer supported\. "
+            "Pass the 'tz' keyword or call tz_localize after construction instead",
+            ".*included an un-recognized timezone",
+        ]
     )
     dtstr = "Jan 15 2004 03:00 EST"
 


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/59893