### PR TITLE
DOC: Typo fix in "comparison_with_r

### DIFF
--- a/doc/source/getting_started/comparison/comparison_with_r.rst
+++ b/doc/source/getting_started/comparison/comparison_with_r.rst
@@ -405,7 +405,7 @@ In Python, this list would be a list of tuples, so
    a = list(enumerate(list(range(1, 5)) + [np.NAN]))
    pd.DataFrame(a)
 
-For more details and examples see :ref:`the Into to Data Structures
+For more details and examples see :ref:`the Intro to Data Structures
 documentation <dsintro>`.
 
 meltdf


### PR DESCRIPTION
While reviewing documentation I identified a trivial typo in the "comparison_with_r" getting started guide.

In line 408 the "Intro to Data Structures" documentation omitted an "r" in "Into". This distracted me enough I'm submitting a pull request.

Thank you!