### PR TITLE
Add table of contents support to ecosystem page

### DIFF
--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -1,4 +1,5 @@
 # Ecosystem
+[TOC]
 
 Increasingly, packages are being built on top of pandas to address
 specific needs in data preparation, analysis and visualization. This is

--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -1,4 +1,5 @@
 # Ecosystem
+
 [TOC]
 
 Increasingly, packages are being built on top of pandas to address


### PR DESCRIPTION
This PR adds a table of contents to the Ecosystem page using the Markdown `TocExtension`.

- Inserted `[TOC]` placeholder in `ecosystem.md`
- Enabled `toc` extension in `web.py`
- Configured `toc_depth` for h2 and h3 headers
- Closes #61587
