### PR TITLE
upgrade to the latest version of PyData Sphinx Theme

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -87,7 +87,7 @@ dependencies:
   - google-auth
   - natsort  # DataFrame.sort_values doctest
   - numpydoc
-  - pydata-sphinx-theme=0.14
+  - pydata-sphinx-theme=0.16
   - pytest-cython  # doctest
   - sphinx
   - sphinx-design

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -62,7 +62,7 @@ gitdb
 google-auth
 natsort
 numpydoc
-pydata-sphinx-theme==0.14
+pydata-sphinx-theme==0.16
 pytest-cython
 sphinx
 sphinx-design


### PR DESCRIPTION
upgrade PyData Sphinx Theme from 0.14 to the latest 0.16

it is needed to get the latest font-awesome pack to be able to display the new twitter-x icon.

https://github.com/pandas-dev/pandas/pull/60426

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
