### PR TITLE
BUG: Fixes .convert_dtypes(dtype_backend="pyarrow") stripping timezone from tz-aware pyarrow timestamp Series

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -649,6 +649,7 @@ Conversion
 - Bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)
 - Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
+- Bug in :meth: 'Series.convert_dtype' strips the timezone on an already Timezone aware pyarrow timestamp dtype (:issue:'60237')
 
 Strings
 ^^^^^^^

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2277,18 +2277,6 @@ class ArrowDtype(StorageExtensionDtype):
     @cache_readonly
     def numpy_dtype(self) -> np.dtype:
         """Return an instance of the related numpy dtype"""
-        if pa.types.is_timestamp(self.pyarrow_dtype):
-            # pa.timestamp(unit).to_pandas_dtype() returns ns units
-            # regardless of the pyarrow timestamp units.
-            # This can be removed if/when pyarrow addresses it:
-            # https://github.com/apache/arrow/issues/34462
-            return np.dtype(f"datetime64[{self.pyarrow_dtype.unit}]")
-        if pa.types.is_duration(self.pyarrow_dtype):
-            # pa.duration(unit).to_pandas_dtype() returns ns units
-            # regardless of the pyarrow duration units
-            # This can be removed if/when pyarrow addresses it:
-            # https://github.com/apache/arrow/issues/34462
-            return np.dtype(f"timedelta64[{self.pyarrow_dtype.unit}]")
         if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(
             self.pyarrow_dtype
         ):

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2277,11 +2277,6 @@ class ArrowDtype(StorageExtensionDtype):
     @cache_readonly
     def numpy_dtype(self) -> np.dtype:
         """Return an instance of the related numpy dtype"""
-        if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(
-            self.pyarrow_dtype
-        ):
-            # pa.string().to_pandas_dtype() = object which we don't want
-            return np.dtype(str)
         try:
             return np.dtype(self.pyarrow_dtype.to_pandas_dtype())
         except (NotImplementedError, TypeError):

--- a/pandas/tests/copy_view/test_astype.py
+++ b/pandas/tests/copy_view/test_astype.py
@@ -11,6 +11,7 @@ from pandas import (
     Series,
     Timestamp,
     date_range,
+    to_datetime,
 )
 import pandas._testing as tm
 from pandas.tests.copy_view.util import get_array
@@ -236,3 +237,13 @@ def test_convert_dtypes(using_infer_string):
     df2.iloc[0, 0] = "x"
     df2.iloc[0, 1] = 10
     tm.assert_frame_equal(df, df_orig)
+
+
+def test_convert_dtypes_pyarrow_timezone():
+    # GH 60237
+    expected = Series(
+        to_datetime(range(5), utc=True, unit="h"),
+        dtype="timestamp[ns, tz=UTC][pyarrow]",
+    )
+    result = expected.convert_dtypes(dtype_backend="pyarrow")
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Removed if statement blocks in numpy_dtype(self), added test case to ensure time zone is maintained, and added documentation of bug fix.
