### PR TITLE
chore: use temp_file instead of ensure_clean in test

### DIFF
--- a/pandas/tests/io/xml/test_xml_dtypes.py
+++ b/pandas/tests/io/xml/test_xml_dtypes.py
@@ -31,11 +31,10 @@ def iterparse(request):
     return request.param
 
 
-def read_xml_iterparse(data, **kwargs):
-    with tm.ensure_clean() as path:
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(data)
-        return read_xml(path, **kwargs)
+def read_xml_iterparse(data, temp_file, **kwargs):
+    with open(temp_file, "w", encoding="utf-8") as f:
+        f.write(data)
+    return read_xml(temp_file, **kwargs)
 
 
 xml_types = """\
@@ -84,13 +83,14 @@ xml_dates = """<?xml version='1.0' encoding='utf-8'?>
 # DTYPE
 
 
-def test_dtype_single_str(parser):
+def test_dtype_single_str(parser, temp_file):
     df_result = read_xml(StringIO(xml_types), dtype={"degrees": "str"}, parser=parser)
     df_iter = read_xml_iterparse(
         xml_types,
         parser=parser,
         dtype={"degrees": "str"},
         iterparse={"row": ["shape", "degrees", "sides"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -105,13 +105,14 @@ def test_dtype_single_str(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
-def test_dtypes_all_str(parser):
+def test_dtypes_all_str(parser, temp_file):
     df_result = read_xml(StringIO(xml_dates), dtype="string", parser=parser)
     df_iter = read_xml_iterparse(
         xml_dates,
         parser=parser,
         dtype="string",
         iterparse={"row": ["shape", "degrees", "sides", "date"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -128,7 +129,7 @@ def test_dtypes_all_str(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
-def test_dtypes_with_names(parser):
+def test_dtypes_with_names(parser, temp_file):
     df_result = read_xml(
         StringIO(xml_dates),
         names=["Col1", "Col2", "Col3", "Col4"],
@@ -141,6 +142,7 @@ def test_dtypes_with_names(parser):
         names=["Col1", "Col2", "Col3", "Col4"],
         dtype={"Col2": "string", "Col3": "Int64", "Col4": "datetime64[ns]"},
         iterparse={"row": ["shape", "degrees", "sides", "date"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -158,13 +160,14 @@ def test_dtypes_with_names(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
-def test_dtype_nullable_int(parser):
+def test_dtype_nullable_int(parser, temp_file):
     df_result = read_xml(StringIO(xml_types), dtype={"sides": "Int64"}, parser=parser)
     df_iter = read_xml_iterparse(
         xml_types,
         parser=parser,
         dtype={"sides": "Int64"},
         iterparse={"row": ["shape", "degrees", "sides"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -179,13 +182,14 @@ def test_dtype_nullable_int(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
-def test_dtype_float(parser):
+def test_dtype_float(parser, temp_file):
     df_result = read_xml(StringIO(xml_types), dtype={"degrees": "float"}, parser=parser)
     df_iter = read_xml_iterparse(
         xml_types,
         parser=parser,
         dtype={"degrees": "float"},
         iterparse={"row": ["shape", "degrees", "sides"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -209,7 +213,7 @@ def test_wrong_dtype(xml_books, parser, iterparse):
         )
 
 
-def test_both_dtype_converters(parser):
+def test_both_dtype_converters(parser, temp_file):
     df_expected = DataFrame(
         {
             "shape": ["square", "circle", "triangle"],
@@ -231,6 +235,7 @@ def test_both_dtype_converters(parser):
             converters={"degrees": str},
             parser=parser,
             iterparse={"row": ["shape", "degrees", "sides"]},
+            temp_file=temp_file,
         )
 
         tm.assert_frame_equal(df_result, df_expected)
@@ -240,7 +245,7 @@ def test_both_dtype_converters(parser):
 # CONVERTERS
 
 
-def test_converters_str(parser):
+def test_converters_str(parser, temp_file):
     df_result = read_xml(
         StringIO(xml_types), converters={"degrees": str}, parser=parser
     )
@@ -249,6 +254,7 @@ def test_converters_str(parser):
         parser=parser,
         converters={"degrees": str},
         iterparse={"row": ["shape", "degrees", "sides"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -263,7 +269,7 @@ def test_converters_str(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
-def test_converters_date(parser):
+def test_converters_date(parser, temp_file):
     convert_to_datetime = lambda x: to_datetime(x)
     df_result = read_xml(
         StringIO(xml_dates), converters={"date": convert_to_datetime}, parser=parser
@@ -273,6 +279,7 @@ def test_converters_date(parser):
         parser=parser,
         converters={"date": convert_to_datetime},
         iterparse={"row": ["shape", "degrees", "sides", "date"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -312,13 +319,14 @@ def test_callable_str_converters(xml_books, parser, iterparse):
 # PARSE DATES
 
 
-def test_parse_dates_column_name(parser):
+def test_parse_dates_column_name(parser, temp_file):
     df_result = read_xml(StringIO(xml_dates), parse_dates=["date"], parser=parser)
     df_iter = read_xml_iterparse(
         xml_dates,
         parser=parser,
         parse_dates=["date"],
         iterparse={"row": ["shape", "degrees", "sides", "date"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -334,13 +342,14 @@ def test_parse_dates_column_name(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
-def test_parse_dates_column_index(parser):
+def test_parse_dates_column_index(parser, temp_file):
     df_result = read_xml(StringIO(xml_dates), parse_dates=[3], parser=parser)
     df_iter = read_xml_iterparse(
         xml_dates,
         parser=parser,
         parse_dates=[3],
         iterparse={"row": ["shape", "degrees", "sides", "date"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -356,7 +365,7 @@ def test_parse_dates_column_index(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
-def test_parse_dates_true(parser):
+def test_parse_dates_true(parser, temp_file):
     df_result = read_xml(StringIO(xml_dates), parse_dates=True, parser=parser)
 
     df_iter = read_xml_iterparse(
@@ -364,6 +373,7 @@ def test_parse_dates_true(parser):
         parser=parser,
         parse_dates=True,
         iterparse={"row": ["shape", "degrees", "sides", "date"]},
+        temp_file=temp_file,
     )
 
     df_expected = DataFrame(
@@ -379,7 +389,7 @@ def test_parse_dates_true(parser):
     tm.assert_frame_equal(df_iter, df_expected)
 
 
-def test_day_first_parse_dates(parser):
+def test_day_first_parse_dates(parser, temp_file):
     xml = """\
 <?xml version='1.0' encoding='utf-8'?>
 <data>
@@ -421,6 +431,7 @@ def test_day_first_parse_dates(parser):
             parse_dates=["date"],
             parser=parser,
             iterparse={"row": ["shape", "degrees", "sides", "date"]},
+            temp_file=temp_file,
         )
 
         tm.assert_frame_equal(df_result, df_expected)


### PR DESCRIPTION
- [x] Assists #62435 
- [ ] ~[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] ~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~
- [ ] ~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~
