### PR TITLE
BUG: Index allows one item to be `list` among others that are not

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -745,6 +745,7 @@ Indexing
 - Bug in :meth:`MultiIndex.insert` when a new value inserted to a datetime-like level gets cast to ``NaT`` and fails indexing (:issue:`60388`)
 - Bug in printing :attr:`Index.names` and :attr:`MultiIndex.levels` would not escape single quotes (:issue:`60190`)
 - Bug in reindexing of :class:`DataFrame` with :class:`PeriodDtype` columns in case of consolidated block (:issue:`60980`, :issue:`60273`)
+- Bug in creating :class:`Index` with one item being a ``list`` among others thar aren't (should raise ValueError) (:issue:`60925`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -567,6 +567,10 @@ class Index(IndexOpsMixin, PandasObject):
                 # Ensure we get 1-D array of tuples instead of 2D array.
                 data = com.asarray_tuplesafe(data, dtype=_dtype_obj)
 
+            #60925 should raise when one of index's items is a list and others are not
+            if any(isinstance(el, list) for el in data) and not all(isinstance(el, list) for el in data):
+                raise ValueError("Index names must all be hashable, or all lists to make MultiIndex")
+            
         try:
             arr = sanitize_array(data, None, dtype=dtype, copy=copy)
         except ValueError as err:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -568,9 +568,12 @@ class Index(IndexOpsMixin, PandasObject):
                 data = com.asarray_tuplesafe(data, dtype=_dtype_obj)
 
             #60925 should raise when one of index's items is a list and others are not
-            if any(isinstance(el, list) for el in data) and not all(isinstance(el, list) for el in data):
-                raise ValueError("Index names must all be hashable, or all lists to make MultiIndex")
-            
+            if (any(isinstance(el, list) for el in data) and
+                not all(isinstance(el, list) for el in data)):
+                raise ValueError(
+                    "Index names must all be hashable, or all lists to make MultiIndex"
+                )
+
         try:
             arr = sanitize_array(data, None, dtype=dtype, copy=copy)
         except ValueError as err:

--- a/pandas/tests/frame/test_repr.py
+++ b/pandas/tests/frame/test_repr.py
@@ -71,9 +71,12 @@ class TestDataFrameRepr:
         repr(df)
 
         # this travels an improper code path
+        # #60925 should raise when one of index's items is a list and others are not
         index[0] = ["faz", "boo"]
-        df.index = index
-        repr(df)
+        msg = "Index names must all be hashable, or all lists to make MultiIndex"
+        with pytest.raises(ValueError, match=msg):
+            df.index = index
+            repr(df)
 
     def test_repr_with_mi_nat(self):
         df = DataFrame({"X": [1, 2]}, index=[[NaT, Timestamp("20130101")], ["a", "b"]])

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -188,6 +188,17 @@ class TestIndexConstructorInference:
         expected = Index([dt1, dt2], dtype=object)
         tm.assert_index_equal(result, expected)
 
+    def test_constructor_list_between_elems(self):
+        # #60925 should raise when one of index's items is a list and others are not
+        msg = "Index names must all be hashable, or all lists to make MultiIndex"
+
+        data = ['a', ['b', 'c'], ['b', 'c']]
+        with pytest.raises(ValueError, match=msg):
+            Index(data)
+            
+        data = [['b', 'c'], ('b', 'c')]
+        with pytest.raises(ValueError, match=msg):
+            Index(data)
 
 class TestDtypeEnforced:
     # check we don't silently ignore the dtype keyword

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -195,7 +195,7 @@ class TestIndexConstructorInference:
         data = ['a', ['b', 'c'], ['b', 'c']]
         with pytest.raises(ValueError, match=msg):
             Index(data)
-            
+
         data = [['b', 'c'], ('b', 'c')]
         with pytest.raises(ValueError, match=msg):
             Index(data)


### PR DESCRIPTION
- [X] closes #60925
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug.

Corrected test pandas/tests/frame/test_repr.py::[test_assign_index_sequences] that was passing when should be raising.
Added test to check if raises correctly.
