### PR TITLE
Clean up compiler warnings

### DIFF
--- a/pandas/_libs/byteswap.pyx
+++ b/pandas/_libs/byteswap.pyx
@@ -15,7 +15,7 @@ from libc.string cimport memcpy
 
 def read_float_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
     cdef uint32_t value
-    assert offset + sizeof(value) < len(data)
+    assert offset + <Py_ssize_t>sizeof(value) < len(data)
     cdef const void *ptr = <unsigned char*>(data) + offset
     memcpy(&value, ptr, sizeof(value))
     if byteswap:
@@ -28,7 +28,7 @@ def read_float_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
 
 def read_double_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
     cdef uint64_t value
-    assert offset + sizeof(value) < len(data)
+    assert offset + <Py_ssize_t>sizeof(value) < len(data)
     cdef const void *ptr = <unsigned char*>(data) + offset
     memcpy(&value, ptr, sizeof(value))
     if byteswap:
@@ -41,7 +41,7 @@ def read_double_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
 
 def read_uint16_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
     cdef uint16_t res
-    assert offset + sizeof(res) < len(data)
+    assert offset + <Py_ssize_t>sizeof(res) < len(data)
     memcpy(&res, <const unsigned char*>(data) + offset, sizeof(res))
     if byteswap:
         res = _byteswap2(res)
@@ -50,7 +50,7 @@ def read_uint16_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
 
 def read_uint32_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
     cdef uint32_t res
-    assert offset + sizeof(res) < len(data)
+    assert offset + <Py_ssize_t>sizeof(res) < len(data)
     memcpy(&res, <const unsigned char*>(data) + offset, sizeof(res))
     if byteswap:
         res = _byteswap4(res)
@@ -59,7 +59,7 @@ def read_uint32_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
 
 def read_uint64_with_byteswap(bytes data, Py_ssize_t offset, bint byteswap):
     cdef uint64_t res
-    assert offset + sizeof(res) < len(data)
+    assert offset + <Py_ssize_t>sizeof(res) < len(data)
     memcpy(&res, <const unsigned char*>(data) + offset, sizeof(res))
     if byteswap:
         res = _byteswap8(res)

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -34,11 +34,9 @@ static void *traced_calloc(size_t num, size_t size) {
 }
 
 static void *traced_realloc(void *old_ptr, size_t size) {
+  PyTraceMalloc_Untrack(KHASH_TRACE_DOMAIN, (uintptr_t)old_ptr);
   void *ptr = realloc(old_ptr, size);
   if (ptr != NULL) {
-    if (old_ptr != ptr) {
-      PyTraceMalloc_Untrack(KHASH_TRACE_DOMAIN, (uintptr_t)old_ptr);
-    }
     PyTraceMalloc_Track(KHASH_TRACE_DOMAIN, (uintptr_t)ptr, size);
   }
   return ptr;

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -149,18 +149,18 @@ def cast_from_unit_vectorized(
     if p:
         frac = np.round(frac, p)
 
-    try:
-        for i in range(len(values)):
+    for i in range(len(values)):
+        try:
             if base[i] == NPY_NAT:
                 out[i] = NPY_NAT
             else:
                 out[i] = <int64_t>(base[i] * m) + <int64_t>(frac[i] * m)
-    except (OverflowError, FloatingPointError) as err:
-        # FloatingPointError can be issued if we have float dtype and have
-        #  set np.errstate(over="raise")
-        raise OutOfBoundsDatetime(
-            f"cannot convert input {values[i]} with the unit '{unit}'"
-        ) from err
+        except (OverflowError, FloatingPointError) as err:
+            # FloatingPointError can be issued if we have float dtype and have
+            #  set np.errstate(over="raise")
+            raise OutOfBoundsDatetime(
+                f"cannot convert input {values[i]} with the unit '{unit}'"
+            ) from err
     return out
 
 


### PR DESCRIPTION
Not sure why these aren't getting caught in CI, but they show up locally

```
  [56/152] Compiling C object pandas/_libs/tslibs/conversion.cpython-310-x86_64-linux-gnu.so.p/meson-generated_pandas__libs_tslibs_conversion.pyx.c.o
  In function '__pyx_pf_6pandas_5_libs_6tslibs_10conversion_cast_from_unit_vectorized',
      inlined from '__pyx_pw_6pandas_5_libs_6tslibs_10conversion_1cast_from_unit_vectorized' at pandas/_libs/tslibs/conversion.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/conversion.pyx.c:23647:13:
  pandas/_libs/tslibs/conversion.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/conversion.pyx.c:3055:79: warning: '__pyx_v_i' may be used uninitialized [-Wmaybe-uninitialized]
   3054 |     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ?\
        |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   3055 |     __Pyx_GetItemInt_Fast(o, (Py_ssize_t)i, is_list, wraparound, boundscheck) :\
        |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
   3056 |     (is_list ? (PyErr_SetString(PyExc_IndexError, "list index out of range"), (PyObject*)NULL) :\
        |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   3057 |                __Pyx_GetItemInt_Generic(o, to_py_func(i))))
        |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  pandas/_libs/tslibs/conversion.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/conversion.pyx.c:24573:22: note: in expansion of macro '__Pyx_GetItemInt'
  24573 |         __pyx_t_29 = __Pyx_GetItemInt(((PyObject *)__pyx_v_values), __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(!__pyx_t_29)) __PYX_ERR(0, 162, __pyx_L23_error)
        |                      ^~~~~~~~~~~~~~~~
  pandas/_libs/tslibs/conversion.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/conversion.pyx.c: In function '__pyx_pw_6pandas_5_libs_6tslibs_10conversion_1cast_from_unit_vectorized':
  pandas/_libs/tslibs/conversion.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/conversion.pyx.c:23669:14: note: '__pyx_v_i' was declared here
  23669 |   Py_ssize_t __pyx_v_i;
[87/152] Compiling C object pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/meson-generated_pandas__libs_byteswap.pyx.c.o
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c: In function '__pyx_pf_6pandas_5_libs_8byteswap_read_float_with_byteswap':
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c:2477:61: warning: comparison of integer expressions of different signedness: 'long unsigned int' and 'Py_ssize_t' {aka 'long int'} [-Wsign-compare]
   2477 |     __pyx_t_2 = ((__pyx_v_offset + (sizeof(__pyx_v_value))) < __pyx_t_1);
        |                                                             ^
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c: In function '__pyx_pf_6pandas_5_libs_8byteswap_2read_double_with_byteswap':
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c:2747:61: warning: comparison of integer expressions of different signedness: 'long unsigned int' and 'Py_ssize_t' {aka 'long int'} [-Wsign-compare]
   2747 |     __pyx_t_2 = ((__pyx_v_offset + (sizeof(__pyx_v_value))) < __pyx_t_1);
        |                                                             ^
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c: In function '__pyx_pf_6pandas_5_libs_8byteswap_4read_uint16_with_byteswap':
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c:3015:59: warning: comparison of integer expressions of different signedness: 'long unsigned int' and 'Py_ssize_t' {aka 'long int'} [-Wsign-compare]
   3015 |     __pyx_t_2 = ((__pyx_v_offset + (sizeof(__pyx_v_res))) < __pyx_t_1);
        |                                                           ^
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c: In function '__pyx_pf_6pandas_5_libs_8byteswap_6read_uint32_with_byteswap':
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c:3265:59: warning: comparison of integer expressions of different signedness: 'long unsigned int' and 'Py_ssize_t' {aka 'long int'} [-Wsign-compare]
   3265 |     __pyx_t_2 = ((__pyx_v_offset + (sizeof(__pyx_v_res))) < __pyx_t_1);
        |                                                           ^
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c: In function '__pyx_pf_6pandas_5_libs_8byteswap_8read_uint64_with_byteswap':
  pandas/_libs/byteswap.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/byteswap.pyx.c:3515:59: warning: comparison of integer expressions of different signedness: 'long unsigned int' and 'Py_ssize_t' {aka 'long int'} [-Wsign-compare]
   3515 |     __pyx_t_2 = ((__pyx_v_offset + (sizeof(__pyx_v_res))) < __pyx_t_1);
  [99/152] Compiling C object pandas/_libs/parsers.cpython-310-x86_64-linux-gnu.so.p/meson-generated_pandas__libs_parsers.pyx.c.o
  In file included from pandas/_libs/parsers.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/parsers.pyx.c:1236:
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h: In function 'traced_realloc':
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h:40:7: warning: pointer 'old_ptr' may be used after 'realloc' [-Wuse-after-free]
     40 |       PyTraceMalloc_Untrack(KHASH_TRACE_DOMAIN, (uintptr_t)old_ptr);
        |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h:37:15: note: call to 'realloc' here
     37 |   void *ptr = realloc(old_ptr, size);
  [147/152] Compiling C object pandas/_libs/algos.cpython-310-x86_64-linux-gnu.so.p/meson-generated_pandas__libs_algos.pyx.c.o
  In file included from pandas/_libs/algos.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/algos.pyx.c:1236:
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h: In function 'traced_realloc':
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h:40:7: warning: pointer 'old_ptr' may be used after 'realloc' [-Wuse-after-free]
     40 |       PyTraceMalloc_Untrack(KHASH_TRACE_DOMAIN, (uintptr_t)old_ptr);
        |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h:37:15: note: call to 'realloc' here
     37 |   void *ptr = realloc(old_ptr, size);
        |               ^~~~~~~~~~~~~~~~~~~~~~
  [149/152] Compiling C object pandas/_libs/hashtable.cpython-310-x86_64-linux-gnu.so.p/meson-generated_pandas__libs_hashtable.pyx.c.o
  In file included from pandas/_libs/hashtable.cpython-310-x86_64-linux-gnu.so.p/pandas/_libs/hashtable.pyx.c:1232:
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h: In function 'traced_realloc':
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h:40:7: warning: pointer 'old_ptr' may be used after 'realloc' [-Wuse-after-free]
     40 |       PyTraceMalloc_Untrack(KHASH_TRACE_DOMAIN, (uintptr_t)old_ptr);
        |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../pandas/_libs/include/pandas/vendored/klib/khash_python.h:37:15: note: call to 'realloc' here
     37 |   void *ptr = realloc(old_ptr, size);
        |               ^~~~~~~~~~~~~~~~~~~~~~
```

There's an additional one about some memory view code not being used which probably has to do with Cython, but I haven't looked too far into that