### PR TITLE
TST: Test coverage for Excel Formatter.py

### DIFF
--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -566,7 +566,7 @@ class ExcelFormatter:
         if cols is not None:
             # all missing, raise
             if not len(Index(cols).intersection(df.columns)):
-                raise KeyError("Passed columns are not ALL present dataframe")
+                raise KeyError("passes columns are not ALL present dataframe")
 
             if len(Index(cols).intersection(df.columns)) != len(set(cols)):
                 # Deprecated in GH#17295, enforced in 1.0.0

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -566,7 +566,7 @@ class ExcelFormatter:
         if cols is not None:
             # all missing, raise
             if not len(Index(cols).intersection(df.columns)):
-                raise KeyError("passes columns are not ALL present dataframe")
+                raise KeyError("Passed columns are not ALL present dataframe")
 
             if len(Index(cols).intersection(df.columns)) != len(set(cols)):
                 # Deprecated in GH#17295, enforced in 1.0.0

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -625,24 +625,21 @@ class TestExcelFormatter:
             ("Amazing", "C"), ("Amazing", "D")
         ]
         columns = MultiIndex.from_tuples(header)
+        rng = np.random.default_rng()
         df = DataFrame(
-            np.random.randn(4, 4),
+            rng.standard_normal((4, 4)),
             columns=columns
         )
         formatter = ExcelFormatter(df, index=False)
         assert(formatter.columns.nlevels > 1 and not formatter.index)
-        msg = (
-            "Writing to Excel with MultiIndex columns and no "
-            "index ('index'=False) is not yet implemented."
-        )
         with pytest.raises(NotImplementedError):
             list(formatter._format_header_mi())
 
     def test_returns_none_no_header(self):
         df = DataFrame({"A": [1,2], "B": [3,4]})
         formatter = ExcelFormatter(df,header=False)
-        assert(formatter._has_aliases == False)
-        assert(list(formatter._format_header_mi()) == list())
+        assert(not formatter._has_aliases)
+        assert(list(formatter._format_header_mi()) == [])
 
     @pytest.mark.parametrize(
         "df, merge_cells, expected_cells",
@@ -1014,7 +1011,8 @@ class TestExcelFormatter:
             ),
         ],
     )
-    def test_get_formatted_cells_integration(self, df, formatter_options, expected_values):
+    def test_get_formatted_cells_integration(self, df, formatter_options,
+                                             expected_values):
         """
         Integration test for get_formatted_cells to ensure it chains all
         formatting methods and applies final value formatting correctly.

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -1,20 +1,24 @@
 """Tests formatting as writer-agnostic ExcelCells"""
 
-import numpy as np
-
 import string
+from unittest.mock import (
+    Mock,
+    call,
+    patch,
+)
 
+import numpy as np
 import pytest
+
+from pandas.errors import CSSWarning
 
 from pandas import (
     DataFrame,
     Index,
     MultiIndex,
+    NaT,
     Timestamp,
-    NaT
 )
-from pandas.errors import CSSWarning
-
 import pandas._testing as tm
 
 from pandas.io.formats.excel import (
@@ -23,10 +27,8 @@ from pandas.io.formats.excel import (
     ExcelCell,
     ExcelFormatter,
 )
-
 from pandas.io.formats.style import Styler
 
-from unittest.mock import Mock, patch, call
 
 @pytest.mark.parametrize(
     "css,expected",
@@ -581,7 +583,7 @@ class TestExcelFormatter:
         formatter = ExcelFormatter(df, na_rep=na_rep)
         result = formatter._format_value(val)
         assert result == expected
-    
+
     @pytest.mark.parametrize(
         "val, float_format, inf_rep, expected",
         [
@@ -626,7 +628,7 @@ class TestExcelFormatter:
         df = DataFrame(
             np.random.randn(4, 4),
             columns=columns
-        )        
+        )
         formatter = ExcelFormatter(df, index=False)
         assert(formatter.columns.nlevels > 1 and not formatter.index)
         msg = (
@@ -635,13 +637,13 @@ class TestExcelFormatter:
         )
         with pytest.raises(NotImplementedError):
             list(formatter._format_header_mi())
-    
+
     def test_returns_none_no_header(self):
         df = DataFrame({"A": [1,2], "B": [3,4]})
         formatter = ExcelFormatter(df,header=False)
         assert(formatter._has_aliases == False)
         assert(list(formatter._format_header_mi()) == list())
-    
+
     @pytest.mark.parametrize(
         "df, merge_cells, expected_cells",
         [
@@ -840,7 +842,7 @@ class TestExcelFormatter:
             for cell in result
         ]
         assert result_tuples == expected_cells
-    
+
     @pytest.mark.parametrize(
         "df, formatter_options, expected_cells",
         [
@@ -980,10 +982,10 @@ class TestExcelFormatter:
                     "inf_rep": "Infinity",
                 },
                 [
-                    "A",        # Column header                    
+                    "A",        # Column header
                     "idx",      # Index header
                     0,          # Index value
-                    1,          # Index value                    
+                    1,          # Index value
                     "NULL",     # Formatted NaN
                     1.23,       # Formatted float
                 ],

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -526,42 +526,29 @@ class TestExcelFormatter:
         assert formatter.df is df
         assert isinstance(formatter.style_converter, CSSToExcelConverter)
 
-    @pytest.mark.parametrize("columns", [
-        ["A","C"],
-        ["A","B","C"]
-    ])
+    @pytest.mark.parametrize("columns", [["A", "C"], ["A", "B", "C"]])
     def test_column_missmatch(self, columns):
         """Testing that we throw an error when the specified columns are not found"""
         df = DataFrame({"A": [1, 2], "B": [3, 4]})
-        msg="Not all names specified in 'columns' are found"
+        msg = "Not all names specified in 'columns' are found"
         with pytest.raises(KeyError, match=msg):
             ExcelFormatter(df, cols=columns)
 
-    @pytest.mark.parametrize("columns",[
-    ["C"],
-    ["D"],
-    ["C","D"]
-    ])
-    def test_column_full_miss(self,columns):
+    @pytest.mark.parametrize("columns", [["C"], ["D"], ["C", "D"]])
+    def test_column_full_miss(self, columns):
         """Testing that we throw an error when all of the columns are not in"""
         df = DataFrame({"A": [1, 2], "B": [3, 4]})
-        msg="passes columns are not ALL present dataframe"
+        msg = "passes columns are not ALL present dataframe"
         with pytest.raises(KeyError, match=msg):
             ExcelFormatter(df, cols=columns)
 
-    @pytest.mark.parametrize("merge_cells", [
-        "1",
-        "invalid",
-        1,
-        0
-    ])
+    @pytest.mark.parametrize("merge_cells", ["1", "invalid", 1, 0])
     def test_merge_cells_not_bool_throws(self, merge_cells):
         """Testing that we throw an error when merge_cells is not a boolean"""
         df = DataFrame({"A": [1, 2], "B": [3, 4]})
         msg = f"Unexpected value for {merge_cells=}."
         with pytest.raises(ValueError, match=msg):
             ExcelFormatter(df, merge_cells=merge_cells)
-
 
     @pytest.mark.parametrize(
         "val, na_rep, expected",
@@ -594,9 +581,7 @@ class TestExcelFormatter:
         Test that _format_value correctly handles float values.
         """
         df = DataFrame()
-        formatter = ExcelFormatter(
-            df, float_format=float_format, inf_rep=inf_rep
-        )
+        formatter = ExcelFormatter(df, float_format=float_format, inf_rep=inf_rep)
         result = formatter._format_value(val)
         assert result == expected
 
@@ -616,26 +601,20 @@ class TestExcelFormatter:
             formatter._format_value(val)
 
     def test_formated_header_mi_multi_index_throws(self):
-        header = [
-            ("Cool", "A"), ("Cool", "B"),
-            ("Amazing", "C"), ("Amazing", "D")
-        ]
+        header = [("Cool", "A"), ("Cool", "B"), ("Amazing", "C"), ("Amazing", "D")]
         columns = MultiIndex.from_tuples(header)
         rng = np.random.default_rng(42)
-        df = DataFrame(
-            rng.standard_normal((4, 4)),
-            columns=columns
-        )
+        df = DataFrame(rng.standard_normal((4, 4)), columns=columns)
         formatter = ExcelFormatter(df, index=False)
-        assert(formatter.columns.nlevels > 1 and not formatter.index)
+        assert formatter.columns.nlevels > 1 and not formatter.index
         with pytest.raises(NotImplementedError):
             list(formatter._format_header_mi())
 
     def test_returns_none_no_header(self):
-        df = DataFrame({"A": [1,2], "B": [3,4]})
-        formatter = ExcelFormatter(df,header=False)
-        assert(not formatter._has_aliases)
-        assert(list(formatter._format_header_mi()) == [])
+        df = DataFrame({"A": [1, 2], "B": [3, 4]})
+        formatter = ExcelFormatter(df, header=False)
+        assert not formatter._has_aliases
+        assert list(formatter._format_header_mi()) == []
 
     @pytest.mark.parametrize(
         "df, merge_cells, expected_cells",
@@ -707,7 +686,6 @@ class TestExcelFormatter:
         ]
         assert result_tuples == expected_cells
 
-
     @pytest.mark.parametrize(
         "df, formatter_options, expected_cells",
         [
@@ -773,8 +751,8 @@ class TestExcelFormatter:
                 {},
                 [
                     (1, 0, "idx", None, None),  # Index label
-                    (2, 0, "r1", None, None),   # Index value
-                    (2, 1, 10, None, None),   # Body value
+                    (2, 0, "r1", None, None),  # Index value
+                    (2, 1, 10, None, None),  # Body value
                 ],
             ),
             # Case 2: index=False
@@ -937,8 +915,10 @@ class TestExcelFormatter:
                 0,
                 0,
                 [
-                    (0, 0, 10), (1, 0, 20),  # Column A
-                    (0, 1, 30), (1, 1, 40),  # Column B
+                    (0, 0, 10),
+                    (1, 0, 20),  # Column A
+                    (0, 1, 30),
+                    (1, 1, 40),  # Column B
                 ],
             ),
             # Case 2: With offsets
@@ -947,8 +927,10 @@ class TestExcelFormatter:
                 1,  # Simulates index=True
                 1,  # Simulates header=True
                 [
-                    (1, 1, 10), (2, 1, 20),  # Column A
-                    (1, 2, 30), (2, 2, 40),  # Column B
+                    (1, 1, 10),
+                    (2, 1, 20),  # Column A
+                    (1, 2, 30),
+                    (2, 2, 40),  # Column B
                 ],
             ),
         ],
@@ -975,12 +957,12 @@ class TestExcelFormatter:
                     "inf_rep": "Infinity",
                 },
                 [
-                    "A",        # Column header
-                    "idx",      # Index header
-                    0,          # Index value
-                    1,          # Index value
-                    "NULL",     # Formatted NaN
-                    1.23,       # Formatted float
+                    "A",  # Column header
+                    "idx",  # Index header
+                    0,  # Index value
+                    1,  # Index value
+                    "NULL",  # Formatted NaN
+                    1.23,  # Formatted float
                 ],
             ),
             # Case 2: No index or header
@@ -998,17 +980,22 @@ class TestExcelFormatter:
                 ),
                 {"na_rep": "Missing"},
                 [
-                    "c1", "c2",             # Column headers
-                    "A", "a",
-                    "i1", "i2",             # Index headers
-                    1, "Missing",           # Index values (NaT formatted)
-                    "Missing",              # Body value (NaN formatted)
+                    "c1",
+                    "c2",  # Column headers
+                    "A",
+                    "a",
+                    "i1",
+                    "i2",  # Index headers
+                    1,
+                    "Missing",  # Index values (NaT formatted)
+                    "Missing",  # Body value (NaN formatted)
                 ],
             ),
         ],
     )
-    def test_get_formatted_cells_integration(self, df, formatter_options,
-                                             expected_values):
+    def test_get_formatted_cells_integration(
+        self, df, formatter_options, expected_values
+    ):
         """
         Integration test for get_formatted_cells to ensure it chains all
         formatting methods and applies final value formatting correctly.

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -621,7 +621,7 @@ class TestExcelFormatter:
             ("Amazing", "C"), ("Amazing", "D")
         ]
         columns = MultiIndex.from_tuples(header)
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(42)
         df = DataFrame(
             rng.standard_normal((4, 4)),
             columns=columns

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -1,11 +1,6 @@
 """Tests formatting as writer-agnostic ExcelCells"""
 
 import string
-from unittest.mock import (
-    Mock,
-    call,
-    patch,
-)
 
 import numpy as np
 import pytest
@@ -26,7 +21,6 @@ import pandas._testing as tm
 from pandas.io.formats.excel import (
     CssExcelCell,
     CSSToExcelConverter,
-    ExcelCell,
     ExcelFormatter,
 )
 from pandas.io.formats.style import Styler

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -10,6 +10,8 @@ from unittest.mock import (
 import numpy as np
 import pytest
 
+pytest.importorskip("jinja2")
+
 from pandas.errors import CSSWarning
 
 from pandas import (

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -545,7 +545,7 @@ class TestExcelFormatter:
     def test_column_full_miss(self,columns):
         """Testing that we throw an error when all of the columns are not in"""
         df = DataFrame({"A": [1, 2], "B": [3, 4]})
-        msg="Passed columns are not ALL present dataframe"
+        msg="passes columns are not ALL present dataframe"
         with pytest.raises(KeyError, match=msg):
             ExcelFormatter(df, cols=columns)
 


### PR DESCRIPTION
- ✅  [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- ✅  All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
Added tests to the ExcelFormatter class, which gets the file up to 93\% test coverage in total. The only exception is the `.write` function, (otherwise writing to excel in the first place is not tested) but is already most definitely covered, but should be tested further.


- Leo