### PR TITLE
BUG: Fix convert_dtype complex

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1037,6 +1037,7 @@ Conversion
 - Bug in :meth:`DataFrame.astype` not casting ``values`` for Arrow-based dictionary dtype correctly (:issue:`58479`)
 - Bug in :meth:`DataFrame.update` bool dtype being converted to object (:issue:`55509`)
 - Bug in :meth:`Series.astype` might modify read-only array inplace when casting to a string dtype (:issue:`57212`)
+- Bug in :meth:`Series.convert_dtypes` and :meth:`DataFrame.convert_dtypes` raising ``TypeError`` when called on data with complex dtype (:issue:`60129`)
 - Bug in :meth:`Series.convert_dtypes` and :meth:`DataFrame.convert_dtypes` removing timezone information for objects with :class:`ArrowDtype` (:issue:`60237`)
 - Bug in :meth:`Series.reindex` not maintaining ``float32`` type when a ``reindex`` introduces a missing value (:issue:`45857`)
 - Bug in :meth:`to_datetime` and :meth:`to_timedelta` with input ``None`` returning ``None`` instead of ``NaT``, inconsistent with other conversion methods (:issue:`23055`)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -934,6 +934,10 @@ def convert_dtypes(
     if (
         convert_string or convert_integer or convert_boolean or convert_floating
     ) and isinstance(input_array, np.ndarray):
+
+        if input_array.dtype.kind == 'c':
+            return input_array.dtype
+
         if input_array.dtype == object:
             inferred_dtype = lib.infer_dtype(input_array)
         else:
@@ -954,7 +958,7 @@ def convert_dtypes(
                 inferred_dtype = NUMPY_INT_TO_DTYPE.get(
                     input_array.dtype, target_int_dtype
                 )
-            elif input_array.dtype.kind in "fcb":
+            elif input_array.dtype.kind in "fb":
                 # TODO: de-dup with maybe_cast_to_integer_array?
                 arr = input_array[notna(input_array)]
                 if len(arr) < len(input_array) and not is_nan_na():
@@ -972,7 +976,7 @@ def convert_dtypes(
                 inferred_dtype = target_int_dtype
 
         if convert_floating:
-            if input_array.dtype.kind in "fcb":
+            if input_array.dtype.kind in "fb":
                 # i.e. numeric but not integer
                 from pandas.core.arrays.floating import NUMPY_FLOAT_TO_DTYPE
 
@@ -1028,11 +1032,11 @@ def convert_dtypes(
 
         if (
             (convert_integer and inferred_dtype.kind in "iu")
-            or (convert_floating and inferred_dtype.kind in "fc")
+            or (convert_floating and inferred_dtype.kind in "f")
             or (convert_boolean and inferred_dtype.kind == "b")
             or (convert_string and isinstance(inferred_dtype, StringDtype))
             or (
-                inferred_dtype.kind not in "iufcb"
+                inferred_dtype.kind not in "iufb"
                 and not isinstance(inferred_dtype, StringDtype)
                 and not isinstance(inferred_dtype, CategoricalDtype)
             )

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -934,8 +934,7 @@ def convert_dtypes(
     if (
         convert_string or convert_integer or convert_boolean or convert_floating
     ) and isinstance(input_array, np.ndarray):
-
-        if input_array.dtype.kind == 'c':
+        if input_array.dtype.kind == "c":
             return input_array.dtype
 
         if input_array.dtype == object:

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -231,7 +231,6 @@ class TestConvertDtypes:
 
     def test_convert_dtypes_complex(self):
         # GH 60129
-        df = pd.DataFrame({"a": [1.0 + 5.0j, 1.5 - 3.0j]})
+        df = pd.DataFrame({"a": [1.0 + 5.0j, 1.5 - 3.0j], "b": [1, 2]})
         result = df.convert_dtypes()
         tm.assert_frame_equal(result, df)
-        assert result["a"].dtype.kind == "c"

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -231,7 +231,7 @@ class TestConvertDtypes:
 
     def test_convert_dtypes_complex(self):
         # GH 60129
-        df = pd.DataFrame({'a': [1.0+5.0j, 1.5-3.0j]})
+        df = pd.DataFrame({"a": [1.0 + 5.0j, 1.5 - 3.0j]})
         result = df.convert_dtypes()
         tm.assert_frame_equal(result, df)
-        assert result['a'].dtype.kind == 'c'
+        assert result["a"].dtype.kind == "c"

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -232,5 +232,11 @@ class TestConvertDtypes:
     def test_convert_dtypes_complex(self):
         # GH 60129
         df = pd.DataFrame({"a": [1.0 + 5.0j, 1.5 - 3.0j], "b": [1, 2]})
+        expected = pd.DataFrame(
+            {
+                "a": pd.array([1.0 + 5.0j, 1.5 - 3.0j], dtype="complex128"),
+                "b": pd.array([1, 2], dtype="Int64"),
+            }
+        )
         result = df.convert_dtypes()
-        tm.assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -228,3 +228,10 @@ class TestConvertDtypes:
         result = df.convert_dtypes(dtype_backend="pyarrow")
         expected = df.copy()
         tm.assert_frame_equal(result, expected)
+
+    def test_convert_dtypes_complex(self):
+        # GH 60129
+        df = pd.DataFrame({'a': [1.0+5.0j, 1.5-3.0j]})
+        result = df.convert_dtypes()
+        tm.assert_frame_equal(result, df)
+        assert result['a'].dtype.kind == 'c'

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -335,7 +335,7 @@ class TestSeriesConvertDtypes:
 
     def test_convert_dtypes_complex(self):
         # GH 60129
-        ser = pd.Series([1.5+3.0j, 1.5-3.0j])
+        ser = pd.Series([1.5 + 3.0j, 1.5 - 3.0j])
         result = ser.convert_dtypes()
         tm.assert_series_equal(result, ser)
-        assert result.dtype.kind == 'c'
+        assert result.dtype.kind == "c"

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -332,3 +332,10 @@ class TestSeriesConvertDtypes:
         result = ser.convert_dtypes(dtype_backend="pyarrow")
         expected = ser.copy()
         tm.assert_series_equal(result, expected)
+
+    def test_convert_dtypes_complex(self):
+        # GH 60129
+        ser = pd.Series([1.5+3.0j, 1.5-3.0j])
+        result = ser.convert_dtypes()
+        tm.assert_series_equal(result, ser)
+        assert result.dtype.kind == 'c'

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -338,4 +338,3 @@ class TestSeriesConvertDtypes:
         ser = pd.Series([1.5 + 3.0j, 1.5 - 3.0j])
         result = ser.convert_dtypes()
         tm.assert_series_equal(result, ser)
-        assert result.dtype.kind == "c"


### PR DESCRIPTION
- [x] closes #60129  
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.

## Changes : 
 - Modified `pandas/core/dtypes/cast.py` to preserve complex dtypes (kind 'c') instead of attempting to convert them
- Since there is no Numpy-nullable complex array nor a PyArrow complex dtype, this is effectively a no-op (leaves complex data as-is)
- Removed 'c' (complex) from dtype kind checks where it was incorrectly grouped with floats
- Added tests for both `DataFrame.convert_dtypes()` and `Series.convert_dtypes()` with complex data


Example script and output : 
```python
import pandas as pd
print(pd.DataFrame(['1.0+5j', '1.5-3j']).astype(complex).convert_dtypes())
```
Output : 
```bash
(pandas-dev) jha@MAGICIAN:~/workspace/opensource/reports/pandas-60129$ python3 main.py
          0
0  1.0+5.0j
1  1.5-3.0j
```