### PR TITLE
BUG: Fix pyarrow and numpy logical bug concerning bool and string

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -651,6 +651,8 @@ Conversion
 - Bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)
 - Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
+- Bug in :meth:`Ops.logical_op` not correctly casting numpy-backed string arrays to boolean when used in logical operations with other boolean arrays (:issue:`60234`)
+- Bug in :meth:`ArrowExtensionArray._evaluate_op_method` not correctly casting pyarrow-backed string arrays to boolean when used in logical operations with other boolean arrays (:issue:`60234`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -117,7 +117,7 @@ if not pa_version_under10p1:
         is_x_bool = pa.types.is_boolean(x.type)
         is_y_bool = pa.types.is_boolean(y.type)
 
-        if (is_x_bool ^ is_y_bool):
+        if (is_x_bool != is_y_bool):
             return convert_string_to_boolean_array(x), convert_string_to_boolean_array(y)
         return x, y
 
@@ -838,7 +838,7 @@ class ArrowExtensionArray(
             raise TypeError(self._op_method_error_message(other_original, op)) from err
         
         if (op.__name__ in ARROW_LOGICAL_FUNCS 
-            and (isinstance(self, pa.lib.BooleanArray) ^
+            and (isinstance(self, pa.lib.BooleanArray) !=
             isinstance(other, pa.lib.BooleanArray))
             ):
             return pc.cast(result, pa.bool_())

--- a/pandas/core/ops/array_ops.py
+++ b/pandas/core/ops/array_ops.py
@@ -435,6 +435,13 @@ def logical_op(left: ArrayLike, right: Any, op) -> ArrayLike:
     rvalues = right
 
     if should_extension_dispatch(lvalues, rvalues):
+        # Must cast if logical op between a boolean array and numpy-backed string array
+        if ((lvalues.dtype == np.bool_ and rvalues.dtype == "string[python]")
+            or (lvalues.dtype == "string[python]" and rvalues.dtype == np.bool_)
+        ):
+            lvalues = lvalues.astype(bool)
+            rvalues = rvalues.astype(bool)
+            
         # Call the method on lvalues
         res_values = op(lvalues, rvalues)
 

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -767,3 +767,27 @@ def test_xor_pyarrow_string(dtype):
         result = ser1 ^ ser2
         expected = pd.Series([False, True], dtype=bool)
         tm.assert_series_equal(result, expected)
+
+@pytest.mark.parametrize("dtype", ["string[python]"])
+def test_or_numpy_string(dtype):
+    ser1 = pd.Series([False, False])
+    ser2 = pd.Series(["", "b"], dtype=dtype)
+    result = ser1 | ser2
+    expected = pd.Series([False, True], dtype=bool)
+    tm.assert_series_equal(result, expected)
+
+@pytest.mark.parametrize("dtype", ["string[python]"])
+def test_and_numpy_string(dtype):
+    ser1 = pd.Series([False, False])
+    ser2 = pd.Series(["", "b"], dtype=dtype)
+    result = ser1 & ser2
+    expected = pd.Series([False, False], dtype=bool)
+    tm.assert_series_equal(result, expected)
+
+@pytest.mark.parametrize("dtype", ["string[python]"])
+def test_xor_numpy_string(dtype):
+    ser1 = pd.Series([False, False])
+    ser2 = pd.Series(["", "b"], dtype=dtype)
+    result = ser1 ^ ser2
+    expected = pd.Series([False, True], dtype=bool)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -740,3 +740,12 @@ def test_tolist(dtype):
     result = arr.tolist()
     expected = vals
     tm.assert_equal(result, expected)
+
+@pytest.mark.parametrize("dtype", ["string[python]", "string[pyarrow]"])
+def test_logical_operators_pyarrow_string(dtype):
+    with pd.option_context("future.infer_string", True):
+        ser1 = pd.Series([False, False])
+        ser2 = pd.Series(["", "b"], dtype=dtype)
+        result = ser1 | ser2
+        expected = pd.Series([False, True], dtype=bool)
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -741,11 +741,29 @@ def test_tolist(dtype):
     expected = vals
     tm.assert_equal(result, expected)
 
-@pytest.mark.parametrize("dtype", ["string[python]", "string[pyarrow]"])
-def test_logical_operators_pyarrow_string(dtype):
+@pytest.mark.parametrize("dtype", ["string[pyarrow]"])
+def test_or_pyarrow_string(dtype):
     with pd.option_context("future.infer_string", True):
         ser1 = pd.Series([False, False])
         ser2 = pd.Series(["", "b"], dtype=dtype)
         result = ser1 | ser2
+        expected = pd.Series([False, True], dtype=bool)
+        tm.assert_series_equal(result, expected)
+
+@pytest.mark.parametrize("dtype", ["string[pyarrow]"])
+def test_and_pyarrow_string(dtype):
+    with pd.option_context("future.infer_string", True):
+        ser1 = pd.Series([False, False])
+        ser2 = pd.Series(["", "b"], dtype=dtype)
+        result = ser1 & ser2
+        expected = pd.Series([False, False], dtype=bool)
+        tm.assert_series_equal(result, expected)
+
+@pytest.mark.parametrize("dtype", ["string[pyarrow]"])
+def test_xor_pyarrow_string(dtype):
+    with pd.option_context("future.infer_string", True):
+        ser1 = pd.Series([False, False])
+        ser2 = pd.Series(["", "b"], dtype=dtype)
+        result = ser1 ^ ser2
         expected = pd.Series([False, True], dtype=bool)
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #60234 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

Using logical operators (e.g., |, &) on non-boolean data, where this data should be cast to bool, works for most types (e.g., float, strings). However, these operations fail with pyarrow-backed strings and numpy-backed strings. 

This PR fixes the issues with pyarrow-backed string arrays by casting them into boolean arrays when they are used with logical operators. The newly implemented helper functions `convert_string_to_boolean_array` and `cast_for_logical` perform the casting, while the `ARROW_LOGICAL_FUNCS` dictionary has been modified to use these helper functions in the process of performing logical operations (see [pandas/core/arrays/arrow/array.py](https://github.com/ldlin1/pandas/commit/d97c8378a4830fde48aad1e99e60eea7a2cea5ff)).

This PR fixes the issues with numpy-backed string arrays by casting them into boolean arrays whenever they are used with boolean arrays in logical operations. This is done in the `logical_op` function (see [pandas/core/ops/array_ops.py](https://github.com/ldlin1/pandas/commit/7188634652e87c8be8e7b983565c6ee0d9970d34)).