### PR TITLE
DOC: Clarify loc and iloc functionality in user_guide/indexing.html

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -858,9 +858,9 @@ and :ref:`Advanced Indexing <advanced>` you may select along more than one axis 
 
 .. warning::
 
-   While ``loc`` supports two kinds of boolean indexing, ``iloc`` only supports indexing with a 
-   boolean array. If the indexer is a boolean ``Series``, an error will be raised. For instance, 
-   in the following example, ``df.iloc[s.values, 1]`` is ok. The boolean indexer is an array. 
+   While ``loc`` supports two kinds of boolean indexing, ``iloc`` only supports indexing with a
+   boolean array. If the indexer is a boolean ``Series``, an error will be raised. For instance,
+   in the following example, ``df.iloc[s.values, 1]`` is ok. The boolean indexer is an array.
    But ``df.iloc[s, 1]`` would raise ``ValueError``.
 
    .. ipython:: python

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -858,9 +858,10 @@ and :ref:`Advanced Indexing <advanced>` you may select along more than one axis 
 
 .. warning::
 
-   ``iloc`` supports two kinds of boolean indexing. If the indexer is a boolean ``Series``,
-   an error will be raised. For instance, in the following example, ``df.iloc[s.values, 1]`` is ok.
-   The boolean indexer is an array. But ``df.iloc[s, 1]`` would raise ``ValueError``.
+   While ``loc`` supports two kinds of boolean indexing, ``iloc`` only supports indexing with a 
+   boolean array. If the indexer is a boolean ``Series``, an error will be raised. For instance, 
+   in the following example, ``df.iloc[s.values, 1]`` is ok. The boolean indexer is an array. 
+   But ``df.iloc[s, 1]`` would raise ``ValueError``.
 
    .. ipython:: python
 


### PR DESCRIPTION
- [ ] Addresses #47224 

This PR fixes the incorrect description of iloc and adds a brief comparison to loc to make the warning more clear:

"While loc supports two kinds of boolean indexing, iloc only supports indexing with a boolean array."