### PR TITLE
DOC: Change Twitter to X in pandas maintenance

### DIFF
--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -488,7 +488,7 @@ Post-Release
    for reference):
 
     - The pandas-dev and pydata mailing lists
-    - Twitter, Mastodon, Telegram and LinkedIn
+    - X, Mastodon, Telegram and LinkedIn
 
 7. Update this release instructions to fix anything incorrect and to update about any
    change since the last release.


### PR DESCRIPTION
Change Twitter to X in the dev version

Update maintaining.rst by changing Twitter to X.
<https://pandas.pydata.org/docs/dev/development/maintaining.html>

Relevant Pull Requests: #60426, #60382, #59482
