### PR TITLE
[backport 2.3.x] DOC: prepare 2.3.3 whatsnew notes for release (#62499)

### DIFF
--- a/doc/source/whatsnew/v2.3.2.rst
+++ b/doc/source/whatsnew/v2.3.2.rst
@@ -22,8 +22,6 @@ become the default string dtype in pandas 3.0. See
 
 Bug fixes
 ^^^^^^^^^
-- Fix :meth:`~Series.str.isdigit` to correctly recognize unicode superscript
-  characters as digits for :class:`StringDtype` backed by PyArrow (:issue:`61466`)
 - Fix :meth:`~DataFrame.to_json` with ``orient="table"`` to correctly use the
   "string" type in the JSON Table Schema for :class:`StringDtype` columns
   (:issue:`61889`)
@@ -39,4 +37,4 @@ Bug fixes
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v2.3.1..v2.3.2|HEAD
+.. contributors:: v2.3.1..v2.3.2

--- a/doc/source/whatsnew/v2.3.3.rst
+++ b/doc/source/whatsnew/v2.3.3.rst
@@ -69,12 +69,6 @@ Other bug fixes
 - Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
 - The :meth:`DataFrame.iloc` now works correctly with ``copy_on_write`` option when assigning values after subsetting the columns of a homogeneous DataFrame (:issue:`60309`)
 
-Other Bug fixes
-~~~~~~~~~~~~~~~~
-
-- Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
-
-
 .. ---------------------------------------------------------------------------
 .. _whatsnew_233.contributors:
 

--- a/doc/source/whatsnew/v2.3.3.rst
+++ b/doc/source/whatsnew/v2.3.3.rst
@@ -75,4 +75,4 @@ Other bug fixes
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v2.3.1..v2.3.2|HEAD
+.. contributors:: v2.3.2..v2.3.3|HEAD

--- a/doc/source/whatsnew/v2.3.3.rst
+++ b/doc/source/whatsnew/v2.3.3.rst
@@ -1,6 +1,6 @@
 .. _whatsnew_233:
 
-What's new in 2.3.3 (September XX, 2025)
+What's new in 2.3.3 (September 29, 2025)
 ----------------------------------------
 
 These are the changes in pandas 2.3.3. See :ref:`release` for a full changelog
@@ -8,7 +8,7 @@ including other versions of pandas.
 
 {{ header }}
 
-.. _whatsnew_220.py14_compat:
+.. _whatsnew_233.py14_compat:
 
 Pandas 2.3.3 is now compatible with Python 3.14
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -37,26 +37,22 @@ Improvements
   specifying ``include=["object"]`` for backwards compatibility. In a future
   release, this will be deprecated and code for pandas 3+ should be updated to
   do ``include=["str"]`` (:issue:`61916`)
-
+- Support the ``/`` operation between a ``pathlib.Path`` object and a :class:`StringDtype`
+  Series, similarly as it works for object-dtype Series (:issue:`61940`)
 
 .. _whatsnew_233.string_fixes.bugs:
 
 Bug fixes
 ^^^^^^^^^
 - Fix bug in :meth:`Series.str.replace` using named capture groups (e.g., ``\g<name>``) with the Arrow-backed dtype would raise an error (:issue:`57636`)
-- Fix regression in ``~Series.str.contains``, ``~Series.str.match`` and ``~Series.str.fullmatch``
+- Fix regression in :meth:`Series.str.contains`, :meth:`~Series.str.match` and :meth:`~Series.str.fullmatch`
   with a compiled regex and custom flags (:issue:`62240`)
-- Fix :meth:`Series.str.match` and :meth:`Series.str.fullmatch` not matching patterns with groups correctly for the Arrow-backed string dtype (:issue:`61072`)
+- Fix :meth:`Series.str.match` and :meth:`~Series.str.fullmatch` not matching patterns with groups correctly for the Arrow-backed string dtype (:issue:`61072`)
+- Fix bug in :meth:`~DataFrame.groupby` with ``sum()`` and unobserved categories resulting in ``0`` instead of the empty string ``""`` (:issue:`61909`)
+- Fix :meth:`Series.str.isdigit` to correctly recognize unicode superscript
+  characters as digits for :class:`StringDtype` backed by PyArrow (:issue:`61466`)
 - Fix comparing a :class:`StringDtype` Series with mixed objects raising an error (:issue:`60228`)
 - Fix error being raised when using a numpy ufunc with a Python-backed string array (:issue:`40800`)
-
-Improvements and fixes for Copy-on-Write
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Bug fixes
-^^^^^^^^^
-
-- The :meth:`DataFrame.iloc` now works correctly with ``copy_on_write`` option when assigning values after subsetting the columns of a homogeneous DataFrame (:issue:`60309`)
 
 Other changes
 ~~~~~~~~~~~~~
@@ -66,6 +62,12 @@ Other changes
   Resampling with a :class:`PeriodIndex` is supported again, but a subset of
   methods that return incorrect results will raise an error in pandas 3.0 (:issue:`57033`)
 
+Other bug fixes
+~~~~~~~~~~~~~~~~
+
+- Fix memory leak in :meth:`DataFrame.to_json` with datetime columns (:issue:`62204`)
+- Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
+- The :meth:`DataFrame.iloc` now works correctly with ``copy_on_write`` option when assigning values after subsetting the columns of a homogeneous DataFrame (:issue:`60309`)
 
 Other Bug fixes
 ~~~~~~~~~~~~~~~~
@@ -78,3 +80,5 @@ Other Bug fixes
 
 Contributors
 ~~~~~~~~~~~~
+
+.. contributors:: v2.3.1..v2.3.2|HEAD


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/62499 and https://github.com/pandas-dev/pandas/pull/62509