### PR TITLE
CI/BUG: Remove `trim()` function on `comment-commands.yml`

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   issue_assign:
     runs-on: ubuntu-22.04
-    if: (!github.event.issue.pull_request) && trim(github.event.comment.body) == 'take'
+    if: (!github.event.issue.pull_request) && github.event.comment.body == 'take'
     concurrency:
       group: ${{ github.actor }}-issue-assign
     steps:


### PR DESCRIPTION
- [x] closes #60396 (Replace xxxx with the GitHub issue number)

Since there are no trim or related split commands on github workflows, you'd have to use a shell to be able to trim it. 
See: https://stackoverflow.com/questions/64049306/github-actions-how-to-trim-a-string-in-a-condition
```steps:
  ...
  - name: Check if person has accepted and signed CLA
    shell: python
    run: |
      import sys

      def check_user_accepted_and_signed(text):
        """Some complex natural language processing will go here"""
      
      comment = '''${{ github.event.comment.body }}'''
      if not check_user_accepted_and_signed(comment):
        sys.exit(1)  # This will abort the job
  - name: Not accepted or signed
    if: ${{ failure() }}
    run: optionally do something if the check fails
  - name: Move on if the check passed
    run: ...
```
Which in my opinion would be a lot of work and extra compute time for a simple "strip" on comments. I suggest to revert it as original.

