### PR TITLE
DEPR: Improve commenting around two deprecations

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -3018,7 +3018,7 @@ class Period(_Period):
             # GH#53446
             import warnings
 
-            # TODO: Enforce in 3.0 (#53511)
+            # TODO: Need to find an alternative before this deprecation can be enforced (#53511)
             from pandas.util._exceptions import find_stack_level
             warnings.warn(
                 "Period with BDay freq is deprecated and will be removed "

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9136,7 +9136,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         from pandas.core.resample import get_resampler
 
         if convention is not lib.no_default:
-            # TODO: Enforce in 3.0 (#55968)
+            # TODO: Plan to fix resampling with PeriodIndex instead (#55968)
+            # see https://github.com/pandas-dev/pandas/pull/62270#issuecomment-3262411892
             warnings.warn(
                 f"The 'convention' keyword in {type(self).__name__}.resample is "
                 "deprecated and will be removed in a future version. "

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1945,7 +1945,8 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
     @property
     def _resampler_for_grouping(self):
-        # TODO: Enforce in 3.0 (#55968)
+        # TODO: Plan to fix resampling with PeriodIndex instead (#55968)
+        # see https://github.com/pandas-dev/pandas/pull/62270#issuecomment-3262411892
         warnings.warn(
             "Resampling a groupby with a PeriodIndex is deprecated. "
             "Cast to DatetimeIndex before resampling instead.",

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -473,6 +473,7 @@ def test_resample_empty_dtypes(index, dtype, resample_method):
     warn = None
     if isinstance(index, PeriodIndex):
         # GH#53511
+        # TODO: Need to find an alternative before this deprecation can be enforced
         index = PeriodIndex([], freq="B", name=index.name)
         warn = FutureWarning
     msg = "Resampling with a PeriodIndex is deprecated"


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I believe these two deprecations are not ready to be enforced, and while we won't enforce in 3.0 we want to keep them as FutureWarnings. With this I plan to move the line items from the 3.0 deprecation issue to the 4.0 issue.

cc @jbrockmendel 