### PR TITLE
Don't discard blank Series/dicts

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1914,11 +1914,11 @@ class DataFrame(NDFrame, OpsMixin):
         orient = orient.lower()  # type: ignore[assignment]
         if orient == "index":
             if len(data) > 0:
+                index = list(data.keys())
                 # TODO speed up Series case
                 if isinstance(next(iter(data.values())), (Series, dict)):
                     data = _from_nested_dict(data)
                 else:
-                    index = list(data.keys())
                     # error: Incompatible types in assignment (expression has type
                     # "List[Any]", variable has type "Dict[Any, Any]")
                     data = list(data.values())  # type: ignore[assignment]


### PR DESCRIPTION
Just leaving a drive-by PR, in the hope that it assists the bug report #62775. I probably won't have time to push this through 'properly'; I offer this with the hope that it helps communicate the problem and a potential solution.

A simple test case is that
```python
pd.DataFrame.from_dict({'good': pd.Series(dict(a=1, b=2)), 'blank': pd.Series()}, orient='index').shape == (2, 2)
```

- [X] closes #62775
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
