### PR TITLE
Add warning to `.groupby` when null keys would be dropped due to default `dropna`

### DIFF
--- a/doc/source/reference/testing.rst
+++ b/doc/source/reference/testing.rst
@@ -46,6 +46,7 @@ Exceptions and warnings
    errors.MergeError
    errors.NoBufferPresent
    errors.NullFrequencyError
+   errors.NullKeyWarning
    errors.NumbaUtilError
    errors.NumExprClobberingError
    errors.OptionError

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -457,6 +457,22 @@ with cf.config_prefix("mode"):
     )
 
 
+null_grouper_warning = """
+: string
+    Whether to show or hide NullKeyWarning if default grouping would result in a
+    null group key being dropped,
+    The default is False
+"""
+
+with cf.config_prefix("mode"):
+    cf.register_option(
+        "null_grouper_warning",
+        False,
+        null_grouper_warning,
+        validator=is_bool,
+    )
+
+
 string_storage_doc = """
 : string
     The default storage for StringDtype.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9148,7 +9148,7 @@ class DataFrame(NDFrame, OpsMixin):
         sort: bool = True,
         group_keys: bool = True,
         observed: bool = True,
-        dropna: bool = True,
+        dropna: bool | lib.NoDefault = lib.no_default,
     ) -> DataFrameGroupBy:
         from pandas.core.groupby.generic import DataFrameGroupBy
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -285,12 +285,18 @@ class Grouper:
         self.level = level
         self.freq = freq
         self.sort = sort
-        self.dropna = dropna
+        self._dropna = dropna
 
         self._indexer_deprecated: npt.NDArray[np.intp] | None = None
         self.binner = None
         self._grouper = None
         self._indexer: npt.NDArray[np.intp] | None = None
+
+    @property
+    def dropna(self):
+        if self._dropna is lib.no_default:
+            return True
+        return self._dropna
 
     def _get_grouper(
         self, obj: NDFrameT, validate: bool = True
@@ -694,7 +700,7 @@ class Grouping:
             if (
                 get_option("null_grouper_warning")
                 and unspecified_dropna
-                and codes.min() == -1
+                and codes.min(initial=0) == -1
             ):
                 warnings.warn(
                     _NULL_KEY_MESSAGE,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1972,7 +1972,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         sort: bool = True,
         group_keys: bool = True,
         observed: bool = False,
-        dropna: bool = True,
+        dropna: bool | lib.NoDefault = lib.no_default,
     ) -> SeriesGroupBy:
         from pandas.core.groupby.generic import SeriesGroupBy
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -878,6 +878,29 @@ class CategoricalConversionWarning(Warning):
     """
 
 
+class NullKeyWarning(Warning):
+    """
+    Warning raised when grouping on null/NA keys with default `dropna` argument.
+
+    This warning helps ensure data integrity and alerts users to potential issues
+    during grouping/aggregating when the default value of `dropna` would lead to
+    null keys being dropped from the output.
+
+    For more information, see discussion of [PDEP-11](#53094)
+
+    See Also
+    --------
+    DataFrame.groupby : Group DataFrame using a mapper or by a Series of columns.
+    DataFrame.pivot_table : Create a spreadsheet-style pivot table as a DataFrame.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({"A": ["a", None], "B": [1, 2]})
+    >>> df.groupby(["A"]).sum()  # doctest: +SKIP
+    ... # NullKeyWarning: ...
+    """
+
+
 class LossySetitemError(Exception):
     """
     Raised when trying to do a __setitem__ on an np.ndarray that is not lossless.
@@ -927,6 +950,7 @@ __all__ = [
     "MergeError",
     "NoBufferPresent",
     "NullFrequencyError",
+    "NullKeyWarning",
     "NumExprClobberingError",
     "NumbaUtilError",
     "OptionError",

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -192,7 +192,7 @@ def test_basic_cut_grouping():
     # GH 9603
     df = DataFrame({"a": [1, 0, 0, 0]})
     c = pd.cut(df.a, [0, 1, 2, 3, 4], labels=Categorical(list("abcd")))
-    result = df.groupby(c, observed=False).apply(len)
+    result = df.groupby(c, observed=False, dropna=True).apply(len)
 
     exp_index = CategoricalIndex(c.values.categories, ordered=c.values.ordered)
     expected = Series([1, 0, 0, 0], index=exp_index)
@@ -568,7 +568,7 @@ def test_observed_groups_with_nan(observed):
             "vals": [1, 2, 3],
         }
     )
-    g = df.groupby("cat", observed=observed)
+    g = df.groupby("cat", observed=observed, dropna=True)
     result = g.groups
     if observed:
         expected = {"a": Index([0, 2], dtype="int64")}
@@ -587,7 +587,7 @@ def test_observed_nth():
     ser = Series([1, 2, 3])
     df = DataFrame({"cat": cat, "ser": ser})
 
-    result = df.groupby("cat", observed=False)["ser"].nth(0)
+    result = df.groupby("cat", observed=False, dropna=True)["ser"].nth(0)
     expected = df["ser"].iloc[[0]]
     tm.assert_series_equal(result, expected)
 
@@ -597,7 +597,7 @@ def test_dataframe_categorical_with_nan(observed):
     s1 = Categorical([np.nan, "a", np.nan, "a"], categories=["a", "b", "c"])
     s2 = Series([1, 2, 3, 4])
     df = DataFrame({"s1": s1, "s2": s2})
-    result = df.groupby("s1", observed=observed).first().reset_index()
+    result = df.groupby("s1", observed=observed, dropna=True).first().reset_index()
     if observed:
         expected = DataFrame(
             {"s1": Categorical(["a"], categories=["a", "b", "c"]), "s2": [2]}
@@ -768,7 +768,9 @@ def test_categorical_series(series, data):
     # Group the given series by a series with categorical data type such that group A
     # takes indices 0 and 3 and group B indices 1 and 2, obtaining the values mapped in
     # the given data.
-    groupby = series.groupby(Series(list("ABBA"), dtype="category"), observed=False)
+    groupby = series.groupby(
+        Series(list("ABBA"), dtype="category"), observed=False, dropna=True
+    )
     result = groupby.aggregate(list)
     expected = Series(data, index=CategoricalIndex(data.keys()))
     tm.assert_series_equal(result, expected)
@@ -973,7 +975,7 @@ def test_groupby_empty_with_category():
     # test fix for when group by on None resulted in
     # coercion of dtype categorical -> float
     df = DataFrame({"A": [None] * 3, "B": Categorical(["train", "train", "test"])})
-    result = df.groupby("A").first()["B"]
+    result = df.groupby("A", dropna=True).first()["B"]
     expected = Series(
         Categorical([], categories=["test", "train"]),
         index=Series([], dtype="object", name="A"),

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -10,6 +10,12 @@ import pandas._testing as tm
 from pandas.tests.groupby import get_groupby_method_args
 
 
+@pytest.fixture(scope="module", autouse=True)
+def setup_warnings():
+    with pd.option_context("mode.null_grouper_warning", True):
+        yield
+
+
 @pytest.mark.parametrize(
     "dropna, tuples, outputs",
     [

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -421,6 +421,34 @@ def test_groupby_nan_included_warns(by, dropna):
         result = grouped.indices  # noqa:F841
 
 
+@pytest.mark.parametrize(
+    "by_type",
+    [
+        "level",
+        "argument",
+    ],
+)
+@pytest.mark.parametrize("dropna", [True, False, None])
+def test_groupby_series_nan_included_warns(by_type, dropna):
+    # GH 61339
+    index = ["a", "a", "b", np.nan]
+    ser = pd.Series([1, 2, 3, 3])
+
+    if by_type == "level":
+        ser = ser.set_axis(index, axis=0)
+        kwargs = {"level": 0}
+    elif by_type == "argument":
+        kwargs = {"by": index}
+
+    warning_type = pd.errors.NullKeyWarning
+    if dropna is not None:
+        kwargs["dropna"] = dropna
+        warning_type = None
+
+    with tm.assert_produces_warning(warning_type):
+        ser.groupby(**kwargs).sum()
+
+
 def test_groupby_drop_nan_with_multi_index():
     # GH 39895
     df = pd.DataFrame([[np.nan, 0, 1]], columns=["a", "b", "c"])

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -397,8 +397,9 @@ def test_groupby_nan_included_warns(by, dropna):
     # GH 61339
     data = {"group": ["g1", np.nan, "g1", "g2", np.nan], "B": [0, 1, 2, 3, 4]}
     df = pd.DataFrame(data)
-    if by == "_index":
+    if isinstance(by, str) and by == "_index":
         df = df.set_index("group")
+        by = "group"
 
     kwargs = {}
     warning_type = pd.errors.NullKeyWarning

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -389,13 +389,22 @@ def test_groupby_nan_included():
     [
         pytest.param("group", id="column"),
         pytest.param(pd.Series(["g1", np.nan, "g1", "g2", np.nan]), id="Series"),
+        pytest.param(
+            pd.Series(["g1", np.nan, "g1", "g2", np.nan]).astype("category"),
+            id="Categorical",
+        ),
         pytest.param("_index", id="index"),
+        pytest.param(["group", "group2"], id="multikey"),
     ],
 )
 @pytest.mark.parametrize("dropna", [True, False, None])
 def test_groupby_nan_included_warns(by, dropna):
     # GH 61339
-    data = {"group": ["g1", np.nan, "g1", "g2", np.nan], "B": [0, 1, 2, 3, 4]}
+    data = {
+        "group": ["g1", np.nan, "g1", "g2", np.nan],
+        "group2": ["g1", "g2", np.nan, "g2", np.nan],
+        "B": [0, 1, 2, 3, 4],
+    }
     df = pd.DataFrame(data)
     if isinstance(by, str) and by == "_index":
         df = df.set_index("group")

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -691,7 +691,7 @@ class TestGrouping:
 
         # factorizing doesn't confuse things
         s = Series(np.arange(8.0), index=index)
-        result = s.groupby(level=0, sort=sort).sum()
+        result = s.groupby(level=0, sort=sort, dropna=True).sum()
         expected = Series([6.0, 18.0], index=[0.0, 1.0])
         tm.assert_series_equal(result, expected)
 
@@ -817,7 +817,7 @@ class TestGrouping:
         df = DataFrame(
             [["x", np.nan, 10], [None, np.nan, 20]], columns=["A", "B", "C"]
         ).set_index(["A", "B"])
-        result = df.groupby(level=["A", "B"]).sum()
+        result = df.groupby(level=["A", "B"], dropna=True).sum()
         expected = DataFrame(
             data=[],
             index=MultiIndex(

--- a/pandas/tests/groupby/test_indexing.py
+++ b/pandas/tests/groupby/test_indexing.py
@@ -294,6 +294,7 @@ def test_groupby_duplicated_columns(func):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.filterwarnings("ignore::pandas.errors.NullKeyWarning")
 def test_groupby_get_nonexisting_groups():
     # GH#32492
     df = pd.DataFrame(

--- a/pandas/tests/groupby/test_missing.py
+++ b/pandas/tests/groupby/test_missing.py
@@ -83,7 +83,9 @@ def test_min_count(func, min_count, value):
 def test_indices_with_missing():
     # GH 9304
     df = DataFrame({"a": [1, 1, np.nan], "b": [2, 3, 4], "c": [5, 6, 7]})
-    g = df.groupby(["a", "b"])
-    result = g.indices
+    # GH 61339
+    with tm.assert_produces_warning(pd.errors.NullKeyWarning):
+        g = df.groupby(["a", "b"])
+        result = g.indices
     expected = {(1.0, 2): np.array([0]), (1.0, 3): np.array([1])}
     assert result == expected

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -656,7 +656,7 @@ def test_multifunc_skipna(func, values, dtype, result_dtype, skipna):
     tm.assert_series_equal(result, expected)
 
 
-def test_cython_median():
+def test_cython_median(dropna):
     arr = np.random.default_rng(2).standard_normal(1000)
     arr[::2] = np.nan
     df = DataFrame(arr)
@@ -664,24 +664,26 @@ def test_cython_median():
     labels = np.random.default_rng(2).integers(0, 50, size=1000).astype(float)
     labels[::17] = np.nan
 
-    result = df.groupby(labels).median()
-    exp = df.groupby(labels).agg(np.nanmedian)
+    result = df.groupby(labels, dropna=dropna).median()
+    exp = df.groupby(labels, dropna=dropna).agg(np.nanmedian)
     tm.assert_frame_equal(result, exp)
 
     df = DataFrame(np.random.default_rng(2).standard_normal((1000, 5)))
-    rs = df.groupby(labels).agg(np.median)
-    xp = df.groupby(labels).median()
+    rs = df.groupby(labels, dropna=dropna).agg(np.median)
+    xp = df.groupby(labels, dropna=dropna).median()
     tm.assert_frame_equal(rs, xp)
 
 
-def test_median_empty_bins(observed):
+def test_median_empty_bins(observed, dropna):
     df = DataFrame(np.random.default_rng(2).integers(0, 44, 500))
 
     grps = range(0, 55, 5)
     bins = pd.cut(df[0], grps)
 
-    result = df.groupby(bins, observed=observed).median()
-    expected = df.groupby(bins, observed=observed).agg(lambda x: x.median())
+    result = df.groupby(bins, observed=observed, dropna=dropna).median()
+    expected = df.groupby(bins, observed=observed, dropna=dropna).agg(
+        lambda x: x.median()
+    )
     tm.assert_frame_equal(result, expected)
 
 
@@ -1069,6 +1071,7 @@ def test_max_nan_bug():
 
 
 @pytest.mark.slow
+@pytest.mark.filterwarnings("ignore::pandas.errors.NullKeyWarning")
 @pytest.mark.parametrize("with_nan", [True, False])
 @pytest.mark.parametrize("keys", [["joe"], ["joe", "jim"]])
 def test_series_groupby_nunique(sort, dropna, as_index, with_nan, keys):


### PR DESCRIPTION
- [X] closes #61339
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

TODO:

- [X] Check performance for `codes` check approaches (`codes.min()` was about 3x faster)
- [ ] Run full test suite to ensure nothing broke
- [ ] Add tests/implementation for `.pivot_table`/`.stack`/etc. (possibly in a follow-up PR?)