### PR TITLE
TST: Avoid hashing np.timedelta64 without unit

### DIFF
--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1254,7 +1254,7 @@ class TestValueCounts:
         result_dt = algos.value_counts_internal(dt)
         tm.assert_series_equal(result_dt, exp_dt)
 
-        exp_td = Series({np.timedelta64(10000): 1}, name="count")
+        exp_td = Series([1], index=[np.timedelta64(10000)], name="count")
         result_td = algos.value_counts_internal(td)
         tm.assert_series_equal(result_td, exp_td)
 


### PR DESCRIPTION
Avoids

```bash
____________________ TestValueCounts.test_value_counts_nat _____________________
[gw3] linux -- Python 3.13.0 /opt/hostedtoolcache/Python/3.13.0/x64/bin/python

self = <pandas.tests.test_algos.TestValueCounts object at 0x7f7c3f35dd20>

    def test_value_counts_nat(self):
        td = Series([np.timedelta64(10000), NaT], dtype="timedelta64[ns]")
        dt = to_datetime(["NaT", "2014-01-01"])
    
        for ser in [td, dt]:
            vc = algos.value_counts_internal(ser)
            vc_with_na = algos.value_counts_internal(ser, dropna=False)
            assert len(vc) == 1
            assert len(vc_with_na) == 2
    
        exp_dt = Series({Timestamp("2014-01-01 00:00:00"): 1}, name="count")
        result_dt = algos.value_counts_internal(dt)
        tm.assert_series_equal(result_dt, exp_dt)
    
>       exp_td = Series({np.timedelta64(10000): 1}, name="count")
E       ValueError: Can't hash generic timedelta64

pandas/tests/test_algos.py:1257: ValueError
```