### PR TITLE
BUG: Preserve timezone in numpy_dtype for ArrowDtype

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -614,7 +614,7 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :attr:`is_year_start` where a DateTimeIndex constructed via a date_range with frequency 'MS' wouldn't have the correct year or quarter start attributes (:issue:`57377`)
-- Bug in :class:`ArrowDtype` where `.convert_dtypes(dtype_backend="pyarrow")` stripped timezone information from timezone-aware PyArrow timestamps, resulting in a loss of timezone data. This has been fixed to ensure timezone information is preserved during conversions. (:issue:`60237`)
+- Bug in :class:`ArrowDtype` where ``.convert_dtypes(dtype_backend="pyarrow")`` stripped timezone information from timezone-aware PyArrow timestamps, resulting in a loss of timezone data. This has been fixed to ensure timezone information is preserved during conversions. (:issue:`60237`)
 - Bug in :class:`DataFrame` raising ``ValueError`` when ``dtype`` is ``timedelta64`` and ``data`` is a list containing ``None`` (:issue:`60064`)
 - Bug in :class:`Timestamp` constructor failing to raise when ``tz=None`` is explicitly specified in conjunction with timezone-aware ``tzinfo`` or data (:issue:`48688`)
 - Bug in :func:`date_range` where the last valid timestamp would sometimes not be produced (:issue:`56134`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -614,6 +614,7 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :attr:`is_year_start` where a DateTimeIndex constructed via a date_range with frequency 'MS' wouldn't have the correct year or quarter start attributes (:issue:`57377`)
+- Bug in :class:`ArrowDtype` where `.convert_dtypes(dtype_backend="pyarrow")` stripped timezone information from timezone-aware PyArrow timestamps, resulting in a loss of timezone data. This has been fixed to ensure timezone information is preserved during conversions. (:issue:`60237`)
 - Bug in :class:`DataFrame` raising ``ValueError`` when ``dtype`` is ``timedelta64`` and ``data`` is a list containing ``None`` (:issue:`60064`)
 - Bug in :class:`Timestamp` constructor failing to raise when ``tz=None`` is explicitly specified in conjunction with timezone-aware ``tzinfo`` or data (:issue:`48688`)
 - Bug in :func:`date_range` where the last valid timestamp would sometimes not be produced (:issue:`56134`)
@@ -637,7 +638,7 @@ Timedelta
 
 Timezones
 ^^^^^^^^^
--
+- Fixed an issue where `.convert_dtypes(dtype_backend="pyarrow")` stripped timezone information from timezone-aware PyArrow timestamps. Timezone data is now correctly preserved during conversions. (:issue:`60237`)
 -
 
 Numeric

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -638,7 +638,7 @@ Timedelta
 
 Timezones
 ^^^^^^^^^
-- Fixed an issue where `.convert_dtypes(dtype_backend="pyarrow")` stripped timezone information from timezone-aware PyArrow timestamps. Timezone data is now correctly preserved during conversions. (:issue:`60237`)
+- Fixed an issue where ``.convert_dtypes(dtype_backend="pyarrow")`` stripped timezone information from timezone-aware PyArrow timestamps. Timezone data is now correctly preserved during conversions. (:issue:`60237`)
 -
 
 Numeric

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -257,7 +257,11 @@ def where(cond, left_op, right_op, use_numexpr: bool = True):
         Whether to try to use numexpr.
     """
     assert _where is not None
-    return _where(cond, left_op, right_op) if use_numexpr else _where_standard(cond, left_op, right_op)
+    return (
+        _where(cond, left_op, right_op)
+        if use_numexpr
+        else _where_standard(cond, left_op, right_op)
+    )
 
 
 def set_test_mode(v: bool = True) -> None:

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -108,7 +108,7 @@ def _evaluate_numexpr(op, op_str, left_op, right_op):
         try:
             result = ne.evaluate(
                 f"left_value {op_str} right_value",
-                local_dict={"left_value": left_value, "right_value": right_op},
+                local_dict={"left_value": left_value, "right_value": right_value},
                 casting="safe",
             )
         except TypeError:

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -274,7 +274,9 @@ class BinOp(ops.BinOp):
             # string quoting
             return TermValue(conv_val, stringify(conv_val), "string")
         else:
-            raise TypeError(f"Cannot compare {conv_val} of type {type(conv_val)} to {kind} column")
+            raise TypeError(
+                f"Cannot compare {conv_val} of type {type(conv_val)} to {kind} column"
+            )
 
     def convert_values(self) -> None:
         pass

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1113,7 +1113,7 @@ def convert_dtypes(
     else:
         inferred_dtype = input_array.dtype
 
-    if dtype_backend == "pyarrow":
+    if dtype_backend == "pyarrow" and not isinstance(inferred_dtype, ArrowDtype):
         from pandas.core.arrays.arrow.array import to_pyarrow_type
         from pandas.core.arrays.string_ import StringDtype
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2277,7 +2277,10 @@ class ArrowDtype(StorageExtensionDtype):
         """Return an instance of the related numpy dtype."""
         # For string-like arrow dtypes, pa.string().to_pandas_dtype() = object
         # so we handle them explicitly.
-        if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(self.pyarrow_dtype):
+        if (
+            pa.types.is_string(self.pyarrow_dtype)
+            or pa.types.is_large_string(self.pyarrow_dtype)
+        ):
             return np.dtype(str)
 
         try:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2275,18 +2275,31 @@ class ArrowDtype(StorageExtensionDtype):
     @cache_readonly
     def numpy_dtype(self) -> np.dtype:
         """Return an instance of the related numpy dtype."""
-        # For string-like arrow dtypes, pa.string().to_pandas_dtype() = object
-        # so we handle them explicitly.
-        if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(
-            self.pyarrow_dtype
-        ):
+        pa_type = self.pyarrow_dtype
+
+        # handle tz-aware timestamps
+        if pa.types.is_timestamp(pa_type):
+            if pa_type.tz is not None:
+                # preserve tz by NOT calling numpy_dtype for this dtype.
+                return np.dtype("datetime64[ns]")
+            else:
+                # For tz-naive timestamps, just return the corresponding unit
+                return np.dtype(f"datetime64[{pa_type.unit}]")
+
+        if pa.types.is_duration(pa_type):
+            return np.dtype(f"timedelta64[{pa_type.unit}]")
+
+        if pa.types.is_string(pa_type) or pa.types.is_large_string(pa_type):
             return np.dtype(str)
 
         try:
-            np_dtype = self.pyarrow_dtype.to_pandas_dtype()
+            np_dtype = pa_type.to_pandas_dtype()
+            if isinstance(np_dtype, DatetimeTZDtype):
+                # In theory we shouldn't get here for tz-aware arrow timestamps
+                # if we've handled them above. This is a fallback.
+                return np.dtype("datetime64[ns]")
             return np.dtype(np_dtype)
         except (NotImplementedError, TypeError):
-            # Fallback if something unexpected happens
             return np.dtype(object)
 
     @cache_readonly

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2274,26 +2274,31 @@ class ArrowDtype(StorageExtensionDtype):
 
     @cache_readonly
     def numpy_dtype(self) -> np.dtype:
-        """Return an instance of the related numpy dtype"""
-        if pa.types.is_timestamp(self.pyarrow_dtype):
-            if self.pyarrow_dtype.tz is not None:
-                # Handle timezone-aware timestamps
-                return np.dtype(f"datetime64[{self.pyarrow_dtype.unit}]")
+    """Return an instance of the related numpy dtype."""
+    if pa.types.is_timestamp(self.pyarrow_dtype):
+        if self.pyarrow_dtype.tz is not None:
             return np.dtype(f"datetime64[{self.pyarrow_dtype.unit}]")
-        if pa.types.is_duration(self.pyarrow_dtype):
-            return np.dtype(f"timedelta64[{self.pyarrow_dtype.unit}]")
-        if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(
-            self.pyarrow_dtype
-        ):
-            return np.dtype(str)
-        try:
-            np_dtype = self.pyarrow_dtype.to_pandas_dtype()
-            if isinstance(np_dtype, DatetimeTZDtype):
-                # Convert timezone-aware to naive datetime64
-                return np.dtype(f"datetime64[{np_dtype.unit}]")
-            return np.dtype(np_dtype)
-        except (NotImplementedError, TypeError):
-            return np.dtype(object)
+        return np.dtype(f"datetime64[{self.pyarrow_dtype.unit}]")
+    if pa.types.is_duration(self.pyarrow_dtype):
+        return np.dtype(f"timedelta64[{self.pyarrow_dtype.unit}]")
+    if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(
+        self.pyarrow_dtype
+    ):
+        return np.dtype(str)
+    try:
+        np_dtype = self.pyarrow_dtype.to_pandas_dtype()
+        
+        if isinstance(np_dtype, object):
+            if hasattr(np_dtype, "categories") and isinstance(np_dtype.categories, pd.IntervalIndex):
+                return np.dtype(object)
+        
+        if isinstance(np_dtype, DatetimeTZDtype):
+            return np.dtype(f"datetime64[{np_dtype.unit}]")
+        
+        return np.dtype(np_dtype)
+    except (NotImplementedError, TypeError):
+        return np.dtype(object)
+
 
 
     @cache_readonly

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2277,9 +2277,8 @@ class ArrowDtype(StorageExtensionDtype):
         """Return an instance of the related numpy dtype."""
         # For string-like arrow dtypes, pa.string().to_pandas_dtype() = object
         # so we handle them explicitly.
-        if (
-            pa.types.is_string(self.pyarrow_dtype)
-            or pa.types.is_large_string(self.pyarrow_dtype)
+        if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(
+            self.pyarrow_dtype
         ):
             return np.dtype(str)
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2289,7 +2289,8 @@ class ArrowDtype(StorageExtensionDtype):
             np_dtype = self.pyarrow_dtype.to_pandas_dtype()
             
             if isinstance(np_dtype, object):
-                if hasattr(np_dtype, "categories") and isinstance(np_dtype.categories, pd.IntervalIndex):
+                from pandas.core.indexes.interval import IntervalIndex
+                if hasattr(np_dtype, "categories") and isinstance(np_dtype.categories, IntervalIndex):
                     return np.dtype(object)
             
             if isinstance(np_dtype, DatetimeTZDtype):

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2287,15 +2287,18 @@ class ArrowDtype(StorageExtensionDtype):
             return np.dtype(str)
         try:
             np_dtype = self.pyarrow_dtype.to_pandas_dtype()
-            
+
             if isinstance(np_dtype, object):
                 from pandas.core.indexes.interval import IntervalIndex
-                if hasattr(np_dtype, "categories") and isinstance(np_dtype.categories, IntervalIndex):
+
+                if hasattr(np_dtype, "categories") and isinstance(
+                    np_dtype.categories, IntervalIndex
+                ):
                     return np.dtype(object)
-            
+
             if isinstance(np_dtype, DatetimeTZDtype):
                 return np.dtype(f"datetime64[{np_dtype.unit}]")
-            
+
             return np.dtype(np_dtype)
         except (NotImplementedError, TypeError):
             return np.dtype(object)

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2274,32 +2274,30 @@ class ArrowDtype(StorageExtensionDtype):
 
     @cache_readonly
     def numpy_dtype(self) -> np.dtype:
-    """Return an instance of the related numpy dtype."""
-    if pa.types.is_timestamp(self.pyarrow_dtype):
-        if self.pyarrow_dtype.tz is not None:
+        """Return an instance of the related numpy dtype."""
+        if pa.types.is_timestamp(self.pyarrow_dtype):
+            if self.pyarrow_dtype.tz is not None:
+                return np.dtype(f"datetime64[{self.pyarrow_dtype.unit}]")
             return np.dtype(f"datetime64[{self.pyarrow_dtype.unit}]")
-        return np.dtype(f"datetime64[{self.pyarrow_dtype.unit}]")
-    if pa.types.is_duration(self.pyarrow_dtype):
-        return np.dtype(f"timedelta64[{self.pyarrow_dtype.unit}]")
-    if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(
-        self.pyarrow_dtype
-    ):
-        return np.dtype(str)
-    try:
-        np_dtype = self.pyarrow_dtype.to_pandas_dtype()
-        
-        if isinstance(np_dtype, object):
-            if hasattr(np_dtype, "categories") and isinstance(np_dtype.categories, pd.IntervalIndex):
-                return np.dtype(object)
-        
-        if isinstance(np_dtype, DatetimeTZDtype):
-            return np.dtype(f"datetime64[{np_dtype.unit}]")
-        
-        return np.dtype(np_dtype)
-    except (NotImplementedError, TypeError):
-        return np.dtype(object)
-
-
+        if pa.types.is_duration(self.pyarrow_dtype):
+            return np.dtype(f"timedelta64[{self.pyarrow_dtype.unit}]")
+        if pa.types.is_string(self.pyarrow_dtype) or pa.types.is_large_string(
+            self.pyarrow_dtype
+        ):
+            return np.dtype(str)
+        try:
+            np_dtype = self.pyarrow_dtype.to_pandas_dtype()
+            
+            if isinstance(np_dtype, object):
+                if hasattr(np_dtype, "categories") and isinstance(np_dtype.categories, pd.IntervalIndex):
+                    return np.dtype(object)
+            
+            if isinstance(np_dtype, DatetimeTZDtype):
+                return np.dtype(f"datetime64[{np_dtype.unit}]")
+            
+            return np.dtype(np_dtype)
+        except (NotImplementedError, TypeError):
+            return np.dtype(object)
 
     @cache_readonly
     def kind(self) -> str:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2295,7 +2295,6 @@ class ArrowDtype(StorageExtensionDtype):
         except (NotImplementedError, TypeError):
             return np.dtype(object)
 
-
     @cache_readonly
     def kind(self) -> str:
         if pa.types.is_timestamp(self.pyarrow_dtype):

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2282,21 +2282,6 @@ class ArrowDtype(StorageExtensionDtype):
 
         try:
             np_dtype = self.pyarrow_dtype.to_pandas_dtype()
-<<<<<<< HEAD
-=======
-
-            if isinstance(np_dtype, object):
-                from pandas.core.indexes.interval import IntervalIndex
-
-                if hasattr(np_dtype, "categories") and isinstance(
-                    np_dtype.categories, IntervalIndex
-                ):
-                    return np.dtype(object)
-
-            if isinstance(np_dtype, DatetimeTZDtype):
-                return np.dtype(f"datetime64[{np_dtype.unit}]")
-
->>>>>>> c5bfdf876b467a48df7f731765c0155950d67477
             return np.dtype(np_dtype)
         except (NotImplementedError, TypeError):
             # Fallback if something unexpected happens

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1104,26 +1104,29 @@ class TestCategoricalDtypeParametrized:
         with pytest.raises(ValueError, match=msg):
             dtype.update_dtype(bad_dtype)
 
+import pytest
+
 class TestArrowDtype(Base):
     @pytest.fixture
     def dtype(self):
         """Fixture for ArrowDtype."""
-        import pyarrow as pa
+        pa = pytest.importorskip("pyarrow")
         return ArrowDtype(pa.timestamp("ns", tz="UTC"))
 
     def test_numpy_dtype_preserves_timezone(self, dtype):
+        pa = pytest.importorskip("pyarrow")
         # Test timezone-aware timestamp
         assert dtype.numpy_dtype == dtype.pyarrow_dtype.to_pandas_dtype()
 
     def test_numpy_dtype_naive_timestamp(self):
-        import pyarrow as pa
+        pa = pytest.importorskip("pyarrow")
         arrow_type = pa.timestamp("ns")
         dtype = ArrowDtype(arrow_type)
         assert dtype.numpy_dtype == pa.timestamp("ns").to_pandas_dtype()
 
     @pytest.mark.parametrize("tz", ["UTC", "America/New_York", None])
     def test_numpy_dtype_with_varied_timezones(self, tz):
-        import pyarrow as pa
+        pa = pytest.importorskip("pyarrow")
         arrow_type = pa.timestamp("ns", tz=tz)
         dtype = ArrowDtype(arrow_type)
         if tz:

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1104,36 +1104,6 @@ class TestCategoricalDtypeParametrized:
         with pytest.raises(ValueError, match=msg):
             dtype.update_dtype(bad_dtype)
 
-import pytest
-
-class TestArrowDtype(Base):
-    @pytest.fixture
-    def dtype(self):
-        """Fixture for ArrowDtype."""
-        pa = pytest.importorskip("pyarrow")
-        return ArrowDtype(pa.timestamp("ns", tz="UTC"))
-
-    def test_numpy_dtype_preserves_timezone(self, dtype):
-        pa = pytest.importorskip("pyarrow")
-        # Test timezone-aware timestamp
-        assert dtype.numpy_dtype == dtype.pyarrow_dtype.to_pandas_dtype()
-
-    def test_numpy_dtype_naive_timestamp(self):
-        pa = pytest.importorskip("pyarrow")
-        arrow_type = pa.timestamp("ns")
-        dtype = ArrowDtype(arrow_type)
-        assert dtype.numpy_dtype == pa.timestamp("ns").to_pandas_dtype()
-
-    @pytest.mark.parametrize("tz", ["UTC", "America/New_York", None])
-    def test_numpy_dtype_with_varied_timezones(self, tz):
-        pa = pytest.importorskip("pyarrow")
-        arrow_type = pa.timestamp("ns", tz=tz)
-        dtype = ArrowDtype(arrow_type)
-        if tz:
-            assert dtype.numpy_dtype == arrow_type.to_pandas_dtype()
-        else:
-            assert dtype.numpy_dtype == pa.timestamp("ns").to_pandas_dtype()
-
 @pytest.mark.parametrize(
     "dtype", [CategoricalDtype, IntervalDtype, DatetimeTZDtype, PeriodDtype]
 )

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1103,6 +1103,24 @@ class TestCategoricalDtypeParametrized:
         with pytest.raises(ValueError, match=msg):
             dtype.update_dtype(bad_dtype)
 
+class TestArrowDtype:
+    @pytest.mark.parametrize(
+        "tz",
+        ["UTC", "America/New_York", "Europe/London", "Asia/Tokyo"]
+    )
+    def test_pyarrow_timestamp_tz_preserved(self, tz):
+        pytest.importorskip("pyarrow")
+        s = pd.Series(
+            pd.to_datetime(range(5), unit="h", utc=True).tz_convert(tz),
+            dtype=f"timestamp[ns, tz={tz}][pyarrow]"
+        )
+
+        result = s.convert_dtypes(dtype_backend="pyarrow")
+        assert result.dtype == s.dtype, f"Expected {s.dtype}, got {result.dtype}"
+
+        assert str(result.iloc[0].tzinfo) == str(s.iloc[0].tzinfo)
+        tm.assert_series_equal(result, s)
+
 
 @pytest.mark.parametrize(
     "dtype", [CategoricalDtype, IntervalDtype, DatetimeTZDtype, PeriodDtype]

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1110,7 +1110,7 @@ class TestArrowDtype:
     )
     def test_pyarrow_timestamp_tz_preserved(self, tz):
         pytest.importorskip("pyarrow")
-        s = pd.Series(
+        s = Series(
             pd.to_datetime(range(5), unit="h", utc=True).tz_convert(tz),
             dtype=f"timestamp[ns, tz={tz}][pyarrow]"
         )

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1103,25 +1103,6 @@ class TestCategoricalDtypeParametrized:
         with pytest.raises(ValueError, match=msg):
             dtype.update_dtype(bad_dtype)
 
-
-class TestArrowDtype:
-    @pytest.mark.parametrize(
-        "tz", ["UTC", "America/New_York", "Europe/London", "Asia/Tokyo"]
-    )
-    def test_pyarrow_timestamp_tz_preserved(self, tz):
-        pytest.importorskip("pyarrow")
-        s = Series(
-            pd.to_datetime(range(5), unit="h", utc=True).tz_convert(tz),
-            dtype=f"timestamp[ns, tz={tz}][pyarrow]",
-        )
-
-        result = s.convert_dtypes(dtype_backend="pyarrow")
-        assert result.dtype == s.dtype, f"Expected {s.dtype}, got {result.dtype}"
-
-        assert str(result.iloc[0].tzinfo) == str(s.iloc[0].tzinfo)
-        tm.assert_series_equal(result, s)
-
-
 @pytest.mark.parametrize(
     "dtype", [CategoricalDtype, IntervalDtype, DatetimeTZDtype, PeriodDtype]
 )

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -20,11 +20,11 @@ from pandas.core.dtypes.common import (
     is_string_dtype,
 )
 from pandas.core.dtypes.dtypes import (
+    ArrowDtype,
     CategoricalDtype,
     DatetimeTZDtype,
     IntervalDtype,
     PeriodDtype,
-    ArrowDtype,
 )
 
 import pandas as pd

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1103,6 +1103,7 @@ class TestCategoricalDtypeParametrized:
         with pytest.raises(ValueError, match=msg):
             dtype.update_dtype(bad_dtype)
 
+
 @pytest.mark.parametrize(
     "dtype", [CategoricalDtype, IntervalDtype, DatetimeTZDtype, PeriodDtype]
 )

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1103,16 +1103,16 @@ class TestCategoricalDtypeParametrized:
         with pytest.raises(ValueError, match=msg):
             dtype.update_dtype(bad_dtype)
 
+
 class TestArrowDtype:
     @pytest.mark.parametrize(
-        "tz",
-        ["UTC", "America/New_York", "Europe/London", "Asia/Tokyo"]
+        "tz", ["UTC", "America/New_York", "Europe/London", "Asia/Tokyo"]
     )
     def test_pyarrow_timestamp_tz_preserved(self, tz):
         pytest.importorskip("pyarrow")
         s = Series(
             pd.to_datetime(range(5), unit="h", utc=True).tz_convert(tz),
-            dtype=f"timestamp[ns, tz={tz}][pyarrow]"
+            dtype=f"timestamp[ns, tz={tz}][pyarrow]",
         )
 
         result = s.convert_dtypes(dtype_backend="pyarrow")

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -20,7 +20,6 @@ from pandas.core.dtypes.common import (
     is_string_dtype,
 )
 from pandas.core.dtypes.dtypes import (
-    ArrowDtype,
     CategoricalDtype,
     DatetimeTZDtype,
     IntervalDtype,
@@ -1103,6 +1102,7 @@ class TestCategoricalDtypeParametrized:
         msg = "a CategoricalDtype must be passed to perform an update, "
         with pytest.raises(ValueError, match=msg):
             dtype.update_dtype(bad_dtype)
+
 
 @pytest.mark.parametrize(
     "dtype", [CategoricalDtype, IntervalDtype, DatetimeTZDtype, PeriodDtype]

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -50,8 +50,8 @@ from pandas.core.dtypes.dtypes import (
 )
 
 import pandas as pd
-import pandas._testing as tm
 from pandas import Series
+import pandas._testing as tm
 from pandas.api.extensions import no_default
 from pandas.api.types import (
     is_bool_dtype,
@@ -3514,7 +3514,7 @@ def test_map_numeric_na_action():
 def test_pyarrow_timestamp_tz_preserved(tz):
     s = Series(
         pd.to_datetime(range(5), unit="h", utc=True).tz_convert(tz),
-        dtype=f"timestamp[ns, tz={tz}][pyarrow]"
+        dtype=f"timestamp[ns, tz={tz}][pyarrow]",
     )
 
     result = s.convert_dtypes(dtype_backend="pyarrow")

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -50,10 +50,6 @@ from pandas.core.dtypes.dtypes import (
 )
 
 import pandas as pd
-<<<<<<< HEAD
-=======
-from pandas import Series
->>>>>>> e0062fa66ce6b25fa06dee1f447d3ed0651031ad
 import pandas._testing as tm
 from pandas.api.extensions import no_default
 from pandas.api.types import (

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -51,7 +51,6 @@ from pandas.core.dtypes.dtypes import (
 
 import pandas as pd
 import pandas._testing as tm
-from pandas import Series
 from pandas.api.extensions import no_default
 from pandas.api.types import (
     is_bool_dtype,
@@ -3512,7 +3511,7 @@ def test_map_numeric_na_action():
     "tz", ["UTC", "America/New_York", "Europe/London", "Asia/Tokyo"]
 )
 def test_pyarrow_timestamp_tz_preserved(tz):
-    s = Series(
+    s = pd.Series(
         pd.to_datetime(range(5), unit="h", utc=True).tz_convert(tz),
         dtype=f"timestamp[ns, tz={tz}][pyarrow]"
     )

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -51,6 +51,7 @@ from pandas.core.dtypes.dtypes import (
 
 import pandas as pd
 import pandas._testing as tm
+from pandas import Series
 from pandas.api.extensions import no_default
 from pandas.api.types import (
     is_bool_dtype,
@@ -3505,3 +3506,19 @@ def test_map_numeric_na_action():
     result = ser.map(lambda x: 42, na_action="ignore")
     expected = pd.Series([42.0, 42.0, np.nan], dtype="float64")
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "tz", ["UTC", "America/New_York", "Europe/London", "Asia/Tokyo"]
+)
+def test_pyarrow_timestamp_tz_preserved(tz):
+    s = Series(
+        pd.to_datetime(range(5), unit="h", utc=True).tz_convert(tz),
+        dtype=f"timestamp[ns, tz={tz}][pyarrow]"
+    )
+
+    result = s.convert_dtypes(dtype_backend="pyarrow")
+    assert result.dtype == s.dtype, f"Expected {s.dtype}, got {result.dtype}"
+
+    assert str(result.iloc[0].tzinfo) == str(s.iloc[0].tzinfo)
+    tm.assert_series_equal(result, s)


### PR DESCRIPTION
- [x] closes #60237
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
* Added tests in pandas/tests/dtypes/test_dtypes.py to ensure numpy_dtype preserves timezone information for ArrowDtype.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
* Type annotations are already present in the modified numpy_dtype function.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
* Added a note in the bug fixes section: `- Fixed an issue where .convert_dtypes(dtype_backend="pyarrow") would strip timezone information from timezone-aware PyArrow timestamps. [GH#60237](https://github.com/pandas-dev/pandas/issues/60237)
`

