### PR TITLE
BUG: Validate path type in read_parquet, reject non-path/file-like

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -27,6 +27,8 @@ from pandas.util._decorators import (
 )
 from pandas.util._validators import check_dtype_backend
 
+from pandas.core.dtypes.common import is_file_like
+
 from pandas import (
     DataFrame,
     get_option,
@@ -656,6 +658,13 @@ def read_parquet(
     0    3    8
     1    4    9
     """
+    # gh-62922: validate path type early to match documented API expectations
+    # and provide a consistent, clear user error immediately.
+    if not (isinstance(path, (str, os.PathLike)) or is_file_like(path)):
+        raise TypeError(
+            f"read_parquet expected str/os.PathLike or file-like object, "
+            f"got {type(path).__name__} type"
+        )
 
     impl = get_engine(engine)
     check_dtype_backend(dtype_backend)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -248,6 +248,42 @@ def check_partition_names(path, expected):
     assert dataset.partitioning.schema.names == expected
 
 
+def test_read_parquet_invalid_path_types(tmp_path, engine):
+    # GH #62922
+    df = pd.DataFrame({"a": [1]})
+    path = tmp_path / "test_read_parquet.parquet"
+    df.to_parquet(path, engine=engine)
+
+    bad_path_types = [
+        [str(path)],  # list
+        (str(path),),  # tuple
+        b"raw-bytes",  # bytes
+    ]
+    for bad in bad_path_types:
+        match = (
+            f"read_parquet expected str/os.PathLike or file-like object, "
+            f"got {type(bad).__name__} type"
+        )
+        with pytest.raises(TypeError, match=match):
+            read_parquet(bad, engine=engine)
+
+
+def test_read_parquet_valid_path_types(tmp_path, engine):
+    # GH #62922
+    df = pd.DataFrame({"a": [1]})
+    path = tmp_path / "test_read_parquet.parquet"
+    df.to_parquet(path, engine=engine)
+    # str
+    read_parquet(str(path), engine=engine)
+    # os.PathLike
+    read_parquet(pathlib.Path(path), engine=engine)
+    # file-like object
+    buf = BytesIO()
+    df.to_parquet(buf, engine=engine)
+    buf.seek(0)
+    read_parquet(buf, engine=engine)
+
+
 def test_invalid_engine(df_compat, temp_file):
     msg = "engine must be one of 'pyarrow', 'fastparquet'"
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -254,34 +254,12 @@ def test_read_parquet_invalid_path_types(tmp_path, engine):
     path = tmp_path / "test_read_parquet.parquet"
     df.to_parquet(path, engine=engine)
 
-    bad_path_types = [
-        [str(path)],  # list
-        (str(path),),  # tuple
-        b"raw-bytes",  # bytes
-    ]
-    for bad in bad_path_types:
-        match = (
-            f"read_parquet expected str/os.PathLike or file-like object, "
-            f"got {type(bad).__name__} type"
-        )
-        with pytest.raises(TypeError, match=match):
-            read_parquet(bad, engine=engine)
-
-
-def test_read_parquet_valid_path_types(tmp_path, engine):
-    # GH #62922
-    df = pd.DataFrame({"a": [1]})
-    path = tmp_path / "test_read_parquet.parquet"
-    df.to_parquet(path, engine=engine)
-    # str
-    read_parquet(str(path), engine=engine)
-    # os.PathLike
-    read_parquet(pathlib.Path(path), engine=engine)
-    # file-like object
-    buf = BytesIO()
-    df.to_parquet(buf, engine=engine)
-    buf.seek(0)
-    read_parquet(buf, engine=engine)
+    msg = (
+        f"read_parquet expected str/os.PathLike or file-like object, "
+        f"got list type"
+    )
+    with pytest.raises(TypeError, match=msg):
+        read_parquet([str(path)], engine=engine)
 
 
 def test_invalid_engine(df_compat, temp_file):


### PR DESCRIPTION

- [x] closes #62922
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] No whatsnew entry required (small API validation change, no behavior change for valid inputs)

## Description
`read_parquet` documentation specifies that only `str` / `os.PathLike` or `file-like` objects are supported.
Previously, passing unexpected container types such as list would reach backends and fail inconsistently.

This PR adds an early `TypeError` check at the public API boundary to provide clear, consistent behaviour across pyarrow / fastparquet engines.

Tests are added for both valid and invalid path types.