### PR TITLE
DOC: Add link to WebGL in pandas ecosystem

### DIFF
--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -141,7 +141,7 @@ pd.set_option("plotting.backend", "hvplot")
 
 [Plotly's](https://plot.ly/) [Python API](https://plot.ly/python/)
 enables interactive figures and web shareability. Maps, 2D, 3D, and
-live-streaming graphs are rendered with WebGL and
+live-streaming graphs are rendered with [WebGL](https://www.khronos.org/webgl/) and
 [D3.js](https://d3js.org/). The library supports plotting directly from
 a pandas DataFrame and cloud-based collaboration. Users of [matplotlib,
 ggplot for Python, and


### PR DESCRIPTION
Add link to WebGL in pandas ecosystem.
https://www.khronos.org/webgl/

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
