### PR TITLE
DOC: Validate versions.json before building docs #61573

### DIFF
--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -441,6 +441,16 @@ def main(
     For ``.md`` and ``.html`` files, render them with the context
     before copying them. ``.md`` files are transformed to HTML.
     """
+    # Sanity check: validate that versions.json is valid JSON
+    versions_path = os.path.join(source_path, "versions.json")
+    with open(versions_path, encoding="utf-8") as f:
+        try:
+            json.load(f)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f"Invalid versions.json: {e}. Ensure it is valid JSON."
+            ) from e
+
     config_fname = os.path.join(source_path, "config.yml")
 
     shutil.rmtree(target_path, ignore_errors=True)


### PR DESCRIPTION
Adds a JSON validity check for `versions.json` directly inside `pandas_web` during context generation. This ensures malformed JSON (e.g., trailing commas) is caught early, preventing issues like the broken version dropdown in #61572

- [x] Closes #61573