### PR TITLE
Relax meson pins in CI and Fix Missed Warnings

### DIFF
--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1, <0.16.0
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1
+  - meson-python>=0.13.1, <0.16.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.2.1
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -8,8 +8,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.2.1
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -9,7 +9,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1
+  - meson-python>=0.13.1, <0.16.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -9,7 +9,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1, <0.16.0
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -7,7 +7,7 @@ dependencies:
   # build dependencies
   - versioneer
   - meson>=1.2.1
-  - meson-python>=0.13.1, <0.16.0
+  - meson-python>=0.13.1
   - cython>=0.29.33
 
   # test dependencies

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -7,7 +7,7 @@ dependencies:
   # build dependencies
   - versioneer
   - meson>=1.2.1
-  - meson-python>=0.13.1
+  - meson-python>=0.13.1, <0.16.0
   - cython>=0.29.33
 
   # test dependencies

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -6,8 +6,8 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.2.1
+  - meson-python>=0.13.1
   - cython>=0.29.33
 
   # test dependencies

--- a/ci/deps/actions-311-pyarrownightly.yaml
+++ b/ci/deps/actions-311-pyarrownightly.yaml
@@ -6,9 +6,9 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson=1.2.1
+  - meson>=1.2.1
   - cython>=0.29.33
-  - meson-python=0.13.1
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-pyarrownightly.yaml
+++ b/ci/deps/actions-311-pyarrownightly.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - meson>=1.2.1
   - cython>=0.29.33
-  - meson-python>=0.13.1, <0.16.0
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311-pyarrownightly.yaml
+++ b/ci/deps/actions-311-pyarrownightly.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - meson>=1.2.1
   - cython>=0.29.33
-  - meson-python>=0.13.1
+  - meson-python>=0.13.1, <0.16.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1, <0.16.0
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1
+  - meson-python>=0.13.1, <0.16.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.2.1
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1, <0.16.0
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -8,7 +8,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1
+  - meson-python>=0.13.1, <0.16.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.2.1
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-pypy-39.yaml
+++ b/ci/deps/actions-pypy-39.yaml
@@ -11,7 +11,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1
+  - meson-python>=0.13.1, <0.16.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-pypy-39.yaml
+++ b/ci/deps/actions-pypy-39.yaml
@@ -11,7 +11,7 @@ dependencies:
   - versioneer
   - cython>=0.29.33
   - meson>=1.2.1
-  - meson-python>=0.13.1, <0.16.0
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/ci/deps/actions-pypy-39.yaml
+++ b/ci/deps/actions-pypy-39.yaml
@@ -10,8 +10,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=0.29.33
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.2.1
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - versioneer
   - cython~=3.0.5
   - meson>=1.2.1
-  - meson-python>=0.13.1, <0.16.0
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython~=3.0.5
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.2.1
+  - meson-python>=0.13.1
 
   # test dependencies
   - pytest>=7.3.2

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - versioneer
   - cython~=3.0.5
   - meson>=1.2.1
-  - meson-python>=0.13.1
+  - meson-python>=0.13.1, <0.16.0
 
   # test dependencies
   - pytest>=7.3.2

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ project_args = [
     # ignore some MSVC warnings for narrowing
     '/wd4244',
     '/wd4267',
+    '/wd4551',
 ]
 
 c_args = cc.get_supported_arguments(project_args)

--- a/meson.build
+++ b/meson.build
@@ -15,19 +15,25 @@ py = import('python').find_installation(pure: false)
 tempita = files('generate_pxi.py')
 versioneer = files('generate_version.py')
 
+cc = meson.get_compiler('c')
+cp = meson.get_compiler('cpp')
 
-add_project_arguments('-DNPY_NO_DEPRECATED_API=0', language: 'c')
-add_project_arguments('-DNPY_NO_DEPRECATED_API=0', language: 'cpp')
-
-# Allow supporting older numpys than the version compiled against
-# Set the define to the min supported version of numpy for pandas
-# e.g. right now this is targeting numpy 1.21+
-add_project_arguments('-DNPY_TARGET_VERSION=NPY_1_21_API_VERSION', language: 'c')
-add_project_arguments(
+project_args = [
+    '-DNPY_NO_DEPRECATED_API=0',
+    # Allow supporting older numpys than the version compiled against
+    # Set the define to the min supported version of numpy for pandas
+    # e.g. right now this is targeting numpy 1.21+
     '-DNPY_TARGET_VERSION=NPY_1_21_API_VERSION',
-    language: 'cpp',
-)
+    # ignore some MSVC warnings for narrowing
+    '/wd4244',
+    '/wd4267',
+]
 
+c_args = cc.get_supported_arguments(project_args)
+cpp_args = cp.get_supported_arguments(project_args)
+
+add_project_arguments(c_args, language: 'c')
+add_project_arguments(cpp_args, language: 'cpp')
 
 if fs.exists('_version_meson.py')
     py.install_sources('_version_meson.py', subdir: 'pandas')

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -114,7 +114,15 @@ cdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna, const uint8
         result_counts[i] = table.vals[k]
 
     if na_counter > 0:
-        assert n > 0  # val will be uninitialized without this
+        # gcc-11.4 on ubuntu 22.04 cannot see that val won't be unassigned
+        # when we make it into this branch
+        assert n > 0
+        {{if dtype == 'object'}}
+        val = values[n - 1]
+        {{else}}
+        val = {{to_c_type}}(values[n - 1])
+        {{endif}}
+
         result_counts[table.size] = na_counter
         result_keys.append(val)
 

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -114,6 +114,7 @@ cdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna, const uint8
         result_counts[i] = table.vals[k]
 
     if na_counter > 0:
+        assert n > 0  # val will be uninitialized without this
         result_counts[table.size] = na_counter
         result_keys.append(val)
 

--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -86,7 +86,8 @@ libs_sources = {
     },
     'lib': {
         'sources': ['lib.pyx', 'src/parser/tokenizer.c'],
-        'c_args': ['-Wno-unused-function'],  # cython issue 6603
+        # cython issue 6603
+        'c_args': cc.get_supported_arguments(['-Wno-unused-function']),
     },
     'missing': {'sources': ['missing.pyx']},
     'pandas_datetime': {
@@ -122,7 +123,8 @@ libs_sources = {
     'properties': {'sources': ['properties.pyx']},
     'reshape': {
         'sources': ['reshape.pyx'],
-        'c_args': ['-Wno-unused-function'],  # cython issue 6603
+        # cython issue 6603
+        'c_args': cc.get_supported_arguments(['-Wno-unused-function']),
     },
     'sas': {'sources': ['sas.pyx']},
     'byteswap': {'sources': ['byteswap.pyx']},

--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -84,7 +84,10 @@ libs_sources = {
         'sources': ['join.pyx', _khash_primitive_helper],
         'deps': _khash_primitive_helper_dep,
     },
-    'lib': {'sources': ['lib.pyx', 'src/parser/tokenizer.c']},
+    'lib': {
+        'sources': ['lib.pyx', 'src/parser/tokenizer.c'],
+        'c_args': ['-Wno-unused-function'],  # cython issue 6603
+    },
     'missing': {'sources': ['missing.pyx']},
     'pandas_datetime': {
         'sources': [
@@ -117,7 +120,10 @@ libs_sources = {
     'ops': {'sources': ['ops.pyx']},
     'ops_dispatch': {'sources': ['ops_dispatch.pyx']},
     'properties': {'sources': ['properties.pyx']},
-    'reshape': {'sources': ['reshape.pyx']},
+    'reshape': {
+        'sources': ['reshape.pyx'],
+        'c_args': ['-Wno-unused-function'],  # cython issue 6603
+    },
     'sas': {'sources': ['sas.pyx']},
     'byteswap': {'sources': ['byteswap.pyx']},
     'sparse': {'sources': ['sparse.pyx', _sparse_op_helper]},
@@ -142,6 +148,7 @@ foreach ext_name, ext_dict : libs_sources
         cython_args: cython_args,
         include_directories: [inc_np, inc_pd],
         dependencies: ext_dict.get('deps', ''),
+        c_args: ext_dict.get('c_args', []),
         subdir: 'pandas/_libs',
         install: true,
     )

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -6,6 +6,7 @@ from collections.abc import (
     Sequence,
 )
 from functools import partial
+import pathlib
 import re
 from typing import (
     TYPE_CHECKING,
@@ -71,7 +72,9 @@ class StylerRenderer:
     Base class to process rendering a Styler with a specified jinja2 template.
     """
 
-    loader = jinja2.PackageLoader("pandas", "io/formats/templates")
+    thisdir = pathlib.Path(__file__).parent.resolve()
+    template_dir = thisdir / "templates"
+    loader = jinja2.FileSystemLoader(template_dir)
     env = jinja2.Environment(loader=loader, trim_blocks=True)
     template_html = env.get_template("html.tpl")
     template_html_table = env.get_template("html_table.tpl")

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -1,3 +1,4 @@
+import pathlib
 from textwrap import (
     dedent,
     indent,
@@ -18,7 +19,9 @@ from pandas.io.formats.style import Styler
 
 @pytest.fixture
 def env():
-    loader = jinja2.PackageLoader("pandas", "io/formats/templates")
+    project_dir = pathlib.Path(__file__).parent.parent.parent.parent.parent.resolve()
+    template_dir = project_dir / "io" / "formats" / "templates"
+    loader = jinja2.FileSystemLoader(template_dir)
     env = jinja2.Environment(loader=loader, trim_blocks=True)
     return env
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
     "meson-python>=0.13.1",
-    "meson>=1.2.1,<2",
+    "meson>=1.2.1",
     "wheel",
     "Cython~=3.0.5",  # Note: sync with setup.py, environment.yml and asv.conf.json
     # Force numpy higher than 2.0rc1, so that built wheels are compatible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ setup = ['--vsenv'] # For Windows
 [tool.cibuildwheel]
 skip = "cp36-* cp37-* cp38-* cp39-* pp* *_i686 *_ppc64le *_s390x"
 build-verbosity = "3"
-environment = {LDFLAGS="-Wl,--strip-all"}
 test-requires = "hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0"
 test-command = """
   PANDAS_CI='1' python -c 'import pandas as pd; \
@@ -158,6 +157,12 @@ test-command = """
   """
 free-threaded-support = true
 before-build = "PACKAGE_DIR={package} bash {package}/scripts/cibw_before_build.sh"
+
+[tool.cibuildwheel.macos]
+environment = {LDFLAGS="-Wl,--strip-all"}
+
+[tool.cibuildwheel.linux]
+environment = {LDFLAGS="-Wl,--strip-all"}
 
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel && bash {package}/scripts/cibw_before_build_windows.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
-    "meson-python>=0.13.1",
+    "meson-python>=0.13.1, <0.16.0",
     "meson>=1.2.1",
     "wheel",
     "Cython~=3.0.5",  # Note: sync with setup.py, environment.yml and asv.conf.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
-    "meson-python>=0.13.1, <0.16.0",
+    "meson-python>=0.13.1",
     "meson>=1.2.1",
     "wheel",
     "Cython~=3.0.5",  # Note: sync with setup.py, environment.yml and asv.conf.json

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@
 pip
 versioneer[toml]
 cython~=3.0.5
-meson[ninja]==1.2.1
-meson-python==0.13.1
+meson[ninja]>=1.2.1
+meson-python>=0.13.1
 pytest>=7.3.2
 pytest-cov
 pytest-xdist>=3.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pip
 versioneer[toml]
 cython~=3.0.5
 meson[ninja]>=1.2.1
-meson-python>=0.13.1, <0.16.0
+meson-python>=0.13.1
 pytest>=7.3.2
 pytest-cov
 pytest-xdist>=3.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pip
 versioneer[toml]
 cython~=3.0.5
 meson[ninja]>=1.2.1
-meson-python>=0.13.1
+meson-python>=0.13.1, <0.16.0
 pytest>=7.3.2
 pytest-cov
 pytest-xdist>=3.4.0


### PR DESCRIPTION
Back in https://github.com/pandas-dev/pandas/pull/60089 we relaxed the meson pin in our pyproject, but all of our CI still hard codes the minimum version. This updates it to treat the meson dependencies the same way as Cython, i.e. newer versions are used in CI