### PR TITLE
[backport 2.3.x] TST: run python-dev CI on 3.14-dev (#61950)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -392,7 +392,7 @@ jobs:
       - name: Set up Python Dev Version
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13-dev'
+          python-version: '3.14-dev'
 
       - name: Build Environment
         run: |
@@ -406,3 +406,5 @@ jobs:
 
       - name: Run Tests
         uses: ./.github/actions/run-tests
+        # TEMP allow this to fail until we fixed all test failures (related to chained assignment warnings)
+        continue-on-error: true

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -20,6 +20,7 @@ from pandas.compat._constants import (
     PY310,
     PY311,
     PY312,
+    PY314,
     PYPY,
 )
 import pandas.compat.compressors
@@ -205,5 +206,6 @@ __all__ = [
     "PY310",
     "PY311",
     "PY312",
+    "PY314",
     "PYPY",
 ]

--- a/pandas/compat/_constants.py
+++ b/pandas/compat/_constants.py
@@ -16,6 +16,7 @@ IS64 = sys.maxsize > 2**32
 PY310 = sys.version_info >= (3, 10)
 PY311 = sys.version_info >= (3, 11)
 PY312 = sys.version_info >= (3, 12)
+PY314 = sys.version_info >= (3, 14)
 PYPY = platform.python_implementation() == "PyPy"
 ISMUSL = "musl" in (sysconfig.get_config_var("HOST_GNU_TYPE") or "")
 REF_COUNT = 2 if PY311 else 3
@@ -26,5 +27,6 @@ __all__ = [
     "PY310",
     "PY311",
     "PY312",
+    "PY314",
     "PYPY",
 ]

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -17,6 +17,7 @@ contain tests for the corresponding methods specific to those Index subclasses.
 import numpy as np
 import pytest
 
+from pandas.compat import PY314
 from pandas.errors import InvalidIndexError
 
 from pandas.core.dtypes.common import (
@@ -160,13 +161,19 @@ class TestContains:
         with pytest.raises(TypeError, match=msg):
             [] in index
 
+        if PY314:
+            container_or_iterable = "a container or iterable"
+        else:
+            container_or_iterable = "iterable"
+
         msg = "|".join(
             [
                 r"unhashable type: 'dict'",
                 r"must be real number, not dict",
                 r"an integer is required",
                 r"\{\}",
-                r"pandas\._libs\.interval\.IntervalTree' is not iterable",
+                r"pandas\._libs\.interval\.IntervalTree' is not "
+                f"{container_or_iterable}",
             ]
         )
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/io/parser/test_quoting.py
+++ b/pandas/tests/io/parser/test_quoting.py
@@ -8,7 +8,10 @@ from io import StringIO
 
 import pytest
 
-from pandas.compat import PY311
+from pandas.compat import (
+    PY311,
+    PY314,
+)
 from pandas.errors import ParserError
 
 from pandas import DataFrame
@@ -21,15 +24,24 @@ xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
 skip_pyarrow = pytest.mark.usefixtures("pyarrow_skip")
 
 
+if PY314:
+    # TODO: write a regex that works with all new possitibilities here
+    MSG1 = ""
+    MSG2 = r"[\s\S]*"
+else:
+    MSG1 = "a(n)? 1-character string"
+    MSG2 = "string( or None)?"
+
+
 @pytest.mark.parametrize(
     "kwargs,msg",
     [
-        ({"quotechar": "foo"}, '"quotechar" must be a(n)? 1-character string'),
+        ({"quotechar": "foo"}, f'"quotechar" must be {MSG1}'),
         (
             {"quotechar": None, "quoting": csv.QUOTE_MINIMAL},
             "quotechar must be set if quoting enabled",
         ),
-        ({"quotechar": 2}, '"quotechar" must be string( or None)?, not int'),
+        ({"quotechar": 2}, f'"quotechar" must be {MSG2}, not int'),
     ],
 )
 @skip_pyarrow  # ParserError: CSV parse error: Empty CSV file or block
@@ -88,8 +100,12 @@ def test_null_quote_char(all_parsers, quoting, quote_char):
 
     if quoting != csv.QUOTE_NONE:
         # Sanity checking.
+        if not PY314:
+            msg = "1-character string"
+        else:
+            msg = "unicode character or None"
         msg = (
-            '"quotechar" must be a 1-character string'
+            f'"quotechar" must be a {msg}'
             if PY311 and all_parsers.engine == "python" and quote_char == ""
             else "quotechar must be set if quoting enabled"
         )

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -8,6 +8,8 @@ import re
 import numpy as np
 import pytest
 
+from pandas.compat import PY314
+
 from pandas.core.dtypes.common import (
     is_object_dtype,
     is_string_dtype,
@@ -2394,10 +2396,18 @@ def test_merge_suffix_raises(suffixes):
         merge(a, b, left_index=True, right_index=True, suffixes=suffixes)
 
 
+TWO_GOT_THREE = "2, got 3" if PY314 else "2"
+
+
 @pytest.mark.parametrize(
     "col1, col2, suffixes, msg",
     [
-        ("a", "a", ("a", "b", "c"), r"too many values to unpack \(expected 2\)"),
+        (
+            "a",
+            "a",
+            ("a", "b", "c"),
+            (rf"too many values to unpack \(expected {TWO_GOT_THREE}\)"),
+        ),
         ("a", "a", tuple("a"), r"not enough values to unpack \(expected 2, got 1\)"),
     ],
 )

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -16,6 +16,7 @@ from pandas._libs.tslibs.ccalendar import (
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 from pandas._libs.tslibs.parsing import DateParseError
 from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
+from pandas.compat import PY314
 
 from pandas import (
     NaT,
@@ -342,7 +343,10 @@ class TestPeriodConstruction:
         msg = '^Given date string "-2000" not likely a datetime$'
         with pytest.raises(ValueError, match=msg):
             Period("-2000", "Y")
-        msg = "day is out of range for month"
+        if PY314:
+            msg = "day 0 must be in range 1..31 for month 1 in year 1: 0"
+        else:
+            msg = "day is out of range for month"
         with pytest.raises(DateParseError, match=msg):
             Period("0", "Y")
         msg = "Unknown datetime string format, unable to parse"

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -18,7 +18,10 @@ import pytest
 import pytz
 
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
-from pandas.compat import PY310
+from pandas.compat import (
+    PY310,
+    PY314,
+)
 from pandas.errors import OutOfBoundsDatetime
 
 from pandas import (
@@ -225,7 +228,10 @@ class TestTimestampConstructorPositionalAndKeywordSupport:
         with pytest.raises(ValueError, match=msg):
             Timestamp(2000, 13, 1)
 
-        msg = "day is out of range for month"
+        if PY314:
+            msg = "must be in range 1..31 for month 1 in year 2000"
+        else:
+            msg = "day is out of range for month"
         with pytest.raises(ValueError, match=msg):
             Timestamp(2000, 1, 0)
         with pytest.raises(ValueError, match=msg):
@@ -249,7 +255,10 @@ class TestTimestampConstructorPositionalAndKeywordSupport:
         with pytest.raises(ValueError, match=msg):
             Timestamp(year=2000, month=13, day=1)
 
-        msg = "day is out of range for month"
+        if PY314:
+            msg = "must be in range 1..31 for month 1 in year 2000"
+        else:
+            msg = "day is out of range for month"
         with pytest.raises(ValueError, match=msg):
             Timestamp(year=2000, month=1, day=0)
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -62,10 +62,11 @@ if PY314:
     NOT_99 = ", not 99"
     DAY_IS_OUT_OF_RANGE = (
         r"day \d{1,2} must be in range 1\.\.\d{1,2} for month \d{1,2} in year \d{4}"
+        ", at position 0"
     )
 else:
     NOT_99 = ""
-    DAY_IS_OUT_OF_RANGE = "day is out of range for month"
+    DAY_IS_OUT_OF_RANGE = "day is out of range for month, at position 0"
 
 
 pytestmark = pytest.mark.filterwarnings(
@@ -1459,10 +1460,10 @@ class TestToDatetime:
             [
                 r'^time data "a" doesn\'t match format "%H:%M:%S", at position 0. '
                 f"{PARSING_ERR_MSG}$",
-                r'^Given date string "a" not likely a datetime$',
-                r'^unconverted data remains when parsing with format "%H:%M:%S": "9". '
-                f"{PARSING_ERR_MSG}$",
-                rf"^second must be in 0..59{NOT_99}: 00:01:99$",
+                r'^Given date string "a" not likely a datetime, at position 0$',
+                r'^unconverted data remains when parsing with format "%H:%M:%S": "9", '
+                f"at position 0. {PARSING_ERR_MSG}$",
+                rf"^second must be in 0..59{NOT_99}: 00:01:99, at position 0$",
             ]
         )
         with pytest.raises(ValueError, match=msg):
@@ -1518,9 +1519,9 @@ class TestToDatetime:
                 r'^Given date string "a" not likely a datetime, at position 0$',
                 r'^time data "a" doesn\'t match format "%H:%M:%S", at position 0. '
                 f"{PARSING_ERR_MSG}$",
-                r'^unconverted data remains when parsing with format "%H:%M:%S": "9". '
-                f"{PARSING_ERR_MSG}$",
-                rf"^second must be in 0..59{NOT_99}: 00:01:99$",
+                r'^unconverted data remains when parsing with format "%H:%M:%S": "9", '
+                f"at position 0. {PARSING_ERR_MSG}$",
+                rf"^second must be in 0..59{NOT_99}: 00:01:99, at position 0$",
             ]
         )
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -22,6 +22,7 @@ from pandas._libs.tslibs import (
     iNaT,
     parsing,
 )
+from pandas.compat import PY314
 from pandas.errors import (
     OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
@@ -56,6 +57,16 @@ PARSING_ERR_MSG = (
     r"for each element individually. You might want to use `dayfirst` "
     r"alongside this."
 )
+
+if PY314:
+    NOT_99 = ", not 99"
+    DAY_IS_OUT_OF_RANGE = (
+        r"day \d{1,2} must be in range 1\.\.\d{1,2} for month \d{1,2} in year \d{4}"
+    )
+else:
+    NOT_99 = ""
+    DAY_IS_OUT_OF_RANGE = "day is out of range for month"
+
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:errors='ignore' is deprecated:FutureWarning"
@@ -1448,10 +1459,10 @@ class TestToDatetime:
             [
                 r'^time data "a" doesn\'t match format "%H:%M:%S", at position 0. '
                 f"{PARSING_ERR_MSG}$",
-                r'^Given date string "a" not likely a datetime, at position 0$',
-                r'^unconverted data remains when parsing with format "%H:%M:%S": "9", '
-                f"at position 0. {PARSING_ERR_MSG}$",
-                r"^second must be in 0..59: 00:01:99, at position 0$",
+                r'^Given date string "a" not likely a datetime$',
+                r'^unconverted data remains when parsing with format "%H:%M:%S": "9". '
+                f"{PARSING_ERR_MSG}$",
+                rf"^second must be in 0..59{NOT_99}: 00:01:99$",
             ]
         )
         with pytest.raises(ValueError, match=msg):
@@ -1507,9 +1518,9 @@ class TestToDatetime:
                 r'^Given date string "a" not likely a datetime, at position 0$',
                 r'^time data "a" doesn\'t match format "%H:%M:%S", at position 0. '
                 f"{PARSING_ERR_MSG}$",
-                r'^unconverted data remains when parsing with format "%H:%M:%S": "9", '
-                f"at position 0. {PARSING_ERR_MSG}$",
-                r"^second must be in 0..59: 00:01:99, at position 0$",
+                r'^unconverted data remains when parsing with format "%H:%M:%S": "9". '
+                f"{PARSING_ERR_MSG}$",
+                rf"^second must be in 0..59{NOT_99}: 00:01:99$",
             ]
         )
         with pytest.raises(ValueError, match=msg):
@@ -3012,7 +3023,10 @@ class TestDaysInMonth:
         assert isna(to_datetime(arg, errors="coerce", format=format, cache=cache))
 
     def test_day_not_in_month_raise(self, cache):
-        msg = "day is out of range for month: 2015-02-29, at position 0"
+        if PY314:
+            msg = "day 29 must be in range 1..28 for month 2 in year 2015: 2015-02-29"
+        else:
+            msg = "day is out of range for month: 2015-02-29"
         with pytest.raises(ValueError, match=msg):
             to_datetime("2015-02-29", errors="raise", cache=cache)
 
@@ -3022,12 +3036,12 @@ class TestDaysInMonth:
             (
                 "2015-02-29",
                 "%Y-%m-%d",
-                f"^day is out of range for month, at position 0. {PARSING_ERR_MSG}$",
+                f"^{DAY_IS_OUT_OF_RANGE}. {PARSING_ERR_MSG}$",
             ),
             (
                 "2015-29-02",
                 "%Y-%d-%m",
-                f"^day is out of range for month, at position 0. {PARSING_ERR_MSG}$",
+                f"^{DAY_IS_OUT_OF_RANGE}. {PARSING_ERR_MSG}$",
             ),
             (
                 "2015-02-32",
@@ -3044,12 +3058,12 @@ class TestDaysInMonth:
             (
                 "2015-04-31",
                 "%Y-%m-%d",
-                f"^day is out of range for month, at position 0. {PARSING_ERR_MSG}$",
+                f"^{DAY_IS_OUT_OF_RANGE}. {PARSING_ERR_MSG}$",
             ),
             (
                 "2015-31-04",
                 "%Y-%d-%m",
-                f"^day is out of range for month, at position 0. {PARSING_ERR_MSG}$",
+                f"^{DAY_IS_OUT_OF_RANGE}. {PARSING_ERR_MSG}$",
             ),
         ],
     )


### PR DESCRIPTION
Backport of #61950. Just checking how cleanly this backports, to assess how easy it would be to add Python 3.14 support to 2.3.x