### PR TITLE
[backport 2.3.x] BUG: Fix Series.str.contains with compiled regex on Arrow string dtype (#61946)

### DIFF
--- a/doc/source/whatsnew/v2.3.2.rst
+++ b/doc/source/whatsnew/v2.3.2.rst
@@ -25,8 +25,8 @@ Bug fixes
 - Fix :meth:`~DataFrame.to_json` with ``orient="table"`` to correctly use the
   "string" type in the JSON Table Schema for :class:`StringDtype` columns
   (:issue:`61889`)
-- Fixed ``~Series.str.match`` and ``~Series.str.fullmatch`` with compiled regex
-  for the Arrow-backed string dtype (:issue:`61964`)
+- Fixed ``~Series.str.match``, ``~Series.str.fullmatch`` and ``~Series.str.contains``
+  with compiled regex for the Arrow-backed string dtype (:issue:`61964`, :issue:`61942`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_232.contributors:

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -355,6 +355,8 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
     ):
         if flags:
             return super()._str_contains(pat, case, flags, na, regex)
+        if isinstance(pat, re.Pattern):
+            pat = pat.pattern
 
         return ArrowStringArrayMixin._str_contains(self, pat, case, flags, na, regex)
 

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -290,6 +290,19 @@ def test_contains_nan(any_string_dtype):
     tm.assert_series_equal(result, expected)
 
 
+def test_contains_compiled_regex(any_string_dtype):
+    # GH#61942
+    ser = Series(["foo", "bar", "baz"], dtype=any_string_dtype)
+    pat = re.compile("ba.")
+    result = ser.str.contains(pat)
+
+    expected_dtype = (
+        np.bool_ if is_object_or_nan_string_dtype(any_string_dtype) else "boolean"
+    )
+    expected = Series([False, True, True], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
 # --------------------------------------------------------------------------------------
 # str.startswith
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/61946