### PR TITLE
CI: Use macos-15-intel in python-dev job

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -320,8 +320,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Separate out macOS 13 and 14, since macOS 14 is arm64 only
-        os: [ubuntu-24.04, macOS-13, macOS-14, windows-2025]
+        os: [ubuntu-24.04, macos-15-intel, macos-15, windows-2025]
 
     timeout-minutes: 90
 


### PR DESCRIPTION
e.g. https://github.com/pandas-dev/pandas/actions/runs/19078287540/job/54499758874
```
This is a scheduled macos-13 brownout. The macOS-13 based runner images are being deprecated. For more details, see https://github.com/actions/runner-images/issues/13046.
```