### PR TITLE
BUG: Building pandas via pip fails in AIX due to use of lower meson version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 # Minimum requirements for the build system to execute.
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
-    "meson-python>=0.13.1",
-    "meson>=1.2.1,<2",
+    "meson-python>=0.14.0",
+    "meson>=1.3.0,<2",
     "wheel",
     "Cython~=3.0.5",  # Note: sync with setup.py, environment.yml and asv.conf.json
     # Force numpy higher than 2.0rc1, so that built wheels are compatible


### PR DESCRIPTION
Closes #60495

Log after this change for pandas build in AIX.
pip3.11 install . -v
Created wheel for pandas: filename=pandas-0+untagged.35796.gca91dd4.dirty-cp311-cp311-aix_7205_2419_64.whl size=18419603 sha256=599e0b2217ca31130ae15bc58fbeb260488a276aceb3ee6607b5e8c602031a6b
  Stored in directory: /tmp/pip-ephem-wheel-cache-0rxkiefk/wheels/b4/7d/f8/eb241896ce6eabb73cb53844efadd6cf4f368800addd37e52d
Successfully built pandas
Installing collected packages: tzdata, six, numpy, python-dateutil, pandas
  changing mode of /opt/freeware/bin/f2py to 755
  changing mode of /opt/freeware/bin/numpy-config to 755
Successfully installed numpy-2.2.0 pandas-0+untagged.35796.gca91dd4.dirty python-dateutil-2.9.0.post0 six-1.17.0 tzdata-2024.2 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
