### PR TITLE
Set up ty in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,6 +150,14 @@ repos:
         types: [pyi]
         args: [scripts/run_stubtest.py]
         stages: [manual]
+    -   id: ty
+        # note: assumes python env is setup and activated
+        name: ty
+        entry: ty check
+        language: system
+        pass_filenames: false
+        types: [python]
+        stages: [manual]
     -   id: inconsistent-namespace-usage
         name: 'Check for inconsistent use of pandas namespace'
         entry: python scripts/check_for_inconsistent_pandas_namespace.py

--- a/environment.yml
+++ b/environment.yml
@@ -77,6 +77,7 @@ dependencies:
   # code checks
   - flake8=7.1.0  # run in subprocess over docstring examples
   - mypy=1.13.0  # pre-commit uses locally installed mypy
+  - ty=0.0.1a14 # pre-commit uses locally installed ty
   - tokenize-rt  # scripts/check_for_inconsistent_pandas_namespace.py
   - pre-commit>=4.2.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -663,6 +663,30 @@ module = [
 ]
 ignore_errors = true
 
+[tool.ty.src]
+include = ["pandas"]
+
+### TODO: Enable gradually
+[tool.ty.rules]
+unresolved-attribute = "ignore"
+invalid-return-type = "ignore"
+unsupported-operator = "ignore"
+invalid-assignment = "ignore"
+invalid-argument-type = "ignore"
+unresolved-import = "ignore"
+no-matching-overload = "ignore"
+possibly-unbound-attribute = "ignore"
+call-non-callable = "ignore"
+missing-argument = "ignore"
+non-subscriptable = "ignore"
+unknown-argument = "ignore"
+not-iterable = "ignore"
+unresolved-reference = "ignore"
+invalid-context-manager = "ignore"
+too-many-positional-arguments = "ignore"
+invalid-type-form = "ignore"
+parameter-already-assigned = "ignore"
+
 # To be kept consistent with "Import Formatting" section in contributing.rst
 [tool.isort]
 known_pre_libs = "pandas._config"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -54,6 +54,7 @@ moto
 asv>=0.6.1
 flake8==7.1.0
 mypy==1.13.0
+ty==0.0.1a14
 tokenize-rt
 pre-commit>=4.2.0
 gitpython


### PR DESCRIPTION
Hello,

This PR sets up [`ty`](https://github.com/astral-sh/ty), a type checker developed by the creator of `ruff`, in CI.

I'm aware that `ty` is still in preview but there can be a couple of benefits in adding it now. 
- It's already very fast and can help us debug faster. `mypy` is quite slow and disrupts the coding flow.
- The cost of setup is pretty cheap, as it's mostly similar to `mypy` and `pyright`. Currently I ignore all errors so that we can fix and enable them gradually, like the other linting and typing errors.
- This also allows us to evaluate if/when `ty` can be a replacement of `mypy` and `pyright`.

Let me know what you think.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
