### PR TITLE
Update v3.0.0.rst to use Month XX, 2025 instead of 2024

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1,6 +1,6 @@
 .. _whatsnew_300:
 
-What's new in 3.0.0 (Month XX, 2024)
+What's new in 3.0.0 (Month XX, 2025)
 ------------------------------------
 
 These are the changes in pandas 3.0.0. See :ref:`release` for a full changelog


### PR DESCRIPTION
2024 is over and pandas v3 hasn't happened yet, so update year to 2025