### PR TITLE
BUG: NA.__and__, __or__, __xor__ with np.bool_ objects

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -762,6 +762,7 @@ Indexing
 Missing
 ^^^^^^^
 - Bug in :meth:`DataFrame.fillna` and :meth:`Series.fillna` that would ignore the ``limit`` argument on :class:`.ExtensionArray` dtypes (:issue:`58001`)
+- Bug in :meth:`NA.__and__`, :meth:`NA.__or__` and :meth:`NA.__xor__` when operating with ``np.bool_`` objects (:issue:`58427`)
 -
 
 MultiIndex

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -471,6 +471,10 @@ class NAType(C_NAType):
             return False
         elif other is True or other is C_NA:
             return NA
+        elif util.is_bool_object(other):
+            if not other:
+                return False
+            return NA
         return NotImplemented
 
     __rand__ = __and__
@@ -480,12 +484,16 @@ class NAType(C_NAType):
             return True
         elif other is False or other is C_NA:
             return NA
+        elif util.is_bool_object(other):
+            if not other:
+                return NA
+            return True
         return NotImplemented
 
     __ror__ = __or__
 
     def __xor__(self, other):
-        if other is False or other is True or other is C_NA:
+        if util.is_bool_object(other) or other is C_NA:
             return NA
         return NotImplemented
 

--- a/pandas/tests/scalar/test_na_scalar.py
+++ b/pandas/tests/scalar/test_na_scalar.py
@@ -167,6 +167,12 @@ def test_logical_and():
     assert False & NA is False
     assert NA & NA is NA
 
+    # GH#58427
+    assert NA & np.bool_(True) is NA
+    assert np.bool_(True) & NA is NA
+    assert NA & np.bool_(False) is False
+    assert np.bool_(False) & NA is False
+
     msg = "unsupported operand type"
     with pytest.raises(TypeError, match=msg):
         NA & 5
@@ -179,6 +185,12 @@ def test_logical_or():
     assert False | NA is NA
     assert NA | NA is NA
 
+    # GH#58427
+    assert NA | np.bool_(True) is True
+    assert np.bool_(True) | NA is True
+    assert NA | np.bool_(False) is NA
+    assert np.bool_(False) | NA is NA
+
     msg = "unsupported operand type"
     with pytest.raises(TypeError, match=msg):
         NA | 5
@@ -190,6 +202,12 @@ def test_logical_xor():
     assert NA ^ False is NA
     assert False ^ NA is NA
     assert NA ^ NA is NA
+
+    # GH#58427
+    assert NA ^ np.bool_(True) is NA
+    assert np.bool_(True) ^ NA is NA
+    assert NA ^ np.bool_(False) is NA
+    assert np.bool_(False) ^ NA is NA
 
     msg = "unsupported operand type"
     with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
- [x] closes #58427 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I expected this to break some other tests, but nope.