### PR TITLE
CoW: disable chained assignment detection for Python 3.14

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -358,8 +358,6 @@ jobs:
 
       - name: Run Tests
         uses: ./.github/actions/run-tests
-        # TEMP allow this to fail until we fixed all test failures (related to chained assignment warnings)
-        continue-on-error: true
 
   # NOTE: this job must be kept in sync with the Pyodide build job in wheels.yml
   emscripten:

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -12,7 +12,10 @@ from typing import (
 )
 import uuid
 
-from pandas.compat import PYPY
+from pandas.compat import (
+    PYPY,
+    WARNING_CHECK_BROKEN,
+)
 from pandas.errors import ChainedAssignmentError
 
 from pandas.io.common import get_handle
@@ -163,7 +166,7 @@ def with_csv_dialect(name: str, **kwargs) -> Generator[None]:
 def raises_chained_assignment_error(extra_warnings=(), extra_match=()):
     from pandas._testing import assert_produces_warning
 
-    if PYPY:
+    if PYPY or WARNING_CHECK_BROKEN:
         if not extra_warnings:
             from contextlib import nullcontext
 

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -14,7 +14,7 @@ import uuid
 
 from pandas.compat import (
     PYPY,
-    WARNING_CHECK_BROKEN,
+    WARNING_CHECK_DISABLED,
 )
 from pandas.errors import ChainedAssignmentError
 
@@ -166,7 +166,7 @@ def with_csv_dialect(name: str, **kwargs) -> Generator[None]:
 def raises_chained_assignment_error(extra_warnings=(), extra_match=()):
     from pandas._testing import assert_produces_warning
 
-    if PYPY or WARNING_CHECK_BROKEN:
+    if PYPY or WARNING_CHECK_DISABLED:
         if not extra_warnings:
             from contextlib import nullcontext
 

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -21,7 +21,7 @@ from pandas.compat._constants import (
     PY312,
     PY314,
     PYPY,
-    WARNING_CHECK_BROKEN,
+    WARNING_CHECK_DISABLED,
     WASM,
 )
 from pandas.compat.numpy import is_numpy_dev
@@ -159,7 +159,7 @@ __all__ = [
     "PY314",
     "PYARROW_MIN_VERSION",
     "PYPY",
-    "WARNING_CHECK_BROKEN",
+    "WARNING_CHECK_DISABLED",
     "WASM",
     "is_numpy_dev",
     "pa_version_under14p0",

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -21,6 +21,7 @@ from pandas.compat._constants import (
     PY312,
     PY314,
     PYPY,
+    WARNING_CHECK_BROKEN,
     WASM,
 )
 from pandas.compat.numpy import is_numpy_dev
@@ -158,6 +159,7 @@ __all__ = [
     "PY314",
     "PYARROW_MIN_VERSION",
     "PYPY",
+    "WARNING_CHECK_BROKEN",
     "WASM",
     "is_numpy_dev",
     "pa_version_under14p0",

--- a/pandas/compat/_constants.py
+++ b/pandas/compat/_constants.py
@@ -19,7 +19,7 @@ PYPY = platform.python_implementation() == "PyPy"
 WASM = (sys.platform == "emscripten") or (platform.machine() in ["wasm32", "wasm64"])
 ISMUSL = "musl" in (sysconfig.get_config_var("HOST_GNU_TYPE") or "")
 REF_COUNT = 2
-WARNING_CHECK_BROKEN = PY314
+WARNING_CHECK_DISABLED = PY314
 
 
 __all__ = [

--- a/pandas/compat/_constants.py
+++ b/pandas/compat/_constants.py
@@ -19,6 +19,8 @@ PYPY = platform.python_implementation() == "PyPy"
 WASM = (sys.platform == "emscripten") or (platform.machine() in ["wasm32", "wasm64"])
 ISMUSL = "musl" in (sysconfig.get_config_var("HOST_GNU_TYPE") or "")
 REF_COUNT = 2
+WARNING_CHECK_BROKEN = PY314
+
 
 __all__ = [
     "IS64",

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -52,7 +52,7 @@ from pandas._libs.lib import is_range_indexer
 from pandas.compat import PYPY
 from pandas.compat._constants import (
     REF_COUNT,
-    WARNING_CHECK_BROKEN,
+    WARNING_CHECK_DISABLED,
 )
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
@@ -4299,7 +4299,7 @@ class DataFrame(NDFrame, OpsMixin):
         z  3  50
         # Values for 'a' and 'b' are completely ignored!
         """
-        if not PYPY and not WARNING_CHECK_BROKEN:
+        if not PYPY and not WARNING_CHECK_DISABLED:
             if sys.getrefcount(self) <= REF_COUNT + 1:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
@@ -9214,7 +9214,7 @@ class DataFrame(NDFrame, OpsMixin):
         1  2  500.0
         2  3    6.0
         """
-        if not PYPY and not WARNING_CHECK_BROKEN:
+        if not PYPY and not WARNING_CHECK_DISABLED:
             if sys.getrefcount(self) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_method_msg,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -50,7 +50,10 @@ from pandas._libs import (
 from pandas._libs.hashtable import duplicated
 from pandas._libs.lib import is_range_indexer
 from pandas.compat import PYPY
-from pandas.compat._constants import REF_COUNT
+from pandas.compat._constants import (
+    REF_COUNT,
+    WARNING_CHECK_BROKEN,
+)
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
@@ -4296,8 +4299,8 @@ class DataFrame(NDFrame, OpsMixin):
         z  3  50
         # Values for 'a' and 'b' are completely ignored!
         """
-        if not PYPY:
-            if sys.getrefcount(self) <= 3:
+        if not PYPY and not WARNING_CHECK_BROKEN:
+            if sys.getrefcount(self) <= REF_COUNT + 1:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )
@@ -9211,7 +9214,7 @@ class DataFrame(NDFrame, OpsMixin):
         1  2  500.0
         2  3    6.0
         """
-        if not PYPY:
+        if not PYPY and not WARNING_CHECK_BROKEN:
             if sys.getrefcount(self) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_method_msg,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -85,7 +85,7 @@ from pandas._typing import (
 from pandas.compat import PYPY
 from pandas.compat._constants import (
     REF_COUNT,
-    WARNING_CHECK_BROKEN,
+    WARNING_CHECK_DISABLED,
 )
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
@@ -7073,7 +7073,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and not WARNING_CHECK_BROKEN:
+            if not PYPY and not WARNING_CHECK_DISABLED:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7304,7 +7304,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and not WARNING_CHECK_BROKEN:
+            if not PYPY and not WARNING_CHECK_DISABLED:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7444,7 +7444,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and not WARNING_CHECK_BROKEN:
+            if not PYPY and not WARNING_CHECK_DISABLED:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7529,7 +7529,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and not WARNING_CHECK_BROKEN:
+            if not PYPY and not WARNING_CHECK_DISABLED:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7892,7 +7892,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         if inplace:
-            if not PYPY and not WARNING_CHECK_BROKEN:
+            if not PYPY and not WARNING_CHECK_DISABLED:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -8476,7 +8476,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         if inplace:
-            if not PYPY and not WARNING_CHECK_BROKEN:
+            if not PYPY and not WARNING_CHECK_DISABLED:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -10086,7 +10086,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and not WARNING_CHECK_BROKEN:
+            if not PYPY and not WARNING_CHECK_DISABLED:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -10150,7 +10150,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> Self | None:
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and not WARNING_CHECK_BROKEN:
+            if not PYPY and not WARNING_CHECK_DISABLED:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -83,7 +83,10 @@ from pandas._typing import (
     npt,
 )
 from pandas.compat import PYPY
-from pandas.compat._constants import REF_COUNT
+from pandas.compat._constants import (
+    REF_COUNT,
+    WARNING_CHECK_BROKEN,
+)
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
@@ -7070,7 +7073,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY:
+            if not PYPY and not WARNING_CHECK_BROKEN:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7301,7 +7304,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY:
+            if not PYPY and not WARNING_CHECK_BROKEN:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7441,7 +7444,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY:
+            if not PYPY and not WARNING_CHECK_BROKEN:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7526,7 +7529,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY:
+            if not PYPY and not WARNING_CHECK_BROKEN:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7889,7 +7892,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         if inplace:
-            if not PYPY:
+            if not PYPY and not WARNING_CHECK_BROKEN:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -8473,7 +8476,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         if inplace:
-            if not PYPY:
+            if not PYPY and not WARNING_CHECK_BROKEN:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -10083,7 +10086,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY:
+            if not PYPY and not WARNING_CHECK_BROKEN:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -10147,7 +10150,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> Self | None:
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY:
+            if not PYPY and not WARNING_CHECK_BROKEN:
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2585,8 +2585,8 @@ class _AtIndexer(_ScalarAccessIndexer):
         return super().__getitem__(key)
 
     def __setitem__(self, key, value) -> None:
-        if not PYPY:
-            if sys.getrefcount(self.obj) <= 2:
+        if not PYPY and not WARNING_CHECK_BROKEN:
+            if sys.getrefcount(self.obj) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )
@@ -2616,8 +2616,8 @@ class _iAtIndexer(_ScalarAccessIndexer):
         return key
 
     def __setitem__(self, key, value) -> None:
-        if not PYPY:
-            if sys.getrefcount(self.obj) <= 2:
+        if not PYPY and not WARNING_CHECK_BROKEN:
+            if sys.getrefcount(self.obj) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -16,6 +16,10 @@ import numpy as np
 from pandas._libs.indexing import NDFrameIndexerBase
 from pandas._libs.lib import item_from_zerodim
 from pandas.compat import PYPY
+from pandas.compat._constants import (
+    REF_COUNT,
+    WARNING_CHECK_BROKEN,
+)
 from pandas.errors import (
     AbstractMethodError,
     ChainedAssignmentError,
@@ -913,8 +917,8 @@ class _LocationIndexer(NDFrameIndexerBase):
 
     @final
     def __setitem__(self, key, value) -> None:
-        if not PYPY:
-            if sys.getrefcount(self.obj) <= 2:
+        if not PYPY and not WARNING_CHECK_BROKEN:
+            if sys.getrefcount(self.obj) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -18,7 +18,7 @@ from pandas._libs.lib import item_from_zerodim
 from pandas.compat import PYPY
 from pandas.compat._constants import (
     REF_COUNT,
-    WARNING_CHECK_BROKEN,
+    WARNING_CHECK_DISABLED,
 )
 from pandas.errors import (
     AbstractMethodError,
@@ -917,7 +917,7 @@ class _LocationIndexer(NDFrameIndexerBase):
 
     @final
     def __setitem__(self, key, value) -> None:
-        if not PYPY and not WARNING_CHECK_BROKEN:
+        if not PYPY and not WARNING_CHECK_DISABLED:
             if sys.getrefcount(self.obj) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
@@ -2585,7 +2585,7 @@ class _AtIndexer(_ScalarAccessIndexer):
         return super().__getitem__(key)
 
     def __setitem__(self, key, value) -> None:
-        if not PYPY and not WARNING_CHECK_BROKEN:
+        if not PYPY and not WARNING_CHECK_DISABLED:
             if sys.getrefcount(self.obj) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
@@ -2616,7 +2616,7 @@ class _iAtIndexer(_ScalarAccessIndexer):
         return key
 
     def __setitem__(self, key, value) -> None:
-        if not PYPY and not WARNING_CHECK_BROKEN:
+        if not PYPY and not WARNING_CHECK_DISABLED:
             if sys.getrefcount(self.obj) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -35,7 +35,10 @@ from pandas._libs import (
 )
 from pandas._libs.lib import is_range_indexer
 from pandas.compat import PYPY
-from pandas.compat._constants import REF_COUNT
+from pandas.compat._constants import (
+    REF_COUNT,
+    WARNING_CHECK_BROKEN,
+)
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
@@ -1055,8 +1058,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             return self.iloc[loc]
 
     def __setitem__(self, key, value) -> None:
-        if not PYPY:
-            if sys.getrefcount(self) <= 3:
+        if not PYPY and not WARNING_CHECK_BROKEN:
+            if sys.getrefcount(self) <= REF_COUNT + 1:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )
@@ -3336,7 +3339,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         2    3
         dtype: int64
         """
-        if not PYPY:
+        if not PYPY and not WARNING_CHECK_BROKEN:
             if sys.getrefcount(self) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_method_msg,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -37,7 +37,7 @@ from pandas._libs.lib import is_range_indexer
 from pandas.compat import PYPY
 from pandas.compat._constants import (
     REF_COUNT,
-    WARNING_CHECK_BROKEN,
+    WARNING_CHECK_DISABLED,
 )
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
@@ -1058,7 +1058,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             return self.iloc[loc]
 
     def __setitem__(self, key, value) -> None:
-        if not PYPY and not WARNING_CHECK_BROKEN:
+        if not PYPY and not WARNING_CHECK_DISABLED:
             if sys.getrefcount(self) <= REF_COUNT + 1:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
@@ -3339,7 +3339,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         2    3
         dtype: int64
         """
-        if not PYPY and not WARNING_CHECK_BROKEN:
+        if not PYPY and not WARNING_CHECK_DISABLED:
             if sys.getrefcount(self) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_method_msg,

--- a/pandas/tests/copy_view/test_chained_assignment_deprecation.py
+++ b/pandas/tests/copy_view/test_chained_assignment_deprecation.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat import WARNING_CHECK_BROKEN
 from pandas.errors import ChainedAssignmentError
 
 from pandas import DataFrame
@@ -17,6 +18,8 @@ def test_series_setitem(indexer):
 
     # using custom check instead of tm.assert_produces_warning because that doesn't
     # fail if multiple warnings are raised
+    if WARNING_CHECK_BROKEN:
+        return
     with pytest.warns() as record:  # noqa: TID251
         df["a"][indexer] = 0
     assert len(record) == 1

--- a/pandas/tests/copy_view/test_chained_assignment_deprecation.py
+++ b/pandas/tests/copy_view/test_chained_assignment_deprecation.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import WARNING_CHECK_BROKEN
+from pandas.compat import WARNING_CHECK_DISABLED
 from pandas.errors import ChainedAssignmentError
 
 from pandas import DataFrame
@@ -18,7 +18,7 @@ def test_series_setitem(indexer):
 
     # using custom check instead of tm.assert_produces_warning because that doesn't
     # fail if multiple warnings are raised
-    if WARNING_CHECK_BROKEN:
+    if WARNING_CHECK_DISABLED:
         return
     with pytest.warns() as record:  # noqa: TID251
         df["a"][indexer] = 0


### PR DESCRIPTION
Summary: this disables all chained assignment warnings in case of Python 3.14+, but afterwards https://github.com/pandas-dev/pandas/pull/62070 will enable it again specifically for the chained setitem indexing.

@ngoldbaum I extracted the warning disable parts from https://github.com/pandas-dev/pandas/pull/61950. I had removed it from that PR thinking we won't need it because of my follow-up PR https://github.com/pandas-dev/pandas/pull/62070, but in the end we still need the disabling for the inplace methods (my PR for now only fixes the indexing cases), and we might also need it if we want to backport the python 3.14 support to 2.3.x 

