### PR TITLE
Warn on setitems that do not change dtype #52593

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -956,7 +956,15 @@ class _LocationIndexer(NDFrameIndexerBase):
             and key[0] == slice(None)
         ):
             # This is a `df.loc[:, foo] = bar` call
-            if is_hashable(key[1]) and key[1] in self.obj.columns:
+            if (
+                is_hashable(key[1])
+                and not isinstance(key[1], slice)
+                and not (
+                    isinstance(key[1], tuple)
+                    and any(isinstance(x, slice) for x in key[1])
+                )
+                and key[1] in self.obj.columns
+            ):
                 obj = self.obj[key[1]]
                 if isinstance(obj, ABCSeries) and isinstance(
                     value, (ABCSeries, Index, ExtensionArray, np.ndarray)

--- a/pandas/tests/copy_view/test_indexing.py
+++ b/pandas/tests/copy_view/test_indexing.py
@@ -308,7 +308,10 @@ def test_subset_set_column_with_loc(backend, dtype):
     df_orig = df.copy()
     subset = df[1:3]
 
-    subset.loc[:, "a"] = np.array([10, 11], dtype="int64")
+    msg = r"Setting `df.loc\[:, col\] = values` does \*not\* change"
+    err = UserWarning if backend[0] != "numpy" else None
+    with tm.assert_produces_warning(err, match=msg):
+        subset.loc[:, "a"] = np.array([10, 11], dtype="int64")
 
     subset._mgr._verify_integrity()
     expected = DataFrame(

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -792,7 +792,9 @@ class TestDataFrameSetItem:
     def test_loc_setitem_ea_dtype(self):
         # GH#55604
         df = DataFrame({"a": np.array([10], dtype="i8")})
-        df.loc[:, "a"] = Series([11], dtype="Int64")
+        msg = r"Setting `df.loc\[:, col\] = values` does \*not\* change"
+        with tm.assert_produces_warning(UserWarning, match=msg):
+            df.loc[:, "a"] = Series([11], dtype="Int64")
         expected = DataFrame({"a": np.array([11], dtype="i8")})
         tm.assert_frame_equal(df, expected)
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -548,7 +548,9 @@ class TestFancy:
 
         # GH5702 (loc)
         df = df_orig.copy()
-        df.loc[:, "A"] = df.loc[:, "A"].astype(np.int64)
+        msg = r"Setting `df.loc\[:, col\] = values` does \*not\* change"
+        with tm.assert_produces_warning(UserWarning, match=msg):
+            df.loc[:, "A"] = df.loc[:, "A"].astype(np.int64)
         expected = DataFrame(
             [[1, "2", "3", ".4", 5, 6.0, "foo"]], columns=list("ABCDEFG")
         )
@@ -570,12 +572,14 @@ class TestFancy:
 
         # With the enforcement of GH#45333 in 2.0, this assignment occurs inplace,
         #  so float64 is retained
+        msg = r"Setting `df.loc\[:, col\] = values` does \*not\* change"
         df.iloc[:, 0] = df["A"].astype(np.int64)
         expected = DataFrame({"A": [1.0, 2.0, 3.0, 4.0]})
         tm.assert_frame_equal(df, expected)
 
         df = DataFrame({"A": [1.0, 2.0, 3.0, 4.0]})
-        df.loc[:, "A"] = df["A"].astype(np.int64)
+        with tm.assert_produces_warning(UserWarning, match=msg):
+            df.loc[:, "A"] = df["A"].astype(np.int64)
         tm.assert_frame_equal(df, expected)
 
     @pytest.mark.parametrize("indexer", [tm.getitem, tm.loc])

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -318,7 +318,9 @@ class TestPartialSetting:
         df["B"] = df["B"].astype(np.float64)
         # as of 2.0, df.loc[:, "B"] = ... attempts (and here succeeds) at
         #  setting inplace
-        df.loc[:, "B"] = df.loc[:, "A"]
+        msg = r"Setting `df.loc\[:, col\] = values` does \*not\* change"
+        with tm.assert_produces_warning(UserWarning, match=msg):
+            df.loc[:, "B"] = df.loc[:, "A"]
         tm.assert_frame_equal(df, expected)
 
         # single dtype frame, partial setting


### PR DESCRIPTION
- [x] closes #52593 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

May merit discussion, but #52593 and a couple of other issues ive seen suggest that users get confused by this frequently.