### PR TITLE
Update pytables.py to include a more thorough description of the min_itemsize variable

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1170,8 +1170,12 @@ class HDFStore:
         complevel : int, 0-9, default None
             Specifies a compression level for data.
             A value of 0 or None disables compression.
-        min_itemsize : int, dict, or None
-            Dict of columns that specify minimum str sizes.
+        min_itemsize : int, dict, or None, default None
+            Refers to the minimum size for string columns in bytes.
+            When the format = 'table'.
+            Since this specifies the byte length after encoding,
+            multi-byte characters need to be calculated using 
+            their encoded byte length rather than character count. 
         nan_rep : str
             Str to use as str nan representation.
         data_columns : list of columns or True, default None
@@ -1203,6 +1207,9 @@ class HDFStore:
         >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
         >>> store = pd.HDFStore("store.h5", "w")  # doctest: +SKIP
         >>> store.put("data", df)  # doctest: +SKIP
+
+        >>> The word 'hello' = 5 bytes
+        >>> Japanese character "勉" = 2 bytes
         """
         if format is None:
             format = get_option("io.hdf.default_format") or "fixed"
@@ -1330,8 +1337,12 @@ class HDFStore:
             A value of 0 or None disables compression.
         columns : default None
             This parameter is currently not accepted, try data_columns.
-        min_itemsize : int, dict, or None
-            Dict of columns that specify minimum str sizes.
+        min_itemsize : int, dict, or None, default None
+            Refers to the minimum size for string columns in bytes.
+            When the format = 'table'.
+            Since this specifies the byte length after encoding,
+            multi-byte characters need to be calculated using 
+            their encoded byte length rather than character count.
         nan_rep : str
             Str to use as str nan representation.
         chunksize : int or None
@@ -1377,6 +1388,9 @@ class HDFStore:
         1  3  4
         0  5  6
         1  7  8
+
+        >>> The word 'hello' = 5 bytes
+        >>> Japanese character "勉" = 2 bytes
         """
         if columns is not None:
             raise TypeError(


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I am a student contributing for the first time, none of the additions were generated with AI and this PR description is not generated by AI. 

I am addressing Issue 14601 where the current documentation for 'min_itemsize' is not thorough enough. It seems to me based on my research that the issue is that people treat it as though it counts characters instead of byte size for strings being input into a table. 

I kept the additions simple to avoid any confusion and am open to suggestions on how I can improve this contribution. If there are any specific issues please point me to the location in your contribution guide so I can better understand any errors I might have made. 
