### PR TITLE
BUG: fix SeriesGroupBy.plot does not respect cmap parameter

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -437,6 +437,7 @@ class GroupByPlot(PandasObject):
         color = kwargs.get("color", None)
         if colormap is not None and color is None:
             from pandas.plotting._matplotlib.style import get_standard_colors
+
             group_keys = list(self._groupby.groups.keys())
             colors = get_standard_colors(
                 num_colors=len(group_keys),
@@ -445,15 +446,19 @@ class GroupByPlot(PandasObject):
             )
             kwargs = dict(kwargs)
             kwargs.pop("colormap", None)
+
             def f(group, color, label):
                 return group.plot(*args, color=color, label=label, **kwargs)
+
             results = []
             for i, (name, group) in enumerate(self._groupby):
                 results.append(f(group, colors[i], name))
             return results
         else:
+
             def f(self):
                 return self.plot(*args, **kwargs)
+
             f.__name__ = "plot"
             return self._groupby._python_apply_general(f, self._groupby._selected_obj)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -447,8 +447,13 @@ class GroupByPlot(PandasObject):
             kwargs = dict(kwargs)
             kwargs.pop("colormap", None)
 
-            def f(group, color, label):
-                return group.plot(*args, color=color, label=label, **kwargs)
+            def f(obj, color=None, label=None):
+                plot_kwargs = dict(kwargs)
+                if color is not None:
+                    plot_kwargs["color"] = color
+                if label is not None:
+                    plot_kwargs["label"] = label
+                return obj.plot(*args, **plot_kwargs)
 
             results = []
             for i, (name, group) in enumerate(self._groupby):
@@ -456,8 +461,13 @@ class GroupByPlot(PandasObject):
             return results
         else:
 
-            def f(self):
-                return self.plot(*args, **kwargs)
+            def f(obj, color=None, label=None):
+                plot_kwargs = dict(kwargs)
+                if color is not None:
+                    plot_kwargs["color"] = color
+                if label is not None:
+                    plot_kwargs["label"] = label
+                return obj.plot(*args, **plot_kwargs)
 
             f.__name__ = "plot"
             return self._groupby._python_apply_general(f, self._groupby._selected_obj)


### PR DESCRIPTION
- [x] closes #56697 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Following screenshot is from running 
```
chunk = pd.DataFrame(index=[7, 8, 2])
df = pd.concat([chunk.assign(y=i, i=i) for i in range(10)])
df.groupby("i")["y"].plot(legend=True, colormap="Pastel1")
```
<img width="559" height="437" alt="image" src="https://github.com/user-attachments/assets/fd83b608-e40a-41e1-9598-861038bb6812" />

