### PR TITLE
CI: avoid bad combination of pyopenssl and cryptography versions

### DIFF
--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -56,6 +56,8 @@ dependencies:
   - xlrd>=2.0.1
   - xlsxwriter>=3.0.5
   - zstandard>=0.19.0
+  # TEMP to avoid error when the env gets cryptography >= 42 but older pyopenssl
+  - pyopenssl>=23.2.0
 
   - pip:
     - adbc-driver-postgresql>=0.10.0

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -56,6 +56,8 @@ dependencies:
   - xlrd>=2.0.1
   - xlsxwriter>=3.0.5
   - zstandard>=0.19.0
+  # TEMP to avoid error when the env gets cryptography >= 42 but older pyopenssl
+  - pyopenssl>=23.2.0
 
   - pip:
     - adbc-driver-postgresql>=0.10.0

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -56,6 +56,8 @@ dependencies:
   - xlrd>=2.0.1
   - xlsxwriter>=3.0.5
   - zstandard>=0.19.0
+  # TEMP to avoid error when the env gets cryptography >= 42 but older pyopenssl
+  - pyopenssl>=23.2.0
 
   - pip:
     - adbc-driver-postgresql>=0.10.0

--- a/ci/deps/circle-311-arm64.yaml
+++ b/ci/deps/circle-311-arm64.yaml
@@ -56,6 +56,9 @@ dependencies:
   - xlrd>=2.0.1
   - xlsxwriter>=3.0.5
   - zstandard>=0.19.0
+  # TEMP to avoid error when the env gets cryptography >= 42 but older pyopenssl
+  - pyopenssl>=23.2.0
+
   - pip:
     - adbc-driver-postgresql>=0.8.0
     - adbc-driver-sqlite>=0.8.0


### PR DESCRIPTION
We are running into https://github.com/conda/conda/issues/13619#issuecomment-2075825121 in some of our envs, seeing what it gives to force a newer pyopenssl version.