### PR TITLE
CI: add test build with numpy 1.26 (<2)

### DIFF
--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -20,7 +20,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy
+  - numpy<2
 
   # optional dependencies
   - beautifulsoup4>=4.11.2


### PR DESCRIPTION
I removed a `numpy<2` pin in https://github.com/pandas-dev/pandas/pull/60144, but it might be good to keep testing in one of the builds with numpy 1.26 (latest <2). 
For the rest we only pin numpy to 1.23 in `ci/deps/actions-310-minimum_versions.yaml` to test the minimal supported version.

