### PR TITLE
REF: avoid inferred_type checks in plotting

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -643,7 +643,6 @@ generated/pandas.Index.get_slice_bound,../reference/api/pandas.Index.get_slice_b
 generated/pandas.Index.groupby,../reference/api/pandas.Index.groupby
 generated/pandas.Index.has_duplicates,../reference/api/pandas.Index.has_duplicates
 generated/pandas.Index.hasnans,../reference/api/pandas.Index.hasnans
-generated/pandas.Index.holds_integer,../reference/api/pandas.Index.holds_integer
 generated/pandas.Index,../reference/api/pandas.Index
 generated/pandas.Index.identical,../reference/api/pandas.Index.identical
 generated/pandas.Index.inferred_type,../reference/api/pandas.Index.inferred_type

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 
 def holds_integer(column: Index) -> bool:
-    return column.inferred_type in {"integer", "mixed-integer"}
+    return column.dtype.kind in "iu"
 
 
 def hist_series(

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -101,7 +101,7 @@ if TYPE_CHECKING:
 
 
 def holds_integer(column: Index) -> bool:
-    return column.inferred_type in {"integer", "mixed-integer"}
+    return column.dtype.kind in "iu"
 
 
 def _color_in_style(style: str) -> bool:


### PR DESCRIPTION
- [x] closes #55897 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Doesn't look like any tests rely on this behavior.  Not clear how to do this as a deprecation.  Think there is anyone out there with object-dtype columns relying on this?