### PR TITLE
Revert "[2.3.x] DEPS: Drop Python 3.9 (#60792)"

### DIFF
--- a/.github/workflows/package-checks.yml
+++ b/.github/workflows/package-checks.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
       fail-fast: false
     name: Test Conda Forge Recipe - Python ${{ matrix.python-version }}
     concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-22.04, ubuntu-24.04-arm]
-        env_file: [actions-310.yaml, actions-311.yaml, actions-312.yaml]
+        env_file: [actions-39.yaml, actions-310.yaml, actions-311.yaml, actions-312.yaml]
         # Prevent the include jobs from overriding other jobs
         pattern: [""]
         pandas_future_infer_string: ["0"]
@@ -38,7 +38,7 @@ jobs:
             pytest_target: "pandas/tests/test_downstream.py"
             platform: ubuntu-22.04
           - name: "Minimum Versions"
-            env_file: actions-310-minimum_versions.yaml
+            env_file: actions-39-minimum_versions.yaml
             pattern: "not slow and not network and not single_cpu"
             platform: ubuntu-22.04
           - name: "Locale: it_IT"
@@ -63,6 +63,11 @@ jobs:
             # It will be temporarily activated during tests with locale.setlocale
             extra_loc: "zh_CN"
             platform: ubuntu-22.04
+          - name: "Copy-on-Write 3.9"
+            env_file: actions-39.yaml
+            pattern: "not slow and not network and not single_cpu"
+            pandas_copy_on_write: "1"
+            platform: ubuntu-22.04
           - name: "Copy-on-Write 3.10"
             env_file: actions-310.yaml
             pattern: "not slow and not network and not single_cpu"
@@ -85,6 +90,11 @@ jobs:
             platform: ubuntu-22.04
           - name: "Copy-on-Write 3.10 (warnings)"
             env_file: actions-310.yaml
+            pattern: "not slow and not network and not single_cpu"
+            pandas_copy_on_write: "warn"
+            platform: ubuntu-22.04
+          - name: "Copy-on-Write 3.9 (warnings)"
+            env_file: actions-39.yaml
             pattern: "not slow and not network and not single_cpu"
             pandas_copy_on_write: "warn"
             platform: ubuntu-22.04
@@ -218,7 +228,7 @@ jobs:
       matrix:
         # Note: Don't use macOS latest since macos 14 appears to be arm64 only
         os: [macos-13, macos-14, windows-latest]
-        env_file: [actions-310.yaml, actions-311.yaml, actions-312.yaml]
+        env_file: [actions-39.yaml, actions-310.yaml, actions-311.yaml, actions-312.yaml]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ format('{0} {1}', matrix.os, matrix.env_file) }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,7 +100,7 @@ jobs:
         - [macos-14, macosx_arm64]
         - [windows-2022, win_amd64]
         # TODO: support PyPy?
-        python: [["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"]]
+        python: [["cp39", "3.9"], ["cp310", "3.10"], ["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"]]
         include:
         # TODO: Remove this plus installing build deps in cibw_before_build.sh
         # after pandas can be built with a released NumPy/Cython

--- a/ci/deps/actions-39-minimum_versions.yaml
+++ b/ci/deps/actions-39-minimum_versions.yaml
@@ -4,7 +4,7 @@ name: pandas-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.9
 
   # build dependencies
   - versioneer

--- a/ci/deps/actions-39.yaml
+++ b/ci/deps/actions-39.yaml
@@ -1,0 +1,64 @@
+name: pandas-dev
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+
+  # build dependencies
+  - versioneer[toml]
+  - cython>=0.29.33
+  - meson[ninja]=1.2.1
+  - meson-python=0.13.1
+
+  # test dependencies
+  - pytest>=7.3.2
+  - pytest-cov
+  - pytest-xdist>=2.2.0
+  - pytest-qt>=4.2.0
+  - boto3
+
+  # required dependencies
+  - python-dateutil
+  - numpy
+  # pytz 2024.2 timezones cause wrong results
+  - pytz<2024.2
+
+  # optional dependencies
+  - beautifulsoup4>=4.11.2
+  - blosc>=1.21.3
+  - bottleneck>=1.3.6
+  - fastparquet>=2022.12.0
+  - fsspec>=2022.11.0
+  - html5lib>=1.1
+  - hypothesis>=6.46.1
+  - gcsfs>=2022.11.0
+  - jinja2>=3.1.2
+  - lxml>=4.9.2
+  - matplotlib>=3.6.3
+  - numba>=0.56.4
+  - numexpr>=2.8.4
+  - odfpy>=1.4.1
+  - qtpy>=2.3.0
+  - openpyxl>=3.1.0
+  - psycopg2>=2.9.6
+  - pyarrow>=10.0.1
+  - pymysql>=1.0.2
+  - pyqt>=5.15.9
+  - pyreadstat>=1.2.0
+  - pytables>=3.8.0
+  - python-calamine>=0.1.7
+  - pyxlsb>=1.0.10
+  - s3fs>=2022.11.0
+  - scipy>=1.10.0
+  - sqlalchemy>=2.0.0
+  - tabulate>=0.9.0
+  - xarray>=2022.12.0
+  - xlrd>=2.0.1
+  - xlsxwriter>=3.0.5
+  - zstandard>=0.19.0
+
+  - pip:
+    - adbc-driver-postgresql>=0.8.0
+    - adbc-driver-sqlite>=0.8.0
+    - tzdata>=2022.7
+    - pytest-localserver>=0.7.1


### PR DESCRIPTION
This reverts commit 2e617d36af3592a371fe09a1aec8282f9db550da.

Re-enables 3.9 wheels and testing for the 2.3.x branch
xref https://github.com/pandas-dev/pandas/issues/61590


- [ ] closes #61579 (Replace xxxx with the GitHub issue number)