### PR TITLE
Fix rolling var bug 

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1081,6 +1081,7 @@ Groupby/resample/rolling
 - Bug in :meth:`Rolling.apply` for ``method="table"`` where column order was not being respected due to the columns getting sorted by default. (:issue:`59666`)
 - Bug in :meth:`Rolling.apply` where the applied function could be called on fewer than ``min_period`` periods if ``method="table"``. (:issue:`58868`)
 - Bug in :meth:`Series.resample` could raise when the date range ended shortly before a non-existent time. (:issue:`58380`)
+- Bug in :meth:`Series.rolling.var` and :meth:`Series.rolling.std` where the end of window was not indexed correctly. (:issue:`47721`, :issue:`52407`, :issue:`54518`, :issue:`55343`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -442,7 +442,7 @@ def roll_var(const float64_t[:] values, ndarray[int64_t] start,
 
             # Over the first window, observations can only be added
             # never removed
-            if i == 0 or not is_monotonic_increasing_bounds or s >= end[i - 1]:
+            if i == 0 or not is_monotonic_increasing_bounds or s <= end[i]:
 
                 prev_value = values[s]
                 num_consecutive_same_value = 0

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -442,7 +442,7 @@ def roll_var(const float64_t[:] values, ndarray[int64_t] start,
 
             # Over the first window, observations can only be added
             # never removed
-            if i == 0 or not is_monotonic_increasing_bounds or s <= end[i]:
+            if i == 0 or not is_monotonic_increasing_bounds or s < end[i]:
 
                 prev_value = values[s]
                 num_consecutive_same_value = 0

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -1156,7 +1156,7 @@ def test_rolling_sem(frame_or_series):
 def test_rolling_var_correctness(func, values, window, ddof, expected_values):
     # GH: 37051, 42064, 54518, 52407, 47721
     ts = Series(values)
-    result = getattr(ts.rolling(window=window, center=True), func)(ddof=ddof)
+    result = getattr(ts.rolling(window=window), func)(ddof=ddof)
     if result.last_valid_index():
         result = result[
             result.first_valid_index() : result.last_valid_index() + 1

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -5,15 +5,10 @@ from datetime import (
 
 import numpy as np
 from numpy.lib.stride_tricks import sliding_window_view
-
-
 import pytest
 
 from pandas.compat import (
     IS64,
-    is_platform_arm,
-    is_platform_power,
-    is_platform_riscv64,
 )
 from pandas.errors import Pandas4Warning
 
@@ -1084,19 +1079,88 @@ def test_rolling_sem(frame_or_series):
     expected = Series([np.nan] + [0.7071067811865476] * 2)
     tm.assert_series_equal(result, expected)
 
+
 @pytest.mark.parametrize(
-  ("func", "values", "window", "ddof", "exp_value"),
-  [
-    ("var", [2.72993945, 1.58444294, 4.14371708, 4.92961687, 2.7138744 ,3.48168586, 0.69505519, 1.87511994, 4.20167276, 0.04797675], 3, 1, "numpy_compute"),
-    ("std", [2.72993945, 1.58444294, 4.14371708, 4.92961687, 2.7138744 ,3.48168586, 0.69505519, 1.87511994, 4.20167276, 0.04797675], 3, 1, "numpy_compute"),
-    ("var", [2.72993945, 1.58444294, 4.14371708, 4.92961687, 2.7138744 ,3.48168586, 0.69505519, 1.87511994, 4.20167276, 0.04797675], 2, 1, "numpy_compute"),
-    ("std", [2.72993945, 1.58444294, 4.14371708, 4.92961687, 2.7138744 ,3.48168586, 0.69505519, 1.87511994, 4.20167276, 0.04797675], 2, 1, "numpy_compute"),
-    ("var", [99999999999999999, 1, 1, 2, 3, 1, 1], 2, 1, 0),
-    ("std", [99999999999999999, 1, 1, 2, 3, 1, 1], 2, 1, 0),
-    ("var", [99999999999999999, 1, 2, 2, 3, 1, 1], 2, 1, 0),
-    ("var", [99999999999999999, 1, 2, 2, 3, 1, 1], 2, 1, 0),
-    ("var", [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], 5, 0, "numpy_compute"),
-  ],
+    ("func", "values", "window", "ddof", "exp_value"),
+    [
+        (
+            "var",
+            [
+                2.72993945,
+                1.58444294,
+                4.14371708,
+                4.92961687,
+                2.7138744,
+                3.48168586,
+                0.69505519,
+                1.87511994,
+                4.20167276,
+                0.04797675,
+            ],
+            3,
+            1,
+            "numpy_compute",
+        ),
+        (
+            "std",
+            [
+                2.72993945,
+                1.58444294,
+                4.14371708,
+                4.92961687,
+                2.7138744,
+                3.48168586,
+                0.69505519,
+                1.87511994,
+                4.20167276,
+                0.04797675,
+            ],
+            3,
+            1,
+            "numpy_compute",
+        ),
+        (
+            "var",
+            [
+                2.72993945,
+                1.58444294,
+                4.14371708,
+                4.92961687,
+                2.7138744,
+                3.48168586,
+                0.69505519,
+                1.87511994,
+                4.20167276,
+                0.04797675,
+            ],
+            2,
+            1,
+            "numpy_compute",
+        ),
+        (
+            "std",
+            [
+                2.72993945,
+                1.58444294,
+                4.14371708,
+                4.92961687,
+                2.7138744,
+                3.48168586,
+                0.69505519,
+                1.87511994,
+                4.20167276,
+                0.04797675,
+            ],
+            2,
+            1,
+            "numpy_compute",
+        ),
+        ("var", [99999999999999999, 1, 1, 2, 3, 1, 1], 2, 1, 0),
+        ("std", [99999999999999999, 1, 1, 2, 3, 1, 1], 2, 1, 0),
+        ("var", [99999999999999999, 1, 2, 2, 3, 1, 1], 2, 1, 0),
+        ("std", [99999999999999999, 1, 2, 2, 3, 1, 1], 2, 1, 0),
+        ("var", [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], 5, 0, "numpy_compute"),
+    ],
 )
 def test_rolling_var_correctness(func, values, window, ddof, exp_value):
     # This tests subsume the previous tests under test_rolling_var_numerical_issues
@@ -1104,27 +1168,46 @@ def test_rolling_var_correctness(func, values, window, ddof, exp_value):
     ts = Series(values)
     result = getattr(ts.rolling(window=window, center=True), func)(ddof=ddof)
     if result.last_valid_index():
-        result = result[result.first_valid_index() : result.last_valid_index()+1].reset_index(drop=True)
-    expected = Series(getattr(sliding_window_view(values, window_shape=window), func)(axis=-1, ddof=ddof)) #.var(axis=-1, ddof=ddof))
+        result = result[
+            result.first_valid_index() : result.last_valid_index() + 1
+        ].reset_index(drop=True)
+    expected = Series(
+        getattr(sliding_window_view(values, window_shape=window), func)(
+            axis=-1, ddof=ddof
+        )
+    )
     tm.assert_series_equal(result, expected, atol=1e-55)
     # GH 42064
     if exp_value == 0:
-       # new `roll_var` will output 0.0 correctly
-        tm.assert_series_equal(result==0, expected==0)
+        # new `roll_var` will output 0.0 correctly
+        tm.assert_series_equal(result == 0, expected == 0)
+
 
 def test_rolling_var_numerical_stability():
     # GH 52407
-    A = [0.00000000e+00, 0.00000000e+00, 3.16188252e-18, 2.95781651e-16,
-    2.23153542e-51, 0.00000000e+00, 0.00000000e+00, 5.39943432e-48,
-    1.38206260e-73, 0.00000000e+00]
+    A = [
+        0.00000000e00,
+        0.00000000e00,
+        3.16188252e-18,
+        2.95781651e-16,
+        2.23153542e-51,
+        0.00000000e00,
+        0.00000000e00,
+        5.39943432e-48,
+        1.38206260e-73,
+        0.00000000e00,
+    ]
     ts = Series(A)
 
     result = ts.rolling(window=3, center=True).var(ddof=1)
-    result = result[result.first_valid_index() : result.last_valid_index()+1].reset_index(drop=True)
-    
+    result = result[
+        result.first_valid_index() : result.last_valid_index() + 1
+    ].reset_index(drop=True)
+
     # numpy implementation
     expected = Series(sliding_window_view(A, window_shape=3).var(axis=-1, ddof=1))
     tm.assert_series_equal(result, expected, atol=1e-55)
+
 
 def test_timeoffset_as_window_parameter_for_corr(unit):
     # GH: 28266


### PR DESCRIPTION
Rolling variance previously had an indexing bug in the end of the window, in `pandas/_libs/window/aggregations.pyx`

The implementation now matches numpy rolling variance results, passes "rolling variance correctness" test cases, and all other "rolling_var/std" tests (18/18). It also addresses all of these reported (open) rolling std/var issues 

-  closes 
https://github.com/pandas-dev/pandas/issues/52407
https://github.com/pandas-dev/pandas/issues/55343
https://github.com/pandas-dev/pandas/issues/54518
https://github.com/pandas-dev/pandas/issues/47721

- Potentially closes 
https://github.com/pandas-dev/pandas/issues/37398
https://github.com/pandas-dev/pandas/issues/38921, 
https://github.com/pandas-dev/pandas/issues/41740

- All tests for rolling variance that were previously failing now pass.
- Added tests from 52407, 47721, 54518
