### PR TITLE
BUG/TST (string dtype): raise proper TypeError in interpolate

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2160,7 +2160,7 @@ class ArrowExtensionArray(
         """
         # NB: we return type(self) even if copy=False
         if not self.dtype._is_numeric:
-            raise ValueError("Values must be numeric.")
+            raise TypeError(f"Cannot interpolate with {self.dtype} dtype")
 
         if (
             not pa_version_under13p0

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -287,6 +287,9 @@ class NumpyExtensionArray(  # type: ignore[misc]
         See NDFrame.interpolate.__doc__.
         """
         # NB: we return type(self) even if copy=False
+        if not self.dtype._is_numeric:
+            raise TypeError(f"Cannot interpolate with {self.dtype} dtype")
+
         if not copy:
             out_data = self._ndarray
         else:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3451,7 +3451,9 @@ def test_string_to_datetime_parsing_cast():
 )
 def test_interpolate_not_numeric(data):
     if not data.dtype._is_numeric:
-        with pytest.raises(ValueError, match="Values must be numeric."):
+        ser = pd.Series(data)
+        msg = re.escape(f"Cannot interpolate with {ser.dtype} dtype")
+        with pytest.raises(TypeError, match=msg):
             pd.Series(data).interpolate()
 
 

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -64,11 +64,7 @@ class TestDataFrameInterpolate:
         assert np.shares_memory(orig, obj.values)
         assert orig.squeeze()[1] == 1.5
 
-    # TODO(infer_string) raise proper TypeError in case of string dtype
-    @pytest.mark.xfail(
-        using_string_dtype(), reason="interpolate doesn't work for string"
-    )
-    def test_interp_basic(self):
+    def test_interp_basic(self, using_infer_string):
         df = DataFrame(
             {
                 "A": [1, 2, np.nan, 4],
@@ -77,7 +73,8 @@ class TestDataFrameInterpolate:
                 "D": list("abcd"),
             }
         )
-        msg = "DataFrame cannot interpolate with object dtype"
+        dtype = "str" if using_infer_string else "object"
+        msg = f"[Cc]annot interpolate with {dtype} dtype"
         with pytest.raises(TypeError, match=msg):
             df.interpolate()
 
@@ -88,7 +85,8 @@ class TestDataFrameInterpolate:
 
         # check we DID operate inplace
         assert np.shares_memory(df["C"]._values, cvalues)
-        assert np.shares_memory(df["D"]._values, dvalues)
+        if not using_infer_string:
+            assert np.shares_memory(df["D"]._values, dvalues)
 
     @pytest.mark.xfail(
         using_string_dtype(), reason="interpolate doesn't work for string"

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -84,9 +84,8 @@ class TestDataFrameInterpolate:
             df.interpolate(inplace=True)
 
         # check we DID operate inplace
-        assert np.shares_memory(df["C"]._values, cvalues)
-        if not using_infer_string:
-            assert np.shares_memory(df["D"]._values, dvalues)
+        assert tm.shares_memory(df["C"]._values, cvalues)
+        assert tm.shares_memory(df["D"]._values, dvalues)
 
     @pytest.mark.xfail(
         using_string_dtype(), reason="interpolate doesn't work for string"


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
