### PR TITLE
[backport 2.3.x] MNT: migrate from codecs.open to open (#62073)

### DIFF
--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -1,4 +1,3 @@
-import codecs
 from datetime import datetime
 from textwrap import dedent
 
@@ -42,7 +41,7 @@ class TestToLatex:
         df = DataFrame([["au\xdfgangen"]])
         with tm.ensure_clean("test.tex") as path:
             df.to_latex(path, encoding="utf-8")
-            with codecs.open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 assert df.to_latex() == f.read()
 
     def test_to_latex_to_file_utf8_without_encoding(self):
@@ -50,7 +49,7 @@ class TestToLatex:
         df = DataFrame([["au\xdfgangen"]])
         with tm.ensure_clean("test.tex") as path:
             df.to_latex(path)
-            with codecs.open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 assert df.to_latex() == f.read()
 
     def test_to_latex_tabular_with_index(self):

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -513,9 +513,8 @@ def test_is_fsspec_url():
     assert icom.is_fsspec_url("RFC-3986+compliant.spec://something")
 
 
-@pytest.mark.parametrize("encoding", [None, "utf-8"])
 @pytest.mark.parametrize("format", ["csv", "json"])
-def test_codecs_encoding(encoding, format):
+def test_codecs_encoding(format):
     # GH39247
     expected = pd.DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
@@ -523,9 +522,9 @@ def test_codecs_encoding(encoding, format):
         index=pd.Index([f"i-{i}" for i in range(30)]),
     )
     with tm.ensure_clean() as path:
-        with codecs.open(path, mode="w", encoding=encoding) as handle:
+        with open(path, mode="w", encoding="utf-8") as handle:
             getattr(expected, f"to_{format}")(handle)
-        with codecs.open(path, mode="r", encoding=encoding) as handle:
+        with open(path, encoding="utf-8") as handle:
             if format == "csv":
                 df = pd.read_csv(handle, index_col=0)
             else:

--- a/pandas/util/_print_versions.py
+++ b/pandas/util/_print_versions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import codecs
 import json
 import locale
 import os
@@ -139,7 +138,7 @@ def show_versions(as_json: str | bool = False) -> None:
             sys.stdout.writelines(json.dumps(j, indent=2))
         else:
             assert isinstance(as_json, str)  # needed for mypy
-            with codecs.open(as_json, "wb", encoding="utf8") as f:
+            with open(as_json, "w", encoding="utf-8") as f:
                 json.dump(j, f, indent=2)
 
     else:


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/62073