### PR TITLE
CI: Always install pandas in non-editable mode in CI

### DIFF
--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -1,9 +1,6 @@
 name: Build pandas
 description: Rebuilds the C extensions and installs pandas
 inputs:
-  editable:
-    description: Whether to build pandas in editable mode (default true)
-    default: true
   werror:
     description: Enable werror flag for build
     default: true
@@ -26,12 +23,5 @@ runs:
       shell: bash -el {0}
 
     - name: Build Pandas
-      run: |
-        if [[ ${{ inputs.editable }} == "true" ]]; then
-          pip install -e . --no-build-isolation -v --no-deps \
-            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }}
-        else
-          pip install . --no-build-isolation -v --no-deps \
-            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }}
-        fi
+      run: pip install . --no-build-isolation -v --no-deps ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }}
       shell: bash -el {0}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -43,14 +43,8 @@ jobs:
     - name: Build Pandas
       id: build
       uses: ./.github/actions/build_pandas
-      with:
-        editable: false
 
     # The following checks are independent of each other and should still be run if one fails
-
-    # TODO: The doctests have to be run first right now, since the Cython doctests only work
-    # with pandas installed in non-editable mode
-    # This can be removed once pytest-cython doesn't require C extensions to be installed inplace
 
     - name: Extra installs
       # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
@@ -59,13 +53,6 @@ jobs:
     - name: Run doctests
       run: cd ci && ./code_checks.sh doctests
       if: ${{ steps.build.outcome == 'success' && always() }}
-
-    - name: Install pandas in editable mode
-      id: build-editable
-      if: ${{ steps.build.outcome == 'success' && always() }}
-      uses: ./.github/actions/build_pandas
-      with:
-        editable: true
 
     - name: Check for no warnings when building single-page docs
       run: ci/code_checks.sh single-docs


### PR DESCRIPTION
May be needed to avoid the jinja2 errors in CI in https://github.com/pandas-dev/pandas/pull/62086, xref https://github.com/mesonbuild/meson-python/issues/716