### PR TITLE
BUG: Catch TypeError in _is_dtype_type when converting abstract numpy types (#62018)

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1654,7 +1654,10 @@ def _is_dtype_type(arr_or_dtype, condition) -> bool:
     elif isinstance(arr_or_dtype, type):
         if issubclass(arr_or_dtype, ExtensionDtype):
             arr_or_dtype = arr_or_dtype.type
-        return condition(np.dtype(arr_or_dtype).type)
+         try:
+            return condition(np.dtype(arr_or_dtype).type)
+        except TypeError:
+            return condition(type(None))
 
     # if we have an array-like
     if hasattr(arr_or_dtype, "dtype"):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -33,6 +33,7 @@ from pandas._libs.tslibs import (
     Timestamp,
     to_offset,
 )
+
 from pandas._typing import (
     AlignJoin,
     AnyArrayLike,
@@ -67,7 +68,8 @@ from pandas._typing import (
     Renamer,
     Scalar,
     Self,
-    SequenceNotStr,
+
+SequenceNotStr,
     SortKind,
     StorageOptions,
     Suffixes,
@@ -9946,7 +9948,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The {name} method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``{cond}`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with axis of
+       ``other`` is used. If the axis of ``other`` does not align with axis of
         ``cond`` {klass}, the values of ``cond`` on misaligned index positions
         will be filled with {cond_rev}.
 
@@ -9982,6 +9984,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> t = pd.Series([True, False])
         >>> s.where(t, 99)
         0     0
+ 
         1    99
         2    99
         3    99
@@ -10017,7 +10020,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         1  2  3
         2  4  5
         3  6  7
-        4  8  9
+        4
+        8  9
         >>> m = df % 3 == 0
         >>> df.where(m, -df)
            A  B


### PR DESCRIPTION
- Closes #62018
- Wrap np.dtype() call in try/except to handle abstract numpy types (e.g. np.floating, np.inexact).
- On TypeError, return condition(type(None)) to indicate mismatch rather than raising.

This prevents `is_signed_integer_dtype` and similar functions from raising on abstract NumPy classes and restores expected behaviour.