### PR TITLE
BUG: fix indexing with ArrowExtensionArray in .iloc

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1609,9 +1609,16 @@ class _iLocIndexer(_LocationIndexer):
             if not is_numeric_dtype(arr.dtype):
                 raise IndexError(f".iloc requires numeric indexers, got {arr}")
 
-            # check that the key does not exceed the maximum size of the index
-            if len(arr) and (arr.max() >= len_axis or arr.min() < -len_axis):
-                raise IndexError("positional indexers are out-of-bounds")
+            if len(arr):
+                # convert to numpy array for min/max with ExtensionArrays
+                if hasattr(arr, "to_numpy"):
+                    np_arr = arr.to_numpy()
+                else:
+                    np_arr = np.asarray(arr)
+
+                # check that the key does not exceed the maximum size
+                if np.max(np_arr) >= len_axis or np.min(np_arr) < -len_axis:
+                    raise IndexError("positional indexers are out-of-bounds")
         else:
             raise ValueError(f"Can only index by location with a [{self._valid_types}]")
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1610,7 +1610,6 @@ class _iLocIndexer(_LocationIndexer):
                 raise IndexError(f".iloc requires numeric indexers, got {arr}")
 
             if len(arr):
-                # handle ExtensionArray using _reduce method else use numpy
                 if isinstance(arr.dtype, ExtensionDtype):
                     arr_max = arr._reduce("max")
                     arr_min = arr._reduce("min")

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1610,14 +1610,15 @@ class _iLocIndexer(_LocationIndexer):
                 raise IndexError(f".iloc requires numeric indexers, got {arr}")
 
             if len(arr):
-                # convert to numpy array for min/max with ExtensionArrays
-                if hasattr(arr, "to_numpy"):
-                    np_arr = arr.to_numpy()
+                # handle ExtensionArray safely using _reduce method else use numpy
+                if isinstance(arr.dtype, ExtensionDtype):
+                    arr_max = arr._reduce("max")
+                    arr_min = arr._reduce("min")
                 else:
-                    np_arr = np.asarray(arr)
+                    arr_max = np.max(arr)
+                    arr_min = np.min(arr)
 
-                # check that the key does not exceed the maximum size
-                if np.max(np_arr) >= len_axis or np.min(np_arr) < -len_axis:
+                if arr_max >= len_axis or arr_min < -len_axis:
                     raise IndexError("positional indexers are out-of-bounds")
         else:
             raise ValueError(f"Can only index by location with a [{self._valid_types}]")

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1610,7 +1610,7 @@ class _iLocIndexer(_LocationIndexer):
                 raise IndexError(f".iloc requires numeric indexers, got {arr}")
 
             if len(arr):
-                # handle ExtensionArray safely using _reduce method else use numpy
+                # handle ExtensionArray using _reduce method else use numpy
                 if isinstance(arr.dtype, ExtensionDtype):
                     arr_max = arr._reduce("max")
                     arr_min = arr._reduce("min")
@@ -1618,6 +1618,7 @@ class _iLocIndexer(_LocationIndexer):
                     arr_max = np.max(arr)
                     arr_min = np.min(arr)
 
+                # check that the key does not exceed the maximum size
                 if arr_max >= len_axis or arr_min < -len_axis:
                     raise IndexError("positional indexers are out-of-bounds")
         else:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1478,3 +1478,14 @@ class TestILocSeries:
         result = DataFrame({"a": ["test"], "b": [np.nan]})
         with pytest.raises(TypeError, match="Invalid value"):
             result.loc[:, "b"] = result.loc[:, "b"].astype("Int64")
+
+    def test_iloc_arrow_extension_array(self):
+        # GH#61311
+        pytest.importorskip("pyarrow")
+
+        df = DataFrame({"a": [1, 2], "c": [0, 2], "d": ["c", "a"]})
+
+        df_arrow = df.convert_dtypes(dtype_backend="pyarrow")
+        result = df_arrow.iloc[:, df_arrow["c"]]
+        expected = df_arrow.iloc[:, [0, 2]]
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1482,10 +1482,10 @@ class TestILocSeries:
     def test_iloc_arrow_extension_array(self):
         # GH#61311
         pytest.importorskip("pyarrow")
-
         df = DataFrame({"a": [1, 2], "c": [0, 2], "d": ["c", "a"]})
-
-        df_arrow = df.convert_dtypes(dtype_backend="pyarrow")
+        df_arrow = DataFrame(
+            {"a": [1, 2], "c": [0, 2], "d": ["c", "a"]}
+        ).convert_dtypes(dtype_backend="pyarrow")
+        expected = df.iloc[:, df["c"]]
         result = df_arrow.iloc[:, df_arrow["c"]]
-        expected = df_arrow.iloc[:, [0, 2]]
-        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected, check_dtype=False)


### PR DESCRIPTION
- [X] closes #61311 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

The core problem is that when using .iloc with PyArrow-backed DataFrames, pandas' indexing validation calls min() and max() methods on the ArrowExtensionArray for bounds checking, but these methods were not implemented, resulting in AttributeError: 'ArrowExtensionArray' object has no attribute 'max'. This breaks basic indexing functionality that works with regular pandas DataFrames, creating an inconsistency in the PyArrow backend experience.

Proposed Solution - 
My proposed solution addresses the issue by modifying _validate_key in pandas/core/indexing.py to detect ExtensionArrays and convert them to numpy arrays using to_numpy() or np.asarray(). Included a test case in the file pandas/tests/indexing/test_iloc.py that reproduces the issue to verify the implementation.