### PR TITLE
DOC: fixed docstring of timedelta.ceil to match docstring of datetimeindex…

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -2109,6 +2109,11 @@ class Timedelta(_Timedelta):
         """
         Round the Timedelta to the specified resolution.
 
+        This method rounds the Timedelta to the nearest specified frequency.
+        It is useful for aligning time durations to regular intervals,
+        such as seconds, minutes, or hours, ensuring that the resulting
+        Timedelta is expressed in fixed units.
+
         Parameters
         ----------
         freq : str
@@ -2143,6 +2148,11 @@ class Timedelta(_Timedelta):
         """
         Return a new Timedelta floored to this resolution.
 
+        This method truncates the Timedelta to the nearest specified frequency,
+        effectively rounding down the duration to the nearest interval defined
+        by the provided frequency string. This is useful for situations where
+        you want to ensure that the Timedelta does not exceed a certain duration.
+
         Parameters
         ----------
         freq : str
@@ -2173,11 +2183,17 @@ class Timedelta(_Timedelta):
         """
         Return a new Timedelta ceiled to this resolution.
 
+        This method rounds up the Timedelta to the nearest specified frequency,
+        ensuring that the result represents a valid time duration aligned with
+        the given frequency.
+
         Parameters
         ----------
         freq : str
-            Frequency string indicating the ceiling resolution.
-            It uses the same units as class constructor :class:`~pandas.Timedelta`.
+            The frequency level to ceil the index to. Must be a fixed
+            frequency like ‘S’ (second) not ‘ME’ (month end).
+            See :ref:`frequency aliases <timeseries.offset_aliases>`
+            for a list of possible `freq` values.
 
         Returns
         -------


### PR DESCRIPTION
This PR fixes the document for pandas Timedelta.ceil.

It also adds summary to pandas Timedelta.ceil, Timedelta.floor and Timedelta.round to pass the [docstring validation](https://pandas.pydata.org/docs/dev/development/contributing_documentation.html#updating-a-pandas-docstring)

- [x] closes #59902 (Replace xxxx with the GitHub issue number)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).


Attaching screenshots for changes, tested in local:
<img width="1421" alt="Screenshot 2024-10-16 at 14 02 45" src="https://github.com/user-attachments/assets/e4ae20a7-4ee7-462f-b47a-2fcb6416f450">
<img width="1409" alt="Screenshot 2024-10-16 at 12 48 42" src="https://github.com/user-attachments/assets/68af401d-6b6b-4f12-bd7a-fdb0d129aeec">
<img width="1403" alt="Screenshot 2024-10-16 at 12 48 52" src="https://github.com/user-attachments/assets/c8219cb0-a7ea-47f1-9d1f-acc8f76d1b57">
