### PR TITLE
Avoid reindexing values assigned to a multi-index when cols_droplevel contains empty values 

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -995,6 +995,7 @@ MultiIndex
 - Bug in :class:`DataFrame` arithmetic operations with :class:`Series` in case of unaligned MultiIndex (:issue:`61009`)
 - Bug in :meth:`MultiIndex.from_tuples` causing wrong output with input of type tuples having NaN values (:issue:`60695`, :issue:`60988`)
 - Bug in :meth:`DataFrame.reindex` and :meth:`Series.reindex` where reindexing :class:`Index` to a :class:`MultiIndex` would incorrectly set all values to ``NaN``.(:issue:`60923`)
+- Bug in :meth:`DataFrame.__setitem__` where column alignment logic would reindex the assigned value with an empty index, incorrectly setting all values to ``NaN``.(:issue:`61841`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -994,8 +994,8 @@ MultiIndex
 - Bug in :class:`DataFrame` arithmetic operations in case of unaligned MultiIndex columns (:issue:`60498`)
 - Bug in :class:`DataFrame` arithmetic operations with :class:`Series` in case of unaligned MultiIndex (:issue:`61009`)
 - Bug in :meth:`MultiIndex.from_tuples` causing wrong output with input of type tuples having NaN values (:issue:`60695`, :issue:`60988`)
-- Bug in :meth:`DataFrame.reindex` and :meth:`Series.reindex` where reindexing :class:`Index` to a :class:`MultiIndex` would incorrectly set all values to ``NaN``.(:issue:`60923`)
 - Bug in :meth:`DataFrame.__setitem__` where column alignment logic would reindex the assigned value with an empty index, incorrectly setting all values to ``NaN``.(:issue:`61841`)
+- Bug in :meth:`DataFrame.reindex` and :meth:`Series.reindex` where reindexing :class:`Index` to a :class:`MultiIndex` would incorrectly set all values to ``NaN``.(:issue:`60923`)
 
 I/O
 ^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4450,6 +4450,11 @@ class DataFrame(NDFrame, OpsMixin):
                 loc, (slice, Series, np.ndarray, Index)
             ):
                 cols_droplevel = maybe_droplevels(cols, key)
+                if (
+                    not isinstance(cols_droplevel, MultiIndex)
+                    and not cols_droplevel.any()
+                ):
+                    return
                 if len(cols_droplevel) and not cols_droplevel.equals(value.columns):
                     value = value.reindex(cols_droplevel, axis=1)
 

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -249,3 +249,20 @@ class TestMultiIndexBasic:
         expected = getattr(a, operation)(b.sort_index(ascending=False))
 
         tm.assert_series_equal(result, expected)
+
+    def test_multiindex_assign_aligns_as_implicit_tuple(self):
+        # GH 61841
+        cols = MultiIndex.from_tuples([("A", "B")])
+        df1 = DataFrame([[i] for i in range(3)], columns=cols)
+        df2 = DataFrame([[i] for i in range(3)], columns=cols)
+        df3 = DataFrame([[i] for i in range(3)], columns=cols)
+        s1 = df1["A"].rolling(2).mean()
+        s2 = df2["A"].rolling(2).mean()
+        s3 = df3["A"].rolling(2).mean()
+        df1["C"] = s1
+        df1["C"] = s1
+        df1["C"] = s1
+        df2["C"] = s2
+        df3[("C", "")] = s3
+        tm.assert_frame_equal(df1, df2)
+        tm.assert_frame_equal(df1, df3)

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -254,15 +254,20 @@ class TestMultiIndexBasic:
         # GH 61841
         cols = MultiIndex.from_tuples([("A", "B")])
         df1 = DataFrame([[i] for i in range(3)], columns=cols)
-        df2 = DataFrame([[i] for i in range(3)], columns=cols)
-        df3 = DataFrame([[i] for i in range(3)], columns=cols)
+        df2 = df1.copy()
+        df3 = df1.copy()
         s1 = df1["A"].rolling(2).mean()
-        s2 = df2["A"].rolling(2).mean()
-        s3 = df3["A"].rolling(2).mean()
-        df1["C"] = s1
-        df1["C"] = s1
-        df1["C"] = s1
+        s2 = s1.copy()
+        s3 = s1.copy()
+
         df2["C"] = s2
         df3[("C", "")] = s3
+        tm.assert_frame_equal(df2, df3)
+
+        df1["C"] = s1
+        tm.assert_frame_equal(df1, df2)
+        tm.assert_frame_equal(df1, df3)
+
+        df1["C"] = s1
         tm.assert_frame_equal(df1, df2)
         tm.assert_frame_equal(df1, df3)


### PR DESCRIPTION
- [x] closes #61841 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
