### PR TITLE
API: make construct_array_type non-classmethod

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -418,7 +418,7 @@ Other API changes
   an empty ``RangeIndex`` or empty ``Index`` with object dtype when determining
   the dtype of the resulting Index (:issue:`60797`)
 - :class:`IncompatibleFrequency` now subclasses ``TypeError`` instead of ``ValueError``. As a result, joins with mismatched frequencies now cast to object like other non-comparable joins, and arithmetic with indexes with mismatched frequencies align (:issue:`55782`)
-- :meth:`ExtensionDtype.construct_array_type` is not a regular method instead of a ``classmethod`` (:issue:`58663`)
+- :meth:`ExtensionDtype.construct_array_type` is now a regular method instead of a ``classmethod`` (:issue:`58663`)
 - Comparison operations between :class:`Index` and :class:`Series` now consistently return :class:`Series` regardless of which object is on the left or right (:issue:`36759`)
 - Numpy functions like ``np.isinf`` that return a bool dtype when called on a :class:`Index` object now return a bool-dtype :class:`Index` instead of ``np.ndarray`` (:issue:`52676`)
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -418,6 +418,7 @@ Other API changes
   an empty ``RangeIndex`` or empty ``Index`` with object dtype when determining
   the dtype of the resulting Index (:issue:`60797`)
 - :class:`IncompatibleFrequency` now subclasses ``TypeError`` instead of ``ValueError``. As a result, joins with mismatched frequencies now cast to object like other non-comparable joins, and arithmetic with indexes with mismatched frequencies align (:issue:`55782`)
+- :meth:`ExtensionDtype.construct_array_type` is not a regular method instead of a ``classmethod`` (:issue:`58663`)
 - Comparison operations between :class:`Index` and :class:`Series` now consistently return :class:`Series` regardless of which object is on the left or right (:issue:`36759`)
 - Numpy functions like ``np.isinf`` that return a bool dtype when called on a :class:`Index` object now return a bool-dtype :class:`Index` instead of ``np.ndarray`` (:issue:`52676`)
 

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -85,8 +85,7 @@ class BooleanDtype(BaseMaskedDtype):
     def numpy_dtype(self) -> np.dtype:
         return np.dtype("bool")
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[BooleanArray]:
+    def construct_array_type(self) -> type_t[BooleanArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -28,8 +28,7 @@ class FloatingDtype(NumericDtype):
     _default_np_dtype = np.dtype(np.float64)
     _checker = is_float_dtype
 
-    @classmethod
-    def construct_array_type(cls) -> type[FloatingArray]:
+    def construct_array_type(self) -> type[FloatingArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -28,8 +28,7 @@ class IntegerDtype(NumericDtype):
     _default_np_dtype = np.dtype(np.int64)
     _checker = is_integer_dtype
 
-    @classmethod
-    def construct_array_type(cls) -> type[IntegerArray]:
+    def construct_array_type(self) -> type[IntegerArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -150,7 +150,7 @@ def _coerce_to_data_and_mask(
     if dtype is not None:
         dtype = dtype_cls._standardize_dtype(dtype)
 
-    cls = dtype_cls.construct_array_type()
+    cls = dtype_cls().construct_array_type()
     if isinstance(values, cls):
         values, mask = values._data, values._mask
         if dtype is not None:

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -283,12 +283,7 @@ class StringDtype(StorageExtensionDtype):
         else:
             raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
 
-    # https://github.com/pandas-dev/pandas/issues/36126
-    # error: Signature of "construct_array_type" incompatible with supertype
-    # "ExtensionDtype"
-    def construct_array_type(  # type: ignore[override]
-        self,
-    ) -> type_t[BaseStringArray]:
+    def construct_array_type(self) -> type_t[BaseStringArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -211,8 +211,7 @@ class ExtensionDtype:
         """
         return None
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[ExtensionArray]:
+    def construct_array_type(self) -> type_t[ExtensionArray]:
         """
         Return the array type associated with this dtype.
 
@@ -220,7 +219,7 @@ class ExtensionDtype:
         -------
         type
         """
-        raise AbstractMethodError(cls)
+        raise AbstractMethodError(self)
 
     def empty(self, shape: Shape) -> ExtensionArray:
         """

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -527,8 +527,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         combined_hashed = combine_hash_arrays(iter(cat_array), num_items=len(cat_array))
         return np.bitwise_xor.reduce(combined_hashed)
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[Categorical]:
+    def construct_array_type(self) -> type_t[Categorical]:
         """
         Return the array type associated with this dtype.
 
@@ -856,8 +855,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
         """
         return self._tz
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[DatetimeArray]:
+    def construct_array_type(self) -> type_t[DatetimeArray]:
         """
         Return the array type associated with this dtype.
 
@@ -1174,8 +1172,7 @@ class PeriodDtype(PeriodDtypeBase, PandasExtensionDtype):
                 return False
         return super().is_dtype(dtype)
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[PeriodArray]:
+    def construct_array_type(self) -> type_t[PeriodArray]:
         """
         Return the array type associated with this dtype.
 
@@ -1363,8 +1360,7 @@ class IntervalDtype(PandasExtensionDtype):
         """
         return self._subtype
 
-    @classmethod
-    def construct_array_type(cls) -> type[IntervalArray]:
+    def construct_array_type(self) -> type[IntervalArray]:
         """
         Return the array type associated with this dtype.
 
@@ -1576,8 +1572,7 @@ class NumpyEADtype(ExtensionDtype):
             raise TypeError(msg) from err
         return cls(dtype)
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[NumpyExtensionArray]:
+    def construct_array_type(self) -> type_t[NumpyExtensionArray]:
         """
         Return the array type associated with this dtype.
 
@@ -1649,8 +1644,7 @@ class BaseMaskedDtype(ExtensionDtype):
         """Return the number of bytes in this dtype"""
         return self.numpy_dtype.itemsize
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[BaseMaskedArray]:
+    def construct_array_type(self) -> type_t[BaseMaskedArray]:
         """
         Return the array type associated with this dtype.
 
@@ -1914,8 +1908,7 @@ class SparseDtype(ExtensionDtype):
     def __repr__(self) -> str:
         return self.name
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[SparseArray]:
+    def construct_array_type(self) -> type_t[SparseArray]:
         """
         Return the array type associated with this dtype.
 
@@ -2316,8 +2309,7 @@ class ArrowDtype(StorageExtensionDtype):
         """Return the number of bytes in this dtype"""
         return self.numpy_dtype.itemsize
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[ArrowExtensionArray]:
+    def construct_array_type(self) -> type_t[ArrowExtensionArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -487,8 +487,7 @@ def test_bounds_check():
 class DecimalDtype2(DecimalDtype):
     name = "decimal2"
 
-    @classmethod
-    def construct_array_type(cls):
+    def construct_array_type(self):
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -576,8 +576,7 @@ def test_is_numeric_dtype():
         def name(self):
             raise NotImplementedError
 
-        @classmethod
-        def construct_array_type(cls):
+        def construct_array_type(self):
             raise NotImplementedError
 
         def _is_numeric(self) -> bool:

--- a/pandas/tests/extension/array_with_attr/array.py
+++ b/pandas/tests/extension/array_with_attr/array.py
@@ -24,8 +24,7 @@ class FloatAttrDtype(ExtensionDtype):
     name = "float_attr"
     na_value = np.nan
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[FloatAttrArray]:
+    def construct_array_type(self) -> type_t[FloatAttrArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/extension/date/array.py
+++ b/pandas/tests/extension/date/array.py
@@ -48,8 +48,7 @@ class DateDtype(ExtensionDtype):
         else:
             raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
 
-    @classmethod
-    def construct_array_type(cls):
+    def construct_array_type(self):
         return DateArray
 
     @property

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -50,8 +50,7 @@ class DecimalDtype(ExtensionDtype):
     def __repr__(self) -> str:
         return f"DecimalDtype(context={self.context})"
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[DecimalArray]:
+    def construct_array_type(self) -> type_t[DecimalArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -286,8 +286,7 @@ def test_combine_from_sequence_raises(monkeypatch):
     # https://github.com/pandas-dev/pandas/issues/22850
     cls = DecimalArrayWithoutFromSequence
 
-    @classmethod
-    def construct_array_type(cls):
+    def construct_array_type(self):
         return DecimalArrayWithoutFromSequence
 
     monkeypatch.setattr(DecimalDtype, "construct_array_type", construct_array_type)

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -54,8 +54,7 @@ class JSONDtype(ExtensionDtype):
     name = "json"
     na_value: Mapping[str, Any] = UserDict()
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[JSONArray]:
+    def construct_array_type(self) -> type_t[JSONArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/extension/list/array.py
+++ b/pandas/tests/extension/list/array.py
@@ -30,8 +30,7 @@ class ListDtype(ExtensionDtype):
     name = "list"
     na_value = np.nan
 
-    @classmethod
-    def construct_array_type(cls) -> type_t[ListArray]:
+    def construct_array_type(self) -> type_t[ListArray]:
         """
         Return the array type associated with this dtype.
 

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -857,8 +857,7 @@ class IntegerArrayNoCopy(pd.core.arrays.IntegerArray):
 class Int16DtypeNoCopy(pd.Int16Dtype):
     # GH 42501
 
-    @classmethod
-    def construct_array_type(cls):
+    def construct_array_type(self):
         return IntegerArrayNoCopy
 
 


### PR DESCRIPTION
- [x] closes #58663 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Makes the method robust to the possibility of keywords (e.g. na_value, storage) that determine what EA subclass you get.  StringDtype already does this.