### PR TITLE
ENH: Preserve nullable boolean dtype in pivot_table (GH#62244)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -163,6 +163,7 @@ Other enhancements
 - :class:`pandas.api.typing.SASReader` is available for typing the output of :func:`read_sas` (:issue:`55689`)
 - Added :meth:`.Styler.to_typst` to write Styler objects to file, buffer or string in Typst format (:issue:`57617`)
 - Added missing :meth:`pandas.Series.info` to API reference (:issue:`60926`)
+- Pivoting or unstacking boolean columns (e.g., with :meth:`DataFrame.pivot_table`, :meth:`DataFrame.unstack`) now preserves them as nullable BooleanDtype, with missing values as ``pd.NA`` for improved memory usage and correctness. (:issue:`62244`)
 - :class:`pandas.api.typing.NoDefault` is available for typing ``no_default``
 - :func:`DataFrame.to_excel` now raises an ``UserWarning`` when the character count in a cell exceeds Excel's limitation of 32767 characters (:issue:`56954`)
 - :func:`pandas.merge` now validates the ``how`` parameter input (merge type) (:issue:`59435`)
@@ -292,6 +293,7 @@ These improvements also fixed certain bugs in groupby:
 - :meth:`.DataFrameGroupBy.nunique` would fail when there are multiple groupings, unobserved groups, and ``as_index=False`` (:issue:`52848`)
 - :meth:`.DataFrameGroupBy.sum` would have incorrect values when there are multiple groupings, unobserved groups, and non-numeric data (:issue:`43891`)
 - :meth:`.DataFrameGroupBy.value_counts` would produce incorrect results when used with some categorical and some non-categorical groupings and ``observed=False`` (:issue:`56016`)
+- Fixed boolean columns being upcast to float or object in :meth:`DataFrame.pivot_table` and :meth:`DataFrame.unstack`; these now remain as nullable BooleanDtype with missing values as ``pd.NA``. (:issue:`62244`)
 
 .. _whatsnew_300.notable_bug_fixes.notable_bug_fix2:
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2618,6 +2618,25 @@ class TestPivotTable:
         expected.columns.name = "g2"
         tm.assert_frame_equal(result, expected, check_dtype=False)
 
+    def test_pivot_table_bool_preserves_boolean_dtype(self):
+        # GH#62244
+        df = DataFrame(
+            {
+                "A": ["foo", "foo", "bar"],
+                "B": ["x", "y", "x"],
+                "val": [True, False, True],
+            }
+        )
+
+        result = pivot_table(df, values="val", index="A", columns="B", aggfunc="any")
+
+        assert all(str(dtype) == "boolean" for dtype in result.dtypes)
+
+        assert result.loc["foo", "x"]
+        assert not result.loc["foo", "y"]
+        assert result.loc["bar", "x"]
+        assert pd.isna(result.loc["bar", "y"])
+
 
 class TestPivot:
     def test_pivot(self):


### PR DESCRIPTION
- Convert bool/object columns to BooleanDtype
- Skip dtype conversion for margin columns that are DataFrames
- Updated test_pivot_table_bool_preserves_boolean_dtype with safe assertions

- [x] closes #62244
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

ENH: Preserve nullable boolean dtype in pivot_table (GH#62244)

This PR ensures pivot_table preserves nullable boolean dtype instead of upcasting to float
for boolean columns or object columns containing only booleans. It also skips dtype conversion
for margin columns that are returned as DataFrames.

Includes updated test_pivot_table_bool_preserves_boolean_dtype with safe assertions
(assert / assert not) to comply with linting rules.