### PR TITLE
MNT: migrate from codecs.open to open

### DIFF
--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -1,4 +1,3 @@
-import codecs
 from datetime import datetime
 from textwrap import dedent
 
@@ -42,7 +41,7 @@ class TestToLatex:
         df = DataFrame([["au\xdfgangen"]])
         with tm.ensure_clean("test.tex") as path:
             df.to_latex(path, encoding="utf-8")
-            with codecs.open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 assert df.to_latex() == f.read()
 
     def test_to_latex_to_file_utf8_without_encoding(self):
@@ -50,7 +49,7 @@ class TestToLatex:
         df = DataFrame([["au\xdfgangen"]])
         with tm.ensure_clean("test.tex") as path:
             df.to_latex(path)
-            with codecs.open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 assert df.to_latex() == f.read()
 
     def test_to_latex_tabular_with_index(self):

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -523,9 +523,9 @@ def test_codecs_encoding(encoding, format):
         index=pd.Index([f"i-{i}" for i in range(30)]),
     )
     with tm.ensure_clean() as path:
-        with codecs.open(path, mode="w", encoding=encoding) as handle:
+        with open(path, mode="w", encoding=encoding) as handle:
             getattr(expected, f"to_{format}")(handle)
-        with codecs.open(path, mode="r", encoding=encoding) as handle:
+        with open(path, encoding=encoding) as handle:
             if format == "csv":
                 df = pd.read_csv(handle, index_col=0)
             else:

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -513,9 +513,8 @@ def test_is_fsspec_url_chained():
     assert not icom.is_fsspec_url("filecache::://pandas/test.csv")
 
 
-@pytest.mark.parametrize("encoding", [None, "utf-8"])
 @pytest.mark.parametrize("format", ["csv", "json"])
-def test_codecs_encoding(encoding, format):
+def test_codecs_encoding(format):
     # GH39247
     expected = pd.DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
@@ -523,9 +522,9 @@ def test_codecs_encoding(encoding, format):
         index=pd.Index([f"i-{i}" for i in range(30)]),
     )
     with tm.ensure_clean() as path:
-        with open(path, mode="w", encoding=encoding) as handle:
+        with open(path, mode="w", encoding="utf-8") as handle:
             getattr(expected, f"to_{format}")(handle)
-        with open(path, encoding=encoding) as handle:
+        with open(path, encoding="utf-8") as handle:
             if format == "csv":
                 df = pd.read_csv(handle, index_col=0)
             else:

--- a/pandas/util/_print_versions.py
+++ b/pandas/util/_print_versions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import codecs
 import json
 import locale
 import os
@@ -143,7 +142,7 @@ def show_versions(as_json: str | bool = False) -> None:
             sys.stdout.writelines(json.dumps(j, indent=2))
         else:
             assert isinstance(as_json, str)  # needed for mypy
-            with codecs.open(as_json, "wb", encoding="utf8") as f:
+            with open(as_json, "w", encoding="utf-8") as f:
                 json.dump(j, f, indent=2)
 
     else:


### PR DESCRIPTION
c.f. #61950, towards supporting Python 3.14

See [the 3.14 deprecations](https://docs.python.org/3.14/whatsnew/3.14.html#deprecated) and https://github.com/python/cpython/issues/133036 for more details.

There is one spot that was nontrivial - the use in `pandas.util._print_versions` I think was buggy - it wanted to write a file in bytes mode and also specified an encoding. `codecs.open` didn't blink at this but regular `open` is more restrictive. I think what I updated it to is correct and this is a latent bug, probably introduced a long time ago in the 2->3 transition.

- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
