### PR TITLE
DOC: Fix dark mode text visibility in Getting Started accordion (#60024)

### DIFF
--- a/doc/source/_static/css/getting_started.css
+++ b/doc/source/_static/css/getting_started.css
@@ -249,6 +249,7 @@ ul.task-bullet > li > p:first-child {
 
 .tutorial-card .card-header {
   --bs-card-cap-color: var(--pst-color-text-base);
+  color: var(--pst-color-text-base);
   cursor: pointer;
   background-color: var(--pst-color-surface);
   border: 1px solid var(--pst-color-border)
@@ -256,6 +257,7 @@ ul.task-bullet > li > p:first-child {
 
 .tutorial-card .card-body {
   background-color: var(--pst-color-on-background);
+  color: var(--pst-color-text-base);
 }
 
 .tutorial-card .badge {


### PR DESCRIPTION
- [x] closes [#61377](https://github.com/pandas-dev/pandas/issues/61377) (duplicate of [#60024](https://github.com/pandas-dev/pandas/issues/60024))

### 📄 **Description**

This pull request fixes the issue described in [#61377](https://github.com/pandas-dev/pandas/issues/61377), where the text in the accordion content of the *Getting Started* tutorial section was not visible in dark mode.

Although #61377 is a duplicate, the underlying problem was originally reported in [#60024](https://github.com/pandas-dev/pandas/issues/60024), and later duplicated in [#60041](https://github.com/pandas-dev/pandas/issues/60041) and [#60921](https://github.com/pandas-dev/pandas/issues/60921). This PR addresses the root cause described in those issues.

### ✅ **Changes Made**

Added CSS variables to ensure that text and background colors are consistent with the active theme:

```css
.tutorial-card .card-header {
  --bs-card-cap-color: var(--pst-color-text-base);
  color: var(--pst-color-text-base);
  cursor: pointer;
  background-color: var(--pst-color-surface);
  border: 1px solid var(--pst-color-border);
}

.tutorial-card .card-body {
  background-color: var(--pst-color-on-background);
  color: var(--pst-color-text-base);
}
```
