### PR TITLE
Add version constraints to reduce micromamba CI environment resolution time

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - meson=1.2.1
   - meson-python=0.13.1
 
-  # test dependencies 
+  # test dependencies
   - pytest>=7.3.2
   - pytest-cov
   - pytest-xdist>=3.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - meson=1.2.1
   - meson-python=0.13.1
 
-  # test dependencies
+  # test dependencies 
   - pytest>=7.3.2
   - pytest-cov
   - pytest-xdist>=3.4.0
@@ -33,7 +33,7 @@ dependencies:
   - html5lib>=1.1
   - hypothesis>=6.84.0
   - gcsfs>=2023.12.2
-  - ipython
+  - ipython>=8.21.0
   - pickleshare  # Needed for IPython Sphinx directive in the docs GH#60429
   - jinja2>=3.1.3
   - lxml>=4.9.2
@@ -61,8 +61,8 @@ dependencies:
   - zstandard>=0.22.0
 
   # downstream packages
-  - dask-core
-  - seaborn-base
+  - dask-core>=2024.4.2
+  - seaborn-base>=0.13.2
 
   # local testing dependencies
   - moto
@@ -100,9 +100,9 @@ dependencies:
   - nbconvert>=7.11.0
   - nbsphinx
   - pandoc
-  - ipywidgets
-  - nbformat
-  - notebook>=7.0.6
+  - ipywidgets>=8.1.2
+  - nbformat>=5.9.2
+  - notebook>=7.0.6,<7.2.0
   - ipykernel
 
   # web

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ fsspec>=2023.12.2
 html5lib>=1.1
 hypothesis>=6.84.0
 gcsfs>=2023.12.2
-ipython
+ipython>=8.21.0
 pickleshare
 jinja2>=3.1.3
 lxml>=4.9.2
@@ -48,8 +48,8 @@ xarray>=2024.1.1
 xlrd>=2.0.1
 xlsxwriter>=3.2.0
 zstandard>=0.22.0
-dask
-seaborn
+dask>=2024.4.2
+seaborn>=0.13.2
 moto
 flask
 asv>=0.6.1
@@ -73,9 +73,9 @@ types-setuptools
 nbconvert>=7.11.0
 nbsphinx
 pandoc
-ipywidgets
-nbformat
-notebook>=7.0.6
+ipywidgets>=8.1.2
+nbformat>=5.9.2
+notebook>=7.0.6,<7.2.0
 ipykernel
 markdown
 feedparser


### PR DESCRIPTION
This PR updates the `environment.yml` file to add version constraints to several frequently resolved dependencies. These changes help reduce environment resolution time in CI workflows using micromamba, which was previously leading to timeouts (see #61531).

Updated packages:
- ipywidgets>=8.1.2
- nbformat>=5.9.2
- notebook>=7.0.6,<7.2.0
- dask-core>=2024.4.2
- seaborn-base>=0.13.2

Fixes: #61531