### PR TITLE
WIP: Fix precision of DataFrame.combine and DataFrame.combine_first

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1145,7 +1145,7 @@ Reshaping
 ^^^^^^^^^
 - Bug in :func:`qcut` where values at the quantile boundaries could be incorrectly assigned (:issue:`59355`)
 - Bug in :meth:`DataFrame.combine_first` not preserving the column order (:issue:`60427`)
-- Bug in :meth:`DataFrame.combine_first` where large ``int64``/``uint64`` values could lose precision when an outer alignment introduced missing values. (:issue:`60128`)
+- Bug in :meth:`DataFrame.combine_first` where very large integers could lose precision after the operation. (:issue:`60128`)
 - Bug in :meth:`DataFrame.explode` producing incorrect result for :class:`pyarrow.large_list` type (:issue:`61091`)
 - Bug in :meth:`DataFrame.join` inconsistently setting result index name (:issue:`55815`)
 - Bug in :meth:`DataFrame.join` when a :class:`DataFrame` with a :class:`MultiIndex` would raise an ``AssertionError`` when :attr:`MultiIndex.names` contained ``None``. (:issue:`58721`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1145,6 +1145,7 @@ Reshaping
 ^^^^^^^^^
 - Bug in :func:`qcut` where values at the quantile boundaries could be incorrectly assigned (:issue:`59355`)
 - Bug in :meth:`DataFrame.combine_first` not preserving the column order (:issue:`60427`)
+- Bug in :meth:`DataFrame.combine_first` where large ``int64``/``uint64`` values could lose precision when an outer alignment introduced missing values. (:issue:`60128`)
 - Bug in :meth:`DataFrame.explode` producing incorrect result for :class:`pyarrow.large_list` type (:issue:`61091`)
 - Bug in :meth:`DataFrame.join` inconsistently setting result index name (:issue:`55815`)
 - Bug in :meth:`DataFrame.join` when a :class:`DataFrame` with a :class:`MultiIndex` would raise an ``AssertionError`` when :attr:`MultiIndex.names` contained ``None``. (:issue:`58721`)

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -992,6 +992,7 @@ Numeric
 ^^^^^^^
 - Bug in :func:`api.types.infer_dtype` returning "mixed" for complex and ``pd.NA`` mix (:issue:`61976`)
 - Bug in :func:`api.types.infer_dtype` returning "mixed-integer-float" for float and ``pd.NA`` mix (:issue:`61621`)
+- Bug in :meth:`DataFrame.combine` and :meth:`DataFrame.combine_first` where integers with absolute value greater than ``2**53`` could lose precision after the operation. (:issue:`60128`)
 - Bug in :meth:`DataFrame.corr` where numerical precision errors resulted in correlations above ``1.0`` (:issue:`61120`)
 - Bug in :meth:`DataFrame.cov` raises a ``TypeError`` instead of returning potentially incorrect results or other errors (:issue:`53115`)
 - Bug in :meth:`DataFrame.quantile` where the column type was not preserved when ``numeric_only=True`` with a list-like ``q`` produced an empty result (:issue:`59035`)
@@ -1145,7 +1146,6 @@ Reshaping
 ^^^^^^^^^
 - Bug in :func:`qcut` where values at the quantile boundaries could be incorrectly assigned (:issue:`59355`)
 - Bug in :meth:`DataFrame.combine_first` not preserving the column order (:issue:`60427`)
-- Bug in :meth:`DataFrame.combine_first` where very large integers could lose precision after the operation. (:issue:`60128`)
 - Bug in :meth:`DataFrame.explode` producing incorrect result for :class:`pyarrow.large_list` type (:issue:`61091`)
 - Bug in :meth:`DataFrame.join` inconsistently setting result index name (:issue:`55815`)
 - Bug in :meth:`DataFrame.join` when a :class:`DataFrame` with a :class:`MultiIndex` would raise an ``AssertionError`` when :attr:`MultiIndex.names` contained ``None``. (:issue:`58721`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9156,7 +9156,7 @@ class DataFrame(NDFrame, OpsMixin):
             combined = combined.astype(other.dtypes)
         else:
             # GH#60128 Avoid precision loss from int64/uint64 <-> float64 round-trip.
-            def _cast_64_bit_ints_to_nullable(df: DataFrame) -> DataFrame:
+            def _promote_ints_to_nullable(df: DataFrame) -> DataFrame:
                 cast_map: dict[str, str] = {}
 
                 for col, dt in df.dtypes.items():
@@ -9167,11 +9167,8 @@ class DataFrame(NDFrame, OpsMixin):
 
                 return df.astype(cast_map) if cast_map else df
 
-            # Only need to cast sides that gain rows on outer align (introduces <NA>).
-            if len(other.index.difference(self.index, sort=False)):
-                self = _cast_64_bit_ints_to_nullable(self)
-            if len(self.index.difference(other.index, sort=False)):
-                other = _cast_64_bit_ints_to_nullable(other)
+            self = _promote_ints_to_nullable(self)
+            other = _promote_ints_to_nullable(other)
 
             combined = self.combine(other, combiner, overwrite=False)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9185,10 +9185,9 @@ class DataFrame(NDFrame, OpsMixin):
                 return df.astype(cast_map) if cast_map else df
 
             # Only cast frames whose index expand to the union (i.e., get <NA> on align)
-            union_index = self.index.union(other.index)
-            if not self.index.equals(union_index):
+            if len(other.index.difference(self.index, sort=False)):
                 self = _cast_large_numpy_ints_to_nullable(self)
-            if not other.index.equals(union_index):
+            if len(self.index.difference(other.index, sort=False)):
                 other = _cast_large_numpy_ints_to_nullable(other)
 
             combined = self.combine(other, combiner, overwrite=False)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9062,13 +9062,14 @@ class DataFrame(NDFrame, OpsMixin):
                     ]
                     if dtypes_to_resolve:
                         if isna(ser).any():
-                            # Currently, align upcasts to float64 when NAs are present.
-                            # Do this so we don't have to modify any tests that expect
-                            # float dtype when NAs are present. BUT we could consider
-                            # embracing nullable integer dtype since large integers are
-                            # still losing information on conversion to float -- it's
-                            # just not obvious because they aren't cast back to int
-                            # when NAs are present.
+                            # Currently, align upcasts to float64 when NAs are
+                            # present. Do this so we don't have to modify any
+                            # tests that expect float dtype when NAs are
+                            # present. BUT we could consider embracing nullable
+                            # integer dtypes since large integers are still
+                            # losing information on conversion to float -- it's
+                            # just not obvious because they aren't cast back to
+                            # int when NAs are present.
                             dtypes_to_resolve.append(np.dtype("float64"))
                         target_type = find_common_type(dtypes_to_resolve)
                         cast_map[col] = target_type

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9048,7 +9048,7 @@ class DataFrame(NDFrame, OpsMixin):
         self = _promote_wide_ints(self)
         other = _promote_wide_ints(other)
 
-        def _restore_wide_ints(df: DataFrame):
+        def _restore_wide_ints(df: DataFrame) -> DataFrame:
             """Restores previously int64/uint64 columns if they don't have NAs."""
             cast_map: dict[str, str] = {}
             for col in df.columns:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9174,7 +9174,7 @@ class DataFrame(NDFrame, OpsMixin):
 
                 return df.astype(cast_map) if cast_map else df
 
-            # Cast any side that will gain rows on outer align (introduces <NA>).
+            # Only need to cast sides that gain rows on outer align (introduces <NA>).
             if len(other.index.difference(self.index, sort=False)):
                 self = _cast_large_numpy_ints_to_nullable(self)
             if len(self.index.difference(other.index, sort=False)):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9052,16 +9052,16 @@ class DataFrame(NDFrame, OpsMixin):
                 orig_dt_self = self_original.dtypes.get(col)
                 orig_dt_other = other_original.dtypes.get(col)
 
-                is_at_risk = (orig_dt_self in [np.int64, np.uint64]) or (
+                was_promoted = (orig_dt_self in [np.int64, np.uint64]) or (
                     orig_dt_other in [np.int64, np.uint64]
                 )
 
-                if is_at_risk and not isna(ser).any():
+                if was_promoted and not isna(ser).any():
                     dtypes_to_resolve = [
                         dt for dt in (orig_dt_self, orig_dt_other) if dt is not None
                     ]
                     if dtypes_to_resolve:
-                        # if we had different dtypes, possibly promote
+                        # if we had different dtypes, reconcile
                         cast_map[col] = find_common_type(dtypes_to_resolve)
 
             if cast_map:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -144,6 +144,10 @@ from pandas.core.arrays import (
     PeriodArray,
     TimedeltaArray,
 )
+from pandas.core.arrays.integer import (
+    Int64Dtype,
+    UInt64Dtype,
+)
 from pandas.core.arrays.sparse import SparseFrameAccessor
 from pandas.core.arrays.string_ import StringDtype
 from pandas.core.construction import (
@@ -9031,12 +9035,12 @@ class DataFrame(NDFrame, OpsMixin):
         # int64 and uint64 to their nullable ExtensionDtypes, Int64 and UInt64.
         def _ensure_nullable_int64_dtypes(df: DataFrame) -> DataFrame:
             """Promote int64/uint64 DataFrame columns to Int64/UInt64."""
-            cast_map: dict[str, str] = {}
+            cast_map: dict[IndexLabel, DtypeObj] = {}
             for col, dt in df.dtypes.items():
                 if dt == np.int64:
-                    cast_map[col] = "Int64"
+                    cast_map[col] = Int64Dtype()
                 elif dt == np.uint64:
-                    cast_map[col] = "UInt64"
+                    cast_map[col] = UInt64Dtype()
 
             if cast_map:
                 df = df.astype(cast_map)
@@ -9049,7 +9053,7 @@ class DataFrame(NDFrame, OpsMixin):
             self_orig: DataFrame, other_orig: DataFrame, combined_df: DataFrame
         ) -> DataFrame:
             """Resolve the combined dtypes according to the original dtypes."""
-            cast_map: dict[str, str] = {}
+            cast_map: dict[IndexLabel, DtypeObj] = {}
             for col in combined_df.columns:
                 ser = combined_df[col]
                 orig_dt_self = self_orig.dtypes.get(col)
@@ -9072,7 +9076,7 @@ class DataFrame(NDFrame, OpsMixin):
                             # obvious (since we don't cast back). Consider
                             # embracing nullable ExtensionDtypes instead
                             # and dropping this whole restoration step.
-                            dtypes_to_resolve.append(np.dtype("float64"))
+                            dtypes_to_resolve.append(np.dtype(np.float64))
                         target_type = find_common_type(dtypes_to_resolve)
                         cast_map[col] = target_type
 

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -398,6 +398,21 @@ class TestDataFrameCombineFirst:
         ).set_index(["a", "b"])
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "wide_val, dtype, EAdtype",
+        (
+            (1666880195890293744, "uint64", "UInt64"),
+            (-1666880195890293744, "int64", "Int64"),
+        ),
+    )
+    def test_combine_first_preserve_precision(self, wide_val, dtype, EAdtype):
+        # GH#60128
+        df1 = DataFrame({"A": [wide_val, 5]}, dtype=dtype)
+        df2 = DataFrame({"A": [6, 7, wide_val]}, dtype=dtype)
+        result = df1.combine_first(df2)
+        expected = DataFrame({"A": [wide_val, 5, wide_val]}, dtype=dtype)
+        tm.assert_frame_equal(result, expected)
+
 
 @pytest.mark.parametrize(
     "scalar1, scalar2",

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -487,7 +487,7 @@ def test_combine_first_with_nan_multiindex():
     expected = DataFrame(
         {
             "c": [np.nan, np.nan, 1, 1, 1, 1, 1, np.nan, 1, np.nan, 1],
-            "d": [1, 4, np.nan, 2, 5, np.nan, np.nan, 3, np.nan, 6, np.nan],
+            "d": [1.0, 4.0, np.nan, 2.0, 5.0, np.nan, np.nan, 3.0, np.nan, 6.0, np.nan],
         },
         index=mi_expected,
     )

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -490,7 +490,6 @@ def test_combine_first_with_nan_multiindex():
             "d": [1, 4, np.nan, 2, 5, np.nan, np.nan, 3, np.nan, 6, np.nan],
         },
         index=mi_expected,
-        dtype="Int64",
     )
     tm.assert_frame_equal(res, expected)
 
@@ -537,7 +536,6 @@ def test_combine_first_duplicates_rows_for_nan_index_values():
         index=MultiIndex.from_arrays(
             [[1, 2, 3, 4], [np.nan, 5, 6, 7]], names=["a", "b"]
         ),
-        dtype="Int64",
     )
     combined = df1.combine_first(df2)
     tm.assert_frame_equal(combined, expected)

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -472,7 +472,7 @@ def test_combine_first_with_nan_multiindex():
     expected = DataFrame(
         {
             "c": [np.nan, np.nan, 1, 1, 1, 1, 1, np.nan, 1, np.nan, 1],
-            "d": [1.0, 4.0, np.nan, 2.0, 5.0, np.nan, np.nan, 3.0, np.nan, 6.0, np.nan],
+            "d": [1, 4, np.nan, 2, 5, np.nan, np.nan, 3, np.nan, 6, np.nan],
         },
         index=mi_expected,
         dtype="Int64",

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -475,6 +475,7 @@ def test_combine_first_with_nan_multiindex():
             "d": [1.0, 4.0, np.nan, 2.0, 5.0, np.nan, np.nan, 3.0, np.nan, 6.0, np.nan],
         },
         index=mi_expected,
+        dtype="Int64",
     )
     tm.assert_frame_equal(res, expected)
 
@@ -521,6 +522,7 @@ def test_combine_first_duplicates_rows_for_nan_index_values():
         index=MultiIndex.from_arrays(
             [[1, 2, 3, 4], [np.nan, 5, 6, 7]], names=["a", "b"]
         ),
+        dtype="Int64",
     )
     combined = df1.combine_first(df2)
     tm.assert_frame_equal(combined, expected)

--- a/pandas/tests/frame/methods/test_combine_first.py
+++ b/pandas/tests/frame/methods/test_combine_first.py
@@ -399,13 +399,13 @@ class TestDataFrameCombineFirst:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "wide_val, dtype, EAdtype",
+        "wide_val, dtype",
         (
-            (1666880195890293744, "uint64", "UInt64"),
-            (-1666880195890293744, "int64", "Int64"),
+            (1666880195890293744, "uint64"),
+            (-1666880195890293744, "int64"),
         ),
     )
-    def test_combine_first_preserve_precision(self, wide_val, dtype, EAdtype):
+    def test_combine_first_preserve_precision(self, wide_val, dtype):
         # GH#60128
         df1 = DataFrame({"A": [wide_val, 5]}, dtype=dtype)
         df2 = DataFrame({"A": [6, 7, wide_val]}, dtype=dtype)


### PR DESCRIPTION
EDIT: This was my first attempt. Converting to EA Dtypes and back just to prevent lossy conversion is a discouraged approach not taken in this codebase, according to maintainers.

- [] closes #60128
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
