### PR TITLE
DOC: Add missing period in sample docstring

### DIFF
--- a/pandas/core/sample.py
+++ b/pandas/core/sample.py
@@ -123,7 +123,7 @@ def sample(
     random_state: np.random.RandomState | np.random.Generator,
 ) -> np.ndarray:
     """
-    Randomly sample `size` indices in `np.arange(obj_len)`
+    Randomly sample `size` indices in `np.arange(obj_len)`.
 
     Parameters
     ----------


### PR DESCRIPTION
- Minor documentation fix.
- Adds a missing period at the end of the "random_state" description in the `sample` function docstring.
- No functional changes.

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
