### PR TITLE
STY: Add strict=True in zip() in to_dict.py

### DIFF
--- a/pandas/core/methods/to_dict.py
+++ b/pandas/core/methods/to_dict.py
@@ -198,7 +198,7 @@ def to_dict(
                 if i in object_dtype_indices_as_set
                 else list(map(maybe_box_native, v.to_numpy())),
             )
-            for i, (box_na_value, (k, v)) in enumerate(zip(box_na_values, df.items()))
+            for i, (box_na_value, (k, v)) in enumerate(zip(box_na_values, df.items(), strict=True))
         )
 
     elif orient == "split":
@@ -235,12 +235,12 @@ def to_dict(
         columns = df.columns.tolist()
         if are_all_object_dtype_cols:
             return [
-                into_c(zip(columns, map(maybe_box_native, row)))
+                into_c(zip(columns, map(maybe_box_native, row), strict=True))
                 for row in df.itertuples(index=False, name=None)
             ]
         else:
             data = [
-                into_c(zip(columns, t)) for t in df.itertuples(index=False, name=None)
+                into_c(zip(columns, t, strict=True)) for t in df.itertuples(index=False, name=None)
             ]
             if box_native_indices:
                 object_dtype_indices_as_set = set(box_native_indices)
@@ -260,7 +260,7 @@ def to_dict(
         columns = df.columns.tolist()
         if are_all_object_dtype_cols:
             return into_c(
-                (t[0], dict(zip(df.columns, map(maybe_box_native, t[1:]))))
+                (t[0], dict(zip(df.columns, map(maybe_box_native, t[1:]), strict=True)))
                 for t in df.itertuples(name=None)
             )
         elif box_native_indices:
@@ -272,14 +272,14 @@ def to_dict(
                         column: maybe_box_native(v)
                         if i in object_dtype_indices_as_set
                         else v
-                        for i, (column, v) in enumerate(zip(columns, t[1:]))
+                        for i, (column, v) in enumerate(zip(columns, t[1:], strict=True))
                     },
                 )
                 for t in df.itertuples(name=None)
             )
         else:
             return into_c(
-                (t[0], dict(zip(columns, t[1:]))) for t in df.itertuples(name=None)
+                (t[0], dict(zip(columns, t[1:], strict=True))) for t in df.itertuples(name=None)
             )
 
     else:

--- a/pandas/core/methods/to_dict.py
+++ b/pandas/core/methods/to_dict.py
@@ -198,7 +198,9 @@ def to_dict(
                 if i in object_dtype_indices_as_set
                 else list(map(maybe_box_native, v.to_numpy())),
             )
-            for i, (box_na_value, (k, v)) in enumerate(zip(box_na_values, df.items(), strict=True))
+            for i, (box_na_value, (k, v)) in enumerate(
+                zip(box_na_values, df.items(), strict=True)
+            )
         )
 
     elif orient == "split":
@@ -240,7 +242,8 @@ def to_dict(
             ]
         else:
             data = [
-                into_c(zip(columns, t, strict=True)) for t in df.itertuples(index=False, name=None)
+                into_c(zip(columns, t, strict=True))
+                for t in df.itertuples(index=False, name=None)
             ]
             if box_native_indices:
                 object_dtype_indices_as_set = set(box_native_indices)
@@ -272,14 +275,17 @@ def to_dict(
                         column: maybe_box_native(v)
                         if i in object_dtype_indices_as_set
                         else v
-                        for i, (column, v) in enumerate(zip(columns, t[1:], strict=True))
+                        for i, (column, v) in enumerate(
+                            zip(columns, t[1:], strict=True)
+                        )
                     },
                 )
                 for t in df.itertuples(name=None)
             )
         else:
             return into_c(
-                (t[0], dict(zip(columns, t[1:], strict=True))) for t in df.itertuples(name=None)
+                (t[0], dict(zip(columns, t[1:], strict=True)))
+                for t in df.itertuples(name=None)
             )
 
     else:


### PR DESCRIPTION
## Summary
This change enforces Ruff rule B905 (`zip-without-explicit-strict`) by adding `strict=True` to all `zip()` function calls in `pandas/core/methods/to_dict.py`. This ensures that input iterables are of equal length, preventing silent truncation and potential data inconsistencies.

## Modified File
- `pandas/core/methods/to_dict.py`

## Specific Changes
The following 6 `zip()` calls were updated to include `strict=True`:

1. **Line 201**: `zip(box_na_values, df.items())` → `zip(box_na_values, df.items(), strict=True)`
2. **Line 238**: `zip(columns, map(maybe_box_native, row))` → `zip(columns, map(maybe_box_native, row), strict=True)`
3. **Line 243**: `zip(columns, t)` → `zip(columns, t, strict=True)`
4. **Line 263**: `zip(df.columns, map(maybe_box_native, t[1:]))` → `zip(df.columns, map(maybe_box_native, t[1:]), strict=True)`
5. **Line 275**: `zip(columns, t[1:])` → `zip(columns, t[1:], strict=True)`
6. **Line 282**: `zip(columns, t[1:])` → `zip(columns, t[1:], strict=True)`

