### PR TITLE
REF: make copy keyword in recode_for_categories keyword only

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -803,7 +803,7 @@ cdef class BaseMultiIndexCodesEngine:
         int_keys : 1-dimensional array of dtype uint64 or object
             Integers representing one combination each
         """
-        level_codes = list(target._recode_for_new_levels(self.levels))
+        level_codes = list(target._recode_for_new_levels(self.levels, copy=True))
         for i, codes in enumerate(level_codes):
             if self.levels[i].hasnans:
                 na_index = self.levels[i].isna().nonzero()[0][0]

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -318,7 +318,8 @@ def union_categoricals(
             categories = categories.sort_values()
 
         new_codes = [
-            recode_for_categories(c.codes, c.categories, categories) for c in to_union
+            recode_for_categories(c.codes, c.categories, categories, copy=False)
+            for c in to_union
         ]
         new_codes = np.concatenate(new_codes)
     else:

--- a/pandas/core/groupby/categorical.py
+++ b/pandas/core/groupby/categorical.py
@@ -53,7 +53,7 @@ def recode_for_groupby(c: Categorical, sort: bool, observed: bool) -> Categorica
 
         # we recode according to the uniques
         categories = c.categories.take(take_codes)
-        codes = recode_for_categories(c.codes, c.categories, categories)
+        codes = recode_for_categories(c.codes, c.categories, categories, copy=False)
 
         # return a new categorical that maps our new codes
         # and categories

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2675,7 +2675,7 @@ class MultiIndex(Index):
         )
 
     def _recode_for_new_levels(
-        self, new_levels, copy: bool = True
+        self, new_levels, *, copy: bool
     ) -> Generator[np.ndarray]:
         if len(new_levels) > self.nlevels:
             raise AssertionError(

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -480,7 +480,7 @@ class TestPrivateCategoricalAPI:
         expected = np.asanyarray(expected, dtype=np.int8)
         old = Index(old)
         new = Index(new)
-        result = recode_for_categories(codes, old, new)
+        result = recode_for_categories(codes, old, new, copy=True)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_recode_to_categories_large(self):
@@ -489,5 +489,5 @@ class TestPrivateCategoricalAPI:
         old = Index(codes)
         expected = np.arange(N - 1, -1, -1, dtype=np.int16)
         new = Index(expected)
-        result = recode_for_categories(codes, old, new)
+        result = recode_for_categories(codes, old, new, copy=True)
         tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/arrays/categorical/test_dtypes.py
+++ b/pandas/tests/arrays/categorical/test_dtypes.py
@@ -49,12 +49,12 @@ class TestCategoricalDtypes:
 
     def test_set_dtype_same(self):
         c = Categorical(["a", "b", "c"])
-        result = c._set_dtype(CategoricalDtype(["a", "b", "c"]))
+        result = c._set_dtype(CategoricalDtype(["a", "b", "c"]), copy=True)
         tm.assert_categorical_equal(result, c)
 
     def test_set_dtype_new_categories(self):
         c = Categorical(["a", "b", "c"])
-        result = c._set_dtype(CategoricalDtype(list("abcd")))
+        result = c._set_dtype(CategoricalDtype(list("abcd")), copy=True)
         tm.assert_numpy_array_equal(result.codes, c.codes)
         tm.assert_index_equal(result.dtype.categories, Index(list("abcd")))
 
@@ -86,12 +86,12 @@ class TestCategoricalDtypes:
     def test_set_dtype_many(self, values, categories, new_categories, ordered):
         c = Categorical(values, categories)
         expected = Categorical(values, new_categories, ordered)
-        result = c._set_dtype(expected.dtype)
+        result = c._set_dtype(expected.dtype, copy=True)
         tm.assert_categorical_equal(result, expected)
 
     def test_set_dtype_no_overlap(self):
         c = Categorical(["a", "b", "c"], ["d", "e"])
-        result = c._set_dtype(CategoricalDtype(["a", "b"]))
+        result = c._set_dtype(CategoricalDtype(["a", "b"]), copy=True)
         expected = Categorical([None, None, None], categories=["a", "b"])
         tm.assert_categorical_equal(result, expected)
 

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -52,7 +52,7 @@ class TestCategoricalMissing:
 
     def test_set_dtype_nans(self):
         c = Categorical(["a", "b", np.nan])
-        result = c._set_dtype(CategoricalDtype(["a", "c"]))
+        result = c._set_dtype(CategoricalDtype(["a", "c"]), copy=True)
         tm.assert_numpy_array_equal(result.codes, np.array([0, -1, -1], dtype="int8"))
 
     def test_set_item_nan(self):


### PR DESCRIPTION
Follows up to https://github.com/pandas-dev/pandas/pull/62000

`recode_for_categories` had a default `copy=True` to copy the passed codes if the codes didn't need re-coding. This PR makes this argument keyword only to make it explicit if the caller wants to copy - to avoid unnecessary copying when blindly using `recode_for_categories`