### PR TITLE
CLN: Use RangeIndex placeholder for Manager.reduce

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12180,6 +12180,7 @@ class DataFrame(NDFrame, OpsMixin):
         #  simple case where we can use BlockManager.reduce
         res = df._mgr.reduce(blk_func)
         out = df._constructor_from_mgr(res, axes=res.axes).iloc[0]
+        out.name = None
         if out_dtype is not None and out.dtype != "boolean":
             out = out.astype(out_dtype)
         elif (df._mgr.get_dtypes() == object).any() and name not in ["any", "all"]:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -350,7 +350,7 @@ class Block(PandasObject, libinternals.Block):
         return self._split_op_result(result)
 
     @final
-    def reduce(self, func) -> list[Block]:
+    def reduce(self, func) -> Block:
         # We will apply the function and reshape the result into a single-row
         #  Block with the same mgr_locs; squeezing will be done at a higher level
         assert self.ndim == 2
@@ -362,8 +362,7 @@ class Block(PandasObject, libinternals.Block):
         else:
             res_values = result.reshape(-1, 1)
 
-        nb = self.make_block(res_values)
-        return [nb]
+        return self.make_block(res_values)
 
     @final
     def _split_op_result(self, result: ArrayLike) -> list[Block]:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1656,7 +1656,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             nbs = blk.reduce(func)
             res_blocks.extend(nbs)
 
-        index = Index([None])  # placeholder
+        index = default_index(1)  # placeholder
         new_mgr = type(self).from_blocks(res_blocks, [self.items, index])
         return new_mgr
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1651,11 +1651,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         # If 2D, we assume that we're operating column-wise
         assert self.ndim == 2
 
-        res_blocks: list[Block] = []
-        for blk in self.blocks:
-            nbs = blk.reduce(func)
-            res_blocks.extend(nbs)
-
+        res_blocks = [blk.reduce(func) for blk in self.blocks]
         index = default_index(1)  # placeholder
         new_mgr = type(self).from_blocks(res_blocks, [self.items, index])
         return new_mgr


### PR DESCRIPTION
IMO it doesn't appear completely necessary to hold the `name=None` label in an `Index` when we can just assign it after the reduce operation