### PR TITLE
PERF: improve construct_1d_object_array_from_listlike

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -87,7 +87,7 @@ from pandas.io._util import _arrow_dtype_mapping
 
 if TYPE_CHECKING:
     from collections.abc import (
-        Iterable,
+        Collection,
         Sequence,
     )
 
@@ -1581,7 +1581,7 @@ def _maybe_box_and_unbox_datetimelike(value: Scalar, dtype: DtypeObj):
     return _maybe_unbox_datetimelike(value, dtype)
 
 
-def construct_1d_object_array_from_listlike(values: Iterable) -> np.ndarray:
+def construct_1d_object_array_from_listlike(values: Collection) -> np.ndarray:
     """
     Transform any list-like object in a 1-dimensional numpy array of object
     dtype.
@@ -1599,12 +1599,9 @@ def construct_1d_object_array_from_listlike(values: Iterable) -> np.ndarray:
     -------
     1-dimensional numpy array of dtype object
     """
-    # numpy will try to interpret nested lists as further dimensions, hence
-    # making a 1D array that contains list-likes is a bit tricky:
-    result = np.empty(len(values), dtype="object")
-    for i, obj in enumerate(values):
-        result[i] = obj
-    return result
+    # numpy will try to interpret nested lists as further dimensions in np.array(),
+    # hence explicitly making a 1D array using np.fromiter
+    return np.fromiter(values, dtype="object", count=len(values))
 
 
 def maybe_cast_to_integer_array(arr: list | np.ndarray, dtype: np.dtype) -> np.ndarray:

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -87,8 +87,8 @@ from pandas.io._util import _arrow_dtype_mapping
 
 if TYPE_CHECKING:
     from collections.abc import (
+        Iterable,
         Sequence,
-        Sized,
     )
 
     from pandas._typing import (
@@ -1581,7 +1581,7 @@ def _maybe_box_and_unbox_datetimelike(value: Scalar, dtype: DtypeObj):
     return _maybe_unbox_datetimelike(value, dtype)
 
 
-def construct_1d_object_array_from_listlike(values: Sized) -> np.ndarray:
+def construct_1d_object_array_from_listlike(values: Iterable) -> np.ndarray:
     """
     Transform any list-like object in a 1-dimensional numpy array of object
     dtype.
@@ -1602,7 +1602,8 @@ def construct_1d_object_array_from_listlike(values: Sized) -> np.ndarray:
     # numpy will try to interpret nested lists as further dimensions, hence
     # making a 1D array that contains list-likes is a bit tricky:
     result = np.empty(len(values), dtype="object")
-    result[:] = values
+    for i, obj in enumerate(values):
+        result[i] = obj
     return result
 
 


### PR DESCRIPTION
This improved `construct_1d_object_array_from_listlike`, especially for the case where the objects inside the array like are itself array-likes with a potentially expensive conversion to numpy. 
It seems that when doing `result[:] = values`, numpy will still check the `__array__` method for each object in `values`, while when iterating and assigning the objects one by one, that does not happen. 

And even in the case where `__array__` is not expensive at all (or is absent), it seems that iterating is faster than the single assignment:

```
In [12]: class A:
    ...:     def __init__(self):
    ...:         self.data = np.random.randn(5)
    ...:     def __array__(self, dtype=None, copy=None):
    ...:         #print("calling __array__")
    ...:         return self.data

In [13]: N = 10_000

In [14]: data = [A() for _ in range(N)]

In [17]: %%timeit
    ...: arr = np.empty((N, ), dtype=object)
    ...: arr[:] = data
    ...: 
5.39 ms ± 33.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [18]: %%timeit
    ...: arr = np.empty((N, ), dtype=object)
    ...: for i, obj in enumerate(data):
    ...:     arr[i] = obj
    ...: 
424 µs ± 6.78 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

This is a useful performance improvement in general, I assume, but I am specifically doing it to fix the performance issue reported in https://github.com/pandas-dev/pandas/issues/59657. That does is mostly for the 2.3.x branch, because that issue is avoided on main because of https://github.com/pandas-dev/pandas/pull/57205 (avoid Series construction, which ends up calling `construct_1d_object_array_from_listlike`, in the first place)


- [ ] closes #59657
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


