### PR TITLE
ENH: Improved error message and raise new error for small-string NaN edge case in HDFStore.append

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3524,14 +3524,12 @@ class Table(Fixed):
                     # Value of type "Optional[Any]" is not indexable  [index]
                     oax = ov[i]  # type: ignore[index]
                     if sax != oax:
-                        ## Raise clearer error if mismatching type on values_axes
                         if c == "values_axes" and sax.kind != oax.kind:
-                            raise TypeError(
+                            raise ValueError(
                                 f"Cannot serialize the column [{oax.values[0]}] "
                                 f"because its data contents are not [{sax.kind}] "
                                 f"but [{oax.kind}] object dtype"
                             )
-                        # Fallback if other source of difference
                         raise ValueError(
                             f"invalid combination of [{c}] on appending data "
                             f"[{sax}] vs current table [{oax}]"

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3528,8 +3528,8 @@ class Table(Fixed):
                         if c == "values_axes" and sax.kind != oax.kind:
                             raise TypeError(
                                 f"Cannot serialize the column [{oax.values[0]}] "
-                                f"because its data contents are not [{oax.kind}] "
-                                f"but [{sax.kind}] object dtype"
+                                f"because its data contents are not [{sax.kind}] "
+                                f"but [{oax.kind}] object dtype"
                             )
                         # Fallback if other source of difference
                         raise ValueError(

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3524,6 +3524,14 @@ class Table(Fixed):
                     # Value of type "Optional[Any]" is not indexable  [index]
                     oax = ov[i]  # type: ignore[index]
                     if sax != oax:
+                        ## Raise clearer error if mismatching type on values_axes
+                        if c == "values_axes" and sax.kind != oax.kind:
+                            raise TypeError(
+                                f"Cannot serialize the column [{oax.values[0]}] "
+                                f"because its data contents are not [{oax.kind}] "
+                                f"but [{sax.kind}] object dtype"
+                            )
+                        # Fallback if other source of difference
                         raise ValueError(
                             f"invalid combination of [{c}] on appending data "
                             f"[{sax}] vs current table [{oax}]"
@@ -5135,6 +5143,9 @@ def _maybe_convert_for_string_atom(
     mask = isna(bvalues)
     data = bvalues.copy()
     data[mask] = nan_rep
+
+    if existing_col and mask.any() and len(nan_rep) > existing_col.itemsize:
+        raise ValueError("NaN representation is too large for existing column size")
 
     # see if we have a valid string type
     inferred_type = lib.infer_dtype(data, skipna=False)

--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -830,7 +830,11 @@ because its data contents are not [string] but [mixed] object dtype"""
         df["foo"] = Timestamp("20130101")
         store.append("df", df)
         df["foo"] = "bar"
-        msg = re.escape("Cannot serialize the column [foo] but [string] object dtype")
+        msg = re.escape(
+            "Cannot serialize the column [foo] "
+            "because its data contents are not [string] "
+            "but [datetime64[s]] object dtype"
+        )
         with pytest.raises(TypeError, match=msg):
             store.append("df", df)
 

--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -421,6 +421,14 @@ def test_append_with_strings(setup_path):
         with pytest.raises(ValueError, match=msg):
             store.append("df_new", df_new)
 
+        # bigger NaN representation on next append
+        df_new = DataFrame([[124, "a"], [346, "b"]])
+        store.append("df_new2", df_new)
+        df_new = DataFrame([[124, None], [346, "b"]])
+        msg = "NaN representation is too large for existing column size"
+        with pytest.raises(ValueError, match=msg):
+            store.append("df_new2", df_new)
+
         # min_itemsize on Series index (GH 11412)
         df = DataFrame(
             {
@@ -822,15 +830,8 @@ because its data contents are not [string] but [mixed] object dtype"""
         df["foo"] = Timestamp("20130101")
         store.append("df", df)
         df["foo"] = "bar"
-        msg = re.escape(
-            "invalid combination of [values_axes] on appending data "
-            "[name->values_block_1,cname->values_block_1,"
-            "dtype->bytes24,kind->string,shape->(1, 30)] "
-            "vs current table "
-            "[name->values_block_1,cname->values_block_1,"
-            "dtype->datetime64[s],kind->datetime64[s],shape->None]"
-        )
-        with pytest.raises(ValueError, match=msg):
+        msg = re.escape("Cannot serialize the column [foo] but [string] object dtype")
+        with pytest.raises(TypeError, match=msg):
             store.append("df", df)
 
 

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -213,14 +213,11 @@ def test_table_values_dtypes_roundtrip(setup_path):
 
         # incompatible dtype
         msg = re.escape(
-            "invalid combination of [values_axes] on appending data "
-            "[name->values_block_0,cname->values_block_0,"
-            "dtype->float64,kind->float,shape->(1, 3)] vs "
-            "current table [name->values_block_0,"
-            "cname->values_block_0,dtype->int64,kind->integer,"
-            "shape->None]"
+            "Cannot serialize the column [a] "
+            "because its data contents are not [float] "
+            "but [integer] object dtype"
         )
-        with pytest.raises(ValueError, match=msg):
+        with pytest.raises(TypeError, match=msg):
             store.append("df_i8", df1)
 
         # check creation/storage/retrieval of float32 (a bit hacky to

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -217,7 +217,7 @@ def test_table_values_dtypes_roundtrip(setup_path):
             "because its data contents are not [float] "
             "but [integer] object dtype"
         )
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(ValueError, match=msg):
             store.append("df_i8", df1)
 
         # check creation/storage/retrieval of float32 (a bit hacky to


### PR DESCRIPTION
Updated **pytables.py** to improve error messages caused by datatype mismatches in **HDFStore.append**. Also added **ValueError** for when the NaN representation cannot fit into the column. Modified tests concerning the improved error message and added new test for when column is type string with length <3 and as such **nan_rep** 'nan' is too big.

- [ ] closes #16300
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).