### PR TITLE
TST/CI: skipif numba tests on Ubuntu ARM for numba 0.61

### DIFF
--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -4,6 +4,8 @@ import warnings
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_arm
+
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 import pandas as pd
@@ -16,6 +18,7 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.tests.frame.common import zip_frames
+from pandas.util.version import Version
 
 
 @pytest.fixture
@@ -65,6 +68,13 @@ def test_apply(float_frame, engine, request):
 @pytest.mark.parametrize("raw", [True, False])
 @pytest.mark.parametrize("nopython", [True, False])
 def test_apply_args(float_frame, axis, raw, engine, nopython):
+    numba = pytest.importorskip("numba")
+    if (
+        engine == "numba"
+        and Version(numba.__version__) == Version("0.61")
+        and is_platform_arm()
+    ):
+        pytest.skip(f"Segfaults on ARM platforms with numba {numba.__version__}")
     engine_kwargs = {"nopython": nopython}
     result = float_frame.apply(
         lambda x, y: x + y,

--- a/pandas/tests/apply/test_numba.py
+++ b/pandas/tests/apply/test_numba.py
@@ -12,7 +12,15 @@ from pandas import (
 import pandas._testing as tm
 from pandas.util.version import Version
 
-pytestmark = [td.skip_if_no("numba"), pytest.mark.single_cpu]
+pytestmark = [td.skip_if_no("numba"), pytest.mark.single_cpu, pytest.mark.skipif()]
+
+numba = pytest.importorskip("numba")
+pytestmark.append(
+    pytest.mark.skipif(
+        Version(numba.__version__) == Version("0.61") and is_platform_arm(),
+        reason=f"Segfaults on ARM platforms with numba {numba.__version__}",
+    )
+)
 
 
 @pytest.fixture(params=[0, 1])
@@ -21,9 +29,6 @@ def apply_axis(request):
 
 
 def test_numba_vs_python_noop(float_frame, apply_axis):
-    numba = pytest.importorskip("numba")
-    if Version(numba.__version__) == Version("0.61") and is_platform_arm():
-        pytest.skip(f"Segfaults on ARM platforms with numba {numba.__version__}")
     func = lambda x: x
     result = float_frame.apply(func, engine="numba", axis=apply_axis)
     expected = float_frame.apply(func, engine="python", axis=apply_axis)
@@ -32,9 +37,6 @@ def test_numba_vs_python_noop(float_frame, apply_axis):
 
 def test_numba_vs_python_string_index():
     # GH#56189
-    numba = pytest.importorskip("numba")
-    if Version(numba.__version__) == Version("0.61") and is_platform_arm():
-        pytest.skip(f"Segfaults on ARM platforms with numba {numba.__version__}")
     df = DataFrame(
         1,
         index=Index(["a", "b"], dtype=pd.StringDtype(na_value=np.nan)),

--- a/pandas/tests/apply/test_numba.py
+++ b/pandas/tests/apply/test_numba.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_arm
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -9,6 +10,7 @@ from pandas import (
     Index,
 )
 import pandas._testing as tm
+from pandas.util.version import Version
 
 pytestmark = [td.skip_if_no("numba"), pytest.mark.single_cpu]
 
@@ -19,6 +21,9 @@ def apply_axis(request):
 
 
 def test_numba_vs_python_noop(float_frame, apply_axis):
+    numba = pytest.importorskip("numba")
+    if Version(numba.__version__) == Version("0.61") and is_platform_arm():
+        pytest.skip(f"Segfaults on ARM platforms with numba {numba.__version__}")
     func = lambda x: x
     result = float_frame.apply(func, engine="numba", axis=apply_axis)
     expected = float_frame.apply(func, engine="python", axis=apply_axis)

--- a/pandas/tests/apply/test_numba.py
+++ b/pandas/tests/apply/test_numba.py
@@ -32,6 +32,9 @@ def test_numba_vs_python_noop(float_frame, apply_axis):
 
 def test_numba_vs_python_string_index():
     # GH#56189
+    numba = pytest.importorskip("numba")
+    if Version(numba.__version__) == Version("0.61") and is_platform_arm():
+        pytest.skip(f"Segfaults on ARM platforms with numba {numba.__version__}")
     df = DataFrame(
         1,
         index=Index(["a", "b"], dtype=pd.StringDtype(na_value=np.nan)),

--- a/pandas/tests/frame/methods/test_info.py
+++ b/pandas/tests/frame/methods/test_info.py
@@ -11,6 +11,7 @@ from pandas.compat import (
     HAS_PYARROW,
     IS64,
     PYPY,
+    is_platform_arm,
 )
 
 from pandas import (
@@ -23,6 +24,7 @@ from pandas import (
     option_context,
 )
 import pandas._testing as tm
+from pandas.util.version import Version
 
 
 @pytest.fixture
@@ -544,7 +546,9 @@ def test_memory_usage_empty_no_warning(using_infer_string):
 @pytest.mark.single_cpu
 def test_info_compute_numba():
     # GH#51922
-    pytest.importorskip("numba")
+    numba = pytest.importorskip("numba")
+    if Version(numba.__version__) == Version("0.61") and is_platform_arm():
+        pytest.skip(f"Segfaults on ARM platforms with numba {numba.__version__}")
     df = DataFrame([[1, 2], [3, 4]])
 
     with option_context("compute.use_numba", True):

--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_arm
 from pandas.errors import NumbaUtilError
 
 from pandas import (
@@ -11,8 +12,17 @@ from pandas import (
     option_context,
 )
 import pandas._testing as tm
+from pandas.util.version import Version
 
-pytestmark = pytest.mark.single_cpu
+pytestmark = [pytest.mark.single_cpu]
+
+numba = pytest.importorskip("numba")
+pytestmark.append(
+    pytest.mark.skipif(
+        Version(numba.__version__) == Version("0.61") and is_platform_arm(),
+        reason=f"Segfaults on ARM platforms with numba {numba.__version__}",
+    )
+)
 
 
 def test_correct_function_signature():

--- a/pandas/tests/groupby/test_numba.py
+++ b/pandas/tests/groupby/test_numba.py
@@ -1,15 +1,24 @@
 import pytest
 
+from pandas.compat import is_platform_arm
+
 from pandas import (
     DataFrame,
     Series,
     option_context,
 )
 import pandas._testing as tm
+from pandas.util.version import Version
 
-pytestmark = pytest.mark.single_cpu
+pytestmark = [pytest.mark.single_cpu]
 
-pytest.importorskip("numba")
+numba = pytest.importorskip("numba")
+pytestmark.append(
+    pytest.mark.skipif(
+        Version(numba.__version__) == Version("0.61") and is_platform_arm(),
+        reason=f"Segfaults on ARM platforms with numba {numba.__version__}",
+    )
+)
 
 
 @pytest.mark.filterwarnings("ignore")

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_arm
 from pandas.errors import NumbaUtilError
 
 from pandas import (
@@ -9,8 +10,17 @@ from pandas import (
     option_context,
 )
 import pandas._testing as tm
+from pandas.util.version import Version
 
-pytestmark = pytest.mark.single_cpu
+pytestmark = [pytest.mark.single_cpu]
+
+numba = pytest.importorskip("numba")
+pytestmark.append(
+    pytest.mark.skipif(
+        Version(numba.__version__) == Version("0.61") and is_platform_arm(),
+        reason=f"Segfaults on ARM platforms with numba {numba.__version__}",
+    )
+)
 
 
 def test_correct_function_signature():

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -236,7 +236,7 @@ def test_frame_setitem_dask_array_into_new_col(request):
 
         if Version(dask.__version__) >= Version("2025.1.0"):
             request.applymarker(
-                pytest.mark.xfail("loc.__setitem__ incorrectly mutated column c")
+                pytest.mark.xfail(reason="loc.__setitem__ incorrectly mutated column c")
             )
         dda = da.array([1, 2])
         df = DataFrame({"a": ["a", "b"]})

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -240,10 +240,6 @@ def test_frame_setitem_dask_array_into_new_col(request):
                 pytest.mark.xfail(reason="loc.__setitem__ incorrectly mutated column c")
             )
 
-        if Version(dask.__version__) >= Version("2025.1.0"):
-            request.applymarker(
-                pytest.mark.xfail(reason="loc.__setitem__ incorrectly mutated column c")
-            )
         dda = da.array([1, 2])
         df = DataFrame({"a": ["a", "b"]})
         df["b"] = dda

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_arm
 from pandas.errors import NumbaUtilError
 import pandas.util._test_decorators as td
 
@@ -11,8 +12,17 @@ from pandas import (
     to_datetime,
 )
 import pandas._testing as tm
+from pandas.util.version import Version
 
-pytestmark = pytest.mark.single_cpu
+pytestmark = [pytest.mark.single_cpu]
+
+numba = pytest.importorskip("numba")
+pytestmark.append(
+    pytest.mark.skipif(
+        Version(numba.__version__) == Version("0.61") and is_platform_arm(),
+        reason=f"Segfaults on ARM platforms with numba {numba.__version__}",
+    )
+)
 
 
 @pytest.fixture(params=["single", "table"])

--- a/pandas/tests/window/test_online.py
+++ b/pandas/tests/window/test_online.py
@@ -1,15 +1,24 @@
 import numpy as np
 import pytest
 
+from pandas.compat import is_platform_arm
+
 from pandas import (
     DataFrame,
     Series,
 )
 import pandas._testing as tm
+from pandas.util.version import Version
 
-pytestmark = pytest.mark.single_cpu
+pytestmark = [pytest.mark.single_cpu]
 
-pytest.importorskip("numba")
+numba = pytest.importorskip("numba")
+pytestmark.append(
+    pytest.mark.skipif(
+        Version(numba.__version__) == Version("0.61") and is_platform_arm(),
+        reason=f"Segfaults on ARM platforms with numba {numba.__version__}",
+    )
+)
 
 
 @pytest.mark.filterwarnings("ignore")


### PR DESCRIPTION
cc @phofl could use help looking into the failure in `test_frame_setitem_dask_array_into_new_col`

https://github.com/pandas-dev/pandas/actions/runs/13127760620/job/36627207210