### PR TITLE
BUG: Fix JSON typo that breaks javascript in the docs

### DIFF
--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -13,7 +13,7 @@
     {
         "name": "2.2",
         "version": "2.2",
-        "url": "https://pandas.pydata.org/pandas-docs/version/2.2/",
+        "url": "https://pandas.pydata.org/pandas-docs/version/2.2/"
     },
     {
         "name": "2.1",


### PR DESCRIPTION
Closes #61571 

As opposed to Python, JSON doesn't accept commas after the last element of a dict, and it's strict about it. We added this as a typo (I think I did the same during a release, I'll create an issue to validate this JSON in the CI) when updating the JSON that provides the versions for the documentation drop down. This seems to be breaking all the javascript in our docs.

@mroeschke I would merge this before waiting for the CI, but up to you.