### PR TITLE
BUG: Fix DataFrame reduction to preserve NaN vs <NA> in mixed dtypes (GH#62024)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11850,6 +11850,14 @@ class DataFrame(NDFrame, OpsMixin):
         if axis is not None:
             axis = self._get_axis_number(axis)
 
+        if axis == 0:
+            data = self._get_numeric_data() if numeric_only else self
+            results = {}
+            for col in data.columns:
+                ser = data[col]
+                results[col] = getattr(ser, name)(skipna=skipna, **kwds)
+            return self._constructor_sliced(results)
+
         def func(values: np.ndarray):
             # We only use this in the case that operates on self.values
             return op(values, axis=axis, skipna=skipna, **kwds)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -221,6 +221,20 @@ def float_frame_with_na():
     return df
 
 
+def test_mixed_reduction_nan_vs_NA():
+    df = DataFrame(
+        {
+            "B": [1, None, 3],
+            "C": pd.array([1, None, 3], dtype="Int64"),
+        }
+    )
+    result = df.skew()
+    assert np.isnan(result["B"])
+    assert isna(result["C"]) and type(result["C"]).__name__ == "NAType"
+    result_B = df[["B"]].skew()
+    assert np.isnan(result_B["B"])
+
+
 class TestDataFrameAnalytics:
     # ---------------------------------------------------------------------
     # Reductions


### PR DESCRIPTION
(GH#62024)

This PR fixes a bug in  (DataFrame._reduce) where reductions on (DataFrames) with mixed dtypes (e.g., float64 and nullable integer Int64) would incorrectly upcast all results to use pd.NA and the Float64 dtype if any column was a pandas extension type.

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou!

