### PR TITLE
TST: remove expected warnings for new `numexpr` version

### DIFF
--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -11,6 +11,8 @@ import re
 import numpy as np
 import pytest
 
+from pandas.compat._optional import import_optional_dependency
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -24,6 +26,7 @@ from pandas.tests.frame.common import (
     _check_mixed_float,
     _check_mixed_int,
 )
+from pandas.util.version import Version
 
 
 @pytest.fixture
@@ -1114,6 +1117,8 @@ class TestFrameArithmetic:
             (operator.mod, "complex128"),
         }
 
+        ne = import_optional_dependency("numexpr", errors="ignore")
+        ne_warns_on_op = ne is not None and Version(ne.__version__) < Version("2.13.1")
         if (op, dtype) in invalid:
             warn = None
             if (dtype == "<M8[ns]" and op == operator.add) or (
@@ -1142,7 +1147,11 @@ class TestFrameArithmetic:
 
         elif (op, dtype) in skip:
             if op in [operator.add, operator.mul]:
-                if expr.USE_NUMEXPR and switch_numexpr_min_elements == 0:
+                if (
+                    expr.USE_NUMEXPR
+                    and switch_numexpr_min_elements == 0
+                    and ne_warns_on_op
+                ):
                     warn = UserWarning
                 else:
                     warn = None

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from pandas._libs import lib
+from pandas.compat._optional import import_optional_dependency
 
 import pandas as pd
 from pandas import (
@@ -25,7 +26,7 @@ from pandas import (
 import pandas._testing as tm
 from pandas.core import ops
 from pandas.core.computation import expressions as expr
-from pandas.core.computation.check import NUMEXPR_INSTALLED
+from pandas.util.version import Version
 
 
 @pytest.fixture(autouse=True, params=[0, 1000000], ids=["numexpr", "python"])
@@ -348,9 +349,12 @@ class TestSeriesArithmetic:
 
     def test_add_list_to_masked_array_boolean(self, request):
         # GH#22962
+        ne = import_optional_dependency("numexpr", errors="ignore")
         warning = (
             UserWarning
-            if request.node.callspec.id == "numexpr" and NUMEXPR_INSTALLED
+            if request.node.callspec.id == "numexpr"
+            and ne
+            and Version(ne.__version__) < Version("2.13.1")
             else None
         )
         ser = Series([True, None, False], dtype="boolean")


### PR DESCRIPTION
Remove expected warning from NumExpr for `+` and `*` operators in boolean arrays for `numexpr>=2.13.1`.

It seems it was implemented on https://github.com/pydata/numexpr/pull/536.

I think this will make the CI green again.

closes https://github.com/pandas-dev/pandas/issues/62545
