### PR TITLE
MNT: simplify `cibuildwheel` configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,10 +144,10 @@ parentdir_prefix = "pandas-"
 setup = ['--vsenv'] # For Windows
 
 [tool.cibuildwheel]
-skip = "cp38-* cp39-* *_i686 *_ppc64le *_s390x"
+skip = ["*_i686", "*_ppc64le", "*_s390x"]
 build-verbosity = 3
 environment = {LDFLAGS="-Wl,--strip-all"}
-test-requires = "hypothesis>=6.84.0 pytest>=7.3.2 pytest-xdist>=3.4.0"
+test-extras = "test"
 test-command = """
   PANDAS_CI='1' python -c 'import pandas as pd; \
   pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db", "-n 2", "--no-strict-data-files"]); \


### PR DESCRIPTION
follow up to https://github.com/pandas-dev/pandas/pull/61981#discussion_r2237723118
This reduce the maintenance burden for `cibuildwheel` config parameters:
- cibw takes `project.requires-python` into account for target selection, so there is no need for explicitly excluding unsupported versions
- using `test-extras` instead of `test-requires` avoids a repetition and keeps `project.optional-dependencies` as the one source of truth in this area

- [N/A] closes #xxxx (Replace xxxx with the GitHub issue number)
- [N/A] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [N/A] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [N/A] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
