### PR TITLE
Raise a TypeError when CustumBusinessDay is passed a non-np.busdaycalendar calendar

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -4424,7 +4424,7 @@ cdef class CustomBusinessDay(BusinessDay):
     ):
         BusinessDay.__init__(self, n, normalize, offset)
         if (calendar is not None) and not isinstance(calendar, np.busdaycalendar):
-            warnings.warn("Warning: `calendar` is expected to be either an instance of `np.busdaycalendar` or `None`.")
+            raise TypeError("`calendar` is expected to be either an instance of `np.busdaycalendar` or `None`.")
         self._init_custom(weekmask, holidays, calendar)
 
     cpdef __setstate__(self, state):

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -4423,6 +4423,8 @@ cdef class CustomBusinessDay(BusinessDay):
         offset=timedelta(0),
     ):
         BusinessDay.__init__(self, n, normalize, offset)
+        if (calendar is not None) and not isinstance(calendar, np.busdaycalendar):
+            warnings.warn("Warning: `calendar` is expected to be either an instance of `np.busdaycalendar` or `None`.")
         self._init_custom(weekmask, holidays, calendar)
 
     cpdef __setstate__(self, state):


### PR DESCRIPTION
Closes #60647.

When `CustomBusinessDay()` is passed a value for the `calendar` parameter that isn't an instance of `np.busdaycalendar`, raises an error.