### PR TITLE
CI/TST: Use tm.external_error_raised for test_from_arrow_respecting_given_dtype_unsafe

### DIFF
--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1647,7 +1647,7 @@ def test_from_arrow_respecting_given_dtype():
 
 def test_from_arrow_respecting_given_dtype_unsafe():
     array = pa.array([1.5, 2.5], type=pa.float64())
-    with pytest.raises(pa.ArrowInvalid, match="Float value 1.5 was truncated"):
+    with tm.external_error_raised(pa.ArrowInvalid):
         array.to_pandas(types_mapper={pa.float64(): ArrowDtype(pa.int64())}.get)
 
 


### PR DESCRIPTION
Appears that pyarrow changed the exception message that we were matching against, so we should be using `external_error_raised` instead 

e.g. https://github.com/pandas-dev/pandas/actions/runs/12281514975/job/34270563333?pr=60541 
