### PR TITLE
Backport PR #62217 on branch 2.3.x (BUG: fix memory leak in JSON datetime serialization)

### DIFF
--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -346,7 +346,8 @@ static char *PyDateTimeToIsoCallback(JSOBJ obj, JSONTypeContext *tc,
   }
 
   NPY_DATETIMEUNIT base = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
-  return PyDateTimeToIso(obj, base, len);
+  GET_TC(tc)->cStr = PyDateTimeToIso(obj, base, len);
+  return GET_TC(tc)->cStr;
 }
 
 static char *PyTimeToJSON(JSOBJ _obj, JSONTypeContext *tc, size_t *outLen) {


### PR DESCRIPTION
Backport PR https://github.com/pandas-dev/pandas/pull/62217: BUG: fix memory leak in JSON datetime serialization

(NOTE: includes only the changes required to fix the memory leak, not the additional refactoring that was included in the PR to main, some of which doesn't apply)