### PR TITLE
DOC: Document attributes of Timedelta #59698

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -76,9 +76,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.dt.freq GL08" \
         -i "pandas.Series.dt.unit GL08" \
         -i "pandas.Series.pad PR01,SA01" \
-        -i "pandas.Timedelta.max PR02" \
-        -i "pandas.Timedelta.min PR02" \
-        -i "pandas.Timedelta.resolution PR02" \
         -i "pandas.Timestamp.max PR02" \
         -i "pandas.Timestamp.min PR02" \
         -i "pandas.Timestamp.nanosecond GL08" \

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1893,6 +1893,21 @@ class Timedelta(_Timedelta):
         Values for construction in compat with datetime.timedelta.
         Numpy ints and floats will be coerced to python ints and floats.
 
+    Attributes
+    ----------
+    resolution: Timedelta
+        Represents the smallest difference between two time units that can be
+        represented by the Timedelta object.
+        Fixed at 0 days 00:00:00.000000001 (1 nanosecond).
+    min : Timedelta
+        Returns the minimum Timedelta value that can be created or used in
+        pandas operations.
+        Fixed at -106752 days +00:12:43.145224193
+    max : Timedelta
+        Returns the maximum Timedelta value that can be created or used in
+        pandas operations.
+        Fixed at 106751 days 23:47:16.854775807.
+
     See Also
     --------
     Timestamp : Represents a single timestamp in time.


### PR DESCRIPTION
Part of https://github.com/pandas-dev/pandas/issues/59698

Addresses:

pandas.Timedelta

Added the missing explanations (PRO2) for min, max, and resolution.

Removed:

    i "pandas.Timedelta.resolution PR02" \
    i "pandas.Timedelta.min PR02" \
    i "pandas.Timedelta.resolution PR02" \

from code_checks.sh