### PR TITLE
BUG: Decimal(NaN) incorrectly allowed in ArrowEA constructor with tim…

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -707,6 +707,8 @@ Datetimelike
 - Bug in :meth:`to_datetime` with ``format="ISO8601"`` and ``utc=True`` where naive timestamps incorrectly inherited timezone offset from previous timestamps in a series. (:issue:`61389`)
 - Bug in :meth:`to_datetime` wrongly converts when ``arg`` is a ``np.datetime64`` object with unit of ``ps``. (:issue:`60341`)
 - Bug in setting scalar values with mismatched resolution into arrays with non-nanosecond ``datetime64``, ``timedelta64`` or :class:`DatetimeTZDtype` incorrectly truncating those scalars (:issue:`56410`)
+- Bug in constructing arrays with :class:`ArrowDtype` with ``timestamp`` type incorrectly allowing ``Decimal("NaN")`` (:issue:`??`)
+-
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -707,8 +707,8 @@ Datetimelike
 - Bug in :meth:`to_datetime` with ``format="ISO8601"`` and ``utc=True`` where naive timestamps incorrectly inherited timezone offset from previous timestamps in a series. (:issue:`61389`)
 - Bug in :meth:`to_datetime` wrongly converts when ``arg`` is a ``np.datetime64`` object with unit of ``ps``. (:issue:`60341`)
 - Bug in constructing arrays with :class:`ArrowDtype` with ``timestamp`` type incorrectly allowing ``Decimal("NaN")`` (:issue:`61773`)
+- Bug in constructing arrays with a timezone-aware :class:`ArrowDtype` from timezone-naive datetime objects incorrectly treating those as UTC times instead of wall times like :class:`DatetimeTZDtype` (:issue:`61775`)
 - Bug in setting scalar values with mismatched resolution into arrays with non-nanosecond ``datetime64``, ``timedelta64`` or :class:`DatetimeTZDtype` incorrectly truncating those scalars (:issue:`56410`)
--
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -706,8 +706,8 @@ Datetimelike
 - Bug in :meth:`to_datetime` reports incorrect index in case of any failure scenario. (:issue:`58298`)
 - Bug in :meth:`to_datetime` with ``format="ISO8601"`` and ``utc=True`` where naive timestamps incorrectly inherited timezone offset from previous timestamps in a series. (:issue:`61389`)
 - Bug in :meth:`to_datetime` wrongly converts when ``arg`` is a ``np.datetime64`` object with unit of ``ps``. (:issue:`60341`)
+- Bug in constructing arrays with :class:`ArrowDtype` with ``timestamp`` type incorrectly allowing ``Decimal("NaN")`` (:issue:`61773`)
 - Bug in setting scalar values with mismatched resolution into arrays with non-nanosecond ``datetime64``, ``timedelta64`` or :class:`DatetimeTZDtype` incorrectly truncating those scalars (:issue:`56410`)
-- Bug in constructing arrays with :class:`ArrowDtype` with ``timestamp`` type incorrectly allowing ``Decimal("NaN")`` (:issue:`??`)
 -
 
 Timedelta

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -520,7 +520,7 @@ class ArrowExtensionArray(
                     )
                 mask = dta.isna()
                 value_i8 = dta.view("i8")
-                if not value_i8.flags["WRITEABLE"]:
+                if not np.asarray(value_i8).flags["WRITEABLE"]:
                     # e.g. test_setitem_frame_2d_values
                     value_i8 = value_i8.copy()
                     dta = DatetimeArray._from_sequence(value_i8, dtype=dta.dtype)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -500,6 +500,12 @@ class ArrowExtensionArray(
                 value = to_timedelta(value, unit=pa_type.unit).as_unit(pa_type.unit)
                 value = value.to_numpy()
 
+            if pa_type is not None and pa.types.is_timestamp(pa_type):
+                # Use to_datetime to handle NaNs, disallow Decimal("NaN")
+                from pandas import to_datetime
+
+                value = to_datetime(value).as_unit(pa_type.unit)
+
             try:
                 pa_array = pa.array(value, type=pa_type, from_pandas=True)
             except (pa.ArrowInvalid, pa.ArrowTypeError):

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -63,6 +63,7 @@ from pandas.core.arrays.base import (
 from pandas.core.arrays.masked import BaseMaskedArray
 from pandas.core.arrays.string_ import StringDtype
 import pandas.core.common as com
+from pandas.core.construction import extract_array
 from pandas.core.indexers import (
     check_array_indexer,
     unpack_tuple_and_ellipses,
@@ -501,10 +502,31 @@ class ArrowExtensionArray(
                 value = value.to_numpy()
 
             if pa_type is not None and pa.types.is_timestamp(pa_type):
-                # Use to_datetime to handle NaNs, disallow Decimal("NaN")
-                from pandas import to_datetime
+                # Use DatetimeArray to exclude Decimal(NaN) (GH#61774) and
+                #  ensure constructor treats tznaive the same as non-pyarrow
+                #  dtypes (GH#61775)
+                from pandas.core.arrays.datetimes import (
+                    DatetimeArray,
+                    tz_to_dtype,
+                )
 
-                value = to_datetime(value).as_unit(pa_type.unit)
+                pass_dtype = tz_to_dtype(tz=pa_type.tz, unit=pa_type.unit)
+                value = extract_array(value, extract_numpy=True)
+                if isinstance(value, DatetimeArray):
+                    dta = value
+                else:
+                    dta = DatetimeArray._from_sequence(
+                        value, copy=copy, dtype=pass_dtype
+                    )
+                mask = dta.isna()
+                value_i8 = dta.view("i8")
+                if not value_i8.flags["WRITEABLE"]:
+                    # e.g. test_setitem_frame_2d_values
+                    value_i8 = value_i8.copy()
+                    dta = DatetimeArray._from_sequence(value_i8, dtype=dta.dtype)
+                value_i8[mask] = 0  # GH#61776 avoid __sub__ overflow
+                pa_array = pa.array(dta._ndarray, type=pa_type, mask=mask)
+                return pa_array
 
             try:
                 pa_array = pa.array(value, type=pa_type, from_pandas=True)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -518,14 +518,14 @@ class ArrowExtensionArray(
                     dta = DatetimeArray._from_sequence(
                         value, copy=copy, dtype=pass_dtype
                     )
-                mask = dta.isna()
-                value_i8 = dta.view("i8")
-                if not np.asarray(value_i8).flags["WRITEABLE"]:
+                dta_mask = dta.isna()
+                value_i8 = cast("npt.NDArray", dta.view("i8"))
+                if not value_i8.flags["WRITEABLE"]:
                     # e.g. test_setitem_frame_2d_values
                     value_i8 = value_i8.copy()
                     dta = DatetimeArray._from_sequence(value_i8, dtype=dta.dtype)
-                value_i8[mask] = 0  # GH#61776 avoid __sub__ overflow
-                pa_array = pa.array(dta._ndarray, type=pa_type, mask=mask)
+                value_i8[dta_mask] = 0  # GH#61776 avoid __sub__ overflow
+                pa_array = pa.array(dta._ndarray, type=pa_type, mask=dta_mask)
                 return pa_array
 
             try:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3548,3 +3548,17 @@ def test_arrow_json_type():
     dtype = ArrowDtype(pa.json_(pa.string()))
     result = dtype.type
     assert result == str
+
+
+def test_timestamp_dtype_disallows_decimal():
+    # constructing with pyarrow timestamp dtype should disallow Decimal NaN,
+    # just like pd.to_datetime
+    vals = [pd.Timestamp("2016-01-02 03:04:05"), Decimal("NaN")]
+
+    msg = "<class 'decimal.Decimal'> is not convertible to datetime"
+    with pytest.raises(TypeError, match=msg):
+        # Check that the non-pyarrow version raises as expected
+        pd.to_datetime(vals)
+
+    with pytest.raises(TypeError, match=msg):
+        pd.array(vals, dtype=ArrowDtype(pa.timestamp("us")))

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3551,8 +3551,8 @@ def test_arrow_json_type():
 
 
 def test_timestamp_dtype_disallows_decimal():
-    # constructing with pyarrow timestamp dtype should disallow Decimal NaN,
-    # just like pd.to_datetime
+    # GH#61773 constructing with pyarrow timestamp dtype should disallow
+    #  Decimal NaN, just like pd.to_datetime
     vals = [pd.Timestamp("2016-01-02 03:04:05"), Decimal("NaN")]
 
     msg = "<class 'decimal.Decimal'> is not convertible to datetime"

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1041,6 +1041,7 @@ def test_dataframe_to_sql_arrow_dtypes_missing(conn, request, nulls_fixture):
     pytest.importorskip("pyarrow")
     if isinstance(nulls_fixture, Decimal):
         pytest.skip(
+            # GH#61773
             reason="Decimal('NaN') not supported in constructor for timestamp dtype"
         )
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -8,6 +8,7 @@ from datetime import (
     time,
     timedelta,
 )
+from decimal import Decimal
 from io import StringIO
 from pathlib import Path
 import sqlite3
@@ -1038,6 +1039,11 @@ def test_dataframe_to_sql_arrow_dtypes(conn, request):
 def test_dataframe_to_sql_arrow_dtypes_missing(conn, request, nulls_fixture):
     # GH 52046
     pytest.importorskip("pyarrow")
+    if isinstance(nulls_fixture, Decimal):
+        pytest.skip(
+            reason="Decimal('NaN') not supported in constructor for timestamp dtype"
+        )
+
     df = DataFrame(
         {
             "datetime": pd.array(


### PR DESCRIPTION
…estamp type

- [x] closes #61775
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Surfaced by #61732