### PR TITLE
DOC: Improve examples in Series.str.isnumeric shared docstring to include decimal, fraction, negatives and exponents (#60750)

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -3549,12 +3549,29 @@ class StringMethods(NoNewAttributesMixin):
     also includes other characters that can represent quantities such as
     unicode fractions.
 
-    >>> s1 = pd.Series(['one', 'one1', '1', ''])
+    >>> s1 = pd.Series(['one', 'one1', '1', '', '³', '⅕'])
     >>> s1.str.isnumeric()
     0    False
     1    False
     2     True
     3    False
+    4     True
+    5     True
+    dtype: bool
+
+    For a string to be considered numeric, all its characters must have a Unicode 
+    numeric property. As a consequence, the following cases are **not** recognized
+    as numeric:
+
+    - **Decimal numbers** (e.g., "1.1"): due to period ``"."`` 
+    - **Negative numbers** (e.g., "-5"):  due to minus sign ``"-"`` 
+    - **Scientific notation** (e.g., "1e3"): due to characters like ``"e"`` 
+
+    >>> s2 = pd.Series(["1.1", "-5", "1e3"])
+    >>> s2.str.isnumeric()
+    0    False
+    1    False
+    2    False
     dtype: bool
     """
     _shared_docs["isalnum"] = """

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -3559,13 +3559,13 @@ class StringMethods(NoNewAttributesMixin):
     5     True
     dtype: bool
 
-    For a string to be considered numeric, all its characters must have a Unicode 
+    For a string to be considered numeric, all its characters must have a Unicode
     numeric property. As a consequence, the following cases are **not** recognized
     as numeric:
 
-    - **Decimal numbers** (e.g., "1.1"): due to period ``"."`` 
-    - **Negative numbers** (e.g., "-5"):  due to minus sign ``"-"`` 
-    - **Scientific notation** (e.g., "1e3"): due to characters like ``"e"`` 
+    - **Decimal numbers** (e.g., "1.1"): due to period ``"."``
+    - **Negative numbers** (e.g., "-5"):  due to minus sign ``"-"``
+    - **Scientific notation** (e.g., "1e3"): due to characters like ``"e"``
 
     >>> s2 = pd.Series(["1.1", "-5", "1e3"])
     >>> s2.str.isnumeric()

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -3560,8 +3560,8 @@ class StringMethods(NoNewAttributesMixin):
     dtype: bool
 
     For a string to be considered numeric, all its characters must have a Unicode
-    numeric property. As a consequence, the following cases are **not** recognized
-    as numeric:
+    numeric property matching :py:meth:`str.is_numeric`. As a consequence,
+    the following cases are **not** recognized as numeric:
 
     - **Decimal numbers** (e.g., "1.1"): due to period ``"."``
     - **Negative numbers** (e.g., "-5"):  due to minus sign ``"-"``


### PR DESCRIPTION
- [x] closes #60750 
- [x] All [code checks passed](https://pandas.pydata.org/docs/dev/development/contributing_documentation.html#previewing-changes)
- [x] Validated changes for formatting issues using `scripts/validate_docstrings.py`

### Tasks performed

1.  Improved the existing example for `Series.str.isnumeric` to include Unicode fractions using shared docs.

2. Add a new example to clear confusion regarding decimals, exponents and negative values

### Before
![image](https://github.com/user-attachments/assets/e599b678-2736-4200-8e01-21445e5b59de)


### After 
![image](https://github.com/user-attachments/assets/c6180846-de53-4058-829d-5fb7da8c58a3)




