### PR TITLE
DEPS: update python version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.8
+FROM python:3.11.13
 WORKDIR /home/pandas
 
 RUN apt-get update && \


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.



commit -> https://github.com/pandas-dev/pandas/commit/7863029c3084c79b226c0a1c3daeac82929534f1
pull request -> https://github.com/pandas-dev/pandas/pull/62066

Due to the recent change of the python version 3.10 -> 3.11, the gitpod and docker deployments are failing with the following error:

```bash
meson-python: error: Unsupported Python version 3.10.8, expected >=3.11
  error: subprocess-exited-with-error
  
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /usr/local/bin/python /usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_editable /tmp/tmpxivcdhnp
  cwd: /workspace/pandas
  Preparing editable metadata (pyproject.toml) ... error
  ```
  
Updating the 3.10.8 in the Dockerfile to 3.11.13 solves the problem.