### PR TITLE
BUG: Fix frozenset display in pprint

### DIFF
--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -112,7 +112,7 @@ def _pprint_seq(
     if isinstance(seq, set):
         fmt = "{{{body}}}"
     elif isinstance(seq, frozenset):
-        fmt = "frozenset({body})"
+        fmt = "frozenset({{{body}}})"
     else:
         fmt = "[{body}]" if hasattr(seq, "__setitem__") else "({body})"
 

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -83,7 +83,7 @@ class TestPPrintThing:
         assert printing.pprint_thing(MyMapping()) == "{'a': 4, 'b': 4}"
 
     def test_repr_frozenset(self):
-        assert printing.pprint_thing(frozenset([1, 2])) == "frozenset(1, 2)"
+        assert printing.pprint_thing(frozenset([1, 2])) == "frozenset({1, 2})"
 
 
 class TestFormatBase:


### PR DESCRIPTION
- [x] closes #60690
    - Fixed in #60828 but with a bug
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- ~~[ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~~
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
    - Already added by #60828