### PR TITLE
Miscellaneous updates for Pyodide 0.27: bump WASM CI and revise Arrow compatibility note

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -430,20 +430,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python for Pyodide
+      - name: Set up Python for pyodide-build
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11.3'
+          python-version: '3.12'
 
       - name: Set up Emscripten toolchain
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: '3.1.46'
+          version: '3.1.58'
           actions-cache-folder: emsdk-cache
 
       - name: Install pyodide-build
-        run: pip install "pyodide-build==0.25.1"
+        run: pip install "pyodide-build>=0.29.2"
 
       - name: Build pandas for Pyodide
         run: |
@@ -452,7 +452,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Set up Pyodide virtual environment
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -455,7 +455,10 @@ jobs:
           node-version: '20'
 
       - name: Set up Pyodide virtual environment
+        env:
+          pyodide-version: '0.27.1'
         run: |
+          pyodide xbuildenv install ${{ env.pyodide-version }}
           pyodide venv .venv-pyodide
           source .venv-pyodide/bin/activate
           pip install dist/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ doc/source/savefig/
 # Interactive terminal generated files #
 ########################################
 .jupyterlite.doit.db
+
+# Pyodide/WASM related files #
+##############################
+/.pyodide-xbuildenv-*

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -9,7 +9,6 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import WASM
 from pandas.compat.numpy import np_version_gte1p24
 from pandas.errors import IndexingError
 
@@ -1449,7 +1448,6 @@ class TestCoercionFloat64(CoercionTest):
                         np_version_gte1p24
                         and os.environ.get("NPY_PROMOTION_STATE", "weak") != "weak"
                     )
-                    or WASM
                 ),
                 reason="np.float32(1.1) ends up as 1.100000023841858, so "
                 "np_can_hold_element raises and we cast to float64",

--- a/web/pandas/pdeps/0010-required-pyarrow-dependency.md
+++ b/web/pandas/pdeps/0010-required-pyarrow-dependency.md
@@ -185,7 +185,6 @@ Additionally, if a user is installing pandas in an environment where wheels are 
 the user will need to also build Arrow C++ and related dependencies when installing from source. These environments include
 
 - Alpine linux (commonly used as a base for Docker containers)
-- WASM (pyodide and pyscript)
 - Python development versions
 
 Lastly, pandas development and releases will need to be mindful of PyArrow's development and release cadance. For example when


### PR DESCRIPTION
- [ ] ~closes #xxxx (Replace xxxx with the GitHub issue number)~
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] ~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~
- [ ] ~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~

I noticed via #60747 that the Pyodide CI job for `pandas` in `unit-tests.yml` is still using a version of Pyodide[^1] that is quite old by this point; we no longer support it, as we have recently released Pyodide 0.27 this January (https://github.com/pyodide/pyodide/releases/tag/0.27.1). On the other hand, `cibuildwheel` in `wheels.yml` builds against Pyodide 0.26 at the moment.

Other notes around the changes here:
- we unvendored `pyodide-build` from the Pyodide runtime/repository, so its version does not stay in sync with the Pyodide runtime version.
- the Node.js version has been bumped to 20, though 22 should work, too.
- the Pyodide cross-build environment folder has been added to the `.gitignore` file
- PyArrow is now [supported](https://github.com/joemarshall/pyarrow-pyodide/) in Pyodide/WASM ([docs on compilation](https://arrow.apache.org/docs/developers/cpp/emscripten.html)), and I've updated the PDEP-10 document here to remove the point surrounding its previous unavailability in Pyodide/PyScript/other WASM environments.
- I removed an expected failure case in `TestCoercionFloat32.test_setitem` that now xpasses with Emscripten 3.1.58.

Please let me know if you want me to split any of the changes to a different PR. Thank you!

[^1]: I have plans in mind to make these upgrades more seamless via https://github.com/pyodide/pyodide-actions/issues/12 by letting Dependabot do such a job, but I haven't got around to sitting down and spending a bit of time doing so.