### PR TITLE
Fix WeekOfMonth offset constructor offsets.pyx

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -3835,7 +3835,8 @@ cdef class Week(SingleConstructorOffset):
         return cls(weekday=weekday)
 
 
-cdef class WeekOfMonth(WeekOfMonthMixin):
+cdef class pandas.tseries.offsets.WeekOfMonth(n=1, week=0, weekday=0, normalize=False, offset=timedelta(0))
+
     """
     Describes monthly dates like "the Tuesday of the 2nd week of each month".
 


### PR DESCRIPTION
Related to issue #52431, went and scanned the checklist commented previously by a user on Aug 4th, 2024. Noticed WeekOfMonth has incorrect offset constructors, and updated according to an earlier comment by @Dr-Irv  
