### PR TITLE
TYP: add type annotations for holidays and dtypes modules

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -123,7 +123,7 @@ class PandasExtensionDtype(ExtensionDtype):
     # problem dealing with multiple inheritance from PandasExtensionDtype
     # and ExtensionDtype's @properties in the subclasses below. The kind and
     # type variables in those subclasses are explicitly typed below.
-    subdtype = None
+    subdtype: DtypeObj | None = None
     str: str_type
     num = 100
     shape: tuple[int, ...] = ()
@@ -1604,7 +1604,7 @@ class BaseMaskedDtype(ExtensionDtype):
     Base class for dtypes for BaseMaskedArray subclasses.
     """
 
-    base = None
+    base: DtypeObj | None = None
     type: type
     _internal_fill_value: Scalar
 


### PR DESCRIPTION
- Add overloads and type annotations to Holiday.dates and AbstractHolidayCalendar.holidays
- Add type annotations for holiday_calendars and _cache
- Add missing type annotations for subdtype and base in dtypes.py

towards enabling local-partial-types xref https://github.com/pandas-dev/pandas/pull/62315#discussion_r2341808711