### PR TITLE
[backport 2.3.x] TST/CI: temporary upper pin for scipy in downstream tests for compat with statsmodels (#61750)

### DIFF
--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -51,7 +51,8 @@ dependencies:
   - python-calamine>=0.1.7
   - pyxlsb>=1.0.10
   - s3fs>=2022.11.0
-  - scipy>=1.10.0
+  # TEMP upper pin for scipy (https://github.com/statsmodels/statsmodels/issues/9584)
+  - scipy>=1.10.0,<1.16
   - sqlalchemy>=2.0.0
   - tabulate>=0.9.0
   - xarray>=2022.12.0, <=2024.9.0


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/61750