### PR TITLE
[backport 2.3.x] TST (string dtype): add explicit object vs str dtype to index fixture (#60116)

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -615,7 +615,8 @@ def _create_mi_with_dt64tz_level():
 
 
 indices_dict = {
-    "string": Index([f"pandas_{i}" for i in range(100)]),
+    "object": Index([f"pandas_{i}" for i in range(100)], dtype=object),
+    "string": Index([f"pandas_{i}" for i in range(100)], dtype="str"),
     "datetime": date_range("2020-01-01", periods=100),
     "datetime-tz": date_range("2020-01-01", periods=100, tz="US/Pacific"),
     "period": period_range("2020-01-01", periods=100, freq="D"),

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -931,7 +931,7 @@ def value_counts_internal(
             # For backwards compatibility, we let Index do its normal type
             #  inference, _except_ for if if infers from object to bool.
             idx = Index(keys)
-            if idx.dtype == bool and keys.dtype == object:
+            if idx.dtype in [bool, "string"] and keys.dtype == object:
                 idx = idx.astype(object)
             elif (
                 idx.dtype != keys.dtype  # noqa: PLR1714  # # pylint: disable=R1714

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -165,6 +165,7 @@ def test_searchsorted(request, index_or_series_obj):
     assert 0 <= index <= len(obj)
 
 
+@pytest.mark.filterwarnings(r"ignore:Dtype inference:FutureWarning")
 def test_access_by_position(index_flat):
     index = index_flat
 

--- a/pandas/tests/indexes/test_any_index.py
+++ b/pandas/tests/indexes/test_any_index.py
@@ -45,7 +45,7 @@ def test_map_identity_mapping(index, request):
     # GH#12766
 
     result = index.map(lambda x: x)
-    if index.dtype == object and result.dtype == bool:
+    if index.dtype == object and result.dtype in [bool, "string"]:
         assert (index == result).all()
         # TODO: could work that into the 'exact="equiv"'?
         return  # FIXME: doesn't belong in this file anymore!

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -147,6 +147,7 @@ class TestCommon:
         new_copy = index.copy(deep=True, name="banana")
         assert new_copy.name == "banana"
 
+    @pytest.mark.filterwarnings(r"ignore:Dtype inference:FutureWarning")
     def test_copy_name(self, index_flat):
         # GH#12309: Check that the "name" argument
         # passed at initialization is honored.

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -485,6 +485,7 @@ class TestBase:
         with pytest.raises(IndexError, match=msg):
             index.delete(length)
 
+    @pytest.mark.filterwarnings(r"ignore:Dtype inference:FutureWarning")
     @pytest.mark.filterwarnings(r"ignore:PeriodDtype\[B\] is deprecated:FutureWarning")
     def test_equals(self, index):
         if isinstance(index, IntervalIndex):

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -260,7 +260,7 @@ class TestBase:
                 "RangeIndex cannot be initialized from data, "
                 "MultiIndex and CategoricalIndex are tested separately"
             )
-        elif index.dtype == object and index.inferred_type == "boolean":
+        elif index.dtype == object and index.inferred_type in ["boolean", "string"]:
             init_kwargs["dtype"] = index.dtype
 
         index_type = type(index)

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -293,7 +293,13 @@ class TestSetOps:
                 first.difference([1, 2, 3], sort)
 
     @pytest.mark.filterwarnings(r"ignore:PeriodDtype\[B\] is deprecated:FutureWarning")
-    def test_symmetric_difference(self, index):
+    def test_symmetric_difference(self, index, using_infer_string, request):
+        if (
+            using_infer_string
+            and index.dtype == "object"
+            and index.inferred_type == "string"
+        ):
+            request.applymarker(pytest.mark.xfail(reason="TODO: infer_string"))
         if isinstance(index, CategoricalIndex):
             pytest.skip(f"Not relevant for {type(index).__name__}")
         if len(index) < 2:

--- a/pandas/tests/series/methods/test_map.py
+++ b/pandas/tests/series/methods/test_map.py
@@ -221,6 +221,7 @@ def test_map_category_string():
     tm.assert_series_equal(a.map(c), exp)
 
 
+@pytest.mark.filterwarnings(r"ignore:Dtype inference:FutureWarning")
 def test_map_empty(request, index):
     if isinstance(index, MultiIndex):
         request.applymarker(

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -65,6 +65,7 @@ class TestFactorize:
         expected_uniques = np.array([(1 + 0j), (2 + 0j), (2 + 1j)], dtype=object)
         tm.assert_numpy_array_equal(uniques, expected_uniques)
 
+    @pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string)", strict=False)
     @pytest.mark.parametrize("sort", [True, False])
     def test_factorize(self, index_or_series_obj, sort):
         obj = index_or_series_obj


### PR DESCRIPTION

Backport of https://github.com/pandas-dev/pandas/pull/60116