### PR TITLE
ENH: Add a new parameter to pandas.read_csv #61172

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -718,7 +718,6 @@ def _read(
         if kwds.get("return_empty", False):
             raise
         else:
-            print("Empty DataFrame")
             return DataFrame()
 
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -716,10 +716,8 @@ def _read(
         parser = TextFileReader(filepath_or_buffer, **kwds)
     except pandas.errors.EmptyDataError:
         if kwds.get("return_empty", False):
-            raise
-        else:
             return DataFrame()
-
+        raise
 
     if chunksize or iterator:
         return parser

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -26,6 +26,7 @@ import warnings
 
 import numpy as np
 
+import pandas.errors
 from pandas._libs import lib
 from pandas._libs.parsers import STR_NA_VALUES
 from pandas.errors import (
@@ -709,8 +710,17 @@ def _read(
     # Check for duplicates in names.
     _validate_names(kwds.get("names", None))
 
-    # Create the parser.
-    parser = TextFileReader(filepath_or_buffer, **kwds)
+    # Check for empty file.
+    try:
+        # Create the parser.
+        parser = TextFileReader(filepath_or_buffer, **kwds)
+    except pandas.errors.EmptyDataError:
+        if kwds.get("return_empty", False):
+            raise
+        else:
+            print("Empty DataFrame")
+            return DataFrame()
+
 
     if chunksize or iterator:
         return parser
@@ -832,6 +842,7 @@ def read_csv(
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
     storage_options: StorageOptions | None = None,
     dtype_backend: DtypeBackend | lib.NoDefault = lib.no_default,
+    return_empty: bool = False,
 ) -> DataFrame | TextFileReader:
     # locals() should never be modified
     kwds = locals().copy()
@@ -968,6 +979,7 @@ def read_table(
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
     storage_options: StorageOptions | None = None,
     dtype_backend: DtypeBackend | lib.NoDefault = lib.no_default,
+    return_empty: bool = False,
 ) -> DataFrame | TextFileReader:
     # locals() should never be modified
     kwds = locals().copy()


### PR DESCRIPTION
- [x] closes #61172
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

### Notes:
I tried to fix this issue by adding a new parameter named `return_empty` for `pandas.read_csv` which is by default _**False**_ and will return an empty DataFrame if set to _**True**_.

I am not familiar with Tests and didn't test it but should not break anythings.