### PR TITLE
BUG: raise a proper exception when str.rsplit is passed a regex and clarify the docs

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -306,6 +306,7 @@ Strings
 ^^^^^^^
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
+- Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
 
 Interval
 ^^^^^^^^

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3485,6 +3485,9 @@ class ArrowExtensionArray(
         return self._from_pyarrow_array(split_func(self._pa_array, max_splits=n))
 
     def _str_rsplit(self, pat: str | None = None, n: int | None = -1) -> Self:
+        if pat is not None and not isinstance(pat, str):
+            msg = f"expected a string object, not {type(pat).__name__}"
+            raise TypeError(msg)
         if n in {-1, 0}:
             n = None
         if pat is None:

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -748,12 +748,12 @@ class StringMethods(NoNewAttributesMixin):
 
         See Also
         --------
-        Series.str.split : Split strings around given separator/delimiter.
         Series.str.rsplit : Splits string around given separator/delimiter,
             starting from the right.
         Series.str.join : Join lists contained as elements in the Series/Index
             with passed delimiter.
-        str.split : Standard library version for split.
+        re.split : Standard library version for split with ``regex=True``.
+        str.split : Standard library version for split with ``regex=False``.
         str.rsplit : Standard library version for rsplit.
 
         Notes
@@ -909,7 +909,7 @@ class StringMethods(NoNewAttributesMixin):
         Parameters
         ----------
         pat : str, optional
-            String to split on.
+            String to split on. Does not support regex.
             If not specified, split on whitespace.
         n : int, default -1 (all)
             Limit number of splits in output.
@@ -927,12 +927,12 @@ class StringMethods(NoNewAttributesMixin):
 
         See Also
         --------
-        Series.str.split : Split strings around given separator/delimiter.
-        Series.str.rsplit : Splits string around given separator/delimiter,
-            starting from the right.
+        Series.str.split : Split strings around given separator/delimiter or
+            regular expression.
         Series.str.join : Join lists contained as elements in the Series/Index
             with passed delimiter.
-        str.split : Standard library version for split.
+        re.split : Standard library version for split with ``regex=True``.
+        str.split : Standard library version for split with ``regex=False``.
         str.rsplit : Standard library version for rsplit.
 
         Notes

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -385,6 +385,9 @@ class ObjectStringArrayMixin:
         return self._str_map(f, dtype=object)
 
     def _str_rsplit(self, pat=None, n=-1):
+        if pat is not None and not isinstance(pat, str):
+            msg = f"expected a string object, not {type(pat).__name__}"
+            raise TypeError(msg)
         if n is None or n == 0:
             n = -1
         f = lambda x: x.rsplit(pat, n)

--- a/pandas/tests/strings/test_split_partition.py
+++ b/pandas/tests/strings/test_split_partition.py
@@ -122,12 +122,18 @@ def test_split_n(any_string_dtype, method, n):
 
 
 def test_rsplit(any_string_dtype):
-    # regex split is not supported by rsplit
     values = Series(["a,b_c", "c_d,e", np.nan, "f,g,h"], dtype=any_string_dtype)
     result = values.str.rsplit("[,_]")
     exp = Series([["a,b_c"], ["c_d,e"], np.nan, ["f,g,h"]])
     exp = _convert_na_value(values, exp)
     tm.assert_series_equal(result, exp)
+
+
+def test_rsplit_with_regex(any_string_dtype):
+    # regex split is not supported by rsplit
+    values = Series(["a,b_c", "c_d,e", np.nan, "f,g,h"], dtype=any_string_dtype)
+    with pytest.raises(TypeError, match="expected a string object, not Pattern"):
+        values.str.rsplit(re.compile("[,_]"))
 
 
 def test_rsplit_max_number(any_string_dtype):


### PR DESCRIPTION
- [x] closes #29633
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Noticed this while working on https://github.com/pandas-dev/pandas-stubs/pull/1278. `rsplit` doesn't accept regular expressions but was silently accepting them and producing bad results. I added a check on the type of the input and updated the documentation.