### PR TITLE
DOC: Fix `GroupBy.ffill()` doc reference to rows

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3833,7 +3833,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         3  1.0  3.0  NaN  NaN
         4  1.0  1.0  NaN  NaN
 
-        Only replace the first NaN element within a group along rows.
+        Only replace the first NaN element within a group along columns.
 
         >>> df.groupby("key").ffill(limit=1)
              A    B    C


### PR DESCRIPTION
## Description

The very last example in the GroupBy FFill documentation says "along rows", but (to be consistent with the convention established in the preceding examples) actually shows an example operating "along columns". Fix the reference.

## Checklist

- [X] closes #xxxx (Replace xxxx with the GitHub issue number) (No associated issue)
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature (Strictly documentation change)
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (No new args/funcs)
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. (No bugfix or new feature, just a minor documentation fix)
