### PR TITLE
fix: dataframe conditional where axis=1 

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1205,6 +1205,7 @@ Other
 - Bug in :meth:`DataFrame.sort_index` when passing ``axis="columns"`` and ``ignore_index=True`` and ``ascending=False`` not returning a :class:`RangeIndex` columns (:issue:`57293`)
 - Bug in :meth:`DataFrame.sort_values` where sorting by a column explicitly named ``None`` raised a ``KeyError`` instead of sorting by the column as expected. (:issue:`61512`)
 - Bug in :meth:`DataFrame.transform` that was returning the wrong order unless the index was monotonically increasing. (:issue:`57069`)
+- Bug in :meth:`DataFrame.where` where ``axis=1`` argument returns a 'float object is not suscriptable' ``TypeError`` (:issue:`58190`)
 - Bug in :meth:`DataFrame.where` where using a non-bool type array in the function would return a ``ValueError`` instead of a ``TypeError`` (:issue:`56330`)
 - Bug in :meth:`Index.sort_values` when passing a key function that turns values into tuples, e.g. ``key=natsort.natsort_key``, would raise ``TypeError`` (:issue:`56081`)
 - Bug in :meth:`MultiIndex.fillna` error message was referring to ``isna`` instead of ``fillna`` (:issue:`60974`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9921,12 +9921,18 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 other = self._constructor(
                     other, **self._construct_axes_dict(), copy=False
                 )
+        if axis is None:
+            axis = 0
+        if self.ndim == getattr(other, "ndim", 0):
+            align = True
+        else:
+            align = self._get_axis_number(axis) == 1
 
         if inplace:
             # we may have different type blocks come out of putmask, so
             # reconstruct the block manager
 
-            new_data = self._mgr.putmask(mask=cond, new=other)
+            new_data = self._mgr.putmask(mask=cond, new=other, align=align)
             result = self._constructor_from_mgr(new_data, axes=new_data.axes)
             return self._update_inplace(result)
 
@@ -9934,6 +9940,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             new_data = self._mgr.where(
                 other=other,
                 cond=cond,
+                align=align,
             )
             result = self._constructor_from_mgr(new_data, axes=new_data.axes)
             return result.__finalize__(self)

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -431,6 +431,8 @@ class BaseBlockManager(PandasObject):
                             kwargs[k] = obj.iloc[b.mgr_locs.indexer]._values
                         else:
                             kwargs[k] = obj.iloc[:, b.mgr_locs.indexer]._values
+                    elif isinstance(obj, lib._NoDefault):
+                        pass
                     else:
                         # otherwise we have an ndarray
                         kwargs[k] = obj[b.mgr_locs.indexer]

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -431,7 +431,7 @@ class BaseBlockManager(PandasObject):
                             kwargs[k] = obj.iloc[b.mgr_locs.indexer]._values
                         else:
                             kwargs[k] = obj.iloc[:, b.mgr_locs.indexer]._values
-                    elif isinstance(obj, np.ndarray):
+                    elif isinstance(obj, (np.ndarray, list)):
                         # otherwise we have an ndarray
                         kwargs[k] = obj[b.mgr_locs.indexer]
             if callable(f):
@@ -461,9 +461,12 @@ class BaseBlockManager(PandasObject):
         )
 
     @final
-    def where(self, other, cond) -> Self:
-        align_keys = ["other", "cond"]
-        other = extract_array(other, extract_numpy=True)
+    def where(self, other, cond, align: bool) -> Self:
+        if align:
+            align_keys = ["other", "cond"]
+        else:
+            align_keys = ["cond"]
+            other = extract_array(other, extract_numpy=True)
 
         return self.apply(
             "where",
@@ -473,9 +476,12 @@ class BaseBlockManager(PandasObject):
         )
 
     @final
-    def putmask(self, mask, new) -> Self:
-        align_keys = ["new", "mask"]
-        new = extract_array(new, extract_numpy=True)
+    def putmask(self, mask, new, align: bool = True) -> Self:
+        if align:
+            align_keys = ["new", "mask"]
+        else:
+            align_keys = ["mask"]
+            new = extract_array(new, extract_numpy=True)
 
         return self.apply(
             "putmask",

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -431,12 +431,9 @@ class BaseBlockManager(PandasObject):
                             kwargs[k] = obj.iloc[b.mgr_locs.indexer]._values
                         else:
                             kwargs[k] = obj.iloc[:, b.mgr_locs.indexer]._values
-                    elif isinstance(obj, lib._NoDefault):
-                        pass
-                    else:
+                    elif isinstance(obj, np.ndarray):
                         # otherwise we have an ndarray
                         kwargs[k] = obj[b.mgr_locs.indexer]
-
             if callable(f):
                 applied = b.apply(f, **kwargs)
             else:
@@ -464,12 +461,9 @@ class BaseBlockManager(PandasObject):
         )
 
     @final
-    def where(self, other, cond, align: bool) -> Self:
-        if align:
-            align_keys = ["other", "cond"]
-        else:
-            align_keys = ["cond"]
-            other = extract_array(other, extract_numpy=True)
+    def where(self, other, cond) -> Self:
+        align_keys = ["other", "cond"]
+        other = extract_array(other, extract_numpy=True)
 
         return self.apply(
             "where",
@@ -479,12 +473,9 @@ class BaseBlockManager(PandasObject):
         )
 
     @final
-    def putmask(self, mask, new, align: bool = True) -> Self:
-        if align:
-            align_keys = ["new", "mask"]
-        else:
-            align_keys = ["mask"]
-            new = extract_array(new, extract_numpy=True)
+    def putmask(self, mask, new) -> Self:
+        align_keys = ["new", "mask"]
+        new = extract_array(new, extract_numpy=True)
 
         return self.apply(
             "putmask",

--- a/pandas/tests/series/indexing/test_where.py
+++ b/pandas/tests/series/indexing/test_where.py
@@ -446,23 +446,91 @@ def test_where_datetimelike_categorical(tz_naive_fixture):
 
 
 @pytest.mark.parametrize(
-    "original,conditional,expected",
+    "original,conditional,inplace,expected",
     [
         (
             [[0.0, 0.5, 0.0], [0.1, 0.0, 0.2], [0.2, 0.0, 0.0]],
             [True, True, False],
-            [[0.0, 0.5, 0.0], [0.1, 0.0, 0.2], [np.nan, np.nan, np.nan]],
+            False,
+            [[0.0, 0.5, np.nan], [0.1, 0.0, np.nan], [0.2, 0.0, np.nan]],
         ),
         (
             [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
             [True, False, True],
-            [[1.0, 2.0, 3.0], [np.nan, np.nan, np.nan], [7.0, 8.0, 9.0]],
+            False,
+            [[1.0, np.nan, 3.0], [4.0, np.nan, 6.0], [7.0, np.nan, 9.0]],
+        ),
+        (
+            [[0.0, 0.5, 0.0], [0.1, 0.0, 0.2], [0.2, 0.0, 0.0]],
+            [True, True, False],
+            True,
+            [[0.0, 0.5, np.nan], [0.1, 0.0, np.nan], [0.2, 0.0, np.nan]],
+        ),
+        (
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+            [True, False, True],
+            True,
+            [[1.0, np.nan, 3.0], [4.0, np.nan, 6.0], [7.0, np.nan, 9.0]],
         ),
     ],
 )
-def test_where_axis1(original, conditional, expected):
+def test_where_axis1(original, conditional, inplace, expected):
     # GH 58190, 58144
     A = pd.DataFrame(original)
-    res = A.where(Series(conditional), axis=1)
     expected = pd.DataFrame(expected)
+
+    if inplace:
+        A.where(Series(conditional), axis=1, inplace=True)
+        tm.assert_frame_equal(A, expected)
+    else:
+        res = A.where(Series(conditional), axis=1)
+        tm.assert_frame_equal(res, expected, check_dtype=False)
+
+
+@pytest.mark.parametrize(
+    "original,conditional,expected",
+    [
+        (
+            [
+                ["2001-02-03", "2001-02-04", "2001-02-05"],
+                ["2002-02-03", "2002-02-04", "2002-02-05"],
+                ["2003-02-03", "2003-02-04", "2003-02-05"],
+            ],
+            [True, True, False],
+            [
+                ["2001-02-03", "2001-02-04", pd.NaT],
+                ["2002-02-03", "2002-02-04", pd.NaT],
+                ["2003-02-03", "2003-02-04", pd.NaT],
+            ],
+        ),
+    ],
+)
+def test_where_axis1_datetime(original, conditional, expected):
+    A = pd.DataFrame(original).apply(pd.to_datetime)
+    expected = pd.DataFrame(expected).apply(pd.to_datetime)
+    res = A.where(Series(conditional), axis=1)
+    tm.assert_frame_equal(res, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype,original,conditional,expected",
+    [
+        (
+            "Int64",
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            [True, False, True],
+            [[1, pd.NA, 3], [4, pd.NA, 6], [7, pd.NA, 9]],
+        ),
+        (
+            "Float64",
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            [True, False, True],
+            [[1, pd.NA, 3], [4, pd.NA, 6], [7, pd.NA, 9]],
+        ),
+    ],
+)
+def test_where_axis1_special_dtypes(dtype, original, conditional, expected):
+    A = pd.DataFrame(original, dtype=dtype)
+    expected = pd.DataFrame(expected, dtype=dtype)
+    res = A.where(Series(conditional), axis=1)
     tm.assert_frame_equal(res, expected)

--- a/pandas/tests/series/indexing/test_where.py
+++ b/pandas/tests/series/indexing/test_where.py
@@ -443,3 +443,26 @@ def test_where_datetimelike_categorical(tz_naive_fixture):
     res = pd.DataFrame(lvals).where(mask[:, None], pd.DataFrame(rvals))
 
     tm.assert_frame_equal(res, pd.DataFrame(dr))
+
+
+@pytest.mark.parametrize(
+    "original,conditional,expected",
+    [
+        (
+            [[0.0, 0.5, 0.0], [0.1, 0.0, 0.2], [0.2, 0.0, 0.0]],
+            [True, True, False],
+            [[0.0, 0.5, 0.0], [0.1, 0.0, 0.2], [np.nan, np.nan, np.nan]],
+        ),
+        (
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+            [True, False, True],
+            [[1.0, 2.0, 3.0], [np.nan, np.nan, np.nan], [7.0, 8.0, 9.0]],
+        ),
+    ],
+)
+def test_where_axis1(original, conditional, expected):
+    # GH 58190, 58144
+    A = pd.DataFrame(original)
+    res = A.where(Series(conditional), axis=1)
+    expected = pd.DataFrame(expected)
+    tm.assert_frame_equal(res, expected)


### PR DESCRIPTION
Previously, dataframe where-conditional with axis=1 was failing due to underlying `_NoDefault object is not suscriptable` in `pandas/core/internals/managers.py` 

In addition, the conditional dataframe for axis=1 was not being constructed correctly. This PR fixes that via: https://github.com/pandas-dev/pandas/blob/0524ff2766fdb32dcec5f54db6b85ecaa8686cd1/pandas/core/generic.py#L9803

- [x] closes #58190 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
