### PR TITLE
ENH: set __module__ on concat function in concat.py

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -17,8 +17,8 @@ import warnings
 import numpy as np
 
 from pandas._libs import lib
-from pandas.util._exceptions import find_stack_level
 from pandas.util._decorators import set_module
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_bool,

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from pandas._libs import lib
 from pandas.util._exceptions import find_stack_level
+from pandas.util._decorators import set_module
 
 from pandas.core.dtypes.common import (
     is_bool,
@@ -149,6 +150,7 @@ def concat(
 ) -> DataFrame | Series: ...
 
 
+@set_module("pandas")
 def concat(
     objs: Iterable[Series | DataFrame] | Mapping[HashableT, Series | DataFrame],
     *,

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -417,6 +417,7 @@ def test_set_module():
     assert pd.Period.__module__ == "pandas"
     assert pd.Timestamp.__module__ == "pandas"
     assert pd.Timedelta.__module__ == "pandas"
+    assert pd.concat.__module__ == "pandas"
     assert pd.isna.__module__ == "pandas"
     assert pd.notna.__module__ == "pandas"
     assert pd.merge.__module__ == "pandas"


### PR DESCRIPTION
- [ ] Part of #55178 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This decorates `concat` with `@set_module('pandas')` (similar to #55171)
