### PR TITLE
ENH: Support `Series[bool]` as indexer for `iloc.__getitem__`  

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -68,6 +68,7 @@ Other enhancements
 - :func:`read_parquet` accepts ``to_pandas_kwargs`` which are forwarded to :meth:`pyarrow.Table.to_pandas` which enables passing additional keywords to customize the conversion to pandas, such as ``maps_as_pydicts`` to read the Parquet map data type as python dictionaries (:issue:`56842`)
 - :meth:`.DataFrameGroupBy.transform`, :meth:`.SeriesGroupBy.transform`, :meth:`.DataFrameGroupBy.agg`, :meth:`.SeriesGroupBy.agg`, :meth:`.SeriesGroupBy.apply`, :meth:`.DataFrameGroupBy.apply` now support ``kurt`` (:issue:`40139`)
 - :meth:`DataFrame.apply` supports using third-party execution engines like the Bodo.ai JIT compiler (:issue:`60668`)
+- :meth:`DataFrame.iloc` and :meth:`Series.iloc` now support boolean masks in ``__getitem__`` for more consistent indexing behavior (:issue:`60994`)
 - :meth:`DataFrameGroupBy.transform`, :meth:`SeriesGroupBy.transform`, :meth:`DataFrameGroupBy.agg`, :meth:`SeriesGroupBy.agg`, :meth:`RollingGroupby.apply`, :meth:`ExpandingGroupby.apply`, :meth:`Rolling.apply`, :meth:`Expanding.apply`, :meth:`DataFrame.apply` with ``engine="numba"`` now supports positional arguments passed as kwargs (:issue:`58995`)
 - :meth:`Rolling.agg`, :meth:`Expanding.agg` and :meth:`ExponentialMovingWindow.agg` now accept :class:`NamedAgg` aggregations through ``**kwargs`` (:issue:`28333`)
 - :meth:`Series.map` can now accept kwargs to pass on to func (:issue:`59814`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1582,11 +1582,7 @@ class _iLocIndexer(_LocationIndexer):
         if com.is_bool_indexer(key):
             if hasattr(key, "index") and isinstance(key.index, Index):
                 if key.index.inferred_type == "integer":
-                    raise NotImplementedError(
-                        "iLocation based boolean "
-                        "indexing on an integer type "
-                        "is not available"
-                    )
+                    return
                 raise ValueError(
                     "iLocation based boolean indexing cannot use an indexable as a mask"
                 )

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -770,7 +770,7 @@ class TestiLocBaseIndependent:
         for idx in [None, "index", "locs"]:
             mask = (df.nums > 2).values
             if idx:
-                mask_index = getattr(df, idx if idx == "index" else "locs")[::-1]
+                mask_index = getattr(df, idx)[::-1]
                 mask = Series(mask, list(mask_index))
             for method in ["", ".loc", ".iloc"]:
                 try:
@@ -779,10 +779,7 @@ class TestiLocBaseIndependent:
                     else:
                         accessor = df
                     answer = str(bin(accessor[mask]["nums"].sum()))
-                except (
-                    ValueError,
-                    IndexingError,
-                ) as err:
+                except (ValueError, IndexingError) as err:
                     answer = str(err)
 
                 key = (

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -758,9 +758,7 @@ class TestiLocBaseIndependent:
         tm.assert_frame_equal(result, df)
 
         result = df.iloc[Series([True, False, True, False, True], dtype=bool)]
-        tm.assert_frame_equal(
-            result, DataFrame({"a": [0, 2, 4]}, index=[0, 2, 4])
-        )
+        tm.assert_frame_equal(result, DataFrame({"a": [0, 2, 4]}, index=[0, 2, 4]))
 
         df = DataFrame(list(range(5)), index=list("ABCDE"), columns=["a"])
 

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -734,7 +734,6 @@ class TestiLocBaseIndependent:
             df.iloc[mask]
 
         mask.index = range(len(mask))
-        result = df.iloc[mask]
         msg = "Unalignable boolean Series provided as indexer"
         with pytest.raises(IndexingError, match=msg):
             df.iloc[mask]

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -742,10 +742,27 @@ class TestiLocBaseIndependent:
         result = df.iloc[np.array([True] * len(mask), dtype=bool)]
         tm.assert_frame_equal(result, df)
 
-        result2 = df.iloc[np.array([True, False, True, False, True], dtype=bool)]
+        result = df.iloc[np.array([True, False, True, False, True], dtype=bool)]
         tm.assert_frame_equal(
-            result2, DataFrame({"a": [0, 2, 4]}, index=["A", "C", "E"])
+            result, DataFrame({"a": [0, 2, 4]}, index=["A", "C", "E"])
         )
+
+        # series (index does not match)
+        msg = "Unalignable boolean Series provided as indexer"
+        with pytest.raises(IndexingError, match=msg):
+            df.iloc[Series([True] * len(mask), dtype=bool)]
+
+        df = DataFrame(list(range(5)), columns=["a"])
+
+        result = df.iloc[Series([True] * len(mask), dtype=bool)]
+        tm.assert_frame_equal(result, df)
+
+        result = df.iloc[Series([True, False, True, False, True], dtype=bool)]
+        tm.assert_frame_equal(
+            result, DataFrame({"a": [0, 2, 4]}, index=[0, 2, 4])
+        )
+
+        df = DataFrame(list(range(5)), index=list("ABCDE"), columns=["a"])
 
         # the possibilities
         locs = np.arange(4)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -742,6 +742,9 @@ class TestiLocBaseIndependent:
         result = df.iloc[np.array([True] * len(mask), dtype=bool)]
         tm.assert_frame_equal(result, df)
 
+        result2 = df.iloc[np.array([True, False, True, False, True], dtype=bool)]
+        tm.assert_frame_equal(result2, DataFrame({"a": [0, 2, 4]}, index=["A", "C", "E"]))
+
         # the possibilities
         locs = np.arange(4)
         nums = 2**locs

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -743,7 +743,9 @@ class TestiLocBaseIndependent:
         tm.assert_frame_equal(result, df)
 
         result2 = df.iloc[np.array([True, False, True, False, True], dtype=bool)]
-        tm.assert_frame_equal(result2, DataFrame({"a": [0, 2, 4]}, index=["A", "C", "E"]))
+        tm.assert_frame_equal(
+            result2, DataFrame({"a": [0, 2, 4]}, index=["A", "C", "E"])
+        )
 
         # the possibilities
         locs = np.arange(4)


### PR DESCRIPTION
- [x] closes #60994 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
