### PR TITLE
STY: Enforce Ruff rule B905 for pandas/core/frame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6567,7 +6567,11 @@ class DataFrame(NDFrame, OpsMixin):
             names = self.index._get_default_index_names(names, default)
 
             if isinstance(self.index, MultiIndex):
-                to_insert = zip(reversed(self.index.levels), reversed(self.index.codes), strict=True)
+                to_insert = zip(
+                    reversed(self.index.levels),
+                    reversed(self.index.codes),
+                    strict=True,
+                )
             else:
                 to_insert = ((self.index, None),)
 
@@ -7342,7 +7346,10 @@ class DataFrame(NDFrame, OpsMixin):
                 f" != length of by ({len(by)})"
             )
         if len(by) > 1:
-            keys = (self._get_label_or_level_values(x, axis=axis) for x in by)
+            keys_data = [
+                Series(k, name=name)
+                for (k, name) in zip(keys, by, strict=True)
+            ]
 
             # need to rewrap columns in Series to apply key function
             if key is not None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1524,7 +1524,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         columns = self.columns
         klass = self._constructor_sliced
-        for k, v in zip(self.index, self.values):
+        for k, v in zip(self.index, self.values, strict=True):
             s = klass(v, index=columns, name=k).__finalize__(self)
             if self._mgr.is_single_block:
                 s._mgr.add_references(self._mgr)
@@ -1607,10 +1607,10 @@ class DataFrame(NDFrame, OpsMixin):
             itertuple = collections.namedtuple(  # type: ignore[misc]
                 name, fields, rename=True
             )
-            return map(itertuple._make, zip(*arrays))
+            return map(itertuple._make, zip(*arrays, strict=True))
 
         # fallback to regular tuples
-        return zip(*arrays)
+        return zip(*arrays, strict=True)
 
     def __len__(self) -> int:
         """
@@ -4359,7 +4359,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             if isinstance(value, DataFrame):
                 check_key_length(self.columns, key, value)
-                for k1, k2 in zip(key, value.columns):
+                for k1, k2 in zip(key, value.columns, strict=True):
                     self[k1] = value[k2]
 
             elif not is_list_like(value):
@@ -4465,7 +4465,7 @@ class DataFrame(NDFrame, OpsMixin):
                 if len(cols_droplevel) and not cols_droplevel.equals(value.columns):
                     value = value.reindex(cols_droplevel, axis=1)
 
-                for col, col_droplevel in zip(cols, cols_droplevel):
+                for col, col_droplevel in zip(cols, cols_droplevel, strict=True):
                     self[col] = value[col_droplevel]
                 return
 
@@ -6567,7 +6567,7 @@ class DataFrame(NDFrame, OpsMixin):
             names = self.index._get_default_index_names(names, default)
 
             if isinstance(self.index, MultiIndex):
-                to_insert = zip(reversed(self.index.levels), reversed(self.index.codes))
+                to_insert = zip(reversed(self.index.levels), reversed(self.index.codes), strict=True)
             else:
                 to_insert = ((self.index, None),)
 
@@ -7093,7 +7093,7 @@ class DataFrame(NDFrame, OpsMixin):
             result.name = None
         else:
             vals = (col.values for name, col in self.items() if name in subset)
-            labels, shape = map(list, zip(*map(f, vals)))
+            labels, shape = map(list, zip(*map(f, vals), strict=True))
 
             ids = get_group_index(labels, tuple(shape), sort=False, xnull=False)
             result = self._constructor_sliced(duplicated(ids, keep), index=self.index)
@@ -7346,7 +7346,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             # need to rewrap columns in Series to apply key function
             if key is not None:
-                keys_data = [Series(k, name=name) for (k, name) in zip(keys, by)]
+                keys_data = [Series(k, name=name) for (k, name) in zip(keys, by, strict=True)]
             else:
                 # error: Argument 1 to "list" has incompatible type
                 # "Generator[ExtensionArray | ndarray[Any, Any], None, None]";
@@ -8208,7 +8208,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             arrays = [
                 array_op(_left, _right)
-                for _left, _right in zip(self._iter_column_arrays(), right)
+                for _left, _right in zip(self._iter_column_arrays(), right, strict=True)
             ]
 
         elif isinstance(right, Series):
@@ -11745,7 +11745,7 @@ class DataFrame(NDFrame, OpsMixin):
                 return nanops.nancorr(x[0], x[1], method=method)
 
             correl = self._constructor_sliced(
-                map(c, zip(left.values.T, right.values.T)),
+                map(c, zip(left.values.T, right.values.T, strict=True)),
                 index=left.columns,
                 copy=False,
             )


### PR DESCRIPTION
Part of #62434

This PR enforces Ruff rule B905 (`zip-without-explicit-strict`) by adding explicit `strict=True` to all `zip()` calls in `pandas/core/frame.py`.

- Updated `zip(self.index, self.values)` to `zip(self.index, self.values, strict=True)`
- Updated `zip(*arrays)` to `zip(*arrays, strict=True)`
- Updated `zip(key, value.columns)` to `zip(key, value.columns, strict=True)`
- Updated `zip(cols, cols_droplevel)` to `zip(cols, cols_droplevel, strict=True)`
- Updated `zip(reversed(self.index.levels), reversed(self.index.codes))` to `zip(reversed(self.index.levels), reversed(self.index.codes), strict=True)`
- Updated `zip(*map(f, vals))` to `zip(*map(f, vals), strict=True)`
- Updated `zip(keys, by)` to `zip(keys, by, strict=True)`
- Updated `zip(self._iter_column_arrays(), right)` to `zip(self._iter_column_arrays(), right, strict=True)`
- Updated `zip(left.values.T, right.values.T)` to `zip(left.values.T, right.values.T, strict=True)`

Checklist:
- [x] Part of #62434
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

I am a contributor working through multiple directories. Please let me know if any changes are needed!