### PR TITLE
BUG: Raise clear error for duplicate id_vars in melt (GH61475)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -847,6 +847,7 @@ Reshaping
 - Bug in :meth:`DataFrame.stack` with the new implementation where ``ValueError`` is raised when ``level=[]`` (:issue:`60740`)
 - Bug in :meth:`DataFrame.unstack` producing incorrect results when manipulating empty :class:`DataFrame` with an :class:`ExtentionDtype` (:issue:`59123`)
 - Bug in :meth:`concat` where concatenating DataFrame and Series with ``ignore_index = True`` drops the series name (:issue:`60723`, :issue:`56257`)
+- Bug in :func:`melt` where calling with duplicate column names in ``id_vars`` raised a misleading ``AttributeError`` (:issue:`61475`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -173,7 +173,6 @@ def melt(
     1      b          B          E      3
     2      c          B          E      5
     """
-
     if value_name in frame.columns:
         raise ValueError(
             f"value_name ({value_name}) cannot match an element in "

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -173,9 +173,7 @@ def melt(
     1      b          B          E      3
     2      c          B          E      5
     """
-    # GH61475 - prevent AttributeError when duplicate column in id_vars
-    if id_vars and any(frame.columns.tolist().count(col) > 1 for col in id_vars):
-        raise ValueError("id_vars cannot contain duplicate columns.")
+
     if value_name in frame.columns:
         raise ValueError(
             f"value_name ({value_name}) cannot match an element in "
@@ -184,6 +182,10 @@ def melt(
     id_vars = ensure_list_vars(id_vars, "id_vars", frame.columns)
     value_vars_was_not_none = value_vars is not None
     value_vars = ensure_list_vars(value_vars, "value_vars", frame.columns)
+
+    # GH61475 - prevent AttributeError when duplicate column in id_vars
+    if len(frame.columns.get_indexer_for(id_vars)) > len(id_vars):
+        raise ValueError("id_vars cannot contain duplicate columns.")
 
     if id_vars or value_vars:
         if col_level is not None:

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -239,6 +239,9 @@ def melt(
     mdata: dict[Hashable, AnyArrayLike] = {}
     for col in id_vars:
         id_data = frame.pop(col)
+        # GH61475 - prevent AttributeError when duplicate column
+        if not hasattr(id_data, "dtype"):
+            raise Exception(f"{col} is a duplicate column header")
         if not isinstance(id_data.dtype, np.dtype):
             # i.e. ExtensionDtype
             if num_cols_adjusted > 0:

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -173,6 +173,9 @@ def melt(
     1      b          B          E      3
     2      c          B          E      5
     """
+    # GH61475 - prevent AttributeError when duplicate column in id_vars
+    if id_vars and any(frame.columns.tolist().count(col) > 1 for col in id_vars):
+        raise ValueError("id_vars cannot contain duplicate columns.")
     if value_name in frame.columns:
         raise ValueError(
             f"value_name ({value_name}) cannot match an element in "
@@ -239,9 +242,6 @@ def melt(
     mdata: dict[Hashable, AnyArrayLike] = {}
     for col in id_vars:
         id_data = frame.pop(col)
-        # GH61475 - prevent AttributeError when duplicate column
-        if not hasattr(id_data, "dtype"):
-            raise Exception(f"{col} is a duplicate column header")
         if not isinstance(id_data.dtype, np.dtype):
             # i.e. ExtensionDtype
             if num_cols_adjusted > 0:

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -555,6 +555,14 @@ class TestMelt:
         ):
             df.melt(var_name=["first", "second", "third"])
 
+    def test_melt_duplicate_column_header_raises(self):
+        # GH61475
+        df = DataFrame([[1, 2, 3], [3, 4, 5]], columns=["A", "A", "B"])
+        msg = "A is a duplicate column header"
+
+        with pytest.raises(Exception, match=msg):
+            df.melt(id_vars=["A"], value_vars=["B"])
+
 
 class TestLreshape:
     def test_pairs(self):

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -558,9 +558,9 @@ class TestMelt:
     def test_melt_duplicate_column_header_raises(self):
         # GH61475
         df = DataFrame([[1, 2, 3], [3, 4, 5]], columns=["A", "A", "B"])
-        msg = "A is a duplicate column header"
+        msg = "id_vars cannot contain duplicate columns."
 
-        with pytest.raises(Exception, match=msg):
+        with pytest.raises(ValueError, match=msg):
             df.melt(id_vars=["A"], value_vars=["B"])
 
 


### PR DESCRIPTION
- [x] closes #61475 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
