### PR TITLE
CI: Fix slow mamba solver issue by limiting boto3 versions

### DIFF
--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3>=1.27.0
 
   # required dependencies
   - python-dateutil=2.8.2

--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3>=1.27.0
+  - boto3
 
   # required dependencies
   - python-dateutil=2.8.2

--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3=1.37.3
 
   # required dependencies
   - python-dateutil=2.8.2

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3>=1.27.0
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3>=1.27.0
+  - boto3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3=1.37.3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -17,7 +17,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3>=1.27.0
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -17,7 +17,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3>=1.27.0
+  - boto3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -17,7 +17,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3=1.37.3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3>=1.27.0
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3>=1.27.0
+  - boto3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3=1.37.3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3>=1.27.0
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3>=1.27.0
+  - boto3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3=1.37.3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -48,7 +48,7 @@ dependencies:
   - python-calamine>=0.1.7
   - pytz>=2023.4
   - pyxlsb>=1.0.10
-  - s3fs>=2023.12.2
+  - s3fs>=2025.5.1
   - scipy>=1.12.0
   - sqlalchemy>=2.0.0
   - tabulate>=0.9.0

--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3>=1.27.0
+  - boto3=1.37.3
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-xdist>=3.4.0
   - pytest-localserver>=0.8.1
   - pytest-qt>=4.4.0
-  - boto3
+  - boto3>=1.27.0
 
   # required dependencies
   - python-dateutil

--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -48,7 +48,7 @@ dependencies:
   - python-calamine>=0.1.7
   - pytz>=2023.4
   - pyxlsb>=1.0.10
-  - s3fs>=2025.5.1
+  - s3fs>=2023.12.2
   - scipy>=1.12.0
   - sqlalchemy>=2.0.0
   - tabulate>=0.9.0


### PR DESCRIPTION
Closes #61531

Probably better to rerun the CI 3 or 4 times to be sure this is the problem and the solution. But based on local tests, seems like boto3 has a huge number of versions (they release almost every day), and that's the problem with the mamba solver. Limiting the number of versions provided to the solver should help. 1.27 is from 2 years ago, consistent with other packages. Why only fails for  3.13? No idea