### PR TITLE
[backport 2.3.x] BUG: fix construction of Series / Index from dict keys when "str" dtype is specified explicitly (#60436)

### DIFF
--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -589,6 +589,8 @@ def sanitize_array(
         # create an extension array from its dtype
         _sanitize_non_ordered(data)
         cls = dtype.construct_array_type()
+        if not hasattr(data, "__array__"):
+            data = list(data)
         subarr = cls._from_sequence(data, dtype=dtype, copy=copy)
 
     # GH#846

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -177,3 +177,14 @@ class TestConstruction:
         arr.flags.writeable = False
         result = constructor(arr)
         tm.assert_equal(result, expected)
+
+    def test_constructor_from_dict_keys(self, constructor, using_infer_string):
+        # https://github.com/pandas-dev/pandas/issues/60343
+        d = {"a": 1, "b": 2}
+        result = constructor(d.keys(), dtype="str")
+        if using_infer_string:
+            assert result.dtype == "str"
+        else:
+            assert result.dtype == "object"
+        expected = constructor(list(d.keys()), dtype="str")
+        tm.assert_equal(result, expected)

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -197,7 +197,6 @@ def test_arrowparquet_options(fsspectest):
 
 
 @td.skip_array_manager_not_yet_implemented  # TODO(ArrayManager) fastparquet
-@pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string) fastparquet")
 def test_fastparquet_options(fsspectest):
     """Regression test for writing to a not-yet-existent GCS Parquet file."""
     pytest.importorskip("fastparquet")


### PR DESCRIPTION
(cherry picked from commit 84bf1ef82912ebf497a304b0ffd90914bfc41ea9)

Backport of https://github.com/pandas-dev/pandas/pull/60436