### PR TITLE
DOC: Fix docstring validation errors for pandas.core.groupby

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -74,8 +74,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Period.ordinal GL08" \
         -i "pandas.errors.IncompatibleFrequency SA01,SS06,EX01" \
         -i "pandas.api.extensions.ExtensionArray.value_counts EX01,RT03,SA01" \
-        -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
-        -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \
         -i "pandas.core.resample.Resampler.quantile PR01,PR07" \
         -i "pandas.tseries.offsets.BDay PR02,SA01" \
         -i "pandas.tseries.offsets.BHalfYearBegin.is_on_offset GL08" \

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -760,11 +760,6 @@ class PlotAccessor(PandasObject):
     Uses the backend specified by the
     option ``plotting.backend``. By default, matplotlib is used.
 
-    Parameters
-    ----------
-    data : Series or DataFrame
-        The object for which the method is called.
-
     Attributes
     ----------
     x : label or position, default None


### PR DESCRIPTION
- [x] closes #60365
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Ran docstring validation for all methods in the issue fixed by other contributors:
```
scripts/validate_docstrings.py pandas.core.groupby.DataFrameGroupBy.boxplot
scripts/validate_docstrings.py pandas.core.groupby.DataFrameGroupBy.get_group
scripts/validate_docstrings.py pandas.core.groupby.DataFrameGroupBy.indices
scripts/validate_docstrings.py pandas.core.groupby.DataFrameGroupBy.nth
scripts/validate_docstrings.py pandas.core.groupby.DataFrameGroupBy.nunique
scripts/validate_docstrings.py pandas.core.groupby.DataFrameGroupBy.sem
scripts/validate_docstrings.py pandas.core.groupby.SeriesGroupBy.get_group
scripts/validate_docstrings.py pandas.core.groupby.SeriesGroupBy.indices
scripts/validate_docstrings.py pandas.core.groupby.SeriesGroupBy.is_monotonic_decreasing
scripts/validate_docstrings.py pandas.core.groupby.SeriesGroupBy.is_monotonic_increasing
scripts/validate_docstrings.py pandas.core.groupby.SeriesGroupBy.nth
scripts/validate_docstrings.py pandas.core.groupby.SeriesGroupBy.sem
```

And fixed the PR02 errors in:
```
 -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \ 
 -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \ 
```

All validation tests now pass with the exception of a couple of ES01 errors, which can be ignored as stated. Issue #60365 can be closed after this PR merges.