### PR TITLE
ENH: Format `decimal.Decimal` as full precision strings in `.to_json(...)`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -51,6 +51,7 @@ Other enhancements
 - :meth:`DataFrame.ewm` now allows ``adjust=False`` when ``times`` is provided (:issue:`54328`)
 - :meth:`DataFrame.fillna` and :meth:`Series.fillna` can now accept ``value=None``; for non-object dtype the corresponding NA value will be used (:issue:`57723`)
 - :meth:`DataFrame.pivot_table` and :func:`pivot_table` now allow the passing of keyword arguments to ``aggfunc`` through ``**kwargs`` (:issue:`57884`)
+- :meth:`DataFrame.to_json` now encodes ``Decimal`` as strings instead of floats (:issue:`60698`)
 - :meth:`Series.cummin` and :meth:`Series.cummax` now supports :class:`CategoricalDtype` (:issue:`52335`)
 - :meth:`Series.plot` now correctly handle the ``ylabel`` parameter for pie charts, allowing for explicit control over the y-axis label (:issue:`58239`)
 - :meth:`DataFrame.plot.scatter` argument ``c`` now accepts a column of strings, where rows with the same string are colored identically (:issue:`16827` and :issue:`16485`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -376,25 +376,21 @@ static char *PyTimeToJSON(JSOBJ _obj, JSONTypeContext *tc, size_t *outLen) {
 static char *PyDecimalToUTF8Callback(JSOBJ _obj, JSONTypeContext *tc,
                                      size_t *len) {
   PyObject *obj = (PyObject *)_obj;
-  PyObject *str = PyObject_Str(obj);
+  PyObject *format_spec = PyUnicode_FromStringAndSize("f", 1);
+  PyObject *str = PyObject_Format(obj, format_spec);
+  Py_DECREF(format_spec);
+
   if (str == NULL) {
-    *len = 0;
-    if (!PyErr_Occurred()) {
-      PyErr_SetString(PyExc_ValueError, "Failed to convert decimal");
-    }
     ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
     return NULL;
-  }
-  if (PyUnicode_Check(str)) {
-    PyObject *tmp = str;
-    str = PyUnicode_AsUTF8String(str);
-    Py_DECREF(tmp);
   }
 
   GET_TC(tc)->newObj = str;
 
-  *len = PyBytes_GET_SIZE(str);
-  char *outValue = PyBytes_AS_STRING(str);
+  Py_ssize_t s_len;
+  char *outValue = (char *)PyUnicode_AsUTF8AndSize(str, &s_len);
+  *len = s_len;
+
   return outValue;
 }
 

--- a/pandas/tests/io/json/test_json_table_schema_ext_dtype.py
+++ b/pandas/tests/io/json/test_json_table_schema_ext_dtype.py
@@ -159,7 +159,7 @@ class TestTableOrient:
         expected = OrderedDict(
             [
                 ("schema", schema),
-                ("data", [OrderedDict([("id", 0), ("a", 10.0)])]),
+                ("data", [OrderedDict([("id", 0), ("a", "10")])]),
             ]
         )
 
@@ -245,7 +245,7 @@ class TestTableOrient:
                 [
                     ("idx", 0),
                     ("A", "2021-10-10T00:00:00.000"),
-                    ("B", 10.0),
+                    ("B", "10"),
                     ("C", "pandas"),
                     ("D", 10),
                 ]

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1,6 +1,5 @@
 import datetime
 from datetime import timedelta
-from decimal import Decimal
 from io import StringIO
 import json
 import os
@@ -2025,12 +2024,8 @@ class TestPandasContainer:
             timeout -= 0.1
             assert timeout > 0, "Timed out waiting for file to appear on moto"
 
-    def test_json_pandas_nulls(self, nulls_fixture, request):
+    def test_json_pandas_nulls(self, nulls_fixture):
         # GH 31615
-        if isinstance(nulls_fixture, Decimal):
-            mark = pytest.mark.xfail(reason="not implemented")
-            request.applymarker(mark)
-
         expected_warning = None
         msg = (
             "The default 'epoch' date format is deprecated and will be removed "

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -57,56 +57,56 @@ class TestUltraJSONTests:
         sut = decimal.Decimal("1337.1337")
         encoded = ujson.ujson_dumps(sut, double_precision=15)
         decoded = ujson.ujson_loads(encoded)
-        assert decoded == 1337.1337
+        assert decoded == "1337.1337"
 
         sut = decimal.Decimal("0.95")
         encoded = ujson.ujson_dumps(sut, double_precision=1)
-        assert encoded == "1.0"
+        assert encoded == '"0.95"'
 
         decoded = ujson.ujson_loads(encoded)
-        assert decoded == 1.0
+        assert decoded == "0.95"
 
         sut = decimal.Decimal("0.94")
         encoded = ujson.ujson_dumps(sut, double_precision=1)
-        assert encoded == "0.9"
+        assert encoded == '"0.94"'
 
         decoded = ujson.ujson_loads(encoded)
-        assert decoded == 0.9
+        assert decoded == "0.94"
 
         sut = decimal.Decimal("1.95")
         encoded = ujson.ujson_dumps(sut, double_precision=1)
-        assert encoded == "2.0"
+        assert encoded == '"1.95"'
 
         decoded = ujson.ujson_loads(encoded)
-        assert decoded == 2.0
+        assert decoded == "1.95"
 
         sut = decimal.Decimal("-1.95")
         encoded = ujson.ujson_dumps(sut, double_precision=1)
-        assert encoded == "-2.0"
+        assert encoded == '"-1.95"'
 
         decoded = ujson.ujson_loads(encoded)
-        assert decoded == -2.0
+        assert decoded == "-1.95"
 
         sut = decimal.Decimal("0.995")
         encoded = ujson.ujson_dumps(sut, double_precision=2)
-        assert encoded == "1.0"
+        assert encoded == '"0.995"'
 
         decoded = ujson.ujson_loads(encoded)
-        assert decoded == 1.0
+        assert decoded == "0.995"
 
         sut = decimal.Decimal("0.9995")
         encoded = ujson.ujson_dumps(sut, double_precision=3)
-        assert encoded == "1.0"
+        assert encoded == '"0.9995"'
 
         decoded = ujson.ujson_loads(encoded)
-        assert decoded == 1.0
+        assert decoded == "0.9995"
 
         sut = decimal.Decimal("0.99999999999999944")
         encoded = ujson.ujson_dumps(sut, double_precision=15)
-        assert encoded == "1.0"
+        assert encoded == '"0.99999999999999944"'
 
         decoded = ujson.ujson_loads(encoded)
-        assert decoded == 1.0
+        assert decoded == "0.99999999999999944"
 
     @pytest.mark.parametrize("ensure_ascii", [True, False])
     def test_encode_string_conversion(self, ensure_ascii):


### PR DESCRIPTION
Encodes `decimal.Decimal` as full precision strings in `.to_json(...)`. The old behaviour is to convert `decimal.Decimal` to floats potentially loosing precision.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
