### PR TITLE
BUG: Fix DataFrame constructor misclassification of array-like with 'name' attribute (#61443)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -904,6 +904,7 @@ Other
 - Bug in ``Series.list`` methods not preserving the original name. (:issue:`60522`)
 - Bug in printing a :class:`DataFrame` with a :class:`DataFrame` stored in :attr:`DataFrame.attrs` raised a ``ValueError`` (:issue:`60455`)
 - Bug in printing a :class:`Series` with a :class:`DataFrame` stored in :attr:`Series.attrs` raised a ``ValueError`` (:issue:`60568`)
+- Fixed bug where the :class:`DataFrame` constructor misclassified array-like objects with a ``.name`` attribute as :class:`Series` or :class:`Index` (:issue:`61443`)
 - Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
 
 .. ***DO NOT USE THIS SECTION***

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -116,6 +116,10 @@ from pandas.core.dtypes.missing import (
     isna,
     notna,
 )
+from pandas.core.dtypes.generic import (
+    ABCSeries,
+    ABCIndex
+)
 
 from pandas.core import (
     algorithms,
@@ -795,7 +799,7 @@ class DataFrame(NDFrame, OpsMixin):
                     dtype,
                     copy,
                 )
-            elif getattr(data, "name", None) is not None:
+            elif isinstance(data, (ABCSeries, ABCIndex)) and data.name is not None:
                 # i.e. Series/Index with non-None name
                 mgr = dict_to_mgr(
                     # error: Item "ndarray" of "Union[ndarray, Series, Index]" has no

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -112,13 +112,13 @@ from pandas.core.dtypes.dtypes import (
     BaseMaskedDtype,
     ExtensionDtype,
 )
+from pandas.core.dtypes.generic import (
+    ABCIndex,
+    ABCSeries,
+)
 from pandas.core.dtypes.missing import (
     isna,
     notna,
-)
-from pandas.core.dtypes.generic import (
-    ABCSeries,
-    ABCIndex
 )
 
 from pandas.core import (
@@ -804,7 +804,7 @@ class DataFrame(NDFrame, OpsMixin):
                 mgr = dict_to_mgr(
                     # error: Item "ndarray" of "Union[ndarray, Series, Index]" has no
                     # attribute "name"
-                    {data.name: data},  # type: ignore[union-attr]
+                    {data.name: data},
                     index,
                     columns,
                     dtype=dtype,

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2792,6 +2792,7 @@ class TestDataFrameConstructors:
         expected = DataFrame(np.eye(3))
         tm.assert_frame_equal(df, expected)
 
+
 class TestDataFrameConstructorIndexInference:
     def test_frame_from_dict_of_series_overlapping_monthly_period_indexes(self):
         rng1 = pd.period_range("1/1/1999", "1/1/2012", freq="M")

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2780,6 +2780,17 @@ class TestDataFrameConstructors:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_dataframe_from_array_like_with_name_attribute(self):
+        class DummyArray(np.ndarray):
+            def __new__(cls, input_array):
+                obj = np.asarray(input_array).view(cls)
+                obj.name = "foo"
+                return obj
+
+        dummy = DummyArray(np.eye(3))
+        df = DataFrame(dummy)
+        expected = DataFrame(np.eye(3))
+        tm.assert_frame_equal(df, expected)
 
 class TestDataFrameConstructorIndexInference:
     def test_frame_from_dict_of_series_overlapping_monthly_period_indexes(self):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2781,6 +2781,7 @@ class TestDataFrameConstructors:
         tm.assert_frame_equal(result, expected)
 
     def test_dataframe_from_array_like_with_name_attribute(self):
+        # GH#61443
         class DummyArray(np.ndarray):
             def __new__(cls, input_array):
                 obj = np.asarray(input_array).view(cls)


### PR DESCRIPTION
BUG: Fix DataFrame constructor misclassification of array-like with 'name' attribute

Previously, any object with a `.name` attribute (like some `vtkArray`-like objects) was assumed to be a `Series` or `Index`, causing the DataFrame constructor to misinterpret the input and raise errors when passed valid 2D array-likes.

This fix ensures we only apply the named-Series/Index logic when the input is **actually** an instance of `ABCSeries` or `ABCIndex`, and the `name` is not `None`.

A new test was added to ensure array-like subclasses with `.name` are handled correctly.

---

- [x] Closes #61443
- [x] Tests added and passing
- [x] Code passes all checks via `pre-commit`
- [x] Behavior verified with array-like + `.name` case
- [x] Entry added in `doc/source/whatsnew/v3.0.0.rst`