### PR TITLE
BUG: limit select_dtypes(object) back compat fix to default str dtype

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -144,6 +144,7 @@ from pandas.core.arrays import (
     TimedeltaArray,
 )
 from pandas.core.arrays.sparse import SparseFrameAccessor
+from pandas.core.arrays.string_ import StringDtype
 from pandas.core.construction import (
     ensure_wrapped_if_datetimelike,
     sanitize_array,
@@ -5157,7 +5158,12 @@ class DataFrame(NDFrame, OpsMixin):
                     and getattr(dtype, "_is_numeric", False)
                     and not is_bool_dtype(dtype)
                 )
-                or (dtype.type is str and np.object_ in dtypes_set)
+                # backwards compat for the default `str` dtype being selected by object
+                or (
+                    isinstance(dtype, StringDtype)
+                    and dtype.na_value is np.nan
+                    and np.object_ in dtypes_set
+                )
             )
 
         def predicate(arr: ArrayLike) -> bool:

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -485,3 +485,27 @@ class TestSelectDtypes:
         result = df.select_dtypes(include=["number"])
         result.iloc[0, 0] = 0
         tm.assert_frame_equal(df, df_orig)
+
+    def test_select_dtype_object_and_str(self, using_infer_string):
+        # https://github.com/pandas-dev/pandas/issues/61916
+        df = DataFrame(
+            {
+                "a": ["a", "b", "c"],
+                "b": [1, 2, 3],
+                "c": pd.array(["a", "b", "c"], dtype="string"),
+            }
+        )
+
+        # with "object" -> only select the object or default str dtype column
+        result = df.select_dtypes(include=["object"])
+        expected = df[["a"]]
+        tm.assert_frame_equal(result, expected)
+
+        # with "string" -> select both the default 'str' and the nullable 'string'
+        result = df.select_dtypes(include=["string"])
+        if using_infer_string:
+            expected = df[["a", "c"]]
+        else:
+            expected = df[["c"]]
+        expected = df[["a", "c"]]
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -507,5 +507,4 @@ class TestSelectDtypes:
             expected = df[["a", "c"]]
         else:
             expected = df[["c"]]
-        expected = df[["a", "c"]]
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/62323

While reviewing the backport of that PR, I realized that we might want to limit this "backwards compatibility" change for _only_ the default NaN `str` dtype, and not for the NA `string` dtype. 
Because right now, for existing users of the `string` dtype, they should already be used to the fact that `object` does not select the `string` column (and they can already do `include=["string"]` to select the string columns). And if we now start to do that, that could be seen as a regression for the nullable `string` dtype.

That of course creates an inconsistency between default str vs nullable string dtype .. so we can certainly go either way.

I am already including this change in the backport https://github.com/pandas-dev/pandas/pull/62400 itself, so if we go forward with this change, this PR can target 3.0 and does not need to be backported separately.