### PR TITLE
BUG: improve future warning for boolean operations with missaligned indexes

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6161,9 +6161,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                         np.bool_,
                     ):
                         warnings.warn(
-                            "Operation between non boolean Series with different "
-                            "indexes will no longer return a boolean result in "
-                            "a future version. Cast both Series to object type "
+                            "Operation between Series with different indexes "
+                            "that are not of numpy boolean or object dtype "
+                            "will no longer return a numpy boolean result "
+                            "in a future version. "
+                            "Cast both Series to object type "
                             "to maintain the prior behavior.",
                             FutureWarning,
                             stacklevel=find_stack_level(),


### PR DESCRIPTION
- [x] closes #62260 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

> [!NOTE]
This change is for v.2.3.3 release

This change makes the warning more explicit about data types, where it states that are talking about boolean NumPy backend and object dtype.

---

This change just addresses the future warning, doesn't change the behavior to ensure parity between the results of arrow backend and numpy backend. Mainly beause of https://github.com/pandas-dev/pandas/issues/62260#issuecomment-3258679215:

> For the result on main / pandas 3.0, this actually seems correct to me.
