### PR TITLE
TST: Add test for `pd.read_csv` date parsing not working with `dtype_backend="pyarrow"` and missing values

### DIFF
--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -5,6 +5,7 @@ Tests for the pandas.io.common functionalities
 import codecs
 import errno
 from functools import partial
+import io
 from io import (
     BytesIO,
     StringIO,
@@ -674,3 +675,11 @@ def test_pickle_reader(reader):
     # GH 22265
     with BytesIO() as buffer:
         pickle.dump(reader, buffer)
+
+
+def test_pyarrow_read_csv_datetime_dtype():
+    data = "date,id\n20/12/2025,a\n,b\n31/12/2020,c"
+    df = pd.read_csv(
+        io.StringIO(data), parse_dates=["date"], dayfirst=True, dtype_backend="pyarrow"
+    )
+    assert (df["date"].dtype) == "datetime64[s]"

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -676,6 +676,7 @@ def test_pickle_reader(reader):
         pickle.dump(reader, buffer)
 
 
+@td.skip_if_no("pyarrow")
 def test_pyarrow_read_csv_datetime_dtype():
     data = "date,id\n20/12/2025,a\n,b\n31/12/2020,c"
     df = pd.read_csv(

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -683,10 +683,8 @@ def test_pyarrow_read_csv_datetime_dtype():
     result = pd.read_csv(
         StringIO(data), parse_dates=["date"], dayfirst=True, dtype_backend="pyarrow"
     )
-    expect_data = pd.Series(
-        pd.to_datetime(["20/12/2025", pd.NaT, "31/12/2020"], dayfirst=True)
-    )
+
+    expect_data = pd.to_datetime(["20/12/2025", pd.NaT, "31/12/2020"], dayfirst=True)
     expect = pd.DataFrame({"date": expect_data})
 
-    assert (result["date"].dtype) == "datetime64[s]"
     tm.assert_frame_equal(expect, result)

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -5,7 +5,6 @@ Tests for the pandas.io.common functionalities
 import codecs
 import errno
 from functools import partial
-import io
 from io import (
     BytesIO,
     StringIO,
@@ -680,6 +679,6 @@ def test_pickle_reader(reader):
 def test_pyarrow_read_csv_datetime_dtype():
     data = "date,id\n20/12/2025,a\n,b\n31/12/2020,c"
     df = pd.read_csv(
-        io.StringIO(data), parse_dates=["date"], dayfirst=True, dtype_backend="pyarrow"
+        StringIO(data), parse_dates=["date"], dayfirst=True, dtype_backend="pyarrow"
     )
     assert (df["date"].dtype) == "datetime64[s]"


### PR DESCRIPTION
- [x] closes #59904 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
