### PR TITLE
WEB: Moving maintainers to inactive status

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -82,15 +82,11 @@ maintainers:
   - simonjayhawkins
   - topper-123
   - alimcmaster1
-  - bashtage
   - Dr-Irv
   - rhshadrach
   - phofl
   - attack68
   - fangchenli
-  - lithomas1
-  - lukemanley
-  - noatamir
   inactive:
   - lodagro
   - jseabold
@@ -108,6 +104,10 @@ maintainers:
   - mzeitlin11
   - twoertwein
   - MarcoGorelli
+  - bashtage
+  - noatamir
+  - lithomas1
+  - lukemanley
 workgroups:
   coc:
     name: Code of Conduct


### PR DESCRIPTION
A sad PR, but after checking with some maintainers, they confirmed that they became inactive and wish to be changed status. I think 3 more people will also be moved unfortunately, but still waiting for confirmation from them.
