### PR TITLE
BUG: Avoid copying categorical codes if `copy=False`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -687,6 +687,7 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 - Bug in :func:`Series.apply` where ``nan`` was ignored for :class:`CategoricalDtype` (:issue:`59938`)
+- Bug in :meth:`Categorical.astype` where ``copy=False`` would still trigger a copy of the codes (:issue:`62000`)
 - Bug in :meth:`DataFrame.pivot` and :meth:`DataFrame.set_index` raising an ``ArrowNotImplementedError`` for columns with pyarrow dictionary dtype (:issue:`53051`)
 - Bug in :meth:`Series.convert_dtypes` with ``dtype_backend="pyarrow"`` where empty :class:`CategoricalDtype` :class:`Series` raised an error or got converted to ``null[pyarrow]`` (:issue:`59934`)
 -

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -575,7 +575,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             # GH 10696/18593/18630
             dtype = self.dtype.update_dtype(dtype)
             self = self.copy() if copy else self
-            result = self._set_dtype(dtype)
+            result = self._set_dtype(dtype, copy=False)
 
         elif isinstance(dtype, ExtensionDtype):
             return super().astype(dtype, copy=copy)
@@ -945,7 +945,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         super().__init__(self._ndarray, new_dtype)
 
-    def _set_dtype(self, dtype: CategoricalDtype) -> Self:
+    def _set_dtype(self, dtype: CategoricalDtype, copy: bool = True) -> Self:
         """
         Internal method for directly updating the CategoricalDtype
 
@@ -958,7 +958,9 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         We don't do any validation here. It's assumed that the dtype is
         a (valid) instance of `CategoricalDtype`.
         """
-        codes = recode_for_categories(self.codes, self.categories, dtype.categories)
+        codes = recode_for_categories(
+            self.codes, self.categories, dtype.categories, copy
+        )
         return type(self)._simple_new(codes, dtype=dtype)
 
     def set_ordered(self, value: bool) -> Self:

--- a/pandas/tests/arrays/categorical/test_astype.py
+++ b/pandas/tests/arrays/categorical/test_astype.py
@@ -134,9 +134,9 @@ class TestAstype:
         # GH#62000
         cat = Categorical([3, 2, 4, 1])
         new = cat.astype("category", copy=False)
-        assert new.codes.base is cat.codes.base or new.codes is cat.codes
+        assert tm.shares_memory(new.codes, cat.codes)
         new = cat.astype("category", copy=True)
-        assert not (new.codes.base is cat.codes.base or new.codes is cat.codes)
+        assert not tm.shares_memory(new.codes, cat.codes)
 
     def test_astype_object_datetime_categories(self):
         # GH#40754

--- a/pandas/tests/arrays/categorical/test_astype.py
+++ b/pandas/tests/arrays/categorical/test_astype.py
@@ -131,8 +131,8 @@ class TestAstype:
             tm.assert_categorical_equal(result, expected)
 
     def test_astype_category_copy_false_nocopy_codes(self):
+        # GH#62000
         cat = Categorical([3, 2, 4, 1])
-        # ensure that the categories are not copied
         assert cat.codes.base is not None
 
         new = cat.astype("category", copy=False)

--- a/pandas/tests/arrays/categorical/test_astype.py
+++ b/pandas/tests/arrays/categorical/test_astype.py
@@ -130,6 +130,16 @@ class TestAstype:
             expected = cat
             tm.assert_categorical_equal(result, expected)
 
+    def test_astype_category_copy_false_nocopy_codes(self):
+        cat = Categorical([3, 2, 4, 1])
+        # ensure that the categories are not copied
+        assert cat.codes.base is not None
+
+        new = cat.astype("category", copy=False)
+        assert new.codes.base is cat.codes.base or new.codes is cat.codes
+        new = cat.astype("category", copy=True)
+        assert not (new.codes.base is cat.codes.base or new.codes is cat.codes)
+
     def test_astype_object_datetime_categories(self):
         # GH#40754
         cat = Categorical(to_datetime(["2021-03-27", NaT]))

--- a/pandas/tests/arrays/categorical/test_astype.py
+++ b/pandas/tests/arrays/categorical/test_astype.py
@@ -133,8 +133,6 @@ class TestAstype:
     def test_astype_category_copy_false_nocopy_codes(self):
         # GH#62000
         cat = Categorical([3, 2, 4, 1])
-        assert cat.codes.base is not None
-
         new = cat.astype("category", copy=False)
         assert new.codes.base is cat.codes.base or new.codes is cat.codes
         new = cat.astype("category", copy=True)


### PR DESCRIPTION
Categorical codes are always copied by `recode_for_categories` regardless of the copy argument. This fixes it by passing the copy argument down to `recode_for_categories`

- ~[ ] closes #xxxx (Replace xxxx with the GitHub issue number)~
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
