### PR TITLE
TST: Add test for x-axis labels in subplot with `secondary_y=True`

### DIFF
--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -958,3 +958,17 @@ class TestSeriesPlots:
         # TODO(3.0): this can be removed once Period[B] deprecation is enforced
         with tm.assert_produces_warning(False):
             _ = ts.plot()
+
+    @pytest.mark.slow
+    def test_secondary_y_subplot_axis_labels(self):
+        # GH#14102
+        s1 = Series([5, 7, 6, 8, 7], index=[1, 2, 3, 4, 5])
+        s2 = Series([6, 4, 5, 3, 4], index=[1, 2, 3, 4, 5])
+
+        ax = plt.subplot(2, 1, 1)
+        s1.plot(ax=ax)
+        s2.plot(ax=ax, secondary_y=True)
+        ax2 = plt.subplot(2, 1, 2)
+        s1.plot(ax=ax2)
+        assert len(ax.xaxis.get_minor_ticks()) == 0
+        assert len(ax.get_xticklabels()) > 0

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -959,7 +959,6 @@ class TestSeriesPlots:
         with tm.assert_produces_warning(False):
             _ = ts.plot()
 
-    @pytest.mark.slow
     def test_secondary_y_subplot_axis_labels(self):
         # GH#14102
         s1 = Series([5, 7, 6, 8, 7], index=[1, 2, 3, 4, 5])


### PR DESCRIPTION
- [x] closes #14102  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

This PR adds a unit test to `pandas/tests/plotting/test_series.py` to verify that X-axis labels are preserved when using `secondary_y=True` and creaitng a new subplot. Adds a test for the solved issue described in https://github.com/pandas-dev/pandas/issues/14102.
