### PR TITLE
BUG: treat missing sentinels as equal across dtypes when check_dtype=…

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1105,6 +1105,33 @@ def assert_series_equal(
             index_values=left.index,
             obj=str(obj),
         )
+    elif not check_dtype:
+ 
+        left_na = left.isna().to_numpy(dtype=bool, copy=False)
+        right_na = right.isna().to_numpy(dtype=bool, copy=False)
+        assert_numpy_array_equal(
+            left_na, right_na, obj=f"{obj} NA mask", index_values=left.index
+    )
+
+    
+        def _normalize(arr):
+        
+            return [
+                (None if pd.isna(x) else x)
+                for x in arr.to_numpy(dtype=object)
+            ]
+        left_valid = _normalize(left[~left_na])
+        right_valid = _normalize(right[~right_na])
+
+        _testing.assert_almost_equal(
+        left_valid,
+        right_valid,
+        check_dtype=False,
+        rtol=rtol,
+        atol=atol,
+        obj=str(obj),
+        index_values=left.index,
+    )
     else:
         _testing.assert_almost_equal(
             left._values,
@@ -1488,3 +1515,4 @@ def assert_metadata_equivalent(
             assert val is None
         else:
             assert val == getattr(right, attr, None)
+

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -5,6 +5,7 @@ from pandas.errors import Pandas4Warning
 import pandas as pd
 from pandas import DataFrame
 import pandas._testing as tm
+from pandas.testing import assert_frame_equal
 
 
 @pytest.fixture(params=[True, False])
@@ -399,6 +400,7 @@ def test_assert_frame_equal_set_mismatch():
         tm.assert_frame_equal(df1, df2)
 
 
+
 def test_datetimelike_compat_deprecated():
     # GH#55638
     df = DataFrame({"a": [1]})
@@ -413,3 +415,10 @@ def test_datetimelike_compat_deprecated():
         tm.assert_series_equal(df["a"], df["a"], check_datetimelike_compat=True)
     with tm.assert_produces_warning(Pandas4Warning, match=msg):
         tm.assert_series_equal(df["a"], df["a"], check_datetimelike_compat=False)
+
+
+def test_assert_frame_equal_na_object_vs_int32_check_dtype_false():
+    
+    df1 = pd.DataFrame({"x": pd.Series([pd.NA], dtype="Int32")})
+    df2 = pd.DataFrame({"x": pd.Series([pd.NA], dtype="object")})
+    assert_frame_equal(df1, df2, check_dtype=False)


### PR DESCRIPTION
- [ ] closes #61473 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
