### PR TITLE
[backport 2.3.x] TST: update expected dtype for sum of decimals with pyarrow 21+ (#61799)

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -36,6 +36,7 @@ from pandas.compat.pyarrow import (
     pa_version_under18p0,
     pa_version_under19p0,
     pa_version_under20p0,
+    pa_version_under21p0,
 )
 
 if TYPE_CHECKING:
@@ -197,6 +198,7 @@ __all__ = [
     "pa_version_under18p0",
     "pa_version_under19p0",
     "pa_version_under20p0",
+    "pa_version_under21p0",
     "HAS_PYARROW",
     "IS64",
     "ISMUSL",

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -20,6 +20,7 @@ try:
     pa_version_under18p0 = _palv < Version("18.0.0")
     pa_version_under19p0 = _palv < Version("19.0.0")
     pa_version_under20p0 = _palv < Version("20.0.0")
+    pa_version_under21p0 = _palv < Version("21.0.0")
     HAS_PYARROW = True
 except ImportError:
     pa_version_under10p1 = True
@@ -34,4 +35,5 @@ except ImportError:
     pa_version_under18p0 = True
     pa_version_under19p0 = True
     pa_version_under20p0 = True
+    pa_version_under21p0 = True
     HAS_PYARROW = False

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -41,6 +41,7 @@ from pandas.compat import (
     pa_version_under13p0,
     pa_version_under14p0,
     pa_version_under20p0,
+    pa_version_under21p0,
 )
 
 from pandas.core.dtypes.dtypes import (
@@ -580,7 +581,10 @@ class TestArrowArray(base.ExtensionTests):
         if op_name in ["max", "min"]:
             cmp_dtype = arr.dtype
         elif arr.dtype.name == "decimal128(7, 3)[pyarrow]":
-            if op_name not in ["median", "var", "std", "skew"]:
+            if op_name == "sum" and not pa_version_under21p0:
+                # https://github.com/apache/arrow/pull/44184
+                cmp_dtype = ArrowDtype(pa.decimal128(38, 3))
+            elif op_name not in ["median", "var", "std", "skew"]:
                 cmp_dtype = arr.dtype
             else:
                 cmp_dtype = "float64[pyarrow]"


### PR DESCRIPTION
Backport of #61799