### PR TITLE
Zip strict strings

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -334,7 +334,7 @@ class StringMethods(NoNewAttributesMixin):
                 )
                 result = {
                     label: ArrowExtensionArray(pa.array(res))
-                    for label, res in zip(name, result.T)
+                    for label, res in zip(name, result.T, strict=True)
                 }
             elif is_object_dtype(result):
 
@@ -684,7 +684,8 @@ class StringMethods(NoNewAttributesMixin):
         elif na_rep is not None and union_mask.any():
             # fill NaNs with na_rep in case there are actually any NaNs
             all_cols = [
-                np.where(nm, na_rep, col) for nm, col in zip(na_masks, all_cols)
+                np.where(nm, na_rep, col)
+                for nm, col in zip(na_masks, all_cols, strict=True)
             ]
             result = cat_safe(all_cols, sep)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -470,7 +470,6 @@ exclude = [
 "pandas/core/reshape/merge.py" = ["B905"]
 "pandas/core/reshape/pivot.py" = ["B905"]
 "pandas/core/reshape/reshape.py" = ["B905"]
-"pandas/core/strings/accessor.py" = ["B905"]
 "pandas/core/window/rolling.py" = ["B905"]
 "pandas/_testing/asserters.py" = ["B905"]
 "pandas/_testing/_warnings.py" = ["B905"]


### PR DESCRIPTION
This PR adds the `strict=True` argument to the `zip()` calls in `pandas/core/strings` in order to enforce Ruff rule B905.

**Changes**
- Added to `strict=True`  to two zip function calls in `pandas/core/strings/accessor.py`.

**Testing**
- All relevant tests in `pandas/tests/strings/` passed successfully with the exception of 15 tests that had previously been marked as xfail.

- [X] part of #62434
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
