### PR TITLE
EHN: `df.to_latex(escape=True)` also escape index names

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3568,6 +3568,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         elif formatters is None and float_format is not None:
             formatters_ = partial(_wrap, alt_format_=lambda v: v)
         format_index_ = [index_format_, column_format_]
+        format_index_names_ = [index_format_, column_format_]
 
         # Deal with hiding indexes and relabelling column names
         hide_: list[dict] = []
@@ -3584,6 +3585,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         elif isinstance(header, (list, tuple)):
             relabel_index_.append({"labels": header, "axis": "columns"})
             format_index_ = [index_format_]  # column_format is overwritten
+            format_index_names_ = [index_format_]  # column_format is overwritten
 
         if index is False:
             hide_.append({"axis": "index"})
@@ -3616,6 +3618,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             relabel_index=relabel_index_,
             format={"formatter": formatters_, **base_format_},
             format_index=format_index_,
+            format_index_names=format_index_names_,
             render_kwargs=render_kwargs_,
         )
 
@@ -3628,6 +3631,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         relabel_index: dict | list[dict] | None = None,
         format: dict | list[dict] | None = None,
         format_index: dict | list[dict] | None = None,
+        format_index_names: dict | list[dict] | None = None,
         render_kwargs: dict | None = None,
     ):
         """
@@ -3672,7 +3676,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         self = cast("DataFrame", self)
         styler = Styler(self, uuid="")
 
-        for kw_name in ["hide", "relabel_index", "format", "format_index"]:
+        for kw_name in [
+            "hide",
+            "relabel_index",
+            "format",
+            "format_index",
+            "format_index_names",
+        ]:
             kw = vars()[kw_name]
             if isinstance(kw, dict):
                 getattr(styler, kw_name)(**kw)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3585,7 +3585,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         elif isinstance(header, (list, tuple)):
             relabel_index_.append({"labels": header, "axis": "columns"})
             format_index_ = [index_format_]  # column_format is overwritten
-            format_index_names_ = [index_format_]  # column_format is overwritten
 
         if index is False:
             hide_.append({"axis": "index"})

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -845,6 +845,25 @@ class TestToLatexEscape:
         )
         assert result == expected
 
+    def test_to_latex_escape_special_chars_in_column_name(self):
+        df = DataFrame({"A": [1, 2, 3], "B": ["a", "b", "c"]})
+        df.columns.name = "_^~"
+        result = df.to_latex(escape=True)
+        expected = _dedent(
+            r"""
+            \begin{tabular}{lrl}
+            \toprule
+            \_\textasciicircum \textasciitilde  & A & B \\
+            \midrule
+            0 & 1 & a \\
+            1 & 2 & b \\
+            2 & 3 & c \\
+            \bottomrule
+            \end{tabular}
+            """
+        )
+        assert result == expected
+
     def test_to_latex_specified_header_special_chars_without_escape(self):
         # GH 7124
         df = DataFrame({"a": [1, 2], "b": ["b1", "b2"]})

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -825,6 +825,9 @@ class TestToLatexEscape:
         assert result == expected
 
     def test_to_latex_escape_special_chars_in_index_names(self):
+        # https://github.com/pandas-dev/pandas/issues/61309
+        # https://github.com/pandas-dev/pandas/issues/57362
+
         index = "&%$#_{}}~^\\"
         df = DataFrame({index: [1, 2, 3]}).set_index(index)
         result = df.to_latex(escape=True)

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -824,6 +824,33 @@ class TestToLatexEscape:
         )
         assert result == expected
 
+    def test_to_latex_escape_special_chars_in_index_names(self):
+        special_characters = ["&", "%", "$", "#", "_", "{", "}", "~", "^", "\\"]
+        df = DataFrame([special_characters, special_characters]).T.set_index(0)
+        result = df.to_latex(escape=True)
+        expected = _dedent(
+            r"""
+            \begin{tabular}{ll}
+            \toprule
+             & 1 \\
+            0 &  \\
+            \midrule
+            \& & \& \\
+            \% & \% \\
+            \$ & \$ \\
+            \# & \# \\
+            \_ & \_ \\
+            \{ & \{ \\
+            \} & \} \\
+            \textasciitilde  & \textasciitilde  \\
+            \textasciicircum  & \textasciicircum  \\
+            \textbackslash  & \textbackslash  \\
+            \bottomrule
+            \end{tabular}
+            """
+        )
+        assert result == expected
+
     def test_to_latex_specified_header_special_chars_without_escape(self):
         # GH 7124
         df = DataFrame({"a": [1, 2], "b": ["b1", "b2"]})

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -825,26 +825,18 @@ class TestToLatexEscape:
         assert result == expected
 
     def test_to_latex_escape_special_chars_in_index_names(self):
-        special_characters = ["&", "%", "$", "#", "_", "{", "}", "~", "^", "\\"]
-        df = DataFrame([special_characters, special_characters]).T.set_index(0)
+        index = "&%$#_{}}~^\\"
+        df = DataFrame({index: [1, 2, 3]}).set_index(index)
         result = df.to_latex(escape=True)
         expected = _dedent(
             r"""
-            \begin{tabular}{ll}
+            \begin{tabular}{l}
             \toprule
-             & 1 \\
-            0 &  \\
+            \&\%\$\#\_\{\}\}\textasciitilde \textasciicircum \textbackslash  \\
             \midrule
-            \& & \& \\
-            \% & \% \\
-            \$ & \$ \\
-            \# & \# \\
-            \_ & \_ \\
-            \{ & \{ \\
-            \} & \} \\
-            \textasciitilde  & \textasciitilde  \\
-            \textasciicircum  & \textasciicircum  \\
-            \textbackslash  & \textbackslash  \\
+            1 \\
+            2 \\
+            3 \\
             \bottomrule
             \end{tabular}
             """

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -827,7 +827,6 @@ class TestToLatexEscape:
     def test_to_latex_escape_special_chars_in_index_names(self):
         # https://github.com/pandas-dev/pandas/issues/61309
         # https://github.com/pandas-dev/pandas/issues/57362
-
         index = "&%$#_{}}~^\\"
         df = DataFrame({index: [1, 2, 3]}).set_index(index)
         result = df.to_latex(escape=True)


### PR DESCRIPTION
- [ ] closes #57362 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Stage 3. Part of an multi-stages effort: https://github.com/pandas-dev/pandas/pull/57880#issuecomment-2003636401
Part 2 has a issue at https://github.com/pandas-dev/pandas/issues/59324
But in the process of implementing, I realized the current implementation of `df.to_latex(escape)` does not go through `styler.to_latex` but to call `styler.format_index`. This implementation follows the same flow. So maybe part 2 is not really relevant.
