### PR TITLE
BUG: Fix formatting of complex numbers with exponents

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -789,6 +789,7 @@ Other
 - Bug in :meth:`Series.dt` methods in :class:`ArrowDtype` that were returning incorrect values. (:issue:`57355`)
 - Bug in :meth:`Series.rank` that doesn't preserve missing values for nullable integers when ``na_option='keep'``. (:issue:`56976`)
 - Bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently replacing matching instances when ``regex=True`` and missing values are present. (:issue:`56599`)
+- Bug in :meth:`Series.to_string` when series contains complex floats with exponents (:issue:`60405`)
 - Bug in :meth:`read_csv` where chained fsspec TAR file and ``compression="infer"`` fails with ``tarfile.ReadError`` (:issue:`60028`)
 - Bug in Dataframe Interchange Protocol implementation was returning incorrect results for data buffers' associated dtype, for string and datetime columns (:issue:`54781`)
 - Bug in ``Series.list`` methods not preserving the original :class:`Index`. (:issue:`58425`)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1749,7 +1749,7 @@ def _trim_zeros_complex(str_complexes: ArrayLike, decimal: str = ".") -> list[st
         # The split will give [{"", "-"}, "xxx", "+/-", "xxx", "j", ""]
         # Therefore, the imaginary part is the 4th and 3rd last elements,
         # and the real part is everything before the imaginary part
-        trimmed = re.split(r"([j+-])", x)
+        trimmed = re.split(r"(?<!e)([j+-])", x)
         real_part.append("".join(trimmed[:-4]))
         imag_part.append("".join(trimmed[-4:-2]))
 

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -422,6 +422,24 @@ class TestToStringNumericFormatting:
             )
             assert result == expected
 
+    def test_to_string_complex_float_formatting_with_exponents(self):
+        # GH #60393
+        with option_context("display.precision", 6):
+            df = DataFrame(
+                {
+                    "x": [
+                        (1.8816e-09 + 0j),
+                        (1.8816e-09 + 3.39676e-09j),
+                    ]
+                }
+            )
+            result = df.to_string()
+            expected = (
+                "                            x\n0  1.881600e-09+0.000000e+00j\n"
+                "1  1.881600e-09+3.396760e-09j"
+            )
+            assert result == expected
+
     def test_to_string_format_inf(self):
         # GH#24861
         df = DataFrame(


### PR DESCRIPTION
- [ ] closes #60393 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

```
>>> input_array=[(1.8816e-09+0j), (3.39676e-09+0j)]
>>> pd.Series(input_array)
0    1.881600e-09+0.000000e+                    00j
1    3.396760e-09+0.000000e+                    00j
dtype: complex128
```

The issue was due to the regex in the _trim_zeros_complex function not being able to handle +/- in the exponent. It assumes the complex number string to be of the form (-)xxx(+/)yyyj. I fixed the regex so it doesn't split on +/- if preceded by an exponent.
Post the fix:

```
>>> input_array=[(1.8816e-09+0j), (3.39676e-09+0j)]
>>> pd.Series(input_array)
0    1.881600e-09+0.000000e+00j
1    3.396760e-09+0.000000e+00j
dtype: complex128
```