### PR TITLE
Fix warning for extra fields in read_csv with on_bad_lines callable 

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -137,7 +137,7 @@ class DocBuilder:
 
         cmd = ["sphinx-build", "-b", kind]
         if self.num_jobs:
-            cmd += ["-j", self.num_jobs]
+            cmd += ["-j", "1"]
         if self.warnings_are_errors:
             cmd += ["-W", "--keep-going"]
         if self.verbosity:

--- a/doc/make.py
+++ b/doc/make.py
@@ -130,7 +130,7 @@ class DocBuilder:
 
         Examples
         --------
-        >>> DocBuilder(num_jobs=4)._sphinx_build("html")
+        >>> DocBuilder(num_jobs=1)._sphinx_build("html")
         """
         if kind not in ("html", "latex", "linkcheck"):
             raise ValueError(f"kind must be html, latex or linkcheck, not {kind}")

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -817,10 +817,7 @@ I/O
 - Bug in :meth:`set_option` where setting the pandas option ``display.html.use_mathjax`` to ``False`` has no effect (:issue:`59884`)
 - Bug in :meth:`to_csv` where ``quotechar``` is not escaped when ``escapechar`` is not None (:issue:`61407`)
 - Bug in :meth:`to_excel` where :class:`MultiIndex` columns would be merged to a single row when ``merge_cells=False`` is passed (:issue:`60274`)
-- Bug in :func:`read_csv` with ``engine="python"`` and callable ``on_bad_lines`` 
-  where a ``ParserWarning`` for extra fields returned by the callable was only 
-  raised when ``index_col`` was ``None``. Now the warning is consistently raised 
-  regardless of ``index_col`` (:issue:`#61837`)
+- Bug in :func:`read_csv` with ``engine="python"`` and callable ``on_bad_lines`` where a ``ParserWarning`` for extra fields returned by the callable was only raised when ``index_col`` was ``None``. Now the warning is consistently raised regardless of ``index_col`` (:issue:`#61837`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -817,6 +817,10 @@ I/O
 - Bug in :meth:`set_option` where setting the pandas option ``display.html.use_mathjax`` to ``False`` has no effect (:issue:`59884`)
 - Bug in :meth:`to_csv` where ``quotechar``` is not escaped when ``escapechar`` is not None (:issue:`61407`)
 - Bug in :meth:`to_excel` where :class:`MultiIndex` columns would be merged to a single row when ``merge_cells=False`` is passed (:issue:`60274`)
+- Bug in :func:`read_csv` with ``engine="python"`` and callable ``on_bad_lines`` 
+  where a ``ParserWarning`` for extra fields returned by the callable was only 
+  raised when ``index_col`` was ``None``. Now the warning is consistently raised 
+  regardless of ``index_col`` (:issue:`#61837`)
 
 Period
 ^^^^^^

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -614,11 +614,7 @@ class ParserBase:
         columns: list of column names
         data: list of array-likes containing the data column-wise.
         """
-        if not self.index_col and len(columns) != len(data) and columns:
-            # error: No overload variant of "__ror__" of "ndarray" matches
-            # argument type "ExtensionArray"
-            if len(data) > len(columns) :
-                return
+        if columns and len(data)!=len(columns):
             warnings.warn(
                 f"Length of header or names ({len(columns)}) does not match number of "
                 f"fields in line ({len(data)}). Extra field will be dropped.",

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -614,7 +614,7 @@ class ParserBase:
         columns: list of column names
         data: list of array-likes containing the data column-wise.
         """
-        if columns and len(data)!=len(columns):
+        if columns and len(data) != len(columns):
             warnings.warn(
                 f"Length of header or names ({len(columns)}) does not match number of "
                 f"fields in line ({len(data)}). Extra field will be dropped.",

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -615,15 +615,13 @@ class ParserBase:
         data: list of array-likes containing the data column-wise.
         """
         if not self.index_col and len(columns) != len(data) and columns:
-            empty_str = is_object_dtype(data[-1]) and data[-1] == ""
             # error: No overload variant of "__ror__" of "ndarray" matches
             # argument type "ExtensionArray"
-            empty_str_or_na = empty_str | isna(data[-1])  # type: ignore[operator]
-            if len(columns) == len(data) - 1 and np.all(empty_str_or_na):
+            if len(data) > len(columns) :
                 return
             warnings.warn(
-                "Length of header or names does not match length of data. This leads "
-                "to a loss of data with index_col=False.",
+                f"Length of header or names ({len(columns)}) does not match number of "
+                f"fields in line ({len(data)}). Extra field will be dropped.",
                 ParserWarning,
                 stacklevel=find_stack_level(),
             )

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -334,11 +334,12 @@ def test_on_bad_lines_extra_fields_warns(python_parser_only):
         return ["1", "2", "3", "4", "5"]
 
     expected_warning = (
-            r"Length of header or names \(3\) does not match number of fields in line \(5\)\. Extra field will be dropped\."
+            r"Length of header or names \(3\) does not match number of fields in line \(5\)\. "
+            r"Extra field will be dropped\."
             )
 
     for index_col in [None, 0]:
-        with pytest.warns(ParserWarning, match=expected_warning):
+        with tm.assert_produces_warning(ParserWarning, match=expected_warning):
             parser.read_csv(
                 StringIO(data), on_bad_lines=line_fixer, index_col=index_col
             )

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -335,6 +335,7 @@ def test_on_bad_lines_extra_fields_warns(python_parser_only):
 
     expected_warning = (
             r"Length of head or names \(3)\ does not match number of fields in line \(5\)\. Extra field will be dropped\."
+            )
 
     for index_col in [None, 0]:
         with pytest.warns(ParserWarning, match=expected_warning):

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -334,9 +334,9 @@ def test_on_bad_lines_extra_fields_warns(python_parser_only):
         return ["1", "2", "3", "4", "5"]
 
     expected_warning = (
-            r"Length of header or names \(3\) does not match number of fields in "
-            r"line \(5\)\. Extra field will be dropped\."
-            )
+        r"Length of header or names \(3\) does not match number of fields in "
+        r"line \(5\)\. Extra field will be dropped\."
+    )
 
     for index_col in [None, 0]:
         with tm.assert_produces_warning(ParserWarning, match=expected_warning):

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -334,8 +334,8 @@ def test_on_bad_lines_extra_fields_warns(python_parser_only):
         return ["1", "2", "3", "4", "5"]
 
     expected_warning = (
-            r"Length of header or names \(3\) does not match number of fields in line \(5\)\. "
-            r"Extra field will be dropped\."
+            r"Length of header or names \(3\) does not match number of fields in "
+            r"line \(5\)\. Extra field will be dropped\."
             )
 
     for index_col in [None, 0]:

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -332,11 +332,12 @@ def test_on_bad_lines_extra_fields_warns(python_parser_only):
 
     def line_fixer(_line):
         return ["1", "2", "3", "4", "5"]
+
     for index_col in [None, 0]:
         with tm.assert_produces_warning(ParserWarning):
             parser.read_csv(
-                    StringIO(data), on_bad_lines=line_fixer, index_col=index_col
-                    )
+                StringIO(data), on_bad_lines=line_fixer, index_col=index_col
+            )
 
 
 def test_python_engine_file_no_next(python_parser_only):

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -322,6 +322,23 @@ footer
         parser.read_csv(StringIO(data), header=1, comment="#", skipfooter=1)
 
 
+def test_on_bad_lines_extra_fields_warns(python_parser_only):
+    parser = python_parser_only
+    data = """id,field_1,field_2
+101,A,B
+102,C,D, E
+103,F,G
+"""
+
+    def line_fixer(_line):
+        return ["1", "2", "3", "4", "5"]
+    for index_col in [None, 0]:
+        with tm.assert_produces_warning(ParserWarning):
+            parser.read_csv(
+                    StringIO(data), on_bad_lines=line_fixer, index_col=index_col
+                    )
+
+
 def test_python_engine_file_no_next(python_parser_only):
     parser = python_parser_only
 

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -334,7 +334,7 @@ def test_on_bad_lines_extra_fields_warns(python_parser_only):
         return ["1", "2", "3", "4", "5"]
 
     expected_warning = (
-            r"Length of head or names \(3)\ does not match number of fields in line \(5\)\. Extra field will be dropped\."
+            r"Length of header or names \(3\) does not match number of fields in line \(5\)\. Extra field will be dropped\."
             )
 
     for index_col in [None, 0]:

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -333,8 +333,11 @@ def test_on_bad_lines_extra_fields_warns(python_parser_only):
     def line_fixer(_line):
         return ["1", "2", "3", "4", "5"]
 
+    expected_warning = (
+            r"Length of head or names \(3)\ does not match number of fields in line \(5\)\. Extra field will be dropped\."
+
     for index_col in [None, 0]:
-        with tm.assert_produces_warning(ParserWarning):
+        with pytest.warns(ParserWarning, match=expected_warning):
             parser.read_csv(
                 StringIO(data), on_bad_lines=line_fixer, index_col=index_col
             )


### PR DESCRIPTION
- [ ] closes #61837  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
