### PR TITLE
BUG: fix boxplot column misorder

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1354,6 +1354,7 @@ Other
 - Bug in ``divmod`` and ``rdivmod`` with :class:`DataFrame`, :class:`Series`, and :class:`Index` with ``bool`` dtypes failing to raise, which was inconsistent with ``__floordiv__`` behavior (:issue:`46043`)
 - Bug in printing a :class:`DataFrame` with a :class:`DataFrame` stored in :attr:`DataFrame.attrs` raised a ``ValueError`` (:issue:`60455`)
 - Bug in printing a :class:`Series` with a :class:`DataFrame` stored in :attr:`Series.attrs` raised a ``ValueError`` (:issue:`60568`)
+- Bug in :class: `BoxPlot` when column order was not respected in ticklabels. (:issue: `50427`)
 - Bug when calling :py:func:`copy.copy` on a :class:`DataFrame` or :class:`Series` which would return a deep copy instead of a shallow copy (:issue:`62971`)
 - Deprecated the keyword ``check_datetimelike_compat`` in :meth:`testing.assert_frame_equal` and :meth:`testing.assert_series_equal` (:issue:`55638`)
 - Fixed bug in :meth:`Series.replace` and :meth:`DataFrame.replace` when trying to replace :class:`NA` values in a :class:`Float64Dtype` object with ``np.nan``; this now works with ``pd.set_option("mode.nan_is_na", False)`` and is irrelevant otherwise (:issue:`55127`)

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -212,9 +212,10 @@ class BoxPlot(LinePlot):
 
                     # When `by` is assigned, the ticklabels will become unique grouped
                     # values, instead of label which is used as subtitle in this case.
-                    # error: "Index" has no attribute "levels"; maybe "nlevels"?
-                    levels = self.data.columns.levels  # type: ignore[attr-defined]
-                    ticklabels = [pprint_thing(col) for col in self.data.columns.get_level_values(0)] # 
+                    ticklabels = [
+                        pprint_thing(col)
+                        for col in self.data.columns.get_level_values(0)
+                    ]
                 else:
                     ticklabels = [pprint_thing(label)]
 

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -214,7 +214,7 @@ class BoxPlot(LinePlot):
                     # values, instead of label which is used as subtitle in this case.
                     # error: "Index" has no attribute "levels"; maybe "nlevels"?
                     levels = self.data.columns.levels  # type: ignore[attr-defined]
-                    ticklabels = [pprint_thing(col) for col in levels[0]]
+                    ticklabels = [pprint_thing(col) for col in self.data.columns.get_level_values(0)] # 
                 else:
                     ticklabels = [pprint_thing(label)]
 

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from pandas import (
+    Categorical,
     DataFrame,
     MultiIndex,
     Series,
@@ -408,6 +409,14 @@ class TestDataFramePlots:
             )
             assert target_label == pprint_thing(["group"])
 
+    @pytest.mark.filterwarnings("ignore:set_ticklabels:UserWarning")
+    def test_boxplot_group_xlabel_ylabel(self, vert):
+        df = DataFrame({'value': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                   'label': ['c', 'c', 'c', 'c', 'b', 'b', 'b', 'b', 'a', 'a']})
+        df.label = Categorical(df.label, categories=['c', 'b', 'a'], ordered=True)
+        ax = df.boxplot(by="label")
+        xticklabels = ax.get_xticklabels()
+        assert [x.get_text() for x in xticklabels] == ['c', 'b', 'a']
 
 class TestDataFrameGroupByPlots:
     def test_boxplot_legacy1(self, hist_df):

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -411,6 +411,7 @@ class TestDataFramePlots:
 
     @pytest.mark.filterwarnings("ignore:set_ticklabels:UserWarning")
     def test_boxplot_group_ordered_ticklabel(self, vert):
+        # GH 50427
         df = DataFrame(
             {
                 "value": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -410,13 +410,18 @@ class TestDataFramePlots:
             assert target_label == pprint_thing(["group"])
 
     @pytest.mark.filterwarnings("ignore:set_ticklabels:UserWarning")
-    def test_boxplot_group_xlabel_ylabel(self, vert):
-        df = DataFrame({'value': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                   'label': ['c', 'c', 'c', 'c', 'b', 'b', 'b', 'b', 'a', 'a']})
-        df.label = Categorical(df.label, categories=['c', 'b', 'a'], ordered=True)
+    def test_boxplot_group_ordered_ticklabel(self, vert):
+        df = DataFrame(
+            {
+                "value": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                "label": ["c", "c", "c", "c", "b", "b", "b", "b", "a", "a"],
+            }
+        )
+        df.label = Categorical(df.label, categories=["c", "b", "a"], ordered=True)
         ax = df.boxplot(by="label")
         xticklabels = ax.get_xticklabels()
-        assert [x.get_text() for x in xticklabels] == ['c', 'b', 'a']
+        assert [x.get_text() for x in xticklabels] == ["c", "b", "a"]
+
 
 class TestDataFrameGroupByPlots:
     def test_boxplot_legacy1(self, hist_df):


### PR DESCRIPTION
- [x] closes #50427 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.


the data.column is MultiIndex, for example 
```
data.columns: MultiIndex([('c', 'value'),
        ('b', 'value'),
        ('a', 'value')],
       )
```
The problem with the original code is not respecting the order of `by`

expected output from the original issue
<img width="563" height="444" alt="image" src="https://github.com/user-attachments/assets/59a78f73-46e9-4598-8700-c325236260bf" />

    
           
