### PR TITLE
Feature auto infer orient as table or split in read_json

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -70,6 +70,7 @@ Other enhancements
 - :meth:`Series.map` can now accept kwargs to pass on to func (:issue:`59814`)
 - :meth:`Series.str.get_dummies` now accepts a  ``dtype`` parameter to specify the dtype of the resulting DataFrame (:issue:`47872`)
 - :meth:`pandas.concat` will raise a ``ValueError`` when ``ignore_index=True`` and ``keys`` is not ``None`` (:issue:`59274`)
+- :meth:`pandas.read_json` now automatically infers the ``orient`` parameter if it is not explicitly specified. This allows the correct format to be detected based on the input JSON structure. This only works if json schema matches for split or table. (:issue:`52713`).
 - :py:class:`frozenset` elements in pandas objects are now natively printed (:issue:`60690`)
 - Errors occurring during SQL I/O will now throw a generic :class:`.DatabaseError` instead of the raw Exception type from the underlying driver manager library (:issue:`60748`)
 - Implemented :meth:`Series.str.isascii` and :meth:`Series.str.isascii` (:issue:`59091`)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2283,3 +2283,35 @@ def test_large_number():
     )
     expected = Series([9999999999999999])
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "json_data, should_fail",
+    [
+        (
+            json.dumps(
+                {
+                    "schema": {"fields": [{"name": "A", "type": "integer"}]},
+                    "data": [{"A": 1}, {"A": 2}, {"A": 3}],
+                }
+            ),
+            False,
+        ),
+        (json.dumps({"columns": ["A"], "data": [[1], [2], [3]]}), False),
+    ],
+)
+def test_read_json_auto_infer(json_data, should_fail, tmp_path):
+    """Test pd.read_json auto-infers 'table' and 'split' formats."""
+
+    # Use tmp_path to create a temporary file
+    temp_file = tmp_path / "test_read_json.json"
+
+    # Write the json_data to the temporary file
+    with open(temp_file, "w") as f:
+        f.write(json_data)
+
+    if should_fail:
+        with pytest.raises(ValueError, match=".*expected.*"):
+            read_json(temp_file)
+    else:
+        read_json(temp_file)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2300,7 +2300,7 @@ def test_large_number():
         (json.dumps({"columns": ["A"], "data": [[1], [2], [3]]}), False),
     ],
 )
-def test_read_json_auto_infer(json_data, should_fail, tmp_path):
+def test_read_json_auto_infer_orient_table_split(json_data, should_fail, tmp_path):
     """Test pd.read_json auto-infers 'table' and 'split' formats."""
 
     # Use tmp_path to create a temporary file


### PR DESCRIPTION
- [x] closes #52713
- [x] [Tests added and passed]
- [x] All [code checks passed]
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

### Example:

This example demonstrates how to use the updated functionality of `read_json` to correctly handle the new `orient='table'` format.

#### Saving DataFrame to JSON with orient='table':

```python
import pandas as pd

# Create a sample DataFrame
df = pd.DataFrame({"A": [1, 2, 3]})

df.to_json('test.json', indent=1, orient='table')
read = pd.read_json('test.json')
print(read)

   A
0  1
1  2
2  3
```

#### Saving DataFrame to JSON with orient='split':

```python
df = pd.DataFrame({"A": [1, 2, 3]})

df.to_json('test.json', indent=1, orient='split')
read = pd.read_json('test.json')
print(read)

   A
0  1
1  2
2  3
```