### PR TITLE
CI Use released numpy for Windows wheels testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,6 @@ before-build = "PACKAGE_DIR={package} bash {package}/scripts/cibw_before_build.s
 
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel && bash {package}/scripts/cibw_before_build_windows.sh"
-before-test = "bash {package}/scripts/cibw_before_test_windows.sh"
 test-command = """
   set PANDAS_CI='1' && \
   python -c "import pandas as pd; \

--- a/scripts/cibw_before_build_windows.sh
+++ b/scripts/cibw_before_build_windows.sh
@@ -5,10 +5,9 @@ for file in $PACKAGE_DIR/LICENSES/*; do
 done
 
 # TODO: Delete when there's a PyPI Cython release that supports free-threaded Python 3.13
-# and a NumPy Windows wheel for the free-threaded build on PyPI.
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -U pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    python -m pip install ninja meson-python versioneer[toml]
+    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+    python -m pip install ninja meson-python versioneer[toml] numpy
 fi

--- a/scripts/cibw_before_test_windows.sh
+++ b/scripts/cibw_before_test_windows.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# TODO: Delete when there's a NumPy Windows wheel for the free-threaded build on PyPI.
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-fi


### PR DESCRIPTION
Following #61249 this also used released numpy for testing on Windows free-threaded wheels.