### PR TITLE
DOC: Add to_julian_date to DatetimeIndex methods listing

### DIFF
--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -390,6 +390,7 @@ Conversion
    DatetimeIndex.to_pydatetime
    DatetimeIndex.to_series
    DatetimeIndex.to_frame
+   DatetimeIndex.to_julian_date
 
 Methods
 ~~~~~~~

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2256,7 +2256,7 @@ default 'raise'
         """
         Convert TimeStamp to a Julian Date.
 
-        This method returns the number of days as a float since
+        This method returns the number of days as a float since noon January 1, 4713 BC.
 
         https://en.wikipedia.org/wiki/Julian_day
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2267,7 +2267,7 @@ default 'raise'
 
         See Also
         --------
-        Timestamp.to_julian_date : this same method on ``Timestamp`` objects.
+        Timestamp.to_julian_date : Equivalent method on ``Timestamp`` objects.
 
         Examples
         --------

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2254,9 +2254,26 @@ default 'raise'
 
     def to_julian_date(self) -> npt.NDArray[np.float64]:
         """
-        Convert Datetime Array to float64 ndarray of Julian Dates.
-        0 Julian date is noon January 1, 4713 BC.
+        Convert TimeStamp to a Julian Date.
+
+        This method returns the number of days as a float since
+
         https://en.wikipedia.org/wiki/Julian_day
+
+        Returns
+        -------
+        ndarray or Index
+            Float values that represent each date in Julian Calendar.
+
+        See Also
+        --------
+        Timestamp.to_julian_date : this same method on ``Timestamp`` objects.
+
+        Examples
+        --------
+        >>> idx = pd.DatetimeIndex(["2028-08-12 00:54", "2028-08-12 02:06"])
+        >>> idx.to_julian_date()
+        Index([2461995.5375, 2461995.5875], dtype='float64')
         """
 
         # http://mysite.verizon.net/aesir_research/date/jdalg2.htm

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -222,6 +222,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     to_pydatetime
     to_series
     to_frame
+    to_julian_date
     month_name
     day_name
     mean


### PR DESCRIPTION
First time contributor here.

- ~[ ] closes #xxxx (Replace xxxx with the GitHub issue number)~ No issue related
- ~[ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~
- ~[ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).~
- ~[ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~ Nothing new
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Add `to_julian_date` documentation entry to `pandas.DatetimeIndex`.

Currently, it is not listed nor can be found in the documentation: https://pandas.pydata.org/docs/reference/api/pandas.DatetimeIndex.html
`pandas.Timestamp` already has it linked https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.to_julian_date.html
from the time it was added v0.14.0 https://pandas.pydata.org/docs/whatsnew/v0.14.0.html

I haven't read through the contributing section, please point out if there is something missing. If it looks okay, tell me to proceed with the whatsnew task.

Docs artifact for second commit (it works): https://github.com/pandas-dev/pandas/actions/runs/16895776565/job/47865152612?pr=62090