### PR TITLE
TST: Add test for exceptional behavior when calling `view()` on `BaseStringArray`

### DIFF
--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -758,3 +758,9 @@ def test_tolist(dtype):
     result = arr.tolist()
     expected = vals
     tm.assert_equal(result, expected)
+
+
+def test_string_array_view_type_error():
+    arr = pd.array(["a", "b", "c"], dtype="string")
+    with pytest.raises(TypeError, match="Cannot change data-type for string array."):
+        arr.view("i8")

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1351,6 +1351,10 @@ class TestIndex:
 
         tm.assert_index_equal(result, expected)
 
+    def test_string_array_view_type_error(self):
+        arr = pd.array(["a", "b", "c"], dtype="string")
+        with pytest.raises(TypeError, match="Cannot change data-type for string array."):
+            arr.view("i8")
 
 class TestMixedIntIndex:
     # Mostly the tests from common.py for which the results differ

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1351,13 +1351,6 @@ class TestIndex:
 
         tm.assert_index_equal(result, expected)
 
-    def test_string_array_view_type_error(self):
-        arr = pd.array(["a", "b", "c"], dtype="string")
-        with pytest.raises(
-            TypeError, match="Cannot change data-type for string array."
-        ):
-            arr.view("i8")
-
 
 class TestMixedIntIndex:
     # Mostly the tests from common.py for which the results differ

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1353,8 +1353,11 @@ class TestIndex:
 
     def test_string_array_view_type_error(self):
         arr = pd.array(["a", "b", "c"], dtype="string")
-        with pytest.raises(TypeError, match="Cannot change data-type for string array."):
+        with pytest.raises(
+            TypeError, match="Cannot change data-type for string array."
+        ):
             arr.view("i8")
+
 
 class TestMixedIntIndex:
     # Mostly the tests from common.py for which the results differ


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR introduces additional tests for the view method of BaseStringArray, which was recently added in PR [#60713](https://github.com/pandas-dev/pandas/pull/60713). The existing test suite did not cover this method, as shown in the coverage reports below. (I also run the entire test suite locally and double checked that the line is not covered).

To verify the tests, you can run:
```bash
cd tooling/
pytest --cov=$PWD/../pandas/core/arrays/ --cov-report=xml ../pandas/tests/indexes/test_base.py::TestIndex
```
Note: Currently, running pytest from the root directory is resulting in an error in the coverage collection (regardless of which test). If you have any suggestions on how to resolve this issue, please let me know.

This PR aims to ensure that the `view` method is thoroughly tested and meets the pandas testing standards. Your feedback and suggestions are welcome.

## Coverage Before
![test_pr_60713_coverage_before_anonymized](https://github.com/user-attachments/assets/4cfa79e5-9451-432f-b177-8dc966ff6d4e)


## Coverage After
![test_pr_60713_coverage_after_anonymized](https://github.com/user-attachments/assets/98c8ca7a-dfe3-4680-b153-b5d8d57c4b52)


Thanks in advance, let me know if you need any more input from my side

