### PR TITLE
DOC: Update tolerance parameter type to include list-like in Index.reindex

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4168,7 +4168,7 @@ class Index(IndexOpsMixin, PandasObject):
         limit : int, optional
             Maximum number of consecutive labels in ``target`` to match for
             inexact matches.
-        tolerance : int or float, optional
+        tolerance : int, float, or list-like, optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.


### PR DESCRIPTION
Updated the type description for the `tolerance` parameter in `Index.reindex` to accurately reflect that it can accept list-like types in addition to scalar values.

Changed: `tolerance : int or float, optional` → `tolerance : int, float, or list-like, optional`

The parameter description already documented that tolerance can be list-like (list, tuple, array, Series), but the type annotation was incomplete.

Closes #62923