### PR TITLE
ENH: Include line number and number of fields when read_csv() callable with `engine="python"` raises ParserWarning

### DIFF
--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -1201,7 +1201,7 @@ class PythonParser(ParserBase):
 
                 if actual_len > col_len:
                     if callable(self.on_bad_lines):
-                        new_l = self.on_bad_lines(_content, col_len, actual_len, i + 2)
+                        new_l = self.on_bad_lines(col_len, actual_len, i + 2, _content)
                         if new_l is not None:
                             content.append(new_l)  # pyright: ignore[reportArgumentType]
                     elif self.on_bad_lines in (

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -1201,7 +1201,7 @@ class PythonParser(ParserBase):
 
                 if actual_len > col_len:
                     if callable(self.on_bad_lines):
-                        new_l = self.on_bad_lines(_content)
+                        new_l = self.on_bad_lines(_content, col_len, actual_len, i + 2)
                         if new_l is not None:
                             content.append(new_l)  # pyright: ignore[reportArgumentType]
                     elif self.on_bad_lines in (

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -414,8 +414,11 @@ on_bad_lines : {{'error', 'warn', 'skip'}} or Callable, default 'error'
     - ``'skip'``, skip bad lines without raising or warning when they are encountered.
     - Callable, function that will process a single bad line.
         - With ``engine='python'``, function with signature
-          ``(bad_line: list[str]) -> list[str] | None``.
+          ``(bad_line: list[str], expected_columns: int, actual_columns: int, row: int) -> list[str] | None``.
           ``bad_line`` is a list of strings split by the ``sep``.
+          ``expected_columns`` is the expected number of columns.
+          ``actual_columns`` is the actual number of columns.
+          ``row`` is the row number of the bad line.
           If the function returns ``None``, the bad line will be ignored.
           If the function returns a new ``list`` of strings with more elements than
           expected, a ``ParserWarning`` will be emitted while dropping extra elements.

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -414,11 +414,11 @@ on_bad_lines : {{'error', 'warn', 'skip'}} or Callable, default 'error'
     - ``'skip'``, skip bad lines without raising or warning when they are encountered.
     - Callable, function that will process a single bad line.
         - With ``engine='python'``, function with signature
-          ``(bad_line: list[str], expected_columns: int, actual_columns: int, row: int) -> list[str] | None``.
-          ``bad_line`` is a list of strings split by the ``sep``.
+          ``(expected_columns: int, actual_columns: int, row: int, bad_line: list[str]) -> list[str] | None``.
           ``expected_columns`` is the expected number of columns.
           ``actual_columns`` is the actual number of columns.
           ``row`` is the row number of the bad line.
+          ``bad_line`` is a list of strings split by the ``sep``.
           If the function returns ``None``, the bad line will be ignored.
           If the function returns a new ``list`` of strings with more elements than
           expected, a ``ParserWarning`` will be emitted while dropping extra elements.

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -154,7 +154,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         # GH 5686
         # GH 54643
         sio = StringIO("a,b\n1,2")
-        bad_lines_func = lambda x: x
+        bad_lines_func = lambda x, y, z, a: a
         parser = all_parsers
         if all_parsers.engine not in ["python", "pyarrow"]:
             msg = (


### PR DESCRIPTION
- [X] closes #61838  
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

## Description of the change
`read_csv()` currently provides the description of an invalid row(expected_columns, actual_columns, number, text) when the row has too many elements where `engine="pyarrow"`, but the callable can only include the contents of the row when `engine="python"`.

(For more details on pyarrow.csv.InvalidRow, see [pyarrow documentation](https://arrow.apache.org/docs/python/generated/pyarrow.csv.ParseOptions.html#pyarrow.csv.ParseOptions.invalid_row_handler))

This PR proposes to additionally pass `expected_columns`, `actual_columns` and `row` when `on_bad_lines` is a callable and `engine="python"`, so that users can desribe the invalid row more in detail.

The order of the arguments has been aligned with `pyarrow`.