### PR TITLE
WEB: Add table of contents to the Ecosystem

### DIFF
--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -1,5 +1,7 @@
 # Ecosystem
 
+[TOC]
+
 Increasingly, packages are being built on top of pandas to address
 specific needs in data preparation, analysis and visualization. This is
 encouraging because it means pandas is not only helping users to handle

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -14,7 +14,6 @@ main:
   - pandas_web.Preprocessors.home_add_releases
   - pandas_web.Preprocessors.roadmap_pdeps
   markdown_extensions:
-  - toc
   - tables
   - fenced_code
   - meta

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -42,6 +42,7 @@ import typing
 import feedparser
 import jinja2
 import markdown
+from markdown.extensions.toc import TocExtension
 from packaging import version
 import requests
 import yaml
@@ -470,29 +471,14 @@ def main(
             with (source_path / fname).open(encoding="utf-8") as f:
                 content = f.read()
             if extension == ".md":
-                if len(fname.parts) > 1 and fname.parts[1] == "pdeps":
-                    from markdown.extensions.toc import TocExtension
-
-                    body = markdown.markdown(
-                        content,
-                        extensions=[
-                            # Ignore the title of the PDEP in the table of contents
-                            TocExtension(
-                                title="Table of Contents",
-                                toc_depth="2-3",
-                                permalink=" #",
-                            ),
-                            "tables",
-                            "fenced_code",
-                            "meta",
-                            "footnotes",
-                            "codehilite",
-                        ],
-                    )
-                else:
-                    body = markdown.markdown(
-                        content, extensions=context["main"]["markdown_extensions"]
-                    )
+                toc = TocExtension(
+                    title="Table of Contents",
+                    toc_depth="2-3",
+                    permalink=" #",
+                )
+                body = markdown.markdown(
+                    content, extensions=context["main"]["markdown_extensions"] + [toc]
+                )
                 # Apply Bootstrap's table formatting manually
                 # Python-Markdown doesn't let us config table attributes by hand
                 body = body.replace("<table>", '<table class="table table-bordered">')


### PR DESCRIPTION
Supersedes #61595

Changes to make the tables of contents in the website the same in all pages (we had customized the PDEP ones before).

Adding the ToC to Ecosystem. It renders like this:

![Screenshot at 2025-06-13 19-02-56](https://github.com/user-attachments/assets/a3471680-b9f9-46e6-b02d-0d379d75efec)


I can make it just one level if preferred. I think with one level looks nicer, but with two, it's uglier but more practical (and simpler since it's the same for all pages). But no strong preference from my side
