### PR TITLE
Bugfix/apply inconsistent with categorical data

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1469,10 +1469,7 @@ class SeriesApply(NDFrameApply):
         # row-wise access
         # apply doesn't have a `na_action` keyword and for backward compat reasons
         # we need to give `na_action="ignore"` for categorical data.
-        # TODO: remove the `na_action="ignore"` when that default has been changed in
-        #  Categorical (GH51645).
-        action = "ignore" if isinstance(obj.dtype, CategoricalDtype) else None
-        mapped = obj._map_values(mapper=curried, na_action=action)
+        mapped = obj._map_values(mapper=curried)
 
         if len(mapped) and isinstance(mapped[0], ABCSeries):
             # GH#43986 Need to do list(mapped) in order to get treated as nested

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -38,9 +38,7 @@ from pandas.core.dtypes.common import (
     is_numeric_dtype,
     is_sequence,
 )
-from pandas.core.dtypes.dtypes import (
-    ExtensionDtype,
-)
+from pandas.core.dtypes.dtypes import ExtensionDtype
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCNDFrame,

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -39,7 +39,6 @@ from pandas.core.dtypes.common import (
     is_sequence,
 )
 from pandas.core.dtypes.dtypes import (
-    CategoricalDtype,
     ExtensionDtype,
 )
 from pandas.core.dtypes.generic import (


### PR DESCRIPTION
Previously, the apply method set na_action="ignore" for categorical data to maintain backward compatibility. With the changes introduced in [#51645](https://github.com/pandas-dev/pandas/pull/51645), this is no longer needed. Removing the redundant parameter simplifies the codebase and ensures consistency with the updated default behavior.
