### PR TITLE
Remove unused code

### DIFF
--- a/pandas/core/computation/parsing.py
+++ b/pandas/core/computation/parsing.py
@@ -123,16 +123,6 @@ def clean_column_name(name: Hashable) -> Hashable:
     -------
     name : hashable
         Returns the name after tokenizing and cleaning.
-
-    Notes
-    -----
-        For some cases, a name cannot be converted to a valid Python identifier.
-        In that case :func:`tokenize_string` raises a SyntaxError.
-        In that case, we just return the name unmodified.
-
-        If this name was used in the query string (this makes the query call impossible)
-        an error will be raised by :func:`tokenize_backtick_quoted_string` instead,
-        which is not caught and propagates to the user level.
     """
     try:
         # Escape backticks
@@ -143,40 +133,6 @@ def clean_column_name(name: Hashable) -> Hashable:
         return create_valid_python_identifier(tokval)
     except SyntaxError:
         return name
-
-
-def tokenize_backtick_quoted_string(
-    token_generator: Iterator[tokenize.TokenInfo], source: str, string_start: int
-) -> tuple[int, str]:
-    """
-    Creates a token from a backtick quoted string.
-
-    Moves the token_generator forwards till right after the next backtick.
-
-    Parameters
-    ----------
-    token_generator : Iterator[tokenize.TokenInfo]
-        The generator that yields the tokens of the source string (Tuple[int, str]).
-        The generator is at the first token after the backtick (`)
-
-    source : str
-        The Python source code string.
-
-    string_start : int
-        This is the start of backtick quoted string inside the source string.
-
-    Returns
-    -------
-    tok: Tuple[int, str]
-        The token that represents the backtick quoted string.
-        The integer is equal to BACKTICK_QUOTED_STRING (100).
-    """
-    for _, tokval, start, _, _ in token_generator:
-        if tokval == "`":
-            string_end = start[1]
-            break
-
-    return BACKTICK_QUOTED_STRING, source[string_start:string_end]
 
 
 class ParseState(Enum):


### PR DESCRIPTION
After https://github.com/pandas-dev/pandas/pull/59296 is merged, the note is no longer relevant and the function `tokenize_backtick_quoted_string` is unused

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
