### PR TITLE
TYP: Typing fixes and improvements related to ``scipy.interpolate``

### DIFF
--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -45,7 +45,11 @@ from pandas.core.dtypes.missing import (
 )
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from pandas import Index
+
+    _CubicBC: TypeAlias = Literal["not-a-knot", "clamped", "natural", "periodic"]
 
 
 def check_value_size(value, mask: npt.NDArray[np.bool_], length: int):
@@ -700,9 +704,9 @@ def _cubicspline_interpolate(
     yi: np.ndarray,
     x: np.ndarray,
     axis: AxisInt = 0,
-    bc_type: str | tuple[Any, Any] = "not-a-knot",
-    extrapolate=None,
-):
+    bc_type: _CubicBC | tuple[Any, Any] = "not-a-knot",
+    extrapolate: Literal["periodic"] | bool | None = None,
+) -> np.ndarray:
     """
     Convenience function for cubic spline data interpolator.
 

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -652,7 +652,7 @@ def _akima_interpolate(
     xi: np.ndarray,
     yi: np.ndarray,
     x: np.ndarray,
-    der: int | list[int] | None = 0,
+    der: int = 0,
     axis: AxisInt = 0,
 ):
     """
@@ -673,10 +673,8 @@ def _akima_interpolate(
     x : np.ndarray
         Of length M.
     der : int, optional
-        How many derivatives to extract; None for all potentially
-        nonzero derivatives (that is a number equal to the number
-        of points), or a list of derivatives to extract. This number
-        includes the function value as 0th derivative.
+        How many derivatives to extract. This number includes the function
+        value as 0th derivative.
     axis : int, optional
         Axis in the yi array corresponding to the x-coordinate values.
 


### PR DESCRIPTION
I noticed that when [`scipy-stubs`](https://github.com/scipy/scipy-stubs) is installed, mypy reports several new errors in `pandas.core.missing`. At first I thought that scipy-stubs (i.e. me) was to blame, but as it turns out, these errors were there for a good reason.

Instances of `scipy.interpolate.Akima1DInterpolator` can only be called with `der: int`. If `None` or some `list[int]` is passed, it will raise a `TypeError`, originating at  https://github.com/scipy/scipy/blob/ec99caa218bce81c7773f6983ead9fdda7eb42c6/scipy/interpolate/_ppoly.pyx#L31 .

The other error popped up in `_cubicspline_interpolate`, because `CubicSpline` only accepts certain literal strings for the `bc_type` parameter of the `scipy.interpolate.CubicSpline` constructor. But the `bc_type` that's passed to it, is annotated as `str`, which isn't assignable to these literal strings. So I figured it could be a nice opportunity to tighten up the `_cubicspline_interpolate` function annotations. 

---

Note that this is only part of the story, as there were more errors like these in other places as well. So if it's ok with you, I'd like to tackle these as well in follow-up PR's (probably one or two).
And once they're all fixed, I could add `scipy-stubs` as dev dependency so that issues like this one could be avoided in the future. Having scipy-stubs installed in your dev env can also help quite a bit with IDE support for things like autocompletion and inline documentation and stuff. 

---

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
