### PR TITLE
Fix BUG: Cannot shift Intervals that are not closed='right' (the default)

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1055,7 +1055,9 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             from pandas import Index
 
             fill_value = Index(self._left, copy=False)._na_value
-            empty = IntervalArray.from_breaks([fill_value] * (empty_len + 1))
+            empty = IntervalArray.from_breaks(
+                [fill_value] * (empty_len + 1), closed=self.closed
+            )
         else:
             empty = self._from_sequence([fill_value] * empty_len, dtype=self.dtype)
 

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -757,3 +757,12 @@ class TestDataFrameShift:
         df_shifted = DataFrame(index=shifted_dates)
         result = df.shift(freq=offset)
         tm.assert_frame_equal(result, df_shifted)
+
+    def test_series_shift_interval_preserves_closed(self):
+        # GH#60389
+        ser = Series(
+            [pd.Interval(1, 2, closed="right"), pd.Interval(2, 3, closed="right")]
+        )
+        result = ser.shift(1)
+        expected = Series([np.nan, pd.Interval(1, 2, closed="right")])
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #60389 
- [x] Tests added and passed
- [x] All code checks passed

I made a small modification by adding the closed attribute when creating empty positions for movement. Now we can output the moved result correctly according to the requirements in the issue
```
0           NaN
1    [1.0, 2.0)
dtype: interval
```

At the same time, I added a little test for this modification.

If my understanding of the problem is beyond the problem, or if my modifications are incorrect, please feel free to point them out
