### PR TITLE
Added legend_loc parameter to plot function

### DIFF
--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -173,6 +173,7 @@ class MPLPlot(ABC):
         stacked: bool = False,
         label: Hashable | None = None,
         style=None,
+        legend_loc: str | tuple[float, float] ='best',
         **kwds,
     ) -> None:
         # if users assign an empty list or tuple, raise `ValueError`
@@ -241,6 +242,8 @@ class MPLPlot(ABC):
         self.legend = legend
         self.legend_handles: list[Artist] = []
         self.legend_labels: list[Hashable] = []
+        self.legend_loc = legend_loc
+
 
         self.logx = type(self)._validate_log_kwd("logx", logx)
         self.logy = type(self)._validate_log_kwd("logy", logy)
@@ -909,7 +912,8 @@ class MPLPlot(ABC):
                     title = self.legend_title
 
             if len(handles) > 0:
-                ax.legend(handles, labels, loc="best", title=title)
+                # ax.legend(handles, labels, loc="best", title=title)
+                ax.legend(handles, labels, loc=self.legend_loc, title=title)
 
         elif self.subplots and self.legend:
             for ax in self.axes:
@@ -920,7 +924,8 @@ class MPLPlot(ABC):
                             "No artists with labels found to put in legend.",
                             UserWarning,
                         )
-                        ax.legend(loc="best")
+                        # ax.legend(loc="best")
+                        ax.legend(loc=self.legend_loc)
 
     @final
     @staticmethod

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -173,7 +173,7 @@ class MPLPlot(ABC):
         stacked: bool = False,
         label: Hashable | None = None,
         style=None,
-        legend_loc: str | tuple[float, float] ='best',
+        legend_loc: str | tuple[float, float] = "best",
         **kwds,
     ) -> None:
         # if users assign an empty list or tuple, raise `ValueError`
@@ -243,7 +243,6 @@ class MPLPlot(ABC):
         self.legend_handles: list[Artist] = []
         self.legend_labels: list[Hashable] = []
         self.legend_loc = legend_loc
-
 
         self.logx = type(self)._validate_log_kwd("logx", logx)
         self.logy = type(self)._validate_log_kwd("logy", logy)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -911,7 +911,6 @@ class MPLPlot(ABC):
                     title = self.legend_title
 
             if len(handles) > 0:
-                # ax.legend(handles, labels, loc="best", title=title)
                 ax.legend(handles, labels, loc=self.legend_loc, title=title)
 
         elif self.subplots and self.legend:
@@ -923,7 +922,6 @@ class MPLPlot(ABC):
                             "No artists with labels found to put in legend.",
                             UserWarning,
                         )
-                        # ax.legend(loc="best")
                         ax.legend(loc=self.legend_loc)
 
     @final

--- a/pandas/tests/plotting/frame/test_frame_legend.py
+++ b/pandas/tests/plotting/frame/test_frame_legend.py
@@ -292,7 +292,7 @@ class TestFrameLegend:
         [
             ("line", ["a", "b"]),
             ("bar", ["a", "b"]),
-            ("scatter", ["b"]),  # scatter(x="a", y="b") usually labels the y series
+            ("scatter", ["b"]),
         ],
     )
     def test_across_kinds_legend_loc(self, kind, labels):

--- a/pandas/tests/plotting/frame/test_frame_legend.py
+++ b/pandas/tests/plotting/frame/test_frame_legend.py
@@ -10,8 +10,8 @@ from pandas import (
 from pandas.tests.plotting.common import (
     _check_legend_labels,
     _check_legend_marker,
-    _check_text_labels,
     _check_plot_works,
+    _check_text_labels,
 )
 
 mpl = pytest.importorskip("matplotlib")

--- a/pandas/tests/plotting/frame/test_frame_legend.py
+++ b/pandas/tests/plotting/frame/test_frame_legend.py
@@ -282,16 +282,19 @@ class TestFrameLegend:
         _check_legend_labels(ax, labels=["a", "b (right)", "c"])
         ax = df2.plot(legend=False, ax=ax)
         _check_legend_labels(ax, labels=["a", "b (right)", "c"])
-        ax = df3.plot(kind="bar", legend=True, secondary_y="h", legend_loc="upper right", ax=ax)
+        ax = df3.plot(
+            kind="bar", legend=True, secondary_y="h", legend_loc="upper right", ax=ax
+        )
         _check_legend_labels(ax, labels=["a", "b (right)", "c", "g", "h (right)", "i"])
 
     @pytest.mark.parametrize(
-            "kind, labels",
-            [
-                ("line", ["a", "b"]),
-                ("bar",  ["a", "b"]),
-                ("scatter", ["b"]),  # scatter(x="a", y="b") usually labels the y series
-                ])
+        "kind, labels",
+        [
+            ("line", ["a", "b"]),
+            ("bar", ["a", "b"]),
+            ("scatter", ["b"]),  # scatter(x="a", y="b") usually labels the y series
+        ],
+    )
     def test_across_kinds_legend_loc(self, kind, labels):
         df = DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
         if kind == "scatter":
@@ -302,14 +305,11 @@ class TestFrameLegend:
                 y="b",
                 label="b",
                 legend=True,
-                legend_loc="upper right"
+                legend_loc="upper right",
             )
         else:
             ax = _check_plot_works(
-                df.plot,
-                kind=kind,
-                legend=True,
-                legend_loc="upper right"
-                )
+                df.plot, kind=kind, legend=True, legend_loc="upper right"
+            )
         _check_legend_labels(ax, labels=labels)
         assert ax.get_legend() is not None

--- a/pandas/tests/plotting/frame/test_frame_legend.py
+++ b/pandas/tests/plotting/frame/test_frame_legend.py
@@ -11,6 +11,7 @@ from pandas.tests.plotting.common import (
     _check_legend_labels,
     _check_legend_marker,
     _check_text_labels,
+    _check_plot_works,
 )
 
 mpl = pytest.importorskip("matplotlib")
@@ -260,3 +261,55 @@ class TestFrameLegend:
 
         _check_legend_labels(ax, labels=["A", "B", "C"])
         _check_legend_marker(ax, expected_markers=[".", ".", "."])
+
+    def test_no_legend_when_legend_false_legend_loc(self):
+        df = DataFrame({"a": [1, 2, 3]})
+        ax = _check_plot_works(df.plot, legend=False, legend_loc="upper right")
+        assert ax.get_legend() is None
+
+    def test_df_legend_labels_secondary_y_legend_loc(self):
+        pytest.importorskip("scipy")
+        df = DataFrame(np.random.default_rng(2).random((3, 3)), columns=["a", "b", "c"])
+        df2 = DataFrame(
+            np.random.default_rng(2).random((3, 3)), columns=["d", "e", "f"]
+        )
+        df3 = DataFrame(
+            np.random.default_rng(2).random((3, 3)), columns=["g", "h", "i"]
+        )
+
+        # preserves "best" behaviour if no legend_loc specified
+        ax = df.plot(legend=True, secondary_y="b", legend_loc=None)
+        _check_legend_labels(ax, labels=["a", "b (right)", "c"])
+        ax = df2.plot(legend=False, ax=ax)
+        _check_legend_labels(ax, labels=["a", "b (right)", "c"])
+        ax = df3.plot(kind="bar", legend=True, secondary_y="h", legend_loc="upper right", ax=ax)
+        _check_legend_labels(ax, labels=["a", "b (right)", "c", "g", "h (right)", "i"])
+
+    @pytest.mark.parametrize(
+            "kind, labels",
+            [
+                ("line", ["a", "b"]),
+                ("bar",  ["a", "b"]),
+                ("scatter", ["b"]),  # scatter(x="a", y="b") usually labels the y series
+                ])
+    def test_across_kinds_legend_loc(self, kind, labels):
+        df = DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]})
+        if kind == "scatter":
+            ax = _check_plot_works(
+                df.plot,
+                kind="scatter",
+                x="a",
+                y="b",
+                label="b",
+                legend=True,
+                legend_loc="upper right"
+            )
+        else:
+            ax = _check_plot_works(
+                df.plot,
+                kind=kind,
+                legend=True,
+                legend_loc="upper right"
+                )
+        _check_legend_labels(ax, labels=labels)
+        assert ax.get_legend() is not None


### PR DESCRIPTION
- [x] closes #20183 Added 'legend_loc' parameter to the plot function in pandas that calls matplotlib's legend loc internally. 
- [x] Tests added and passed. Fixing a bug or adding a new feature
- [x] All code checks passed.
- [x] Added type annotations to new arguments.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
