### PR TITLE
BUG: Fix dt64[non_nano] + some_offsets incorrectly rounding

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -142,6 +142,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
+- Fixed applying offsets with a non-zero ``offset`` (e.g. :class:`~pandas.tseries.offsets.CustomBusinessDay`) to a ``DatetimeIndex`` with non-nanosecond resolution incorrectly rounding/truncating the result to the original unit (:issue:`56586`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -78,6 +78,8 @@ import pandas.core.common as com
 from pandas.tseries.frequencies import get_period_alias
 from pandas.tseries.offsets import (
     BusinessDay,
+    BusinessHour,
+    CustomBusinessHour,
     DateOffset,
     Day,
     Tick,
@@ -885,6 +887,8 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 and offset.offset is not None
                 and not isinstance(offset, Tick)
                 and type(offset) is not BusinessDay
+                and type(offset) is not BusinessHour
+                and type(offset) is not CustomBusinessHour
             ):
                 offset_td = Timedelta(offset.offset)
                 if offset_td.value != 0:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -876,7 +876,11 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 micro = offset.kwds.get("microseconds", 0)
                 if micro and self.unit != "ns":
                     res_unit = "us"
-            elif hasattr(offset, "offset") and offset.offset is not None:
+            if (
+                hasattr(offset, "offset")
+                and offset.offset is not None
+                and not isinstance(offset, Tick)
+            ):
                 offset_td = Timedelta(offset.offset)
                 if offset_td.value != 0:
                     offset_unit = offset_td.unit

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -48,6 +48,7 @@ from pandas._libs.tslibs import (
     tzconversion,
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
+from pandas._libs.tslibs.offsets import DateOffset
 from pandas.errors import PerformanceWarning
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
@@ -77,8 +78,6 @@ import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias
 from pandas.tseries.offsets import (
-    BusinessHour,
-    CustomBusinessDay,
     Day,
     Tick,
 )
@@ -874,7 +873,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             ]
             res_unit = self.unit
             if hasattr(offset, "offset") and offset.offset is not None:
-                if isinstance(offset, (CustomBusinessDay, BusinessHour)):
+                if not isinstance(offset, DateOffset):
                     offset_td = Timedelta(offset.offset)
                     if offset_td.value != 0:
                         offset_unit = offset_td.unit

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -864,14 +864,27 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             result = type(self)._from_sequence(res_values, dtype=self.dtype)
 
         else:
-            units = ["ns", "us", "ms", "s", "m", "h", "D"]
+            units = [
+                "ns",
+                "us",
+                "ms",
+                "s",
+            ]
             res_unit = self.unit
-            if hasattr(offset, "offset"):
-                offset_unit = Timedelta(offset.offset).unit
-                idx_self = units.index(self.unit)
-                idx_offset = units.index(offset_unit)
-                res_unit = units[min(idx_self, idx_offset)]
+            # Only try to adjust unit if both units are recognized
+            try:
+                if hasattr(offset, "offset"):
+                    offset_td = Timedelta(offset.offset)
+                    offset_unit = offset_td.unit
+                    if self.unit in units and offset_unit in units:
+                        idx_self = units.index(self.unit)
+                        idx_offset = units.index(offset_unit)
+                        res_unit = units[min(idx_self, idx_offset)]
+            except Exception:
+                res_unit = self.unit
             dtype = tz_to_dtype(self.tz, unit=res_unit)
+            if res_values.dtype != f"datetime64[{res_unit}]":
+                res_values = res_values.astype(f"datetime64[{res_unit}]")
             result = type(self)._simple_new(res_values, dtype=dtype)
 
             if offset.normalize:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -861,8 +861,11 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     PerformanceWarning,
                     stacklevel=find_stack_level(),
                 )
-            res_values = self.astype("O") + offset
-            result = type(self)._from_sequence(res_values, dtype=self.dtype)
+            res_values = np.array(
+                [Timestamp(x) + offset for x in self],
+                dtype="object",
+            )
+            result = type(self)._from_sequence(res_values)
 
         else:
             units = [

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -865,7 +865,8 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 )
             # Handle non-vectorized DateOffsets with both calendar and
             # timedelta parts, preserving time resolution.
-            res_values = self.astype("O") + offset
+            values_ns = values.as_unit("ns") if values.unit != "ns" else values
+            res_values = np.array([ts + offset for ts in values_ns], dtype=object)
 
             res_unit = self.unit
 
@@ -873,7 +874,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if off is not None:
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = offset_td.unit
+                    offset_unit = offset_td.resolution_string
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)
@@ -893,7 +894,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if off is not None:
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = offset_td.unit
+                    offset_unit = offset_td.resolution_string
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -845,6 +845,8 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         else:
             values = self
 
+        units = ["ns", "us", "ms", "s"]
+
         try:
             res_values = offset._apply_array(values._ndarray)
             if res_values.dtype.kind == "i":
@@ -861,45 +863,27 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     PerformanceWarning,
                     stacklevel=find_stack_level(),
                 )
-
             # Handle non-vectorized DateOffsets with both calendar and
             # timedelta parts, preserving time resolution.
-            if getattr(offset, "offset", None):
-                try:
-                    kwds = offset.kwds.copy()
-                    if "offset" in kwds:
-                        del kwds["offset"]
-                        base_offset = type(offset)(**kwds)
-                        result = self._add_offset(base_offset) + offset.offset
+            values_ns = values.as_unit("ns") if values.unit != "ns" else values
+            res_values = np.array([ts + offset for ts in values_ns], dtype=object)
 
-                        offset_td = Timedelta(offset.offset)
-                        offset_unit = offset_td.unit
-                        if offset_unit == "ns":
-                            res_str = offset_td.resolution_string
-                            if res_str in ["ms", "us", "s"]:
-                                offset_unit = res_str
+            res_unit = self.unit
 
-                        units = ["ns", "us", "ms", "s"]
-                        if self.unit in units and offset_unit in units:
-                            idx_self = units.index(self.unit)
-                            idx_offset = units.index(offset_unit)
-                            res_unit = units[min(idx_self, idx_offset)]
-                            return result.as_unit(res_unit)
+            off = getattr(offset, "offset", None)
+            if off is not None:
+                offset_td = Timedelta(off)
+                if offset_td.value != 0:
+                    offset_unit = offset_td.resolution_string
+                    if self.unit in units and offset_unit in units:
+                        idx_self = units.index(self.unit)
+                        idx_offset = units.index(offset_unit)
+                        res_unit = units[min(idx_self, idx_offset)]
 
-                        return result
-                except Exception:
-                    pass
-
-            res_values = self.astype("O") + offset
-            result = type(self)._from_sequence(res_values, dtype=self.dtype)
+            dtype = np.dtype(f"datetime64[{res_unit}]")
+            result = type(self)._from_sequence(res_values, dtype=dtype)
 
         else:
-            units = [
-                "ns",
-                "us",
-                "ms",
-                "s",
-            ]
             res_unit = self.unit
             if type(offset) is DateOffset:
                 if "nanoseconds" in offset.kwds:
@@ -916,12 +900,12 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
             result = result.as_unit(res_unit)
 
-            if offset.normalize:
-                result = result.normalize()
-                result._freq = None
+        if offset.normalize:
+            result = result.normalize()
+            result._freq = None
 
-            if self.tz is not None:
-                result = result.tz_localize(self.tz)
+        if self.tz is not None:
+            result = result.tz_localize(self.tz)
 
         return result
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -874,9 +874,15 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if off is not None:
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = getattr(off, "unit", None)
-                    if offset_unit not in units:
-                        offset_unit = offset_td.resolution_string
+                    offset_unit = offset_td.resolution_string
+                    off_unit = getattr(off, "unit", None)
+                    if off_unit in units:
+                        if not (
+                            off_unit == "ns"
+                            and offset_unit in units
+                            and offset_unit != "ns"
+                        ):
+                            offset_unit = off_unit
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)
@@ -896,9 +902,15 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if off is not None:
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = getattr(off, "unit", None)
-                    if offset_unit not in units:
-                        offset_unit = offset_td.resolution_string
+                    offset_unit = offset_td.resolution_string
+                    off_unit = getattr(off, "unit", None)
+                    if off_unit in units:
+                        if not (
+                            off_unit == "ns"
+                            and offset_unit in units
+                            and offset_unit != "ns"
+                        ):
+                            offset_unit = off_unit
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -77,7 +77,8 @@ import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias
 from pandas.tseries.offsets import (
-    DateOffset as TSeriesDateOffset,
+    BusinessDay,
+    DateOffset,
     Day,
     Tick,
 )
@@ -872,14 +873,18 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 "s",
             ]
             res_unit = self.unit
-            if isinstance(offset, TSeriesDateOffset):
+            if type(offset) is DateOffset:
+                nano = offset.kwds.get("nanoseconds", 0)
                 micro = offset.kwds.get("microseconds", 0)
-                if micro and self.unit != "ns":
+                if nano:
+                    res_unit = "ns"
+                elif micro and self.unit != "ns":
                     res_unit = "us"
             if (
                 hasattr(offset, "offset")
                 and offset.offset is not None
                 and not isinstance(offset, Tick)
+                and type(offset) is not BusinessDay
             ):
                 offset_td = Timedelta(offset.offset)
                 if offset_td.value != 0:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -67,6 +67,7 @@ from pandas.core.dtypes.dtypes import (
 )
 from pandas.core.dtypes.missing import isna
 
+from pandas import Timedelta
 from pandas.core.arrays import datetimelike as dtl
 from pandas.core.arrays._ranges import (
     generate_daily_offset_range,
@@ -100,7 +101,6 @@ if TYPE_CHECKING:
 
     from pandas import (
         DataFrame,
-        Timedelta,
     )
     from pandas.core.arrays import PeriodArray
 
@@ -871,27 +871,27 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 "s",
             ]
             res_unit = self.unit
-            # Only try to adjust unit if both units are recognized
-            try:
-                if hasattr(offset, "offset"):
-                    offset_td = Timedelta(offset.offset)
-                    offset_unit = offset_td.unit
-                    if self.unit in units and offset_unit in units:
-                        idx_self = units.index(self.unit)
-                        idx_offset = units.index(offset_unit)
-                        res_unit = units[min(idx_self, idx_offset)]
-            except Exception:
-                res_unit = self.unit
-            dtype = tz_to_dtype(self.tz, unit=res_unit)
-            if res_values.dtype != f"datetime64[{res_unit}]":
-                res_values = res_values.astype(f"datetime64[{res_unit}]")
-            result = type(self)._simple_new(res_values, dtype=dtype)
+            if hasattr(offset, "offset"):
+                offset_td = Timedelta(offset.offset)
+                offset_unit = offset_td.unit
+                if self.unit in units and offset_unit in units:
+                    idx_self = units.index(self.unit)
+                    idx_offset = units.index(offset_unit)
+                    res_unit = units[min(idx_self, idx_offset)]
+            dtype_naive = np.dtype(f"datetime64[{res_unit}]")
+            if res_values.dtype != dtype_naive:
+                res_values = res_values.astype(dtype_naive)
+            result = type(self)._simple_new(res_values, dtype=dtype_naive)
 
             if offset.normalize:
                 result = result.normalize()
                 result._freq = None
 
-            if self.tz is not None:
+            if (
+                self.tz is not None
+                and getattr(result.dtype, "tz", None) is None
+                and res_unit == "ns"
+            ):
                 result = result.tz_localize(self.tz)
 
         return result

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -862,6 +862,12 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     stacklevel=find_stack_level(),
                 )
             res_values = self.astype("O") + offset
+            res_values = [
+                Timestamp(x)
+                if isinstance(x, datetime) and not isinstance(x, Timestamp)
+                else x
+                for x in res_values
+            ]
             result = type(self)._from_sequence(res_values, dtype=self.dtype)
 
         else:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -875,7 +875,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
                     offset_unit = offset_td.resolution_string
-                    if self.unit in units and offset_unit in units:
+                    if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)
                         res_unit = units[min(idx_self, idx_offset)]
@@ -890,13 +890,15 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     res_unit = "ns"
                 elif "microseconds" in offset.kwds and self.unit != "ns":
                     res_unit = "us"
-            if hasattr(offset, "offset") and offset.offset is not None:
-                offset_td = Timedelta(offset.offset)
+            off = getattr(offset, "offset", None)
+            if off is not None:
+                offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = offset_td.unit
-                    idx_self = units.index(self.unit)
-                    idx_offset = units.index(offset_unit)
-                    res_unit = units[min(idx_self, idx_offset)]
+                    offset_unit = offset_td.resolution_string
+                    if offset_unit in units:
+                        idx_self = units.index(self.unit)
+                        idx_offset = units.index(offset_unit)
+                        res_unit = units[min(idx_self, idx_offset)]
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
             result = result.as_unit(res_unit)
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -873,17 +873,11 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             ]
             res_unit = self.unit
             if type(offset) is DateOffset:
-                nano = offset.kwds.get("nanoseconds", 0)
-                micro = offset.kwds.get("microseconds", 0)
-                if nano:
+                if "nanoseconds" in offset.kwds:
                     res_unit = "ns"
-                elif micro and self.unit != "ns":
+                elif "microseconds" in offset.kwds and self.unit != "ns":
                     res_unit = "us"
-            if (
-                hasattr(offset, "offset")
-                and offset.offset is not None
-                and not isinstance(offset, Tick)
-            ):
+            if hasattr(offset, "offset") and offset.offset is not None:
                 offset_td = Timedelta(offset.offset)
                 if offset_td.value != 0:
                     offset_unit = offset_td.unit

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -865,8 +865,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 )
             # Handle non-vectorized DateOffsets with both calendar and
             # timedelta parts, preserving time resolution.
-            values_ns = values.as_unit("ns") if values.unit != "ns" else values
-            res_values = np.array([ts + offset for ts in values_ns], dtype=object)
+            res_values = self.astype("O") + offset
 
             res_unit = self.unit
 
@@ -874,7 +873,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if off is not None:
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = offset_td.resolution_string
+                    offset_unit = offset_td.unit
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)
@@ -894,7 +893,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if off is not None:
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = offset_td.resolution_string
+                    offset_unit = offset_td.unit
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -876,13 +876,10 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 if offset_td.value != 0:
                     offset_unit = offset_td.resolution_string
                     off_unit = getattr(off, "unit", None)
-                    if off_unit in units:
-                        if not (
-                            off_unit == "ns"
-                            and offset_unit in units
-                            and offset_unit != "ns"
-                        ):
-                            offset_unit = off_unit
+                    if off_unit in units and (
+                        off_unit != "ns" or offset_unit not in units
+                    ):
+                        offset_unit = off_unit
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)
@@ -904,13 +901,10 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 if offset_td.value != 0:
                     offset_unit = offset_td.resolution_string
                     off_unit = getattr(off, "unit", None)
-                    if off_unit in units:
-                        if not (
-                            off_unit == "ns"
-                            and offset_unit in units
-                            and offset_unit != "ns"
-                        ):
-                            offset_unit = off_unit
+                    if off_unit in units and (
+                        off_unit != "ns" or offset_unit not in units
+                    ):
+                        offset_unit = off_unit
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -874,7 +874,9 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if off is not None:
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = offset_td.resolution_string
+                    offset_unit = getattr(off, "unit", None)
+                    if offset_unit not in units:
+                        offset_unit = offset_td.resolution_string
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)
@@ -894,7 +896,9 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if off is not None:
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
-                    offset_unit = offset_td.resolution_string
+                    offset_unit = getattr(off, "unit", None)
+                    if offset_unit not in units:
+                        offset_unit = offset_td.resolution_string
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -861,13 +861,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     PerformanceWarning,
                     stacklevel=find_stack_level(),
                 )
-            res_values = np.array(
-                [Timestamp(x) + offset for x in self],
-                dtype="object",
-            )
-            result = type(self)._from_sequence(res_values)
-
-        else:
+            res_values = self.astype("O") + offset
             units = [
                 "ns",
                 "us",
@@ -887,8 +881,12 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     idx_self = units.index(self.unit)
                     idx_offset = units.index(offset_unit)
                     res_unit = units[min(idx_self, idx_offset)]
+            dtype = tz_to_dtype(self.tz, unit=res_unit)
+            result = type(self)._from_sequence(res_values, dtype=dtype)
+
+        else:
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
-            result = result.as_unit(res_unit)
+            result = result.as_unit(self.unit)
 
             if offset.normalize:
                 result = result.normalize()

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -861,6 +861,35 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     PerformanceWarning,
                     stacklevel=find_stack_level(),
                 )
+
+            # Handle non-vectorized DateOffsets with both calendar and
+            # timedelta parts, preserving time resolution.
+            if getattr(offset, "offset", None):
+                try:
+                    kwds = offset.kwds.copy()
+                    if "offset" in kwds:
+                        del kwds["offset"]
+                        base_offset = type(offset)(**kwds)
+                        result = self._add_offset(base_offset) + offset.offset
+
+                        offset_td = Timedelta(offset.offset)
+                        offset_unit = offset_td.unit
+                        if offset_unit == "ns":
+                            res_str = offset_td.resolution_string
+                            if res_str in ["ms", "us", "s"]:
+                                offset_unit = res_str
+
+                        units = ["ns", "us", "ms", "s"]
+                        if self.unit in units and offset_unit in units:
+                            idx_self = units.index(self.unit)
+                            idx_offset = units.index(offset_unit)
+                            res_unit = units[min(idx_self, idx_offset)]
+                            return result.as_unit(res_unit)
+
+                        return result
+                except Exception:
+                    pass
+
             res_values = self.astype("O") + offset
             result = type(self)._from_sequence(res_values, dtype=self.dtype)
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -48,7 +48,6 @@ from pandas._libs.tslibs import (
     tzconversion,
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
-from pandas._libs.tslibs.offsets import DateOffset
 from pandas.errors import PerformanceWarning
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
@@ -78,6 +77,7 @@ import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias
 from pandas.tseries.offsets import (
+    DateOffset as TSeriesDateOffset,
     Day,
     Tick,
 )
@@ -873,7 +873,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             ]
             res_unit = self.unit
             if hasattr(offset, "offset") and offset.offset is not None:
-                if not isinstance(offset, DateOffset):
+                if not isinstance(offset, TSeriesDateOffset):
                     offset_td = Timedelta(offset.offset)
                     if offset_td.value != 0:
                         offset_unit = offset_td.unit

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -77,9 +77,6 @@ import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias
 from pandas.tseries.offsets import (
-    BusinessDay,
-    BusinessHour,
-    CustomBusinessHour,
     DateOffset,
     Day,
     Tick,
@@ -886,9 +883,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 hasattr(offset, "offset")
                 and offset.offset is not None
                 and not isinstance(offset, Tick)
-                and type(offset) is not BusinessDay
-                and type(offset) is not BusinessHour
-                and type(offset) is not CustomBusinessHour
             ):
                 offset_td = Timedelta(offset.offset)
                 if offset_td.value != 0:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -861,11 +861,8 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     PerformanceWarning,
                     stacklevel=find_stack_level(),
                 )
-            res_values = np.array(
-                [Timestamp(x) + offset for x in self],
-                dtype="object",
-            )
-            result = type(self)._from_sequence(res_values)
+            res_values = self.astype("O") + offset
+            result = type(self)._from_sequence(res_values, dtype=self.dtype)
 
         else:
             units = [

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -878,10 +878,8 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     idx_self = units.index(self.unit)
                     idx_offset = units.index(offset_unit)
                     res_unit = units[min(idx_self, idx_offset)]
-            dtype_naive = np.dtype(f"datetime64[{res_unit}]")
-            if res_values.dtype != dtype_naive:
-                res_values = res_values.astype(dtype_naive)
-            result = type(self)._simple_new(res_values, dtype=dtype_naive)
+            result = type(self)._simple_new(res_values, dtype=res_values.dtype)
+            result = result.as_unit(res_unit)
 
             if offset.normalize:
                 result = result.normalize()

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -864,7 +864,16 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             result = type(self)._from_sequence(res_values, dtype=self.dtype)
 
         else:
-            result = type(self)._simple_new(res_values, dtype=res_values.dtype)
+            units = ["ns", "us", "ms", "s", "m", "h", "D"]
+            res_unit = self.unit
+            if hasattr(offset, "offset"):
+                offset_unit = Timedelta(offset.offset).unit
+                idx_self = units.index(self.unit)
+                idx_offset = units.index(offset_unit)
+                res_unit = units[min(idx_self, idx_offset)]
+            dtype = tz_to_dtype(self.tz, unit=res_unit)
+            result = type(self)._simple_new(res_values, dtype=dtype)
+
             if offset.normalize:
                 result = result.normalize()
                 result._freq = None

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -872,14 +872,17 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 "s",
             ]
             res_unit = self.unit
-            if hasattr(offset, "offset") and offset.offset is not None:
-                if not isinstance(offset, TSeriesDateOffset):
-                    offset_td = Timedelta(offset.offset)
-                    if offset_td.value != 0:
-                        offset_unit = offset_td.unit
-                        idx_self = units.index(self.unit)
-                        idx_offset = units.index(offset_unit)
-                        res_unit = units[min(idx_self, idx_offset)]
+            if isinstance(offset, TSeriesDateOffset):
+                micro = offset.kwds.get("microseconds", 0)
+                if micro and self.unit != "ns":
+                    res_unit = "us"
+            elif hasattr(offset, "offset") and offset.offset is not None:
+                offset_td = Timedelta(offset.offset)
+                if offset_td.value != 0:
+                    offset_unit = offset_td.unit
+                    idx_self = units.index(self.unit)
+                    idx_offset = units.index(offset_unit)
+                    res_unit = units[min(idx_self, idx_offset)]
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
             result = result.as_unit(res_unit)
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -861,7 +861,13 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     PerformanceWarning,
                     stacklevel=find_stack_level(),
                 )
-            res_values = self.astype("O") + offset
+            res_values = np.array(
+                [Timestamp(x) + offset for x in self],
+                dtype="object",
+            )
+            result = type(self)._from_sequence(res_values)
+
+        else:
             units = [
                 "ns",
                 "us",
@@ -881,12 +887,8 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     idx_self = units.index(self.unit)
                     idx_offset = units.index(offset_unit)
                     res_unit = units[min(idx_self, idx_offset)]
-            dtype = tz_to_dtype(self.tz, unit=res_unit)
-            result = type(self)._from_sequence(res_values, dtype=dtype)
-
-        else:
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
-            result = result.as_unit(self.unit)
+            result = result.as_unit(res_unit)
 
             if offset.normalize:
                 result = result.normalize()

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -862,12 +862,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     stacklevel=find_stack_level(),
                 )
             res_values = self.astype("O") + offset
-            res_values = [
-                Timestamp(x)
-                if isinstance(x, datetime) and not isinstance(x, Timestamp)
-                else x
-                for x in res_values
-            ]
             result = type(self)._from_sequence(res_values, dtype=self.dtype)
 
         else:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -30,6 +30,7 @@ from pandas._libs.tslibs import (
     OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
     Resolution,
+    Timedelta,
     Timestamp,
     astype_overflowsafe,
     fields,
@@ -67,7 +68,6 @@ from pandas.core.dtypes.dtypes import (
 )
 from pandas.core.dtypes.missing import isna
 
-from pandas import Timedelta
 from pandas.core.arrays import datetimelike as dtl
 from pandas.core.arrays._ranges import (
     generate_daily_offset_range,

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -871,12 +871,13 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 "s",
             ]
             res_unit = self.unit
-            if hasattr(offset, "offset"):
+            if hasattr(offset, "offset") and offset.offset is not None:
                 offset_td = Timedelta(offset.offset)
-                offset_unit = offset_td.unit
-                idx_self = units.index(self.unit)
-                idx_offset = units.index(offset_unit)
-                res_unit = units[min(idx_self, idx_offset)]
+                if offset_td.value != 0:
+                    offset_unit = offset_td.unit
+                    idx_self = units.index(self.unit)
+                    idx_offset = units.index(offset_unit)
+                    res_unit = units[min(idx_self, idx_offset)]
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
             result = result.as_unit(res_unit)
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -874,10 +874,9 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             if hasattr(offset, "offset"):
                 offset_td = Timedelta(offset.offset)
                 offset_unit = offset_td.unit
-                if self.unit in units and offset_unit in units:
-                    idx_self = units.index(self.unit)
-                    idx_offset = units.index(offset_unit)
-                    res_unit = units[min(idx_self, idx_offset)]
+                idx_self = units.index(self.unit)
+                idx_offset = units.index(offset_unit)
+                res_unit = units[min(idx_self, idx_offset)]
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
             result = result.as_unit(res_unit)
 
@@ -885,11 +884,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 result = result.normalize()
                 result._freq = None
 
-            if (
-                self.tz is not None
-                and getattr(result.dtype, "tz", None) is None
-                and res_unit == "ns"
-            ):
+            if self.tz is not None:
                 result = result.tz_localize(self.tz)
 
         return result

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -77,6 +77,8 @@ import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias
 from pandas.tseries.offsets import (
+    BusinessHour,
+    CustomBusinessDay,
     Day,
     Tick,
 )
@@ -872,12 +874,13 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             ]
             res_unit = self.unit
             if hasattr(offset, "offset") and offset.offset is not None:
-                offset_td = Timedelta(offset.offset)
-                if offset_td.value != 0:
-                    offset_unit = offset_td.unit
-                    idx_self = units.index(self.unit)
-                    idx_offset = units.index(offset_unit)
-                    res_unit = units[min(idx_self, idx_offset)]
+                if isinstance(offset, (CustomBusinessDay, BusinessHour)):
+                    offset_td = Timedelta(offset.offset)
+                    if offset_td.value != 0:
+                        offset_unit = offset_td.unit
+                        idx_self = units.index(self.unit)
+                        idx_offset = units.index(offset_unit)
+                        res_unit = units[min(idx_self, idx_offset)]
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
             result = result.as_unit(res_unit)
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -875,11 +875,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
                     offset_unit = offset_td.resolution_string
-                    off_unit = getattr(off, "unit", None)
-                    if off_unit in units and (
-                        off_unit != "ns" or offset_unit not in units
-                    ):
-                        offset_unit = off_unit
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)
@@ -900,11 +895,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 offset_td = Timedelta(off)
                 if offset_td.value != 0:
                     offset_unit = offset_td.resolution_string
-                    off_unit = getattr(off, "unit", None)
-                    if off_unit in units and (
-                        off_unit != "ns" or offset_unit not in units
-                    ):
-                        offset_unit = off_unit
                     if offset_unit in units:
                         idx_self = units.index(self.unit)
                         idx_offset = units.index(offset_unit)

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -855,8 +855,7 @@ def test_factorize_sort_without_freq():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:Non-vectorized DateOffset being applied to Series or DatetimeIndex:"
-    "PerformanceWarning"
+    "ignore:Non-vectorized DateOffset being applied to Series or DatetimeIndex"
 )
 def test_dt64_non_nano_offset_no_rounding():
     # GH#56586

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -852,3 +852,20 @@ def test_factorize_sort_without_freq():
     tda = dta - dta[0]
     with pytest.raises(NotImplementedError, match=msg):
         tda.factorize(sort=True)
+
+
+def test_dt64_non_nano_offset_no_rounding():
+    # GH#56586
+    dti = pd.date_range("2016-01-01", periods=3, unit="s")
+    offset = pd.offsets.CustomBusinessDay(offset=pd.Timedelta("1ms"))
+    result = dti + offset
+
+    assert result.dtype == np.dtype("datetime64[ms]")
+    expected = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2016-01-02 00:00:00.001"),
+            pd.Timestamp("2016-01-03 00:00:00.001"),
+            pd.Timestamp("2016-01-04 00:00:00.001"),
+        ]
+    )
+    assert all(result == expected)

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -854,6 +854,10 @@ def test_factorize_sort_without_freq():
         tda.factorize(sort=True)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Non-vectorized DateOffset being applied to Series or DatetimeIndex:"
+    "PerformanceWarning"
+)
 def test_dt64_non_nano_offset_no_rounding():
     # GH#56586
     dti = pd.date_range("2016-01-01", periods=3, unit="s")

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -867,8 +867,8 @@ def test_dt64_non_nano_offset_no_rounding():
     expected = pd.DatetimeIndex(
         [
             pd.Timestamp("2016-01-04 00:00:00.001"),
-            pd.Timestamp("2016-01-04 00:00:00.001"),
-            pd.Timestamp("2016-01-04 00:00:00.001"),
+            pd.Timestamp("2016-01-05 00:00:00.001"),
+            pd.Timestamp("2016-01-06 00:00:00.001"),
         ]
-    )
+    ).as_unit("ms")
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -866,8 +866,8 @@ def test_dt64_non_nano_offset_no_rounding():
     assert result.dtype == np.dtype("datetime64[ms]")
     expected = pd.DatetimeIndex(
         [
-            pd.Timestamp("2016-01-02 00:00:00.001"),
-            pd.Timestamp("2016-01-03 00:00:00.001"),
+            pd.Timestamp("2016-01-04 00:00:00.001"),
+            pd.Timestamp("2016-01-04 00:00:00.001"),
             pd.Timestamp("2016-01-04 00:00:00.001"),
         ]
     )

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -868,4 +868,4 @@ def test_dt64_non_nano_offset_no_rounding():
             pd.Timestamp("2016-01-04 00:00:00.001"),
         ]
     )
-    assert all(result == expected)
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #56586  (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature

This PR updates logic selects the finest unit between the array and the offset, preventing rounding errors. A regression test is included to confirm correct behavior for affected offsets and units.

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !

