### PR TITLE
DOC: Clarify deprecation warning for iloc

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -160,7 +160,7 @@ class IndexingMixin:
 
         .. versionchanged:: 3.0
 
-           Returning a tuple from a callable is deprecated.
+           Callables which return a tuple are deprecated as input.
 
         ``.iloc[]`` is primarily integer position based (from ``0`` to
         ``length-1`` of the axis), but may also be used with a boolean


### PR DESCRIPTION
Changed the wording of the deprecation warning to make clearer what exactly is deprecated.

The previous formulation was confusing (see e.g. [here](https://www.reddit.com/r/learnprogramming/comments/1c6a20o/is_pandas_iloc_being_depreciated/), even though the change from the "Deprecated since..." warning in 2.2 to "Changed in version 3.0" makes it slightly better). It is not "returning a tuple" which is deprecated but to use such a callable as an input/index.