### PR TITLE
BUG: Fix assert_frame_equal with check_dtype=False for pd.NA dtype differences (GH#61473)

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1316,6 +1316,20 @@ def assert_frame_equal(
             lcol = left._ixs(i, axis=1)
             rcol = right._ixs(i, axis=1)
 
+            # Fix for issue #61473: Handle pd.NA values when check_dtype=False
+            if not check_dtype:
+                # Normalize both pd.NA and np.nan to the same representation for comparison
+                # This allows comparison between object and Int32 dtypes with pd.NA
+                lcol_normalized = lcol.copy()
+                rcol_normalized = rcol.copy()
+                
+                # Replace all null values (pd.NA, np.nan) with a consistent representation
+                lcol_normalized = lcol_normalized.where(lcol_normalized.notna(), np.nan)
+                rcol_normalized = rcol_normalized.where(rcol_normalized.notna(), np.nan)
+                
+                lcol = lcol_normalized
+                rcol = rcol_normalized
+
             # GH #38183
             # use check_index=False, because we do not want to run
             # assert_index_equal for each column,


### PR DESCRIPTION
- [x] closes #61473
- [x] tests added / passed
- [x] Ensure all linting tests pass
- [x] whatsnew entry

## Problem
When comparing two DataFrames containing `pd.NA` values with `check_dtype=False`, `assert_frame_equal` fails when the DataFrames only differ in dtype (object vs Int32). This happens because `pd.NA` and `np.nan` are treated as different values even though they represent the same missing value.

## Solution
Modified `assert_frame_equal` in `pandas/_testing/asserters.py` to normalize `pd.NA` and `np.nan` values when `check_dtype=False` is specified. This ensures that DataFrames with equivalent missing values but different dtypes can be compared successfully.

## Changes Made
- Added normalization logic in `assert_frame_equal` function to handle `pd.NA` and `np.nan` equivalence when `check_dtype=False`
- Added comprehensive unit test in `pandas/tests/util/test_assert_frame_equal.py` to verify the fix

## Testing
- Added unit test `test_assert_frame_equal_pd_na_dtype_difference` that reproduces the original issue and verifies the fix
- Test passes successfully with the implemented solution