### PR TITLE
BUG: merge with CategoricalDtype RecursionError

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1064,6 +1064,8 @@ Reshaping
 - Bug in :meth:`concat` where concatenating DataFrame and Series with ``ignore_index = True`` drops the series name (:issue:`60723`, :issue:`56257`)
 - Bug in :func:`melt` where calling with duplicate column names in ``id_vars`` raised a misleading ``AttributeError`` (:issue:`61475`)
 - Bug in :meth:`DataFrame.merge` where user-provided suffixes could result in duplicate column names if the resulting names matched existing columns. Now raises a :class:`MergeError` in such cases. (:issue:`61402`)
+- Bug in :meth:`DataFrame.merge` with :class:`CategoricalDtype` columns incorrectly raising ``RecursionError`` (:issue:`56376`)
+-
 
 Sparse
 ^^^^^^

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1727,6 +1727,17 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
 
         if tipo is not None:
             # TODO: itemsize check?
+
+            if isinstance(tipo, CategoricalDtype):
+                # GH#56376
+                if tipo.categories.dtype.kind not in "iuf":
+                    # Anything other than float/integer we cannot hold
+                    raise LossySetitemError
+                casted = np.asarray(element, dtype=dtype)
+                if np.array_equal(casted, element, equal_nan=True):
+                    return casted
+                raise LossySetitemError
+
             if tipo.kind not in "iuf":
                 # Anything other than float/integer we cannot hold
                 raise LossySetitemError

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5386,6 +5386,12 @@ class Index(IndexOpsMixin, PandasObject):
 
             # See also: Block.coerce_to_target_dtype
             dtype = self._find_common_type_compat(value)
+            if dtype == self.dtype:
+                # GH#56376 avoid RecursionError
+                raise AssertionError(
+                    "Something has gone wrong. Please report a bug at "
+                    "github.com/pandas-dev/pandas"
+                ) from err
             return self.astype(dtype).putmask(mask, value)
 
         values = self._values.copy()

--- a/pandas/tests/dtypes/cast/test_can_hold_element.py
+++ b/pandas/tests/dtypes/cast/test_can_hold_element.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from pandas.core.dtypes.cast import can_hold_element
 
+from pandas import Categorical
+
 
 def test_can_hold_element_range(any_int_numpy_dtype):
     # GH#44261
@@ -96,3 +98,11 @@ def test_can_hold_element_bool():
     assert not can_hold_element(arr, element)
     assert not can_hold_element(arr, np.array([element]))
     assert not can_hold_element(arr, np.array([element], dtype=object))
+
+
+def test_can_hold_element_categorical():
+    # GH#56376
+    arr = np.array([], dtype=np.float64)
+    cat = Categorical([1, 2, None])
+
+    assert can_hold_element(arr, cat)


### PR DESCRIPTION
- [x] closes #56376 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
