### PR TITLE
[backport 2.3.x] DOC: move and reword whatsnew note for replace fix (GH-57865) (#62153)

### DIFF
--- a/doc/source/whatsnew/v2.3.2.rst
+++ b/doc/source/whatsnew/v2.3.2.rst
@@ -28,6 +28,8 @@ Bug fixes
 - Boolean operations (``|``, ``&``, ``^``) with bool-dtype objects on the left and :class:`StringDtype` objects on the right now cast the string to bool, with a deprecation warning (:issue:`60234`)
 - Fixed ``~Series.str.match``, ``~Series.str.fullmatch`` and ``~Series.str.contains``
   with compiled regex for the Arrow-backed string dtype (:issue:`61964`, :issue:`61942`)
+- Bug in :meth:`Series.replace` and :meth:`DataFrame.replace` inconsistently
+  replacing matching values when missing values are present for string dtypes (:issue:`56599`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_232.contributors:


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/62153