### PR TITLE
TST: fix duplicate parametrization/xfail in test_setitem_integer_with_missing_raises

### DIFF
--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -356,18 +356,25 @@ class TestJSONArray(base.ExtensionTests):
             request.applymarker(mark)
         super().test_setitem_integer_array(data, idx, box_in_series)
 
-    @pytest.mark.xfail(reason="list indices must be integers or slices, not NAType")
     @pytest.mark.parametrize(
-        "idx, box_in_series",
+        "idx",
         [
-            ([0, 1, 2, pd.NA], False),
-            pytest.param(
-                [0, 1, 2, pd.NA], True, marks=pytest.mark.xfail(reason="GH-31948")
-            ),
-            (pd.array([0, 1, 2, pd.NA], dtype="Int64"), False),
-            (pd.array([0, 1, 2, pd.NA], dtype="Int64"), True),
+            [0, 1, 2, pd.NA],
+            pd.array([0, 1, 2, pd.NA], dtype="Int64"),
         ],
-        ids=["list-False", "list-True", "integer-array-False", "integer-array-True"],
+        ids=["list", "integer-array"],
+    )
+    @pytest.mark.parametrize(
+        "box_in_series",
+        [
+            True,
+            pytest.param(
+                False,
+                marks=pytest.mark.xfail(
+                    reason="list indices must be integers or slices, not NAType"
+                ),
+            ),
+        ],
     )
     def test_setitem_integer_with_missing_raises(self, data, idx, box_in_series):
         super().test_setitem_integer_with_missing_raises(data, idx, box_in_series)


### PR DESCRIPTION
- [x] closes #56727 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
