### PR TITLE
BUG: divmod with bool dtype failing to raise

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1119,6 +1119,7 @@ Other
 - Bug in ``Series.list`` methods not preserving the original :class:`Index`. (:issue:`58425`)
 - Bug in ``Series.list`` methods not preserving the original name. (:issue:`60522`)
 - Bug in ``Series.replace`` when the Series was created from an :class:`Index` and Copy-On-Write is enabled (:issue:`61622`)
+- Bug in ``divmod`` and ``rdivmod`` with :class:`DataFrame`, :class:`Series`, and :class:`Index` with ``bool`` dtypes failing to raise, which was inconsistent with ``__floordiv__`` behavior (:issue:`46043`)
 - Bug in printing a :class:`DataFrame` with a :class:`DataFrame` stored in :attr:`DataFrame.attrs` raised a ``ValueError`` (:issue:`60455`)
 - Bug in printing a :class:`Series` with a :class:`DataFrame` stored in :attr:`Series.attrs` raised a ``ValueError`` (:issue:`60568`)
 - Fixed bug where the :class:`DataFrame` constructor misclassified array-like objects with a ``.name`` attribute as :class:`Series` or :class:`Index` (:issue:`61443`)

--- a/pandas/core/ops/array_ops.py
+++ b/pandas/core/ops/array_ops.py
@@ -585,6 +585,8 @@ _BOOL_OP_NOT_ALLOWED = {
     roperator.rfloordiv,
     operator.pow,
     roperator.rpow,
+    divmod,
+    roperator.rdivmod,
 }
 
 

--- a/pandas/tests/arithmetic/test_bool.py
+++ b/pandas/tests/arithmetic/test_bool.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pandas import (
+    DataFrame,
+    Series,
+)
+import pandas._testing as tm
+
+
+def test_divmod_bool_raises(box_with_array):
+    # GH#46043 // raises, so divmod should too
+    ser = Series([True, False])
+    obj = tm.box_expected(ser, box_with_array)
+
+    msg = "operator 'floordiv' not implemented for bool dtypes"
+    with pytest.raises(NotImplementedError, match=msg):
+        obj // obj
+
+    if box_with_array is DataFrame:
+        msg = "operator 'floordiv' not implemented for bool dtypes"
+    else:
+        msg = "operator 'divmod' not implemented for bool dtypes"
+    with pytest.raises(NotImplementedError, match=msg):
+        divmod(obj, obj)
+
+    # go through __rdivmod__
+    with pytest.raises(NotImplementedError, match=msg):
+        divmod(True, obj)


### PR DESCRIPTION
- [x] closes #46043 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
