### PR TITLE
[minor edit] fix typo: psudocode -> pseudocode

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Feature Description
       description: >
-        Please describe how the new feature would be implemented, using psudocode if relevant.
+        Please describe how the new feature would be implemented, using pseudocode if relevant.
       placeholder: >
         Add a new parameter to DataFrame, to_series, to return a Series if possible.
 


### PR DESCRIPTION
this PR fixes this typo spotted here:

https://github.com/pandas-dev/pandas/blob/a811388727bb0640528962191b0f4e50d8235cfd/.github/ISSUE_TEMPLATE/feature_request.yaml#L34

<!--
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
//-->