### PR TITLE
STY: Add strict=True to zip() calls in pandas/_testing

### DIFF
--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -110,7 +110,7 @@ def assert_produces_warning(
                         if isinstance(match, tuple)
                         else (match,) * len(expected_warning)
                     )
-                    for warning_type, warning_match in zip(expected_warning, match):
+                    for warning_type, warning_match in zip(expected_warning, match, strict=True):
                         _assert_caught_expected_warnings(
                             caught_warnings=w,
                             expected_warning=warning_type,

--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -110,7 +110,9 @@ def assert_produces_warning(
                         if isinstance(match, tuple)
                         else (match,) * len(expected_warning)
                     )
-                    for warning_type, warning_match in zip(expected_warning, match, strict=True):
+                    for warning_type, warning_match in zip(
+                        expected_warning, match, strict=True
+                    ):
                         _assert_caught_expected_warnings(
                             caught_warnings=w,
                             expected_warning=warning_type,

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -675,7 +675,7 @@ def assert_numpy_array_equal(
                 )
 
             diff = 0
-            for left_arr, right_arr in zip(left, right):
+            for left_arr, right_arr in zip(left, right, strict=True):
                 # count up differences
                 if not array_equivalent(left_arr, right_arr, strict_nan=strict_nan):
                     diff += 1
@@ -1447,7 +1447,7 @@ def assert_copy(iter1, iter2, **eql_kwargs) -> None:
     the same object. (Does not check that items
     in sequences are also not the same object)
     """
-    for elem1, elem2 in zip(iter1, iter2):
+    for elem1, elem2 in zip(iter1, iter2, strict=True):
         assert_almost_equal(elem1, elem2, **eql_kwargs)
         msg = (
             f"Expected object {type(elem1)!r} and object {type(elem2)!r} to be "


### PR DESCRIPTION
Add explicit strict=True to zip() calls in pandas/_testing to satisfy Ruff rule B905 (zip-without-explicit-strict).
- Add explicit strict=True to zip() calls in pandas/_testing/asserters.py (2 calls)
- Add explicit strict=True to zip() calls in pandas/_testing/_warnings.py (1 call)
- Satisfies Ruff rule B905 (zip-without-explicit-strict)

Towards #62434

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
