### PR TITLE
DOC: Fix description of skipna parameter in groupby reductions

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2170,8 +2170,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 numeric_only no longer accepts ``None`` and defaults to ``False``.
 
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 3.0.0
 
@@ -2271,8 +2270,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 numeric_only no longer accepts ``None`` and defaults to False.
 
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 3.0.0
 
@@ -2405,8 +2403,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 numeric_only now defaults to ``False``.
 
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 3.0.0
 
@@ -2524,8 +2521,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 numeric_only now defaults to ``False``.
 
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 3.0.0
 
@@ -2742,8 +2738,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 numeric_only now defaults to ``False``.
 
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 3.0.0
 
@@ -3021,8 +3016,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             than ``min_count`` non-NA values are present the result will be NA.
 
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 3.0.0
 
@@ -3242,8 +3236,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             The required number of valid values to perform the operation. If fewer
             than ``min_count`` valid values are present the result will be NA.
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 2.2.1
 
@@ -3329,8 +3322,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             The required number of valid values to perform the operation. If fewer
             than ``min_count`` valid values are present the result will be NA.
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 2.2.1
 
@@ -5530,8 +5522,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         numeric_only : bool, default False
             Include only float, int, boolean columns.
         skipna : bool, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA.
+            Exclude NA/null values. If an entire group is NA, the result will be NA.
         ignore_unobserved : bool, default False
             When True and an unobserved group is encountered, do not raise. This used
             for transform where unobserved groups do not play an impact on the result.


### PR DESCRIPTION
Fixing some issues in descriptions of the `skipna` parameter in groupby reductions (identified while working on #60752)