### PR TITLE
BUG: Fix inconsistency with DateOffset near DST

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -161,6 +161,7 @@ Datetimelike
 
 Timedelta
 ^^^^^^^^^
+- Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
 - Bug in :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 -
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -317,8 +317,11 @@ _relativedelta_kwds = {"years", "months", "weeks", "days", "year", "month",
 
 cdef _determine_offset(kwds):
     if not kwds:
-        # GH 45643/45890: (historically) defaults to 1 day
-        return timedelta(days=1), False
+        # GH 45643, 45890: (historically) defaults to 1 day
+        # GH 61862: changed from timedelta to relativedelta for DST consistency
+        from dateutil.relativedelta import relativedelta
+
+        return relativedelta(days=1), True
 
     if "millisecond" in kwds:
         raise NotImplementedError(

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -9,6 +9,7 @@ from datetime import (
     timedelta,
 )
 
+from dateutil.relativedelta import relativedelta
 import numpy as np
 import pytest
 
@@ -1101,9 +1102,9 @@ def test_dateoffset_misc():
 
 @pytest.mark.parametrize("n", [-1, 1, 3])
 def test_construct_int_arg_no_kwargs_assumed_days(n):
-    # GH 45890, 45643
+    # GH 45643, 45890, 61862
     offset = DateOffset(n)
-    assert offset._offset == timedelta(1)
+    assert offset._offset == relativedelta(days=1)
     result = Timestamp(2022, 1, 2) + offset
     expected = Timestamp(2022, 1, 2 + n)
     assert result == expected
@@ -1238,6 +1239,15 @@ def test_is_yqm_start_end():
 def test_multiply_dateoffset_typeerror(left, right):
     with pytest.raises(TypeError, match="Cannot multiply"):
         left * right
+
+
+def test_dateoffset_days_vs_n_near_dst_transition():
+    # GH#61862
+    ts = Timestamp("2022-10-30", tz="Europe/Brussels")
+
+    offset_days = ts + offsets.DateOffset(days=1)
+    offset_n = ts + offsets.DateOffset(1)
+    assert offset_days == offset_n
 
 
 @pytest.mark.parametrize("n", [1, 2])


### PR DESCRIPTION
- [x] closes #61862
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] ~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This fix ensures that `pd.offsets.DateOffset(1)` and `pd.offsets.DateOffset(days=1)` return the same value near a DST transition. 