### PR TITLE
TST/CI: Address enforced numpy DeprecationWarning in test_pandas_dtype_numpy_warning

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1836,6 +1836,8 @@ def pandas_dtype(dtype) -> DtypeObj:
     # raise a consistent TypeError if failed
     try:
         with warnings.catch_warnings():
+            # TODO: warnings.catch_warnings can be removed when numpy>2.2.2
+            # is the minimum version
             # GH#51523 - Series.astype(np.integer) doesn't show
             # numpy deprecation warning of np.integer
             # Hence enabling DeprecationWarning

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -22,6 +22,7 @@ import pandas as pd
 import pandas._testing as tm
 from pandas.api.types import pandas_dtype
 from pandas.arrays import SparseArray
+from pandas.util.version import Version
 
 
 # EA & Actual Dtypes
@@ -788,11 +789,18 @@ def test_validate_allhashable():
 
 def test_pandas_dtype_numpy_warning():
     # GH#51523
-    with tm.assert_produces_warning(
-        DeprecationWarning,
-        check_stacklevel=False,
-        match="Converting `np.integer` or `np.signedinteger` to a dtype is deprecated",
-    ):
+    if Version(np.__version__) <= Version("2.2.2"):
+        ctx = tm.assert_produces_warning(
+            DeprecationWarning,
+            check_stacklevel=False,
+            match=(
+                "Converting `np.integer` or `np.signedinteger` to a dtype is deprecated"
+            ),
+        )
+    else:
+        ctx = tm.external_error_raised(TypeError)
+
+    with ctx:
         pandas_dtype(np.integer)
 
 


### PR DESCRIPTION
e.g.

```bash
=================================== FAILURES ===================================
_______________________ test_pandas_dtype_numpy_warning ________________________
[gw1] linux -- Python 3.11.11 /home/runner/micromamba/envs/test/bin/python3.11

    def test_pandas_dtype_numpy_warning():
        # GH#51523
        with tm.assert_produces_warning(
            DeprecationWarning,
            check_stacklevel=False,
            match="Converting `np.integer` or `np.signedinteger` to a dtype is deprecated",
        ):
>           pandas_dtype(np.integer)

pandas/tests/dtypes/test_common.py:796: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

dtype = <class 'numpy.integer'>

    def pandas_dtype(dtype) -> DtypeObj:
        """
        Convert input into a pandas only dtype object or a numpy dtype object.
    
        Parameters
        ----------
        dtype : object
            The object to be converted into a dtype.
    
        Returns
        -------
        np.dtype or a pandas dtype
            The converted dtype, which can be either a numpy dtype or a pandas dtype.
    
        Raises
        ------
        TypeError if not a dtype
    
        See Also
        --------
        api.types.is_dtype : Return true if the condition is satisfied for the arr_or_dtype.
    
        Examples
        --------
        >>> pd.api.types.pandas_dtype(int)
        dtype('int64')
        """
        # short-circuit
        if isinstance(dtype, np.ndarray):
            return dtype.dtype
        elif isinstance(dtype, (np.dtype, ExtensionDtype)):
            return dtype
    
        # builtin aliases
        if dtype is str and using_string_dtype():
            from pandas.core.arrays.string_ import StringDtype
    
            return StringDtype(na_value=np.nan)
    
        # registered extension types
        result = registry.find(dtype)
        if result is not None:
            if isinstance(result, type):
                # GH 31356, GH 54592
                warnings.warn(
                    f"Instantiating {result.__name__} without any arguments."
                    f"Pass a {result.__name__} instance to silence this warning.",
                    UserWarning,
                    stacklevel=find_stack_level(),
                )
                result = result()
            return result
    
        # try a numpy dtype
        # raise a consistent TypeError if failed
        try:
            with warnings.catch_warnings():
                # GH#51523 - Series.astype(np.integer) doesn't show
                # numpy deprecation warning of np.integer
                # Hence enabling DeprecationWarning
                warnings.simplefilter("always", DeprecationWarning)
>               npdtype = np.dtype(dtype)
E               TypeError: Converting 'np.integer' or 'np.signedinteger' to a dtype is not allowed

pandas/core/dtypes/common.py:1843: TypeError

During handling of the above exception, another exception occurred:

    def test_pandas_dtype_numpy_warning():
        # GH#51523
>       with tm.assert_produces_warning(
            DeprecationWarning,
            check_stacklevel=False,
            match="Converting `np.integer` or `np.signedinteger` to a dtype is deprecated",
        ):

pandas/tests/dtypes/test_common.py:791: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../micromamba/envs/test/lib/python3.11/contextlib.py:158: in __exit__
    self.gen.throw(typ, value, traceback)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _assert_caught_expected_warnings(
        *,
        caught_warnings: Sequence[warnings.WarningMessage],
Warning:         expected_warning: type[Warning] | tuple[type[Warning], ...],
        match: str | None,
        check_stacklevel: bool,
    ) -> None:
        """Assert that there was the expected warning among the caught warnings."""
        saw_warning = False
        matched_message = False
        unmatched_messages = []
        warning_name = (
            tuple(x.__name__ for x in expected_warning)
            if isinstance(expected_warning, tuple)
            else expected_warning.__name__
        )
    
        for actual_warning in caught_warnings:
            if issubclass(actual_warning.category, expected_warning):
                saw_warning = True
    
                if check_stacklevel:
                    _assert_raised_with_correct_stacklevel(actual_warning)
    
                if match is not None:
                    if re.search(match, str(actual_warning.message)):
                        matched_message = True
                    else:
                        unmatched_messages.append(actual_warning.message)
    
        if not saw_warning:
>           raise AssertionError(f"Did not see expected warning of class {warning_name!r}")
E           AssertionError: Did not see expected warning of class 'DeprecationWarning'

pandas/_testing/_warnings.py:188: AssertionError

```