### PR TITLE
TST: Replace ensure_clean utility function with the temp_file in \_testing

### DIFF
--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -61,13 +61,18 @@ def round_trip_pickle(
         # Only join tmpdir with _path when _path is a string or Path-like.
         # _path may be a ReadPickleBuffer (file-like) in which case it
         # should be used directly for pickle operations.
-        temp_path: pathlib.Path | ReadPickleBuffer
         if isinstance(_path, (str, pathlib.Path)):
-            temp_path = pathlib.Path(tmpdir) / _path
+            temp_path: FilePath = pathlib.Path(tmpdir) / _path
+            pd.to_pickle(obj, temp_path)
         else:
-            temp_path = _path
-        pd.to_pickle(obj, temp_path)
-        return pd.read_pickle(temp_path)
+            # _path is a ReadPickleBuffer (file-like object)
+            pd.to_pickle(obj, _path)  # type: ignore[arg-type]
+
+        # For read_pickle, handle both cases
+        if isinstance(_path, (str, pathlib.Path)):
+            return pd.read_pickle(pathlib.Path(tmpdir) / _path)
+        else:
+            return pd.read_pickle(_path)
 
 
 def round_trip_pathlib(writer, reader, path: str | None = None):

--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -61,6 +61,7 @@ def round_trip_pickle(
         # Only join tmpdir with _path when _path is a string or Path-like.
         # _path may be a ReadPickleBuffer (file-like) in which case it
         # should be used directly for pickle operations.
+        temp_path: pathlib.Path | ReadPickleBuffer
         if isinstance(_path, (str, pathlib.Path)):
             temp_path = pathlib.Path(tmpdir) / _path
         else:

--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -58,7 +58,13 @@ def round_trip_pickle(
     # keeping an open file handle (important on Windows) while still
     # ensuring automatic cleanup.
     with tempfile.TemporaryDirectory() as tmpdir:
-        temp_path = pathlib.Path(tmpdir) / _path
+        # Only join tmpdir with _path when _path is a string or Path-like.
+        # _path may be a ReadPickleBuffer (file-like) in which case it
+        # should be used directly for pickle operations.
+        if isinstance(_path, (str, pathlib.Path)):
+            temp_path = pathlib.Path(tmpdir) / _path
+        else:
+            temp_path = _path
         pd.to_pickle(obj, temp_path)
         return pd.read_pickle(temp_path)
 


### PR DESCRIPTION
Summary
-------
This PR replace uses of the internal ``ensure_clean`` helper with standard temporary-directory semantics in test helpers to avoid leaving open file handles on Windows and to prepare tests for migration to pytest's `temp_file` fixture.

Files Changed
-------------
- pandas/_testing/_io.py

Changes
-------
- Replaced usage of the contextmanager-based ``ensure_clean`` with ``tempfile.TemporaryDirectory()`` in helper functions used by tests.
