### PR TITLE
DOC: fix docstrings validation for pandas.core.groupby.DataFrameGroupBy.boxplot

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -84,7 +84,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.arrays.IntervalArray.length SA01" \
         -i "pandas.arrays.NumpyExtensionArray SA01" \
         -i "pandas.arrays.TimedeltaArray PR07,SA01" \
-        -i "pandas.core.groupby.DataFrameGroupBy.boxplot PR07,RT03,SA01" \
         -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
         -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \
         -i "pandas.core.resample.Resampler.max PR01,RT03,SA01" \

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -611,7 +611,7 @@ def boxplot_frame_groupby(
 
     See Also
     --------
-    pandas.DataFrame.boxplot : Create a box plot from a DataFrame.
+    DataFrame.boxplot : Create a box plot from a DataFrame.
     Series.plot : Plot a Series.
 
     Examples

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -612,7 +612,7 @@ def boxplot_frame_groupby(
     See Also
     --------
     pandas.DataFrame.boxplot : Create a box plot from a DataFrame.
-    pandas.Series.plot : Plot a Series.
+    Series.plot : Plot a Series.
 
     Examples
     --------

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -605,10 +605,10 @@ def boxplot_frame_groupby(
     Returns
     -------
     dict or DataFrame.boxplot return value
-        If ``subplots=True``, returns a dictionary of group keys to the boxplot 
-        return values. If ``subplots=False``, returns the boxplot return value 
+        If ``subplots=True``, returns a dictionary of group keys to the boxplot
+        return values. If ``subplots=False``, returns the boxplot return value
         of a single DataFrame.
-    
+
     See Also
     --------
     pandas.DataFrame.boxplot : Create a box plot from a DataFrame.

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -570,18 +570,23 @@ def boxplot_frame_groupby(
 
     Parameters
     ----------
-    grouped : Grouped DataFrame
+    grouped : DataFrameGroupBy
+        The grouped DataFrame object over which to create the box plots.
     subplots : bool
         * ``False`` - no subplots will be used
         * ``True`` - create a subplot for each group.
-
     column : column name or list of names, or vector
         Can be any valid input to groupby.
     fontsize : float or str
-    rot : label rotation angle
-    grid : Setting this to True will show the grid
+        Font size for the labels.
+    rot : float
+        Rotation angle of labels (in degrees) on the x-axis.
+    grid : bool
+        Whether to show grid lines on the plot.
     ax : Matplotlib axis object, default None
-    figsize : A tuple (width, height) in inches
+        The axes on which to draw the plots. If None, uses the current axes.
+    figsize : tuple of (float, float)
+        The figure size in inches (width, height).
     layout : tuple (optional)
         The layout of the plot: (rows, columns).
     sharex : bool, default False
@@ -599,8 +604,15 @@ def boxplot_frame_groupby(
 
     Returns
     -------
-    dict of key/value = group key/DataFrame.boxplot return value
-    or DataFrame.boxplot return value in case subplots=figures=False
+    dict or DataFrame.boxplot return value
+        If ``subplots=True``, returns a dictionary of group keys to the boxplot 
+        return values. If ``subplots=False``, returns the boxplot return value 
+        of a single DataFrame.
+    
+    See Also
+    --------
+    pandas.DataFrame.boxplot : Create a box plot from a DataFrame.
+    pandas.Series.plot : Plot a Series.
 
     Examples
     --------


### PR DESCRIPTION
Part of Issue #60365

Fixed docstring validation for pandas.core.groupby.DataFrameGroupBy.boxplot

The following errors were addressed:

- PR07    Parameter "grouped" has no description
- PR07    Parameter "fontsize" has no description
- PR07    Parameter "rot" has no description
- PR07    Parameter "grid" has no description
- PR07    Parameter "ax" has no description
- PR07    Parameter "figsize" has no description
- RT03    Return value has no description
- RT03    Return value has no description
- SA01    See Also section not found
