### PR TITLE
Fix false friends in implicit string concatenation in tests

### DIFF
--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -802,8 +802,9 @@ class TestDateRanges:
     )
     def test_date_range_depr_lowercase_frequency(self, freq, freq_depr):
         # GH#58998
-        depr_msg = f"'{freq_depr[1:]}' is deprecated and will be removed "
-        "in a future version."
+        depr_msg = (
+            f"'{freq_depr[1:]}' is deprecated and will be removed in a future version."
+        )
 
         expected = date_range("1/1/2000", periods=4, freq=freq)
         with tm.assert_produces_warning(FutureWarning, match=depr_msg):

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -206,8 +206,10 @@ class TestPeriodRangeDisallowedFreqs:
     @pytest.mark.parametrize("freq_depr", ["2MIN", "2US", "2NS"])
     def test_uppercase_freq_deprecated_from_time_series(self, freq_depr):
         # GH#52536, GH#54939
-        msg = f"'{freq_depr[1:]}' is deprecated and will be removed in a "
-        f"future version. Please use '{freq_depr.lower()[1:]}' instead."
+        msg = (
+            f"'{freq_depr[1:]}' is deprecated and will be removed in a "
+            f"future version, please use '{freq_depr.lower()[1:]}' instead."
+        )
 
         with tm.assert_produces_warning(FutureWarning, match=msg):
             period_range("2020-01-01 00:00:00 00:00", periods=2, freq=freq_depr)
@@ -230,8 +232,10 @@ class TestPeriodRangeDisallowedFreqs:
     @pytest.mark.parametrize("freq", ["2w"])
     def test_lowercase_freq_from_time_series_deprecated(self, freq):
         # GH#52536, GH#54939
-        msg = f"'{freq[1:]}' is deprecated and will be removed in a "
-        f"future version. Please use '{freq.upper()[1:]}' instead."
+        msg = (
+            f"'{freq[1:]}' is deprecated and will be removed in a "
+            f"future version, please use '{freq.upper()[1:]}' instead."
+        )
 
         with tm.assert_produces_warning(FutureWarning, match=msg):
             period_range(freq=freq, start="1/1/2001", end="12/1/2009")

--- a/pandas/tests/tslibs/test_to_offset.py
+++ b/pandas/tests/tslibs/test_to_offset.py
@@ -207,8 +207,10 @@ def test_to_offset_lowercase_frequency_raises(freq_depr):
 @pytest.mark.parametrize("freq_depr", ["2MIN", "2Us", "2NS"])
 def test_to_offset_uppercase_frequency_deprecated(freq_depr):
     # GH#54939
-    depr_msg = f"'{freq_depr[1:]}' is deprecated and will be removed in a "
-    f"future version, please use '{freq_depr.lower()[1:]}' instead."
+    depr_msg = (
+        f"'{freq_depr[1:]}' is deprecated and will be removed in a "
+        f"future version, please use '{freq_depr.lower()[1:]}' instead."
+    )
 
     with tm.assert_produces_warning(FutureWarning, match=depr_msg):
         to_offset(freq_depr)


### PR DESCRIPTION
[In a PR](https://github.com/nvim-treesitter/nvim-treesitter/pull/7788) about how to syntax-highlight Python docstrings, @rmuir and I discovered that instead of implicit concatenation of strings a string plus a docstring have been written.

Since this is a subtle one, I want to briefly show the differences:
 
The false friend of implicit string concatenation
```python
# var == "foo"

var = "foo"  # <-- no implicit string concatenation
"bar"        # <-- docstring, legal for the bytecode compiler, against PEP 257
```

can be fixed for example with surrounding brackets:
```python
# var == "foobar"

var = (
    "foo"    # <-- gets implicitly concatenated
    "bar"
)
```

I felt free to fix the ones I found right away such that the tests pass.

I searched with [`ripgrep`](https://github.com/BurntSushi/ripgrep) like so:

```sh
# in path/to/cloned/pandas
rg -A 1 -B 2 -U ' = f?"[^"]*"\s+f?"[^"]+"\s*' pandas/
```

I am pretty confident, but not entirely sure, to have catched all cases. :thinking: 