### PR TITLE
STY: Add strict=True to zip() calls in pandas/core/reshape/concat.py

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -840,7 +840,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
     if (levels is None and isinstance(keys[0], tuple)) or (
         levels is not None and len(levels) > 1
     ):
-        zipped = list(zip(*keys))
+        zipped = list(zip(*keys, strict=True))
         if names is None:
             names = [None] * len(zipped)
 
@@ -866,13 +866,13 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
         # things are potentially different sizes, so compute the exact codes
         # for each level and pass those to MultiIndex.from_arrays
 
-        for hlevel, level in zip(zipped, levels):
+        for hlevel, level in zip(zipped, levels, strict=True):
             to_concat = []
             if isinstance(hlevel, Index) and hlevel.equals(level):
                 lens = [len(idx) for idx in indexes]
                 codes_list.append(np.repeat(np.arange(len(hlevel)), lens))
             else:
-                for key, index in zip(hlevel, indexes):
+                for key, index in zip(hlevel, indexes, strict=True):
                     # Find matching codes, include matching nan values as equal.
                     mask = (isna(level) & isna(key)) | (level == key)
                     if not mask.any():
@@ -922,7 +922,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
 
     # do something a bit more speedy
 
-    for hlevel, level in zip(zipped, levels):
+    for hlevel, level in zip(zipped, levels, strict=True):
         hlevel_index = ensure_index(hlevel)
         mapped = level.get_indexer(hlevel_index)
 


### PR DESCRIPTION
Some more changes to add 'strict=True' parameter to zip calls.

- [ ] xref #62434 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
