### PR TITLE
DOC: Add GL08 for pandas.Timestamp.tzinfo

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -78,7 +78,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.max PR02" \
         -i "pandas.Timestamp.min PR02" \
         -i "pandas.Timestamp.resolution PR02" \
-        -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
         -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \
         -i "pandas.core.resample.Resampler.quantile PR01,PR07" \

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2233,7 +2233,6 @@ class Timestamp(_Timestamp):
 
         >>> ts_naive = pd.Timestamp("2023-01-01 12:00:00")
         >>> ts_naive.tzinfo
-        None
         """
         return super().tzinfo
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2229,7 +2229,7 @@ class Timestamp(_Timestamp):
         --------
         >>> ts = pd.Timestamp("2023-01-01 12:00:00", tz="UTC")
         >>> ts.tzinfo
-        UTC
+        datetime.timezone.utc
 
         >>> ts_naive = pd.Timestamp("2023-01-01 12:00:00")
         >>> ts_naive.tzinfo

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2208,6 +2208,35 @@ class Timestamp(_Timestamp):
         """
         return super().tzname()
 
+    @property
+    def tzinfo(self):
+        """
+        Returns the timezone info of the Timestamp.
+
+        This property returns a `datetime.tzinfo` object if the Timestamp
+        is timezone-aware. If the Timestamp has no timezone, it returns `None`.
+        If the Timestamp is in UTC or a fixed-offset timezone,
+        it returns `datetime.timezone`. If the Timestamp uses an
+        IANA timezone (e.g., "America/New_York"), it returns `zoneinfo.ZoneInfo`.
+
+        See Also
+        --------
+        Timestamp.tz : Alias for `tzinfo`, may return a `zoneinfo.ZoneInfo` object.
+        Timestamp.tz_convert : Convert timezone-aware Timestamp to another time zone.
+        Timestamp.tz_localize : Localize the Timestamp to a specific timezone.
+
+        Examples
+        --------
+        >>> ts = pd.Timestamp("2023-01-01 12:00:00", tz="UTC")
+        >>> ts.tzinfo
+        UTC
+
+        >>> ts_naive = pd.Timestamp("2023-01-01 12:00:00")
+        >>> ts_naive.tzinfo
+        None
+        """
+        return super().tzinfo
+
     def utcoffset(self):
         """
         Return utc offset.


### PR DESCRIPTION
- [x] xref [DOC: Enforce Numpy Docstring Validation for pandas.Timestamp #58550](https://github.com/pandas-dev/pandas/issues/58505)

fixes
```
pandas.Timestamp.tzinfo
```
