### PR TITLE
TYP: Enable mypy stricter typing for partial types

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -202,7 +202,7 @@ class TimedeltaArray(dtl.TimelikeOps):
     # ----------------------------------------------------------------
     # Constructors
 
-    _freq = None
+    _freq: Tick | Day | None = None
 
     @classmethod
     def _validate_dtype(cls, values, dtype):

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -69,7 +69,7 @@ TD64NS_DTYPE = conversion.TD64NS_DTYPE
 INT64_DTYPE = np.dtype(np.int64)
 
 # oh the troubles to reduce import time
-_is_scipy_sparse = None
+_is_scipy_sparse: Callable[[ArrayLike], bool] | None = None
 
 ensure_float64 = algos.ensure_float64
 ensure_int64 = algos.ensure_int64

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -470,7 +470,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     str = Accessor("str", StringMethods)
 
-    _references = None
+    _references: BlockValuesRefs | None = None
 
     # --------------------------------------------------------------------
     # Constructors
@@ -640,7 +640,10 @@ class Index(IndexOpsMixin, PandasObject):
 
     @classmethod
     def _simple_new(
-        cls, values: ArrayLike, name: Hashable | None = None, refs=None
+        cls,
+        values: ArrayLike,
+        name: Hashable | None = None,
+        refs: BlockValuesRefs | None = None,
     ) -> Self:
         """
         We require that we have a dtype compat for the values. If we are passed

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1181,9 +1181,6 @@ class ExcelWriter(Generic[_WorkbookT]):
 
         return object.__new__(cls)
 
-    # declare external properties you can count on
-    _path = None
-
     @property
     def supported_extensions(self) -> tuple[str, ...]:
         """Extensions that writer engine supports."""

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -114,7 +114,10 @@ if TYPE_CHECKING:
         Iterator,
         Sequence,
     )
-    from types import TracebackType
+    from types import (
+        ModuleType,
+        TracebackType,
+    )
 
     from tables import (
         Col,
@@ -227,7 +230,7 @@ with config.config_prefix("io.hdf"):
     )
 
 # oh the troubles to reduce import time
-_table_mod = None
+_table_mod: ModuleType | None = None
 _table_file_open_policy_is_strict = False
 
 

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -63,10 +63,10 @@ if TYPE_CHECKING:
     from pandas._libs.tslibs.offsets import BaseOffset
 
 
-_mpl_units = {}  # Cache for units overwritten by us
+_mpl_units: dict = {}  # Cache for units overwritten by us
 
 
-def get_pairs():
+def get_pairs() -> list[tuple[type, type[mdates.DateConverter]]]:
     pairs = [
         (Timestamp, DatetimeConverter),
         (Period, PeriodConverter),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -534,7 +534,7 @@ enable_error_code = "ignore-without-code"
 # Miscellaneous strictness flags
 allow_untyped_globals = false
 allow_redefinition = false
-local_partial_types = false
+local_partial_types = true
 implicit_reexport = true
 strict_equality = true
 # Configuring error messages


### PR DESCRIPTION
follow up to #62327

The mypy setting `local_partial_types` restricts where mypy is allowed to infer a "partial type" from incomplete initialization. With this option enabled mypy will permit partial types only for variables that are local to functions. Module level and class attribute initializations that would otherwise produce a partial type become errors unless you provide an explicit annotation. This forces you to add annotations where mypy otherwise would have silently inferred a partly-known type.

