### PR TITLE
BUG: OverflowError when fillna on DataFrame with a pd.Timestamp (#61208)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -648,6 +648,7 @@ Datetimelike
 - Bug in :func:`date_range` where using a negative frequency value would not include all points between the start and end values (:issue:`56147`)
 - Bug in :func:`tseries.api.guess_datetime_format` would fail to infer time format when "%Y" == "%H%M" (:issue:`57452`)
 - Bug in :func:`tseries.frequencies.to_offset` would fail to parse frequency strings starting with "LWOM" (:issue:`59218`)
+- Bug in :meth:`DataFrame.fillna` raising an `AssertionError` instead of `OutOfBoundsDatetime` when filling a `datetime64[ns]` column with an out-of-bounds timestamp (e.g., `'0001-01-01'`). Now correctly raises `OutOfBoundsDatetime`. (:issue:`61208`)
 - Bug in :meth:`DataFrame.min` and :meth:`DataFrame.max` casting ``datetime64`` and ``timedelta64`` columns to ``float64`` and losing precision (:issue:`60850`)
 - Bug in :meth:`Dataframe.agg` with df with missing values resulting in IndexError (:issue:`58810`)
 - Bug in :meth:`DatetimeIndex.is_year_start` and :meth:`DatetimeIndex.is_quarter_start` does not raise on Custom business days frequencies bigger then "1C" (:issue:`58664`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -648,7 +648,7 @@ Datetimelike
 - Bug in :func:`date_range` where using a negative frequency value would not include all points between the start and end values (:issue:`56147`)
 - Bug in :func:`tseries.api.guess_datetime_format` would fail to infer time format when "%Y" == "%H%M" (:issue:`57452`)
 - Bug in :func:`tseries.frequencies.to_offset` would fail to parse frequency strings starting with "LWOM" (:issue:`59218`)
-- Bug in :meth:`DataFrame.fillna` raising an `AssertionError` instead of `OutOfBoundsDatetime` when filling a `datetime64[ns]` column with an out-of-bounds timestamp (e.g., `'0001-01-01'`). Now correctly raises `OutOfBoundsDatetime`. (:issue:`61208`)
+- Bug in :meth:`DataFrame.fillna` raising an ``AssertionError`` instead of ``OutOfBoundsDatetime`` when filling a ``datetime64[ns]`` column with an out-of-bounds timestamp (e.g., ``'0001-01-01'``). Now correctly raises ``OutOfBoundsDatetime``. (:issue:`61208`)
 - Bug in :meth:`DataFrame.min` and :meth:`DataFrame.max` casting ``datetime64`` and ``timedelta64`` columns to ``float64`` and losing precision (:issue:`60850`)
 - Bug in :meth:`Dataframe.agg` with df with missing values resulting in IndexError (:issue:`58810`)
 - Bug in :meth:`DatetimeIndex.is_year_start` and :meth:`DatetimeIndex.is_quarter_start` does not raise on Custom business days frequencies bigger then "1C" (:issue:`58664`)


### PR DESCRIPTION
- [x] closes #61208
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (Does not apply)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

### Fix for `fillna` with Out-of-Bounds Datetime Values

**Issue**: Using `fillna` on a `datetime64[ns]` column with an out-of-bounds timestamp (e.g., `'0001-01-01'`) raised an `AssertionError` instead of the expected `OutOfBoundsDatetime`.

**Fix**: Modified the `putmask` method in `pandas/core/internals/blocks.py` to catch and re-raise `OutOfBoundsDatetime` directly, preventing the `AssertionError`.

**Test Added**:
- Created `test_fillna_out_of_bounds_datetime` in `pandas/tests/frame/methods/test_fillna.py`.
- The test:
  - Sets up a DataFrame with a `datetime64[ns]` column containing `NaT`.
  - Attempts to fill `NaT` with `'0001-01-01'`.
  - Expects `OutOfBoundsDatetime`.