### PR TITLE
DOC: Replace @Appender with inline docstring for DataFrame.items

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1472,8 +1472,54 @@ class DataFrame(NDFrame, OpsMixin):
         Name: population, dtype: int64
         """
 
-    @Appender(_shared_docs["items"])
     def items(self) -> Iterable[tuple[Hashable, Series]]:
+        """
+        Iterate over (column name, Series) pairs.
+
+        Iterates over the DataFrame columns, returning a tuple with
+        the column name and the content as a Series.
+
+        Yields
+        ------
+        label : object
+            The column names for the DataFrame being iterated over.
+        content : Series
+            The column entries belonging to each label, as a Series.
+
+        See Also
+        --------
+        DataFrame.iterrows : Iterate over DataFrame rows as
+            (index, Series) pairs.
+        DataFrame.itertuples : Iterate over DataFrame rows as namedtuples
+            of the values.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'species': ['bear', 'bear', 'marsupial'],
+        ...                   'population': [1864, 22000, 80000]},
+        ...                   index=['panda', 'polar', 'koala'])
+        >>> df
+                species   population
+        panda   bear      1864
+        polar   bear      22000
+        koala   marsupial 80000
+        >>> for label, content in df.items():
+        ...     print(f'label: {label}')
+        ...     print(f'content: {content}', sep='\n')
+        ...
+        label: species
+        content:
+        panda         bear
+        polar         bear
+        koala    marsupial
+        Name: species, dtype: object
+        label: population
+        content:
+        panda     1864
+        polar    22000
+        koala    80000
+        Name: population, dtype: int64
+        """
         for i, k in enumerate(self.columns):
             yield k, self._ixs(i, axis=1)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1473,7 +1473,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
 
     def items(self) -> Iterable[tuple[Hashable, Series]]:
-        """
+        r"""
         Iterate over (column name, Series) pairs.
 
         Iterates over the DataFrame columns, returning a tuple with

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1495,18 +1495,21 @@ class DataFrame(NDFrame, OpsMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame({'species': ['bear', 'bear', 'marsupial'],
-        ...                   'population': [1864, 22000, 80000]},
-        ...                   index=['panda', 'polar', 'koala'])
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "species": ["bear", "bear", "marsupial"],
+        ...         "population": [1864, 22000, 80000],
+        ...     },
+        ...     index=["panda", "polar", "koala"],
+        ... )
         >>> df
                 species   population
         panda   bear      1864
         polar   bear      22000
         koala   marsupial 80000
         >>> for label, content in df.items():
-        ...     print(f'label: {label}')
-        ...     print(f'content: {content}', sep='\n')
-        ...
+        ...     print(f"label: {label}")
+        ...     print(f"content: {content}", sep="\n")
         label: species
         content:
         panda         bear


### PR DESCRIPTION
xref #62437

## Description
This PR replaces the `@Appender` decorator with an inline docstring for the `DataFrame.items()` method as part of the effort to remove dynamic docstring generation in pandas.

## Changes Made
- Removed `@Appender(_shared_docs["items"])` decorator from `DataFrame.items()` in `pandas/core/frame.py`
- Inlined the complete docstring directly into the method definition
- No functional changes - only documentation improvement

## Why This Change?
As described in #62437, removing these decorators:
1. Reduces indirection and improves code clarity for new contributors
2. Allows docstring standardization rules from Ruff to apply
3. Makes docstrings more maintainable

## Testing
- Verified pandas imports successfully
- Confirmed `DataFrame.items()` functionality works correctly
- Checked docstring renders properly using `DataFrame.items.__doc__`

cc @mroeschke