### PR TITLE
[backport 2.3.x] TST (string dtype): avoid hardcoded object dtype for columns in datetime_frame fixture (#60192)

### DIFF
--- a/pandas/tests/frame/conftest.py
+++ b/pandas/tests/frame/conftest.py
@@ -18,7 +18,7 @@ def datetime_frame() -> DataFrame:
     """
     return DataFrame(
         np.random.default_rng(2).standard_normal((100, 4)),
-        columns=Index(list("ABCD"), dtype=object),
+        columns=Index(list("ABCD")),
         index=date_range("2000-01-01", periods=100, freq="B"),
     )
 

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -183,7 +183,6 @@ class TestDataFrameIndexing:
                 if bif[c].dtype != bifw[c].dtype:
                     assert bif[c].dtype == df[c].dtype
 
-    @pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string)")
     def test_getitem_boolean_casting(self, datetime_frame):
         # don't upcast if we don't need to
         df = datetime_frame.copy()

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -35,7 +35,6 @@ class TestDataFrameToCSV:
 
         return read_csv(path, **params)
 
-    @pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string)")
     def test_to_csv_from_csv1(self, float_frame, datetime_frame):
         with tm.ensure_clean("__tmp_to_csv_from_csv1__") as path:
             float_frame.iloc[:5, float_frame.columns.get_loc("A")] = np.nan
@@ -533,7 +532,6 @@ class TestDataFrameToCSV:
             assert return_value is None
             tm.assert_frame_equal(to_df, recons)
 
-    @pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string)")
     def test_to_csv_multiindex(self, float_frame, datetime_frame):
         frame = float_frame
         old_index = frame.index


### PR DESCRIPTION
(cherry picked from commit 34387bddffacb158a60a249b08411a8a1fe44455)

Backport of https://github.com/pandas-dev/pandas/pull/60192
