### PR TITLE
[backport 2.3.x] TST(string_dtype): Refine scope of string xfail in test_http_headers (#60811)

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash -el {0}
 
     - name: Publish test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Test results
         path: test-data.xml

--- a/pandas/tests/io/test_http_headers.py
+++ b/pandas/tests/io/test_http_headers.py
@@ -85,7 +85,6 @@ def stata_responder(df):
         return bio.getvalue()
 
 
-@pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string)", strict=False)
 @pytest.mark.parametrize(
     "responder, read_method",
     [
@@ -108,6 +107,7 @@ def stata_responder(df):
                 td.skip_if_no("fastparquet"),
                 td.skip_if_no("fsspec"),
                 td.skip_array_manager_not_yet_implemented,
+                pytest.mark.xfail(using_string_dtype(), reason="TODO(infer_string"),
             ],
         ),
         (pickle_respnder, pd.read_pickle),


### PR DESCRIPTION
(cherry picked from commit c430c613e6c712a39d07146b8adb083d55943840)

Backport of https://github.com/pandas-dev/pandas/pull/60811