### PR TITLE
BUG: Skip axis=1 concat in merge for empty non-key columns (#62949)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1206,6 +1206,7 @@ Reshaping
 - Bug in :meth:`DataFrame.merge` where user-provided suffixes could result in duplicate column names if the resulting names matched existing columns. Now raises a :class:`MergeError` in such cases. (:issue:`61402`)
 - Bug in :meth:`DataFrame.merge` with :class:`CategoricalDtype` columns incorrectly raising ``RecursionError`` (:issue:`56376`)
 - Bug in :meth:`DataFrame.merge` with a ``float32`` index incorrectly casting the index to ``float64`` (:issue:`41626`)
+- Bug in :meth:`DataFrame.join`` when joining with empty columns of differing dtypes (:issue:`62949``)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1131,7 +1131,14 @@ class _MergeOperation:
 
         left.columns = llabels
         right.columns = rlabels
-        result = concat([left, right], axis=1)
+        if len(left.columns) == 0 and len(right.columns) == 0:
+            result = left.copy()
+        elif len(left.columns) == 0:
+            result = right.copy()
+        elif len(right.columns) == 0:
+            result = left.copy()
+        else:
+            result = concat([left, right], axis=1)
         return result
 
     def get_result(self) -> DataFrame:

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -738,6 +738,21 @@ class TestMerge:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_join_empty_columns_warning(self):
+        pd.set_option("infer_string", True)
+        df = DataFrame({"a": "x", "b": ["y", "z"]}).set_index(["a", "b"])
+        df.columns = Index([], dtype="int64")
+        ser = DataFrame({"b": ["y", "z"], "value": [1, 2]}).set_index("b")["value"]
+
+        with tm.assert_produces_warning(None):  # No warning expected
+            result = df.join(ser, on="b")
+
+        expected = DataFrame(
+            {"value": [1, 2]},
+            index=MultiIndex.from_tuples([("x", "y"), ("x", "z")], names=["a", "b"]),
+        )
+        tm.assert_frame_equal(result, expected)
+
     @pytest.mark.parametrize("unit", ["D", "h", "m", "s", "ms", "us", "ns"])
     def test_other_datetime_unit(self, unit):
         # GH 13389


### PR DESCRIPTION
- [x] closes #62949 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) for fixing the bug.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file for fixing the bug.
