### PR TITLE
BUG: RuntimeWarning from np.ndarray.astype when converting large `int64[pyarrow]` values

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1007,6 +1007,7 @@ Conversion
 - Bug in :meth:`Series.convert_dtypes` and :meth:`DataFrame.convert_dtypes` removing timezone information for objects with :class:`ArrowDtype` (:issue:`60237`)
 - Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
 - Bug in :meth:`to_datetime` and :meth:`to_timedelta` with input ``None`` returning ``None`` instead of ``NaT``, inconsistent with other conversion methods (:issue:`23055`)
+- Bug in :meth:`DataFrame.convert_dtypes` with `dtype_backend='pyarrow'` for large `int64` values (:issue:`58485`)
 
 Strings
 ^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1002,12 +1002,12 @@ Numeric
 Conversion
 ^^^^^^^^^^
 - Bug in :meth:`DataFrame.astype` not casting ``values`` for Arrow-based dictionary dtype correctly (:issue:`58479`)
+- Bug in :meth:`DataFrame.convert_dtypes` with ``dtype_backend='pyarrow'`` for large ``int64`` values (:issue:`58485`)
 - Bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)
 - Bug in :meth:`Series.convert_dtypes` and :meth:`DataFrame.convert_dtypes` removing timezone information for objects with :class:`ArrowDtype` (:issue:`60237`)
 - Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
 - Bug in :meth:`to_datetime` and :meth:`to_timedelta` with input ``None`` returning ``None`` instead of ``NaT``, inconsistent with other conversion methods (:issue:`23055`)
-- Bug in :meth:`DataFrame.convert_dtypes` with `dtype_backend='pyarrow'` for large `int64` values (:issue:`58485`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -960,7 +960,7 @@ def convert_dtypes(
                 if len(arr) < len(input_array) and not is_nan_na():
                     # In the presence of NaNs, we cannot convert to IntegerDtype
                     pass
-                elif (arr.astype(int) == arr).all():
+                elif np.array_equal(arr, np.trunc(arr), equal_nan=True):
                     inferred_dtype = target_int_dtype
                 else:
                     inferred_dtype = input_array.dtype
@@ -987,7 +987,7 @@ def convert_dtypes(
                     if len(arr) < len(input_array) and not is_nan_na():
                         # In the presence of NaNs, we can't convert to IntegerDtype
                         inferred_dtype = inferred_float_dtype
-                    elif (arr.astype(int) == arr).all():
+                    elif np.array_equal(arr, np.trunc(arr)):
                         inferred_dtype = pandas_dtype_func("Int64")
                     else:
                         inferred_dtype = inferred_float_dtype

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -228,3 +228,30 @@ class TestConvertDtypes:
         result = df.convert_dtypes(dtype_backend="pyarrow")
         expected = df.copy()
         tm.assert_frame_equal(result, expected)
+
+    def test_convert_dtype_pyarrow_int64_limits_warning(self):
+        # GH 58485
+        pytest.importorskip("pyarrow")
+        data = {
+            "a": [
+                -9223372036854775808,
+                4611686018427387904,
+                9223372036854775807,
+                None,
+            ],
+            "b": [
+                -9223372036854775808,
+                4611686018427387904,
+                9223372036854775807,
+                None,
+            ],
+            "c": [
+                -9223372036854775808,
+                4611686018427387904,
+                9223372036854775807,
+                None,
+            ],
+        }
+        result = pd.DataFrame(data).convert_dtypes(dtype_backend="pyarrow")
+        expected = pd.DataFrame(data, dtype="int64[pyarrow]")
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #58485
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
