### PR TITLE
CI/BLD: don't use strict xfail for '%m.%Y' format in test_hypothesis_delimited_date

### DIFF
--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -402,7 +402,8 @@ def test_hypothesis_delimited_date(
         request.applymarker(
             pytest.mark.xfail(
                 reason="parse_datetime_string cannot reliably tell whether "
-                "e.g. %m.%Y is a float or a date"
+                "e.g. %m.%Y is a float or a date",
+                strict=False,
             )
         )
     date_string = test_datetime.strftime(date_format.replace(" ", delimiter))


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/62093

The last days, some linux wheel builds have been failing while testing with:

```
   ________________ test_hypothesis_delimited_date[%m %Y-False-.] _________________
  [XPASS(strict)] parse_datetime_string cannot reliably tell whether e.g. %m.%Y is a float or a date
```

I am not directly sure what is going on (it also only happens on wheel builds, and it is a hypothesis tests, so I am not even sure _when_ this happens (i.e. with which input data). Do we print somewhere some hash so we can reproduce hypothesis failures?). 
And it is also not happening consistently on the same builds (in one nightly build, it failed for cp312-musllinux_aarch64, but then in another for cp313, in another for manylinux, etc).

So for now just making this a non-strict xfail to get the nightly wheels working