### PR TITLE
CI/BLD: fix upload of arm64 windows wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -189,7 +189,7 @@ jobs:
         # installing wheel here because micromamba step was skipped
         if: matrix.buildplat[1] == 'win_arm64'
         shell: bash -el {0}
-        run: python -m pip install wheel
+        run: python -m pip install wheel anaconda-client
 
       - name: Validate wheel RECORD
         shell: bash -el {0}


### PR DESCRIPTION
The upload step is currently failing for the arm64_win wheels, see eg https://github.com/pandas-dev/pandas/actions/runs/16926890715/job/47964412481. And I suppose this should fix the issue (the other platforms use mamba and also install anaconda-client)