### PR TITLE
CI: Ignore prompting in test-arm when apt-get installing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
             fi
             python -m pip install --no-build-isolation -ve . -Csetup-args="--werror"
             PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH
-            DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y libegl1 libopengl0
             ci/run_tests.sh
   test-linux-musl:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             fi
             python -m pip install --no-build-isolation -ve . -Csetup-args="--werror"
             PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH
-            sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
+            DEBIAN_FRONTEND=noninteractive apt-get update && sudo apt-get install -y libegl1 libopengl0
             ci/run_tests.sh
   test-linux-musl:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             fi
             python -m pip install --no-build-isolation -ve . -Csetup-args="--werror"
             PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH
-            DEBIAN_FRONTEND=noninteractive apt-get update && sudo apt-get install -y libegl1 libopengl0
+            DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y libegl1 libopengl0
             ci/run_tests.sh
   test-linux-musl:
     docker:


### PR DESCRIPTION
To avoid failing `test-arm` job in CircleCI

e.g. https://app.circleci.com/pipelines/github/pandas-dev/pandas/52272/workflows/b0a99609-7665-423f-a195-7154c661fdf1/jobs/242579/parallel-runs/0/steps/0-102