### PR TITLE
STY: Add `strict=True` in `zip()` in pandas\core\array_algos\quantile.py

### DIFF
--- a/pandas/core/array_algos/quantile.py
+++ b/pandas/core/array_algos/quantile.py
@@ -197,7 +197,7 @@ def _nanquantile(
         assert mask.shape == values.shape
         result = [
             _nanquantile_1d(val, m, qs, na_value, interpolation=interpolation)
-            for (val, m) in zip(list(values), list(mask))
+            for (val, m) in zip(list(values), list(mask), strict=True)
         ]
         if values.dtype.kind == "f":
             # preserve itemsize


### PR DESCRIPTION
Added `strict=True` to the `zip()` call in `pandas/core/array_algos/quantile.py`.

- [x] Fixes a single file as part of #62434
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.

