### PR TITLE
BUG FIX: pandas.arrays.IntervalArray.overlaps() incorrectly documents that it accepts IntervalArray.

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1375,7 +1375,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
         Parameters
         ----------
-        other : %(klass)s
+        other : Interval
             Interval to check against for an overlap.
 
         Returns


### PR DESCRIPTION
in `pandas.arrays.IntervalArray.overlaps`, it does not support _IntervalArray_ yet. so parameter _other_ should be _Interval_ in the docs.
Reference: https://pandas.pydata.org/docs/reference/api/pandas.arrays.IntervalArray.overlaps.html

- [x] closes #62004
 