### PR TITLE
BUG: to_numeric fails to convert a Pyarrow Decimal series containing NA values

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -884,6 +884,7 @@ Other
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`eval` with ``engine="numexpr"`` returning unexpected result for float division. (:issue:`59736`)
 - Bug in :func:`to_numeric` raising ``TypeError`` when ``arg`` is a :class:`Timedelta` or :class:`Timestamp` scalar. (:issue:`59944`)
+- Bug in :func:`to_numeric` with :class:`ArrowDtype` raising ``ValueError`` when the array contained NA values. (:issue:`61641`)
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
 - Bug in :meth:`DataFrame.apply` where passing ``engine="numba"`` ignored ``args`` passed to the applied function (:issue:`58712`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which caused an exception when using NumPy attributes via ``@`` notation, e.g., ``df.eval("@np.floor(a)")``. (:issue:`58041`)

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -211,8 +211,15 @@ def to_numeric(
 
     values_dtype = getattr(values, "dtype", None)
     if isinstance(values_dtype, ArrowDtype):
+        if is_numeric_dtype(values_dtype):
+            if is_series:
+                return arg._constructor(values, index=arg.index, name=arg.name)
+            else:
+                return values
+
         mask = values.isna()
         values = values.dropna().to_numpy()
+
     new_mask: np.ndarray | None = None
     if is_numeric_dtype(values_dtype):
         pass

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -919,3 +919,14 @@ def test_coerce_pyarrow_backend():
     result = to_numeric(ser, errors="coerce", dtype_backend="pyarrow")
     expected = Series([1, 2, None], dtype=ArrowDtype(pa.int64()))
     tm.assert_series_equal(result, expected)
+
+
+def test_to_numeric_arrow_decimal_with_na():
+    # GH 61641
+    pa = pytest.importorskip("pyarrow")
+    decimal_type = ArrowDtype(pa.decimal128(3, scale=2))
+    series = Series([1, None], dtype=decimal_type)
+    result = to_numeric(series, errors="coerce")
+
+    expected = Series([1.00, pd.NA], dtype=decimal_type)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #61641
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
