### PR TITLE
CLN: Enforce deprecation of arg in Series.map

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -609,6 +609,7 @@ Other Removals
 - Enforced deprecation of :meth:`.DataFrameGroupBy.get_group` and :meth:`.SeriesGroupBy.get_group` allowing the ``name`` argument to be a non-tuple when grouping by a list of length 1 (:issue:`54155`)
 - Enforced deprecation of :meth:`Series.interpolate` and :meth:`DataFrame.interpolate` for object-dtype (:issue:`57820`)
 - Enforced deprecation of :meth:`offsets.Tick.delta`, use ``pd.Timedelta(obj)`` instead (:issue:`55498`)
+- Enforced deprecation of ``arg`` argument in ``Series.map`` (:issue:`61264`)
 - Enforced deprecation of ``axis=None`` acting the same as ``axis=0`` in the DataFrame reductions ``sum``, ``prod``, ``std``, ``var``, and ``sem``, passing ``axis=None`` will now reduce over both axes; this is particularly the case when doing e.g. ``numpy.sum(df)`` (:issue:`21597`)
 - Enforced deprecation of ``core.internals`` member ``DatetimeTZBlock`` (:issue:`58467`)
 - Enforced deprecation of ``date_parser`` in :func:`read_csv`, :func:`read_table`, :func:`read_fwf`, and :func:`read_excel` in favour of ``date_format`` (:issue:`50601`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -54,9 +54,6 @@ from pandas.util._decorators import (
     doc,
     set_module,
 )
-from pandas.util._exceptions import (
-    find_stack_level,
-)
 from pandas.util._validators import (
     validate_ascending,
     validate_bool_kwarg,
@@ -4328,7 +4325,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
     def map(
         self,
-        func: Callable | Mapping | Series | None = None,
+        func: Callable | Mapping | Series,
         na_action: Literal["ignore"] | None = None,
         engine: Callable | None = None,
         **kwargs,
@@ -4368,7 +4365,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         **kwargs
             Additional keyword arguments to pass as keywords arguments to
-            `arg`.
+            `func`.
 
             .. versionadded:: 3.0.0
 
@@ -4432,19 +4429,6 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         3  I am a rabbit
         dtype: object
         """
-        if func is None:
-            if "arg" in kwargs:
-                # `.map(arg=my_func)`
-                func = kwargs.pop("arg")
-                warnings.warn(
-                    "The parameter `arg` has been renamed to `func`, and it "
-                    "will stop being supported in a future version of pandas.",
-                    FutureWarning,
-                    stacklevel=find_stack_level(),
-                )
-            else:
-                raise ValueError("The `func` parameter is required")
-
         if engine is not None:
             if not callable(func):
                 raise ValueError(

--- a/pandas/tests/series/methods/test_map.py
+++ b/pandas/tests/series/methods/test_map.py
@@ -614,28 +614,11 @@ def test_map_kwargs():
     tm.assert_series_equal(result, expected)
 
 
-def test_map_arg_as_kwarg():
-    with tm.assert_produces_warning(
-        FutureWarning, match="`arg` has been renamed to `func`"
-    ):
-        Series([1, 2]).map(arg={})
-
-
 def test_map_func_and_arg():
     # `arg`is considered a normal kwarg that should be passed to the function
     result = Series([1, 2]).map(lambda _, arg: arg, arg=3)
     expected = Series([3, 3])
     tm.assert_series_equal(result, expected)
-
-
-def test_map_no_func_or_arg():
-    with pytest.raises(ValueError, match="The `func` parameter is required"):
-        Series([1, 2]).map()
-
-
-def test_map_func_is_none():
-    with pytest.raises(ValueError, match="The `func` parameter is required"):
-        Series([1, 2]).map(func=None)
 
 
 @pytest.mark.parametrize("func", [{}, {1: 2}, Series([3, 4])])


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
