### PR TITLE
TST: Replace ensure_clean with temp_file in read_xml_iterparse test

### DIFF
--- a/pandas/tests/io/xml/test_xml.py
+++ b/pandas/tests/io/xml/test_xml.py
@@ -263,11 +263,10 @@ def parser(request):
     return request.param
 
 
-def read_xml_iterparse(data, **kwargs):
-    with tm.ensure_clean() as path:
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(data)
-        return read_xml(path, **kwargs)
+def read_xml_iterparse(data, temp_file, **kwargs):
+    with open(temp_file, "w", encoding="utf-8") as f:
+        f.write(data)
+    return read_xml(temp_file, **kwargs)
 
 
 def read_xml_iterparse_comp(comp_path, compression_only, **kwargs):


### PR DESCRIPTION
- Replace `tm.ensure_clean()` context manager with `temp_file` pytest fixture in `read_xml_iterparse` helper function 
- Associated iterparse tests in `pandas/tests/io/xml/test_xml.py`.

This is part of the ongoing effort to replace `ensule_clean()` with `temp_file` fixture.

- xref #62435
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest whatsnew