### PR TITLE
FIX : Missing 'pickleshare' package when running 'sphinx-build' command

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,7 @@ dependencies:
   - hypothesis>=6.84.0
   - gcsfs>=2022.11.0
   - ipython
+  - pickleshare  # Needed for ipython>=8.17 GH#60429
   - jinja2>=3.1.2
   - lxml>=4.9.2
   - matplotlib>=3.6.3

--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,7 @@ dependencies:
   - hypothesis>=6.84.0
   - gcsfs>=2022.11.0
   - ipython
-  - pickleshare  # Needed for ipython>=8.17 GH#60429
+  - pickleshare  # Needed for IPython Sphinx directive in the docs GH#60429
   - jinja2>=3.1.2
   - lxml>=4.9.2
   - matplotlib>=3.6.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,7 @@ html5lib>=1.1
 hypothesis>=6.84.0
 gcsfs>=2022.11.0
 ipython
+pickleshare
 jinja2>=3.1.2
 lxml>=4.9.2
 matplotlib>=3.6.3


### PR DESCRIPTION
- [ ] closes #60429
- [ ] All code checks passed

Add pickleshare requirement in environment.yml and requirements-dev.txt.
I’ve also added the issue number. 