### PR TITLE
DOC: Link `pandas.merge` API page to User Guide (:ref:`merging`)

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -274,6 +274,7 @@ def merge(
     merge_ordered : Merge with optional filling/interpolation.
     merge_asof : Merge on nearest keys.
     DataFrame.join : Similar method using indices.
+    :ref:`merging` : User Guide on merging, joining, concantenating, and comparing.
 
     Examples
     --------


### PR DESCRIPTION
### Summary
Adds a cross-link from the `pandas.merge` API reference (*See also* section) to the User Guide section `:ref:`merging`` (“Merge, join, concatenate and compare”) to improve discoverability for new users.

### What’s changed
- Edit: `pandas/core/reshape/merge.py`
  - In the `merge` docstring’s **See also** block, add:
    `:ref:`merging` : User Guide on merging, joining, concatenating, and comparing.`

### Rationale
The API page currently lists related functions but not the tutorial-style User Guide page. Adding the `:ref:`merging`` link makes it easier to jump from API to the relevant guide.

### Notes
- Docs-only change; no API/behavior changes.
- No whatsnew entry needed.
- If maintainers prefer, I can follow up with similar links for `DataFrame.join` and related functions.
