### PR TITLE
BUG: Fix assert_frame_equal with check_dtype=False for pd.NA with different dtypes

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -994,6 +994,7 @@ Other
 - Bug in printing a :class:`Series` with a :class:`DataFrame` stored in :attr:`Series.attrs` raised a ``ValueError`` (:issue:`60568`)
 - Fixed bug where the :class:`DataFrame` constructor misclassified array-like objects with a ``.name`` attribute as :class:`Series` or :class:`Index` (:issue:`61443`)
 - Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
+- Bug in :func:`assert_frame_equal` with ``check_dtype=False`` failing to compare DataFrames containing ``pd.NA`` that differ only in dtype (``object`` vs ``Int32``). (:issue:`61473`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -955,6 +955,7 @@ Other
 ^^^^^
 - Bug in :class:`DataFrame` when passing a ``dict`` with a NA scalar and ``columns`` that would always return ``np.nan`` (:issue:`57205`)
 - Bug in :class:`Series` ignoring errors when trying to convert :class:`Series` input data to the given ``dtype`` (:issue:`60728`)
+- Bug in :func:`assert_frame_equal` with ``check_dtype=False`` failing to compare DataFrames containing ``pd.NA`` that differ only in dtype (``object`` vs ``Int32``). (:issue:`61473`)
 - Bug in :func:`eval` on :class:`ExtensionArray` on including division ``/`` failed with a ``TypeError``. (:issue:`58748`)
 - Bug in :func:`eval` where method calls on binary operations like ``(x + y).dropna()`` would raise ``AttributeError: 'BinOp' object has no attribute 'value'`` (:issue:`61175`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
@@ -994,7 +995,6 @@ Other
 - Bug in printing a :class:`Series` with a :class:`DataFrame` stored in :attr:`Series.attrs` raised a ``ValueError`` (:issue:`60568`)
 - Fixed bug where the :class:`DataFrame` constructor misclassified array-like objects with a ``.name`` attribute as :class:`Series` or :class:`Index` (:issue:`61443`)
 - Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
-- Bug in :func:`assert_frame_equal` with ``check_dtype=False`` failing to compare DataFrames containing ``pd.NA`` that differ only in dtype (``object`` vs ``Int32``). (:issue:`61473`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1031,10 +1031,16 @@ def assert_series_equal(
         else:
             # convert both to NumPy if not, check_dtype would raise earlier
             lv, rv = left_values, right_values
-            if isinstance(left_values, ExtensionArray):
-                lv = left_values.to_numpy()
-            if isinstance(right_values, ExtensionArray):
-                rv = right_values.to_numpy()
+            if check_dtype:
+                if isinstance(left_values, ExtensionArray):
+                    lv = left_values.to_numpy()
+                if isinstance(right_values, ExtensionArray):
+                    rv = right_values.to_numpy()
+            else:
+                if isinstance(left_values, ExtensionArray):
+                    lv = left_values.to_numpy(dtype="object")
+                if isinstance(right_values, ExtensionArray):
+                    rv = right_values.to_numpy(dtype="object")
             assert_numpy_array_equal(
                 lv,
                 rv,

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -395,3 +395,11 @@ def test_assert_frame_equal_set_mismatch():
     msg = r'DataFrame.iloc\[:, 0\] \(column name="set_column"\) values are different'
     with pytest.raises(AssertionError, match=msg):
         tm.assert_frame_equal(df1, df2)
+
+
+def test_assert_frame_equal_pdNa_ignore_dtype():
+    # GH#61473
+    df1 = DataFrame({"x": pd.Series([pd.NA], dtype="Int32")})
+    df2 = DataFrame({"x": pd.Series([pd.NA], dtype="object")})
+
+    tm.assert_frame_equal(df1, df2, check_dtype=False)


### PR DESCRIPTION
- [x] closes #61473
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.



Fixes a bug where assert_frame_equal failed when comparing DataFrames containing pd.NA with different dtypes (object vs Int32) if check_dtype=False.