### PR TITLE
BUGFIX: itemsize wrong for date32[day][pyarrow] dtype #57948

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2308,8 +2308,34 @@ class ArrowDtype(StorageExtensionDtype):
 
     @cache_readonly
     def itemsize(self) -> int:
-        """Return the number of bytes in this dtype"""
-        return self.numpy_dtype.itemsize
+        """
+        Return the number of bytes in this dtype.
+
+        For Arrow-backed dtypes:
+        - Returns the fixed-width bit size divided by 8 for standard fixed-width types.
+        - For boolean types, returns the NumPy itemsize.
+        - Falls back to the NumPy dtype itemsize for variable-width or unsupported types.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> dtype = pd.ArrowDtype(pa.int32())
+        >>> dtype.itemsize
+        4
+
+        >>> dtype = pd.ArrowDtype(pa.bool_())
+        >>> dtype.itemsize  # falls back to numpy dtype
+        1
+        """
+        # Use pyarrow itemsize for fixed-width data types
+        # e.g. int32 -> 32 bits // 8 = 4 bytes
+        try:
+            if pa.types.is_boolean(self.pyarrow_dtype):
+                return self.numpy_dtype.itemsize
+            return self.pyarrow_dtype.bit_width // 8
+        except (ValueError, AttributeError):
+            return self.numpy_dtype.itemsize
 
     def construct_array_type(self) -> type_t[ArrowExtensionArray]:
         """

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1259,3 +1259,92 @@ def test_categorical_nan_no_dtype_conversion():
     expected = pd.DataFrame({"a": Categorical([1], [1]), "b": [1]})
     df.loc[0, "a"] = np.array([1])
     tm.assert_frame_equal(df, expected)
+
+
+@pytest.fixture
+def pa():
+    return pytest.importorskip("pyarrow")
+
+
+@pytest.mark.parametrize(
+    "type_name, expected_size",
+    [
+        # Integer types
+        ("int8", 1),
+        ("int16", 2),
+        ("int32", 4),
+        ("int64", 8),
+        ("uint8", 1),
+        ("uint16", 2),
+        ("uint32", 4),
+        ("uint64", 8),
+        # Floating point types
+        ("float16", 2),
+        ("float32", 4),
+        ("float64", 8),
+        # Boolean
+        ("bool_", 1),
+        # Date and timestamp types
+        ("date32", 4),
+        ("date64", 8),
+        ("timestamp", 8),
+        # Time types
+        ("time32", 4),
+        ("time64", 8),
+        # Decimal types
+        ("decimal128", 16),
+        ("decimal256", 32),
+    ],
+) # type: ignore[misc]
+def test_arrow_dtype_itemsize_fixed_width(pa, type_name, expected_size):
+    # GH 57948
+
+    parametric_type_map = {
+        "timestamp": pa.timestamp("ns"),
+        "time32": pa.time32("s"),
+        "time64": pa.time64("ns"),
+        "decimal128": pa.decimal128(38, 10),
+        "decimal256": pa.decimal256(76, 10),
+    }
+
+    if type_name in parametric_type_map:
+        arrow_type = parametric_type_map.get(type_name)
+    else:
+        arrow_type = getattr(pa, type_name)()
+    dtype = pd.ArrowDtype(arrow_type)
+
+    if type_name == "bool_":
+        expected_size = dtype.numpy_dtype.itemsize
+
+    assert dtype.itemsize == expected_size, (
+        f"{type_name} expected {expected_size}, got {dtype.itemsize} "
+        f"(bit_width={getattr(dtype.pyarrow_dtype, 'bit_width', 'N/A')})"
+    )
+
+
+@pytest.mark.parametrize("type_name", ["string", "binary", "large_string"])
+def test_arrow_dtype_itemsize_variable_width(pa, type_name):
+    # GH 57948
+
+    arrow_type = getattr(pa, type_name)()
+    dtype = pd.ArrowDtype(arrow_type)
+
+    assert dtype.itemsize == dtype.numpy_dtype.itemsize
+
+
+def test_arrow_dtype_error_fallback(pa, monkeypatch):
+    # GH 57948
+
+    dtype = pd.ArrowDtype(pa.int32())
+
+    class ErrorType:
+        id = None
+        @property
+        def bit_width(self):
+            raise ValueError("Simulated Error")
+
+        def to_pandas_dtype(self):
+            return pd.Series([0]).dtype
+
+    monkeypatch.setattr(dtype, "pyarrow_dtype", ErrorType())
+    assert dtype.itemsize == dtype.numpy_dtype.itemsize


### PR DESCRIPTION
- [x] closes #57948
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Fixes #57948

## Summary
`ArrowDtype.itemsize` was incorrectly returning `8` bytes for `date32[day]` and other `fixed-width` PyArrow types because it always fell back to `numpy_dtype.itemsize`. This PR uses PyArrow's `bit_width` for `fixed-width` types and gracefully falls back to `numpy` for `variable-width` types and `booleans`.

## Changes

- Modified `ArrowDtype.itemsize` to use `pyarrow_dtype.bit_width` when available
- Added comprehensive regression test covering the fix

## Example

Before: `ArrowDtype(pa.date32()).itemsize == 8`
After:  `ArrowDtype(pa.date32()).itemsize == 4`