### PR TITLE
TST: update expected dtype for sum of decimals with pyarrow 21+

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -35,6 +35,7 @@ from pandas.compat.pyarrow import (
     pa_version_under18p0,
     pa_version_under19p0,
     pa_version_under20p0,
+    pa_version_under21p0,
 )
 
 if TYPE_CHECKING:
@@ -168,4 +169,5 @@ __all__ = [
     "pa_version_under18p0",
     "pa_version_under19p0",
     "pa_version_under20p0",
+    "pa_version_under21p0",
 ]

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -18,6 +18,7 @@ try:
     pa_version_under18p0 = _palv < Version("18.0.0")
     pa_version_under19p0 = _palv < Version("19.0.0")
     pa_version_under20p0 = _palv < Version("20.0.0")
+    pa_version_under21p0 = _palv < Version("21.0.0")
     HAS_PYARROW = _palv >= Version("12.0.1")
 except ImportError:
     pa_version_under12p1 = True
@@ -30,4 +31,5 @@ except ImportError:
     pa_version_under18p0 = True
     pa_version_under19p0 = True
     pa_version_under20p0 = True
+    pa_version_under21p0 = True
     HAS_PYARROW = False

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -43,6 +43,7 @@ from pandas.compat import (
     pa_version_under14p0,
     pa_version_under19p0,
     pa_version_under20p0,
+    pa_version_under21p0,
 )
 
 from pandas.core.dtypes.dtypes import (
@@ -542,7 +543,10 @@ class TestArrowArray(base.ExtensionTests):
             else:
                 cmp_dtype = arr.dtype
         elif arr.dtype.name == "decimal128(7, 3)[pyarrow]":
-            if op_name not in ["median", "var", "std", "sem", "skew"]:
+            if op_name == "sum" and not pa_version_under21p0:
+                # https://github.com/apache/arrow/pull/44184
+                cmp_dtype = ArrowDtype(pa.decimal128(38, 3))
+            elif op_name not in ["median", "var", "std", "sem", "skew"]:
                 cmp_dtype = arr.dtype
             else:
                 cmp_dtype = "float64[pyarrow]"


### PR DESCRIPTION
This should fix the failure we started having for the pyarrow nightly build (behaviour change in https://github.com/apache/arrow/pull/44184 to increase the precision of the resulting decimal for sum)