### PR TITLE
BUG: Don't ignore errors when casting dtype in Series constructor

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -793,6 +793,7 @@ Styler
 Other
 ^^^^^
 - Bug in :class:`DataFrame` when passing a ``dict`` with a NA scalar and ``columns`` that would always return ``np.nan`` (:issue:`57205`)
+- Bug in :class:`Series` ignoring errors when trying to convert :class:`Series` input data to the given ``dtype`` (:issue:`60728`)
 - Bug in :func:`eval` on :class:`ExtensionArray` on including division ``/`` failed with a ``TypeError``. (:issue:`58748`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`eval` with ``engine="numexpr"`` returning unexpected result for float division. (:issue:`59736`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -500,7 +500,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         # create/copy the manager
         if isinstance(data, SingleBlockManager):
             if dtype is not None:
-                data = data.astype(dtype=dtype, errors="ignore")
+                data = data.astype(dtype=dtype)
             elif copy:
                 data = data.copy()
         else:

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -90,6 +90,13 @@ class TestSeriesConstructors:
         with pytest.raises(ValueError, match=msg):
             Series(np.array(vals, dtype=object), dtype="datetime64[ns]")
 
+    def test_invalid_dtype_conversion_datetime_to_timedelta(self):
+        # GH#60728
+        vals = Series([NaT, Timestamp(2025, 1, 1)], dtype="datetime64[ns]")
+        msg = r"^Cannot cast DatetimeArray to dtype timedelta64\[ns\]$"
+        with pytest.raises(TypeError, match=msg):
+            Series(vals, dtype="timedelta64[ns]")
+
     @pytest.mark.parametrize(
         "constructor",
         [


### PR DESCRIPTION
- [ ] closes #60728
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

In the constructor for `Series`, when the input data is another `Series` with a different `dtype` than the one specified in the constructor, the dtype conversion currently doesn't throw errors and silently sets the wrong dtype.
```
>>> example = pd.Series(
...     pd.Series([pd.NaT], dtype="datetime64[ns]"), dtype="timedelta64[ns]"
... )
>>> print(example.dtype)
datetime64[ns]
```
