### PR TITLE
DOC: fix docstring validation errors for pandas.util.hash_pandas_object and pandas.Timestamp.resolution

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -77,7 +77,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timedelta.resolution PR02" \
         -i "pandas.Timestamp.max PR02" \
         -i "pandas.Timestamp.min PR02" \
-        -i "pandas.Timestamp.resolution PR02" \
         -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
         -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \
@@ -274,8 +273,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.YearEnd.is_on_offset GL08" \
         -i "pandas.tseries.offsets.YearEnd.month GL08" \
         -i "pandas.tseries.offsets.YearEnd.n GL08" \
-        -i "pandas.tseries.offsets.YearEnd.normalize GL08" \
-        -i "pandas.util.hash_pandas_object PR07,SA01" # There should be no backslash in the final line, please keep this comment in the last ignored function
+        -i "pandas.tseries.offsets.YearEnd.normalize GL08" # There should be no backslash in the final line, please keep this comment in the last ignored function
 
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -94,6 +94,7 @@ def hash_pandas_object(
     Parameters
     ----------
     obj : Index, Series, or DataFrame
+        The input object to hash.
     index : bool, default True
         Include the index in the hash (if Series/DataFrame).
     encoding : str, default 'utf8'
@@ -106,9 +107,14 @@ def hash_pandas_object(
 
     Returns
     -------
-    Series of uint64
-        Same length as the object.
+    Series
+        Containing unsigned integers, same length as object.
 
+    See Also
+    --------
+    util.hash_tuples : Hash an MultiIndex / listlike-of-tuples efficiently.
+    util.hash_array : Hash an array.
+    
     Examples
     --------
     >>> pd.util.hash_pandas_object(pd.Series([1, 2, 3]))

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -114,7 +114,7 @@ def hash_pandas_object(
     --------
     util.hash_tuples : Hash an MultiIndex / listlike-of-tuples efficiently.
     util.hash_array : Hash an array.
-    
+
     Examples
     --------
     >>> pd.util.hash_pandas_object(pd.Series([1, 2, 3]))


### PR DESCRIPTION
follow up on issue #59458 and #27977

for pandas.util.hash_pandas_object:
- Add parameter description to obj parameter
- Correct the Returns section
	- Change the type line to correctly callout 'Series' type
	- Update return description to describe the type contained in the Series
- Add See Also section
- Removed from code_checks.sh

for pandas.Timestamp.resolution
- Removed from code_checks.sh (I don't believe more work is needed because resolution is no longer a function, see #29910 