### PR TITLE
BUG: Timestamp.replace failing to update unit

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -901,6 +901,7 @@ Datetimelike
 - Bug in :meth:`DatetimeIndex.union` and :meth:`DatetimeIndex.intersection` when ``unit`` was non-nanosecond (:issue:`59036`)
 - Bug in :meth:`Index.union` with a ``pyarrow`` timestamp dtype incorrectly returning ``object`` dtype (:issue:`58421`)
 - Bug in :meth:`Series.dt.microsecond` producing incorrect results for pyarrow backed :class:`Series`. (:issue:`59154`)
+- Bug in :meth:`Timestamp.replace` failing to update ``unit`` attribute when replacement introduces non-zero ``nanosecond`` or ``microsecond`` (:issue:`57749`)
 - Bug in :meth:`to_datetime` not respecting dayfirst if an uncommon date string was passed. (:issue:`58859`)
 - Bug in :meth:`to_datetime` on float array with missing values throwing ``FloatingPointError`` (:issue:`58419`)
 - Bug in :meth:`to_datetime` on float32 df with year, month, day etc. columns leads to precision issues and incorrect result. (:issue:`60506`)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -642,7 +642,7 @@ class TestPivotTable:
         )
 
         df = df.set_index("ts").reset_index()
-        mins = df.ts.map(lambda x: x.replace(hour=0, minute=0, second=0, microsecond=0))
+        mins = df.ts.map(lambda x: x.replace(hour=0, minute=0, second=0))
 
         result = pivot_table(
             df.set_index("ts").reset_index(),

--- a/pandas/tests/scalar/timestamp/methods/test_replace.py
+++ b/pandas/tests/scalar/timestamp/methods/test_replace.py
@@ -199,7 +199,7 @@ class TestTimestampReplace:
     def test_replace_updates_unit(self):
         # GH#57749
         ts = Timestamp("2023-07-15 23:08:12.134567123")
-        ts2 = Timestamp(datetime.utcfromtimestamp(int(ts.timestamp())))
+        ts2 = Timestamp("2023-07-15 23:08:12.000000")
         assert ts2.unit == "us"
         result = ts2.replace(microsecond=ts.microsecond, nanosecond=ts.nanosecond)
         assert result.unit == "ns"

--- a/pandas/tests/scalar/timestamp/methods/test_replace.py
+++ b/pandas/tests/scalar/timestamp/methods/test_replace.py
@@ -195,3 +195,17 @@ class TestTimestampReplace:
         ts_replaced = ts.replace(second=1)
 
         assert ts_replaced.fold == fold
+
+    def test_replace_updates_unit(self):
+        # GH#57749
+        ts = Timestamp("2023-07-15 23:08:12.134567123")
+        ts2 = Timestamp(datetime.utcfromtimestamp(int(ts.timestamp())))
+        assert ts2.unit == "us"
+        result = ts2.replace(microsecond=ts.microsecond, nanosecond=ts.nanosecond)
+        assert result.unit == "ns"
+        assert result == ts
+
+        ts3 = Timestamp("2023-07-15 23:08:12").as_unit("s")
+        result = ts3.replace(microsecond=ts2.microsecond)
+        assert result.unit == "us"
+        assert result == ts2


### PR DESCRIPTION
- [x] closes #57749 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
