### PR TITLE
Support for pyarrow version under 22.0.0, hardening for AttributeError

### DIFF
--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -18,8 +18,9 @@ try:
     pa_version_under19p0 = _palv < Version("19.0.0")
     pa_version_under20p0 = _palv < Version("20.0.0")
     pa_version_under21p0 = _palv < Version("21.0.0")
+    pa_version_under22p0 = _palv < Version("22.0.0")
     HAS_PYARROW = _palv >= Version(PYARROW_MIN_VERSION)
-except ImportError:
+except (ImportError,AttributeError):
     pa_version_under14p0 = True
     pa_version_under14p1 = True
     pa_version_under15p0 = True
@@ -29,4 +30,5 @@ except ImportError:
     pa_version_under19p0 = True
     pa_version_under20p0 = True
     pa_version_under21p0 = True
+    pa_version_under22p0 = True
     HAS_PYARROW = False

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -20,7 +20,7 @@ try:
     pa_version_under21p0 = _palv < Version("21.0.0")
     pa_version_under22p0 = _palv < Version("22.0.0")
     HAS_PYARROW = _palv >= Version(PYARROW_MIN_VERSION)
-except (ImportError,AttributeError):
+except (ImportError, AttributeError):
     pa_version_under14p0 = True
     pa_version_under14p1 = True
     pa_version_under15p0 = True


### PR DESCRIPTION
Some broken installation of PyArrow may pass the import but then fail upon the retrieval of the __version__ attribute.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)

Have not created an issue.

Experiencing this locally while packaging PyArrow for Debian. Found this also mentioned on
https://stackoverflow.com/questions/78417768/pyarrow-version-error-when-importing-pandas-on-jupyter-notebook#:~:text=The%20error%20message%20indicates%20that,doesn't%20resolve%20the%20issue.

- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature

Works locally for me, no new feature added beyond compatibility with the latest release of Arrow, see https://github.com/apache/arrow/tags

- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

This is just a casual contribution.

- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Not sure if this small bit already qualifies to be mentioned. Will do if you are so insisting. Was just helping myself locally.
