### PR TITLE
API: Use strict comparison in array_equivalent_object with deprecation warning

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -573,7 +573,7 @@ def maybe_booleans_to_slice(ndarray[uint8_t, ndim=1] mask):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def array_equivalent_object(ndarray left, ndarray right) -> bool:
+def array_equivalent_object(ndarray left, ndarray right, strict=False) -> bool:
     """
     Perform an element by element comparison on N-d object arrays
     taking into account nan positions.
@@ -599,14 +599,14 @@ def array_equivalent_object(ndarray left, ndarray right) -> bool:
                 if x.shape != y.shape:
                     return False
                 if x.dtype == y.dtype == object:
-                    if not array_equivalent_object(x, y):
+                    if not array_equivalent_object(x, y, strict):
                         return False
                 else:
                     # Circular import isn't great, but so it goes.
                     # TODO: could use np.array_equal?
                     from pandas.core.dtypes.missing import array_equivalent
 
-                    if not array_equivalent(x, y):
+                    if not array_equivalent(x, y, strict):
                         return False
 
             elif PyArray_Check(x) or PyArray_Check(y):

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -44,6 +44,8 @@ from pandas.core.dtypes.generic import (
 )
 from pandas.core.dtypes.inference import is_list_like
 
+import pandas as pd
+
 if TYPE_CHECKING:
     from re import Pattern
 
@@ -502,9 +504,15 @@ def _array_equivalent_object(
             mask = None
 
     try:
+        warnings.warn(
+            "array_equivalent_object now uses strict=True for comparison. "
+            "This may break code that relied on non-strict comparison.",
+            pd.errors.FutureWarning,
+            stacklevel=2,
+        )
         if mask is None:
-            return lib.array_equivalent_object(left, right)
-        if not lib.array_equivalent_object(left[~mask], right[~mask]):
+            return lib.array_equivalent_object(left, right, strict=True)
+        if not lib.array_equivalent_object(left[~mask], right[~mask], strict=True):
             return False
         left_remaining = left[mask]
         right_remaining = right[mask]

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -44,8 +44,6 @@ from pandas.core.dtypes.generic import (
 )
 from pandas.core.dtypes.inference import is_list_like
 
-import pandas as pd
-
 if TYPE_CHECKING:
     from re import Pattern
 
@@ -504,12 +502,6 @@ def _array_equivalent_object(
             mask = None
 
     try:
-        warnings.warn(
-            "array_equivalent_object now uses strict=True for comparison. "
-            "This may break code that relied on non-strict comparison.",
-            pd.errors.FutureWarning,
-            stacklevel=2,
-        )
         if mask is None:
             return lib.array_equivalent_object(left, right, strict=True)
         if not lib.array_equivalent_object(left[~mask], right[~mask], strict=True):

--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.core.dtypes.missing import _array_equivalent_object
+
 import pandas as pd
 import pandas._testing as tm
 
@@ -179,3 +181,8 @@ class BaseMissingTests:
         expected = pd.DataFrame({"A": data, "B": [0.0] * len(result)})
 
         tm.assert_frame_equal(result, expected)
+
+    def test_array_equivalent_object_strict_comparison(self):
+        arr1 = np.array([1, 2, 3], dtype="int32")
+        arr2 = np.array([1, 2, 3], dtype="int64")
+        assert not _array_equivalent_object(arr1, arr2, strict_nan=False)


### PR DESCRIPTION
- [ ] closes #55492  (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

This PR updates the array_equivalent_object logic to use strict comparison (strict=True) when comparing arrays.
Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !