### PR TITLE
Backport PR #60711: TST(string dtype): Resolve xfail in groupby.test_…

### DIFF
--- a/pandas/tests/groupby/methods/test_size.py
+++ b/pandas/tests/groupby/methods/test_size.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas._config import using_string_dtype
-
 from pandas.core.dtypes.common import is_integer_dtype
 
 from pandas import (
@@ -108,18 +106,16 @@ def test_size_series_masked_type_returns_Int64(dtype):
     tm.assert_series_equal(result, expected)
 
 
-# TODO(infer_string) in case the column is object dtype, it should preserve that dtype
-# for the result's index
-@pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string)", strict=False)
-def test_size_strings(any_string_dtype):
+def test_size_strings(any_string_dtype, using_infer_string):
     # GH#55627
     dtype = any_string_dtype
     df = DataFrame({"a": ["a", "a", "b"], "b": "a"}, dtype=dtype)
     result = df.groupby("a")["b"].size()
     exp_dtype = "Int64" if dtype == "string[pyarrow]" else "int64"
+    exp_index_dtype = "str" if using_infer_string and dtype == "object" else dtype
     expected = Series(
         [2, 1],
-        index=Index(["a", "b"], name="a", dtype=dtype),
+        index=Index(["a", "b"], name="a", dtype=exp_index_dtype),
         name="b",
         dtype=exp_dtype,
     )


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/60711