### PR TITLE
BUG: If both index and axis are passed to DataFrame.drop, raise a clear error

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4569,6 +4569,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             axis_name = self._get_axis_name(axis)
             axes = {axis_name: labels}
         elif index is not None or columns is not None:
+            if axis == 1 and index is not None:
+                raise ValueError("Cannot specify both 'axis' and 'index'")
             axes = {"index": index}
             if self.ndim == 2:
                 axes["columns"] = columns

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4569,8 +4569,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             axis_name = self._get_axis_name(axis)
             axes = {axis_name: labels}
         elif index is not None or columns is not None:
-            if axis == 1 and index is not None:
-                raise ValueError("Cannot specify both 'axis' and 'index'")
+            if axis == 1:
+                raise ValueError("Cannot specify both 'axis' and 'index'/'columns'")
             axes = {"index": index}
             if self.ndim == 2:
                 axes["columns"] = columns

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -347,6 +347,7 @@ class TestDataFrameDrop:
         tm.assert_frame_equal(result, expected)
 
     def test_drop_raise_with_both_axis_and_index(self):
+        # GH#61823
         df = DataFrame(
             [[1, 2, 3], [3, 4, 5], [5, 6, 7]],
             index=["a", "b", "c"],

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -346,12 +346,11 @@ class TestDataFrameDrop:
         )
         tm.assert_frame_equal(result, expected)
 
-    def test_drop_multiindex_with_axis_and_index(self):
+    def test_drop_with_both_axis_and_index(self):
         df = DataFrame({"a": [1, 2, 3], "b": ["foo", "foo", "bar"]})
-        df = pd.concat([df], keys=["foo"], axis=1)
-        msg = "Cannot specify both 'axis' and 'index'"
+        msg = "Cannot specify both 'axis' and 'index'/'columns'"
         with pytest.raises(ValueError, match=msg):
-            df.drop(index="b", level=1, axis=1)
+            df.drop(index="b", axis=1)
 
     def test_drop_nonunique(self):
         df = DataFrame(

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -346,8 +346,13 @@ class TestDataFrameDrop:
         )
         tm.assert_frame_equal(result, expected)
 
-    def test_drop_with_both_axis_and_index(self):
-        df = DataFrame({"a": [1, 2, 3], "b": ["foo", "foo", "bar"]})
+    def test_drop_raise_with_both_axis_and_index(self):
+        df = DataFrame(
+            [[1, 2, 3], [3, 4, 5], [5, 6, 7]],
+            index=["a", "b", "c"],
+            columns=["d", "e", "f"],
+        )
+
         msg = "Cannot specify both 'axis' and 'index'/'columns'"
         with pytest.raises(ValueError, match=msg):
             df.drop(index="b", axis=1)

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -346,6 +346,13 @@ class TestDataFrameDrop:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_drop_multiindex_with_axis_and_index(self):
+        df = DataFrame({'a': [1, 2, 3], 'b': ['foo', 'foo', 'bar']})
+        df = pd.concat([df], keys=['foo'], axis=1)
+        msg = "Cannot specify both 'axis' and 'index'"
+        with pytest.raises(ValueError, match=msg):
+            df.drop(index='b', level=1, axis=1)
+
     def test_drop_nonunique(self):
         df = DataFrame(
             [

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -347,11 +347,11 @@ class TestDataFrameDrop:
         tm.assert_frame_equal(result, expected)
 
     def test_drop_multiindex_with_axis_and_index(self):
-        df = DataFrame({'a': [1, 2, 3], 'b': ['foo', 'foo', 'bar']})
-        df = pd.concat([df], keys=['foo'], axis=1)
+        df = DataFrame({"a": [1, 2, 3], "b": ["foo", "foo", "bar"]})
+        df = pd.concat([df], keys=["foo"], axis=1)
         msg = "Cannot specify both 'axis' and 'index'"
         with pytest.raises(ValueError, match=msg):
-            df.drop(index='b', level=1, axis=1)
+            df.drop(index="b", level=1, axis=1)
 
     def test_drop_nonunique(self):
         df = DataFrame(


### PR DESCRIPTION
- [x] closes #61823