### PR TITLE
BLD: allow to build with non-MSVC compilers on Windows

### DIFF
--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -26,9 +26,9 @@ runs:
       run: |
         if [[ ${{ inputs.editable }} == "true" ]]; then
           pip install -e . --no-build-isolation -v --no-deps \
-            -Csetup-args="--werror"
+            -Csetup-args="--werror" -Csetup-args="--vsenv"
         else
           pip install . --no-build-isolation -v --no-deps \
-            -Csetup-args="--werror"
+            -Csetup-args="--werror" -Csetup-args="--vsenv"
         fi
       shell: bash -el {0}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -356,7 +356,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel meson[ninja]==1.2.1 meson-python==0.13.1
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0 pytest-cov
-          python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
+          python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror" -Csetup-args="--vsenv"
           python -m pip list
 
       - name: Run Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,9 +143,6 @@ versionfile_build = "pandas/_version.py"
 tag_prefix = "v"
 parentdir_prefix = "pandas-"
 
-[tool.meson-python.args]
-setup = ['--vsenv'] # For Windows
-
 [tool.cibuildwheel]
 skip = "cp36-* cp37-* cp38-* cp39-* pp* *_i686 *_ppc64le *_s390x"
 build-verbosity = 3
@@ -162,6 +159,7 @@ before-build = "PACKAGE_DIR={package} bash {package}/scripts/cibw_before_build.s
 [tool.cibuildwheel.windows]
 environment = {}
 before-build = "pip install delvewheel && bash {package}/scripts/cibw_before_build_windows.sh"
+config-settings = "setup-args=--vsenv"
 test-command = """
   set PANDAS_CI='1' && \
   python -c "import pandas as pd; \


### PR DESCRIPTION
Always passing --vsenv to meson means pandas can't be built with gcc/clang
on Windows.

Instead add it to the cibuildwheel config so MSVC is still forced in CI
when building wheels, and in various places where it is built via pip.