### PR TITLE
TST: Change sqlite test query string values to single quotes

### DIFF
--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -4282,11 +4282,11 @@ def test_xsqlite_execute_fail(sqlite_buildin):
     cur.execute(create_sql)
 
     with sql.pandasSQL_builder(sqlite_buildin) as pandas_sql:
-        pandas_sql.execute('INSERT INTO test VALUES("foo", "bar", 1.234)')
-        pandas_sql.execute('INSERT INTO test VALUES("foo", "baz", 2.567)')
+        pandas_sql.execute("INSERT INTO test VALUES('foo', 'bar', 1.234)")
+        pandas_sql.execute("INSERT INTO test VALUES('foo', 'baz', 2.567)")
 
         with pytest.raises(sql.DatabaseError, match="Execution failed on sql"):
-            pandas_sql.execute('INSERT INTO test VALUES("foo", "bar", 7)')
+            pandas_sql.execute("INSERT INTO test VALUES('foo', 'bar', 7)")
 
 
 def test_xsqlite_execute_closed_connection():
@@ -4304,7 +4304,7 @@ def test_xsqlite_execute_closed_connection():
         cur.execute(create_sql)
 
         with sql.pandasSQL_builder(conn) as pandas_sql:
-            pandas_sql.execute('INSERT INTO test VALUES("foo", "bar", 1.234)')
+            pandas_sql.execute("INSERT INTO test VALUES('foo', 'bar', 1.234)")
 
     msg = "Cannot operate on a closed database."
     with pytest.raises(sqlite3.ProgrammingError, match=msg):


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/actions/runs/13505086719/job/37732738398

Might be a new failure interaction with `sqlite3` and sqlite 3.49 being released recently https://www.sqlite.org/changes.html, but if this query is backward compatible we might as well use this form.

closes https://github.com/pandas-dev/pandas/issues/60989