### PR TITLE
DOC: fix doctests for pandas/core/base.py for new string dtype

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -751,7 +751,7 @@ def factorize(
     array([0, 0, 1])
     >>> uniques
     ['a', 'c']
-    Categories (3, object): ['a', 'b', 'c']
+    Categories (3, str): [a, b, c]
 
     Notice that ``'b'`` is in ``uniques.categories``, despite not being
     present in ``cat.values``.
@@ -764,7 +764,7 @@ def factorize(
     >>> codes
     array([0, 0, 1])
     >>> uniques
-    Index(['a', 'c'], dtype='object')
+    Index(['a', 'c'], dtype='str')
 
     If NaN is in the values, and we want to include NaN in the uniques of the
     values, it can be achieved by setting ``use_na_sentinel=False``.

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -323,12 +323,12 @@ class IndexOpsMixin(OpsMixin):
         0     Ant
         1    Bear
         2     Cow
-        dtype: object
+        dtype: str
         >>> s.T
         0     Ant
         1    Bear
         2     Cow
-        dtype: object
+        dtype: str
 
         For Index:
 
@@ -383,7 +383,7 @@ class IndexOpsMixin(OpsMixin):
         0     Ant
         1    Bear
         2     Cow
-        dtype: object
+        dtype: str
         >>> s.ndim
         1
 
@@ -452,9 +452,9 @@ class IndexOpsMixin(OpsMixin):
         0     Ant
         1    Bear
         2     Cow
-        dtype: object
+        dtype: str
         >>> s.nbytes
-        24
+        34
 
         For Index:
 
@@ -487,7 +487,7 @@ class IndexOpsMixin(OpsMixin):
         0     Ant
         1    Bear
         2     Cow
-        dtype: object
+        dtype: str
         >>> s.size
         3
 
@@ -567,7 +567,7 @@ class IndexOpsMixin(OpsMixin):
         >>> ser = pd.Series(pd.Categorical(["a", "b", "a"]))
         >>> ser.array
         ['a', 'b', 'a']
-        Categories (2, object): ['a', 'b']
+        Categories (2, str): [a, b]
         """
         raise AbstractMethodError(self)
 
@@ -1076,7 +1076,7 @@ class IndexOpsMixin(OpsMixin):
 
         >>> df.dtypes
         a    category
-        b      object
+        b      str
         c    category
         d    category
         dtype: object
@@ -1084,7 +1084,7 @@ class IndexOpsMixin(OpsMixin):
         >>> df.dtypes.value_counts()
         category    2
         category    1
-        object      1
+        str         1
         Name: count, dtype: int64
         """
         return algorithms.value_counts_internal(
@@ -1386,7 +1386,7 @@ class IndexOpsMixin(OpsMixin):
         ... )
         >>> ser
         ['apple', 'bread', 'bread', 'cheese', 'milk']
-        Categories (4, object): ['apple' < 'bread' < 'cheese' < 'milk']
+        Categories (4, str): [apple < bread < cheese < milk]
 
         >>> ser.searchsorted('bread')
         np.int64(1)


### PR DESCRIPTION
This is an attempt to fixe the failing doctests for `pandas/core/base.py` referenced in issue #61886  


Test run

```
================================================================================================================================ test session starts =================================================================================================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
PyQt5 5.15.11 -- Qt runtime 5.15.17 -- Qt compiled 5.15.14
rootdir: /Users/paul/code/a/pandas
configfile: pyproject.toml
plugins: anyio-4.9.0, xdist-3.8.0, localserver-0.9.0.post0, cov-6.2.1, qt-4.5.0, hypothesis-6.135.32, cython-0.3.1
collected 21 items                                                                                                                                                                                                                                                                   

pandas/core/base.py .....................

------------------------------------------------------------------------------------------------------------ generated xml file: /Users/paul/code/a/pandas/test-data.xml -------------------------------------------------------------------------------------------------------------
================================================================================================================================ slowest 30 durations ================================================================================================================================

(30 durations < 0.005s hidden.  Use -vv to show these durations.)
================================================================================================================================= 21 passed in 0.03s =================================================================================================================================
```