### PR TITLE
CHORE: Enable mistakenly ignored tests

### DIFF
--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -132,20 +132,17 @@ class TestDataFrameToStringFormatters:
         )
         assert result == expected
 
-        def test_to_string_index_formatter(self):
-            df = DataFrame([range(5), range(5, 10), range(10, 15)])
-
-            rs = df.to_string(formatters={"__index__": lambda x: "abc"[x]})
-
-            xp = dedent(
-                """\
-                0   1   2   3   4
-            a   0   1   2   3   4
-            b   5   6   7   8   9
-            c  10  11  12  13  14\
-            """
-            )
-            assert rs == xp
+    def test_to_string_index_formatter(self):
+        df = DataFrame([range(5), range(5, 10), range(10, 15)])
+        rs = df.to_string(formatters={"__index__": lambda x: "abc"[x]})
+        xp = dedent(
+            """\
+            0   1   2   3   4
+        a   0   1   2   3   4
+        b   5   6   7   8   9
+        c  10  11  12  13  14"""
+        )
+        assert rs == xp
 
     def test_no_extra_space(self):
         # GH#52690: Check that no extra space is given


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

While working on another issue, I came across this test that is ignored because of the wrong indentation. This PR is to enable it. Please confirm since you are the last author @jbrockmendel 
