### PR TITLE
BUG: PeriodIndex.to_datetime inconsistent with its docstring

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -745,6 +745,7 @@ I/O
 
 Period
 ^^^^^^
+- Bug in :meth:`PeriodIndex.to_timestamp` casting to a DatetimeIndex of timestamps at the end of the period, instead of at the beginning of the period. (:issue:`59371`)
 - Fixed error message when passing invalid period alias to :meth:`PeriodIndex.to_timestamp` (:issue:`58974`)
 -
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -822,7 +822,14 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
 
         new_parr = self.asfreq(freq, how=how)
 
-        new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
+        is_start = how == "S"
+        if is_start:
+            new_data = np.asarray(
+                [getattr(period, "start_time", period) for period in new_parr]
+            )
+        else:
+            new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
+
         dta = DatetimeArray._from_sequence(new_data, dtype=np.dtype("M8[ns]"))
 
         if self.freq.name == "B":

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -824,9 +824,10 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
 
         is_start = how == "S"
         if is_start:
-            new_data = np.asarray(
-                [(NaT if period is NaT else period.start_time) for period in new_parr]
+            start_time = np.vectorize(
+                lambda period: (NaT if period is NaT else period.start_time)
             )
+            new_data = start_time(new_parr)
         else:
             new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -825,7 +825,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         is_start = how == "S"
         if is_start:
             new_data = np.asarray(
-                [getattr(period, "start_time", period) for period in new_parr]
+                [(NaT if period is NaT else period.start_time) for period in new_parr]
             )
         else:
             new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)

--- a/pandas/tests/indexes/datetimes/methods/test_to_period.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_period.py
@@ -116,13 +116,12 @@ class TestToPeriod:
 
         tm.assert_index_equal(pi1, pi2)
 
-    @pytest.mark.filterwarnings(r"ignore:PeriodDtype\[B\] is deprecated:FutureWarning")
     def test_period_dt64_round_trip(self):
-        dti = date_range("1/1/2000", "1/7/2002", freq="B")
+        dti = date_range("1/1/2000", "1/7/2002", freq="D")
         pi = dti.to_period()
         tm.assert_index_equal(pi.to_timestamp(), dti)
 
-        dti = date_range("1/1/2000", "1/7/2002", freq="B")
+        dti = date_range("1/1/2000", "1/7/2002", freq="D")
         pi = dti.to_period(freq="h")
         tm.assert_index_equal(pi.to_timestamp(), dti)
 

--- a/pandas/tests/indexes/period/methods/test_to_timestamp.py
+++ b/pandas/tests/indexes/period/methods/test_to_timestamp.py
@@ -141,6 +141,18 @@ class TestToTimestamp:
         result = index.to_timestamp()
         assert result[0] == Timestamp("1/1/2012")
 
+    def test_cast_to_timestamps_at_beginning_of_period(self):
+        # GH 59371
+        index = period_range("2000", periods=3, freq="M")
+        result = index.to_timestamp("M")
+
+        expected = DatetimeIndex(
+            ["2000-01-01", "2000-02-01", "2000-03-01"],
+            dtype="datetime64[ns]",
+            freq="MS",
+        )
+        tm.assert_equal(result, expected)
+
 
 def test_ms_to_timestamp_error_message():
     # https://github.com/pandas-dev/pandas/issues/58974#issuecomment-2164265446

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -862,15 +862,12 @@ class TestTSPlot:
         for line in ax.get_lines():
             assert PeriodIndex(data=line.get_xdata()).freq == "min"
 
-    @pytest.mark.filterwarnings(r"ignore:PeriodDtype\[B\] is deprecated:FutureWarning")
     def test_mixed_freq_irreg_period(self):
         ts = Series(
             np.arange(30, dtype=np.float64), index=date_range("2020-01-01", periods=30)
         )
         irreg = ts.iloc[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 18, 29]]
-        msg = r"PeriodDtype\[B\] is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
-            rng = period_range("1/3/2000", periods=30, freq="B")
+        rng = period_range("1/3/2000", periods=30, freq="D")
         ps = Series(np.random.default_rng(2).standard_normal(len(rng)), rng)
         _, ax = mpl.pyplot.subplots()
         irreg.plot(ax=ax)

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -150,7 +150,9 @@ class TestPeriodIndex:
             if period == "B"
             else "Resampling with a PeriodIndex is deprecated"
         )
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             result = getattr(ts.resample(period, convention=conv), meth)()
             expected = result.to_timestamp(period, how=conv)
             expected = expected.asfreq(offset, meth).to_period()
@@ -193,7 +195,9 @@ class TestPeriodIndex:
         result = ts.resample("Y-DEC").mean()
 
         msg = "The 'convention' keyword in Series.resample is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             resampled = result.resample(freq, convention="end").ffill()
         expected = result.to_timestamp(freq, how="end")
         expected = expected.asfreq(freq, "ffill").to_period(freq)
@@ -204,7 +208,9 @@ class TestPeriodIndex:
         ts = Series(np.random.default_rng(2).standard_normal(len(rng)), rng)
 
         msg = "The 'convention' keyword in Series.resample is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             result = ts.resample("M", convention="end").ffill(limit=2)
         expected = ts.asfreq("M").reindex(result.index, method="ffill", limit=2)
         tm.assert_series_equal(result, expected)
@@ -249,7 +255,9 @@ class TestPeriodIndex:
             if period == "B"
             else "Resampling with a PeriodIndex is deprecated"
         )
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             result = ts.resample(period, convention=convention).ffill()
             expected = result.to_timestamp(period, how=convention)
             expected = expected.asfreq(offset, "ffill").to_period()
@@ -265,7 +273,9 @@ class TestPeriodIndex:
             if target == "D"
             else r"PeriodDtype\[B\] is deprecated"
         )
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             result = ts.resample(target, convention=convention).ffill()
             expected = result.to_timestamp(target, how=convention)
             expected = expected.asfreq(target, "ffill").to_period()
@@ -346,7 +356,7 @@ class TestPeriodIndex:
         series = Series(1, index=index)
         series = series.tz_convert(local_timezone)
         msg = "Converting to PeriodArray/Index representation will drop timezone"
-        with tm.assert_produces_warning(UserWarning, match=msg):
+        with tm.assert_produces_warning(UserWarning, match=msg, check_stacklevel=False):
             result = series.resample("D").mean().to_period()
 
         # Create the expected series
@@ -438,7 +448,7 @@ class TestPeriodIndex:
         if warn is None:
             msg = "Resampling with a PeriodIndex is deprecated"
             warn = FutureWarning
-        with tm.assert_produces_warning(warn, match=msg):
+        with tm.assert_produces_warning(warn, match=msg, check_stacklevel=False):
             result = ts.resample(target, convention=convention).ffill()
             expected = result.to_timestamp(target, how=convention)
             expected = expected.asfreq(target, "ffill").to_period()
@@ -473,7 +483,9 @@ class TestPeriodIndex:
         # conforms, but different month
         ts = simple_period_range_series("1990", "1992", freq="Y-JUN")
         msg = "The 'convention' keyword in Series.resample is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             result = ts.resample("Q-MAR", convention=how).ffill()
         expected = ts.asfreq("Q-MAR", how=how)
         expected = expected.reindex(result.index, method="ffill")
@@ -523,7 +535,9 @@ class TestPeriodIndex:
 
         ts = simple_period_range_series("1/1/2000", "2/1/2000")
         msg = "The 'convention' keyword in Series.resample is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             result = ts.resample("h", convention="s").asfreq()
         exp_rng = period_range("1/1/2000", "2/1/2000 23:00", freq="h")
         expected = ts.asfreq("h", how="s").reindex(exp_rng)
@@ -586,7 +600,7 @@ class TestPeriodIndex:
 
         # for good measure
         msg = "Converting to PeriodArray/Index representation will drop timezone "
-        with tm.assert_produces_warning(UserWarning, match=msg):
+        with tm.assert_produces_warning(UserWarning, match=msg, check_stacklevel=False):
             result = s.resample("D").mean().to_period()
         ex_index = period_range("2001-09-20", periods=1, freq="D")
         expected = Series([1.5], index=ex_index)
@@ -885,7 +899,9 @@ class TestPeriodIndex:
         )
         expected = DataFrame(expected_values, index=expected_index)
         msg = "Resampling with a PeriodIndex is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             rs = frame.resample(freq)
         result = rs.mean()
         tm.assert_frame_equal(result, expected)
@@ -924,7 +940,9 @@ class TestPeriodIndex:
         pi = period_range(start, end, freq=start_freq)
         ser = Series(np.arange(len(pi)), index=pi)
         msg = "Resampling with a PeriodIndex is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             rs = ser.resample(end_freq, offset=offset)
         result = rs.mean()
         result = result.to_timestamp(end_freq)
@@ -937,7 +955,9 @@ class TestPeriodIndex:
         pi = period_range("19910905 12:00", "19910909 1:00", freq="h")
         ser = Series(np.arange(len(pi)), index=pi)
         msg = "Resampling with a PeriodIndex is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             rs = ser.resample("M", offset="3h")
         result = rs.mean()
         result = result.to_timestamp("M")
@@ -985,7 +1005,9 @@ class TestPeriodIndex:
         data[3:6] = np.nan
         s = Series(data, index).to_period()
         msg = "Resampling with a PeriodIndex is deprecated"
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            FutureWarning, match=msg, check_stacklevel=False
+        ):
             rs = s.resample("Q")
         result = rs.sum(min_count=1)
         expected = Series(
@@ -1073,7 +1095,7 @@ def test_corner_cases_period(simple_period_range_series):
     len0pts = simple_period_range_series("2007-01", "2010-05", freq="M")[:0]
     # it works
     msg = "Resampling with a PeriodIndex is deprecated"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(FutureWarning, match=msg, check_stacklevel=False):
         result = len0pts.resample("Y-DEC").mean()
     assert len(result) == 0
 


### PR DESCRIPTION
- [x] closes #59371
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
