### PR TITLE
TST: Add test for visibility of x label and xtick labels for `plot.hexbin`

### DIFF
--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -2589,6 +2589,14 @@ class TestDataFramePlots:
         result = ax.get_lines()[0].get_xdata()
         assert all(str(result[i]) == str(expected[i]) for i in range(4))
 
+    def test_plot_display_xlabel_and_xticks(self):
+        # GH#44050
+        df = DataFrame(np.random.default_rng(2).random((10, 2)), columns=["a", "b"])
+        ax = df.plot.hexbin(x="a", y="b")
+
+        _check_visible([ax.xaxis.get_label()], visible=True)
+        _check_visible(ax.get_xticklabels(), visible=True)
+
 
 def _generate_4_axes_via_gridspec():
     gs = mpl.gridspec.GridSpec(2, 2)


### PR DESCRIPTION
- [x] closes #44050 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

This PR adds a unit test to `pandas/tests/plotting/frame/test_frame.py` to verify that hexbin plots correctly display x labels and xtick labels. Adds a test for the solved issue described in GH https://github.com/pandas-dev/pandas/issues/44050.

