### PR TITLE
POC: PDEP16 default to masked nullable dtypes

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2786,17 +2786,21 @@ def maybe_convert_objects(ndarray[object] objects,
         seen.object_ = True
 
     elif seen.str_:
-        if convert_to_nullable_dtype and is_string_array(objects, skipna=True):
-            from pandas.core.arrays.string_ import StringDtype
+        if is_string_array(objects, skipna=True):
+            if convert_to_nullable_dtype:
+                from pandas.core.arrays.string_ import StringDtype
 
-            dtype = StringDtype()
-            return dtype.construct_array_type()._from_sequence(objects, dtype=dtype)
+                if using_string_dtype():
+                    dtype = StringDtype(na_value=np.nan)
+                else:
+                    dtype = StringDtype()
+                return dtype.construct_array_type()._from_sequence(objects, dtype=dtype)
 
-        elif using_string_dtype() and is_string_array(objects, skipna=True):
-            from pandas.core.arrays.string_ import StringDtype
+            elif using_string_dtype():
+                from pandas.core.arrays.string_ import StringDtype
 
-            dtype = StringDtype(na_value=np.nan)
-            return dtype.construct_array_type()._from_sequence(objects, dtype=dtype)
+                dtype = StringDtype(na_value=np.nan)
+                return dtype.construct_array_type()._from_sequence(objects, dtype=dtype)
 
         seen.object_ = True
     elif seen.interval_:

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -307,6 +307,8 @@ def box_expected(expected, box_cls, transpose: bool = True):
             expected = pd.concat([expected] * 2, ignore_index=True)
     elif box_cls is np.ndarray or box_cls is np.array:
         expected = np.array(expected)
+        if expected.dtype.kind in "iufb" and pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected, copy=False)
     elif box_cls is to_array:
         expected = to_array(expected)
     else:

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -89,6 +89,9 @@ if TYPE_CHECKING:
         NpDtype,
     )
 
+# Alias so we can update old `assert obj.dtype == np_dtype` checks to PDEP16
+#  behavior.
+to_dtype = pd.core.dtypes.common.pandas_dtype
 
 UNSIGNED_INT_NUMPY_DTYPES: list[NpDtype] = ["uint8", "uint16", "uint32", "uint64"]
 UNSIGNED_INT_EA_DTYPES: list[Dtype] = ["UInt8", "UInt16", "UInt32", "UInt64"]

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -323,13 +323,19 @@ def assert_index_equal(
     elif check_exact and check_categorical:
         if not left.equals(right):
             mismatch = left._values != right._values
+            if isinstance(left, RangeIndex) and not mismatch.any():
+                # TODO: probably need to fix RangeIndex.equals?
+                pass
+            elif isinstance(right, RangeIndex) and not mismatch.any():
+                # TODO: probably need to fix some other equals method?
+                pass
+            else:
+                if not isinstance(mismatch, np.ndarray):
+                    mismatch = cast("ExtensionArray", mismatch).fillna(True)
 
-            if not isinstance(mismatch, np.ndarray):
-                mismatch = cast("ExtensionArray", mismatch).fillna(True)
-
-            diff = np.sum(mismatch.astype(int)) * 100.0 / len(left)
-            msg = f"{obj} values are different ({np.round(diff, 5)} %)"
-            raise_assert_detail(obj, msg, left, right)
+                diff = np.sum(mismatch.astype(int)) * 100.0 / len(left)
+                msg = f"{obj} values are different ({np.round(diff, 5)} %)"
+                raise_assert_detail(obj, msg, left, right)
     else:
         # if we have "equiv", this becomes True
         exact_bool = bool(exact)

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -127,7 +127,7 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):  # type: ignor
             #  pass those through to the underlying ndarray
             return self._ndarray.view(dtype)
 
-        dtype = pandas_dtype(dtype)
+        dtype = pandas_dtype(dtype, allow_numpy_dtypes=True)
         arr = self._ndarray
 
         if isinstance(dtype, PeriodDtype):

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1702,6 +1702,8 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
         if op.how in op.cast_blocklist:
             # i.e. how in ["rank"], since other cast_blocklist methods don't go
             #  through cython_operation
+            # if get_option("mode.pdep16_data_types"):
+            #    return pd_array(res_values)  # breaks bc they dont support 2D
             return res_values
 
         # We did a view to M8[ns] above, now we go the other direction

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -837,7 +837,7 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
             arr_ea = self.copy()
             mask = self.isna()
             arr_ea[mask] = "0"
-            values = arr_ea.astype(dtype.numpy_dtype)
+            values = arr_ea.to_numpy(dtype=dtype.numpy_dtype)
             return FloatingArray(values, mask, copy=False)
         elif isinstance(dtype, ExtensionDtype):
             # Skip the NumpyExtensionArray.astype method

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -444,6 +444,9 @@ class BaseStringArray(ExtensionArray):
             elif dtype == np.dtype("bool"):
                 # GH#55736
                 na_value = bool(na_value)
+
+            dtype = pandas_dtype(dtype)
+            pass_dtype = dtype.numpy_dtype
             result = lib.map_infer_mask(
                 arr,
                 f,
@@ -453,7 +456,7 @@ class BaseStringArray(ExtensionArray):
                 # error: Argument 1 to "dtype" has incompatible type
                 # "Union[ExtensionDtype, str, dtype[Any], Type[object]]"; expected
                 # "Type[object]"
-                dtype=np.dtype(cast(type, dtype)),
+                dtype=np.dtype(cast(type, pass_dtype)),
             )
 
             if not na_value_is_na:

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -507,6 +507,10 @@ class TimedeltaArray(dtl.TimelikeOps):
             # numpy >= 2.1 may not raise a TypeError
             # and seems to dispatch to others.__rmul__?
             raise TypeError(f"Cannot multiply with {type(other).__name__}")
+        if isinstance(result, type(self)):
+            # e.g. if other is IntegerArray
+            assert result.dtype == self.dtype
+            return result
         return type(self)._simple_new(result, dtype=result.dtype)
 
     __rmul__ = __mul__

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -427,6 +427,15 @@ with cf.config_prefix("mode"):
         validator=is_one_of_factory([True, False, "warn"]),
     )
 
+with cf.config_prefix("mode"):
+    cf.register_option(
+        "pdep16_data_types",
+        True,
+        "Whether to default to numpy-nullable dtypes for integer, float, "
+        "and bool dtypes",
+        validator=is_one_of_factory([True, False]),
+    )
+
 
 # user warnings
 chained_assignment = """

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -16,7 +16,10 @@ from typing import (
 import numpy as np
 from numpy import ma
 
-from pandas._config import using_string_dtype
+from pandas._config import (
+    get_option,
+    using_string_dtype,
+)
 
 from pandas._libs import lib
 from pandas._libs.tslibs import (
@@ -612,7 +615,9 @@ def sanitize_array(
         if dtype is None:
             subarr = data
             if data.dtype == object and infer_object:
-                subarr = maybe_infer_to_datetimelike(data)
+                subarr = maybe_infer_to_datetimelike(
+                    data, convert_to_nullable_dtype=get_option("mode.pdep16_data_types")
+                )
             elif data.dtype.kind == "U" and using_string_dtype():
                 from pandas.core.arrays.string_ import StringDtype
 
@@ -659,7 +664,10 @@ def sanitize_array(
             subarr = maybe_convert_platform(data)
             if subarr.dtype == object:
                 subarr = cast(np.ndarray, subarr)
-                subarr = maybe_infer_to_datetimelike(subarr)
+                subarr = maybe_infer_to_datetimelike(
+                    subarr,
+                    convert_to_nullable_dtype=get_option("mode.pdep16_data_types"),
+                )
 
     subarr = _sanitize_ndim(subarr, data, dtype, index, allow_2d=allow_2d)
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -18,7 +18,10 @@ import warnings
 
 import numpy as np
 
-from pandas._config import using_string_dtype
+from pandas._config import (
+    get_option,
+    using_string_dtype,
+)
 
 from pandas._libs import (
     Interval,
@@ -135,7 +138,9 @@ def maybe_convert_platform(
 
     if arr.dtype == _dtype_obj:
         arr = cast(np.ndarray, arr)
-        arr = lib.maybe_convert_objects(arr)
+        arr = lib.maybe_convert_objects(
+            arr, convert_to_nullable_dtype=get_option("mode.pdep16_data_types")
+        )
 
     return arr
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1777,7 +1777,7 @@ class SparseDtype(ExtensionDtype):
         )
         from pandas.core.dtypes.missing import na_value_for_dtype
 
-        dtype = pandas_dtype(dtype)
+        dtype = pandas_dtype(dtype, allow_numpy_dtypes=True)
         if is_string_dtype(dtype):
             dtype = np.dtype("object")
         if not isinstance(dtype, np.dtype):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -141,6 +141,7 @@ from pandas.core.arrays import (
 )
 from pandas.core.arrays.sparse import SparseFrameAccessor
 from pandas.core.construction import (
+    array as pd_array,
     ensure_wrapped_if_datetimelike,
     sanitize_array,
     sanitize_masked_array,
@@ -4411,6 +4412,14 @@ class DataFrame(NDFrame, OpsMixin):
     def _set_item_mgr(
         self, key, value: ArrayLike, refs: BlockValuesRefs | None = None
     ) -> None:
+        if get_option("mode.pdep16_data_types"):
+            # TODO: possibly handle this at a lower level?
+            if (
+                isinstance(value, np.ndarray)
+                and value.dtype.kind in "iufb"
+                and value.dtype != np.float16
+            ):
+                value = pd_array(value, copy=False)
         try:
             loc = self._info_axis.get_loc(key)
         except KeyError:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -2166,9 +2166,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         )
 
         def arr_func(bvalues: ArrayLike) -> ArrayLike:
-            return self._grouper._cython_operation(
+            blk_res = self._grouper._cython_operation(
                 "transform", bvalues, how, 1, **kwargs
             )
+            return blk_res
 
         res_mgr = mgr.apply(arr_func)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -172,6 +172,7 @@ from pandas.core.base import (
 )
 import pandas.core.common as com
 from pandas.core.construction import (
+    array as pd_array,
     ensure_wrapped_if_datetimelike,
     extract_array,
     sanitize_array,
@@ -576,6 +577,8 @@ class Index(IndexOpsMixin, PandasObject):
                 raise ValueError("Index data must be 1-dimensional") from err
             raise
         arr = ensure_wrapped_if_datetimelike(arr)
+        if arr.dtype.kind in "iufb" and get_option("mode.pdep16_data_types"):
+            arr = pd_array(arr, copy=False)
 
         klass = cls._dtype_to_subclass(arr.dtype)
 
@@ -5391,6 +5394,8 @@ class Index(IndexOpsMixin, PandasObject):
 
             # See also: Block.coerce_to_target_dtype
             dtype = self._find_common_type_compat(value)
+            assert self.dtype != dtype, (self.dtype, value)
+            # FIXME: should raise with useful message to report a bug!
             return self.astype(dtype).putmask(mask, value)
 
         values = self._values.copy()

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7137,7 +7137,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Wrapper used to dispatch comparison operations.
         """
-        if self.is_(other):
+        if False:  # self.is_(other):
             # fastpath
             if op in {operator.eq, operator.le, operator.ge}:
                 arr = np.ones(len(self), dtype=bool)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -557,7 +557,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         # because test_setops_preserve_freq fails with _validate_frequency raising.
         # This raising is incorrect, as 'on_freq' is incorrect. This will
         # be fixed by GH#41493
-        res_values = res_i8.values.view(self._data._ndarray.dtype)
+        res_values = np.asarray(res_i8.values).view(self._data._ndarray.dtype)
         result = type(self._data)._simple_new(
             # error: Argument "dtype" to "_simple_new" of "DatetimeArray" has
             # incompatible type "Union[dtype[Any], ExtensionDtype]"; expected

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -18,6 +18,8 @@ from typing import (
 
 import numpy as np
 
+from pandas._config import get_option
+
 from pandas._libs import (
     index as libindex,
     lib,
@@ -44,7 +46,10 @@ from pandas.core.dtypes.generic import ABCTimedeltaIndex
 
 from pandas.core import ops
 import pandas.core.common as com
-from pandas.core.construction import extract_array
+from pandas.core.construction import (
+    array as pd_array,
+    extract_array,
+)
 from pandas.core.indexers import check_array_indexer
 import pandas.core.indexes.base as ibase
 from pandas.core.indexes.base import (
@@ -278,7 +283,10 @@ class RangeIndex(Index):
 
         The constructed array is saved in ``_cache``.
         """
-        return np.arange(self.start, self.stop, self.step, dtype=np.int64)
+        data = np.arange(self.start, self.stop, self.step, dtype=np.int64)
+        if get_option("mode.pdep16_data_types"):
+            return pd_array(data)
+        return data
 
     def _get_data_as_items(self) -> list[tuple[str, int]]:
         """return a list of tuples of start, stop, step"""

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -38,6 +38,7 @@ from pandas.core.dtypes.common import (
     is_integer,
     is_scalar,
     is_signed_integer_dtype,
+    pandas_dtype,
 )
 from pandas.core.dtypes.generic import ABCTimedeltaIndex
 
@@ -441,7 +442,7 @@ class RangeIndex(Index):
 
     @property
     def dtype(self) -> np.dtype:
-        return _dtype_int64
+        return pandas_dtype(_dtype_int64)
 
     @property
     def is_unique(self) -> bool:
@@ -1409,7 +1410,7 @@ class RangeIndex(Index):
                 raise IndexError(
                     f"index {ind_min} is out of bounds for axis 0 with size {len(self)}"
                 )
-            taken = indices.astype(self.dtype, casting="safe")
+            taken = indices.astype("int64", casting="safe")
             if ind_min < 0:
                 taken %= len(self)
             if self.step != 1:
@@ -1417,7 +1418,8 @@ class RangeIndex(Index):
             if self.start != 0:
                 taken += self.start
 
-        return self._shallow_copy(taken, name=self.name)
+        # TODO(PDEP16): prevent shallow_copy from allowing int64?
+        return self._shallow_copy(taken, name=self.name).astype(self.dtype, copy=False)
 
     def value_counts(
         self,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -361,6 +361,11 @@ class Block(PandasObject, libinternals.Block):
         else:
             res_values = result.reshape(-1, 1)
 
+        if self.values.dtype == object:
+            if res_values.dtype.kind == "f":
+                # TODO: this is kludgy; does it mean there is a problem
+                #  at a higher level?
+                res_values = res_values.astype(object)
         nb = self.make_block(res_values)
         return [nb]
 
@@ -2226,6 +2231,8 @@ def new_block_2d(
     klass = get_block_type(values.dtype)
 
     values = maybe_coerce_values(values)
+    if isinstance(values, np.ndarray):
+        assert values.dtype == np.float16 or values.dtype.kind not in "iufb"
     return klass(values, ndim=2, placement=placement, refs=refs)
 
 
@@ -2241,6 +2248,8 @@ def new_block(
     # - check_ndim/ensure_block_shape already checked
     # - maybe_coerce_values already called/unnecessary
     klass = get_block_type(values.dtype)
+    if isinstance(values, np.ndarray):
+        assert values.dtype == np.float16 or values.dtype.kind not in "iufb"
     return klass(values, ndim=ndim, placement=placement, refs=refs)
 
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -130,7 +130,10 @@ def arrays_to_mgr(
                 )
     if get_option("mode.pdep16_data_types"):
         arrays = [
-            pd_array(x, copy=False) if x.dtype.kind in "iufb" else x for x in arrays
+            pd_array(x, copy=False)
+            if x.dtype.kind in "iufb" and x.dtype != np.float16
+            else x
+            for x in arrays
         ]
 
     columns = ensure_index(columns)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -27,6 +27,8 @@ import warnings
 
 import numpy as np
 
+from pandas._config import get_option
+
 from pandas._libs import (
     lib,
     properties,
@@ -508,6 +510,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                 data = data.copy()
         else:
             data = sanitize_array(data, index, dtype, copy)
+            if data.dtype.kind in "iufb" and get_option("mode.pdep16_data_types"):
+                data = pd_array(data, copy=False)
             data = SingleBlockManager.from_array(data, index, refs=refs)
 
         NDFrame.__init__(self, data)

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -74,6 +74,10 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
             na_value = self.dtype.na_value  # type: ignore[attr-defined]
 
         if not len(self):
+            if dtype == "Int64":
+                from pandas.core.construction import array as pd_array
+
+                return pd_array([], dtype=dtype)
             return np.array([], dtype=dtype)
 
         arr = np.asarray(self, dtype=object)
@@ -110,12 +114,17 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
             np.putmask(result, mask, na_value)
             if convert and result.dtype == object:
                 result = lib.maybe_convert_objects(result)
+
+        if dtype == "Int64":
+            from pandas.core.construction import array as pd_array
+
+            return pd_array(result, dtype=dtype)
         return result
 
     def _str_count(self, pat, flags: int = 0):
         regex = re.compile(pat, flags=flags)
         f = lambda x: len(regex.findall(x))
-        return self._str_map(f, dtype="int64")
+        return self._str_map(f, dtype="Int64")
 
     def _str_pad(
         self,
@@ -298,7 +307,7 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
             f = lambda x: getattr(x, method)(sub, start)
         else:
             f = lambda x: getattr(x, method)(sub, start, end)
-        return self._str_map(f, dtype="int64")
+        return self._str_map(f, dtype="Int64")
 
     def _str_findall(self, pat, flags: int = 0):
         regex = re.compile(pat, flags=flags)
@@ -319,14 +328,14 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
             f = lambda x: x.index(sub, start, end)
         else:
             f = lambda x: x.index(sub, start, end)
-        return self._str_map(f, dtype="int64")
+        return self._str_map(f, dtype="Int64")
 
     def _str_rindex(self, sub, start: int = 0, end=None):
         if end:
             f = lambda x: x.rindex(sub, start, end)
         else:
             f = lambda x: x.rindex(sub, start, end)
-        return self._str_map(f, dtype="int64")
+        return self._str_map(f, dtype="Int64")
 
     def _str_join(self, sep: str):
         return self._str_map(sep.join)
@@ -339,7 +348,7 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
         return self._str_map(lambda x: x.rpartition(sep), dtype="object")
 
     def _str_len(self):
-        return self._str_map(len, dtype="int64")
+        return self._str_map(len, dtype="Int64")
 
     def _str_slice(self, start=None, stop=None, step=None):
         obj = slice(start, stop, step)

--- a/pandas/tests/arithmetic/common.py
+++ b/pandas/tests/arithmetic/common.py
@@ -10,6 +10,7 @@ from pandas import (
     Index,
     Series,
     array,
+    get_option,
 )
 import pandas._testing as tm
 from pandas.core.arrays import (
@@ -110,6 +111,9 @@ def assert_invalid_comparison(left, right, box):
             # NB: we are assuming no pd.NAs for now
             return x.astype(bool)
         return x
+
+    if xbox is np.array and get_option("mode.pdep16_data_types"):
+        xbox = BooleanArray._from_sequence
 
     # rev_box: box to use for reversed comparisons
     rev_box = xbox

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -399,7 +399,7 @@ class TestDivisionByZero:
     @pytest.mark.parametrize("op", [operator.truediv, operator.floordiv])
     def test_div_negative_zero(self, zero, numeric_idx, op):
         # Check that -1 / -0.0 returns np.inf, not -np.inf
-        if numeric_idx.dtype == np.uint64:
+        if numeric_idx.dtype == tm.to_dtype(np.uint64):
             pytest.skip(f"Div by negative 0 not relevant for {numeric_idx.dtype}")
         idx = numeric_idx - 3
 
@@ -687,7 +687,7 @@ class TestMultiplicationDivision:
         result = idx * np.array(5, dtype="int64")
         tm.assert_index_equal(result, idx * 5)
 
-        arr_dtype = "uint64" if idx.dtype == np.uint64 else "int64"
+        arr_dtype = "uint64" if idx.dtype == tm.to_dtype(np.uint64) else "int64"
         result = idx * np.arange(5, dtype=arr_dtype)
         tm.assert_index_equal(result, didx)
 
@@ -695,7 +695,7 @@ class TestMultiplicationDivision:
         idx = numeric_idx
         didx = idx * idx
 
-        arr_dtype = "uint64" if idx.dtype == np.uint64 else "int64"
+        arr_dtype = "uint64" if idx.dtype == tm.to_dtype(np.uint64) else "int64"
         result = idx * Series(np.arange(5, dtype=arr_dtype))
         tm.assert_series_equal(result, Series(didx))
 

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -1122,38 +1122,38 @@ class TestUFuncCompat:
         box = index_or_series
 
         result = np.sqrt(idx)
-        assert result.dtype == "f8" and isinstance(result, box)
+        assert result.dtype == tm.to_dtype("f8") and isinstance(result, box)
         exp = Index(np.sqrt(np.array([1, 2, 3, 4, 5], dtype=np.float64)), name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         result = np.divide(idx, 2.0)
-        assert result.dtype == "f8" and isinstance(result, box)
+        assert result.dtype == tm.to_dtype("f8") and isinstance(result, box)
         exp = Index([0.5, 1.0, 1.5, 2.0, 2.5], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         # _evaluate_numeric_binop
         result = idx + 2.0
-        assert result.dtype == "f8" and isinstance(result, box)
+        assert result.dtype == tm.to_dtype("f8") and isinstance(result, box)
         exp = Index([3.0, 4.0, 5.0, 6.0, 7.0], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         result = idx - 2.0
-        assert result.dtype == "f8" and isinstance(result, box)
+        assert result.dtype == tm.to_dtype("f8") and isinstance(result, box)
         exp = Index([-1.0, 0.0, 1.0, 2.0, 3.0], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         result = idx * 1.0
-        assert result.dtype == "f8" and isinstance(result, box)
+        assert result.dtype == tm.to_dtype("f8") and isinstance(result, box)
         exp = Index([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)
 
         result = idx / 2.0
-        assert result.dtype == "f8" and isinstance(result, box)
+        assert result.dtype == tm.to_dtype("f8") and isinstance(result, box)
         exp = Index([0.5, 1.0, 1.5, 2.0, 2.5], dtype=np.float64, name="x")
         exp = tm.box_expected(exp, box)
         tm.assert_equal(result, exp)

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -85,6 +85,8 @@ class TestPeriodArrayLikeComparisons:
         xbox = get_upcast_box(idx, other, True)
 
         expected = np.array([True, True, False])
+        if pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected)
         expected = tm.box_expected(expected, xbox)
 
         result = idx == other
@@ -102,6 +104,8 @@ class TestPeriodArrayLikeComparisons:
 
         result = pi <= other
         expected = np.array([True, False, False, False])
+        if pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected)
         expected = tm.box_expected(expected, xbox)
         tm.assert_equal(result, expected)
 
@@ -251,31 +255,43 @@ class TestPeriodIndexComparisons:
         xbox = get_upcast_box(base, per, True)
 
         exp = np.array([False, True, False, False])
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         exp = tm.box_expected(exp, xbox)
         tm.assert_equal(base == per, exp)
         tm.assert_equal(per == base, exp)
 
         exp = np.array([True, False, True, True])
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         exp = tm.box_expected(exp, xbox)
         tm.assert_equal(base != per, exp)
         tm.assert_equal(per != base, exp)
 
         exp = np.array([False, False, True, True])
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         exp = tm.box_expected(exp, xbox)
         tm.assert_equal(base > per, exp)
         tm.assert_equal(per < base, exp)
 
         exp = np.array([True, False, False, False])
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         exp = tm.box_expected(exp, xbox)
         tm.assert_equal(base < per, exp)
         tm.assert_equal(per > base, exp)
 
         exp = np.array([False, True, True, True])
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         exp = tm.box_expected(exp, xbox)
         tm.assert_equal(base >= per, exp)
         tm.assert_equal(per <= base, exp)
 
         exp = np.array([True, True, False, False])
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         exp = tm.box_expected(exp, xbox)
         tm.assert_equal(base <= per, exp)
         tm.assert_equal(per >= base, exp)
@@ -357,42 +373,66 @@ class TestPeriodIndexComparisons:
 
         result = idx1 > per
         exp = np.array([False, False, False, True])
-        tm.assert_numpy_array_equal(result, exp)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[-2] = pd.NA
+        tm.assert_equal(result, exp)
         result = per < idx1
-        tm.assert_numpy_array_equal(result, exp)
+        tm.assert_equal(result, exp)
 
         result = idx1 == pd.NaT
         exp = np.array([False, False, False, False])
-        tm.assert_numpy_array_equal(result, exp)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[-2] = pd.NA
+        tm.assert_equal(result, exp)
         result = pd.NaT == idx1
-        tm.assert_numpy_array_equal(result, exp)
+        tm.assert_equal(result, exp)
 
         result = idx1 != pd.NaT
         exp = np.array([True, True, True, True])
-        tm.assert_numpy_array_equal(result, exp)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[-2] = pd.NA
+        tm.assert_equal(result, exp)
         result = pd.NaT != idx1
-        tm.assert_numpy_array_equal(result, exp)
+        tm.assert_equal(result, exp)
 
         idx2 = PeriodIndex(["2011-02", "2011-01", "2011-04", "NaT"], freq=freq)
         result = idx1 < idx2
         exp = np.array([True, False, False, False])
-        tm.assert_numpy_array_equal(result, exp)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[-2:] = pd.NA
+        tm.assert_equal(result, exp)
 
         result = idx1 == idx2
         exp = np.array([False, False, False, False])
-        tm.assert_numpy_array_equal(result, exp)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[-2:] = pd.NA
+        tm.assert_equal(result, exp)
 
         result = idx1 != idx2
         exp = np.array([True, True, True, True])
-        tm.assert_numpy_array_equal(result, exp)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[-2:] = pd.NA
+        tm.assert_equal(result, exp)
 
         result = idx1 == idx1
         exp = np.array([True, True, False, True])
-        tm.assert_numpy_array_equal(result, exp)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[-2] = pd.NA
+        tm.assert_equal(result, exp)
 
         result = idx1 != idx1
         exp = np.array([False, False, True, False])
-        tm.assert_numpy_array_equal(result, exp)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[-2] = pd.NA
+        tm.assert_equal(result, exp)
 
     @pytest.mark.parametrize("freq", ["M", "2M", "3M"])
     def test_pi_cmp_nat_mismatched_freq_raises(self, freq):
@@ -405,7 +445,10 @@ class TestPeriodIndexComparisons:
 
         result = idx1 == diff
         expected = np.array([False, False, False, False], dtype=bool)
-        tm.assert_numpy_array_equal(result, expected)
+        if pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected)
+            expected[-2:] = pd.NA
+        tm.assert_equal(result, expected)
 
     # TODO: De-duplicate with test_pi_cmp_nat
     @pytest.mark.parametrize("dtype", [object, None])
@@ -419,23 +462,40 @@ class TestPeriodIndexComparisons:
 
         result = left == right
         expected = np.array([False, False, True])
-        tm.assert_numpy_array_equal(result, expected)
+        if pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected)
+            expected[:2] = pd.NA
+        tm.assert_equal(result, expected)
 
         result = left != right
         expected = np.array([True, True, False])
-        tm.assert_numpy_array_equal(result, expected)
+        if pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected)
+            expected[:2] = pd.NA
+        tm.assert_equal(result, expected)
 
         expected = np.array([False, False, False])
-        tm.assert_numpy_array_equal(left == pd.NaT, expected)
-        tm.assert_numpy_array_equal(pd.NaT == right, expected)
+        if pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected)
+            expected[1] = pd.NA
+        tm.assert_equal(left == pd.NaT, expected)
+        if pd.get_option("mode.pdep16_data_types"):
+            expected[:2] = pd.NA
+        tm.assert_equal(pd.NaT == right, expected)
 
         expected = np.array([True, True, True])
-        tm.assert_numpy_array_equal(left != pd.NaT, expected)
-        tm.assert_numpy_array_equal(pd.NaT != left, expected)
+        if pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected)
+            expected[1] = pd.NA
+        tm.assert_equal(left != pd.NaT, expected)
+        tm.assert_equal(pd.NaT != left, expected)
 
         expected = np.array([False, False, False])
-        tm.assert_numpy_array_equal(left < pd.NaT, expected)
-        tm.assert_numpy_array_equal(pd.NaT > left, expected)
+        if pd.get_option("mode.pdep16_data_types"):
+            expected = pd.array(expected)
+            expected[1] = pd.NA
+        tm.assert_equal(left < pd.NaT, expected)
+        tm.assert_equal(pd.NaT > left, expected)
 
 
 class TestPeriodSeriesComparisons:
@@ -490,7 +550,7 @@ class TestPeriodIndexSeriesComparisonConsistency:
         result = func(idx)
 
         # check that we don't pass an unwanted type to tm.assert_equal
-        assert isinstance(expected, (pd.Index, np.ndarray))
+        # assert isinstance(expected, (pd.Index, np.ndarray))
         tm.assert_equal(result, expected)
 
         s = Series(values)
@@ -507,26 +567,36 @@ class TestPeriodIndexSeriesComparisonConsistency:
 
         f = lambda x: x == per
         exp = np.array([False, False, True, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         self._check(idx, f, exp)
         f = lambda x: per == x
         self._check(idx, f, exp)
 
         f = lambda x: x != per
         exp = np.array([True, True, False, True], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         self._check(idx, f, exp)
         f = lambda x: per != x
         self._check(idx, f, exp)
 
         f = lambda x: per >= x
         exp = np.array([True, True, True, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         self._check(idx, f, exp)
 
         f = lambda x: x > per
         exp = np.array([False, False, False, True], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         self._check(idx, f, exp)
 
         f = lambda x: per >= x
         exp = np.array([True, True, True, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
         self._check(idx, f, exp)
 
     def test_pi_comp_period_nat(self):
@@ -537,42 +607,66 @@ class TestPeriodIndexSeriesComparisonConsistency:
 
         f = lambda x: x == per
         exp = np.array([False, False, True, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[1] = pd.NA
         self._check(idx, f, exp)
         f = lambda x: per == x
         self._check(idx, f, exp)
 
         f = lambda x: x == pd.NaT
         exp = np.array([False, False, False, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[1] = pd.NA
         self._check(idx, f, exp)
         f = lambda x: pd.NaT == x
         self._check(idx, f, exp)
 
         f = lambda x: x != per
         exp = np.array([True, True, False, True], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[1] = pd.NA
         self._check(idx, f, exp)
         f = lambda x: per != x
         self._check(idx, f, exp)
 
         f = lambda x: x != pd.NaT
         exp = np.array([True, True, True, True], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[1] = pd.NA
         self._check(idx, f, exp)
         f = lambda x: pd.NaT != x
         self._check(idx, f, exp)
 
         f = lambda x: per >= x
         exp = np.array([True, False, True, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[1] = pd.NA
         self._check(idx, f, exp)
 
         f = lambda x: x < per
         exp = np.array([True, False, False, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[1] = pd.NA
         self._check(idx, f, exp)
 
         f = lambda x: x > pd.NaT
         exp = np.array([False, False, False, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[1] = pd.NA
         self._check(idx, f, exp)
 
         f = lambda x: pd.NaT >= x
         exp = np.array([False, False, False, False], dtype=np.bool_)
+        if pd.get_option("mode.pdep16_data_types"):
+            exp = pd.array(exp)
+            exp[1] = pd.NA
         self._check(idx, f, exp)
 
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -130,6 +130,9 @@ def idx_func_dict():
 
 
 class TestEval:
+    @pytest.mark.xfail(
+        run=False, reason="RecursionError when we default to nullable dtypes."
+    )
     @pytest.mark.parametrize(
         "cmp1",
         ["!=", "==", "<=", ">=", "<", ">"],
@@ -239,6 +242,9 @@ class TestEval:
             result = pd.eval(ex, engine=engine, parser=parser)
             tm.assert_almost_equal(expected, result)
 
+    @pytest.mark.xfail(
+        run=False, reason="RecursionError when we default to nullable dtypes."
+    )
     @pytest.mark.parametrize("cmp1", ["<", ">"])
     @pytest.mark.parametrize("cmp2", ["<", ">"])
     def test_chained_cmp_op(self, cmp1, cmp2, lhs, midhs, rhs, engine, parser):
@@ -264,6 +270,9 @@ class TestEval:
 
                 tm.assert_almost_equal(result, expected)
 
+    @pytest.mark.xfail(
+        run=False, reason="RecursionError when we default to nullable dtypes."
+    )
     @pytest.mark.parametrize(
         "arith1", sorted(set(ARITH_OPS_SYMS).difference({"**", "//", "%"}))
     )
@@ -299,6 +308,10 @@ class TestEval:
 
     # modulus, pow, and floor division require special casing
 
+    # FIXME: this actually only gets RecursionError for DataFrame/DataFrame
+    @pytest.mark.xfail(
+        run=False, reason="RecursionError when we default to nullable dtypes."
+    )
     def test_modulus(self, lhs, rhs, engine, parser):
         ex = r"lhs % rhs"
         result = pd.eval(ex, engine=engine, parser=parser)
@@ -801,6 +814,9 @@ class TestAlignment:
         res = pd.eval(s, engine=engine, parser=parser)
         tm.assert_frame_equal(res, df * ~2)
 
+    @pytest.mark.xfail(
+        run=False, reason="RecursionError when we default to nullable dtypes."
+    )
     @pytest.mark.filterwarnings("always::RuntimeWarning")
     @pytest.mark.parametrize("lr_idx_type", lhs_index_types)
     @pytest.mark.parametrize("rr_idx_type", index_types)
@@ -847,6 +863,9 @@ class TestAlignment:
         res = pd.eval("df < df3", engine=engine, parser=parser)
         tm.assert_frame_equal(res, df < df3)
 
+    @pytest.mark.xfail(
+        run=False, reason="RecursionError when we default to nullable dtypes."
+    )
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     @pytest.mark.parametrize("r1", lhs_index_types)
     @pytest.mark.parametrize("c1", index_types)

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -457,9 +457,9 @@ class BaseMethodsTests:
         df = pd.DataFrame({"A": data, "B": [1.0] * 5})
         result = df.diff(periods)
         if periods == 1:
-            b = [np.nan, 0, 0, 0, 0]
+            b = [np.nan, 0.0, 0.0, 0.0, 0.0]
         else:
-            b = [0, 0, 0, np.nan, np.nan]
+            b = [0.0, 0.0, 0.0, np.nan, np.nan]
         expected = pd.DataFrame({"A": expected, "B": b})
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -291,7 +291,7 @@ class TestDtypeEnforced:
     def test_constructor_dtypes_to_int(self, vals, any_int_numpy_dtype):
         dtype = any_int_numpy_dtype
         index = Index(vals, dtype=dtype)
-        assert index.dtype == dtype
+        assert index.dtype == tm.to_dtype(dtype)
 
     @pytest.mark.parametrize(
         "vals",

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -99,14 +99,14 @@ class TestSetitemCoercion(CoercionBase):
         exp = pd.Series([1, 2, 3, 4, 5], index=expected_index)
         tm.assert_series_equal(temp, exp)
         # check dtype explicitly for sure
-        assert temp.index.dtype == expected_dtype
+        assert temp.index.dtype == tm.to_dtype(expected_dtype)
 
         temp = original_series.copy()
         temp.loc[loc_key] = 5
         exp = pd.Series([1, 2, 3, 4, 5], index=expected_index)
         tm.assert_series_equal(temp, exp)
         # check dtype explicitly for sure
-        assert temp.index.dtype == expected_dtype
+        assert temp.index.dtype == tm.to_dtype(expected_dtype)
 
     @pytest.mark.parametrize(
         "val,exp_dtype", [("x", object), (5, IndexError), (1.1, object)]
@@ -123,7 +123,7 @@ class TestSetitemCoercion(CoercionBase):
     )
     def test_setitem_index_int64(self, val, exp_dtype):
         obj = pd.Series([1, 2, 3, 4])
-        assert obj.index.dtype == np.int64
+        assert obj.index.dtype == tm.to_dtype(np.int64)
 
         exp_index = pd.Index([0, 1, 2, 3, val])
         self._assert_setitem_index_conversion(obj, val, exp_index, exp_dtype)
@@ -133,7 +133,7 @@ class TestSetitemCoercion(CoercionBase):
     )
     def test_setitem_index_float64(self, val, exp_dtype, request):
         obj = pd.Series([1, 2, 3, 4], index=[1.1, 2.1, 3.1, 4.1])
-        assert obj.index.dtype == np.float64
+        assert obj.index.dtype == tm.to_dtype(np.float64)
 
         exp_index = pd.Index([1.1, 2.1, 3.1, 4.1, val])
         self._assert_setitem_index_conversion(obj, val, exp_index, exp_dtype)
@@ -176,7 +176,7 @@ class TestInsertIndexCoercion(CoercionBase):
         target = original.copy()
         res = target.insert(1, value)
         tm.assert_index_equal(res, expected)
-        assert res.dtype == expected_dtype
+        assert res.dtype == tm.to_dtype(expected_dtype)
 
     @pytest.mark.parametrize(
         "insert, coerced_val, coerced_dtype",
@@ -827,7 +827,7 @@ class TestReplaceSeriesCoercion(CoercionBase):
         index = pd.Index([3, 4], name="xxx")
         obj = pd.Series(self.rep[from_key], index=index, name="yyy")
         obj = obj.astype(from_key)
-        assert obj.dtype == from_key
+        assert obj.dtype == tm.to_dtype(from_key)
 
         if from_key.startswith("datetime") and to_key.startswith("datetime"):
             # tested below
@@ -870,7 +870,7 @@ class TestReplaceSeriesCoercion(CoercionBase):
         if using_infer_string and to_key == "object":
             assert exp.dtype == "string"
         else:
-            assert exp.dtype == to_key
+            assert exp.dtype == tm.to_dtype(to_key)
 
         result = obj.replace(replacer)
         tm.assert_series_equal(result, exp, check_dtype=False)

--- a/pandas/tests/series/accessors/test_cat_accessor.py
+++ b/pandas/tests/series/accessors/test_cat_accessor.py
@@ -254,5 +254,5 @@ class TestCatAccessor:
             {"int_cat": [1, 2, 3], "bool_cat": [True, False, False]}, dtype="category"
         )
         value = df["bool_cat"].cat.categories.dtype
-        expected = np.dtype(np.bool_)
-        assert value is expected
+        expected = tm.to_dtype(np.dtype(np.bool_))
+        assert value == expected

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -200,7 +200,7 @@ class TestSeriesDatetimeValues:
 
             result = ser.dt.total_seconds()
             assert isinstance(result, Series)
-            assert result.dtype == "float64"
+            assert result.dtype == tm.to_dtype("float64")
 
             freq_result = ser.dt.freq
             assert freq_result == TimedeltaIndex(ser.values, freq="infer").freq

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -448,7 +448,7 @@ class TestSeriesComparison:
         const = 2
         result = getattr(ser, opname)(const).dtypes
         expected = np.dtype("bool")
-        assert result == expected
+        assert result == tm.to_dtype(expected)
 
     @pytest.mark.parametrize("opname", ["eq", "ne", "gt", "lt", "ge", "le"])
     def test_ser_flex_cmp_return_dtypes_empty(self, opname):
@@ -458,7 +458,7 @@ class TestSeriesComparison:
         const = 2
         result = getattr(empty, opname)(const).dtypes
         expected = np.dtype("bool")
-        assert result == expected
+        assert result == tm.to_dtype(expected)
 
     @pytest.mark.parametrize(
         "names", [(None, None, None), ("foo", "bar", None), ("baz", "baz", "baz")]


### PR DESCRIPTION
This is the second of several POCs stemming from the discussion in #61618 (see also #61708).  The main goal is to see how invasive it would be.

Specifically, this implements the part of PDEP16 #58988 that changes the default numeric/bool dtypes to use numpy-nullable dtypes.  So `pd.Series(foo)` will behave roughly like `pd.Series(pd.array(foo))` does in main.

Notes:
- For POC purposes this takes the stand that we _never_ give numpy numeric/bool dtypes and always map `dtype=np.int64` to the masked dtype.
- The get_option checks will need to be updated to user a more performant check like for `using_string_dtype`
- The simplification in core.internals.construction will eventually be reverted as the MaskedArrays are updated to support 2D.
- This does *not* incorporate #61708.
- Currently 16773 tests failing locally (with `-m "not slow and not db"`).  705 in window, 2036 in io (almost all of pytables is failing), 1997 (plus a ton more I already xfailed bc they get RecursionError) in computation.  tests.groupby.test_raises has 1110 that look to be mostly about getting the wrong class of exception or exception message.  Many in sparse too, though I don't have a number ATM.  Some of these merit issues:
    - [x] #61709
    - [ ] #30188
    - [ ] RangeIndex.equals issue, see comments in asserters.py diff.
