### PR TITLE
Add to_snake_case and to_camel_case for index label conversion using …

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7191,6 +7191,63 @@ class Index(IndexOpsMixin, PandasObject):
         return self._unary_method(operator.inv)
 
     # --------------------------------------------------------------------
+    # String Case Conversion Methods
+
+    def to_snake_case(self):
+        """
+        Convert index labels to snake_case.
+
+        Returns
+        -------
+        Index
+            A new Index with labels converted to snake_case.
+
+        Notes
+        -----
+        This method uses the `inflection.underscore` function to perform the
+        conversion. Non-string values in the index are left unchanged.
+
+        Examples
+        --------
+        >>> idx = pd.Index(["ColumnName", "AnotherColumn", 123])
+        >>> idx.to_snake_case()
+        Index(['column_name', 'another_column', 123], dtype='object')
+        """
+        from inflection import underscore
+
+        return self.map(
+            lambda x: underscore(x.replace(" ", "_")) if isinstance(x, str) else x
+        )
+
+    def to_camel_case(self):
+        """
+        Convert index labels to camelCase.
+
+        Returns
+        -------
+        Index
+            A new Index with labels converted to camelCase.
+
+        Notes
+        -----
+        This method uses the `inflection.camelize` function to perform the
+        conversion. Non-string values in the index are left unchanged.
+
+        Examples
+        --------
+        >>> idx = pd.Index(["column_name", "another_column", 123])
+        >>> idx.to_camel_case()
+        Index(['columnName', 'anotherColumn', 123], dtype='object')
+        """
+        from inflection import camelize
+
+        return self.map(
+            lambda x: camelize(x.replace(" ", "_"), uppercase_first_letter=False)
+            if isinstance(x, str)
+            else x
+        )
+
+    # --------------------------------------------------------------------
     # Reductions
 
     def any(self, *args, **kwargs):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1350,6 +1350,38 @@ class TestIndex:
 
         tm.assert_index_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "input_labels, expected_snake_case",
+        [
+            (
+                ["ColumnName", "AnotherColumn", 123],
+                ["column_name", "another_column", 123],
+            ),
+            (["MixedCase", "with spaces", None], ["mixed_case", "with_spaces", None]),
+        ],
+    )
+    def test_to_snake_case(self, input_labels, expected_snake_case):
+        idx = Index(input_labels)
+        result = idx.to_snake_case()
+        expected = Index(expected_snake_case)
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "input_labels, expected_camel_case",
+        [
+            (
+                ["column_name", "another_column", 123],
+                ["columnName", "anotherColumn", 123],
+            ),
+            (["with_spaces", "Mixed_Case", None], ["withSpaces", "mixedCase", None]),
+        ],
+    )
+    def test_to_camel_case(self, input_labels, expected_camel_case):
+        idx = Index(input_labels)
+        result = idx.to_camel_case()
+        expected = Index(expected_camel_case)
+        tm.assert_index_equal(result, expected)
+
 
 class TestMixedIntIndex:
     # Mostly the tests from common.py for which the results differ


### PR DESCRIPTION
**Add `to_snake_case` and `to_camel_case` methods for Index label conversion**

This PR adds two new string transformation methods to the `pandas.Index` class:

### 🚀 New methods
- `to_snake_case()`: Converts string index labels to `snake_case` using `inflection.underscore`
- `to_camel_case()`: Converts string index labels to `camelCase` using `inflection.camelize`

Both methods:
- Leave non-string values (e.g. integers, `None`) unchanged
- Are chainable and return a new `Index` instance

### 🧪 Tests
Added unit tests for both methods in `test_base.py`:
- Covers strings with mixed case and spaces
- Verifies behavior with mixed-type labels

### 📌 Example
```python
import pandas as pd

df = pd.DataFrame({"first name": [1], "another_column": [1]})
df.columns = df.columns.to_camel_case()
print(df.columns)
# Index(['firstName', 'anotherColumn'], dtype='object')

df.columns = df.columns.to_snake_case()
print(df.columns)
# Index(['first_name', 'another_column'], dtype='object')
```

