### PR TITLE
BUG: DataFrame.resample is changing the index type to MultiIndex when the dataframe is empty

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -772,6 +772,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGroupBy.quantile` when ``interpolation="nearest"`` is inconsistent with :meth:`DataFrame.quantile` (:issue:`47942`)
 - Bug in :meth:`.Resampler.interpolate` on a :class:`DataFrame` with non-uniform sampling and/or indices not aligning with the resulting resampled index would result in wrong interpolation (:issue:`21351`)
 - Bug in :meth:`DataFrame.ewm` and :meth:`Series.ewm` when passed ``times`` and aggregation functions other than mean (:issue:`51695`)
+- Bug in :meth:`DataFrame.resample` changing index type to :class:`MultiIndex` when the dataframe is empty and using an upsample method (:issue:`55572`)
 - Bug in :meth:`DataFrameGroupBy.agg` that raises ``AttributeError`` when there is dictionary input and duplicated columns, instead of returning a DataFrame with the aggregation of all duplicate columns. (:issue:`55041`)
 - Bug in :meth:`DataFrameGroupBy.apply` and :meth:`SeriesGroupBy.apply` for empty data frame with ``group_keys=False`` still creating output index using group keys. (:issue:`60471`)
 - Bug in :meth:`DataFrameGroupBy.apply` that was returning a completely empty DataFrame when all return values of ``func`` were ``None`` instead of returning an empty DataFrame with the original columns and dtypes. (:issue:`57775`)

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -438,9 +438,7 @@ def test_resample_size_empty_dataframe(freq, index):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "index", [DatetimeIndex([]), TimedeltaIndex([])]
-)
+@pytest.mark.parametrize("index", [DatetimeIndex([]), TimedeltaIndex([])])
 @pytest.mark.parametrize("freq", ["D", "h"])
 @pytest.mark.parametrize(
     "method", ["ffill", "bfill", "nearest", "asfreq", "interpolate", "mean"]
@@ -456,6 +454,7 @@ def test_resample_apply_empty_dataframe(index, freq, method):
     expected = DataFrame([], index=expected_index)
 
     tm.assert_frame_equal(result, expected)
+
 
 @pytest.mark.parametrize(
     "index",

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -439,6 +439,25 @@ def test_resample_size_empty_dataframe(freq, index):
 
 
 @pytest.mark.parametrize(
+    "index", [DatetimeIndex([]), TimedeltaIndex([])]
+)
+@pytest.mark.parametrize("freq", ["D", "h"])
+@pytest.mark.parametrize(
+    "method", ["ffill", "bfill", "nearest", "asfreq", "interpolate", "mean"]
+)
+def test_resample_apply_empty_dataframe(index, freq, method):
+    # GH#55572
+    empty_frame_dti = DataFrame(index=index)
+
+    rs = empty_frame_dti.resample(freq)
+    result = rs.apply(getattr(rs, method))
+
+    expected_index = _asfreq_compat(empty_frame_dti.index, freq)
+    expected = DataFrame([], index=expected_index)
+
+    tm.assert_frame_equal(result, expected)
+
+@pytest.mark.parametrize(
     "index",
     [
         PeriodIndex([], freq="M", name="a"),


### PR DESCRIPTION
BUG: DataFrame.resample is changing the index type to MultiIndex when the dataframe is empty

very easy bug to reproduce. the bug has been opened for 1 year.

```
# repro
import pandas as pd

df = pd.DataFrame(columns = ["a", "b"], index = pd.DatetimeIndex([]))
sampled = df.resample("8h").apply(pd.Series.mean)

print(df.index)
print(sampled.index)
```

output on pandas 1
```
DatetimeIndex([], dtype='datetime64[ns]', freq=None)
DatetimeIndex([], dtype='datetime64[ns]', freq='8H')
```

output on pandas 2 and main branch
```
DatetimeIndex([], dtype='datetime64[ns]', freq=None)
MultiIndex([], )
```


- [X] closes #55572 (Replace xxxx with the GitHub issue number)
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
