### PR TITLE
[2.3.x] Only use new string dtype repr for the new (NaN-based) string dtype

### DIFF
--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -119,10 +119,10 @@ class StringDtype(StorageExtensionDtype):
     Examples
     --------
     >>> pd.StringDtype()
-    <StringDtype(storage='python', na_value=<NA>)>
+    string[python]
 
     >>> pd.StringDtype(storage="pyarrow")
-    <StringDtype(na_value=<NA>)>
+    string[pyarrow]
     """
 
     @property
@@ -194,8 +194,11 @@ class StringDtype(StorageExtensionDtype):
         self._na_value = na_value
 
     def __repr__(self) -> str:
-        storage = "" if self.storage == "pyarrow" else "storage='python', "
-        return f"<StringDtype({storage}na_value={self._na_value})>"
+        if self._na_value is libmissing.NA:
+            return f"{self.name}[{self.storage}]"
+        else:
+            storage = "" if self.storage == "pyarrow" else "storage='python', "
+            return f"<StringDtype({storage}na_value={self._na_value})>"
 
     def __eq__(self, other: object) -> bool:
         # we need to override the base class __eq__ because na_value (NA or NaN)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7021,13 +7021,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2  3  z   <NA>  <NA>    20  200.0
 
         >>> dfn.dtypes
-        a      Int32
-        b     string
-        c    boolean
-        d     string
-        e      Int64
-        f    Float64
-        dtype: object
+        a             Int32
+        b    string[python]
+        c           boolean
+        d    string[python]
+        e             Int64
+        f           Float64
 
         Start with a Series of strings and missing data represented by ``np.nan``.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7027,6 +7027,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         d    string[python]
         e             Int64
         f           Float64
+        dtype: object
 
         Start with a Series of strings and missing data represented by ``np.nan``.
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -66,6 +66,7 @@ from pandas.core.arrays import (
     ExtensionArray,
     TimedeltaArray,
 )
+from pandas.core.arrays.string_ import StringDtype
 from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.indexes.api import (
@@ -1231,6 +1232,8 @@ class _GenericArrayFormatter:
                 return self.na_rep
             elif isinstance(x, PandasObject):
                 return str(x)
+            elif isinstance(x, StringDtype) and x.na_value is NA:
+                return repr(x)
             else:
                 # object dtype
                 return str(formatter(x))

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -126,11 +126,11 @@ def test_repr(dtype):
 def test_dtype_repr(dtype):
     if dtype.storage == "pyarrow":
         if dtype.na_value is pd.NA:
-            assert repr(dtype) == "<StringDtype(na_value=<NA>)>"
+            assert repr(dtype) == "string[pyarrow]"
         else:
             assert repr(dtype) == "<StringDtype(na_value=nan)>"
     elif dtype.na_value is pd.NA:
-        assert repr(dtype) == "<StringDtype(storage='python', na_value=<NA>)>"
+        assert repr(dtype) == "string[python]"
     else:
         assert repr(dtype) == "<StringDtype(storage='python', na_value=nan)>"
 

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -758,9 +758,9 @@ class TestDataFrameToString:
         result = df.dtypes.to_string()
         expected = dedent(
             """\
-            x            string
-            y            string
-            z    int64[pyarrow]"""
+            x    string[pyarrow]
+            y     string[python]
+            z     int64[pyarrow]"""
         )
         assert result == expected
 


### PR DESCRIPTION
I was a bit fast with merging the backport https://github.com/pandas-dev/pandas/pull/62329 for updating the StringDtype repr. I thought it was good to already have this change on 2.3 as well (since it eg shows up when looking at the dtype, when we print the dtype in assert messages, etc). 
But probably safest to not change it in 2.3.x for the existing NA-based StringDtype that people are already using, but only for the new one (where there are less concerns about backwards compatibility in a bugfix release)