### PR TITLE
CI: temporary pin numpy to 2.2 for avoiding typing failures

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,9 @@ dependencies:
 
   # required dependencies
   - python-dateutil
-  - numpy<3
+  # TEMP pin to avoid typing failures
+  # - numpy<3
+  - numpy=2.2.6
 
   # optional dependencies
   - adbc-driver-postgresql>=1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ pytest-localserver
 PyQt5>=5.15.9
 coverage
 python-dateutil
-numpy<3
+numpy==2.2.6
 adbc-driver-postgresql>=1.2.0
 adbc-driver-sqlite>=1.2.0
 beautifulsoup4>=4.12.3


### PR DESCRIPTION
The typing step is failing on CI at the moment since yesterday, and the one difference I see in the env is an update of numpy. Seeing if temporary pinning this gives us green CI.