### PR TITLE
BUGFIX: escape `quotechar` when `escapechar` is not None (even if quoting=csv.QUOTE_NONE)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -790,8 +790,8 @@ I/O
 - Bug in :meth:`read_stata` where extreme value integers were incorrectly interpreted as missing for format versions 111 and prior (:issue:`58130`)
 - Bug in :meth:`read_stata` where the missing code for double was not recognised for format versions 105 and prior (:issue:`58149`)
 - Bug in :meth:`set_option` where setting the pandas option ``display.html.use_mathjax`` to ``False`` has no effect (:issue:`59884`)
+- Bug in :meth:`to_csv` where ``quotechar``` is not escaped when ``escapechar`` is not None (:issue:`61407`)
 - Bug in :meth:`to_excel` where :class:`MultiIndex` columns would be merged to a single row when ``merge_cells=False`` is passed (:issue:`60274`)
-
 Period
 ^^^^^^
 - Fixed error message when passing invalid period alias to :meth:`PeriodIndex.to_timestamp` (:issue:`58974`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -792,6 +792,7 @@ I/O
 - Bug in :meth:`set_option` where setting the pandas option ``display.html.use_mathjax`` to ``False`` has no effect (:issue:`59884`)
 - Bug in :meth:`to_csv` where ``quotechar``` is not escaped when ``escapechar`` is not None (:issue:`61407`)
 - Bug in :meth:`to_excel` where :class:`MultiIndex` columns would be merged to a single row when ``merge_cells=False`` is passed (:issue:`60274`)
+
 Period
 ^^^^^^
 - Fixed error message when passing invalid period alias to :meth:`PeriodIndex.to_timestamp` (:issue:`58974`)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -90,9 +90,9 @@ class CSVFormatter:
         self.index_label = self._initialize_index_label(index_label)
         self.errors = errors
         self.quoting = quoting or csvlib.QUOTE_MINIMAL
-        self.quotechar = self._initialize_quotechar(quotechar)
         self.doublequote = doublequote
         self.escapechar = escapechar
+        self.quotechar = self._initialize_quotechar(quotechar)
         self.lineterminator = lineterminator or os.linesep
         self.date_format = date_format
         self.cols = self._initialize_columns(cols)
@@ -141,7 +141,7 @@ class CSVFormatter:
         return [""] if index_label is None else [index_label]
 
     def _initialize_quotechar(self, quotechar: str | None) -> str | None:
-        if self.quoting != csvlib.QUOTE_NONE:
+        if self.quoting != csvlib.QUOTE_NONE or self.escapechar is not None:
             # prevents crash in _csv
             return quotechar
         return None

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -1450,3 +1450,22 @@ class TestDataFrameToCSV:
             RuntimeWarning, match=msg, raise_on_extra_warnings=False
         ):
             df.to_csv(tar_path, mode="a")
+
+    def test_to_csv_escape_quotechar(self):
+        # GH61514
+        df = DataFrame(
+            {
+                "col_a": ["a", "a2"],
+                "col_b": ['b"c', None],
+                "col_c": ['de,f"', '"c'],
+            }
+        )
+
+        result = df.to_csv(quotechar='"', escapechar="\\", quoting=csv.QUOTE_NONE)
+        expected_rows = [
+            ",col_a,col_b,col_c",
+            '0,a,b\\"c,de\\,f\\"',
+            '1,a2,,\\"c',
+        ]
+        expected = tm.convert_rows_list_to_csv_str(expected_rows)
+        assert result == expected


### PR DESCRIPTION
- [x] closes #61407 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
---
Found the issue on `CSVFormatter._initialize_quotechar`, wherein it only returns quotechar when `self.quoting` is not `csvlib.QUOTE_NONE`:
```python
if self.quoting != csvlib.QUOTE_NONE:
    # prevents crash in _csv
    return quotechar
return None
```
to follow the same behavior of `csv.writer` (escape when `escapechar is not None`), I improved the if function to **return quotechar when `self.escapechar is not None`**

in the `CSVFormatter.__init__`, moved the initialization of `self.escapechar` higher than `self.quotechar` since the initial solution was returning errors from calling `self.escapechar` before its initialization

initially marked as draft to let the CIs run & check if there are tests affected by this change