### PR TITLE
TST: update xfail xarray version check in to_xarray test

### DIFF
--- a/pandas/tests/generic/test_to_xarray.py
+++ b/pandas/tests/generic/test_to_xarray.py
@@ -93,6 +93,7 @@ class TestSeriesToXArray:
             isinstance(index.dtype, StringDtype)
             and index.dtype.storage == "pyarrow"
             and Version(xarray.__version__) > Version("2024.9.0")
+            and Version(xarray.__version__) < Version("2025.6.0")
         ):
             request.applymarker(
                 pytest.mark.xfail(


### PR DESCRIPTION
Started to see xpass in https://github.com/pandas-dev/pandas/pull/61594, so updating the version check here. Not sure this is entirely covered by CI, but tested this locally with a few different xarray versions.