### PR TITLE
Data frame snapshots

### DIFF
--- a/asv_bench/benchmarks/bench_snapshot_memory.py
+++ b/asv_bench/benchmarks/bench_snapshot_memory.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import numpy as np
+import tracemalloc
+
+def make_df(nrows=1_000_000):
+    return pd.DataFrame({
+        "a": np.random.randint(0, 100, size=nrows),
+        "b": np.random.random(size=nrows),
+        "c": np.random.choice(list("abcdefghijklmnopqrstuvwxyz"), size=nrows)
+    })
+
+df = make_df(200_000)
+tracemalloc.start()
+snap = df.snapshot("bench")
+snap_shot = tracemalloc.take_snapshot()
+top_stats = snap_shot.statistics('lineno')
+print("Top memory stats:", top_stats[:3])

--- a/pandas/core/frame_versioning.py
+++ b/pandas/core/frame_versioning.py
@@ -1,0 +1,69 @@
+# pandas/core/frame_versioning.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import uuid
+from typing import Dict, Optional
+
+import pandas as pd
+
+
+def _generate_snapshot_id(name: Optional[str] = None) -> str:
+    if name:
+        return name
+    ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S%fZ")
+    uid = uuid.uuid4().hex[:8]
+    return f"{ts}-{uid}"
+
+
+@dataclass
+class SnapshotMeta:
+    name: str
+    created_at: datetime
+
+
+class DataFrameSnapshotStore:
+    """
+    Per-DataFrame snapshot store.
+    Stores deep copies of DataFrames (safe, simple).
+    """
+
+    def __init__(self) -> None:
+        # snapshot_id -> DataFrame
+        self._snapshots: Dict[str, pd.DataFrame] = {}
+        self._meta: Dict[str, SnapshotMeta] = {}
+
+    def snapshot(self, df: pd.DataFrame, name: Optional[str] = None) -> str:
+        sid = _generate_snapshot_id(name)
+        # deep copy for safety
+        self._snapshots[sid] = df.copy(deep=True)
+        self._meta[sid] = SnapshotMeta(name=sid, created_at=datetime.utcnow())
+        return sid
+
+    def restore(self, name: str) -> pd.DataFrame:
+        if name not in self._snapshots:
+            raise KeyError(f"Snapshot not found: {name}")
+        # return a deep copy so modifications don't change stored snapshot
+        return self._snapshots[name].copy(deep=True)
+
+    def list(self) -> list[str]:
+        return list(self._snapshots.keys())
+
+    def drop(self, name: str) -> None:
+        if name not in self._snapshots:
+            raise KeyError(f"Snapshot not found: {name}")
+        del self._snapshots[name]
+        del self._meta[name]
+
+    def clear(self) -> None:
+        self._snapshots.clear()
+        self._meta.clear()
+
+    def info(self, name: Optional[str] = None) -> dict:
+        if name:
+            if name not in self._meta:
+                raise KeyError(f"Snapshot not found: {name}")
+            meta = self._meta[name]
+            return {"name": meta.name, "created_at": meta.created_at.isoformat()}
+        return {"count": len(self._snapshots), "snapshots": [m.name for m in self._meta.values()]}

--- a/pandas/tests/frame/test_versioning.py
+++ b/pandas/tests/frame/test_versioning.py
@@ -1,0 +1,54 @@
+# pandas/tests/frame/test_versioning.py
+import pandas as pd
+import pytest
+
+
+def test_snapshot_and_restore_returns_dataframe():
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    sid = df.snapshot("t1")
+    assert sid in df.list_snapshots()
+    df.loc[0, "x"] = 99
+    restored = df.restore(sid)
+    assert list(restored["x"]) == [1, 2, 3]
+
+
+def test_restore_inplace_mutates_dataframe():
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    sid = df.snapshot("t2")
+    df.loc[1, "x"] = 999
+    df.restore(sid, inplace=True)
+    assert list(df["x"]) == [1, 2, 3]
+
+
+def test_drop_and_clear_behaviour():
+    df = pd.DataFrame({"a": [1, 2]})
+    sid1 = df.snapshot("s1")
+    sid2 = df.snapshot("s2")
+    assert set(df.list_snapshots()) == {sid1, sid2}
+    df.drop_snapshot(sid1)
+    assert sid1 not in df.list_snapshots()
+    df.clear_snapshots()
+    assert df.list_snapshots() == []
+
+
+def test_snapshot_on_empty_dataframe():
+    df = pd.DataFrame()
+    sid = df.snapshot()
+    df.loc[0, "a"] = 1
+    restored = df.restore(sid)
+    assert restored.empty
+
+
+def test_copy_does_not_inherit_snapshots():
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    sid = df.snapshot("orig")
+    df2 = df.copy()
+    # design decision: copies do not copy snapshots
+    assert df2.list_snapshots() == []
+    assert sid in df.list_snapshots()
+
+
+def test_missing_snapshot_raises():
+    df = pd.DataFrame({"x": [1]})
+    with pytest.raises(KeyError):
+        df.restore("no-such-snapshot")


### PR DESCRIPTION
This pull request introduces a new snapshot feature for pandas DataFrames, allowing users to create, restore, list, drop, and clear named snapshots of a DataFrame's state. The implementation includes a per-DataFrame snapshot store, deep copy safety, and comprehensive tests for all new functionality.

**New DataFrame snapshot functionality:**

* Added methods to `DataFrame` for snapshot management: `snapshot`, `restore`, `list_snapshots`, `drop_snapshot`, `clear_snapshots`, and `snapshot_info`. These allow users to save and revert to previous states of a DataFrame, as well as manage snapshots.
* Introduced the `DataFrameSnapshotStore` class in the new file `pandas/core/frame_versioning.py`, which handles the storage, retrieval, and metadata of DataFrame snapshots using deep copies for safety.
* Implemented the helper function `_ensure_snapshot_store` to attach and manage the snapshot store per DataFrame instance.
* Added a comprehensive test suite in `pandas/tests/frame/test_versioning.py` to verify snapshot creation, restoration, inplace mutation, deletion, clearing, copy behavior, and error handling for missing snapshots.

**Integration and usage example:**

* Provided a usage example in `asv_bench/benchmarks/bench_snapshot_memory.py` demonstrating how to create a snapshot and inspect memory usage, showcasing the new API in practice.