### PR TITLE
ENH: add option to save json without escaping forward slashes

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -161,6 +161,7 @@ Other enhancements
   :func:`pandas.concat`.
 - :class:`pandas.api.typing.FrozenList` is available for typing the outputs of :attr:`MultiIndex.names`, :attr:`MultiIndex.codes` and :attr:`MultiIndex.levels` (:issue:`58237`)
 - :class:`pandas.api.typing.SASReader` is available for typing the output of :func:`read_sas` (:issue:`55689`)
+- Added functionality to support saving json without escaping forward slashes by adding to :meth:`DataFrame.to_json` (:issue:`61442`)
 - Added :meth:`.Styler.to_typst` to write Styler objects to file, buffer or string in Typst format (:issue:`57617`)
 - Added missing :meth:`pandas.Series.info` to API reference (:issue:`60926`)
 - :class:`pandas.api.typing.NoDefault` is available for typing ``no_default``
@@ -228,7 +229,6 @@ Other enhancements
 - Support reading Stata 102-format (Stata 1) dta files (:issue:`58978`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
 - Switched wheel upload to **PyPI Trusted Publishing** (OIDC) for release-tag pushes in ``wheels.yml``. (:issue:`61718`)
-- Added functionality to support saving json without escaping forward slashes by adding to :meth:`DataFrame.to_json` (:issue:`61442`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -228,7 +228,7 @@ Other enhancements
 - Support reading Stata 102-format (Stata 1) dta files (:issue:`58978`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
 - Switched wheel upload to **PyPI Trusted Publishing** (OIDC) for release-tag pushes in ``wheels.yml``. (:issue:`61718`)
-- Added functionality to support saving json without escpaing forward slashes by adding to :meth:`DataFrame.to_json` (:issue:`61442`)
+- Added functionality to support saving json without escaping forward slashes by adding to :meth:`DataFrame.to_json` (:issue:`61442`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -228,7 +228,7 @@ Other enhancements
 - Support reading Stata 102-format (Stata 1) dta files (:issue:`58978`)
 - Support reading Stata 110-format (Stata 7) dta files (:issue:`47176`)
 - Switched wheel upload to **PyPI Trusted Publishing** (OIDC) for release-tag pushes in ``wheels.yml``. (:issue:`61718`)
--
+- Added functionality to support saving json without escpaing forward slashes by adding to :meth:`DataFrame.to_json` (:issue:`61442`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -161,8 +161,8 @@ Other enhancements
   :func:`pandas.concat`.
 - :class:`pandas.api.typing.FrozenList` is available for typing the outputs of :attr:`MultiIndex.names`, :attr:`MultiIndex.codes` and :attr:`MultiIndex.levels` (:issue:`58237`)
 - :class:`pandas.api.typing.SASReader` is available for typing the output of :func:`read_sas` (:issue:`55689`)
-- Added functionality to support saving json without escaping forward slashes by adding to :meth:`DataFrame.to_json` (:issue:`61442`)
 - Added :meth:`.Styler.to_typst` to write Styler objects to file, buffer or string in Typst format (:issue:`57617`)
+- Added functionality to support saving json without escaping forward slashes by adding to :meth:`DataFrame.to_json` (:issue:`61442`)
 - Added missing :meth:`pandas.Series.info` to API reference (:issue:`60926`)
 - :class:`pandas.api.typing.NoDefault` is available for typing ``no_default``
 - :func:`DataFrame.to_excel` now raises an ``UserWarning`` when the character count in a cell exceeds Excel's limitation of 32767 characters (:issue:`56954`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2342,6 +2342,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         indent: int | None = None,
         storage_options: StorageOptions | None = None,
         mode: Literal["a", "w"] = "w",
+        escape_forward_slashes: bool = True,
     ) -> str | None:
         """
         Convert the object to a JSON string.
@@ -2428,6 +2429,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Specify the IO mode for output when supplying a path_or_buf.
             Accepted args are 'w' (writing) and 'a' (append) only.
             mode='a' is only supported when lines is True and orient is 'records'.
+
+        escape_forward_slashes : bool, optional, default True
+            Remove backward slashes that get added in conversion to json.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2633,6 +2633,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             indent=indent,
             storage_options=storage_options,
             mode=mode,
+            escape_forward_slashes=escape_forward_slashes,
         )
 
     @final

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -153,7 +153,7 @@ def to_json(
     indent: int = 0,
     storage_options: StorageOptions | None = None,
     mode: Literal["a", "w"] = "w",
-    escape_forward_slashes: Literal[True, False] = Literal[True],
+    escape_forward_slashes: Literal[True, False] = True,
 ) -> str | None:
     if orient in ["records", "values"] and index is True:
         raise ValueError(

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -137,6 +137,7 @@ def to_json(
     escape_forward_slashes: bool | True = ...,
 ) -> str: ...
 
+
 def to_json(
     path_or_buf: FilePath | WriteBuffer[str] | WriteBuffer[bytes] | None,
     obj: NDFrame,

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -114,7 +114,7 @@ def to_json(
     indent: int = ...,
     storage_options: StorageOptions = ...,
     mode: Literal["a", "w"] = ...,
-    escape_forward_slashes: bool | True = ...,
+    escape_forward_slashes: Literal[True, False] = ...,
 ) -> None: ...
 
 
@@ -134,8 +134,9 @@ def to_json(
     indent: int = ...,
     storage_options: StorageOptions = ...,
     mode: Literal["a", "w"] = ...,
-    escape_forward_slashes: bool | True = ...,
+    escape_forward_slashes: Literal[True, False] = ...,
 ) -> str: ...
+
 
 def to_json(
     path_or_buf: FilePath | WriteBuffer[str] | WriteBuffer[bytes] | None,
@@ -152,7 +153,7 @@ def to_json(
     indent: int = 0,
     storage_options: StorageOptions | None = None,
     mode: Literal["a", "w"] = "w",
-    escape_forward_slashes: bool | True = ...,
+    escape_forward_slashes: Literal[True, False] = Literal[True],
 ) -> str | None:
     if orient in ["records", "values"] and index is True:
         raise ValueError(

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -223,8 +223,22 @@ def to_json(
             handles.handle.write(s)
     else:
         if not escape_forward_slashes:
-            pattern = "\\\\/"
-            s = re.sub(pattern, "/", "s")
+            pattern = r"\/"
+            i = 1
+            new_s = ""
+            skip = False
+            for letter in s:
+                if skip is False:
+                    if letter + s[i] == pattern:
+                        new_s = new_s + r"/"
+                        skip = True
+                    else:
+                        new_s = new_s + letter
+                else:
+                    skip = False
+                if i < len(s) - 1:
+                    i = i + 1
+            return new_s
         return s
     return None
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -19,6 +19,8 @@ from typing import (
 
 import numpy as np
 
+import re
+
 from pandas._config import option_context
 
 from pandas._libs import lib
@@ -220,6 +222,9 @@ def to_json(
         ) as handles:
             handles.handle.write(s)
     else:
+        if not escape_forward_slashes:
+            pattern = "\\\\/"
+            s = re.sub(pattern, "/", "s")
         return s
     return None
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -19,8 +19,6 @@ from typing import (
 
 import numpy as np
 
-import re
-
 from pandas._config import option_context
 
 from pandas._libs import lib

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -114,6 +114,7 @@ def to_json(
     indent: int = ...,
     storage_options: StorageOptions = ...,
     mode: Literal["a", "w"] = ...,
+    escape_forward_slashes: bool | True = ...,
 ) -> None: ...
 
 
@@ -133,8 +134,8 @@ def to_json(
     indent: int = ...,
     storage_options: StorageOptions = ...,
     mode: Literal["a", "w"] = ...,
+    escape_forward_slashes: bool | True = ...,
 ) -> str: ...
-
 
 def to_json(
     path_or_buf: FilePath | WriteBuffer[str] | WriteBuffer[bytes] | None,
@@ -151,6 +152,7 @@ def to_json(
     indent: int = 0,
     storage_options: StorageOptions | None = None,
     mode: Literal["a", "w"] = "w",
+    escape_forward_slashes: bool | True = ...,
 ) -> str | None:
     if orient in ["records", "values"] and index is True:
         raise ValueError(

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2298,10 +2298,8 @@ def test_to_json_escape_forward_slashes():
         }
     )
     result = df.to_json(orient="records", escape_forward_slashes=False)
-    expected1 = """[{"path1":"/escape/three/slashes","path2":"/","path3":"ending/""" ""
-    expected2 = (
-        ""","path4":"/beginning","path5":"/multiples//multiple","path6":"//"}]"""
-    )
+    expected1 = '[{"path1":"/escape/three/slashes","path2":"/","path3":"ending/"'
+    expected2 = ',"path4":"/beginning","path5":"/multiples//multiple","path6":"//"}]'
     expected = expected1 + expected2
 
     assert result == expected

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2285,6 +2285,23 @@ def test_to_json_ea_null():
 """
     assert result == expected
 
+def test_to_json_escape_forward_slashes():
+    df = DataFrame(
+        {
+            "path1": Series(["/escape/three/slashes"], dtype="str"),
+            "path2": Series(["/"], dtype="str"),
+            "path3": Series(["ending/"], dtype="str"),
+            "path4": Series(["/beginning"], dtype="str"),
+            "path5": Series(["/multiples//multiple"], dtype="str"),
+            "path6": Series(["//"], dtype="str")
+        }
+    )
+    result = df.to_json(escape_forward_slashes=False)
+    expected = """{"path1":"/escape/three/slashes", "path2":"/", 
+    "path3":"ending/", "path4":"/beginning", 
+    "path5":"/multiples//multiple", "path6":"//"}"""
+
+    assert result == expected
 
 def test_read_json_lines_rangeindex():
     # GH 57429

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2285,6 +2285,7 @@ def test_to_json_ea_null():
 """
     assert result == expected
 
+
 def test_to_json_escape_forward_slashes():
     df = DataFrame(
         {
@@ -2293,13 +2294,18 @@ def test_to_json_escape_forward_slashes():
             "path3": Series(["ending/"], dtype="str"),
             "path4": Series(["/beginning"], dtype="str"),
             "path5": Series(["/multiples//multiple"], dtype="str"),
-            "path6": Series(["//"], dtype="str")
+            "path6": Series(["//"], dtype="str"),
         }
     )
     result = df.to_json(orient="records", escape_forward_slashes=False)
-    expected = """[{"path1":"/escape/three/slashes","path2":"/","path3":"ending/","path4":"/beginning","path5":"/multiples//multiple","path6":"//"}]"""
+    expected1 = """[{"path1":"/escape/three/slashes","path2":"/","path3":"ending/""" ""
+    expected2 = (
+        ""","path4":"/beginning","path5":"/multiples//multiple","path6":"//"}]"""
+    )
+    expected = expected1 + expected2
 
     assert result == expected
+
 
 def test_read_json_lines_rangeindex():
     # GH 57429

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2296,10 +2296,8 @@ def test_to_json_escape_forward_slashes():
             "path6": Series(["//"], dtype="str")
         }
     )
-    result = df.to_json(escape_forward_slashes=False)
-    expected = """{"path1":"/escape/three/slashes", "path2":"/", 
-    "path3":"ending/", "path4":"/beginning", 
-    "path5":"/multiples//multiple", "path6":"//"}"""
+    result = df.to_json(orient="records", escape_forward_slashes=False)
+    expected = """[{"path1":"/escape/three/slashes","path2":"/","path3":"ending/","path4":"/beginning","path5":"/multiples//multiple","path6":"//"}]"""
 
     assert result == expected
 


### PR DESCRIPTION
- [x] closes #61442 : add option to save json without escaping forward slashes
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
    - Test added to tests/io/json/test_pandas.py
    - Test added named test_to_json_escape_forward_slashes
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
    - Entry is the last dot point in V3.0.0.rst

Added code in the to_json() function in pandas/io/json/__json.py file.
Will replace escaped forward slashes with forward slashes if escape_forward_slashes parameter is set to False.
Particularly useful for file paths, so the path doesn't get changed.