### PR TITLE
TST: Add regression test for pyarrow datetime merge with duplicates (GH#61926)

### DIFF
--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -3118,7 +3118,7 @@ def test_merge_pyarrow_datetime_duplicates():
     # This should work without raising ValueError
     result = merge(df1, df2, on="time", how="left")
 
-    # Should return 6 rows (df1's 3 timestamps × 2 matches each from df2)
+    # Should return 6 rows (df1's 3 timestamps x 2 matches each from df2)
     assert len(result) == 6
     assert result["val1"].tolist() == [1, 1, 2, 2, 3, 3]
     assert result["val2"].tolist() == [10, 20, 30, 40, 50, 60]

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -3101,24 +3101,23 @@ def test_merge_categorical_key_recursion():
 
 def test_merge_pyarrow_datetime_duplicates():
     # GH#61926
-    # Regression test for merge failing on pyarrow datetime columns with duplicates
     pytest.importorskip("pyarrow")
 
-    # Create datetime index
     t = pd.date_range("2025-07-06", periods=3, freq="h")
-
-    # Left dataframe: one row per timestamp
     df1 = DataFrame({"time": t, "val1": [1, 2, 3]})
     df1 = df1.convert_dtypes(dtype_backend="pyarrow")
 
-    # Right dataframe: two rows per timestamp (duplicates)
     df2 = DataFrame({"time": t.repeat(2), "val2": [10, 20, 30, 40, 50, 60]})
     df2 = df2.convert_dtypes(dtype_backend="pyarrow")
 
-    # This should work without raising ValueError
     result = merge(df1, df2, on="time", how="left")
 
-    # Should return 6 rows (df1's 3 timestamps x 2 matches each from df2)
-    assert len(result) == 6
-    assert result["val1"].tolist() == [1, 1, 2, 2, 3, 3]
-    assert result["val2"].tolist() == [10, 20, 30, 40, 50, 60]
+    expected = DataFrame(
+        {
+            "time": t.repeat(2),
+            "val1": [1, 1, 2, 2, 3, 3],
+            "val2": [10, 20, 30, 40, 50, 60],
+        }
+    )
+    expected = expected.convert_dtypes(dtype_backend="pyarrow")
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
This PR adds a regression test for issue #61926, which was fixed by PR #62276.

**Issue:**
Merge operations were failing with `ValueError: Length mismatch` when using pyarrow datetime columns where the right dataframe had duplicate timestamps.

**Fix:**
PR #62276 improved `Index._get_join_target` to properly handle pyarrow datetime types by casting them to int64 (i8) for join operations, similar to how numpy datetime types are handled.

**This PR:**
Adds a test case to ensure this bug doesn't regress in the future. The test:
- Creates two dataframes with pyarrow datetime columns
- Left has 3 unique timestamps, right has 6 rows (each timestamp duplicated)
- Performs a left merge that should return 6 rows
- Validates the merge completes successfully without ValueError

Closes #61926