### PR TITLE
String dtype: more informative repr (keeping brief __str__)

### DIFF
--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -198,11 +198,8 @@ class StringDtype(StorageExtensionDtype):
         self._na_value = na_value
 
     def __repr__(self) -> str:
-        if self._na_value is libmissing.NA:
-            return f"{self.name}[{self.storage}]"
-        else:
-            # TODO add more informative repr
-            return self.name
+        storage = "" if self.storage == "pyarrow" else "storage='python', "
+        return f"<StringDtype({storage}na_value={self._na_value})>"
 
     def __eq__(self, other: object) -> bool:
         # we need to override the base class __eq__ because na_value (NA or NaN)

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -123,10 +123,10 @@ class StringDtype(StorageExtensionDtype):
     Examples
     --------
     >>> pd.StringDtype()
-    StringDtype(storage='python', na_value=<NA>)>
+    <StringDtype(storage='python', na_value=<NA>)>
 
     >>> pd.StringDtype(storage="pyarrow")
-    StringDtype(na_value=<NA>)>
+    <StringDtype(na_value=<NA>)>
     """
 
     @property

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -123,10 +123,10 @@ class StringDtype(StorageExtensionDtype):
     Examples
     --------
     >>> pd.StringDtype()
-    string[python]
+    StringDtype(storage='python', na_value=<NA>)>
 
     >>> pd.StringDtype(storage="pyarrow")
-    string[pyarrow]
+    StringDtype(na_value=<NA>)>
     """
 
     @property

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6809,12 +6809,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2  3  z   <NA>  <NA>    20  200.0
 
         >>> dfn.dtypes
-        a             Int32
-        b    string[python]
-        c           boolean
-        d    string[python]
-        e             Int64
-        f           Float64
+        a      Int32
+        b     string
+        c    boolean
+        d     string
+        e      Int64
+        f    Float64
         dtype: object
 
         Start with a Series of strings and missing data represented by ``np.nan``.

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -67,7 +67,6 @@ from pandas.core.arrays import (
     ExtensionArray,
     TimedeltaArray,
 )
-from pandas.core.arrays.string_ import StringDtype
 from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.indexes.api import (
@@ -1218,8 +1217,6 @@ class _GenericArrayFormatter:
                 return self.na_rep
             elif isinstance(x, PandasObject):
                 return str(x)
-            elif isinstance(x, StringDtype):
-                return repr(x)
             else:
                 # object dtype
                 return str(formatter(x))

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -103,6 +103,18 @@ def test_repr(dtype):
     assert repr(df.A.array) == expected
 
 
+def test_dtype_repr(dtype):
+    if dtype.storage == "pyarrow":
+        if dtype.na_value is pd.NA:
+            assert repr(dtype) == "<StringDtype(na_value=<NA>)>"
+        else:
+            assert repr(dtype) == "<StringDtype(na_value=nan)>"
+    elif dtype.na_value is pd.NA:
+        assert repr(dtype) == "<StringDtype(storage='python', na_value=<NA>)>"
+    else:
+        assert repr(dtype) == "<StringDtype(storage='python', na_value=nan)>"
+
+
 def test_none_to_nan(cls, dtype):
     a = cls._from_sequence(["a", None, "b"], dtype=dtype)
     assert a[1] is not None

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -777,9 +777,9 @@ class TestDataFrameToString:
         result = df.dtypes.to_string()
         expected = dedent(
             """\
-            x    string[pyarrow]
-            y     string[python]
-            z     int64[pyarrow]"""
+            x            string
+            y            string
+            z    int64[pyarrow]"""
         )
         assert result == expected
 


### PR DESCRIPTION
Attempt to address https://github.com/pandas-dev/pandas/issues/59342

With the current version of the PR, the reprs for the different dtype variants are:

```python
# default NaN variants
<StringDtype(na_value=nan)>
<StringDtype(storage='python', na_value=nan)>
# nullable NA variants
<StringDtype(na_value=<NA>)>
<StringDtype(storage='python', na_value=<NA>)>
```

Some questions to decide on:

- Do we use surrounding `<...>` or not? (we are somewhat inconsistent internally for similar reprs; e.g. the Index repr does not use it, the ExtensionArray repr does)
  - Including the `<..>` makes it clearer that it is not necessarily exactly executable code, I think 
- Do we keep the current `__str__` as is (i.e. just `"str"` or `"string"`), or do we include the storage for the `"string"` case (to preserve the current repr behaviour). i.e. make it to have the options `"str"`, `"string[pyarrow]"` or `"string[python]"`.
  - Essentially, this comes down to changing the `dtype.name` attribute or not (which right now is defined to be "str" or "string")
  - As comparison, for DatetimeTZDtype we do include the [] parametrization in `.name` (e.g. "datetime64[s, UTC]"), while for CategoricalDtype we do not (there it is just "category")
  - If we don't use it in the name/str, we actually never show `"string[python]"`, while we still allow that as string alias for `dtype` arguments (e.g. in constructors or in `astype()`)
- Currently I just use their own repr for `pd.NA` and `np.nan`, which means they are displayed as `<NA>` and `nan`
  - But we could also make it to look like `pd.NA` and `np.nan`. This makes it a more "executable" repr, which could be nice, but on the other hand I also don't want to encourage that too much.