### PR TITLE
WEB: Moving maintainers to inactive (no answer from them)

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -74,6 +74,7 @@ maintainers:
   active:
   - jorisvandenbossche
   - TomAugspurger
+  - jreback
   - WillAyd
   - mroeschke
   - jbrockmendel
@@ -107,7 +108,6 @@ maintainers:
   - lukemanley
   - topper-123
   - alimcmaster1
-  - jreback
 workgroups:
   coc:
     name: Code of Conduct

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -80,6 +80,7 @@ maintainers:
   - jbrockmendel
   - datapythonista
   - simonjayhawkins
+  - alimcmaster1
   - Dr-Irv
   - rhshadrach
   - phofl
@@ -107,7 +108,6 @@ maintainers:
   - lithomas1
   - lukemanley
   - topper-123
-  - alimcmaster1
 workgroups:
   coc:
     name: Code of Conduct

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -74,14 +74,11 @@ maintainers:
   active:
   - jorisvandenbossche
   - TomAugspurger
-  - jreback
   - WillAyd
   - mroeschke
   - jbrockmendel
   - datapythonista
   - simonjayhawkins
-  - topper-123
-  - alimcmaster1
   - Dr-Irv
   - rhshadrach
   - phofl
@@ -108,6 +105,9 @@ maintainers:
   - noatamir
   - lithomas1
   - lukemanley
+  - topper-123
+  - alimcmaster1
+  - jreback
 workgroups:
   coc:
     name: Code of Conduct


### PR DESCRIPTION
I couldn't get an answer from @jreback @topper-123 @alimcmaster1 regarding being active or unactive for some time.

I'll leave this open for few days, in case they see it an can confirm. But in the past we've been moving people to inactive if they didn't seem active for a long time and we couldn't get confirmation from them on whether they want to continue to be active or not.