### PR TITLE
BUG: zero result in `Series.kurt` for low variance arrays

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1148,7 +1148,7 @@ Other
 - Bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
 - Bug in :meth:`Series.dt` methods in :class:`ArrowDtype` that were returning incorrect values. (:issue:`57355`)
 - Bug in :meth:`Series.isin` raising ``TypeError`` when series is large (>10**6) and ``values`` contains NA (:issue:`60678`)
-- Bug in :meth:`Series.kurt` resulting in zero for low variance arrays (:issue:`57972`)
+- Bug in :meth:`Series.kurt` and :meth:`Series.skew` resulting in zero for low variance arrays (:issue:`57972`)
 - Bug in :meth:`Series.map` with a ``timestamp[pyarrow]`` dtype or ``duration[pyarrow]`` dtype incorrectly returning all-``NaN`` entries (:issue:`61231`)
 - Bug in :meth:`Series.mode` where an exception was raised when taking the mode with nullable types with no null values in the series. (:issue:`58926`)
 - Bug in :meth:`Series.rank` that doesn't preserve missing values for nullable integers when ``na_option='keep'``. (:issue:`56976`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1148,6 +1148,7 @@ Other
 - Bug in :meth:`Series.diff` allowing non-integer values for the ``periods`` argument. (:issue:`56607`)
 - Bug in :meth:`Series.dt` methods in :class:`ArrowDtype` that were returning incorrect values. (:issue:`57355`)
 - Bug in :meth:`Series.isin` raising ``TypeError`` when series is large (>10**6) and ``values`` contains NA (:issue:`60678`)
+- Bug in :meth:`Series.kurt` resulting in zero for low variance arrays (:issue:`57972`)
 - Bug in :meth:`Series.map` with a ``timestamp[pyarrow]`` dtype or ``duration[pyarrow]`` dtype incorrectly returning all-``NaN`` entries (:issue:`61231`)
 - Bug in :meth:`Series.mode` where an exception was raised when taking the mode with nullable types with no null values in the series. (:issue:`58926`)
 - Bug in :meth:`Series.rank` that doesn't preserve missing values for nullable integers when ``na_option='keep'``. (:issue:`56976`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1275,7 +1275,7 @@ def nanskew(
     m3 = adjusted3.sum(axis, dtype=np.float64)
 
     # floating point error. See comment in [nankurt]
-    max_abs = np.abs(values).max(axis)
+    max_abs = np.abs(values).max(axis, initial=0.0)
     eps = np.finfo(m2.dtype).eps
     constant_tolerance2 = ((eps * max_abs) ** 2) * count
     constant_tolerance3 = ((eps * max_abs) ** 3) * count
@@ -1382,7 +1382,7 @@ def nankurt(
     # |m2 - y| <= n|m2|e²
     #
     # We will use max (x²) to estimate |m2|
-    max_abs = np.abs(values).max(axis)
+    max_abs = np.abs(values).max(axis, initial=0.0)
     eps = np.finfo(m2.dtype).eps
     constant_tolerance2 = ((eps * max_abs) ** 2) * count
     constant_tolerance4 = ((eps * max_abs) ** 4) * count

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1363,6 +1363,10 @@ def nankurt(
     m4 = adjusted4.sum(axis, dtype=np.float64)
 
     # Several floating point errors may occur during the summation due to rounding.
+    # This computation is similar to the one in Scipy
+    # https://github.com/scipy/scipy/blob/04d6d9c460b1fed83f2919ecec3d743cfa2e8317/scipy/stats/_stats_py.py#L1429
+    # With a few modifications, like using the maximum value instead of the averages
+    # and some adaptations because they use the average and we use the sum for `m2`.
     # We need to estimate an upper bound to the error to consider the data constant.
     # Lets call:
     # x: true value in data

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1278,9 +1278,11 @@ def nanskew(
     #
     # #18044 in _libs/windows.pyx calc_skew follow this behavior
     # to fix the fperr to treat m2 <1e-14 as zero
-    constant_tolerance = (np.finfo(m2.dtype).eps * total) ** 2
-    m2 = _zero_out_fperr(m2, constant_tolerance)
-    m3 = _zero_out_fperr(m3, constant_tolerance)
+    constant_tolerance = np.finfo(m2.dtype).eps * total
+    constant_tolerance2 = constant_tolerance**2  # match order of m2
+    constant_tolerance3 = constant_tolerance2 * constant_tolerance  # match order of m3
+    m2 = _zero_out_fperr(m2, constant_tolerance2)
+    m3 = _zero_out_fperr(m3, constant_tolerance3)
 
     with np.errstate(invalid="ignore", divide="ignore"):
         result = (count * (count - 1) ** 0.5 / (count - 2)) * (m3 / m2**1.5)
@@ -1376,9 +1378,10 @@ def nankurt(
     # #57972 arbitrary <1e-14 tolerance leads to problematic behaviour on low variance.
     # We adapted the tolerance to use one similar to scipy:
     # https://github.com/scipy/scipy/blob/04d6d9c460b1fed83f2919ecec3d743cfa2e8317/scipy/stats/_stats_py.py#L1429
-    constant_tolerance = (np.finfo(m2.dtype).eps * total) ** 2
-    numerator = _zero_out_fperr(numerator, constant_tolerance)
-    denominator = _zero_out_fperr(denominator, constant_tolerance)
+    constant_tolerance2 = (np.finfo(m2.dtype).eps * total) ** 2  # match order of m2
+    constant_tolerance4 = constant_tolerance2**2  # match order of m4
+    numerator = _zero_out_fperr(numerator, constant_tolerance2)
+    denominator = _zero_out_fperr(denominator, constant_tolerance4)
 
     if not isinstance(denominator, np.ndarray):
         # if ``denom`` is a scalar, check these corner cases first before

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1608,7 +1608,7 @@ def check_below_min_count(
     return False
 
 
-def _zero_out_fperr(arg, tol):
+def _zero_out_fperr(arg, tol: float | np.ndarray):
     # #18044 reference this behavior to fix rolling skew/kurt issue
     if isinstance(arg, np.ndarray):
         return np.where(np.abs(arg) < tol, 0, arg)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1278,7 +1278,7 @@ def nanskew(
     #
     # #18044 in _libs/windows.pyx calc_skew follow this behavior
     # to fix the fperr to treat m2 <1e-14 as zero
-    constant_tolerance = np.finfo(m2.dtype).eps * total
+    constant_tolerance = np.finfo(m2.dtype).eps * np.abs(total)
     constant_tolerance2 = constant_tolerance**2  # match order of m2
     constant_tolerance3 = constant_tolerance2 * constant_tolerance  # match order of m3
     m2 = _zero_out_fperr(m2, constant_tolerance2)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1261,8 +1261,7 @@ def nanskew(
         return np.nan
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        total = values.sum(axis, dtype=np.float64)
-        mean = total / count
+        mean = values.sum(axis, dtype=np.float64) / count
     if axis is not None:
         mean = np.expand_dims(mean, axis)
 
@@ -1351,8 +1350,7 @@ def nankurt(
         return np.nan
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        total = values.sum(axis, dtype=np.float64)
-        mean = total / count
+        mean = values.sum(axis, dtype=np.float64) / count
     if axis is not None:
         mean = np.expand_dims(mean, axis)
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1366,22 +1366,18 @@ def nankurt(
     m2 = adjusted2.sum(axis, dtype=np.float64)
     m4 = adjusted4.sum(axis, dtype=np.float64)
 
+    # #57972: tolerance to consider the central moment equals to zero.
+    # We adapted the tolerance from scipy:
+    # https://github.com/scipy/scipy/blob/04d6d9c460b1fed83f2919ecec3d743cfa2e8317/scipy/stats/_stats_py.py#L1429
+    constant_tolerance2 = (np.finfo(m2.dtype).eps * total) ** 2  # match order of m2
+    constant_tolerance4 = constant_tolerance2**2  # match order of m4
+    m2 = _zero_out_fperr(m2, constant_tolerance2)
+    m4 = _zero_out_fperr(m4, constant_tolerance4)
+
     with np.errstate(invalid="ignore", divide="ignore"):
         adj = 3 * (count - 1) ** 2 / ((count - 2) * (count - 3))
         numerator = count * (count + 1) * (count - 1) * m4
         denominator = (count - 2) * (count - 3) * m2**2
-
-    # floating point error
-    #
-    # #18044 in _libs/windows.pyx calc_kurt follow this behavior
-    # to fix the fperr to treat denom <1e-14 as zero
-    # #57972 arbitrary <1e-14 tolerance leads to problematic behaviour on low variance.
-    # We adapted the tolerance to use one similar to scipy:
-    # https://github.com/scipy/scipy/blob/04d6d9c460b1fed83f2919ecec3d743cfa2e8317/scipy/stats/_stats_py.py#L1429
-    constant_tolerance2 = (np.finfo(m2.dtype).eps * total) ** 2  # match order of m2
-    constant_tolerance4 = constant_tolerance2**2  # match order of m4
-    numerator = _zero_out_fperr(numerator, constant_tolerance2)
-    denominator = _zero_out_fperr(denominator, constant_tolerance4)
 
     if not isinstance(denominator, np.ndarray):
         # if ``denom`` is a scalar, check these corner cases first before

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1072,7 +1072,7 @@ class TestNankurtFixedValues:
         # xref GH 11974
         data = val * np.ones(300)
         kurt = nanops.nankurt(data)
-        assert kurt == 0.0
+        tm.assert_equal(kurt, 0.0)
 
     def test_all_finite(self):
         alpha, beta = 0.3, 0.1
@@ -1101,6 +1101,14 @@ class TestNankurtFixedValues:
         samples = np.hstack([samples, np.nan])
         kurt = nanops.nankurt(samples, skipna=True)
         tm.assert_almost_equal(kurt, actual_kurt)
+
+    def test_low_variance(self):
+        # GH#57972
+        data_list = [-2.05191341e-05, -4.10391103e-05] + ([0.0] * 27)
+        data = np.array(data_list)
+        kurt = nanops.nankurt(data)
+        expected = 18.087646853025614  # scipy.stats.kurtosis(data, bias=False)
+        tm.assert_almost_equal(kurt, expected)
 
     @property
     def prng(self):

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1051,12 +1051,22 @@ class TestNanskewFixedValues:
         skew = nanops.nanskew(samples, skipna=True)
         tm.assert_almost_equal(skew, actual_skew)
 
-    def test_low_variance(self):
-        data_list = [-2.05191341e-06, -4.10391103e-07] + ([0.0] * 27)
-        data = np.array(data_list)
-        kurt = nanops.nanskew(data)
-        expected = -5.092092799675377  # scipy.stats.skew(data, bias=False)
-        tm.assert_almost_equal(kurt, expected)
+    @pytest.mark.parametrize(
+        "initial_data, nobs",
+        [
+            ([-2.05191341e-05, -4.10391103e-05], 27),
+            ([-2.05191341e-10, -4.10391103e-10], 27),
+            ([-2.05191341e-05, -4.10391103e-05], 10_000),
+            ([-2.05191341e-10, -4.10391103e-10], 10_000),
+        ],
+    )
+    def test_low_variance(self, initial_data, nobs):
+        st = pytest.importorskip("scipy.stats")
+        data = np.zeros((nobs,), dtype=np.float64)
+        data[: len(initial_data)] = initial_data
+        skew = nanops.nanskew(data)
+        expected = st.skew(data, bias=False)
+        tm.assert_almost_equal(skew, expected)
 
     @property
     def prng(self):
@@ -1109,12 +1119,22 @@ class TestNankurtFixedValues:
         kurt = nanops.nankurt(samples, skipna=True)
         tm.assert_almost_equal(kurt, actual_kurt)
 
-    def test_low_variance(self):
+    @pytest.mark.parametrize(
+        "initial_data, nobs",
+        [
+            ([-2.05191341e-05, -4.10391103e-05], 27),
+            ([-2.05191341e-10, -4.10391103e-10], 27),
+            ([-2.05191341e-05, -4.10391103e-05], 10_000),
+            ([-2.05191341e-10, -4.10391103e-10], 10_000),
+        ],
+    )
+    def test_low_variance(self, initial_data, nobs):
         # GH#57972
-        data_list = [-2.05191341e-05, -4.10391103e-05] + ([0.0] * 27)
-        data = np.array(data_list)
+        st = pytest.importorskip("scipy.stats")
+        data = np.zeros((nobs,), dtype=np.float64)
+        data[: len(initial_data)] = initial_data
         kurt = nanops.nankurt(data)
-        expected = 18.087646853025614  # scipy.stats.kurtosis(data, bias=False)
+        expected = st.kurtosis(data, bias=False)
         tm.assert_almost_equal(kurt, expected)
 
     @property

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1051,6 +1051,13 @@ class TestNanskewFixedValues:
         skew = nanops.nanskew(samples, skipna=True)
         tm.assert_almost_equal(skew, actual_skew)
 
+    def test_low_variance(self):
+        data_list = [-2.05191341e-06, -4.10391103e-07] + ([0.0] * 27)
+        data = np.array(data_list)
+        kurt = nanops.nanskew(data)
+        expected = -5.092092799675377  # scipy.stats.skew(data, bias=False)
+        tm.assert_almost_equal(kurt, expected)
+
     @property
     def prng(self):
         return np.random.default_rng(2)


### PR DESCRIPTION
- [x] closes #57972 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

This PR fixes a bug in `Series.kurt` where a fixed tolerance of `1e-14` caused incorrect results for low-variance arrays.

The tolerance is now computed based on the data magnitude, using an approach based on [SciPy's implementation](https://github.com/scipy/scipy/blob/04d6d9c460b1fed83f2919ecec3d743cfa2e8317/scipy/stats/_stats_py.py#L1429).

---

Additional notes:
- I changed the assertion on `test_constant_series` because it was only showing `AssertionError` when I broke this test.
- The expected value in the test is different from the one presented in the Issue because pandas computes the [unbiased kurtosis estimator](https://en.wikipedia.org/wiki/Kurtosis#Standard_unbiased_estimator).
    - `st.kurtosis(data, bias=False)`: 18.087646853025614
    - `st.kurtosis(data, bias=True)`: 14.916104870028551