### PR TITLE
CI: Fix scripts tests when running from another directory

### DIFF
--- a/scripts/tests/test_validate_min_versions_in_sync.py
+++ b/scripts/tests/test_validate_min_versions_in_sync.py
@@ -10,36 +10,36 @@ from scripts.validate_min_versions_in_sync import (
     pin_min_versions_to_yaml_file,
 )
 
-BASE_PATH = pathlib.Path(__file__).parents[2]
+DATA_PATH = pathlib.Path(__file__).parents[2] / "scripts/tests/data/"
 
 
 @pytest.mark.parametrize(
     "src_toml, src_yaml, expected_yaml",
     [
         (
-            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
-            BASE_PATH / "scripts/tests/data/deps_unmodified_random.yaml",
-            BASE_PATH / "scripts/tests/data/deps_expected_random.yaml",
+            DATA_PATH / "deps_minimum.toml",
+            DATA_PATH / "deps_unmodified_random.yaml",
+            DATA_PATH / "deps_expected_random.yaml",
         ),
         (
-            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
-            BASE_PATH / "scripts/tests/data/deps_unmodified_same_version.yaml",
-            BASE_PATH / "scripts/tests/data/deps_expected_same_version.yaml",
+            DATA_PATH / "deps_minimum.toml",
+            DATA_PATH / "deps_unmodified_same_version.yaml",
+            DATA_PATH / "deps_expected_same_version.yaml",
         ),
         (
-            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
-            BASE_PATH / "scripts/tests/data/deps_unmodified_duplicate_package.yaml",
-            BASE_PATH / "scripts/tests/data/deps_expected_duplicate_package.yaml",
+            DATA_PATH / "deps_minimum.toml",
+            DATA_PATH / "deps_unmodified_duplicate_package.yaml",
+            DATA_PATH / "deps_expected_duplicate_package.yaml",
         ),
         (
-            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
-            BASE_PATH / "scripts/tests/data/deps_unmodified_no_version.yaml",
-            BASE_PATH / "scripts/tests/data/deps_expected_no_version.yaml",
+            DATA_PATH / "deps_minimum.toml",
+            DATA_PATH / "deps_unmodified_no_version.yaml",
+            DATA_PATH / "deps_expected_no_version.yaml",
         ),
         (
-            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
-            BASE_PATH / "scripts/tests/data/deps_unmodified_range.yaml",
-            BASE_PATH / "scripts/tests/data/deps_expected_range.yaml",
+            DATA_PATH / "deps_minimum.toml",
+            DATA_PATH / "deps_unmodified_range.yaml",
+            DATA_PATH / "deps_expected_range.yaml",
         ),
     ],
 )

--- a/scripts/tests/test_validate_min_versions_in_sync.py
+++ b/scripts/tests/test_validate_min_versions_in_sync.py
@@ -10,34 +10,36 @@ from scripts.validate_min_versions_in_sync import (
     pin_min_versions_to_yaml_file,
 )
 
+BASE_PATH = pathlib.Path(__file__).parents[2]
+
 
 @pytest.mark.parametrize(
     "src_toml, src_yaml, expected_yaml",
     [
         (
-            pathlib.Path("scripts/tests/data/deps_minimum.toml"),
-            pathlib.Path("scripts/tests/data/deps_unmodified_random.yaml"),
-            pathlib.Path("scripts/tests/data/deps_expected_random.yaml"),
+            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
+            BASE_PATH / "scripts/tests/data/deps_unmodified_random.yaml",
+            BASE_PATH / "scripts/tests/data/deps_expected_random.yaml",
         ),
         (
-            pathlib.Path("scripts/tests/data/deps_minimum.toml"),
-            pathlib.Path("scripts/tests/data/deps_unmodified_same_version.yaml"),
-            pathlib.Path("scripts/tests/data/deps_expected_same_version.yaml"),
+            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
+            BASE_PATH / "scripts/tests/data/deps_unmodified_same_version.yaml",
+            BASE_PATH / "scripts/tests/data/deps_expected_same_version.yaml",
         ),
         (
-            pathlib.Path("scripts/tests/data/deps_minimum.toml"),
-            pathlib.Path("scripts/tests/data/deps_unmodified_duplicate_package.yaml"),
-            pathlib.Path("scripts/tests/data/deps_expected_duplicate_package.yaml"),
+            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
+            BASE_PATH / "scripts/tests/data/deps_unmodified_duplicate_package.yaml",
+            BASE_PATH / "scripts/tests/data/deps_expected_duplicate_package.yaml",
         ),
         (
-            pathlib.Path("scripts/tests/data/deps_minimum.toml"),
-            pathlib.Path("scripts/tests/data/deps_unmodified_no_version.yaml"),
-            pathlib.Path("scripts/tests/data/deps_expected_no_version.yaml"),
+            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
+            BASE_PATH / "scripts/tests/data/deps_unmodified_no_version.yaml",
+            BASE_PATH / "scripts/tests/data/deps_expected_no_version.yaml",
         ),
         (
-            pathlib.Path("scripts/tests/data/deps_minimum.toml"),
-            pathlib.Path("scripts/tests/data/deps_unmodified_range.yaml"),
-            pathlib.Path("scripts/tests/data/deps_expected_range.yaml"),
+            BASE_PATH / "scripts/tests/data/deps_minimum.toml",
+            BASE_PATH / "scripts/tests/data/deps_unmodified_range.yaml",
+            BASE_PATH / "scripts/tests/data/deps_expected_range.yaml",
         ),
     ],
 )

--- a/scripts/tests/test_validate_unwanted_patterns.py
+++ b/scripts/tests/test_validate_unwanted_patterns.py
@@ -10,7 +10,7 @@ class TestStringsWithWrongPlacedWhitespace:
         "data",
         [
             (
-                """
+                r"""
     msg = (
         "foo\n"
         " bar"

--- a/scripts/validate_min_versions_in_sync.py
+++ b/scripts/validate_min_versions_in_sync.py
@@ -23,19 +23,20 @@ import yaml
 
 from scripts.generate_pip_deps_from_conda import CONDA_TO_PIP
 
-DOC_PATH = pathlib.Path("doc/source/getting_started/install.rst").resolve()
+BASE_PATH = pathlib.Path(__file__).parents[1]
+DOC_PATH = (BASE_PATH / "doc/source/getting_started/install.rst").resolve()
 CI_PATH = next(
-    pathlib.Path("ci/deps").absolute().glob("actions-*-minimum_versions.yaml")
+    (BASE_PATH / "ci/deps").absolute().glob("actions-*-minimum_versions.yaml")
 )
-CODE_PATH = pathlib.Path("pandas/compat/_optional.py").resolve()
-SETUP_PATH = pathlib.Path("pyproject.toml").resolve()
-YAML_PATH = pathlib.Path("ci/deps")
-ENV_PATH = pathlib.Path("environment.yml")
+CODE_PATH = (BASE_PATH / "pandas/compat/_optional.py").resolve()
+SETUP_PATH = (BASE_PATH / "pyproject.toml").resolve()
+YAML_PATH = BASE_PATH / "ci/deps"
+ENV_PATH = BASE_PATH / "environment.yml"
 EXCLUDE_DEPS = {"tzdata", "pyqt", "pyqt5"}
 # pandas package is not available
 # in pre-commit environment
-sys.path.append("pandas/compat")
-sys.path.append("pandas/util")
+sys.path.append(str(BASE_PATH / "pandas/compat"))
+sys.path.append(str(BASE_PATH / "pandas/util"))
 import _exceptions
 import version
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

`scripts/` tests fail when you don't run from the root directory of the repository.

