### PR TITLE
BUG: Fix is_signed_integer_dtype to handle abstract floating types (GH 62018)

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -840,6 +840,10 @@ def is_signed_integer_dtype(arr_or_dtype) -> bool:
     >>> is_signed_integer_dtype(np.array([1, 2], dtype=np.uint32))  # unsigned
     False
     """
+    if isinstance(arr_or_dtype, type) and issubclass(
+        arr_or_dtype, (np.floating, np.inexact, np.generic)
+    ):
+        return False
     return _is_dtype_type(
         arr_or_dtype, _classes_and_not_datetimelike(np.signedinteger)
     ) or _is_dtype(

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -17,7 +17,6 @@ from pandas.core.dtypes.common import (
     is_dtype_equal,
     is_interval_dtype,
     is_period_dtype,
-    is_signed_integer_dtype,
     is_string_dtype,
 )
 from pandas.core.dtypes.dtypes import (
@@ -250,10 +249,14 @@ class TestDatetimeTZDtype(Base):
 
     def test_alias_to_unit_bad_alias_raises(self):
         # 23990
-        with pytest.raises(TypeError, match=""):
+        with pytest.raises(
+            TypeError, match="Cannot construct a 'DatetimeTZDtype' from"
+        ):
             DatetimeTZDtype("this is a bad string")
 
-        with pytest.raises(TypeError, match=""):
+        with pytest.raises(
+            TypeError, match="Cannot construct a 'DatetimeTZDtype' from"
+        ):
             DatetimeTZDtype("datetime64[ns, US/NotATZ]")
 
     def test_hash_vs_equality(self, dtype):
@@ -1145,13 +1148,6 @@ def test_registry_find(dtype, expected):
 def test_is_bool_dtype(dtype, expected):
     result = is_bool_dtype(dtype)
     assert result is expected
-
-
-def test_is_signed_integer_dtype_with_abstract_types():
-    # GH 62018
-    assert is_signed_integer_dtype(np.floating) is False
-    assert is_signed_integer_dtype(np.inexact) is False
-    assert is_signed_integer_dtype(np.generic) is False
 
 
 def test_is_bool_dtype_sparse():

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -17,6 +17,7 @@ from pandas.core.dtypes.common import (
     is_dtype_equal,
     is_interval_dtype,
     is_period_dtype,
+    is_signed_integer_dtype,
     is_string_dtype,
 )
 from pandas.core.dtypes.dtypes import (
@@ -1148,6 +1149,13 @@ def test_registry_find(dtype, expected):
 def test_is_bool_dtype(dtype, expected):
     result = is_bool_dtype(dtype)
     assert result is expected
+
+
+def test_is_signed_integer_dtype_with_abstract_types():
+    # GH 62018
+    assert is_signed_integer_dtype(np.floating) is False
+    assert is_signed_integer_dtype(np.inexact) is False
+    assert is_signed_integer_dtype(np.generic) is False
 
 
 def test_is_bool_dtype_sparse():

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -17,6 +17,7 @@ from pandas.core.dtypes.common import (
     is_dtype_equal,
     is_interval_dtype,
     is_period_dtype,
+    is_signed_integer_dtype,
     is_string_dtype,
 )
 from pandas.core.dtypes.dtypes import (
@@ -249,14 +250,10 @@ class TestDatetimeTZDtype(Base):
 
     def test_alias_to_unit_bad_alias_raises(self):
         # 23990
-        with pytest.raises(
-            TypeError, match="Cannot construct a 'DatetimeTZDtype' from"
-        ):
+        with pytest.raises(TypeError, match=""):
             DatetimeTZDtype("this is a bad string")
 
-        with pytest.raises(
-            TypeError, match="Cannot construct a 'DatetimeTZDtype' from"
-        ):
+        with pytest.raises(TypeError, match=""):
             DatetimeTZDtype("datetime64[ns, US/NotATZ]")
 
     def test_hash_vs_equality(self, dtype):
@@ -1148,6 +1145,13 @@ def test_registry_find(dtype, expected):
 def test_is_bool_dtype(dtype, expected):
     result = is_bool_dtype(dtype)
     assert result is expected
+
+
+def test_is_signed_integer_dtype_with_abstract_types():
+    # GH 62018
+    assert is_signed_integer_dtype(np.floating) is False
+    assert is_signed_integer_dtype(np.inexact) is False
+    assert is_signed_integer_dtype(np.generic) is False
 
 
 def test_is_bool_dtype_sparse():


### PR DESCRIPTION
(#GH 62018)
This PR fixes a bug in (is_signed_integer_dtype) where abstarct Numpy floating types would raise a TypeError .
Now, the function returns False for these types, as expected.

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !




