### PR TITLE
DOC: Add release notes template for 2.3.2

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -24,6 +24,7 @@ Version 2.3
 .. toctree::
    :maxdepth: 2
 
+   v2.3.2
    v2.3.1
    v2.3.0
 

--- a/doc/source/whatsnew/v2.3.2.rst
+++ b/doc/source/whatsnew/v2.3.2.rst
@@ -1,0 +1,31 @@
+.. _whatsnew_232:
+
+What's new in 2.3.2 (August XX, 2025)
+-------------------------------------
+
+These are the changes in pandas 2.3.2. See :ref:`release` for a full changelog
+including other versions of pandas.
+
+{{ header }}
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_232.string_fixes:
+
+Improvements and fixes for the StringDtype
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Most changes in this release are related to :class:`StringDtype` which will
+become the default string dtype in pandas 3.0. See
+:ref:`whatsnew_230.upcoming_changes` for more details.
+
+.. _whatsnew_232.string_fixes.bugs:
+
+Bug fixes
+^^^^^^^^^
+-
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_232.contributors:
+
+Contributors
+~~~~~~~~~~~~


### PR DESCRIPTION
For the case we do another 2.3.x release, this makes it easier to already backport things (and if we end up not doing another release, we can just move the items later)

And going to merge this quickly, to unblock other PRs