### PR TITLE
BUG: Fix Memory Leak in to_json

### DIFF
--- a/pandas/_libs/src/datetime/pd_datetime.c
+++ b/pandas/_libs/src/datetime/pd_datetime.c
@@ -55,9 +55,23 @@ static int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
   out->month = 1;
   out->day = 1;
 
-  out->year = PyLong_AsLong(PyObject_GetAttrString(obj, "year"));
-  out->month = PyLong_AsLong(PyObject_GetAttrString(obj, "month"));
-  out->day = PyLong_AsLong(PyObject_GetAttrString(obj, "day"));
+  tmp = PyObject_GetAttrString(obj, "year");
+  if (tmp == NULL)
+    return -1;
+  out->year = PyLong_AsLong(tmp);
+  Py_DECREF(tmp);
+
+  tmp = PyObject_GetAttrString(obj, "month");
+  if (tmp == NULL)
+    return -1;
+  out->month = PyLong_AsLong(tmp);
+  Py_DECREF(tmp);
+
+  tmp = PyObject_GetAttrString(obj, "day");
+  if (tmp == NULL)
+    return -1;
+  out->day = PyLong_AsLong(tmp);
+  Py_DECREF(tmp);
 
   // TODO(anyone): If we can get PyDateTime_IMPORT to work, we could use
   // PyDateTime_Check here, and less verbose attribute lookups.
@@ -70,10 +84,29 @@ static int convert_pydatetime_to_datetimestruct(PyObject *dtobj,
     return 0;
   }
 
-  out->hour = PyLong_AsLong(PyObject_GetAttrString(obj, "hour"));
-  out->min = PyLong_AsLong(PyObject_GetAttrString(obj, "minute"));
-  out->sec = PyLong_AsLong(PyObject_GetAttrString(obj, "second"));
-  out->us = PyLong_AsLong(PyObject_GetAttrString(obj, "microsecond"));
+  tmp = PyObject_GetAttrString(obj, "hour");
+  if (tmp == NULL)
+    return -1;
+  out->hour = PyLong_AsLong(tmp);
+  Py_DECREF(tmp);
+
+  tmp = PyObject_GetAttrString(obj, "minute");
+  if (tmp == NULL)
+    return -1;
+  out->min = PyLong_AsLong(tmp);
+  Py_DECREF(tmp);
+
+  tmp = PyObject_GetAttrString(obj, "second");
+  if (tmp == NULL)
+    return -1;
+  out->sec = PyLong_AsLong(tmp);
+  Py_DECREF(tmp);
+
+  tmp = PyObject_GetAttrString(obj, "microsecond");
+  if (tmp == NULL)
+    return -1;
+  out->us = PyLong_AsLong(tmp);
+  Py_DECREF(tmp);
 
   if (PyObject_HasAttrString(obj, "tzinfo")) {
     PyObject *offset = extract_utc_offset(obj);


### PR DESCRIPTION
- [x] closes #62204 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

This patch decrements all references obtained from `PyObject_GetAttrString` to fix the memory leak.

I used this script to reproduce the memory leak:
```python
import pandas as pd

for _ in range(10_000):
    df = pd.DataFrame({'col1': [12.34]}, 
                      index=pd.date_range('1/1/2019', '10/1/2019', freq="D", tz="UTC"))
    result = df.reset_index().to_json()
```

and pinpointed the problem with valgrind, which have shown this:
```
==59316== 87,674,752 bytes in 2,739,836 blocks are definitely lost in loss record 32,561 of 32,561
==59316==    at 0x4842B26: malloc (vg_replace_malloc.c:446)
==59316==    by 0x49AC853: UnknownInlinedFun (obmalloc.c:62)
==59316==    by 0x49AC853: UnknownInlinedFun (obmalloc.c:982)
==59316==    by 0x49AC853: UnknownInlinedFun (obmalloc.c:2238)
==59316==    by 0x49AC853: UnknownInlinedFun (obmalloc.c:1400)
==59316==    by 0x49AC853: UnknownInlinedFun (longobject.c:209)
==59316==    by 0x49AC853: PyLong_FromLong (longobject.c:305)
==59316==    by 0x43559F5C: __pyx_getprop_6pandas_5_libs_6tslibs_10timestamps_10_Timestamp_year (in /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/tslibs/timestamps.cpython-313-x86_64-linux-gnu.so)
==59316==    by 0x49E765C: _PyObject_GenericGetAttrWithDict (object.c:1665)
==59316==    by 0x49B8B4A: UnknownInlinedFun (object.c:1751)
==59316==    by 0x49B8B4A: PyObject_GetAttr (object.c:1261)
==59316==    by 0x49F6741: PyObject_GetAttrString (object.c:1131)
==59316==    by 0x42F9C027: convert_pydatetime_to_datetimestruct (in /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/pandas_datetime.cpython-313-x86_64-linux-gnu.so)
==59316==    by 0x42F9C2C1: PyDateTimeToEpoch (in /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/pandas_datetime.cpython-313-x86_64-linux-gnu.so)
==59316==    by 0x52ACA92D: Object_beginTypeContext (in /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/json.cpython-313-x86_64-linux-gnu.so)
==59316==    by 0x52ACCB9C: encode (in /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/json.cpython-313-x86_64-linux-gnu.so)
==59316==    by 0x52ACCE41: encode (in /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/json.cpython-313-x86_64-linux-gnu.so)
==59316==    by 0x52ACCE41: encode (in /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/json.cpython-313-x86_64-linux-gnu.so)
```
