### PR TITLE
Disallow empty comment

### DIFF
--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -125,7 +125,6 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
         return result
 
     def __array_ufunc__(self, ufunc: np.ufunc, method: str, *inputs, **kwargs):
-        #
         if not all(
             isinstance(t, self._HANDLED_TYPES + (DecimalArray,)) for t in inputs
         ):

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -991,7 +991,6 @@ class TestPeriodProperties:
         qedec_date = Period(freq="Q-DEC", year=2007, quarter=1)
         qejan_date = Period(freq="Q-JAN", year=2007, quarter=1)
         qejun_date = Period(freq="Q-JUN", year=2007, quarter=1)
-        #
         for x in range(3):
             for qd in (qedec_date, qejan_date, qejun_date):
                 assert (qd + x).qyear == 2007
@@ -1016,7 +1015,6 @@ class TestPeriodProperties:
     def test_properties_weekly(self):
         # Test properties on Periods with daily frequency.
         w_date = Period(freq="W", year=2007, month=1, day=7)
-        #
         assert w_date.year == 2007
         assert w_date.quarter == 1
         assert w_date.month == 1
@@ -1046,7 +1044,6 @@ class TestPeriodProperties:
         # Test properties on Periods with daily frequency.
         with tm.assert_produces_warning(FutureWarning, match=bday_msg):
             b_date = Period(freq="B", year=2007, month=1, day=1)
-        #
         assert b_date.year == 2007
         assert b_date.quarter == 1
         assert b_date.month == 1
@@ -1089,7 +1086,6 @@ class TestPeriodProperties:
     def test_properties_minutely(self):
         # Test properties on Periods with minutely frequency.
         t_date = Period(freq="Min", year=2007, month=1, day=1, hour=0, minute=0)
-        #
         assert t_date.quarter == 1
         assert t_date.month == 1
         assert t_date.day == 1
@@ -1108,7 +1104,6 @@ class TestPeriodProperties:
         s_date = Period(
             freq="Min", year=2007, month=1, day=1, hour=0, minute=0, second=0
         )
-        #
         assert s_date.year == 2007
         assert s_date.quarter == 1
         assert s_date.month == 1

--- a/pandas/tests/scalar/timestamp/methods/test_round.py
+++ b/pandas/tests/scalar/timestamp/methods/test_round.py
@@ -165,7 +165,6 @@ class TestTimestampRound:
         # GH 18946 round near "fall back" DST
         ts = Timestamp("2017-10-29 00:00:00", tz="UTC").tz_convert("Europe/Madrid")
         ts = ts.as_unit(unit)
-        #
         result = getattr(ts, method)("h", ambiguous=True)
         assert result == ts
         assert result._creso == getattr(NpyDatetimeUnit, f"NPY_FR_{unit}").value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,8 +362,6 @@ ignore = [
   "PLR1733", # 5 errors, it seems like we wannt to ignore these
   # Unnecessary lookup of list item by index
   "PLR1736", # 4 errors, we're currently having inline pylint ignore
-  # empty-comment
-  "PLR2044", # autofixable
   # Unpacking a dictionary in iteration without calling `.items()`
   "PLE1141", # autofixable
   # import-outside-toplevel


### PR DESCRIPTION
Look like the intent of the empty comments in some places is to create a visual block of code, but this is done fairly rarely, compared to just use a new line, so I think it's reasonable to enable this rule to avoid code clutter or empty comments as the result of some massy search and replace.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
