### PR TITLE
TST: add test for `dtype` argument in `str.decode`

### DIFF
--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -783,7 +783,7 @@ def test_series_str_decode():
 
 def test_decode_with_dtype_none():
     with option_context("future.infer_string", True):
-        ser = Series([b"a", b"b", b"c"])  # Use byte strings
+        ser = Series([b"a", b"b", b"c"])
         result = ser.str.decode("utf-8", dtype=None)
         expected = Series(["a", "b", "c"], dtype="str")
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -11,6 +11,7 @@ from pandas import (
     Index,
     MultiIndex,
     Series,
+    set_option,
 )
 import pandas._testing as tm
 from pandas.core.strings.accessor import StringMethods
@@ -777,4 +778,13 @@ def test_series_str_decode():
     # GH 22613
     result = Series([b"x", b"y"]).str.decode(encoding="UTF-8", errors="strict")
     expected = Series(["x", "y"], dtype="str")
+    tm.assert_series_equal(result, expected)
+
+
+def test_decode_with_dtype_none():
+    # Ensure that future.infer_string is enabled
+    set_option("future.infer_string", True)
+    ser = Series([b"a", b"b", b"c"])  # Use byte strings
+    result = ser.str.decode("utf-8", dtype=None)
+    expected = Series(["a", "b", "c"], dtype="str")
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -782,7 +782,6 @@ def test_series_str_decode():
 
 
 def test_decode_with_dtype_none():
-    # Ensure that future.infer_string is enabled
     with option_context("future.infer_string", True):
         ser = Series([b"a", b"b", b"c"])  # Use byte strings
         result = ser.str.decode("utf-8", dtype=None)

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -11,7 +11,7 @@ from pandas import (
     Index,
     MultiIndex,
     Series,
-    set_option,
+    option_context,
 )
 import pandas._testing as tm
 from pandas.core.strings.accessor import StringMethods
@@ -783,8 +783,8 @@ def test_series_str_decode():
 
 def test_decode_with_dtype_none():
     # Ensure that future.infer_string is enabled
-    set_option("future.infer_string", True)
-    ser = Series([b"a", b"b", b"c"])  # Use byte strings
-    result = ser.str.decode("utf-8", dtype=None)
-    expected = Series(["a", "b", "c"], dtype="str")
-    tm.assert_series_equal(result, expected)
+    with option_context("future.infer_string", True):
+        ser = Series([b"a", b"b", b"c"])  # Use byte strings
+        result = ser.str.decode("utf-8", dtype=None)
+        expected = Series(["a", "b", "c"], dtype="str")
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
This PR adds a test case for `str.decode` and ensures it correctly infers the string datatype, when `dtype=None` and the option `future.infer_string` is used. This argument was introduced in PR https://github.com/pandas-dev/pandas/pull/60940 but has no test for None. This test adds coverage to the following line:


```py
    def decode(
        self, encoding, errors: str = "strict", dtype: str | DtypeObj | None = None
    ):
        ...
        if dtype is not None and not is_string_dtype(dtype):
            raise ValueError(f"dtype must be string or object, got {dtype=}")
        if dtype is None and get_option("future.infer_string"):
            dtype = "str" #✅ NOW COVERED
        # TODO: Add a similar _bytes interface.
        if encoding in _cpython_optimized_decoders:
            # CPython optimized implementation
            f = lambda x: x.decode(encoding, errors)
        ...
```

Note: Parts of this test have been automatically generated by a novel technique that we're currently developing as part of an academic research project aiming at improving test coverage. *To not waste developer time, two researchers manually checked the test before submitting it.* We appreciate the developers' time and any feedback is welcomed.