### PR TITLE
DOC: Simplify pandas theme footer (GH-51536)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -391,9 +391,9 @@ header = f"""\
 
 
 html_context = {
-    'display_version': True,
-    'versions_dropdown': True,
-    'github_url': 'https://github.com/pandas-dev/pandas',
+    "display_version": True,
+    "versions_dropdown": True,
+    "github_url": "https://github.com/pandas-dev/pandas",
     # Remove the following items to simplify the footer
     # 'other_versions': [
     #     ("stable", "/pandas-docs/stable/"),
@@ -855,5 +855,5 @@ linkcheck_ignore = [
             "https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022",
             "pandas.zip",
         ]
-]
+    ],
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -391,16 +391,23 @@ header = f"""\
 
 
 html_context = {
-    "redirects": dict(moved_api_pages),
-    "header": header,
+    'display_version': True,
+    'versions_dropdown': True,
+    'github_url': 'https://github.com/pandas-dev/pandas',
+    # Remove the following items to simplify the footer
+    # 'other_versions': [
+    #     ("stable", "/pandas-docs/stable/"),
+    #     ("dev", "/pandas-docs/dev/"),
+    # ],
+    # 'last_updated': datetime.now().strftime('%Y-%m-%d'),
+    # 'last_updated_date': datetime.now().strftime('%Y-%m-%d'),
 }
 
 # If false, no module index is generated.
 html_use_modindex = True
 
 # If false, no index is generated.
-# html_use_index = True
-
+# html
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
@@ -848,5 +855,5 @@ linkcheck_ignore = [
             "https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022",
             "pandas.zip",
         ]
-    ],
+]
 ]

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1001,6 +1001,7 @@ Numeric
 - Bug in :meth:`Series.dot` returning ``object`` dtype for :class:`ArrowDtype` and nullable-dtype data (:issue:`61375`)
 - Bug in :meth:`Series.std` and :meth:`Series.var` when using complex-valued data (:issue:`61645`)
 - Bug in ``np.matmul`` with :class:`Index` inputs raising a ``TypeError`` (:issue:`57079`)
+- Bug in arithmetic operations between objects with numpy-nullable dtype and :class:`ArrowDtype` incorrectly raising (:issue:`58602`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3702,6 +3702,28 @@ def test_pow_with_all_na_float():
     tm.assert_series_equal(result, expected)
 
 
+def test_mul_numpy_nullable_with_pyarrow_float():
+    # GH#58602
+    left = pd.Series(range(5), dtype="Float64")
+    right = pd.Series(range(5), dtype="float64[pyarrow]")
+
+    expected = pd.Series([0, 1, 4, 9, 16], dtype="float64[pyarrow]")
+
+    result = left * right
+    tm.assert_series_equal(result, expected)
+
+    result2 = right * left
+    tm.assert_series_equal(result2, expected)
+
+    # while we're here, let's check __eq__
+    result3 = left == right
+    expected3 = pd.Series([True] * 5, dtype="bool[pyarrow]")
+    tm.assert_series_equal(result3, expected3)
+
+    result4 = right == left
+    tm.assert_series_equal(result4, expected3)
+
+
 @pytest.mark.parametrize(
     "type_name, expected_size",
     [


### PR DESCRIPTION
Simplified the documentation theme footer by removing extra version and timestamp context from doc/source/conf.py.