### PR TITLE
Update describe.py

### DIFF
--- a/pandas/core/methods/describe.py
+++ b/pandas/core/methods/describe.py
@@ -353,10 +353,7 @@ def _refine_percentiles(
 
     # get them all to be in [0, 1]
     validate_percentile(percentiles)
-
-    # median should always be included
-    if 0.5 not in percentiles:
-        percentiles.append(0.5)
+    
 
     percentiles = np.asarray(percentiles)
 


### PR DESCRIPTION
This PR fixes an issue where passing a single value to .describe(percentiles=[...]) would incorrectly include the 50th percentile (median) in the output. The fix ensures that only the explicitly requested percentiles are returned.

Changes:
Modified the .describe() method to avoid adding the 50th percentile by default when a custom percentiles list is provided.

Closes: #60550