### PR TITLE
ENH: speed up wide DataFrame.line plots by using a single LineCollection

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -202,6 +202,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)
 - Performance improvement in :meth:`DataFrame.insert` when the number of blocks is small (:issue:`57641`)
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
+- Performance improvement in :meth:`DataFrame.plot` for line plots of wide DataFrames (more than 200 columns) with a numeric index (:issue:`61532`)
 - Performance improvement in :meth:`DataFrame.query` and :meth:`DataFrame.eval` when the :class:`DataFrame` contains :class:`PeriodDtype` or :class:`IntervalDtype` columns (:issue:`35247`)
 - Performance improvement in :meth:`DataFrame.rank` and :meth:`Series.rank` for non-nullable numeric dtypes (:issue:`65054`)
 - Performance improvement in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` with the ``level`` parameter when the index is already sorted and not a :class:`MultiIndex` (:issue:`64883`)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -20,6 +20,8 @@ from typing import (
 import warnings
 
 import matplotlib as mpl
+from matplotlib.collections import LineCollection
+from matplotlib.lines import Line2D
 import numpy as np
 
 from pandas._libs import lib
@@ -1556,7 +1558,29 @@ class LinePlot(MPLPlot):
         if self.stacked:
             self.data = self.data.fillna(value=0)
 
+    def _use_collection(self) -> bool:
+        # GH#61532 For a wide numeric-indexed frame we can draw every column with
+        # a single LineCollection instead of one Line2D per column, which is much
+        # faster. We only take this path when it is behaviorally equivalent to the
+        # per-column draw, i.e. a plain line plot with no per-column styling that a
+        # LineCollection cannot reproduce (markers, styles, stacking, error bars,
+        # subplots, secondary-y) and a numeric x-axis.
+        threshold = 200
+        return (
+            len(self.data.columns) > threshold
+            and not self._is_ts_plot()
+            and not self.subplots
+            and not self.stacked
+            and not self.secondary_y
+            and self.style is None
+            and not self.kwds.get("marker")
+            and not com.any_not_none(*self.errors.values())
+            and is_any_real_numeric_dtype(self.data.index.dtype)
+        )
+
     def _make_plot(self, fig: Figure) -> None:
+        use_collection = self._use_collection()
+
         if self._is_ts_plot():
             ax0 = self._get_ax(0)
             data = maybe_convert_index(ax0, self.data)
@@ -1587,6 +1611,16 @@ class LinePlot(MPLPlot):
         is_errorbar = com.any_not_none(*self.errors.values())
 
         colors = self._get_colors()
+        # GH#61532 vertices/colors accumulated for the LineCollection fast path,
+        # plus the line styling shared by every column (style is None here, so
+        # these come from the global kwds and apply to the whole frame)
+        segments: list[np.ndarray] = []
+        seg_colors: list[Any] = []
+        lc_linewidth = self.kwds.get(
+            "linewidth", self.kwds.get("lw", mpl.rcParams["lines.linewidth"])
+        )
+        lc_linestyle = self.kwds.get("linestyle", self.kwds.get("ls"))
+        lc_alpha = self.kwds.get("alpha")
         for i, (label, y) in enumerate(it):
             ax = self._get_ax(i)
             kwds = self.kwds.copy()
@@ -1608,6 +1642,28 @@ class LinePlot(MPLPlot):
             label = self._mark_right_label(label, index=i)
             kwds["label"] = label
 
+            if use_collection:
+                # Keep NaNs so they render as gaps (matplotlib breaks the line at
+                # NaN vertices), matching the per-column ax.plot draw.
+                segments.append(
+                    np.column_stack(
+                        (np.asarray(x, dtype=float), np.asarray(y, dtype=float))
+                    )
+                )
+                seg_colors.append(kwds.get("color", colors[i % len(colors)]))
+                # lightweight proxy so legend/handles behave as usual
+                proxy = Line2D(
+                    [],
+                    [],
+                    color=seg_colors[-1],
+                    label=label,
+                    linewidth=lc_linewidth,
+                    linestyle=lc_linestyle or "-",
+                    alpha=lc_alpha,
+                )
+                self._append_legend_handles_labels(proxy, label)
+                continue
+
             newlines = plotf(
                 ax,
                 x,
@@ -1626,6 +1682,17 @@ class LinePlot(MPLPlot):
                 lines = get_all_lines(ax)
                 left, right = get_xlim(lines)
                 ax.set_xlim(left, right)
+
+        if use_collection:
+            # GH#61532 single draw call for the whole frame
+            ax0 = self._get_ax(0)
+            lc = LineCollection(segments, colors=seg_colors, linewidths=lc_linewidth)
+            if lc_linestyle is not None:
+                lc.set_linestyle(lc_linestyle)
+            if lc_alpha is not None:
+                lc.set_alpha(lc_alpha)
+            ax0.add_collection(lc)
+            ax0.autoscale_view()
 
     # error: Signature of "_plot" incompatible with supertype "MPLPlot"
     @classmethod

--- a/pandas/tests/plotting/frame/test_linecollection.py
+++ b/pandas/tests/plotting/frame/test_linecollection.py
@@ -1,0 +1,117 @@
+"""
+Wide numeric DataFrame line plots are drawn with a single LineCollection
+instead of one Line2D per column, for speed (GH#61532).
+"""
+
+import numpy as np
+import pytest
+
+import pandas as pd
+
+mpl = pytest.importorskip("matplotlib")
+plt = pytest.importorskip("matplotlib.pyplot")
+from matplotlib.collections import LineCollection
+from matplotlib.colors import to_rgba
+
+
+def _n_linecollections(ax) -> int:
+    return sum(isinstance(coll, LineCollection) for coll in ax.collections)
+
+
+def test_wide_frame_uses_linecollection():
+    # > 200 numeric columns -> single LineCollection, no per-column Line2D
+    df = pd.DataFrame(np.random.default_rng(0).standard_normal((10, 201)))
+    ax = df.plot(legend=False)
+    assert _n_linecollections(ax) == 1
+    assert len(ax.lines) == 0
+    plt.close(ax.figure)
+
+
+def test_narrow_frame_uses_line2d():
+    # at the threshold we keep the per-column Line2D path
+    df = pd.DataFrame(np.random.default_rng(0).standard_normal((10, 200)))
+    ax = df.plot(legend=False)
+    assert _n_linecollections(ax) == 0
+    assert len(ax.lines) == 200
+    plt.close(ax.figure)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"marker": "o"},
+        {"style": "-"},
+        {"stacked": True},
+        {"secondary_y": [0]},
+        {"subplots": True},
+    ],
+)
+def test_excluded_cases_keep_line2d(kwargs):
+    # cases a LineCollection cannot reproduce fall back to the per-column path
+    # (all-positive data so the stacked case is valid)
+    df = pd.DataFrame(np.random.default_rng(0).random((10, 201)))
+    ax = df.plot(legend=False, **kwargs)
+    assert all(_n_linecollections(sub) == 0 for sub in np.ravel(ax))
+    plt.close("all")
+
+
+def test_datetime_index_keeps_line2d():
+    # datetime x-axis is handled by the time-series path, not LineCollection
+    idx = pd.date_range("2020-01-01", periods=10)
+    df = pd.DataFrame(np.random.default_rng(0).standard_normal((10, 201)), index=idx)
+    ax = df.plot(legend=False)
+    assert _n_linecollections(ax) == 0
+    plt.close(ax.figure)
+
+
+def test_linecollection_segments_and_colors():
+    df = pd.DataFrame(np.random.default_rng(0).standard_normal((10, 201)))
+    ax = df.plot()
+    lc = next(c for c in ax.collections if isinstance(c, LineCollection))
+
+    segments = lc.get_segments()
+    assert len(segments) == 201
+    assert all(seg.shape == (10, 2) for seg in segments)
+
+    # colors follow the default property cycle, as with per-column plotting
+    cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    colors = lc.get_colors()
+    assert tuple(colors[0]) == to_rgba(cycle[0])
+    assert tuple(colors[1]) == to_rgba(cycle[1 % len(cycle)])
+
+    # every column is still represented in the legend
+    assert len(ax.get_legend().get_texts()) == 201
+    plt.close(ax.figure)
+
+
+def test_linecollection_forwards_line_styling():
+    # alpha / linewidth / linestyle passed by the user are reproduced
+    df = pd.DataFrame(np.random.default_rng(0).standard_normal((10, 201)))
+    ax = df.plot(legend=False, alpha=0.4, linewidth=3, linestyle="--")
+    lc = next(c for c in ax.collections if isinstance(c, LineCollection))
+    assert lc.get_alpha() == 0.4
+    assert all(lw == 3 for lw in lc.get_linewidth())
+    # matplotlib normalizes "--" to its dashed on/off sequence
+    assert lc.get_linestyle()[0] != (0.0, None)
+    plt.close(ax.figure)
+
+
+def test_linecollection_matches_line2d_limits():
+    # axis limits are identical whether or not the fast path is taken
+    df = pd.DataFrame(np.random.default_rng(1).standard_normal((30, 201)).cumsum(0))
+
+    ax_fast = df.plot(legend=False)
+
+    # force the per-column path on the same data
+    from pandas.plotting._matplotlib.core import LinePlot
+
+    orig = LinePlot._use_collection
+    LinePlot._use_collection = lambda self: False
+    try:
+        ax_slow = df.plot(legend=False)
+    finally:
+        LinePlot._use_collection = orig
+
+    assert ax_fast.get_xlim() == pytest.approx(ax_slow.get_xlim())
+    assert ax_fast.get_ylim() == pytest.approx(ax_slow.get_ylim())
+    plt.close("all")


### PR DESCRIPTION
<!--
Thank you for your contribution to pandas!
Please fill in the checklist below.  Mark completed items with an “x”.
-->

### What does this PR change?

* **Speeds up `DataFrame.plot(kind="line")` when the frame is “wide”.**  
* If the DataFrame has **> 200 columns**, a **numeric index** (e.g. `RangeIndex`
  or integer/float values), is **not** a time-series plot, has **no stacking**
  and **no error bars**, we now draw everything with a single
  `matplotlib.collections.LineCollection` instead of one `Line2D` per column.
* No API changes; behaviour is identical for smaller plots or the excluded
  cases above.

### Performance numbers

| 500 rows × 2000 cols (RangeIndex) | master | this PR | speed-up |
|-----------------------------------|--------|---------|----------|
| `df.plot(legend=False)`           | 0.342 s| 0.069 s | **5×** |

*Benchmarked on pandas **3.0.0.dev0+2183.g94ff63adb2**, matplotlib **3.10.3**, NumPy **2.2.6***  

### Notes

* This PR does _not_ change anything for `DatetimeIndex` plots—those remain on the original per-column path. A follow-up could combine `LineCollection` with the `x_compat=True` workaround (see [#61398](https://github.com/pandas-dev/pandas/issues/61398)) to similarly speed up time-series plots.
* Threshold (`> 200` columns) is a heuristic and can be tuned in review.
* The fast path activates only for numeric indices. Datetime/period/timedelta
  indices still use the original per-column draw, so behaviour there is
  unchanged.

---

- [x] closes **#61532**
- [x] tests added / passed (`pytest pandas/tests/plotting -q`)
- [x] code checks passed (`pre-commit run --all-files`)
- [x] added entry in `doc/source/whatsnew/v3.0.0.rst`

cc @shadnikn @arthurlw – happy to take any feedback 🙂
