### PR TITLE
Use jinja2 FileSystemLoader instead of PackageLoader for compat newer meson-python and editable installs

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -6,6 +6,7 @@ from collections.abc import (
     Sequence,
 )
 from functools import partial
+import pathlib
 import re
 from typing import (
     TYPE_CHECKING,
@@ -70,7 +71,9 @@ class StylerRenderer:
     Base class to process rendering a Styler with a specified jinja2 template.
     """
 
-    loader = jinja2.PackageLoader("pandas", "io/formats/templates")
+    this_dir = pathlib.Path(__file__).parent.resolve()
+    template_dir = this_dir / "templates"
+    loader = jinja2.FileSystemLoader(template_dir)
     env = jinja2.Environment(loader=loader, trim_blocks=True)
     template_html = env.get_template("html.tpl")
     template_html_table = env.get_template("html_table.tpl")

--- a/pandas/tests/io/formats/style/test_html.py
+++ b/pandas/tests/io/formats/style/test_html.py
@@ -1,3 +1,4 @@
+import pathlib
 from textwrap import (
     dedent,
     indent,
@@ -18,7 +19,9 @@ from pandas.io.formats.style import Styler
 
 @pytest.fixture
 def env():
-    loader = jinja2.PackageLoader("pandas", "io/formats/templates")
+    project_dir = pathlib.Path(__file__).parent.parent.parent.parent.parent.resolve()
+    template_dir = project_dir / "io" / "formats" / "templates"
+    loader = jinja2.FileSystemLoader(template_dir)
     env = jinja2.Environment(loader=loader, trim_blocks=True)
     return env
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/62086, https://github.com/pandas-dev/pandas/pull/62110 and https://github.com/mesonbuild/meson-python/issues/716

Currently, if you use a more recent meson-python version than the 0.13 we have pinned in the dev env yml file, and install pandas in an editable mode in you local development environment, any usage of the styler functionality gives a `ValueError: PackageLoader could not find a 'io/formats/templates' directory in the 'pandas' package.` error.

This change as suggested by @WillAyd (extracted from https://github.com/pandas-dev/pandas/pull/60681/) seems to work fine for me locally