### PR TITLE
TST: Update numpy version check for test_pandas_dtype_numpy_warning

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1836,7 +1836,7 @@ def pandas_dtype(dtype) -> DtypeObj:
     # raise a consistent TypeError if failed
     try:
         with warnings.catch_warnings():
-            # TODO: warnings.catch_warnings can be removed when numpy>2.2.2
+            # TODO: warnings.catch_warnings can be removed when numpy>2.3.0
             # is the minimum version
             # GH#51523 - Series.astype(np.integer) doesn't show
             # numpy deprecation warning of np.integer

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -789,7 +789,7 @@ def test_validate_allhashable():
 
 def test_pandas_dtype_numpy_warning():
     # GH#51523
-    if Version(np.__version__) <= Version("2.2.2"):
+    if Version(np.__version__) <= Version("2.3.0"):
         ctx = tm.assert_produces_warning(
             DeprecationWarning,
             check_stacklevel=False,

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -789,7 +789,7 @@ def test_validate_allhashable():
 
 def test_pandas_dtype_numpy_warning():
     # GH#51523
-    if Version(np.__version__) <= Version("2.3.0"):
+    if Version(np.__version__) < Version("2.3.0.dev0"):
         ctx = tm.assert_produces_warning(
             DeprecationWarning,
             check_stacklevel=False,


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/60875

I guess I incorrectly assumed that this would be removed in 2.2.3.