### PR TITLE
DOC: Added note acknowledging iloc dtype conversion behaviour

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -186,9 +186,9 @@ class IndexingMixin:
         ``.iloc`` will raise ``IndexError`` if a requested indexer is
         out-of-bounds, except *slice* indexers which allow out-of-bounds
         indexing (this conforms with python/numpy *slice* semantics).
-        
-        It is also worth noting, iloc converts all elements returned into the same 
-        pandas dtype and all numeric dtype conversions follow the numpy promotion 
+
+        It is also worth noting, iloc converts all elements returned into the same
+        pandas dtype and all numeric dtype conversions follow the numpy promotion
         rules.
 
         See more at :ref:`Selection by Position <indexing.integer>`.

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -182,6 +182,10 @@ class IndexingMixin:
         ``.iloc`` will raise ``IndexError`` if a requested indexer is
         out-of-bounds, except *slice* indexers which allow out-of-bounds
         indexing (this conforms with python/numpy *slice* semantics).
+        
+        It is also worth noting, iloc converts all elements returned into the same 
+        pandas dtype and all numeric dtype conversions follow the numpy promotion 
+        rules.
 
         See more at :ref:`Selection by Position <indexing.integer>`.
 


### PR DESCRIPTION
Added a note clarifying dtype conversions for returned outputs of the .iloc function

- [ ] closes https://github.com/pandas-dev/pandas/issues/61537
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

