### PR TITLE
DEPR: automatic upcasting in reindex

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -95,6 +95,7 @@ Deprecations
 ~~~~~~~~~~~~
 - Deprecated :meth:`.DataFrameGroupBy.agg` and :meth:`.Resampler.agg` unpacking a scalar when the provided ``func`` returns a Series or array of length 1; in the future this will result in the Series or array being in the result. Users should unpack the scalar in ``func`` itself (:issue:`64014`)
 - Deprecated arithmetic operations between pandas objects (:class:`DataFrame`, :class:`Series`, :class:`Index`, and pandas-implemented :class:`ExtensionArray` subclasses) and list-likes other than ``list``, ``np.ndarray``, :class:`ExtensionArray`, :class:`Index`, :class:`Series`, :class:`DataFrame`. For e.g. ``tuple`` or ``range``, explicitly cast these to a supported object instead. In a future version, these will be treated as scalar-like for pointwise operation (:issue:`62423`)
+- Deprecated automatic dtype promotion when reindexing with a ``fill_value`` that cannot be held by the original dtype. Explicitly cast to a common dtype instead (:issue:`53910`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
 -
 

--- a/pandas/core/array_algos/take.py
+++ b/pandas/core/array_algos/take.py
@@ -581,7 +581,10 @@ def _take_preprocess_indexer_and_fill_value(
             fill_value = int(fill_value)
         dtype, fill_value = maybe_promote(arr.dtype, fill_value)
         if dtype != arr.dtype:
-            if not (lib.is_float(fill_value) and np.isnan(fill_value)):
+            if not (
+                (lib.is_float(fill_value) and np.isnan(fill_value))
+                or (arr.dtype.kind == "U" and isinstance(fill_value, str))
+            ):
                 # GH#53910
                 warnings.warn(
                     "reindexing with a fill_value that cannot be held by the "

--- a/pandas/core/array_algos/take.py
+++ b/pandas/core/array_algos/take.py
@@ -6,6 +6,7 @@ from typing import (
     cast,
     overload,
 )
+import warnings
 
 import numpy as np
 
@@ -13,6 +14,8 @@ from pandas._libs import (
     algos as libalgos,
     lib,
 )
+from pandas.errors import Pandas4Warning
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.cast import maybe_promote
 from pandas.core.dtypes.common import (
@@ -94,6 +97,15 @@ def take_nd(
         fill_value = na_value_for_dtype(arr.dtype, compat=False)
     elif lib.is_np_dtype(arr.dtype, "mM"):
         dtype, fill_value = maybe_promote(arr.dtype, fill_value)
+        if dtype != arr.dtype:
+            # GH#53910
+            warnings.warn(
+                "reindexing with a fill_value that cannot be held by the "
+                "original dtype is deprecated. Explicitly cast to a common "
+                f"dtype (in this case {dtype}) instead.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
         if arr.dtype != dtype:
             # EA.take is strict about returning a new object of the same type
             # so for that case cast upfront
@@ -189,6 +201,10 @@ def take_2d_multi(
     indexer = row_idx, col_idx
     mask_info = None
 
+    if lib.is_float(fill_value) and fill_value.is_integer():
+        # Avoid warning if possible
+        fill_value = int(fill_value)
+
     # check for promotion based on types only (do this first because
     # it's faster than computing a mask)
     dtype, fill_value = maybe_promote(arr.dtype, fill_value)
@@ -205,6 +221,20 @@ def take_2d_multi(
             # (it won't be used but we don't want the cython code
             # to crash when trying to cast it to dtype)
             dtype, fill_value = arr.dtype, arr.dtype.type()
+
+        if dtype != arr.dtype and not (
+            arr.dtype.kind in "iub"
+            and lib.is_float(fill_value)
+            and np.isnan(fill_value)
+        ):
+            # GH#53910
+            warnings.warn(
+                "reindexing with a fill_value that cannot be held by the "
+                "original dtype is deprecated. Explicitly cast to a common "
+                f"dtype (in this case {dtype}) instead.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
 
     # at this point, it's guaranteed that dtype can hold both the arr values
     # and the fill_value
@@ -546,8 +576,20 @@ def _take_preprocess_indexer_and_fill_value(
     else:
         # check for promotion based on types only (do this first because
         # it's faster than computing a mask)
+        if lib.is_float(fill_value) and fill_value.is_integer():
+            # Avoid warning if possible
+            fill_value = int(fill_value)
         dtype, fill_value = maybe_promote(arr.dtype, fill_value)
         if dtype != arr.dtype:
+            if not (lib.is_float(fill_value) and np.isnan(fill_value)):
+                # GH#53910
+                warnings.warn(
+                    "reindexing with a fill_value that cannot be held by the "
+                    "original dtype is deprecated. Explicitly cast to a common "
+                    f"dtype (in this case {dtype}) instead.",
+                    Pandas4Warning,
+                    stacklevel=find_stack_level(),
+                )
             # check if promotion is actually required based on indexer
             if mask is not None:
                 needs_masking = True

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5836,14 +5836,6 @@ class DataFrame(NDFrame, OpsMixin):
         IE10                   404           0.08
         Chrome                 200           0.02
 
-        >>> df.reindex(new_index, fill_value="missing")
-                      http_status response_time
-        Safari                404          0.07
-        Iceweasel         missing       missing
-        Comodo Dragon     missing       missing
-        IE10                  404          0.08
-        Chrome                200          0.02
-
         We can also reindex the columns.
 
         >>> df.reindex(columns=["http_status", "user_agent"])

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5330,14 +5330,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         IE10                   404           0.08
         Chrome                 200           0.02
 
-        >>> df.reindex(new_index, fill_value="missing")
-                      http_status response_time
-        Safari                404          0.07
-        Iceweasel         missing       missing
-        Comodo Dragon     missing       missing
-        IE10                  404          0.08
-        Chrome                200          0.02
-
         We can also reindex the columns.
 
         >>> df.reindex(columns=["http_status", "user_agent"])

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -8090,18 +8090,13 @@ def get_values_for_csv(
     csv.writer.writerows.
     """
     if isinstance(values, Categorical) and values.categories.dtype.kind in "Mm":
-        # GH#40754 Convert categorical datetimes to datetime array
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                "reindexing with a fill_value that cannot be held",
-                Pandas4Warning,
-            )
-            values = algos.take_nd(
-                values.categories._values,
-                ensure_platform_int(values._codes),
-                fill_value=na_rep,
-            )
+        # GH#40754 Convert categorical datetimes to datetime array.
+        # Fill missing with NaT (not na_rep) to avoid dtype promotion (GH#53910);
+        # downstream _format_native_types handles NaT -> na_rep.
+        values = algos.take_nd(
+            values.categories._values,
+            ensure_platform_int(values._codes),
+        )
 
     values = ensure_wrapped_if_datetimelike(values)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -8091,11 +8091,17 @@ def get_values_for_csv(
     """
     if isinstance(values, Categorical) and values.categories.dtype.kind in "Mm":
         # GH#40754 Convert categorical datetimes to datetime array
-        values = algos.take_nd(
-            values.categories._values,
-            ensure_platform_int(values._codes),
-            fill_value=na_rep,
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                "reindexing with a fill_value that cannot be held",
+                Pandas4Warning,
+            )
+            values = algos.take_nd(
+                values.categories._values,
+                ensure_platform_int(values._codes),
+                fill_value=na_rep,
+            )
 
     values = ensure_wrapped_if_datetimelike(values)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5603,14 +5603,6 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         IE10                   404           0.08
         Chrome                 200           0.02
 
-        >>> df.reindex(new_index, fill_value="missing")
-                      http_status response_time
-        Safari                404          0.07
-        Iceweasel         missing       missing
-        Comodo Dragon     missing       missing
-        IE10                  404          0.08
-        Chrome                200          0.02
-
         We can also reindex the columns.
 
         >>> df.reindex(columns=["http_status", "user_agent"])

--- a/pandas/tests/arrays/numpy_/test_numpy.py
+++ b/pandas/tests/arrays/numpy_/test_numpy.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from pandas.compat.numpy import np_version_gt2
+from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.dtypes import NumpyEADtype
 
@@ -374,7 +375,17 @@ def test_take_assigns_floating_point_dtype(dtype):
     result = array.take([-1], allow_fill=True)
     assert result.dtype.numpy_dtype == expected
 
-    result = array.take([-1], allow_fill=True, fill_value=5.0)
+    # For integer dtypes, we cast round-float fill_value to int, so do not
+    #  get a warning here. This casting is not ideal, but is the lesser evil
+    #  preventing other breakage when doing this deprecation.
+    msg = (
+        "reindexing with a fill_value that cannot be held by the "
+        "original dtype is deprecated"
+    )
+    warn = Pandas4Warning if dtype == np.bool_ else None
+    expected = object if dtype == np.bool_ else array.dtype.numpy_dtype
+    with tm.assert_produces_warning(warn, match=msg):
+        result = array.take([-1], allow_fill=True, fill_value=5.0)
     assert result.dtype.numpy_dtype == expected
 
 

--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -168,7 +168,10 @@ class TestDataFrameSelectReindex:
         ts = df.iloc[0, 0]
         fv = ts.date()
 
-        res = df.reindex(index=range(4), columns=["A", "B", "C"], fill_value=fv)
+        msg = "reindexing with a fill_value that cannot be held"
+
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            res = df.reindex(index=range(4), columns=["A", "B", "C"], fill_value=fv)
 
         expected = DataFrame(
             {"A": [*df["A"].tolist(), fv], "B": [*df["B"].tolist(), fv], "C": [fv] * 4},
@@ -177,7 +180,8 @@ class TestDataFrameSelectReindex:
         tm.assert_frame_equal(res, expected)
 
         # only reindexing rows
-        res = df.reindex(index=range(4), fill_value=fv)
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            res = df.reindex(index=range(4), fill_value=fv)
         tm.assert_frame_equal(res, expected[["A", "B"]])
 
         # same with a datetime-castable str
@@ -796,7 +800,9 @@ class TestDataFrameSelectReindex:
 
         # other dtypes
         df["foo"] = "foo"
-        result = df.reindex(range(15), fill_value="0")
+        msg = "reindexing with a fill_value that cannot be held"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            result = df.reindex(range(15), fill_value="0")
         expected = df.reindex(range(15)).fillna("0")
         tm.assert_frame_equal(result, expected)
 
@@ -1234,7 +1240,9 @@ class TestDataFrameSelectReindex:
         index = df.index.append(Index([1]))
         columns = df.columns.append(Index(["foo"]))
 
-        res = df.reindex(index=index, columns=columns, fill_value=fv)
+        msg = "reindexing with a fill_value that cannot be held"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            res = df.reindex(index=index, columns=columns, fill_value=fv)
 
         expected = DataFrame(
             {

--- a/pandas/tests/series/methods/test_reindex.py
+++ b/pandas/tests/series/methods/test_reindex.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     NA,
     Categorical,
@@ -314,7 +316,9 @@ def test_reindex_fill_value_datetimelike_upcast(dtype, fill_value):
 
     ser = Series([NaT], dtype=dtype)
 
-    result = ser.reindex([0, 1], fill_value=fill_value)
+    msg = "reindexing with a fill_value that cannot be held"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = ser.reindex([0, 1], fill_value=fill_value)
     expected = Series([NaT, fill_value], index=range(2), dtype=object)
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pandas._libs import iNaT
+from pandas.errors import Pandas4Warning
 
 from pandas import array
 import pandas._testing as tm
@@ -15,7 +16,7 @@ import pandas.core.algorithms as algos
         (np.int8, np.int16(127), np.int8),
         (np.int8, np.int16(128), np.int16),
         (np.int32, 1, np.int32),
-        (np.int32, 2.0, np.float64),
+        (np.int32, 2.0, np.int32),
         (np.int32, 3.0 + 4.0j, np.complex128),
         (np.int32, True, np.object_),
         (np.int32, "", np.object_),
@@ -43,75 +44,104 @@ def dtype_fill_out_dtype(request):
 class TestTake:
     def test_1d_fill_nonna(self, dtype_fill_out_dtype):
         dtype, fill_value, out_dtype = dtype_fill_out_dtype
+
+        warn = None
+        if out_dtype != dtype:
+            warn = Pandas4Warning
+        msg = "reindexing with a fill_value that cannot be held"
+
         data = np.random.default_rng(2).integers(0, 2, 4).astype(dtype)
         indexer = [2, 1, 0, -1]
 
-        result = algos.take_nd(data, indexer, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, fill_value=fill_value)
         assert (result[[0, 1, 2]] == data[[2, 1, 0]]).all()
         assert result[3] == fill_value
         assert result.dtype == out_dtype
 
         indexer = [2, 1, 0, 1]
 
-        result = algos.take_nd(data, indexer, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, fill_value=fill_value)
         assert (result[[0, 1, 2, 3]] == data[indexer]).all()
         assert result.dtype == dtype
 
     def test_2d_fill_nonna(self, dtype_fill_out_dtype):
         dtype, fill_value, out_dtype = dtype_fill_out_dtype
+
+        warn = None
+        if out_dtype != dtype:
+            warn = Pandas4Warning
+        msg = "reindexing with a fill_value that cannot be held"
+
         data = np.random.default_rng(2).integers(0, 2, (5, 3)).astype(dtype)
         indexer = [2, 1, 0, -1]
 
-        result = algos.take_nd(data, indexer, axis=0, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=0, fill_value=fill_value)
         assert (result[[0, 1, 2], :] == data[[2, 1, 0], :]).all()
         assert (result[3, :] == fill_value).all()
         assert result.dtype == out_dtype
 
-        result = algos.take_nd(data, indexer, axis=1, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=1, fill_value=fill_value)
         assert (result[:, [0, 1, 2]] == data[:, [2, 1, 0]]).all()
         assert (result[:, 3] == fill_value).all()
         assert result.dtype == out_dtype
 
         indexer = [2, 1, 0, 1]
-        result = algos.take_nd(data, indexer, axis=0, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=0, fill_value=fill_value)
         assert (result[[0, 1, 2, 3], :] == data[indexer, :]).all()
         assert result.dtype == dtype
 
-        result = algos.take_nd(data, indexer, axis=1, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=1, fill_value=fill_value)
         assert (result[:, [0, 1, 2, 3]] == data[:, indexer]).all()
         assert result.dtype == dtype
 
     def test_3d_fill_nonna(self, dtype_fill_out_dtype):
         dtype, fill_value, out_dtype = dtype_fill_out_dtype
 
+        warn = None
+        if out_dtype != dtype:
+            warn = Pandas4Warning
+        msg = "reindexing with a fill_value that cannot be held"
+
         data = np.random.default_rng(2).integers(0, 2, (5, 4, 3)).astype(dtype)
         indexer = [2, 1, 0, -1]
 
-        result = algos.take_nd(data, indexer, axis=0, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=0, fill_value=fill_value)
         assert (result[[0, 1, 2], :, :] == data[[2, 1, 0], :, :]).all()
         assert (result[3, :, :] == fill_value).all()
         assert result.dtype == out_dtype
 
-        result = algos.take_nd(data, indexer, axis=1, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=1, fill_value=fill_value)
         assert (result[:, [0, 1, 2], :] == data[:, [2, 1, 0], :]).all()
         assert (result[:, 3, :] == fill_value).all()
         assert result.dtype == out_dtype
 
-        result = algos.take_nd(data, indexer, axis=2, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=2, fill_value=fill_value)
         assert (result[:, :, [0, 1, 2]] == data[:, :, [2, 1, 0]]).all()
         assert (result[:, :, 3] == fill_value).all()
         assert result.dtype == out_dtype
 
         indexer = [2, 1, 0, 1]
-        result = algos.take_nd(data, indexer, axis=0, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=0, fill_value=fill_value)
         assert (result[[0, 1, 2, 3], :, :] == data[indexer, :, :]).all()
         assert result.dtype == dtype
 
-        result = algos.take_nd(data, indexer, axis=1, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=1, fill_value=fill_value)
         assert (result[:, [0, 1, 2, 3], :] == data[:, indexer, :]).all()
         assert result.dtype == dtype
 
-        result = algos.take_nd(data, indexer, axis=2, fill_value=fill_value)
+        with tm.assert_produces_warning(warn, match=msg):
+            result = algos.take_nd(data, indexer, axis=2, fill_value=fill_value)
         assert (result[:, :, [0, 1, 2, 3]] == data[:, :, indexer]).all()
         assert result.dtype == dtype
 


### PR DESCRIPTION
- [x] closes #53910 (Replace xxxx with the GitHub issue number)
- [x] closes #24246
- [x] closes #23833
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This deprecates `Series[int].reindex(..., fill_value=anything_other_than_int_or_nan)` following PDEP6-like-logic.  Because we have deprecated the analogous behavior in all of the other places where maybe_promote is called, this also closes the two issues about that function.
