### PR TITLE
TST: Replace ensure_clean with pytest temp_file/tmp_path fixture.

### DIFF
--- a/pandas/tests/io/parser/common/test_read_errors.py
+++ b/pandas/tests/io/parser/common/test_read_errors.py
@@ -246,7 +246,7 @@ def test_null_byte_char(request, all_parsers):
 
 
 @pytest.mark.filterwarnings("always::ResourceWarning")
-def test_open_file(all_parsers):
+def test_open_file(all_parsers, temp_file):
     # GH 39024
     parser = all_parsers
 
@@ -259,14 +259,13 @@ def test_open_file(all_parsers):
         msg = "'utf-8' codec can't decode byte 0xe4"
         err = ValueError
 
-    with tm.ensure_clean() as path:
-        file = Path(path)
-        file.write_bytes(b"\xe4\na\n1")
+    file = Path(temp_file)
+    file.write_bytes(b"\xe4\na\n1")
 
-        with tm.assert_produces_warning(None):
-            # should not trigger a ResourceWarning
-            with pytest.raises(err, match=msg):
-                parser.read_csv(file, sep=None, encoding_errors="replace")
+    with tm.assert_produces_warning(None):
+        # should not trigger a ResourceWarning
+        with pytest.raises(err, match=msg):
+            parser.read_csv(file, sep=None, encoding_errors="replace")
 
 
 def test_invalid_on_bad_line(all_parsers):

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -29,7 +29,9 @@ xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
 @pytest.mark.parametrize("dtype", [str, object])
 @pytest.mark.parametrize("check_orig", [True, False])
 @pytest.mark.usefixtures("pyarrow_xfail")
-def test_dtype_all_columns(all_parsers, dtype, check_orig, using_infer_string):
+def test_dtype_all_columns(
+    all_parsers, dtype, check_orig, using_infer_string, tmp_path
+):
     # see gh-3795, gh-6607
     parser = all_parsers
 
@@ -39,20 +41,20 @@ def test_dtype_all_columns(all_parsers, dtype, check_orig, using_infer_string):
         index=["1A", "1B", "1C", "1D", "1E"],
     )
 
-    with tm.ensure_clean("__passing_str_as_dtype__.csv") as path:
-        df.to_csv(path)
+    path = tmp_path / "__passing_str_as_dtype__.csv"
+    df.to_csv(path)
 
-        result = parser.read_csv(path, dtype=dtype, index_col=0)
+    result = parser.read_csv(path, dtype=dtype, index_col=0)
 
-        if check_orig:
-            expected = df.copy()
-            result = result.astype(float)
-        elif using_infer_string and dtype is str:
-            expected = df.astype(str)
-        else:
-            expected = df.astype(str).astype(object)
+    if check_orig:
+        expected = df.copy()
+        result = result.astype(float)
+    elif using_infer_string and dtype is str:
+        expected = df.astype(str)
+    else:
+        expected = df.astype(str).astype(object)
 
-        tm.assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.usefixtures("pyarrow_xfail")

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -130,7 +130,7 @@ nan 2
     ],
     ids=["dt64-0", "dt64-1", "td64", f"{tm.ENDIAN}U8"],
 )
-def test_unsupported_dtype(c_parser_only, match, kwargs):
+def test_unsupported_dtype(c_parser_only, match, kwargs, tmp_path):
     parser = c_parser_only
     df = DataFrame(
         np.random.default_rng(2).random((5, 2)),
@@ -138,11 +138,11 @@ def test_unsupported_dtype(c_parser_only, match, kwargs):
         index=["1A", "1B", "1C", "1D", "1E"],
     )
 
-    with tm.ensure_clean("__unsupported_dtype__.csv") as path:
-        df.to_csv(path)
+    path = tmp_path / "__unsupported_dtype__.csv"
+    df.to_csv(path)
 
-        with pytest.raises(TypeError, match=match):
-            parser.read_csv(path, index_col=0, **kwargs)
+    with pytest.raises(TypeError, match=match):
+        parser.read_csv(path, index_col=0, **kwargs)
 
 
 @td.skip_if_32bit
@@ -563,27 +563,27 @@ def test_file_handles_mmap(c_parser_only, csv1):
             assert not m.closed
 
 
-def test_file_binary_mode(c_parser_only):
+def test_file_binary_mode(c_parser_only, temp_file):
     # see gh-23779
     parser = c_parser_only
     expected = DataFrame([[1, 2, 3], [4, 5, 6]])
 
-    with tm.ensure_clean() as path:
-        with open(path, "w", encoding="utf-8") as f:
-            f.write("1,2,3\n4,5,6")
+    path = temp_file
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("1,2,3\n4,5,6")
 
-        with open(path, "rb") as f:
-            result = parser.read_csv(f, header=None)
-            tm.assert_frame_equal(result, expected)
+    with open(path, "rb") as f:
+        result = parser.read_csv(f, header=None)
+        tm.assert_frame_equal(result, expected)
 
 
-def test_unix_style_breaks(c_parser_only):
+def test_unix_style_breaks(c_parser_only, temp_file):
     # GH 11020
     parser = c_parser_only
-    with tm.ensure_clean() as path:
-        with open(path, "w", newline="\n", encoding="utf-8") as f:
-            f.write("blah\n\ncol_1,col_2,col_3\n\n")
-        result = parser.read_csv(path, skiprows=2, encoding="utf-8", engine="c")
+    path = temp_file
+    with open(path, "w", newline="\n", encoding="utf-8") as f:
+        f.write("blah\n\ncol_1,col_2,col_3\n\n")
+    result = parser.read_csv(path, skiprows=2, encoding="utf-8", engine="c")
     expected = DataFrame(columns=["col_1", "col_2", "col_3"])
     tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
# Summary of Changes: Replace ensure_clean with pytest temp_file/tmp_path

This PR refactors three test files to replace usage of the legacy `tm.ensure_clean` context manager with pytest's modern temporary file fixtures (`tmp_path` or `temp_file`). This change aligns with pandas testing best practices and improves test reliability and readability.

## Modified Files
- `pandas/tests/io/parser/test_c_parser_only.py`
- `pandas/tests/io/parser/dtypes/test_dtypes_basic.py`
- `pandas/tests/io/parser/common/test_read_errors.py`

## Key Changes
- All usages of `tm.ensure_clean` were replaced with either `tmp_path` (for custom filenames) or `temp_file` (for generic temp files).
- Corresponding test functions were updated to accept the required pytest fixture as an argument.