### PR TITLE
Remove incorrect line in Series init docstring

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -263,7 +263,6 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Data type for the output Series. If not specified, this will be
         inferred from `data`.
         See the :ref:`user guide <basics.dtypes>` for more usages.
-        If ``data`` is Series then is ignored.
     name : Hashable, default None
         The name to give to the Series.
     copy : bool, default False


### PR DESCRIPTION
- [x] closes #61848
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


Copied over from the issue for convenience
```
    dtype : str, numpy.dtype, or ExtensionDtype, optional
        Data type for the output Series. If not specified, this will be
        inferred from `data`.
        See the :ref:`user guide <basics.dtypes>` for more usages.
        If ``data`` is Series then is ignored.
```
The last line here is incorrect. specifying a dtype will override the default behavior. See this example
```
>>> import pandas as pd
>>> ser = pd.Series([1,2,3])
>>> ser
0    1
1    2
2    3
dtype: int64
>>> pd.Series(ser, dtype=float)
0    1.0
1    2.0
2    3.0
dtype: float64
```