### PR TITLE
DOC: Add 

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -211,6 +211,67 @@ for :ref:`building pandas with GitPod <contributing-gitpod>`.
 Step 3: build and install pandas
 --------------------------------
 
+Quick start (pip + meson, editable)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you just want the fastest route to a working development install using the
+Meson backend through pip (PEP 517), use the following. This performs an
+editable install and will automatically rebuild C/Cython components when
+you import pandas.
+
+.. code-block:: shell
+
+   # from the repo root, after creating/activating your env
+   # fetch tags so the version string can be computed
+   git fetch upstream --tags
+
+   # install in editable mode with meson backend
+   python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true
+
+.. tip::
+   Set a build directory to speed up rebuilds by keeping artifacts in one place::
+
+      python -m pip install -ve . --no-build-isolation \
+          -Cbuilddir=".meson_build" -Csetup-args="-Dbuildtype=debug"
+
+   The ``-Dbuildtype=debug`` flag improves debugging of C extensions. Omit it
+   for optimized builds.
+
+Windows-specific notes
+^^^^^^^^^^^^^^^^^^^^^^
+
+* Ensure the "Build Tools for Visual Studio 2022" with the
+  "Desktop development with C++" workload is installed. If Meson cannot
+  find ``cl.exe``, add the optional component
+  ``MSVC v142 - VS 2019 C++ x64/x86 build tools`` from the installer.
+* Use an elevated "x64 Native Tools Command Prompt for VS 2022" or a standard
+  PowerShell where the build tools are on ``PATH``.
+* Long paths: enable them to avoid build errors when the source path is deep::
+
+     git config --global core.longpaths true
+
+* PowerShell execution policy can block virtualenv activation scripts. If needed::
+
+     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+* To see Meson’s automatic rebuild output on import every time, either pass
+  ``-Ceditable-verbose=true`` in the install command (above) or set the env var::
+
+     set MESONPY_EDITABLE_VERBOSE=1   # PowerShell/cmd (for current session)
+
+Next steps
+^^^^^^^^^^
+
+* Verify the install::
+
+     python -c "import pandas, sys; print(pandas.__version__, sys.executable)"
+
+* Run a focused test subset before the full suite::
+
+     pytest pandas/tests/frame/test_constructors.py -q
+
+The sections below describe the supported build methods in more detail.
+
 There are currently two supported ways of building pandas, pip/meson and setuptools(setup.py).
 Historically, pandas has only supported using setuptools to build pandas. However, this method
 requires a lot of convoluted code in setup.py and also has many issues in compiling pandas in parallel


### PR DESCRIPTION
- Added a concise “Quick start (pip + meson, editable)” section to 
`doc/source/development/contributing_environment.rst`.
- Included Windows-specific guidance (VS Build Tools, PATH, long paths, execution policy, and Meson editable verbosity).
- Provided a “Next steps” sanity check and focused test command.

**Motivation**
- Streamlines the dev install path using pip + Meson (PEP 517), which auto-rebuilds C/Cython on import.
- Addresses common Windows pitfalls that frequently block first-time contributors.

**Key changes**
- New quick-start code block for editable install:
  - `git fetch upstream --tags`
  - `python -m pip install -ve . --no-build-isolation -Ceditable-verbose=true`
  - Optional `-Cbuilddir=".meson_build"` and `-Csetup-args="-Dbuildtype=debug"` tips

_Windows notes:_ Build Tools, long paths, execution policy, and `MESONPY_EDITABLE_VERBOSE`.

**Validation steps**
- Local editable install built successfully on Windows (3.12, MSVC, Meson).
- Sphinx `html` docs built locally; the new section renders correctly in:
  - `doc/build/html/development/contributing_environment.html`

Please note that the change is purely documentation; no API or behavior changes.
<img width="1539" height="979" alt="Screenshot 2025-10-09 001025" src="https://github.com/user-attachments/assets/a2b33e6d-c6e3-4424-b0ff-0fabb1cde6bc" />
<img width="1733" height="945" alt="Screenshot 2025-10-09 001156" src="https://github.com/user-attachments/assets/b9a6d017-88c0-408d-a8a3-7be9e2c36686" />
<img width="1555" height="896" alt="Screenshot 2025-10-09 001222" src="https://github.com/user-attachments/assets/0b1a5b94-5a4d-43ae-bd7b-7e8121ca75d5" />
