### PR TITLE
BUG: Series.round with pd.NA no longer raises; coerce object+NA to nullable float and round; add test (#61712)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -82,6 +82,7 @@ Other enhancements
 - :meth:`Series.map` can now accept kwargs to pass on to func (:issue:`59814`)
 - :meth:`Series.map` now accepts an ``engine`` parameter to allow execution with a third-party execution engine (:issue:`61125`)
 - :meth:`Series.rank` and :meth:`DataFrame.rank` with numpy-nullable dtypes preserve ``NA`` values and return ``UInt64`` dtype where appropriate instead of casting ``NA`` to ``NaN`` with ``float64`` dtype (:issue:`62043`)
+- :meth:`Series.round` raising ``TypeError`` for ``object`` dtype with ``pd.NA``. The result now coerces to nullable ``Float64`` and rounds as expected (:issue:`61712`).
 - :meth:`Series.str.get_dummies` now accepts a  ``dtype`` parameter to specify the dtype of the resulting DataFrame (:issue:`47872`)
 - :meth:`pandas.concat` will raise a ``ValueError`` when ``ignore_index=True`` and ``keys`` is not ``None`` (:issue:`59274`)
 - :py:class:`frozenset` elements in pandas objects are now natively printed (:issue:`60690`)
@@ -97,7 +98,7 @@ Other enhancements
 - Support passing a :class:`Iterable[Hashable]` input to :meth:`DataFrame.drop_duplicates` (:issue:`59237`)
 - Support reading Stata 102-format (Stata 1) dta files (:issue:`58978`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
--
+
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2516,7 +2516,12 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         """
         nv.validate_round(args, kwargs)
         if self.dtype == "object":
-            raise TypeError("Expected numeric dtype, got object instead.")
+            # Try to safely cast to numeric type (like float) if values are pd.NA or numbers
+            try:
+                converted = self.astype("Float64")
+                return converted.round(decimals)
+            except Exception:
+                raise TypeError("Expected numeric dtype, got object instead.")
         new_mgr = self._mgr.round(decimals=decimals)
         return self._constructor_from_mgr(new_mgr, axes=new_mgr.axes).__finalize__(
             self, method="round"

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2516,12 +2516,13 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         """
         nv.validate_round(args, kwargs)
         if self.dtype == "object":
-            # Try to safely cast to numeric type (like float) if values are pd.NA or numbers
+            # Try to safely cast to a numeric nullable dtype when
+            # values are numbers or pd.NA.
             try:
                 converted = self.astype("Float64")
                 return converted.round(decimals)
-            except Exception:
-                raise TypeError("Expected numeric dtype, got object instead.")
+            except Exception as err:
+                raise TypeError("Expected numeric dtype, got object instead.") from err
         new_mgr = self._mgr.round(decimals=decimals)
         return self._constructor_from_mgr(new_mgr, axes=new_mgr.axes).__finalize__(
             self, method="round"

--- a/pandas/tests/series/methods/test_round.py
+++ b/pandas/tests/series/methods/test_round.py
@@ -79,3 +79,11 @@ class TestSeriesRound:
         msg = "Expected numeric dtype, got object instead."
         with pytest.raises(TypeError, match=msg):
             ser.round()
+
+    def test_round_with_pd_na(self):
+        import pandas as pd
+        import numpy as np
+        s = pd.Series([0.5, pd.NA], dtype="object")
+        result = s.round(0)
+        expected = pd.Series([0.0, pd.NA], dtype="Float64")
+        pd.testing.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_round.py
+++ b/pandas/tests/series/methods/test_round.py
@@ -81,9 +81,8 @@ class TestSeriesRound:
             ser.round()
 
     def test_round_with_pd_na(self):
-        import pandas as pd
-        import numpy as np
-        s = pd.Series([0.5, pd.NA], dtype="object")
+        # GH61712
+        s = Series([0.5, pd.NA], dtype="object")
         result = s.round(0)
-        expected = pd.Series([0.0, pd.NA], dtype="Float64")
-        pd.testing.assert_series_equal(result, expected)
+        expected = Series([0.0, pd.NA], dtype="Float64")
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION

Summary: 
Fixes Series.round raising TypeError for object-dtype Series containing pd.NA by coercing to nullable Float64 before rounding, preserving pd.NA values.

Description:
This PR fixes an issue where calling Series.round on an object-dtype Series containing pd.NA would raise a TypeError.
The method now attempts to safely cast to the nullable Float64 dtype before rounding, preserving pd.NA values.

Includes:

Bug fix in Series.round to coerce object with pd.NA to Float64 and round as expected.

New test in test_round.py covering the case of object-dtype Series with pd.NA.

Added changelog entry in doc/source/whatsnew/v3.0.0.rst.

 closes #61712

 [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)

 All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)

 Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) (N/A – no new functions/args)

 Added an entry in the latest doc/source/whatsnew/v3.0.0.rst file