### PR TITLE
[2.3.x] TST: remove leftover xfail in excel test_readers.py

### DIFF
--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -16,8 +16,6 @@ from zipfile import BadZipFile
 import numpy as np
 import pytest
 
-from pandas._config import using_string_dtype
-
 from pandas.compat import is_platform_windows
 import pandas.util._test_decorators as td
 
@@ -655,9 +653,6 @@ class TestReaders:
             )
         tm.assert_frame_equal(result, df)
 
-    @pytest.mark.xfail(
-        using_string_dtype(), reason="infer_string takes precedence", strict=False
-    )
     def test_dtype_backend_string(self, read_ext, string_storage):
         # GH#36712
         if read_ext in (".xlsb", ".xls"):


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/pull/60349#issuecomment-2559398071