### PR TITLE
Avoid re-enabling the GIL at runtime

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ if cy.version().version_compare('>=3.1.0')
         command: [
             cy,
             '-3',
+            '-Xfreethreading_compatible=true',
             '--fast-fail',
             '--generate-shared=' + meson.current_build_dir() / '_cyutility.c',
         ],


### PR DESCRIPTION
The GIL gets dynamically reenabled because the shared utility Cython build does not include the `freethreading_compatible` directive.

- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
