### PR TITLE
DOC: Fix hyperlinks to NumPy methods in DataFrame.shape / DataFrame.ndim

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1018,7 +1018,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         See Also
         --------
-        ndarray.shape : Tuple of array dimensions.
+        numpy.ndarray.shape : Tuple of array dimensions.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -640,7 +640,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         See Also
         --------
-        ndarray.ndim : Number of array dimensions.
+        numpy.ndarray.ndim : Number of array dimensions.
 
         Examples
         --------


### PR DESCRIPTION
- [X] closes #60515 

Updated the "See Also" section for ndarray.shape and ndarray.ndim to allow the hyperlinks to work.
Let me know if any additional changes are needed!
