### PR TITLE
BUG: DataFrame.explode fails with str dtype

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -24,6 +24,7 @@ Version 2.3
 .. toctree::
    :maxdepth: 2
 
+   v2.3.1
    v2.3.0
 
 Version 2.2

--- a/doc/source/whatsnew/v2.3.1.rst
+++ b/doc/source/whatsnew/v2.3.1.rst
@@ -40,5 +40,3 @@ Other
 
 Contributors
 ~~~~~~~~~~~~
-
-.. contributors:: v2.3.0..v2.3.1

--- a/doc/source/whatsnew/v2.3.1.rst
+++ b/doc/source/whatsnew/v2.3.1.rst
@@ -1,0 +1,44 @@
+.. _whatsnew_231:
+
+What's new in 2.3.1 (Month XX, 2025)
+---------------------------------------
+
+These are the changes in pandas 2.3.1. See :ref:`release` for a full changelog
+including other versions of pandas.
+
+{{ header }}
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_231.enhancements:
+
+Enhancements
+~~~~~~~~~~~~
+-
+
+.. _whatsnew_231.regressions:
+
+Fixed regressions
+~~~~~~~~~~~~~~~~~
+-
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_231.bug_fixes:
+
+Bug fixes
+~~~~~~~~~
+- Fixed bug in :meth:`DataFrame.explode` and :meth:`Series.explode` where methods would fail with ``dtype="str"`` (:issue:`???`)
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_231.other:
+
+Other
+~~~~~
+-
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_231.contributors:
+
+Contributors
+~~~~~~~~~~~~
+
+.. contributors:: v2.3.0..v2.3.1

--- a/doc/source/whatsnew/v2.3.1.rst
+++ b/doc/source/whatsnew/v2.3.1.rst
@@ -26,7 +26,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
-- Fixed bug in :meth:`DataFrame.explode` and :meth:`Series.explode` where methods would fail with ``dtype="str"`` (:issue:`???`)
+- Fixed bug in :meth:`DataFrame.explode` and :meth:`Series.explode` where methods would fail with ``dtype="str"`` (:issue:`61623`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_231.other:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1935,9 +1935,9 @@ class ArrowExtensionArray(
         """
         # child class explode method supports only list types; return
         # default implementation for non list types.
-        if not (
-            pa.types.is_list(self.dtype.pyarrow_dtype)
-            or pa.types.is_large_list(self.dtype.pyarrow_dtype)
+        if not hasattr(self.dtype, "pyarrow_dtype") or (
+            not pa.types.is_list(self.dtype.pyarrow_dtype)
+            and not pa.types.is_large_list(self.dtype.pyarrow_dtype)
         ):
             return super()._explode()
         values = self

--- a/pandas/tests/frame/methods/test_explode.py
+++ b/pandas/tests/frame/methods/test_explode.py
@@ -297,3 +297,10 @@ def test_multi_columns_nan_empty():
         index=[0, 0, 1, 2, 3, 3],
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_str_dtype():
+    df = pd.DataFrame({"a": ["x", "y"]}, dtype="str")
+    result = df.explode(column="a")
+    assert result is not df
+    tm.assert_frame_equal(result, df)

--- a/pandas/tests/frame/methods/test_explode.py
+++ b/pandas/tests/frame/methods/test_explode.py
@@ -300,6 +300,7 @@ def test_multi_columns_nan_empty():
 
 
 def test_str_dtype():
+    # https://github.com/pandas-dev/pandas/pull/61623
     df = pd.DataFrame({"a": ["x", "y"]}, dtype="str")
     result = df.explode(column="a")
     assert result is not df

--- a/pandas/tests/series/methods/test_explode.py
+++ b/pandas/tests/series/methods/test_explode.py
@@ -178,6 +178,7 @@ def test_explode_pyarrow_non_list_type(ignore_index):
 
 
 def test_str_dtype():
+    # https://github.com/pandas-dev/pandas/pull/61623
     ser = pd.Series(["x", "y"], dtype="str")
     result = ser.explode()
     assert result is not ser

--- a/pandas/tests/series/methods/test_explode.py
+++ b/pandas/tests/series/methods/test_explode.py
@@ -175,3 +175,10 @@ def test_explode_pyarrow_non_list_type(ignore_index):
     result = ser.explode(ignore_index=ignore_index)
     expected = pd.Series([1, 2, 3], dtype="int64[pyarrow]", index=[0, 1, 2])
     tm.assert_series_equal(result, expected)
+
+
+def test_str_dtype():
+    ser = pd.Series(["x", "y"], dtype="str")
+    result = ser.explode()
+    assert result is not ser
+    tm.assert_series_equal(result, ser)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This operation works on all other dtypes, e.g.

```python
df = pd.DataFrame({"a": [1, 2]})
print(df.explode(column="a"))
#    a
# 0  1
# 1  2
```
