### PR TITLE
ENH: Add dtype argument to str.decode

### DIFF
--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -39,6 +39,7 @@ Other enhancements
 - :meth:`~Series.to_hdf` and :meth:`~DataFrame.to_hdf` now round-trip with ``StringDtype``  (:issue:`60663`)
 - The :meth:`~Series.cumsum`, :meth:`~Series.cummin`, and :meth:`~Series.cummax` reductions are now implemented for ``StringDtype`` columns when backed by PyArrow (:issue:`60633`)
 - The :meth:`~Series.sum` reduction is now implemented for ``StringDtype`` columns (:issue:`59853`)
+- The :meth:`Series.str.decode` has gained the argument ``dtype`` to control the dtype of the result (:issue:`???`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_230.notable_bug_fixes:

--- a/doc/source/whatsnew/v2.3.0.rst
+++ b/doc/source/whatsnew/v2.3.0.rst
@@ -37,9 +37,9 @@ Other enhancements
   updated to work correctly with NumPy >= 2 (:issue:`57739`)
 - :meth:`Series.str.decode` result now has ``StringDtype`` when ``future.infer_string`` is True (:issue:`60709`)
 - :meth:`~Series.to_hdf` and :meth:`~DataFrame.to_hdf` now round-trip with ``StringDtype``  (:issue:`60663`)
+- The :meth:`Series.str.decode` has gained the argument ``dtype`` to control the dtype of the result (:issue:`60940`)
 - The :meth:`~Series.cumsum`, :meth:`~Series.cummin`, and :meth:`~Series.cummax` reductions are now implemented for ``StringDtype`` columns when backed by PyArrow (:issue:`60633`)
 - The :meth:`~Series.sum` reduction is now implemented for ``StringDtype`` columns (:issue:`59853`)
-- The :meth:`Series.str.decode` has gained the argument ``dtype`` to control the dtype of the result (:issue:`???`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_230.notable_bug_fixes:

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2149,7 +2149,6 @@ class StringMethods(NoNewAttributesMixin):
         if (
             dtype is not None
             and not is_string_dtype(dtype)
-            and not is_object_dtype(dtype)
         ):
             raise ValueError(f"dtype must be string or object, got {dtype=}")
         if dtype is None and get_option("future.infer_string"):

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2103,7 +2103,9 @@ class StringMethods(NoNewAttributesMixin):
         result = self._data.array._str_slice_replace(start, stop, repl)
         return self._wrap_result(result)
 
-    def decode(self, encoding, errors: str = "strict", dtype: str | DtypeObj = None):
+    def decode(
+        self, encoding, errors: str = "strict", dtype: str | DtypeObj | None = None
+    ):
         """
         Decode character string in the Series/Index using indicated encoding.
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2122,6 +2122,8 @@ class StringMethods(NoNewAttributesMixin):
             object dtype. When ``None``, the dtype of the result is determined by
             ``pd.options.future.infer_string``.
 
+            .. versionadded:: 2.3.0
+
         Returns
         -------
         Series or Index

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2150,6 +2150,8 @@ class StringMethods(NoNewAttributesMixin):
             and not is_object_dtype(dtype)
         ):
             raise ValueError(f"dtype must be string or object, got {dtype=}")
+        if dtype is None and get_option("future.infer_string"):
+            dtype = "str"
         # TODO: Add a similar _bytes interface.
         if encoding in _cpython_optimized_decoders:
             # CPython optimized implementation
@@ -2159,8 +2161,6 @@ class StringMethods(NoNewAttributesMixin):
             f = lambda x: decoder(x, errors)[0]
         arr = self._data.array
         result = arr._str_map(f)
-        if dtype is None and get_option("future.infer_string"):
-            dtype = "str"
         return self._wrap_result(result, dtype=dtype)
 
     @forbid_nonstring_types(["bytes"])

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2146,10 +2146,7 @@ class StringMethods(NoNewAttributesMixin):
         2   ()
         dtype: object
         """
-        if (
-            dtype is not None
-            and not is_string_dtype(dtype)
-        ):
+        if dtype is not None and not is_string_dtype(dtype):
             raise ValueError(f"dtype must be string or object, got {dtype=}")
         if dtype is None and get_option("future.infer_string"):
             dtype = "str"

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -2159,8 +2159,8 @@ class StringMethods(NoNewAttributesMixin):
             f = lambda x: decoder(x, errors)[0]
         arr = self._data.array
         result = arr._str_map(f)
-        if dtype is None:
-            dtype = "str" if get_option("future.infer_string") else None
+        if dtype is None and get_option("future.infer_string"):
+            dtype = "str"
         return self._wrap_result(result, dtype=dtype)
 
     @forbid_nonstring_types(["bytes"])

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -602,6 +602,7 @@ def test_decode_errors_kwarg():
 
 
 def test_decode_string_dtype(string_dtype):
+    # https://github.com/pandas-dev/pandas/pull/60940
     ser = Series([b"a", b"b"])
     result = ser.str.decode("utf-8", dtype=string_dtype)
     expected = Series(["a", "b"], dtype=string_dtype)
@@ -609,6 +610,7 @@ def test_decode_string_dtype(string_dtype):
 
 
 def test_decode_object_dtype(object_dtype):
+    # https://github.com/pandas-dev/pandas/pull/60940
     ser = Series([b"a", rb"\ud800"])
     result = ser.str.decode("utf-8", dtype=object_dtype)
     expected = Series(["a", r"\ud800"], dtype=object_dtype)
@@ -616,6 +618,7 @@ def test_decode_object_dtype(object_dtype):
 
 
 def test_decode_bad_dtype():
+    # https://github.com/pandas-dev/pandas/pull/60940
     ser = Series([b"a", b"b"])
     msg = "dtype must be string or object, got dtype='int64'"
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -601,6 +601,27 @@ def test_decode_errors_kwarg():
     tm.assert_series_equal(result, expected)
 
 
+def test_decode_string_dtype(string_dtype):
+    ser = Series([b"a", b"b"])
+    result = ser.str.decode("utf-8", dtype=string_dtype)
+    expected = Series(["a", "b"], dtype=string_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+def test_decode_object_dtype(object_dtype):
+    ser = Series([b"a", rb"\ud800"])
+    result = ser.str.decode("utf-8", dtype=object_dtype)
+    expected = Series(["a", r"\ud800"], dtype=object_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+def test_decode_bad_dtype():
+    ser = Series([b"a", b"b"])
+    msg = "dtype must be string or object, got dtype='int64'"
+    with pytest.raises(ValueError, match=msg):
+        ser.str.decode("utf-8", dtype="int64")
+
+
 @pytest.mark.parametrize(
     "form, expected",
     [


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ref: https://github.com/pandas-dev/pandas/pull/60795#discussion_r1947937837

PyArrow-backed strings cannot handle surrogates. When users have `infer_string=True` and PyArrow installed, they can end up with a failure they can't workaround when calling `str.decode`. Adding the dtype argument allows for a workaround.