### PR TITLE
Fix docstring errors for SeriesGroupBy.plot and SeriesGroupBy.indices

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -94,7 +94,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
         -i "pandas.core.groupby.DataFrameGroupBy.sem SA01" \
         -i "pandas.core.groupby.SeriesGroupBy.get_group RT03,SA01" \
-        -i "pandas.core.groupby.SeriesGroupBy.indices SA01" \
         -i "pandas.core.groupby.SeriesGroupBy.sem SA01" \
         -i "pandas.core.resample.Resampler.get_group RT03,SA01" \
         -i "pandas.core.resample.Resampler.indices SA01" \

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -95,7 +95,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.core.groupby.DataFrameGroupBy.sem SA01" \
         -i "pandas.core.groupby.SeriesGroupBy.get_group RT03,SA01" \
         -i "pandas.core.groupby.SeriesGroupBy.indices SA01" \
-        -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \
         -i "pandas.core.groupby.SeriesGroupBy.sem SA01" \
         -i "pandas.core.resample.Resampler.get_group RT03,SA01" \
         -i "pandas.core.resample.Resampler.indices SA01" \

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -515,6 +515,15 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         """
         Dict {group name -> group indices}.
 
+        See Also
+        --------
+        core.groupby.DataFrameGroupBy.indices : Provides a mapping of group names 
+          to positions of the elements in object.
+        core.resample.Resampler.indices : Provides a mapping of group names 
+          to positions of the elements in object.
+        core.resample.Resampler.indices : Provides a mapping of group names 
+          to positions of the elements in object.
+
         Examples
         --------
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -517,12 +517,12 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
 
         See Also
         --------
-        core.groupby.DataFrameGroupBy.indices : Provides a mapping of group names 
-          to positions of the elements in object.
-        core.resample.Resampler.indices : Provides a mapping of group names 
-          to positions of the elements in object.
-        core.resample.Resampler.indices : Provides a mapping of group names 
-          to positions of the elements in object.
+        core.groupby.DataFrameGroupBy.indices : Provides a mapping of group names to
+         positions of the elements in object.
+        core.resample.Resampler.indices : Provides a mapping of group names to
+         positions of the elements in object.
+        core.resample.Resampler.indices : Provides a mapping of group names to
+         positions of the elements in object.
 
         Examples
         --------

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -648,11 +648,6 @@ class PlotAccessor(PandasObject):
     Uses the backend specified by the
     option ``plotting.backend``. By default, matplotlib is used.
 
-    Parameters
-    ----------
-    data : Series or DataFrame
-        The object for which the method is called.
-
     Attributes
     ----------
     x : label or position, default None


### PR DESCRIPTION
Edit: Closing this PR, I noticed I made some mistakes and it's not passing code checks for other broken docstrings. Apologies, I am new to pandas so still figuring out which tests I need to run locally. I am still going to try and work on the pandas.core.groupby.SeriesGroupBy.plot docstring but I will break it apart into a separate PR. That one seems a bit tricky to fix, so it will take me more time.

Fixing docstrings for the below functions 
```
 -i "pandas.core.groupby.SeriesGroupBy.indices SA01" \ 
 -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \ 
```