### PR TITLE
DOC: Correct error message in AbstractMethodError for methodtype argument

### DIFF
--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -379,7 +379,7 @@ class AbstractMethodError(NotImplementedError):
         types = {"method", "classmethod", "staticmethod", "property"}
         if methodtype not in types:
             raise ValueError(
-                f"methodtype must be one of {methodtype}, got {types} instead."
+               f"methodtype must be one of {types}, got {methodtype} instead."
             )
         self.methodtype = methodtype
         self.class_instance = class_instance

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -379,7 +379,7 @@ class AbstractMethodError(NotImplementedError):
         types = {"method", "classmethod", "staticmethod", "property"}
         if methodtype not in types:
             raise ValueError(
-               f"methodtype must be one of {types}, got {methodtype} instead."
+                f"methodtype must be one of {types}, got {methodtype} instead."
             )
         self.methodtype = methodtype
         self.class_instance = class_instance


### PR DESCRIPTION
Fixing an error message in the AbstractMethodError class found in pandas/errors/__init__.py.
Currently:
raise ValueError(
    f"methodtype must be one of {methodtype}, got {types} instead."
)
Here, {methodtype} and {types} are swapped.
This means if you called this error with methodtype="foo", the message would read:
methodtype must be one of foo, got {'method', 'classmethod', 'staticmethod', 'property'} instead.

That’s confusing, because the set of valid types should be listed after “must be one of”, and the invalid value you passed should be listed after “got”.


Corrected:
=======
raise ValueError(
    f"methodtype must be one of {types}, got {methodtype} instead."
)
Now, if you called this error with methodtype="foo", the message would read:
methodtype must be one of {'method', 'classmethod', 'staticmethod', 'property'}, got foo instead.

This is clearer and follows standard error message conventions.