### PR TITLE
Backport to 2.3.x: REGR: from_records not initializing subclasses properly (#60726)

### DIFF
--- a/doc/source/whatsnew/v2.3.3.rst
+++ b/doc/source/whatsnew/v2.3.3.rst
@@ -58,6 +58,12 @@ Bug fixes
 - The :meth:`DataFrame.iloc` now works correctly with ``copy_on_write`` option when assigning values after subsetting the columns of a homogeneous DataFrame (:issue:`60309`)
 
 
+Other Bug fixes
+~~~~~~~~~~~~~~~~
+
+- Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
+
+
 .. ---------------------------------------------------------------------------
 .. _whatsnew_233.contributors:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2549,8 +2549,10 @@ class DataFrame(NDFrame, OpsMixin):
 
         manager = _get_option("mode.data_manager", silent=True)
         mgr = arrays_to_mgr(arrays, columns, result_index, typ=manager)
-
-        return cls._from_mgr(mgr, axes=mgr.axes)
+        df = DataFrame._from_mgr(mgr, axes=mgr.axes)
+        if cls is not DataFrame:
+            return cls(df, copy=False)
+        return df
 
     def to_records(
         self, index: bool = True, column_dtypes=None, index_dtypes=None

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -784,6 +784,13 @@ def test_constructor_with_metadata():
     assert isinstance(subset, MySubclassWithMetadata)
 
 
+def test_constructor_with_metadata_from_records():
+    # GH#57008
+    df = MySubclassWithMetadata.from_records([{"a": 1, "b": 2}])
+    assert df.my_metadata is None
+    assert type(df) is MySubclassWithMetadata
+
+
 class SimpleDataFrameSubClass(DataFrame):
     """A subclass of DataFrame that does not define a constructor."""
 


### PR DESCRIPTION
Backports #60726 to the 2.3 series to alleviate some downstream issues in geopandas and xarray see https://github.com/pandas-dev/pandas/pull/60726#issuecomment-3282586850


- [NA?] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [i hope! ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [NA] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


tested the new test locally:

```
(pandas-dev) ➜  pandas git:(backport-60726-to-2.3.x) ✗ python -m pytest pandas/tests/frame/test_subclass.py::test_constructor_with_metadata_from_records -v
/Users/ian/miniforge3/envs/pandas-dev/lib/python3.10/site-packages/pytest_cython/__init__.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution
+ /Users/ian/miniforge3/envs/pandas-dev/bin/ninja
[1/1] Generating write_version_file with a custom command
========================================================= test session starts =========================================================
platform darwin -- Python 3.10.18, pytest-8.4.2, pluggy-1.6.0 -- /Users/ian/miniforge3/envs/pandas-dev/bin/python
cachedir: .pytest_cache
hypothesis profile 'ci' -> deadline=None, suppress_health_check=(HealthCheck.too_slow, HealthCheck.differing_executors)
PyQt5 5.15.11 -- Qt runtime 5.15.15 -- Qt compiled 5.15.15
rootdir: /Users/ian/Documents/dev/pandas
configfile: pyproject.toml
plugins: anyio-4.11.0, hypothesis-6.140.2, xdist-3.8.0, qt-4.5.0, cython-0.3.1, cov-7.0.0
collected 1 item

pandas/tests/frame/test_subclass.py::test_constructor_with_metadata_from_records PASSED

---------------------------------- generated xml file: /Users/ian/Documents/dev/pandas/test-data.xml ----------------------------------
======================================================== slowest 30 durations =========================================================

(3 durations < 0.005s hidden.  Use -vv to show these durations.)
========================================================== 1 passed in 0.03s ==========================================================
```
