### PR TITLE
TST(string dtype): Resolve some HDF5 xfails

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -5297,6 +5297,8 @@ def _dtype_to_kind(dtype_str: str) -> str:
         kind = "integer"
     elif dtype_str == "object":
         kind = "object"
+    elif dtype_str == "str":
+        kind = "str"
     else:
         raise ValueError(f"cannot interpret dtype of [{dtype_str}]")
 

--- a/pandas/tests/io/pytables/test_file_handling.py
+++ b/pandas/tests/io/pytables/test_file_handling.py
@@ -17,7 +17,6 @@ from pandas.errors import (
     PossibleDataLossError,
 )
 
-import pandas as pd
 from pandas import (
     DataFrame,
     HDFStore,
@@ -35,6 +34,10 @@ from pandas.tests.io.pytables.common import (
 
 from pandas.io import pytables
 from pandas.io.pytables import Term
+
+pytestmark = [
+    pytest.mark.single_cpu,
+]
 
 
 @pytest.mark.parametrize("mode", ["r", "r+", "a", "w"])
@@ -88,9 +91,7 @@ def test_mode(setup_path, tmp_path, mode, using_infer_string):
     else:
         result = read_hdf(path, "df", mode=mode)
         if using_infer_string:
-            df.columns = df.columns.astype(
-                pd.StringDtype(storage="pyarrow", na_value=np.nan)
-            )
+            df.columns = df.columns.astype("str")
         tm.assert_frame_equal(result, df)
 
 
@@ -104,11 +105,10 @@ def test_default_mode(tmp_path, setup_path, using_infer_string):
     path = tmp_path / setup_path
     df.to_hdf(path, key="df", mode="w")
     result = read_hdf(path, "df")
+    expected = df.copy()
     if using_infer_string:
-        df.columns = df.columns.astype(
-            pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        )
-    tm.assert_frame_equal(result, df)
+        expected.columns = expected.columns.astype("str")
+    tm.assert_frame_equal(result, expected)
 
 
 def test_reopen_handle(tmp_path, setup_path):
@@ -184,12 +184,8 @@ def test_open_args(setup_path, using_infer_string):
 
         expected = df.copy()
         if using_infer_string:
-            expected.index = expected.index.astype(
-                pd.StringDtype(storage="pyarrow", na_value=np.nan)
-            )
-            expected.columns = expected.columns.astype(
-                pd.StringDtype(storage="pyarrow", na_value=np.nan)
-            )
+            expected.index = expected.index.astype("str")
+            expected.columns = expected.columns.astype("str")
 
         tm.assert_frame_equal(store["df"], expected)
         tm.assert_frame_equal(store["df2"], expected)
@@ -222,12 +218,8 @@ def test_complibs_default_settings(tmp_path, setup_path, using_infer_string):
     result = read_hdf(tmpfile, "df")
     expected = df.copy()
     if using_infer_string:
-        expected.index = expected.index.astype(
-            pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        )
-        expected.columns = expected.columns.astype(
-            pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        )
+        expected.index = expected.index.astype("str")
+        expected.columns = expected.columns.astype("str")
     tm.assert_frame_equal(result, expected)
 
     with tables.open_file(tmpfile, mode="r") as h5file:
@@ -241,12 +233,8 @@ def test_complibs_default_settings(tmp_path, setup_path, using_infer_string):
     result = read_hdf(tmpfile, "df")
     expected = df.copy()
     if using_infer_string:
-        expected.index = expected.index.astype(
-            pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        )
-        expected.columns = expected.columns.astype(
-            pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        )
+        expected.index = expected.index.astype("str")
+        expected.columns = expected.columns.astype("str")
     tm.assert_frame_equal(result, expected)
 
     with tables.open_file(tmpfile, mode="r") as h5file:
@@ -260,12 +248,8 @@ def test_complibs_default_settings(tmp_path, setup_path, using_infer_string):
     result = read_hdf(tmpfile, "df")
     expected = df.copy()
     if using_infer_string:
-        expected.index = expected.index.astype(
-            pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        )
-        expected.columns = expected.columns.astype(
-            pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        )
+        expected.index = expected.index.astype("str")
+        expected.columns = expected.columns.astype("str")
     tm.assert_frame_equal(result, expected)
 
     with tables.open_file(tmpfile, mode="r") as h5file:
@@ -379,7 +363,7 @@ def test_encoding(setup_path):
     ],
 )
 @pytest.mark.parametrize("dtype", ["category", object])
-def test_latin_encoding(tmp_path, setup_path, dtype, val, using_infer_string):
+def test_latin_encoding(tmp_path, setup_path, dtype, val):
     enc = "latin-1"
     nan_rep = ""
     key = "data"

--- a/pandas/tests/io/pytables/test_subclass.py
+++ b/pandas/tests/io/pytables/test_subclass.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_string_dtype
-
 from pandas import (
     DataFrame,
     Series,
@@ -19,7 +17,6 @@ pytest.importorskip("tables")
 
 class TestHDFStoreSubclass:
     # GH 33748
-    @pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string)")
     def test_supported_for_subclass_dataframe(self, tmp_path):
         data = {"a": [1, 2], "b": [3, 4]}
         sdf = tm.SubclassedDataFrame(data, dtype=np.intp)

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -19,8 +19,6 @@ import tempfile
 import numpy as np
 import pytest
 
-from pandas._config import using_string_dtype
-
 from pandas.compat import (
     WASM,
     is_platform_windows,
@@ -365,7 +363,6 @@ Look,a snake,🐍"""
                     expected = f_path.read()
                     assert result == expected
 
-    @pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string) hdf support")
     def test_write_fspath_hdf5(self):
         # Same test as write_fspath_all, except HDF5 files aren't
         # necessarily byte-for-byte identical for a given dataframe, so we'll


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The behavior here is that if you write out strings using object dtype, then you still get the inferred string dtype when reading back in. That is, we (likely) do not round-trip dtypes if the value of `future.infer_string` is different when reading/writing.