### PR TITLE
BUG: Fix memory leak when slicing Series and assigning to self

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -928,7 +928,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         # axis kwarg is retained for compat with NDFrame method
         #  _slice is *always* positional
         mgr = self._mgr.get_slice(slobj, axis=axis)
-        out = self._constructor_from_mgr(mgr, axes=mgr.axes)
+        out = self._constructor_from_mgr(mgr, axes=mgr.axes).copy(deep=True)
         out._name = self._name
         return out.__finalize__(self)
 

--- a/pandas/tests/series/methods/test_slice.py
+++ b/pandas/tests/series/methods/test_slice.py
@@ -14,7 +14,7 @@ def count_dummy_instances():
 
 
 def test_slicing_releases_dummy_instances():
-    """Ensure that slicing a Series does not retain references to all original Dummy instances."""
+    """Ensure slicing a Series does not retain references to original Dummy instances."""
     NDATA = 100_000
     baseline = count_dummy_instances()
     a = Series([Dummy(i) for i in range(NDATA)])

--- a/pandas/tests/series/methods/test_slice.py
+++ b/pandas/tests/series/methods/test_slice.py
@@ -1,0 +1,27 @@
+import gc
+import pandas as pd
+from pandas import Series
+
+
+class Dummy:
+    def __init__(self, val):
+        self.val = val
+
+
+def count_dummy_instances():
+    gc.collect()
+    return sum(1 for obj in gc.get_objects() if isinstance(obj, Dummy))
+
+
+def test_slicing_releases_dummy_instances():
+    """Ensure that slicing a Series does not retain references to all original Dummy instances."""
+    NDATA = 100_000
+    baseline = count_dummy_instances()
+    a = Series([Dummy(i) for i in range(NDATA)])
+    a = a[-1:]
+    gc.collect()
+    after = count_dummy_instances()
+    retained = after - baseline
+    assert (
+        retained <= 1
+    ), f"{retained} Dummy instances were retained; expected at most 1"

--- a/pandas/tests/series/methods/test_slice.py
+++ b/pandas/tests/series/methods/test_slice.py
@@ -1,5 +1,5 @@
 import gc
-import pandas as pd
+
 from pandas import Series
 
 
@@ -14,7 +14,7 @@ def count_dummy_instances():
 
 
 def test_slicing_releases_dummy_instances():
-    """Ensure slicing a Series does not retain references to original Dummy instances."""
+    """Ensure Series slicing does not retain references to original Dummy data."""
     NDATA = 100_000
     baseline = count_dummy_instances()
     a = Series([Dummy(i) for i in range(NDATA)])
@@ -22,6 +22,6 @@ def test_slicing_releases_dummy_instances():
     gc.collect()
     after = count_dummy_instances()
     retained = after - baseline
-    assert (
-        retained <= 1
-    ), f"{retained} Dummy instances were retained; expected at most 1"
+    assert retained <= 1, (
+        f"{retained} Dummy instances were retained; expected at most 1"
+    )


### PR DESCRIPTION
This PR fixes a memory leak that occurs when a Series is sliced and reassigned to itself, e.g., a = a[-1:].

The underlying BlockManager retained references to the original data, preventing garbage collection. This is resolved by ensuring the sliced result copies the backing data.

Closes #60640.