### PR TITLE
DOC: Warn about dtype inference with raw=True in DataFrame.apply

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10629,6 +10629,13 @@ class DataFrame(NDFrame, OpsMixin):
               If you are just applying a NumPy reduction function this will
               achieve much better performance.
 
+        .. warning::
+
+            When ``raw=True``, the output dtype is inferred from the 
+            **first returned value**. If that value is not ``None``but
+            later calls return ``Nonw``, a ``TypeError`` may be raised
+            because Numpy infers a non-nullable dtype.
+
         result_type : {'expand', 'reduce', 'broadcast', None}, default None
             These only act when ``axis=1`` (columns):
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10629,7 +10629,7 @@ class DataFrame(NDFrame, OpsMixin):
               If you are just applying a NumPy reduction function this will
               achieve much better performance.
 
-         .. warning::
+         .. note::
 
             When ``raw=True``, the result dtype is inferred from the **first**
             returned value.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10631,8 +10631,8 @@ class DataFrame(NDFrame, OpsMixin):
 
          .. note::
 
-            When ``raw=True``, the result dtype is inferred from the **first**
-            returned value.
+                When ``raw=True``, the result dtype is inferred from the **first**
+                returned value.
 
         result_type : {'expand', 'reduce', 'broadcast', None}, default None
             These only act when ``axis=1`` (columns):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10629,12 +10629,12 @@ class DataFrame(NDFrame, OpsMixin):
               If you are just applying a NumPy reduction function this will
               achieve much better performance.
 
-        .. warning::
+         .. warning::
 
-            When ``raw=True``, the output dtype is inferred from the 
-            **first returned value**. If that value is not ``None``but
-            later calls return ``Nonw``, a ``TypeError`` may be raised
-            because Numpy infers a non-nullable dtype.
+            When ``raw=True``, the result dtype is inferred from the **first**
+            returned value. If that value is not ``None`` but later calls return
+            ``None``, a ``TypeError`` may occur because NumPy infers a
+            non-nullable dtype.
 
         result_type : {'expand', 'reduce', 'broadcast', None}, default None
             These only act when ``axis=1`` (columns):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10632,9 +10632,7 @@ class DataFrame(NDFrame, OpsMixin):
          .. warning::
 
             When ``raw=True``, the result dtype is inferred from the **first**
-            returned value. If that value is not ``None`` but later calls return
-            ``None``, a ``TypeError`` may occur because NumPy infers a
-            non-nullable dtype.
+            returned value.
 
         result_type : {'expand', 'reduce', 'broadcast', None}, default None
             These only act when ``axis=1`` (columns):


### PR DESCRIPTION
- [x] closes #61632
- [x] Adds a note in DataFrame.apply docstring explaining that when raw=True, 
      the dtype is inferred from the first returned value, and returning None 
      may cause a TypeError.
- [x] All pre-commit checks passed.