### PR TITLE
Fix KeyError by adding check for _convert_dates

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2611,7 +2611,7 @@ class StataWriter(StataParser):
         # Check date conversion, and fix key if needed
         if self._convert_dates:
             for c, o in zip(columns, original_columns):
-                if c != o:
+                if c != o and o in self._convert_dates:
                     self._convert_dates[c] = self._convert_dates[o]
                     del self._convert_dates[o]
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -2591,6 +2591,7 @@ def test_many_strl(temp_file, version):
 
 @pytest.mark.parametrize("version", [114, 117, 118, 119, None])
 def test_convert_dates_key_handling(tmp_path, version):
+    # GH 60536
     temp_file = tmp_path / "test.dta"
     df = DataFrame({"old_name": [1, 2, 3], "some_other_name": [4, 5, 6]})
 


### PR DESCRIPTION
Closes #60536

This PR adds a check to prevent a KeyError when renaming columns by ensuring the original column name exists in the _convert_dates dictionary before updating it.
