### PR TITLE
ENH: Adding hint to to_sql

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -156,7 +156,7 @@ All warnings for upcoming changes in pandas will have the base class :class:`pan
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
-- :func:`DataFrame.to_sql` now accepts a ``hints`` parameter to pass database-specific query hints for optimizing insert performance. The hints are specified as a dictionary mapping dialect names to hint strings (e.g., ``{'oracle': '/*+ APPEND PARALLEL(4) */', 'mysql': 'DELAYED'}``). Users are responsible for providing correctly formatted hint strings for their target database (:issue:`XXXXX`)
+- :func:`DataFrame.to_sql` now accepts a ``hints`` parameter to pass database-specific query hints for optimizing insert performance. The hints are specified as a dictionary mapping dialect names to hint strings (e.g., ``{'oracle': '/*+ APPEND PARALLEL(4) */', 'mysql': 'DELAYED'}``). Users are responsible for providing correctly formatted hint strings for their target database (:issue:`61370`)
 - :func:`pandas.merge` propagates the ``attrs`` attribute to the result if all
   inputs have identical ``attrs``, as has so far already been the case for
   :func:`pandas.concat`.

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -156,6 +156,7 @@ All warnings for upcoming changes in pandas will have the base class :class:`pan
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
+- :func:`DataFrame.to_sql` now accepts a ``hints`` parameter to pass database-specific query hints for optimizing insert performance. The hints are specified as a dictionary mapping dialect names to hint strings (e.g., ``{'oracle': '/*+ APPEND PARALLEL(4) */', 'mysql': 'DELAYED'}``). Users are responsible for providing correctly formatted hint strings for their target database (:issue:`XXXXX`)
 - :func:`pandas.merge` propagates the ``attrs`` attribute to the result if all
   inputs have identical ``attrs``, as has so far already been the case for
   :func:`pandas.concat`.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2862,6 +2862,21 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
             Details and a sample callable implementation can be found in the
             section :ref:`insert method <io.sql.method>`.
+        hints : dict[str, str], optional
+            Dictionary of SQL hints to optimize insertion performance, keyed by
+            database dialect name (e.g., 'oracle', 'mysql', 'postgresql', 'mssql').
+            Each value should be a complete hint string formatted exactly as required
+            by the target database. The user is responsible for providing correctly
+            formatted hint strings.
+
+            Examples: ``{'oracle': '/*+ APPEND PARALLEL(4) */', 'mysql': 'DELAYED'}``
+
+            .. note::
+                - Hints are database-specific and ignored for unsupported dialects.
+                - SQLite raises a ``UserWarning`` (hints not supported).
+                - ADBC connections raise ``NotImplementedError``.
+
+            .. versionadded:: 3.0.0
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2798,6 +2798,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         chunksize: int | None = None,
         dtype: DtypeArg | None = None,
         method: Literal["multi"] | Callable | None = None,
+        hints: dict[str, str | list[str]] | None = None,
     ) -> int | None:
         """
         Write records stored in a DataFrame to a SQL database.
@@ -3044,6 +3045,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             chunksize=chunksize,
             dtype=dtype,
             method=method,
+            hints=hints,
         )
 
     @final

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2798,7 +2798,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         chunksize: int | None = None,
         dtype: DtypeArg | None = None,
         method: Literal["multi"] | Callable | None = None,
-        hints: dict[str, str | list[str]] | None = None,
+        hints: dict[str, str] | None = None,
     ) -> int | None:
         """
         Write records stored in a DataFrame to a SQL database.

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2040,8 +2040,8 @@ class SQLDatabase(PandasSQL):
         chunksize: int | None = None,
         dtype: DtypeArg | None = None,
         method: Literal["multi"] | Callable | None = None,
-        engine: str = "auto",
         hints: dict[str, str] | None = None,
+        engine: str = "auto",
         **engine_kwargs,
     ) -> int | None:
         """
@@ -2407,8 +2407,8 @@ class ADBCDatabase(PandasSQL):
         chunksize: int | None = None,
         dtype: DtypeArg | None = None,
         method: Literal["multi"] | Callable | None = None,
-        engine: str = "auto",
         hints: dict[str, str] | None = None,
+        engine: str = "auto",
         **engine_kwargs,
     ) -> int | None:
         """
@@ -2641,7 +2641,9 @@ class SQLiteTable(SQLTable):
         )
         return insert_statement
 
-    def _execute_insert(self, conn, keys, data_iter, hints) -> int:
+    def _execute_insert(
+        self, conn, keys: list[str], data_iter, hint_str: str | None = None
+    ) -> int:
         from sqlite3 import Error
 
         data_list = list(data_iter)
@@ -2651,7 +2653,9 @@ class SQLiteTable(SQLTable):
             raise DatabaseError("Execution failed") from exc
         return conn.rowcount
 
-    def _execute_insert_multi(self, conn, keys, data_iter, hints) -> int:
+    def _execute_insert_multi(
+        self, conn, keys: list[str], data_iter, hint_str: str | None = None
+    ) -> int:
         data_list = list(data_iter)
         flattened_data = [x for row in data_list for x in row]
         conn.execute(self.insert_statement(num_rows=len(data_list)), flattened_data)
@@ -2887,8 +2891,8 @@ class SQLiteDatabase(PandasSQL):
         chunksize: int | None = None,
         dtype: DtypeArg | None = None,
         method: Literal["multi"] | Callable | None = None,
-        engine: str = "auto",
         hints: dict[str, str] | None = None,
+        engine: str = "auto",
         **engine_kwargs,
     ) -> int | None:
         """

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -837,7 +837,7 @@ def to_sql(
             - SQLite will raise a UserWarning (hints not supported)
             - ADBC connections will raise NotImplementedError
 
-        .. versionadded::
+        .. versionadded:: 3.0.0
 
     **engine_kwargs
         Any additional kwargs are passed to the engine.

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1055,7 +1055,7 @@ class SQLTable(PandasObject):
         data = [dict(zip(keys, row, strict=False)) for row in data_iter]
 
         if hint_str:
-            stmt = self.table.insert().prefix_with(hint_str)
+            stmt = self.table.insert().with_statement_hint(hint_str)
         else:
             stmt = self.table.insert()
 
@@ -1082,7 +1082,7 @@ class SQLTable(PandasObject):
         data = [dict(zip(keys, row, strict=False)) for row in data_iter]
 
         if hint_str:
-            stmt = insert(self.table).values(data).prefix_with(hint_str)
+            stmt = insert(self.table).values(data).with_statement_hint(hint_str)
         else:
             stmt = insert(self.table).values(data)
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1055,7 +1055,7 @@ class SQLTable(PandasObject):
         data = [dict(zip(keys, row, strict=False)) for row in data_iter]
 
         if hint_str:
-            stmt = self.table.insert().with_statement_hint(hint_str)
+            stmt = self.table.insert().prefix_with(hint_str)
         else:
             stmt = self.table.insert()
 
@@ -1082,7 +1082,7 @@ class SQLTable(PandasObject):
         data = [dict(zip(keys, row, strict=False)) for row in data_iter]
 
         if hint_str:
-            stmt = insert(self.table).values(data).with_statement_hint(hint_str)
+            stmt = insert(self.table).values(data).prefix_with(hint_str)
         else:
             stmt = insert(self.table).values(data)
 


### PR DESCRIPTION
This PR adds a new hints parameter to DataFrame.to_sql() and Series.to_sql() that allows users to pass database-specific query hints to optimize INSERT performance. The parameter accepts a dictionary mapping dialect names (e.g., 'oracle', 'mysql', 'postgresql') to complete hint strings (e.g., {'oracle': '/*+ APPEND PARALLEL(4) */', 'mysql': 'DELAYED'}). Users have full control over hint formatting as pandas passes the strings as-is without modification. SQLite raises a UserWarning since hints aren't supported, and ADBC connections raise NotImplementedError. Includes comprehensive tests and documentation updates.

- [x] closes #61370 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
