### PR TITLE
BUG: fix combine_first reorders columns

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -758,6 +758,7 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 - Bug in :func:`qcut` where values at the quantile boundaries could be incorrectly assigned (:issue:`59355`)
+- Bug in :meth:`DataFrame.combine_first` not preserving the column order (:issue:`60427`)
 - Bug in :meth:`DataFrame.join` inconsistently setting result index name (:issue:`55815`)
 - Bug in :meth:`DataFrame.join` when a :class:`DataFrame` with a :class:`MultiIndex` would raise an ``AssertionError`` when :attr:`MultiIndex.names` contained ``None``. (:issue:`58721`)
 - Bug in :meth:`DataFrame.merge` where merging on a column containing only ``NaN`` values resulted in an out-of-bounds array access (:issue:`59421`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8672,6 +8672,9 @@ class DataFrame(NDFrame, OpsMixin):
         """
         other_idxlen = len(other.index)  # save for compare
 
+        # preserve column order
+        new_columns = self.columns.union(other.columns, sort=False)
+
         this, other = self.align(other)
         new_index = this.index
 
@@ -8681,8 +8684,6 @@ class DataFrame(NDFrame, OpsMixin):
         if self.empty and len(other) == other_idxlen:
             return other.copy()
 
-        # sorts if possible; otherwise align above ensures that these are set-equal
-        new_columns = this.columns.union(other.columns)
         do_fill = fill_value is not None
         result = {}
         for col in new_columns:
@@ -8806,10 +8807,7 @@ class DataFrame(NDFrame, OpsMixin):
             )
             combined = combined.astype(other.dtypes)
         else:
-            # preserve column order
-            new_columns = self.columns.union(other.columns, sort=False)
             combined = self.combine(other, combiner, overwrite=False)
-            combined = combined.reindex(columns=new_columns)
 
         dtypes = {
             col: find_common_type([self.dtypes[col], other.dtypes[col]])

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8671,9 +8671,7 @@ class DataFrame(NDFrame, OpsMixin):
         2  NaN  3.0 1.0
         """
         other_idxlen = len(other.index)  # save for compare
-
-        # preserve column order
-        new_columns = self.columns.union(other.columns, sort=False)
+        other_columns = other.columns
 
         this, other = self.align(other)
         new_index = this.index
@@ -8684,6 +8682,8 @@ class DataFrame(NDFrame, OpsMixin):
         if self.empty and len(other) == other_idxlen:
             return other.copy()
 
+        # preserve column order
+        new_columns = self.columns.union(other_columns, sort=False)
         do_fill = fill_value is not None
         result = {}
         for col in new_columns:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8806,7 +8806,10 @@ class DataFrame(NDFrame, OpsMixin):
             )
             combined = combined.astype(other.dtypes)
         else:
+            # preserve column order
+            new_columns = self.columns.union(other.columns, sort=False)
             combined = self.combine(other, combiner, overwrite=False)
+            combined = combined.reindex(columns=new_columns)
 
         dtypes = {
             col: find_common_type([self.dtypes[col], other.dtypes[col]])

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -380,7 +380,7 @@ class TestDataFrameCombineFirst:
         df2 = DataFrame({"isBool": [True]})
 
         res = df1.combine_first(df2)
-        exp = DataFrame({"isBool": [True], "isNum": [val]})
+        exp = DataFrame({"isNum": [val], "isBool": [True]})
 
         tm.assert_frame_equal(res, exp)
 
@@ -554,4 +554,14 @@ def test_combine_first_empty_columns():
     right = DataFrame(columns=["a", "c"])
     result = left.combine_first(right)
     expected = DataFrame(columns=["a", "b", "c"])
+    tm.assert_frame_equal(result, expected)
+
+
+def test_combine_first_preserve_column_order():
+    # GH#60427
+    df1 = DataFrame({"B": [1, 2, 3], "A": [4, None, 6]})
+    df2 = DataFrame({"A": [5]}, index=[1])
+
+    result = df1.combine_first(df2)
+    expected = DataFrame({"B": [1, 2, 3], "A": [4.0, 5.0, 6.0]})
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
I changed an old test for the correct order of columns.

~~Note that the fix can also be done in `combine`, if it is preferred to be fixed there, since `combine_first` calls `combine`.~~

With my previous fix, a test in "Future infer strings" failed, which is the corner case when `self` is an empty dataframe. I then made the fix in `combine`.

- [x] closes #60427 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
