### PR TITLE
DOC: Added docstrings to min, max, and reso

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -72,9 +72,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Series.dt PR01" `# Accessors are implemented as classes, but we do not document the Parameters section` \
         -i "pandas.Period.freq GL08" \
         -i "pandas.Period.ordinal GL08" \
-        -i "pandas.Timestamp.max PR02" \
-        -i "pandas.Timestamp.min PR02" \
-        -i "pandas.Timestamp.resolution PR02" \
         -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
         -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \
         -i "pandas.core.resample.Resampler.quantile PR01,PR07" \

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -200,8 +200,9 @@ class MinMaxReso:
 
     See also: timedeltas.MinMaxReso
     """
-    def __init__(self, name):
+    def __init__(self, name, docstring):
         self._name = name
+        self.__doc__ = docstring
 
     def __get__(self, obj, type=None):
         cls = Timestamp
@@ -216,11 +217,15 @@ class MinMaxReso:
 
         if obj is None:
             # i.e. this is on the class, default to nanos
-            return cls(val)
+            result = cls(val)
         elif self._name == "resolution":
-            return Timedelta._from_value_and_reso(val, obj._creso)
+            result = Timedelta._from_value_and_reso(val, obj._creso)
         else:
-            return Timestamp._from_value_and_reso(val, obj._creso, tz=None)
+            result = Timestamp._from_value_and_reso(val, obj._creso, tz=None)
+
+        result.__doc__ = self.__doc__
+
+        return result
 
     def __set__(self, obj, value):
         raise AttributeError(f"{self._name} is not settable.")
@@ -235,9 +240,74 @@ cdef class _Timestamp(ABCTimestamp):
     dayofweek = _Timestamp.day_of_week
     dayofyear = _Timestamp.day_of_year
 
-    min = MinMaxReso("min")
-    max = MinMaxReso("max")
-    resolution = MinMaxReso("resolution")  # GH#21336, GH#21365
+    _docstring_min = """
+    Returns the minimum bound possible for Timestamp.
+
+    This property provides access to the smallest possible value that
+    can be represented by a Timestamp object.
+
+    Returns
+    -------
+    Timestamp
+
+    See Also
+    --------
+    Timestamp.max: Returns the maximum bound possible for Timestamp.
+    Timestamp.resolution: Returns the smallest possible difference between
+        non-equal Timestamp objects.
+
+    Examples
+    --------
+    >>> pd.Timestamp.min
+    Timestamp('1677-09-21 00:12:43.145224193')
+    """
+
+    _docstring_max = """
+    Returns the maximum bound possible for Timestamp.
+
+    This property provides access to the largest possible value that
+    can be represented by a Timestamp object.
+
+    Returns
+    -------
+    Timestamp
+
+    See Also
+    --------
+    Timestamp.min: Returns the minimum bound possible for Timestamp.
+    Timestamp.resolution: Returns the smallest possible difference between
+        non-equal Timestamp objects.
+
+    Examples
+    --------
+    >>> pd.Timestamp.max
+    Timestamp('2262-04-11 23:47:16.854775807')
+    """
+
+    _docstring_reso = """
+    Returns the smallest possible difference between non-equal Timestamp objects.
+
+    The resolution value is determined by the underlying representation of time
+    units and is equivalent to Timedelta(nanoseconds=1).
+
+    Returns
+    -------
+    Timedelta
+
+    See Also
+    --------
+    Timestamp.max: Returns the maximum bound possible for Timestamp.
+    Timestamp.min: Returns the minimum bound possible for Timestamp.
+
+    Examples
+    --------
+    >>> pd.Timestamp.resolution
+    Timedelta('0 days 00:00:00.000000001')
+    """
+
+    min = MinMaxReso("min", _docstring_min)
+    max = MinMaxReso("max", _docstring_max)
+    resolution = MinMaxReso("resolution", _docstring_reso)  # GH#21336, GH#21365
 
     @property
     def value(self) -> int:


### PR DESCRIPTION
Closes #59458

Added docstrings to `min`, `max`, and `resolution` for class `Timestamp`. Used same approach as seen in PR #61119

- [x] closes #59458 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
