### PR TITLE
BUG: Fixes regression in Series.pow with all-NA double[pyarrow] values in in pandas 3.x

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1226,6 +1226,7 @@ Other
 - Fixed bug in the :meth:`Series.rank` with object dtype and extremely small float values (:issue:`62036`)
 - Fixed bug where the :class:`DataFrame` constructor misclassified array-like objects with a ``.name`` attribute as :class:`Series` or :class:`Index` (:issue:`61443`)
 - Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
+- Fixed regression in :meth:`Series.pow` on Series with all-NA ``float64[pyarrow]`` values; this now returns Series with :class:`NA` values (:issue:`62520`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1226,7 +1226,6 @@ Other
 - Fixed bug in the :meth:`Series.rank` with object dtype and extremely small float values (:issue:`62036`)
 - Fixed bug where the :class:`DataFrame` constructor misclassified array-like objects with a ``.name`` attribute as :class:`Series` or :class:`Index` (:issue:`61443`)
 - Fixed regression in :meth:`DataFrame.from_records` not initializing subclasses properly (:issue:`57008`)
-- Fixed regression in :meth:`Series.pow` on Series with all-NA ``float64[pyarrow]`` values; this now returns Series with :class:`NA` values (:issue:`62520`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1051,7 +1051,7 @@ class ArrowExtensionArray(
         result = self._evaluate_op_method(other, op, ARROW_ARITHMETIC_FUNCS)
         if is_nan_na() and result.dtype.kind == "f":
             parr = result._pa_array
-            mask = pc.is_nan(parr).to_numpy()
+            mask = pc.is_nan(parr).fill_null(False).to_numpy()
             arr = pc.replace_with_mask(parr, mask, pa.scalar(None, type=parr.type))
             result = type(self)(arr)
         return result

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3691,3 +3691,12 @@ def test_setitem_float_nan_is_na(using_nan_is_na):
         ser[2] = np.nan
         assert isinstance(ser[2], float)
         assert np.isnan(ser[2])
+
+
+def test_pow_with_all_na_float():
+    # GH#62520
+
+    s = pd.Series([None, None], dtype="float64[pyarrow]")
+    result = s.pow(2)
+    expected = pd.Series([pd.NA, pd.NA], dtype="float64[pyarrow]")
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #62520 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

### Notes
Makes the recommended 1-line change suggested in #62520 to ArrowExtensionArray._arith_method() to convert Series with all None float64[pyarrow] values to Series with all pd.NA float64[pyarrow] values. This fixes the regression in Series.pow in pandas 3.x to match functionality in previous versions. 