### PR TITLE
TST: add regression test for GH#14407 fillna numeric conversion

### DIFF
--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -14,6 +14,7 @@ from pandas import (
     Timestamp,
     date_range,
     to_datetime,
+    to_numeric,
 )
 import pandas._testing as tm
 from pandas.tests.frame.common import _check_mixed_float
@@ -669,6 +670,26 @@ class TestFillNA:
             }
         )
         tm.assert_frame_equal(pdf.fillna({("x", "b"): -2, "x": -1}), expected)
+
+    def test_fillna_preserves_numeric_conversion(self):
+        # GH#14407 regression test
+        df = DataFrame(
+            {
+                "c1": ["A", "B", "C"],
+                "c2": ["1", "2", "3"],
+                "c3": [0.1, 0.2, 0.3],
+                "c4": [0, 1, 2],
+            }
+        )
+
+        result = df.apply(lambda x: to_numeric(x, errors="coerce")).fillna(df)
+
+        expected = Series(
+            {"c1": "object", "c2": "int64", "c3": "float64", "c4": "int64"},
+            name="dtype",
+        )
+
+        assert result.dtypes.astype(str).equals(expected)
 
 
 def test_fillna_nonconsolidated_frame():


### PR DESCRIPTION
- [x] closes #14407 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

---

Added a test in TestFillNA to ensure that fillna preserves numeric conversions when using to_numeric with errors="coerce". Confirms that columns retain their expected dtypes after filling missing values.

Thanks!
