### PR TITLE
STY: Add `strict` parameter with appropriate value in `zip()` in pandas/tests/series/methods/

### DIFF
--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -209,11 +209,14 @@ class TestSeriesConvertDtypes:
             "convert_boolean",
             "convert_floating",
         ]
-        params_dict = dict(zip(param_names, params))
+        params_dict = dict(zip(param_names, params, strict=True))
 
         expected_dtype = expected_default
         for spec, dtype in expected_other.items():
-            if all(params_dict[key] is val for key, val in zip(spec[::2], spec[1::2])):
+            if all(
+                params_dict[key] is val
+                for key, val in zip(spec[::2], spec[1::2], strict=False)
+            ):
                 expected_dtype = dtype
         if (
             using_infer_string

--- a/pandas/tests/series/methods/test_rename.py
+++ b/pandas/tests/series/methods/test_rename.py
@@ -21,7 +21,7 @@ class TestRename:
         assert renamed.index[0] == renamer(ts.index[0])
 
         # dict
-        rename_dict = dict(zip(ts.index, renamed.index))
+        rename_dict = dict(zip(ts.index, renamed.index, strict=True))
         renamed2 = ts.rename(rename_dict)
         tm.assert_series_equal(renamed, renamed2)
 

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -648,7 +648,7 @@ class TestSeriesReplace:
         labs = pd.Series([1, 1, 1, 0, 0, 2, 2, 2], dtype=any_int_numpy_dtype)
 
         maps = pd.Series([0, 2, 1], dtype=any_int_numpy_dtype)
-        map_dict = dict(zip(maps.values, maps.index))
+        map_dict = dict(zip(maps.values, maps.index, strict=True))
 
         result = labs.replace(map_dict)
         expected = labs.replace({0: 0, 2: 1, 1: 2})

--- a/pandas/tests/series/methods/test_reset_index.py
+++ b/pandas/tests/series/methods/test_reset_index.py
@@ -146,7 +146,7 @@ class TestResetIndex:
             ["bar", "bar", "baz", "baz", "qux", "qux", "foo", "foo"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = zip(*arrays)
+        tuples = zip(*arrays, strict=True)
         index = MultiIndex.from_tuples(tuples)
         data = np.random.default_rng(2).standard_normal(8)
         ser = Series(data, index=index)

--- a/pandas/tests/series/methods/test_sort_index.py
+++ b/pandas/tests/series/methods/test_sort_index.py
@@ -186,7 +186,7 @@ class TestSeriesSortIndex:
             ["one", "two", "one", "two", "one", "two", "one", "two"],
             [4, 3, 2, 1, 4, 3, 2, 1],
         ]
-        tuples = zip(*arrays)
+        tuples = zip(*arrays, strict=True)
         mi = MultiIndex.from_tuples(tuples, names=["first", "second", "third"])
         ser = Series(range(8), index=mi)
 


### PR DESCRIPTION
Added `strict` parameter with appropriate value to the `zip()` call in multiple files in pandas/tests/series/methods, namely:

* test_rename.py
* test_convert_dtypes.py
* test_replace.py
* test_reset_index.py
* test_sort_index.py

- [x] Fixes multiple files in a subfolder `methods` under `pandas/tests/series` as part of #62434 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
