### PR TITLE
DOC: Move NumPy Byte Order page in gotchas.rst

### DIFF
--- a/doc/source/user_guide/gotchas.rst
+++ b/doc/source/user_guide/gotchas.rst
@@ -372,5 +372,5 @@ constructors using something similar to the following:
    s = pd.Series(newx)
 
 See `the NumPy documentation on byte order
-<https://numpy.org/doc/stable/user/basics.byteswapping.html>`__ for more
+<https://numpy.org/doc/stable/user/byteswapping.html>`__ for more
 details.


### PR DESCRIPTION
Move NumPy Byte Order page in `gotchas.rst`.

New link: https://numpy.org/doc/stable/user/byteswapping.html

Old link does not work.
https://numpy.org/doc/stable/user/basics.byteswapping.html

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
