### PR TITLE
ENH: Expose NoDefault in pandas.api.extensions

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -30,7 +30,7 @@ Other enhancements
 ^^^^^^^^^^^^^^^^^^
 - :class:`pandas.api.typing.FrozenList` is available for typing the outputs of :attr:`MultiIndex.names`, :attr:`MultiIndex.codes` and :attr:`MultiIndex.levels` (:issue:`58237`)
 - :class:`pandas.api.typing.SASReader` is available for typing the output of :func:`read_sas` (:issue:`55689`)
-- :class:`pandas.api.extensions.NoDefault` is available for typing ``no_default``
+- :class:`pandas.api.typing.NoDefault` is available for typing ``no_default``
 - :func:`DataFrame.to_excel` now raises an ``UserWarning`` when the character count in a cell exceeds Excel's limitation of 32767 characters (:issue:`56954`)
 - :func:`pandas.merge` now validates the ``how`` parameter input (merge type) (:issue:`59435`)
 - :func:`read_spss` now supports kwargs to be passed to pyreadstat (:issue:`56356`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -30,6 +30,7 @@ Other enhancements
 ^^^^^^^^^^^^^^^^^^
 - :class:`pandas.api.typing.FrozenList` is available for typing the outputs of :attr:`MultiIndex.names`, :attr:`MultiIndex.codes` and :attr:`MultiIndex.levels` (:issue:`58237`)
 - :class:`pandas.api.typing.SASReader` is available for typing the output of :func:`read_sas` (:issue:`55689`)
+- :class:`pandas.api.extensions.NoDefault` is available for typing ``no_default``
 - :func:`DataFrame.to_excel` now raises an ``UserWarning`` when the character count in a cell exceeds Excel's limitation of 32767 characters (:issue:`56954`)
 - :func:`pandas.merge` now validates the ``how`` parameter input (merge type) (:issue:`59435`)
 - :func:`read_spss` now supports kwargs to be passed to pyreadstat (:issue:`56356`)

--- a/pandas/api/extensions/__init__.py
+++ b/pandas/api/extensions/__init__.py
@@ -2,7 +2,10 @@
 Public API for extending pandas objects.
 """
 
-from pandas._libs.lib import no_default
+from pandas._libs.lib import (
+    NoDefault,
+    no_default,
+)
 
 from pandas.core.dtypes.base import (
     ExtensionDtype,
@@ -24,6 +27,7 @@ __all__ = [
     "ExtensionArray",
     "ExtensionDtype",
     "ExtensionScalarOpsMixin",
+    "NoDefault",
     "no_default",
     "register_dataframe_accessor",
     "register_extension_dtype",

--- a/pandas/api/extensions/__init__.py
+++ b/pandas/api/extensions/__init__.py
@@ -2,10 +2,7 @@
 Public API for extending pandas objects.
 """
 
-from pandas._libs.lib import (
-    NoDefault,
-    no_default,
-)
+from pandas._libs.lib import no_default
 
 from pandas.core.dtypes.base import (
     ExtensionDtype,
@@ -27,7 +24,6 @@ __all__ = [
     "ExtensionArray",
     "ExtensionDtype",
     "ExtensionScalarOpsMixin",
-    "NoDefault",
     "no_default",
     "register_dataframe_accessor",
     "register_extension_dtype",

--- a/pandas/api/typing/__init__.py
+++ b/pandas/api/typing/__init__.py
@@ -3,6 +3,7 @@ Public API classes that store intermediate results useful for type-hinting.
 """
 
 from pandas._libs import NaTType
+from pandas._libs.lib import NoDefault
 from pandas._libs.missing import NAType
 
 from pandas.core.groupby import (
@@ -44,6 +45,7 @@ __all__ = [
     "JsonReader",
     "NAType",
     "NaTType",
+    "NoDefault",
     "PeriodIndexResamplerGroupby",
     "Resampler",
     "Rolling",

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -261,6 +261,7 @@ class TestApi(Base):
         "JsonReader",
         "NaTType",
         "NAType",
+        "NoDefault",
         "PeriodIndexResamplerGroupby",
         "Resampler",
         "Rolling",
@@ -328,7 +329,6 @@ class TestApi(Base):
     ]
     allowed_api_extensions = [
         "no_default",
-        "NoDefault",
         "ExtensionDtype",
         "register_extension_dtype",
         "register_dataframe_accessor",

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -328,6 +328,7 @@ class TestApi(Base):
     ]
     allowed_api_extensions = [
         "no_default",
+        "NoDefault",
         "ExtensionDtype",
         "register_extension_dtype",
         "register_dataframe_accessor",


### PR DESCRIPTION
- [ ] closes #60488
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

From the original issue -
```
No type is provided for the pandas.api.extensions.no_default sentinel.

This is a problem when trying to type annotate functions or methods that forward arguments into Pandas functions that accept the no_default sentinel.
```