### PR TITLE
BLD: Build wheels for 3.9 and musllinux-aarch64 for pandas 2.3

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,7 +100,7 @@ jobs:
         - [macos-14, macosx_arm64]
         - [windows-2022, win_amd64]
         # TODO: support PyPy?
-        python: [["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"]]
+        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"]]
         include:
         # TODO: Remove this plus installing build deps in cibw_before_build.sh
         # after pandas can be built with a released NumPy/Cython

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -95,6 +95,7 @@ jobs:
         - [ubuntu-22.04, manylinux_x86_64]
         - [ubuntu-22.04, musllinux_x86_64]
         - [ubuntu-24.04-arm, manylinux_aarch64]
+        - [ubuntu-24.04-arm, musllinux_aarch64]
         - [macos-13, macosx_x86_64]
         # Note: M1 images on Github Actions start from macOS 14
         - [macos-14, macosx_arm64]

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 project(
     'pandas',
     'c', 'cpp', 'cython',
-    version: '2.3.0',
+    version: run_command(['generate_version.py', '--print'], check: true).stdout().strip(),
     license: 'BSD-3',
     meson_version: '>=1.2.1',
     default_options: [

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 project(
     'pandas',
     'c', 'cpp', 'cython',
-    version: run_command(['generate_version.py', '--print'], check: true).stdout().strip(),
+    version: '2.3.0',
     license: 'BSD-3',
     meson_version: '>=1.2.1',
     default_options: [


### PR DESCRIPTION
@lithomas1 would I need to re-tag the 2.3.x branch if/when we merge this?

xref https://github.com/pandas-dev/pandas/issues/61563 https://github.com/pandas-dev/pandas/issues/61574