### PR TITLE
DOC: Added docstring to Timestamp.tzinfo

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -78,7 +78,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Timestamp.max PR02" \
         -i "pandas.Timestamp.min PR02" \
         -i "pandas.Timestamp.resolution PR02" \
-        -i "pandas.Timestamp.tzinfo GL08" \
         -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
         -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \
         -i "pandas.core.resample.Resampler.quantile PR01,PR07" \

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2977,6 +2977,28 @@ timedelta}, default 'raise'
         """
         return self.tzinfo
 
+    @property
+    def tzinfo(self):
+        """
+        Returns the timezone information of the Timestamp.
+
+        For pandas-specific timezone operations, the `tz` property is the
+        recommended interface.
+
+        See Also
+        --------
+        Timestamp.tz : Alias for tzinfo.
+        Timestamp.tz_convert : Convert timezone-aware Timestamp to another time zone.
+        Timestamp.tz_localize : Localize the Timestamp to a timezone.
+
+        Examples
+        --------
+        >>> ts = pd.Timestamp(1584226800, unit='s', tz='Europe/Stockholm')
+        >>> ts.tzinfo
+        zoneinfo.ZoneInfo(key='Europe/Stockholm')
+        """
+        return self.tzinfo
+
     @tz.setter
     def tz(self, value):
         # GH 3746: Prevent localizing or converting the index by setting tz

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2997,7 +2997,7 @@ timedelta}, default 'raise'
         >>> ts.tzinfo
         zoneinfo.ZoneInfo(key='Europe/Stockholm')
         """
-        return self.tzinfo
+        return super().tzinfo
 
     @tz.setter
     def tz(self, value):


### PR DESCRIPTION
Follow up on #59458

Added docstring to `Timestamp.tzinfo`. Emphasized that `Timestamp.tz` is preferred due to its Pandas-specific functionality. Sections added are as follows:
- Summary
- Extended Summary
- See Also
- Examples

Removed `Timestamp.tzinfo` from code_checks.sh

- [ ] closes #59458 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
