### PR TITLE
ENH: Change default dtype of str.get_dummies() to bool

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -397,19 +397,19 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
 
     def _str_get_dummies(self, sep: str = "|", dtype: NpDtype | None = None):
         if dtype is None:
-            dtype = np.int64
+            dtype = np.bool_
         dummies_pa, labels = ArrowExtensionArray(self._pa_array)._str_get_dummies(
             sep, dtype
         )
-        if len(labels) == 0:
-            return np.empty(shape=(0, 0), dtype=dtype), labels
-        dummies = np.vstack(dummies_pa.to_numpy())
         _dtype = pandas_dtype(dtype)
         dummies_dtype: NpDtype
         if isinstance(_dtype, np.dtype):
             dummies_dtype = _dtype
         else:
             dummies_dtype = np.bool_
+        if len(labels) == 0:
+            return np.empty(shape=(0, 0), dtype=dummies_dtype), labels
+        dummies = np.vstack(dummies_pa.to_numpy())
         return dummies.astype(dummies_dtype, copy=False), labels
 
     def _convert_int_result(self, result):

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2536,14 +2536,14 @@ class StringMethods(NoNewAttributesMixin):
             if isinstance(input_dtype, ArrowDtype):
                 import pyarrow as pa
 
-                dtype = ArrowDtype(pa.bool_())
+                dtype = ArrowDtype(pa.bool_())  # type: ignore[assignment]
             elif (
                 isinstance(input_dtype, StringDtype)
                 and input_dtype.na_value is not np.nan
             ):
                 from pandas.core.dtypes.common import pandas_dtype
 
-                dtype = pandas_dtype("boolean")
+                dtype = pandas_dtype("boolean")  # type: ignore[assignment]
             else:
                 dtype = np.bool_
 

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -416,7 +416,7 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
         from pandas import Series
 
         if dtype is None:
-            dtype = np.int64
+            dtype = np.bool_
         arr = Series(self).fillna("")
         try:
             arr = sep + arr + sep

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2206,6 +2206,16 @@ def test_get_dummies():
     )
     tm.assert_frame_equal(result, expected)
 
+    ser = pd.Series(
+        ["a", "b"],
+        dtype=pd.CategoricalDtype(pd.Index(["a", "b"], dtype=ArrowDtype(pa.string()))),
+    )
+    result = ser.str.get_dummies()
+    expected = pd.DataFrame(
+        [[True, False], [False, True]], dtype=ArrowDtype(pa.bool_()), columns=["a", "b"]
+    )
+    tm.assert_frame_equal(result, expected)
+
 
 def test_str_partition():
     ser = pd.Series(["abcba", None], dtype=ArrowDtype(pa.string()))


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

### Overview
This PR changes the default dtype of the result from `str.get_dummies()` from `np.int64` to boolean (`bool` or `boolean`). This modification ensures consistent behavior between `pd.get_dummies()` and `str.get_dummies()`. Additionally, the implementation now adapts to the input data type to return the corresponding boolean type.

---

### Background
Currently, `pd.get_dummies()` returns a boolean dtype by default, while `str.get_dummies()` returns an integer dtype (`np.int64`). This inconsistency may cause confusion for users.

- In PR #48022, the default dtype of `pd.get_dummies()` was changed to bool.
- In PR #56291, `pd.get_dummies()` was updated to return a corresponding boolean dtype (e.g., `boolean[pyarrow]`) when the input is an `ExtensionArray`.

This PR aligns the behavior of `str.get_dummies()` with these changes.

---

### Changes Made
- Changed the default dtype of the result from `str.get_dummies()` from `np.int64` to boolean.
- Implemented support for returning the corresponding boolean type when the input data is an `ExtensionArray`. For example, when the input is of type `string[pyarrow]`, the result will be of type `boolean[pyarrow]`.

---

### Behavior Before and After the Change

#### Before
```python
>>> sr = pd.Series(["A", "B", "A"])
>>> sr.str.get_dummies()
   A  B
0  1  0
1  0  1
2  1  0
```

#### After
```python
>>> sr = pd.Series(["A", "B", "A"])
>>> sr.str.get_dummies()
       A      B
0   True  False
1  False   True
2   True  False
```

---

### Additional Notes

The following code demonstrates the difference in behavior between `pd.get_dummies()` and `str.get_dummies()` before the change:

```python
import numpy as np
import pandas as pd
import pyarrow as pa

sr_list = [pd.Series(["A", "B", "A"]),
           pd.Series(["A", "B", "A"], dtype=pd.StringDtype()),
           pd.Series(["A", "B", "A"], dtype=pd.StringDtype("pyarrow")),
           pd.Series(["A", "B", "A"], dtype=pd.StringDtype("pyarrow_numpy")),
           pd.Series(["A", "B", "A"], dtype=pd.ArrowDtype(pa.string())),
           pd.Series(["A", "B", "A"], dtype="category"),
           pd.Series(["A", "B", "A"], dtype=pd.CategoricalDtype(pd.Index(["A", "B"], dtype=pd.ArrowDtype(pa.string()))))
]

for i, sr in enumerate(sr_list):
    print(f"----- case {i}. {sr.dtype=} -----")
    print(f"pd.get_dummies: {pd.get_dummies(sr)['A'].dtype}")
    print(f"str.get_dummies: {sr.str.get_dummies()['A'].dtype}")
```

#### Output Before the Change:
(Note: In case 4, the outputs of `pd.get_dummies()` and `str.get_dummies()` already match.)

```
----- case 0. sr.dtype=dtype('O') -----
pd.get_dummies: bool
str.get_dummies: int64
----- case 1. sr.dtype=string[python] -----
pd.get_dummies: boolean
str.get_dummies: int64
----- case 2. sr.dtype=string[pyarrow] -----
pd.get_dummies: boolean
str.get_dummies: int64
----- case 3. sr.dtype=str -----
pd.get_dummies: bool
str.get_dummies: int64
----- case 4. sr.dtype=string[pyarrow] -----
pd.get_dummies: bool[pyarrow]
str.get_dummies: bool[pyarrow]
----- case 5. sr.dtype=CategoricalDtype(categories=['A', 'B'], ordered=False, categories_dtype=object) -----
pd.get_dummies: bool
str.get_dummies: int64
----- case 6. sr.dtype=CategoricalDtype(categories=['A', 'B'], ordered=False, categories_dtype=string[pyarrow]) -----
pd.get_dummies: bool[pyarrow]
str.get_dummies: int64
```

#### Output After the Change:
```
----- case 0. sr.dtype=dtype('O') -----
pd.get_dummies: bool
str.get_dummies: bool
----- case 1. sr.dtype=string[python] -----
pd.get_dummies: boolean
str.get_dummies: boolean
----- case 2. sr.dtype=string[pyarrow] -----
pd.get_dummies: boolean
str.get_dummies: boolean
----- case 3. sr.dtype=str -----
pd.get_dummies: bool
str.get_dummies: bool
----- case 4. sr.dtype=string[pyarrow] -----
pd.get_dummies: bool[pyarrow]
str.get_dummies: bool[pyarrow]
----- case 5. sr.dtype=CategoricalDtype(categories=['A', 'B'], ordered=False, categories_dtype=object) -----
pd.get_dummies: bool
str.get_dummies: bool
----- case 6. sr.dtype=CategoricalDtype(categories=['A', 'B'], ordered=False, categories_dtype=string[pyarrow]) -----
pd.get_dummies: bool[pyarrow]
str.get_dummies: bool[pyarrow]
```