### PR TITLE
BUG: OverflowError when fillna on DataFrame with a pd.Timestamp (#61208) 

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -644,6 +644,7 @@ Datetimelike
 - Bug in :func:`date_range` where using a negative frequency value would not include all points between the start and end values (:issue:`56147`)
 - Bug in :func:`tseries.api.guess_datetime_format` would fail to infer time format when "%Y" == "%H%M" (:issue:`57452`)
 - Bug in :func:`tseries.frequencies.to_offset` would fail to parse frequency strings starting with "LWOM" (:issue:`59218`)
+- Bug in :meth:`DataFrame.fillna` raising an ``AssertionError`` instead of ``OutOfBoundsDatetime`` when filling a ``datetime64[ns]`` column with an out-of-bounds timestamp. Now correctly raises ``OutOfBoundsDatetime``. (:issue:`61208`)
 - Bug in :meth:`DataFrame.min` and :meth:`DataFrame.max` casting ``datetime64`` and ``timedelta64`` columns to ``float64`` and losing precision (:issue:`60850`)
 - Bug in :meth:`Dataframe.agg` with df with missing values resulting in IndexError (:issue:`58810`)
 - Bug in :meth:`DatetimeIndex.is_year_start` and :meth:`DatetimeIndex.is_quarter_start` does not raise on Custom business days frequencies bigger then "1C" (:issue:`58664`)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1682,6 +1682,8 @@ class EABackedBlock(Block):
 
         try:
             res_values = arr._where(cond, other).T
+        except OutOfBoundsDatetime:
+            raise
         except (ValueError, TypeError):
             if self.ndim == 1 or self.shape[0] == 1:
                 if isinstance(self.dtype, (IntervalDtype, StringDtype)):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1749,6 +1749,8 @@ class EABackedBlock(Block):
         try:
             # Caller is responsible for ensuring matching lengths
             values._putmask(mask, new)
+        except OutOfBoundsDatetime as e:
+            raise
         except (TypeError, ValueError):
             if self.ndim == 1 or self.shape[0] == 1:
                 if isinstance(self.dtype, IntervalDtype):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1749,7 +1749,7 @@ class EABackedBlock(Block):
         try:
             # Caller is responsible for ensuring matching lengths
             values._putmask(mask, new)
-        except OutOfBoundsDatetime as e:
+        except OutOfBoundsDatetime:
             raise
         except (TypeError, ValueError):
             if self.ndim == 1 or self.shape[0] == 1:

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -15,6 +15,7 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.tests.frame.common import _check_mixed_float
+from pandas.errors import OutOfBoundsDatetime
 
 
 class TestFillNA:
@@ -781,3 +782,19 @@ def test_fillna_with_none_object(test_frame, dtype):
     if test_frame:
         expected = expected.to_frame()
     tm.assert_equal(result, expected)
+    
+    
+def test_fillna_out_of_bounds_datetime():
+    # GH#61208
+    df = DataFrame({
+        'datetime': date_range('1/1/2011', periods=3, freq='h'),
+        'value': [1, 2, 3]
+    })
+    df.iloc[0, 0] = None
+
+    msg="Cannot cast 0001-01-01 00:00:00 to unit='ns' without overflow"
+    with pytest.raises(
+        OutOfBoundsDatetime,
+        match=msg
+    ):
+        df.fillna(Timestamp('0001-01-01'), inplace=True)

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -794,4 +794,4 @@ def test_fillna_out_of_bounds_datetime():
 
     msg = "Cannot cast 0001-01-01 00:00:00 to unit='ns' without overflow"
     with pytest.raises(OutOfBoundsDatetime, match=msg):
-        df.fillna(Timestamp("0001-01-01"), inplace=True)
+        df.fillna(Timestamp("0001-01-01"))

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import OutOfBoundsDatetime
+
 from pandas import (
     Categorical,
     DataFrame,
@@ -15,7 +17,6 @@ from pandas import (
 )
 import pandas._testing as tm
 from pandas.tests.frame.common import _check_mixed_float
-from pandas.errors import OutOfBoundsDatetime
 
 
 class TestFillNA:
@@ -782,19 +783,15 @@ def test_fillna_with_none_object(test_frame, dtype):
     if test_frame:
         expected = expected.to_frame()
     tm.assert_equal(result, expected)
-    
-    
+
+
 def test_fillna_out_of_bounds_datetime():
     # GH#61208
-    df = DataFrame({
-        'datetime': date_range('1/1/2011', periods=3, freq='h'),
-        'value': [1, 2, 3]
-    })
+    df = DataFrame(
+        {"datetime": date_range("1/1/2011", periods=3, freq="h"), "value": [1, 2, 3]}
+    )
     df.iloc[0, 0] = None
 
-    msg="Cannot cast 0001-01-01 00:00:00 to unit='ns' without overflow"
-    with pytest.raises(
-        OutOfBoundsDatetime,
-        match=msg
-    ):
-        df.fillna(Timestamp('0001-01-01'), inplace=True)
+    msg = "Cannot cast 0001-01-01 00:00:00 to unit='ns' without overflow"
+    with pytest.raises(OutOfBoundsDatetime, match=msg):
+        df.fillna(Timestamp("0001-01-01"), inplace=True)


### PR DESCRIPTION
- Now correctly raises OutOfBoundsDatetime
- Added test_fillna_out_of_bounds_datetime()

- [x] closes #61208
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (does not apply)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


### Fix for `fillna` with Out-of-Bounds Datetime Values

**Issue**: Using `fillna` on a `datetime64[ns]` column with an out-of-bounds timestamp (e.g., `'0001-01-01'`) raised an `AssertionError` instead of the expected `OutOfBoundsDatetime`.

**Fix**: Modified the `where` method in `pandas/core/internals/blocks.py` to catch and re-raise `OutOfBoundsDatetime` directly, preventing the `AssertionError`.


**Fix (`inplace=True`)**: Modified the `putmask` method in `pandas/core/internals/blocks.py` to catch and re-raise `OutOfBoundsDatetime` directly, preventing the `AssertionError`.


**Test Added**:
- Created `test_fillna_out_of_bounds_datetime` in `pandas/tests/frame/methods/test_fillna.py`.
- The test:
  - Sets up a DataFrame with a `datetime64[ns]` column containing `NaT`.
  - Attempts to fill `NaT` with `'0001-01-01'`.
  - Expects `OutOfBoundsDatetime`.
