### PR TITLE
TYP: stricter typing of return value of to_numpy_dtype_inference helper function

### DIFF
--- a/pandas/core/arrays/_utils.py
+++ b/pandas/core/arrays/_utils.py
@@ -15,13 +15,14 @@ from pandas.core.dtypes.common import is_numeric_dtype
 
 if TYPE_CHECKING:
     from pandas._typing import (
-        ArrayLike,
         npt,
     )
 
+    from pandas.core.arrays.base import ExtensionArray
+
 
 def to_numpy_dtype_inference(
-    arr: ArrayLike, dtype: npt.DTypeLike | None, na_value, hasna: bool
+    arr: ExtensionArray, dtype: npt.DTypeLike | None, na_value, hasna: bool
 ) -> tuple[np.dtype | None, Any]:
     result_dtype: np.dtype | None
     inferred_numeric_dtype = False
@@ -34,11 +35,11 @@ def to_numpy_dtype_inference(
                 if arr.dtype.kind in "iu":
                     result_dtype = np.dtype(np.float64)
                 else:
-                    result_dtype = arr.dtype.numpy_dtype  # type: ignore[union-attr]
+                    result_dtype = arr.dtype.numpy_dtype  # type: ignore[attr-defined]
                 if na_value is lib.no_default:
                     na_value = np.nan
         else:
-            result_dtype = arr.dtype.numpy_dtype  # type: ignore[union-attr]
+            result_dtype = arr.dtype.numpy_dtype  # type: ignore[attr-defined]
     elif dtype is not None:
         result_dtype = np.dtype(dtype)
     else:

--- a/pandas/core/arrays/_utils.py
+++ b/pandas/core/arrays/_utils.py
@@ -34,11 +34,11 @@ def to_numpy_dtype_inference(
                 if arr.dtype.kind in "iu":
                     result_dtype = np.dtype(np.float64)
                 else:
-                    result_dtype = arr.dtype.numpy_dtype
+                    result_dtype = arr.dtype.numpy_dtype  # type: ignore[union-attr]
                 if na_value is lib.no_default:
                     na_value = np.nan
         else:
-            result_dtype = arr.dtype.numpy_dtype
+            result_dtype = arr.dtype.numpy_dtype  # type: ignore[union-attr]
     elif dtype is not None:
         result_dtype = np.dtype(dtype)
     else:

--- a/pandas/core/arrays/_utils.py
+++ b/pandas/core/arrays/_utils.py
@@ -45,13 +45,13 @@ def to_numpy_dtype_inference(
         result_dtype = None
 
     if na_value is lib.no_default:
-        if dtype is None or not hasna:
+        if result_dtype is None or not hasna:
             na_value = arr.dtype.na_value
-        elif dtype.kind == "f":  # type: ignore[union-attr]
+        elif result_dtype.kind == "f":
             na_value = np.nan
-        elif dtype.kind == "M":  # type: ignore[union-attr]
+        elif result_dtype.kind == "M":
             na_value = np.datetime64("nat")
-        elif dtype.kind == "m":  # type: ignore[union-attr]
+        elif result_dtype.kind == "m":
             na_value = np.timedelta64("nat")
         else:
             na_value = arr.dtype.na_value


### PR DESCRIPTION
Encountered this in another PR, but this function always returns a numpy dtype instance (or None), not just any dtype-like descriptor. Rewriting the function slightly to allow specify a stricter return type.