### PR TITLE
Use annotations from the standard library

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -22,7 +22,6 @@ from typing import (
     Literal,
     Optional,
     Protocol,
-    Type as type_t,
     TypeVar,
     Union,
     overload,
@@ -208,7 +207,7 @@ RandomState = Union[
 ]
 
 # dtypes
-NpDtype = Union[str, np.dtype, type_t[Union[str, complex, bool, object]]]
+NpDtype = Union[str, np.dtype, type[Union[str, complex, bool, object]]]
 Dtype = Union["ExtensionDtype", NpDtype]
 AstypeArg = Union["ExtensionDtype", "npt.DTypeLike"]
 # DtypeArg specifies all allowable dtypes in a functions its dtype argument

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
-    Type,
     cast,
 )
 
@@ -59,35 +58,35 @@ def create_pandas_abc_type(name, attr, comp) -> type:
 
 
 ABCRangeIndex = cast(
-    "Type[RangeIndex]",
+    "type[RangeIndex]",
     create_pandas_abc_type("ABCRangeIndex", "_typ", ("rangeindex",)),
 )
 ABCMultiIndex = cast(
-    "Type[MultiIndex]",
+    "type[MultiIndex]",
     create_pandas_abc_type("ABCMultiIndex", "_typ", ("multiindex",)),
 )
 ABCDatetimeIndex = cast(
-    "Type[DatetimeIndex]",
+    "type[DatetimeIndex]",
     create_pandas_abc_type("ABCDatetimeIndex", "_typ", ("datetimeindex",)),
 )
 ABCTimedeltaIndex = cast(
-    "Type[TimedeltaIndex]",
+    "type[TimedeltaIndex]",
     create_pandas_abc_type("ABCTimedeltaIndex", "_typ", ("timedeltaindex",)),
 )
 ABCPeriodIndex = cast(
-    "Type[PeriodIndex]",
+    "type[PeriodIndex]",
     create_pandas_abc_type("ABCPeriodIndex", "_typ", ("periodindex",)),
 )
 ABCCategoricalIndex = cast(
-    "Type[CategoricalIndex]",
+    "type[CategoricalIndex]",
     create_pandas_abc_type("ABCCategoricalIndex", "_typ", ("categoricalindex",)),
 )
 ABCIntervalIndex = cast(
-    "Type[IntervalIndex]",
+    "type[IntervalIndex]",
     create_pandas_abc_type("ABCIntervalIndex", "_typ", ("intervalindex",)),
 )
 ABCIndex = cast(
-    "Type[Index]",
+    "type[Index]",
     create_pandas_abc_type(
         "ABCIndex",
         "_typ",
@@ -106,35 +105,35 @@ ABCIndex = cast(
 
 
 ABCNDFrame = cast(
-    "Type[NDFrame]",
+    "type[NDFrame]",
     create_pandas_abc_type("ABCNDFrame", "_typ", ("series", "dataframe")),
 )
 ABCSeries = cast(
-    "Type[Series]",
+    "type[Series]",
     create_pandas_abc_type("ABCSeries", "_typ", ("series",)),
 )
 ABCDataFrame = cast(
-    "Type[DataFrame]", create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
+    "type[DataFrame]", create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
 )
 
 ABCCategorical = cast(
-    "Type[Categorical]",
+    "type[Categorical]",
     create_pandas_abc_type("ABCCategorical", "_typ", ("categorical")),
 )
 ABCDatetimeArray = cast(
-    "Type[DatetimeArray]",
+    "type[DatetimeArray]",
     create_pandas_abc_type("ABCDatetimeArray", "_typ", ("datetimearray")),
 )
 ABCTimedeltaArray = cast(
-    "Type[TimedeltaArray]",
+    "type[TimedeltaArray]",
     create_pandas_abc_type("ABCTimedeltaArray", "_typ", ("timedeltaarray")),
 )
 ABCPeriodArray = cast(
-    "Type[PeriodArray]",
+    "type[PeriodArray]",
     create_pandas_abc_type("ABCPeriodArray", "_typ", ("periodarray",)),
 )
 ABCExtensionArray = cast(
-    "Type[ExtensionArray]",
+    "type[ExtensionArray]",
     create_pandas_abc_type(
         "ABCExtensionArray",
         "_typ",
@@ -143,6 +142,6 @@ ABCExtensionArray = cast(
     ),
 )
 ABCNumpyExtensionArray = cast(
-    "Type[NumpyExtensionArray]",
+    "type[NumpyExtensionArray]",
     create_pandas_abc_type("ABCNumpyExtensionArray", "_typ", ("npy_extension",)),
 )

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -34,7 +34,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AnyStr,
-    DefaultDict,
     Generic,
     Literal,
     TypeVar,
@@ -1262,7 +1261,7 @@ def dedup_names(
     ['x', 'y', 'x.1', 'x.2']
     """
     names = list(names)  # so we can index
-    counts: DefaultDict[Hashable, int] = defaultdict(int)
+    counts: defaultdict[Hashable, int] = defaultdict(int)
 
     for i, col in enumerate(names):
         cur_count = counts[col]

--- a/pandas/io/excel/_odswriter.py
+++ b/pandas/io/excel/_odswriter.py
@@ -6,7 +6,6 @@ import json
 from typing import (
     TYPE_CHECKING,
     Any,
-    DefaultDict,
     cast,
     overload,
 )
@@ -126,8 +125,8 @@ class ODSWriter(ExcelWriter):
         for _ in range(startrow):
             wks.addElement(TableRow())
 
-        rows: DefaultDict = defaultdict(TableRow)
-        col_count: DefaultDict = defaultdict(int)
+        rows: defaultdict = defaultdict(TableRow)
+        col_count: defaultdict = defaultdict(int)
 
         for cell in sorted(cells, key=lambda cell: (cell.row, cell.col)):
             # only add empty cells if the row is still empty

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -10,7 +10,6 @@ import re
 from typing import (
     TYPE_CHECKING,
     Any,
-    DefaultDict,
     Optional,
     TypedDict,
     Union,
@@ -128,28 +127,28 @@ class StylerRenderer:
         self.hide_columns_: list = [False] * self.columns.nlevels
         self.hidden_rows: Sequence[int] = []  # sequence for specific hidden rows/cols
         self.hidden_columns: Sequence[int] = []
-        self.ctx: DefaultDict[tuple[int, int], CSSList] = defaultdict(list)
-        self.ctx_index: DefaultDict[tuple[int, int], CSSList] = defaultdict(list)
-        self.ctx_columns: DefaultDict[tuple[int, int], CSSList] = defaultdict(list)
-        self.cell_context: DefaultDict[tuple[int, int], str] = defaultdict(str)
+        self.ctx: defaultdict[tuple[int, int], CSSList] = defaultdict(list)
+        self.ctx_index: defaultdict[tuple[int, int], CSSList] = defaultdict(list)
+        self.ctx_columns: defaultdict[tuple[int, int], CSSList] = defaultdict(list)
+        self.cell_context: defaultdict[tuple[int, int], str] = defaultdict(str)
         self._todo: list[tuple[Callable, tuple, dict]] = []
         self.tooltips: Tooltips | None = None
         precision = (
             get_option("styler.format.precision") if precision is None else precision
         )
-        self._display_funcs: DefaultDict[  # maps (row, col) -> format func
+        self._display_funcs: defaultdict[  # maps (row, col) -> format func
             tuple[int, int], Callable[[Any], str]
         ] = defaultdict(lambda: partial(_default_formatter, precision=precision))
-        self._display_funcs_index: DefaultDict[  # maps (row, level) -> format func
+        self._display_funcs_index: defaultdict[  # maps (row, level) -> format func
             tuple[int, int], Callable[[Any], str]
         ] = defaultdict(lambda: partial(_default_formatter, precision=precision))
-        self._display_funcs_index_names: DefaultDict[  # maps index level -> format func
+        self._display_funcs_index_names: defaultdict[  # maps index level -> format func
             int, Callable[[Any], str]
         ] = defaultdict(lambda: partial(_default_formatter, precision=precision))
-        self._display_funcs_columns: DefaultDict[  # maps (level, col) -> format func
+        self._display_funcs_columns: defaultdict[  # maps (level, col) -> format func
             tuple[int, int], Callable[[Any], str]
         ] = defaultdict(lambda: partial(_default_formatter, precision=precision))
-        self._display_funcs_column_names: DefaultDict[  # maps col level -> format func
+        self._display_funcs_column_names: defaultdict[  # maps col level -> format func
             int, Callable[[Any], str]
         ] = defaultdict(lambda: partial(_default_formatter, precision=precision))
 
@@ -338,7 +337,7 @@ class StylerRenderer:
             max_cols,
         )
 
-        self.cellstyle_map_columns: DefaultDict[tuple[CSSPair, ...], list[str]] = (
+        self.cellstyle_map_columns: defaultdict[tuple[CSSPair, ...], list[str]] = (
             defaultdict(list)
         )
         head = self._translate_header(sparse_cols, max_cols)
@@ -350,10 +349,10 @@ class StylerRenderer:
         )
         d.update({"index_lengths": idx_lengths})
 
-        self.cellstyle_map: DefaultDict[tuple[CSSPair, ...], list[str]] = defaultdict(
+        self.cellstyle_map: defaultdict[tuple[CSSPair, ...], list[str]] = defaultdict(
             list
         )
-        self.cellstyle_map_index: DefaultDict[tuple[CSSPair, ...], list[str]] = (
+        self.cellstyle_map_index: defaultdict[tuple[CSSPair, ...], list[str]] = (
             defaultdict(list)
         )
         body: list = self._translate_body(idx_lengths, max_rows, max_cols)

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -10,7 +10,6 @@ import copy
 from typing import (
     TYPE_CHECKING,
     Any,
-    DefaultDict,
     overload,
 )
 
@@ -539,7 +538,7 @@ def json_normalize(
     records: list = []
     lengths = []
 
-    meta_vals: DefaultDict = defaultdict(list)
+    meta_vals: defaultdict = defaultdict(list)
     meta_keys = [sep.join(val) for val in _meta]
 
     def _recursive_extract(data, path, seen_meta, level: int = 0) -> None:

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -11,7 +11,6 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
-    DefaultDict,
     Literal,
     cast,
     final,
@@ -628,7 +627,7 @@ class PythonParser(ParserBase):
                         this_columns.append(c)
 
                 if not have_mi_columns:
-                    counts: DefaultDict = defaultdict(int)
+                    counts: defaultdict = defaultdict(int)
                     # Ensure that regular columns are used before unnamed ones
                     # to keep given names and mangle unnamed columns
                     col_loop_order = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,9 @@ select = [
   # flake8-slots
   "SLOT",
   # flake8-raise
-  "RSE"
+  "RSE",
+  # pyupgrade - selected rules
+  "UP006"
 ]
 
 ignore = [


### PR DESCRIPTION
This is the preferred way to annotate starting from Python 3.9. All changes are auto-fixed by `ruff`

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
