### PR TITLE
TST: regression test for GH#56853 (insert/delete with MultiIndex datetime)

### DIFF
--- a/pandas/tests/frame/indexing/test_insert.py
+++ b/pandas/tests/frame/indexing/test_insert.py
@@ -10,6 +10,9 @@ import pytest
 from pandas import (
     DataFrame,
     Index,
+    MultiIndex,
+    NaT,
+    Timestamp,
 )
 import pandas._testing as tm
 
@@ -94,3 +97,23 @@ class TestDataFrameInsert:
         df = DataFrame({"a": [1, 2]})
         df.insert(np.int64(0), "b", 0)
         tm.assert_frame_equal(df, DataFrame({"b": [0, 0], "a": [1, 2]}))
+
+    def test_insert_delete_mixed_multiindex_columns(self):
+        # GH#56853
+
+        df = DataFrame({("A", Timestamp("2024-01-01")): [0]})
+        df.insert(1, "B", [1])
+
+        expected = DataFrame(
+            [[0, 1]],
+            columns=MultiIndex.from_tuples(
+                [("A", Timestamp("2024-01-01")), ("B", NaT)]
+            ),
+        )
+        tm.assert_frame_equal(df, expected)
+
+        # Should not raise RecursionError (this was the original bug)
+        del df["B"]
+
+        expected = DataFrame({("A", Timestamp("2024-01-01")): [0]})
+        tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
- [x] closes #56853
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

---

This PR adds a regression test for a bug where inserting and then deleting
a column in a DataFrame with two-level MultiIndex columns (with a Timestamp
level) used to raise a RecursionError.

The bug is already fixed on main, but this test makes sure it won’t come back.

**Test location:** `pandas/tests/frame/indexing/test_insert.py`  
**Test method:** `TestDataFrameInsert.test_insert_delete_mixed_multiindex_columns`
