### PR TITLE
STY: Enforce Ruff rule B905 for pandas/core/window

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -351,7 +351,7 @@ class BaseWindow(SelectionMixin):
         )
         self._check_window_bounds(start, end, len(obj))
 
-        for s, e in zip(start, end):
+        for s, e in zip(start, end, strict=True):
             result = obj.iloc[slice(s, e)]
             yield result
 
@@ -802,7 +802,7 @@ class BaseWindowGroupby(BaseWindow):
             groupby_codes = []
             groupby_levels = []
             # e.g. [[1, 2], [4, 5]] as [[1, 4], [2, 5]]
-            for gb_level_pair in map(list, zip(*gb_pairs)):
+            for gb_level_pair in map(list, zip(*gb_pairs, strict=True)):
                 labels = np.repeat(np.array(gb_level_pair), old_result_len)
                 codes, levels = factorize(labels)
                 groupby_codes.append(codes)


### PR DESCRIPTION
Part of #62434

This PR enforces Ruff rule B905 (`zip-without-explicit-strict`) by adding explicit `strict=True` to all `zip()` calls in `pandas/core/window`.

- Updated `zip(start, end)` to `zip(start, end, strict=True)`
- Updated `zip(*gb_pairs)` to `zip(*gb_pairs, strict=True)`

Checklist:
- [x] Part of #62434
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I am a first-time contributor. Please let me know if any changes are needed!
