### PR TITLE
Resolved issue 62094

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -509,7 +509,10 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             return self.copy()
 
         if self.freq is None:
-            raise NullFrequencyError("Cannot shift with no freq")
+            if(len(self) > 1):
+                self.freq = self[1] - self[0]
+            else:
+                raise NullFrequencyError("Cannot shift with no freq")
 
         start = self[0] + periods * self.freq
         end = self[-1] + periods * self.freq


### PR DESCRIPTION
Using default frequency as difference between two TimeDeltas

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
