### PR TITLE
ENH: Adding DataFrame plotting benchmarks for large datasets

### DIFF
--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -189,6 +189,9 @@ class DataFramePlottingLarge:
                 np.random.randn(rows, cols),
                 columns=[f"col_{i}" for i in range(cols)]
             )
+        
+        # Pre-select single column for baseline comparison
+        self.single_column = self.df.iloc[:, 0]
 
     def time_plot_large_dataframe(self, size, datetime_index):
         """Benchmark plotting large DataFrames (bottleneck #61398/#61532)"""
@@ -196,7 +199,7 @@ class DataFramePlottingLarge:
 
     def time_plot_large_dataframe_single_column(self, size, datetime_index):
         """Baseline: plotting single column for comparison"""
-        self.df.iloc[:, 0].plot()
+        self.single_column.plot()
 
 
 from .pandas_vb_common import setup  # noqa isort:skip


### PR DESCRIPTION
- [ ] related to #61532  - Adding in performance benchmarks for DataFrame plotting with large datasets.
- [ ] Description: Added 'DataFramePlottingLarge' benchmark class to track performance issues related to bottlenecks in #61398 and #61532. Tests multiple DataFrame sizes with/w/o DatetimeIndex & provides a baseline single-column comparison.
- [ ] Intended to cover:
          - DataFrame sizes: (1000,10) to (10000,10)
          - DatetimeIndex vs. regular index comparison
          - Multi-column vs. single-column plotting.
