### PR TITLE
BUG: PeriodIndex.to_datetime inconsistent with its docstring

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -640,6 +640,7 @@ I/O
 
 Period
 ^^^^^^
+- Bug in :meth:`PeriodIndex.to_timestamp` casting to a DatetimeIndex of timestamps at the end of the period, instead of at the beginning of the period. (:issue:`59371`)
 - Fixed error message when passing invalid period alias to :meth:`PeriodIndex.to_timestamp` (:issue:`58974`)
 -
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -814,7 +814,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         is_start = how == "S"
         if is_start:
             new_data = np.asarray(
-                [getattr(period, "start_time", period) for period in new_parr]
+                [(NaT if period is NaT else period.start_time) for period in new_parr]
             )
         else:
             new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -811,7 +811,14 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
 
         new_parr = self.asfreq(freq, how=how)
 
-        new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
+        is_start = how == "S"
+        if is_start:
+            new_data = np.asarray(
+                [getattr(period, "start_time", period) for period in new_parr]
+            )
+        else:
+            new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
+
         dta = DatetimeArray._from_sequence(new_data, dtype=np.dtype("M8[ns]"))
 
         if self.freq.name == "B":

--- a/pandas/tests/indexes/period/methods/test_to_timestamp.py
+++ b/pandas/tests/indexes/period/methods/test_to_timestamp.py
@@ -141,6 +141,18 @@ class TestToTimestamp:
         result = index.to_timestamp()
         assert result[0] == Timestamp("1/1/2012")
 
+    def test_cast_to_timestamps_at_beginning_of_period(self):
+        # GH 59371
+        index = period_range("2000", periods=3, freq="M")
+        result = index.to_timestamp("M")
+
+        expected = DatetimeIndex(
+            ["2000-01-01", "2000-02-01", "2000-03-01"],
+            dtype="datetime64[ns]",
+            freq="MS",
+        )
+        tm.assert_equal(result, expected)
+
 
 def test_ms_to_timestamp_error_message():
     # https://github.com/pandas-dev/pandas/issues/58974#issuecomment-2164265446


### PR DESCRIPTION
- [x] closes #59371
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
