### PR TITLE
BUG: Fix typos in test method names

### DIFF
--- a/pandas/tests/groupby/test_libgroupby.py
+++ b/pandas/tests/groupby/test_libgroupby.py
@@ -285,7 +285,7 @@ def test_cython_group_mean_not_datetimelike_but_has_NaT_values():
     )
 
 
-def test_cython_group_mean_Inf_at_begining_and_end():
+def test_cython_group_mean_Inf_at_beginning_and_end():
     # GH 50367
     actual = np.array([[np.nan, np.nan], [np.nan, np.nan]], dtype="float64")
     counts = np.array([0, 0], dtype="int64")
@@ -314,7 +314,7 @@ def test_cython_group_mean_Inf_at_begining_and_end():
         ([[np.inf], [-np.inf], [-np.inf]], [[np.inf], [-np.inf]]),
     ],
 )
-def test_cython_group_sum_Inf_at_begining_and_end(values, out):
+def test_cython_group_sum_Inf_at_beginning_and_end(values, out):
     # GH #53606
     actual = np.array([[np.nan], [np.nan]], dtype="float64")
     counts = np.array([0, 0], dtype="int64")

--- a/pandas/tests/reshape/test_from_dummies.py
+++ b/pandas/tests/reshape/test_from_dummies.py
@@ -100,7 +100,7 @@ def test_error_contains_non_dummies():
         from_dummies(dummies)
 
 
-def test_error_with_prefix_multiple_seperators():
+def test_error_with_prefix_multiple_separators():
     dummies = DataFrame(
         {
             "col1_a": [1, 0, 1],


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

This PR fixes three typos in test method names.

In `pandas/tests/groupby/test_libgroupby.py`:

```diff
-def test_cython_group_mean_Inf_at_begining_and_end():
+def test_cython_group_mean_Inf_at_beginning_and_end():
```

```diff
-def test_cython_group_sum_Inf_at_begining_and_end():
+def test_cython_group_sum_Inf_at_beginning_and_end():
```

And in `pandas/tests/reshape/test_from_dummies.py`:

```diff
-def test_error_with_prefix_multiple_seperators():
+def test_error_with_prefix_multiple_separators():
```

Since these are not part of the public API, no deprecation notice is necessary, and pytest should pick up the corrected names without a problem.