### PR TITLE
BUG: Bug fix for implicit upcast to float64 for large series (more than 1000000 rows)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -752,6 +752,7 @@ Conversion
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)
 - Bug in :meth:`Series.convert_dtypes` and :meth:`DataFrame.convert_dtypes` removing timezone information for objects with :class:`ArrowDtype` (:issue:`60237`)
 - Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
+- Bug in :meth:`_array_ops._maybe_prepare_scalar_for_op` not maintaining ``float32`` type when converting NumPy floating scalars (:issue:`61951`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/ops/array_ops.py
+++ b/pandas/core/ops/array_ops.py
@@ -573,7 +573,7 @@ def maybe_prepare_scalar_for_op(obj, shape: Shape):
         return int(obj)
 
     elif isinstance(obj, np.floating):
-        return float(obj)
+        return np.dtype(obj.dtype).type(obj)
 
     return obj
 

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -318,3 +318,9 @@ class TestSeriesConvertDtypes:
         result = ser.convert_dtypes(dtype_backend="pyarrow")
         expected = ser.copy()
         tm.assert_series_equal(result, expected)
+    
+    def test_float32_series_addition_preserves_dtype(self):
+        # GH#61951
+        ser_a = pd.Series(np.zeros(1000000), dtype="float32") + np.float32(1)
+        ser_b = pd.Series(np.zeros(1000001), dtype="float32") + np.float32(1)
+        assert all(dtype == np.float32 for dtype in (ser_a.dtype, ser_b.dtype))

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -318,7 +318,7 @@ class TestSeriesConvertDtypes:
         result = ser.convert_dtypes(dtype_backend="pyarrow")
         expected = ser.copy()
         tm.assert_series_equal(result, expected)
-    
+
     def test_float32_series_addition_preserves_dtype(self):
         # GH#61951
         ser_a = pd.Series(np.zeros(1000000), dtype="float32") + np.float32(1)


### PR DESCRIPTION
## PR Requirements
- [x] closes #61951
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

## Issue Description
Performing binary operations on larger `Series` with `dtype == 'float32'` leads to unexpected upcasts to float64.
Above example prints `float32 float64`.
Using `to_numpy()` on the series before addition inhibits the implicit upcast.

## Expected Behavior
I expect above snippet to print `float32 float32`.

## Bug Fix
Changed scalar conversion logic for NumPy floating scalars to avoid automatic conversion to Python `float`. Now returns a scalar of the original NumPy dtype to preserve type and prevent unintended dtype upcasts.