### PR TITLE
Zip Strict for pandas/core/dtypes

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -514,7 +514,7 @@ def _array_equivalent_object(
         left_remaining = left
         right_remaining = right
 
-    for left_value, right_value in zip(left_remaining, right_remaining):
+    for left_value, right_value in zip(left_remaining, right_remaining, strict=True):
         if left_value is NaT and right_value is not NaT:
             return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -453,7 +453,6 @@ exclude = [
 "pandas/core/computation/align.py" = ["B905"]
 "pandas/core/computation/expr.py" = ["B905"]
 "pandas/core/computation/ops.py" = ["B905"]
-"pandas/core/dtypes/missing.py" = ["B905"]
 "pandas/core/groupby/generic.py" = ["B905"]
 "pandas/core/groupby/groupby.py" = ["B905"]
 "pandas/core/groupby/grouper.py" = ["B905"]


### PR DESCRIPTION
This PR adds the `strict=True` argument to the `zip()` calls in `pandas/core/dtypes` in order to enforce Ruff rule B905.

**Changes**
- Added to `strict=True`  to a zip function call in `pandas/core/dtypes/missing.py`.
- Caller function `array_equivalent()` already applies an [array length check](https://github.com/pandas-dev/pandas/blob/main/pandas/core/dtypes/missing.py#L437) before calling `_array_equivalent_object()` which invokes the zip function on the given arrays.

**Testing**
- All relevant tests in `pandas/tests/dtypes/missing.py` passed successfully with the exception of 4 tests that had previously been marked as xfail.

- [X] part of #62434
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
