### PR TITLE
Backport PR #60873: TST/CI: xfail test_frame_setitem_dask_array_into_new_col for numpy>2.1

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -23,6 +23,7 @@ from pandas.core.arrays import (
     DatetimeArray,
     TimedeltaArray,
 )
+from pandas.util.version import Version
 
 
 @pytest.fixture
@@ -223,7 +224,7 @@ def test_missing_required_dependency():
         assert name in output
 
 
-def test_frame_setitem_dask_array_into_new_col():
+def test_frame_setitem_dask_array_into_new_col(request):
     # GH#47128
 
     # dask sets "compute.use_numexpr" to False, so catch the current value
@@ -231,7 +232,14 @@ def test_frame_setitem_dask_array_into_new_col():
     olduse = pd.get_option("compute.use_numexpr")
 
     try:
+        dask = pytest.importorskip("dask")
         da = pytest.importorskip("dask.array")
+        if Version(dask.__version__) <= Version("2025.1.0") and Version(
+            np.__version__
+        ) >= Version("2.1"):
+            request.applymarker(
+                pytest.mark.xfail(reason="loc.__setitem__ incorrectly mutated column c")
+            )
 
         dda = da.array([1, 2])
         df = DataFrame({"a": ["a", "b"]})


### PR DESCRIPTION
Manual backport of https://github.com/pandas-dev/pandas/pull/60873#issuecomment-2643779671