### PR TITLE
CI: specify supported glibc/musl versions for wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,10 @@ test-command = """
   pd.test(extra_args=["-m not clipboard and single_cpu and not slow and not network and not db", "--no-strict-data-files"]);' \
   """
 enable = ["cpython-freethreading"]
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.windows]
 environment = {}


### PR DESCRIPTION
- [x] xref #62515 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

This PR specifies the image used to build the wheel to avoid the surprise seen in #62515. I specified `manylinux_2_28` mainly because:
1. this is for version 3;
2. manylinux_2_24 and prior reached EOL according to [PEP600 compliance check](https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#); and 
3. NumPy uses these [versions](https://github.com/numpy/numpy/blob/50204c8ef6bd66176341bc6d29c97ad94a8a3b68/pyproject.toml#L199-L202) too.

I am happy to change the image if support for `manylinux_2_17` is still desired.

