### PR TITLE
remove unnecessary trailing slashes from URLs

### DIFF
--- a/web/pandas/_templates/layout.html
+++ b/web/pandas/_templates/layout.html
@@ -73,12 +73,12 @@
                     </a>
                 </li>
                 <li class="list-inline-item">
-                    <a href="https://x.com/pandas_dev/">
+                    <a href="https://x.com/pandas_dev">
                         <i class="fab bi bi-twitter-x"></i>
                     </a>
                 </li>
                 <li class="list-inline-item">
-                    <a href="https://github.com/pandas-dev/pandas/">
+                    <a href="https://github.com/pandas-dev/pandas">
                         <i class="fab bi bi-github"></i>
                     </a>
                 </li>


### PR DESCRIPTION
remove unnecessary trailing slashes from x.com and github.com URLs