### PR TITLE
BUG: fix treatment of NaNs when .apply() function is used on categorical columns.

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -490,6 +490,7 @@ Other Removals
 - Removed the ``method`` keyword in ``ExtensionArray.fillna``, implement ``ExtensionArray._pad_or_backfill`` instead (:issue:`53621`)
 - Removed the attribute ``dtypes`` from :class:`.DataFrameGroupBy` (:issue:`51997`)
 - Enforced deprecation of ``argmin``, ``argmax``, ``idxmin``, and ``idxmax`` returning a result when ``skipna=False`` and an NA value is encountered or all values are NA values; these operations will now raise in such cases (:issue:`33941`, :issue:`51276`)
+- Removed support for ``action="ignore"`` for :class:`SeriesApply` in :meth:`SeriesApply.apply_standard`, categorical NA value now returns ``False`` (:issue:`59938`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.performance:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -544,7 +544,7 @@ Bug fixes
 
 Categorical
 ^^^^^^^^^^^
-- Removed support for ``action="ignore"`` for :class:`SeriesApply` in :meth:`SeriesApply.apply_standard`, categorical NA value now returns ``False`` (:issue:`59938`)
+- Bug in :func:`Series.apply` where ``nan`` was ignored for :class:`CategoricalDtype` (:issue:`59938`)
 -
 
 Datetimelike

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -490,7 +490,6 @@ Other Removals
 - Removed the ``method`` keyword in ``ExtensionArray.fillna``, implement ``ExtensionArray._pad_or_backfill`` instead (:issue:`53621`)
 - Removed the attribute ``dtypes`` from :class:`.DataFrameGroupBy` (:issue:`51997`)
 - Enforced deprecation of ``argmin``, ``argmax``, ``idxmin``, and ``idxmax`` returning a result when ``skipna=False`` and an NA value is encountered or all values are NA values; these operations will now raise in such cases (:issue:`33941`, :issue:`51276`)
-- Removed support for ``action="ignore"`` for :class:`SeriesApply` in :meth:`SeriesApply.apply_standard`, categorical NA value now returns ``False`` (:issue:`59938`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.performance:
@@ -545,7 +544,7 @@ Bug fixes
 
 Categorical
 ^^^^^^^^^^^
--
+- Removed support for ``action="ignore"`` for :class:`SeriesApply` in :meth:`SeriesApply.apply_standard`, categorical NA value now returns ``False`` (:issue:`59938`)
 -
 
 Datetimelike

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1462,10 +1462,6 @@ class SeriesApply(NDFrameApply):
 
         else:
             curried = func
-
-        #  remove the `na_action="ignore"` as default has been changed in
-        #  Categorical (GH 51645).
-        # Reference for below fix (GH 59966)
         mapped = obj._map_values(mapper=curried)
 
         if len(mapped) and isinstance(mapped[0], ABCSeries):

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1464,8 +1464,8 @@ class SeriesApply(NDFrameApply):
             curried = func
 
         #  remove the `na_action="ignore"` as default has been changed in
-        #  Categorical (GH51645).
-        # Reference for below fix (GH )
+        #  Categorical (GH 51645).
+        # Reference for below fix (GH 59966)
         mapped = obj._map_values(mapper=curried)
 
         if len(mapped) and isinstance(mapped[0], ABCSeries):

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -38,10 +38,7 @@ from pandas.core.dtypes.common import (
     is_numeric_dtype,
     is_sequence,
 )
-from pandas.core.dtypes.dtypes import (
-    CategoricalDtype,
-    ExtensionDtype,
-)
+from pandas.core.dtypes.dtypes import ExtensionDtype
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCNDFrame,
@@ -1466,13 +1463,10 @@ class SeriesApply(NDFrameApply):
         else:
             curried = func
 
-        # row-wise access
-        # apply doesn't have a `na_action` keyword and for backward compat reasons
-        # we need to give `na_action="ignore"` for categorical data.
-        # TODO: remove the `na_action="ignore"` when that default has been changed in
+        #  remove the `na_action="ignore"` as default has been changed in
         #  Categorical (GH51645).
-        action = "ignore" if isinstance(obj.dtype, CategoricalDtype) else None
-        mapped = obj._map_values(mapper=curried, na_action=action)
+        # Reference for below fix (GH )
+        mapped = obj._map_values(mapper=curried)
 
         if len(mapped) and isinstance(mapped[0], ABCSeries):
             # GH#43986 Need to do list(mapped) in order to get treated as nested

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -742,7 +742,7 @@ def test_apply_category_equalness(val):
     result = df.a.apply(lambda x: x == val)
     expected = Series(
         [False if pd.isnull(x) else x == val for x in df_values], name="a"
-    )
+    ) # False since behavior of NaN for categorical dtype has been changed (GH 59966)
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -741,7 +741,7 @@ def test_apply_category_equalness(val):
 
     result = df.a.apply(lambda x: x == val)
     expected = Series(
-        [np.nan if pd.isnull(x) else x == val for x in df_values], name="a"
+        [False if pd.isnull(x) else x == val for x in df_values], name="a"
     )
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -742,7 +742,8 @@ def test_apply_category_equalness(val):
     result = df.a.apply(lambda x: x == val)
     expected = Series(
         [False if pd.isnull(x) else x == val for x in df_values], name="a"
-    )  # False since behavior of NaN for categorical dtype has been changed (GH 59966)
+    )
+    # False since behavior of NaN for categorical dtype has been changed (GH 59966)
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -742,7 +742,7 @@ def test_apply_category_equalness(val):
     result = df.a.apply(lambda x: x == val)
     expected = Series(
         [False if pd.isnull(x) else x == val for x in df_values], name="a"
-    ) # False since behavior of NaN for categorical dtype has been changed (GH 59966)
+    )  # False since behavior of NaN for categorical dtype has been changed (GH 59966)
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -236,10 +236,10 @@ def test_apply_categorical_with_nan_values(series, by_row):
         with pytest.raises(AttributeError, match=msg):
             s.apply(lambda x: x.split("-")[0], by_row=by_row)
         return
-
-    result = s.apply(lambda x: x.split("-")[0], by_row=by_row)
+    # NaN for cat dtype fixed in (GH 59966)
+    result = s.apply(lambda x: x.split("-")[0] if pd.notna(x) else False, by_row=by_row)
     result = result.astype(object)
-    expected = Series(["1", "1", np.nan], dtype="category")
+    expected = Series(["1", "1", False], dtype="category")
     expected = expected.astype(object)
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
- [x] closes #59938
- [x] [Tests added and passed] (modified existing test function to accommodate change for `NaN` in cat columns)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
