### PR TITLE
TST: add regression test for interpolate(method='time') with Int64/Float64 (#40252)

### DIFF
--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -441,3 +441,19 @@ class TestDataFrameInterpolate:
         result = df.interpolate(limit=2)
         expected = DataFrame({"a": [1, 1.5, 2.0, None, 3]}, dtype="float64[pyarrow]")
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "Int64",
+            "Float64",
+        ],
+    )
+    def test_interpolate_time_nullable_int_float(self, dtype):
+        # GH#40252
+        idx = date_range("1970-01-02", periods=3, freq="D")
+
+        df = DataFrame({"a": [1, None, 2]}, index=idx, dtype=dtype)
+        result = df.interpolate(method="time")
+        expected = DataFrame({"a": [1.0, 1.5, 2.0]}, index=idx, dtype="Float64")
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #40252 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

---

This PR adds a regression test for GH#40252. Confirms that `interpolate(method="time")` now works correctly on nullable Int64 and Float64 dtypes. No code changes, test-only. Ensures the behavior is locked in to prevent regressions.

Thanks!
