### PR TITLE
[backport 2.3.x] String dtype: disallow specifying the 'str' dtype with storage in [..] in string alias (#60661)

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2242,7 +2242,7 @@ class ArrowDtype(StorageExtensionDtype):
             )
         if not string.endswith("[pyarrow]"):
             raise TypeError(f"'{string}' must end with '[pyarrow]'")
-        if string == "string[pyarrow]":
+        if string in ("string[pyarrow]", "str[pyarrow]"):
             # Ensure Registry.find skips ArrowDtype to use StringDtype instead
             raise TypeError("string[pyarrow] should be constructed by StringDtype")
 

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -835,3 +835,30 @@ def test_pandas_dtype_string_dtypes(string_storage):
     with pd.option_context("string_storage", string_storage):
         result = pandas_dtype("string")
     assert result == pd.StringDtype(string_storage, na_value=pd.NA)
+
+
+def test_pandas_dtype_string_dtype_alias_with_storage():
+    with pytest.raises(TypeError, match="not understood"):
+        pandas_dtype("str[python]")
+
+    with pytest.raises(TypeError, match="not understood"):
+        pandas_dtype("str[pyarrow]")
+
+    result = pandas_dtype("string[python]")
+    assert result == pd.StringDtype("python", na_value=pd.NA)
+
+    if HAS_PYARROW:
+        result = pandas_dtype("string[pyarrow]")
+        assert result == pd.StringDtype("pyarrow", na_value=pd.NA)
+    else:
+        with pytest.raises(
+            ImportError, match="required for PyArrow backed StringArray"
+        ):
+            pandas_dtype("string[pyarrow]")
+
+
+@td.skip_if_installed("pyarrow")
+def test_construct_from_string_without_pyarrow_installed():
+    # GH 57928
+    with pytest.raises(ImportError, match="pyarrow>=10.0.1 is required"):
+        pd.Series([-1.5, 0.2, None], dtype="float32[pyarrow]")

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -855,10 +855,3 @@ def test_pandas_dtype_string_dtype_alias_with_storage():
             ImportError, match="required for PyArrow backed StringArray"
         ):
             pandas_dtype("string[pyarrow]")
-
-
-@td.skip_if_installed("pyarrow")
-def test_construct_from_string_without_pyarrow_installed():
-    # GH 57928
-    with pytest.raises(ImportError, match="pyarrow>=10.0.1 is required"):
-        pd.Series([-1.5, 0.2, None], dtype="float32[pyarrow]")


### PR DESCRIPTION
(cherry picked from commit 7415aca37159a99f8f99d93a1908070ddf36178c)

Backport of https://github.com/pandas-dev/pandas/pull/60661