### PR TITLE
BUG: drop pyqt5 dependency in docker for linux/arm

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -132,15 +132,22 @@ jobs:
         asv run --quick --dry-run --durations=30 --python=same --show-stderr
 
   build_docker_dev_environment:
-    name: Build Docker Dev Environment
-    runs-on: ubuntu-24.04
+    name: Build Docker Dev Environment (${{ matrix.arch }})
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            platform: ubuntu-24.04
+          - arch: arm64
+            platform: ubuntu-24.04-arm
     defaults:
       run:
         shell: bash -el {0}
 
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-build_docker_dev_environment
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-build_docker_dev_environment-${{ matrix.arch }}
       cancel-in-progress: true
 
     steps:
@@ -153,10 +160,10 @@ jobs:
           fetch-depth: 0
 
       - name: Build image
-        run: docker build --pull --no-cache --tag pandas-dev-env .
+        run: docker build --pull --no-cache --tag pandas-dev-env-${{ matrix.arch }} .
 
       - name: Show environment
-        run: docker run --rm pandas-dev-env python -c "import pandas as pd; print(pd.show_versions())"
+        run: docker run --rm pandas-dev-env-${{ matrix.arch }} python -c "import pandas as pd; print(pd.show_versions())"
 
   requirements-dev-text-installable:
     name: Test install requirements-dev.txt

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -132,22 +132,15 @@ jobs:
         asv run --quick --dry-run --durations=30 --python=same --show-stderr
 
   build_docker_dev_environment:
-    name: Build Docker Dev Environment (${{ matrix.arch }})
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      matrix:
-        include:
-          - arch: amd64
-            platform: ubuntu-24.04
-          - arch: arm64
-            platform: ubuntu-24.04-arm
+    name: Build Docker Dev Environment
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash -el {0}
 
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-build_docker_dev_environment-${{ matrix.arch }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-build_docker_dev_environment
       cancel-in-progress: true
 
     steps:
@@ -160,10 +153,10 @@ jobs:
           fetch-depth: 0
 
       - name: Build image
-        run: docker build --pull --no-cache --tag pandas-dev-env-${{ matrix.arch }} .
+        run: docker build --pull --no-cache --tag pandas-dev-env .
 
       - name: Show environment
-        run: docker run --rm pandas-dev-env-${{ matrix.arch }} python -c "import pandas as pd; print(pd.show_versions())"
+        run: docker run --rm pandas-dev-env python -c "import pandas as pd; print(pd.show_versions())"
 
   requirements-dev-text-installable:
     name: Test install requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.11.13
 WORKDIR /home/pandas
 
+# https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
+ARG TARGETPLATFORM
+
 RUN apt-get update && \
     apt-get --no-install-recommends -y upgrade && \
     apt-get --no-install-recommends -y install \
@@ -13,7 +16,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements-dev.txt /tmp
-RUN python -m pip install --no-cache-dir --upgrade pip && \
+
+RUN case "$TARGETPLATFORM" in \
+    linux/arm*) \
+        # Drop PyQt5 for ARM GH#61037
+        sed -i "/^pyqt5/Id" /tmp/requirements-dev.txt \
+        ;; \
+    esac && \
+    python -m pip install --no-cache-dir --upgrade pip && \
     python -m pip install --no-cache-dir -r /tmp/requirements-dev.txt
 RUN git config --global --add safe.directory /home/pandas
 


### PR DESCRIPTION
- [x] closes #61037 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---
- The main problem is that PyQt5 doesn't provide [pre-compiled binaries ](https://pypi.org/project/PyQt5/#files)for linux-arm64.
- This solution is based on the suggestion from https://github.com/pandas-dev/pandas/pull/61611#discussion_r2370278522
- Before installing the dependencies with pip, I remove the `PyQt5` dependency with `sed`
- The flags in `sed` are case-`I`nsensetive and `d`elete.
- I added a new CI job to test the build on arm64, just to verify if my solution works. I can remove it later if needed.