### PR TITLE
Sparse array cumsum leads to infinite recursion 62669

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1169,6 +1169,7 @@ Sparse
 - Bug in :class:`SparseDtype` for equal comparison with na fill value. (:issue:`54770`)
 - Bug in :meth:`DataFrame.sparse.from_spmatrix` which hard coded an invalid ``fill_value`` for certain subtypes. (:issue:`59063`)
 - Bug in :meth:`DataFrame.sparse.to_dense` which ignored subclassing and always returned an instance of :class:`DataFrame` (:issue:`59913`)
+- Bug in :meth:`cumsum` for integer arrays Calling SparseArray.cumsum caused max recursion depth error. (:issue:`62669`)
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1570,10 +1570,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if axis is not None and axis >= self.ndim:  # Mimic ndarray behaviour.
             raise ValueError(f"axis(={axis}) out of bounds")
 
-        if not self._null_fill_value:
-            if isinstance(self, SparseArray) and self.fill_value == 0:
-                # special case where we can avoid max recursion depth
-                return SparseArray(self.to_dense().cumsum())
+        if not self._null_fill_value and self.fill_value != 0:
             return SparseArray(self.to_dense()).cumsum()
 
         return SparseArray(

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1572,7 +1572,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         if not self._null_fill_value:
             if isinstance(self, SparseArray) and self.fill_value == 0:
-                # special case where we can avoid densifying
+                # special case where we can avoid max recursion depth
                 return SparseArray(self.to_dense().cumsum())
             return SparseArray(self.to_dense()).cumsum()
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1571,6 +1571,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             raise ValueError(f"axis(={axis}) out of bounds")
 
         if not self._null_fill_value:
+            if isinstance(self, SparseArray) and self.fill_value == 0:
+                # special case where we can avoid densifying
+                return SparseArray(self.to_dense().cumsum())
             return SparseArray(self.to_dense()).cumsum()
 
         return SparseArray(

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1570,8 +1570,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if axis is not None and axis >= self.ndim:  # Mimic ndarray behaviour.
             raise ValueError(f"axis(={axis}) out of bounds")
 
-        if not self._null_fill_value and self.fill_value != 0:
-            return SparseArray(self.to_dense()).cumsum()
+        if not self._null_fill_value:
+            return SparseArray(self.to_dense(), fill_value=np.nan).cumsum()
 
         return SparseArray(
             self.sp_values.cumsum(),

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -363,6 +363,20 @@ def test_setting_fill_value_fillna_still_works():
     tm.assert_numpy_array_equal(result, expected)
 
 
+def test_cumsum_integer_no_recursion():
+    # GH 62669: RecursionError in integer SparseArray.cumsum
+    arr = SparseArray([1, 2, 3])
+    result = arr.cumsum()
+    expected = SparseArray([1, 3, 6])
+    tm.assert_sp_array_equal(result, expected)
+
+    # Also test with some zeros interleaved
+    arr2 = SparseArray([0, 1, 0, 2])
+    result2 = arr2.cumsum()
+    expected2 = SparseArray([0, 1, 1, 3])
+    tm.assert_sp_array_equal(result2, expected2)
+
+
 def test_setting_fill_value_updates():
     arr = SparseArray([0.0, np.nan], fill_value=0)
     arr.fill_value = np.nan

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -367,14 +367,22 @@ def test_cumsum_integer_no_recursion():
     # GH 62669: RecursionError in integer SparseArray.cumsum
     arr = SparseArray([1, 2, 3])
     result = arr.cumsum()
-    expected = SparseArray([1, 3, 6])
+    expected = SparseArray([1, 3, 6], fill_value=np.nan)
     tm.assert_sp_array_equal(result, expected)
 
     # Also test with some zeros interleaved
     arr2 = SparseArray([0, 1, 0, 2])
     result2 = arr2.cumsum()
-    expected2 = SparseArray([0, 1, 1, 3])
+    expected2 = SparseArray([0, 1, 1, 3], fill_value=np.nan)
     tm.assert_sp_array_equal(result2, expected2)
+
+
+def test_cumsum_float_fill_value_zero():
+    # GH 62669
+    arr = pd.arrays.SparseArray([1.0, 0.0, np.nan, 3.0], fill_value=0.0)
+    result = arr.cumsum()
+    expected = SparseArray([1.0, 1.0, None, 4.0], fill_value=np.nan)
+    tm.assert_sp_array_equal(result, expected)
 
 
 def test_setting_fill_value_updates():


### PR DESCRIPTION
- [x] closes #62669
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
