### PR TITLE
DOC: fix mask/where docstring alignment note (#61781)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9946,9 +9946,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The {name} method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``{cond}`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with axis of
-        ``cond`` {klass}, the values of ``cond`` on misaligned index positions
-        will be filled with {cond_rev}.
+        ``other`` is used. If the axis of ``self`` does not align with axis of
+        ``cond``, misaligned index positions will be filled with the original value
+        from ``self``.
 
         The signature for :func:`Series.where` or
         :func:`DataFrame.where` differs from :func:`numpy.where`.


### PR DESCRIPTION
The explanatory paragraph wrongly said that alignment is between `other` and `cond`.  It is between *self* and `cond`; values fall back to *self* for mis-aligned positions.  Update both generic docstring templates so all Series/DataFrame variants inherit the correct wording.

Closes #61781

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
