### PR TITLE
Remove WillAyd from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,6 @@ doc/cheatsheet                    @Dr-Irv
 doc/source/development            @noatamir
 
 # pandas
-pandas/_libs/                     @WillAyd
 pandas/_typing.py                 @Dr-Irv
 pandas/core/groupby/*             @rhshadrach
 pandas/io/excel/*                 @rhshadrach


### PR DESCRIPTION
This was well intentioned but I do not follow every change to _libs, and this ends up creating more notifications than I follow