### PR TITLE
[2.3.x] CI: temporarily pin numpy to 2.2 until latest numexpr is available

### DIFF
--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -19,7 +19,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy
+  - numpy=2.2
   # pytz 2024.2 timezones cause wrong results
   - pytz<2024.2
 


### PR DESCRIPTION
Some tests involving numexpr are failing in the CI of the backport PRs, which is happening since the release of numpy 2.3, I think.
On the main branch this is not happening (yet), because I think numpy gets restricted there to 2.2 because of the presence of numba in the env. In the 2.3.x branch however, mamba ends up getting numpy 2.3

I reported the wrong results from numexpr upstream (https://github.com/pydata/numexpr/issues/515), although it seems it might be solved with the latest numexpr release.

