### PR TITLE
TST(string dtype): Resolve xfail in groupby.test_size

### DIFF
--- a/pandas/tests/groupby/methods/test_size.py
+++ b/pandas/tests/groupby/methods/test_size.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_string_dtype
-
 from pandas import (
     DataFrame,
     Index,
@@ -76,18 +74,16 @@ def test_size_series_masked_type_returns_Int64(dtype):
     tm.assert_series_equal(result, expected)
 
 
-# TODO(infer_string) in case the column is object dtype, it should preserve that dtype
-# for the result's index
-@pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string)", strict=False)
-def test_size_strings(any_string_dtype):
+def test_size_strings(any_string_dtype, using_infer_string):
     # GH#55627
     dtype = any_string_dtype
     df = DataFrame({"a": ["a", "a", "b"], "b": "a"}, dtype=dtype)
     result = df.groupby("a")["b"].size()
     exp_dtype = "Int64" if dtype == "string[pyarrow]" else "int64"
+    exp_index_dtype = "str" if using_infer_string and dtype == "object" else dtype
     expected = Series(
         [2, 1],
-        index=Index(["a", "b"], name="a", dtype=dtype),
+        index=Index(["a", "b"], name="a", dtype=exp_index_dtype),
         name="b",
         dtype=exp_dtype,
     )


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

groupby does inference on the group labels across the board.

```python
df = pd.DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]}, dtype="object")
gb = df.groupby("a")
result = gb.sum()
print(result.index.dtype)
# int64
```

While I agree long-term I'd prefer to preserve object dytpe, I do not think we should be changing this at this point.