### PR TITLE
ENH: Support pd.json_normalize for normalizing only meta fields

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -64,6 +64,7 @@ Other enhancements
 - Support passing a :class:`Iterable[Hashable]` input to :meth:`DataFrame.drop_duplicates` (:issue:`59237`)
 - Support reading Stata 102-format (Stata 1) dta files (:issue:`58978`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
+- :func:`pandas.json_normalize` now supports normalizing specified ``meta`` fields from an array of records when the ``record_path`` is ``None`` or an empty list (``[]``)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -569,6 +569,29 @@ class TestJSONNormalize:
         result = json_normalize(series, "counties")
         tm.assert_index_equal(result.index, idx.repeat([3, 2]))
 
+    @pytest.mark.parametrize("path", [None, []])
+    def test_empty_record_path_and_not_empty_meta(self, state_data, path):
+        ex_data = [
+            {
+                "shortname": "FL",
+                "state": "Florida",
+                "info.governor": "Rick Scott",
+            },
+            {
+                "shortname": "OH",
+                "state": "Ohio",
+                "info.governor": "John Kasich",
+            },
+        ]
+        expected = DataFrame(ex_data)
+
+        result = json_normalize(
+            state_data,
+            record_path=path,
+            meta=["shortname", "state", ["info", "governor"]],
+        )
+        tm.assert_frame_equal(result, expected)
+
 
 class TestNestedToRecord:
     def test_flat_stays_flat(self):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Currently, `meta` is used with when `record_path` is not None. The logic is to extract both the `record_path` and ethe `meta`. For example:

```
data = [
    {
        "state": "Florida",
        "shortname": "FL",
        "info": {"governor": "Rick Scott", "year": 2014},
        "counties": [
            {"name": "Dade", "population": 12345},
            {"name": "Broward", "population": 40000},
            {"name": "Palm Beach", "population": 60000},
        ],
    },
    {
        "state": "Ohio",
        "shortname": "OH",
        "info": {"governor": "John Kasich", "year": 2015},
        "counties": [
            {"name": "Summit", "population": 1234},
            {"name": "Cuyahoga", "population": 1337},
        ],
    },
]
result = pd.json_normalize(
    data, "counties", ["state", "shortname", ["info", "governor"]]
)

result
         name  population    state shortname info.governor
0        Dade       12345   Florida    FL    Rick Scott
1     Broward       40000   Florida    FL    Rick Scott
2  Palm Beach       60000   Florida    FL    Rick Scott
3      Summit        1234   Ohio       OH    John Kasich
4    Cuyahoga        1337   Ohio       OH    John Kasich
```

In the above example, `pd.json_normalize` not only retrieves `counties`, but also retrieves `state`, `shortname` and `info.governor`.

When `record_path` is not given, `meta` is ignored, for example:

```
result = pd.json_normalize(
    data, meta=["state", "shortname", ["info", "governor"]]
)

result
     state shortname                                           counties    info.governor   info.year
0  Florida        FL  [{'name': 'Dade', 'population': 12345}, {'name...       Rick Scott        2014
1     Ohio        OH  [{'name': 'Summit', 'population': 1234}, {'nam...      John Kasich        2015
```

------------------

This PR adds a feature when `record_path` is None or an empty list, only extracts the `meta`.

```
result = pd.json_normalize(
    data, meta=["state", "shortname", ["info", "governor"]]
)

result
  shortname    state info.governor
0        FL  Florida    Rick Scott
1        OH     Ohio   John Kasich
```

The behavior can be summarized as:

- `record_path` is None, `meta` is None: normalize all records.
- `record_path` is not None, `meta` is None: normalize only `record_path`.
- `record_path` is not None, `meta` is not None: normalize `record_path` and `meta`.
- `record_path` is None, `meta` is not None: normalize only `meta`. [**This PR**]
