### PR TITLE
BUG: fix regex numeric group replacement in PyArrow string arrays

### DIFF
--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -175,7 +175,7 @@ class ArrowStringArrayMixin:
             or flags
             or (
                 isinstance(repl, str)
-                and (r"\g<" in repl or re.search(r"\\\d", repl) is not None)
+                and r"\g<" in repl  # Block named group references (\g<name>); numeric groups (\1) are supported by PyArrow
             )
         ):
             raise NotImplementedError(


### PR DESCRIPTION
- [x] closes #62653
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file


## Problem
PyArrow string arrays incorrectly raised `NotImplementedError` for numeric group references (`\1`, `\2`) in `str.replace`, even though PyArrow supports them. This caused failures when using regex patterns with group references on PyArrow-backed string arrays.

## Solution
Modified the condition in `pandas/core/arrays/_arrow_string_mixins.py` to only block named group references (`\g<name>`) while allowing numeric group references.

## Changes Made
- Removed the blanket prohibition on all backslash+digit patterns in replacement strings
- Only block named group references (detected by `r"\g<" in repl`)
- All other unsupported features (callable repl, case=False, flags != 0, re.Pattern objects) still properly raise NotImplementedError

## Testing
Manually verified the fix works with:
- Basic numeric group replacement: `s.str.replace(r'\[(\d+)\]', r'(\1)', regex=True)`
- Multiple numeric groups: `s.str.replace(r'(\w+)\[(\d+)\](\w+)', r'\1-\2-\3', regex=True)`
- Confirmed named groups still properly raise NotImplementedError

## Example
```python
# This now works (was broken before):
s = pd.Series(["var.one[0]", "var.two[1]"]).convert_dtypes(dtype_backend="pyarrow")
result = s.str.replace(r'\[(\d+)\]', r'(\1)', regex=True)
# result: ["var.one(0)", "var.two(1)"]

# This still properly fails (named groups not supported):
s.str.replace(r'\[(?P<digit>\d+)\]', r'(\g<digit>)', regex=True)  # Raises NotImplementedError
```
**Note:** I haven't added formal tests yet due to local environment issues with the test framework, but I've manually verified the fix works. I'm happy to add tests if maintainers can help me resolve the test environment setup.