### PR TITLE
STY: Enforce Ruff rule B905 for pandas/_config

### DIFF
--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -271,7 +271,7 @@ def set_option(*args) -> None:
     if not nargs or nargs % 2 != 0:
         raise ValueError("Must provide an even number of non-keyword arguments")
 
-    for k, v in zip(args[::2], args[1::2]):
+    for k, v in zip(args[::2], args[1::2], strict=True):
         key = _get_single_key(k)
 
         opt = _get_registered_option(key)
@@ -502,7 +502,7 @@ def option_context(*args) -> Generator[None]:
             "option_context(pat, val, pat, val...)."
         )
 
-    ops = tuple(zip(args[::2], args[1::2]))
+    ops = tuple(zip(args[::2], args[1::2], strict=True))
     try:
         undo = tuple((pat, get_option(pat)) for pat, val in ops)
         for pat, val in ops:


### PR DESCRIPTION
This PR adds `strict=True` to all `zip()` calls in the `pandas/_config/` directory to enforce Ruff rule B905.

**Changes made:**
- Added `strict=True` to `zip()` call in `set_option()` function (line 274)
- Added `strict=True` to `zip()` call in `option_context()` function (line 505)

Both functions use `args[::2]` and `args[1::2]` which are guaranteed to have equal length since the code validates that `len(args) % 2 == 0` before the zip operations.

Closes #62434 for the `pandas/_config/` directory.

**Testing:**
- Syntax validation passed
- No functional changes - both zip operations already assume equal-length iterables

**Note:** This is part of a larger effort to enforce strict zip usage across the pandas codebase.