### PR TITLE
[backport 2.3.x] BUG: preserve (object) dtype in factorize (#60118)

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -48,6 +48,7 @@ from pandas.core.dtypes.dtypes import ExtensionDtype
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCIndex,
+    ABCMultiIndex,
     ABCSeries,
 )
 from pandas.core.dtypes.missing import (
@@ -1198,13 +1199,18 @@ class IndexOpsMixin(OpsMixin):
         if uniques.dtype == np.float16:
             uniques = uniques.astype(np.float32)
 
-        if isinstance(self, ABCIndex):
-            # preserve e.g. MultiIndex
+        if isinstance(self, ABCMultiIndex):
+            # preserve MultiIndex
             uniques = self._constructor(uniques)
         else:
             from pandas import Index
 
-            uniques = Index(uniques)
+            try:
+                uniques = Index(uniques, dtype=self.dtype)
+            except NotImplementedError:
+                # not all dtypes are supported in Index that are allowed for Series
+                # e.g. float16 or bytes
+                uniques = Index(uniques)
         return codes, uniques
 
     _shared_docs[


### PR DESCRIPTION
(cherry picked from commit 13926e5e298acf328b0c1347f008ef3f9c4eb078)

Backport of https://github.com/pandas-dev/pandas/pull/60118