### PR TITLE
CI: temporarily pin numpydoc<1.7 to unblock docstring validation (GH#61720)

### DIFF
--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -197,6 +197,7 @@ a ``Series``, this returns a ``Series`` (with the same index), while a list-like
 is converted to a ``DatetimeIndex``:
 
 .. ipython:: python
+    :okwarning:
 
     pd.to_datetime(pd.Series(["Jul 31, 2009", "Jan 10, 2010", None]))
 

--- a/environment.yml
+++ b/environment.yml
@@ -84,7 +84,7 @@ dependencies:
   # documentation
   - gitpython  # obtain contributors from git for whatsnew
   - natsort  # DataFrame.sort_values doctest
-  - numpydoc
+  - numpydoc<1.7
   - pydata-sphinx-theme=0.16
   - pytest-cython  # doctest
   - sphinx

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -462,11 +462,6 @@ def option_context(*args) -> Generator[None]:
         interpreted as (pattern, value) pairs. Alternatively, a single
         dictionary of {pattern: value} may be provided.
 
-    Returns
-    -------
-    None
-        No return value.
-
     Yields
     ------
     None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -59,7 +59,7 @@ tokenize-rt
 pre-commit>=4.2.0
 gitpython
 natsort
-numpydoc
+numpydoc<1.7
 pydata-sphinx-theme==0.16
 pytest-cython
 sphinx


### PR DESCRIPTION
Temporarily pin **numpydoc<1.7** to unblock the *docstring-validation* job.

`numpydoc` 1.7.0 raises  
`AttributeError: 'getset_descriptor' object has no attribute '__module__'`  
inside `numpydoc/validate.py`, causing pandas’ *Code Checks / Docstring validation*
step to fail before any pandas code is run (see GH #61720).

This PR

* **pins** `numpydoc<1.7` in `environment.yml`  
  (propagated to `requirements-dev.txt`);
* **fixes** a duplicate **Returns / Yields** section in
  `pandas/_config/config.py::option_context`;
* **marks** an expected warning in `doc/user_guide/timeseries.rst`
  with `:okwarning:` so Sphinx no longer treats it as an error.

Together these changes restore a green CI across all jobs.

### Notes
* All changes are limited to **dev/CI and docs**—no impact on end users.
* Once an upstream fix lands in numpydoc, we’ll remove the version pin.
* No new tests are required; a successful CI run itself demonstrates the fix.

---

- [x] closes #61720  
- [x] CI green locally (`pre-commit run --all-files` & `doc/make.py --warnings-are-errors`)  
- [ ] added to `doc/source/whatsnew/vX.X.X.rst` → **not needed** (CI-only)

