### PR TITLE
Backport PR #61933 on branch 2.3.x (unpin scipy since statsmodels was fixed)

### DIFF
--- a/ci/deps/actions-311-downstream_compat.yaml
+++ b/ci/deps/actions-311-downstream_compat.yaml
@@ -50,9 +50,8 @@ dependencies:
   - pytables>=3.8.0
   - python-calamine>=0.1.7
   - pyxlsb>=1.0.10
-  - s3fs>=2022.11.0
-  # TEMP upper pin for scipy (https://github.com/statsmodels/statsmodels/issues/9584)
-  - scipy>=1.10.0,<1.16
+  - s3fs>=2023.12.2
+  - scipy>=1.12.0
   - sqlalchemy>=2.0.0
   - tabulate>=0.9.0
   - xarray>=2022.12.0, <=2024.9.0


### PR DESCRIPTION
Backport of #61933