### PR TITLE
Added note on isin() to cookbook

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -239,6 +239,14 @@ Ambiguity arises when an index consists of integers with a non-zero start or non
 
    df[~((df.AAA <= 6) & (df.index.isin([0, 2, 4])))]
 
+Using isin() to filter for values directly (this returns a series of boolean values).
+
+.. ipython:: python
+   df = pd.DataFrame(
+       {"AAA": [4, 5, 6, 7], "BBB": [10, 20, 30, 40], "CCC": [100, 50, -30, -50]}
+   )
+   df["AAA"].isin([5, 7])
+
 New columns
 ***********
 

--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -242,6 +242,7 @@ Ambiguity arises when an index consists of integers with a non-zero start or non
 Using isin() to filter for values directly (this returns a series of boolean values).
 
 .. ipython:: python
+
    df = pd.DataFrame(
        {"AAA": [4, 5, 6, 7], "BBB": [10, 20, 30, 40], "CCC": [100, 50, -30, -50]}
    )


### PR DESCRIPTION
The cookbook examples contained isin() within the context of choosing indexes, I have included an example for filtering values directly.

- [x] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
