### PR TITLE
Fix explode to preserve datetime unit in Series and DataFrame; update…

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10,7 +10,7 @@ labeling information
 """
 
 from __future__ import annotations
-import pandas as pd
+
 import collections
 from collections import abc
 from collections.abc import (
@@ -121,6 +121,7 @@ from pandas.core.dtypes.missing import (
     notna,
 )
 
+import pandas as pd
 from pandas.core import (
     algorithms,
     common as com,

--- a/pandas/tests/series/methods/test_explode.py
+++ b/pandas/tests/series/methods/test_explode.py
@@ -176,16 +176,27 @@ def test_explode_pyarrow_non_list_type(ignore_index):
     expected = pd.Series([1, 2, 3], dtype="int64[pyarrow]", index=[0, 1, 2])
     tm.assert_series_equal(result, expected)
 
+
 def test_explode_preserves_datetime_unit():
     # Create datetime64[ms] array manually
-    dt64_ms = np.array(["2020-01-01T00:00:00.000", "2020-01-01T01:00:00.000", "2020-01-01T02:00:00.000"], dtype="datetime64[ms]")
+    dt64_ms = np.array(
+        [
+            "2020-01-01T00:00:00.000",
+            "2020-01-01T01:00:00.000",
+            "2020-01-01T02:00:00.000",
+        ],
+        dtype="datetime64[ms]",
+    )
     s = pd.Series([dt64_ms])
 
     # Explode the Series
     result = s.explode()
 
     # Ensure the dtype (including unit) is preserved
-    assert result.dtype == dt64_ms.dtype, f"Expected dtype {dt64_ms.dtype}, got {result.dtype}"
+    assert result.dtype == dt64_ms.dtype, (
+        f"Expected dtype {dt64_ms.dtype}, got {result.dtype}"
+    )
+
 
 def test_single_column_explode_preserves_datetime_unit():
     # Use freq in ms since unit='ms'
@@ -193,6 +204,7 @@ def test_single_column_explode_preserves_datetime_unit():
     s = pd.Series([rng])
     result = s.explode()
     assert result.dtype == rng.dtype
+
 
 def test_multi_column_explode_preserves_datetime_unit():
     rng1 = pd.date_range("2020-01-01", periods=2, freq="3600000ms", unit="ms")

--- a/pandas/tests/series/methods/test_explode.py
+++ b/pandas/tests/series/methods/test_explode.py
@@ -175,3 +175,29 @@ def test_explode_pyarrow_non_list_type(ignore_index):
     result = ser.explode(ignore_index=ignore_index)
     expected = pd.Series([1, 2, 3], dtype="int64[pyarrow]", index=[0, 1, 2])
     tm.assert_series_equal(result, expected)
+
+def test_explode_preserves_datetime_unit():
+    # Create datetime64[ms] array manually
+    dt64_ms = np.array(["2020-01-01T00:00:00.000", "2020-01-01T01:00:00.000", "2020-01-01T02:00:00.000"], dtype="datetime64[ms]")
+    s = pd.Series([dt64_ms])
+
+    # Explode the Series
+    result = s.explode()
+
+    # Ensure the dtype (including unit) is preserved
+    assert result.dtype == dt64_ms.dtype, f"Expected dtype {dt64_ms.dtype}, got {result.dtype}"
+
+def test_single_column_explode_preserves_datetime_unit():
+    # Use freq in ms since unit='ms'
+    rng = pd.date_range("2020-01-01T00:00:00Z", periods=3, freq="3600000ms", unit="ms")
+    s = pd.Series([rng])
+    result = s.explode()
+    assert result.dtype == rng.dtype
+
+def test_multi_column_explode_preserves_datetime_unit():
+    rng1 = pd.date_range("2020-01-01", periods=2, freq="3600000ms", unit="ms")
+    rng2 = pd.date_range("2020-01-01", periods=2, freq="3600000ms", unit="ms")
+    df = pd.DataFrame({"A": [rng1], "B": [rng2]})
+    result = df.explode(["A", "B"])
+    assert result["A"].dtype == rng1.dtype
+    assert result["B"].dtype == rng2.dtype


### PR DESCRIPTION

This PR fixes an issue where the explode method in both Series and DataFrame does not preserve the datetime unit information (such as milliseconds or microseconds) of DatetimeIndex or datetime-like data. Previously, exploding a datetime-like Series or DataFrame column would convert timestamps to nanosecond resolution, losing the original unit precision.

The fix ensures that after exploding, the resulting Series or DataFrame retains the original datetime unit dtype, maintaining consistency and avoiding unwanted dtype changes.

Additionally, relevant tests have been updated and extended to verify that the datetime unit is preserved through explode operations in both single- and multi-column cases.

- [x] closes #61610 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
