### PR TITLE
BUG: Timedelta from Tick offsets now behaves like keyword arguments (GH#62310)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -919,6 +919,7 @@ Timedelta
 ^^^^^^^^^
 - Accuracy improvement in :meth:`Timedelta.to_pytimedelta` to round microseconds consistently for large nanosecond based Timedelta (:issue:`57841`)
 - Bug in :class:`Timedelta` constructor failing to raise when passed an invalid keyword (:issue:`53801`)
+- Bug in :class:`Timedelta` when constructed from Tick offsets (e.g., ``Timedelta(offsets.Hour(1))``) that could produce incorrect results in arithmetic. Timedelta now handles Hour, Minute, and Second offsets consistently with keyword arguments (:issue:`62310`)
 - Bug in :meth:`DataFrame.cumsum` which was raising ``IndexError`` if dtype is ``timedelta64[ns]`` (:issue:`57956`)
 - Bug in multiplication operations with ``timedelta64`` dtype failing to raise ``TypeError`` when multiplying by ``bool`` objects or dtypes (:issue:`58054`)
 


### PR DESCRIPTION
- [x] closes #62310 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

Fix Timedelta from Tick offsets (e.g., ``Timedelta(offsets.Hour(1))``) giving wrong arithmetic. Hour, Minute, and Second offsets now behave like keyword arguments. Added a test to ensure consistency.

Thanks!