### PR TITLE
TYP: Ignore xlsxwriter _book typing

### DIFF
--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -213,7 +213,7 @@ class XlsxWriter(ExcelWriter):
         )
 
         try:
-            self._book = Workbook(self._handles.handle, **engine_kwargs)
+            self._book = Workbook(self._handles.handle, **engine_kwargs)  # type: ignore[arg-type]
         except TypeError:
             self._handles.handle.close()
             raise


### PR DESCRIPTION
e.g. https://github.com/pandas-dev/pandas/actions/runs/17741519922/job/50416374964

A way to better type `_book` can be done in a follow up.