### PR TITLE
Enable get-attr-with-constant (B009)

### DIFF
--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -329,7 +329,7 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
         reconstruct_axes = dict(zip(self._AXIS_ORDERS, self.axes))
 
     if self.ndim == 1:
-        names = {getattr(x, "name") for x in inputs if hasattr(x, "name")}
+        names = {x.name for x in inputs if hasattr(x, "name")}
         name = names.pop() if len(names) == 1 else None
         reconstruct_kwargs = {"name": name}
     else:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -359,7 +359,7 @@ def is_full_slice(obj, line: int) -> bool:
 def get_callable_name(obj):
     # typical case has name
     if hasattr(obj, "__name__"):
-        return getattr(obj, "__name__")
+        return obj.__name__
     # some objects don't; could recurse
     if isinstance(obj, partial):
         return get_callable_name(obj.func)

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2021,7 +2021,7 @@ class Styler(StylerRenderer):
         more details.
         """
         self._todo.append(
-            (lambda instance: getattr(instance, "_apply"), (func, axis, subset), kwargs)
+            (lambda instance: instance._apply, (func, axis, subset), kwargs)
         )
         return self
 
@@ -2128,7 +2128,7 @@ class Styler(StylerRenderer):
         """
         self._todo.append(
             (
-                lambda instance: getattr(instance, "_apply_index"),
+                lambda instance: instance._apply_index,
                 (func, axis, level, "apply"),
                 kwargs,
             )
@@ -2157,7 +2157,7 @@ class Styler(StylerRenderer):
     ) -> Styler:
         self._todo.append(
             (
-                lambda instance: getattr(instance, "_apply_index"),
+                lambda instance: instance._apply_index,
                 (func, axis, level, "map"),
                 kwargs,
             )
@@ -2231,7 +2231,7 @@ class Styler(StylerRenderer):
         more details.
         """
         self._todo.append(
-            (lambda instance: getattr(instance, "_map"), (func, subset), kwargs)
+            (lambda instance: instance._map, (func, subset), kwargs)
         )
         return self
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2230,9 +2230,7 @@ class Styler(StylerRenderer):
         See `Table Visualization <../../user_guide/style.ipynb>`_ user guide for
         more details.
         """
-        self._todo.append(
-            (lambda instance: instance._map, (func, subset), kwargs)
-        )
+        self._todo.append((lambda instance: instance._map, (func, subset), kwargs))
         return self
 
     def set_table_attributes(self, attributes: str) -> Styler:

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -644,7 +644,7 @@ def test_timedelta_methods(method):
         operator.methodcaller("add_categories", ["c"]),
         operator.methodcaller("as_ordered"),
         operator.methodcaller("as_unordered"),
-        lambda x: getattr(x, "codes"),
+        lambda x: x.codes,
         operator.methodcaller("remove_categories", "a"),
         operator.methodcaller("remove_unused_categories"),
         operator.methodcaller("rename_categories", {"a": "A", "b": "B"}),

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1390,7 +1390,7 @@ def test_empty_df(method, op):
     # GH 47985
     empty_df = DataFrame({"a": [], "b": []})
     gb = empty_df.groupby("a", group_keys=True)
-    group = getattr(gb, "b")
+    group = gb.b
 
     result = getattr(group, method)(op)
     expected = Series(

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -264,7 +264,7 @@ def test_attr_wrapper(ts):
     # make sure raises error
     msg = "'SeriesGroupBy' object has no attribute 'foo'"
     with pytest.raises(AttributeError, match=msg):
-        getattr(grouped, "foo")
+        grouped.foo
 
 
 def test_frame_groupby(tsframe):

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -311,7 +311,7 @@ def test_getattr(setup_path):
         # test attribute access
         result = store.a
         tm.assert_series_equal(result, s)
-        result = getattr(store, "a")
+        result = store.a
         tm.assert_series_equal(result, s)
 
         df = DataFrame(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,8 +272,6 @@ ignore = [
   "B007",
   # controversial
   "B008",
-  # setattr is used to side-step mypy
-  "B009",
   # getattr is used to side-step mypy
   "B010",
   # tests use comparisons but not their returned value


### PR DESCRIPTION
The original reasoning to disable this rule is because `getattr` is needed to side step `mypy`, but `mypy` doesn't complain about the fix anymore.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
