### PR TITLE
BUG: RuntimeWarning from np.ndarray.astype during dtype inference when mixing large integer values with None without explicit dtype

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1001,6 +1001,7 @@ Numeric
 
 Conversion
 ^^^^^^^^^^
+- Bug in :func:`maybe_convert_objects` for large ``int`` values mixed with ``None`` (:issue:`58485`)
 - Bug in :meth:`DataFrame.astype` not casting ``values`` for Arrow-based dictionary dtype correctly (:issue:`58479`)
 - Bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -116,6 +116,11 @@ cdef:
     object oUINT64_MAX = <uint64_t>UINT64_MAX
 
     float64_t NaN = <float64_t>np.nan
+    # the maximum absolute integer value that a 64-bit IEEE floating point number can store is when all 52 bits of its significand/mantissa are 1
+    # see: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+    # related concept in JavaScript:
+    # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+    float64_t F64_SAFE_INT64_MAX = <float64_t>(2**53 - 1)
 
 # python-visible
 i8max = <int64_t>INT64_MAX
@@ -2868,6 +2873,9 @@ def maybe_convert_objects(ndarray[object] objects,
                             result = uints
                         else:
                             result = ints
+                    elif (np.absolute(floats) > F64_SAFE_INT64_MAX).any():
+                        # GH 58485
+                        raise ValueError("integer values with non-nullable dtype too large to be represented by float64, specify an integer dtype explicitly")
                     else:
                         result = floats
                 elif seen.nan_:

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -116,7 +116,8 @@ cdef:
     object oUINT64_MAX = <uint64_t>UINT64_MAX
 
     float64_t NaN = <float64_t>np.nan
-    # the maximum absolute integer value that a 64-bit IEEE floating point number can store is when all 52 bits of its significand/mantissa are 1
+    # the maximum absolute integer value that a 64-bit IEEE floating point number
+    # can store is when all 52 bits of its significand/mantissa are 1
     # see: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
     # related concept in JavaScript:
     # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
@@ -2875,7 +2876,11 @@ def maybe_convert_objects(ndarray[object] objects,
                             result = ints
                     elif (np.absolute(floats) > F64_SAFE_INT64_MAX).any():
                         # GH 58485
-                        raise ValueError("integer values with non-nullable dtype too large to be represented by float64, specify an integer dtype explicitly")
+                        raise ValueError(
+                            "integer values with non-nullable dtype too large "
+                            "to be represented by float64"
+                            ", specify an integer dtype explicitly"
+                        )
                     else:
                         result = floats
                 elif seen.nan_:

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -960,7 +960,7 @@ def convert_dtypes(
                 if len(arr) < len(input_array) and not is_nan_na():
                     # In the presence of NaNs, we cannot convert to IntegerDtype
                     pass
-                elif (arr.astype(int) == arr).all():
+                elif np.array_equal(arr, np.trunc(arr), equal_nan=True):
                     inferred_dtype = target_int_dtype
                 else:
                     inferred_dtype = input_array.dtype
@@ -987,7 +987,7 @@ def convert_dtypes(
                     if len(arr) < len(input_array) and not is_nan_na():
                         # In the presence of NaNs, we can't convert to IntegerDtype
                         inferred_dtype = inferred_float_dtype
-                    elif (arr.astype(int) == arr).all():
+                    elif np.array_equal(arr, np.trunc(arr)):
                         inferred_dtype = pandas_dtype_func("Int64")
                     else:
                         inferred_dtype = inferred_float_dtype

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1747,6 +1747,20 @@ class TestTypeInference:
         inferred = lib.infer_dtype(val, skipna=skipna)
         assert inferred == "boolean"
 
+    def test_large_non_nullable_integer_objects(self):
+        # GH 58485
+        arr = np.array(
+            [
+                -9223372036854775808,
+                4611686018427387904,
+                9223372036854775807,
+                None,
+            ],
+            dtype="object",
+        )
+        with pytest.raises(ValueError, match="too large to be represented by float64"):
+            lib.maybe_convert_objects(arr)
+
 
 class TestNumberScalar:
     def test_is_number(self):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2793,6 +2793,31 @@ class TestDataFrameConstructors:
         expected = DataFrame(np.eye(3))
         tm.assert_frame_equal(df, expected)
 
+    def test_large_non_nullable_integer_objects(self):
+        # GH 58485
+        data = {
+            "a": [
+                -9223372036854775808,
+                4611686018427387904,
+                9223372036854775807,
+                None,
+            ],
+            "b": [
+                -9223372036854775808,
+                4611686018427387904,
+                9223372036854775807,
+                None,
+            ],
+            "c": [
+                -9223372036854775808,
+                4611686018427387904,
+                9223372036854775807,
+                None,
+            ],
+        }
+        with pytest.raises(ValueError, match="too large to be represented by float64"):
+            pd.DataFrame(data)
+
 
 class TestDataFrameConstructorIndexInference:
     def test_frame_from_dict_of_series_overlapping_monthly_period_indexes(self):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2816,7 +2816,7 @@ class TestDataFrameConstructors:
             ],
         }
         with pytest.raises(ValueError, match="too large to be represented by float64"):
-            pd.DataFrame(data)
+            DataFrame(data)
 
 
 class TestDataFrameConstructorIndexInference:


### PR DESCRIPTION
- [x] closes #58485
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.