### PR TITLE
BUG: concat([ints, bools]) incorrect casting

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1176,6 +1176,7 @@ Groupby/resample/rolling
 
 Reshaping
 ^^^^^^^^^
+- Bug in :func:`concat` with mixed integer and bool dtypes incorrectly casting the bools to integers (:issue:`45101`)
 - Bug in :func:`qcut` where values at the quantile boundaries could be incorrectly assigned (:issue:`59355`)
 - Bug in :meth:`DataFrame.combine_first` not preserving the column order (:issue:`60427`)
 - Bug in :meth:`DataFrame.explode` producing incorrect result for :class:`pyarrow.large_list` type (:issue:`61091`)

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -162,7 +162,7 @@ def _get_result_dtype(
                 target_dtype = np.dtype(object)
                 kinds = {"o"}
     elif "b" in kinds and len(kinds) > 1:
-        # GH#21108
+        # GH#21108, GH#45101
         target_dtype = np.dtype(object)
         kinds = {"o"}
     else:

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -161,6 +161,10 @@ def _get_result_dtype(
                 # coerce to object
                 target_dtype = np.dtype(object)
                 kinds = {"o"}
+    elif "b" in kinds and len(kinds) > 1:
+        # GH#21108
+        target_dtype = np.dtype(object)
+        kinds = {"o"}
     else:
         # error: Argument 1 to "np_find_common_type" has incompatible type
         # "*Set[Union[ExtensionDtype, Any]]"; expected "dtype[Any]"

--- a/pandas/tests/reshape/concat/test_series.py
+++ b/pandas/tests/reshape/concat/test_series.py
@@ -14,6 +14,18 @@ import pandas._testing as tm
 
 
 class TestSeriesConcat:
+    @pytest.mark.parametrize("bool_dtype", [bool, "boolean"])
+    @pytest.mark.parametrize("dtype", [np.int64, np.float64, "Int64", "Float64"])
+    def test_concat_bool_and_numeric(self, bool_dtype, dtype):
+        # GH#21108, GH#45101
+        left = Series([True, False], dtype=bool_dtype)
+        right = Series([1, 2], dtype=dtype)
+        result = concat([left, right], ignore_index=True)
+        expected = Series([True, False, 1, 2], dtype=object)
+        assert result.iloc[0] is True
+        assert type(result.iloc[2]) in [int, float]  # i.e. not bool
+        tm.assert_series_equal(result, expected)
+
     def test_concat_series(self):
         ts = Series(
             np.arange(20, dtype=np.float64),


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
