### PR TITLE
DEPS: Bump NumPy and tzdata

### DIFF
--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   # required dependencies
   - python-dateutil=2.8.2
-  - numpy=1.23.5
+  - numpy=1.26.0
 
   # optional dependencies
   - beautifulsoup4=4.12.3

--- a/ci/deps/actions-310-minimum_versions.yaml
+++ b/ci/deps/actions-310-minimum_versions.yaml
@@ -62,4 +62,4 @@ dependencies:
   - pip:
     - adbc-driver-postgresql==0.10.0
     - adbc-driver-sqlite==0.8.0
-    - tzdata==2022.7
+    - tzdata==2023.3

--- a/ci/deps/actions-310.yaml
+++ b/ci/deps/actions-310.yaml
@@ -60,4 +60,4 @@ dependencies:
   - pip:
     - adbc-driver-postgresql>=0.10.0
     - adbc-driver-sqlite>=0.8.0
-    - tzdata>=2022.7
+    - tzdata>=2023.3

--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -73,4 +73,4 @@ dependencies:
   - pip:
     - adbc-driver-postgresql>=0.10.0
     - adbc-driver-sqlite>=0.8.0
-    - tzdata>=2022.7
+    - tzdata>=2023.3

--- a/ci/deps/actions-311-numpydev.yaml
+++ b/ci/deps/actions-311-numpydev.yaml
@@ -24,4 +24,4 @@ dependencies:
     - "--extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
     - "--pre"
     - "numpy"
-    - "tzdata>=2022.7"
+    - "tzdata>=2023.3"

--- a/ci/deps/actions-311-pyarrownightly.yaml
+++ b/ci/deps/actions-311-pyarrownightly.yaml
@@ -22,7 +22,7 @@ dependencies:
   - pip
 
   - pip:
-    - "tzdata>=2022.7"
+    - "tzdata>=2023.3"
     - "--extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
     - "--prefer-binary"
     - "--pre"

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -60,4 +60,4 @@ dependencies:
   - pip:
     - adbc-driver-postgresql>=0.10.0
     - adbc-driver-sqlite>=0.8.0
-    - tzdata>=2022.7
+    - tzdata>=2023.3

--- a/ci/deps/actions-313-freethreading.yaml
+++ b/ci/deps/actions-313-freethreading.yaml
@@ -25,5 +25,5 @@ dependencies:
   - pip:
     # No free-threaded coveragepy (with the C-extension) on conda-forge yet
     - pytest-cov
-    - "tzdata>=2022.7"
+    - tzdata>=2023.3
     - "--extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"

--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -60,4 +60,4 @@ dependencies:
   - pip:
     - adbc-driver-postgresql>=0.10.0
     - adbc-driver-sqlite>=0.8.0
-    - tzdata>=2022.7
+    - tzdata>=2023.3

--- a/ci/deps/actions-pypy-39.yaml
+++ b/ci/deps/actions-pypy-39.yaml
@@ -23,4 +23,4 @@ dependencies:
   - numpy
   - python-dateutil
   - pip:
-    - tzdata>=2022.7
+    - tzdata>=2023.3

--- a/ci/meta.yaml
+++ b/ci/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - numpy >=1.21.6  # [py<311]
     - numpy >=1.23.2  # [py>=311]
     - python-dateutil >=2.8.2
-    - python-tzdata >=2022.7
+    - python-tzdata >=2023.3
 
 test:
   imports:

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -148,7 +148,7 @@ pandas requires the following dependencies.
 ================================================================ ==========================
 Package                                                          Minimum supported version
 ================================================================ ==========================
-`NumPy <https://numpy.org>`__                                    1.23.5
+`NumPy <https://numpy.org>`__                                    1.26.0
 `python-dateutil <https://dateutil.readthedocs.io/en/stable/>`__ 2.8.2
 `tzdata <https://pypi.org/project/tzdata/>`__                    2022.7
 ================================================================ ==========================

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -150,7 +150,7 @@ Package                                                          Minimum support
 ================================================================ ==========================
 `NumPy <https://numpy.org>`__                                    1.26.0
 `python-dateutil <https://dateutil.readthedocs.io/en/stable/>`__ 2.8.2
-`tzdata <https://pypi.org/project/tzdata/>`__                    2022.7
+`tzdata <https://pypi.org/project/tzdata/>`__                    2023.3
 ================================================================ ==========================
 
 .. _install.optional_dependencies:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -311,7 +311,7 @@ If installed, we now require:
 +-----------------+-----------------+----------+---------+
 | Package         | Minimum Version | Required | Changed |
 +=================+=================+==========+=========+
-| numpy           | 1.23.5          |    X     |    X    |
+| numpy           | 1.26.0          |    X     |    X    |
 +-----------------+-----------------+----------+---------+
 
 For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -306,13 +306,15 @@ pandas 3.0.0 supports Python 3.10 and higher.
 Increased minimum versions for dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Some minimum supported versions of dependencies were updated.
-If installed, we now require:
+The following required dependencies were updated:
 
-+-----------------+-----------------+----------+---------+
-| Package         | Minimum Version | Required | Changed |
-+=================+=================+==========+=========+
-| numpy           | 1.26.0          |    X     |    X    |
-+-----------------+-----------------+----------+---------+
++-----------------+----------------------+
+| Package         | New Minimum Version  |
++=================+======================+
+| numpy           | 1.26.0               |
++-----------------+----------------------+
+| tzdata          | 2023.3               |
++-----------------+----------------------+
 
 For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.

--- a/environment.yml
+++ b/environment.yml
@@ -123,4 +123,4 @@ dependencies:
       - adbc-driver-postgresql>=0.10.0
       - adbc-driver-sqlite>=0.8.0
       - typing_extensions; python_version<"3.11"
-      - tzdata>=2022.7
+      - tzdata>=2023.3

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -54,7 +54,6 @@ VERSIONS = {
     "xlrd": "2.0.1",
     "xlsxwriter": "3.2.0",
     "zstandard": "0.22.0",
-    "tzdata": "2022.7",
     "qtpy": "2.3.0",
     "pyqt5": "5.15.9",
 }

--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -9,19 +9,15 @@ from pandas.util.version import Version
 # numpy versioning
 _np_version = np.__version__
 _nlv = Version(_np_version)
-np_version_gte1p24 = _nlv >= Version("1.24")
-np_version_gte1p24p3 = _nlv >= Version("1.24.3")
-np_version_gte1p25 = _nlv >= Version("1.25")
 np_version_gt2 = _nlv >= Version("2.0.0")
 is_numpy_dev = _nlv.dev is not None
-_min_numpy_ver = "1.23.5"
+_min_numpy_ver = "1.26.0"
 
 
 if _nlv < Version(_min_numpy_ver):
     raise ImportError(
-        f"this version of pandas is incompatible with numpy < {_min_numpy_ver}\n"
-        f"your numpy version is {_np_version}.\n"
-        f"Please upgrade numpy to >= {_min_numpy_ver} to use this pandas version"
+        f"Please upgrade numpy to >= {_min_numpy_ver} to use this pandas version.\n"
+        f"Your numpy version is {_np_version}."
     )
 
 
@@ -49,5 +45,4 @@ else:
 __all__ = [
     "_np_version",
     "is_numpy_dev",
-    "np",
 ]

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -29,12 +29,10 @@ from typing import (
     cast,
     overload,
 )
-import warnings
 
 import numpy as np
 
 from pandas._libs import lib
-from pandas.compat.numpy import np_version_gte1p24
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import (
@@ -243,12 +241,7 @@ def asarray_tuplesafe(values: Iterable, dtype: NpDtype | None = None) -> ArrayLi
         return construct_1d_object_array_from_listlike(values)
 
     try:
-        with warnings.catch_warnings():
-            # Can remove warning filter once NumPy 1.24 is min version
-            if not np_version_gte1p24:
-                # np.VisibleDeprecationWarning only in np.exceptions in 2.0
-                warnings.simplefilter("ignore", np.VisibleDeprecationWarning)  # type: ignore[attr-defined]
-            result = np.asarray(values, dtype=dtype)
+        result = np.asarray(values, dtype=dtype)
     except ValueError:
         # Using try/except since it's more performant than checking is_list_like
         # over each element

--- a/pandas/tests/apply/test_frame_apply_relabeling.py
+++ b/pandas/tests/apply/test_frame_apply_relabeling.py
@@ -1,7 +1,4 @@
 import numpy as np
-import pytest
-
-from pandas.compat.numpy import np_version_gte1p25
 
 import pandas as pd
 import pandas._testing as tm
@@ -45,7 +42,6 @@ def test_agg_relabel_multi_columns_multi_methods():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(np_version_gte1p25, reason="name of min now equals name of np.min")
 def test_agg_relabel_partial_functions():
     # GH 26513, test on partial, functools or more complex cases
     df = pd.DataFrame({"A": [1, 2, 1, 2], "B": [1, 2, 3, 4], "C": [3, 4, 5, 6]})
@@ -57,7 +53,7 @@ def test_agg_relabel_partial_functions():
 
     result = df.agg(
         foo=("A", min),
-        bar=("A", np.min),
+        bar=("B", np.min),
         cat=("B", max),
         dat=("C", "min"),
         f=("B", np.sum),
@@ -65,8 +61,8 @@ def test_agg_relabel_partial_functions():
     )
     expected = pd.DataFrame(
         {
-            "A": [1.0, 1.0, np.nan, np.nan, np.nan, np.nan],
-            "B": [np.nan, np.nan, 4.0, np.nan, 10.0, 1.0],
+            "A": [1.0, np.nan, np.nan, np.nan, np.nan, np.nan],
+            "B": [np.nan, 1.0, 4.0, np.nan, 10.0, 1.0],
             "C": [np.nan, np.nan, np.nan, 3.0, np.nan, np.nan],
         },
         index=pd.Index(["foo", "bar", "cat", "dat", "f", "kk"]),

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -26,7 +26,6 @@ from pandas._libs import (
     iNaT,
 )
 from pandas.compat import is_platform_windows
-from pandas.compat.numpy import np_version_gte1p24
 
 from pandas.core.dtypes.dtypes import PeriodDtype
 
@@ -104,7 +103,7 @@ class TestPeriodArray(base.ExtensionTests):
 
     @pytest.mark.parametrize("periods", [1, -2])
     def test_diff(self, data, periods):
-        if is_platform_windows() and np_version_gte1p24:
+        if is_platform_windows():
             with tm.assert_produces_warning(RuntimeWarning, check_stacklevel=False):
                 super().test_diff(data, periods)
         else:

--- a/pandas/tests/frame/methods/test_compare.py
+++ b/pandas/tests/frame/methods/test_compare.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import np_version_gte1p25
-
 import pandas as pd
 import pandas._testing as tm
 
@@ -270,7 +268,7 @@ def test_compare_ea_and_np_dtype(val1, val2):
         # GH#18463 TODO: is this really the desired behavior?
         expected.loc[1, ("a", "self")] = np.nan
 
-    if val1 is pd.NA and np_version_gte1p25:
+    if val1 is pd.NA:
         # can't compare with numpy array if it contains pd.NA
         with pytest.raises(TypeError, match="boolean value of NA is ambiguous"):
             result = df1.compare(df2, keep_shape=True)

--- a/pandas/tests/frame/test_unary.py
+++ b/pandas/tests/frame/test_unary.py
@@ -3,8 +3,6 @@ from decimal import Decimal
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import np_version_gte1p25
-
 import pandas as pd
 import pandas._testing as tm
 
@@ -123,13 +121,10 @@ class TestDataFrameUnaryOperators:
     def test_pos_object_raises(self):
         # GH#21380
         df = pd.DataFrame({"a": ["a", "b"]})
-        if np_version_gte1p25:
-            with pytest.raises(
-                TypeError, match=r"^bad operand type for unary \+: \'str\'$"
-            ):
-                tm.assert_frame_equal(+df, df)
-        else:
-            tm.assert_series_equal(+df["a"], df["a"])
+        with pytest.raises(
+            TypeError, match=r"^bad operand type for unary \+: \'str\'$"
+        ):
+            tm.assert_frame_equal(+df, df)
 
     def test_pos_raises(self):
         df = pd.DataFrame({"a": pd.to_datetime(["2017-01-22", "1970-01-01"])})

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -14,7 +14,6 @@ import numpy as np
 import pytest
 
 from pandas.compat import IS64
-from pandas.compat.numpy import np_version_gte1p25
 
 from pandas.core.dtypes.common import (
     is_integer_dtype,
@@ -381,13 +380,11 @@ class TestCommon:
         else:
             index.name = "idx"
 
-        warn = None
-        if index.dtype.kind == "c" and dtype in ["float64", "int64", "uint64"]:
-            # imaginary components discarded
-            if np_version_gte1p25:
-                warn = np.exceptions.ComplexWarning
-            else:
-                warn = np.ComplexWarning
+        warn = (
+            np.exceptions.ComplexWarning
+            if index.dtype.kind == "c" and dtype in ["float64", "int64", "uint64"]
+            else None
+        )
 
         is_pyarrow_str = str(index.dtype) == "string[pyarrow]" and dtype == "category"
         try:

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -19,7 +19,6 @@ import numpy as np
 import pytest
 
 from pandas.compat import WASM
-from pandas.compat.numpy import np_version_gte1p24
 from pandas.errors import (
     ParserError,
     ParserWarning,
@@ -90,10 +89,9 @@ nan 2
 3.0 3
 """
     # fallback casting, but not castable
-    warning = RuntimeWarning if np_version_gte1p24 else None
     if not WASM:  # no fp exception support in wasm
         with pytest.raises(ValueError, match="cannot safely convert"):
-            with tm.assert_produces_warning(warning, check_stacklevel=False):
+            with tm.assert_produces_warning(RuntimeWarning, check_stacklevel=False):
                 parser.read_csv(
                     StringIO(data),
                     sep=r"\s+",

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -82,6 +82,9 @@ def test_complex_mixed_fixed(tmp_path, setup_path):
     tm.assert_frame_equal(df, reread)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:`alltrue` is deprecated as of NumPy 1.25.0:DeprecationWarning"
+)
 def test_complex_mixed_table(tmp_path, setup_path):
     complex64 = np.array(
         [1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j], dtype=np.complex64

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -42,6 +42,9 @@ gettz_dateutil = lambda x: maybe_get_tz("dateutil/" + x)
 gettz_pytz = lambda x: x
 
 
+@pytest.mark.filterwarnings(
+    "ignore:`alltrue` is deprecated as of NumPy 1.25.0:DeprecationWarning"
+)
 @pytest.mark.parametrize("gettz", [gettz_dateutil, gettz_pytz])
 def test_append_with_timezones(setup_path, gettz):
     # as columns
@@ -332,6 +335,9 @@ def test_dst_transitions(setup_path):
             tm.assert_frame_equal(result, df)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:`alltrue` is deprecated as of NumPy 1.25.0:DeprecationWarning"
+)
 def test_read_with_where_tz_aware_index(tmp_path, setup_path):
     # GH 11926
     periods = 10

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from pandas.compat import is_platform_linux
-from pandas.compat.numpy import np_version_gte1p24
 
 import pandas as pd
 from pandas import (
@@ -423,7 +422,7 @@ class TestDataFramePlotsSubplots:
         assert len(ax.right_ax.lines) == 5
 
     @pytest.mark.xfail(
-        np_version_gte1p24 and is_platform_linux(),
+        is_platform_linux(),
         reason="Weird rounding problems",
         strict=False,
     )
@@ -438,7 +437,7 @@ class TestDataFramePlotsSubplots:
         tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), expected)
 
     @pytest.mark.xfail(
-        np_version_gte1p24 and is_platform_linux(),
+        is_platform_linux(),
         reason="Weird rounding problems",
         strict=False,
     )

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 from pandas.compat import is_platform_linux
-from pandas.compat.numpy import np_version_gte1p24
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -277,7 +276,7 @@ class TestSeriesPlots:
         assert label2 == ""
 
     @pytest.mark.xfail(
-        np_version_gte1p24 and is_platform_linux(),
+        is_platform_linux(),
         reason="Weird rounding problems",
         strict=False,
     )
@@ -290,7 +289,7 @@ class TestSeriesPlots:
         tm.assert_numpy_array_equal(getattr(ax, axis).get_ticklocs(), expected)
 
     @pytest.mark.xfail(
-        np_version_gte1p24 and is_platform_linux(),
+        is_platform_linux(),
         reason="Weird rounding problems",
         strict=False,
     )

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -11,8 +11,6 @@ import pytest
 
 from pandas._config import using_string_dtype
 
-from pandas.compat.numpy import np_version_gte1p25
-
 import pandas as pd
 from pandas import (
     ArrowDtype,
@@ -2134,13 +2132,6 @@ class TestPivotTable:
         data = data.drop(columns="C")
         result = pivot_table(data, index="A", columns="B", aggfunc=f)
         expected = pivot_table(data, index="A", columns="B", aggfunc=f_numpy)
-
-        if not np_version_gte1p25 and isinstance(f_numpy, list):
-            # Prior to 1.25, np.min/np.max would come through as amin and amax
-            mapper = {"amin": "min", "amax": "max", "sum": "sum", "mean": "mean"}
-            expected.columns = expected.columns.map(
-                lambda x: (mapper[x[0]], x[1], x[2])
-            )
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.slow

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import iNaT
-from pandas.compat.numpy import np_version_gte1p24p3
 
 from pandas import (
     DatetimeIndex,
@@ -537,24 +536,10 @@ def test_to_numpy_alias():
     [
         Timedelta(0),
         Timedelta(0).to_pytimedelta(),
-        pytest.param(
-            Timedelta(0).to_timedelta64(),
-            marks=pytest.mark.xfail(
-                not np_version_gte1p24p3,
-                reason="td64 doesn't return NotImplemented, see numpy#17017",
-                # When this xfail is fixed, test_nat_comparisons_numpy
-                #  can be removed.
-            ),
-        ),
+        Timedelta(0).to_timedelta64(),
         Timestamp(0),
         Timestamp(0).to_pydatetime(),
-        pytest.param(
-            Timestamp(0).to_datetime64(),
-            marks=pytest.mark.xfail(
-                not np_version_gte1p24p3,
-                reason="dt64 doesn't return NotImplemented, see numpy#17017",
-            ),
-        ),
+        Timestamp(0).to_datetime64(),
         Timestamp(0).tz_localize("UTC"),
         NaT,
     ],
@@ -568,18 +553,6 @@ def test_nat_comparisons(compare_operators_no_eq_ne, other):
     op = getattr(operator, opname.strip("_"))
     assert op(NaT, other) is False
     assert op(other, NaT) is False
-
-
-@pytest.mark.parametrize("other", [np.timedelta64(0, "ns"), np.datetime64("now", "ns")])
-def test_nat_comparisons_numpy(other):
-    # Once numpy#17017 is fixed and the xfailed cases in test_nat_comparisons
-    #  pass, this test can be removed
-    assert not NaT == other
-    assert NaT != other
-    assert not NaT < other
-    assert not NaT > other
-    assert not NaT <= other
-    assert not NaT >= other
 
 
 @pytest.mark.parametrize("other_and_type", [("foo", "str"), (2, "int"), (2.0, "float")])

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -4,11 +4,11 @@ from datetime import (
     datetime,
 )
 from decimal import Decimal
-import os
 
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import np_version_gt2
 from pandas.errors import IndexingError
 
 from pandas.core.dtypes.common import is_list_like
@@ -1440,7 +1440,7 @@ class TestCoercionFloat64(CoercionTest):
             np.float32,
             False,
             marks=pytest.mark.xfail(
-                os.environ.get("NPY_PROMOTION_STATE", "weak") != "weak",
+                not np_version_gt2,
                 reason="np.float32(1.1) ends up as 1.100000023841858, so "
                 "np_can_hold_element raises and we cast to float64",
             ),

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -9,7 +9,6 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import np_version_gte1p24
 from pandas.errors import IndexingError
 
 from pandas.core.dtypes.common import is_list_like
@@ -1441,13 +1440,7 @@ class TestCoercionFloat64(CoercionTest):
             np.float32,
             False,
             marks=pytest.mark.xfail(
-                (
-                    not np_version_gte1p24
-                    or (
-                        np_version_gte1p24
-                        and os.environ.get("NPY_PROMOTION_STATE", "weak") != "weak"
-                    )
-                ),
+                os.environ.get("NPY_PROMOTION_STATE", "weak") != "weak",
                 reason="np.float32(1.1) ends up as 1.100000023841858, so "
                 "np_can_hold_element raises and we cast to float64",
             ),

--- a/pandas/tests/series/methods/test_describe.py
+++ b/pandas/tests/series/methods/test_describe.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import np_version_gte1p25
-
 from pandas.core.dtypes.common import (
     is_complex_dtype,
     is_extension_array_dtype,
@@ -167,7 +165,7 @@ class TestSeriesDescribe:
             dtype = "complex128" if is_complex_dtype(any_numeric_dtype) else None
 
         ser = Series([0, 1], dtype=any_numeric_dtype)
-        if dtype == "complex128" and np_version_gte1p25:
+        if dtype == "complex128":
             with pytest.raises(
                 TypeError, match=r"^a must be an array of real numbers$"
             ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = '>=3.10'
 dependencies = [
   "numpy>=1.26.0",
   "python-dateutil>=2.8.2",
-  "tzdata>=2022.7"
+  "tzdata>=2023.3"
 ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ authors = [
 license = {file = 'LICENSE'}
 requires-python = '>=3.10'
 dependencies = [
-  "numpy>=1.23.5; python_version<'3.12'",
-  "numpy>=1.26.0; python_version>='3.12'",
+  "numpy>=1.26.0",
   "python-dateutil>=2.8.2",
   "tzdata>=2022.7"
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -86,4 +86,4 @@ jupyterlite-pyodide-kernel
 adbc-driver-postgresql>=0.10.0
 adbc-driver-sqlite>=0.8.0
 typing_extensions; python_version<"3.11"
-tzdata>=2022.7
+tzdata>=2023.3

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -24,7 +24,7 @@ else:
 import yaml
 
 EXCLUDE = {"python", "c-compiler", "cxx-compiler"}
-REMAP_VERSION = {"tzdata": "2022.7"}
+REMAP_VERSION = {"tzdata": "2023.3"}
 CONDA_TO_PIP = {
     "versioneer": "versioneer[toml]",
     "meson": "meson[ninja]",

--- a/scripts/tests/data/deps_minimum.toml
+++ b/scripts/tests/data/deps_minimum.toml
@@ -55,7 +55,7 @@ matplotlib = "pandas:plotting._matplotlib"
 [project.optional-dependencies]
 test = ['hypothesis>=6.34.2', 'pytest>=7.3.2', 'pytest-xdist>=3.4.0']
 performance = ['bottleneck>=1.3.2', 'numba>=0.53.1', 'numexpr>=2.7.1']
-timezone = ['tzdata>=2022.1']
+timezone = ['tzdata>=2023.3']
 computation = ['scipy>=1.7.1', 'xarray>=0.21.0']
 fss = ['fsspec>=2021.07.0']
 aws = ['s3fs>=2021.08.0']
@@ -103,7 +103,7 @@ all = ['beautifulsoup4>=5.9.3',
        'SQLAlchemy>=1.4.16',
        'tables>=3.6.1',
        'tabulate>=0.8.9',
-       'tzdata>=2022.1',
+       'tzdata>=2023.3',
        'xarray>=0.21.0',
        'xlrd>=2.0.1',
        'xlsxwriter>=1.4.3',


### PR DESCRIPTION
These dependencies should have been released ~2 years ago by the time we release pandas 3.0

closes https://github.com/pandas-dev/pandas/issues/61588