### PR TITLE
fix reproducibility issue

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -2068,6 +2068,9 @@ class Timedelta(_Timedelta):
 
         disallow_ambiguous_unit(unit)
 
+        cdef:
+            int64_t new_value;
+
         # GH 30543 if pd.Timedelta already passed, return it
         # check that only value is passed
         if isinstance(value, _Timedelta):

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -2069,7 +2069,7 @@ class Timedelta(_Timedelta):
         disallow_ambiguous_unit(unit)
 
         cdef:
-            int64_t new_value;
+            int64_t new_value
 
         # GH 30543 if pd.Timedelta already passed, return it
         # check that only value is passed


### PR DESCRIPTION
The type of new_value is either `npy_timedelta' or `int64_t'

In build/pandas/_libs/tslibs/timedeltas.cpython-313-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/timedeltas.pyx.c
...
npy_timedelta __pyx_v_new_value;
...

In build/pandas/_libs/tslibs/timedeltas.cpython-313-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/timedeltas.pyx.c 
...
__pyx_t_5numpy_int64_t __pyx_v_new_value;
...

Explicitly define it as int64_t to assure the generated source is reproducibility [1] between builds

[1] https://reproducible-builds.org/
