### PR TITLE
WEB: Partial update of workgroups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,6 @@
 # ci
 ci/                               @mroeschke
 
-# web
-web/                              @datapythonista
-
 # docs
 doc/cheatsheet                    @Dr-Irv
 doc/source/development            @noatamir

--- a/web/pandas/about/team.md
+++ b/web/pandas/about/team.md
@@ -41,8 +41,6 @@ If you want to support pandas development, you can find information in the [dona
 
 ## Governance
 
-Wes McKinney is the Benevolent Dictator for Life (BDFL).
-
 The project governance is available in the [project governance page]({{ base_url }}about/governance.html).
 
 ## Workgroups

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -132,8 +132,7 @@ workgroups:
     contact: infrastructure@pandas.pydata.org
     responsibilities: "Keep the pandas infrastructure up and working. In particular the servers for the website, benchmarks, CI and others needed."
     members:
-    - Marc Garcia
-    - Matthew Roeschke
+    - William Ayd
     - Thomas Li
   communications:
     name: Communications
@@ -141,7 +140,6 @@ workgroups:
     responsibilities: "Share relevant information with the broader community, mainly via our social networks, as well as being the main point of contact between NumFOCUS and the core team."
     members:
     - Marco Gorelli
-    - Marc Garcia
 sponsors:
   active:
   - name: "NumFOCUS"


### PR DESCRIPTION
Making a first update for the new teams structure. I think some more will be needed, including the steering committee one, but for now updating just this, as it's useful for the OVH discussions.
