### PR TITLE
BUG: value_counts() check Index with PyArrow categorical columns

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -447,7 +447,10 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             if isinstance(values.dtype, ArrowDtype) and issubclass(
                 values.dtype.type, CategoricalDtypeType
             ):
-                arr = values._pa_array.combine_chunks()
+                if values.__class__.__name__ == 'Index':
+                    arr = values._data._pa_array.combine_chunks()
+                else:
+                    arr = values._pa_array.combine_chunks()
                 categories = arr.dictionary.to_pandas(types_mapper=ArrowDtype)
                 codes = arr.indices.to_numpy()
                 dtype = CategoricalDtype(categories, values.dtype.pyarrow_dtype.ordered)

--- a/pandas/tests/arrays/categorical/test_dtypes.py
+++ b/pandas/tests/arrays/categorical/test_dtypes.py
@@ -2,7 +2,10 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from pandas.core.dtypes.dtypes import CategoricalDtype
+from pandas.core.dtypes.dtypes import (
+    ArrowDtype,
+    CategoricalDtype,
+)
 
 from pandas import (
     Categorical,
@@ -12,7 +15,6 @@ from pandas import (
     Series,
     Timestamp,
 )
-from pandas.core.dtypes.dtypes import ArrowDtype
 import pandas._testing as tm
 
 
@@ -141,14 +143,14 @@ class TestCategoricalDtypes:
 
     def test_values_is_index():
         # GH 60563
-        values = Index(['a1', 'a2'], dtype=ArrowDtype(pa.string()))
+        values = Index(["a1", "a2"], dtype=ArrowDtype(pa.string()))
         arr = values._data._pa_array.combine_chunks()
 
         assert arr.equals(values._data._pa_array.combine_chunks())
 
     def test_values_is_not_index():
         # GH 60563
-        values = Series(['a1', 'a2'], dtype=ArrowDtype(pa.string()))
+        values = Series(["a1", "a2"], dtype=ArrowDtype(pa.string()))
         arr = values._pa_array.combine_chunks()
 
         assert arr.equals(values._pa_array.combine_chunks())

--- a/pandas/tests/arrays/categorical/test_dtypes.py
+++ b/pandas/tests/arrays/categorical/test_dtypes.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pyarrow as pa
 import pytest
 
 from pandas.core.dtypes.dtypes import CategoricalDtype
@@ -11,6 +12,7 @@ from pandas import (
     Series,
     Timestamp,
 )
+from pandas.core.dtypes.dtypes import ArrowDtype
 import pandas._testing as tm
 
 
@@ -136,3 +138,17 @@ class TestCategoricalDtypes:
             [0, 1], [1, 2], dtype="interval[uint64, right]"
         )
         tm.assert_index_equal(result, expected)
+
+    def test_values_is_index():
+        # GH 60563
+        values = Index(['a1', 'a2'], dtype=ArrowDtype(pa.string()))
+        arr = values._data._pa_array.combine_chunks()
+
+        assert arr.equals(values._data._pa_array.combine_chunks())
+
+    def test_values_is_not_index():
+        # GH 60563
+        values = Series(['a1', 'a2'], dtype=ArrowDtype(pa.string()))
+        arr = values._pa_array.combine_chunks()
+
+        assert arr.equals(values._pa_array.combine_chunks())


### PR DESCRIPTION
- [x] closes #60563
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This is my first issue, thank you in advance for your patience and feedback! 