### PR TITLE
CI: Use Cython nightlies for Windows wheel builds again

### DIFF
--- a/scripts/cibw_before_build_windows.sh
+++ b/scripts/cibw_before_build_windows.sh
@@ -8,8 +8,6 @@ done
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -U pip
-    # python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-    # TODO: Remove below and uncomment above once https://github.com/cython/cython/pull/6717 no longer breaks tests
-    python -m pip install git+https://github.com/cython/cython.git@3276b588720a053c78488e5de788605950f4b136
+    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     python -m pip install ninja meson-python versioneer[toml] numpy
 fi


### PR DESCRIPTION
Validated that the wheel tests should pass now from https://github.com/pandas-dev/pandas/pull/61354