### PR TITLE
BUG: Recognize 2-tuple state without attrs dict

### DIFF
--- a/pandas/_libs/arrays.pyx
+++ b/pandas/_libs/arrays.pyx
@@ -101,6 +101,7 @@ cdef class NDArrayBacked:
                     self.__setstate__(state[0])
                     return
                 elif len(state) == 2:
+                    # GH#62820: Handle missing attrs dict during auto-unpickling
                     self.__setstate__((*state, {}))
                     return
                 raise NotImplementedError(state)  # pragma: no cover

--- a/pandas/_libs/arrays.pyx
+++ b/pandas/_libs/arrays.pyx
@@ -100,6 +100,9 @@ cdef class NDArrayBacked:
                 if len(state) == 1 and isinstance(state[0], dict):
                     self.__setstate__(state[0])
                     return
+                elif len(state) == 2:
+                    self.__setstate__((*state, {}))
+                    return
                 raise NotImplementedError(state)  # pragma: no cover
 
             data, dtype = state[:2]


### PR DESCRIPTION
- [x] closes #62820
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

## Description

Fixes a `pickle.load` failure discovered in pyodide CI (see #62820).

Changed `NDArrayBacked.__setstate__` to accept 2-tuple states. When a 2-tuple `(data, dtype)` is encountered, it is treated as `(data, dtype, {})` and normal restoration continues.