### PR TITLE
ENH (string dtype): convert string_view columns to future string dtype instead of object dtype in Parquet/Feather IO

### DIFF
--- a/pandas/io/_util.py
+++ b/pandas/io/_util.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from pandas.compat import pa_version_under18p0
 from pandas.compat._optional import import_optional_dependency
 
 import pandas as pd
@@ -35,7 +36,11 @@ def _arrow_dtype_mapping() -> dict:
 def arrow_string_types_mapper() -> Callable:
     pa = import_optional_dependency("pyarrow")
 
-    return {
+    mapping = {
         pa.string(): pd.StringDtype(na_value=np.nan),
         pa.large_string(): pd.StringDtype(na_value=np.nan),
-    }.get
+    }
+    if not pa_version_under18p0:
+        mapping[pa.string_view()] = pd.StringDtype(na_value=np.nan)
+
+    return mapping.get

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -6,6 +6,8 @@ import zoneinfo
 import numpy as np
 import pytest
 
+from pandas.compat.pyarrow import pa_version_under18p0
+
 import pandas as pd
 import pandas._testing as tm
 
@@ -246,6 +248,23 @@ class TestFeather:
             result = read_feather(path)
         expected = pd.DataFrame(
             data={"a": ["x", "y"]}, dtype=pd.StringDtype(na_value=np.nan)
+        )
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.skipif(pa_version_under18p0, reason="not supported before 18.0")
+    def test_string_inference_string_view_type(self, tmp_path):
+        # GH#54798
+        import pyarrow as pa
+        from pyarrow import feather
+
+        path = tmp_path / "string_view.parquet"
+        table = pa.table({"a": pa.array([None, "b", "c"], pa.string_view())})
+        feather.write_feather(table, path)
+
+        with pd.option_context("future.infer_string", True):
+            result = read_feather(path)
+        expected = pd.DataFrame(
+            data={"a": [None, "b", "c"]}, dtype=pd.StringDtype(na_value=np.nan)
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -263,9 +263,10 @@ class TestFeather:
 
         with pd.option_context("future.infer_string", True):
             result = read_feather(path)
-        expected = pd.DataFrame(
-            data={"a": [None, "b", "c"]}, dtype=pd.StringDtype(na_value=np.nan)
-        )
+
+            expected = pd.DataFrame(
+                data={"a": [None, "b", "c"]}, dtype=pd.StringDtype(na_value=np.nan)
+            )
         tm.assert_frame_equal(result, expected)
 
     def test_out_of_bounds_datetime_to_feather(self):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -17,7 +17,6 @@ from pandas.compat.pyarrow import (
     pa_version_under13p0,
     pa_version_under15p0,
     pa_version_under17p0,
-    pa_version_under18p0,
 )
 
 import pandas as pd
@@ -1134,26 +1133,6 @@ class TestParquetPyArrow(Base):
         path = tmp_path / "large_string.p"
 
         table = pa.table({"a": pa.array([None, "b", "c"], pa.large_string())})
-        pq.write_table(table, path)
-
-        with pd.option_context("future.infer_string", True):
-            result = read_parquet(path)
-        expected = pd.DataFrame(
-            data={"a": [None, "b", "c"]},
-            dtype=pd.StringDtype(na_value=np.nan),
-            columns=pd.Index(["a"], dtype=pd.StringDtype(na_value=np.nan)),
-        )
-        tm.assert_frame_equal(result, expected)
-
-    @pytest.mark.skipif(pa_version_under18p0, reason="not supported before 18.0")
-    def test_infer_string_string_view_type(self, tmp_path, pa):
-        # GH#54798
-        import pyarrow as pa
-        import pyarrow.parquet as pq
-
-        path = tmp_path / "string_view.parquet"
-
-        table = pa.table({"a": pa.array([None, "b", "c"], pa.string_view())})
         pq.write_table(table, path)
 
         with pd.option_context("future.infer_string", True):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -17,6 +17,7 @@ from pandas.compat.pyarrow import (
     pa_version_under13p0,
     pa_version_under15p0,
     pa_version_under17p0,
+    pa_version_under18p0,
 )
 
 import pandas as pd
@@ -1133,6 +1134,26 @@ class TestParquetPyArrow(Base):
         path = tmp_path / "large_string.p"
 
         table = pa.table({"a": pa.array([None, "b", "c"], pa.large_string())})
+        pq.write_table(table, path)
+
+        with pd.option_context("future.infer_string", True):
+            result = read_parquet(path)
+        expected = pd.DataFrame(
+            data={"a": [None, "b", "c"]},
+            dtype=pd.StringDtype(na_value=np.nan),
+            columns=pd.Index(["a"], dtype=pd.StringDtype(na_value=np.nan)),
+        )
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.skipif(pa_version_under18p0, reason="not supported before 18.0")
+    def test_infer_string_string_view_type(self, tmp_path, pa):
+        # GH#54798
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        path = tmp_path / "string_view.parquet"
+
+        table = pa.table({"a": pa.array([None, "b", "c"], pa.string_view())})
         pq.write_table(table, path)
 
         with pd.option_context("future.infer_string", True):


### PR DESCRIPTION
This is a follow-up on https://github.com/pandas-dev/pandas/pull/60222, which allows passing string_view data to the string dtype constructor, but in this PR ensuring we also use this capability when reading Parquet (or Feather, ORC) files that might use that type.

PyArrow does not yet support writing string_view to Parquet, so we can't test it yet with Parquet, only with Feather.

