### PR TITLE
DOC: fix ES01 for pandas.plotting.autocorrelation_plot

### DIFF
--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -635,13 +635,12 @@ def autocorrelation_plot(series: Series, ax: Axes | None = None, **kwargs) -> Ax
 
     This method generates an autocorrelation plot for a given time series,
     which helps to identify any periodic structure or correlation within the
-    data across various lags. The autocorrelations are computed for increasing
-    lags and plotted as vertical bars. Horizontal lines at 95% and 99% confidence
-    intervals are shown to assist in identifying statistically significant lags. The
-    dashed line corresponds to the 99% confidence band, which can help detect
-    whether observed autocorrelations deviate significantly from what would
-    be expected under white noise. This plot is useful in time series analysis for
-    identifying potential model structures, such as autoregressive components.
+    data across various lags. It shows the correlation of a time series with a delayed
+    copy of itself as a function of delay. Autocorrelation plots are useful for
+    checking randomness in a data set. If the data are random, the autocorrelations
+    should be near zero for any and all time-lag separations. If the data are not
+    random, then one or more of the autocorrelations will be significantly
+    non-zero.
 
     Parameters
     ----------

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -635,8 +635,8 @@ def autocorrelation_plot(series: Series, ax: Axes | None = None, **kwargs) -> Ax
 
     This method generates an autocorrelation plot for a given time series,
     which helps to identify any periodic structure or correlation within the
-    data across various lags. It shows the correlation of a time series with a delayed
-    copy of itself as a function of delay. Autocorrelation plots are useful for
+    data across various lags. It shows the correlation of a time series with a
+    delayed copy of itself as a function of delay. Autocorrelation plots are useful for
     checking randomness in a data set. If the data are random, the autocorrelations
     should be near zero for any and all time-lag separations. If the data are not
     random, then one or more of the autocorrelations will be significantly

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -633,6 +633,16 @@ def autocorrelation_plot(series: Series, ax: Axes | None = None, **kwargs) -> Ax
     """
     Autocorrelation plot for time series.
 
+    This method generates an autocorrelation plot for a given time series,
+    which helps to identify any periodic structure or correlation within the
+    data across various lags. The autocorrelations are computed for increasing
+    lags and plotted as vertical bars. Horizontal lines at 95% and 99% confidence
+    intervals are shown to assist in identifying statistically significant lags. The
+    dashed line corresponds to the 99% confidence band, which can help detect
+    whether observed autocorrelations deviate significantly from what would
+    be expected under white noise. This plot is useful in time series analysis for
+    identifying potential model structures, such as autoregressive components.
+
     Parameters
     ----------
     series : Series


### PR DESCRIPTION
fixes

```
pandas.plotting.autocorrelation_plot ES01
```

This includes a crisp extended summary of the method which talks about what it does, how it does it and whats the value of it. 
