### PR TITLE
DOC: Fix numpydoc section underlines

### DIFF
--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -704,7 +704,7 @@ class NaTType(_NaT):
         difference between the current timezone and UTC.
 
         Returns
-        --------
+        -------
         timedelta
             The difference between UTC and the local time as a `timedelta` object.
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2217,7 +2217,7 @@ class Timestamp(_Timestamp):
         difference between the current timezone and UTC.
 
         Returns
-        --------
+        -------
         timedelta
             The difference between UTC and the local time as a `timedelta` object.
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -3700,7 +3700,7 @@ class StringMethods(NoNewAttributesMixin):
     Series.str.isupper : Check whether all characters are uppercase.
 
     Examples
-    ------------
+    --------
     The ``s5.str.istitle`` method checks for whether all words are in title
     case (whether only the first letter of each word is capitalized). Words are
     assumed to be as any sequence of non-numeric characters separated by


### PR DESCRIPTION
e.g

```bash
/home/runner/micromamba/envs/test/lib/python3.10/site-packages/numpydoc/docscrape.py:203: UserWarning: potentially wrong underline length... 
Returns 
-------- in 

Return utc offset.... in the docstring of utcoffset
  while not self._is_at_section() and not self._doc.eof():
/home/runner/micromamba/envs/test/lib/python3.10/site-packages/numpydoc/docscrape.py:203: UserWarning: potentially wrong underline length... 
Examples 
------------ in 

Check whether all characters in each string are titlecase.... in the docstring of istitle in /home/runner/work/pandas/pandas/pandas/core/strings/accessor.py.
  while not self._is_at_section() and not self._doc.eof():
```