### PR TITLE
BUG: Fix GroupBy aggregate coersion of outputs inconsistency for pyarrow dtypes

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1064,6 +1064,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.resample` changing index type to :class:`MultiIndex` when the dataframe is empty and using an upsample method (:issue:`55572`)
 - Bug in :meth:`DataFrameGroupBy.agg` and :meth:`SeriesGroupBy.agg` that was returning numpy dtype values when input values are pyarrow dtype values, instead of returning pyarrow dtype values. (:issue:`53030`)
 - Bug in :meth:`DataFrameGroupBy.agg` that raises ``AttributeError`` when there is dictionary input and duplicated columns, instead of returning a DataFrame with the aggregation of all duplicate columns. (:issue:`55041`)
+- Bug in :meth:`DataFrameGroupBy.agg` when applied to columns with :class:`ArrowDtype`, where pandas attempted to cast the result back to the original dtype (:issue:`61636`)
 - Bug in :meth:`DataFrameGroupBy.agg` where applying a user-defined function to an empty DataFrame returned a Series instead of an empty DataFrame. (:issue:`61503`)
 - Bug in :meth:`DataFrameGroupBy.apply` and :meth:`SeriesGroupBy.apply` for empty data frame with ``group_keys=False`` still creating output index using group keys. (:issue:`60471`)
 - Bug in :meth:`DataFrameGroupBy.apply` that was returning a completely empty DataFrame when all return values of ``func`` were ``None`` instead of returning an empty DataFrame with the original columns and dtypes. (:issue:`57775`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -311,13 +311,15 @@ class ArrowExtensionArray(
 
     @classmethod
     def _from_scalars(cls, scalars, dtype: DtypeObj) -> Self:
+        inferred_dtype = lib.infer_dtype(scalars, skipna=True)
         try:
             pa_array = cls._from_sequence(scalars, dtype=dtype)
-        except pa.ArrowNotImplementedError:
+        except pa.ArrowNotImplementedError as err:
             # _from_scalars should only raise ValueError or TypeError.
-            raise ValueError
+            raise ValueError from err
 
-        if lib.infer_dtype(scalars, skipna=True) != lib.infer_dtype(pa_array, skipna=True):
+        same_dtype = lib.infer_dtype(pa_array, skipna=True) == inferred_dtype
+        if not same_dtype:
             raise ValueError
         return pa_array
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -189,6 +189,7 @@ if TYPE_CHECKING:
         ArrayLike,
         AxisInt,
         Dtype,
+        DtypeObj,
         FillnaOptions,
         InterpolateOptions,
         Iterator,
@@ -307,6 +308,18 @@ class ArrowExtensionArray(
                 f"Unsupported type '{type(values)}' for ArrowExtensionArray"
             )
         self._dtype = ArrowDtype(self._pa_array.type)
+
+    @classmethod
+    def _from_scalars(cls, scalars, dtype: DtypeObj) -> Self:
+        try:
+            pa_array = cls._from_sequence(scalars, dtype=dtype)
+        except pa.ArrowNotImplementedError:
+            # _from_scalars should only raise ValueError or TypeError.
+            raise ValueError
+
+        if lib.infer_dtype(scalars, skipna=True) != lib.infer_dtype(pa_array, skipna=True):
+            raise ValueError
+        return pa_array
 
     @classmethod
     def _from_sequence(

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from pandas._typing import (
         ArrayLike,
         Dtype,
+        DtypeObj,
         NpDtype,
         Scalar,
         npt,
@@ -189,6 +190,12 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
         length : int
         """
         return len(self._pa_array)
+
+    @classmethod
+    def _from_scalars(cls, scalars, dtype: DtypeObj) -> Self:
+        if lib.infer_dtype(scalars, skipna=True) not in ["string", "empty"]:
+            raise ValueError
+        return cls._from_sequence(scalars, dtype=dtype)
 
     @classmethod
     def _from_sequence(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3251,6 +3251,27 @@ def test_groupby_count_return_arrow_dtype(data_missing):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "func, func_dtype",
+    [
+        [lambda x: x.to_dict(), "object"],
+        [lambda x: 1, "int64"],
+        [lambda x: "s", ArrowDtype(pa.string())],
+    ],
+)
+def test_groupby_aggregate_coersion(func, func_dtype):
+    # GH 61636
+    df = pd.DataFrame(
+        {
+            "b": pd.array([0, 1]),
+            "c": pd.array(["X", "Y"], dtype=ArrowDtype(pa.string())),
+        },
+        index=pd.Index(["A", "B"], name="a"),
+    )
+    result = df.groupby("b").agg(func)
+    assert result["c"].dtype == func_dtype
+
+
 def test_fixed_size_list():
     # GH#55000
     ser = pd.Series(


### PR DESCRIPTION
- [x] closes #61636
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

## Description
Fix a bug in `DataFrameGroupBy.agg` when applied to columns with `ArrowDtype`, where pandas attempted to cast the result back to the original dtype.

## Cause
1. `ExtensionArray._from_scalars()` should raise only `ValueError` or `TypeError`, instead of `pa.ArrowNotImplementedError`.
2. `ArrowExtensionArray._from_sequence()` may attempt an invalid cast, and if it succeeds, it can unintentionally alter the actual data type.