### PR TITLE
BUG: use arrow backend for digits references in `str.replace`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1035,6 +1035,7 @@ Conversion
 
 Strings
 ^^^^^^^
+- Bug in :meth:`Series.str.replace` raising an error on valid group references (``\1``, ``\2``, etc.) on series converted to PyArrow backend dtype (:issue:`62653`)
 - Bug in :meth:`Series.str.zfill` raising ``AttributeError`` for :class:`ArrowDtype` (:issue:`61485`)
 - Bug in :meth:`Series.value_counts` would not respect ``sort=False`` for series having ``string`` dtype (:issue:`55224`)
 - Bug in multiplication with a :class:`StringDtype` incorrectly allowing multiplying by bools; explicitly cast to integers instead (:issue:`62595`)

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -173,15 +173,12 @@ class ArrowStringArrayMixin:
             or callable(repl)
             or not case
             or flags
-            or (
-                isinstance(repl, str)
-                and r"\g<" in repl  # Block named group references (\g<name>); numeric groups (\1) are supported by PyArrow
-            )
+            or (isinstance(repl, str) and r"\g<" in repl)
         ):
             raise NotImplementedError(
                 "replace is not supported with a re.Pattern, callable repl, "
                 "case=False, flags!=0, or when the replacement string contains "
-                "named group references (\\g<...>, \\d+)"
+                "named group references (\\g<...>)"
             )
 
         func = pc.replace_substring_regex if regex else pc.replace_substring

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -175,7 +175,7 @@ class ArrowStringArrayMixin:
             or flags
             or (
                 isinstance(repl, str)
-                and (r"\g<" in repl or re.search(r"\\\d", repl) is not None)
+                and r"\g<" in repl  # Block named group references (\g<name>); numeric groups (\1) are supported by PyArrow
             )
         ):
             raise NotImplementedError(

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -425,8 +425,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
             or flags
             or (  # substitution contains a named group pattern
                 # https://docs.python.org/3/library/re.html
-                isinstance(repl, str)
-                and (r"\g<" in repl or re.search(r"\\\d", repl) is not None)
+                isinstance(repl, str) and r"\g<" in repl
             )
         ):
             return super()._str_replace(pat, repl, n, case, flags, regex)

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -696,6 +696,7 @@ def test_pyarrow_ambiguous_group_references(pyarrow_string_dtype, pattern, repl)
         ),
     ],
 )
+@td.skip_if_no("pyarrow")
 def test_pyarrow_backend_group_replacement(pattern, repl, expected_list):
     ser = Series(["var.one[0]", "var.two[1]", "var.three[2]"]).convert_dtypes(
         dtype_backend="pyarrow"

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -639,6 +639,20 @@ def test_replace_named_groups_regex_swap_expected_fail(
         ser.str.replace(pattern, repl, regex=True)
 
 
+@pytest.mark.parametrize("use_compile", [True, False])
+def test_replace_non_named_group(any_string_dtype, use_compile):
+    ser = Series(["var.one[0]", "var.two[1]", "var.three[2]"], dtype=any_string_dtype)
+    pattern = r"\[(\d+)\]"
+    if use_compile:
+        pattern = re.compile(pattern)
+    repl = r"(\1)"
+    result = ser.str.replace(pattern, repl, regex=True)
+    expected = Series(
+        ["var.one(0)", "var.two(1)", "var.three(2)"], dtype=any_string_dtype
+    )
+    tm.assert_series_equal(result, expected)
+
+
 def test_replace_callable_named_groups(any_string_dtype):
     # test regex named groups
     ser = Series(["Foo Bar Baz", np.nan], dtype=any_string_dtype)

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -9,6 +9,7 @@ import pandas.util._test_decorators as td
 import pandas as pd
 from pandas import (
     Series,
+    StringDtype,
     _testing as tm,
 )
 from pandas.tests.strings import (
@@ -585,6 +586,10 @@ def test_replace_callable_raises(any_string_dtype, repl):
             ["Three Two One", "Baz Bar Foo"],
         ),
         (
+            r"\3 \2 \1",
+            ["Three Two One", "Baz Bar Foo"],
+        ),
+        (
             r"\g<3> \g<2> \g<1>",
             ["Three Two One", "Baz Bar Foo"],
         ),
@@ -599,6 +604,7 @@ def test_replace_callable_raises(any_string_dtype, repl):
     ],
     ids=[
         "named_groups_full_swap",
+        "numbered_groups_no_g_full_swap",
         "numbered_groups_full_swap",
         "single_group_with_literal",
         "mixed_group_reference_with_literal",
@@ -623,33 +629,79 @@ def test_replace_named_groups_regex_swap(
     [
         r"\g<20>",
         r"\20",
+        r"\40",
+        r"\4",
     ],
 )
 @pytest.mark.parametrize("use_compile", [True, False])
 def test_replace_named_groups_regex_swap_expected_fail(
-    any_string_dtype, repl, use_compile
+    any_string_dtype, repl, use_compile, request
 ):
     # GH#57636
+    if (
+        not use_compile
+        and r"\g" not in repl
+        and isinstance(any_string_dtype, StringDtype)
+        and any_string_dtype.storage == "pyarrow"
+    ):
+        # calls pyarrow method directly
+        if repl == r"\20":
+            mark = pytest.mark.xfail(reason="PyArrow interprets as group + literal")
+            request.applymarker(mark)
+
+        pa = pytest.importorskip("pyarrow")
+        error_type = pa.ArrowInvalid
+        error_msg = r"only has \d parenthesized subexpressions"
+    else:
+        error_type = re.error
+        error_msg = "invalid group reference"
+
     pattern = r"(?P<one>\w+) (?P<two>\w+) (?P<three>\w+)"
     if use_compile:
         pattern = re.compile(pattern)
     ser = Series(["One Two Three", "Foo Bar Baz"], dtype=any_string_dtype)
 
-    with pytest.raises(re.error, match="invalid group reference"):
+    with pytest.raises(error_type, match=error_msg):
         ser.str.replace(pattern, repl, regex=True)
 
 
-@pytest.mark.parametrize("use_compile", [True, False])
-def test_replace_non_named_group(any_string_dtype, use_compile):
-    ser = Series(["var.one[0]", "var.two[1]", "var.three[2]"], dtype=any_string_dtype)
-    pattern = r"\[(\d+)\]"
-    if use_compile:
-        pattern = re.compile(pattern)
-    repl = r"(\1)"
+@pytest.mark.parametrize(
+    "pattern, repl",
+    [
+        (r"(\w+) (\w+) (\w+)", r"\20"),
+        (r"(?P<one>\w+) (?P<two>\w+) (?P<three>\w+)", r"\20"),
+    ],
+)
+def test_pyarrow_ambiguous_group_references(pyarrow_string_dtype, pattern, repl):
+    # GH#62653
+    ser = Series(["One Two Three", "Foo Bar Baz"], dtype=pyarrow_string_dtype)
+
     result = ser.str.replace(pattern, repl, regex=True)
-    expected = Series(
-        ["var.one(0)", "var.two(1)", "var.three(2)"], dtype=any_string_dtype
+    expected = Series(["Two0", "Bar0"], dtype=pyarrow_string_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "pattern, repl, expected_list",
+    [
+        (
+            r"\[(?P<one>\d+)\]",
+            r"(\1)",
+            ["var.one(0)", "var.two(1)", "var.three(2)"],
+        ),
+        (
+            r"\[(\d+)\]",
+            r"(\1)",
+            ["var.one(0)", "var.two(1)", "var.three(2)"],
+        ),
+    ],
+)
+def test_pyarrow_backend_group_replacement(pattern, repl, expected_list):
+    ser = Series(["var.one[0]", "var.two[1]", "var.three[2]"]).convert_dtypes(
+        dtype_backend="pyarrow"
     )
+    result = ser.str.replace(pattern, repl, regex=True)
+    expected = Series(expected_list).convert_dtypes(dtype_backend="pyarrow")
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #62653 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

I also had to update some tests, because PyArrow replacement differs from python `re` module, where in `re`, if you use a reference with another digit (e.g., `\10`) it is considered invalid. In PyArrow, it's considered reference + literal.

Additionally, I could only reproduce the error reported in #62653 when converting with `.convert_dtypes(dtype_backend="pyarrow")`, constructing the series with an arrow dtype didn't reproduce.