### PR TITLE
BUG: fix #60128 BUG: Series.combine_first loss of precision

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8640,7 +8640,10 @@ class DataFrame(NDFrame, OpsMixin):
         """
         other_idxlen = len(other.index)  # save for compare
 
-        this, other = self.align(other)
+        fill_value_for_align = None
+        if all(self.dtypes.eq(np.int64)) and all(other.dtypes.eq(np.int64)):
+            fill_value_for_align = 0
+        this, other = self.align(other, fill_value=fill_value_for_align)
         new_index = this.index
 
         if other.empty and len(new_index) == len(self.index):


### PR DESCRIPTION
- Issue: There was int64->float64->int64 conversions
- Fix: Carry out the operation without passing through float64

- [X] closes #60128
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
