### PR TITLE
[2.3.x] COMPAT: fix construct_1d_object_array_from_listlike for older numpy

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1606,7 +1606,10 @@ def construct_1d_object_array_from_listlike(values: Collection) -> np.ndarray:
     """
     # numpy will try to interpret nested lists as further dimensions in np.array(),
     # hence explicitly making a 1D array using np.fromiter
-    return np.fromiter(values, dtype="object", count=len(values))
+    result = np.empty(len(values), dtype="object")
+    for i, obj in enumerate(values):
+        result[i] = obj
+    return result
 
 
 def maybe_cast_to_integer_array(arr: list | np.ndarray, dtype: np.dtype) -> np.ndarray:


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/60483, as it seems this caused a failing test in the minimum versions build. 
Essentially going back to an earlier version in the original PR before switching to `np.fromiter`