### PR TITLE
DOC: Fix sparse and dense array memory usage comparison.

### DIFF
--- a/doc/source/user_guide/sparse.rst
+++ b/doc/source/user_guide/sparse.rst
@@ -40,8 +40,8 @@ and in the Python interpreter.
 
 .. ipython:: python
 
-   'dense : {:0.2f} bytes'.format(df.memory_usage().sum() / 1e3)
-   'sparse: {:0.2f} bytes'.format(sdf.memory_usage().sum() / 1e3)
+   f'dense: {df.memory_usage().sum()} bytes'
+   f'sparse: {sdf.memory_usage().sum()} bytes'
 
 Functionally, their behavior should be nearly
 identical to their dense counterparts.


### PR DESCRIPTION
This MR fixes misleading part of sparse user guide, which suggests that dataframes consume far less memory than they really do, due to wrong units calculation.

Also changed usage of `str.format()` to more modern f-string syntax in part of guide which was mentioned above.