### PR TITLE
Add information about code coverage to docs

### DIFF
--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -300,7 +300,7 @@ use cases and writing corresponding tests.
 
 We use `code coverage <https://en.wikipedia.org/wiki/Code_coverage>`_ to help understand
 the amount of code which is covered by a test. We recommend striving to ensure code
-you add or change within Pandas is covered by a test. Please see our 
+you add or change within Pandas is covered by a test. Please see our
 `code coverage dashboard through Codecov <https://app.codecov.io/github/pandas-dev/pandas>`_
 for more information.
 

--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -298,6 +298,12 @@ So, before actually writing any code, you should write your tests.  Often the te
 taken from the original GitHub issue.  However, it is always worth considering additional
 use cases and writing corresponding tests.
 
+We use `code coverage <https://en.wikipedia.org/wiki/Code_coverage>`_ to help understand
+the amount of code which is covered by a test. We recommend striving to ensure code
+you add or change within Pandas is covered by a test. Please see our 
+`code coverage dashboard through Codecov <https://app.codecov.io/github/pandas-dev/pandas>`_
+for more information.
+
 Adding tests is one of the most common requests after code is pushed to pandas.  Therefore,
 it is worth getting in the habit of writing tests ahead of time so this is never an issue.
 


### PR DESCRIPTION
Hello! This change adds code coverage documentation and also includes a link to the Codecov dashboard for Pandas within the contributing docs. Some of this information is otherwise implicit and I thought could be helpful for developers to understand or have an easy link handy.

Thank you for any thoughts or feedback you may have! And cheers on the great work with Pandas more broadly.

- [x] closes #60010 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

