### PR TITLE
STY: add strict=True to zip() in pandas/tests/indexes

### DIFF
--- a/pandas/tests/indexes/categorical/test_map.py
+++ b/pandas/tests/indexes/categorical/test_map.py
@@ -138,7 +138,7 @@ def test_map_with_dict_or_series():
     # Order of categories in result can be different
     tm.assert_index_equal(result, expected)
 
-    mapper = dict(zip(orig_values[:-1], new_values[:-1]))
+    mapper = dict(zip(orig_values[:-1], new_values[:-1], strict=True))
     result = cur_index.map(mapper)
     # Order of categories in result can be different
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/methods/test_astype.py
+++ b/pandas/tests/indexes/datetimes/methods/test_astype.py
@@ -239,7 +239,7 @@ class TestDatetimeIndex:
         def _check_rng(rng):
             converted = rng.to_pydatetime()
             assert isinstance(converted, np.ndarray)
-            for x, stamp in zip(converted, rng):
+            for x, stamp in zip(converted, rng, strict=True):
                 assert isinstance(x, datetime)
                 assert x == stamp.to_pydatetime()
                 assert x.tzinfo == stamp.tzinfo
@@ -258,7 +258,7 @@ class TestDatetimeIndex:
         def _check_rng(rng):
             converted = rng.to_pydatetime()
             assert isinstance(converted, np.ndarray)
-            for x, stamp in zip(converted, rng):
+            for x, stamp in zip(converted, rng, strict=True):
                 assert isinstance(x, datetime)
                 assert x == stamp.to_pydatetime()
                 assert x.tzinfo == stamp.tzinfo
@@ -275,7 +275,7 @@ class TestDatetimeIndex:
         def _check_rng(rng):
             converted = rng.to_pydatetime()
             assert isinstance(converted, np.ndarray)
-            for x, stamp in zip(converted, rng):
+            for x, stamp in zip(converted, rng, strict=True):
                 assert isinstance(x, datetime)
                 assert x == stamp.to_pydatetime()
                 assert x.tzinfo == stamp.tzinfo

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -264,7 +264,8 @@ class TestDatetimeIndexRendering:
         exp6 = """DatetimeIndex: 3 entries, 2011-01-01 09:00:00-05:00 to NaT"""
 
         for idx, expected in zip(
-            [idx1, idx2, idx3, idx4, idx5, idx6], [exp1, exp2, exp3, exp4, exp5, exp6], strict=True
+            [idx1, idx2, idx3, idx4, idx5, idx6], [exp1, exp2, exp3, exp4, exp5, exp6]
+            , strict=True
         ):
             result = idx._summary()
             assert result == expected

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -175,7 +175,7 @@ class TestDatetimeIndexRendering:
         )
 
         with pd.option_context("display.width", 300):
-            for index, expected in zip(idxs, exp):
+            for index, expected in zip(idxs, exp, strict=True):
                 index = index.as_unit(unit)
                 expected = expected.replace("[ns", f"[{unit}")
                 result = repr(index)
@@ -226,7 +226,7 @@ class TestDatetimeIndexRendering:
         with pd.option_context("display.width", 300):
             for idx, expected in zip(
                 [idx1, idx2, idx3, idx4, idx5, idx6, idx7],
-                [exp1, exp2, exp3, exp4, exp5, exp6, exp7],
+                [exp1, exp2, exp3, exp4, exp5, exp6, exp7], strict=True,
             ):
                 ser = Series(idx.as_unit(unit))
                 result = repr(ser)
@@ -264,7 +264,7 @@ class TestDatetimeIndexRendering:
         exp6 = """DatetimeIndex: 3 entries, 2011-01-01 09:00:00-05:00 to NaT"""
 
         for idx, expected in zip(
-            [idx1, idx2, idx3, idx4, idx5, idx6], [exp1, exp2, exp3, exp4, exp5, exp6]
+            [idx1, idx2, idx3, idx4, idx5, idx6], [exp1, exp2, exp3, exp4, exp5, exp6], strict=True
         ):
             result = idx._summary()
             assert result == expected

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -279,7 +279,7 @@ class TestSlicing:
             # Timestamp with the same resolution as index
             # Should be exact match for Series (return scalar)
             # and raise KeyError for Frame
-            for timestamp, expected in zip(index, values):
+            for timestamp, expected in zip(index, values, strict=True):
                 ts_string = timestamp.strftime(formats[rnum])
                 # make ts_string as precise as index
                 result = df["a"][ts_string]
@@ -319,7 +319,7 @@ class TestSlicing:
 
             # Not compatible with existing key
             # Should raise KeyError
-            for fmt, res in list(zip(formats, resolutions))[rnum + 1 :]:
+            for fmt, res in list(zip(formats, resolutions, strict=True))[rnum + 1 :]:
                 ts = index[1] + Timedelta("1 " + res)
                 ts_string = ts.strftime(fmt)
                 msg = rf"^'{ts_string}'$"

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -184,7 +184,8 @@ class TestDatetimeIndexOps:
             "Saturday",
             "Sunday",
         ]
-        for day, name, eng_name in zip(range(4, 11), expected_days, english_days, strict=True):
+        for day, name, eng_name in zip(range(4, 11), expected_days, english_days,
+                                       strict=True):
             name = name.capitalize()
             assert dti.day_name(locale=time_locale)[day] == name
             assert dti.day_name(locale=None)[day] == eng_name

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -184,7 +184,7 @@ class TestDatetimeIndexOps:
             "Saturday",
             "Sunday",
         ]
-        for day, name, eng_name in zip(range(4, 11), expected_days, english_days):
+        for day, name, eng_name in zip(range(4, 11), expected_days, english_days, strict=True):
             name = name.capitalize()
             assert dti.day_name(locale=time_locale)[day] == name
             assert dti.day_name(locale=None)[day] == eng_name
@@ -206,7 +206,7 @@ class TestDatetimeIndexOps:
 
         tm.assert_index_equal(result, expected)
 
-        for item, expected in zip(dti, expected_months):
+        for item, expected in zip(dti, expected_months, strict=True):
             result = item.month_name(locale=time_locale)
             expected = expected.capitalize()
 

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -162,7 +162,7 @@ class TestDatetimeIndexTimezones:
         eastern_range = utc_range.tz_convert("US/Eastern")
         berlin_range = utc_range.tz_convert("Europe/Berlin")
 
-        for a, b, c in zip(utc_range, eastern_range, berlin_range):
+        for a, b, c in zip(utc_range, eastern_range, berlin_range, strict=True):
             assert a == b
             assert b == c
             assert a == c

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -333,7 +333,7 @@ class TestFromTuples(ConstructorTests):
         if len(breaks) == 0:
             return {"data": breaks}
 
-        tuples = list(zip(breaks[:-1], breaks[1:]))
+        tuples = list(zip(breaks[:-1], breaks[1:], strict=True))
         if isinstance(breaks, (list, tuple)):
             return {"data": tuples}
         elif isinstance(getattr(breaks, "dtype", None), CategoricalDtype):
@@ -386,7 +386,7 @@ class TestClassConstructors(ConstructorTests):
 
         ivs = [
             Interval(left, right, closed) if notna(left) else left
-            for left, right in zip(breaks[:-1], breaks[1:])
+            for left, right in zip(breaks[:-1], breaks[1:], strict=True)
         ]
 
         if isinstance(breaks, list):

--- a/pandas/tests/indexes/interval/test_formats.py
+++ b/pandas/tests/indexes/interval/test_formats.py
@@ -45,7 +45,7 @@ class TestIntervalIndexRendering:
                     Interval(left, right)
                     for left, right in zip(
                         Index([329.973, 345.137], dtype="float64"),
-                        Index([345.137, 360.191], dtype="float64"),
+                        Index([345.137, 360.191], dtype="float64"), strict=True,
                     )
                 ]
             ),

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -49,7 +49,7 @@ class TestIntervalIndex:
 
         ivs = [
             Interval(left, right, closed)
-            for left, right in zip(range(10), range(1, 11))
+            for left, right in zip(range(10), range(1, 11), strict=True)
         ]
         expected = np.array(ivs, dtype=object)
         tm.assert_numpy_array_equal(np.asarray(index), expected)
@@ -71,7 +71,7 @@ class TestIntervalIndex:
 
         ivs = [
             Interval(left, right, closed) if notna(left) else np.nan
-            for left, right in zip(expected_left, expected_right)
+            for left, right in zip(expected_left, expected_right, strict=True)
         ]
         expected = np.array(ivs, dtype=object)
         tm.assert_numpy_array_equal(np.asarray(index), expected)
@@ -789,14 +789,14 @@ class TestIntervalIndex:
     @pytest.mark.parametrize(
         "tuples",
         [
-            zip(range(10), range(1, 11)),
+            zip(range(10), range(1, 11), strict=True),
             zip(
                 date_range("20170101", periods=10),
-                date_range("20170101", periods=10),
+                date_range("20170101", periods=10), strict=True,
             ),
             zip(
                 timedelta_range("0 days", periods=10),
-                timedelta_range("1 day", periods=10),
+                timedelta_range("1 day", periods=10), strict=True,
             ),
         ],
     )
@@ -811,18 +811,18 @@ class TestIntervalIndex:
     @pytest.mark.parametrize(
         "tuples",
         [
-            list(zip(range(10), range(1, 11))) + [np.nan],
+            list(zip(range(10), range(1, 11), strict=True)) + [np.nan],
             list(
                 zip(
                     date_range("20170101", periods=10),
-                    date_range("20170101", periods=10),
+                    date_range("20170101", periods=10), strict=True,
                 )
             )
             + [np.nan],
             list(
                 zip(
                     timedelta_range("0 days", periods=10),
-                    timedelta_range("1 day", periods=10),
+                    timedelta_range("1 day", periods=10), strict=True,
                 )
             )
             + [np.nan],

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -185,7 +185,7 @@ def test_map(idx):
 @pytest.mark.parametrize(
     "mapper",
     [
-        lambda values, idx: {i: e for e, i in zip(values, idx)},
+        lambda values, idx: {i: e for e, i in zip(values, idx, strict=True)},
         lambda values, idx: pd.Series(values, idx),
     ],
 )

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -155,7 +155,7 @@ def test_copy_in_constructor():
 def test_from_arrays(idx):
     arrays = [
         np.asarray(lev).take(level_codes)
-        for lev, level_codes in zip(idx.levels, idx.codes)
+        for lev, level_codes in zip(idx.levels, idx.codes, strict=True)
     ]
 
     # list of arrays as input
@@ -172,7 +172,7 @@ def test_from_arrays_iterator(idx):
     # GH 18434
     arrays = [
         np.asarray(lev).take(level_codes)
-        for lev, level_codes in zip(idx.levels, idx.codes)
+        for lev, level_codes in zip(idx.levels, idx.codes, strict=True)
     ]
 
     # iterator as input
@@ -188,7 +188,7 @@ def test_from_arrays_iterator(idx):
 def test_from_arrays_tuples(idx):
     arrays = tuple(
         tuple(np.asarray(lev).take(level_codes))
-        for lev, level_codes in zip(idx.levels, idx.codes)
+        for lev, level_codes in zip(idx.levels, idx.codes, strict=True)
     )
 
     # tuple of tuples as input
@@ -368,7 +368,7 @@ def test_from_tuples_iterator():
         levels=[[1, 3], [2, 4]], codes=[[0, 1], [0, 1]], names=["a", "b"]
     )
 
-    result = MultiIndex.from_tuples(zip([1, 3], [2, 4]), names=["a", "b"])
+    result = MultiIndex.from_tuples(zip([1, 3], [2, 4]), names=["a", "b"], strict=True)
     tm.assert_index_equal(result, expected)
 
     # input non-iterables

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -223,7 +223,7 @@ def test_equals_missing_values_differently_sorted():
 
 
 def test_is_():
-    mi = MultiIndex.from_tuples(zip(range(10), range(10)))
+    mi = MultiIndex.from_tuples(zip(range(10), range(10), strict=True))
     assert mi.is_(mi)
     assert mi.is_(mi.view())
     assert mi.is_(mi.view().view().view().view())

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -15,7 +15,7 @@ def assert_matching(actual, expected, check_dtype=False):
     # avoid specifying internal representation
     # as much as possible
     assert len(actual) == len(expected)
-    for act, exp in zip(actual, expected):
+    for act, exp in zip(actual, expected, strict=True):
         act = np.asarray(act)
         exp = np.asarray(exp)
         tm.assert_numpy_array_equal(act, exp, check_dtype=check_dtype)

--- a/pandas/tests/indexes/period/methods/test_asfreq.py
+++ b/pandas/tests/indexes/period/methods/test_asfreq.py
@@ -106,7 +106,7 @@ class TestPeriodIndex:
     def test_asfreq_combined_pi(self):
         pi = PeriodIndex(["2001-01-01 00:00", "2001-01-02 02:00", "NaT"], freq="h")
         exp = PeriodIndex(["2001-01-01 00:00", "2001-01-02 02:00", "NaT"], freq="25h")
-        for freq, how in zip(["1D1h", "1h1D"], ["S", "E"]):
+        for freq, how in zip(["1D1h", "1h1D"], ["S", "E"], strict=True):
             result = pi.asfreq(freq, how=how)
             tm.assert_index_equal(result, exp)
             assert result.freq == exp.freq

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -430,7 +430,7 @@ class TestPeriodIndex:
         year = Series([2001, 2002, 2003])
         quarter = year - 2000
         idx = PeriodIndex.from_fields(year=year, quarter=quarter)
-        strs = [f"{t[0]:d}Q{t[1]:d}" for t in zip(quarter, year)]
+        strs = [f"{t[0]:d}Q{t[1]:d}" for t in zip(quarter, year, strict=True)]
         lops = list(map(Period, strs))
         p = PeriodIndex(lops)
         tm.assert_index_equal(p, idx)

--- a/pandas/tests/indexes/period/test_formats.py
+++ b/pandas/tests/indexes/period/test_formats.py
@@ -83,7 +83,7 @@ class TestPeriodIndexRendering:
 
         for idx, expected in zip(
             [idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9, idx10],
-            [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9, exp10],
+            [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9, exp10], strict=True,
         ):
             result = getattr(idx, method)()
             assert result == expected
@@ -140,7 +140,7 @@ dtype: period[Q-DEC]"""
 
         for idx, expected in zip(
             [idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9],
-            [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9],
+            [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9], strict=True,
         ):
             result = repr(Series(idx))
             assert result == expected
@@ -187,7 +187,7 @@ Freq: Q-DEC"""
 
         for idx, expected in zip(
             [idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9],
-            [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9],
+            [exp1, exp2, exp3, exp4, exp5, exp6, exp7, exp8, exp9], strict=True,
         ):
             result = idx._summary()
             assert result == expected

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -102,7 +102,7 @@ class TestPeriodIndex:
 
         field_idx = getattr(periodindex, field)
         assert len(periodindex) == len(field_idx)
-        for x, val in zip(periods, field_idx):
+        for x, val in zip(periods, field_idx, strict=True):
             assert getattr(x, field) == val
 
         if len(ser) == 0:
@@ -110,7 +110,7 @@ class TestPeriodIndex:
 
         field_s = getattr(ser.dt, field)
         assert len(periodindex) == len(field_s)
-        for x, val in zip(periods, field_s):
+        for x, val in zip(periods, field_s, strict=True):
             assert getattr(x, field) == val
 
     def test_is_(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -534,7 +534,7 @@ class TestIndex:
         # Test that returning a single object from a MultiIndex
         #   returns an Index.
         first_level = ["foo", "bar", "baz"]
-        multi_index = MultiIndex.from_tuples(zip(first_level, [1, 2, 3]))
+        multi_index = MultiIndex.from_tuples(zip(first_level, [1, 2, 3], strict=True))
         reduced_index = multi_index.map(lambda x: x[0])
         tm.assert_index_equal(reduced_index, Index(first_level))
 
@@ -562,7 +562,7 @@ class TestIndex:
     @pytest.mark.parametrize(
         "mapper",
         [
-            lambda values, index: {i: e for e, i in zip(values, index)},
+            lambda values, index: {i: e for e, i in zip(values, index, strict=True)},
             lambda values, index: Series(values, index),
         ],
     )
@@ -576,7 +576,7 @@ class TestIndex:
     @pytest.mark.parametrize(
         "mapper",
         [
-            lambda values, index: {i: e for e, i in zip(values, index)},
+            lambda values, index: {i: e for e, i in zip(values, index, strict=True)},
             lambda values, index: Series(values, index),
         ],
     )

--- a/pandas/tests/indexes/test_datetimelike.py
+++ b/pandas/tests/indexes/test_datetimelike.py
@@ -109,7 +109,7 @@ class TestDatetimeLike:
     @pytest.mark.parametrize(
         "mapper",
         [
-            lambda values, index: {i: e for e, i in zip(values, index)},
+            lambda values, index: {i: e for e, i in zip(values, index, strict=True)},
             lambda values, index: pd.Series(values, index, dtype=object),
         ],
     )

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -669,7 +669,7 @@ class TestBase:
     @pytest.mark.parametrize(
         "mapper",
         [
-            lambda values, index: {i: e for e, i in zip(values, index)},
+            lambda values, index: {i: e for e, i in zip(values, index, strict=True)},
             lambda values, index: Series(values, index),
         ],
     )

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -914,7 +914,7 @@ class TestSetOpsUnsorted:
             op(a)
 
     def test_symmetric_difference_mi(self, sort):
-        index1 = MultiIndex.from_tuples(zip(["foo", "bar", "baz"], [1, 2, 3]))
+        index1 = MultiIndex.from_tuples(zip(["foo", "bar", "baz"], [1, 2, 3], strict=True))
         index2 = MultiIndex.from_tuples([("foo", 1), ("bar", 3)])
         result = index1.symmetric_difference(index2, sort=sort)
         expected = MultiIndex.from_tuples([("bar", 2), ("baz", 3), ("bar", 3)])

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -914,7 +914,8 @@ class TestSetOpsUnsorted:
             op(a)
 
     def test_symmetric_difference_mi(self, sort):
-        index1 = MultiIndex.from_tuples(zip(["foo", "bar", "baz"], [1, 2, 3], strict=True))
+        index1 = MultiIndex.from_tuples(zip(["foo", "bar", "baz"], [1, 2, 3],
+                                            strict=True))
         index2 = MultiIndex.from_tuples([("foo", 1), ("bar", 3)])
         result = index1.symmetric_difference(index2, sort=sort)
         expected = MultiIndex.from_tuples([("bar", 2), ("baz", 3), ("bar", 3)])

--- a/pandas/tests/indexes/timedeltas/test_formats.py
+++ b/pandas/tests/indexes/timedeltas/test_formats.py
@@ -46,7 +46,8 @@ class TestTimedeltaIndexRendering:
 
         with pd.option_context("display.width", 300):
             for idx, expected in zip(
-                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5], strict=True
+                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5],
+                strict=True
             ):
                 result = getattr(idx, method)()
                 assert result == expected
@@ -76,7 +77,8 @@ class TestTimedeltaIndexRendering:
 
         with pd.option_context("display.width", 300):
             for idx, expected in zip(
-                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5], strict=True
+                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5],
+                strict=True
             ):
                 result = repr(Series(idx))
                 assert result == expected

--- a/pandas/tests/indexes/timedeltas/test_formats.py
+++ b/pandas/tests/indexes/timedeltas/test_formats.py
@@ -46,7 +46,7 @@ class TestTimedeltaIndexRendering:
 
         with pd.option_context("display.width", 300):
             for idx, expected in zip(
-                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5]
+                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5], strict=True
             ):
                 result = getattr(idx, method)()
                 assert result == expected
@@ -76,7 +76,7 @@ class TestTimedeltaIndexRendering:
 
         with pd.option_context("display.width", 300):
             for idx, expected in zip(
-                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5]
+                [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5], strict=True
             ):
                 result = repr(Series(idx))
                 assert result == expected
@@ -100,7 +100,7 @@ class TestTimedeltaIndexRendering:
         exp5 = "TimedeltaIndex: 3 entries, 1 days 00:00:01 to 3 days 00:00:00"
 
         for idx, expected in zip(
-            [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5]
+            [idx1, idx2, idx3, idx4, idx5], [exp1, exp2, exp3, exp4, exp5], strict=True
         ):
             result = idx._summary()
             assert result == expected


### PR DESCRIPTION
This pull request adds strict=True to zip() in pandas/tests/indexes to enforce Ruff rule B905.

- [x] Fixes a part of #62434
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
