### PR TITLE
Remove custom footer template in favor of theme options (#51536)

### DIFF
--- a/doc/_templates/pandas_footer.html
+++ b/doc/_templates/pandas_footer.html
@@ -1,3 +1,0 @@
-<p class="copyright">
-    &copy {{copyright}} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>.
-</p>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -241,8 +241,14 @@ else:
     switcher_version = ".".join(version.split(".")[:2])
 
 html_theme_options = {
-    "external_links": [],
-    "footer_start": ["pandas_footer", "sphinx-version"],
+    "external_links": [
+        {
+            "url": "https://github.com/pandas-dev/pandas",
+            "name": "GitHub",
+        },
+    ],
+    "footer_start": ["copyright"],
+    "footer_end": ["sphinx-version", "theme-version"],
     "github_url": "https://github.com/pandas-dev/pandas",
     "analytics": {
         "plausible_analytics_domain": "pandas.pydata.org",
@@ -255,6 +261,7 @@ html_theme_options = {
         "json_url": "https://pandas.pydata.org/versions.json",
         "version_match": switcher_version,
     },
+
     # This shows a warning for patch releases since the
     # patch version doesn't compare as equal (e.g. 2.2.1 != 2.2.0 but it should be)
     "show_version_warning_banner": False,


### PR DESCRIPTION
- Removed custom footer override in `_templates/` (footer.html/layout.html)
- Configured footer directly in `html_theme_options` within conf.py
- Footer now shows:
  - Copyright
  - Sphinx + theme version
  - External GitHub link

This simplifies the documentation theme configuration and avoids maintaining a custom footer template.

Closes #51536
