### PR TITLE
chore(build): exlude tests in build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 include = ["pandas", "pandas.*"]
+exclude = ["pandas.tests", "pandas.tests.*"]
 namespaces = false
 
 [tool.setuptools.exclude-package-data]


### PR DESCRIPTION
Tests in pandas wheel introduces additional time the first I install pandas using pip on Windows. It takes 1 minutes or so to install pandas alone, and the time is basically taken during the pyc build phase.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
