### PR TITLE
ENH: Allow third-party packages to register IO engines

### DIFF
--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -550,7 +550,7 @@ look at the entry points, will find the ``EmptyDataEngine`` engine, and will cal
 method on it with the arguments provided by the user (except the ``engine`` parameter).
 
 To avoid conflicts in the names of engines, we keep an "IO engines" section in our
-[Ecosystem page](https://pandas.pydata.org/community/ecosystem.html#io-engines).
+`Ecosystem page <https://pandas.pydata.org/community/ecosystem.html#io-engines>`_.
 
 .. _extending.pandas_priority:
 

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -494,7 +494,7 @@ https://github.com/pandas-dev/pandas/blob/main/pandas/plotting/__init__.py#L1.
 IO engines
 -----------
 
-pandas provides several IO connectors such as :func:`read_csv` or :meth:`to_parquet`, and many
+pandas provides several IO connectors such as :func:`read_csv` or :meth:`DataFrame.to_parquet`, and many
 of those support multiple engines. For example, :func:`read_csv` supports the ``python``, ``c``
 and ``pyarrow`` engines, each with its advantages and disadvantages, making each more appropriate
 for certain use cases.

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -545,7 +545,7 @@ If a user has the package of the example installed, them it would be possible to
 
     pd.read_json("myfile.json", engine="empty")
 
-When pandas detects that no ``empty`` engine exists for the ``read_json`` reader in pandas, will
+When pandas detects that no ``empty`` engine exists for the ``read_json`` reader in pandas, it will
 look at the entry points, will find the ``EmptyDataEngine`` engine, and will call the ``read_json``
 method on it with the arguments provided by the user (except the ``engine`` parameter).
 

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -489,7 +489,7 @@ registers the default "matplotlib" backend as follows.
 More information on how to implement a third-party plotting backend can be found at
 https://github.com/pandas-dev/pandas/blob/main/pandas/plotting/__init__.py#L1.
 
-.. _extending.plotting-backends:
+.. _extending.io-engines:
 
 IO engines
 -----------

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -489,6 +489,69 @@ registers the default "matplotlib" backend as follows.
 More information on how to implement a third-party plotting backend can be found at
 https://github.com/pandas-dev/pandas/blob/main/pandas/plotting/__init__.py#L1.
 
+.. _extending.plotting-backends:
+
+IO engines
+-----------
+
+pandas provides several IO connectors such as :func:`read_csv` or :meth:`to_parquet`, and many
+of those support multiple engines. For example, :func:`read_csv` supports the ``python``, ``c``
+and ``pyarrow`` engines, each with its advantages and disadvantages, making each more appropriate
+for certain use cases.
+
+Third-party package developers can implement engines for any of the pandas readers and writers.
+When a ``pandas.read_*`` function or ``DataFrame.to_*`` method are called with an ``engine="<name>"``
+that is not known to pandas, pandas will look into the entry points registered in the group
+``pandas.io_engine`` by the packages in the environment, and will call the corresponding method.
+
+An engine is a simple Python class which implements one or more of the pandas readers and writers
+as class methods:
+
+.. code-block:: python
+
+    class EmptyDataEngine:
+        @classmethod
+        def read_json(cls, path_or_buf=None, **kwargs):
+            return pd.DataFrame()
+
+        @classmethod
+        def to_json(cls, path_or_buf=None, **kwargs):
+            with open(path_or_buf, "w") as f:
+                f.write()
+
+        @classmethod
+        def read_clipboard(cls, sep='\\s+', dtype_backend=None, **kwargs):
+            return pd.DataFrame()
+
+A single engine can support multiple readers and writers. When possible, it is a good practice for
+a reader to provide both a reader and writer for the supported formats. But it is possible to
+provide just one of them.
+
+The package implementing the engine needs to create an entry point for pandas to be able to discover
+it. This is done in ``pyproject.toml``:
+
+```toml
+[project.entry-points."pandas.io_engine"]
+empty = empty_data:EmptyDataEngine
+```
+
+The first line should always be the same, creating the entry point in the ``pandas.io_engine`` group.
+In the second line, ``empty`` is the name of the engine, and ``empty_data:EmptyDataEngine`` is where
+to find the engine class in the package (``empty_data`` is the module name in this case).
+
+If a user have the package of the example installed, them it would be possible to use:
+
+.. code-block:: python
+
+    pd.read_json("myfile.json", engine="empty")
+
+When pandas detects that no ``empty`` engine exists for the ``read_json`` reader in pandas, will
+look at the entry points, will find the ``EmptyDataEngine`` engine, and will call the ``read_json``
+method on it with the arguments provided by the user (except the ``engine`` parameter).
+
+To avoid conflicts in the names of engines, we keep an "IO engines" section in our
+[Ecosystem page](https://pandas.pydata.org/community/ecosystem.html#io-engines).
+
 .. _extending.pandas_priority:
 
 Arithmetic with 3rd party types

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -539,7 +539,7 @@ The first line should always be the same, creating the entry point in the ``pand
 In the second line, ``empty`` is the name of the engine, and ``empty_data:EmptyDataEngine`` is where
 to find the engine class in the package (``empty_data`` is the module name in this case).
 
-If a user have the package of the example installed, them it would be possible to use:
+If a user has the package of the example installed, them it would be possible to use:
 
 .. code-block:: python
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -88,6 +88,7 @@ Other enhancements
 - Support passing a :class:`Iterable[Hashable]` input to :meth:`DataFrame.drop_duplicates` (:issue:`59237`)
 - Support reading Stata 102-format (Stata 1) dta files (:issue:`58978`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
+- Third-party packages can now register engines that can be used in pandas I/O operations :func:`read_iceberg` and :meth:`DataFrame.to_iceberg` (:issue:`61584`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3588,7 +3588,7 @@ class DataFrame(NDFrame, OpsMixin):
         engine : str, optional
             The engine to use. Engines can be installed via third-party packages. For an
             updated list of existing pandas I/O engines check the I/O engines section of
-            our Ecosystem page.
+            the pandas Ecosystem page.
 
         See Also
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -188,7 +188,10 @@ from pandas.core.sorting import (
     nargsort,
 )
 
-from pandas.io.common import get_handle
+from pandas.io.common import (
+    allow_third_party_engines,
+    get_handle,
+)
 from pandas.io.formats import (
     console,
     format as fmt,
@@ -3547,6 +3550,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         return xml_formatter.write_output()
 
+    @allow_third_party_engines
     def to_iceberg(
         self,
         table_identifier: str,
@@ -3556,6 +3560,7 @@ class DataFrame(NDFrame, OpsMixin):
         location: str | None = None,
         append: bool = False,
         snapshot_properties: dict[str, str] | None = None,
+        engine: str | None = None,
     ) -> None:
         """
         Write a DataFrame to an Apache Iceberg table.
@@ -3580,6 +3585,10 @@ class DataFrame(NDFrame, OpsMixin):
             If ``True``, append data to the table, instead of replacing the content.
         snapshot_properties : dict of {str: str}, optional
             Custom properties to be added to the snapshot summary
+        engine : str, optional
+            The engine to use. Engines can be installed via third-party packages. For an
+            updated list of existing pandas I/O engines check the I/O engines section of
+            our Ecosystem page.
 
         See Also
         --------

--- a/pandas/io/iceberg.py
+++ b/pandas/io/iceberg.py
@@ -6,7 +6,10 @@ from pandas.compat._optional import import_optional_dependency
 
 from pandas import DataFrame
 
+from pandas.io.common import allow_third_party_engines
 
+
+@allow_third_party_engines()
 def read_iceberg(
     table_identifier: str,
     catalog_name: str | None = None,
@@ -18,6 +21,7 @@ def read_iceberg(
     snapshot_id: int | None = None,
     limit: int | None = None,
     scan_properties: dict[str, Any] | None = None,
+    engine: str | None = None,
 ) -> DataFrame:
     """
     Read an Apache Iceberg table into a pandas DataFrame.
@@ -52,6 +56,10 @@ def read_iceberg(
     scan_properties : dict of {str: obj}, optional
         Additional Table properties as a dictionary of string key value pairs to use
         for this scan.
+    engine : str, optional
+        The engine to use. Engines can be installed via third-party packages. For an
+        updated list of existing pandas I/O engines check the I/O engines section of
+        our Ecosystem page.
 
     Returns
     -------

--- a/pandas/io/iceberg.py
+++ b/pandas/io/iceberg.py
@@ -9,7 +9,7 @@ from pandas import DataFrame
 from pandas.io.common import allow_third_party_engines
 
 
-@allow_third_party_engines()
+@allow_third_party_engines
 def read_iceberg(
     table_identifier: str,
     catalog_name: str | None = None,

--- a/pandas/tests/io/test_io_engines.py
+++ b/pandas/tests/io/test_io_engines.py
@@ -1,0 +1,48 @@
+import pytest
+
+from pandas.io import common
+
+
+@pytest.fixture
+def patch_engine(monkeypatch):
+    class MockIoEngine:
+        @classmethod
+        def read_foo(cls, fname):
+            return "third-party"
+
+    monkeypatch.setattr(common, "_get_io_engine", lambda name: MockIoEngine)
+
+
+class TestIoEngines:
+    def test_decorator_with_no_engine(self, patch_engine):
+        @common.allow_third_party_engines
+        def read_foo(fname, engine=None):
+            return "default"
+
+        result = read_foo("myfile.foo")
+        assert result == "default"
+
+    def test_decorator_with_skipped_engine(self, patch_engine):
+        @common.allow_third_party_engines(skip_engines=["c"])
+        def read_foo(fname, engine=None):
+            return "default"
+
+        result = read_foo("myfile.foo", engine="c")
+        assert result == "default"
+
+    def test_decorator_with_third_party_engine(self, patch_engine):
+        @common.allow_third_party_engines
+        def read_foo(fname, engine=None):
+            return "default"
+
+        result = read_foo("myfile.foo", engine="third-party")
+        assert result == "third-party"
+
+    def test_decorator_with_third_party_engine_but_no_method(self, patch_engine):
+        @common.allow_third_party_engines
+        def read_bar(fname, engine=None):
+            return "default"
+
+        msg = "'third-party' does not provide a 'read_bar'"
+        with pytest.raises(ValueError, match=msg):
+            read_bar("myfile.foo", engine="third-party")

--- a/pandas/tests/io/test_io_engines.py
+++ b/pandas/tests/io/test_io_engines.py
@@ -1,16 +1,57 @@
+from types import SimpleNamespace
+
 import pytest
+
+import pandas._testing as tm
 
 from pandas.io import common
 
 
+class _MockIoEngine:
+    @classmethod
+    def read_foo(cls, fname):
+        return "third-party"
+
+
 @pytest.fixture
 def patch_engine(monkeypatch):
-    class MockIoEngine:
-        @classmethod
-        def read_foo(cls, fname):
-            return "third-party"
+    monkeypatch.setattr(common, "_get_io_engine", lambda name: _MockIoEngine)
 
-    monkeypatch.setattr(common, "_get_io_engine", lambda name: MockIoEngine)
+
+@pytest.fixture
+def patch_entry_points(monkeypatch):
+    class MockEntryPoint:
+        name = "myengine"
+        dist = SimpleNamespace(metadata={"Name": "mypackage"})
+
+        @staticmethod
+        def load():
+            return _MockIoEngine
+
+    class MockDuplicate1:
+        name = "duplicate"
+        dist = SimpleNamespace(metadata={"Name": "package1"})
+
+        @staticmethod
+        def load():
+            return SimpleNamespace(read_foo=lambda fname: "dup1")
+
+    class MockDuplicate2:
+        name = "duplicate"
+        dist = SimpleNamespace(metadata={"Name": "package2"})
+
+        @staticmethod
+        def load():
+            return SimpleNamespace(read_foo=lambda fname: "dup1")
+
+    monkeypatch.setattr(common, "_io_engines", None)
+    monkeypatch.setattr(
+        common,
+        "entry_points",
+        lambda: SimpleNamespace(
+            select=lambda group: [MockEntryPoint, MockDuplicate1, MockDuplicate2]
+        ),
+    )
 
 
 class TestIoEngines:
@@ -46,3 +87,19 @@ class TestIoEngines:
         msg = "'third-party' does not provide a 'read_bar'"
         with pytest.raises(ValueError, match=msg):
             read_bar("myfile.foo", engine="third-party")
+
+    def test_correct_io_engine(self, patch_entry_points):
+        result = common._get_io_engine("myengine")
+        assert result is _MockIoEngine
+
+    def test_unknown_io_engine(self, patch_entry_points):
+        with pytest.raises(ValueError, match="'unknown' is not a known engine"):
+            common._get_io_engine("unknown")
+
+    def test_duplicate_engine(self, patch_entry_points):
+        with tm.assert_produces_warning(
+            RuntimeWarning,
+            match="'duplicate' has been registered by the package 'package1'",
+        ):
+            result = common._get_io_engine("duplicate")
+        assert hasattr(result, "read_foo")

--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -712,6 +712,18 @@ authors to coordinate on the namespace.
   | [staircase](https://www.staircase.dev/)                              | `sc`       | `Series`, `DataFrame` |
   | [woodwork](https://github.com/alteryx/woodwork)                      | `slice`    | `Series`, `DataFrame` |
 
+## IO engines
+
+Table with the third-party [IO engines](https://pandas.pydata.org/docs/development/extending.html#io-engines)
+available to `read_*` functions and `DataFrame.to_*` methods.
+
+  | Engine name     | Library                                               | Supported formats               |
+  | ----------------|------------------------------------------------------ | ------------------------------- |
+  |                 |                                                       |                                 |
+
+IO engines can be used by specifying the engine when calling a reader or writer
+(e.g. `pd.read_csv("myfile.csv", engine="myengine")`).
+
 ## Development tools
 
 ### [pandas-stubs](https://github.com/VirtusLab/pandas-stubs)


### PR DESCRIPTION
- [X] xref #61584 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Added the new system to the Iceberg connection only to keep this smaller. The idea is to add the decorator to all other connectors, happy to do it here or in a follow up PR.