### PR TITLE
DOC: Update from_records docstring to not mention DataFrame as valid input

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2115,7 +2115,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Convert structured or record ndarray to DataFrame.
 
-        Creates a DataFrame object from a structured ndarray, sequence of
+        Creates a DataFrame object from a structured ndarray, or sequence of
         tuples or dicts.
 
         Parameters

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2116,7 +2116,7 @@ class DataFrame(NDFrame, OpsMixin):
         Convert structured or record ndarray to DataFrame.
 
         Creates a DataFrame object from a structured ndarray, sequence of
-        tuples or dicts, or DataFrame.
+        tuples or dicts.
 
         Parameters
         ----------


### PR DESCRIPTION


- closes #60307 

Removed mention of DataFrame as an acceptable input type, as it is no longer supported
`
        Convert structured or record ndarray to DataFrame.

        Creates a DataFrame object from a structured ndarray, sequence of
        tuples or dicts.

`

Ensured compatibility with numpydoc format by validating against validate_docstrings.py