### PR TITLE
BUG: Passing original properties of `DataFrame` and `Series` subclasses to their constructors

### DIFF
--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -402,23 +402,50 @@ To let original data structures have additional properties, you should let ``pan
 
 1. Define ``_internal_names`` and ``_internal_names_set`` for temporary properties which WILL NOT be passed to manipulation results.
 2. Define ``_metadata`` for normal properties which will be passed to manipulation results.
+If used, a ``Series`` subclass must also be defined with the same ``_metadata`` property and the first parameter of the constructors must be the data.
+Avoid the following names for your normal properties: ``data``, ``index``, ``columns``, ``dtype``, ``copy``, ``name``, ``_name`` and ``fastpath``.
 
 Below is an example to define two original properties, "internal_cache" as a temporary property and "added_property" as a normal property
 
 .. code-block:: python
 
-   class SubclassedDataFrame2(pd.DataFrame):
+    class SubclassedDataFrame(pd.DataFrame):
 
-       # temporary properties
-       _internal_names = pd.DataFrame._internal_names + ["internal_cache"]
-       _internal_names_set = set(_internal_names)
+        # temporary properties
+        _internal_names = pd.DataFrame._internal_names + ["internal_cache"]
+        _internal_names_set = set(_internal_names)
 
-       # normal properties
-       _metadata = ["added_property"]
+        # normal properties
+        _metadata = ["added_property"]
 
-       @property
-       def _constructor(self):
-           return SubclassedDataFrame2
+        def __init__(self, data=None, added_property=None, *args, **kwargs):
+            super().__init__(data, *args, **kwargs)
+            self.added_property = added_property
+
+        @property
+        def _constructor(self):
+            return SubclassedDataFrame
+
+        @property
+        def _constructor_sliced(self):
+            return SubclassedSeries
+
+    class SubclassedSeries(pd.Series):
+
+        # normal properties
+        _metadata = ["original_property"]
+
+        def __init__(self, data=None, original_property=None, *args, **kwargs):
+            super().__init__(data, *args, **kwargs)
+            self.original_property = original_property
+
+        @property
+        def _constructor(self):
+            return SubclassedSeries
+
+        @property
+        def _constructor_expanddim(self):
+            return SubclassedDataFrame
 
 .. code-block:: python
 

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -402,10 +402,11 @@ To let original data structures have additional properties, you should let ``pan
 
 1. Define ``_internal_names`` and ``_internal_names_set`` for temporary properties which WILL NOT be passed to manipulation results.
 2. Define ``_metadata`` for normal properties which will be passed to manipulation results.
-If used, a ``Series`` subclass must also be defined with the same ``_metadata`` property and the first parameter of the constructors must be the data.
+
+If ``_metadata`` is used, a ``Series`` subclass must also be defined with the same ``_metadata`` property and the first parameter of the constructors must be the data.
 Avoid the following names for your normal properties: ``data``, ``index``, ``columns``, ``dtype``, ``copy``, ``name``, ``_name`` and ``fastpath``.
 
-Below is an example to define two original properties, "internal_cache" as a temporary property and "added_property" as a normal property
+Below is an example to define two original properties, "internal_cache" as a temporary property and "added_property" as a normal property.
 
 .. code-block:: python
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -843,6 +843,7 @@ Other
 - Bug in Dataframe Interchange Protocol implementation was returning incorrect results for data buffers' associated dtype, for string and datetime columns (:issue:`54781`)
 - Bug in ``Series.list`` methods not preserving the original :class:`Index`. (:issue:`58425`)
 - Bug in ``Series.list`` methods not preserving the original name. (:issue:`60522`)
+- Bug in original properties ``_metadata`` of :class:`Dataframe` and :class:`Series` subclasses'. For some operations (i.e. ``concat``) the new object wasn't receiving the original properties (:issue:`34177`)
 - Bug in printing a :class:`DataFrame` with a :class:`DataFrame` stored in :attr:`DataFrame.attrs` raised a ``ValueError`` (:issue:`60455`)
 - Bug in printing a :class:`Series` with a :class:`DataFrame` stored in :attr:`Series.attrs` raised a ``ValueError`` (:issue:`60568`)
 - Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -325,32 +325,35 @@ def to_array(obj):
 
 
 class SubclassedSeries(Series):
-    _metadata = ["testattr", "name"]
+    _metadata = ["testattr"]
+
+    def __init__(self, data=None, testattr=None, *args, **kwargs):
+        super().__init__(data, *args, **kwargs)
+        self.testattr = testattr
 
     @property
     def _constructor(self):
-        # For testing, those properties return a generic callable, and not
-        # the actual class. In this case that is equivalent, but it is to
-        # ensure we don't rely on the property returning a class
-        # See https://github.com/pandas-dev/pandas/pull/46018 and
-        # https://github.com/pandas-dev/pandas/issues/32638 and linked issues
-        return lambda *args, **kwargs: SubclassedSeries(*args, **kwargs)
+        return SubclassedSeries
 
     @property
     def _constructor_expanddim(self):
-        return lambda *args, **kwargs: SubclassedDataFrame(*args, **kwargs)
+        return SubclassedDataFrame
 
 
 class SubclassedDataFrame(DataFrame):
     _metadata = ["testattr"]
 
+    def __init__(self, data=None, testattr=None, *args, **kwargs):
+        super().__init__(data, *args, **kwargs)
+        self.testattr = testattr
+
     @property
     def _constructor(self):
-        return lambda *args, **kwargs: SubclassedDataFrame(*args, **kwargs)
+        return SubclassedDataFrame
 
     @property
     def _constructor_sliced(self):
-        return lambda *args, **kwargs: SubclassedSeries(*args, **kwargs)
+        return SubclassedSeries
 
 
 def convert_rows_list_to_csv_str(rows_list: list[str]) -> str:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -675,7 +675,8 @@ class DataFrame(NDFrame, OpsMixin):
 
         # We assume that the subclass __init__ knows how to handle a
         #  pd.DataFrame object.
-        return self._constructor(df)
+        metadata = {k: getattr(self, k) for k in self._metadata}
+        return self._constructor(df, **metadata)
 
     _constructor_sliced: Callable[..., Series] = Series
 
@@ -690,7 +691,8 @@ class DataFrame(NDFrame, OpsMixin):
 
         # We assume that the subclass __init__ knows how to handle a
         #  pd.Series object.
-        return self._constructor_sliced(ser)
+        metadata = {k: getattr(self, k) for k in self._metadata}
+        return self._constructor_sliced(ser, **metadata)
 
     # ----------------------------------------------------------------------
     # Constructors


### PR DESCRIPTION
- [x] closes #34177 BUG: Subclassed DataFrame doesn't persist \_metadata properties across binary operations
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
No new arguments, methods nor functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

While implementing a subclass of `Dataframe`, I found that in some operations, objects that subclass's `DataFrame` and `Series` forget their original properties.

```python
import pandas as pd

class SubclassedSeries(pd.Series):
    _metadata = ['original_property']
    def __init__(self, data=None, original_property=None, *args, **kwargs):
        super().__init__(data, *args, **kwargs)
        self.original_property = original_property
    @property
    def _constructor(self):
        return SubclassedSeries
    @property
    def _constructor_expanddim(self):
        return SubclassedDataFrame


class SubclassedDataFrame(pd.DataFrame):
    _metadata = ['original_property']
    def __init__(self, data=None, original_property=None, *args, **kwargs):
        super().__init__(data, *args, **kwargs)
        self.original_property = original_property
    @property
    def _constructor(self):
        return SubclassedDataFrame
    @property
    def _constructor_sliced(self):
        return SubclassedSeries

## __init__
df = SubclassedDataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'], 'value': [1, 2, 3, 5]}, original_property='original_property')
print(f'__init__: {df.original_property}')

## Select
select_df = df[df['value'] == '1']
print(f'Select: {df.original_property}')

## loc
loc_df = df.loc[df['lkey'] == 'foo']
print(f'loc: {loc_df.original_property}')

## Concat
df = pd.concat([df, df])
print(f'Concat: {df.original_property}')

## Merge
df1 = SubclassedDataFrame({'lkey': ['foo', 'bar', 'baz', 'foo'],
                   'value': [1, 2, 3, 5]}, original_property='original_property')
df2 = SubclassedDataFrame({'rkey': ['foo', 'bar', 'baz', 'foo'],
                   'value': [5, 6, 7, 8]}, original_property='original_property')
merged_df = df1.merge(df2, left_on='lkey', right_on='rkey')
print(f'Merge: {merged_df.original_property}')

## Series
series = df['value']
print(f'Series: {series.original_property}')

## Sum
sum_df = df1 + df2
print(f'Sum: {sum_df.original_property}')

(df * 2).added_property
```
This functionality is critical for my project so I decided to fix it. I had the following considerations:

- `__init__` parameters in both parent classes weren't modified.
- `_name` stays in `Series._metadata` and their children because [@540db96b](https://github.com/pandas-dev/pandas/commit/540db96b8179c2ed83e427b9d501b04d68ee1804). It is removed right before the calling the constructor and added again in `__init__` of parent class.
- I added a unit test covering the cases mentioned above. I mentioned #34177 but I think #32860, #35415, #32638, #19850 and #8572 are related.
- Each `DataFrame` child must come with their respective `Series` child (and vice versa). Both children must contain and handle the same `_metadata` parameters.
- The constructors' parameters of both children must begin with `data=None`. The example with `(self, data=None, **_metadata, *args, **kwargs)` was the cleanest I was able to think without having to clean `*args` and `**kwargs` (like the old unit test in pandas/tests/frame/test_subclass.py:MySubclassWithMetadata). Not enforcing `data` as the first parameter and having to clean up `*args` and `**kwargs` felt as wrong as adding `*args` and `**kwargs` to `__init__` in both parents.

My environment consist on SUSE 15.6 and Python 3.11.11

Edit: Removed WIP comments about tests and code checks.