### PR TITLE
ENH: Support NamedAggs in kwargs in Rolling/Expanding/EWM agg method

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -56,6 +56,7 @@ Other enhancements
 - :meth:`DataFrame.plot.scatter` argument ``c`` now accepts a column of strings, where rows with the same string are colored identically (:issue:`16827` and :issue:`16485`)
 - :func:`read_parquet` accepts ``to_pandas_kwargs`` which are forwarded to :meth:`pyarrow.Table.to_pandas` which enables passing additional keywords to customize the conversion to pandas, such as ``maps_as_pydicts`` to read the Parquet map data type as python dictionaries (:issue:`56842`)
 - :meth:`DataFrameGroupBy.transform`, :meth:`SeriesGroupBy.transform`, :meth:`DataFrameGroupBy.agg`, :meth:`SeriesGroupBy.agg`, :meth:`RollingGroupby.apply`, :meth:`ExpandingGroupby.apply`, :meth:`Rolling.apply`, :meth:`Expanding.apply`, :meth:`DataFrame.apply` with ``engine="numba"`` now supports positional arguments passed as kwargs (:issue:`58995`)
+- :meth:`Rolling.agg`, :meth:`Expanding.agg` and :meth:`ExponentialMovingWindow.agg` now accept :class:`NamedAgg` aggregations through ``**kwargs`` (:issue:`28333`)
 - :meth:`Series.map` can now accept kwargs to pass on to func (:issue:`59814`)
 - :meth:`pandas.concat` will raise a ``ValueError`` when ``ignore_index=True`` and ``keys`` is not ``None`` (:issue:`59274`)
 - :meth:`str.get_dummies` now accepts a  ``dtype`` parameter to specify the dtype of the resulting DataFrame (:issue:`47872`)

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -981,7 +981,7 @@ class OnlineExponentialMovingWindow(ExponentialMovingWindow):
         """
         self._mean.reset()
 
-    def aggregate(self, func, *args, **kwargs):
+    def aggregate(self, func=None, *args, **kwargs):
         raise NotImplementedError("aggregate is not implemented.")
 
     def std(self, bias: bool = False, *args, **kwargs):

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -490,7 +490,7 @@ class ExponentialMovingWindow(BaseWindow):
         klass="Series/Dataframe",
         axis="",
     )
-    def aggregate(self, func, *args, **kwargs):
+    def aggregate(self, func=None, *args, **kwargs):
         return super().aggregate(func, *args, **kwargs)
 
     agg = aggregate

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -167,7 +167,7 @@ class Expanding(RollingAndExpandingMixin):
         klass="Series/Dataframe",
         axis="",
     )
-    def aggregate(self, func, *args, **kwargs):
+    def aggregate(self, func=None, *args, **kwargs):
         return super().aggregate(func, *args, **kwargs)
 
     agg = aggregate

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -652,9 +652,9 @@ class BaseWindow(SelectionMixin):
     def aggregate(self, func=None, *args, **kwargs):
         relabeling, func, columns, order = reconstruct_func(func, **kwargs)
         result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
-        if result is not None and isinstance(result, ABCDataFrame) and relabeling:
+        if (result is not None) and isinstance(result, ABCDataFrame) and relabeling:
             result = result.iloc[:, order]
-            result = result.set_axis(columns, axis=1)
+            result.columns = columns
         if result is None:
             return self.apply(func, raw=False, args=args, kwargs=kwargs)
         return result

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -654,7 +654,7 @@ class BaseWindow(SelectionMixin):
         result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is not None and isinstance(result, ABCDataFrame) and relabeling:
             result = result.iloc[:, order]
-            result.columns = columns
+            result = result.set_axis(columns, axis=1)
         if result is None:
             return self.apply(func, raw=False, args=args, kwargs=kwargs)
         return result

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -652,7 +652,7 @@ class BaseWindow(SelectionMixin):
     def aggregate(self, func=None, *args, **kwargs):
         relabeling, func, columns, order = reconstruct_func(func, **kwargs)
         result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
-        if (result is not None) and isinstance(result, ABCDataFrame) and relabeling:
+        if isinstance(result, ABCDataFrame) and relabeling:
             result = result.iloc[:, order]
             result.columns = columns
         if result is None:

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -652,11 +652,10 @@ class BaseWindow(SelectionMixin):
     def aggregate(self, func=None, *args, **kwargs):
         relabeling, func, columns, order = reconstruct_func(func, **kwargs)
         result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
-        if result is not None:
-            if isinstance(result, ABCDataFrame) and relabeling:
-                result = result.iloc[:, order]
-                result.columns = columns
-        else:
+        if result is not None and isinstance(result, ABCDataFrame) and relabeling:
+            result = result.iloc[:, order]
+            result.columns = columns
+        if result is None:
             return self.apply(func, raw=False, args=args, kwargs=kwargs)
         return result
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -653,7 +653,7 @@ class BaseWindow(SelectionMixin):
         relabeling, func, columns, order = reconstruct_func(func, **kwargs)
         result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is not None:
-            if relabeling:
+            if isinstance(result, ABCDataFrame) and relabeling:
                 result = result.iloc[:, order]
                 result.columns = columns
         else:
@@ -1247,7 +1247,7 @@ class Window(BaseWindow):
         klass="Series/DataFrame",
         axis="",
     )
-    def aggregate(self, func, *args, **kwargs):
+    def aggregate(self, func=None, *args, **kwargs):
         result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is None:
             # these must apply directly

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -654,7 +654,7 @@ class BaseWindow(SelectionMixin):
         result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if isinstance(result, ABCDataFrame) and relabeling:
             result = result.iloc[:, order]
-            result.columns = columns
+            result.columns = columns  # type: ignore[union-attr]
         if result is None:
             return self.apply(func, raw=False, args=args, kwargs=kwargs)
         return result


### PR DESCRIPTION
- [x] closes #28333 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

Currently, `Rolling.agg()`, `Expanding.agg()` and `ExponentialMovingWindow.agg()` methods don't support specifying `NamedAgg`s through `**kwargs`, while `Groupby.agg()` does. This change fixes that.