### PR TITLE
Fix: AttributeError when using .iloc with pyarrow-backed Series in Pandas #61311

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1610,7 +1610,7 @@ class _iLocIndexer(_LocationIndexer):
                 raise IndexError(f".iloc requires numeric indexers, got {arr}")
 
             # check that the key does not exceed the maximum size of the index
-            if len(arr) and (arr.max() >= len_axis or arr.min() < -len_axis):
+            if np.max(arr) >= len_axis or np.min(arr) < -len_axis:
                 raise IndexError("positional indexers are out-of-bounds")
         else:
             raise ValueError(f"Can only index by location with a [{self._valid_types}]")


### PR DESCRIPTION
fix : #61311
### Solution:
The problem arises when the code tries to access `.max()` and `.min()` on `ArrowExtensionArray`. To fix this, we can replace `.max()` and `.min()` with `np.max()` and `np.min()`, which can handle these arrays correctly.

Here is the modification to be made:

```python
# check that the key does not exceed the maximum size of the index
if np.max(arr) >= len_axis or np.min(arr) < -len_axis:
    raise IndexError("positional indexers are out-of-bounds")
```

---