### PR TITLE
DOC: inconsistent default values in the initialiser for RangeIndex

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -88,11 +88,11 @@ class RangeIndex(Index):
 
     Parameters
     ----------
-    start : int (default: 0), range, or other RangeIndex instance
+    start : int, range, or other RangeIndex instance, default None
         If int and "stop" is not given, interpreted as "stop" instead.
-    stop : int (default: 0)
+    stop : int, default None
         The end value of the range (exclusive).
-    step : int (default: 1)
+    step : int, default None
         The step size of the range.
     dtype : np.int64
         Unused, accepted for homogeneity with other index types.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -94,7 +94,7 @@ class RangeIndex(Index):
         The end value of the range (exclusive).
     step : int, default None
         The step size of the range.
-    dtype : np.int64
+    dtype : np.int64, default None
         Unused, accepted for homogeneity with other index types.
     copy : bool, default False
         Unused, accepted for homogeneity with other index types.


### PR DESCRIPTION
- [x] closes #62899

Updated the docstring in the initialiser for RangeIndex. 
I noticed, if `step` parameter is None, it defaults to 1. We have a similar case in `slice_indexer`
https://github.com/pandas-dev/pandas/blob/ce3298b948b8536f37a8d0c44da079cbf4a32533/pandas/core/indexes/base.py#L6637-L6644

should we also clarify for `step` parameter: `If None, defaults to 1.`?