### PR TITLE
BUG: Fix read_csv MultiIndex empty value handling (#59560)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -681,6 +681,7 @@ MultiIndex
 - :meth:`DataFrame.melt` would not accept multiple names in ``var_name`` when the columns were a :class:`MultiIndex` (:issue:`58033`)
 - :meth:`MultiIndex.insert` would not insert NA value correctly at unified location of index -1 (:issue:`59003`)
 - :func:`MultiIndex.get_level_values` accessing a :class:`DatetimeIndex` does not carry the frequency attribute along (:issue:`58327`, :issue:`57949`)
+- :func:`read_csv` now handles empty values in :class:`MultiIndex` columns and indexes consistently, replacing them with empty strings instead of "Unnamed: ..." when uniqueness can be ensured. (:issue:`59560`)
 -
 
 I/O


### PR DESCRIPTION
- [x] closes #59560 (Fixes inconsistency in `read_csv` handling of MultiIndex with empty values)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)  
      Added `test_multiindex_empty_values_handling` in `pandas/tests/io/parser/test_index_col.py` to validate that `read_csv` correctly handles MultiIndex with empty values, leaving them as empty strings instead of replacing them with `"Unnamed: ..."`.  
      All relevant tests passed successfully.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.  
      Updated the `MultiIndex` section with the following entry:
      
      ```rst
      - :func:`read_csv` now properly handles MultiIndex with empty values by leaving them as empty strings, ensuring consistency in index and column handling (:issue:`59560`).
      ```

