### PR TITLE
unpin scipy since statsmodels was fixed

### DIFF
--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -50,8 +50,7 @@ dependencies:
   - pytz>=2023.4
   - pyxlsb>=1.0.10
   - s3fs>=2023.12.2
-  # TEMP upper pin for scipy (https://github.com/statsmodels/statsmodels/issues/9584)
-  - scipy>=1.12.0,<1.16
+  - scipy>=1.12.0
   - sqlalchemy>=2.0.0
   - tabulate>=0.9.0
   - xarray>=2024.1.1


### PR DESCRIPTION
In #61750 and #61754 @jorisvandenbossche pinned scipy due to a `statsmodels` issue.  That has apparently been fixed, so this unpins the upper bound on scipy.

