### PR TITLE
CI: properly enable the string dtype also for custom CI builds

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -91,7 +91,7 @@ jobs:
       LANG: ${{ matrix.lang || 'C.UTF-8' }}
       LC_ALL: ${{ matrix.lc_all || '' }}
       PANDAS_CI: '1'
-      PANDAS_FUTURE_INFER_STRING: ${{ matrix.pandas_future_infer_string || '0' }}
+      PANDAS_FUTURE_INFER_STRING: ${{ matrix.pandas_future_infer_string || '1' }}
       TEST_ARGS: ${{ matrix.test_args || '' }}
       PYTEST_WORKERS: 'auto'
       PYTEST_TARGET: ${{ matrix.pytest_target || 'pandas' }}

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -6,6 +6,7 @@ import re
 import numpy as np
 import pytest
 
+from pandas.compat import pa_version_under16p0
 from pandas.errors import IndexingError
 
 from pandas import (
@@ -140,6 +141,9 @@ class TestiLocBaseIndependent:
         df = ser.to_frame()
         assert df.iloc._is_scalar_access((1, 0))
 
+    @pytest.mark.skipif(
+        pa_version_under16p0, reason="https://github.com/apache/arrow/issues/40642"
+    )
     def test_iloc_exceeds_bounds(self):
         # GH6296
         # iloc should allow indexers that exceed the bounds

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -216,7 +216,6 @@ def test_to_parquet_gcs_new_file(monkeypatch, tmpdir):
         {
             "int": [1, 3],
             "float": [2.0, np.nan],
-            "str": ["t", "s"],
             "dt": date_range("2018-06-18", periods=2),
         }
     )


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/61722, where I forgot to set the default of the env variable to 1 if not specified in the matrix (I included it in the main matrix, but then all custom builds that were explicitly listed in the `include: ` section of the matrix would not have the variable, and therefore still default to turn off the string dtype)