### PR TITLE
BUG: Fix keyerror bug when indexing multiindex columns with NaT values

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -667,6 +667,7 @@ Indexing
 ^^^^^^^^
 - Bug in :meth:`DataFrame.__getitem__` returning modified columns when called with ``slice`` in Python 3.12 (:issue:`57500`)
 - Bug in :meth:`DataFrame.from_records` throwing a ``ValueError`` when passed an empty list in ``index`` (:issue:`58594`)
+- Bug in :meth:`MultiIndex.insert` when a new value inserted to a datetime-like level gets cast to ``NaT`` and fails indexing (:issue:`60388`)
 - Bug in printing :attr:`Index.names` and :attr:`MultiIndex.levels` would not escape single quotes (:issue:`60190`)
 
 Missing

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4084,11 +4084,10 @@ class MultiIndex(Index):
                 # have to insert into level
                 # must insert at end otherwise you have to recompute all the
                 # other codes
-                if isna(k):  # GH 59003
+                lev_loc = len(level)
+                level = level.insert(lev_loc, k)
+                if isna(level[lev_loc]):  # GH 59003, 60388
                     lev_loc = -1
-                else:
-                    lev_loc = len(level)
-                    level = level.insert(lev_loc, k)
             else:
                 lev_loc = level.get_loc(k)
 

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -544,6 +544,27 @@ class TestResetIndex:
         result = df.reset_index()
         tm.assert_frame_equal(result, expected)
 
+    def test_reset_index_multiindex_dt_with_nan(self):
+        # GH#60388
+        df = DataFrame(
+            {
+                "Date": [
+                    datetime(2024, 11, 1),
+                    datetime(2024, 11, 1),
+                    datetime(2024, 11, 2),
+                    datetime(2024, 11, 2),
+                ],
+                "sub": ["a", "b", "c", "d"],
+                "value1": [1, 2, 3, 4],
+                "value2": [5, 6, 7, 8],
+            }
+        )
+        df = df.pivot(index="sub", columns="Date", values=["value1", "value2"])
+        df = df.reset_index()
+        result = df[df.columns[0]]
+        expected = Series(["a", "b", "c", "d"], name=("sub", np.nan))
+        tm.assert_series_equal(result, expected)
+
     def test_reset_index_period(self):
         # GH#7746
         idx = MultiIndex.from_product(

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -544,27 +544,6 @@ class TestResetIndex:
         result = df.reset_index()
         tm.assert_frame_equal(result, expected)
 
-    def test_reset_index_multiindex_dt_with_nan(self):
-        # GH#60388
-        df = DataFrame(
-            {
-                "Date": [
-                    datetime(2024, 11, 1),
-                    datetime(2024, 11, 1),
-                    datetime(2024, 11, 2),
-                    datetime(2024, 11, 2),
-                ],
-                "sub": ["a", "b", "c", "d"],
-                "value1": [1, 2, 3, 4],
-                "value2": [5, 6, 7, 8],
-            }
-        )
-        df = df.pivot(index="sub", columns="Date", values=["value1", "value2"])
-        df = df.reset_index()
-        result = df[df.columns[0]]
-        expected = Series(["a", "b", "c", "d"], name=("sub", np.nan))
-        tm.assert_series_equal(result, expected)
-
     def test_reset_index_period(self):
         # GH#7746
         idx = MultiIndex.from_product(

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -295,6 +295,29 @@ class TestMultiLevel:
         df[na, "B"] = 1
         tm.assert_frame_equal(df[na], DataFrame([1], columns=["B"]))
 
+    def test_multiindex_dt_with_nan(self):
+        # GH#60388
+        df = DataFrame(
+            [
+                [1, np.nan, 5, np.nan],
+                [2, np.nan, 6, np.nan],
+                [np.nan, 3, np.nan, 7],
+                [np.nan, 4, np.nan, 8],
+            ],
+            index=Series(["a", "b", "c", "d"], dtype=object, name="sub"),
+            columns=MultiIndex.from_product(
+                [
+                    ["value1", "value2"],
+                    [datetime.datetime(2024, 11, 1), datetime.datetime(2024, 11, 2)],
+                ],
+                names=[None, "Date"],
+            ),
+        )
+        df = df.reset_index()
+        result = df[df.columns[0]]
+        expected = Series(["a", "b", "c", "d"], name=("sub", np.nan))
+        tm.assert_series_equal(result, expected)
+
 
 class TestSorted:
     """everything you wanted to test about sorting"""


### PR DESCRIPTION
- [x] closes #60388 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
