### PR TITLE
DOC: fix docstring validation errors for pandas.arrays

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -82,7 +82,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.arrays.ArrowExtensionArray PR07,SA01" \
         -i "pandas.arrays.IntervalArray.length SA01" \
-        -i "pandas.arrays.NumpyExtensionArray SA01" \
         -i "pandas.arrays.TimedeltaArray PR07,SA01" \
         -i "pandas.core.groupby.DataFrameGroupBy.boxplot PR07,RT03,SA01" \
         -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -71,6 +71,11 @@ class NumpyExtensionArray(  # type: ignore[misc]
     -------
     None
 
+    See Also
+    -------
+    array : Create an array.
+    Series.to_numpy : Convert a Series to a NumPy array.
+
     Examples
     --------
     >>> pd.arrays.NumpyExtensionArray(np.array([0, 1, 2, 3]))


### PR DESCRIPTION
Partially addresses https://github.com/pandas-dev/pandas/issues/59592

Fixes:

`-i "pandas.arrays.NumpyExtensionArray SA01" \`

(Added a See Also section in the docstring for `pandas.arrays.NumpyExtensionArray`)