### PR TITLE
API: rank with nullable dtypes preserve NA

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -95,6 +95,7 @@ Other enhancements
 - Support passing a :class:`Iterable[Hashable]` input to :meth:`DataFrame.drop_duplicates` (:issue:`59237`)
 - Support reading Stata 102-format (Stata 1) dta files (:issue:`58978`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
+- :meth:`Series.rank` and :meth:`DataFrame.rank` with numpy-nullable dtypes preserve ``NA`` values and return ``UInt64`` dtype where appropriate instead of casting ``NA`` to ``NaN`` with ``float64`` dtype (:issue:`??`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -81,6 +81,7 @@ Other enhancements
 - :meth:`Rolling.agg`, :meth:`Expanding.agg` and :meth:`ExponentialMovingWindow.agg` now accept :class:`NamedAgg` aggregations through ``**kwargs`` (:issue:`28333`)
 - :meth:`Series.map` can now accept kwargs to pass on to func (:issue:`59814`)
 - :meth:`Series.map` now accepts an ``engine`` parameter to allow execution with a third-party execution engine (:issue:`61125`)
+- :meth:`Series.rank` and :meth:`DataFrame.rank` with numpy-nullable dtypes preserve ``NA`` values and return ``UInt64`` dtype where appropriate instead of casting ``NA`` to ``NaN`` with ``float64`` dtype (:issue:`62043`)
 - :meth:`Series.str.get_dummies` now accepts a  ``dtype`` parameter to specify the dtype of the resulting DataFrame (:issue:`47872`)
 - :meth:`pandas.concat` will raise a ``ValueError`` when ``ignore_index=True`` and ``keys`` is not ``None`` (:issue:`59274`)
 - :py:class:`frozenset` elements in pandas objects are now natively printed (:issue:`60690`)
@@ -95,7 +96,6 @@ Other enhancements
 - Support passing a :class:`Iterable[Hashable]` input to :meth:`DataFrame.drop_duplicates` (:issue:`59237`)
 - Support reading Stata 102-format (Stata 1) dta files (:issue:`58978`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
-- :meth:`Series.rank` and :meth:`DataFrame.rank` with numpy-nullable dtypes preserve ``NA`` values and return ``UInt64`` dtype where appropriate instead of casting ``NA`` to ``NaN`` with ``float64`` dtype (:issue:`??`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1002,7 +1002,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         ascending: bool = True,
         pct: bool = False,
     ):
-        # Avoid going through copy-making ensure_data in algorithms.rank
+        # GH#62043 Avoid going through copy-making ensure_data in algorithms.rank
         if axis != 0 or self.ndim != 1:
             raise NotImplementedError
 

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -308,6 +308,7 @@ class TestSeriesRank:
             else:
                 exp_dtype = "uint64[pyarrow]"
         elif dtype == "Float64":
+            # GH#62043
             if rank_method == "average":
                 exp_dtype = "Float64"
             else:

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -68,6 +68,11 @@ def expected_dtype(dtype, method, pct=False):
             exp_dtype = "double[pyarrow]"
         else:
             exp_dtype = "uint64[pyarrow]"
+    elif dtype in ["Float64", "Int64"]:
+        if method == "average" or pct:
+            exp_dtype = "Float64"
+        else:
+            exp_dtype = "UInt64"
 
     return exp_dtype
 
@@ -257,7 +262,7 @@ class TestSeriesRank:
         exp = Series([None, 2, None, 3, 3, 2, 3, 1], dtype="Int64")
         result = exp.rank(na_option="keep")
 
-        expected = Series([np.nan, 2.5, np.nan, 5.0, 5.0, 2.5, 5.0, 1.0])
+        expected = Series([None, 2.5, None, 5.0, 5.0, 2.5, 5.0, 1.0], dtype="Float64")
 
         tm.assert_series_equal(result, expected)
 
@@ -302,6 +307,11 @@ class TestSeriesRank:
                 exp_dtype = "float64[pyarrow]"
             else:
                 exp_dtype = "uint64[pyarrow]"
+        elif dtype == "Float64":
+            if rank_method == "average":
+                exp_dtype = "Float64"
+            else:
+                exp_dtype = "UInt64"
         else:
             exp_dtype = "float64"
 
@@ -327,7 +337,8 @@ class TestSeriesRank:
         result = iseries.rank(
             method=rank_method, na_option=na_option, ascending=ascending
         )
-        tm.assert_series_equal(result, Series(expected, dtype=exp_dtype))
+        exp_ser = Series(expected, dtype=exp_dtype)
+        tm.assert_series_equal(result, exp_ser)
 
     def test_rank_desc_mix_nans_infs(self):
         # GH 19538
@@ -439,7 +450,7 @@ class TestSeriesRank:
             dtype="Float64",
         )
         result = ser.rank(method="min")
-        expected = Series([4, 1, 3, np.nan, 2])
+        expected = Series([4, 1, 3, NA, 2], dtype="UInt64")
         tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
