### PR TITLE
DOC: Fix docs for BusinessDay constructor #52431

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1836,7 +1836,7 @@ cdef class BusinessMixin(SingleConstructorOffset):
         BaseOffset.__setstate__(self, state)
 
 
-cdef class BusinessDay(BusinessMixin):
+cdef class pandas.tseries.offsets.BusinessDay( n=1, normalize=False, offset=timedelta(0)):
     """
     DateOffset subclass representing possibly n business days.
 


### PR DESCRIPTION
fix constructor for offset BusinessDay

- [ ] addresses #52431 
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
