### PR TITLE
Implement String Accumulations with nanoarrow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: |
             /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
             . ~/virtualenvs/pandas-dev/bin/activate
-            python -m pip install --no-cache-dir -U pip wheel setuptools meson-python meson[ninja]
+            python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.14.0 meson[ninja]==1.2.1
             python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
             python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
             python -m pip list --no-cache-dir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: |
             /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
             . ~/virtualenvs/pandas-dev/bin/activate
-            python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.13.1 meson[ninja]==1.2.1
+            python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.14.0 meson[ninja]==1.2.1
             python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
             python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
             python -m pip list --no-cache-dir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: |
             /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
             . ~/virtualenvs/pandas-dev/bin/activate
-            python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.14.0 meson[ninja]==1.2.1
+            python -m pip install --no-cache-dir -U pip wheel setuptools meson-python meson[ninja]
             python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
             python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
             python -m pip list --no-cache-dir

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja]==1.3.2 meson-python==0.14.0
+          python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja] meson-python
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
@@ -272,7 +272,7 @@ jobs:
         run: |
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.14.0 meson[ninja]==1.3.2
+          python -m pip install --no-cache-dir -U pip wheel setuptools meson-python  meson[ninja]
           python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
@@ -344,7 +344,7 @@ jobs:
       - name: Build Environment
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.14.0
+          python -m pip install --upgrade pip setuptools wheel meson[ninja] meson-python
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil tzdata cython hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
@@ -389,7 +389,7 @@ jobs:
         # Tests segfault with numpy 2.2.0: https://github.com/numpy/numpy/pull/27955
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.14.0
+          python -m pip install --upgrade pip setuptools wheel meson[ninja] meson-python
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil pytz tzdata hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja] meson-python
+          python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja]==1.3.2 meson-python==0.14.0
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
@@ -272,7 +272,7 @@ jobs:
         run: |
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel setuptools meson-python  meson[ninja]
+          python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.14.0 meson[ninja]==1.3.2
           python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
@@ -344,7 +344,7 @@ jobs:
       - name: Build Environment
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel meson[ninja] meson-python
+          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.14.0
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil tzdata cython hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
@@ -389,7 +389,7 @@ jobs:
         # Tests segfault with numpy 2.2.0: https://github.com/numpy/numpy/pull/27955
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel meson[ninja] meson-python
+          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.14.0
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil pytz tzdata hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja]==1.2.1 meson-python==0.13.1
+          python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja]==1.3.2 meson-python==0.13.1
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
@@ -272,7 +272,7 @@ jobs:
         run: |
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.13.1 meson[ninja]==1.2.1
+          python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.13.1 meson[ninja]==1.3.2
           python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
@@ -344,7 +344,7 @@ jobs:
       - name: Build Environment
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.2.1 meson-python==0.13.1
+          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.13.1
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil tzdata cython hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
@@ -389,7 +389,7 @@ jobs:
         # Tests segfault with numpy 2.2.0: https://github.com/numpy/numpy/pull/27955
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.2.1 meson-python==0.13.1
+          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.13.1
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil pytz tzdata hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja]==1.3.2 meson-python==0.13.1
+          python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja]==1.3.2 meson-python==0.14.0
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
@@ -272,7 +272,7 @@ jobs:
         run: |
           /opt/python/cp311-cp311/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.13.1 meson[ninja]==1.3.2
+          python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.14.0 meson[ninja]==1.3.2
           python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
@@ -344,7 +344,7 @@ jobs:
       - name: Build Environment
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.13.1
+          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.14.0
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil tzdata cython hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
@@ -389,7 +389,7 @@ jobs:
         # Tests segfault with numpy 2.2.0: https://github.com/numpy/numpy/pull/27955
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.13.1
+          python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.3.2 meson-python==0.14.0
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil pytz tzdata hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ doc/source/savefig/
 # Interactive terminal generated files #
 ########################################
 .jupyterlite.doit.db
+
+# meson subproject files #
+##########################
+subprojects/*
+!subprojects/packagefiles
+!subprojects/*.wrap

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,7 @@ repos:
     rev: v19.1.6
     hooks:
     - id: clang-format
-      files: ^pandas/_libs/src|^pandas/_libs/include
+      files: ^pandas/_libs|pandas/_libs/src|^pandas/_libs/include
       args: [-i]
       types_or: [c, c++]
 -   repo: local

--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -9,8 +9,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson
-  - meson-python
+  - meson=1.3.2
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -9,8 +9,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.3.2
-  - meson-python=0.14.0
+  - meson
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -9,7 +9,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
+  - meson=1.3.2
   - meson-python=0.13.1
 
   # test dependencies

--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -10,7 +10,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson=1.3.2
-  - meson-python=0.13.1
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -7,7 +7,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
+  - meson=1.3.2
   - meson-python=0.13.1
 
   # test dependencies

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson
-  - meson-python
+  - meson=1.3.2
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.3.2
-  - meson-python=0.14.0
+  - meson
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson=1.3.2
-  - meson-python=0.13.1
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -8,8 +8,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson
-  - meson-python
+  - meson=1.3.2
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -8,8 +8,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.3.2
-  - meson-python=0.14.0
+  - meson
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -9,7 +9,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson=1.3.2
-  - meson-python=0.13.1
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -8,7 +8,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
+  - meson=1.3.2
   - meson-python=0.13.1
 
   # test dependencies

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -6,8 +6,8 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson=1.3.2
-  - meson-python=0.14.0
+  - meson
+  - meson-python
   - cython>=0.29.33
 
   # test dependencies

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -6,7 +6,7 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson=1.2.1
+  - meson=1.3.2
   - meson-python=0.13.1
   - cython>=0.29.33
 

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -7,7 +7,7 @@ dependencies:
   # build dependencies
   - versioneer
   - meson=1.3.2
-  - meson-python=0.13.1
+  - meson-python=0.14.0
   - cython>=0.29.33
 
   # test dependencies

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -6,8 +6,8 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson
-  - meson-python
+  - meson=1.3.2
+  - meson-python=0.14.0
   - cython>=0.29.33
 
   # test dependencies

--- a/ci/deps/actions-311-pyarrownightly.yaml
+++ b/ci/deps/actions-311-pyarrownightly.yaml
@@ -6,7 +6,7 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson=1.2.1
+  - meson=1.3.2
   - cython>=0.29.33
   - meson-python=0.13.1
 

--- a/ci/deps/actions-311-pyarrownightly.yaml
+++ b/ci/deps/actions-311-pyarrownightly.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - meson=1.3.2
   - cython>=0.29.33
-  - meson-python=0.13.1
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-pyarrownightly.yaml
+++ b/ci/deps/actions-311-pyarrownightly.yaml
@@ -6,9 +6,9 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson=1.3.2
+  - meson
   - cython>=0.29.33
-  - meson-python=0.14.0
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-pyarrownightly.yaml
+++ b/ci/deps/actions-311-pyarrownightly.yaml
@@ -6,9 +6,9 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson
+  - meson=1.3.2
   - cython>=0.29.33
-  - meson-python
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -7,7 +7,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
+  - meson=1.3.2
   - meson-python=0.13.1
 
   # test dependencies

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson
-  - meson-python
+  - meson=1.3.2
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.3.2
-  - meson-python=0.14.0
+  - meson
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson=1.3.2
-  - meson-python=0.13.1
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -7,7 +7,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
+  - meson=1.3.2
   - meson-python=0.13.1
 
   # test dependencies

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson
-  - meson-python
+  - meson=1.3.2
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.3.2
-  - meson-python=0.14.0
+  - meson
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson=1.3.2
-  - meson-python=0.13.1
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-pypy-39.yaml
+++ b/ci/deps/actions-pypy-39.yaml
@@ -10,8 +10,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.3.2
-  - meson-python=0.14.0
+  - meson
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-pypy-39.yaml
+++ b/ci/deps/actions-pypy-39.yaml
@@ -10,8 +10,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson
-  - meson-python
+  - meson=1.3.2
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-pypy-39.yaml
+++ b/ci/deps/actions-pypy-39.yaml
@@ -10,7 +10,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
+  - meson=1.3.2
   - meson-python=0.13.1
 
   # test dependencies

--- a/ci/deps/actions-pypy-39.yaml
+++ b/ci/deps/actions-pypy-39.yaml
@@ -11,7 +11,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson=1.3.2
-  - meson-python=0.13.1
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/circle-311-arm64.yaml
+++ b/ci/deps/circle-311-arm64.yaml
@@ -7,7 +7,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
+  - meson=1.3.2
   - meson-python=0.13.1
 
   # test dependencies

--- a/ci/deps/circle-311-arm64.yaml
+++ b/ci/deps/circle-311-arm64.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson
-  - meson-python
+  - meson=1.3.2
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/circle-311-arm64.yaml
+++ b/ci/deps/circle-311-arm64.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.3.2
-  - meson-python=0.14.0
+  - meson
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/circle-311-arm64.yaml
+++ b/ci/deps/circle-311-arm64.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson=1.3.2
-  - meson-python=0.13.1
+  - meson-python=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - versioneer
   - cython~=3.0.5
   - meson>=1.3.0
-  - meson-python>=0.13.1
+  - meson-python>=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython~=3.0.5
-  - meson>=1.3.0
-  - meson-python>=0.14.0
+  - meson
+  - meson-python
 
   # test dependencies
   - pytest>=7.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython~=3.0.5
-  - meson
-  - meson-python
+  - meson>=1.3.0
+  - meson-python>=0.14.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython~=3.0.5
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.3.0
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/meson.build
+++ b/meson.build
@@ -4,11 +4,13 @@ project(
     'c', 'cpp', 'cython',
     version: run_command(['generate_version.py', '--print'], check: true).stdout().strip(),
     license: 'BSD-3',
-    meson_version: '>=1.2.1',
+    meson_version: '>=1.3.0',
     default_options: [
         'buildtype=release',
         'c_std=c11',
+        'cpp_std=c++20',
         'warning_level=2',
+        'default_library=static',
     ]
 )
 

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
     default_options: [
         'buildtype=release',
         'c_std=c11',
-        'cpp_std=c++20',
+        'cpp_std=c++17',
         'warning_level=2',
         'default_library=static',
         # TODO: how can we only set this for nanobind?

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,8 @@ project(
         'cpp_std=c++20',
         'warning_level=2',
         'default_library=static',
+        # TODO: how can we only set this for nanobind?
+        'cpp_args=-Wno-sign-compare'
     ]
 )
 

--- a/pandas/_libs/arrow_string_accumulations.cc
+++ b/pandas/_libs/arrow_string_accumulations.cc
@@ -1,0 +1,214 @@
+#include <functional>
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <tuple>
+
+#include <nanoarrow/nanoarrow.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/string.h>
+
+using namespace nanoarrow::literals;
+namespace nb = nanobind;
+
+static auto ReleaseArrowArray(void *ptr) noexcept -> void {
+  auto array = static_cast<struct ArrowArray *>(ptr);
+  if (array->release != nullptr) {
+    ArrowArrayRelease(array);
+  }
+
+  delete array;
+}
+
+static auto ReleaseArrowSchema(void *ptr) noexcept -> void {
+  auto schema = static_cast<struct ArrowSchema *>(ptr);
+  if (schema->release != nullptr) {
+    ArrowSchemaRelease(schema);
+  }
+
+  delete schema;
+}
+
+static auto CumSum(const struct ArrowArrayView *array_view,
+                   struct ArrowArray *out, bool skipna) {
+  bool seen_na = false;
+  std::stringstream ss{};
+
+  for (int64_t i = 0; i < array_view->length; i++) {
+    const bool isna = ArrowArrayViewIsNull(array_view, i);
+    if (!skipna && (seen_na || isna)) {
+      seen_na = true;
+      ArrowArrayAppendNull(out, 1);
+    } else {
+      if (!isna) {
+        const auto std_sv = ArrowArrayViewGetStringUnsafe(array_view, i);
+        ss << std::string_view{std_sv.data,
+                               static_cast<size_t>(std_sv.size_bytes)};
+      }
+      const auto str = ss.str();
+      const ArrowStringView asv{str.c_str(), static_cast<int64_t>(str.size())};
+      NANOARROW_THROW_NOT_OK(ArrowArrayAppendString(out, asv));
+    }
+  }
+}
+
+template <typename T>
+concept MinOrMaxOp =
+    std::same_as<T, std::less<>> || std::same_as<T, std::greater<>>;
+
+template <auto Op>
+  requires MinOrMaxOp<decltype(Op)>
+static auto CumMinOrMax(const struct ArrowArrayView *array_view,
+                        struct ArrowArray *out, bool skipna) {
+  bool seen_na = false;
+  std::optional<std::string> current_str{};
+
+  for (int64_t i = 0; i < array_view->length; i++) {
+    const bool isna = ArrowArrayViewIsNull(array_view, i);
+    if (!skipna && (seen_na || isna)) {
+      seen_na = true;
+      ArrowArrayAppendNull(out, 1);
+    } else {
+      if (!isna || current_str) {
+        if (!isna) {
+          const auto asv = ArrowArrayViewGetStringUnsafe(array_view, i);
+          const nb::str pyval{asv.data, static_cast<size_t>(asv.size_bytes)};
+
+          if (current_str) {
+            const nb::str pycurrent{current_str->data(), current_str->size()};
+            if (Op(pyval, pycurrent)) {
+              current_str =
+                  std::string{asv.data, static_cast<size_t>(asv.size_bytes)};
+            }
+          } else {
+            current_str =
+                std::string{asv.data, static_cast<size_t>(asv.size_bytes)};
+          }
+        }
+
+        struct ArrowStringView out_sv{
+            current_str->data(), static_cast<int64_t>(current_str->size())};
+        NANOARROW_THROW_NOT_OK(ArrowArrayAppendString(out, out_sv));
+      } else {
+        ArrowArrayAppendEmpty(out, 1);
+      }
+    }
+  }
+}
+
+class ArrowStringAccumulation {
+public:
+  ArrowStringAccumulation(nb::object array_object, std::string accumulation,
+                          bool skipna)
+      : skipna_(skipna) {
+    if ((accumulation == "cumsum") || (accumulation == "cummin") ||
+        (accumulation == "cummax")) {
+      accumulation_ = std::move(accumulation);
+    } else {
+      const auto error_message =
+          std::string("Unsupported accumulation: ") + accumulation;
+      throw nb::value_error(error_message.c_str());
+    }
+
+    const auto obj = nb::getattr(array_object, "__arrow_c_stream__")();
+    const auto pycapsule_obj = nb::cast<nb::capsule>(obj);
+
+    const auto stream = static_cast<struct ArrowArrayStream *>(
+        PyCapsule_GetPointer(pycapsule_obj.ptr(), "arrow_array_stream"));
+    if (stream == nullptr) {
+      throw std::invalid_argument("Invalid Arrow Stream capsule provided!");
+    }
+
+    if (stream->get_schema(stream, schema_.get()) != 0) {
+      std::string error_msg{stream->get_last_error(stream)};
+      throw std::runtime_error("Could not read from arrow schema:" + error_msg);
+    }
+    struct ArrowSchemaView schema_view{};
+    NANOARROW_THROW_NOT_OK(
+        ArrowSchemaViewInit(&schema_view, schema_.get(), nullptr));
+
+    switch (schema_view.type) {
+    case NANOARROW_TYPE_STRING:
+    case NANOARROW_TYPE_LARGE_STRING:
+    case NANOARROW_TYPE_STRING_VIEW:
+      break;
+    default:
+      const auto error_message =
+          std::string("Expected a string-like array type, got: ") +
+          ArrowTypeString(schema_view.type);
+      throw std::invalid_argument(error_message);
+    }
+
+    ArrowArrayStreamMove(stream, stream_.get());
+  }
+
+  std::pair<nb::capsule, nb::capsule> Accumulate(nb::object requested_schema) {
+    struct ArrowSchemaView schema_view{};
+    NANOARROW_THROW_NOT_OK(
+        ArrowSchemaViewInit(&schema_view, schema_.get(), nullptr));
+    auto uschema = nanoarrow::UniqueSchema{};
+    ArrowSchemaInit(uschema.get());
+    NANOARROW_THROW_NOT_OK(ArrowSchemaSetType(uschema.get(), schema_view.type));
+
+    // TODO: even though we are reading a stream we are returning an array
+    // We should return a like sized stream of data in the future
+    auto uarray_out = nanoarrow::UniqueArray{};
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayInitFromSchema(uarray_out.get(), uschema.get(), nullptr));
+
+    NANOARROW_THROW_NOT_OK(ArrowArrayStartAppending(uarray_out.get()));
+
+    nanoarrow::UniqueArray chunk{};
+    int errcode{};
+
+    while ((errcode = ArrowArrayStreamGetNext(stream_.get(), chunk.get(),
+                                              nullptr) == 0) &&
+           chunk->release != nullptr) {
+      struct ArrowArrayView array_view{};
+      NANOARROW_THROW_NOT_OK(
+          ArrowArrayViewInitFromSchema(&array_view, schema_.get(), nullptr));
+
+      NANOARROW_THROW_NOT_OK(
+          ArrowArrayViewSetArray(&array_view, chunk.get(), nullptr));
+
+      if (accumulation_ == "cumsum") {
+        CumSum(&array_view, uarray_out.get(), skipna_);
+      } else if (accumulation_ == "cummin") {
+        CumMinOrMax<std::less{}>(&array_view, uarray_out.get(), skipna_);
+      } else if (accumulation_ == "cummax") {
+        CumMinOrMax<std::greater{}>(&array_view, uarray_out.get(), skipna_);
+      } else {
+        throw std::runtime_error("Unexpected branch");
+      }
+
+      chunk.reset();
+    }
+
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayFinishBuildingDefault(uarray_out.get(), nullptr));
+
+    auto out_schema = new struct ArrowSchema;
+    ArrowSchemaMove(uschema.get(), out_schema);
+    nb::capsule schema_capsule{out_schema, "arrow_schema", &ReleaseArrowSchema};
+
+    auto out_array = new struct ArrowArray;
+    ArrowArrayMove(uarray_out.get(), out_array);
+    nb::capsule array_capsule{out_array, "arrow_array", &ReleaseArrowArray};
+
+    return std::pair<nb::capsule, nb::capsule>{schema_capsule, array_capsule};
+  }
+
+private:
+  nanoarrow::UniqueArrayStream stream_;
+  nanoarrow::UniqueSchema schema_;
+  std::string accumulation_;
+  bool skipna_;
+};
+
+NB_MODULE(arrow_string_accumulations, m) {
+  nb::class_<ArrowStringAccumulation>(m, "ArrowStringAccumulation")
+      .def(nb::init<nb::object, std::string, bool>())
+      .def("__arrow_c_array__", &ArrowStringAccumulation::Accumulate,
+           nb::arg("requested_schema") = nb::none());
+}

--- a/pandas/_libs/arrow_string_accumulations.cc
+++ b/pandas/_libs/arrow_string_accumulations.cc
@@ -53,12 +53,12 @@ static auto CumSum(const struct ArrowArrayView *array_view,
   }
 }
 
-template <typename T>
-concept MinOrMaxOp =
-    std::same_as<T, std::less<>> || std::same_as<T, std::greater<>>;
+// template <typename T>
+// concept MinOrMaxOp =
+//     std::same_as<T, std::less<>> || std::same_as<T, std::greater<>>;
 
 template <auto Op>
-  requires MinOrMaxOp<decltype(Op)>
+//  requires MinOrMaxOp<decltype(Op)>
 static auto CumMinOrMax(const struct ArrowArrayView *array_view,
                         struct ArrowArray *out, bool skipna) {
   bool seen_na = false;

--- a/pandas/_libs/arrow_string_accumulations.cc
+++ b/pandas/_libs/arrow_string_accumulations.cc
@@ -36,9 +36,25 @@ static auto CumSum(struct ArrowArrayStream *array_stream,
   bool seen_na = false;
   std::stringstream ss{};
 
+  // TODO: we can simplify this further if we just iterate on the array
+  // and not the array view, but there is an upstream bug in nanoarrow
+  // that prevents that
+  // https://github.com/apache/arrow-nanoarrow/issues/701
+  nanoarrow::UniqueArrayView array_view{};
+  nanoarrow::UniqueSchema schema{};
+  NANOARROW_THROW_NOT_OK(
+      ArrowArrayStreamGetSchema(array_stream, schema.get(), nullptr));
+
   nanoarrow::ViewArrayStream array_stream_view(array_stream);
   for (const auto &array : array_stream_view) {
-    for (const auto &sv : nanoarrow::ViewArrayAsBytes<OffsetSize>(&array)) {
+    array_view.reset();
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr));
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayViewSetArray(array_view.get(), &array, nullptr));
+
+    for (const auto &sv :
+         nanoarrow::ViewArrayAsBytes<OffsetSize>(array_view.get())) {
       if ((!sv || seen_na) && !skipna) {
         seen_na = true;
         ArrowArrayAppendNull(out, 1);
@@ -68,9 +84,25 @@ static auto CumMinOrMax(struct ArrowArrayStream *array_stream,
   bool seen_na = false;
   std::optional<std::string> current_str{};
 
+  // TODO: we can simplify this further if we just iterate on the array
+  // and not the array view, but there is an upstream bug in nanoarrow
+  // that prevents that
+  // https://github.com/apache/arrow-nanoarrow/issues/701
+  nanoarrow::UniqueArrayView array_view{};
+  nanoarrow::UniqueSchema schema{};
+  NANOARROW_THROW_NOT_OK(
+      ArrowArrayStreamGetSchema(array_stream, schema.get(), nullptr));
+
   nanoarrow::ViewArrayStream array_stream_view(array_stream);
   for (const auto &array : array_stream_view) {
-    for (const auto &sv : nanoarrow::ViewArrayAsBytes<OffsetSize>(&array)) {
+    array_view.reset();
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr));
+    NANOARROW_THROW_NOT_OK(
+        ArrowArrayViewSetArray(array_view.get(), &array, nullptr));
+
+    for (const auto &sv :
+         nanoarrow::ViewArrayAsBytes<OffsetSize>(array_view.get())) {
       if ((!sv || seen_na) && !skipna) {
         seen_na = true;
         ArrowArrayAppendNull(out, 1);

--- a/pandas/_libs/arrow_string_accumulations.cc
+++ b/pandas/_libs/arrow_string_accumulations.cc
@@ -143,7 +143,7 @@ public:
     ArrowArrayStreamMove(stream, stream_.get());
   }
 
-  std::pair<nb::capsule, nb::capsule> Accumulate(nb::object requested_schema) {
+  std::pair<nb::capsule, nb::capsule> Accumulate(nb::object) {
     struct ArrowSchemaView schema_view{};
     NANOARROW_THROW_NOT_OK(
         ArrowSchemaViewInit(&schema_view, schema_.get(), nullptr));

--- a/pandas/_libs/arrow_string_accumulations.cc
+++ b/pandas/_libs/arrow_string_accumulations.cc
@@ -36,25 +36,13 @@ static auto CumSum(struct ArrowArrayStream *array_stream,
   bool seen_na = false;
   std::stringstream ss{};
 
-  // TODO: we can simplify this further if we just iterate on the array
-  // and not the array view, but there is an upstream bug in nanoarrow
-  // that prevents that
-  // https://github.com/apache/arrow-nanoarrow/issues/701
-  nanoarrow::UniqueArrayView array_view{};
   nanoarrow::UniqueSchema schema{};
   NANOARROW_THROW_NOT_OK(
       ArrowArrayStreamGetSchema(array_stream, schema.get(), nullptr));
 
   nanoarrow::ViewArrayStream array_stream_view(array_stream);
   for (const auto &array : array_stream_view) {
-    array_view.reset();
-    NANOARROW_THROW_NOT_OK(
-        ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr));
-    NANOARROW_THROW_NOT_OK(
-        ArrowArrayViewSetArray(array_view.get(), &array, nullptr));
-
-    for (const auto &sv :
-         nanoarrow::ViewArrayAsBytes<OffsetSize>(array_view.get())) {
+    for (const auto &sv : nanoarrow::ViewArrayAsBytes<OffsetSize>(&array)) {
       if ((!sv || seen_na) && !skipna) {
         seen_na = true;
         ArrowArrayAppendNull(out, 1);
@@ -84,25 +72,13 @@ static auto CumMinOrMax(struct ArrowArrayStream *array_stream,
   bool seen_na = false;
   std::optional<std::string> current_str{};
 
-  // TODO: we can simplify this further if we just iterate on the array
-  // and not the array view, but there is an upstream bug in nanoarrow
-  // that prevents that
-  // https://github.com/apache/arrow-nanoarrow/issues/701
-  nanoarrow::UniqueArrayView array_view{};
   nanoarrow::UniqueSchema schema{};
   NANOARROW_THROW_NOT_OK(
       ArrowArrayStreamGetSchema(array_stream, schema.get(), nullptr));
 
   nanoarrow::ViewArrayStream array_stream_view(array_stream);
   for (const auto &array : array_stream_view) {
-    array_view.reset();
-    NANOARROW_THROW_NOT_OK(
-        ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr));
-    NANOARROW_THROW_NOT_OK(
-        ArrowArrayViewSetArray(array_view.get(), &array, nullptr));
-
-    for (const auto &sv :
-         nanoarrow::ViewArrayAsBytes<OffsetSize>(array_view.get())) {
+    for (const auto &sv : nanoarrow::ViewArrayAsBytes<OffsetSize>(&array)) {
       if ((!sv || seen_na) && !skipna) {
         seen_na = true;
         ArrowArrayAppendNull(out, 1);

--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -122,6 +122,16 @@ foreach ext_name, ext_dict : libs_sources
     )
 endforeach
 
+nanobind_dep = dependency('nanobind')
+nanoarrow_dep = dependency('nanoarrow')
+py.extension_module(
+    'arrow_string_accumulations',
+    sources: ['arrow_string_accumulations.cc'],
+    dependencies: [nanobind_dep, nanoarrow_dep],
+    subdir: 'pandas/_libs',
+    install: true,
+)
+
 # Basically just __init__.py and the .pyi files
 sources_to_install = [
     '__init__.py',

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1319,20 +1319,16 @@ def nullable_string_dtype(request):
 
 @pytest.fixture(
     params=[
-        pytest.param(
-            pd.StringDtype("pyarrow", na_value=np.nan), marks=td.skip_if_no("pyarrow")
-        ),
-        pytest.param(
-            pd.StringDtype("pyarrow", na_value=pd.NA), marks=td.skip_if_no("pyarrow")
-        ),
+        pytest.param("str[pyarrow]", marks=td.skip_if_no("pyarrow")),
+        pytest.param("string[pyarrow]", marks=td.skip_if_no("pyarrow")),
     ]
 )
 def pyarrow_string_dtype(request):
     """
     Parametrized fixture for string dtypes backed by Pyarrow.
 
-    * 'pd.StringDtype("pyarrow", na_value=np.nan)'
-    * 'pd.StringDtype("pyarrow", na_value=pd.NA)'
+    * 'str[pyarrow]'
+    * 'string[pyarrow]'
     """
     return request.param
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1319,6 +1319,26 @@ def nullable_string_dtype(request):
 
 @pytest.fixture(
     params=[
+        pytest.param(
+            pd.StringDtype("pyarrow", na_value=np.nan), marks=td.skip_if_no("pyarrow")
+        ),
+        pytest.param(
+            pd.StringDtype("pyarrow", na_value=pd.NA), marks=td.skip_if_no("pyarrow")
+        ),
+    ]
+)
+def pyarrow_string_dtype(request):
+    """
+    Parametrized fixture for string dtypes backed by Pyarrow.
+
+    * 'pd.StringDtype("pyarrow", na_value=np.nan)'
+    * 'pd.StringDtype("pyarrow", na_value=pd.NA)'
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
         "python",
         pytest.param("pyarrow", marks=td.skip_if_no("pyarrow")),
     ]

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -41,6 +41,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_numeric_dtype,
     is_scalar,
+    is_string_dtype,
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
@@ -1619,6 +1620,9 @@ class ArrowExtensionArray(
         ------
         NotImplementedError : subclass does not define accumulations
         """
+        if is_string_dtype(self):
+            return self._str_accumulate(name=name, skipna=skipna, **kwargs)
+
         pyarrow_name = {
             "cummax": "cumulative_max",
             "cummin": "cumulative_min",
@@ -1653,6 +1657,58 @@ class ArrowExtensionArray(
             result = result.cast(pa_dtype)
 
         return type(self)(result)
+
+    def _str_accumulate(
+        self, name: str, *, skipna: bool = True, **kwargs
+    ) -> ArrowExtensionArray | ExtensionArray:
+        """
+        Accumulate implementation for strings, see `_accumulate` docstring for details.
+
+        pyarrow.compute does not implement these methods for strings.
+        """
+        if name == "cumprod":
+            msg = f"operation '{name}' not supported for dtype '{self.dtype}'"
+            raise TypeError(msg)
+
+        # When present and skipna is False, we stop of at the first NA value.
+        # as the tail becomes all NA values.
+        head: pa.array | None = None
+        tail: pa.array | None = None
+        pa_array = self._pa_array
+        np_func = {
+            "cumsum": np.cumsum,
+            "cummin": np.minimum.accumulate,
+            "cummax": np.maximum.accumulate,
+        }[name]
+
+        if self._hasna:
+            if skipna:
+                if name == "cumsum":
+                    pa_array = pc.fill_null(pa_array, "")
+                else:
+                    pa_array = pc.fill_null_forward(pa_array)
+                    nulls = pc.is_null(pa_array)
+                    idx = pc.index(nulls, False).as_py()
+                    if idx == -1:
+                        idx = len(pa_array)
+                    if idx > 0:
+                        head = pa.array([""] * idx, type=pa_array.type)
+                        pa_array = pa_array[idx:].combine_chunks()
+            else:
+                nulls = pc.is_null(pa_array)
+                idx = pc.index(nulls, True).as_py()
+                tail = pa.nulls(len(pa_array) - idx, type=pa_array.type)
+                pa_array = pa_array[:idx].combine_chunks()
+
+        pa_result = pa.array(np_func(pa_array), type=pa_array.type)
+
+        if head is not None or tail is not None:
+            head = pa.array([], type=pa_array.type) if head is None else head
+            tail = pa.array([], type=pa_array.type) if tail is None else tail
+            pa_result = pa.concat_arrays([head, pa_result, tail])
+
+        result = type(self)(pa_result)
+        return result
 
     def _reduce_pyarrow(self, name: str, *, skipna: bool = True, **kwargs) -> pa.Scalar:
         """

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1670,8 +1670,7 @@ class ArrowExtensionArray(
             msg = f"operation '{name}' not supported for dtype '{self.dtype}'"
             raise TypeError(msg)
 
-        # When present and skipna is False, we stop of at the first NA value.
-        # as the tail becomes all NA values.
+        # We may need to strip out leading / trailing NA values
         head: pa.array | None = None
         tail: pa.array | None = None
         pa_array = self._pa_array

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -16,6 +16,7 @@ import unicodedata
 import numpy as np
 
 from pandas._libs import lib
+import pandas._libs.arrow_string_accumulations as sa
 from pandas._libs.tslibs import (
     Timedelta,
     Timestamp,
@@ -1670,49 +1671,8 @@ class ArrowExtensionArray(
             msg = f"operation '{name}' not supported for dtype '{self.dtype}'"
             raise TypeError(msg)
 
-        # We may need to strip out leading / trailing NA values
-        head: pa.array | None = None
-        tail: pa.array | None = None
-        pa_array = self._pa_array
-        np_func = {
-            "cumsum": np.cumsum,
-            "cummin": np.minimum.accumulate,
-            "cummax": np.maximum.accumulate,
-        }[name]
-
-        if self._hasna:
-            if skipna:
-                if name == "cumsum":
-                    pa_array = pc.fill_null(pa_array, "")
-                else:
-                    # After the first non-NA value we can retain the running min/max
-                    # by forward filling.
-                    pa_array = pc.fill_null_forward(pa_array)
-                    # But any leading NA values should result in "".
-                    nulls = pc.is_null(pa_array)
-                    idx = pc.index(nulls, False).as_py()
-                    if idx == -1:
-                        idx = len(pa_array)
-                    if idx > 0:
-                        head = pa.array([""] * idx, type=pa_array.type)
-                        pa_array = pa_array[idx:].combine_chunks()
-            else:
-                # When not skipping NA values, the result should be null from
-                # the first NA value onward.
-                nulls = pc.is_null(pa_array)
-                idx = pc.index(nulls, True).as_py()
-                tail = pa.nulls(len(pa_array) - idx, type=pa_array.type)
-                pa_array = pa_array[:idx].combine_chunks()
-
-        # error: Cannot call function of unknown type
-        pa_result = pa.array(np_func(pa_array), type=pa_array.type)  # type: ignore[operator]
-
-        assert head is None or tail is None
-        if head is not None:
-            pa_result = pa.concat_arrays([head, pa_result])
-        elif tail is not None:
-            pa_result = pa.concat_arrays([pa_result, tail])
-
+        # TODO: we can use arrow_c_stream instead of arrow_c_array
+        pa_result = pa.array(sa.ArrowStringAccumulation(self._pa_array, name, skipna))
         result = type(self)(pa_result)
         return result
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1671,7 +1671,6 @@ class ArrowExtensionArray(
             msg = f"operation '{name}' not supported for dtype '{self.dtype}'"
             raise TypeError(msg)
 
-        # TODO: we can use arrow_c_stream instead of arrow_c_array
         pa_result = pa.array(sa.ArrowStringAccumulation(self._pa_array, name, skipna))
         result = type(self)(pa_result)
         return result

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1704,7 +1704,8 @@ class ArrowExtensionArray(
                 tail = pa.nulls(len(pa_array) - idx, type=pa_array.type)
                 pa_array = pa_array[:idx].combine_chunks()
 
-        pa_result = pa.array(np_func(pa_array), type=pa_array.type)
+        # error: Cannot call function of unknown type
+        pa_result = pa.array(np_func(pa_array), type=pa_array.type)  # type: ignore[operator]
 
         assert head is None or tail is None
         if head is not None:

--- a/pandas/tests/apply/test_str.py
+++ b/pandas/tests/apply/test_str.py
@@ -159,17 +159,10 @@ def test_agg_cython_table_series(series, func, expected):
         ),
     ),
 )
-def test_agg_cython_table_transform_series(request, series, func, expected):
+def test_agg_cython_table_transform_series(series, func, expected):
     # GH21224
     # test transforming functions in
     # pandas.core.base.SelectionMixin._cython_table (cumprod, cumsum)
-    if series.dtype == "string" and func == "cumsum":
-        request.applymarker(
-            pytest.mark.xfail(
-                raises=(TypeError, NotImplementedError),
-                reason="TODO(infer_string) cumsum not yet implemented for string",
-            )
-        )
     warn = None if isinstance(func, str) else FutureWarning
     with tm.assert_produces_warning(warn, match="is currently using Series.*"):
         result = series.agg(func)

--- a/pandas/tests/apply/test_str.py
+++ b/pandas/tests/apply/test_str.py
@@ -4,7 +4,10 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import WASM
+from pandas.compat import (
+    HAS_PYARROW,
+    WASM,
+)
 
 from pandas.core.dtypes.common import is_number
 
@@ -159,10 +162,17 @@ def test_agg_cython_table_series(series, func, expected):
         ),
     ),
 )
-def test_agg_cython_table_transform_series(series, func, expected):
+def test_agg_cython_table_transform_series(request, series, func, expected):
     # GH21224
     # test transforming functions in
     # pandas.core.base.SelectionMixin._cython_table (cumprod, cumsum)
+    if series.dtype == "string" and func == "cumsum" and not HAS_PYARROW:
+        request.applymarker(
+            pytest.mark.xfail(
+                raises=NotImplementedError,
+                reason="TODO(infer_string) cumsum not yet implemented for string",
+            )
+        )
     warn = None if isinstance(func, str) else FutureWarning
     with tm.assert_produces_warning(warn, match="is currently using Series.*"):
         result = series.agg(func)

--- a/pandas/tests/extension/base/accumulate.py
+++ b/pandas/tests/extension/base/accumulate.py
@@ -18,8 +18,9 @@ class BaseAccumulateTests:
     def check_accumulate(self, ser: pd.Series, op_name: str, skipna: bool):
         try:
             alt = ser.astype("float64")
-        except TypeError:
-            # e.g. Period can't be cast to float64
+        except (TypeError, ValueError):
+            # e.g. Period can't be cast to float64 (TypeError)
+            #      String can't be cast to float64 (ValueError)
             alt = ser.astype(object)
 
         result = getattr(ser, op_name)(skipna=skipna)

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -393,12 +393,11 @@ class TestArrowArray(base.ExtensionTests):
         # attribute "pyarrow_dtype"
         pa_type = ser.dtype.pyarrow_dtype  # type: ignore[union-attr]
 
-        if (
-            pa.types.is_string(pa_type)
-            or pa.types.is_binary(pa_type)
-            or pa.types.is_decimal(pa_type)
-        ):
+        if pa.types.is_binary(pa_type) or pa.types.is_decimal(pa_type):
             if op_name in ["cumsum", "cumprod", "cummax", "cummin"]:
+                return False
+        elif pa.types.is_string(pa_type):
+            if op_name == "cumprod":
                 return False
         elif pa.types.is_boolean(pa_type):
             if op_name in ["cumprod", "cummax", "cummin"]:
@@ -414,6 +413,12 @@ class TestArrowArray(base.ExtensionTests):
     def test_accumulate_series(self, data, all_numeric_accumulations, skipna, request):
         pa_type = data.dtype.pyarrow_dtype
         op_name = all_numeric_accumulations
+
+        if pa.types.is_string(pa_type) and op_name in ["cumsum", "cummin", "cummax"]:
+            # https://github.com/pandas-dev/pandas/pull/60633
+            # Doesn't fit test structure, tested in series/test_cumulative.py instead.
+            return
+
         ser = pd.Series(data)
 
         if not self._supports_accumulation(ser, op_name):

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -192,6 +192,13 @@ class TestStringArray(base.ExtensionTests):
             and op_name in ("any", "all")
         )
 
+    def _supports_accumulation(self, ser: pd.Series, op_name: str) -> bool:
+        return ser.dtype.storage == "pyarrow" and op_name in [
+            "cummin",
+            "cummax",
+            "cumsum",
+        ]
+
     def _cast_pointwise_result(self, op_name: str, obj, other, pointwise_result):
         dtype = cast(StringDtype, tm.get_dtype(obj))
         if op_name in ["__add__", "__radd__"]:

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -24,6 +24,8 @@ import pytest
 
 from pandas.compat import HAS_PYARROW
 
+from pandas.core.dtypes.base import StorageExtensionDtype
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.api.types import is_string_dtype
@@ -193,6 +195,7 @@ class TestStringArray(base.ExtensionTests):
         )
 
     def _supports_accumulation(self, ser: pd.Series, op_name: str) -> bool:
+        assert isinstance(ser.dtype, StorageExtensionDtype)
         return ser.dtype.storage == "pyarrow" and op_name in [
             "cummin",
             "cummax",

--- a/pandas/tests/series/test_cumulative.py
+++ b/pandas/tests/series/test_cumulative.py
@@ -227,3 +227,66 @@ class TestSeriesCumulativeOps:
         ser = pd.Series([pd.Timedelta(days=1), pd.Timedelta(days=3)])
         with pytest.raises(TypeError, match="cumprod not supported for Timedelta"):
             ser.cumprod()
+
+    @pytest.mark.parametrize(
+        "data, skipna, expected_data",
+        [
+            ([], True, []),
+            ([], False, []),
+            (["x", "z", "y"], True, ["x", "xz", "xzy"]),
+            (["x", "z", "y"], False, ["x", "xz", "xzy"]),
+            (["x", pd.NA, "y"], True, ["x", "x", "xy"]),
+            (["x", pd.NA, "y"], False, ["x", pd.NA, pd.NA]),
+            ([pd.NA, pd.NA, pd.NA], True, ["", "", ""]),
+            ([pd.NA, pd.NA, pd.NA], False, [pd.NA, pd.NA, pd.NA]),
+        ],
+    )
+    def test_cumsum_pyarrow_strings(
+        self, pyarrow_string_dtype, data, skipna, expected_data
+    ):
+        ser = pd.Series(data, dtype=pyarrow_string_dtype)
+        expected = pd.Series(expected_data, dtype=pyarrow_string_dtype)
+        result = ser.cumsum(skipna=skipna)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "data, op, skipna, expected_data",
+        [
+            ([], "cummin", True, []),
+            ([], "cummin", False, []),
+            (["y", "z", "x"], "cummin", True, ["y", "y", "x"]),
+            (["y", "z", "x"], "cummin", False, ["y", "y", "x"]),
+            (["y", pd.NA, "x"], "cummin", True, ["y", "y", "x"]),
+            (["y", pd.NA, "x"], "cummin", False, ["y", pd.NA, pd.NA]),
+            ([pd.NA, "y", "x"], "cummin", True, ["", "y", "x"]),
+            ([pd.NA, "y", "x"], "cummin", False, [pd.NA, pd.NA, pd.NA]),
+            ([pd.NA, pd.NA, pd.NA], "cummin", True, ["", "", ""]),
+            ([pd.NA, pd.NA, pd.NA], "cummin", False, [pd.NA, pd.NA, pd.NA]),
+            ([], "cummax", True, []),
+            ([], "cummax", False, []),
+            (["x", "z", "y"], "cummax", True, ["x", "z", "z"]),
+            (["x", "z", "y"], "cummax", False, ["x", "z", "z"]),
+            (["x", pd.NA, "y"], "cummax", True, ["x", "x", "y"]),
+            (["x", pd.NA, "y"], "cummax", False, ["x", pd.NA, pd.NA]),
+            ([pd.NA, "x", "y"], "cummax", True, ["", "x", "y"]),
+            ([pd.NA, "x", "y"], "cummax", False, [pd.NA, pd.NA, pd.NA]),
+            ([pd.NA, pd.NA, pd.NA], "cummax", True, ["", "", ""]),
+            ([pd.NA, pd.NA, pd.NA], "cummax", False, [pd.NA, pd.NA, pd.NA]),
+        ],
+    )
+    def test_cummin_cummax_pyarrow_strings(
+        self, pyarrow_string_dtype, data, op, skipna, expected_data
+    ):
+        ser = pd.Series(data, dtype=pyarrow_string_dtype)
+        if expected_data is None:
+            expected_data = ser.dtype.na_value
+        method = getattr(ser, op)
+        expected = pd.Series(expected_data, dtype=pyarrow_string_dtype)
+        result = method(skipna=skipna)
+        tm.assert_series_equal(result, expected)
+
+    def test_cumprod_pyarrow_strings(self, pyarrow_string_dtype, skipna):
+        ser = pd.Series(list("xyz"), dtype=pyarrow_string_dtype)
+        msg = f"operation 'cumprod' not supported for dtype '{ser.dtype}'"
+        with pytest.raises(TypeError, match=msg):
+            ser.cumprod(skipna=skipna)

--- a/pandas/tests/series/test_cumulative.py
+++ b/pandas/tests/series/test_cumulative.py
@@ -6,6 +6,8 @@ See also
 tests.frame.test_cumulative
 """
 
+import re
+
 import numpy as np
 import pytest
 
@@ -290,6 +292,6 @@ class TestSeriesCumulativeOps:
     def test_cumprod_pyarrow_strings(self, pyarrow_string_dtype, skipna):
         # https://github.com/pandas-dev/pandas/pull/60633
         ser = pd.Series(list("xyz"), dtype=pyarrow_string_dtype)
-        msg = f"operation 'cumprod' not supported for dtype '{ser.dtype}'"
+        msg = re.escape(f"operation 'cumprod' not supported for dtype '{ser.dtype}'")
         with pytest.raises(TypeError, match=msg):
             ser.cumprod(skipna=skipna)

--- a/pandas/tests/series/test_cumulative.py
+++ b/pandas/tests/series/test_cumulative.py
@@ -244,6 +244,7 @@ class TestSeriesCumulativeOps:
     def test_cumsum_pyarrow_strings(
         self, pyarrow_string_dtype, data, skipna, expected_data
     ):
+        # https://github.com/pandas-dev/pandas/pull/60633
         ser = pd.Series(data, dtype=pyarrow_string_dtype)
         expected = pd.Series(expected_data, dtype=pyarrow_string_dtype)
         result = ser.cumsum(skipna=skipna)
@@ -277,6 +278,7 @@ class TestSeriesCumulativeOps:
     def test_cummin_cummax_pyarrow_strings(
         self, pyarrow_string_dtype, data, op, skipna, expected_data
     ):
+        # https://github.com/pandas-dev/pandas/pull/60633
         ser = pd.Series(data, dtype=pyarrow_string_dtype)
         if expected_data is None:
             expected_data = ser.dtype.na_value
@@ -286,6 +288,7 @@ class TestSeriesCumulativeOps:
         tm.assert_series_equal(result, expected)
 
     def test_cumprod_pyarrow_strings(self, pyarrow_string_dtype, skipna):
+        # https://github.com/pandas-dev/pandas/pull/60633
         ser = pd.Series(list("xyz"), dtype=pyarrow_string_dtype)
         msg = f"operation 'cumprod' not supported for dtype '{ser.dtype}'"
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/series/test_cumulative.py
+++ b/pandas/tests/series/test_cumulative.py
@@ -231,30 +231,18 @@ class TestSeriesCumulativeOps:
             ser.cumprod()
 
     @pytest.mark.parametrize(
-        "data, skipna, expected_data",
-        [
-            ([], True, []),
-            ([], False, []),
-            (["x", "z", "y"], True, ["x", "xz", "xzy"]),
-            (["x", "z", "y"], False, ["x", "xz", "xzy"]),
-            (["x", pd.NA, "y"], True, ["x", "x", "xy"]),
-            (["x", pd.NA, "y"], False, ["x", pd.NA, pd.NA]),
-            ([pd.NA, pd.NA, pd.NA], True, ["", "", ""]),
-            ([pd.NA, pd.NA, pd.NA], False, [pd.NA, pd.NA, pd.NA]),
-        ],
-    )
-    def test_cumsum_pyarrow_strings(
-        self, pyarrow_string_dtype, data, skipna, expected_data
-    ):
-        # https://github.com/pandas-dev/pandas/pull/60633
-        ser = pd.Series(data, dtype=pyarrow_string_dtype)
-        expected = pd.Series(expected_data, dtype=pyarrow_string_dtype)
-        result = ser.cumsum(skipna=skipna)
-        tm.assert_series_equal(result, expected)
-
-    @pytest.mark.parametrize(
         "data, op, skipna, expected_data",
         [
+            ([], "cumsum", True, []),
+            ([], "cumsum", False, []),
+            (["x", "z", "y"], "cumsum", True, ["x", "xz", "xzy"]),
+            (["x", "z", "y"], "cumsum", False, ["x", "xz", "xzy"]),
+            (["x", pd.NA, "y"], "cumsum", True, ["x", "x", "xy"]),
+            (["x", pd.NA, "y"], "cumsum", False, ["x", pd.NA, pd.NA]),
+            ([pd.NA, "x", "y"], "cumsum", True, ["", "x", "xy"]),
+            ([pd.NA, "x", "y"], "cumsum", False, [pd.NA, pd.NA, pd.NA]),
+            ([pd.NA, pd.NA, pd.NA], "cumsum", True, ["", "", ""]),
+            ([pd.NA, pd.NA, pd.NA], "cumsum", False, [pd.NA, pd.NA, pd.NA]),
             ([], "cummin", True, []),
             ([], "cummin", False, []),
             (["y", "z", "x"], "cummin", True, ["y", "y", "x"]),
@@ -277,13 +265,11 @@ class TestSeriesCumulativeOps:
             ([pd.NA, pd.NA, pd.NA], "cummax", False, [pd.NA, pd.NA, pd.NA]),
         ],
     )
-    def test_cummin_cummax_pyarrow_strings(
+    def test_cum_methods_pyarrow_strings(
         self, pyarrow_string_dtype, data, op, skipna, expected_data
     ):
         # https://github.com/pandas-dev/pandas/pull/60633
         ser = pd.Series(data, dtype=pyarrow_string_dtype)
-        if expected_data is None:
-            expected_data = ser.dtype.na_value
         method = getattr(ser, op)
         expected = pd.Series(expected_data, dtype=pyarrow_string_dtype)
         result = method(skipna=skipna)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
     "meson-python>=0.13.1",
-    "meson>=1.2.1,<2",
+    "meson>=1.3.0,<2",
     "wheel",
     "Cython~=3.0.5",  # Note: sync with setup.py, environment.yml and asv.conf.json
     # Force numpy higher than 2.0rc1, so that built wheels are compatible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ parentdir_prefix = "pandas-"
 
 [tool.meson-python.args]
 setup = ['--vsenv'] # For Windows
+install = ['--skip-subprojects']
 
 [tool.cibuildwheel]
 skip = "cp36-* cp37-* cp38-* cp39-* pp* *_i686 *_ppc64le *_s390x"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
-    "meson-python>=0.13.1",
+    "meson-python>=0.14.0",
     "meson>=1.3.0,<2",
     "wheel",
     "Cython~=3.0.5",  # Note: sync with setup.py, environment.yml and asv.conf.json

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pip
 versioneer[toml]
 cython~=3.0.5
 meson[ninja]>=1.3.0
-meson-python>=0.13.1
+meson-python>=0.14.0
 pytest>=7.3.2
 pytest-cov
 pytest-xdist>=3.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@
 pip
 versioneer[toml]
 cython~=3.0.5
-meson[ninja]
-meson-python
+meson[ninja]>=1.3.0
+meson-python>=0.14.0
 pytest>=7.3.2
 pytest-cov
 pytest-xdist>=3.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@
 pip
 versioneer[toml]
 cython~=3.0.5
-meson[ninja]==1.2.1
-meson-python==0.13.1
+meson[ninja]>=1.3.0
+meson-python>=0.13.1
 pytest>=7.3.2
 pytest-cov
 pytest-xdist>=3.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@
 pip
 versioneer[toml]
 cython~=3.0.5
-meson[ninja]>=1.3.0
-meson-python>=0.14.0
+meson[ninja]
+meson-python
 pytest>=7.3.2
 pytest-cov
 pytest-xdist>=3.4.0

--- a/subprojects/nanoarrow.wrap
+++ b/subprojects/nanoarrow.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = apache-arrow-nanoarrow-0.6.0
+source_url = https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/apache-arrow-nanoarrow-0.6.0/apache-arrow-nanoarrow-0.6.0.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/nanoarrow_0.6.0-1/apache-arrow-nanoarrow-0.6.0.tar.gz
+source_filename = apache-arrow-nanoarrow-0.6.0.tar.gz
+source_hash = e4a02ac51002ad1875bf09317e70adb959005fad52b240ff59f73b970fa485d1
+wrapdb_version = 0.6.0-1
+
+[provide]
+nanoarrow = nanoarrow_dep

--- a/subprojects/nanoarrow.wrap
+++ b/subprojects/nanoarrow.wrap
@@ -1,10 +1,9 @@
 [wrap-file]
-directory = apache-arrow-nanoarrow-0.6.0
-source_url = https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/apache-arrow-nanoarrow-0.6.0/apache-arrow-nanoarrow-0.6.0.tar.gz
+directory = arrow-nanoarrow-7a808701819cb4c5f6b6ddf7c51c09389cd097ff
+source_url = https://github.com/apache/arrow-nanoarrow/archive/7a808701819cb4c5f6b6ddf7c51c09389cd097ff.tar.gz
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/nanoarrow_0.6.0-1/apache-arrow-nanoarrow-0.6.0.tar.gz
-source_filename = apache-arrow-nanoarrow-0.6.0.tar.gz
-source_hash = e4a02ac51002ad1875bf09317e70adb959005fad52b240ff59f73b970fa485d1
-wrapdb_version = 0.6.0-1
+source_filename = arrow-nanoarrow-7a808701819cb4c5f6b6ddf7c51c09389cd097ff.tar.gz
+source_hash = 1f4924dc341bc3bf357ee23320651f18c05a4e031e089b2bc09eeadee2664855
 
 [provide]
 nanoarrow = nanoarrow_dep

--- a/subprojects/nanobind.wrap
+++ b/subprojects/nanobind.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = nanobind-2.4.0
+source_url = https://github.com/wjakob/nanobind/archive/refs/tags/v2.4.0.tar.gz
+source_filename = nanobind-2.4.0.tar.gz
+source_hash = bb35deaed7efac5029ed1e33880a415638352f757d49207a8e6013fefb6c49a7
+patch_filename = nanobind_2.4.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/nanobind_2.4.0-2/get_patch
+patch_hash = cf493bda0b11ea4e8d9dd42229c3bbdd52af88cc4aedac75a1eccb102b86dd4a
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/nanobind_2.4.0-2/nanobind-2.4.0.tar.gz
+wrapdb_version = 2.4.0-2
+
+[provide]
+nanobind = nanobind_dep

--- a/subprojects/robin-map.wrap
+++ b/subprojects/robin-map.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = robin-map-1.3.0
+source_url = https://github.com/Tessil/robin-map/archive/refs/tags/v1.3.0.tar.gz
+source_filename = robin-map-1.3.0.tar.gz
+source_hash = a8424ad3b0affd4c57ed26f0f3d8a29604f0e1f2ef2089f497f614b1c94c7236
+patch_filename = robin-map_1.3.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/robin-map_1.3.0-1/get_patch
+patch_hash = 6d090f988541ffb053512607e0942cbd0dbc2a4fa0563e44ff6a37e810b8c739
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/robin-map_1.3.0-1/robin-map-1.3.0.tar.gz
+wrapdb_version = 1.3.0-1
+
+[provide]
+robin-map = robin_map_dep


### PR DESCRIPTION
This is an addon to the great work that @rhshadrach is doing in https://github.com/pandas-dev/pandas/pull/60633

Here is performance on this branch:

```python
In [1]: import pandas as pd

In [2]: import pyarrow as pa

In [3]: ser = pd.Series(["foo", "bar", "baz"] * 10000, dtype=pd.ArrowDtype(pa.string()))

In [4]: %timeit ser.cumsum()
504 ms ± 29.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [5]: %timeit ser.cummin()
1.23 ms ± 12.6 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [6]: %timeit ser.cummax()
1.23 ms ± 36.5 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

versus without nanoarrow:

```python
In [1]: import pandas as pd

In [2]: import pyarrow as pa

In [3]: ser = pd.Series(["foo", "bar", "baz"] * 10000, dtype=pd.ArrowDtype(pa.string()))

In [4]: %timeit ser.cumsum()
1.72 s ± 47.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [5]: %timeit ser.cummin()
1.49 ms ± 81.2 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [6]: %timeit ser.cummax()
1.58 ms ± 42.9 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

While they all show some improvement, cummin / cummax don't show as much. I believe this has to do with the fact that the implementations still have to access the Python runtime within a tight loop to perform comparisons. If we cared to optimize further, we could look at utf8proc