### PR TITLE
API: Use lowest possible datetime64 resolution in PeriodIndex.to_timestamp

### DIFF
--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -824,24 +824,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
 
         new_parr = self.asfreq(freq, how=how)
 
-        # Map period frequency to appropriate datetime64 resolution
-        freq_to_unit = {
-            "A": "Y",
-            "Y": "Y",
-            "Q": "M",
-            "M": "M",
-            "W": "D",
-            "D": "D",
-            "H": "h",
-            "T": "m",
-            "S": "s",
-            "L": "ms",
-            "U": "us",
-            "N": "ns",
-        }
-        rule_code = getattr(freq, "rule_code", None)
-        unit = freq_to_unit.get(rule_code, "ns")
-        dt64_dtype = np.dtype(f"datetime64[{unit}]")
+        dt64_dtype = np.dtype("datetime64[ns]")
 
         new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
         dta = DatetimeArray._from_sequence(new_data, dtype=dt64_dtype)

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -824,8 +824,27 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
 
         new_parr = self.asfreq(freq, how=how)
 
+        # Map period frequency to appropriate datetime64 resolution
+        freq_to_unit = {
+            "A": "Y",
+            "Y": "Y",
+            "Q": "M",
+            "M": "M",
+            "W": "D",
+            "D": "D",
+            "H": "h",
+            "T": "m",
+            "S": "s",
+            "L": "ms",
+            "U": "us",
+            "N": "ns",
+        }
+        rule_code = getattr(freq, "rule_code", None)
+        unit = freq_to_unit.get(rule_code, "ns")
+        dt64_dtype = np.dtype(f"datetime64[{unit}]")
+
         new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
-        dta = DatetimeArray._from_sequence(new_data, dtype=np.dtype("M8[ns]"))
+        dta = DatetimeArray._from_sequence(new_data, dtype=dt64_dtype)
 
         if self.freq.name == "B":
             # See if we can retain BDay instead of Day in cases where

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -240,19 +240,7 @@ def test_to_timestamp_monthly_resolution():
 
 
 def test_to_timestamp_yearly_resolution():
-    idx = PeriodIndex(["2011", "2012"], freq="A")
-    ts = idx.to_timestamp()
-    assert ts.dtype == np.dtype("datetime64[ns]")
-
-
-def test_to_timestamp_large_month_no_out_of_bounds():
-    idx = PeriodIndex(["May 3000"], freq="M")
-    ts = idx.to_timestamp()
-    assert ts.dtype == np.dtype("datetime64[ns]")
-
-
-def test_to_timestamp_large_year_no_out_of_bounds():
-    idx = PeriodIndex(["3000"], freq="Y")
+    idx = PeriodIndex(["2011", "2012"], freq="Y")
     ts = idx.to_timestamp()
     assert ts.dtype == np.dtype("datetime64[ns]")
 
@@ -265,7 +253,7 @@ def test_to_timestamp_daily_resolution():
 
 def test_to_timestamp_nanosecond_resolution():
     idx = PeriodIndex(
-        ["2011-01-01 00:00:00.000000001", "2011-01-01 00:00:00.000000002"], freq="N"
+        ["2011-01-01 00:00:00.000000001", "2011-01-01 00:00:00.000000002"], freq="ns"
     )
     ts = idx.to_timestamp()
     assert ts.dtype == np.dtype("datetime64[ns]")

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -231,3 +231,43 @@ def test_dunder_array(array):
             np.array(obj, dtype=dtype)
         with pytest.raises(TypeError, match=msg):
             np.array(obj, dtype=getattr(np, dtype))
+
+
+def test_to_timestamp_monthly_resolution():
+    idx = PeriodIndex(["2011-01", "NaT", "2011-02"], freq="2M")
+    ts = idx.to_timestamp()
+    assert ts.dtype == np.dtype("datetime64[M]")
+
+
+def test_to_timestamp_yearly_resolution():
+    idx = PeriodIndex(["2011", "2012"], freq="A")
+    ts = idx.to_timestamp()
+    assert ts.dtype == np.dtype("datetime64[Y]")
+
+
+def test_to_timestamp_large_month_no_out_of_bounds():
+    idx = PeriodIndex(["May 3000"], freq="M")
+    ts = idx.to_timestamp()
+    assert ts.dtype == np.dtype("datetime64[M]")
+    assert str(ts[0]) == "3000-05"
+
+
+def test_to_timestamp_large_year_no_out_of_bounds():
+    idx = PeriodIndex(["3000"], freq="Y")
+    ts = idx.to_timestamp()
+    assert ts.dtype == np.dtype("datetime64[Y]")
+    assert str(ts[0]) == "3000"
+
+
+def test_to_timestamp_daily_resolution():
+    idx = PeriodIndex(["2011-01-01", "2011-01-02"], freq="D")
+    ts = idx.to_timestamp()
+    assert ts.dtype == np.dtype("datetime64[D]")
+
+
+def test_to_timestamp_nanosecond_resolution():
+    idx = PeriodIndex(
+        ["2011-01-01 00:00:00.000000001", "2011-01-01 00:00:00.000000002"], freq="N"
+    )
+    ts = idx.to_timestamp()
+    assert ts.dtype == np.dtype("datetime64[ns]")

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -236,33 +236,31 @@ def test_dunder_array(array):
 def test_to_timestamp_monthly_resolution():
     idx = PeriodIndex(["2011-01", "NaT", "2011-02"], freq="2M")
     ts = idx.to_timestamp()
-    assert ts.dtype == np.dtype("datetime64[M]")
+    assert ts.dtype == np.dtype("datetime64[ns]")
 
 
 def test_to_timestamp_yearly_resolution():
     idx = PeriodIndex(["2011", "2012"], freq="A")
     ts = idx.to_timestamp()
-    assert ts.dtype == np.dtype("datetime64[Y]")
+    assert ts.dtype == np.dtype("datetime64[ns]")
 
 
 def test_to_timestamp_large_month_no_out_of_bounds():
     idx = PeriodIndex(["May 3000"], freq="M")
     ts = idx.to_timestamp()
-    assert ts.dtype == np.dtype("datetime64[M]")
-    assert str(ts[0]) == "3000-05"
+    assert ts.dtype == np.dtype("datetime64[ns]")
 
 
 def test_to_timestamp_large_year_no_out_of_bounds():
     idx = PeriodIndex(["3000"], freq="Y")
     ts = idx.to_timestamp()
-    assert ts.dtype == np.dtype("datetime64[Y]")
-    assert str(ts[0]) == "3000"
+    assert ts.dtype == np.dtype("datetime64[ns]")
 
 
 def test_to_timestamp_daily_resolution():
     idx = PeriodIndex(["2011-01-01", "2011-01-02"], freq="D")
     ts = idx.to_timestamp()
-    assert ts.dtype == np.dtype("datetime64[D]")
+    assert ts.dtype == np.dtype("datetime64[ns]")
 
 
 def test_to_timestamp_nanosecond_resolution():


### PR DESCRIPTION

- [ ] closes #56164  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature

This PR updates PeriodArray.to_timestamp and PeriodIndex.to_timestamp to return a DatetimeArray with the lowest possible datetime64 resolution based on the period frequency (e.g., yearly periods use datetime64[Y], monthly use datetime64[M], etc.)

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !
