### PR TITLE
BUG: Fix pyarrow categoricals not working for pivot and multiindex

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -638,8 +638,8 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 - Bug in :func:`Series.apply` where ``nan`` was ignored for :class:`CategoricalDtype` (:issue:`59938`)
+- Bug in :meth:`DataFrame.pivot` and :meth:`DataFrame.set_index` raising an ``ArrowNotImplementedError`` for columns with pyarrow dictionary dtype (:issue:`53051`)
 - Bug in :meth:`Series.convert_dtypes` with ``dtype_backend="pyarrow"`` where empty :class:`CategoricalDtype` :class:`Series` raised an error or got converted to ``null[pyarrow]`` (:issue:`59934`)
--
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -640,6 +640,7 @@ Categorical
 - Bug in :func:`Series.apply` where ``nan`` was ignored for :class:`CategoricalDtype` (:issue:`59938`)
 - Bug in :meth:`DataFrame.pivot` and :meth:`DataFrame.set_index` raising an ``ArrowNotImplementedError`` for columns with pyarrow dictionary dtype (:issue:`53051`)
 - Bug in :meth:`Series.convert_dtypes` with ``dtype_backend="pyarrow"`` where empty :class:`CategoricalDtype` :class:`Series` raised an error or got converted to ``null[pyarrow]`` (:issue:`59934`)
+-
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -452,7 +452,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 if isinstance(values, Index):
                     arr = values._data._pa_array.combine_chunks()
                 else:
-                    arr = values._pa_array.combine_chunks()
+                    arr = extract_array(values)._pa_array.combine_chunks()
                 categories = arr.dictionary.to_pandas(types_mapper=ArrowDtype)
                 codes = arr.indices.to_numpy()
                 dtype = CategoricalDtype(categories, values.dtype.pyarrow_dtype.ordered)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2856,9 +2856,14 @@ class TestPivot:
     def test_pivot_with_pyarrow_categorical(self):
         # GH#53051
 
-        # Create dataframe with categorical colum
+        pytest.importorskip("pyarrow")
+
+        # Create dataframe with categorical column
         df = (
-            pd.DataFrame([("A", 1), ("B", 2), ("C", 3)], columns=["string_column", "number_column"])
+            DataFrame(
+                [("A", 1), ("B", 2), ("C", 3)],
+                columns=["string_column", "number_column"],
+            )
             .astype({"string_column": "string", "number_column": "float32"})
             .astype({"string_column": "category", "number_column": "float32"})
         )
@@ -2869,25 +2874,18 @@ class TestPivot:
             buffer.seek(0)  # Reset buffer position
             df = pd.read_parquet(buffer, dtype_backend="pyarrow")
 
-
         # Check that pivot works
         df = df.pivot(columns=["string_column"], values=["number_column"])
 
         # Assert that values of result are correct to prevent silent failure
-        multi_index = pd.MultiIndex.from_arrays(
-            [
-                ["number_column", "number_column", "number_column"],
-                ["A", "B", "C"]
-            ],
-            names=(None, "string_column")
+        multi_index = MultiIndex.from_arrays(
+            [["number_column", "number_column", "number_column"], ["A", "B", "C"]],
+            names=(None, "string_column"),
         )
-        df_expected = pd.DataFrame(
-            [
-                [1.0, np.nan, np.nan],
-                [np.nan, 2.0, np.nan],
-                [np.nan, np.nan, 3.0]
-            ],
-            columns=multi_index
+        df_expected = DataFrame(
+            [[1.0, np.nan, np.nan], [np.nan, 2.0, np.nan], [np.nan, np.nan, 3.0]],
+            columns=multi_index,
         )
-        tm.assert_frame_equal(df, df_expected, check_dtype=False, check_column_type=False)
-
+        tm.assert_frame_equal(
+            df, df_expected, check_dtype=False, check_column_type=False
+        )

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2853,6 +2853,9 @@ class TestPivot:
         )
         tm.assert_frame_equal(result, expected)
 
+    # Ignore deprecation raised by old versions of pyarrow. Already fixed in
+    # newer versions
+    @pytest.mark.filterwarnings("ignore:Passing a BlockManager:DeprecationWarning")
     def test_pivot_with_pyarrow_categorical(self):
         # GH#53051
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2856,26 +2856,21 @@ class TestPivot:
     @pytest.mark.filterwarnings("ignore:Passing a BlockManager:DeprecationWarning")
     def test_pivot_with_pyarrow_categorical(self):
         # GH#53051
-
         pa = pytest.importorskip("pyarrow")
 
-        # Create dataframe with categorical column
-        df = DataFrame(
-            {"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]}
-        ).astype({"string_column": "category", "number_column": "float32"})
-
-        # Convert dataframe to pyarrow backend
-        df = df.astype(
-            {
-                "string_column": ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
-                "number_column": "float[pyarrow]",
-            }
+        df = (
+            DataFrame({"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]})
+            .astype({"string_column": "category", "number_column": "float32"})
+            .astype(
+                {
+                    "string_column": ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
+                    "number_column": "float[pyarrow]",
+                }
+            )
         )
 
-        # Check that pivot works
         df = df.pivot(columns=["string_column"], values=["number_column"])
 
-        # Assert that values of result are correct to prevent silent failure
         multi_index = MultiIndex.from_arrays(
             [["number_column", "number_column", "number_column"], ["A", "B", "C"]],
             names=(None, "string_column"),

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2858,8 +2858,9 @@ class TestPivot:
         # GH#53051
         pa = pytest.importorskip("pyarrow")
 
+        data = {"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]}
         df = (
-            DataFrame({"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]})
+            DataFrame(data)
             .astype({"string_column": "category", "number_column": "float32"})
             .astype(
                 {
@@ -2871,13 +2872,8 @@ class TestPivot:
 
         df = df.pivot(columns=["string_column"], values=["number_column"])
 
-        multi_index = MultiIndex.from_arrays(
-            [["number_column", "number_column", "number_column"], ["A", "B", "C"]],
-            names=(None, "string_column"),
-        )
-        df_expected = DataFrame(
-            [[1.0, np.nan, np.nan], [np.nan, 2.0, np.nan], [np.nan, np.nan, 3.0]],
-            columns=multi_index,
+        df_expected = DataFrame(data).pivot(
+            columns=["string_column"], values=["number_column"]
         )
         tm.assert_frame_equal(
             df, df_expected, check_dtype=False, check_column_type=False

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2858,22 +2858,24 @@ class TestPivot:
         # GH#53051
         pa = pytest.importorskip("pyarrow")
 
-        data = {"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]}
-        df = (
-            DataFrame(data)
-            .astype({"string_column": "category", "number_column": "float32"})
-            .astype(
-                {
-                    "string_column": ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
-                    "number_column": "float[pyarrow]",
-                }
-            )
+        df = DataFrame(
+            {"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]}
+        ).astype(
+            {
+                "string_column": ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
+                "number_column": "float[pyarrow]",
+            }
         )
 
         df = df.pivot(columns=["string_column"], values=["number_column"])
 
-        df_expected = DataFrame(data).pivot(
-            columns=["string_column"], values=["number_column"]
+        multi_index = MultiIndex.from_arrays(
+            [["number_column", "number_column", "number_column"], ["A", "B", "C"]],
+            names=(None, "string_column"),
+        )
+        df_expected = DataFrame(
+            [[1.0, np.nan, np.nan], [np.nan, 2.0, np.nan], [np.nan, np.nan, 3.0]],
+            columns=multi_index,
         )
         tm.assert_frame_equal(
             df, df_expected, check_dtype=False, check_column_type=False

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -319,6 +319,9 @@ class TestMultiLevel:
         expected = Series(["a", "b", "c", "d"], name=("sub", np.nan))
         tm.assert_series_equal(result, expected)
 
+    # Ignore deprecation raised by old versions of pyarrow. Already fixed in
+    # newer versions
+    @pytest.mark.filterwarnings("ignore:Passing a BlockManager:DeprecationWarning")
     def test_multiindex_with_pyarrow_categorical(self):
         # GH#53051
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -322,9 +322,14 @@ class TestMultiLevel:
     def test_multiindex_with_pyarrow_categorical(self):
         # GH#53051
 
-        # Create dataframe with categorical colum
+        pytest.importorskip("pyarrow")
+
+        # Create dataframe with categorical column
         df = (
-            pd.DataFrame([("A", 1), ("B", 2), ("C", 3)], columns=["string_column", "number_column"])
+            DataFrame(
+                [["A", 1], ["B", 2], ["C", 3]],
+                columns=["string_column", "number_column"],
+            )
             .astype({"string_column": "string", "number_column": "float32"})
             .astype({"string_column": "category", "number_column": "float32"})
         )
@@ -334,7 +339,6 @@ class TestMultiLevel:
             df.to_parquet(buffer)
             buffer.seek(0)  # Reset buffer position
             df = pd.read_parquet(buffer, dtype_backend="pyarrow")
-
 
         # Check that index can be set
         df.set_index(["string_column", "number_column"])

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -324,26 +324,27 @@ class TestMultiLevel:
         # GH#53051
         pa = pytest.importorskip("pyarrow")
 
-        data = {"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]}
-        df = (
-            DataFrame(data)
-            .astype({"string_column": "category", "number_column": "float32"})
-            .astype(
-                {
-                    "string_column": ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
-                    "number_column": "float[pyarrow]",
-                }
-            )
+        df = DataFrame(
+            {"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]}
+        ).astype(
+            {
+                "string_column": ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
+                "number_column": "float[pyarrow]",
+            }
         )
 
         df = df.set_index(["string_column", "number_column"])
 
-        df_expected = DataFrame(data).set_index(["string_column", "number_column"])
+        df_expected = DataFrame(
+            index=MultiIndex.from_arrays(
+                [["A", "B", "C"], [1, 2, 3]], names=["string_column", "number_column"]
+            )
+        )
         tm.assert_frame_equal(
             df,
             df_expected,
-            check_dtype=False,
             check_index_type=False,
+            check_column_type=False,
         )
 
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -324,8 +324,9 @@ class TestMultiLevel:
         # GH#53051
         pa = pytest.importorskip("pyarrow")
 
+        data = {"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]}
         df = (
-            DataFrame({"string_column": ["A", "B", "C"], "number_column": [1, 2, 3]})
+            DataFrame(data)
             .astype({"string_column": "category", "number_column": "float32"})
             .astype(
                 {
@@ -337,13 +338,12 @@ class TestMultiLevel:
 
         df = df.set_index(["string_column", "number_column"])
 
-        df_expected = DataFrame(
-            index=MultiIndex.from_arrays(
-                [["A", "B", "C"], [1, 2, 3]], names=["string_column", "number_column"]
-            )
-        )
+        df_expected = DataFrame(data).set_index(["string_column", "number_column"])
         tm.assert_frame_equal(
-            df, df_expected, check_dtype=False, check_column_type=False
+            df,
+            df_expected,
+            check_dtype=False,
+            check_index_type=False,
         )
 
 


### PR DESCRIPTION
- [X] closes #53051
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

<details>
<summary>Disclaimer</summary>
THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

</details>
