### PR TITLE
DOC: Set __module__ attributes and remove `core` from documentation

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -73,10 +73,12 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.Period.freq GL08" \
         -i "pandas.Period.ordinal GL08" \
         -i "pandas.errors.IncompatibleFrequency SA01,SS06,EX01" \
+        -i "pandas.errors.InvalidVersion GL08" \
         -i "pandas.api.extensions.ExtensionArray.value_counts EX01,RT03,SA01" \
-        -i "pandas.core.groupby.DataFrameGroupBy.plot PR02" \
-        -i "pandas.core.groupby.SeriesGroupBy.plot PR02" \
-        -i "pandas.core.resample.Resampler.quantile PR01,PR07" \
+        -i "pandas.api.typing.DataFrameGroupBy.plot PR02" \
+        -i "pandas.api.typing.SeriesGroupBy.plot PR02" \
+        -i "pandas.api.typing.Resampler.quantile PR01,PR07" \
+        -i "pandas.arrays.NumpyExtensionArray GL08" \
         -i "pandas.tseries.offsets.BDay PR02,SA01" \
         -i "pandas.tseries.offsets.BHalfYearBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BHalfYearBegin.n GL08" \

--- a/doc/source/reference/groupby.rst
+++ b/doc/source/reference/groupby.rst
@@ -5,7 +5,7 @@
 =======
 GroupBy
 =======
-.. currentmodule:: pandas.core.groupby
+.. currentmodule:: pandas.api.typing
 
 :class:`pandas.api.typing.DataFrameGroupBy` and :class:`pandas.api.typing.SeriesGroupBy`
 instances are returned by groupby calls :func:`pandas.DataFrame.groupby` and
@@ -40,7 +40,7 @@ Function application helper
 
    NamedAgg
 
-.. currentmodule:: pandas.core.groupby
+.. currentmodule:: pandas.api.typing
 
 Function application
 --------------------

--- a/doc/source/reference/resampling.rst
+++ b/doc/source/reference/resampling.rst
@@ -5,7 +5,7 @@
 ==========
 Resampling
 ==========
-.. currentmodule:: pandas.core.resample
+.. currentmodule:: pandas.api.typing
 
 :class:`pandas.api.typing.Resampler` instances are returned by
 resample calls: :func:`pandas.DataFrame.resample`, :func:`pandas.Series.resample`.

--- a/doc/source/reference/window.rst
+++ b/doc/source/reference/window.rst
@@ -17,7 +17,7 @@ calls: :func:`pandas.DataFrame.ewm` and :func:`pandas.Series.ewm`.
 
 Rolling window functions
 ------------------------
-.. currentmodule:: pandas.core.window.rolling
+.. currentmodule:: pandas.api.typing
 
 .. autosummary::
    :toctree: api/
@@ -48,7 +48,8 @@ Rolling window functions
 
 Weighted window functions
 -------------------------
-.. currentmodule:: pandas.core.window.rolling
+.. currentmodule:: pandas.api.typing
+
 
 .. autosummary::
    :toctree: api/
@@ -62,7 +63,8 @@ Weighted window functions
 
 Expanding window functions
 --------------------------
-.. currentmodule:: pandas.core.window.expanding
+.. currentmodule:: pandas.api.typing
+
 
 .. autosummary::
    :toctree: api/
@@ -93,7 +95,8 @@ Expanding window functions
 
 Exponentially-weighted window functions
 ---------------------------------------
-.. currentmodule:: pandas.core.window.ewm
+.. currentmodule:: pandas.api.typing
+
 
 .. autosummary::
    :toctree: api/

--- a/doc/source/user_guide/enhancingperf.rst
+++ b/doc/source/user_guide/enhancingperf.rst
@@ -455,7 +455,7 @@ by evaluate arithmetic and boolean expression all at once for large :class:`~pan
    :func:`~pandas.eval` is many orders of magnitude slower for
    smaller expressions or objects than plain Python. A good rule of thumb is
    to only use :func:`~pandas.eval` when you have a
-   :class:`~pandas.core.frame.DataFrame` with more than 10,000 rows.
+   :class:`~pandas.DataFrame` with more than 10,000 rows.
 
 Supported syntax
 ~~~~~~~~~~~~~~~~

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,9 @@ versioneer = files('generate_version.py')
 
 add_project_arguments('-DNPY_NO_DEPRECATED_API=0', language: 'c')
 add_project_arguments('-DNPY_NO_DEPRECATED_API=0', language: 'cpp')
+# Enables settings __module__ on cdef classes
+# https://github.com/cython/cython/issues/7231
+add_project_arguments('-DCYTHON_USE_TYPE_SPECS=1', language: 'c')
 
 # Allow supporting older numpys than the version compiled against
 # Set the define to the min supported version of numpy for pandas

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -101,6 +101,7 @@ _reserved_keys: list[str] = ["all"]
 
 
 class OptionError(AttributeError, KeyError):
+    __module__ = "pandas.errors"
     """
     Exception raised for pandas.options.
 

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -101,7 +101,6 @@ _reserved_keys: list[str] = ["all"]
 
 
 class OptionError(AttributeError, KeyError):
-    __module__ = "pandas.errors"
     """
     Exception raised for pandas.options.
 
@@ -117,6 +116,8 @@ class OptionError(AttributeError, KeyError):
     Traceback (most recent call last):
     OptionError: No such option
     """
+
+    __module__ = "pandas.errors"
 
 
 #
@@ -413,6 +414,7 @@ class DictWrapper:
 
     def __setattr__(self, key: str, val: Any) -> None:
         if key == "__module__":
+            # Need to be able to set __module__ to pandas for pandas.options
             super().__setattr__(key, val)
             return
         prefix = object.__getattribute__(self, "prefix")

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -413,10 +413,6 @@ class DictWrapper:
         object.__setattr__(self, "prefix", prefix)
 
     def __setattr__(self, key: str, val: Any) -> None:
-        if key == "__module__":
-            # Need to be able to set __module__ to pandas for pandas.options
-            super().__setattr__(key, val)
-            return
         prefix = object.__getattribute__(self, "prefix")
         if prefix:
             prefix += "."
@@ -447,7 +443,8 @@ class DictWrapper:
 
 
 options = DictWrapper(_global_config)
-options.__module__ = "pandas"
+# DictWrapper defines a custom setattr
+object.__setattr__(options, "__module__", "pandas")
 
 #
 # Functions for use by pandas developers, in addition to User - api

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -412,6 +412,9 @@ class DictWrapper:
         object.__setattr__(self, "prefix", prefix)
 
     def __setattr__(self, key: str, val: Any) -> None:
+        if key == "__module__":
+            super().__setattr__(key, val)
+            return
         prefix = object.__getattribute__(self, "prefix")
         if prefix:
             prefix += "."
@@ -442,6 +445,7 @@ class DictWrapper:
 
 
 options = DictWrapper(_global_config)
+options.__module__ = "pandas"
 
 #
 # Functions for use by pandas developers, in addition to User - api

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -382,6 +382,7 @@ cdef class Interval(IntervalMixin):
     >>> year_2017.length
     Timedelta('365 days 00:00:00')
     """
+    __module__ = "pandas"
     _typ = "interval"
     __array_priority__ = 1000
 

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -445,6 +445,7 @@ cdef class Interval(IntervalMixin):
     >>> interval.closed
     'left'
     """
+    __module__ = "pandas"
 
     def __init__(self, left, right, str closed="right"):
         # note: it is faster to just do these checks than to use a special

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2944,7 +2944,9 @@ class _NoDefault(Enum):
 
 # Note: no_default is exported to the public API in pandas.api.extensions
 no_default = _NoDefault.no_default  # Sentinel indicating the default value.
+no_default.__module__ = "pandas.api.extensions"
 NoDefault = Literal[_NoDefault.no_default]
+NoDefault.__module__ = "pandas.api.typing"
 
 
 @cython.boundscheck(False)

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -393,7 +393,7 @@ class NAType(C_NAType):
     >>> True | pd.NA
     True
     """
-    __module__ = "pandas"
+    __module__ = "pandas.api.typing"
 
     _instance = None
 

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -546,3 +546,4 @@ class NAType(C_NAType):
 
 C_NA = NAType()   # C-visible
 NA = C_NA         # Python-visible
+NA.__module__ = "pandas"

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -1871,6 +1871,7 @@ default 'raise'
 
 c_NaT = NaTType()  # C-visible
 NaT = c_NaT        # Python-visible
+NaT.__module__ = "pandas"
 
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -372,7 +372,7 @@ class NaTType(_NaT):
     1         NaT
     """
 
-    __module__ = "pandas"
+    __module__ = "pandas.api.typing"
 
     def __new__(cls):
         cdef _NaT base

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -192,6 +192,7 @@ class OutOfBoundsDatetime(ValueError):
     OutOfBoundsDatetime: Parsing "08335394550" to datetime overflows,
     at position 0
     """
+    __module__ = "pandas.errors"
     pass
 
 
@@ -212,6 +213,7 @@ class OutOfBoundsTimedelta(ValueError):
     OutOfBoundsTimedelta: Cannot cast 139999 days 00:00:00
     to unit='ns' without overflow.
     """
+    __module__ = "pandas.errors"
     # Timedelta analogue to OutOfBoundsDatetime
     pass
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1819,6 +1819,8 @@ class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
     >>> ts + pd.DateOffset(hour=8)
     Timestamp('2017-01-01 08:10:11')
     """
+    __module__ = "pandas"
+
     def __setattr__(self, name, value):
         raise AttributeError("DateOffset objects are immutable.")
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1627,6 +1627,7 @@ DIFFERENT_FREQ = ("Input has different freq={other_freq} "
 
 
 class IncompatibleFrequency(TypeError):
+    __module__ = "pandas.errors"
     """
     Raised when trying to compare or operate between Periods with different
     frequencies.

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1627,11 +1627,11 @@ DIFFERENT_FREQ = ("Input has different freq={other_freq} "
 
 
 class IncompatibleFrequency(TypeError):
-    __module__ = "pandas.errors"
     """
     Raised when trying to compare or operate between Periods with different
     frequencies.
     """
+    __module__ = "pandas.errors"
     pass
 
 

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -107,7 +107,7 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 
 class SequenceNotStr(Protocol[_T_co]):
-    __module__ = "pandas.api.typing.aliases"
+    __module__: str = "pandas.api.typing.aliases"
 
     @overload
     def __getitem__(self, index: SupportsIndex, /) -> _T_co: ...
@@ -280,7 +280,7 @@ class BaseBuffer(Protocol):
 
 
 class ReadBuffer(BaseBuffer, Protocol[AnyStr_co]):
-    __module__ = "pandas.api.typing.aliases"
+    __module__: str = "pandas.api.typing.aliases"
 
     def read(self, n: int = ..., /) -> AnyStr_co:
         # for BytesIOWrapper, gzip.GzipFile, bz2.BZ2File
@@ -288,7 +288,7 @@ class ReadBuffer(BaseBuffer, Protocol[AnyStr_co]):
 
 
 class WriteBuffer(BaseBuffer, Protocol[AnyStr_contra]):
-    __module__ = "pandas.api.typing.aliases"
+    __module__: str = "pandas.api.typing.aliases"
 
     def write(self, b: AnyStr_contra, /) -> Any:
         # for gzip.GzipFile, bz2.BZ2File
@@ -300,19 +300,19 @@ class WriteBuffer(BaseBuffer, Protocol[AnyStr_contra]):
 
 
 class ReadPickleBuffer(ReadBuffer[bytes], Protocol):
-    __module__ = "pandas.api.typing.aliases"
+    __module__: str = "pandas.api.typing.aliases"
 
     def readline(self) -> bytes: ...
 
 
 class WriteExcelBuffer(WriteBuffer[bytes], Protocol):
-    __module__ = "pandas.api.typing.aliases"
+    __module__: str = "pandas.api.typing.aliases"
 
     def truncate(self, size: int | None = ..., /) -> int: ...
 
 
 class ReadCsvBuffer(ReadBuffer[AnyStr_co], Protocol):
-    __module__ = "pandas.api.typing.aliases"
+    __module__: str = "pandas.api.typing.aliases"
 
     def __iter__(self) -> Iterator[AnyStr_co]:
         # for engine=python

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -107,6 +107,8 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 
 class SequenceNotStr(Protocol[_T_co]):
+    __module__ = "pandas.api.typing.aliases"
+
     @overload
     def __getitem__(self, index: SupportsIndex, /) -> _T_co: ...
 
@@ -278,12 +280,16 @@ class BaseBuffer(Protocol):
 
 
 class ReadBuffer(BaseBuffer, Protocol[AnyStr_co]):
+    __module__ = "pandas.api.typing.aliases"
+
     def read(self, n: int = ..., /) -> AnyStr_co:
         # for BytesIOWrapper, gzip.GzipFile, bz2.BZ2File
         ...
 
 
 class WriteBuffer(BaseBuffer, Protocol[AnyStr_contra]):
+    __module__ = "pandas.api.typing.aliases"
+
     def write(self, b: AnyStr_contra, /) -> Any:
         # for gzip.GzipFile, bz2.BZ2File
         ...
@@ -294,14 +300,20 @@ class WriteBuffer(BaseBuffer, Protocol[AnyStr_contra]):
 
 
 class ReadPickleBuffer(ReadBuffer[bytes], Protocol):
+    __module__ = "pandas.api.typing.aliases"
+
     def readline(self) -> bytes: ...
 
 
 class WriteExcelBuffer(WriteBuffer[bytes], Protocol):
+    __module__ = "pandas.api.typing.aliases"
+
     def truncate(self, size: int | None = ..., /) -> int: ...
 
 
 class ReadCsvBuffer(ReadBuffer[AnyStr_co], Protocol):
+    __module__ = "pandas.api.typing.aliases"
+
     def __iter__(self) -> Iterator[AnyStr_co]:
         # for engine=python
         ...

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -76,7 +76,6 @@ ResType: TypeAlias = dict[int, Any]
 
 
 class BaseExecutionEngine(abc.ABC):
-    __module__ = "pandas.api.executors"
     """
     Base class for execution engines for map and apply methods.
 
@@ -88,6 +87,8 @@ class BaseExecutionEngine(abc.ABC):
     run in parallel, and others. Besides the default executor which
     simply runs the code with the Python interpreter and pandas.
     """
+
+    __module__ = "pandas.api.executors"
 
     @staticmethod
     @abc.abstractmethod

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -76,6 +76,7 @@ ResType: TypeAlias = dict[int, Any]
 
 
 class BaseExecutionEngine(abc.ABC):
+    __module__ = "pandas.api.executors"
     """
     Base class for execution engines for map and apply methods.
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -246,7 +246,6 @@ class ArrowExtensionArray(
     ExtensionArraySupportsAnyAll,
     ArrowStringArrayMixin,
 ):
-    __module__ = "pandas.arrays"
     """
     Pandas ExtensionArray backed by a PyArrow ChunkedArray.
 
@@ -296,6 +295,8 @@ class ArrowExtensionArray(
     [1, 1, <NA>]
     Length: 3, dtype: int64[pyarrow]
     """  # noqa: E501 (http link too long)
+
+    __module__ = "pandas.arrays"
 
     _pa_array: pa.ChunkedArray
     _dtype: ArrowDtype

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -246,6 +246,7 @@ class ArrowExtensionArray(
     ExtensionArraySupportsAnyAll,
     ArrowStringArrayMixin,
 ):
+    __module__ = "pandas.arrays"
     """
     Pandas ExtensionArray backed by a PyArrow ChunkedArray.
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -106,6 +106,7 @@ _extension_array_shared_docs: dict[str, str] = {}
 
 
 class ExtensionArray:
+    __module__ = "pandas.api.extensions"
     """
     Abstract base class for custom 1-D array types.
 
@@ -2787,6 +2788,7 @@ class ExtensionOpsMixin:
 
 
 class ExtensionScalarOpsMixin(ExtensionOpsMixin):
+    __module__ = "pandas.api.extensions"
     """
     A mixin for defining ops on an ExtensionArray.
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -106,7 +106,6 @@ _extension_array_shared_docs: dict[str, str] = {}
 
 
 class ExtensionArray:
-    __module__ = "pandas.api.extensions"
     """
     Abstract base class for custom 1-D array types.
 
@@ -256,6 +255,8 @@ class ExtensionArray:
 
     https://github.com/pandas-dev/pandas/blob/main/pandas/tests/extension/list/array.py
     """
+
+    __module__ = "pandas.api.extensions"
 
     # '_typ' is for pandas.core.dtypes.generic.ABCExtensionArray.
     # Don't override this.
@@ -2788,7 +2789,6 @@ class ExtensionOpsMixin:
 
 
 class ExtensionScalarOpsMixin(ExtensionOpsMixin):
-    __module__ = "pandas.api.extensions"
     """
     A mixin for defining ops on an ExtensionArray.
 
@@ -2813,6 +2813,8 @@ class ExtensionScalarOpsMixin(ExtensionOpsMixin):
        implementation to be called when involved in binary operations
        with NumPy arrays.
     """
+
+    __module__ = "pandas.api.extensions"
 
     @classmethod
     def _create_method(cls, op, coerce_to_dtype: bool = True, result_dtype=None):

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1807,7 +1807,7 @@ class ExtensionArray:
         .. code-block:: python
 
            def take(self, indices, allow_fill=False, fill_value=None):
-               from pandas.core.algorithms import take
+               from pandas.api.extensions import take
 
                # If the ExtensionArray is backed by an ndarray, then
                # just pass that here instead of coercing to object.

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -246,7 +246,6 @@ def coerce_to_array(
 
 
 class BooleanArray(BaseMaskedArray):
-    __module__ = "pandas.arrays"
     """
     Array of boolean (True/False) data with missing values.
 
@@ -304,6 +303,8 @@ class BooleanArray(BaseMaskedArray):
     [True, False, <NA>]
     Length: 3, dtype: boolean
     """
+
+    __module__ = "pandas.arrays"
 
     _TRUE_VALUES = {"True", "TRUE", "true", "1", "1.0"}
     _FALSE_VALUES = {"False", "FALSE", "false", "0", "0.0"}

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -246,6 +246,7 @@ def coerce_to_array(
 
 
 class BooleanArray(BaseMaskedArray):
+    __module__ = "pandas.arrays"
     """
     Array of boolean (True/False) data with missing values.
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -246,7 +246,6 @@ def contains(cat, key, container) -> bool:
 
 
 class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMixin):
-    __module__ = "pandas"
     """
     Represent a categorical variable in classic R / S-plus fashion.
 
@@ -361,6 +360,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     >>> c.min()
     'c'
     """
+
+    __module__ = "pandas"
 
     # For comparisons, so that numpy uses our implementation if the compare
     # ops, which raise

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -246,6 +246,7 @@ def contains(cat, key, container) -> bool:
 
 
 class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMixin):
+    __module__ = "pandas"
     """
     Represent a categorical variable in classic R / S-plus fashion.
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -172,6 +172,7 @@ def _field_accessor(name: str, field: str, docstring: str | None = None):
 
 
 class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
+    __module__ = "pandas.arrays"
     """
     Pandas ExtensionArray for tz-naive or tz-aware datetime data.
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -172,7 +172,6 @@ def _field_accessor(name: str, field: str, docstring: str | None = None):
 
 
 class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
-    __module__ = "pandas.arrays"
     """
     Pandas ExtensionArray for tz-naive or tz-aware datetime data.
 
@@ -223,6 +222,8 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     ['2023-01-01 00:00:00', '2023-01-02 00:00:00']
     Length: 2, dtype: datetime64[s]
     """
+
+    __module__ = "pandas.arrays"
 
     _typ = "datetimearray"
     _internal_fill_value = np.datetime64("NaT", "ns")

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -64,6 +64,7 @@ class FloatingDtype(NumericDtype):
 
 
 class FloatingArray(NumericArray):
+    __module__ = "pandas.arrays"
     """
     Array of floating (optional missing) values.
 

--- a/pandas/core/arrays/floating.py
+++ b/pandas/core/arrays/floating.py
@@ -64,7 +64,6 @@ class FloatingDtype(NumericDtype):
 
 
 class FloatingArray(NumericArray):
-    __module__ = "pandas.arrays"
     """
     Array of floating (optional missing) values.
 
@@ -129,6 +128,8 @@ class FloatingArray(NumericArray):
     [0.1, <NA>, 0.3]
     Length: 3, dtype: Float32
     """
+
+    __module__ = "pandas.arrays"
 
     _dtype_cls = FloatingDtype
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -72,7 +72,6 @@ class IntegerDtype(NumericDtype):
 
 
 class IntegerArray(NumericArray):
-    __module__ = "pandas.arrays"
     """
     Array of integer (optional missing) values.
 
@@ -142,6 +141,8 @@ class IntegerArray(NumericArray):
     [1, <NA>, 3]
     Length: 3, dtype: UInt16
     """
+
+    __module__ = "pandas.arrays"
 
     _dtype_cls = IntegerDtype
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -72,6 +72,7 @@ class IntegerDtype(NumericDtype):
 
 
 class IntegerArray(NumericArray):
+    __module__ = "pandas.arrays"
     """
     Array of integer (optional missing) values.
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -177,7 +177,6 @@ for more.
 
 
 class IntervalArray(IntervalMixin, ExtensionArray):
-    __module__ = "pandas.arrays"
     """
     Pandas array for interval data that are closed on the same side.
 
@@ -243,6 +242,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     methods: :meth:`IntervalArray.from_arrays`,
     :meth:`IntervalArray.from_breaks`, and :meth:`IntervalArray.from_tuples`.
     """
+
+    __module__ = "pandas.arrays"
 
     can_hold_na = True
     _na_value = _fill_value = np.nan

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -177,6 +177,7 @@ for more.
 
 
 class IntervalArray(IntervalMixin, ExtensionArray):
+    __module__ = "pandas.arrays"
     """
     Pandas array for interval data that are closed on the same side.
 

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -57,6 +57,7 @@ class NumpyExtensionArray(
     NDArrayBackedExtensionArray,
     ObjectStringArrayMixin,
 ):
+    __module__ = "pandas.arrays"
     """
     A pandas ExtensionArray for NumPy data.
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -123,6 +123,7 @@ def _field_accessor(name: str, docstring: str | None = None):
 # error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
 # incompatible with definition in base class "ExtensionArray"
 class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
+    __module__ = "pandas.arrays"
     """
     Pandas ExtensionArray for storing Period data.
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -123,7 +123,6 @@ def _field_accessor(name: str, docstring: str | None = None):
 # error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
 # incompatible with definition in base class "ExtensionArray"
 class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
-    __module__ = "pandas.arrays"
     """
     Pandas ExtensionArray for storing Period data.
 
@@ -177,6 +176,8 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
     ['2023-01-01', '2023-01-02']
     Length: 2, dtype: period[D]
     """
+
+    __module__ = "pandas.arrays"
 
     # array priority higher than numpy scalars
     __array_priority__ = 1000

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -300,6 +300,7 @@ def _wrap_result(
 
 
 class SparseArray(OpsMixin, PandasObject, ExtensionArray):
+    __module__ = "pandas.arrays"
     """
     An ExtensionArray for storing sparse data.
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -300,7 +300,6 @@ def _wrap_result(
 
 
 class SparseArray(OpsMixin, PandasObject, ExtensionArray):
-    __module__ = "pandas.arrays"
     """
     An ExtensionArray for storing sparse data.
 
@@ -380,6 +379,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
     IntIndex
     Indices: array([2, 3], dtype=int32)
     """
+
+    __module__ = "pandas.arrays"
 
     _subtyp = "sparse_array"  # register ABCSparseArray
     _hidden_attrs = PandasObject._hidden_attrs | frozenset([])

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -551,7 +551,6 @@ class BaseStringArray(ExtensionArray):
 # error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
 # incompatible with definition in base class "ExtensionArray"
 class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
-    __module__ = "pandas.arrays"
     """
     Extension array for string data.
 
@@ -633,6 +632,8 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
     [True, <NA>, False]
     Length: 3, dtype: boolean
     """
+
+    __module__ = "pandas.arrays"
 
     # undo the NumpyExtensionArray hack
     _typ = "extension"

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -551,6 +551,7 @@ class BaseStringArray(ExtensionArray):
 # error: Definition of "_concat_same_type" in base class "NDArrayBacked" is
 # incompatible with definition in base class "ExtensionArray"
 class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
+    __module__ = "pandas.arrays"
     """
     Extension array for string data.
 

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -82,7 +82,6 @@ def _is_string_view(typ):
 
 
 class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringArray):
-    __module__ = "pandas.arrays"
     """
     Extension array for string data in a ``pyarrow.ChunkedArray``.
 
@@ -125,6 +124,8 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
     ['This is', 'some text', <NA>, 'data.']
     Length: 4, dtype: string
     """
+
+    __module__ = "pandas.arrays"
 
     # error: Incompatible types in assignment (expression has type "StringDtype",
     # base class "ArrowExtensionArray" defined the type as "ArrowDtype")

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -82,6 +82,7 @@ def _is_string_view(typ):
 
 
 class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringArray):
+    __module__ = "pandas.arrays"
     """
     Extension array for string data in a ``pyarrow.ChunkedArray``.
 

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -104,7 +104,6 @@ def _field_accessor(name: str, alias: str, docstring: str):
 
 
 class TimedeltaArray(dtl.TimelikeOps):
-    __module__ = "pandas.arrays"
     """
     Pandas ExtensionArray for timedelta data.
 
@@ -147,6 +146,8 @@ class TimedeltaArray(dtl.TimelikeOps):
     ['0 days 01:00:00', '0 days 02:00:00']
     Length: 2, dtype: timedelta64[ns]
     """
+
+    __module__ = "pandas.arrays"
 
     _typ = "timedeltaarray"
     _internal_fill_value = np.timedelta64("NaT", "ns")

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -104,6 +104,7 @@ def _field_accessor(name: str, alias: str, docstring: str):
 
 
 class TimedeltaArray(dtl.TimelikeOps):
+    __module__ = "pandas.arrays"
     """
     Pandas ExtensionArray for timedelta data.
 

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -70,6 +70,7 @@ def _pretty_print_args_kwargs(*args: Any, **kwargs: Any) -> str:
 
 
 class Expression:
+    __module__ = "pandas.api.typing"
     """
     Class representing a deferred column.
 

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -70,12 +70,13 @@ def _pretty_print_args_kwargs(*args: Any, **kwargs: Any) -> str:
 
 
 class Expression:
-    __module__ = "pandas.api.typing"
     """
     Class representing a deferred column.
 
     This is not meant to be instantiated directly. Instead, use :meth:`pandas.col`.
     """
+
+    __module__ = "pandas.api.typing"
 
     def __init__(self, func: Callable[[DataFrame], Any], repr_str: str) -> None:
         self._func = func

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 
 class ExtensionDtype:
+    __module__ = "pandas.api.extensions"
     """
     A custom data type, to be paired with an ExtensionArray.
 

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
 
 
 class ExtensionDtype:
-    __module__ = "pandas.api.extensions"
     """
     A custom data type, to be paired with an ExtensionArray.
 
@@ -111,6 +110,8 @@ class ExtensionDtype:
     ``pandas.errors.AbstractMethodError`` and no ``register`` method is
     provided for registering virtual subclasses.
     """
+
+    __module__ = "pandas.api.extensions"
 
     _metadata: tuple[str, ...] = ()
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -359,7 +359,7 @@ def is_datetime64tz_dtype(arr_or_dtype) -> bool:
     >>> is_datetime64tz_dtype(pd.DatetimeIndex([1, 2, 3], tz="US/Eastern"))
     True
 
-    >>> from pandas.api.types import DatetimeTZDtype
+    >>> from pandas import DatetimeTZDtype
     >>> dtype = DatetimeTZDtype("ns", tz="US/Eastern")
     >>> s = pd.Series([], dtype=dtype)
     >>> is_datetime64tz_dtype(dtype)

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -359,7 +359,7 @@ def is_datetime64tz_dtype(arr_or_dtype) -> bool:
     >>> is_datetime64tz_dtype(pd.DatetimeIndex([1, 2, 3], tz="US/Eastern"))
     True
 
-    >>> from pandas.core.dtypes.dtypes import DatetimeTZDtype
+    >>> from pandas.api.types import DatetimeTZDtype
     >>> dtype = DatetimeTZDtype("ns", tz="US/Eastern")
     >>> s = pd.Series([], dtype=dtype)
     >>> is_datetime64tz_dtype(dtype)
@@ -407,7 +407,7 @@ def is_timedelta64_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
-    >>> from pandas.core.dtypes.common import is_timedelta64_dtype
+    >>> from pandas.api.types import is_timedelta64_dtype
     >>> is_timedelta64_dtype(object)
     False
     >>> is_timedelta64_dtype(np.timedelta64)
@@ -452,7 +452,7 @@ def is_period_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
-    >>> from pandas.core.dtypes.common import is_period_dtype
+    >>> from pandas.api.types import is_period_dtype
     >>> is_period_dtype(object)
     False
     >>> is_period_dtype(pd.PeriodDtype(freq="D"))
@@ -507,7 +507,7 @@ def is_interval_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
-    >>> from pandas.core.dtypes.common import is_interval_dtype
+    >>> from pandas.api.types import is_interval_dtype
     >>> is_interval_dtype(object)
     False
     >>> is_interval_dtype(pd.IntervalDtype())
@@ -684,10 +684,10 @@ def is_dtype_equal(source, target) -> bool:
     True
     >>> is_dtype_equal(object, "category")
     False
-    >>> from pandas.core.dtypes.dtypes import CategoricalDtype
+    >>> from pandas.api.types import CategoricalDtype
     >>> is_dtype_equal(CategoricalDtype(), "category")
     True
-    >>> from pandas.core.dtypes.dtypes import DatetimeTZDtype
+    >>> from pandas.api.types import DatetimeTZDtype
     >>> is_dtype_equal(DatetimeTZDtype(tz="UTC"), "datetime64")
     False
     """
@@ -811,7 +811,7 @@ def is_signed_integer_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
-    >>> from pandas.core.dtypes.common import is_signed_integer_dtype
+    >>> from pandas.api.types import is_signed_integer_dtype
     >>> is_signed_integer_dtype(str)
     False
     >>> is_signed_integer_dtype(int)
@@ -1006,7 +1006,7 @@ def is_datetime64_any_dtype(arr_or_dtype) -> bool:
     Examples
     --------
     >>> from pandas.api.types import is_datetime64_any_dtype
-    >>> from pandas.core.dtypes.dtypes import DatetimeTZDtype
+    >>> from pandas.api.types import DatetimeTZDtype
     >>> is_datetime64_any_dtype(str)
     False
     >>> is_datetime64_any_dtype(int)
@@ -1066,7 +1066,7 @@ def is_datetime64_ns_dtype(arr_or_dtype) -> bool:
     Examples
     --------
     >>> from pandas.api.types import is_datetime64_ns_dtype
-    >>> from pandas.core.dtypes.dtypes import DatetimeTZDtype
+    >>> from pandas.api.types import DatetimeTZDtype
     >>> is_datetime64_ns_dtype(str)
     False
     >>> is_datetime64_ns_dtype(int)
@@ -1121,7 +1121,7 @@ def is_timedelta64_ns_dtype(arr_or_dtype) -> bool:
 
     Examples
     --------
-    >>> from pandas.core.dtypes.common import is_timedelta64_ns_dtype
+    >>> from pandas.api.types import is_timedelta64_ns_dtype
     >>> is_timedelta64_ns_dtype(np.dtype("m8[ns]"))
     True
     >>> is_timedelta64_ns_dtype(np.dtype("m8[ps]"))  # Wrong frequency

--- a/pandas/core/flags.py
+++ b/pandas/core/flags.py
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
 
 
 class Flags:
-    __module__ = "pandas"
     """
     Flags that apply to pandas objects.
 
@@ -55,6 +54,8 @@ class Flags:
     >>> df.flags
     <Flags(allows_duplicate_labels=True)>
     """
+
+    __module__ = "pandas"
 
     _keys: set[str] = {"allows_duplicate_labels"}
 

--- a/pandas/core/flags.py
+++ b/pandas/core/flags.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 
 
 class Flags:
+    __module__ = "pandas"
     """
     Flags that apply to pandas objects.
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
 
 
 class Grouper:
-    __module__ = "pandas"
     """
     A Grouper allows the user to specify a groupby instruction for an object.
 
@@ -253,6 +252,8 @@ class Grouper:
     2000-10-02 00:24:00    24
     Freq: 17min, dtype: int64
     """
+
+    __module__ = "pandas"
 
     sort: bool
     dropna: bool

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
 
 
 class Grouper:
+    __module__ = "pandas"
     """
     A Grouper allows the user to specify a groupby instruction for an object.
 

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -17,7 +17,6 @@ from pandas.tseries.offsets import Nano
 
 
 class BaseIndexer:
-    __module__ = "pandas.api.indexers"
     """
     Base class for window bounds calculations.
 
@@ -58,6 +57,8 @@ class BaseIndexer:
     3	7.0
     4	4.0
     """
+
+    __module__ = "pandas.api.indexers"
 
     def __init__(
         self, index_array: np.ndarray | None = None, window_size: int = 0, **kwargs
@@ -212,7 +213,6 @@ class VariableWindowIndexer(BaseIndexer):
 
 
 class VariableOffsetWindowIndexer(BaseIndexer):
-    __module__ = "pandas.api.indexers"
     """
     Calculate window boundaries based on a non-fixed offset such as a BusinessDay.
 
@@ -272,6 +272,8 @@ class VariableOffsetWindowIndexer(BaseIndexer):
     2020-01-09   8.0
     2020-01-10   9.0
     """
+
+    __module__ = "pandas.api.indexers"
 
     def __init__(
         self,
@@ -436,7 +438,6 @@ class ExpandingIndexer(BaseIndexer):
 
 
 class FixedForwardWindowIndexer(BaseIndexer):
-    __module__ = "pandas.api.indexers"
     """
     Creates window boundaries for fixed-length windows that include the current row.
 
@@ -480,6 +481,8 @@ class FixedForwardWindowIndexer(BaseIndexer):
     3  4.0
     4  4.0
     """
+
+    __module__ = "pandas.api.indexers"
 
     def get_window_bounds(
         self,

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -17,6 +17,7 @@ from pandas.tseries.offsets import Nano
 
 
 class BaseIndexer:
+    __module__ = "pandas.api.indexers"
     """
     Base class for window bounds calculations.
 
@@ -211,6 +212,7 @@ class VariableWindowIndexer(BaseIndexer):
 
 
 class VariableOffsetWindowIndexer(BaseIndexer):
+    __module__ = "pandas.api.indexers"
     """
     Calculate window boundaries based on a non-fixed offset such as a BusinessDay.
 
@@ -434,6 +436,7 @@ class ExpandingIndexer(BaseIndexer):
 
 
 class FixedForwardWindowIndexer(BaseIndexer):
+    __module__ = "pandas.api.indexers"
     """
     Creates window boundaries for fixed-length windows that include the current row.
 

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -20,6 +20,7 @@ from pandas.io.formats.printing import pprint_thing
 
 
 class FrozenList(PandasObject, list):
+    __module__ = "pandas.api.typing"
     """
     Container that doesn't allow setting item *but*
     because it's technically hashable, will be used

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -20,12 +20,13 @@ from pandas.io.formats.printing import pprint_thing
 
 
 class FrozenList(PandasObject, list):
-    __module__ = "pandas.api.typing"
     """
     Container that doesn't allow setting item *but*
     because it's technically hashable, will be used
     for lookups, appropriately, etc.
     """
+
+    __module__ = "pandas.api.typing"
 
     # Side note: This has to be of type list. Otherwise,
     #            it messes up PyTables type checks.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -77,7 +77,6 @@ def min_fitting_element(start: int, step: int, lower_limit: int) -> int:
 
 @set_module("pandas")
 class RangeIndex(Index):
-    __module__ = "pandas"
     """
     Immutable Index implementing a monotonic integer range.
 
@@ -137,6 +136,8 @@ class RangeIndex(Index):
     >>> list(pd.RangeIndex(1, 0))
     []
     """
+
+    __module__ = "pandas"
 
     _typ = "rangeindex"
     _dtype_validation_metadata = (is_signed_integer_dtype, "signed integer")

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -77,6 +77,7 @@ def min_fitting_element(start: int, step: int, lower_limit: int) -> int:
 
 @set_module("pandas")
 class RangeIndex(Index):
+    __module__ = "pandas"
     """
     Immutable Index implementing a monotonic integer range.
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -30,7 +30,6 @@ from pandas.errors import (
 from pandas.errors.cow import _chained_assignment_msg
 from pandas.util._decorators import (
     doc,
-    set_module,
 )
 
 from pandas.core.dtypes.cast import (
@@ -104,7 +103,6 @@ _one_ellipsis_message = "indexer may only contain one '...' entry"
 
 
 # the public IndexSlicerMaker
-@set_module("pandas")
 class _IndexSlice:
     """
     Create an object to more easily perform multi-index slicing.

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -151,6 +151,7 @@ class _IndexSlice:
 
 
 IndexSlice = _IndexSlice()
+IndexSlice.__module__ = "pandas"
 
 
 class IndexingMixin:

--- a/pandas/core/interchange/dataframe_protocol.py
+++ b/pandas/core/interchange/dataframe_protocol.py
@@ -363,6 +363,7 @@ class Column(ABC):
 
 
 class DataFrame(ABC):
+    __module__ = "pandas.api.interchange"
     """
     A data frame class, with only the methods required by the interchange
     protocol defined.

--- a/pandas/core/interchange/dataframe_protocol.py
+++ b/pandas/core/interchange/dataframe_protocol.py
@@ -363,7 +363,6 @@ class Column(ABC):
 
 
 class DataFrame(ABC):
-    __module__ = "pandas.api.interchange"
     """
     A data frame class, with only the methods required by the interchange
     protocol defined.
@@ -377,6 +376,8 @@ class DataFrame(ABC):
     ``__dataframe__`` method of a public data frame class in a library adhering
     to the dataframe interchange protocol specification.
     """
+
+    __module__ = "pandas.api.interchange"
 
     version = 0  # version of the protocol
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -113,7 +113,6 @@ _shared_docs_kwargs: dict[str, str] = {}
 
 
 class Resampler(BaseGroupBy, PandasObject):
-    __module__ = "pandas.api.typing"
     """
     Class for resampling datetimelike data, a groupby-like operation.
     See aggregate, transform, and apply functions on this object.
@@ -133,6 +132,8 @@ class Resampler(BaseGroupBy, PandasObject):
     -----
     After resampling, see aggregate, apply, and transform functions.
     """
+
+    __module__ = "pandas.api.typing"
 
     _grouper: BinGrouper
     _timegrouper: TimeGrouper
@@ -2170,10 +2171,11 @@ class DatetimeIndexResampler(Resampler):
 class DatetimeIndexResamplerGroupby(  # type: ignore[misc]
     _GroupByMixin, DatetimeIndexResampler
 ):
-    __module__ = "pandas.api.typing"
     """
     Provides a resample of a groupby implementation
     """
+
+    __module__ = "pandas.api.typing"
 
     @property
     def _resampler_cls(self):
@@ -2272,10 +2274,11 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 class PeriodIndexResamplerGroupby(  # type: ignore[misc]
     _GroupByMixin, PeriodIndexResampler
 ):
-    __module__ = "pandas.api.typing"
     """
     Provides a resample of a groupby implementation.
     """
+
+    __module__ = "pandas.api.typing"
 
     @property
     def _resampler_cls(self):
@@ -2309,10 +2312,11 @@ class TimedeltaIndexResampler(DatetimeIndexResampler):
 class TimedeltaIndexResamplerGroupby(  # type: ignore[misc]
     _GroupByMixin, TimedeltaIndexResampler
 ):
-    __module__ = "pandas.api.typing"
     """
     Provides a resample of a groupby implementation.
     """
+
+    __module__ = "pandas.api.typing"
 
     @property
     def _resampler_cls(self):
@@ -2349,7 +2353,6 @@ def get_resampler_for_grouping(
 
 
 class TimeGrouper(Grouper):
-    __module__ = "pandas.api.typing"
     """
     Custom groupby class for time-interval grouping.
 
@@ -2361,6 +2364,8 @@ class TimeGrouper(Grouper):
     convention : {'start', 'end', 'e', 's'}
         If axis is PeriodIndex
     """
+
+    __module__ = "pandas.api.typing"
 
     _attributes = Grouper._attributes + (
         "closed",

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -113,6 +113,7 @@ _shared_docs_kwargs: dict[str, str] = {}
 
 
 class Resampler(BaseGroupBy, PandasObject):
+    __module__ = "pandas.api.typing"
     """
     Class for resampling datetimelike data, a groupby-like operation.
     See aggregate, transform, and apply functions on this object.
@@ -2169,6 +2170,7 @@ class DatetimeIndexResampler(Resampler):
 class DatetimeIndexResamplerGroupby(  # type: ignore[misc]
     _GroupByMixin, DatetimeIndexResampler
 ):
+    __module__ = "pandas.api.typing"
     """
     Provides a resample of a groupby implementation
     """
@@ -2270,6 +2272,7 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 class PeriodIndexResamplerGroupby(  # type: ignore[misc]
     _GroupByMixin, PeriodIndexResampler
 ):
+    __module__ = "pandas.api.typing"
     """
     Provides a resample of a groupby implementation.
     """
@@ -2306,6 +2309,7 @@ class TimedeltaIndexResampler(DatetimeIndexResampler):
 class TimedeltaIndexResamplerGroupby(  # type: ignore[misc]
     _GroupByMixin, TimedeltaIndexResampler
 ):
+    __module__ = "pandas.api.typing"
     """
     Provides a resample of a groupby implementation.
     """
@@ -2345,6 +2349,7 @@ def get_resampler_for_grouping(
 
 
 class TimeGrouper(Grouper):
+    __module__ = "pandas.api.typing"
     """
     Custom groupby class for time-interval grouping.
 

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -130,6 +130,7 @@ def _calculate_deltas(
 
 
 class ExponentialMovingWindow(BaseWindow):
+    __module__ = "pandas.api.typing"
     r"""
     Provide exponentially weighted (EW) calculations.
 
@@ -903,6 +904,7 @@ class ExponentialMovingWindow(BaseWindow):
 
 
 class ExponentialMovingWindowGroupby(BaseWindowGroupby, ExponentialMovingWindow):
+    __module__ = "pandas.api.typing"
     """
     Provide an exponential moving window groupby implementation.
     """

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -130,7 +130,6 @@ def _calculate_deltas(
 
 
 class ExponentialMovingWindow(BaseWindow):
-    __module__ = "pandas.api.typing"
     r"""
     Provide exponentially weighted (EW) calculations.
 
@@ -316,6 +315,8 @@ class ExponentialMovingWindow(BaseWindow):
     3  1.523889
     4  3.233686
     """
+
+    __module__ = "pandas.api.typing"
 
     _attributes = [
         "com",
@@ -904,10 +905,11 @@ class ExponentialMovingWindow(BaseWindow):
 
 
 class ExponentialMovingWindowGroupby(BaseWindowGroupby, ExponentialMovingWindow):
-    __module__ = "pandas.api.typing"
     """
     Provide an exponential moving window groupby implementation.
     """
+
+    __module__ = "pandas.api.typing"
 
     _attributes = ExponentialMovingWindow._attributes + BaseWindowGroupby._attributes
 

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 
 
 class Expanding(RollingAndExpandingMixin):
+    __module__ = "pandas.api.typing"
     """
     Provide expanding window calculations.
 
@@ -1451,6 +1452,7 @@ class Expanding(RollingAndExpandingMixin):
 
 
 class ExpandingGroupby(BaseWindowGroupby, Expanding):
+    __module__ = "pandas.api.typing"
     """
     Provide a expanding groupby implementation.
     """

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
 
 
 class Expanding(RollingAndExpandingMixin):
-    __module__ = "pandas.api.typing"
     """
     Provide expanding window calculations.
 
@@ -106,6 +105,8 @@ class Expanding(RollingAndExpandingMixin):
     3  3.0
     4  7.0
     """
+
+    __module__ = "pandas.api.typing"
 
     _attributes: list[str] = ["min_periods", "method"]
 
@@ -1452,10 +1453,11 @@ class Expanding(RollingAndExpandingMixin):
 
 
 class ExpandingGroupby(BaseWindowGroupby, Expanding):
-    __module__ = "pandas.api.typing"
     """
     Provide a expanding groupby implementation.
     """
+
+    __module__ = "pandas.api.typing"
 
     _attributes = Expanding._attributes + BaseWindowGroupby._attributes
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -856,7 +856,6 @@ class BaseWindowGroupby(BaseWindow):
 
 
 class Window(BaseWindow):
-    __module__ = "pandas.api.typing"
     """
     Provide rolling window calculations.
 
@@ -1111,6 +1110,8 @@ class Window(BaseWindow):
     2020-01-02 2020-01-01  3.0
     2020-01-03 2020-01-02  6.0
     """
+
+    __module__ = "pandas.api.typing"
 
     _attributes = [
         "window",
@@ -3532,10 +3533,11 @@ Rolling.__doc__ = Window.__doc__
 
 
 class RollingGroupby(BaseWindowGroupby, Rolling):
-    __module__ = "pandas.api.typing"
     """
     Provide a rolling groupby implementation.
     """
+
+    __module__ = "pandas.api.typing"
 
     _attributes = Rolling._attributes + BaseWindowGroupby._attributes
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -856,6 +856,7 @@ class BaseWindowGroupby(BaseWindow):
 
 
 class Window(BaseWindow):
+    __module__ = "pandas.api.typing"
     """
     Provide rolling window calculations.
 
@@ -1968,6 +1969,7 @@ class RollingAndExpandingMixin(BaseWindow):
 
 
 class Rolling(RollingAndExpandingMixin):
+    __module__ = "pandas.api.typing"
     _attributes: list[str] = [
         "window",
         "min_periods",
@@ -3530,6 +3532,7 @@ Rolling.__doc__ = Window.__doc__
 
 
 class RollingGroupby(BaseWindowGroupby, Rolling):
+    __module__ = "pandas.api.typing"
     """
     Provide a rolling groupby implementation.
     """

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1331,7 +1331,7 @@ class Window(BaseWindow):
         to pass the parameter `win_type`.
 
         >>> type(ser.rolling(2, win_type="gaussian"))
-        <class 'pandas.core.window.rolling.Window'>
+        <class 'pandas.api.typing.Window'>
 
         In order to use the `SciPy` Gaussian window we need to provide the parameters
         `M` and `std`. The parameter `M` corresponds to 2 in our example.
@@ -1391,7 +1391,7 @@ class Window(BaseWindow):
         to pass the parameter `win_type`.
 
         >>> type(ser.rolling(2, win_type="gaussian"))
-        <class 'pandas.core.window.rolling.Window'>
+        <class 'pandas.api.typing.Window'>
 
         In order to use the `SciPy` Gaussian window we need to provide the parameters
         `M` and `std`. The parameter `M` corresponds to 2 in our example.
@@ -1453,7 +1453,7 @@ class Window(BaseWindow):
         to pass the parameter `win_type`.
 
         >>> type(ser.rolling(2, win_type="gaussian"))
-        <class 'pandas.core.window.rolling.Window'>
+        <class 'pandas.api.typing.Window'>
 
         In order to use the `SciPy` Gaussian window we need to provide the parameters
         `M` and `std`. The parameter `M` corresponds to 2 in our example.
@@ -1508,7 +1508,7 @@ class Window(BaseWindow):
         to pass the parameter `win_type`.
 
         >>> type(ser.rolling(2, win_type="gaussian"))
-        <class 'pandas.core.window.rolling.Window'>
+        <class 'pandas.api.typing.Window'>
 
         In order to use the `SciPy` Gaussian window we need to provide the parameters
         `M` and `std`. The parameter `M` corresponds to 2 in our example.

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -821,6 +821,7 @@ def read_json(
 
 
 class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
+    __module__ = "pandas.api.typing"
     """
     JsonReader provides an interface for reading in a JSON file.
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -821,7 +821,6 @@ def read_json(
 
 
 class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
-    __module__ = "pandas.api.typing"
     """
     JsonReader provides an interface for reading in a JSON file.
 
@@ -829,6 +828,8 @@ class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
     ``chunksize`` lines at a time. Otherwise, calling ``read`` reads in the
     whole document.
     """
+
+    __module__ = "pandas.api.typing"
 
     def __init__(
         self,

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 
 
 class SASReader(Iterator["DataFrame"], ABC):
+    __module__ = "pandas.api.typing"
     """
     Abstract class for XportReader and SAS7BDATReader.
     """

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -38,10 +38,11 @@ if TYPE_CHECKING:
 
 
 class SASReader(Iterator["DataFrame"], ABC):
-    __module__ = "pandas.api.typing"
     """
     Abstract class for XportReader and SAS7BDATReader.
     """
+
+    __module__ = "pandas.api.typing"
 
     @abstractmethod
     def read(self, nrows: int | None = None) -> DataFrame: ...

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1019,6 +1019,7 @@ class StataParser:
 
 
 class StataReader(StataParser, abc.Iterator):
+    __module__ = "pandas.api.typing"
     __doc__ = _stata_reader_doc
 
     _path_or_buf: IO[bytes]  # Will be assigned by `_open_file`.

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -971,6 +971,8 @@ class PlotAccessor(PandasObject):
         >>> plot = df.groupby("col2").plot(kind="bar", title="DataFrameGroupBy Plot")
     """
 
+    __module__ = "pandas.plotting"
+
     _common_kinds = ("line", "bar", "barh", "kde", "density", "area", "hist", "box")
     _series_kinds = ("pie",)
     _dataframe_kinds = ("scatter", "hexbin")

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -766,3 +766,4 @@ class _Options(dict):
 
 
 plot_params = _Options()
+plot_params.__module__ = "pandas.plotting"

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -606,6 +606,8 @@ def get_pandas_objects(
     if not recurse:
         return objs
 
+    # __file__ can, but shouldn't, be None
+    assert isinstance(module.__file__, str)
     paths = [pathlib.Path(module.__file__).parent]
     for module_info in pkgutil.walk_packages(paths):
         name = module_info.name

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -571,14 +571,33 @@ def test_set_module():
     assert api.typing.DataFrameGroupBy.__module__ == "pandas.api.typing"
 
 
-def get_objects(module_name, recurse):
+def get_pandas_objects(
+    module_name: str, recurse: bool
+) -> list[tuple[str, str, object]]:
+    """
+    Get all pandas objects within a module.
+
+    An object is determined to be part of pandas if it has a string
+    __module__ attribute that starts with ``"pandas"``.
+
+    Parameters
+    ----------
+    module_name : str
+        Name of the module to search.
+    recurse : bool
+        Whether to search submodules.
+
+    Returns
+    -------
+        List of all objects that are determined to be a part of pandas.
+    """
     module = importlib.import_module(module_name)
     objs = []
 
     for name, obj in inspect.getmembers(module):
         if inspect.isfunction(obj) or type(obj).__name__ == "cython_function_or_method":
-            # Sphinx does not use the __module__ attribute for functions,
-            # so we do not need to overwrite the attribute.
+            # We have not set __module__ on public functions; may do
+            # so in the future.
             continue
         module_dunder = getattr(obj, "__module__", None)
         if isinstance(module_dunder, str) and module_dunder.startswith("pandas"):
@@ -587,19 +606,14 @@ def get_objects(module_name, recurse):
     if not recurse:
         return objs
 
-    paths = [str(pathlib.Path(module.__file__).parent)]
-    for _, submodule_name, is_pkg in pkgutil.walk_packages(
-        paths, module.__name__ + "."
-    ):
-        tail = submodule_name[submodule_name.rfind(".") + 1 :]
-        if tail.startswith("_"):
+    paths = [pathlib.Path(module.__file__).parent]
+    for module_info in pkgutil.walk_packages(paths):
+        name = module_info.name
+        if name.startswith("_") or name == "internals":
             continue
-        if submodule_name == "pandas.api.internals":
-            continue
-        try:
-            objs.extend(get_objects(submodule_name, recurse))
-        except ImportError:
-            pass
+        objs.extend(
+            get_pandas_objects(f"{module.__name__}.{name}", recurse=module_info.ispkg)
+        )
     return objs
 
 
@@ -617,15 +631,18 @@ def get_objects(module_name, recurse):
     ],
 )
 def test_attributes_module(module_name):
-    objs = get_objects(module_name, recurse=module_name != "pandas")
+    recurse = module_name not in ["pandas", "pandas.testing"]
+    objs = get_pandas_objects(module_name, recurse=recurse)
     failures = [
         (module_name, name, type(obj), obj.__module__)
         for module_name, name, obj in objs
-        if (
-            obj.__module__ != module_name
-            and obj.__module__ != "pandas"
-            # Can't seem to change __module__
-            and name != "Interval"
+        if not (
+            obj.__module__ == module_name
+            # Explicit exceptions
+            or ("Dtype" in name and obj.__module__ == "pandas")
+            or (name == "Categorical" and obj.__module__ == "pandas")
+            # TODO: Can't seem to change __module__
+            or name == "Interval"
         )
     ]
     assert len(failures) == 0, failures

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -590,6 +590,7 @@ def get_classes(module):
     return classes
 
 
+@pytest.mark.slow
 def test_module_attribute():
     # Check that each class pandas defines can be imported from
     # the __module__ attribute

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -643,9 +643,6 @@ def test_attributes_module(module_name):
             # Explicit exceptions
             or ("Dtype" in name and obj.__module__ == "pandas")
             or (name == "Categorical" and obj.__module__ == "pandas")
-            # Setting __module__ on a cdef class has no effect
-            # https://github.com/cython/cython/issues/7231
-            or name == "Interval"
         )
     ]
     assert len(failures) == 0, failures

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import importlib
+import inspect
+import pathlib
+import pkgutil
+
 import pytest
 
 import pandas as pd
@@ -566,12 +571,6 @@ def test_set_module():
     assert api.typing.DataFrameGroupBy.__module__ == "pandas.api.typing"
 
 
-import importlib
-import inspect
-import pathlib
-import pkgutil
-
-
 def get_classes(module):
     classes = []
 
@@ -587,8 +586,7 @@ def get_classes(module):
             submodule = importlib.import_module(submodule_name)
             classes.extend(get_classes(submodule))
         except ImportError:
-            # pass
-            raise
+            pass
     return classes
 
 

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -643,7 +643,8 @@ def test_attributes_module(module_name):
             # Explicit exceptions
             or ("Dtype" in name and obj.__module__ == "pandas")
             or (name == "Categorical" and obj.__module__ == "pandas")
-            # TODO: Can't seem to change __module__
+            # Setting __module__ on a cdef class has no effect
+            # https://github.com/cython/cython/issues/7231
             or name == "Interval"
         )
     ]

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -579,10 +579,7 @@ class TestAstypeCategorical:
         ser = Series(np.random.default_rng(2).integers(0, 10000, 100)).sort_values()
         ser = cut(ser, range(0, 10500, 500), right=False, labels=cat)
 
-        msg = (
-            "dtype '<class 'pandas.core.arrays.categorical.Categorical'>' "
-            "not understood"
-        )
+        msg = "dtype '<class 'pandas.Categorical'>' not understood"
         with pytest.raises(TypeError, match=msg):
             ser.astype(Categorical)
         with pytest.raises(TypeError, match=msg):

--- a/pandas/util/version/__init__.py
+++ b/pandas/util/version/__init__.py
@@ -111,6 +111,7 @@ def parse(version: str) -> Version:
 # The docstring is from an older version of the packaging library to avoid
 # errors in the docstring validation.
 class InvalidVersion(ValueError):
+    __module__ = "pandas.errors"
     """
     An invalid version was found, users should refer to PEP 440.
 

--- a/setup.py
+++ b/setup.py
@@ -321,7 +321,7 @@ else:
     endian_macro = [("__LITTLE_ENDIAN__", "1")]
 
 
-extra_compile_args = ["-DCYTHON_USE_TYPE_SPECS=1"]
+extra_compile_args = []
 extra_link_args = []
 if is_platform_windows():
     if debugging_symbols_requested:
@@ -569,9 +569,6 @@ for name, data in ext_data.items():
         extra_compile_args.append("-qlanglvl=extended0x:nolibext")
         undef_macros.append("_POSIX_THREADS")
 
-    print("-" * 80)
-    print(extra_compile_args)
-    print("-" * 80)
     obj = Extension(
         f"pandas.{name}",
         sources=sources,

--- a/setup.py
+++ b/setup.py
@@ -321,7 +321,7 @@ else:
     endian_macro = [("__LITTLE_ENDIAN__", "1")]
 
 
-extra_compile_args = []
+extra_compile_args = ["-DCYTHON_USE_TYPE_SPECS=1"]
 extra_link_args = []
 if is_platform_windows():
     if debugging_symbols_requested:
@@ -569,6 +569,9 @@ for name, data in ext_data.items():
         extra_compile_args.append("-qlanglvl=extended0x:nolibext")
         undef_macros.append("_POSIX_THREADS")
 
+    print("-" * 80)
+    print(extra_compile_args)
+    print("-" * 80)
     obj = Extension(
         f"pandas.{name}",
         sources=sources,


### PR DESCRIPTION
- [x] closes #55178 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR addresses all `__module__` attributes of public objects that I can find with the exception of functions. It's not clear to me if we want to also be modifying the `__module__` attribute of e.g. `pandas.factorize` and even if we do, I'd like to keep that separate as this PR is already becoming sizable.

Remaining documentation that contains `.core.`:

<details>

### API docs

```
# Ignore redirects
grep -nre "\.core\." doc/build/html/reference/ | grep -v "has been moved" | grep -v "http-equiv=\"refresh\""
```

```
doc/build/html/reference/api/pandas.IndexSlice.html:762:<span class="sig-prename descclassname"><span class="pre">pandas.</span></span><span class="sig-name descname"><span class="pre">IndexSlice</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">&lt;pandas.core.indexing._IndexSlice</span> <span class="pre">object&gt;</span></em><a class="headerlink" href="#pandas.IndexSlice" title="Link to this definition">#</a></dt>
doc/build/html/reference/api/pandas.DataFrame.query.html:843:in combination with the source code in <code class="xref py py-mod docutils literal notranslate"><span class="pre">pandas.core.computation.parsing</span></code>.</p>
```

### User Guide

    grep -nre "\.core\." doc/build/html/user_guide/

```
doc/build/html/user_guide/io.html:3895:<span class="go">&lt;IPython.core.display.HTML object&gt;</span>
doc/build/html/user_guide/io.html:3922:<span class="go">&lt;IPython.core.display.HTML object&gt;</span>
doc/build/html/user_guide/io.html:3953:<span class="go">&lt;IPython.core.display.HTML object&gt;</span>
doc/build/html/user_guide/io.html:3984:<span class="go">&lt;IPython.core.display.HTML object&gt;</span>
doc/build/html/user_guide/io.html:4050:<span class="go">&lt;IPython.core.display.HTML object&gt;</span>
doc/build/html/user_guide/io.html:4091:<span class="go">&lt;IPython.core.display.HTML object&gt;</span>
doc/build/html/user_guide/io.html:4126:<span class="go">&lt;IPython.core.display.HTML object&gt;</span>
```

### Getting Started

    grep -nre "\.core\." doc/build/html/getting_started/

no output.

</details>