### PR TITLE
Bug: Fix convert_dtypes not preserving timezone details for ArrowDtype

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -668,6 +668,7 @@ Conversion
 - Bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)
 - Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
+- Bug in :meth:`convert_dtypes` not preserving timezone details for ArrowDtype in Series and DataFrame (:issue:`60237`)
 
 Strings
 ^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -671,7 +671,7 @@ Conversion
 - Bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)
 - Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
-- Bug in :meth:`convert_dtypes` not preserving timezone details for ArrowDtype in Series and DataFrame (:issue:`60237`)
+- Bug in :meth:`Series.convert_dtypes` and :meth:`DataFrame.convert_dtypes` removing timezone information for objects with :class:`ArrowDtype` (:issue:`60237`)
 
 Strings
 ^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -670,8 +670,8 @@ Conversion
 - Bug in :meth:`DataFrame.astype` not casting ``values`` for Arrow-based dictionary dtype correctly (:issue:`58479`)
 - Bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)
-- Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
 - Bug in :meth:`Series.convert_dtypes` and :meth:`DataFrame.convert_dtypes` removing timezone information for objects with :class:`ArrowDtype` (:issue:`60237`)
+- Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1113,7 +1113,7 @@ def convert_dtypes(
     else:
         inferred_dtype = input_array.dtype
 
-    if dtype_backend == "pyarrow":
+    if dtype_backend == "pyarrow" and not isinstance(inferred_dtype, ArrowDtype):
         from pandas.core.arrays.arrow.array import to_pyarrow_type
         from pandas.core.arrays.string_ import StringDtype
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3511,27 +3511,3 @@ def test_map_numeric_na_action():
     result = ser.map(lambda x: 42, na_action="ignore")
     expected = pd.Series([42.0, 42.0, np.nan], dtype="float64")
     tm.assert_series_equal(result, expected)
-
-
-def test_convert_dtype_pyarrow_timezone_preserve():
-    # GH 60237
-    pytest.importorskip("pyarrow")
-    ser = pd.Series(
-        pd.to_datetime(range(5), utc=True, unit="h"),
-        dtype="timestamp[ns, tz=UTC][pyarrow]",
-    )
-    result = ser.convert_dtypes(dtype_backend="pyarrow")
-    expected = ser.copy()
-    tm.assert_series_equal(result, expected)
-
-    df = pd.DataFrame(
-        {
-            "timestamps": pd.Series(
-                pd.to_datetime(range(5), utc=True, unit="h"),
-                dtype="timestamp[ns, tz=UTC][pyarrow]",
-            )
-        }
-    )
-    result = df.convert_dtypes(dtype_backend="pyarrow")
-    expected = df.copy()
-    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3511,3 +3511,27 @@ def test_map_numeric_na_action():
     result = ser.map(lambda x: 42, na_action="ignore")
     expected = pd.Series([42.0, 42.0, np.nan], dtype="float64")
     tm.assert_series_equal(result, expected)
+
+
+def test_convert_dtype_pyarrow_timezone_preserve():
+    # GH 60237
+    pytest.importorskip("pyarrow")
+    ser = pd.Series(
+        pd.to_datetime(range(5), utc=True, unit="h"),
+        dtype="timestamp[ns, tz=UTC][pyarrow]",
+    )
+    result = ser.convert_dtypes(dtype_backend="pyarrow")
+    expected = ser.copy()
+    tm.assert_series_equal(result, expected)
+
+    df = pd.DataFrame(
+        {
+            "timestamps": pd.Series(
+                pd.to_datetime(range(5), utc=True, unit="h"),
+                dtype="timestamp[ns, tz=UTC][pyarrow]",
+            )
+        }
+    )
+    result = df.convert_dtypes(dtype_backend="pyarrow")
+    expected = df.copy()
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -199,6 +199,7 @@ class TestConvertDtypes:
 
     def test_convert_dtype_pyarrow_timezone_preserve(self):
         # GH 60237
+        pytest.importorskip("pyarrow")
         df = pd.DataFrame(
             {
                 "timestamps": pd.Series(

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -196,3 +196,17 @@ class TestConvertDtypes:
         result = df.convert_dtypes()
         expected = df.astype({"a": "string[python]"})
         tm.assert_frame_equal(result, expected)
+
+    def test_convert_dtype_pyarrow_timezone_preserve(self):
+        # GH 60237
+        df = pd.DataFrame(
+            {
+                "timestamps": pd.Series(
+                    pd.to_datetime(range(5), utc=True, unit="h"),
+                    dtype="timestamp[ns, tz=UTC][pyarrow]",
+                )
+            }
+        )
+        result = df.convert_dtypes(dtype_backend="pyarrow")
+        expected = df.copy()
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -297,3 +297,14 @@ class TestSeriesConvertDtypes:
         result = ser.convert_dtypes(dtype_backend="pyarrow")
         expected = pd.Series([None, None], dtype=pd.ArrowDtype(pa.null()))
         tm.assert_series_equal(result, expected)
+
+    def test_convert_dtype_pyarrow_timezone_preserve(self):
+        # GH 60237
+        pytest.importorskip("pyarrow")
+        ser = pd.Series(
+            pd.to_datetime(range(5), utc=True, unit="h"),
+            dtype="timestamp[ns, tz=UTC][pyarrow]",
+        )
+        result = ser.convert_dtypes(dtype_backend="pyarrow")
+        expected = ser.copy()
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #60237
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
