### PR TITLE
ENH: Add `force_suffixes` boolean argument to `pd.merge`

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11102,6 +11102,7 @@ class DataFrame(NDFrame, OpsMixin):
         right_index: bool = False,
         sort: bool = False,
         suffixes: Suffixes = ("_x", "_y"),
+        force_suffixes: bool = False,
         copy: bool | lib.NoDefault = lib.no_default,
         indicator: str | bool = False,
         validate: MergeValidate | None = None,
@@ -11121,6 +11122,7 @@ class DataFrame(NDFrame, OpsMixin):
             right_index=right_index,
             sort=sort,
             suffixes=suffixes,
+            force_suffixes=force_suffixes,
             indicator=indicator,
             validate=validate,
         )

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2371,13 +2371,35 @@ def test_merge_suffix(col1, col2, kwargs, expected_cols):
 
 @pytest.mark.parametrize("force_suffixes", [False, True])
 def test_merge_suffix_with_force_simple(force_suffixes):
+    df1 = pd.DataFrame({
+                'ID': [1, 2, 3],
+                'Value': ['A', 'B', 'C']
+                })
+
+    df2 = pd.DataFrame({
+                    'ID': [2, 3, 4],
+                    'Value': ['D', 'E', 'F']
+                })
+
+    if force_suffixes:
+        expected = DataFrame([[2, 2, "B", "D"], [3, 3, "C", "E"]], columns=["ID_left", "Value_left", "ID_right", "Value_right"])
+    else:
+        expected = DataFrame([[2, "B", "D"], [3, "C", "E"]], columns=["ID", "Value_left", "Value_right"])
+
+    result = merge(df1, df2, on="ID", suffixes=("_left", "_right"), force_suffixes=force_suffixes)
+    tm.assert_frame_equal(result, expected)
+
+@pytest.mark.parametrize("force_suffixes", [False, True])
+def test_merge_suffix_with_force_multi_column(force_suffixes):
     a = DataFrame({"A": [1, 2, 3, 98], "B": [4, 5, 6, 99], "ALPHABET": ["A", "B", "C", "Z"]})
     b = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "alphabet": ["a", "b", "c"]})
 
     if force_suffixes:
-        expected = DataFrame([[1, 4, "A", 1, 4, "a"], [2, 5, "B", 2, 5, "b"], [3, 6, "C", 3, 6, "c"]], columns=["A_x", "B_x", "ALPHABET_x", "a_y", "b_y", "alphabet_y"])
+        expected = DataFrame([[1, 4, "A", 1, 4, "a"], [2, 5, "B", 2, 5, "b"], [3, 6, "C", 3, 6, "c"]],
+                             columns=["A_x", "B_x", "ALPHABET_x", "a_y", "b_y", "alphabet_y"])
     else:
-        expected = DataFrame([[1, 4, "A", 1, 4, "a"], [2, 5, "B", 2, 5, "b"], [3, 6, "C", 3, 6, "c"]], columns=["A", "B", "ALPHABET", "a", "b", "alphabet"])
+        expected = DataFrame([[1, 4, "A", 1, 4, "a"], [2, 5, "B", 2, 5, "b"], [3, 6, "C", 3, 6, "c"]],
+                             columns=["A", "B", "ALPHABET", "a", "b", "alphabet"])
 
     result = merge(a, b, left_on=["A", "B"], right_on=["a", "b"],
                    force_suffixes=force_suffixes)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2382,8 +2382,8 @@ def test_merge_suffix_with_force_simple(force_suffixes):
                 })
 
     if force_suffixes:
-        expected = DataFrame([[2, 2, "B", "D"], [3, 3, "C", "E"]],
-                             columns=["ID_left", "Value_left", "ID_right", "Value_right"])
+        expected = DataFrame([[2, "B", "D"], [3, "C", "E"]],
+                             columns=["ID", "Value_left", "Value_right"])
     else:
         expected = DataFrame([[2, "B", "D"], [3, "C", "E"]],
                              columns=["ID", "Value_left", "Value_right"])
@@ -2399,7 +2399,7 @@ def test_merge_suffix_with_force_multi_column(force_suffixes):
 
     if force_suffixes:
         expected = DataFrame([[1, 4, "A", 1, 4, "a"], [2, 5, "B", 2, 5, "b"], [3, 6, "C", 3, 6, "c"]],
-                             columns=["A_x", "B_x", "ALPHABET_x", "a_y", "b_y", "alphabet_y"])
+                             columns=["A", "B", "ALPHABET_x", "a", "b", "alphabet_y"])
     else:
         expected = DataFrame([[1, 4, "A", 1, 4, "a"], [2, 5, "B", 2, 5, "b"], [3, 6, "C", 3, 6, "c"]],
                              columns=["A", "B", "ALPHABET", "a", "b", "alphabet"])

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2369,6 +2369,52 @@ def test_merge_suffix(col1, col2, kwargs, expected_cols):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("force_suffixes", [False, True])
+def test_merge_suffix_with_force_simple(force_suffixes):
+    a = DataFrame({"A": [1, 2, 3, 98], "B": [4, 5, 6, 99], "ALPHABET": ["A", "B", "C", "Z"]})
+    b = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "alphabet": ["a", "b", "c"]})
+
+    if force_suffixes:
+        expected = DataFrame([[1, 4, "A", 1, 4, "a"], [2, 5, "B", 2, 5, "b"], [3, 6, "C", 3, 6, "c"]], columns=["A_x", "B_x", "ALPHABET_x", "a_y", "b_y", "alphabet_y"])
+    else:
+        expected = DataFrame([[1, 4, "A", 1, 4, "a"], [2, 5, "B", 2, 5, "b"], [3, 6, "C", 3, 6, "c"]], columns=["A", "B", "ALPHABET", "a", "b", "alphabet"])
+
+    result = merge(a, b, left_on=["A", "B"], right_on=["a", "b"],
+                   force_suffixes=force_suffixes)
+    tm.assert_frame_equal(result, expected)
+
+@pytest.mark.parametrize(
+    "col1, col2, kwargs, expected_cols",
+    [
+        (0, 0, {"suffixes": ("", "_dup")}, ["0", "0_dup"]),
+        (0, 0, {"suffixes": (None, "_dup")}, [0, "0_dup"]),
+        (0, 0, {"suffixes": ("_x", "_y")}, ["0_x", "0_y"]),
+        (0, 0, {"suffixes": ["_x", "_y"]}, ["0_x", "0_y"]),
+        ("a", 0, {"suffixes": (None, "_y")}, ["a", "0_y"]),
+        (0.0, 0.0, {"suffixes": ("_x", None)}, ["0.0_x", 0.0]),
+        ("b", "b", {"suffixes": (None, "_y")}, ["b", "b_y"]),
+        ("a", "a", {"suffixes": ("_x", None)}, ["a_x", "a"]),
+        ("a", "b", {"suffixes": ("_x", None)}, ["a_x", "b"]),
+        ("a", "a", {"suffixes": (None, "_x")}, ["a", "a_x"]),
+        (0, 0, {"suffixes": ("_a", None)}, ["0_a", 0]),
+        ("a", "a", {}, ["a_x", "a_y"]),
+        (0, 0, {}, ["0_x", "0_y"]),
+    ],
+)
+def test_merge_suffix_with_force(col1, col2, kwargs, expected_cols):
+    # issue: 24782
+    a = DataFrame({col1: [1, 2, 3]})
+    b = DataFrame({col2: [4, 5, 6]})
+
+    expected = DataFrame([[1, 4], [2, 5], [3, 6]], columns=expected_cols)
+
+    result = a.merge(b, left_index=True, right_index=True, force_suffixes=True, **kwargs)
+    tm.assert_frame_equal(result, expected)
+
+    result = merge(a, b, left_index=True, right_index=True, force_suffixes=True, **kwargs)
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "how,expected",
     [
@@ -2575,6 +2621,7 @@ def test_categorical_non_unique_monotonic(n_categories):
         index=left_index,
     )
     tm.assert_frame_equal(expected, result)
+
 
 
 def test_merge_join_categorical_multiindex():

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2382,11 +2382,14 @@ def test_merge_suffix_with_force_simple(force_suffixes):
                 })
 
     if force_suffixes:
-        expected = DataFrame([[2, 2, "B", "D"], [3, 3, "C", "E"]], columns=["ID_left", "Value_left", "ID_right", "Value_right"])
+        expected = DataFrame([[2, 2, "B", "D"], [3, 3, "C", "E"]],
+                             columns=["ID_left", "Value_left", "ID_right", "Value_right"])
     else:
-        expected = DataFrame([[2, "B", "D"], [3, "C", "E"]], columns=["ID", "Value_left", "Value_right"])
+        expected = DataFrame([[2, "B", "D"], [3, "C", "E"]],
+                             columns=["ID", "Value_left", "Value_right"])
 
-    result = merge(df1, df2, on="ID", suffixes=("_left", "_right"), force_suffixes=force_suffixes)
+    result = merge(df1, df2, on="ID", suffixes=("_left", "_right"),
+                   force_suffixes=force_suffixes)
     tm.assert_frame_equal(result, expected)
 
 @pytest.mark.parametrize("force_suffixes", [False, True])


### PR DESCRIPTION
## Motivation

Often, when working with wide (i.e. multiple columns) dataframes in exploratory, merging them leads to an even wider dataframe. Currently, the `suffixes` mechanism is only applied on *equally named* columns from both dataframes.

However, often developers alter the column names beforehand, or use solutions similar to the one suggested [here](https://github.com/pandas-dev/pandas/issues/17834#issuecomment-1242794050).

## Changes

This PR adds a `force_suffixes` boolean argument to `pd.merge` which applies the suffixes on all columns, no matter if they equally named or not.

The goal is to have the following:

```python
df1 = pd.DataFrame({
                'ID': [1, 2, 3],
                'Value': ['A', 'B', 'C']
                })

  df2 = pd.DataFrame({
                  'ID': [2, 3, 4],
                  'Value': ['D', 'E', 'F']
              })

merged_df = pd.merge(df1, df2, on='ID', how="inner", suffixes=('_left', '_right'), force_suffixes=True)

# Goal:
expected = DataFrame([[2, 2, "B", "D"], [3, 3, "C", "E"]],
                                        columns=["ID_left", "Value_left", "ID_right", "Value_right"])
```
- [x] addresses #17834
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
