### PR TITLE
TST: Add test for assert_frame_equal when nested DataFrame contains NA

### DIFF
--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pandas.errors import Pandas4Warning
@@ -415,9 +416,10 @@ def test_datetimelike_compat_deprecated():
         tm.assert_series_equal(df["a"], df["a"], check_datetimelike_compat=False)
 
 
-def test_assert_frame_equal_nested_df_na():
+@pytest.mark.parametrize("na_value", [pd.NA, np.nan, None])
+def test_assert_frame_equal_nested_df_na(na_value):
     # GH#43022
-    inner = DataFrame({"a": [1, pd.NA]})
+    inner = DataFrame({"a": [1, na_value]})
     df1 = DataFrame({"df": [inner]})
     df2 = DataFrame({"df": [inner]})
     tm.assert_frame_equal(df1, df2)

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -413,3 +413,11 @@ def test_datetimelike_compat_deprecated():
         tm.assert_series_equal(df["a"], df["a"], check_datetimelike_compat=True)
     with tm.assert_produces_warning(Pandas4Warning, match=msg):
         tm.assert_series_equal(df["a"], df["a"], check_datetimelike_compat=False)
+
+
+def test_assert_frame_equal_nested_df_na():
+    # GH#43022
+    inner = DataFrame({"a": [1, pd.NA]})
+    df1 = DataFrame({"df": [inner]})
+    df2 = DataFrame({"df": [inner]})
+    tm.assert_frame_equal(df1, df2)


### PR DESCRIPTION
- [x] closes #43022  
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR adds a test for a reported issue (first reported 4years ago) which is no longer present on main. Adding this test ensures that the behavior remains and isn't accidentally reverted.

I think maybe [this is the PR that fixed the issue](https://github.com/pandas-dev/pandas/pull/49363) - I tried to confirm but ran into build issues when trying to build from before that commit from nearly 3years ago.