### PR TITLE
TST: test that re-using a list of groupers will not throw ValueError

### DIFF
--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -876,19 +876,16 @@ class TestGrouping:
         tm.assert_frame_equal(result.reset_index(drop=True), expected)
 
     def test_groupby_grouper_immutable_list_item(self):
-        # GH 26564 - prevent 'ValueError: all keys need to be the same shape' when re-using a list of groupers
-        df1 = pd.DataFrame(
-            [
-                ["05/29/2019"], 
-                ["05/28/2019"]
-            ], 
-            columns=["date"]).assign(date=lambda df: pd.to_datetime(df["date"])
+        # GH 26564 - prevent 'ValueError: all keys need to be the same shape'
+        # when reusing a list of groupers
+        df1 = DataFrame([["05/29/2019"], ["05/28/2019"]], columns=["date"]).assign(
+            date=lambda df: pd.to_datetime(df["date"])
         )
-        df2 = pd.DataFrame(
-            columns=["date"]).assign(date=lambda df: pd.to_datetime(df["date"])
+        df2 = DataFrame(columns=["date"]).assign(
+            date=lambda df: pd.to_datetime(df["date"])
         )
 
-        groupers = [pd.Grouper(key="date", freq="1D")]
+        groupers = [Grouper(key="date", freq="1D")]
 
         df1.groupby(groupers).head()
         # no error

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -875,6 +875,25 @@ class TestGrouping:
         expected = expected[result.columns]
         tm.assert_frame_equal(result.reset_index(drop=True), expected)
 
+    def test_groupby_grouper_immutable_list_item(self):
+        # GH 26564 - prevent 'ValueError: all keys need to be the same shape' when re-using a list of groupers
+        df1 = pd.DataFrame(
+            [
+                ["05/29/2019"], 
+                ["05/28/2019"]
+            ], 
+            columns=["date"]).assign(date=lambda df: pd.to_datetime(df["date"])
+        )
+        df2 = pd.DataFrame(
+            columns=["date"]).assign(date=lambda df: pd.to_datetime(df["date"])
+        )
+
+        groupers = [pd.Grouper(key="date", freq="1D")]
+
+        df1.groupby(groupers).head()
+        # no error
+        df2.groupby(groupers).head()
+
 
 # get_group
 # --------------------------------


### PR DESCRIPTION
- [ ] closes #26564 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Added test to ensure that pd.Grouper is immutable as list item and can be safely reused in different DataFrames. I run the same test on older pandas version (1.3.5) and ensured that the test fails with an error: `ValueError: all keys need to be the same shape`


