### PR TITLE
BLD: Decrease size of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM python:3.10.8
 WORKDIR /home/pandas
 
 RUN apt-get update && \
-    apt-get -y upgrade && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y \
+    apt-get --no-install-recommends -y upgrade && \
+    apt-get --no-install-recommends -y install \
     build-essential \
     bash-completion \
     # hdf5 needed for pytables installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
 FROM python:3.10.8
 WORKDIR /home/pandas
 
-RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y build-essential bash-completion
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    rm -rf /var/lib/apt/lists/*
 
-# hdf5 needed for pytables installation
-# libgles2-mesa needed for pytest-qt
-RUN apt-get install -y libhdf5-dev libgles2-mesa-dev
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    bash-completion \
+    # hdf5 needed for pytables installation
+    libhdf5-dev \
+    # libgles2-mesa needed for pytest-qt
+    libgles2-mesa-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip
 COPY requirements-dev.txt /tmp
-RUN python -m pip install -r /tmp/requirements-dev.txt
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir -r /tmp/requirements-dev.txt
 RUN git config --global --add safe.directory /home/pandas
 
 ENV SHELL="/bin/bash"


### PR DESCRIPTION
This PR reduces the size of the docker image by:
- combining RUN commands to minimise the number of layers 
- removing the apt lists files to reduce total size 
- use --no-cache-dir when installing with pip

In my tests it reduced the size of the final image with approximately 0.47GB (most of it due to the --no-cache-dir). 

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
