### PR TITLE
CLN: Remove deprecations of groupby.fillna in tests

### DIFF
--- a/pandas/tests/groupby/__init__.py
+++ b/pandas/tests/groupby/__init__.py
@@ -2,7 +2,7 @@ def get_groupby_method_args(name, obj):
     """
     Get required arguments for a groupby method.
 
-    When parametrizing a test over groupby methods (e.g. "sum", "mean", "fillna"),
+    When parametrizing a test over groupby methods (e.g. "sum", "mean"),
     it is often the case that arguments are required for certain methods.
 
     Parameters
@@ -16,7 +16,7 @@ def get_groupby_method_args(name, obj):
     -------
     A tuple of required arguments for the method.
     """
-    if name in ("nth", "fillna", "take"):
+    if name in ("nth", "take"):
         return (0,)
     if name == "quantile":
         return (0.5,)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1963,10 +1963,7 @@ def test_category_order_transformer(
         df = df.set_index(keys)
     args = get_groupby_method_args(transformation_func, df)
     gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
-    warn = FutureWarning if transformation_func == "fillna" else None
-    msg = "DataFrameGroupBy.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=msg):
-        op_result = getattr(gb, transformation_func)(*args)
+    op_result = getattr(gb, transformation_func)(*args)
     result = op_result.index.get_level_values("a").categories
     expected = Index([1, 4, 3, 2])
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2098,36 +2098,14 @@ def test_group_on_empty_multiindex(transformation_func, request):
     df["col_3"] = df["col_3"].astype(int)
     df["col_4"] = df["col_4"].astype(int)
     df = df.set_index(["col_1", "col_2"])
-    if transformation_func == "fillna":
-        args = ("ffill",)
-    else:
-        args = ()
-    warn = FutureWarning if transformation_func == "fillna" else None
-    warn_msg = "DataFrameGroupBy.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=warn_msg):
-        result = df.iloc[:0].groupby(["col_1"]).transform(transformation_func, *args)
-    with tm.assert_produces_warning(warn, match=warn_msg):
-        expected = df.groupby(["col_1"]).transform(transformation_func, *args).iloc[:0]
+    result = df.iloc[:0].groupby(["col_1"]).transform(transformation_func)
+    expected = df.groupby(["col_1"]).transform(transformation_func).iloc[:0]
     if transformation_func in ("diff", "shift"):
         expected = expected.astype(int)
     tm.assert_equal(result, expected)
 
-    warn_msg = "SeriesGroupBy.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=warn_msg):
-        result = (
-            df["col_3"]
-            .iloc[:0]
-            .groupby(["col_1"])
-            .transform(transformation_func, *args)
-        )
-    warn_msg = "SeriesGroupBy.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=warn_msg):
-        expected = (
-            df["col_3"]
-            .groupby(["col_1"])
-            .transform(transformation_func, *args)
-            .iloc[:0]
-        )
+    result = df["col_3"].iloc[:0].groupby(["col_1"]).transform(transformation_func)
+    expected = df["col_3"].groupby(["col_1"]).transform(transformation_func).iloc[:0]
     if transformation_func in ("diff", "shift"):
         expected = expected.astype(int)
     tm.assert_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -36,11 +36,11 @@ def test_groupby_preserves_subclass(obj, groupby_func):
 
     args = get_groupby_method_args(groupby_func, obj)
 
-    warn = FutureWarning if groupby_func == "fillna" else None
-    msg = f"{type(grouped).__name__}.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=msg, raise_on_extra_warnings=False):
+    warn = FutureWarning if groupby_func == "corrwith" else None
+    msg = f"{type(grouped).__name__}.corrwith is deprecated"
+    with tm.assert_produces_warning(warn, match=msg):
         result1 = getattr(grouped, groupby_func)(*args)
-    with tm.assert_produces_warning(warn, match=msg, raise_on_extra_warnings=False):
+    with tm.assert_produces_warning(warn, match=msg):
         result2 = grouped.agg(groupby_func, *args)
 
     # Reduction or transformation kernels should preserve type

--- a/pandas/tests/groupby/test_numeric_only.py
+++ b/pandas/tests/groupby/test_numeric_only.py
@@ -278,14 +278,11 @@ def test_numeric_only(kernel, has_arg, numeric_only, keys):
         kernel in ("first", "last")
         or (
             # kernels that work on any dtype and don't have numeric_only arg
-            kernel in ("any", "all", "bfill", "ffill", "fillna", "nth", "nunique")
+            kernel in ("any", "all", "bfill", "ffill", "nth", "nunique")
             and numeric_only is lib.no_default
         )
     ):
-        warn = FutureWarning if kernel == "fillna" else None
-        msg = "DataFrameGroupBy.fillna is deprecated"
-        with tm.assert_produces_warning(warn, match=msg):
-            result = method(*args, **kwargs)
+        result = method(*args, **kwargs)
         assert "b" in result.columns
     elif has_arg:
         assert numeric_only is not True

--- a/pandas/tests/groupby/test_raises.py
+++ b/pandas/tests/groupby/test_raises.py
@@ -144,7 +144,6 @@ def test_groupby_raises_string(
         ),
         "diff": (TypeError, "unsupported operand type"),
         "ffill": (None, ""),
-        "fillna": (None, ""),
         "first": (None, ""),
         "idxmax": (None, ""),
         "idxmin": (None, ""),
@@ -211,10 +210,7 @@ def test_groupby_raises_string(
         elif groupby_func == "corrwith":
             msg = "Cannot perform reduction 'mean' with string dtype"
 
-    if groupby_func == "fillna":
-        kind = "Series" if groupby_series else "DataFrame"
-        warn_msg = f"{kind}GroupBy.fillna is deprecated"
-    elif groupby_func == "corrwith":
+    if groupby_func == "corrwith":
         warn_msg = "DataFrameGroupBy.corrwith is deprecated"
     else:
         warn_msg = ""
@@ -301,7 +297,6 @@ def test_groupby_raises_datetime(
         "cumsum": (TypeError, "datetime64 type does not support operation 'cumsum'"),
         "diff": (None, ""),
         "ffill": (None, ""),
-        "fillna": (None, ""),
         "first": (None, ""),
         "idxmax": (None, ""),
         "idxmin": (None, ""),
@@ -333,10 +328,7 @@ def test_groupby_raises_datetime(
         "var": (TypeError, "datetime64 type does not support operation 'var'"),
     }[groupby_func]
 
-    if groupby_func == "fillna":
-        kind = "Series" if groupby_series else "DataFrame"
-        warn_msg = f"{kind}GroupBy.fillna is deprecated"
-    elif groupby_func == "corrwith":
+    if groupby_func == "corrwith":
         warn_msg = "DataFrameGroupBy.corrwith is deprecated"
     else:
         warn_msg = ""
@@ -457,7 +449,6 @@ def test_groupby_raises_category(
             r"unsupported operand type\(s\) for -: 'Categorical' and 'Categorical'",
         ),
         "ffill": (None, ""),
-        "fillna": (None, ""),  # no-op with CoW
         "first": (None, ""),
         "idxmax": (None, ""),
         "idxmin": (None, ""),
@@ -532,10 +523,7 @@ def test_groupby_raises_category(
         ),
     }[groupby_func]
 
-    if groupby_func == "fillna":
-        kind = "Series" if groupby_series else "DataFrame"
-        warn_msg = f"{kind}GroupBy.fillna is deprecated"
-    elif groupby_func == "corrwith":
+    if groupby_func == "corrwith":
         warn_msg = "DataFrameGroupBy.corrwith is deprecated"
     else:
         warn_msg = ""
@@ -650,7 +638,6 @@ def test_groupby_raises_category_on_category(
         ),
         "diff": (TypeError, "unsupported operand type"),
         "ffill": (None, ""),
-        "fillna": (None, ""),  # no-op with CoW
         "first": (None, ""),
         "idxmax": (ValueError, "empty group due to unobserved categories")
         if empty_groups
@@ -710,10 +697,7 @@ def test_groupby_raises_category_on_category(
         ),
     }[groupby_func]
 
-    if groupby_func == "fillna":
-        kind = "Series" if groupby_series else "DataFrame"
-        warn_msg = f"{kind}GroupBy.fillna is deprecated"
-    elif groupby_func == "corrwith":
+    if groupby_func == "corrwith":
         warn_msg = "DataFrameGroupBy.corrwith is deprecated"
     else:
         warn_msg = ""

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -329,9 +329,6 @@ def test_transform_transformation_func(transformation_func):
     if transformation_func == "cumcount":
         test_op = lambda x: x.transform("cumcount")
         mock_op = lambda x: Series(range(len(x)), x.index)
-    elif transformation_func == "fillna":
-        test_op = lambda x: x.transform("fillna", value=0)
-        mock_op = lambda x: x.fillna(value=0)
     elif transformation_func == "ngroup":
         test_op = lambda x: x.transform("ngroup")
         counter = -1
@@ -1436,11 +1433,7 @@ def test_null_group_str_transformer_series(dropna, transformation_func):
         dtype = object if transformation_func in ("any", "all") else None
         buffer.append(Series([np.nan], index=[3], dtype=dtype))
     expected = concat(buffer)
-
-    warn = FutureWarning if transformation_func == "fillna" else None
-    msg = "SeriesGroupBy.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=msg):
-        result = gb.transform(transformation_func, *args)
+    result = gb.transform(transformation_func, *args)
 
     tm.assert_equal(result, expected)
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Deprecation has already been enforced.