### PR TITLE
DOC: add reference to select_dtypes section in string migration guide

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -2380,7 +2380,10 @@ To select string columns include ``str``:
 
 .. note::
 
-    This is a change in pandas 3.0. Previously strings were stored in ``object`` dtype columns, so would be selected with ``include=[object]``.  See https://pandas.pydata.org/docs/user_guide/migration-3-strings.html#hardcoded-use-of-object-dtype.
+    This is a change in pandas 3.0. Previously strings were stored in ``object``
+    dtype columns, so would be selected with ``include=[object]``. See
+    :ref:`the migration guide <string_migration.select_dtypes>` for details on
+    how to write code that works with both versions.
 
 To see all the child dtypes of a generic ``dtype`` like ``numpy.number`` you
 can define a function that returns a tree of child dtypes:

--- a/doc/source/user_guide/migration-3-strings.rst
+++ b/doc/source/user_guide/migration-3-strings.rst
@@ -195,6 +195,8 @@ This is actually compatible with pandas 2.x as well, since in pandas < 3,
    of also stringifying missing values in pandas 2.x. See the section
    :ref:`string_migration_guide-astype_str` for more details.
 
+.. _string_migration.select_dtypes:
+
 For selecting string columns with :meth:`~DataFrame.select_dtypes` in a pandas
 2.x and 3.x compatible way, it is not possible to use ``"str"``. While this
 works for pandas 3.x, it raises an error in pandas 2.x.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5253,7 +5253,10 @@ class DataFrame(NDFrame, OpsMixin):
                 "select_dtypes when 'object' dtype is specified. "
                 "This behavior is deprecated and will be removed in a future "
                 "version. Explicitly pass 'str' to `include` to select them, "
-                "or to `exclude` to remove them and silence this warning.",
+                "or to `exclude` to remove them and silence this warning.\nSee "
+                "https://pandas.pydata.org/docs/user_guide/migration-3-strings.html"
+                "#string-migration-select-dtypes for details on how to write code "
+                "that works with pandas 2 and 3.",
                 Pandas4Warning,
                 stacklevel=find_stack_level(),
             )


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/62718