### PR TITLE
Add warning for sharex/sharey when subplots=False in plot method

### DIFF
--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -565,6 +565,14 @@ class MPLPlot(ABC):
     @cache_readonly
     def _axes_and_fig(self) -> tuple[Sequence[Axes], Figure]:
         import matplotlib.pyplot as plt
+        import warnings
+
+        # Warn users that 'sharex' and 'sharey' are ignored when 'subplots' is False
+        if not self.subplots and (self.sharex or self.sharey):
+            warnings.warn(
+                "'sharex' and 'sharey' parameters are ignored when 'subplots' is set to False.",
+                UserWarning
+            )
 
         if self.subplots:
             naxes = (
@@ -602,6 +610,7 @@ class MPLPlot(ABC):
 
         axes_seq = cast(Sequence["Axes"], axes)
         return axes_seq, fig
+
 
     @property
     def result(self):

--- a/pandas/tests/plotting/test_sharex_sharey_warning.py
+++ b/pandas/tests/plotting/test_sharex_sharey_warning.py
@@ -1,0 +1,11 @@
+import pytest
+import pandas as pd
+
+def test_plot_sharex_sharey_warning():
+    # Create a simple DataFrame
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+
+    # Check for UserWarning when sharex or sharey is set with subplots=False
+    with pytest.warns(UserWarning, match="parameters are ignored when 'subplots' is set to False") as record:
+        df.plot(sharex=True, sharey=True, subplots=False)
+    print(record[0].message)


### PR DESCRIPTION
- [x] closes #60299
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
