### PR TITLE
Update getting_started.css

### DIFF
--- a/doc/source/_static/css/getting_started.css
+++ b/doc/source/_static/css/getting_started.css
@@ -245,6 +245,7 @@ ul.task-bullet > li > p:first-child {
   justify-content: flex-start;
   align-items: center;
   font-size: 1.3rem;
+  color: rgb(0, 179, 255);
 }
 
 .tutorial-card .card-header {


### PR DESCRIPTION
The problem is "DOC: Intro to pandas table not readily visible in dark mode #60024"
Perhaps we could set this part of the font color to blue, which is highly visible in either bright or dark mode, so that there is no need to implement a font color that changes with the theme.
So I made a very simple change in the documentation by setting the font color in .tutorial-card-header-2 to blue so that the font can be seen in either bright or dark mode.