### PR TITLE
TST: Speed up hypothesis and slow tests

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -176,23 +176,17 @@ def pytest_collection_modifyitems(items, config) -> None:
                 ignore_doctest_warning(item, path, message)
 
 
-hypothesis_health_checks = [
-    hypothesis.HealthCheck.too_slow,
-    hypothesis.HealthCheck.differing_executors,
-]
-
-# Hypothesis
+# Similar to "ci" config in
+# https://hypothesis.readthedocs.io/en/latest/reference/api.html#built-in-profiles
 hypothesis.settings.register_profile(
     "ci",
-    # Hypothesis timing checks are tuned for scalars by default, so we bump
-    # them from 200ms to 500ms per test case as the global default.  If this
-    # is too short for a specific test, (a) try to make it faster, and (b)
-    # if it really is slow add `@settings(deadline=...)` with a working value,
-    # or `deadline=None` to entirely disable timeouts for that test.
-    # 2022-02-09: Changed deadline from 500 -> None. Deadline leads to
-    # non-actionable, flaky CI failures (# GH 24641, 44969, 45118, 44969)
+    database=None,
     deadline=None,
-    suppress_health_check=tuple(hypothesis_health_checks),
+    max_examples=25,
+    suppress_health_check=(
+        hypothesis.HealthCheck.too_slow,
+        hypothesis.HealthCheck.differing_executors,
+    ),
 )
 hypothesis.settings.load_profile("ci")
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -179,7 +179,7 @@ def pytest_collection_modifyitems(items, config) -> None:
 # Similar to "ci" config in
 # https://hypothesis.readthedocs.io/en/latest/reference/api.html#built-in-profiles
 hypothesis.settings.register_profile(
-    "ci",
+    "pandas_ci",
     database=None,
     deadline=None,
     max_examples=15,
@@ -188,7 +188,7 @@ hypothesis.settings.register_profile(
         hypothesis.HealthCheck.differing_executors,
     ),
 )
-hypothesis.settings.load_profile("ci")
+hypothesis.settings.load_profile("pandas_ci")
 
 # Registering these strategies makes them globally available via st.from_type,
 # which is use for offsets in tests/tseries/offsets/test_offsets_properties.py

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -182,7 +182,7 @@ hypothesis.settings.register_profile(
     "ci",
     database=None,
     deadline=None,
-    max_examples=25,
+    max_examples=15,
     suppress_health_check=(
         hypothesis.HealthCheck.too_slow,
         hypothesis.HealthCheck.differing_executors,

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -2227,7 +2227,7 @@ class TestStackUnstackMultiLevel:
         tm.assert_frame_equal(recons, df)
 
     @pytest.mark.slow
-    def test_unstack_number_of_levels_larger_than_int32(
+    def test_unstack_number_of_levels_larger_than_int32_warns(
         self, performance_warning, monkeypatch
     ):
         # GH#20601
@@ -2238,6 +2238,9 @@ class TestStackUnstackMultiLevel:
                 # __init__ will raise the warning
                 super().__init__(*args, **kwargs)
                 raise Exception("Don't compute final result.")
+
+            def _make_selectors(self) -> None:
+                pass
 
         with monkeypatch.context() as m:
             m.setattr(reshape_lib, "_Unstacker", MockUnstacker)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2144,7 +2144,7 @@ class TestPivotTable:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.slow
-    def test_pivot_number_of_levels_larger_than_int32(
+    def test_pivot_number_of_levels_larger_than_int32_warns(
         self, performance_warning, monkeypatch
     ):
         # GH 20601
@@ -2154,6 +2154,9 @@ class TestPivotTable:
                 # __init__ will raise the warning
                 super().__init__(*args, **kwargs)
                 raise Exception("Don't compute final result.")
+
+            def _make_selectors(self) -> None:
+                pass
 
         with monkeypatch.context() as m:
             m.setattr(reshape_lib, "_Unstacker", MockUnstacker)


### PR DESCRIPTION
* Hypothesis tests seems to be the slowest running tests in CI. Limiting the `max_examples` IMO is OK as we're looking to exercise some edge cases
* Avoiding some work being done in `test_*number_of_levels_larger_than_int32` as we're just looking to check a warning