### PR TITLE
BUG: added fix for column index for DatetimeIndex type

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4002,6 +4002,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         indices = np.asarray(indices, dtype=np.intp)
         if axis == 0 and indices.ndim == 1 and is_range_indexer(indices, len(self)):
             return self.copy(deep=False)
+        
+        
+        if axis == 1 and indices.ndim == 1 and is_range_indexer(indices, len(self.columns)):
+            # check if index is of type period, sets to object for slicing correct columns
+            if isinstance(self.index, DatetimeIndex) or isinstance(self.index, PeriodIndex): 
+                return self.copy(deep=False).astype('object')
+            return self.copy(deep=False)
 
         new_data = self._mgr.take(
             indices,


### PR DESCRIPTION
- [ ] closes #60273 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Added fix in pandas/core/generic.py by adding the lines below to the take() method within core/generic.py, which is called in the getitem method in core/frame.py in order to the columns as objects.

```
        if axis == 1 and indices.ndim == 1 and is_range_indexer(indices, len(self.columns)):
            # check if index is of type period, sets to object for slicing correct columns
            if isinstance(self.index, DatetimeIndex) or isinstance(self.index, PeriodIndex): 
                return self.copy(deep=False).astype('object')
            return self.copy(deep=False)
```

The method was not properly returning the right columns if the datatype was a DatetimeIndex or PeriodIndex. Added tests in pandas/tests/series/indexing/test_getitem.py to reflect these changes.  