### PR TITLE
Fix: Indexing with dates of higher resolution should return empty

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -944,6 +944,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - Bug in :attr:`is_year_start` where a DateTimeIndex constructed via a date_range with frequency 'MS' wouldn't have the correct year or quarter start attributes (:issue:`57377`)
 - Bug in :class:`DataFrame` raising ``ValueError`` when ``dtype`` is ``timedelta64`` and ``data`` is a list containing ``None`` (:issue:`60064`)
+- Bug in :class:`DatetimeIndex` returning KeyError for out of range, failing to return empty slice when the resolution is greater than the current datetime objects. (:issue:`25803`)
 - Bug in :class:`Timestamp` constructor failing to raise when ``tz=None`` is explicitly specified in conjunction with timezone-aware ``tzinfo`` or data (:issue:`48688`)
 - Bug in :class:`Timestamp` constructor failing to raise when given a ``np.datetime64`` object with non-standard unit (:issue:`25611`)
 - Bug in :func:`date_range` where the last valid timestamp would sometimes not be produced (:issue:`56134`)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -317,15 +317,8 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         unbox = self._data._unbox
 
         if self.is_monotonic_increasing:
-            if len(self) and (
-                (t1 < self[0] and t2 < self[0]) or (t1 > self[-1] and t2 > self[-1])
-            ):
-                # we are out of range
-                raise KeyError
-
-            # TODO: does this depend on being monotonic _increasing_?
-
-            # a monotonic (sorted) series can be sliced
+            # a monotonic (sorted) series can be searched in ologn
+            # if date is not found, the empty slice will be returned
             left = vals.searchsorted(unbox(t1), side="left")
             right = vals.searchsorted(unbox(t2), side="right")
             return slice(left, right)

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -247,8 +247,16 @@ class TestSlicing:
         tm.assert_series_equal(s["2005-1-1 00:01:00"], s.iloc[10:])
 
         assert s[Timestamp("2005-1-1 00:00:59.999990")] == s.iloc[0]
-        with pytest.raises(KeyError, match="2005-1-1 00:00:00"):
-            s["2005-1-1 00:00:00"]
+        tm.assert_series_equal(s["2005-1-1 00:00:00"], s.iloc[0:0])
+
+    def test_partial_slice_higher_precision_empty(self):
+        # GH25803
+        s = Series(
+            [1, 2, 3],
+            DatetimeIndex(["2018-01-01T01:01", "2018-02-02T01:01", "2018-02-02T02:02"]),
+        )
+        tm.assert_series_equal(s.loc["2018-03-03"], s.iloc[0:0])
+        assert s.loc["2018-03-03"].size == 0
 
     def test_partial_slicing_dataframe(self):
         # GH14856

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -112,8 +112,8 @@ class TestGetItem:
         rng = period_range("2007-01", periods=50, freq="M")
         ts = Series(np.random.default_rng(2).standard_normal(len(rng)), rng)
 
-        with pytest.raises(KeyError, match=r"^'2006'$"):
-            ts["2006"]
+        # GH 25803
+        assert len(ts["2006"]) == 0
 
         result = ts["2008"]
         assert (result.index.year == 2008).all()


### PR DESCRIPTION
Indexing with out of range datetime objects of higher resolution should return empty slice instead of raising KeyError. 

This is to be "consistent with normal slicing, where out of range slice bounds return an empty object, and don't raise an error".

As per this [issue 25803](https://github.com/pandas-dev/pandas/issues/25803), specifically https://github.com/pandas-dev/pandas/issues/25803#issuecomment-475532254, if the date is of higher resolution than the current object in the series, e.g., day>minutes, then the empty slice should be returned instead of KeyError.

- [x] closes #25803 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [NA] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
