### PR TITLE
DOC: Update warning in `Index.values` docstring to clarify index modification which causes segmentation fault

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4913,7 +4913,7 @@ class Index(IndexOpsMixin, PandasObject):
            a reference to the underlying data or a NumPy array.
 
         .. versionchanged:: 3.0.0
-        
+
            The returned array is read-only.
 
         Returns

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4912,8 +4912,9 @@ class Index(IndexOpsMixin, PandasObject):
            :meth:`Index.to_numpy`, depending on whether you need
            a reference to the underlying data or a NumPy array.
 
-           .. versionchanged:: 3.0.0
-            The returned array is read-only.
+       .. versionchanged:: 3.0.0
+
+          The returned array is read-only.
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4912,9 +4912,8 @@ class Index(IndexOpsMixin, PandasObject):
            :meth:`Index.to_numpy`, depending on whether you need
            a reference to the underlying data or a NumPy array.
 
-           Modifying 'Index.values' directly is not supported and can lead to memory
-           corruption or segmentation faults. This is because 'Index.values' provides
-           a direct reference to internal NumPy data.
+           .. versionchanged:: 3.0.0
+            The returned array is read-only.
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4912,6 +4912,10 @@ class Index(IndexOpsMixin, PandasObject):
            :meth:`Index.to_numpy`, depending on whether you need
            a reference to the underlying data or a NumPy array.
 
+           Modifying 'Index.values' directly is not supported and can lead to memory
+           corruption or segmentation faults. This is because 'Index.values' provides
+           a direct reference to internal NumPy data.
+
         Returns
         -------
         array: numpy.ndarray or ExtensionArray

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4912,9 +4912,9 @@ class Index(IndexOpsMixin, PandasObject):
            :meth:`Index.to_numpy`, depending on whether you need
            a reference to the underlying data or a NumPy array.
 
-       .. versionchanged:: 3.0.0
-
-          The returned array is read-only.
+        .. versionchanged:: 3.0.0
+        
+           The returned array is read-only.
 
         Returns
         -------


### PR DESCRIPTION
Index Modification issues (#60954)

- [x] Added [docstring](pandas/core/indexes/base.py) under existing function.

This PR updates the docstring for Index.values to clearly warn users that modifying it directly is not supported and may lead to memory corruption or segmentation faults. It also recommends safe alternatives, such as using `Index.array` or `Index.to_numpy(copy=True)`.

As per @mroeschke s note, in Pandas 3.0 this operation will raise an error under Copy-on-Write mode, making it clear that modifying is disallowed.

closes https://github.com/pandas-dev/pandas/issues/60954