### PR TITLE
Remove outdated Docker image section, add local cygdb instruction

### DIFF
--- a/doc/source/development/debugging_extensions.rst
+++ b/doc/source/development/debugging_extensions.rst
@@ -10,9 +10,9 @@ pandas uses Cython and C/C++ `extension modules <https://docs.python.org/3/exten
 
 For Python developers with limited or no C/C++ experience this can seem a daunting task. Core developer Will Ayd has written a 3 part blog series to help guide you from the standard Python debugger into these other tools:
 
-1. `Fundamental Python Debugging Part 1 - Python <https://willayd.com/fundamental-python-debugging-part-1-python.html>`_
-2. `Fundamental Python Debugging Part 2 - Python Extensions <https://willayd.com/fundamental-python-debugging-part-2-python-extensions.html>`_
-3. `Fundamental Python Debugging Part 3 - Cython Extensions <https://willayd.com/fundamental-python-debugging-part-3-cython-extensions.html>`_
+1. `Fundamental Python Debugging Part 1 - Python <https://willayd.com/fundamental-python-debugging-part-1-python/>`_
+2. `Fundamental Python Debugging Part 2 - Python Extensions <https://willayd.com/fundamental-python-debugging-part-2-python-extensions/>`_
+3. `Fundamental Python Debugging Part 3 - Cython Extensions <https://willayd.com/fundamental-python-debugging-part-3-cython-extensions/>`_
 
 Debugging locally
 -----------------
@@ -22,29 +22,16 @@ By default building pandas from source will generate a release build. To generat
     pip install -ve . --no-build-isolation -Cbuilddir="debug" -Csetup-args="-Dbuildtype=debug"
 
 .. note::
-
    conda environments update CFLAGS/CPPFLAGS with flags that are geared towards generating releases, and may work counter towards usage in a development environment. If using conda, you should unset these environment variables via ``export CFLAGS=`` and ``export CPPFLAGS=``
 
 By specifying ``builddir="debug"`` all of the targets will be built and placed in the debug directory relative to the project root. This helps to keep your debug and release artifacts separate; you are of course able to choose a different directory name or omit altogether if you do not care to separate build types.
 
-Using Docker
-------------
+Using cygdb for Cython debugging
+---------------------------------
 
-To simplify the debugging process, pandas has created a Docker image with a debug build of Python and the gdb/Cython debuggers pre-installed. You may either ``docker pull pandas/pandas-debug`` to get access to this image or build it from the ``tooling/debug`` folder locally.
+For debugging Cython extensions, ``cygdb`` is the recommended approach. The ``cygdb`` debugger comes pre-installed with Cython, so if you have Cython installed in your development environment, you should already have access to it.
 
-You can then mount your pandas repository into this image via:
-
-.. code-block:: sh
-
-   docker run --rm -it -w /data -v ${PWD}:/data pandas/pandas-debug
-
-Inside the image, you can use meson to build/install pandas and place the build artifacts into a ``debug`` folder using a command as follows:
-
-.. code-block:: sh
-
-    python -m pip install -ve . --no-build-isolation -Cbuilddir="debug" -Csetup-args="-Dbuildtype=debug"
-
-If planning to use cygdb, the files required by that application are placed within the build folder. So you have to first ``cd`` to the build folder, then start that application.
+After building pandas with debug symbols (as shown above), you can use cygdb by navigating to the build folder and starting the debugger:
 
 .. code-block:: sh
 


### PR DESCRIPTION
This PR addresses issue #61511 by updating the debugging_extensions.rst documentation.

## Summary of Changes

- **Removed** the outdated "Using Docker" section as the Docker image is out of date
- **Added** a new "Using cygdb for Cython debugging" section emphasizing local installations
- **Documented** that cygdb comes pre-installed with Cython
- **Updated** to reflect preference for local installations as discussed in the issue

As mentioned by @WillAyd in the issue discussion, the pandas team gets very little usage of the docker containers, so this change removes that documentation and focuses on the preferred local debugging approach using cygdb.

## Closes
- Closes #61511

## Checklist
- [x] This is a documentation-only change
- [x] No tests needed (documentation change only)
- [x] No type annotations needed (documentation change only)
- [x] No whatsnew entry needed (documentation improvement)…nsDOC: Remove outdated Docker image from debugging_extensions documentationDOC: Remove outdated Docker image from debugging_extensions documentationUpdate debugging_extensions.rst

- Removed the 'Using Docker' section as the Docker image is out of date
- Added 'Using cygdb for Cython debugging' section emphasizing local installations
- Documented that cygdb comes pre-installed with Cython
- Updated to reflect preference for local installations as discussed in issue

Closes #61511

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
