### PR TITLE
Remove editable installs from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             if pip show pandas 1>/dev/null; then
                 pip uninstall -y pandas
             fi
-            python -m pip install --no-build-isolation -ve . -Csetup-args="--werror"
+            python -m pip install --no-build-isolation -v . -Csetup-args="--werror"
             PATH=$HOME/miniconda3/envs/pandas-dev/bin:$HOME/miniconda3/condabin:$PATH
             ci/run_tests.sh
   test-linux-musl:
@@ -56,7 +56,7 @@ jobs:
             . ~/virtualenvs/pandas-dev/bin/activate
             python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.13.1 meson[ninja]==1.2.1
             python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
-            python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
+            python -m pip install --no-cache-dir --no-build-isolation -v . -Csetup-args="--werror"
             python -m pip list --no-cache-dir
             export PANDAS_CI=1
             python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml

--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -1,9 +1,5 @@
 name: Build pandas
 description: Rebuilds the C extensions and installs pandas
-inputs:
-  editable:
-    description: Whether to build pandas in editable mode (default true)
-    default: true
 runs:
   using: composite
   steps:
@@ -24,11 +20,6 @@ runs:
 
     - name: Build Pandas
       run: |
-        if [[ ${{ inputs.editable }} == "true" ]]; then
-          pip install -e . --no-build-isolation -v --no-deps \
-            -Csetup-args="--werror"
-        else
           pip install . --no-build-isolation -v --no-deps \
             -Csetup-args="--werror"
-        fi
       shell: bash -el {0}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -43,14 +43,8 @@ jobs:
     - name: Build Pandas
       id: build
       uses: ./.github/actions/build_pandas
-      with:
-        editable: false
 
     # The following checks are independent of each other and should still be run if one fails
-
-    # TODO: The doctests have to be run first right now, since the Cython doctests only work
-    # with pandas installed in non-editable mode
-    # This can be removed once pytest-cython doesn't require C extensions to be installed inplace
 
     - name: Extra installs
       # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
@@ -60,12 +54,9 @@ jobs:
       run: cd ci && ./code_checks.sh doctests
       if: ${{ steps.build.outcome == 'success' && always() }}
 
-    - name: Install pandas in editable mode
-      id: build-editable
+    - name: Install pandas
       if: ${{ steps.build.outcome == 'success' && always() }}
       uses: ./.github/actions/build_pandas
-      with:
-        editable: true
 
     - name: Check for no warnings when building single-page docs
       run: ci/code_checks.sh single-docs

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -236,7 +236,7 @@ jobs:
           python -m pip install --no-cache-dir -U pip wheel setuptools meson[ninja]==1.2.1 meson-python==0.13.1
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
-          python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
+          python -m pip install --no-cache-dir --no-build-isolation -v . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
           export PANDAS_CI=1
           python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
@@ -274,7 +274,7 @@ jobs:
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel setuptools meson-python==0.13.1 meson[ninja]==1.2.1
           python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=7.3.2 pytest-xdist>=3.4.0 hypothesis>=6.84.0
-          python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
+          python -m pip install --no-cache-dir --no-build-isolation -v . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
 
       - name: Run Tests
@@ -348,7 +348,7 @@ jobs:
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil tzdata cython hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
-          python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
+          python -m pip install -v . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
           python -m pip list
 
       - name: Run Tests
@@ -393,7 +393,7 @@ jobs:
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
           python -m pip install versioneer[toml]
           python -m pip install python-dateutil pytz tzdata hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
-          python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
+          python -m pip install -v . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
           python -m pip list
 
       - name: Run Tests


### PR DESCRIPTION
The meson-python team does not suggest using editable installs in a CI environment. See also https://github.com/mesonbuild/meson-python/issues/716#issuecomment-2580286829