### PR TITLE
WEB: Restore website width and improve table of contents style

### DIFF
--- a/web/pandas/static/css/pandas.css
+++ b/web/pandas/static/css/pandas.css
@@ -106,23 +106,22 @@ blockquote {
     color: #787878;
     font-size: 18px;
  }
-
 .toc {
-    background: #f0f0f0;
-    padding: 10px;
+    background: #f9f9f9;
+    padding: 1em;
+    border: 0.1em solid darkgrey;
+    border-radius: 0.4em;
     display: inline-block;
+    margin: 1em 0;
+}
+.toc .toctitle {
+    font-weight: bold;
+    padding-bottom: 1em;
 }
 a.headerlink {
     opacity: 0;
 }
-h2:hover a.headerlink {
+h2:hover a.headerlink, h3:hover a.headerlink {
     opacity: 1;
     transition: opacity 0.5s;
-}
-h3:hover a.headerlink {
-    opacity: 1;
-    transition: opacity 0.5s;
-}
-.container {
-    max-width: 100ch;
 }


### PR DESCRIPTION
Follow up of #58791

This restore the website width (happy to make the content of PDEPs narrower, but it's a bit trickier so I'll leave it to another PR).

I also styled the table of contents more similar to the code blocks, which personally I think it looks a bit nicer.

Before:
![Screenshot at 2025-06-06 23-23-22](https://github.com/user-attachments/assets/7a025b7c-c5b6-4e6a-b921-627f4e3439cf)

After:
![Screenshot at 2025-06-06 23-22-37](https://github.com/user-attachments/assets/178642b6-8376-4992-bef0-224fddb2c97d)

CC @rhshadrach 