### PR TITLE
STY: ignore mypy errors

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -83,7 +83,6 @@ if TYPE_CHECKING:
 
     # numpy compatible types
     NumpyValueArrayLike: TypeAlias = ScalarLike_co | npt.ArrayLike
-    # Name "npt._ArrayLikeInt_co" is not defined  [name-defined]
     NumpySorter: TypeAlias = npt._ArrayLikeInt_co | None
 
 

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -84,7 +84,7 @@ if TYPE_CHECKING:
     # numpy compatible types
     NumpyValueArrayLike: TypeAlias = ScalarLike_co | npt.ArrayLike
     # Name "npt._ArrayLikeInt_co" is not defined  [name-defined]
-    NumpySorter: TypeAlias = npt._ArrayLikeInt_co | None  # type: ignore[name-defined]
+    NumpySorter: TypeAlias = npt._ArrayLikeInt_co | None
 
 
 P = ParamSpec("P")

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -215,14 +215,15 @@ def _reconstruct_data(
         #  that values.dtype == dtype
         cls = dtype.construct_array_type()
 
-        # error: Incompatible types in assignment (expression has type
-        # "ExtensionArray", variable has type "ndarray[Any, Any]")
-        values = cls._from_sequence(values, dtype=dtype)  # type: ignore[assignment]
+        # error: Incompatible return value type
+        # (got "ExtensionArray",
+        # expected "ndarray[tuple[Any, ...], dtype[Any]]")
+        return cls._from_sequence(values, dtype=dtype)  # type: ignore[return-value]
 
-    else:
-        values = values.astype(dtype, copy=False)  # type: ignore[assignment]
-
-    return values
+    # error: Incompatible return value type
+    # (got "ndarray[tuple[Any, ...], dtype[Any]]",
+    # expected "ExtensionArray")
+    return values.astype(dtype, copy=False)  # type: ignore[return-value]
 
 
 def _ensure_arraylike(values, func_name: str) -> ArrayLike:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -220,7 +220,7 @@ def _reconstruct_data(
         values = cls._from_sequence(values, dtype=dtype)  # type: ignore[assignment]
 
     else:
-        values = values.astype(dtype, copy=False)
+        values = values.astype(dtype, copy=False)  # type: ignore[assignment]
 
     return values
 

--- a/pandas/core/array_algos/quantile.py
+++ b/pandas/core/array_algos/quantile.py
@@ -102,7 +102,7 @@ def quantile_with_mask(
             interpolation=interpolation,
         )
 
-        result = np.asarray(result)  # type: ignore[assignment]
+        result = np.asarray(result)
         result = result.T
 
     return result

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -151,7 +151,7 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
 
             td64_values = arr.view(dtype)
             return TimedeltaArray._simple_new(td64_values, dtype=dtype)
-        return arr.view(dtype=dtype)
+        return arr.view(dtype=dtype)  # type: ignore[arg-type]
 
     def take(
         self,

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -151,6 +151,8 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
 
             td64_values = arr.view(dtype)
             return TimedeltaArray._simple_new(td64_values, dtype=dtype)
+        # error: Argument "dtype" to "view" of "ndarray" has incompatible type
+        # "ExtensionDtype | dtype[Any]"; expected "dtype[Any] | _HasDType[dtype[Any]]"
         return arr.view(dtype=dtype)  # type: ignore[arg-type]
 
     def take(

--- a/pandas/core/arrays/arrow/_arrow_utils.py
+++ b/pandas/core/arrays/arrow/_arrow_utils.py
@@ -44,7 +44,7 @@ def pyarrow_array_to_numpy_and_mask(
         mask = pyarrow.BooleanArray.from_buffers(
             pyarrow.bool_(), len(arr), [None, bitmask], offset=arr.offset
         )
-        mask = np.asarray(mask)  # type: ignore[assignment]
+        mask = np.asarray(mask)
     else:
         mask = np.ones(len(arr), dtype=bool)
     return data, mask

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -657,7 +657,7 @@ class ArrowExtensionArray(
             ):
                 arr_value = np.asarray(value, dtype=object)
                 # similar to isna(value) but exclude NaN, NaT, nat-like, nan-like
-                mask = is_pdna_or_none(arr_value)  # type: ignore[assignment]
+                mask = is_pdna_or_none(arr_value)
 
             try:
                 pa_array = pa.array(value, type=pa_type, mask=mask)
@@ -2738,7 +2738,7 @@ class ArrowExtensionArray(
             dummies_dtype = np.bool_
         dummies = np.zeros(n_rows * n_cols, dtype=dummies_dtype)
         dummies[indices] = True
-        dummies = dummies.reshape((n_rows, n_cols))  # type: ignore[assignment]
+        dummies = dummies.reshape((n_rows, n_cols))
         result = self._from_pyarrow_array(pa.array(list(dummies)))
         return result, uniques_sorted.to_pylist()
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1869,7 +1869,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             count = np.bincount(obs, minlength=ncat or 0)
         else:
             count = np.bincount(np.where(mask, code, ncat))
-            ix = np.append(ix, -1)  # type: ignore[assignment]
+            ix = np.append(ix, -1)
 
         ix = coerce_indexer_dtype(ix, self.dtype.categories)
         ix_categorical = self._from_backing_data(ix)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -804,7 +804,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         try:
             res_values = offset._apply_array(values._ndarray)
             if res_values.dtype.kind == "i":
-                res_values = res_values.view(values.dtype)
+                res_values = res_values.view(values.dtype)  # type: ignore[arg-type]
         except NotImplementedError:
             if get_option("performance_warnings"):
                 warnings.warn(

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -804,6 +804,10 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         try:
             res_values = offset._apply_array(values._ndarray)
             if res_values.dtype.kind == "i":
+                # error: Argument 1 to "view" of "ndarray" has
+                # incompatible type
+                # "dtype[datetime64[date | int | None]] | DatetimeTZDtype";
+                # expected "dtype[Any] | _HasDType[dtype[Any]]"  [arg-type]
                 res_values = res_values.view(values.dtype)  # type: ignore[arg-type]
         except NotImplementedError:
             if get_option("performance_warnings"):

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -764,7 +764,7 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
         result = super()._cast_pointwise_result(values)
         if isinstance(result.dtype, StringDtype):
             # Ensure we retain our same na_value/storage
-            result = result.astype(self.dtype)  # type: ignore[call-overload]
+            result = result.astype(self.dtype)
         return result
 
     @classmethod

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1886,7 +1886,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             mask.fill(False)
             mask[indices.astype(int)] = True
             # mask fails to broadcast when passed to where; broadcast manually.
-            mask = np.tile(mask, list(self._selected_obj.shape[1:]) + [1]).T  # type: ignore[assignment]
+            mask = np.tile(mask, list(self._selected_obj.shape[1:]) + [1]).T
             filtered = self._selected_obj.where(mask)  # Fill with NaNs.
         return filtered
 

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -131,8 +131,8 @@ class FixedWindowIndexer(BaseIndexer):
         if closed in ["left", "neither"]:
             end -= 1
 
-        end = np.clip(end, 0, num_values)  # type: ignore[assignment]
-        start = np.clip(start, 0, num_values)  # type: ignore[assignment]
+        end = np.clip(end, 0, num_values)
+        start = np.clip(start, 0, num_values)
 
         return start, end
 
@@ -402,7 +402,7 @@ class FixedForwardWindowIndexer(BaseIndexer):
         start = np.arange(0, num_values, step, dtype="int64")
         end = start + self.window_size
         if self.window_size:
-            end = np.clip(end, 0, num_values)  # type: ignore[assignment]
+            end = np.clip(end, 0, num_values)
 
         return start, end
 
@@ -488,7 +488,7 @@ class GroupbyIndexer(BaseIndexer):
             )
             window_indices_start += len(indices)
             # Extend as we'll be slicing window like [start, end)
-            window_indices = np.append(window_indices, [window_indices[-1] + 1]).astype(  # type: ignore[assignment]
+            window_indices = np.append(window_indices, [window_indices[-1] + 1]).astype(
                 np.int64, copy=False
             )
             start_arrays.append(window_indices.take(ensure_platform_int(start)))

--- a/pandas/core/methods/describe.py
+++ b/pandas/core/methods/describe.py
@@ -353,13 +353,10 @@ def _refine_percentiles(
     if percentiles is None:
         return np.array([0.25, 0.5, 0.75])
 
-    # explicit conversion of `percentiles` to list
-    percentiles = list(percentiles)
+    percentiles = np.asarray(percentiles)
 
     # get them all to be in [0, 1]
     validate_percentile(percentiles)
-
-    percentiles = np.asarray(percentiles)
 
     # sort and check for duplicates
     unique_pcts = np.unique(percentiles)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -651,8 +651,6 @@ def _mask_datetimelike_result(
         # we need to apply the mask
         result = result.astype("i8").view(orig_values.dtype)
         axis_mask = mask.any(axis=axis)
-        # error: Unsupported target for indexed assignment ("Union[ndarray[Any, Any],
-        # datetime64, timedelta64]")
         result[axis_mask] = iNaT
     else:
         if mask.any():

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -653,7 +653,7 @@ def _mask_datetimelike_result(
         axis_mask = mask.any(axis=axis)
         # error: Unsupported target for indexed assignment ("Union[ndarray[Any, Any],
         # datetime64, timedelta64]")
-        result[axis_mask] = iNaT  # type: ignore[index]
+        result[axis_mask] = iNaT
     else:
         if mask.any():
             return np.int64(iNaT).view(orig_values.dtype)

--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -359,7 +359,7 @@ def _get_dummies_1d(
 
         if drop_first:
             # remove first GH12042
-            dummy_mat = dummy_mat[:, 1:]  # type: ignore[assignment]
+            dummy_mat = dummy_mat[:, 1:]
             dummy_cols = dummy_cols[1:]
         return DataFrame(dummy_mat, index=index, columns=dummy_cols, dtype=_dtype)
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1746,6 +1746,8 @@ class _MergeOperation:
 
                     mask = ~np.isnan(lk)
                     match = lk == casted
+                    # error: Item "ExtensionArray" of
+                    # "ExtensionArray | Any" has no attribute "all"
                     if not match[mask].all():  # type: ignore[union-attr]
                         warnings.warn(
                             "You are merging on int and float "
@@ -1766,6 +1768,8 @@ class _MergeOperation:
 
                     mask = ~np.isnan(rk)
                     match = rk == casted
+                    # error: Item "ExtensionArray" of
+                    # "ExtensionArray | Any" has no attribute "all"
                     if not match[mask].all():  # type: ignore[union-attr]
                         warnings.warn(
                             "You are merging on int and float "

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1746,7 +1746,7 @@ class _MergeOperation:
 
                     mask = ~np.isnan(lk)
                     match = lk == casted
-                    if not match[mask].all():
+                    if not match[mask].all():  # type: ignore[union-attr]
                         warnings.warn(
                             "You are merging on int and float "
                             "columns where the float values "
@@ -1766,7 +1766,7 @@ class _MergeOperation:
 
                     mask = ~np.isnan(rk)
                     match = rk == casted
-                    if not match[mask].all():
+                    if not match[mask].all():  # type: ignore[union-attr]
                         warnings.warn(
                             "You are merging on int and float "
                             "columns where the float values "

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -324,8 +324,8 @@ def _hash_ndarray(
             )
 
             codes, categories = factorize(vals, sort=False)
-            tdtype = CategoricalDtype(categories=Index(categories), ordered=False)  
-            cat = Categorical._simple_new(codes, tdtype)  
+            tdtype = CategoricalDtype(categories=Index(categories), ordered=False)
+            cat = Categorical._simple_new(codes, tdtype)
             return cat._hash_pandas_object(
                 encoding=encoding, hash_key=hash_key, categorize=False
             )

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -324,8 +324,8 @@ def _hash_ndarray(
             )
 
             codes, categories = factorize(vals, sort=False)
-            dtype = CategoricalDtype(categories=Index(categories), ordered=False)
-            cat = Categorical._simple_new(codes, dtype)
+            dtype = CategoricalDtype(categories=Index(categories), ordered=False)  # type: ignore[assignment]
+            cat = Categorical._simple_new(codes, dtype)  # type: ignore[arg-type]
             return cat._hash_pandas_object(
                 encoding=encoding, hash_key=hash_key, categorize=False
             )

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -324,8 +324,8 @@ def _hash_ndarray(
             )
 
             codes, categories = factorize(vals, sort=False)
-            dtype = CategoricalDtype(categories=Index(categories), ordered=False)  # type: ignore[assignment]
-            cat = Categorical._simple_new(codes, dtype)  # type: ignore[arg-type]
+            tdtype = CategoricalDtype(categories=Index(categories), ordered=False)  
+            cat = Categorical._simple_new(codes, tdtype)  
             return cat._hash_pandas_object(
                 encoding=encoding, hash_key=hash_key, categorize=False
             )

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3306,13 +3306,13 @@ class GenericFixed(Fixed):
             self._handle.create_array(
                 self.group,
                 key,
-                value.asi8,  # type: ignore[union-attr]
+                value.asi8,
             )
 
             node = getattr(self.group, key)
             # error: Item "ExtensionArray" of "Union[Any, ExtensionArray]" has no
             # attribute "tz"
-            node._v_attrs.tz = _get_tz(value.tz)  # type: ignore[union-attr]
+            node._v_attrs.tz = _get_tz(value.tz)
             node._v_attrs.value_type = f"datetime64[{value.dtype.unit}]"
         elif lib.is_np_dtype(value.dtype, "m"):
             self._handle.create_array(self.group, key, value.view("i8"))
@@ -5196,7 +5196,7 @@ def _maybe_convert_for_string_atom(
 ):
     if isinstance(bvalues.dtype, StringDtype):
         # "ndarray[Any, Any]" has no attribute "to_numpy"
-        bvalues = bvalues.to_numpy()  # type: ignore[union-attr]
+        bvalues = bvalues.to_numpy()
     if bvalues.dtype != object:
         return bvalues
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3306,13 +3306,13 @@ class GenericFixed(Fixed):
             self._handle.create_array(
                 self.group,
                 key,
-                value.asi8,
+                value.asi8,  # type: ignore[attr-defined]
             )
 
             node = getattr(self.group, key)
             # error: Item "ExtensionArray" of "Union[Any, ExtensionArray]" has no
             # attribute "tz"
-            node._v_attrs.tz = _get_tz(value.tz)
+            node._v_attrs.tz = _get_tz(value.tz)  # type: ignore[attr-defined]
             node._v_attrs.value_type = f"datetime64[{value.dtype.unit}]"
         elif lib.is_np_dtype(value.dtype, "m"):
             self._handle.create_array(self.group, key, value.view("i8"))

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3301,8 +3301,7 @@ class GenericFixed(Fixed):
             # store as UTC
             # with a zone
 
-            # error: Item "ExtensionArray" of "Union[Any, ExtensionArray]" has no
-            # attribute "asi8"
+            # error: "ExtensionArray" has no attribute "asi8"
             self._handle.create_array(
                 self.group,
                 key,
@@ -3310,8 +3309,7 @@ class GenericFixed(Fixed):
             )
 
             node = getattr(self.group, key)
-            # error: Item "ExtensionArray" of "Union[Any, ExtensionArray]" has no
-            # attribute "tz"
+            # error: "ExtensionArray" has no attribute "tz"
             node._v_attrs.tz = _get_tz(value.tz)  # type: ignore[attr-defined]
             node._v_attrs.value_type = f"datetime64[{value.dtype.unit}]"
         elif lib.is_np_dtype(value.dtype, "m"):
@@ -5195,7 +5193,6 @@ def _maybe_convert_for_string_atom(
     columns: list[str],
 ):
     if isinstance(bvalues.dtype, StringDtype):
-        # "ndarray[Any, Any]" has no attribute "to_numpy"
         bvalues = bvalues.to_numpy()
     if bvalues.dtype != object:
         return bvalues


### PR DESCRIPTION
I think this will make the CI green again.

The errors are because of a new version of numpy:
```diff
+ numpy==2.3.3
- numpy==2.2.6
+ numpy-typing-compat==20250818.2.3
- numpy-typing-compat==20250818.2.2
```

<details>
<summary>Original errors</summary>

```
# mypy
pandas/core/arrays/arrow/_arrow_utils.py:47: error: Unused "type: ignore" comment  [unused-ignore]
pandas/_typing.py:87: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/util/hashing.py:327: error: Incompatible types in assignment (expression has type "CategoricalDtype", variable has type "dtype[Any]")  [assignment]
pandas/core/util/hashing.py:328: error: Argument 2 to "_simple_new" of "Categorical" has incompatible type "dtype[Any]"; expected "CategoricalDtype"  [arg-type]
pandas/core/nanops.py:656: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/array_algos/quantile.py:105: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/algorithms.py:223: error: Incompatible types in assignment (expression has type "ndarray[tuple[Any, ...], dtype[Any]]", variable has type "ExtensionArray")  [assignment]
pandas/core/arrays/datetimes.py:807: error: Argument 1 to "view" of "ndarray" has incompatible type "dtype[datetime64[date | int | None]] | DatetimeTZDtype"; expected "dtype[Any] | _HasDType[dtype[Any]]"  [arg-type]
pandas/core/arrays/_mixins.py:154: error: Argument "dtype" to "view" of "ndarray" has incompatible type "ExtensionDtype | dtype[Any]"; expected "dtype[Any] | _HasDType[dtype[Any]]"  [arg-type]
pandas/core/arrays/string_.py:767: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/arrays/arrow/array.py:660: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/arrays/arrow/array.py:2741: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/arrays/categorical.py:1872: error: Unused "type: ignore" comment  [unused-ignore]
pandas/io/pytables.py:3309: error: Unused "type: ignore" comment  [unused-ignore]
pandas/io/pytables.py:3309: error: "ExtensionArray" has no attribute "asi8"  [attr-defined]
pandas/io/pytables.py:3309: note: Error code "attr-defined" not covered by "type: ignore" comment
pandas/io/pytables.py:3315: error: Unused "type: ignore" comment  [unused-ignore]
pandas/io/pytables.py:3315: error: "ExtensionArray" has no attribute "tz"  [attr-defined]
pandas/io/pytables.py:3315: note: Error code "attr-defined" not covered by "type: ignore" comment
pandas/io/pytables.py:5199: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/reshape/merge.py:1749: error: Item "ExtensionArray" of "ExtensionArray | Any" has no attribute "all"  [union-attr]
pandas/core/reshape/merge.py:1769: error: Item "ExtensionArray" of "ExtensionArray | Any" has no attribute "all"  [union-attr]
pandas/core/reshape/encoding.py:362: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/indexers/objects.py:134: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/indexers/objects.py:135: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/indexers/objects.py:405: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/indexers/objects.py:491: error: Unused "type: ignore" comment  [unused-ignore]
pandas/core/groupby/groupby.py:1889: error: Unused "type: ignore" comment  [unused-ignore]

# pyright

 pandas/core/methods/describe.py:357:19 - error: Type "list[float | NDArray[Any]]" is not assignable to declared type "Sequence[float] | ndarray[_AnyShape, dtype[Any]] | None"
    Type "list[float | NDArray[Any]]" is not assignable to type "Sequence[float] | ndarray[_AnyShape, dtype[Any]] | None"
      "list[float | NDArray[Any]]" is not assignable to "Sequence[float]"
        Type parameter "_T_co@Sequence" is covariant, but "float | NDArray[Any]" is not a subtype of "float"
          Type "float | NDArray[Any]" is not assignable to type "float"
            "ndarray[_AnyShape, dtype[Any]]" is not assignable to "float"
      "list[float | NDArray[Any]]" is not assignable to "ndarray[_AnyShape, dtype[Any]]"
      "list[float | NDArray[Any]]" is not assignable to "None" (reportAssignmentType)
      
  pandas/core/methods/describe.py:360:25 - error: Argument of type "Sequence[float] | ndarray[_AnyShape, dtype[Any]] | None" cannot be assigned to parameter "q" of type "float | Iterable[float]" in function "validate_percentile"
    Type "Sequence[float] | ndarray[_AnyShape, dtype[Any]] | None" is not assignable to type "float | Iterable[float]"
      Type "None" is not assignable to type "float | Iterable[float]"
        "None" is not assignable to "float"
        "None" is incompatible with protocol "Iterable[float]"
          "__iter__" is not present (reportArgumentType)

```

</details>

