### PR TITLE
Bump to `pypa/cibuildwheel@v2.23.0`; build WASM wheels against Pyodide 0.27

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -153,7 +153,7 @@ jobs:
         run: echo "sdist_name=$(cd ./dist && ls -d */)" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23.0
         with:
          package-dir: ./dist/${{ startsWith(matrix.buildplat[1], 'macosx') && env.sdist_name || needs.build_sdist.outputs.sdist_file }}
         env:


### PR DESCRIPTION
- [x] follow-up of https://github.com/pandas-dev/pandas/pull/60756#issuecomment-2607902892
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This bumps to https://github.com/pypa/cibuildwheel/releases/tag/v2.23.0 that was released a while ago. The notable highlights are that the project now _officially_ supports and tests the `ubuntu-22.04-arm` images, and bumps to Pyodide 0.27, matching the version used in the nightly wheels.

Other ancillary items from the release notes: PyPy 3.11 is now supported, but PyPy has been marked with a TODO and is not addressed here. 