### PR TITLE
DOC: Update contributing docs for Windows build tools instructions

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -35,6 +35,10 @@ You will need `Build Tools for Visual Studio 2022
         scrolling down to "All downloads" -> "Tools for Visual Studio".
         In the installer, select the "Desktop development with C++" Workloads.
 
+        If you encounter an error indicating `cl.exe` is not found when building with Meson, 
+        reopen the installer and also select the optional component 
+        **MSVC v142 - VS 2019 C++ x64/x86 build tools** in the right pane for installation.
+
 Alternatively, you can install the necessary components on the commandline using
 `vs_BuildTools.exe <https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?source=recommendations&view=vs-2022>`_
 

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -35,8 +35,8 @@ You will need `Build Tools for Visual Studio 2022
         scrolling down to "All downloads" -> "Tools for Visual Studio".
         In the installer, select the "Desktop development with C++" Workloads.
 
-        If you encounter an error indicating `cl.exe` is not found when building with Meson, 
-        reopen the installer and also select the optional component 
+        If you encounter an error indicating ``cl.exe`` is not found when building with Meson,
+        reopen the installer and also select the optional component
         **MSVC v142 - VS 2019 C++ x64/x86 build tools** in the right pane for installation.
 
 Alternatively, you can install the necessary components on the commandline using


### PR DESCRIPTION
- [x] closes #59689 

This PR is to update the documentation with the solution to the error described in Issue #59689 by adding a note in contributing_environment.rst instructing users to install MSVC v142 - VS 2019 C++ x64/x86 build tools if they encounter a cl.exe not found error ( Unknown compiler(s): [['cl.exe']]) during the build process.
