### PR TITLE
fix: pd.to_numeric handling of datetime

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1191,6 +1191,7 @@ Other
 - Bug in :func:`eval` where method calls on binary operations like ``(x + y).dropna()`` would raise ``AttributeError: 'BinOp' object has no attribute 'value'`` (:issue:`61175`)
 - Bug in :func:`eval` where the names of the :class:`Series` were not preserved when using ``engine="numexpr"``. (:issue:`10239`)
 - Bug in :func:`eval` with ``engine="numexpr"`` returning unexpected result for float division. (:issue:`59736`)
+- Bug in :func:`to_numeric` inconsistency for ``datetime``, :class:`Series` and ``NaT`` conversion. (:issue:`43280`)
 - Bug in :func:`to_numeric` raising ``TypeError`` when ``arg`` is a :class:`Timedelta` or :class:`Timestamp` scalar. (:issue:`59944`)
 - Bug in :func:`unique` on :class:`Index` not always returning :class:`Index` (:issue:`57043`)
 - Bug in :meth:`DataFrame.apply` raising ``RecursionError`` when passing ``func=list[int]``. (:issue:`61565`)

--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -124,6 +124,7 @@ def maybe_convert_numeric(
     na_values: set,
     convert_empty: bool = ...,
     coerce_numeric: bool = ...,
+    convert_datetime: bool = ...,
     convert_to_masked_nullable: Literal[False] = ...,
 ) -> tuple[np.ndarray, None]: ...
 @overload

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -204,8 +204,12 @@ def to_numeric(
             return float(arg)
         if is_number(arg):
             return arg
-        if isinstance(arg, (Timedelta, Timestamp)):
+        if isinstance(arg, Timedelta):
             return arg._value
+        if isinstance(arg, Timestamp):
+            if arg.tzinfo:
+                arg = arg.tz_convert("UTC").replace(tzinfo=None)
+
         is_scalars = True
         values = np.array([arg], dtype="O")
     elif getattr(arg, "ndim", 1) > 1:
@@ -227,8 +231,6 @@ def to_numeric(
     new_mask: np.ndarray | None = None
     if is_numeric_dtype(values_dtype):
         pass
-    elif lib.is_np_dtype(values_dtype, "mM"):
-        values = values.view(np.int64)
     else:
         values = ensure_object(values)
         coerce_numeric = errors != "raise"

--- a/pandas/io/parsers/base_parser.py
+++ b/pandas/io/parsers/base_parser.py
@@ -490,6 +490,7 @@ class ParserBase:
                     values,
                     na_values,
                     False,
+                    convert_datetime=False,
                     convert_to_masked_nullable=non_default_dtype_backend,  # type: ignore[arg-type]
                 )
             except (ValueError, TypeError):


### PR DESCRIPTION
This PR handles all the cases of inconsistent datetime related `pd.to_numeric` handling from [Issue 42380](https://github.com/pandas-dev/pandas/issues/43280) and is compatible with `pandas/io/parsers/base_parser.py`

1. `pandas/_libs/lib.pyx` contains the core/common logic for datetime related `pd.to_numeric` handling
https://github.com/pandas-dev/pandas/blob/083f01a4d010e448eea2f17c23e8aac865a06cb1/pandas/_libs/lib.pyx#L2453 

2. `pd.Timedelta` will be returned as the direct value, and `pd.Timestamp` with Timezones are handled with the default np.datetime64 UTC conversion. 
  
2. The removal of `elif lib.is_np_dtype(values_dtype, "mM"): values = values.view(np.int64)` in `pandas/core/tools/numeric.py` addresses the bug where int value of NaT are returned ([Issue 42380](https://github.com/pandas-dev/pandas/issues/43280)). 

3. Introduces `convert_datetime` flag in `maybe_convert_numeric`, as this function is used by both `pd.to_numeric` and in the base_parsers. The behavior for `pd.to_numeric` on datetimes is to convert, while the behavior on base_parsers is to **not** convert. 

https://github.com/pandas-dev/pandas/blob/083f01a4d010e448eea2f17c23e8aac865a06cb1/pandas/_libs/lib.pyi#L127

- [x] closes #43280 
- [x] Passes tests from #43280 and related linked PR discussions
- [] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file