### PR TITLE
BUG: Raise OutOfBoundsDatetime in DataFrame.replace when value exceeds datetime64[ns] bounds (GH#61671)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -685,6 +685,7 @@ Datetimelike
 - Bug in :func:`tseries.frequencies.to_offset` would fail to parse frequency strings starting with "LWOM" (:issue:`59218`)
 - Bug in :meth:`DataFrame.fillna` raising an ``AssertionError`` instead of ``OutOfBoundsDatetime`` when filling a ``datetime64[ns]`` column with an out-of-bounds timestamp. Now correctly raises ``OutOfBoundsDatetime``. (:issue:`61208`)
 - Bug in :meth:`DataFrame.min` and :meth:`DataFrame.max` casting ``datetime64`` and ``timedelta64`` columns to ``float64`` and losing precision (:issue:`60850`)
+- Bug in :meth:`DataFrame.replace` where attempting to replace a ``datetime64[ns]`` column with an out-of-bounds timestamp would raise an ``AssertionError`` or silently coerce. Now correctly raises ``OutOfBoundsDatetime``. (:issue:`61671`)
 - Bug in :meth:`Dataframe.agg` with df with missing values resulting in IndexError (:issue:`58810`)
 - Bug in :meth:`DatetimeIndex.is_year_start` and :meth:`DatetimeIndex.is_quarter_start` does not raise on Custom business days frequencies bigger then "1C" (:issue:`58664`)
 - Bug in :meth:`DatetimeIndex.is_year_start` and :meth:`DatetimeIndex.is_quarter_start` returning ``False`` on double-digit frequencies (:issue:`58523`)


### PR DESCRIPTION
Fixes a bug where `DataFrame.replace` would raise a generic `AssertionError` when trying to replace `np.nan` in a `datetime64[ns]` column with an out-of-bounds `datetime.datetime` object (e.g., `datetime(3000, 1, 1)`). 

This PR fixes that by explicitly raising `OutOfBoundsDatetime` when the replacement datetime can't safely fit into the `datetime64[ns]` dtype.
- [x] closes #61671  
- [x] Added a test that reproduces the issue  
- [x] Pre-commit hooks passed  
- [x] Added a changelog entry under `Datetimelike` for 3.0.0  

Let me know if you'd like to test other edge cases or if there's a more idiomatic way to handle this!
