### PR TITLE
ENH: consistent exception messages for arithmetic

### DIFF
--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -36,7 +36,7 @@ REDUCTION_ALIASES = {
 
 
 class OpsMixin:
-    def _supports_scalar_op(self, other, op_name: str):
+    def _supports_scalar_op(self, other, op_name: str) -> bool:
         """
         Return False to have unpack_zerodim_and_defer raise a TypeError with
         standardized exception message.
@@ -53,7 +53,7 @@ class OpsMixin:
         """
         return True
 
-    def _supports_array_op(self, other: ArrayLike, op_name: str):
+    def _supports_array_op(self, other: ArrayLike, op_name: str) -> bool:
         """
         Return False to have unpack_zerodim_and_defer raise a TypeError with
         standardized exception message.

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -8,7 +8,10 @@ Methods that can be shared by many array-like classes or subclasses:
 from __future__ import annotations
 
 import operator
-from typing import Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
 
 import numpy as np
 
@@ -21,6 +24,9 @@ from pandas.core import roperator
 from pandas.core.construction import extract_array
 from pandas.core.ops.common import unpack_zerodim_and_defer
 
+if TYPE_CHECKING:
+    from pandas._typing import ArrayLike
+
 REDUCTION_ALIASES = {
     "maximum": "max",
     "minimum": "min",
@@ -30,6 +36,41 @@ REDUCTION_ALIASES = {
 
 
 class OpsMixin:
+    def _supports_scalar_op(self, other, op_name: str):
+        """
+        Return False to have unpack_zerodim_and_defer raise a TypeError with
+        standardized exception message.
+
+        Parameters
+        ----------
+        other : scalar
+            The type(other).__name__ will be used for the exception message.
+        op_name : str
+
+        Returns
+        -------
+        bool
+        """
+        return True
+
+    def _supports_array_op(self, other: ArrayLike, op_name: str):
+        """
+        Return False to have unpack_zerodim_and_defer raise a TypeError with
+        standardized exception message.
+
+        Parameters
+        ----------
+        other : np.ndarray or ExtensionArray
+            The other.dtype will be used for the exception message.
+        op_name : str
+
+        Returns
+        -------
+        bool
+
+        """
+        return True
+
     # -------------------------------------------------------------
     # Comparisons
 
@@ -220,7 +261,7 @@ class OpsMixin:
     def __floordiv__(self, other):
         return self._arith_method(other, operator.floordiv)
 
-    @unpack_zerodim_and_defer("__rfloordiv")
+    @unpack_zerodim_and_defer("__rfloordiv__")
     def __rfloordiv__(self, other):
         return self._arith_method(other, roperator.rfloordiv)
 

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -12,7 +12,6 @@ import numpy as np
 
 from pandas._libs import (
     lib,
-    missing as libmissing,
 )
 from pandas.util._decorators import set_module
 
@@ -385,14 +384,9 @@ class BooleanArray(BaseMaskedArray):
         elif isinstance(other, np.bool_):
             other = other.item()
 
-        if other_is_scalar and other is not libmissing.NA and not lib.is_bool(other):
-            raise TypeError(
-                "'other' should be pandas.NA or a bool. "
-                f"Got {type(other).__name__} instead."
-            )
-
         if not other_is_scalar and len(self) != len(other):
-            raise ValueError("Lengths must match")
+            msg = ops.get_shape_exception_message(self, other)
+            raise ValueError(msg)
 
         if op.__name__ in {"or_", "ror_"}:
             result, mask = ops.kleene_or(self._data, other, self._mask, mask)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1612,10 +1612,10 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     __le__ = _cat_compare_op(operator.le)
     __ge__ = _cat_compare_op(operator.ge)
 
-    def _supports_scalar_op(self, other, op_name: str):
+    def _supports_scalar_op(self, other, op_name: str) -> bool:
         return True
 
-    def _supports_array_op(self, other, op_name: str):
+    def _supports_array_op(self, other: ArrayLike, op_name: str) -> bool:
         return True
 
     # -------------------------------------------------------------

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1612,6 +1612,12 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     __le__ = _cat_compare_op(operator.le)
     __ge__ = _cat_compare_op(operator.ge)
 
+    def _supports_scalar_op(self, other, op_name: str):
+        return True
+
+    def _supports_array_op(self, other, op_name: str):
+        return True
+
     # -------------------------------------------------------------
     # Validators; ideally these can be de-duplicated
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -91,6 +91,7 @@ from pandas.core.construction import (
 )
 from pandas.core.indexers import check_array_indexer
 from pandas.core.ops import (
+    get_shape_exception_message,
     invalid_comparison,
     unpack_zerodim_and_defer,
 )
@@ -733,11 +734,18 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         self._left[key] = value_left
         self._right[key] = value_right
 
+    def _supports_scalar_op(self, other, op_name):
+        return True
+
+    def _supports_array_op(self, other, op_name):
+        return True
+
     def _cmp_method(self, other, op):
         # ensure pandas array for list-like and eliminate non-interval scalars
         if is_list_like(other):
             if len(self) != len(other):
-                raise ValueError("Lengths must match to compare")
+                msg = get_shape_exception_message(self, other)
+                raise ValueError(msg)
             other = pd_array(other)
         elif not isinstance(other, Interval):
             # non-interval scalar -> no matches

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -734,10 +734,10 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         self._left[key] = value_left
         self._right[key] = value_right
 
-    def _supports_scalar_op(self, other, op_name):
+    def _supports_scalar_op(self, other, op_name: str) -> bool:
         return True
 
-    def _supports_array_op(self, other, op_name):
+    def _supports_array_op(self, other: ArrayLike, op_name: str) -> bool:
         return True
 
     def _cmp_method(self, other, op):

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -72,6 +72,7 @@ from pandas.core.dtypes.generic import (
 )
 from pandas.core.dtypes.missing import isna
 
+from pandas.core import ops
 from pandas.core.arrays import datetimelike as dtl
 import pandas.core.common as com
 
@@ -1070,9 +1071,8 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         """
         if not self.dtype._is_tick_like():
             # We cannot add timedelta-like to non-tick PeriodArray
-            raise TypeError(
-                f"Cannot add or subtract timedelta64[ns] dtype from {self.dtype}"
-            )
+            msg = ops.get_op_exception_message("__add__", self, other)
+            raise TypeError(msg)
 
         dtype = np.dtype(f"m8[{self.dtype._td64_unit}]")
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -66,7 +66,10 @@ from pandas.core.dtypes.missing import (
     notna,
 )
 
-from pandas.core import arraylike
+from pandas.core import (
+    arraylike,
+    ops,
+)
 import pandas.core.algorithms as algos
 from pandas.core.arraylike import OpsMixin
 from pandas.core.arrays import ExtensionArray
@@ -1806,11 +1809,10 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         else:
             other = np.asarray(other)
+            if len(self) != len(other):
+                msg = ops.get_shape_exception_message(self, other)
+                raise ValueError(msg)
             with np.errstate(all="ignore"):
-                if len(self) != len(other):
-                    raise AssertionError(
-                        f"length mismatch: {len(self)} vs. {len(other)}"
-                    )
                 if not isinstance(other, SparseArray):
                     dtype = getattr(other, "dtype", None)
                     other = SparseArray(other, fill_value=self.fill_value, dtype=dtype)
@@ -1827,9 +1829,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         if isinstance(other, SparseArray):
             if len(self) != len(other):
-                raise ValueError(
-                    f"operands have mismatched length {len(self)} and {len(other)}"
-                )
+                msg = ops.get_shape_exception_message(self, other)
+                raise ValueError(msg)
 
             op_name = op.__name__.strip("_")
             return _sparse_array_op(self, other, op, op_name)

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -56,6 +56,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core import (
     nanops,
+    ops,
     roperator,
 )
 from pandas.core.array_algos import datetimelike_accumulations
@@ -465,9 +466,8 @@ class TimedeltaArray(dtl.TimelikeOps):
 
     def _add_offset(self, other):
         assert not isinstance(other, (Tick, Day))
-        raise TypeError(
-            f"cannot add the type {type(other).__name__} to a {type(self).__name__}"
-        )
+        msg = ops.get_op_exception_message(self, other)
+        raise TypeError(msg)
 
     @unpack_zerodim_and_defer("__mul__")
     def __mul__(self, other) -> Self:
@@ -482,7 +482,8 @@ class TimedeltaArray(dtl.TimelikeOps):
             if result.dtype.kind != "m":
                 # numpy >= 2.1 may not raise a TypeError
                 # and seems to dispatch to others.__rmul__?
-                raise TypeError(f"Cannot multiply with {type(other).__name__}")
+                msg = ops.get_op_exception_message(self, other)
+                raise TypeError(msg)
             freq = None
             if self.freq is not None and not isna(other):
                 freq = self.freq * other
@@ -504,7 +505,8 @@ class TimedeltaArray(dtl.TimelikeOps):
         if len(other) != len(self) and not lib.is_np_dtype(other.dtype, "m"):
             # Exclude timedelta64 here so we correctly raise TypeError
             #  for that instead of ValueError
-            raise ValueError("Cannot multiply with unequal lengths")
+            msg = ops.get_shape_exception_message(self, other)
+            raise ValueError(msg)
 
         if is_object_dtype(other.dtype):
             # this multiplication will succeed only if all elements of other
@@ -520,7 +522,8 @@ class TimedeltaArray(dtl.TimelikeOps):
         if result.dtype.kind != "m":
             # numpy >= 2.1 may not raise a TypeError
             # and seems to dispatch to others.__rmul__?
-            raise TypeError(f"Cannot multiply with {type(other).__name__}")
+            msg = ops.get_op_exception_message(self, other)
+            raise TypeError(msg)
         return type(self)._simple_new(result, dtype=result.dtype)
 
     __rmul__ = __mul__
@@ -578,7 +581,8 @@ class TimedeltaArray(dtl.TimelikeOps):
             other = np.array(other)
 
         if len(other) != len(self):
-            raise ValueError("Cannot divide vectors with unequal lengths")
+            msg = ops.get_shape_exception_message(self, other)
+            raise ValueError(msg)
         return other
 
     def _vector_divlike_op(self, other, op) -> np.ndarray | Self:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7151,11 +7151,6 @@ class Index(IndexOpsMixin, PandasObject):
                     arr[self.isna()] = True
                 return arr
 
-        if isinstance(other, (np.ndarray, Index, ABCSeries, ExtensionArray)) and len(
-            self
-        ) != len(other):
-            raise ValueError("Lengths must match to compare")
-
         if not isinstance(other, ABCMultiIndex):
             other = extract_array(other, extract_numpy=True)
         else:

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -16,7 +16,9 @@ from pandas.core.ops.array_ops import (
     maybe_prepare_scalar_for_op,
 )
 from pandas.core.ops.common import (
+    get_op_exception_message,
     get_op_result_name,
+    get_shape_exception_message,
     unpack_zerodim_and_defer,
 )
 from pandas.core.ops.docstrings import make_flex_doc
@@ -70,7 +72,9 @@ __all__ = [
     "comparison_op",
     "fill_binop",
     "get_array_op",
+    "get_op_exception_message",
     "get_op_result_name",
+    "get_shape_exception_message",
     "invalid_comparison",
     "kleene_and",
     "kleene_or",


### PR DESCRIPTION
xref #62423, does not close.

This does not take a stand on whether to support list/tuple in the EA methods.  An EA that currently supports it will continue to, likewise for arrays that don't support it.

Not taking that stand limits the amount of de-duplication/centralization we can do.  Instead of all the exceptions being raised from unpack_zerodim_and_defer, helpers `ops.get_op_exception_message` and `ops.get_shape_exception_message` should at least help us get to consistent messages.

I did a pass to try to use these new helpers where relevant, but definitely didn't get them all.  I also didn't implement `_supports_(scalar|array)_op` yet.

Before I go through the tests to update the exception messages, I'd like to get any bikeshedding out of the way about exactly what those messages should say.