### PR TITLE
BUG: option_context with invalid option (#62726)

### DIFF
--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -503,6 +503,7 @@ def option_context(*args) -> Generator[None]:
         )
 
     ops = tuple(zip(args[::2], args[1::2], strict=True))
+    undo: tuple[tuple[Any, Any], ...] = ()
     try:
         undo = tuple((pat, get_option(pat)) for pat, val in ops)
         for pat, val in ops:

--- a/pandas/tests/config/test_config.py
+++ b/pandas/tests/config/test_config.py
@@ -491,3 +491,9 @@ def test_no_silent_downcasting_deprecated():
         cf.get_option("future.no_silent_downcasting")
     with tm.assert_produces_warning(Pandas4Warning, match="is deprecated"):
         cf.set_option("future.no_silent_downcasting", True)
+
+
+def test_option_context_invalid_option():
+    with pytest.raises(OptionError, match="No such keys"):
+        with cf.option_context("invalid", True):
+            pass


### PR DESCRIPTION
DOC: Simplifies the pandas documentation theme footer as requested in GH-51536.

This PR removes extra version and timestamp information from the footer by simplifying the `html_context` dictionary in `doc/source/conf.py`.

## PR Checklist

- [x] closes #51536
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) (Confirmed documentation build (`build_sphinx`) is clean).
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (N/A: Documentation configuration change)
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. (N/A: Minor documentation configuration change)