### PR TITLE
STY: Enforce Ruff rule B905 for pandas/tests

### DIFF
--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -545,7 +545,9 @@ def test_apply_to_timedelta(by_row):
 )
 def test_apply_listlike_reducer(string_series, ops, names, how, kwargs):
     # GH 39140
-    expected = Series({name: op(string_series) for name, op in zip(names, ops)})
+    expected = Series(
+        {name: op(string_series) for name, op in zip(names, ops, strict=True)}
+    )
     expected.name = "series"
     result = getattr(string_series, how)(ops, **kwargs)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/arithmetic/test_interval.py
+++ b/pandas/tests/arithmetic/test_interval.py
@@ -107,7 +107,9 @@ class TestComparison:
         Helper that performs elementwise comparisons between `array` and `other`
         """
         other = other if is_list_like(other) else [other] * len(interval_array)
-        expected = np.array([op(x, y) for x, y in zip(interval_array, other)])
+        expected = np.array(
+            [op(x, y) for x, y in zip(interval_array, other, strict=True)]
+        )
         if isinstance(other, Series):
             return Series(expected, index=other.index)
         return expected

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -766,7 +766,7 @@ class TestMultiplicationDivision:
             div, mod = divmod(idx.values, 2)
 
         expected = Index(div), Index(mod)
-        for r, e in zip(result, expected):
+        for r, e in zip(result, expected, strict=True):
             tm.assert_index_equal(r, e)
 
     def test_divmod_ndarray(self, numeric_idx):
@@ -778,7 +778,7 @@ class TestMultiplicationDivision:
             div, mod = divmod(idx.values, other)
 
         expected = Index(div), Index(mod)
-        for r, e in zip(result, expected):
+        for r, e in zip(result, expected, strict=True):
             tm.assert_index_equal(r, e)
 
     def test_divmod_series(self, numeric_idx):
@@ -790,7 +790,7 @@ class TestMultiplicationDivision:
             div, mod = divmod(idx.values, other)
 
         expected = Series(div), Series(mod)
-        for r, e in zip(result, expected):
+        for r, e in zip(result, expected, strict=True):
             tm.assert_series_equal(r, e)
 
     @pytest.mark.parametrize("other", [np.nan, 7, -23, 2.718, -3.14, np.inf])
@@ -1088,7 +1088,7 @@ class TestAdditionSubtraction:
         with np.errstate(all="ignore"):
             expecteds = divmod(series.values, np.asarray(other_np))
 
-        for result, expected in zip(results, expecteds):
+        for result, expected in zip(results, expecteds, strict=True):
             # check the values, name, and index separately
             tm.assert_almost_equal(np.asarray(result), expected)
 

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -962,11 +962,11 @@ class TestPeriodIndexArithmetic:
         pi = period_range("2016-01-01", periods=10, freq="2D")
         arr = np.arange(10)
         result = pi + arr
-        expected = pd.Index([x + y for x, y in zip(pi, arr)])
+        expected = pd.Index([x + y for x, y in zip(pi, arr, strict=True)])
         tm.assert_index_equal(result, expected)
 
         result = pi - arr
-        expected = pd.Index([x - y for x, y in zip(pi, arr)])
+        expected = pd.Index([x - y for x, y in zip(pi, arr, strict=True)])
         tm.assert_index_equal(result, expected)
 
     def test_pi_sub_isub_offset(self):

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -130,7 +130,7 @@ def test_map_with_dict_or_series(na_action):
     expected = Categorical(new_values, categories=[3.0, 2, "one"])
     tm.assert_categorical_equal(result, expected)
 
-    mapper = dict(zip(orig_values[:-1], new_values[:-1]))
+    mapper = dict(zip(orig_values[:-1], new_values[:-1], strict=True))
     result = cat.map(mapper, na_action=na_action)
     # Order of categories in result can be different
     tm.assert_categorical_equal(result, expected)

--- a/pandas/tests/arrays/integer/test_construction.py
+++ b/pandas/tests/arrays/integer/test_construction.py
@@ -67,7 +67,7 @@ def test_conversions(data_missing):
     expected = np.array([pd.NA, 1], dtype=object)
     tm.assert_numpy_array_equal(result, expected)
 
-    for r, e in zip(result, expected):
+    for r, e in zip(result, expected, strict=True):
         if pd.isnull(r):
             assert pd.isnull(e)
         elif is_integer(r):

--- a/pandas/tests/arrays/integer/test_function.py
+++ b/pandas/tests/arrays/integer/test_function.py
@@ -104,7 +104,7 @@ def test_ufunc_binary_output(using_nan_is_na):
     assert isinstance(result, tuple)
     assert len(result) == 2
 
-    for x, y in zip(result, expected):
+    for x, y in zip(result, expected, strict=True):
         tm.assert_extension_array_equal(x, y)
 
 

--- a/pandas/tests/arrays/masked/test_arithmetic.py
+++ b/pandas/tests/arrays/masked/test_arithmetic.py
@@ -19,7 +19,9 @@ arrays += [pd.array([True, False, True, None], dtype="boolean")]
 scalars += [False]
 
 
-@pytest.fixture(params=zip(arrays, scalars), ids=[a.dtype.name for a in arrays])
+@pytest.fixture(
+    params=zip(arrays, scalars, strict=True), ids=[a.dtype.name for a in arrays]
+)
 def data(request):
     """Fixture returning parametrized (array, scalar) tuple.
 

--- a/pandas/tests/arrays/sparse/test_constructors.py
+++ b/pandas/tests/arrays/sparse/test_constructors.py
@@ -77,7 +77,10 @@ class TestConstructors:
         assert arr.dtype == SparseDtype(object, False)
         assert arr.fill_value is False
         arr_expected = np.array(data, dtype=object)
-        it = (type(x) == type(y) and x == y for x, y in zip(arr, arr_expected))
+        it = (
+            type(x) == type(y) and x == y
+            for x, y in zip(arr, arr_expected, strict=True)
+        )
         assert np.fromiter(it, dtype=np.bool_).all()
 
     @pytest.mark.parametrize("dtype", [SparseDtype(int, 0), int])

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -144,7 +144,7 @@ class TestNonNano:
     def test_astype_object(self, dta):
         result = dta.astype(object)
         assert all(x._creso == dta._creso for x in result)
-        assert all(x == y for x, y in zip(result, dta))
+        assert all(x == y for x, y in zip(result, dta, strict=True))
 
     def test_to_pydatetime(self, dta_dti):
         dta, dti = dta_dti

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -150,7 +150,7 @@ class TestToIterable:
         vals = [Timestamp("2011-01-01"), Timestamp("2011-01-02")]
         ser = Series(vals).dt.as_unit(unit)
         assert ser.dtype == f"datetime64[{unit}]"
-        for res, exp in zip(ser, vals):
+        for res, exp in zip(ser, vals, strict=True):
             assert isinstance(res, Timestamp)
             assert res.tz is None
             assert res == exp
@@ -164,7 +164,7 @@ class TestToIterable:
         ser = Series(vals).dt.as_unit(unit)
 
         assert ser.dtype == f"datetime64[{unit}, US/Eastern]"
-        for res, exp in zip(ser, vals):
+        for res, exp in zip(ser, vals, strict=True):
             assert isinstance(res, Timestamp)
             assert res.tz == exp.tz
             assert res == exp
@@ -175,7 +175,7 @@ class TestToIterable:
         vals = [Timedelta("1 days"), Timedelta("2 days")]
         ser = Series(vals).dt.as_unit(unit)
         assert ser.dtype == f"timedelta64[{unit}]"
-        for res, exp in zip(ser, vals):
+        for res, exp in zip(ser, vals, strict=True):
             assert isinstance(res, Timedelta)
             assert res == exp
             assert res.unit == unit
@@ -185,7 +185,7 @@ class TestToIterable:
         vals = [pd.Period("2011-01-01", freq="M"), pd.Period("2011-01-02", freq="M")]
         s = Series(vals)
         assert s.dtype == "Period[M]"
-        for res, exp in zip(s, vals):
+        for res, exp in zip(s, vals, strict=True):
             assert isinstance(res, pd.Period)
             assert res.freq == "ME"
             assert res == exp

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1193,7 +1193,7 @@ class TestOperations:
         expec3 = df.a + df.b + df.c[df.b < 0]
         exprs = expr1, expr2, expr3
         expecs = expec1, expec2, expec3
-        for e, expec in zip(exprs, expecs):
+        for e, expec in zip(exprs, expecs, strict=True):
             tm.assert_series_equal(expec, self.eval(e, local_dict={"df": df}))
 
     def test_assignment_fails(self):

--- a/pandas/tests/copy_view/test_functions.py
+++ b/pandas/tests/copy_view/test_functions.py
@@ -305,5 +305,5 @@ def test_join_multiple_dataframes_on_key():
     assert not np.shares_memory(get_array(result, "c"), get_array(dfs_list[1], "c"))
 
     tm.assert_frame_equal(df1, df1_orig)
-    for df, df_orig in zip(dfs_list, dfs_list_orig):
+    for df, df_orig in zip(dfs_list, dfs_list_orig, strict=True):
         tm.assert_frame_equal(df, df_orig)

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -187,10 +187,10 @@ ll_params = [
     (np.nan, False, "NaN"),
     (None, False, "None"),
 ]
-objs, expected, ids = zip(*ll_params)
+objs, expected, ids = zip(*ll_params, strict=True)
 
 
-@pytest.fixture(params=zip(objs, expected), ids=ids)
+@pytest.fixture(params=zip(objs, expected, strict=True), ids=ids)
 def maybe_list_like(request):
     return request.param
 

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -350,7 +350,10 @@ class BaseMethodsTests:
         result = s1.combine(s2, lambda x1, x2: x1 <= x2)
         expected = pd.Series(
             pd.array(
-                [a <= b for (a, b) in zip(list(orig_data1), list(orig_data2))],
+                [
+                    a <= b
+                    for (a, b) in zip(list(orig_data1), list(orig_data2), strict=True)
+                ],
                 dtype=self._combine_le_expected_dtype,
             )
         )
@@ -369,7 +372,7 @@ class BaseMethodsTests:
     def _construct_for_combine_add(self, left, right):
         if isinstance(right, type(left)):
             return left._from_sequence(
-                [a + b for (a, b) in zip(list(left), list(right))],
+                [a + b for (a, b) in zip(list(left), list(right), strict=True)],
                 dtype=left.dtype,
             )
         else:

--- a/pandas/tests/extension/date/array.py
+++ b/pandas/tests/extension/date/array.py
@@ -159,7 +159,7 @@ class DateArray(ExtensionArray):
         self._day[key] = value.day
 
     def __repr__(self) -> str:
-        return f"DateArray{list(zip(self._year, self._month, self._day))}"
+        return f"DateArray{list(zip(self._year, self._month, self._day, strict=True))}"
 
     def copy(self) -> DateArray:
         return DateArray((self._year.copy(), self._month.copy(), self._day.copy()))

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -286,7 +286,7 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
 
         # If the operator is not defined for the underlying objects,
         # a TypeError should be raised
-        res = [op(a, b) for (a, b) in zip(lvalues, rvalues)]
+        res = [op(a, b) for (a, b) in zip(lvalues, rvalues, strict=True)]
 
         return np.asarray(res, dtype=bool)
 

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -135,12 +135,12 @@ class JSONArray(ExtensionArray):
 
             if isinstance(key, np.ndarray) and key.dtype == "bool":
                 # masking
-                for i, (k, v) in enumerate(zip(key, value, strict=True)):
+                for i, (k, v) in enumerate(zip(key, value, strict=False)):
                     if k:
                         assert isinstance(v, self.dtype.type)
                         self.data[i] = v
             else:
-                for k, v in zip(key, value, strict=True):
+                for k, v in zip(key, value, strict=False):
                     assert isinstance(v, self.dtype.type)
                     self.data[k] = v
 

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -120,7 +120,7 @@ class JSONArray(ExtensionArray):
             item = pd.api.indexers.check_array_indexer(self, item)
             if is_bool_dtype(item.dtype):
                 return type(self)._from_sequence(
-                    [x for x, m in zip(self, item) if m], dtype=self.dtype
+                    [x for x, m in zip(self, item, strict=True) if m], dtype=self.dtype
                 )
             # integer
             return type(self)([self.data[i] for i in item])
@@ -135,12 +135,12 @@ class JSONArray(ExtensionArray):
 
             if isinstance(key, np.ndarray) and key.dtype == "bool":
                 # masking
-                for i, (k, v) in enumerate(zip(key, value)):
+                for i, (k, v) in enumerate(zip(key, value, strict=True)):
                     if k:
                         assert isinstance(v, self.dtype.type)
                         self.data[i] = v
             else:
-                for k, v in zip(key, value):
+                for k, v in zip(key, value, strict=True):
                     assert isinstance(v, self.dtype.type)
                     self.data[k] = v
 

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -135,12 +135,12 @@ class JSONArray(ExtensionArray):
 
             if isinstance(key, np.ndarray) and key.dtype == "bool":
                 # masking
-                for i, (k, v) in enumerate(zip(key, value, strict=False)):
+                for i, (k, v) in enumerate(zip(key, value, strict=True)):
                     if k:
                         assert isinstance(v, self.dtype.type)
                         self.data[i] = v
             else:
-                for k, v in zip(key, value, strict=False):
+                for k, v in zip(key, value, strict=True):
                     assert isinstance(v, self.dtype.type)
                     self.data[k] = v
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -282,7 +282,7 @@ class TestArrowArray(base.ExtensionTests):
 
         if isinstance(right, type(left)):
             return left._from_sequence(
-                [a + b for (a, b) in zip(list(left), list(right))],
+                [a + b for (a, b) in zip(list(left), list(right), strict=True)],
                 dtype=dtype,
             )
         else:

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -126,7 +126,7 @@ class TestCategorical(base.ExtensionTests):
         s2 = pd.Series(orig_data2)
         result = s1.combine(s2, lambda x1, x2: x1 + x2)
         expected = pd.Series(
-            [a + b for (a, b) in zip(list(orig_data1), list(orig_data2))]
+            [a + b for (a, b) in zip(list(orig_data1), list(orig_data2), strict=True)]
         )
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -34,7 +34,10 @@ if TYPE_CHECKING:
 def make_data(n: int):
     left_array = np.random.default_rng(2).uniform(size=n).cumsum()
     right_array = left_array + np.random.default_rng(2).uniform(size=n)
-    return [Interval(left, right) for left, right in zip(left_array, right_array)]
+    return [
+        Interval(left, right)
+        for left, right in zip(left_array, right_array, strict=True)
+    ]
 
 
 @pytest.fixture

--- a/pandas/tests/frame/conftest.py
+++ b/pandas/tests/frame/conftest.py
@@ -50,7 +50,7 @@ def mixed_float_frame():
         {
             col: np.random.default_rng(2).random(30, dtype=dtype)
             for col, dtype in zip(
-                list("ABCD"), ["float32", "float32", "float32", "float64"]
+                list("ABCD"), ["float32", "float32", "float32", "float64"], strict=True
             )
         },
         index=Index([f"foo_{i}" for i in range(30)], dtype=object),
@@ -70,7 +70,9 @@ def mixed_int_frame():
     return DataFrame(
         {
             col: np.ones(30, dtype=dtype)
-            for col, dtype in zip(list("ABCD"), ["int32", "uint64", "uint8", "int64"])
+            for col, dtype in zip(
+                list("ABCD"), ["int32", "uint64", "uint8", "int64"], strict=True
+            )
         },
         index=Index([f"foo_{i}" for i in range(30)], dtype=object),
     )

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -29,7 +29,7 @@ class TestFromDict:
 
         result = DataFrame(data)
         expected = DataFrame.from_dict(
-            dict(zip(range(len(data)), data)), orient="index"
+            dict(zip(range(len(data)), data, strict=True)), orient="index"
         )
         tm.assert_frame_equal(result, expected.reindex(result.index))
 
@@ -37,9 +37,9 @@ class TestFromDict:
         data = [OrderedDict([["a", 1.5], ["b", 3], ["c", 4], ["d", 6]])]
 
         result = DataFrame(data)
-        expected = DataFrame.from_dict(dict(zip([0], data)), orient="index").reindex(
-            result.index
-        )
+        expected = DataFrame.from_dict(
+            dict(zip([0], data, strict=True)), orient="index"
+        ).reindex(result.index)
         tm.assert_frame_equal(result, expected)
 
     def test_constructor_list_of_series(self):
@@ -47,7 +47,7 @@ class TestFromDict:
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 4.0]]),
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 6.0]]),
         ]
-        sdict = OrderedDict(zip(["x", "y"], data))
+        sdict = OrderedDict(zip(["x", "y"], data, strict=True))
         idx = Index(["a", "b", "c"])
 
         # all named
@@ -66,7 +66,7 @@ class TestFromDict:
         ]
         result = DataFrame(data2)
 
-        sdict = OrderedDict(zip(["x", "Unnamed 0"], data))
+        sdict = OrderedDict(zip(["x", "Unnamed 0"], data, strict=True))
         expected = DataFrame.from_dict(sdict, orient="index")
         tm.assert_frame_equal(result, expected)
 
@@ -82,7 +82,7 @@ class TestFromDict:
         data = [Series(d) for d in data]
 
         result = DataFrame(data)
-        sdict = OrderedDict(zip(range(len(data)), data))
+        sdict = OrderedDict(zip(range(len(data)), data, strict=True))
         expected = DataFrame.from_dict(sdict, orient="index")
         tm.assert_frame_equal(result, expected.reindex(result.index))
 
@@ -97,7 +97,7 @@ class TestFromDict:
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 4.0]]),
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 6.0]]),
         ]
-        sdict = OrderedDict(zip(range(len(data)), data))
+        sdict = OrderedDict(zip(range(len(data)), data, strict=True))
 
         idx = Index(["a", "b", "c"])
         data2 = [Series([1.5, 3, 4], idx, dtype="O"), Series([1.5, 3, 6], idx)]

--- a/pandas/tests/frame/indexing/test_delitem.py
+++ b/pandas/tests/frame/indexing/test_delitem.py
@@ -52,7 +52,7 @@ class TestDataFrameDelItem:
     def test_delitem_col_still_multiindex(self):
         arrays = [["a", "b", "c", "top"], ["", "", "", "OD"], ["", "", "", "wx"]]
 
-        tuples = sorted(zip(*arrays))
+        tuples = sorted(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples)
 
         df = DataFrame(np.random.default_rng(2).standard_normal((3, 4)), columns=index)

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -114,8 +114,8 @@ class TestGetitemListLike:
             iter,
             Index,
             set,
-            lambda keys: dict(zip(keys, range(len(keys)))),
-            lambda keys: dict(zip(keys, range(len(keys)))).keys(),
+            lambda keys: dict(zip(keys, range(len(keys)), strict=True)),
+            lambda keys: dict(zip(keys, range(len(keys)), strict=True)).keys(),
         ],
         ids=["list", "iter", "Index", "set", "dict", "dict_keys"],
     )

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1523,7 +1523,7 @@ class TestDataFrameIndexing:
         # GH#57457
         columns = ["a"]
         data = [np.array([1, 2], dtype=">f8")]
-        df = DataFrame(dict(zip(columns, data)))
+        df = DataFrame(dict(zip(columns, data, strict=True)))
         result = df[df.columns]
         dfexp = DataFrame({"a": [1, 2]}, dtype=">f8")
         expected = dfexp[dfexp.columns]

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -663,7 +663,7 @@ class TestDataFrameSetItem:
         tm.assert_frame_equal(df, expected)
 
     def test_setitem_list_of_tuples(self, float_frame):
-        tuples = list(zip(float_frame["A"], float_frame["B"]))
+        tuples = list(zip(float_frame["A"], float_frame["B"], strict=True))
         float_frame["tuples"] = tuples
 
         result = float_frame["tuples"]

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -137,7 +137,7 @@ class TestXSWithMultiIndex:
             ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = list(zip(*arrays))
+        tuples = list(zip(*arrays, strict=True))
 
         index = MultiIndex.from_tuples(tuples, names=["first", "second"])
         df = DataFrame(

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -144,7 +144,7 @@ class TestDataFrameDrop:
 
         # non-unique - wheee!
         nu_df = DataFrame(
-            list(zip(range(3), range(-3, 1), list("abc"), strict=True)),
+            list(zip(range(3), range(-3, 1), list("abc"), strict=False)),
             columns=["a", "a", "b"],
         )
         tm.assert_frame_equal(nu_df.drop("a", axis=1), nu_df[["b"]])

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -144,7 +144,8 @@ class TestDataFrameDrop:
 
         # non-unique - wheee!
         nu_df = DataFrame(
-            list(zip(range(3), range(-3, 1), list("abc"))), columns=["a", "a", "b"]
+            list(zip(range(3), range(-3, 1), list("abc"), strict=True)),
+            columns=["a", "a", "b"],
         )
         tm.assert_frame_equal(nu_df.drop("a", axis=1), nu_df[["b"]])
         tm.assert_frame_equal(nu_df.drop("b", axis="columns"), nu_df["a"])
@@ -296,7 +297,7 @@ class TestDataFrameDrop:
             ["", "wx", "wy", "", "", ""],
         ]
 
-        tuples = sorted(zip(*arrays))
+        tuples = sorted(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples)
         df = DataFrame(np.random.default_rng(2).standard_normal((4, 6)), columns=index)
 

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -144,7 +144,7 @@ class TestDataFrameDrop:
 
         # non-unique - wheee!
         nu_df = DataFrame(
-            list(zip(range(3), range(-3, 1), list("abc"), strict=False)),
+            list(zip(range(3), range(-3, 1), list("abc"), strict=True)),
             columns=["a", "a", "b"],
         )
         tm.assert_frame_equal(nu_df.drop("a", axis=1), nu_df[["b"]])

--- a/pandas/tests/frame/methods/test_isin.py
+++ b/pandas/tests/frame/methods/test_isin.py
@@ -92,7 +92,7 @@ class TestDataFrameIsIn:
     def test_isin_tuples(self):
         # GH#16394
         df = DataFrame({"A": [1, 2, 3], "B": ["a", "b", "f"]})
-        df["C"] = list(zip(df["A"], df["B"]))
+        df["C"] = list(zip(df["A"], df["B"], strict=True))
         result = df["C"].isin([(1, "a")])
         tm.assert_series_equal(result, Series([True, False, False], name="C"))
 

--- a/pandas/tests/frame/methods/test_pop.py
+++ b/pandas/tests/frame/methods/test_pop.py
@@ -52,7 +52,7 @@ class TestDataFramePop:
             ["", "wx", "wy", "", "", ""],
         ]
 
-        tuples = sorted(zip(*arrays))
+        tuples = sorted(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples)
         df = DataFrame(np.random.default_rng(2).standard_normal((4, 6)), columns=index)
 

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -890,7 +890,7 @@ class TestDataFrameReplace:
         values = [-2, -1, "missing"]
         result = df.replace(to_rep, values)
         expected = df.copy()
-        for rep, value in zip(to_rep, values):
+        for rep, value in zip(to_rep, values, strict=True):
             return_value = expected.replace(rep, value, inplace=True)
             assert return_value is None
         tm.assert_frame_equal(result, expected)
@@ -1040,8 +1040,8 @@ class TestDataFrameReplace:
         # nested dictionary replacement
         df = DataFrame({"a": list(range(1, 5))})
 
-        result = df.replace({"a": dict(zip(range(1, 5), range(2, 6)))})
-        expected = df.replace(dict(zip(range(1, 5), range(2, 6))))
+        result = df.replace({"a": dict(zip(range(1, 5), range(2, 6), strict=True))})
+        expected = df.replace(dict(zip(range(1, 5), range(2, 6), strict=True)))
         tm.assert_frame_equal(result, expected)
 
     def test_nested_dict_overlapping_keys_replace_str(self):
@@ -1050,8 +1050,8 @@ class TestDataFrameReplace:
         astr = a.astype(str)
         bstr = np.arange(2, 6).astype(str)
         df = DataFrame({"a": astr})
-        result = df.replace(dict(zip(astr, bstr)))
-        expected = df.replace({"a": dict(zip(astr, bstr))})
+        result = df.replace(dict(zip(astr, bstr, strict=True)))
+        expected = df.replace({"a": dict(zip(astr, bstr, strict=True))})
         tm.assert_frame_equal(result, expected)
 
     def test_replace_swapping_bug(self):

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -113,7 +113,7 @@ class TestResetIndex:
         stacked.index.names = names
         deleveled = stacked.reset_index()
         for i, (lev, level_codes) in enumerate(
-            zip(stacked.index.levels, stacked.index.codes)
+            zip(stacked.index.levels, stacked.index.codes, strict=True)
         ):
             values = lev.take(level_codes)
             name = names[i]

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -132,7 +132,7 @@ class TestDataFrameToDict:
         ]
         assert isinstance(recons_data, list)
         assert len(recons_data) == 3
-        for left, right in zip(recons_data, expected_records):
+        for left, right in zip(recons_data, expected_records, strict=True):
             tm.assert_dict_equal(left, right)
 
         # GH#10844

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -78,7 +78,7 @@ class TestDataFrameMisc:
         # them in __dir__.
         df = DataFrame(
             [list("abcd"), list("efgh")],
-            columns=pd.MultiIndex.from_tuples(list(zip("ABCD", "EFGH"))),
+            columns=pd.MultiIndex.from_tuples(list(zip("ABCD", "EFGH", strict=True))),
         )
         for key in list("ABCD"):
             assert key in dir(df)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -374,9 +374,9 @@ class TestDataFrameConstructors:
                 for d in dtypes
             ]
 
-        for d, a in zip(dtypes, arrays):
+        for d, a in zip(dtypes, arrays, strict=True):
             assert a.dtype == d
-        ad.update(dict(zip(dtypes, arrays)))
+        ad.update(dict(zip(dtypes, arrays, strict=True)))
         df = DataFrame(ad)
 
         dtypes = MIXED_FLOAT_DTYPES + MIXED_INT_DTYPES
@@ -491,7 +491,7 @@ class TestDataFrameConstructors:
         nums = list(range(nitems))
         np.random.default_rng(2).shuffle(nums)
         expected = [f"A{i:d}" for i in nums]
-        df = DataFrame(OrderedDict(zip(expected, [[0]] * nitems)))
+        df = DataFrame(OrderedDict(zip(expected, [[0]] * nitems, strict=True)))
         assert expected == list(df.columns)
 
     def test_constructor_dict(self):
@@ -784,8 +784,12 @@ class TestDataFrameConstructors:
     def test_constructor_dict_cast2(self):
         # can't cast to float
         test_data = {
-            "A": dict(zip(range(20), [f"word_{i}" for i in range(20)])),
-            "B": dict(zip(range(15), np.random.default_rng(2).standard_normal(15))),
+            "A": dict(zip(range(20), [f"word_{i}" for i in range(20)], strict=True)),
+            "B": dict(
+                zip(
+                    range(15), np.random.default_rng(2).standard_normal(15), strict=True
+                )
+            ),
         }
         with pytest.raises(ValueError, match="could not convert string"):
             DataFrame(test_data, dtype=float)
@@ -1727,7 +1731,8 @@ class TestDataFrameConstructors:
             Index(["c", "d", "e"], name=name_in3),
         ]
         series = {
-            c: Series([0, 1, 2], index=i) for i, c in zip(indices, ["x", "y", "z"])
+            c: Series([0, 1, 2], index=i)
+            for i, c in zip(indices, ["x", "y", "z"], strict=True)
         }
         result = DataFrame(series)
 

--- a/pandas/tests/frame/test_iteration.py
+++ b/pandas/tests/frame/test_iteration.py
@@ -30,7 +30,7 @@ class TestIteration:
         # GH#17213, GH#13918
         cols = ["a", "b", "c"]
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=cols)
-        for c, (k, v) in zip(cols, df.items()):
+        for c, (k, v) in zip(cols, df.items(), strict=True):
             assert c == k
             assert isinstance(v, Series)
             assert (df[k] == v).all()

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1002,7 +1002,7 @@ class TestDataFrameQueryStrings:
             ops = 2 * ([eq] + [ne])
             msg = r"'(Not)?In' nodes are not implemented"
 
-            for lh, op_, rh in zip(lhs, ops, rhs):
+            for lh, op_, rh in zip(lhs, ops, rhs, strict=True):
                 ex = f"{lh} {op_} {rh}"
                 with pytest.raises(NotImplementedError, match=msg):
                     df.query(
@@ -1043,7 +1043,7 @@ class TestDataFrameQueryStrings:
             ops = 2 * ([eq] + [ne])
             msg = r"'(Not)?In' nodes are not implemented"
 
-            for lh, ops_, rh in zip(lhs, ops, rhs):
+            for lh, ops_, rh in zip(lhs, ops, rhs, strict=True):
                 ex = f"{lh} {ops_} {rh}"
                 with pytest.raises(NotImplementedError, match=msg):
                     df.query(ex, engine=engine, parser=parser)

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -864,7 +864,7 @@ class TestDataFrameReshape:
         assert udf.notna().values.sum() == len(df)
         mk_list = lambda a: list(a) if isinstance(a, tuple) else [a]
         rows, cols = udf["jolie"].notna().values.nonzero()
-        for i, j in zip(rows, cols):
+        for i, j in zip(rows, cols, strict=True):
             left = sorted(udf["jolie"].iloc[i, j].split("."))
             right = mk_list(udf["jolie"].index[i]) + mk_list(udf["jolie"].columns[j])
             right = sorted(map(cast, right))
@@ -928,7 +928,7 @@ class TestDataFrameReshape:
         assert udf.notna().values.sum() == 2 * len(df)
         mk_list = lambda a: list(a) if isinstance(a, tuple) else [a]
         rows, cols = udf[col].notna().values.nonzero()
-        for i, j in zip(rows, cols):
+        for i, j in zip(rows, cols, strict=True):
             left = sorted(udf[col].iloc[i, j].split("."))
             right = mk_list(udf[col].index[i]) + mk_list(udf[col].columns[j])
             right = sorted(map(cast, right))
@@ -946,7 +946,7 @@ class TestDataFrameReshape:
             [3, 0, 1, 2, np.nan, np.nan, np.nan, np.nan],
             [np.nan, np.nan, np.nan, np.nan, 4, 5, 6, 7],
         ]
-        vals = list(map(list, zip(*vals)))
+        vals = list(map(list, zip(*vals, strict=True)))
         idx = Index([np.nan, 0, 1, 2, 4, 5, 6, 7], name="B")
         cols = MultiIndex(
             levels=[["C"], ["a", "b"]], codes=[[0, 0], [0, 1]], names=[None, "A"]
@@ -1416,7 +1416,7 @@ def test_unstack_sort_false_nan(levels2, expected_columns):
     result = df.unstack(level="level2", sort=False)
     expected_data = [[0, 4], [1, 5], [2, 6], [3, 7]]
     expected = DataFrame(
-        dict(zip(expected_columns, expected_data)),
+        dict(zip(expected_columns, expected_data, strict=True)),
         index=Index(["b", "a"], name="level1"),
         columns=MultiIndex.from_tuples(expected_columns, names=[None, "level2"]),
     )

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -231,10 +231,10 @@ class TestDataFrameSubclassing:
         df = tm.SubclassedDataFrame(
             [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
 
@@ -250,7 +250,14 @@ class TestDataFrameSubclassing:
                 [41, 43],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AAAABBBB"), list("ccddccdd"), list("yzyzyzyz"))),
+                list(
+                    zip(
+                        list("AAAABBBB"),
+                        list("ccddccdd"),
+                        list("yzyzyzyz"),
+                        strict=True,
+                    )
+                ),
                 names=["aaa", "ccc", "yyy"],
             ),
             columns=Index(["W", "X"], name="www"),
@@ -274,7 +281,14 @@ class TestDataFrameSubclassing:
                 [42, 43],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AAAABBBB"), list("ccddccdd"), list("WXWXWXWX"))),
+                list(
+                    zip(
+                        list("AAAABBBB"),
+                        list("ccddccdd"),
+                        list("WXWXWXWX"),
+                        strict=True,
+                    )
+                ),
                 names=["aaa", "ccc", "www"],
             ),
             columns=Index(["y", "z"], name="yyy"),
@@ -293,10 +307,10 @@ class TestDataFrameSubclassing:
                 [40, 41, 42.0, 43.0],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
 
@@ -312,7 +326,14 @@ class TestDataFrameSubclassing:
                 [41, 43.0],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AAAABBBB"), list("ccddccdd"), list("yzyzyzyz"))),
+                list(
+                    zip(
+                        list("AAAABBBB"),
+                        list("ccddccdd"),
+                        list("yzyzyzyz"),
+                        strict=True,
+                    )
+                ),
                 names=["aaa", "ccc", "yyy"],
             ),
             columns=Index(["W", "X"], name="www"),
@@ -336,7 +357,14 @@ class TestDataFrameSubclassing:
                 [42.0, 43.0],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AAAABBBB"), list("ccddccdd"), list("WXWXWXWX"))),
+                list(
+                    zip(
+                        list("AAAABBBB"),
+                        list("ccddccdd"),
+                        list("WXWXWXWX"),
+                        strict=True,
+                    )
+                ),
                 names=["aaa", "ccc", "www"],
             ),
             columns=Index(["y", "z"], name="yyy"),
@@ -365,10 +393,10 @@ class TestDataFrameSubclassing:
         df = tm.SubclassedDataFrame(
             [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
 
@@ -376,7 +404,14 @@ class TestDataFrameSubclassing:
             [[10, 20, 11, 21, 12, 22, 13, 23], [30, 40, 31, 41, 32, 42, 33, 43]],
             index=Index(["A", "B"], name="aaa"),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWWWXXXX"), list("yyzzyyzz"), list("cdcdcdcd"))),
+                list(
+                    zip(
+                        list("WWWWXXXX"),
+                        list("yyzzyyzz"),
+                        list("cdcdcdcd"),
+                        strict=True,
+                    )
+                ),
                 names=["www", "yyy", "ccc"],
             ),
         )
@@ -391,7 +426,14 @@ class TestDataFrameSubclassing:
             [[10, 30, 11, 31, 12, 32, 13, 33], [20, 40, 21, 41, 22, 42, 23, 43]],
             index=Index(["c", "d"], name="ccc"),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWWWXXXX"), list("yyzzyyzz"), list("ABABABAB"))),
+                list(
+                    zip(
+                        list("WWWWXXXX"),
+                        list("yyzzyyzz"),
+                        list("ABABABAB"),
+                        strict=True,
+                    )
+                ),
                 names=["www", "yyy", "aaa"],
             ),
         )
@@ -409,10 +451,10 @@ class TestDataFrameSubclassing:
                 [40, 41, 42.0, 43.0],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
 
@@ -423,7 +465,14 @@ class TestDataFrameSubclassing:
             ],
             index=Index(["A", "B"], name="aaa"),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWWWXXXX"), list("yyzzyyzz"), list("cdcdcdcd"))),
+                list(
+                    zip(
+                        list("WWWWXXXX"),
+                        list("yyzzyyzz"),
+                        list("cdcdcdcd"),
+                        strict=True,
+                    )
+                ),
                 names=["www", "yyy", "ccc"],
             ),
         )
@@ -441,7 +490,14 @@ class TestDataFrameSubclassing:
             ],
             index=Index(["c", "d"], name="ccc"),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWWWXXXX"), list("yyzzyyzz"), list("ABABABAB"))),
+                list(
+                    zip(
+                        list("WWWWXXXX"),
+                        list("yyzzyyzz"),
+                        list("ABABABAB"),
+                        strict=True,
+                    )
+                ),
                 names=["www", "yyy", "aaa"],
             ),
         )
@@ -507,7 +563,7 @@ class TestDataFrameSubclassing:
                 "A1980": {0: "d", 1: "e", 2: "f"},
                 "B1970": {0: 2.5, 1: 1.2, 2: 0.7},
                 "B1980": {0: 3.2, 1: 1.3, 2: 0.1},
-                "X": dict(zip(range(3), x)),
+                "X": dict(zip(range(3), x, strict=True)),
             }
         )
 
@@ -604,10 +660,10 @@ class TestDataFrameSubclassing:
         df = tm.SubclassedDataFrame(
             [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
         result = df.count()

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -44,7 +44,7 @@ def test_unary_binary(request, dtype):
     assert len(result_pandas) == 2
     expected_numpy = np.modf(values)
 
-    for result, b in zip(result_pandas, expected_numpy):
+    for result, b in zip(result_pandas, expected_numpy, strict=True):
         expected = pd.DataFrame(b, index=df.index, columns=df.columns)
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -617,7 +617,7 @@ def test_groupby_as_index_cython(df):
     result = grouped.mean()
     expected = data.groupby(["A", "B"]).mean()
 
-    arrays = list(zip(*expected.index.values))
+    arrays = list(zip(*expected.index.values, strict=True))
     expected.insert(0, "A", arrays[0])
     expected.insert(1, "B", arrays[1])
     expected.index = RangeIndex(len(expected))
@@ -943,7 +943,8 @@ def test_groupby_with_hier_columns():
             *[
                 ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
                 ["one", "two", "one", "two", "one", "two", "one", "two"],
-            ]
+            ],
+            strict=True,
         )
     )
     index = MultiIndex.from_tuples(tuples)
@@ -1223,7 +1224,7 @@ def test_groupby_nat_exclude():
     ]
     keys = sorted(grouped.groups.keys())
     assert len(keys) == 2
-    for k, e in zip(keys, expected):
+    for k, e in zip(keys, expected, strict=True):
         # grouped.groups keys are np.datetime64 with system tz
         # not to be affected by tz, only compare values
         tm.assert_index_equal(grouped.groups[k], e)
@@ -1916,7 +1917,7 @@ def test_groupby_multiindex_nat():
 
 def test_groupby_empty_list_raises():
     # GH 5289
-    values = zip(range(10), range(10))
+    values = zip(range(10), range(10), strict=True)
     df = DataFrame(values, columns=["apple", "b"])
     msg = "Grouper and axis must be same length"
     with pytest.raises(ValueError, match=msg):
@@ -1971,12 +1972,14 @@ def test_groups_sort_dropna(sort, dropna):
     gb = df.groupby([0, 1], sort=sort, dropna=dropna)
     result = gb.groups
 
-    for result_key, expected_key in zip(result.keys(), expected.keys()):
+    for result_key, expected_key in zip(result.keys(), expected.keys(), strict=True):
         # Compare as NumPy arrays to handle np.nan
         result_key = np.array(result_key)
         expected_key = np.array(expected_key)
         tm.assert_numpy_array_equal(result_key, expected_key)
-    for result_value, expected_value in zip(result.values(), expected.values()):
+    for result_value, expected_value in zip(
+        result.values(), expected.values(), strict=True
+    ):
         tm.assert_index_equal(result_value, expected_value)
 
 

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -326,7 +326,7 @@ def test_groupby_apply_with_dropna_for_multi_index(dropna, data, selected_data, 
     gb = df.groupby("groups", dropna=dropna)
     result = gb.apply(lambda grp: pd.DataFrame({"values": range(len(grp))}))
 
-    mi_tuples = tuple(zip(data["groups"], selected_data["values"]))
+    mi_tuples = tuple(zip(data["groups"], selected_data["values"], strict=True))
     mi = pd.MultiIndex.from_tuples(mi_tuples, names=["groups", None])
     # Since right now, by default MI will drop NA from levels when we create MI
     # via `from_*`, so we need to add NA for level manually afterwards.
@@ -379,7 +379,9 @@ def test_groupby_nan_included():
         "g2": np.array([3], dtype=dtype),
         np.nan: np.array([1, 4], dtype=dtype),
     }
-    for result_values, expected_values in zip(result.values(), expected.values()):
+    for result_values, expected_values in zip(
+        result.values(), expected.values(), strict=True
+    ):
         tm.assert_numpy_array_equal(result_values, expected_values)
     assert np.isnan(list(result.keys())[2])
     assert list(result.keys())[0:2] == ["g1", "g2"]
@@ -618,7 +620,9 @@ def test_categorical_transformers(transformation_func, observed, sort, as_index)
     expected = getattr(gb_dropna, transformation_func)(*args)
 
     for iloc, value in zip(
-        df[df["x"].isnull()].index.tolist(), null_group_result.values.ravel()
+        df[df["x"].isnull()].index.tolist(),
+        null_group_result.values.ravel(),
+        strict=True,
     ):
         if expected.ndim == 1:
             expected.iloc[iloc] = value

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -326,7 +326,7 @@ def test_groupby_apply_with_dropna_for_multi_index(dropna, data, selected_data, 
     gb = df.groupby("groups", dropna=dropna)
     result = gb.apply(lambda grp: pd.DataFrame({"values": range(len(grp))}))
 
-    mi_tuples = tuple(zip(data["groups"], selected_data["values"], strict=True))
+    mi_tuples = tuple(zip(data["groups"], selected_data["values"], strict=False))
     mi = pd.MultiIndex.from_tuples(mi_tuples, names=["groups", None])
     # Since right now, by default MI will drop NA from levels when we create MI
     # via `from_*`, so we need to add NA for level manually afterwards.

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -326,7 +326,7 @@ def test_groupby_apply_with_dropna_for_multi_index(dropna, data, selected_data, 
     gb = df.groupby("groups", dropna=dropna)
     result = gb.apply(lambda grp: pd.DataFrame({"values": range(len(grp))}))
 
-    mi_tuples = tuple(zip(data["groups"], selected_data["values"], strict=False))
+    mi_tuples = tuple(zip(data["groups"], selected_data["values"], strict=True))
     mi = pd.MultiIndex.from_tuples(mi_tuples, names=["groups", None])
     # Since right now, by default MI will drop NA from levels when we create MI
     # via `from_*`, so we need to add NA for level manually afterwards.

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -300,7 +300,7 @@ class TestGrouping:
     def test_grouper_returning_tuples(self, func):
         # GH 22257 , both with dict and with callable
         df = DataFrame({"X": ["A", "B", "A", "B"], "Y": [1, 4, 3, 2]})
-        mapping = dict(zip(range(4), [("C", 5), ("D", 6)] * 2))
+        mapping = dict(zip(range(4), [("C", 5), ("D", 6)] * 2, strict=True))
 
         if func:
             gb = df.groupby(by=lambda idx: mapping[idx], sort=False)

--- a/pandas/tests/groupby/test_raises.py
+++ b/pandas/tests/groupby/test_raises.py
@@ -29,7 +29,7 @@ from pandas.tests.groupby import get_groupby_method_args
         lambda x: x % 2,
         [0, 0, 0, 1, 2, 2, 2, 3, 3],
         np.array([0, 0, 0, 1, 2, 2, 2, 3, 3]),
-        dict(zip(range(9), [0, 0, 0, 1, 2, 2, 2, 3, 3])),
+        dict(zip(range(9), [0, 0, 0, 1, 2, 2, 2, 3, 3], strict=True)),
         Series([1, 1, 1, 1, 1, 2, 2, 2, 2]),
         [Series([1, 1, 1, 1, 1, 2, 2, 2, 2]), Series([3, 3, 4, 4, 4, 4, 4, 3, 3])],
     ]

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -433,7 +433,7 @@ class TestGroupBy:
 
         for df in [df_original, df_reordered]:
             grouped = df.groupby(Grouper(freq="ME", key="Date"))
-            for t, expected in zip(dt_list, expected_list):
+            for t, expected in zip(dt_list, expected_list, strict=True):
                 dt = Timestamp(t)
                 result = grouped.get_group(dt)
                 tm.assert_frame_equal(result, expected)
@@ -448,7 +448,7 @@ class TestGroupBy:
 
         for df in [df_original, df_reordered]:
             grouped = df.groupby(["Buyer", Grouper(freq="ME", key="Date")])
-            for (b, t), expected in zip(g_list, expected_list):
+            for (b, t), expected in zip(g_list, expected_list, strict=True):
                 dt = Timestamp(t)
                 result = grouped.get_group((b, dt))
                 tm.assert_frame_equal(result, expected)
@@ -465,7 +465,7 @@ class TestGroupBy:
 
         for df in [df_original, df_reordered]:
             grouped = df.groupby(Grouper(freq="ME"))
-            for t, expected in zip(dt_list, expected_list):
+            for t, expected in zip(dt_list, expected_list, strict=True):
                 dt = Timestamp(t)
                 result = grouped.get_group(dt)
                 tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -950,7 +950,7 @@ def test_ffill_bfill_non_unique_multilevel(func, expected_status):
     result = getattr(df.groupby("symbol")["status"], func)()
 
     index = MultiIndex.from_tuples(
-        tuples=list(zip(*[date, symbol])), names=["date", "symbol"]
+        tuples=list(zip(*[date, symbol], strict=True)), names=["date", "symbol"]
     )
     expected = Series(expected_status, index=index, name="status")
 

--- a/pandas/tests/indexes/categorical/test_map.py
+++ b/pandas/tests/indexes/categorical/test_map.py
@@ -138,7 +138,7 @@ def test_map_with_dict_or_series():
     # Order of categories in result can be different
     tm.assert_index_equal(result, expected)
 
-    mapper = dict(zip(orig_values[:-1], new_values[:-1]))
+    mapper = dict(zip(orig_values[:-1], new_values[:-1], strict=True))
     result = cur_index.map(mapper)
     # Order of categories in result can be different
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -239,7 +239,7 @@ class TestDatetimeIndex:
         def _check_rng(rng):
             converted = rng.to_pydatetime()
             assert isinstance(converted, np.ndarray)
-            for x, stamp in zip(converted, rng):
+            for x, stamp in zip(converted, rng, strict=True):
                 assert isinstance(x, datetime)
                 assert x == stamp.to_pydatetime()
                 assert x.tzinfo == stamp.tzinfo
@@ -258,7 +258,7 @@ class TestDatetimeIndex:
         def _check_rng(rng):
             converted = rng.to_pydatetime()
             assert isinstance(converted, np.ndarray)
-            for x, stamp in zip(converted, rng):
+            for x, stamp in zip(converted, rng, strict=True):
                 assert isinstance(x, datetime)
                 assert x == stamp.to_pydatetime()
                 assert x.tzinfo == stamp.tzinfo
@@ -275,7 +275,7 @@ class TestDatetimeIndex:
         def _check_rng(rng):
             converted = rng.to_pydatetime()
             assert isinstance(converted, np.ndarray)
-            for x, stamp in zip(converted, rng):
+            for x, stamp in zip(converted, rng, strict=True):
                 assert isinstance(x, datetime)
                 assert x == stamp.to_pydatetime()
                 assert x.tzinfo == stamp.tzinfo

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -175,7 +175,7 @@ class TestDatetimeIndexRendering:
         )
 
         with pd.option_context("display.width", 300):
-            for index, expected in zip(idxs, exp):
+            for index, expected in zip(idxs, exp, strict=True):
                 index = index.as_unit(unit)
                 expected = expected.replace("[ns", f"[{unit}")
                 result = repr(index)
@@ -227,6 +227,7 @@ class TestDatetimeIndexRendering:
             for idx, expected in zip(
                 [idx1, idx2, idx3, idx4, idx5, idx6, idx7],
                 [exp1, exp2, exp3, exp4, exp5, exp6, exp7],
+                strict=True,
             ):
                 ser = Series(idx.as_unit(unit))
                 result = repr(ser)
@@ -264,7 +265,9 @@ class TestDatetimeIndexRendering:
         exp6 = """DatetimeIndex: 3 entries, 2011-01-01 09:00:00-05:00 to NaT"""
 
         for idx, expected in zip(
-            [idx1, idx2, idx3, idx4, idx5, idx6], [exp1, exp2, exp3, exp4, exp5, exp6]
+            [idx1, idx2, idx3, idx4, idx5, idx6],
+            [exp1, exp2, exp3, exp4, exp5, exp6],
+            strict=True,
         ):
             result = idx._summary()
             assert result == expected

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -279,7 +279,7 @@ class TestSlicing:
             # Timestamp with the same resolution as index
             # Should be exact match for Series (return scalar)
             # and raise KeyError for Frame
-            for timestamp, expected in zip(index, values):
+            for timestamp, expected in zip(index, values, strict=True):
                 ts_string = timestamp.strftime(formats[rnum])
                 # make ts_string as precise as index
                 result = df["a"][ts_string]
@@ -319,7 +319,7 @@ class TestSlicing:
 
             # Not compatible with existing key
             # Should raise KeyError
-            for fmt, res in list(zip(formats, resolutions))[rnum + 1 :]:
+            for fmt, res in list(zip(formats, resolutions, strict=True))[rnum + 1 :]:
                 ts = index[1] + Timedelta("1 " + res)
                 ts_string = ts.strftime(fmt)
                 msg = rf"^'{ts_string}'$"

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -184,7 +184,9 @@ class TestDatetimeIndexOps:
             "Saturday",
             "Sunday",
         ]
-        for day, name, eng_name in zip(range(4, 11), expected_days, english_days):
+        for day, name, eng_name in zip(
+            range(4, 11), expected_days, english_days, strict=True
+        ):
             name = name.capitalize()
             assert dti.day_name(locale=time_locale)[day] == name
             assert dti.day_name(locale=None)[day] == eng_name
@@ -206,7 +208,7 @@ class TestDatetimeIndexOps:
 
         tm.assert_index_equal(result, expected)
 
-        for item, expected in zip(dti, expected_months):
+        for item, expected in zip(dti, expected_months, strict=True):
             result = item.month_name(locale=time_locale)
             expected = expected.capitalize()
 

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -162,7 +162,7 @@ class TestDatetimeIndexTimezones:
         eastern_range = utc_range.tz_convert("US/Eastern")
         berlin_range = utc_range.tz_convert("Europe/Berlin")
 
-        for a, b, c in zip(utc_range, eastern_range, berlin_range):
+        for a, b, c in zip(utc_range, eastern_range, berlin_range, strict=True):
             assert a == b
             assert b == c
             assert a == c

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -333,7 +333,7 @@ class TestFromTuples(ConstructorTests):
         if len(breaks) == 0:
             return {"data": breaks}
 
-        tuples = list(zip(breaks[:-1], breaks[1:]))
+        tuples = list(zip(breaks[:-1], breaks[1:], strict=True))
         if isinstance(breaks, (list, tuple)):
             return {"data": tuples}
         elif isinstance(getattr(breaks, "dtype", None), CategoricalDtype):
@@ -386,7 +386,7 @@ class TestClassConstructors(ConstructorTests):
 
         ivs = [
             Interval(left, right, closed) if notna(left) else left
-            for left, right in zip(breaks[:-1], breaks[1:])
+            for left, right in zip(breaks[:-1], breaks[1:], strict=True)
         ]
 
         if isinstance(breaks, list):

--- a/pandas/tests/indexes/interval/test_formats.py
+++ b/pandas/tests/indexes/interval/test_formats.py
@@ -46,6 +46,7 @@ class TestIntervalIndexRendering:
                     for left, right in zip(
                         Index([329.973, 345.137], dtype="float64"),
                         Index([345.137, 360.191], dtype="float64"),
+                        strict=True,
                     )
                 ]
             ),

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -49,7 +49,7 @@ class TestIntervalIndex:
 
         ivs = [
             Interval(left, right, closed)
-            for left, right in zip(range(10), range(1, 11))
+            for left, right in zip(range(10), range(1, 11), strict=True)
         ]
         expected = np.array(ivs, dtype=object)
         tm.assert_numpy_array_equal(np.asarray(index), expected)
@@ -71,7 +71,7 @@ class TestIntervalIndex:
 
         ivs = [
             Interval(left, right, closed) if notna(left) else np.nan
-            for left, right in zip(expected_left, expected_right)
+            for left, right in zip(expected_left, expected_right, strict=True)
         ]
         expected = np.array(ivs, dtype=object)
         tm.assert_numpy_array_equal(np.asarray(index), expected)
@@ -789,14 +789,16 @@ class TestIntervalIndex:
     @pytest.mark.parametrize(
         "tuples",
         [
-            zip(range(10), range(1, 11)),
+            zip(range(10), range(1, 11), strict=True),
             zip(
                 date_range("20170101", periods=10),
                 date_range("20170101", periods=10),
+                strict=True,
             ),
             zip(
                 timedelta_range("0 days", periods=10),
                 timedelta_range("1 day", periods=10),
+                strict=True,
             ),
         ],
     )
@@ -811,11 +813,12 @@ class TestIntervalIndex:
     @pytest.mark.parametrize(
         "tuples",
         [
-            list(zip(range(10), range(1, 11))) + [np.nan],
+            list(zip(range(10), range(1, 11), strict=True)) + [np.nan],
             list(
                 zip(
                     date_range("20170101", periods=10),
                     date_range("20170101", periods=10),
+                    strict=True,
                 )
             )
             + [np.nan],
@@ -823,6 +826,7 @@ class TestIntervalIndex:
                 zip(
                     timedelta_range("0 days", periods=10),
                     timedelta_range("1 day", periods=10),
+                    strict=True,
                 )
             )
             + [np.nan],

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -185,7 +185,7 @@ def test_map(idx):
 @pytest.mark.parametrize(
     "mapper",
     [
-        lambda values, idx: {i: e for e, i in zip(values, idx)},
+        lambda values, idx: {i: e for e, i in zip(values, idx, strict=True)},
         lambda values, idx: pd.Series(values, idx),
     ],
 )

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -155,7 +155,7 @@ def test_copy_in_constructor():
 def test_from_arrays(idx):
     arrays = [
         np.asarray(lev).take(level_codes)
-        for lev, level_codes in zip(idx.levels, idx.codes)
+        for lev, level_codes in zip(idx.levels, idx.codes, strict=True)
     ]
 
     # list of arrays as input
@@ -172,7 +172,7 @@ def test_from_arrays_iterator(idx):
     # GH 18434
     arrays = [
         np.asarray(lev).take(level_codes)
-        for lev, level_codes in zip(idx.levels, idx.codes)
+        for lev, level_codes in zip(idx.levels, idx.codes, strict=True)
     ]
 
     # iterator as input
@@ -188,7 +188,7 @@ def test_from_arrays_iterator(idx):
 def test_from_arrays_tuples(idx):
     arrays = tuple(
         tuple(np.asarray(lev).take(level_codes))
-        for lev, level_codes in zip(idx.levels, idx.codes)
+        for lev, level_codes in zip(idx.levels, idx.codes, strict=True)
     )
 
     # tuple of tuples as input
@@ -368,7 +368,7 @@ def test_from_tuples_iterator():
         levels=[[1, 3], [2, 4]], codes=[[0, 1], [0, 1]], names=["a", "b"]
     )
 
-    result = MultiIndex.from_tuples(zip([1, 3], [2, 4]), names=["a", "b"])
+    result = MultiIndex.from_tuples(zip([1, 3], [2, 4], strict=True), names=["a", "b"])
     tm.assert_index_equal(result, expected)
 
     # input non-iterables

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -223,7 +223,7 @@ def test_equals_missing_values_differently_sorted():
 
 
 def test_is_():
-    mi = MultiIndex.from_tuples(zip(range(10), range(10)))
+    mi = MultiIndex.from_tuples(zip(range(10), range(10), strict=True))
     assert mi.is_(mi)
     assert mi.is_(mi.view())
     assert mi.is_(mi.view().view().view().view())

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -15,7 +15,7 @@ def assert_matching(actual, expected, check_dtype=False):
     # avoid specifying internal representation
     # as much as possible
     assert len(actual) == len(expected)
-    for act, exp in zip(actual, expected):
+    for act, exp in zip(actual, expected, strict=True):
         act = np.asarray(act)
         exp = np.asarray(exp)
         tm.assert_numpy_array_equal(act, exp, check_dtype=check_dtype)

--- a/pandas/tests/indexes/period/methods/test_asfreq.py
+++ b/pandas/tests/indexes/period/methods/test_asfreq.py
@@ -106,7 +106,7 @@ class TestPeriodIndex:
     def test_asfreq_combined_pi(self):
         pi = PeriodIndex(["2001-01-01 00:00", "2001-01-02 02:00", "NaT"], freq="h")
         exp = PeriodIndex(["2001-01-01 00:00", "2001-01-02 02:00", "NaT"], freq="25h")
-        for freq, how in zip(["1D1h", "1h1D"], ["S", "E"]):
+        for freq, how in zip(["1D1h", "1h1D"], ["S", "E"], strict=True):
             result = pi.asfreq(freq, how=how)
             tm.assert_index_equal(result, exp)
             assert result.freq == exp.freq

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -430,7 +430,7 @@ class TestPeriodIndex:
         year = Series([2001, 2002, 2003])
         quarter = year - 2000
         idx = PeriodIndex.from_fields(year=year, quarter=quarter)
-        strs = [f"{t[0]:d}Q{t[1]:d}" for t in zip(quarter, year)]
+        strs = [f"{t[0]:d}Q{t[1]:d}" for t in zip(quarter, year, strict=True)]
         lops = list(map(Period, strs))
         p = PeriodIndex(lops)
         tm.assert_index_equal(p, idx)

--- a/pandas/tests/indexes/period/test_formats.py
+++ b/pandas/tests/indexes/period/test_formats.py
@@ -84,6 +84,7 @@ class TestPeriodIndexRendering:
         for idx, expected in zip(
             [idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9, idx10],
             [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9, exp10],
+            strict=True,
         ):
             result = getattr(idx, method)()
             assert result == expected
@@ -141,6 +142,7 @@ dtype: period[Q-DEC]"""
         for idx, expected in zip(
             [idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9],
             [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9],
+            strict=True,
         ):
             result = repr(Series(idx))
             assert result == expected
@@ -188,6 +190,7 @@ Freq: Q-DEC"""
         for idx, expected in zip(
             [idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9],
             [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9],
+            strict=True,
         ):
             result = idx._summary()
             assert result == expected

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -102,7 +102,7 @@ class TestPeriodIndex:
 
         field_idx = getattr(periodindex, field)
         assert len(periodindex) == len(field_idx)
-        for x, val in zip(periods, field_idx):
+        for x, val in zip(periods, field_idx, strict=True):
             assert getattr(x, field) == val
 
         if len(ser) == 0:
@@ -110,7 +110,7 @@ class TestPeriodIndex:
 
         field_s = getattr(ser.dt, field)
         assert len(periodindex) == len(field_s)
-        for x, val in zip(periods, field_s):
+        for x, val in zip(periods, field_s, strict=True):
             assert getattr(x, field) == val
 
     def test_is_(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -534,7 +534,7 @@ class TestIndex:
         # Test that returning a single object from a MultiIndex
         #   returns an Index.
         first_level = ["foo", "bar", "baz"]
-        multi_index = MultiIndex.from_tuples(zip(first_level, [1, 2, 3]))
+        multi_index = MultiIndex.from_tuples(zip(first_level, [1, 2, 3], strict=True))
         reduced_index = multi_index.map(lambda x: x[0])
         tm.assert_index_equal(reduced_index, Index(first_level))
 
@@ -562,7 +562,7 @@ class TestIndex:
     @pytest.mark.parametrize(
         "mapper",
         [
-            lambda values, index: {i: e for e, i in zip(values, index)},
+            lambda values, index: {i: e for e, i in zip(values, index, strict=True)},
             lambda values, index: Series(values, index),
         ],
     )
@@ -576,7 +576,7 @@ class TestIndex:
     @pytest.mark.parametrize(
         "mapper",
         [
-            lambda values, index: {i: e for e, i in zip(values, index)},
+            lambda values, index: {i: e for e, i in zip(values, index, strict=True)},
             lambda values, index: Series(values, index),
         ],
     )

--- a/pandas/tests/indexes/test_datetimelike.py
+++ b/pandas/tests/indexes/test_datetimelike.py
@@ -109,7 +109,7 @@ class TestDatetimeLike:
     @pytest.mark.parametrize(
         "mapper",
         [
-            lambda values, index: {i: e for e, i in zip(values, index)},
+            lambda values, index: {i: e for e, i in zip(values, index, strict=True)},
             lambda values, index: pd.Series(values, index, dtype=object),
         ],
     )

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -669,7 +669,7 @@ class TestBase:
     @pytest.mark.parametrize(
         "mapper",
         [
-            lambda values, index: {i: e for e, i in zip(values, index)},
+            lambda values, index: {i: e for e, i in zip(values, index, strict=True)},
             lambda values, index: Series(values, index),
         ],
     )

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -914,7 +914,9 @@ class TestSetOpsUnsorted:
             op(a)
 
     def test_symmetric_difference_mi(self, sort):
-        index1 = MultiIndex.from_tuples(zip(["foo", "bar", "baz"], [1, 2, 3]))
+        index1 = MultiIndex.from_tuples(
+            zip(["foo", "bar", "baz"], [1, 2, 3], strict=True)
+        )
         index2 = MultiIndex.from_tuples([("foo", 1), ("bar", 3)])
         result = index1.symmetric_difference(index2, sort=sort)
         expected = MultiIndex.from_tuples([("bar", 2), ("baz", 3), ("bar", 3)])

--- a/pandas/tests/indexes/timedeltas/test_formats.py
+++ b/pandas/tests/indexes/timedeltas/test_formats.py
@@ -46,7 +46,9 @@ class TestTimedeltaIndexRendering:
 
         with pd.option_context("display.width", 300):
             for idx, expected in zip(
-                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5]
+                [idx1, idx2, idx3, idx4, idx5],
+                [exp1, exp2, exp3, exp4, exp5],
+                strict=True,
             ):
                 result = getattr(idx, method)()
                 assert result == expected
@@ -76,7 +78,9 @@ class TestTimedeltaIndexRendering:
 
         with pd.option_context("display.width", 300):
             for idx, expected in zip(
-                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5]
+                [idx1, idx2, idx3, idx4, idx5],
+                [exp1, exp2, exp3, exp4, exp5],
+                strict=True,
             ):
                 result = repr(Series(idx))
                 assert result == expected
@@ -100,7 +104,7 @@ class TestTimedeltaIndexRendering:
         exp5 = "TimedeltaIndex: 3 entries, 1 days 00:00:01 to 3 days 00:00:00"
 
         for idx, expected in zip(
-            [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5]
+            [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5], strict=True
         ):
             result = idx._summary()
             assert result == expected

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -45,21 +45,21 @@ class TestIntervalIndex:
         idx = IntervalIndex.from_tuples(tpls, closed=closed)
         ser = Series(list("abc"), idx)
 
-        for key, expected in zip(idx.left, ser):
+        for key, expected in zip(idx.left, ser, strict=True):
             if idx.closed_left:
                 assert indexer_sl(ser)[key] == expected
             else:
                 with pytest.raises(KeyError, match=str(key)):
                     indexer_sl(ser)[key]
 
-        for key, expected in zip(idx.right, ser):
+        for key, expected in zip(idx.right, ser, strict=True):
             if idx.closed_right:
                 assert indexer_sl(ser)[key] == expected
             else:
                 with pytest.raises(KeyError, match=str(key)):
                     indexer_sl(ser)[key]
 
-        for key, expected in zip(idx.mid, ser):
+        for key, expected in zip(idx.mid, ser, strict=True):
             assert indexer_sl(ser)[key] == expected
 
     def test_getitem_non_matching(self, series_with_interval_index, indexer_sl):

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -206,7 +206,7 @@ def test_frame_mixed_depth_get():
         ["", "wx", "wy", "", "", ""],
     ]
 
-    tuples = sorted(zip(*arrays))
+    tuples = sorted(zip(*arrays, strict=True))
     index = MultiIndex.from_tuples(tuples)
     df = DataFrame(np.random.default_rng(2).standard_normal((4, 6)), columns=index)
 

--- a/pandas/tests/indexing/multiindex/test_iloc.py
+++ b/pandas/tests/indexing/multiindex/test_iloc.py
@@ -65,7 +65,7 @@ def test_iloc_returns_scalar(simple_multiindex_dataframe):
 
 def test_iloc_getitem_multiple_items():
     # GH 5528
-    tup = zip(*[["a", "a", "b", "b"], ["x", "y", "x", "y"]])
+    tup = zip(*[["a", "a", "b", "b"], ["x", "y", "x", "y"]], strict=True)
     index = MultiIndex.from_tuples(tup)
     df = DataFrame(np.random.default_rng(2).standard_normal((4, 4)), index=index)
     result = df.iloc[[2, 3]]
@@ -156,7 +156,7 @@ def test_iloc_setitem_int_multiindex_series(data, indexes, values, expected_k):
     df = df.set_index(["i", "j"])
 
     series = df.k.copy()
-    for i, v in zip(indexes, values):
+    for i, v in zip(indexes, values, strict=True):
         series.iloc[i] += v
 
     df["k"] = expected_k

--- a/pandas/tests/indexing/multiindex/test_indexing_slow.py
+++ b/pandas/tests/indexing/multiindex/test_indexing_slow.py
@@ -35,7 +35,7 @@ def vals(n):
         np.random.default_rng(2).choice(list("ZYXWVUTSRQ"), n),
         np.random.default_rng(2).standard_normal(n),
     ]
-    vals = list(map(tuple, zip(*vals)))
+    vals = list(map(tuple, zip(*vals, strict=True)))
     return vals
 
 
@@ -50,7 +50,7 @@ def keys(n, m, vals):
         ),
         np.random.default_rng(2).choice(list("ZYXWVUTSRQP"), m),
     ]
-    keys = list(map(tuple, zip(*keys)))
+    keys = list(map(tuple, zip(*keys, strict=True)))
     keys += [t[:-1] for t in vals[:: n // m]]
     return keys
 

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -341,7 +341,7 @@ class TestMultiIndexLoc:
         # of all the valid types
         indexer = tuple(
             convert_nested_indexer(indexer_type, k)
-            for indexer_type, k in zip(types, keys)
+            for indexer_type, k in zip(types, keys, strict=True)
         )
         if indexer_type_1 is set or indexer_type_2 is set:
             with pytest.raises(TypeError, match="as an indexer is not supported"):

--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -457,7 +457,7 @@ class TestSetitemWithExpansionMultiIndex:
             ["", "wx", "wy", "", "", ""],
         ]
 
-        tuples = sorted(zip(*arrays))
+        tuples = sorted(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples)
         df = DataFrame(np.random.default_rng(2).standard_normal((4, 6)), columns=index)
 

--- a/pandas/tests/indexing/multiindex/test_sorted.py
+++ b/pandas/tests/indexing/multiindex/test_sorted.py
@@ -65,7 +65,7 @@ class TestMultiIndexSorted:
             ["bar", "bar", "baz", "baz", "qux", "qux", "foo", "foo"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = zip(*arrays)
+        tuples = zip(*arrays, strict=True)
         index = MultiIndex.from_tuples(tuples)
         index = index.sort_values(  # sort by third letter
             key=lambda x: x.map(lambda entry: entry[2])
@@ -76,7 +76,7 @@ class TestMultiIndexSorted:
             ["foo", "foo", "bar", "bar", "qux", "qux", "baz", "baz"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = zip(*arrays)
+        tuples = zip(*arrays, strict=True)
         index = MultiIndex.from_tuples(tuples)
         expected = DataFrame(range(8), index=index)
 
@@ -117,7 +117,7 @@ class TestMultiIndexSorted:
         df = frame.T
         df["foo", "four"] = "foo"
 
-        arrays = [np.array(x) for x in zip(*df.columns.values)]
+        arrays = [np.array(x) for x in zip(*df.columns.values, strict=True)]
 
         result = df["foo"]
         result2 = df.loc[:, "foo"]
@@ -139,11 +139,11 @@ class TestMultiIndexSorted:
             ["bar", "bar", "baz", "baz", "qux", "qux", "foo", "foo"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = zip(*arrays)
+        tuples = zip(*arrays, strict=True)
         index = MultiIndex.from_tuples(tuples)
         s = Series(np.random.default_rng(2).standard_normal(8), index=index)
 
-        arrays = [np.array(x) for x in zip(*index.values)]
+        arrays = [np.array(x) for x in zip(*index.values, strict=True)]
 
         result = s["qux"]
         result2 = s.loc["qux"]

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -816,7 +816,7 @@ class TestReplaceSeriesCoercion(CoercionBase):
         Object we will pass to `Series.replace`
         """
         if how == "dict":
-            replacer = dict(zip(self.rep[from_key], self.rep[to_key]))
+            replacer = dict(zip(self.rep[from_key], self.rep[to_key], strict=True))
         elif how == "series":
             replacer = pd.Series(self.rep[to_key], index=self.rep[from_key])
         else:

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1123,7 +1123,7 @@ class TestLocBaseIndependent:
 
     def test_loc_copy_vs_view(self, request):
         # GH 15631
-        x = DataFrame(zip(range(3), range(3)), columns=["a", "b"])
+        x = DataFrame(zip(range(3), range(3), strict=True), columns=["a", "b"])
 
         y = x.copy()
         q = y.loc[:, "a"]
@@ -1803,6 +1803,7 @@ class TestLocWithMultiIndex:
             zip(
                 ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
                 ["one", "two", "one", "two", "one", "two", "one", "two"],
+                strict=True,
             ),
             names=["first", "second"],
         )
@@ -2585,7 +2586,7 @@ class TestLocBooleanMask:
             [0, 1, 2, 10, 4, 5, 6, 7, 8, 9],
             [10, 10, 10, 3, 4, 5, 6, 7, 8, 9],
         ]
-        for cond, data in zip(conditions, expected_data):
+        for cond, data in zip(conditions, expected_data, strict=True):
             result = df.copy()
             result.loc[cond, "x"] = 10
 

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -360,7 +360,7 @@ class TestBlock:
             new_block(values[[1]], placement=BlockPlacement([1]), ndim=2),
             new_block(values[[2]], placement=BlockPlacement([6]), ndim=2),
         ]
-        for res, exp in zip(result, expected):
+        for res, exp in zip(result, expected, strict=True):
             assert_block_equal(res, exp)
 
 
@@ -485,7 +485,7 @@ class TestBlockManager:
 
     def test_copy(self, mgr):
         cp = mgr.copy(deep=False)
-        for blk, cp_blk in zip(mgr.blocks, cp.blocks):
+        for blk, cp_blk in zip(mgr.blocks, cp.blocks, strict=True):
             # view assertion
             tm.assert_equal(cp_blk.values, blk.values)
             if isinstance(blk.values, np.ndarray):
@@ -498,7 +498,7 @@ class TestBlockManager:
         #  fail is mgr is not consolidated
         mgr._consolidate_inplace()
         cp = mgr.copy(deep=True)
-        for blk, cp_blk in zip(mgr.blocks, cp.blocks):
+        for blk, cp_blk in zip(mgr.blocks, cp.blocks, strict=True):
             bvals = blk.values
             cpvals = cp_blk.values
 

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -73,9 +73,11 @@ def test_styler_to_excel_unstyled(engine, tmp_excel):
 
     openpyxl = pytest.importorskip("openpyxl")  # test loading only with openpyxl
     with contextlib.closing(openpyxl.load_workbook(tmp_excel)) as wb:
-        for col1, col2 in zip(wb["dataframe"].columns, wb["unstyled"].columns):
+        for col1, col2 in zip(
+            wb["dataframe"].columns, wb["unstyled"].columns, strict=True
+        ):
             assert len(col1) == len(col2)
-            for cell1, cell2 in zip(col1, col2):
+            for cell1, cell2 in zip(col1, col2, strict=True):
                 assert cell1.value == cell2.value
                 assert_equal_cell_styles(cell1, cell2)
 

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -161,7 +161,7 @@ class TestRoundTrip:
         sheets = ["AAA", "BBB", "CCC"]
 
         dfs = [tdf(s) for s in sheets]
-        dfs = dict(zip(sheets, dfs))
+        dfs = dict(zip(sheets, dfs, strict=True))
 
         with ExcelWriter(tmp_excel) as ew:
             for sheetname, df in dfs.items():

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -550,7 +550,7 @@ class TestStyler:
         v = [("color", "white"), ("size", "10px")]
         expected = {(0, 0): v, (1, 0): v}
         assert result.keys() == expected.keys()
-        for v1, v2 in zip(result.values(), expected.values()):
+        for v1, v2 in zip(result.values(), expected.values(), strict=True):
             assert sorted(v1) == sorted(v2)
 
     def test_set_properties_subset(self):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -109,7 +109,7 @@ class TestDataFrameFormatting:
 
             adj = printing.get_adjustment()
 
-            for line, value in zip(r.split("\n"), df["B"]):
+            for line, value in zip(r.split("\n"), df["B"], strict=True):
                 if adj.len(value) + 1 > max_len:
                     assert "..." in line
                 else:
@@ -1742,7 +1742,7 @@ class TestSeriesFormatting:
             ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = list(zip(*arrays))
+        tuples = list(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples, names=["first", "second"])
         s = Series(np.random.default_rng(2).standard_normal(8), index=index)
 

--- a/pandas/tests/io/formats/test_ipython_compat.py
+++ b/pandas/tests/io/formats/test_ipython_compat.py
@@ -20,7 +20,7 @@ class TestTableSchemaRepr:
 
         opt = cf.option_context("display.html.table_schema", True)
         last_obj = None
-        for obj, expected in zip(objects, expected_keys):
+        for obj, expected in zip(objects, expected_keys, strict=True):
             last_obj = obj
             with cf.option_context("display.html.table_schema", True):
                 # Can't reuse opt on all systems GH#58055

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -80,7 +80,7 @@ class TestDataFrameToStringFormatters:
             ("object", lambda x: f"-{x!s}-"),
         ]
         result = df.to_string(formatters=dict(formatters))
-        result2 = df.to_string(formatters=list(zip(*formatters))[1])
+        result2 = df.to_string(formatters=list(zip(*formatters, strict=True))[1])
         assert result == (
             "  int  float    object\n"
             "0 0x1 [ 1.0]  -(1, 2)-\n"
@@ -207,7 +207,7 @@ class TestDataFrameToStringColSpace:
     def test_to_string_repr_tuples(self):
         buf = StringIO()
 
-        df = DataFrame({"tups": list(zip(range(10), range(10)))})
+        df = DataFrame({"tups": list(zip(range(10), range(10), strict=True))})
         repr(df)
         df.to_string(col_space=10, buf=buf)
 

--- a/pandas/tests/io/generate_legacy_storage_files.py
+++ b/pandas/tests/io/generate_legacy_storage_files.py
@@ -161,7 +161,8 @@ def create_pickle_data():
                     *[
                         ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
                         ["one", "two", "one", "two", "one", "two", "one", "two"],
-                    ]
+                    ],
+                    strict=True,
                 )
             ),
             names=["first", "second"],
@@ -178,7 +179,8 @@ def create_pickle_data():
         "mi": Series(
             np.arange(5).astype(np.float64),
             index=MultiIndex.from_tuples(
-                tuple(zip(*[[1, 1, 2, 2, 2], [3, 4, 3, 4, 5]])), names=["one", "two"]
+                tuple(zip(*[[1, 1, 2, 2, 2], [3, 4, 3, 4, 5]], strict=True)),
+                names=["one", "two"],
             ),
         ),
         "dup": Series(np.arange(5).astype(np.float64), index=["A", "B", "C", "D", "A"]),
@@ -203,7 +205,8 @@ def create_pickle_data():
                         *[
                             ["bar", "bar", "baz", "baz", "baz"],
                             ["one", "two", "one", "two", "three"],
-                        ]
+                        ],
+                        strict=True,
                     )
                 ),
                 names=["first", "second"],

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -184,7 +184,7 @@ def _get_all_parser_float_precision_combinations():
     """
     params = []
     ids = []
-    for parser, parser_id in zip(_all_parsers, _all_parser_ids):
+    for parser, parser_id in zip(_all_parsers, _all_parser_ids, strict=True):
         if hasattr(parser, "values"):
             # Wrapped in pytest.param, get the actual parser back
             parser = parser.values[0]

--- a/pandas/tests/io/parser/dtypes/test_categorical.py
+++ b/pandas/tests/io/parser/dtypes/test_categorical.py
@@ -170,7 +170,7 @@ def test_categorical_dtype_chunksize_infer_categories(all_parsers):
     with parser.read_csv(
         StringIO(data), dtype={"b": "category"}, chunksize=2
     ) as actuals:
-        for actual, expected in zip(actuals, expecteds):
+        for actual, expected in zip(actuals, expecteds, strict=True):
             tm.assert_frame_equal(actual, expected)
 
 
@@ -199,7 +199,7 @@ def test_categorical_dtype_chunksize_explicit_categories(all_parsers):
         return
 
     with parser.read_csv(StringIO(data), dtype={"b": dtype}, chunksize=2) as actuals:
-        for actual, expected in zip(actuals, expecteds):
+        for actual, expected in zip(actuals, expecteds, strict=True):
             tm.assert_frame_equal(actual, expected)
 
 

--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -572,7 +572,7 @@ def test_multi_index_unnamed(all_parsers, index_col, columns):
 
         exp_columns.append(col)
 
-    columns = MultiIndex.from_tuples(zip(exp_columns, ["0", "1"], strict=True))
+    columns = MultiIndex.from_tuples(zip(exp_columns, ["0", "1"], strict=False))
     expected = DataFrame([[2, 3], [4, 5]], columns=columns)
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -572,7 +572,7 @@ def test_multi_index_unnamed(all_parsers, index_col, columns):
 
         exp_columns.append(col)
 
-    columns = MultiIndex.from_tuples(zip(exp_columns, ["0", "1"]))
+    columns = MultiIndex.from_tuples(zip(exp_columns, ["0", "1"], strict=True))
     expected = DataFrame([[2, 3], [4, 5]], columns=columns)
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -398,7 +398,7 @@ good{sep}bye
         {"0": "foo", "1": "bar"},
         {"0": "good", "1": "bye"},
     ]
-    for i, (result, expected) in enumerate(zip(result_iter, expecteds)):
+    for i, (result, expected) in enumerate(zip(result_iter, expecteds, strict=True)):
         expected = DataFrame(expected, index=range(i, i + 1))
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -121,7 +121,7 @@ def test_complex_across_dimensions_fixed(tmp_path, setup_path):
 
     objs = [s, df]
     comps = [tm.assert_series_equal, tm.assert_frame_equal]
-    for obj, comp in zip(objs, comps):
+    for obj, comp in zip(objs, comps, strict=True):
         path = tmp_path / setup_path
         obj.to_hdf(path, key="obj", format="fixed")
         reread = read_hdf(path, "obj")

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -1017,7 +1017,7 @@ def test_query_compare_column_type(setup_path):
                     store.select("test", where=query)
 
             for v, col in zip(
-                ["1", "1.1", "2014-01-01"], ["int", "float", "real_date"]
+                ["1", "1.1", "2014-01-01"], ["int", "float", "real_date"], strict=True
             ):
                 query = f"{col} {op} v"
                 result = store.select("test", where=query)
@@ -1050,6 +1050,7 @@ def test_select_large_integer(tmp_path):
         zip(
             ["a", "b", "c", "d"],
             [-9223372036854775801, -9223372036854775802, -9223372036854775803, 123],
+            strict=True,
         ),
         columns=["x", "y"],
     )

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -122,7 +122,7 @@ def test_encoding_options(datapath):
 
     with contextlib.closing(SAS7BDATReader(fname, convert_header_text=False)) as rdr:
         df3 = rdr.read()
-    for x, y in zip(df1.columns, df3.columns):
+    for x, y in zip(df1.columns, df3.columns, strict=True):
         assert x == y.decode()
 
 

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -138,7 +138,7 @@ def assert_equal_zip_safe(result: bytes, expected: bytes, compression: str):
             zipfile.ZipFile(BytesIO(result)) as exp,
             zipfile.ZipFile(BytesIO(expected)) as res,
         ):
-            for res_info, exp_info in zip(res.infolist(), exp.infolist()):
+            for res_info, exp_info in zip(res.infolist(), exp.infolist(), strict=True):
                 assert res_info.CRC == exp_info.CRC
     elif compression == "tar":
         with (
@@ -146,7 +146,7 @@ def assert_equal_zip_safe(result: bytes, expected: bytes, compression: str):
             tarfile.open(fileobj=BytesIO(expected)) as tar_res,
         ):
             for tar_res_info, tar_exp_info in zip(
-                tar_res.getmembers(), tar_exp.getmembers()
+                tar_res.getmembers(), tar_exp.getmembers(), strict=True
             ):
                 actual_file = tar_res.extractfile(tar_res_info)
                 expected_file = tar_exp.extractfile(tar_exp_info)

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -61,7 +61,7 @@ def assert_framelist_equal(list1, list2, *args, **kwargs):
         )
     )
     assert both_frames, msg
-    for frame_i, frame_j in zip(list1, list2):
+    for frame_i, frame_j in zip(list1, list2, strict=True):
         tm.assert_frame_equal(frame_i, frame_j, *args, **kwargs)
         assert not frame_i.empty, "frames are both empty"
 

--- a/pandas/tests/io/test_orc.py
+++ b/pandas/tests/io/test_orc.py
@@ -51,7 +51,7 @@ def test_orc_reader_empty(dirpath, using_infer_string):
         "str" if using_infer_string else "object",
     ]
     expected = pd.DataFrame(index=pd.RangeIndex(0))
-    for colname, dtype in zip(columns, dtypes):
+    for colname, dtype in zip(columns, dtypes, strict=True):
         expected[colname] = pd.Series(dtype=dtype)
     expected.columns = expected.columns.astype("str")
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -191,7 +191,7 @@ def create_and_load_iris(conn, iris_file: Path):
     with iris_file.open(newline=None, encoding="utf-8") as csvfile:
         reader = csv.reader(csvfile)
         header = next(reader)
-        params = [dict(zip(header, row)) for row in reader]
+        params = [dict(zip(header, row, strict=True)) for row in reader]
         stmt = insert(iris).values(params)
         with conn.begin() as con:
             iris.drop(con, checkfirst=True)
@@ -1208,7 +1208,7 @@ def test_to_sql_callable(conn, test_frame1, request):
 
     def sample(pd_table, conn, keys, data_iter):
         check.append(1)
-        data = [dict(zip(keys, row)) for row in data_iter]
+        data = [dict(zip(keys, row, strict=True)) for row in data_iter]
         conn.execute(pd_table.table.insert(), data)
 
     with pandasSQL_builder(conn, need_transaction=True) as pandasSQL:
@@ -1336,7 +1336,7 @@ def test_insertion_method_on_conflict_do_nothing(conn, request):
     from sqlalchemy.sql import text
 
     def insert_on_conflict(table, conn, keys, data_iter):
-        data = [dict(zip(keys, row)) for row in data_iter]
+        data = [dict(zip(keys, row, strict=True)) for row in data_iter]
         stmt = (
             insert(table.table)
             .values(data)
@@ -1418,7 +1418,7 @@ def test_insertion_method_on_conflict_update(conn, request):
     from sqlalchemy.sql import text
 
     def insert_on_conflict(table, conn, keys, data_iter):
-        data = [dict(zip(keys, row)) for row in data_iter]
+        data = [dict(zip(keys, row, strict=True)) for row in data_iter]
         stmt = insert(table.table).values(data)
         stmt = stmt.on_duplicate_key_update(b=stmt.inserted.b, c=stmt.inserted.c)
         result = conn.execute(stmt)

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -839,7 +839,7 @@ class TestStata:
             np.int32,
             np.float64,
         )
-        for c, t in zip(expected.columns, expected_types):
+        for c, t in zip(expected.columns, expected_types, strict=True):
             expected[c] = expected[c].astype(t)
 
         tm.assert_frame_equal(written_and_read_again, expected)
@@ -870,7 +870,9 @@ class TestStata:
 
         with StataReader(path) as sr:
             sr._ensure_open()  # The `_*list` variables are initialized here
-            for variable, fmt, typ in zip(sr._varlist, sr._fmtlist, sr._typlist):
+            for variable, fmt, typ in zip(
+                sr._varlist, sr._fmtlist, sr._typlist, strict=True
+            ):
                 assert int(variable[1:]) == int(fmt[1:-1])
                 assert int(variable[1:]) == typ
 
@@ -981,7 +983,9 @@ class TestStata:
         mm = [0, 0, 59, 0, 0, 0]
         ss = [0, 0, 59, 0, 0, 0]
         expected = []
-        for year, month, day, hour, minute, second in zip(yr, mo, dd, hr, mm, ss):
+        for year, month, day, hour, minute, second in zip(
+            yr, mo, dd, hr, mm, ss, strict=True
+        ):
             row = []
             for j in range(7):
                 if j == 0:

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -127,7 +127,7 @@ def _get_colors_mapped(series, colors):
     unique = series.unique()
     # unique and colors length can be differed
     # depending on slice value
-    mapped = dict(zip(unique, colors, strict=True))
+    mapped = dict(zip(unique, colors, strict=False))
     return [mapped[v] for v in series.values]
 
 

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -80,7 +80,7 @@ def _check_data(xp, rs):
     rs_lines = rs.get_lines()
 
     assert len(xp_lines) == len(rs_lines)
-    for xpl, rsl in zip(xp_lines, rs_lines):
+    for xpl, rsl in zip(xp_lines, rs_lines, strict=True):
         xpdata = xpl.get_xydata()
         rsdata = rsl.get_xydata()
         tm.assert_almost_equal(xpdata, rsdata)
@@ -127,7 +127,7 @@ def _get_colors_mapped(series, colors):
     unique = series.unique()
     # unique and colors length can be differed
     # depending on slice value
-    mapped = dict(zip(unique, colors))
+    mapped = dict(zip(unique, colors, strict=True))
     return [mapped[v] for v in series.values]
 
 
@@ -162,7 +162,7 @@ def _check_colors(collections, linecolors=None, facecolors=None, mapping=None):
             linecolors = linecolors[: len(collections)]
 
         assert len(collections) == len(linecolors)
-        for patch, color in zip(collections, linecolors):
+        for patch, color in zip(collections, linecolors, strict=True):
             if isinstance(patch, Line2D):
                 result = patch.get_color()
                 # Line2D may contains string color expression
@@ -181,7 +181,7 @@ def _check_colors(collections, linecolors=None, facecolors=None, mapping=None):
             facecolors = facecolors[: len(collections)]
 
         assert len(collections) == len(facecolors)
-        for patch, color in zip(collections, facecolors):
+        for patch, color in zip(collections, facecolors, strict=True):
             if isinstance(patch, Collection):
                 # returned as list of np.array
                 result = patch.get_facecolor()[0]
@@ -211,7 +211,7 @@ def _check_text_labels(texts, expected):
     else:
         labels = [t.get_text() for t in texts]
         assert len(labels) == len(expected)
-        for label, e in zip(labels, expected):
+        for label, e in zip(labels, expected, strict=True):
             assert label == e
 
 

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -183,7 +183,7 @@ class TestDataFramePlots:
 
     @pytest.mark.slow
     def test_plot_multiindex(self):
-        tuples = zip(string.ascii_letters[:10], range(10))
+        tuples = zip(string.ascii_letters[:10], range(10), strict=True)
         df = DataFrame(
             np.random.default_rng(2).random((10, 3)),
             index=MultiIndex.from_tuples(tuples),
@@ -513,7 +513,7 @@ class TestDataFramePlots:
 
     def _compare_stacked_y_cood(self, normal_lines, stacked_lines):
         base = np.zeros(len(normal_lines[0].get_data()[1]))
-        for nl, sl in zip(normal_lines, stacked_lines):
+        for nl, sl in zip(normal_lines, stacked_lines, strict=True):
             base += nl.get_data()[1]  # get y coordinates
             sy = sl.get_data()[1]
             tm.assert_numpy_array_equal(base, sy)
@@ -920,7 +920,10 @@ class TestDataFramePlots:
 
         expected_yticklabels = categories
         result_yticklabels = [i.get_text() for i in colorbar.ax.get_ymajorticklabels()]
-        assert all(i == j for i, j in zip(result_yticklabels, expected_yticklabels))
+        assert all(
+            i == j
+            for i, j in zip(result_yticklabels, expected_yticklabels, strict=True)
+        )
 
     @pytest.mark.parametrize("x, y", [("x", "y"), ("y", "x"), ("y", "y")])
     def test_plot_scatter_with_categorical_data(self, x, y):
@@ -1131,7 +1134,7 @@ class TestDataFramePlots:
         )
         _check_axes_shape(axes, axes_num=3, layout=(1, 3))
         _check_ax_scales(axes, xaxis="log")
-        for ax, label in zip(axes, labels):
+        for ax, label in zip(axes, labels, strict=True):
             _check_text_labels(ax.get_yticklabels(), [label])
             assert len(ax.lines) == 7
 
@@ -1258,7 +1261,13 @@ class TestDataFramePlots:
         # GH 33173
         weights = 0.1 * np.ones(shape=weight_shape)
         df = DataFrame(
-            dict(zip(["A", "B"], np.random.default_rng(2).standard_normal((2, 100))))
+            dict(
+                zip(
+                    ["A", "B"],
+                    np.random.default_rng(2).standard_normal((2, 100)),
+                    strict=True,
+                )
+            )
         )
 
         ax1 = _check_plot_works(df.plot, kind="hist", weights=weights)
@@ -1679,7 +1688,7 @@ class TestDataFramePlots:
         assert len(axes) == len(df.columns)
         for ax in axes:
             _check_text_labels(ax.texts, df.index)
-        for ax, ylabel in zip(axes, df.columns):
+        for ax, ylabel in zip(axes, df.columns, strict=True):
             assert ax.get_ylabel() == ""
 
     def test_pie_df_labels_colors(self):
@@ -2381,7 +2390,7 @@ class TestDataFramePlots:
         ax = df.plot.area(x="day")
         ax.set_xlim(-1, 3)
         xticklabels = [t.get_text() for t in ax.get_xticklabels()]
-        labels_position = dict(zip(xticklabels, ax.get_xticks()))
+        labels_position = dict(zip(xticklabels, ax.get_xticks(), strict=True))
         # Testing if the label stayed at the right position
         assert labels_position["Monday"] == 0.0
         assert labels_position["Tuesday"] == 1.0
@@ -2399,7 +2408,7 @@ class TestDataFramePlots:
         ax = df.plot()
         ax.set_xlim(-1, 4)
         xticklabels = [t.get_text() for t in ax.get_xticklabels()]
-        labels_position = dict(zip(xticklabels, ax.get_xticks()))
+        labels_position = dict(zip(xticklabels, ax.get_xticks(), strict=True))
         # Testing if the label stayed at the right position
         assert labels_position["(2012, 1)"] == 0.0
         assert labels_position["(2012, 2)"] == 1.0
@@ -2475,7 +2484,7 @@ class TestDataFramePlots:
         assert len(axes) == 3  # 2 groups + single column a
 
         expected_labels = (["b", "e"], ["c", "d"], ["a"])
-        for ax, labels in zip(axes, expected_labels):
+        for ax, labels in zip(axes, expected_labels, strict=True):
             if kind != "pie":
                 _check_legend_labels(ax, labels=labels)
             if kind == "line":

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -365,7 +365,7 @@ class TestDataFrameColor:
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
 
         axes = df.plot(subplots=True)
-        for ax, c in zip(axes, list(default_colors), strict=True):
+        for ax, c in zip(axes, list(default_colors), strict=False):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     @pytest.mark.parametrize("color", ["k", "green"])
@@ -535,7 +535,7 @@ class TestDataFrameColor:
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
 
         axes = df.plot(kind="kde", subplots=True)
-        for ax, c in zip(axes, list(default_colors), strict=True):
+        for ax, c in zip(axes, list(default_colors), strict=False):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     @pytest.mark.parametrize("colormap", ["k", "red"])

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -324,7 +324,7 @@ class TestDataFrameColor:
         ax2 = df.plot(color=custom_colors)
         lines2 = ax2.get_lines()
 
-        for l1, l2 in zip(ax.get_lines(), lines2):
+        for l1, l2 in zip(ax.get_lines(), lines2, strict=True):
             assert l1.get_color() == l2.get_color()
 
     @pytest.mark.parametrize("colormap", ["jet", cm.jet])
@@ -365,7 +365,7 @@ class TestDataFrameColor:
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
 
         axes = df.plot(subplots=True)
-        for ax, c in zip(axes, list(default_colors)):
+        for ax, c in zip(axes, list(default_colors), strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     @pytest.mark.parametrize("color", ["k", "green"])
@@ -380,7 +380,7 @@ class TestDataFrameColor:
         # GH 9894
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
         axes = df.plot(color=color, subplots=True)
-        for ax, c in zip(axes, list(color)):
+        for ax, c in zip(axes, list(color), strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     def test_line_colors_and_styles_subplots_colormap_hex(self):
@@ -389,7 +389,7 @@ class TestDataFrameColor:
         # GH 10299
         custom_colors = ["#FF0000", "#0000FF", "#FFFF00", "#000000", "#FFFFFF"]
         axes = df.plot(color=custom_colors, subplots=True)
-        for ax, c in zip(axes, list(custom_colors)):
+        for ax, c in zip(axes, list(custom_colors), strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     @pytest.mark.parametrize("cmap", ["jet", cm.jet])
@@ -398,7 +398,7 @@ class TestDataFrameColor:
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
         rgba_colors = [cm.jet(n) for n in np.linspace(0, 1, len(df))]
         axes = df.plot(colormap=cmap, subplots=True)
-        for ax, c in zip(axes, rgba_colors):
+        for ax, c in zip(axes, rgba_colors, strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     def test_line_colors_and_styles_subplots_single_col(self):
@@ -423,7 +423,7 @@ class TestDataFrameColor:
         # list of styles
         styles = list("rgcby")
         axes = df.plot(style=styles, subplots=True)
-        for ax, c in zip(axes, styles):
+        for ax, c in zip(axes, styles, strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     def test_area_colors(self):
@@ -535,7 +535,7 @@ class TestDataFrameColor:
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
 
         axes = df.plot(kind="kde", subplots=True)
-        for ax, c in zip(axes, list(default_colors)):
+        for ax, c in zip(axes, list(default_colors), strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     @pytest.mark.parametrize("colormap", ["k", "red"])
@@ -551,7 +551,7 @@ class TestDataFrameColor:
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
         custom_colors = "rgcby"
         axes = df.plot(kind="kde", color=custom_colors, subplots=True)
-        for ax, c in zip(axes, list(custom_colors)):
+        for ax, c in zip(axes, list(custom_colors), strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     @pytest.mark.parametrize("colormap", ["jet", cm.jet])
@@ -560,7 +560,7 @@ class TestDataFrameColor:
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
         rgba_colors = [cm.jet(n) for n in np.linspace(0, 1, len(df))]
         axes = df.plot(kind="kde", colormap=colormap, subplots=True)
-        for ax, c in zip(axes, rgba_colors):
+        for ax, c in zip(axes, rgba_colors, strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     def test_kde_colors_and_styles_subplots_single_col(self):
@@ -586,7 +586,7 @@ class TestDataFrameColor:
         # list of styles
         styles = list("rgcby")
         axes = df.plot(kind="kde", style=styles, subplots=True)
-        for ax, c in zip(axes, styles):
+        for ax, c in zip(axes, styles, strict=True):
             _check_colors(ax.get_lines(), linecolors=[c])
 
     def test_boxplot_colors(self):
@@ -715,7 +715,7 @@ class TestDataFrameColor:
         result = df_concat.plot()
         legend = result.get_legend()
         handles = legend.legend_handles
-        for legend, line in zip(handles, result.lines):
+        for legend, line in zip(handles, result.lines, strict=True):
             assert legend.get_color() == line.get_color()
 
     def test_invalid_colormap(self):

--- a/pandas/tests/plotting/frame/test_frame_groupby.py
+++ b/pandas/tests/plotting/frame/test_frame_groupby.py
@@ -10,11 +10,11 @@ pytest.importorskip("matplotlib")
 
 class TestDataFramePlotsGroupby:
     def _assert_ytickslabels_visibility(self, axes, expected):
-        for ax, exp in zip(axes, expected):
+        for ax, exp in zip(axes, expected, strict=True):
             _check_visible(ax.get_yticklabels(), visible=exp)
 
     def _assert_xtickslabels_visibility(self, axes, expected):
-        for ax, exp in zip(axes, expected):
+        for ax, exp in zip(axes, expected, strict=True):
             _check_visible(ax.get_xticklabels(), visible=exp)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -42,7 +42,7 @@ class TestDataFramePlotsSubplots:
         _check_axes_shape(axes, axes_num=3, layout=(3, 1))
         assert axes.shape == (3,)
 
-        for ax, column in zip(axes, df.columns):
+        for ax, column in zip(axes, df.columns, strict=True):
             _check_legend_labels(ax, labels=[pprint_thing(column)])
 
         for ax in axes[:-2]:

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -423,7 +423,7 @@ class TestDataFrameGroupByPlots:
 
     @pytest.mark.slow
     def test_boxplot_legacy2(self):
-        tuples = zip(string.ascii_letters[:10], range(10))
+        tuples = zip(string.ascii_letters[:10], range(10), strict=True)
         df = DataFrame(
             np.random.default_rng(2).random((10, 3)),
             index=MultiIndex.from_tuples(tuples),
@@ -435,7 +435,7 @@ class TestDataFrameGroupByPlots:
 
     @pytest.mark.slow
     def test_boxplot_legacy2_return_type(self):
-        tuples = zip(string.ascii_letters[:10], range(10))
+        tuples = zip(string.ascii_letters[:10], range(10), strict=True)
         df = DataFrame(
             np.random.default_rng(2).random((10, 3)),
             index=MultiIndex.from_tuples(tuples),
@@ -744,7 +744,7 @@ class TestDataFrameGroupByPlots:
             ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = list(zip(*arrays))
+        tuples = list(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples, names=["first", "second"])
         df = DataFrame(
             np.random.default_rng(2).standard_normal((3, 8)),

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -324,7 +324,7 @@ class TestTSPlot:
         ret = ser.plot(ax=ax)
         assert ret is not None
 
-        for rs, xp in zip(ax.get_lines()[0].get_xdata(), ser.index):
+        for rs, xp in zip(ax.get_lines()[0].get_xdata(), ser.index, strict=True):
             assert rs == xp
 
     def test_business_freq(self):
@@ -1150,7 +1150,7 @@ class TestTSPlot:
         # verify tick labels
         ticks = ax.get_xticks()
         labels = ax.get_xticklabels()
-        for _tick, _label in zip(ticks, labels):
+        for _tick, _label in zip(ticks, labels, strict=True):
             m, s = divmod(int(_tick), 60)
             h, m = divmod(m, 60)
             rs = _label.get_text()
@@ -1178,7 +1178,7 @@ class TestTSPlot:
         # verify tick labels
         ticks = ax.get_xticks()
         labels = ax.get_xticklabels()
-        for _tick, _label in zip(ticks, labels):
+        for _tick, _label in zip(ticks, labels, strict=True):
             m, s = divmod(int(_tick), 60)
             h, m = divmod(m, 60)
             rs = _label.get_text()
@@ -1195,7 +1195,7 @@ class TestTSPlot:
         # check tick labels again
         ticks = ax.get_xticks()
         labels = ax.get_xticklabels()
-        for _tick, _label in zip(ticks, labels):
+        for _tick, _label in zip(ticks, labels, strict=True):
             m, s = divmod(int(_tick), 60)
             h, m = divmod(m, 60)
             rs = _label.get_text()
@@ -1223,7 +1223,7 @@ class TestTSPlot:
         # verify tick labels
         ticks = ax.get_xticks()
         labels = ax.get_xticklabels()
-        for _tick, _label in zip(ticks, labels):
+        for _tick, _label in zip(ticks, labels, strict=True):
             m, s = divmod(int(_tick), 60)
 
             us = round((_tick - int(_tick)) * 1e6)

--- a/pandas/tests/plotting/test_groupby.py
+++ b/pandas/tests/plotting/test_groupby.py
@@ -109,7 +109,7 @@ class TestDataFrameGroupByPlots:
 
         for axes in g.hist(legend=True, column=column):
             _check_axes_shape(axes, axes_num=expected_axes_num, layout=expected_layout)
-            for ax, expected_label in zip(axes[0], expected_labels):
+            for ax, expected_label in zip(axes[0], expected_labels, strict=True):
                 _check_legend_labels(ax, expected_label)
 
     @pytest.mark.parametrize("column", [None, "b"])

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -532,7 +532,7 @@ class TestDataFramePlots:
         _check_axes_shape(axes, axes_num=expected_axes_num, layout=expected_layout)
         if by is None and column is None:
             axes = axes[0]
-        for expected_label, ax in zip(expected_labels, axes):
+        for expected_label, ax in zip(expected_labels, axes, strict=True):
             _check_legend_labels(ax, expected_label)
 
     @pytest.mark.parametrize("by", [None, "c"])
@@ -644,7 +644,7 @@ class TestDataFramePlots:
             x for x in ax1.get_children() if isinstance(x, mpl.patches.Rectangle)
         ]
         no_nan_heights = [rect.get_height() for rect in no_nan_rects]
-        assert all(h0 == h1 for h0, h1 in zip(heights, no_nan_heights))
+        assert all(h0 == h1 for h0, h1 in zip(heights, no_nan_heights, strict=True))
 
         idxerror_weights = np.array([[0.3, 0.25], [0.45, 0.45]])
 

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -330,11 +330,13 @@ class TestDataFramePlots:
         ax = plotting.parallel_coordinates(df, "class", sort_labels=True)
         polylines, labels = ax.get_legend_handles_labels()
         color_label_tuples = zip(
-            [polyline.get_color() for polyline in polylines], labels
+            [polyline.get_color() for polyline in polylines], labels, strict=True
         )
         ordered_color_label_tuples = sorted(color_label_tuples, key=lambda x: x[1])
         prev_next_tupels = zip(
-            list(ordered_color_label_tuples[0:-1]), list(ordered_color_label_tuples[1:])
+            list(ordered_color_label_tuples[0:-1]),
+            list(ordered_color_label_tuples[1:]),
+            strict=True,
         )
         for prev, nxt in prev_next_tupels:
             # labels and colors are ordered strictly increasing
@@ -524,7 +526,7 @@ class TestDataFramePlots:
         plot_bar = df.plot.bar()
         assert all(
             (a.get_text() == b.get_text())
-            for a, b in zip(plot_bar.get_xticklabels(), expected)
+            for a, b in zip(plot_bar.get_xticklabels(), expected, strict=True)
         )
 
     def test_barh_plot_labels_mixed_integer_string(self):
@@ -539,7 +541,7 @@ class TestDataFramePlots:
         assert all(
             actual.get_text() == expected.get_text()
             for actual, expected in zip(
-                plot_barh.get_yticklabels(), expected_yticklabels
+                plot_barh.get_yticklabels(), expected_yticklabels, strict=True
             )
         )
 
@@ -681,7 +683,7 @@ class TestDataFramePlots:
         _check_plot_works(s.plot.bar)
         assert all(
             (a.get_text() == b.get_text())
-            for a, b in zip(s.plot.bar().get_xticklabels(), expected)
+            for a, b in zip(s.plot.bar().get_xticklabels(), expected, strict=True)
         )
 
 

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -436,7 +436,7 @@ class TestSeriesPlots:
             series.plot.pie, colors=color_args, autopct="%.2f", fontsize=7
         )
         pcts = [f"{s * 100:.2f}" for s in series.values / series.sum()]
-        expected_texts = list(chain.from_iterable(zip(series.index, pcts)))
+        expected_texts = list(chain.from_iterable(zip(series.index, pcts, strict=True)))
         _check_text_labels(ax.texts, expected_texts)
         for t in ax.texts:
             assert t.get_fontsize() == 7

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -485,7 +485,7 @@ def test_resampler_is_iterable(index):
     tg = Grouper(freq=freq, convention="start")
     grouped = series.groupby(tg)
     resampled = series.resample(freq)
-    for (rk, rv), (gk, gv) in zip(resampled, grouped):
+    for (rk, rv), (gk, gv) in zip(resampled, grouped, strict=True):
         assert rk == gk
         tm.assert_series_equal(rv, gv)
 

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -702,7 +702,7 @@ def test_concat_repeated_keys(keys, integrity):
     # GH: 20816
     series_list = [Series({"a": 1}), Series({"b": 2}), Series({"c": 3})]
     result = concat(series_list, keys=keys, verify_integrity=integrity)
-    tuples = list(zip(keys, ["a", "b", "c"]))
+    tuples = list(zip(keys, ["a", "b", "c"], strict=True))
     expected = Series([1, 2, 3], index=MultiIndex.from_tuples(tuples))
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -60,7 +60,8 @@ class TestIndexConcat:
             Index(["c", "d", "e"], name=name_in3),
         ]
         frames = [
-            DataFrame({c: [0, 1, 2]}, index=i) for i, c in zip(indices, ["x", "y", "z"])
+            DataFrame({c: [0, 1, 2]}, index=i)
+            for i, c in zip(indices, ["x", "y", "z"], strict=True)
         ]
         result = concat(frames, axis=1)
 
@@ -218,7 +219,7 @@ class TestMultiIndexConcat:
         level2 = [1] * 5 + [2] * 2
         level1 = [1] * 7
         no_name = list(range(5)) + list(range(2))
-        tuples = list(zip(level2, level1, no_name))
+        tuples = list(zip(level2, level1, no_name, strict=True))
         index = MultiIndex.from_tuples(tuples, names=["level2", "level1", None])
         expected = DataFrame({"col": no_name}, index=index, dtype=np.int32)
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -3249,14 +3249,14 @@ class TestAsOfMerge:
             )
 
         left = pd.DataFrame(
-            list(zip([0, 5, 10, 15, 20, 25], [0, 1, 2, 3, 4, 5])),
+            list(zip([0, 5, 10, 15, 20, 25], [0, 1, 2, 3, 4, 5], strict=True)),
             columns=["time", "left"],
         )
 
         left["time"] = pd.to_timedelta(left["time"], "ms").astype(f"m8[{unit}]")
 
         right = pd.DataFrame(
-            list(zip([0, 3, 9, 12, 15, 18], [0, 1, 2, 3, 4, 5])),
+            list(zip([0, 3, 9, 12, 15, 18], [0, 1, 2, 3, 4, 5], strict=True)),
             columns=["time", "right"],
         )
 
@@ -3268,6 +3268,7 @@ class TestAsOfMerge:
                     [0, 5, 10, 15, 20, 25],
                     [0, 1, 2, 3, 4, 5],
                     [0, np.nan, 2, 4, np.nan, np.nan],
+                    strict=True,
                 )
             ),
             columns=["time", "left", "right"],

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -801,7 +801,7 @@ class TestWideToLong:
                 "A1980": {0: "d", 1: "e", 2: "f"},
                 "B1970": {0: 2.5, 1: 1.2, 2: 0.7},
                 "B1980": {0: 3.2, 1: 1.3, 2: 0.1},
-                "X": dict(zip(range(3), x)),
+                "X": dict(zip(range(3), x, strict=True)),
             }
         )
         df["id"] = df.index
@@ -837,7 +837,7 @@ class TestWideToLong:
                 "A.1980": {0: "d", 1: "e", 2: "f"},
                 "B.1970": {0: 2.5, 1: 1.2, 2: 0.7},
                 "B.1980": {0: 3.2, 1: 1.3, 2: 0.1},
-                "X": dict(zip(range(3), x)),
+                "X": dict(zip(range(3), x, strict=True)),
             }
         )
         df["id"] = df.index
@@ -861,7 +861,7 @@ class TestWideToLong:
                 "A(quarterly)1980": {0: "d", 1: "e", 2: "f"},
                 "B(quarterly)1970": {0: 2.5, 1: 1.2, 2: 0.7},
                 "B(quarterly)1980": {0: 3.2, 1: 1.3, 2: 0.1},
-                "X": dict(zip(range(3), x)),
+                "X": dict(zip(range(3), x, strict=True)),
             }
         )
         df["id"] = df.index

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -304,5 +304,5 @@ def test_qcut_contains(scale, q, precision):
     arr = (scale * np.arange(q + 1)).round(precision)
     result = qcut(arr, q, precision=precision)
 
-    for value, bucket in zip(arr, result):
+    for value, bucket in zip(arr, result, strict=True):
         assert value in bucket

--- a/pandas/tests/scalar/period/test_asfreq.py
+++ b/pandas/tests/scalar/period/test_asfreq.py
@@ -780,7 +780,7 @@ class TestFreqConversion:
 
         # ordinal will not change
         expected = Period("2007", freq="25h")
-        for freq, how in zip(["1D1h", "1h1D"], ["E", "S"]):
+        for freq, how in zip(["1D1h", "1h1D"], ["E", "S"], strict=True):
             result = p.asfreq(freq, how=how)
             assert result == expected
             assert result.ordinal == expected.ordinal

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -484,7 +484,9 @@ class TestSeriesDatetimeValues:
             "Saturday",
             "Sunday",
         ]
-        for day, name, eng_name in zip(range(4, 11), expected_days, english_days):
+        for day, name, eng_name in zip(
+            range(4, 11), expected_days, english_days, strict=True
+        ):
             name = name.capitalize()
             assert ser.dt.day_name(locale=time_locale)[day] == name
             assert ser.dt.day_name(locale=None)[day] == eng_name
@@ -501,7 +503,7 @@ class TestSeriesDatetimeValues:
 
         tm.assert_series_equal(result, expected)
 
-        for s_date, expected in zip(ser, expected_months):
+        for s_date, expected in zip(ser, expected_months, strict=True):
             result = s_date.month_name(locale=time_locale)
             expected = expected.capitalize()
 

--- a/pandas/tests/series/indexing/test_get.py
+++ b/pandas/tests/series/indexing/test_get.py
@@ -149,7 +149,7 @@ def test_get_with_default():
 
     for data, index in ((d0, d1), (d1, d0)):
         s = Series(data, index=index)
-        for i, d in zip(index, data):
+        for i, d in zip(index, data, strict=True):
             assert s.get(i) == d
             assert s.get(i, d) == d
             assert s.get(i, "z") == d

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -209,11 +209,14 @@ class TestSeriesConvertDtypes:
             "convert_boolean",
             "convert_floating",
         ]
-        params_dict = dict(zip(param_names, params))
+        params_dict = dict(zip(param_names, params, strict=True))
 
         expected_dtype = expected_default
         for spec, dtype in expected_other.items():
-            if all(params_dict[key] is val for key, val in zip(spec[::2], spec[1::2])):
+            if all(
+                params_dict[key] is val
+                for key, val in zip(spec[::2], spec[1::2], strict=True)
+            ):
                 expected_dtype = dtype
         if (
             using_infer_string

--- a/pandas/tests/series/methods/test_rename.py
+++ b/pandas/tests/series/methods/test_rename.py
@@ -21,7 +21,7 @@ class TestRename:
         assert renamed.index[0] == renamer(ts.index[0])
 
         # dict
-        rename_dict = dict(zip(ts.index, renamed.index))
+        rename_dict = dict(zip(ts.index, renamed.index, strict=True))
         renamed2 = ts.rename(rename_dict)
         tm.assert_series_equal(renamed, renamed2)
 

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -648,7 +648,7 @@ class TestSeriesReplace:
         labs = pd.Series([1, 1, 1, 0, 0, 2, 2, 2], dtype=any_int_numpy_dtype)
 
         maps = pd.Series([0, 2, 1], dtype=any_int_numpy_dtype)
-        map_dict = dict(zip(maps.values, maps.index))
+        map_dict = dict(zip(maps.values, maps.index, strict=True))
 
         result = labs.replace(map_dict)
         expected = labs.replace({0: 0, 2: 1, 1: 2})

--- a/pandas/tests/series/methods/test_reset_index.py
+++ b/pandas/tests/series/methods/test_reset_index.py
@@ -146,7 +146,7 @@ class TestResetIndex:
             ["bar", "bar", "baz", "baz", "qux", "qux", "foo", "foo"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = zip(*arrays)
+        tuples = zip(*arrays, strict=True)
         index = MultiIndex.from_tuples(tuples)
         data = np.random.default_rng(2).standard_normal(8)
         ser = Series(data, index=index)

--- a/pandas/tests/series/methods/test_sort_index.py
+++ b/pandas/tests/series/methods/test_sort_index.py
@@ -186,7 +186,7 @@ class TestSeriesSortIndex:
             ["one", "two", "one", "two", "one", "two", "one", "two"],
             [4, 3, 2, 1, 4, 3, 2, 1],
         ]
-        tuples = zip(*arrays)
+        tuples = zip(*arrays, strict=True)
         mi = MultiIndex.from_tuples(tuples, names=["first", "second", "third"])
         ser = Series(range(8), index=mi)
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -81,8 +81,8 @@ class TestSeriesMisc:
             Index(np.arange(10), dtype=np.float64),
             Index([True, False]),
             Index([f"a{i}" for i in range(101)]),
-            pd.MultiIndex.from_tuples(zip("ABCD", "EFGH")),
-            pd.MultiIndex.from_tuples(zip([0, 1, 2, 3], "EFGH")),
+            pd.MultiIndex.from_tuples(zip("ABCD", "EFGH", strict=True)),
+            pd.MultiIndex.from_tuples(zip([0, 1, 2, 3], "EFGH", strict=True)),
         ],
     )
     def test_index_tab_completion(self, index):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1401,7 +1401,9 @@ class TestSeriesConstructors:
         values = [42544017.198965244, 1234565, 40512335.181958228, -1]
 
         def create_data(constructor):
-            return dict(zip((constructor(x) for x in dates_as_str), values))
+            return dict(
+                zip((constructor(x) for x in dates_as_str), values, strict=True)
+            )
 
         data_datetime64 = create_data(np.datetime64)
         data_datetime = create_data(lambda x: datetime.strptime(x, "%Y-%m-%d"))

--- a/pandas/tests/strings/conftest.py
+++ b/pandas/tests/strings/conftest.py
@@ -94,9 +94,10 @@ _any_string_method = [
         ],
         [()] * 100,
         [{}] * 100,
+        strict=True,
     )
 )
-ids, _, _ = zip(*_any_string_method)  # use method name as fixture-id
+ids, _, _ = zip(*_any_string_method, strict=True)  # use method name as fixture-id
 missing_methods = {f for f in dir(StringMethods) if not f.startswith("_")} - set(ids)
 
 # test that the above list captures all methods of StringMethods

--- a/pandas/tests/strings/conftest.py
+++ b/pandas/tests/strings/conftest.py
@@ -94,7 +94,7 @@ _any_string_method = [
         ],
         [()] * 100,
         [{}] * 100,
-        strict=True,
+        strict=False,
     )
 )
 ids, _, _ = zip(*_any_string_method, strict=True)  # use method name as fixture-id

--- a/pandas/tests/strings/test_api.py
+++ b/pandas/tests/strings/test_api.py
@@ -22,7 +22,9 @@ _any_allowed_skipna_inferred_dtype = [
     ("empty", []),
     ("mixed-integer", ["a", np.nan, 2]),
 ]
-ids, _ = zip(*_any_allowed_skipna_inferred_dtype)  # use inferred type as id
+ids, _ = zip(
+    *_any_allowed_skipna_inferred_dtype, strict=True
+)  # use inferred type as id
 
 
 @pytest.fixture(params=_any_allowed_skipna_inferred_dtype, ids=ids)

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -757,7 +757,7 @@ def test_cat_on_bytes_raises():
 
 def test_str_accessor_in_apply_func():
     # https://github.com/pandas-dev/pandas/issues/38979
-    df = DataFrame(zip("abc", "def"))
+    df = DataFrame(zip("abc", "def", strict=True))
     expected = Series(["A/D", "B/E", "C/F"])
     result = df.apply(lambda f: "/".join(f.str.upper()), axis=1)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1469,7 +1469,7 @@ class TestDuplicated:
 
         keys = np.empty(8, dtype=object)
         for i, t in enumerate(
-            zip([0, 0, np.nan, np.nan] * 2, [0, np.nan, 0, np.nan] * 2)
+            zip([0, 0, np.nan, np.nan] * 2, [0, np.nan, 0, np.nan] * 2, strict=True)
         ):
             keys[i] = t
 

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -357,7 +357,7 @@ def test_decons(codes_list, shape):
     group_index = get_group_index(codes_list, shape, sort=True, xnull=True)
     codes_list2 = _decons_group_index(group_index, shape)
 
-    for a, b in zip(codes_list, codes_list2):
+    for a, b in zip(codes_list, codes_list2, strict=True):
         tm.assert_numpy_array_equal(a, b)
 
 

--- a/pandas/tests/tseries/offsets/test_month.py
+++ b/pandas/tests/tseries/offsets/test_month.py
@@ -61,7 +61,7 @@ class TestSemiMonthEnd:
             datetime(2008, 12, 31),
         )
 
-        for base, exp_date in zip(dates[:-1], dates[1:]):
+        for base, exp_date in zip(dates[:-1], dates[1:], strict=True):
             assert_offset_equal(SemiMonthEnd(), base, exp_date)
 
         # ensure .apply_index works as expected
@@ -312,7 +312,7 @@ class TestSemiMonthBegin:
             datetime(2008, 12, 15),
         )
 
-        for base, exp_date in zip(dates[:-1], dates[1:]):
+        for base, exp_date in zip(dates[:-1], dates[1:], strict=True):
             assert_offset_equal(SemiMonthBegin(), base, exp_date)
 
         # ensure .apply_index works as expected

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -665,6 +665,7 @@ class TestDateOffset:
                 "2008-01-02 00:00:00.001000000",
                 "2008-01-02 00:00:00.000001000",
             ],
+            strict=True,
         ),
     )
     def test_add(self, arithmatic_offset_type, expected, dt):
@@ -686,6 +687,7 @@ class TestDateOffset:
                 "2008-01-01 23:59:59.999000000",
                 "2008-01-01 23:59:59.999999000",
             ],
+            strict=True,
         ),
     )
     def test_sub(self, arithmatic_offset_type, expected, dt):
@@ -709,6 +711,7 @@ class TestDateOffset:
                 "2008-01-02 00:00:00.008000000",
                 "2008-01-02 00:00:00.000009000",
             ],
+            strict=True,
         ),
     )
     def test_mul_add(self, arithmatic_offset_type, n, expected, dt):
@@ -733,6 +736,7 @@ class TestDateOffset:
                 "2008-01-01 23:59:59.992000000",
                 "2008-01-01 23:59:59.999991000",
             ],
+            strict=True,
         ),
     )
     def test_mul_sub(self, arithmatic_offset_type, n, expected, dt):

--- a/pandas/tests/util/test_validate_kwargs.py
+++ b/pandas/tests/util/test_validate_kwargs.py
@@ -37,7 +37,7 @@ def test_not_all_none(i, _fname):
     kwarg_keys = ("foo", "bar", "baz")
     kwarg_vals = (2, "s", None)
 
-    kwargs = dict(zip(kwarg_keys[:i], kwarg_vals[:i]))
+    kwargs = dict(zip(kwarg_keys[:i], kwarg_vals[:i], strict=True))
 
     with pytest.raises(ValueError, match=msg):
         validate_kwargs(_fname, kwargs, compat_args)

--- a/pandas/tests/window/test_cython_aggregations.py
+++ b/pandas/tests/window/test_cython_aggregations.py
@@ -62,7 +62,7 @@ def _get_rolling_aggregations():
         ]
     )
     # unzip to a list of 2 tuples, names and functions
-    unzipped = list(zip(*named_roll_aggs))
+    unzipped = list(zip(*named_roll_aggs, strict=True))
     return {"ids": unzipped[0], "params": unzipped[1]}
 
 

--- a/pandas/tests/window/test_expanding.py
+++ b/pandas/tests/window/test_expanding.py
@@ -180,7 +180,7 @@ def test_iter_expanding_dataframe(df, expected, min_periods):
     df = DataFrame(df)
     expecteds = [DataFrame(values, index=index) for (values, index) in expected]
 
-    for expected, actual in zip(expecteds, df.expanding(min_periods)):
+    for expected, actual in zip(expecteds, df.expanding(min_periods), strict=True):
         tm.assert_frame_equal(actual, expected)
 
 
@@ -199,7 +199,7 @@ def test_iter_expanding_series(ser, expected, min_periods):
     # GH 11704
     expecteds = [Series(values, index=index) for (values, index) in expected]
 
-    for expected, actual in zip(expecteds, ser.expanding(min_periods)):
+    for expected, actual in zip(expecteds, ser.expanding(min_periods), strict=True):
         tm.assert_series_equal(actual, expected)
 
 

--- a/pandas/tests/window/test_expanding.py
+++ b/pandas/tests/window/test_expanding.py
@@ -180,7 +180,7 @@ def test_iter_expanding_dataframe(df, expected, min_periods):
     df = DataFrame(df)
     expecteds = [DataFrame(values, index=index) for (values, index) in expected]
 
-    for expected, actual in zip(expecteds, df.expanding(min_periods), strict=True):
+    for expected, actual in zip(expecteds, df.expanding(min_periods), strict=False):
         tm.assert_frame_equal(actual, expected)
 
 

--- a/pandas/tests/window/test_expanding.py
+++ b/pandas/tests/window/test_expanding.py
@@ -180,7 +180,7 @@ def test_iter_expanding_dataframe(df, expected, min_periods):
     df = DataFrame(df)
     expecteds = [DataFrame(values, index=index) for (values, index) in expected]
 
-    for expected, actual in zip(expecteds, df.expanding(min_periods), strict=False):
+    for expected, actual in zip(expecteds, df.expanding(min_periods), strict=True):
         tm.assert_frame_equal(actual, expected)
 
 

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -764,7 +764,9 @@ def test_iter_rolling_dataframe(df, expected, window, min_periods):
     df = DataFrame(df)
     expecteds = [DataFrame(values, index=index) for (values, index) in expected]
 
-    for expected, actual in zip(expecteds, df.rolling(window, min_periods=min_periods)):
+    for expected, actual in zip(
+        expecteds, df.rolling(window, min_periods=min_periods), strict=True
+    ):
         tm.assert_frame_equal(actual, expected)
 
 
@@ -810,7 +812,7 @@ def test_iter_rolling_on_dataframe(expected, window):
     expecteds = [
         DataFrame(values, index=df.loc[index, "C"]) for (values, index) in expected
     ]
-    for expected, actual in zip(expecteds, df.rolling(window, on="C")):
+    for expected, actual in zip(expecteds, df.rolling(window, on="C"), strict=True):
         tm.assert_frame_equal(actual, expected)
 
 
@@ -819,7 +821,7 @@ def test_iter_rolling_on_dataframe_unordered():
     df = DataFrame({"a": ["x", "y", "x"], "b": [0, 1, 2]})
     results = list(df.groupby("a").rolling(2))
     expecteds = [df.iloc[idx, [1]] for idx in [[0], [0, 2], [1]]]
-    for result, expected in zip(results, expecteds):
+    for result, expected in zip(results, expecteds, strict=True):
         tm.assert_frame_equal(result, expected)
 
 
@@ -861,7 +863,7 @@ def test_iter_rolling_series(ser, expected, window, min_periods):
     expecteds = [Series(values, index=index) for (values, index) in expected]
 
     for expected, actual in zip(
-        expecteds, ser.rolling(window, min_periods=min_periods)
+        expecteds, ser.rolling(window, min_periods=min_periods), strict=True
     ):
         tm.assert_series_equal(actual, expected)
 
@@ -909,10 +911,11 @@ def test_iter_rolling_datetime(expected, expected_index, window):
     ser = Series(range(5), index=date_range(start="2020-01-01", periods=5, freq="D"))
 
     expecteds = [
-        Series(values, index=idx) for (values, idx) in zip(expected, expected_index)
+        Series(values, index=idx)
+        for (values, idx) in zip(expected, expected_index, strict=True)
     ]
 
-    for expected, actual in zip(expecteds, ser.rolling(window)):
+    for expected, actual in zip(expecteds, ser.rolling(window), strict=True):
         tm.assert_series_equal(actual, expected)
 
 

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -765,7 +765,7 @@ def test_iter_rolling_dataframe(df, expected, window, min_periods):
     expecteds = [DataFrame(values, index=index) for (values, index) in expected]
 
     for expected, actual in zip(
-        expecteds, df.rolling(window, min_periods=min_periods), strict=True
+        expecteds, df.rolling(window, min_periods=min_periods), strict=False
     ):
         tm.assert_frame_equal(actual, expected)
 
@@ -812,7 +812,7 @@ def test_iter_rolling_on_dataframe(expected, window):
     expecteds = [
         DataFrame(values, index=df.loc[index, "C"]) for (values, index) in expected
     ]
-    for expected, actual in zip(expecteds, df.rolling(window, on="C"), strict=True):
+    for expected, actual in zip(expecteds, df.rolling(window, on="C"), strict=False):
         tm.assert_frame_equal(actual, expected)
 
 

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -765,7 +765,7 @@ def test_iter_rolling_dataframe(df, expected, window, min_periods):
     expecteds = [DataFrame(values, index=index) for (values, index) in expected]
 
     for expected, actual in zip(
-        expecteds, df.rolling(window, min_periods=min_periods), strict=False
+        expecteds, df.rolling(window, min_periods=min_periods), strict=True
     ):
         tm.assert_frame_equal(actual, expected)
 
@@ -812,7 +812,7 @@ def test_iter_rolling_on_dataframe(expected, window):
     expecteds = [
         DataFrame(values, index=df.loc[index, "C"]) for (values, index) in expected
     ]
-    for expected, actual in zip(expecteds, df.rolling(window, on="C"), strict=False):
+    for expected, actual in zip(expecteds, df.rolling(window, on="C"), strict=True):
         tm.assert_frame_equal(actual, expected)
 
 


### PR DESCRIPTION
Part of #62434

This PR enforces Ruff rule B905 (`zip-without-explicit-strict`) across the pandas test suite by adding `strict=True` to all relevant `zip()` calls in `pandas/tests`.

- Updated all occurrences of `zip(...)` in test files to use `zip(..., strict=True)` where appropriate.
- Fixed any syntax errors and line length issues related to these changes.
- Ensured all code checks and pre-commit hooks pass after modifications.
- Verified that tests still run successfully after these changes.

**Checklist:**
- [x] Part of #62434
- [x] All code checks passed.
- [ ] Tests added and passed if fixing a bug or adding a new feature.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Please let me know if any changes are needed!
