### PR TITLE
DOC: Add real-world aggregation example to GroupBy user guide

### DIFF
--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -488,6 +488,19 @@ column in a group of values.
    animals
    animals.groupby("kind").sum()
 
+Another real-world style example using sales data:
+
+.. ipython:: python
+
+   df = pd.DataFrame({
+       "Region": ["East", "West", "East", "West"],
+       "Sales": [250, 300, 150, 200]
+   })
+   df
+   df.groupby("Region")["Sales"].sum()
+
+   
+
 In the result, the keys of the groups appear in the index by default. They can be
 instead included in the columns by passing ``as_index=False``.
 

--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -1590,7 +1590,8 @@ order they are first observed.
 Plotting
 ~~~~~~~~
 
-Groupby also works with some plotting methods.  In this case, suppose we
+GroupBy also works with some plotting methods. In this case, suppose we
+
 suspect that the values in column 1 are 3 times higher on average in group "B".
 
 


### PR DESCRIPTION
This PR adds a real-world example using sales data to the GroupBy Aggregation section in the user guide (groupby.rst). This enhances understanding for new users by supplementing the existing animals DataFrame example with a business-style case.