### PR TITLE
docs: Improve README with helpful contributor resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,12 @@ As contributors and maintainers to this project, you are expected to abide by pa
 <hr>
 
 [Go to Top](#table-of-contents)
+
+---
+
+## Helpful Resources
+
+- 📘 [Pandas Cheat Sheet (Official)](https://pandas.pydata.org/Pandas_Cheat_Sheet.pdf)
+- 🎓 [Beginner’s Guide to Pandas](https://realpython.com/pandas-python-explore-dataset/)
+- 🛠️ [Good First Issues to Contribute](https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+- 💬 [Join the Pandas Community on Slack](https://pandas.pydata.org/docs/dev/development/community.html#community-slack)


### PR DESCRIPTION
Added a small section to the end of the README that provides useful resources for new contributors, including:

- Official Pandas cheat sheet
- Beginner tutorials
- “Good first issues” link
- Slack community link

This addition aims to encourage and guide new contributors without altering any of the existing README content.

Let me know if this fits the community guidelines — happy to adjust!