### PR TITLE
BUG (string dtype): let fillna with invalid value upcast to object dtype

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1337,7 +1337,7 @@ class Block(PandasObject, libinternals.Block):
             return [self.copy(deep=False)]
 
         if limit is not None:
-            mask[mask.cumsum(self.ndim - 1) > limit] = False
+            mask[mask.cumsum(self.values.ndim - 1) > limit] = False
 
         if inplace:
             nbs = self.putmask(mask.T, value)
@@ -1857,7 +1857,7 @@ class ExtensionBlock(EABackedBlock):
     ) -> list[Block]:
         if isinstance(self.dtype, (IntervalDtype, StringDtype)):
             # Block.fillna handles coercion (test_fillna_interval)
-            if limit is not None:
+            if isinstance(self.dtype, IntervalDtype) and limit is not None:
                 raise ValueError("limit must be None")
             return super().fillna(
                 value=value,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -108,6 +108,7 @@ from pandas.core.arrays import (
     PeriodArray,
     TimedeltaArray,
 )
+from pandas.core.arrays.string_ import StringDtype
 from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.computation import expressions
@@ -1684,7 +1685,7 @@ class EABackedBlock(Block):
             res_values = arr._where(cond, other).T
         except (ValueError, TypeError):
             if self.ndim == 1 or self.shape[0] == 1:
-                if isinstance(self.dtype, IntervalDtype):
+                if isinstance(self.dtype, (IntervalDtype, StringDtype)):
                     # TestSetitemFloatIntervalWithIntIntervalValues
                     blk = self.coerce_to_target_dtype(orig_other, raise_on_upcast=False)
                     return blk.where(orig_other, orig_cond)
@@ -1854,7 +1855,7 @@ class ExtensionBlock(EABackedBlock):
         limit: int | None = None,
         inplace: bool = False,
     ) -> list[Block]:
-        if isinstance(self.dtype, IntervalDtype):
+        if isinstance(self.dtype, (IntervalDtype, StringDtype)):
             # Block.fillna handles coercion (test_fillna_interval)
             if limit is not None:
                 raise ValueError("limit must be None")

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -1025,15 +1025,9 @@ def test_where_producing_ea_cond_for_np_dtype():
 @pytest.mark.parametrize(
     "replacement", [0.001, True, "snake", None, datetime(2022, 5, 4)]
 )
-def test_where_int_overflow(replacement, using_infer_string):
+def test_where_int_overflow(replacement):
     # GH 31687
     df = DataFrame([[1.0, 2e25, "nine"], [np.nan, 0.1, None]])
-    if using_infer_string and replacement not in (None, "snake"):
-        with pytest.raises(
-            TypeError, match=f"Invalid value '{replacement}' for dtype 'str'"
-        ):
-            df.where(pd.notnull(df), replacement)
-        return
     result = df.where(pd.notnull(df), replacement)
     expected = DataFrame([[1.0, 2e25, "nine"], [replacement, 0.1, replacement]])
 

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -839,11 +839,6 @@ class SetitemCastingEquivalents:
         obj = obj.copy()
         arr = obj._values
 
-        if raises and obj.dtype == "string":
-            with pytest.raises(TypeError, match="Invalid value"):
-                obj.where(~mask, val)
-            return
-
         res = obj.where(~mask, val)
 
         if val is NA and res.dtype == object:


### PR DESCRIPTION
Like I did for `replace()` (issue https://github.com/pandas-dev/pandas/issues/60282 / PR https://github.com/pandas-dev/pandas/pull/60285), it turns out that also for `fillna()` we generally upcast to object dtype if the fill value does not fit the dtype:

```python
>>> ser = pd.Series([1, 2, None], dtype="float")
>>> ser.fillna("a")
Out[4]: 
0    1.0
1    2.0
2      a
dtype: object
```

And similarly as for `replace()`, this was raising an error in the case of `StringDtype`.  
The reason is that for generic (external) ExtensionArrays, we are actually strict and `fillna` is just dispatched to the EA without fallback to object dtype; while for all our own _default_ extension dtypes we do have custom code to ensure to do a fallback (but _not_ for the masked dtypes and ArrowDtype ..).

Given this is the default behaviour right now for other dtypes (and so we also haven't deprecated this for current usage of strings in object dtype), I would preserve this fallback for now to avoid this as another breaking change in 3.0.

xref https://github.com/pandas-dev/pandas/issues/54792
