### PR TITLE
TST : Removed ensure_clean from test_common_basic.py #62425

### DIFF
--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from inspect import signature
 from io import StringIO
 import os
-from pathlib import Path
 import sys
 
 import numpy as np
@@ -615,16 +614,16 @@ def test_sub_character(all_parsers, csv_dir_path):
 
 
 @pytest.mark.parametrize("filename", ["sé-es-vé.csv", "ru-sй.csv", "中文文件名.csv"])
-def test_filename_with_special_chars(all_parsers, filename):
+def test_filename_with_special_chars(all_parsers, filename, tmp_path):
     # see gh-15086.
     parser = all_parsers
     df = DataFrame({"a": [1, 2, 3]})
 
-    with tm.ensure_clean(filename) as path:
-        df.to_csv(path, index=False)
+    path = tmp_path / filename
+    df.to_csv(path, index=False)
 
-        result = parser.read_csv(path)
-        tm.assert_frame_equal(result, df)
+    result = parser.read_csv(path)
+    tm.assert_frame_equal(result, df)
 
 
 def test_read_table_same_signature_as_read_csv(all_parsers):
@@ -786,7 +785,7 @@ def test_dict_keys_as_names(all_parsers):
 
 @pytest.mark.xfail(using_string_dtype() and HAS_PYARROW, reason="TODO(infer_string)")
 @xfail_pyarrow  # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 0
-def test_encoding_surrogatepass(all_parsers):
+def test_encoding_surrogatepass(all_parsers, temp_file):
     # GH39017
     parser = all_parsers
     content = b"\xed\xbd\xbf"
@@ -794,14 +793,14 @@ def test_encoding_surrogatepass(all_parsers):
     expected = DataFrame({decoded: [decoded]}, index=[decoded * 2])
     expected.index.name = decoded * 2
 
-    with tm.ensure_clean() as path:
-        Path(path).write_bytes(
-            content * 2 + b"," + content + b"\n" + content * 2 + b"," + content
-        )
-        df = parser.read_csv(path, encoding_errors="surrogatepass", index_col=0)
-        tm.assert_frame_equal(df, expected)
-        with pytest.raises(UnicodeDecodeError, match="'utf-8' codec can't decode byte"):
-            parser.read_csv(path)
+    path = temp_file
+    path.write_bytes(
+        content * 2 + b"," + content + b"\n" + content * 2 + b"," + content
+    )
+    df = parser.read_csv(path, encoding_errors="surrogatepass", index_col=0)
+    tm.assert_frame_equal(df, expected)
+    with pytest.raises(UnicodeDecodeError, match="'utf-8' codec can't decode byte"):
+        parser.read_csv(path)
 
 
 def test_malformed_second_line(all_parsers):
@@ -835,15 +834,15 @@ def test_short_multi_line(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-def test_read_seek(all_parsers):
+def test_read_seek(all_parsers, temp_file):
     # GH48646
     parser = all_parsers
     prefix = "### DATA\n"
     content = "nkey,value\ntables,rectangular\n"
-    with tm.ensure_clean() as path:
-        Path(path).write_text(prefix + content, encoding="utf-8")
-        with open(path, encoding="utf-8") as file:
-            file.readline()
-            actual = parser.read_csv(file)
-        expected = parser.read_csv(StringIO(content))
+    path = temp_file
+    path.write_text(prefix + content, encoding="utf-8")
+    with open(path, encoding="utf-8") as file:
+        file.readline()
+        actual = parser.read_csv(file)
+    expected = parser.read_csv(StringIO(content))
     tm.assert_frame_equal(actual, expected)

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -785,7 +785,7 @@ def test_dict_keys_as_names(all_parsers):
 
 @pytest.mark.xfail(using_string_dtype() and HAS_PYARROW, reason="TODO(infer_string)")
 @xfail_pyarrow  # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 0
-def test_encoding_surrogatepass(all_parsers, temp_file):
+def test_encoding_surrogatepass(all_parsers, tmp_path):
     # GH39017
     parser = all_parsers
     content = b"\xed\xbd\xbf"
@@ -793,7 +793,7 @@ def test_encoding_surrogatepass(all_parsers, temp_file):
     expected = DataFrame({decoded: [decoded]}, index=[decoded * 2])
     expected.index.name = decoded * 2
 
-    path = temp_file
+    path = tmp_path / "test_encoding.csv"
     path.write_bytes(
         content * 2 + b"," + content + b"\n" + content * 2 + b"," + content
     )
@@ -834,12 +834,12 @@ def test_short_multi_line(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-def test_read_seek(all_parsers, temp_file):
+def test_read_seek(all_parsers, tmp_path):
     # GH48646
     parser = all_parsers
     prefix = "### DATA\n"
     content = "nkey,value\ntables,rectangular\n"
-    path = temp_file
+    path = tmp_path / "test_seek.csv"
     path.write_text(prefix + content, encoding="utf-8")
     with open(path, encoding="utf-8") as file:
         file.readline()


### PR DESCRIPTION
- [x] Assists #62435 in removing ensure_clean from test_common_basic.py
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
