### PR TITLE
BUG: Preserve full float precision when double_precision=15 in to_jso…

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -120,7 +120,8 @@ def _stringify_floats_full_precision(obj: Any) -> Any:
     if isinstance(obj, Series):
         return obj.map(_format_float_full_precision)
     if isinstance(obj, DataFrame):
-        return obj.applymap(_format_float_full_precision)
+        # Apply element-wise via Series.map to avoid deprecated/removed applymap
+        return obj.apply(lambda s: s.map(_format_float_full_precision))
     if isinstance(obj, dict):
         return {k: _stringify_floats_full_precision(v) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -129,6 +130,7 @@ def _stringify_floats_full_precision(obj: Any) -> Any:
         return [_stringify_floats_full_precision(v) for v in obj.tolist()]
     # Scalars
     return _format_float_full_precision(obj)
+
 
 # interface to/from
 @overload

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -292,14 +292,8 @@ class Writer(ABC):
 
     def write(self) -> str:
         iso_dates = self.date_format == "iso"
-        payload = self.obj_to_write
-        # When maximum precision is requested, avoid truncation by stringifying
-        # finite float values at full IEEE-754 precision. Skip for orient='table'
-        # to preserve Table Schema type conformance.
-        if self.double_precision == 15 and not isinstance(self, JSONTableWriter):
-            payload = _stringify_floats_full_precision(payload)
         return ujson_dumps(
-            payload,
+            self.obj_to_write,
             orient=self.orient,
             double_precision=self.double_precision,
             ensure_ascii=self.ensure_ascii,


### PR DESCRIPTION
…n; avoid truncation before serialization (#62072)

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
