### PR TITLE
DOC: Correct a typo in pyarrow.rst

### DIFF
--- a/doc/source/user_guide/pyarrow.rst
+++ b/doc/source/user_guide/pyarrow.rst
@@ -22,7 +22,7 @@ Data Structure Integration
 
 A :class:`Series`, :class:`Index`, or the columns of a :class:`DataFrame` can be directly backed by a :external+pyarrow:py:class:`pyarrow.ChunkedArray`
 which is similar to a NumPy array. To construct these from the main pandas data structures, you can pass in a string of the type followed by
-``[pyarrow]``, e.g. ``"int64[pyarrow]""`` into the ``dtype`` parameter
+``[pyarrow]``, e.g. ``"int64[pyarrow]"`` into the ``dtype`` parameter
 
 .. ipython:: python
 


### PR DESCRIPTION
Correct a typo in pyarrow.rst.  
``"int64[pyarrow]""`` -> Remove the extra double quotation mark at the end.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
