### PR TITLE
fix: pd.to_numeric handling of datetime

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1191,6 +1191,7 @@ Other
 - Bug in :func:`eval` where method calls on binary operations like ``(x + y).dropna()`` would raise ``AttributeError: 'BinOp' object has no attribute 'value'`` (:issue:`61175`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`eval` with ``engine="numexpr"`` returning unexpected result for float division. (:issue:`59736`)
+- Bug in :func:`to_numeric` for ``datetime``, :class:`Series` and ``NaT`` conversions. (:issue:`43280`)
 - Bug in :func:`to_numeric` raising ``TypeError`` when ``arg`` is a :class:`Timedelta` or :class:`Timestamp` scalar. (:issue:`59944`)
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
 - Bug in :meth:`DataFrame.apply` raising ``RecursionError`` when passing ``func=list[int]``. (:issue:`61565`)

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -227,8 +227,6 @@ def to_numeric(
     new_mask: np.ndarray | None = None
     if is_numeric_dtype(values_dtype):
         pass
-    elif lib.is_np_dtype(values_dtype, "mM"):
-        values = values.view(np.int64)
     else:
         values = ensure_object(values)
         coerce_numeric = errors != "raise"


### PR DESCRIPTION
This PR handles all the cases of inconsistent datetime to_numeric handling from [Issue 42380](https://github.com/pandas-dev/pandas/issues/43280)

The changes in `pandas/_libs/lib.pyx`, is the core logic for datetime handling, and is a singular place which handles scalar values, `pd.Series` and `Series(input_value).apply(partial(to_numeric))`
  
The removal of `elif lib.is_np_dtype(values_dtype, "mM"): values = values.view(np.int64)` in [pandas/core/tools/numeric.py](https://github.com/pandas-dev/pandas/pull/62642/files#diff-08fed2587c15d0370931a8b02252eb1034d2c0a650df56760974440a5433a6e0), addresses the bug where int value of NaT are returned.

- [x] closes #43280 
- [x] Passes tests from #43280 and related linked PR discussions
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file
