### PR TITLE
Free dynamically allocated memory prior to returning error

### DIFF
--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -91,6 +91,8 @@ def hash_object_array(
             hash(val)
             data = <bytes>str(val).encode(encoding)
         else:
+            free(vecs)
+            free(lens)
             raise TypeError(
                 f"{val} of type {type(val)} is not a valid type for hashing, "
                 "must be string or null"


### PR DESCRIPTION
Previously, this could cause some asan issues as the `vecs` and `lens` objects were not deleted.

This was noticed internally on our codebase.

This is identical to #62569, but I had to switch github accounts.