### PR TITLE
STY: Add `strict=True` in `zip()` in pandas\tests\io\test_orc.py

### DIFF
--- a/pandas/tests/io/test_orc.py
+++ b/pandas/tests/io/test_orc.py
@@ -51,7 +51,7 @@ def test_orc_reader_empty(dirpath, using_infer_string):
         "str" if using_infer_string else "object",
     ]
     expected = pd.DataFrame(index=pd.RangeIndex(0))
-    for colname, dtype in zip(columns, dtypes):
+    for colname, dtype in zip(columns, dtypes, strict=True):
         expected[colname] = pd.Series(dtype=dtype)
     expected.columns = expected.columns.astype("str")
 


### PR DESCRIPTION
Added `strict=True` to the `zip()` call in pandas\tests\io\test_orc.py.

- [x] Fixes a single file as part of #62434 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.