### PR TITLE
Warn on no-op rounding for datetimelike dtypes

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11521,6 +11521,15 @@ class DataFrame(NDFrame, OpsMixin):
         def _series_round(ser: Series, decimals: int) -> Series:
             if is_integer_dtype(ser.dtype) or is_float_dtype(ser.dtype):
                 return ser.round(decimals)
+            elif isinstance(ser._values, (DatetimeArray, TimedeltaArray, PeriodArray)):
+                # GH#57781
+                # TODO: also the ArrowDtype analogues?
+                warnings.warn(
+                    "obj.round has no effect with datetime, timedelta, "
+                    "or period dtypes. Use obj.dt.round(...) instead.",
+                    UserWarning,
+                    stacklevel=find_stack_level(),
+                )
             return ser
 
         nv.validate_round(args, kwargs)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1514,6 +1514,15 @@ class Block(PandasObject, libinternals.Block):
             Caller is responsible for validating this
         """
         if not self.is_numeric or self.is_bool:
+            if isinstance(self.values, (DatetimeArray, TimedeltaArray, PeriodArray)):
+                # GH#57781
+                # TODO: also the ArrowDtype analogues?
+                warnings.warn(
+                    "obj.round has no effect with datetime, timedelta, "
+                    "or period dtypes. Use obj.dt.round(...) instead.",
+                    UserWarning,
+                    stacklevel=find_stack_level(),
+                )
             return self.copy(deep=False)
         # TODO: round only defined on BaseMaskedArray
         # Series also does this, so would need to fix both places

--- a/pandas/tests/frame/methods/test_round.py
+++ b/pandas/tests/frame/methods/test_round.py
@@ -159,12 +159,16 @@ class TestDataFrameRound:
                 "col3": date_range("20111111", periods=4),
             }
         )
-        tm.assert_frame_equal(df.round(), round_0)
-        tm.assert_frame_equal(df.round(1), df)
+        msg = "obj.round has no effect with datetime, timedelta, or period dtypes"
+        with tm.assert_produces_warning(UserWarning, match=msg):
+            tm.assert_frame_equal(df.round(), round_0)
+        with tm.assert_produces_warning(UserWarning, match=msg):
+            tm.assert_frame_equal(df.round(1), df)
         tm.assert_frame_equal(df.round({"col1": 1}), df)
         tm.assert_frame_equal(df.round({"col1": 0}), round_0)
         tm.assert_frame_equal(df.round({"col1": 0, "col2": 1}), round_0)
-        tm.assert_frame_equal(df.round({"col3": 1}), df)
+        with tm.assert_produces_warning(UserWarning, match=msg):
+            tm.assert_frame_equal(df.round({"col3": 1}), df)
 
     def test_round_with_duplicate_columns(self):
         # GH#11611

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1963,7 +1963,7 @@ class TestToDatetimeUnit:
             dtype="M8[ns]",
         )
         # GH20455 argument will incur floating point errors but no premature rounding
-        result = result.round("ms")
+        result = result.dt.round("ms")
         tm.assert_series_equal(result, expected)
 
     def test_to_datetime_unit_na_values(self):


### PR DESCRIPTION
- [x] closes #57781 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
