### PR TITLE
replace ensure_clean with temp_file in pandas/tests/io/sas/test_sas.py

### DIFF
--- a/pandas/tests/io/sas/test_sas.py
+++ b/pandas/tests/io/sas/test_sas.py
@@ -21,7 +21,6 @@ class TestSas:
     def test_sas_read_no_format_or_extension(self, temp_file):
         # see gh-24548
         msg = "unable to infer format of SAS file.+"
-        # Using the pytest temp_file fixture instead of tm.ensure_clean
         with pytest.raises(ValueError, match=msg):
             read_sas(temp_file)
 

--- a/pandas/tests/io/sas/test_sas.py
+++ b/pandas/tests/io/sas/test_sas.py
@@ -18,12 +18,12 @@ class TestSas:
         with pytest.raises(ValueError, match=msg):
             read_sas(b)
 
-    def test_sas_read_no_format_or_extension(self):
+    def test_sas_read_no_format_or_extension(self, temp_file):
         # see gh-24548
         msg = "unable to infer format of SAS file.+"
-        with tm.ensure_clean("test_file_no_extension") as path:
-            with pytest.raises(ValueError, match=msg):
-                read_sas(path)
+        # Using the pytest temp_file fixture instead of tm.ensure_clean
+        with pytest.raises(ValueError, match=msg):
+            read_sas(temp_file)
 
 
 def test_sas_archive(datapath):


### PR DESCRIPTION
replace ensure_clean with temp_file in pandas/tests/io/sas/test_sas.py
What:
Replace tm.ensure_clean usage with the pytest temp_file fixture in
pandas/tests/io/sas/test_sas.py.

Why:
The project standard is to use the temp_file pytest fixture instead of the
legacy ensure_clean helper. This is one small PR toward pandas-dev/pandas#62435.

Changes:
- test_sas_read_no_format_or_extension: changed signature to accept `temp_file`
  and pass `temp_file` directly to read_sas().

Local verification:
- Ran the file tests locally:
  pytest -q pandas/tests/io/sas/test_sas.py
  pytest -q pandas/tests/io/sas/test_sas.py::TestSas::test_sas_read_no_format_or_extension
- Pre-commit hooks:
  pre-commit run --all-files

Notes:
- This PR only updates a test file and preserves test semantics.
- The change is a small, direct replacement and does not close the overall
  issue; it is part of the multi-PR effort to address #62435 (xref #62435).

Related:
- xref: pandas-dev/pandas#62435
- [√] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [√] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
