### PR TITLE
Update test_describe.py

### DIFF
--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -413,3 +413,9 @@ class TestDataFrameDescribe:
             dtype=pd.ArrowDtype(pa.float64()),
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_describe_single_percentile():
+        df = pd.DataFrame({'A': [1, 2, 3, 4, 5]})
+        result = df.describe(percentiles=[0.25])
+        assert 0.25 in result.index
+        assert 0.5 not in result.index


### PR DESCRIPTION
Added test case

Modified the .describe() method to avoid adding the 50th percentile by default when a custom percentiles list is provided.
Added a test case to verify the behavior when a single percentile is passed.