### PR TITLE
CI: Update Python version to 3.11 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: pandas-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
   - pip
 
   # build dependencies


### PR DESCRIPTION
xref #61585

Let's pin to 3.11 for now (let's see if this doesn't break the CI), and we can continue the discussion on unpinning if needed.
