### PR TITLE
DOC: Update documentation for using natural sort with `sort_values`

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7173,35 +7173,61 @@ class DataFrame(NDFrame, OpsMixin):
         `natural sorting <https://en.wikipedia.org/wiki/Natural_sort_order>`__.
         This can be done using
         ``natsort`` `package <https://github.com/SethMMorton/natsort>`__,
-        which provides sorted indices according
-        to their natural order, as shown below:
+        which provides a function to generate a key
+        to sort data in their natural order:
 
         >>> df = pd.DataFrame(
         ...     {
-        ...         "time": ["0hr", "128hr", "72hr", "48hr", "96hr"],
-        ...         "value": [10, 20, 30, 40, 50],
+        ...         "hours": ["0hr", "128hr", "0hr", "64hr", "64hr", "128hr"],
+        ...         "mins": [
+        ...             "10mins",
+        ...             "40mins",
+        ...             "40mins",
+        ...             "40mins",
+        ...             "10mins",
+        ...             "10mins",
+        ...         ],
+        ...         "value": [10, 20, 30, 40, 50, 60],
         ...     }
         ... )
         >>> df
-            time  value
-        0    0hr     10
-        1  128hr     20
-        2   72hr     30
-        3   48hr     40
-        4   96hr     50
-        >>> from natsort import index_natsorted
-        >>> index_natsorted(df["time"])
-        [0, 3, 2, 4, 1]
+           hours    mins  value
+        0    0hr  10mins     10
+        1  128hr  40mins     20
+        2    0hr  40mins     30
+        3   64hr  40mins     40
+        4   64hr  10mins     50
+        5  128hr  10mins     60
+        >>> from natsort import natsort_keygen
+        >>> natsort_keygen()(df["hours"])
+        (
+            ('', 0, 'hr'),
+            ('', 128, 'hr'),
+            ('', 0, 'hr'),
+            ('', 64, 'hr'),
+            ('', 64, 'hr'),
+            ('', 128, 'hr'),
+        )
+        >>> natsort_keygen()(df["mins"])
+        (
+            ('', 10, 'mins'),
+            ('', 40, 'mins'),
+            ('', 40, 'mins'),
+            ('', 40, 'mins'),
+            ('', 10, 'mins'),
+            ('', 10, 'mins'),
+        )
         >>> df.sort_values(
-        ...     by="time",
-        ...     key=lambda x: np.argsort(index_natsorted(x)),
+        ...     by=["hours", "mins"],
+        ...     key=natsort_keygen(),
         ... )
-            time  value
-        0    0hr     10
-        3   48hr     40
-        2   72hr     30
-        4   96hr     50
-        1  128hr     20
+           hours    mins  value
+        0    0hr  10mins     10
+        2    0hr  40mins     30
+        4   64hr  10mins     50
+        3   64hr  40mins     40
+        5  128hr  10mins     60
+        1  128hr  40mins     20
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         axis = self._get_axis_number(axis)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7199,24 +7199,6 @@ class DataFrame(NDFrame, OpsMixin):
         4   64hr  10mins     50
         5  128hr  10mins     60
         >>> from natsort import natsort_keygen
-        >>> natsort_keygen()(df["hours"])
-        (
-            ('', 0, 'hr'),
-            ('', 128, 'hr'),
-            ('', 0, 'hr'),
-            ('', 64, 'hr'),
-            ('', 64, 'hr'),
-            ('', 128, 'hr'),
-        )
-        >>> natsort_keygen()(df["mins"])
-        (
-            ('', 10, 'mins'),
-            ('', 40, 'mins'),
-            ('', 40, 'mins'),
-            ('', 40, 'mins'),
-            ('', 10, 'mins'),
-            ('', 10, 'mins'),
-        )
         >>> df.sort_values(
         ...     by=["hours", "mins"],
         ...     key=natsort_keygen(),

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5004,27 +5004,56 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         >>> df = pd.DataFrame(
         ...     {
-        ...         "time": ["0hr", "128hr", "72hr", "48hr", "96hr"],
-        ...         "value": [10, 20, 30, 40, 50],
+        ...         "hours": ["0hr", "128hr", "0hr", "64hr", "64hr", "128hr"],
+        ...         "mins": [
+        ...             "10mins",
+        ...             "40mins",
+        ...             "40mins",
+        ...             "40mins",
+        ...             "10mins",
+        ...             "10mins",
+        ...         ],
+        ...         "value": [10, 20, 30, 40, 50, 60],
         ...     }
         ... )
         >>> df
-            time  value
-        0    0hr     10
-        1  128hr     20
-        2   72hr     30
-        3   48hr     40
-        4   96hr     50
-        >>> from natsort import index_natsorted
+           hours    mins  value
+        0    0hr  10mins     10
+        1  128hr  40mins     20
+        2    0hr  40mins     30
+        3   64hr  40mins     40
+        4   64hr  10mins     50
+        5  128hr  10mins     60
+        >>> from natsort import natsort_keygen
+        >>> natsort_keygen()(df["hours"])
+        (
+            ('', 0, 'hr'),
+            ('', 128, 'hr'),
+            ('', 0, 'hr'),
+            ('', 64, 'hr'),
+            ('', 64, 'hr'),
+            ('', 128, 'hr'),
+        )
+        >>> natsort_keygen()(df["mins"])
+        (
+            ('', 10, 'mins'),
+            ('', 40, 'mins'),
+            ('', 40, 'mins'),
+            ('', 40, 'mins'),
+            ('', 10, 'mins'),
+            ('', 10, 'mins'),
+        )
         >>> df.sort_values(
-        ...     by="time", key=lambda x: np.argsort(index_natsorted(df["time"]))
+        ...     by=["hours", "mins"],
+        ...     key=natsort_keygen(),
         ... )
-            time  value
-        0    0hr     10
-        3   48hr     40
-        2   72hr     30
-        4   96hr     50
-        1  128hr     20
+           hours    mins  value
+        0    0hr  10mins     10
+        2    0hr  40mins     30
+        4   64hr  10mins     50
+        3   64hr  40mins     40
+        5  128hr  10mins     60
+        1  128hr  40mins     20
         """
         raise AbstractMethodError(self)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5025,24 +5025,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         4   64hr  10mins     50
         5  128hr  10mins     60
         >>> from natsort import natsort_keygen
-        >>> natsort_keygen()(df["hours"])
-        (
-            ('', 0, 'hr'),
-            ('', 128, 'hr'),
-            ('', 0, 'hr'),
-            ('', 64, 'hr'),
-            ('', 64, 'hr'),
-            ('', 128, 'hr'),
-        )
-        >>> natsort_keygen()(df["mins"])
-        (
-            ('', 10, 'mins'),
-            ('', 40, 'mins'),
-            ('', 40, 'mins'),
-            ('', 40, 'mins'),
-            ('', 10, 'mins'),
-            ('', 10, 'mins'),
-        )
         >>> df.sort_values(
         ...     by=["hours", "mins"],
         ...     key=natsort_keygen(),


### PR DESCRIPTION
The previous documentation recommended to use the lambda function `lambda x: np.argsort(index_natsorted(x))` as a key argument to `sort_values`. However, while this works when sorting on a single column, it causes incorrect sorting when sorting multiple columns with duplicated values. For example:
```
>>> df = pd.DataFrame(
...     {
...         "hours": ["0hr", "128hr", "0hr", "64hr", "64hr", "128hr"],
...         "mins": ["10mins", "40mins", "40mins", "40mins", "10mins", "10mins"],
...         "value": [10, 20, 30, 40, 50, 60],
...     }
... )
>>> df
   hours    mins  value
0    0hr  10mins     10
1  128hr  40mins     20
2    0hr  40mins     30
3   64hr  40mins     40
4   64hr  10mins     50
5  128hr  10mins     60
>>> from natsort import index_natsorted
>>> df.sort_values(
...     by=["hours", "mins"],
...     key=lambda x: np.argsort(index_natsorted(x)),
... )
   hours    mins  value
0    0hr  10mins     10
2    0hr  40mins     30
3   64hr  40mins     40
4   64hr  10mins     50
1  128hr  40mins     20
5  128hr  10mins     60
```
Note how the `hours` column is sorted correctly, but the `mins` column isn't.

This PR updates the documentation to use `natsort_keygen`, which is robust to sorting on multiple columns.

Commit 2: Removes the calls to `natsort_keygen()` in the example code as the output generated was too long and doctest didn't seem to like having the tuple formatted.