### PR TITLE
DOC: Fix docstrings for boxplot, get_group, and indices methods

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -88,9 +88,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.arrays.IntervalArray.length SA01" \
         -i "pandas.arrays.NumpyExtensionArray SA01" \
         -i "pandas.arrays.TimedeltaArray PR07,SA01" \
-        -i "pandas.core.groupby.DataFrameGroupBy.boxplot PR07,RT03,SA01" \
-        -i "pandas.core.groupby.DataFrameGroupBy.get_group RT03,SA01" \
-        -i "pandas.core.groupby.DataFrameGroupBy.indices SA01" \
         -i "pandas.core.groupby.DataFrameGroupBy.nunique SA01" \
         -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
         -i "pandas.core.groupby.DataFrameGroupBy.sem SA01" \

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -724,7 +724,6 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         
         Examples
         --------
-
         For SeriesGroupBy:
 
         >>> lst = ["a", "a", "b"]

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -721,7 +721,7 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         DataFrame.groupby : Apply a groupby operation on a DataFrame.
         Series.groupby : Apply a groupby operation on a Series.
         Resampler.get_group : Get a group from a resampler.
-        
+
         Examples
         --------
         For SeriesGroupBy:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -515,6 +515,12 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         """
         Dict {group name -> group indices}.
 
+        See Also
+        --------
+        DataFrame.groupby : Apply a groupby operation on a DataFrame.
+        Series.groupby : Apply a groupby operation on a Series.
+        Resampler.indices : Return the indices of the groups in a resampler.
+
         Examples
         --------
 
@@ -563,6 +569,7 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         Timestamp('2023-02-01 00:00:00'): [2, 3]})
         """
         return self._grouper.indices
+
 
     @final
     def _get_indices(self, names):
@@ -707,7 +714,14 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         Returns
         -------
         DataFrame or Series
+            A DataFrame or Series corresponding to the group with the specified name.
 
+        See Also
+        --------
+        DataFrame.groupby : Apply a groupby operation on a DataFrame.
+        Series.groupby : Apply a groupby operation on a Series.
+        Resampler.get_group : Get a group from a resampler.
+        
         Examples
         --------
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -570,19 +570,24 @@ def boxplot_frame_groupby(
 
     Parameters
     ----------
-    grouped : Grouped DataFrame
+    grouped : DataFrameGroupBy
+        The grouped DataFrame to plot.
     subplots : bool
         * ``False`` - no subplots will be used
         * ``True`` - create a subplot for each group.
-
     column : column name or list of names, or vector
         Can be any valid input to groupby.
-    fontsize : float or str
-    rot : label rotation angle
-    grid : Setting this to True will show the grid
+    fontsize : int or None
+        Font size for the labels.
+    rot : int
+        Rotation angle of the labels.
+    grid : bool
+        Setting this to True will show the grid.
     ax : Matplotlib axis object, default None
-    figsize : A tuple (width, height) in inches
-    layout : tuple (optional)
+        An axis object to plot on. If None, a new figure and axis will be created.
+    figsize : tuple of (float, float) or None
+        A tuple (width, height) in inches.
+    layout : tuple of (int, int) or None
         The layout of the plot: (rows, columns).
     sharex : bool, default False
         Whether x-axes will be shared among subplots.
@@ -599,8 +604,17 @@ def boxplot_frame_groupby(
 
     Returns
     -------
-    dict of key/value = group key/DataFrame.boxplot return value
-    or DataFrame.boxplot return value in case subplots=figures=False
+    dict of key/value pairs or DataFrame.boxplot
+        When subplots=True, returns a dictionary where keys are group names and
+        values are the matplotlib BoxPlot objects for each group.
+        When subplots=False, returns a single matplotlib BoxPlot object for the
+        combined plot.
+
+    See Also
+    --------
+    DataFrame.boxplot : Make box plots from DataFrame data.
+    Series.boxplot : Make box plots from Series data.
+    pandas.plotting.boxplot : Lower-level method for creating box plots.
 
     Examples
     --------


### PR DESCRIPTION
Fixes docstrings of below methods

```
-i "pandas.core.groupby.DataFrameGroupBy.boxplot PR07,RT03,SA01" \ 
 -i "pandas.core.groupby.DataFrameGroupBy.get_group RT03,SA01" \ 
 -i "pandas.core.groupby.DataFrameGroupBy.indices SA01" \ 
```