### PR TITLE
BUG: Preserve column names in DataFrame.from_records when nrows=0

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2231,7 +2231,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         if is_iterator(data):
             if nrows == 0:
-                return cls()
+                return cls(columns=columns)
 
             try:
                 first_row = next(data)

--- a/pandas/core/frame_test_constructors.py
+++ b/pandas/core/frame_test_constructors.py
@@ -1,0 +1,7 @@
+import pandas as pd
+def test_empty_df_preserve_col():
+    rows = []
+    df = pd.DataFrame.from_records(iter(rows), columns=['col_1', 'Col_2'], nrows=0)
+    assert list(df.columns)==['col_1', 'Col_2']
+    assert len(df) == 0
+    

--- a/pandas/core/frame_test_constructors.py
+++ b/pandas/core/frame_test_constructors.py
@@ -1,7 +1,0 @@
-import pandas as pd
-def test_empty_df_preserve_col():
-    rows = []
-    df = pd.DataFrame.from_records(iter(rows), columns=['col_1', 'Col_2'], nrows=0)
-    assert list(df.columns)==['col_1', 'Col_2']
-    assert len(df) == 0
-    

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -492,3 +492,11 @@ class TestFromRecords:
         expected_result = DataFrame(modified_data)
 
         tm.assert_frame_equal(actual_result, expected_result)
+        
+        
+    def test_from_records_empty_iterator_with_preserve_columns(self):
+        # GH#61140
+        rows = []
+        result = DataFrame.from_records(iter(rows), columns=["col_1", "Col_2"], nrows=0)
+        expected = DataFrame([],columns=["col_1", "Col_2"])
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2780,6 +2780,12 @@ class TestDataFrameConstructors:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_from_records_empty_iterator_with_preserve_columns(self):
+
+        rows = []
+        df = pd.DataFrame.from_records(iter(rows), columns=["col_1", "Col_2"], nrows=0)
+        assert list(df.columns) == ["col_1", "Col_2"]
+        assert len(df) == 0
 
 class TestDataFrameConstructorIndexInference:
     def test_frame_from_dict_of_series_overlapping_monthly_period_indexes(self):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2779,13 +2779,7 @@ class TestDataFrameConstructors:
             ["NaT", "0 days 00:00:00.000000001"], dtype="timedelta64[ns]"
         )
         tm.assert_frame_equal(result, expected)
-
-    def test_from_records_empty_iterator_with_preserve_columns(self):
-
-        rows = []
-        df = pd.DataFrame.from_records(iter(rows), columns=["col_1", "Col_2"], nrows=0)
-        assert list(df.columns) == ["col_1", "Col_2"]
-        assert len(df) == 0
+        
 
 class TestDataFrameConstructorIndexInference:
     def test_frame_from_dict_of_series_overlapping_monthly_period_indexes(self):


### PR DESCRIPTION
### Description
Updates pandas/core/frame.py to preserve column names in empty DataFrames when nrows == 0. Changed from return Cls() to return Cls(columns=columns).

Closes #61140

### Changes Made
- Modified if nrows == 0 in core/frame.py.
- Added test in tests/frame/test_constructors.py.

### Testing
- Added test case for empty DataFrame column retention.
- Verified locally with pytest.
