### PR TITLE
DOC: DataFrame.from_records accepts an Iterable of data in the implementation, which is not specified in the docs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2132,12 +2132,12 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Convert structured or record ndarray to DataFrame.
 
-        Creates a DataFrame object from a structured ndarray, or sequence of
+        Creates a DataFrame object from a structured ndarray, or iterable of
         tuples or dicts.
 
         Parameters
         ----------
-        data : structured ndarray, sequence of tuples or dicts
+        data : structured ndarray, iterable of tuples or dicts
             Structured input data.
         index : str, list of fields, array-like
             Field of array to use as the index, alternately a specific set of


### PR DESCRIPTION
This PR originates from pandas-dev/pandas-stubs#1376, where people recognised that `DataFrame.from_records` supports an Iterable of data (see below), which is not specified in the [current documentation](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.from_records.html).

https://github.com/pandas-dev/pandas/blob/f6fa9b679006d08fa99d8c2b6dbd834ec60875d6/pandas/core/frame.py#L2240-L2263