### PR TITLE
EHN: return early when the result is None

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -90,9 +90,9 @@ def consensus_name_attr(objs):
     for obj in objs[1:]:
         try:
             if obj.name != name:
-                name = None
+                return None
         except ValueError:
-            name = None
+            return None
     return name
 
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -90,9 +90,11 @@ def consensus_name_attr(objs):
     for obj in objs[1:]:
         try:
             if obj.name != name:
-                return None
+                name = None
+                break
         except ValueError:
-            return None
+            name = None
+            break
     return name
 
 


### PR DESCRIPTION
There's no need to continue the loop when the result is destined to be None.