### PR TITLE
DOC: Add release notes template for 2.3.1

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -24,6 +24,7 @@ Version 2.3
 .. toctree::
    :maxdepth: 2
 
+   v2.3.1
    v2.3.0
 
 Version 2.2

--- a/doc/source/whatsnew/v2.3.1.rst
+++ b/doc/source/whatsnew/v2.3.1.rst
@@ -1,0 +1,42 @@
+.. _whatsnew_231:
+
+What's new in 2.3.1 (Month XX, 2025)
+------------------------------------
+
+These are the changes in pandas 2.3.1. See :ref:`release` for a full changelog
+including other versions of pandas.
+
+{{ header }}
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_231.enhancements:
+
+Enhancements
+~~~~~~~~~~~~
+-
+
+.. _whatsnew_231.regressions:
+
+Fixed regressions
+~~~~~~~~~~~~~~~~~
+-
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_231.bug_fixes:
+
+Bug fixes
+~~~~~~~~~
+-
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_231.other:
+
+Other
+~~~~~
+-
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_231.contributors:
+
+Contributors
+~~~~~~~~~~~~


### PR DESCRIPTION
Starting the release notes for 2.3.1, so we can start adding things (for new PRs, but will also follow-up with moving some things from 2.3.0 to 2.3.1)