### PR TITLE
CI/TST: fix tests for compat with numpy 2+ when using legacy promotion

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -1,5 +1,6 @@
 """support numpy compatibility across versions"""
 
+import os
 import warnings
 
 import numpy as np
@@ -13,6 +14,10 @@ np_version_gte1p24 = _nlv >= Version("1.24")
 np_version_gte1p24p3 = _nlv >= Version("1.24.3")
 np_version_gte1p25 = _nlv >= Version("1.25")
 np_version_gt2 = _nlv >= Version("2.0.0")
+np_version_gt2_not_legacy = (
+    _nlv >= Version("2.0.0")
+    and os.environ.get("NPY_PROMOTION_STATE", "weak") != "legacy"
+)
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.23.5"
 

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -34,7 +34,7 @@ from pandas._libs import (
     missing as libmissing,
     ops as libops,
 )
-from pandas.compat.numpy import np_version_gt2
+from pandas.compat.numpy import np_version_gt2_not_legacy
 
 from pandas.core.dtypes import inference
 from pandas.core.dtypes.cast import find_result_type
@@ -1989,7 +1989,7 @@ def test_ensure_int32():
         # find a smaller floating dtype
         (300.0, np.uint16),  # for integer floats, we convert them to ints
         (300.1, np.float64),
-        (np.int16(300), np.int16 if np_version_gt2 else np.uint16),
+        (np.int16(300), np.int16 if np_version_gt2_not_legacy else np.uint16),
     ],
 )
 def test_find_result_type_uint_int(right, result):

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -13,7 +13,7 @@ from pandas.compat import (
     IS64,
     is_platform_windows,
 )
-from pandas.compat.numpy import np_version_gt2
+from pandas.compat.numpy import np_version_gt2_not_legacy
 
 import pandas as pd
 import pandas._testing as tm
@@ -231,7 +231,7 @@ class TestInsertIndexCoercion(CoercionBase):
         obj = pd.Index([1.0, 2.0, 3.0, 4.0], dtype=dtype)
         coerced_dtype = coerced_dtype if coerced_dtype is not None else dtype
 
-        if np_version_gt2 and dtype == "float32" and coerced_val == 1.1:
+        if np_version_gt2_not_legacy and dtype == "float32" and coerced_val == 1.1:
             # Hack, in the 2nd test case, since 1.1 can be losslessly cast to float32
             # the expected dtype will be float32 if the original dtype was float32
             coerced_dtype = np.float32

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -15,7 +15,10 @@ from pandas._libs import (
     lib,
 )
 from pandas.compat import HAS_PYARROW
-from pandas.compat.numpy import np_version_gt2
+from pandas.compat.numpy import (
+    np_version_gt2,
+    np_version_gt2_not_legacy,
+)
 from pandas.errors import IntCastingNaNError
 
 from pandas.core.dtypes.dtypes import CategoricalDtype
@@ -770,7 +773,7 @@ class TestSeriesConstructors:
 
     def test_constructor_signed_int_overflow_raises(self):
         # GH#41734 disallow silent overflow, enforced in 2.0
-        if np_version_gt2:
+        if np_version_gt2_not_legacy:
             msg = "The elements provided in the data cannot all be casted to the dtype"
             err = OverflowError
         else:
@@ -803,7 +806,7 @@ class TestSeriesConstructors:
 
     def test_constructor_unsigned_dtype_overflow(self, any_unsigned_int_numpy_dtype):
         # see gh-15832
-        if np_version_gt2:
+        if np_version_gt2_not_legacy:
             msg = (
                 f"The elements provided in the data cannot "
                 f"all be casted to the dtype {any_unsigned_int_numpy_dtype}"
@@ -1939,7 +1942,7 @@ class TestSeriesConstructors:
 
     def test_constructor_raise_on_lossy_conversion_of_strings(self):
         # GH#44923
-        if not np_version_gt2:
+        if not np_version_gt2_not_legacy:
             raises = pytest.raises(
                 ValueError, match="string values cannot be losslessly cast to int8"
             )


### PR DESCRIPTION
This is trying to fix the current failures on main.

It seems that our test runs were still using numpy 1.26 (because of some downgrade after initial env creation because of removing nomkl), but that stopped being the case some hours ago. This turns up a bunch of failures in our tests when running hem with numpy >= 2 ánd with `NPY_PROMOTION_STATE=legacy`. 

We should properly fix this situation (stop using the legacy promotion state), but this PR should already get CI green again.