### PR TITLE
FIX BUG: Series constructor from dictionary drops key (index) levels when not all keys have same number of entries #60695

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -9,6 +9,7 @@ from collections.abc import (
     Sequence,
 )
 from functools import wraps
+from itertools import zip_longest
 from sys import getsizeof
 from typing import (
     TYPE_CHECKING,
@@ -591,7 +592,7 @@ class MultiIndex(Index):
         elif isinstance(tuples, list):
             arrays = list(lib.to_object_array_tuples(tuples).T)
         else:
-            arrs = zip(*tuples)
+            arrs = zip_longest(*tuples)
             arrays = cast(list[Sequence[Hashable]], arrs)
 
         return cls.from_arrays(arrays, sortorder=sortorder, names=names)

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -409,6 +409,14 @@ def test_from_tuples_with_tuple_label():
     result = pd.DataFrame([2, 3], columns=["c"], index=idx)
     tm.assert_frame_equal(expected, result)
 
+@pytest.mark.parametrize("keys, expected", (
+    ((("l1",), ("l1","l2")), (("l1", np.nan), ("l1","l2"))),
+    ((("l1","l2",), ("l1",)), (("l1","l2"), ("l1", np.nan))),
+))
+def test_from_tuples_with_various_tuple_lengths(keys, expected):
+    # Issue 60695
+    idx = MultiIndex.from_tuples(keys)
+    assert tuple(idx) == expected
 
 # ----------------------------------------------------------------------------
 # from_product


### PR DESCRIPTION

This is a simple fix, the keys were dropped from uneven tuples sue to zip behavior so I changed to zip_longest.  I performance tested zip_longest and on equal length tuple pairs it actually outperforms zip - go figure.
Unit test is also added