### PR TITLE
[backport 2.3.x] CoW: disable chained assignment detection for Python 3.14 (#62324)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -406,5 +406,3 @@ jobs:
 
       - name: Run Tests
         uses: ./.github/actions/run-tests
-        # TEMP allow this to fail until we fixed all test failures (related to chained assignment warnings)
-        continue-on-error: true

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -13,7 +13,10 @@ import uuid
 
 from pandas._config import using_copy_on_write
 
-from pandas.compat import PYPY
+from pandas.compat import (
+    PYPY,
+    WARNING_CHECK_DISABLED,
+)
 from pandas.errors import ChainedAssignmentError
 
 from pandas import set_option
@@ -204,11 +207,11 @@ def raises_chained_assignment_error(warn=True, extra_warnings=(), extra_match=()
 
         return nullcontext()
 
-    if PYPY and not extra_warnings:
+    if (PYPY or WARNING_CHECK_DISABLED) and not extra_warnings:
         from contextlib import nullcontext
 
         return nullcontext()
-    elif PYPY and extra_warnings:
+    elif (PYPY or WARNING_CHECK_DISABLED) and extra_warnings:
         return assert_produces_warning(
             extra_warnings,
             match="|".join(extra_match),

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -250,7 +250,7 @@ def assert_cow_warning(warn=True, match=None, **kwargs):
     """
     from pandas._testing import assert_produces_warning
 
-    if not warn:
+    if not warn or WARNING_CHECK_DISABLED:
         from contextlib import nullcontext
 
         return nullcontext()

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -22,6 +22,7 @@ from pandas.compat._constants import (
     PY312,
     PY314,
     PYPY,
+    WARNING_CHECK_DISABLED,
 )
 import pandas.compat.compressors
 from pandas.compat.numpy import is_numpy_dev
@@ -208,4 +209,5 @@ __all__ = [
     "PY312",
     "PY314",
     "PYPY",
+    "WARNING_CHECK_DISABLED",
 ]

--- a/pandas/compat/_constants.py
+++ b/pandas/compat/_constants.py
@@ -20,6 +20,8 @@ PY314 = sys.version_info >= (3, 14)
 PYPY = platform.python_implementation() == "PyPy"
 ISMUSL = "musl" in (sysconfig.get_config_var("HOST_GNU_TYPE") or "")
 REF_COUNT = 2 if PY311 else 3
+WARNING_CHECK_DISABLED = PY314
+
 
 __all__ = [
     "IS64",

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -90,7 +90,10 @@ from pandas._typing import (
     npt,
 )
 from pandas.compat import PYPY
-from pandas.compat._constants import REF_COUNT
+from pandas.compat._constants import (
+    REF_COUNT,
+    WARNING_CHECK_DISABLED,
+)
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
@@ -7285,7 +7288,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and using_copy_on_write():
+            if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7294,6 +7297,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     )
             elif (
                 not PYPY
+                and not WARNING_CHECK_DISABLED
                 and not using_copy_on_write()
                 and self._is_view_after_cow_rules()
             ):
@@ -7588,7 +7592,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         downcast = self._deprecate_downcast(downcast, "ffill")
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and using_copy_on_write():
+            if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7597,6 +7601,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     )
             elif (
                 not PYPY
+                and not WARNING_CHECK_DISABLED
                 and not using_copy_on_write()
                 and self._is_view_after_cow_rules()
             ):
@@ -7792,7 +7797,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         downcast = self._deprecate_downcast(downcast, "bfill")
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and using_copy_on_write():
+            if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7801,6 +7806,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     )
             elif (
                 not PYPY
+                and not WARNING_CHECK_DISABLED
                 and not using_copy_on_write()
                 and self._is_view_after_cow_rules()
             ):
@@ -7963,7 +7969,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and using_copy_on_write():
+            if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -7972,6 +7978,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     )
             elif (
                 not PYPY
+                and not WARNING_CHECK_DISABLED
                 and not using_copy_on_write()
                 and self._is_view_after_cow_rules()
             ):
@@ -8415,7 +8422,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         if inplace:
-            if not PYPY and using_copy_on_write():
+            if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -8424,6 +8431,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     )
             elif (
                 not PYPY
+                and not WARNING_CHECK_DISABLED
                 and not using_copy_on_write()
                 and self._is_view_after_cow_rules()
             ):
@@ -9057,7 +9065,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         if inplace:
-            if not PYPY and using_copy_on_write():
+            if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -9066,6 +9074,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     )
             elif (
                 not PYPY
+                and not WARNING_CHECK_DISABLED
                 and not using_copy_on_write()
                 and self._is_view_after_cow_rules()
             ):
@@ -10975,7 +10984,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and using_copy_on_write():
+            if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -10984,6 +10993,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     )
             elif (
                 not PYPY
+                and not WARNING_CHECK_DISABLED
                 and not using_copy_on_write()
                 and self._is_view_after_cow_rules()
             ):
@@ -11058,7 +11068,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> Self | None:
         inplace = validate_bool_kwarg(inplace, "inplace")
         if inplace:
-            if not PYPY and using_copy_on_write():
+            if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
                 if sys.getrefcount(self) <= REF_COUNT:
                     warnings.warn(
                         _chained_assignment_method_msg,
@@ -11067,6 +11077,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     )
             elif (
                 not PYPY
+                and not WARNING_CHECK_DISABLED
                 and not using_copy_on_write()
                 and self._is_view_after_cow_rules()
             ):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -21,6 +21,7 @@ from pandas._config import (
 from pandas._libs.indexing import NDFrameIndexerBase
 from pandas._libs.lib import item_from_zerodim
 from pandas.compat import PYPY
+from pandas.compat._constants import WARNING_CHECK_DISABLED
 from pandas.errors import (
     AbstractMethodError,
     ChainedAssignmentError,
@@ -881,12 +882,12 @@ class _LocationIndexer(NDFrameIndexerBase):
 
     @final
     def __setitem__(self, key, value) -> None:
-        if not PYPY and using_copy_on_write():
+        if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
             if sys.getrefcount(self.obj) <= 2:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )
-        elif not PYPY and not using_copy_on_write():
+        elif not PYPY and not WARNING_CHECK_DISABLED and not using_copy_on_write():
             ctr = sys.getrefcount(self.obj)
             ref_count = 2
             if not warn_copy_on_write() and _check_cacher(self.obj):
@@ -2575,12 +2576,12 @@ class _AtIndexer(_ScalarAccessIndexer):
         return super().__getitem__(key)
 
     def __setitem__(self, key, value) -> None:
-        if not PYPY and using_copy_on_write():
+        if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
             if sys.getrefcount(self.obj) <= 2:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )
-        elif not PYPY and not using_copy_on_write():
+        elif not PYPY and not WARNING_CHECK_DISABLED and not using_copy_on_write():
             ctr = sys.getrefcount(self.obj)
             ref_count = 2
             if not warn_copy_on_write() and _check_cacher(self.obj):
@@ -2616,12 +2617,12 @@ class _iAtIndexer(_ScalarAccessIndexer):
         return key
 
     def __setitem__(self, key, value) -> None:
-        if not PYPY and using_copy_on_write():
+        if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
             if sys.getrefcount(self.obj) <= 2:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )
-        elif not PYPY and not using_copy_on_write():
+        elif not PYPY and not WARNING_CHECK_DISABLED and not using_copy_on_write():
             ctr = sys.getrefcount(self.obj)
             ref_count = 2
             if not warn_copy_on_write() and _check_cacher(self.obj):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -39,7 +39,10 @@ from pandas._libs import (
 )
 from pandas._libs.lib import is_range_indexer
 from pandas.compat import PYPY
-from pandas.compat._constants import REF_COUNT
+from pandas.compat._constants import (
+    REF_COUNT,
+    WARNING_CHECK_DISABLED,
+)
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
@@ -1269,12 +1272,12 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
     def __setitem__(self, key, value) -> None:
         warn = True
-        if not PYPY and using_copy_on_write():
+        if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
             if sys.getrefcount(self) <= 3:
                 warnings.warn(
                     _chained_assignment_msg, ChainedAssignmentError, stacklevel=2
                 )
-        elif not PYPY and not using_copy_on_write():
+        elif not PYPY and not WARNING_CHECK_DISABLED and not using_copy_on_write():
             ctr = sys.getrefcount(self)
             ref_count = 3
             if not warn_copy_on_write() and _check_cacher(self):
@@ -3621,14 +3624,19 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         2    3
         dtype: int64
         """
-        if not PYPY and using_copy_on_write():
+        if not PYPY and not WARNING_CHECK_DISABLED and using_copy_on_write():
             if sys.getrefcount(self) <= REF_COUNT:
                 warnings.warn(
                     _chained_assignment_method_msg,
                     ChainedAssignmentError,
                     stacklevel=2,
                 )
-        elif not PYPY and not using_copy_on_write() and self._is_view_after_cow_rules():
+        elif (
+            not PYPY
+            and not WARNING_CHECK_DISABLED
+            and not using_copy_on_write()
+            and self._is_view_after_cow_rules()
+        ):
             ctr = sys.getrefcount(self)
             ref_count = REF_COUNT
             if _check_cacher(self):

--- a/pandas/tests/copy_view/test_chained_assignment_deprecation.py
+++ b/pandas/tests/copy_view/test_chained_assignment_deprecation.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from pandas.compat import PY311
+from pandas.compat import (
+    PY311,
+    WARNING_CHECK_DISABLED,
+)
 from pandas.errors import (
     ChainedAssignmentError,
     SettingWithCopyWarning,
@@ -150,6 +153,9 @@ def test_series_setitem(indexer, using_copy_on_write, warn_copy_on_write):
 
     # using custom check instead of tm.assert_produces_warning because that doesn't
     # fail if multiple warnings are raised
+    if WARNING_CHECK_DISABLED:
+        return
+
     with pytest.warns() as record:
         df["a"][indexer] = 0
     assert len(record) == 1

--- a/pandas/tests/copy_view/test_clip.py
+++ b/pandas/tests/copy_view/test_clip.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from pandas.compat import WARNING_CHECK_DISABLED
+
 from pandas import (
     DataFrame,
     option_context,
@@ -89,7 +91,10 @@ def test_clip_chained_inplace(using_copy_on_write):
             df[["a"]].clip(1, 2, inplace=True)
         tm.assert_frame_equal(df, df_orig)
     else:
-        with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+        with tm.assert_produces_warning(
+            FutureWarning if not WARNING_CHECK_DISABLED else None,
+            match="inplace method",
+        ):
             df["a"].clip(1, 2, inplace=True)
 
         with tm.assert_produces_warning(None):

--- a/pandas/tests/copy_view/test_interp_fillna.py
+++ b/pandas/tests/copy_view/test_interp_fillna.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.compat import WARNING_CHECK_DISABLED
+
 from pandas import (
     NA,
     ArrowDtype,
@@ -404,7 +406,10 @@ def test_fillna_chained_assignment(using_copy_on_write):
             with option_context("mode.chained_assignment", None):
                 df[df.a > 5].fillna(100, inplace=True)
 
-        with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+        with tm.assert_produces_warning(
+            FutureWarning if not WARNING_CHECK_DISABLED else None,
+            match="inplace method",
+        ):
             df["a"].fillna(100, inplace=True)
 
 
@@ -421,7 +426,10 @@ def test_interpolate_chained_assignment(using_copy_on_write, func):
             getattr(df[["a"]], func)(inplace=True)
         tm.assert_frame_equal(df, df_orig)
     else:
-        with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+        with tm.assert_produces_warning(
+            FutureWarning if not WARNING_CHECK_DISABLED else None,
+            match="inplace method",
+        ):
             getattr(df["a"], func)(inplace=True)
 
         with tm.assert_produces_warning(None):

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from pandas.compat import HAS_PYARROW
+from pandas.compat import (
+    HAS_PYARROW,
+    WARNING_CHECK_DISABLED,
+)
 from pandas.errors import SettingWithCopyWarning
 
 import pandas as pd
@@ -1585,7 +1588,10 @@ def test_chained_where_mask(using_copy_on_write, func):
             getattr(df[["a"]], func)(df["a"] > 2, 5, inplace=True)
         tm.assert_frame_equal(df, df_orig)
     else:
-        with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+        with tm.assert_produces_warning(
+            FutureWarning if not WARNING_CHECK_DISABLED else None,
+            match="inplace method",
+        ):
             getattr(df["a"], func)(df["a"] > 2, 5, inplace=True)
 
         with tm.assert_produces_warning(None):
@@ -1864,7 +1870,10 @@ def test_update_chained_assignment(using_copy_on_write):
             df[["a"]].update(ser2.to_frame())
         tm.assert_frame_equal(df, df_orig)
     else:
-        with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+        with tm.assert_produces_warning(
+            FutureWarning if not WARNING_CHECK_DISABLED else None,
+            match="inplace method",
+        ):
             df["a"].update(ser2)
 
         with tm.assert_produces_warning(None):

--- a/pandas/tests/copy_view/test_replace.py
+++ b/pandas/tests/copy_view/test_replace.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.compat import WARNING_CHECK_DISABLED
+
 from pandas import (
     Categorical,
     DataFrame,
@@ -450,7 +452,10 @@ def test_replace_chained_assignment(using_copy_on_write):
             with option_context("mode.chained_assignment", None):
                 df[df.a > 5].replace(1, 100, inplace=True)
 
-        with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+        with tm.assert_produces_warning(
+            FutureWarning if not WARNING_CHECK_DISABLED else None,
+            match="inplace method",
+        ):
             df["a"].replace(1, 100, inplace=True)
 
 

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat import WARNING_CHECK_DISABLED
 import pandas.util._test_decorators as td
 
 from pandas import (
@@ -58,7 +59,10 @@ class TestFillNA:
                 df[0].fillna(-1, inplace=True)
             assert np.isnan(arr[:, 0]).all()
         else:
-            with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+            with tm.assert_produces_warning(
+                FutureWarning if not WARNING_CHECK_DISABLED else None,
+                match="inplace method",
+            ):
                 df[0].fillna(-1, inplace=True)
             assert (arr[:, 0] == -1).all()
 

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -3,6 +3,7 @@ import pytest
 
 from pandas._config import using_string_dtype
 
+from pandas.compat import WARNING_CHECK_DISABLED
 from pandas.errors import ChainedAssignmentError
 import pandas.util._test_decorators as td
 
@@ -391,7 +392,10 @@ class TestDataFrameInterpolate:
             assert return_value is None
             tm.assert_frame_equal(result, expected_cow)
         else:
-            with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+            with tm.assert_produces_warning(
+                FutureWarning if not WARNING_CHECK_DISABLED else None,
+                match="inplace method",
+            ):
                 return_value = result["a"].interpolate(inplace=True)
             assert return_value is None
             tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -7,6 +7,7 @@ import itertools
 import numpy as np
 import pytest
 
+from pandas.compat import WARNING_CHECK_DISABLED
 from pandas.errors import PerformanceWarning
 import pandas.util._test_decorators as td
 
@@ -411,7 +412,10 @@ def test_update_inplace_sets_valid_block_values(using_copy_on_write):
         with tm.raises_chained_assignment_error():
             df["a"].fillna(1, inplace=True)
     else:
-        with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+        with tm.assert_produces_warning(
+            FutureWarning if not WARNING_CHECK_DISABLED else None,
+            match="inplace method",
+        ):
             df["a"].fillna(1, inplace=True)
 
     # check we haven't put a Series into any block.values

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -5,6 +5,7 @@ import re
 import numpy as np
 import pytest
 
+from pandas.compat import WARNING_CHECK_DISABLED
 from pandas.errors import IndexingError
 
 from pandas import (
@@ -301,7 +302,10 @@ def test_underlying_data_conversion(using_copy_on_write):
             df["val"].update(s)
         expected = df_original
     else:
-        with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+        with tm.assert_produces_warning(
+            FutureWarning if not WARNING_CHECK_DISABLED else None,
+            match="inplace method",
+        ):
             df["val"].update(s)
         expected = DataFrame(
             {"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3], "val": [0, 1, 0]}

--- a/pandas/tests/series/methods/test_update.py
+++ b/pandas/tests/series/methods/test_update.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat import WARNING_CHECK_DISABLED
 import pandas.util._test_decorators as td
 
 from pandas import (
@@ -34,7 +35,10 @@ class TestUpdate:
                 df["c"].update(Series(["foo"], index=[0]))
             expected = df_orig
         else:
-            with tm.assert_produces_warning(FutureWarning, match="inplace method"):
+            with tm.assert_produces_warning(
+                FutureWarning if not WARNING_CHECK_DISABLED else None,
+                match="inplace method",
+            ):
                 df["c"].update(Series(["foo"], index=[0]))
             expected = DataFrame(
                 [[1, np.nan, "foo"], [3, 2.0, np.nan]], columns=["a", "b", "c"]


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/62324