### PR TITLE
BUG: Fix #54763 to_julian_date does not consider timezone

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -635,8 +635,8 @@ Timedelta
 
 Timezones
 ^^^^^^^^^
-- Bug in :meth:`Index.to_julian_date()` not accounting for timezone information in `DatetimeIndex`, leading to incorrect Julian date calculations when timezones are present (:issue:`54763`).
-- Bug in :meth:`Timestamp.to_julian_date()` not accounting for timezone in `Timestamp` calculations, resulting in incorrect Julian dates when timezone-aware timestamps are used (:issue:`54763`).
+- Bug in :meth:`Index.to_julian_date` not accounting for timezone information in ``DatetimeIndex``, leading to incorrect Julian date calculations when timezones are present (:issue:`54763`).
+- Bug in :meth:`Timestamp.to_julian_date` not accounting for timezone in ``Timestamp`` calculations, resulting in incorrect Julian dates when timezone-aware timestamps are used (:issue:`54763`).
 -
 
 Numeric

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -635,7 +635,8 @@ Timedelta
 
 Timezones
 ^^^^^^^^^
--
+- Bug in :meth:`Index.to_julian_date()` not accounting for timezone information in `DatetimeIndex`, leading to incorrect Julian date calculations when timezones are present (:issue:`54763`).
+- Bug in :meth:`Timestamp.to_julian_date()` not accounting for timezone in `Timestamp` calculations, resulting in incorrect Julian dates when timezone-aware timestamps are used (:issue:`54763`).
 -
 
 Numeric

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -3319,19 +3319,27 @@ default 'raise'
         if month <= 2:
             year -= 1
             month += 12
-        return (day +
-                np.fix((153 * month - 457) / 5) +
-                365 * year +
-                np.floor(year / 4) -
-                np.floor(year / 100) +
-                np.floor(year / 400) +
-                1721118.5 +
-                (self.hour +
-                 self.minute / 60.0 +
-                 self.second / 3600.0 +
-                 self.microsecond / 3600.0 / 1e+6 +
-                 self.nanosecond / 3600.0 / 1e+9
-                 ) / 24.0)
+        timezone_offset = 0.0
+        if self.tzinfo is not None:
+            timezone_offset = self.utcoffset().total_seconds() / 86400.0
+        return (
+            day
+            + np.fix((153 * month - 457) / 5)
+            + 365 * year
+            + np.floor(year / 4)
+            - np.floor(year / 100)
+            + np.floor(year / 400)
+            + 1721118.5
+            - timezone_offset
+            + (
+                self.hour
+                + self.minute / 60.0
+                + self.second / 3600.0
+                + self.microsecond / 3600.0 / 1e+6
+                + self.nanosecond / 3600.0 / 1e+9
+            ) 
+            / 24.0
+        )
 
     def isoweekday(self):
         """

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -3337,7 +3337,7 @@ default 'raise'
                 + self.second / 3600.0
                 + self.microsecond / 3600.0 / 1e+6
                 + self.nanosecond / 3600.0 / 1e+9
-            ) 
+            )
             / 24.0
         )
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2266,6 +2266,10 @@ default 'raise'
         testarr = month < 3
         year[testarr] -= 1
         month[testarr] += 12
+        timezone_offsets = np.zeros(len(self), dtype=np.float64)
+        for i in range(len(self)):
+            if self[i].tzinfo is not None:
+                timezone_offsets[i] = self[i].utcoffset().total_seconds() / 86400.0
         return (
             day
             + np.fix((153 * month - 457) / 5)
@@ -2274,6 +2278,7 @@ default 'raise'
             - np.floor(year / 100)
             + np.floor(year / 400)
             + 1_721_118.5
+            - timezone_offsets
             + (
                 self.hour
                 + self.minute / 60

--- a/pandas/tests/indexes/datetimes/methods/test_to_julian_date.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_julian_date.py
@@ -1,5 +1,7 @@
-import numpy as np
 from zoneinfo import ZoneInfo
+
+import numpy as np
+import pytest
 
 from pandas import (
     Index,
@@ -8,7 +10,6 @@ from pandas import (
     to_datetime,
 )
 import pandas._testing as tm
-import pytest
 
 
 class TestDateTimeIndexToJulianDate:
@@ -47,36 +48,42 @@ class TestDateTimeIndexToJulianDate:
         assert isinstance(r2, Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
 
-    @pytest.mark.parametrize("tz, expected", [
-        (None, 2400000.5),
-        (ZoneInfo("UTC"), 2400000.5),
-        (ZoneInfo("US/Pacific"), 2400000.5 + (8 / 24)),
-        (ZoneInfo("Europe/London"), 2400000.5 - (1 / 24))
-    ])
+    @pytest.mark.parametrize(
+        "tz, expected",
+        [
+            (None, 2400000.5),
+            (ZoneInfo("UTC"), 2400000.5),
+            (ZoneInfo("US/Pacific"), 2400000.5 + (8 / 24)),
+            (ZoneInfo("Europe/London"), 2400000.5 - (1 / 24)),
+        ],
+    )
     def test_to_julian_date_with_timezones_single_element(self, tz, expected):
         # GH54763: Timestamp.to_julian_date() must consider timezone
-        dates = to_datetime(['1858-11-17T00:00:00.0'])
+        dates = to_datetime(["1858-11-17T00:00:00.0"])
         if tz:
             dates = dates.tz_localize(tz)
         result = Index(dates.to_julian_date())
         expected = Index([expected])
         tm.assert_almost_equal(result, expected, rtol=1e-6, atol=1e-6)
 
-    @pytest.mark.parametrize("tz, offset", [
-        (None, 0),
-        (ZoneInfo("UTC"), 0),
-        (ZoneInfo("US/Pacific"), 8),
-        (ZoneInfo("Europe/London"), -1)
-    ])
+    @pytest.mark.parametrize(
+        "tz, offset",
+        [
+            (None, 0),
+            (ZoneInfo("UTC"), 0),
+            (ZoneInfo("US/Pacific"), 8),
+            (ZoneInfo("Europe/London"), -1),
+        ],
+    )
     def test_to_julian_date_with_timezones_multiple_elements(self, tz, offset):
         # GH54763: Timestamp.to_julian_date() must consider timezone
         dates = to_datetime(
             [
-                '1858-11-17T00:00:00',
-                '1858-11-17T12:00:00',
-                '2000-01-01T00:00:00',
-                '2000-01-01T12:00:00',
-                '2000-01-01T12:00:00'
+                "1858-11-17T00:00:00",
+                "1858-11-17T12:00:00",
+                "2000-01-01T00:00:00",
+                "2000-01-01T12:00:00",
+                "2000-01-01T12:00:00",
             ]
         )
         if tz:
@@ -88,7 +95,7 @@ class TestDateTimeIndexToJulianDate:
                 2400001.0 + (offset / 24),
                 2451544.5 + (offset / 24),
                 2451545.0 + (offset / 24),
-                2451545.0 + (offset / 24)
+                2451545.0 + (offset / 24),
             ]
         )
         tm.assert_almost_equal(result, expected, rtol=1e-6, atol=1e-6)

--- a/pandas/tests/indexes/datetimes/methods/test_to_julian_date.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_julian_date.py
@@ -1,11 +1,14 @@
 import numpy as np
+from zoneinfo import ZoneInfo
 
 from pandas import (
     Index,
     Timestamp,
     date_range,
+    to_datetime,
 )
 import pandas._testing as tm
+import pytest
 
 
 class TestDateTimeIndexToJulianDate:
@@ -43,3 +46,49 @@ class TestDateTimeIndexToJulianDate:
         r2 = dr.to_julian_date()
         assert isinstance(r2, Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
+
+    @pytest.mark.parametrize("tz, expected", [
+        (None, 2400000.5),
+        (ZoneInfo("UTC"), 2400000.5),
+        (ZoneInfo("US/Pacific"), 2400000.5 + (8 / 24)),
+        (ZoneInfo("Europe/London"), 2400000.5 - (1 / 24))
+    ])
+    def test_to_julian_date_with_timezones_single_element(self, tz, expected):
+        # GH54763: Timestamp.to_julian_date() must consider timezone
+        dates = to_datetime(['1858-11-17T00:00:00.0'])
+        if tz:
+            dates = dates.tz_localize(tz)
+        result = Index(dates.to_julian_date())
+        expected = Index([expected])
+        tm.assert_almost_equal(result, expected, rtol=1e-6, atol=1e-6)
+
+    @pytest.mark.parametrize("tz, offset", [
+        (None, 0),
+        (ZoneInfo("UTC"), 0),
+        (ZoneInfo("US/Pacific"), 8),
+        (ZoneInfo("Europe/London"), -1)
+    ])
+    def test_to_julian_date_with_timezones_multiple_elements(self, tz, offset):
+        # GH54763: Timestamp.to_julian_date() must consider timezone
+        dates = to_datetime(
+            [
+                '1858-11-17T00:00:00',
+                '1858-11-17T12:00:00',
+                '2000-01-01T00:00:00',
+                '2000-01-01T12:00:00',
+                '2000-01-01T12:00:00'
+            ]
+        )
+        if tz:
+            dates = dates.tz_localize(tz)
+        result = Index(dates.to_julian_date())
+        expected = Index(
+            [
+                2400000.5 + (offset / 24),
+                2400001.0 + (offset / 24),
+                2451544.5 + (offset / 24),
+                2451545.0 + (offset / 24),
+                2451545.0 + (offset / 24)
+            ]
+        )
+        tm.assert_almost_equal(result, expected, rtol=1e-6, atol=1e-6)

--- a/pandas/tests/scalar/timestamp/methods/test_to_julian_date.py
+++ b/pandas/tests/scalar/timestamp/methods/test_to_julian_date.py
@@ -1,9 +1,9 @@
-from pandas import Timestamp
-
 import zoneinfo
 
-import pandas._testing as tm
 import pytest
+
+from pandas import Timestamp
+import pandas._testing as tm
 
 
 class TestTimestampToJulianDate:
@@ -32,15 +32,18 @@ class TestTimestampToJulianDate:
         res = ts.to_julian_date()
         assert res == 2_451_769.0416666666666666
 
-    @pytest.mark.parametrize("tz, expected", [
-        (None, 2400000.5),
-        (zoneinfo.ZoneInfo("UTC"), 2400000.5),
-        (zoneinfo.ZoneInfo("US/Pacific"), 2400000.5 + (8 / 24)),
-        (zoneinfo.ZoneInfo("Europe/London"), 2400000.5 - (1 / 24))
-    ])
+    @pytest.mark.parametrize(
+        "tz, expected",
+        [
+            (None, 2400000.5),
+            (zoneinfo.ZoneInfo("UTC"), 2400000.5),
+            (zoneinfo.ZoneInfo("US/Pacific"), 2400000.5 + (8 / 24)),
+            (zoneinfo.ZoneInfo("Europe/London"), 2400000.5 - (1 / 24)),
+        ],
+    )
     def test_to_julian_date_with_timezones(self, tz, expected):
         # GH54763: Timestamp.to_julian_date() must consider timezone
-        ts = Timestamp('1858-11-17T00:00:00.0')
+        ts = Timestamp("1858-11-17T00:00:00.0")
         if tz:
             ts.tz_localize(tz)
         result = ts.to_julian_date()

--- a/pandas/tests/scalar/timestamp/methods/test_to_julian_date.py
+++ b/pandas/tests/scalar/timestamp/methods/test_to_julian_date.py
@@ -1,5 +1,10 @@
 from pandas import Timestamp
 
+import zoneinfo
+
+import pandas._testing as tm
+import pytest
+
 
 class TestTimestampToJulianDate:
     def test_compare_1700(self):
@@ -26,3 +31,17 @@ class TestTimestampToJulianDate:
         ts = Timestamp("2000-08-12T13:00:00")
         res = ts.to_julian_date()
         assert res == 2_451_769.0416666666666666
+
+    @pytest.mark.parametrize("tz, expected", [
+        (None, 2400000.5),
+        (zoneinfo.ZoneInfo("UTC"), 2400000.5),
+        (zoneinfo.ZoneInfo("US/Pacific"), 2400000.5 + (8 / 24)),
+        (zoneinfo.ZoneInfo("Europe/London"), 2400000.5 - (1 / 24))
+    ])
+    def test_to_julian_date_with_timezones(self, tz, expected):
+        # GH54763: Timestamp.to_julian_date() must consider timezone
+        ts = Timestamp('1858-11-17T00:00:00.0')
+        if tz:
+            ts.tz_localize(tz)
+        result = ts.to_julian_date()
+        tm.assert_almost_equal(result, expected, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
- [x] closes #54763
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
