### PR TITLE
DOC: Added constructor parameters to DateOffset docstring for API consistency #52431

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1640,7 +1640,7 @@ class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
     Standard kind of date increment used for a date range.
 
     class pandas.tseries.offsets.DateOffset(
-        n = 1, normalize = False, weekday = 0, **kwds
+        n = 1, normalize = False, weekday = 0, ``**kwds``
         )
 
     Works exactly like the keyword argument form of relativedelta.

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1639,8 +1639,10 @@ class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
     """
     Standard kind of date increment used for a date range.
 
-    class pandas.tseries.offsets.DateOffset(n = 1, normalize = False, weekday = 0, **kwds)
-    
+    class pandas.tseries.offsets.DateOffset(
+        n = 1, normalize = False, weekday = 0, **kwds
+        )
+
     Works exactly like the keyword argument form of relativedelta.
     Note that the positional argument form of relativedelta is not
     supported. Use of the keyword n is discouraged-- you would be better

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1637,6 +1637,8 @@ class OffsetMeta(type):
 # TODO: figure out a way to use a metaclass with a cdef class
 class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
     """
+    class pandas.tseries.offsets.DateOffset(n = 1, normalize = False, weekday = 0, **kwds)
+    
     Standard kind of date increment used for a date range.
 
     Works exactly like the keyword argument form of relativedelta.

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1637,10 +1637,10 @@ class OffsetMeta(type):
 # TODO: figure out a way to use a metaclass with a cdef class
 class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
     """
-    class pandas.tseries.offsets.DateOffset(n = 1, normalize = False, weekday = 0, **kwds)
-    
     Standard kind of date increment used for a date range.
 
+    class pandas.tseries.offsets.DateOffset(n = 1, normalize = False, weekday = 0, **kwds)
+    
     Works exactly like the keyword argument form of relativedelta.
     Note that the positional argument form of relativedelta is not
     supported. Use of the keyword n is discouraged-- you would be better


### PR DESCRIPTION
 - Added the constructor signature for DateOffset.
 - No functional changes were made, only documentation improvements.
 - Part of the issue #52431 is addressed by this.