### PR TITLE
BUG: fix bug in str.match for Arrow backend with optional groups

### DIFF
--- a/doc/source/whatsnew/v2.3.3.rst
+++ b/doc/source/whatsnew/v2.3.3.rst
@@ -35,7 +35,7 @@ Bug fixes
 - Fix bug in :meth:`Series.str.replace` using named capture groups (e.g., ``\g<name>``) with the Arrow-backed dtype would raise an error (:issue:`57636`)
 - Fix regression in ``~Series.str.contains``, ``~Series.str.match`` and ``~Series.str.fullmatch``
   with a compiled regex and custom flags (:issue:`62240`)
-- Fix :meth:`Series.str.fullmatch` not matching patterns with groups correctly for the Arrow-backed string dtype (:issue:`61072`)
+- Fix :meth:`Series.str.match` and :meth:`Series.str.fullmatch` not matching patterns with groups correctly for the Arrow-backed string dtype (:issue:`61072`)
 
 
 Improvements and fixes for Copy-on-Write

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -316,7 +316,7 @@ class ArrowStringArrayMixin:
         na: Scalar | lib.NoDefault = lib.no_default,
     ):
         if not pat.startswith("^"):
-            pat = f"^{pat}"
+            pat = f"^({pat})"
         return self._str_contains(pat, case, flags, na, regex=True)
 
     def _str_fullmatch(

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -976,15 +976,18 @@ def test_match_compiled_regex(any_string_dtype):
 @pytest.mark.parametrize(
     "pat, case, exp",
     [
-        ["ab", False, [True]],
-        ["Ab", True, [False]],
-        ["bc", True, [False]],
-        ["a[a-z]{1}", False, [True]],
-        ["A[a-z]{1}", True, [False]],
+        ["ab", False, [True, False]],
+        ["Ab", True, [False, False]],
+        ["bc", True, [False, False]],
+        ["a[a-z]{1}", False, [True, False]],
+        ["A[a-z]{1}", True, [False, False]],
+        # https://github.com/pandas-dev/pandas/issues/61072
+        ["(bc)|(ab)", True, [True, False]],
+        ["((bc)|(ab))", True, [True, False]],
     ],
 )
 def test_str_match_extra_cases(any_string_dtype, pat, case, exp):
-    ser = Series(["abc"], dtype=any_string_dtype)
+    ser = Series(["abc", "Xab"], dtype=any_string_dtype)
     result = ser.str.match(pat, case=case)
 
     expected_dtype = (

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -973,6 +973,27 @@ def test_match_compiled_regex(any_string_dtype):
         values.str.match(re.compile("ab"), flags=re.IGNORECASE)
 
 
+@pytest.mark.parametrize(
+    "pat, case, exp",
+    [
+        ["ab", False, [True]],
+        ["Ab", True, [False]],
+        ["bc", True, [False]],
+        ["a[a-z]{1}", False, [True]],
+        ["A[a-z]{1}", True, [False]],
+    ],
+)
+def test_str_match_extra_cases(any_string_dtype, pat, case, exp):
+    ser = Series(["abc"], dtype=any_string_dtype)
+    result = ser.str.match(pat, case=case)
+
+    expected_dtype = (
+        np.bool_ if is_object_or_nan_string_dtype(any_string_dtype) else "boolean"
+    )
+    expected = Series(exp, dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
 # --------------------------------------------------------------------------------------
 # str.fullmatch
 # --------------------------------------------------------------------------------------
@@ -1108,7 +1129,6 @@ def test_str_fullmatch_extra_cases(any_string_dtype, pat, case, na, exp):
         expected_dtype = (
             "object" if is_object_or_nan_string_dtype(any_string_dtype) else "boolean"
         )
-        expected = Series([True, False, np.nan, False], dtype=expected_dtype)
     expected = Series(exp, dtype=expected_dtype)
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/61073, where this was fixed for `fullmatch`, but we have the same issue for `match`



- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
