### PR TITLE
BUG: Fix multi-index on columns with bool level values does not roundtrip through parquet

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -709,6 +709,7 @@ I/O
 - Bug in :meth:`read_stata` where the missing code for double was not recognised for format versions 105 and prior (:issue:`58149`)
 - Bug in :meth:`set_option` where setting the pandas option ``display.html.use_mathjax`` to ``False`` has no effect (:issue:`59884`)
 - Bug in :meth:`to_excel` where :class:`MultiIndex` columns would be merged to a single row when ``merge_cells=False`` is passed (:issue:`60274`)
+- Bug in :meth:`read_parquet` raising ``ValueError`` if the multi-index contains a level with bools and if that multi-index is on the columns, then while the parquet can be written with the ``pyarrow`` engine, it cannot be read back in using ``pyarrow``.   (:issue:`60508`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -709,7 +709,7 @@ I/O
 - Bug in :meth:`read_stata` where the missing code for double was not recognised for format versions 105 and prior (:issue:`58149`)
 - Bug in :meth:`set_option` where setting the pandas option ``display.html.use_mathjax`` to ``False`` has no effect (:issue:`59884`)
 - Bug in :meth:`to_excel` where :class:`MultiIndex` columns would be merged to a single row when ``merge_cells=False`` is passed (:issue:`60274`)
-- Bug in :meth:`read_parquet` raising ``ValueError`` if the multi-index contains a level with bools and if that multi-index is on the columns, then while the parquet can be written with the ``pyarrow`` engine, it cannot be read back in using ``pyarrow``.   (:issue:`60508`)
+- Bug in :meth:`read_parquet` raising ``ValueError`` if the multi-index contains a level with bools and if that multi-index is on the columns, then while the parquet can be written with the ``pyarrow`` engine, it cannot be read back in using ``pyarrow``. (:issue:`60508`)
 
 Period
 ^^^^^^

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -126,8 +126,9 @@ def _astype_nansafe(
         raise ValueError(msg)
 
     if arr.dtype == object and dtype == bool:
-        # If the dtype is bool and the array is object, we need to replace the False and True of the object type in the ndarray with the bool type
-        # to ensure that the type conversion is correct
+        # If the dtype is bool and the array is object, we need to replace
+        # the False and True of the object type in the ndarray with the
+        # bool type to ensure that the type conversion is correct
         arr[arr == "False"] = np.False_
         arr[arr == "True"] = np.True_
         return arr.astype(dtype, copy=copy)

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -125,6 +125,13 @@ def _astype_nansafe(
         )
         raise ValueError(msg)
 
+    if arr.dtype == object and dtype == bool:
+        # If the dtype is bool and the array is object, we need to replace the False and True of the object type in the ndarray with the bool type
+        # to ensure that the type conversion is correct
+        arr[arr == "False"] = np.False_
+        arr[arr == "True"] = np.True_
+        return arr.astype(dtype, copy=copy)
+
     if copy or arr.dtype == object or dtype == object:
         # Explicit copy, or required since NumPy can't view from / to object.
         return arr.astype(dtype, copy=True)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1468,3 +1468,24 @@ class TestParquetFastParquet(Base):
             df.to_parquet(path)
             with pytest.raises(ValueError, match=msg):
                 read_parquet(path, dtype_backend="numpy")
+
+    def test_bool_multiIndex(self, tmp_path, pa):
+        # GH 60508
+        df = pd.DataFrame(
+            [
+                [1, 2],
+                [4, 5],
+            ],
+            columns=pd.MultiIndex.from_tuples(
+                [
+                    (True, 'B'),
+                    (False, 'C'),
+                ]
+            )
+        )
+        df.to_parquet(
+            path=tmp_path,
+            engine=pa,
+        )
+        result = pd.read_parquet(tmp_path, engine=pa)
+        tm.assert_frame_equal(result, df)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1469,15 +1469,14 @@ class TestParquetFastParquet(Base):
             with pytest.raises(ValueError, match=msg):
                 read_parquet(path, dtype_backend="numpy")
 
-    def test_bool_multiIndex(self, tmp_path, pa):
+    def test_bool_multiIndex_roundtrip_through_parquet(self, pa):
         # GH 60508
         df = pd.DataFrame(
             [[1, 2], [4, 5]],
             columns=pd.MultiIndex.from_tuples([(True, 'B'), (False, 'C')]),
         )
-        df.to_parquet(
-            path=tmp_path,
-            engine=pa,
-        )
-        result = read_parquet(tmp_path, engine=pa)
+        with tm.ensure_clean("test.parquet") as path:
+            df.to_parquet(f, engine=pa)
+
+            result = read_parquet(path, engine=pa)
         tm.assert_frame_equal(result, df)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1476,7 +1476,7 @@ class TestParquetFastParquet(Base):
             columns=pd.MultiIndex.from_tuples([(True, 'B'), (False, 'C')]),
         )
         with tm.ensure_clean("test.parquet") as path:
-            df.to_parquet(f, engine=pa)
+            df.to_parquet(path, engine=pa)
 
             result = read_parquet(path, engine=pa)
         tm.assert_frame_equal(result, df)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1472,20 +1472,12 @@ class TestParquetFastParquet(Base):
     def test_bool_multiIndex(self, tmp_path, pa):
         # GH 60508
         df = pd.DataFrame(
-            [
-                [1, 2],
-                [4, 5],
-            ],
-            columns=pd.MultiIndex.from_tuples(
-                [
-                    (True, 'B'),
-                    (False, 'C'),
-                ]
-            )
+            [[1, 2], [4, 5]],
+            columns=pd.MultiIndex.from_tuples([(True, 'B'), (False, 'C')]),
         )
         df.to_parquet(
             path=tmp_path,
             engine=pa,
         )
-        result = pd.read_parquet(tmp_path, engine=pa)
+        result = read_parquet(tmp_path, engine=pa)
         tm.assert_frame_equal(result, df)


### PR DESCRIPTION
- [x] closes #60508  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
