### PR TITLE
DOC: fix docstring api.types.is_re_compilable

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -82,7 +82,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.min PR02" \
         -i "pandas.Timestamp.resolution PR02" \
         -i "pandas.Timestamp.tzinfo GL08" \
-        -i "pandas.api.types.is_re_compilable PR07,SA01" \
         -i "pandas.arrays.ArrowExtensionArray PR07,SA01" \
         -i "pandas.arrays.IntegerArray SA01" \
         -i "pandas.arrays.IntervalArray.length SA01" \

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -215,7 +215,7 @@ def is_re_compilable(obj: object) -> bool:
         return False
     else:
         return True
-    
+
 
 def is_array_like(obj: object) -> bool:
     """

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -190,11 +190,16 @@ def is_re_compilable(obj: object) -> bool:
     Parameters
     ----------
     obj : The object to check
+        The object to check if the object can be compiled into a regex pattern instance.
 
     Returns
     -------
     bool
         Whether `obj` can be compiled as a regex pattern.
+
+    See Also
+    --------
+    api.types.is_re : Check if the object is a regex pattern instance.
 
     Examples
     --------
@@ -210,7 +215,7 @@ def is_re_compilable(obj: object) -> bool:
         return False
     else:
         return True
-
+    
 
 def is_array_like(obj: object) -> bool:
     """


### PR DESCRIPTION
Fixes docstring of below method
```
-i "pandas.api.types.is_re_compilable PR07,SA01" \
```