### PR TITLE
fix for building docs on Windows

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -114,6 +114,8 @@ if pattern:
                 ):
                     exclude_patterns.append(rel_fname)
                 elif single_doc and rel_fname != pattern:
+                    if "\\" in rel_fname:
+                        rel_fname = rel_fname.replace("\\", "/")
                     exclude_patterns.append(rel_fname)
 
 with open(os.path.join(source_path, "index.rst.template"), encoding="utf-8") as f:

--- a/doc/source/user_guide/enhancingperf.rst
+++ b/doc/source/user_guide/enhancingperf.rst
@@ -83,7 +83,7 @@ using the `prun ipython magic function <https://ipython.readthedocs.io/en/stable
 .. ipython:: python
 
    # most time consuming 4 calls
-   %prun -l 4 df.apply(lambda x: integrate_f(x["a"], x["b"], x["N"]), axis=1)  # noqa E999
+   %prun -l 4 df.apply(lambda x: integrate_f(x['a'], x['b'], x['N']), axis=1)  # noqa E999
 
 By far the majority of time is spend inside either ``integrate_f`` or ``f``,
 hence we'll concentrate our efforts cythonizing these two functions.
@@ -164,7 +164,7 @@ can be improved by passing an ``np.ndarray``.
 
 .. ipython:: python
 
-   %prun -l 4 df.apply(lambda x: integrate_f_typed(x["a"], x["b"], x["N"]), axis=1)
+   %prun -l 4 df.apply(lambda x: integrate_f_typed(x['a'], x['b'], x['N']), axis=1)
 
 .. ipython::
 
@@ -204,7 +204,7 @@ calls are needed to utilize this function.
 
 .. ipython:: python
 
-   %timeit apply_integrate_f(df["a"].to_numpy(), df["b"].to_numpy(), df["N"].to_numpy())
+   %timeit apply_integrate_f(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].astype(int).to_numpy())
 
 Performance has improved from the prior implementation by almost ten times.
 
@@ -218,7 +218,7 @@ and ``wraparound`` checks can yield more performance.
 
 .. ipython:: python
 
-   %prun -l 4 apply_integrate_f(df["a"].to_numpy(), df["b"].to_numpy(), df["N"].to_numpy())
+   %prun -l 4 apply_integrate_f(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].astype(int).to_numpy())
 
 .. ipython::
 
@@ -253,7 +253,7 @@ and ``wraparound`` checks can yield more performance.
 
 .. ipython:: python
 
-   %timeit apply_integrate_f_wrap(df["a"].to_numpy(), df["b"].to_numpy(), df["N"].to_numpy())
+   %timeit apply_integrate_f_wrap(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].astype(int).to_numpy())
 
 However, a loop indexer ``i`` accessing an invalid location in an array would cause a segfault because memory access isn't checked.
 For more about ``boundscheck`` and ``wraparound``, see the Cython docs on

--- a/doc/source/user_guide/enhancingperf.rst
+++ b/doc/source/user_guide/enhancingperf.rst
@@ -50,7 +50,7 @@ We have a :class:`DataFrame` to which we want to apply a function row-wise.
        {
            "a": np.random.randn(1000),
            "b": np.random.randn(1000),
-           "N": np.random.randint(100, 1000, (1000)),
+           "N": np.random.randint(100, 1000, (1000), dtype="int64"),
            "x": "x",
        }
    )
@@ -83,7 +83,7 @@ using the `prun ipython magic function <https://ipython.readthedocs.io/en/stable
 .. ipython:: python
 
    # most time consuming 4 calls
-   %prun -l 4 df.apply(lambda x: integrate_f(x['a'], x['b'], x['N']), axis=1)  # noqa E999
+   %prun -l 4 df.apply(lambda x: integrate_f(x['a'], x['b'], x['N']), axis=1)
 
 By far the majority of time is spend inside either ``integrate_f`` or ``f``,
 hence we'll concentrate our efforts cythonizing these two functions.
@@ -204,7 +204,7 @@ calls are needed to utilize this function.
 
 .. ipython:: python
 
-   %timeit apply_integrate_f(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].astype(int).to_numpy())
+   %timeit apply_integrate_f(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].to_numpy())
 
 Performance has improved from the prior implementation by almost ten times.
 
@@ -218,7 +218,7 @@ and ``wraparound`` checks can yield more performance.
 
 .. ipython:: python
 
-   %prun -l 4 apply_integrate_f(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].astype(int).to_numpy())
+   %prun -l 4 apply_integrate_f(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].to_numpy())
 
 .. ipython::
 
@@ -253,7 +253,7 @@ and ``wraparound`` checks can yield more performance.
 
 .. ipython:: python
 
-   %timeit apply_integrate_f_wrap(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].astype(int).to_numpy())
+   %timeit apply_integrate_f_wrap(df['a'].to_numpy(), df['b'].to_numpy(), df['N'].to_numpy())
 
 However, a loop indexer ``i`` accessing an invalid location in an array would cause a segfault because memory access isn't checked.
 For more about ``boundscheck`` and ``wraparound``, see the Cython docs on


### PR DESCRIPTION
- [x] closes #60149

I was having two issues with building the docs on Windows.

1. Building a single page with `--single` was very slow because it was reading in lots of files.  So there is a fix in `conf.py` that changes any backslashes to `/` in the paths.  Probably a better fix is to not be using `os.join` and use `pathlib`, but that's a larger change.
2. For #60149, there are 2 issues with building `enhancingperf.rst`:
  - As mentioned in https://github.com/pandas-dev/pandas/issues/60149#issuecomment-2600578029 , having double quotes in the ipython strings messes up Windows, so changing them to single quotes makes it work
  - The cython functions expect `int64` dtypes, but the defaults coming from `numpy` when building the DF are `int32`, so the `astype(int)` calls fix that

