### PR TITLE
DOC: add button to edit on GitHub

### DIFF
--- a/doc/_templates/sourcelink.html
+++ b/doc/_templates/sourcelink.html
@@ -1,0 +1,15 @@
+{%- if show_source and has_source and sourcename %}
+  <h3>{{ _('This Page') }}</h3>
+  <ul class="this-page-menu">
+    <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
+           rel="nofollow">{{ _('Show Source') }}</a></li>
+  {%- if show_on_github_url %}
+    <li><a href="{{ show_on_github_url }}"
+           rel="nofollow">{{ _('Show on GitHub') }}</a></li>
+  {%- endif %}
+  {%- if edit_on_github_url %}
+    <li><a href="{{ edit_on_github_url }}"
+           rel="nofollow">{{ _('Edit on GitHub') }}</a></li>
+  {%- endif %}
+  </ul>
+{%- endif %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,6 +44,9 @@ sys.path.extend(
     ]
 )
 
+# Edit on GitHub links
+sys.path.insert(0, os.path.abspath('_ext'))
+
 # -- General configuration -----------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -69,6 +72,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",
     "nbsphinx",
+    'edit_on_github',
 ]
 
 exclude_patterns = [
@@ -114,8 +118,6 @@ if pattern:
                 ):
                     exclude_patterns.append(rel_fname)
                 elif single_doc and rel_fname != pattern:
-                    if "\\" in rel_fname:
-                        rel_fname = rel_fname.replace("\\", "/")
                     exclude_patterns.append(rel_fname)
 
 with open(os.path.join(source_path, "index.rst.template"), encoding="utf-8") as f:
@@ -148,6 +150,10 @@ nbsphinx_requirejs_path = ""
 
 # https://sphinx-toggleprompt.readthedocs.io/en/stable/#offset
 toggleprompt_offset_right = 35
+
+# Configure the "Edit on GitHub links for Sphinx" extention
+edit_on_github_project = 'username/reponame'
+edit_on_github_branch = 'master'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["../_templates"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,9 +44,6 @@ sys.path.extend(
     ]
 )
 
-# Edit on GitHub links
-sys.path.insert(0, os.path.abspath('_ext'))
-
 # -- General configuration -----------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -152,8 +149,8 @@ nbsphinx_requirejs_path = ""
 toggleprompt_offset_right = 35
 
 # Configure the "Edit on GitHub links for Sphinx" extention
-edit_on_github_project = 'username/reponame'
-edit_on_github_branch = 'master'
+edit_on_github_project = 'pandas-dev/pandas'
+edit_on_github_branch = 'main/doc/source'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["../_templates"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -69,7 +69,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",
     "nbsphinx",
-    'edit_on_github',
+    "edit_on_github",
 ]
 
 exclude_patterns = [
@@ -149,8 +149,8 @@ nbsphinx_requirejs_path = ""
 toggleprompt_offset_right = 35
 
 # Configure the "Edit on GitHub links for Sphinx" extention
-edit_on_github_project = 'pandas-dev/pandas'
-edit_on_github_branch = 'main/doc/source'
+edit_on_github_project = "pandas-dev/pandas"
+edit_on_github_branch = "main/doc/source"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["../_templates"]

--- a/doc/sphinxext/edit_on_github.py
+++ b/doc/sphinxext/edit_on_github.py
@@ -1,0 +1,42 @@
+"""
+Sphinx extension to add ReadTheDocs-style "Edit on GitHub" links to the
+sidebar.
+
+Loosely based on https://github.com/astropy/astropy/pull/347
+"""
+
+import os
+import warnings
+
+
+__licence__ = 'BSD (3 clause)'
+
+
+def get_github_url(app, view, path):
+    return 'https://github.com/{project}/{view}/{branch}/{path}'.format(
+        project=app.config.edit_on_github_project,
+        view=view,
+        branch=app.config.edit_on_github_branch,
+        path=path)
+
+
+def html_page_context(app, pagename, templatename, context, doctree):
+    if templatename != 'page.html':
+        return
+
+    if not app.config.edit_on_github_project:
+        warnings.warn("edit_on_github_project not specified")
+        return
+
+    path = os.path.relpath(doctree.get('source'), app.builder.srcdir)
+    show_url = get_github_url(app, 'blob', path)
+    edit_url = get_github_url(app, 'edit', path)
+
+    context['show_on_github_url'] = show_url
+    context['edit_on_github_url'] = edit_url
+
+
+def setup(app):
+    app.add_config_value('edit_on_github_project', '', True)
+    app.add_config_value('edit_on_github_branch', 'master', True)
+    app.connect('html-page-context', html_page_context)

--- a/doc/sphinxext/edit_on_github.py
+++ b/doc/sphinxext/edit_on_github.py
@@ -8,35 +8,35 @@ Loosely based on https://github.com/astropy/astropy/pull/347
 import os
 import warnings
 
-
-__licence__ = 'BSD (3 clause)'
+__licence__ = "BSD (3 clause)"
 
 
 def get_github_url(app, view, path):
-    return 'https://github.com/{project}/{view}/{branch}/{path}'.format(
+    return "https://github.com/{project}/{view}/{branch}/{path}".format(
         project=app.config.edit_on_github_project,
         view=view,
         branch=app.config.edit_on_github_branch,
-        path=path)
+        path=path,
+    )
 
 
 def html_page_context(app, pagename, templatename, context, doctree):
-    if templatename != 'page.html':
+    if templatename != "page.html":
         return
 
     if not app.config.edit_on_github_project:
         warnings.warn("edit_on_github_project not specified")
         return
 
-    path = os.path.relpath(doctree.get('source'), app.builder.srcdir)
-    show_url = get_github_url(app, 'blob', path)
-    edit_url = get_github_url(app, 'edit', path)
+    path = os.path.relpath(doctree.get("source"), app.builder.srcdir)
+    show_url = get_github_url(app, "blob", path)
+    edit_url = get_github_url(app, "edit", path)
 
-    context['show_on_github_url'] = show_url
-    context['edit_on_github_url'] = edit_url
+    context["show_on_github_url"] = show_url
+    context["edit_on_github_url"] = edit_url
 
 
 def setup(app):
-    app.add_config_value('edit_on_github_project', '', True)
-    app.add_config_value('edit_on_github_branch', 'master', True)
-    app.connect('html-page-context', html_page_context)
+    app.add_config_value("edit_on_github_project", "", True)
+    app.add_config_value("edit_on_github_branch", "master", True)
+    app.connect("html-page-context", html_page_context)


### PR DESCRIPTION
- [x] closes #39859 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Changes made:
- Added an extension that allows to have a sidebar with extra "Show on GitHub" and "Edit on GitHub" links. Found [here](https://mg.pov.lt/blog/sphinx-edit-on-github.html).
- Modified conf.py to make sure the extension is added and links direct to editable pages.