### PR TITLE
CLN: Replace warnings with Pandas4Warning

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -5192,13 +5192,15 @@ def _warn_about_deprecated_aliases(name: str, is_period: bool) -> str:
     if name in _lite_rule_alias:
         return name
     if name in c_PERIOD_AND_OFFSET_DEPR_FREQSTR:
-        # TODO: Enforce in 3.0 (#59240)
+        from pandas.errors import Pandas4Warning
+
+        # https://github.com/pandas-dev/pandas/pull/59240
         warnings.warn(
             f"\'{name}\' is deprecated and will be removed "
             f"in a future version, please use "
             f"\'{c_PERIOD_AND_OFFSET_DEPR_FREQSTR.get(name)}\' "
             f"instead.",
-            FutureWarning,
+            Pandas4Warning,
             stacklevel=find_stack_level(),
             )
         return c_PERIOD_AND_OFFSET_DEPR_FREQSTR[name]
@@ -5207,13 +5209,15 @@ def _warn_about_deprecated_aliases(name: str, is_period: bool) -> str:
         if name == _name:
             continue
         if _name in c_PERIOD_AND_OFFSET_DEPR_FREQSTR.values():
-            # TODO: Enforce in 3.0 (#59240)
+            from pandas.errors import Pandas4Warning
+
+            # https://github.com/pandas-dev/pandas/pull/59240
             warnings.warn(
                 f"\'{name}\' is deprecated and will be removed "
                 f"in a future version, please use "
                 f"\'{_name}\' "
                 f"instead.",
-                FutureWarning,
+                Pandas4Warning,
                 stacklevel=find_stack_level(),
                 )
             return _name

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -5192,6 +5192,7 @@ def _warn_about_deprecated_aliases(name: str, is_period: bool) -> str:
     if name in _lite_rule_alias:
         return name
     if name in c_PERIOD_AND_OFFSET_DEPR_FREQSTR:
+        # TODO: Enforce in 3.0 (#59240)
         warnings.warn(
             f"\'{name}\' is deprecated and will be removed "
             f"in a future version, please use "
@@ -5206,6 +5207,7 @@ def _warn_about_deprecated_aliases(name: str, is_period: bool) -> str:
         if name == _name:
             continue
         if _name in c_PERIOD_AND_OFFSET_DEPR_FREQSTR.values():
+            # TODO: Enforce in 3.0 (#59240)
             warnings.warn(
                 f"\'{name}\' is deprecated and will be removed "
                 f"in a future version, please use "

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -3018,6 +3018,7 @@ class Period(_Period):
             # GH#53446
             import warnings
 
+            # TODO: Enforce in 3.0 (#53511)
             from pandas.util._exceptions import find_stack_level
             warnings.warn(
                 "Period with BDay freq is deprecated and will be removed "

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -722,6 +722,7 @@ cpdef inline str parse_timedelta_unit(str unit):
     elif unit == "M":
         return unit
     elif unit in c_DEPR_UNITS:
+        # TODO: Enforce in 3.0 (#59240)
         warnings.warn(
             f"\'{unit}\' is deprecated and will be removed in a "
             f"future version. Please use \'{c_DEPR_UNITS.get(unit)}\' "

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -78,7 +78,9 @@ from pandas._libs.tslibs.np_datetime import (
 )
 
 from pandas._libs.tslibs.offsets cimport is_tick_object
+
 from pandas._libs.tslibs.offsets import Day
+
 from pandas._libs.tslibs.util cimport (
     is_array,
     is_float_object,
@@ -722,12 +724,14 @@ cpdef inline str parse_timedelta_unit(str unit):
     elif unit == "M":
         return unit
     elif unit in c_DEPR_UNITS:
-        # TODO: Enforce in 3.0 (#59240)
+        from pandas.errors import Pandas4Warning
+
+        # https://github.com/pandas-dev/pandas/pull/59240
         warnings.warn(
             f"\'{unit}\' is deprecated and will be removed in a "
             f"future version. Please use \'{c_DEPR_UNITS.get(unit)}\' "
             f"instead of \'{unit}\'.",
-            FutureWarning,
+            Pandas4Warning,
             stacklevel=find_stack_level(),
         )
         unit = c_DEPR_UNITS[unit]

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -930,6 +930,7 @@ class ArrowExtensionArray(
             and isinstance(other, np.ndarray)
             and other.dtype == bool
         ):
+            # TODO: Enforce in 3.0 (#60234)
             # GH#60234 backward compatibility for the move to StringDtype in 3.0
             op_name = op.__name__[1:].strip("_")
             warnings.warn(

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -28,6 +28,7 @@ from pandas.compat import (
     pa_version_under12p1,
     pa_version_under13p0,
 )
+from pandas.errors import Pandas4Warning
 from pandas.util._decorators import doc
 from pandas.util._exceptions import find_stack_level
 
@@ -930,14 +931,13 @@ class ArrowExtensionArray(
             and isinstance(other, np.ndarray)
             and other.dtype == bool
         ):
-            # TODO: Enforce in 3.0 (#60234)
             # GH#60234 backward compatibility for the move to StringDtype in 3.0
             op_name = op.__name__[1:].strip("_")
             warnings.warn(
                 f"'{op_name}' operations between boolean dtype and {self.dtype} are "
                 "deprecated and will raise in a future version. Explicitly "
                 "cast the strings to a boolean dtype before operating instead.",
-                FutureWarning,
+                Pandas4Warning,
                 stacklevel=find_stack_level(),
             )
             return op(other, self.astype(bool))

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -29,7 +29,6 @@ from pandas.compat import (
     pa_version_under12p1,
 )
 from pandas.compat.numpy import function as nv
-from pandas.errors import Pandas4Warning
 from pandas.util._decorators import (
     doc,
     set_module,
@@ -398,11 +397,12 @@ class BaseStringArray(ExtensionArray):
         ):
             # GH#60234 backward compatibility for the move to StringDtype in 3.0
             op_name = op.__name__[1:].strip("_")
+            # TODO: Enforce in 3.0 (#60234)
             warnings.warn(
                 f"'{op_name}' operations between boolean dtype and {self.dtype} are "
                 "deprecated and will raise in a future version. Explicitly "
                 "cast the strings to a boolean dtype before operating instead.",
-                Pandas4Warning,
+                FutureWarning,
                 stacklevel=find_stack_level(),
             )
             return op(other, self.astype(bool))

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -29,6 +29,7 @@ from pandas.compat import (
     pa_version_under12p1,
 )
 from pandas.compat.numpy import function as nv
+from pandas.errors import Pandas4Warning
 from pandas.util._decorators import (
     doc,
     set_module,
@@ -397,12 +398,11 @@ class BaseStringArray(ExtensionArray):
         ):
             # GH#60234 backward compatibility for the move to StringDtype in 3.0
             op_name = op.__name__[1:].strip("_")
-            # TODO: Enforce in 3.0 (#60234)
             warnings.warn(
                 f"'{op_name}' operations between boolean dtype and {self.dtype} are "
                 "deprecated and will raise in a future version. Explicitly "
                 "cast the strings to a boolean dtype before operating instead.",
-                FutureWarning,
+                Pandas4Warning,
                 stacklevel=find_stack_level(),
             )
             return op(other, self.astype(bool))

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -29,6 +29,7 @@ from pandas.compat import (
     pa_version_under12p1,
 )
 from pandas.compat.numpy import function as nv
+from pandas.errors import Pandas4Warning
 from pandas.util._decorators import (
     doc,
     set_module,
@@ -167,6 +168,7 @@ class StringDtype(StorageExtensionDtype):
                     storage = "python"
 
         if storage == "pyarrow_numpy":
+            # TODO: Enforce in 3.0 (#60152)
             warnings.warn(
                 "The 'pyarrow_numpy' storage option name is deprecated and will be "
                 'removed in pandas 3.0. Use \'pd.StringDtype(storage="pyarrow", '
@@ -400,7 +402,7 @@ class BaseStringArray(ExtensionArray):
                 f"'{op_name}' operations between boolean dtype and {self.dtype} are "
                 "deprecated and will raise in a future version. Explicitly "
                 "cast the strings to a boolean dtype before operating instead.",
-                FutureWarning,
+                Pandas4Warning,
                 stacklevel=find_stack_level(),
             )
             return op(other, self.astype(bool))

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -228,6 +228,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
 
     def _convert_bool_result(self, values, na=lib.no_default, method_name=None):
         if na is not lib.no_default and not isna(na) and not isinstance(na, bool):
+            # TODO: Enforce in 3.0 (#59615)
             # GH#59561
             warnings.warn(
                 f"Allowing a non-bool 'na' in obj.str.{method_name} is deprecated "

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -21,6 +21,7 @@ from pandas._libs import (
     lib,
 )
 from pandas._libs.tslibs import conversion
+from pandas.errors import Pandas4Warning
 from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.base import _registry as registry
@@ -235,7 +236,7 @@ def is_sparse(arr) -> bool:
     warnings.warn(
         "is_sparse is deprecated and will be removed in a future "
         "version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-        DeprecationWarning,
+        Pandas4Warning,
         stacklevel=2,
     )
 
@@ -370,7 +371,7 @@ def is_datetime64tz_dtype(arr_or_dtype) -> bool:
     warnings.warn(
         "is_datetime64tz_dtype is deprecated and will be removed in a future "
         "version. Check `isinstance(dtype, pd.DatetimeTZDtype)` instead.",
-        DeprecationWarning,
+        Pandas4Warning,
         stacklevel=2,
     )
     if isinstance(arr_or_dtype, DatetimeTZDtype):
@@ -466,7 +467,7 @@ def is_period_dtype(arr_or_dtype) -> bool:
     warnings.warn(
         "is_period_dtype is deprecated and will be removed in a future version. "
         "Use `isinstance(dtype, pd.PeriodDtype)` instead",
-        DeprecationWarning,
+        Pandas4Warning,
         stacklevel=2,
     )
     if isinstance(arr_or_dtype, ExtensionDtype):
@@ -524,7 +525,7 @@ def is_interval_dtype(arr_or_dtype) -> bool:
     warnings.warn(
         "is_interval_dtype is deprecated and will be removed in a future version. "
         "Use `isinstance(dtype, pd.IntervalDtype)` instead",
-        DeprecationWarning,
+        Pandas4Warning,
         stacklevel=2,
     )
     if isinstance(arr_or_dtype, ExtensionDtype):
@@ -578,7 +579,7 @@ def is_categorical_dtype(arr_or_dtype) -> bool:
     warnings.warn(
         "is_categorical_dtype is deprecated and will be removed in a future "
         "version. Use isinstance(dtype, pd.CategoricalDtype) instead",
-        DeprecationWarning,
+        Pandas4Warning,
         stacklevel=2,
     )
     if isinstance(arr_or_dtype, ExtensionDtype):
@@ -973,7 +974,7 @@ def is_int64_dtype(arr_or_dtype) -> bool:
     warnings.warn(
         "is_int64_dtype is deprecated and will be removed in a future "
         "version. Use dtype == np.int64 instead.",
-        DeprecationWarning,
+        Pandas4Warning,
         stacklevel=2,
     )
     return _is_dtype_type(arr_or_dtype, classes(np.int64))
@@ -1436,7 +1437,7 @@ def is_bool_dtype(arr_or_dtype) -> bool:
                     "The behavior of is_bool_dtype with an object-dtype Index "
                     "of bool objects is deprecated. In a future version, "
                     "this will return False. Cast the Index to a bool dtype instead.",
-                    DeprecationWarning,
+                    Pandas4Warning,
                     stacklevel=2,
                 )
             return True

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -727,7 +727,7 @@ class DataFrame(NDFrame, OpsMixin):
                     f"Passing a {type(data).__name__} to {type(self).__name__} "
                     "is deprecated and will raise in a future version. "
                     "Use public APIs instead.",
-                    DeprecationWarning,
+                    Pandas4Warning,
                     stacklevel=2,
                 )
 
@@ -9887,7 +9887,7 @@ class DataFrame(NDFrame, OpsMixin):
                 "removed in a future version of pandas. See the What's New notes "
                 "for pandas 2.1.0 for details. Do not specify the future_stack "
                 "argument to adopt the new implementation and silence this warning.",
-                FutureWarning,
+                Pandas4Warning,
                 stacklevel=find_stack_level(),
             )
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9133,6 +9133,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         from pandas.core.resample import get_resampler
 
         if convention is not lib.no_default:
+            # TODO: Enforce in 3.0 (#55968)
             warnings.warn(
                 f"The 'convention' keyword in {type(self).__name__}.resample is "
                 "deprecated and will be removed in a future version. "

--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -1,5 +1,3 @@
-from pandas.errors import Pandas4Warning
-
 from pandas.core.internals.api import make_block  # 2023-09-18 pyarrow uses this
 from pandas.core.internals.concat import concatenate_managers
 from pandas.core.internals.managers import (
@@ -21,6 +19,8 @@ __all__ = [
 def __getattr__(name: str):
     # GH#55139
     import warnings
+
+    from pandas.errors import Pandas4Warning
 
     if name == "create_block_manager_from_blocks":
         # GH#33892, GH#58715

--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -1,3 +1,5 @@
+from pandas.errors import Pandas4Warning
+
 from pandas.core.internals.api import make_block  # 2023-09-18 pyarrow uses this
 from pandas.core.internals.concat import concatenate_managers
 from pandas.core.internals.managers import (
@@ -21,11 +23,11 @@ def __getattr__(name: str):
     import warnings
 
     if name == "create_block_manager_from_blocks":
-        # GH#33892
+        # GH#33892, GH#58715
         warnings.warn(
             f"{name} is deprecated and will be removed in a future version. "
             "Use public APIs instead.",
-            FutureWarning,
+            Pandas4Warning,
             # https://github.com/pandas-dev/pandas/pull/55139#pullrequestreview-1720690758
             # on hard-coding stacklevel
             stacklevel=2,
@@ -42,7 +44,7 @@ def __getattr__(name: str):
         warnings.warn(
             f"{name} is deprecated and will be removed in a future version. "
             "Use public APIs instead.",
-            FutureWarning,
+            Pandas4Warning,
             # https://github.com/pandas-dev/pandas/pull/55139#pullrequestreview-1720690758
             # on hard-coding stacklevel
             stacklevel=2,

--- a/pandas/core/internals/api.py
+++ b/pandas/core/internals/api.py
@@ -171,7 +171,7 @@ def maybe_infer_ndim(values, placement: BlockPlacement, ndim: int | None) -> int
     """
     warnings.warn(
         "maybe_infer_ndim is deprecated and will be removed in a future version.",
-        DeprecationWarning,
+        Pandas4Warning,
         stacklevel=2,
     )
     return _maybe_infer_ndim(values, placement, ndim)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -39,6 +39,7 @@ from pandas._typing import (
 from pandas.errors import (
     AbstractMethodError,
     OutOfBoundsDatetime,
+    Pandas4Warning,
 )
 from pandas.util._decorators import cache_readonly
 from pandas.util._exceptions import find_stack_level
@@ -1899,7 +1900,7 @@ class ExtensionBlock(EABackedBlock):
                     "need to implement this keyword or an exception will be "
                     "raised. In the interim, the keyword is ignored by "
                     f"{type(self.values).__name__}.",
-                    DeprecationWarning,
+                    Pandas4Warning,
                     stacklevel=find_stack_level(),
                 )
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1945,6 +1945,7 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
     @property
     def _resampler_for_grouping(self):
+        # TODO: Enforce in 3.0 (#55968)
         warnings.warn(
             "Resampling a groupby with a PeriodIndex is deprecated. "
             "Cast to DatetimeIndex before resampling instead.",

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -384,7 +384,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                     f"Passing a {type(data).__name__} to {type(self).__name__} "
                     "is deprecated and will raise in a future version. "
                     "Use public APIs instead.",
-                    DeprecationWarning,
+                    Pandas4Warning,
                     stacklevel=2,
                 )
             data = data.copy(deep=False)
@@ -408,7 +408,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                     f"Passing a {type(data).__name__} to {type(self).__name__} "
                     "is deprecated and will raise in a future version. "
                     "Use public APIs instead.",
-                    DeprecationWarning,
+                    Pandas4Warning,
                     stacklevel=2,
                 )
 
@@ -477,7 +477,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                     f"Passing a {type(data).__name__} to {type(self).__name__} "
                     "is deprecated and will raise in a future version. "
                     "Use public APIs instead.",
-                    DeprecationWarning,
+                    Pandas4Warning,
                     stacklevel=2,
                 )
                 allow_mgr = True
@@ -4432,6 +4432,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             if "arg" in kwargs:
                 # `.map(arg=my_func)`
                 func = kwargs.pop("arg")
+                # TODO: Enforce in 3.0 (#61264)
                 warnings.warn(
                     "The parameter `arg` has been renamed to `func`, and it "
                     "will stop being supported in a future version of pandas.",

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4432,11 +4432,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             if "arg" in kwargs:
                 # `.map(arg=my_func)`
                 func = kwargs.pop("arg")
-                # TODO: Enforce in 3.0 (#61264)
+                # https://github.com/pandas-dev/pandas/pull/61264
                 warnings.warn(
                     "The parameter `arg` has been renamed to `func`, and it "
                     "will stop being supported in a future version of pandas.",
-                    FutureWarning,
+                    Pandas4Warning,
                     stacklevel=find_stack_level(),
                 )
             else:

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -39,6 +39,7 @@ from pandas._libs.writers import max_len_string_array
 from pandas.errors import (
     CategoricalConversionWarning,
     InvalidColumnName,
+    Pandas4Warning,
     PossiblePrecisionLoss,
     ValueLabelTypeMismatch,
 )
@@ -398,7 +399,7 @@ def _datetime_to_stata_elapsed_vec(dates: Series, fmt: str) -> Series:
                 "Converting object-dtype columns of datetimes to datetime64 when "
                 "writing to stata is deprecated. Call "
                 "`df=df.infer_objects(copy=False)` before writing to stata instead.",
-                FutureWarning,
+                Pandas4Warning,
                 stacklevel=find_stack_level(),
             )
             if delta:

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import tz_compare
+from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
@@ -775,7 +776,7 @@ class TestDatetimeArray:
         )
 
         expected = pd.date_range("1/1/2000", periods=4, freq=freq_depr.lower())
-        with tm.assert_produces_warning(FutureWarning, match=depr_msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             result = pd.date_range("1/1/2000", periods=4, freq=freq_depr)
         tm.assert_index_equal(result, expected)
 
@@ -804,7 +805,7 @@ class TestDatetimeArray:
         depr_msg = "'w' is deprecated and will be removed in a future version"
 
         expected = pd.date_range("1/1/2000", periods=4, freq="2W")
-        with tm.assert_produces_warning(FutureWarning, match=depr_msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             result = pd.date_range("1/1/2000", periods=4, freq="2w")
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import HAS_PYARROW
+from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.astype import astype_array
@@ -184,7 +185,7 @@ def test_get_dtype_error_catch(func):
         or func is com.is_categorical_dtype
         or func is com.is_period_dtype
     ):
-        warn = DeprecationWarning
+        warn = Pandas4Warning
 
     with tm.assert_produces_warning(warn, match=msg):
         assert not func(None)
@@ -204,7 +205,7 @@ def test_is_object():
 )
 def test_is_sparse(check_scipy):
     msg = "is_sparse is deprecated"
-    with tm.assert_produces_warning(DeprecationWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         assert com.is_sparse(SparseArray([1, 2, 3]))
 
         assert not com.is_sparse(np.array([1, 2, 3]))
@@ -234,7 +235,7 @@ def test_is_datetime64_dtype():
 
 def test_is_datetime64tz_dtype():
     msg = "is_datetime64tz_dtype is deprecated"
-    with tm.assert_produces_warning(DeprecationWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         assert not com.is_datetime64tz_dtype(object)
         assert not com.is_datetime64tz_dtype([1, 2, 3])
         assert not com.is_datetime64tz_dtype(pd.DatetimeIndex([1, 2, 3]))
@@ -250,7 +251,7 @@ def test_custom_ea_kind_M_not_datetime64tz():
 
     not_tz_dtype = NotTZDtype()
     msg = "is_datetime64tz_dtype is deprecated"
-    with tm.assert_produces_warning(DeprecationWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         assert not com.is_datetime64tz_dtype(not_tz_dtype)
         assert not com.needs_i8_conversion(not_tz_dtype)
 

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
+from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.base import _registry as registry
 from pandas.core.dtypes.common import (
@@ -165,7 +166,7 @@ class TestCategoricalDtype(Base):
 
     def test_basic(self, dtype):
         msg = "is_categorical_dtype is deprecated"
-        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             assert is_categorical_dtype(dtype)
 
             factor = Categorical(["a", "b", "b", "a", "a", "c", "c", "c"])
@@ -295,7 +296,7 @@ class TestDatetimeTZDtype(Base):
 
     def test_compat(self, dtype):
         msg = "is_datetime64tz_dtype is deprecated"
-        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             assert is_datetime64tz_dtype(dtype)
             assert is_datetime64tz_dtype("datetime64[ns, US/Eastern]")
         assert is_datetime64_any_dtype(dtype)

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -35,6 +35,7 @@ from pandas._libs import (
     ops as libops,
 )
 from pandas.compat.numpy import np_version_gt2
+from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes import inference
 from pandas.core.dtypes.cast import find_result_type
@@ -1858,7 +1859,7 @@ class TestNumberScalar:
         assert is_datetime64_any_dtype(ts)
         assert is_datetime64_any_dtype(tsa)
 
-        with tm.assert_produces_warning(DeprecationWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             assert not is_datetime64tz_dtype("datetime64")
             assert not is_datetime64tz_dtype("datetime64[ns]")
             assert not is_datetime64tz_dtype(ts)

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -5,6 +5,8 @@ import decimal
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.tests.extension import base
@@ -134,7 +136,7 @@ class TestDecimalArray(base.ExtensionTests):
     def test_fillna_frame(self, data_missing):
         msg = "ExtensionArray.fillna added a 'copy' keyword"
         with tm.assert_produces_warning(
-            DeprecationWarning, match=msg, check_stacklevel=False
+            Pandas4Warning, match=msg, check_stacklevel=False
         ):
             super().test_fillna_frame(data_missing)
 

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -3,6 +3,7 @@ import re
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -718,7 +719,7 @@ class TestAstype:
     def test_astype_tz_conversion(self):
         # GH 35973, GH#58998
         msg = "'d' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             val = {
                 "tz": date_range("2020-08-30", freq="d", periods=2, tz="Europe/London")
             }

--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -13,6 +13,7 @@ from pandas.compat import (
     is_platform_windows,
 )
 from pandas.compat.numpy import np_version_gt2
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 from pandas import (
@@ -756,7 +757,7 @@ class TestDataFrameSelectReindex:
         )
 
         msg = "'d' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             time_freq = date_range("2012-01-01", "2012-01-03", freq="d")
         some_cols = ["a", "b"]
 

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -7,6 +7,8 @@ import itertools
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     Categorical,
@@ -44,14 +46,14 @@ class TestDataFrameBlockInternals:
     def test_cast_internals(self, float_frame):
         msg = "Passing a BlockManager to DataFrame"
         with tm.assert_produces_warning(
-            DeprecationWarning, match=msg, check_stacklevel=False
+            Pandas4Warning, match=msg, check_stacklevel=False
         ):
             casted = DataFrame(float_frame._mgr, dtype=int)
         expected = DataFrame(float_frame._series, dtype=int)
         tm.assert_frame_equal(casted, expected)
 
         with tm.assert_produces_warning(
-            DeprecationWarning, match=msg, check_stacklevel=False
+            Pandas4Warning, match=msg, check_stacklevel=False
         ):
             casted = DataFrame(float_frame._mgr, dtype=np.int32)
         expected = DataFrame(float_frame._series, dtype=np.int32)

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from pandas._libs import lib
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 from pandas import (
@@ -1066,7 +1067,7 @@ class TestDataFrameReshape:
         # GH 8039
         t = datetime(2014, 1, 1)
         df = DataFrame([1, 2, 3, 4], columns=MultiIndex.from_tuples([(t, "A", "B")]))
-        warn = None if future_stack else FutureWarning
+        warn = None if future_stack else Pandas4Warning
         msg = "The previous implementation of stack is deprecated"
         with tm.assert_produces_warning(warn, match=msg):
             result = df.stack(future_stack=future_stack)

--- a/pandas/tests/indexes/datetimes/methods/test_snap.py
+++ b/pandas/tests/indexes/datetimes/methods/test_snap.py
@@ -1,5 +1,7 @@
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     DatetimeIndex,
     date_range,
@@ -30,7 +32,7 @@ def test_dti_snap(name, tz, unit):
 
     result = dti.snap(freq="W-MON")
     msg = "'w-mon' is deprecated and will be removed in a future version."
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         expected = date_range("12/31/2001", "1/7/2002", name=name, tz=tz, freq="w-mon")
     expected = expected.repeat([3, 4])
     expected = expected.as_unit(unit)
@@ -42,7 +44,7 @@ def test_dti_snap(name, tz, unit):
     result = dti.snap(freq="B")
 
     msg = "'b' is deprecated and will be removed in a future version."
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         expected = date_range("1/1/2002", "1/7/2002", name=name, tz=tz, freq="b")
     expected = expected.repeat([1, 1, 1, 2, 2])
     expected = expected.as_unit(unit)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -20,7 +20,10 @@ from pandas._libs.tslibs.offsets import (
     MonthEnd,
     prefix_mapping,
 )
-from pandas.errors import OutOfBoundsDatetime
+from pandas.errors import (
+    OutOfBoundsDatetime,
+    Pandas4Warning,
+)
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -807,7 +810,7 @@ class TestDateRanges:
         )
 
         expected = date_range("1/1/2000", periods=4, freq=freq)
-        with tm.assert_produces_warning(FutureWarning, match=depr_msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             result = date_range("1/1/2000", periods=4, freq=freq_depr)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs.period import IncompatibleFrequency
+from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.dtypes import PeriodDtype
 
@@ -85,13 +86,17 @@ class TestPeriodIndexDisallowedFreqs:
             f"'{freq_depr[1:]}' is deprecated and will be removed in a future version."
         )
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            Pandas4Warning, match=msg, raise_on_extra_warnings=False
+        ):
             result = PeriodIndex(["2020-01-01", "2020-01-02"], freq=freq_depr)
 
         expected = PeriodIndex(["2020-01-01", "2020-01-02"], freq=freq)
         tm.assert_index_equal(result, expected)
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            Pandas4Warning, match=msg, raise_on_extra_warnings=False
+        ):
             result = period_range(start="2020-01-01", end="2020-01-02", freq=freq_depr)
 
         expected = period_range(start="2020-01-01", end="2020-01-02", freq=freq)
@@ -539,7 +544,7 @@ class TestPeriodIndex:
         assert i1[-1] == end_intv
 
         msg = "'w' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             end_intv = Period("2006-12-31", "1w")
         i2 = period_range(end=end_intv, periods=10)
         assert len(i1) == len(i2)

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     NaT,
     Period,
@@ -211,7 +213,7 @@ class TestPeriodRangeDisallowedFreqs:
             f"future version, please use '{freq_depr.lower()[1:]}' instead."
         )
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             period_range("2020-01-01 00:00:00 00:00", periods=2, freq=freq_depr)
 
     @pytest.mark.parametrize("freq", ["2m", "2q-sep", "2y", "2H", "2S"])
@@ -237,5 +239,5 @@ class TestPeriodRangeDisallowedFreqs:
             f"future version, please use '{freq.upper()[1:]}' instead."
         )
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             period_range(freq=freq, start="1/1/2001", end="12/1/2009")

--- a/pandas/tests/indexes/timedeltas/test_constructors.py
+++ b/pandas/tests/indexes/timedeltas/test_constructors.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     Timedelta,
@@ -257,10 +259,10 @@ class TestTimedeltaIndex:
         msg = f"'{unit_depr}' is deprecated and will be removed in a future version."
 
         expected = TimedeltaIndex([f"1{unit}", f"2{unit}"])
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = TimedeltaIndex([f"1{unit_depr}", f"2{unit_depr}"])
         tm.assert_index_equal(result, expected)
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             tdi = to_timedelta([1, 2], unit=unit_depr)
         tm.assert_index_equal(tdi, expected)

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -4,6 +4,8 @@ import re
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     Index,
     NaT,
@@ -22,7 +24,7 @@ class TestGetItem:
     def test_getitem_slice_keeps_name(self):
         # GH#4226, GH#59051
         msg = "'d' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             tdi = timedelta_range("1d", "5d", freq="h", name="timebucket")
         assert tdi[1:].name == tdi.name
 
@@ -340,7 +342,7 @@ class TestContains:
         # Checking for any NaT-like objects
         # GH#13603, GH#59051
         msg = "'d' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             td = to_timedelta(range(5), unit="d") + offsets.Hour(1)
         for v in [NaT, None, float("nan"), np.nan]:
             assert v not in td

--- a/pandas/tests/indexes/timedeltas/test_scalar_compat.py
+++ b/pandas/tests/indexes/timedeltas/test_scalar_compat.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs.offsets import INVALID_FREQ_ERR_MSG
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     Index,
@@ -105,7 +106,7 @@ class TestVectorizedTimedelta:
         # note that negative times round DOWN! so don't give whole numbers
         msg = "'d' is deprecated and will be removed in a future version."
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             for freq, s1, s2 in [
                 ("ns", t1, t2),
                 ("us", t1, t2),

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     Index,
@@ -44,7 +46,7 @@ class TestTimedeltaIndex:
     def test_union_coverage(self):
         # GH#59051
         msg = "'d' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             idx = TimedeltaIndex(["3d", "1d", "2d"])
         ordered = TimedeltaIndex(idx.sort_values(), freq="infer")
         result = ordered.union(idx)

--- a/pandas/tests/indexes/timedeltas/test_timedelta_range.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta_range.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     Timedelta,
     timedelta_range,
@@ -49,7 +51,7 @@ class TestTimedeltas:
             f"'{depr_unit}' is deprecated and will be removed in a future version."
         )
         expected = to_timedelta(np.arange(5), unit=unit)
-        with tm.assert_produces_warning(FutureWarning, match=depr_msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             result = to_timedelta(np.arange(5), unit=depr_unit)
             tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/internals/test_api.py
+++ b/pandas/tests/internals/test_api.py
@@ -8,6 +8,8 @@ import datetime
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.api.internals import create_dataframe_from_blocks
@@ -38,7 +40,7 @@ def test_namespace():
     ]
 
     result = [x for x in dir(internals) if not x.startswith("__")]
-    assert set(result) == set(expected + modules)
+    assert set(result) == set(expected + modules), set(result) ^ set(expected + modules)
 
 
 @pytest.mark.parametrize(
@@ -51,7 +53,7 @@ def test_namespace():
 def test_deprecations(name):
     # GH#55139
     msg = f"{name} is deprecated.* Use public APIs instead"
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         getattr(internals, name)
 
 
@@ -60,7 +62,7 @@ def test_make_block_2d_with_dti():
     dti = pd.date_range("2012", periods=3, tz="UTC")
 
     msg = "make_block is deprecated"
-    with tm.assert_produces_warning(DeprecationWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         blk = api.make_block(dti, placement=[0])
 
     assert blk.shape == (1, 3)
@@ -75,7 +77,7 @@ def test_create_block_manager_from_blocks_deprecated():
         "create_block_manager_from_blocks is deprecated and will be "
         "removed in a future version. Use public APIs instead"
     )
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         internals.create_block_manager_from_blocks
 
 

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -10,6 +10,7 @@ import pytest
 
 from pandas._libs.internals import BlockPlacement
 from pandas.compat import IS64
+from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.common import is_scalar
 
@@ -1376,7 +1377,7 @@ def test_validate_ndim():
 
     depr_msg = "make_block is deprecated"
     with pytest.raises(ValueError, match=msg):
-        with tm.assert_produces_warning(DeprecationWarning, match=depr_msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             make_block(values, placement, ndim=2)
 
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -13,6 +13,8 @@ from io import StringIO
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -548,8 +550,8 @@ def test_date_parser_and_names(all_parsers):
     data = StringIO("""x,y\n1,2""")
     warn = UserWarning
     if parser.engine == "pyarrow":
-        # DeprecationWarning for passing a Manager object
-        warn = (UserWarning, DeprecationWarning)
+        # Pandas4Warning for passing a Manager object
+        warn = (UserWarning, Pandas4Warning)
     result = parser.read_csv_check_warnings(
         warn,
         "Could not infer format",

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -13,6 +13,7 @@ import zipfile
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -1035,7 +1036,7 @@ class TestStata:
             "when writing to stata is deprecated"
         )
         exp_object = expected.astype(object)
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             exp_object.to_stata(path, convert_dates=date_conversion)
         written_and_read_again = self.read_dta(path)
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -243,7 +243,7 @@ def test_resample_how_callables(unit):
     # GH#7929
     data = np.arange(5, dtype=np.int64)
     msg = "'d' is deprecated and will be removed in a future version."
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         ind = date_range(start="2014-01-01", periods=len(data), freq="d").as_unit(unit)
     df = DataFrame({"A": data, "B": data}, index=ind)
 
@@ -340,7 +340,7 @@ def test_resample_basic_from_daily(unit):
 
     # to weekly
     msg = "'w-sun' is deprecated and will be removed in a future version."
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = s.resample("w-sun").last()
 
     assert len(result) == 3
@@ -1215,7 +1215,7 @@ def test_anchored_lowercase_buglet(unit):
     ts = Series(np.random.default_rng(2).standard_normal(len(dates)), index=dates)
     # it works!
     msg = "'d' is deprecated and will be removed in a future version."
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         ts.resample("d").mean()
 
 
@@ -2065,7 +2065,7 @@ def test_resample_depr_lowercase_frequency(freq, freq_depr, data):
     msg = f"'{freq_depr[1:]}' is deprecated and will be removed in a future version."
 
     s = Series(range(5), index=date_range("20130101", freq="h", periods=5))
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = s.resample(freq_depr).mean()
 
     exp_dti = DatetimeIndex(data=data, dtype="datetime64[ns]", freq=freq)

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -16,6 +16,7 @@ from pandas._libs.tslibs.ccalendar import (
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 from pandas._libs.tslibs.parsing import DateParseError
 from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     NaT,
@@ -109,7 +110,7 @@ class TestPeriodConstruction:
 
         i1 = Period("1982", freq="min")
         msg = "'MIN' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             i2 = Period("1982", freq="MIN")
         assert i1 == i2
 
@@ -118,7 +119,7 @@ class TestPeriodConstruction:
         assert i1 == i2
 
         msg = "'d' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             i3 = Period(year=2005, month=3, day=1, freq="d")
         assert i1 == i3
 
@@ -169,7 +170,9 @@ class TestPeriodConstruction:
 
     def test_construction_bday(self):
         # Biz day construction, roll forward if non-weekday
-        with tm.assert_produces_warning(FutureWarning, match=bday_msg):
+        with tm.assert_produces_warning(
+            Pandas4Warning, match="'b' is deprecated", raise_on_extra_warnings=False
+        ):
             i1 = Period("3/10/12", freq="B")
             i2 = Period("3/10/12", freq="D")
             assert i1 == i2.asfreq("B")
@@ -628,7 +631,9 @@ class TestPeriodConstruction:
             f"'{freq_depr[1:]}' is deprecated and will be removed in a future version."
         )
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(
+            Pandas4Warning, match=msg, raise_on_extra_warnings=False
+        ):
             result = Period("2016-03-01 09:00", freq=freq_depr)
 
         expected = Period("2016-03-01 09:00", freq=freq)

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -6,6 +6,7 @@ import pytest
 
 from pandas._libs.tslibs import OutOfBoundsTimedelta
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     Index,
@@ -49,7 +50,7 @@ class TestTimedeltaConstructorUnitKeyword:
         msg = f"'{unit_depr}' is deprecated and will be removed in a future version."
 
         expected = Timedelta(1, unit=unit)
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = Timedelta(1, unit=unit_depr)
         tm.assert_equal(result, expected)
 

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -17,7 +17,10 @@ from pandas._libs.tslibs import (
     iNaT,
 )
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
-from pandas.errors import OutOfBoundsTimedelta
+from pandas.errors import (
+    OutOfBoundsTimedelta,
+    Pandas4Warning,
+)
 
 from pandas import (
     Timedelta,
@@ -491,7 +494,7 @@ class TestTimedeltas:
         assert Timedelta("1000ns") == np.timedelta64(1000, "ns")
 
         msg = "'NS' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             assert Timedelta("1000NS") == np.timedelta64(1000, "ns")
 
         assert Timedelta("10us") == np.timedelta64(10000, "ns")
@@ -512,7 +515,7 @@ class TestTimedeltas:
         assert Timedelta("1000s") == np.timedelta64(1000000000000, "ns")
 
         msg = "'d' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             assert Timedelta("1d") == conv(np.timedelta64(1, "D"))
         assert Timedelta("-1D") == -conv(np.timedelta64(1, "D"))
         assert Timedelta("1D") == conv(np.timedelta64(1, "D"))
@@ -684,7 +687,7 @@ class TestTimedeltas:
         # GH#59051
         msg = f"'{unit_depr}' is deprecated and will be removed in a future version."
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = Timedelta(1, unit_depr)
         assert result == Timedelta(1, unit)
 

--- a/pandas/tests/series/methods/test_map.py
+++ b/pandas/tests/series/methods/test_map.py
@@ -8,6 +8,8 @@ import math
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -616,7 +618,7 @@ def test_map_kwargs():
 
 def test_map_arg_as_kwarg():
     with tm.assert_produces_warning(
-        FutureWarning, match="`arg` has been renamed to `func`"
+        Pandas4Warning, match="`arg` has been renamed to `func`"
     ):
         Series([1, 2]).map(arg={})
 

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -6,6 +6,8 @@ from datetime import (
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     NA,
     DataFrame,
@@ -803,7 +805,7 @@ def test_decode_with_dtype_none():
 def test_reversed_logical_ops(any_string_dtype):
     # GH#60234
     dtype = any_string_dtype
-    warn = None if dtype == object else FutureWarning
+    warn = None if dtype == object else Pandas4Warning
     left = Series([True, False, False, True])
     right = Series(["", "", "b", "c"], dtype=dtype)
 

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -10,7 +10,10 @@ from pandas.compat import (
     IS64,
     WASM,
 )
-from pandas.errors import OutOfBoundsTimedelta
+from pandas.errors import (
+    OutOfBoundsTimedelta,
+    Pandas4Warning,
+)
 
 import pandas as pd
 from pandas import (
@@ -58,7 +61,7 @@ class TestTimedeltas:
         expected = Series([timedelta(days=1), timedelta(days=1, seconds=1)])
 
         msg = "'d' is deprecated and will be removed in a future version."
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = to_timedelta(Series(["1d", "1days 00:00:01"]))
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/tslibs/test_to_offset.py
+++ b/pandas/tests/tslibs/test_to_offset.py
@@ -7,6 +7,7 @@ from pandas._libs.tslibs import (
     offsets,
     to_offset,
 )
+from pandas.errors import Pandas4Warning
 
 import pandas._testing as tm
 
@@ -130,7 +131,7 @@ def test_to_offset_leading_zero(freqstr, expected):
 
 
 @pytest.mark.parametrize(
-    "freqstr,expected,wrn", [("+1d", 1, FutureWarning), ("+2h30min", 150, None)]
+    "freqstr,expected,wrn", [("+1d", 1, Pandas4Warning), ("+2h30min", 150, None)]
 )
 def test_to_offset_leading_plus(freqstr, expected, wrn):
     msg = "'d' is deprecated and will be removed in a future version."
@@ -212,7 +213,7 @@ def test_to_offset_uppercase_frequency_deprecated(freq_depr):
         f"future version, please use '{freq_depr.lower()[1:]}' instead."
     )
 
-    with tm.assert_produces_warning(FutureWarning, match=depr_msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
         to_offset(freq_depr)
 
 
@@ -228,7 +229,7 @@ def test_to_offset_lowercase_frequency_deprecated(freq_depr, expected):
     # GH#54939, GH#58998
     msg = f"'{freq_depr[1:]}' is deprecated and will be removed in a future version."
 
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = to_offset(freq_depr)
     assert result == expected
 

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     DataFrame,
     DatetimeIndex,
@@ -639,7 +641,7 @@ class TestRolling:
         )
         msg = "'d' is deprecated and will be removed in a future version."
 
-        with tm.assert_produces_warning(FutureWarning, match=msg):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = (
                 df.groupby("group")
                 .rolling("3d", on="date", closed="left")["column1"]

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -12,6 +12,7 @@ from pandas.compat import (
     is_platform_power,
     is_platform_riscv64,
 )
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     DataFrame,
@@ -1460,7 +1461,7 @@ def test_rolling_descending_date_order_with_offset(frame_or_series):
     # GH#40002
     msg = "'d' is deprecated and will be removed in a future version."
 
-    with tm.assert_produces_warning(FutureWarning, match=msg):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         idx = date_range(start="2020-01-01", end="2020-01-03", freq="1d")
         obj = frame_or_series(range(1, 4), index=idx)
         result = obj.rolling("1d", closed="left").sum()


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Replaces all appropriate FutureWarnings and DeprecationWarnings with Pandas4Warnings. For those that are to be enforced in 3.0, I added `# TODO: Enforce ...`. I plan to introduce linting rules on FutureWarning/DeprecationWarning next.