### PR TITLE
CI: create unassign command

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -18,6 +18,21 @@ jobs:
       - run: |
           echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+  issue_unassign:
+    runs-on: ubuntu-24.04
+    if: (!github.event.issue.pull_request) && github.event.comment.body == 'unassign'
+    concurrency:
+      group: ${{ github.actor }}-issue-unassign
+    steps:
+      - run: |
+          echo "Removing ${{ github.event.comment.user.login }} from issue ${{ github.event.issue.number }} assignees"
+          curl -L \
+            -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees \
+            -d '{"assignees": ["${{ github.event.comment.user.login }}"]}'
   preview_docs:
     runs-on: ubuntu-24.04
     if: github.event.issue.pull_request && github.event.comment.body == '/preview'

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -42,8 +42,11 @@ text ``take`` to automatically assign you the issue
 (this will take seconds and may require refreshing the page to see it).
 
 If for whatever reason you are not able to continue working with the issue, please
-unassign it, so other people know it's available again. You can check the list of
-assigned issues, since people may not be working in them anymore. If you want to work on one
+unassign it, so other people know it's available again.
+On the GitHub issue, a comment with the exact text ``unassign``
+will automatically unassign yourself from the issue.
+You can check the list of assigned issues,
+since people may not be working in them anymore. If you want to work on one
 that is assigned, feel free to kindly ask the current assignee if you can take it
 (please allow at least a week of inactivity before considering work in the issue discontinued).
 


### PR DESCRIPTION
Currently, people without write privileges can't unassign themselves from the issue. This PR creates the "unassign" command for the contributor to remove himself from the assignees.

The command to delete the user from the assignees is adapted from [GitHub rest API documentation](<https://docs.github.com/en/rest/issues/assignees?apiVersion=2022-11-28#remove-assignees-from-an-issue>).

Unfortunately, the docs aren't specific of what happens when the user isn't assigned.
