### PR TITLE
TST: fix decimal cast error message for pyarrow nightly tests

### DIFF
--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3295,7 +3295,7 @@ def test_decimal_parse_raises():
     # GH 56984
     ser = pd.Series(["1.2345"], dtype=ArrowDtype(pa.string()))
     with pytest.raises(
-        pa.lib.ArrowInvalid, match="Rescaling Decimal128 value would cause data loss"
+        pa.lib.ArrowInvalid, match="Rescaling Decimal(128)? value would cause data loss"
     ):
         ser.astype(ArrowDtype(pa.decimal128(1, 0)))
 


### PR DESCRIPTION
PyArrow seems to have updated the error message, this updates our assert to catch both "Decimal" and "Decimal128"