### PR TITLE
DEPR: Deprecate non-ISO date string formats in DatetimeIndex.loc

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -203,7 +203,7 @@ For a :class:`DataFrame`, passing a slice ``:`` selects matching rows:
 .. ipython:: python
 
    df[0:3]
-   df["20130102":"20130104"]
+   df["2013-01-02":"2013-01-04"]
 
 Selection by label
 ~~~~~~~~~~~~~~~~~~

--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -226,7 +226,7 @@ For label slicing, both endpoints are *included*:
 
 .. ipython:: python
 
-   df.loc["20130102":"20130104", ["A", "B"]]
+   df.loc["2013-01-02":"2013-01-04", ["A", "B"]]
 
 Selecting a single row and column label returns a scalar:
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -314,7 +314,7 @@ Selection by label
 
   .. ipython:: python
 
-     dfl.loc['20130102':'20130104']
+     dfl.loc['2013-01-02':'2013-01-04']
 
 pandas provides a suite of methods in order to have **purely label based indexing**. This is a strict inclusion based protocol.
 Every label asked for must be in the index, or a ``KeyError`` will be raised.

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -589,11 +589,11 @@ Dates and strings that parse to timestamps can be passed as indexing parameters:
 
 .. ipython:: python
 
-   ts["1/31/2011"]
+   ts["2011-01-31"]
 
    ts[datetime.datetime(2011, 12, 25):]
 
-   ts["10/31/2011":"12/31/2011"]
+   ts["2011-10-31":"2011-12-31"]
 
 To provide convenience for accessing longer time series, you can also pass in
 the year or year and month as strings:

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -817,6 +817,7 @@ Other Deprecations
 - Deprecated slicing on a :class:`Series` or :class:`DataFrame` with a :class:`DatetimeIndex` using a ``datetime.date`` object, explicitly cast to :class:`Timestamp` instead (:issue:`35830`)
 - Deprecated support for the Dataframe Interchange Protocol (:issue:`56732`)
 - Deprecated the 'inplace' keyword from :meth:`Resampler.interpolate`, as passing ``True`` raises ``AttributeError`` (:issue:`58690`)
+
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.prior_deprecations:
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -809,6 +809,7 @@ Other Deprecations
 - Deprecated allowing ``fill_value`` that cannot be held in the original dtype (excepting NA values for integer and bool dtypes) in :meth:`Series.shift` and :meth:`DataFrame.shift` (:issue:`53802`)
 - Deprecated allowing strings representing full dates in :meth:`DataFrame.at_time` and :meth:`Series.at_time` (:issue:`50839`)
 - Deprecated backward-compatibility behavior for :meth:`DataFrame.select_dtypes` matching "str" dtype when ``np.object_`` is specified (:issue:`61916`)
+- Deprecated non-ISO date string formats in :meth:`DatetimeIndex.__getitem__` with string labels. Use ISO format (YYYY-MM-DD) instead. (:issue:`58302`)
 - Deprecated option "future.no_silent_downcasting", as it is no longer used. In a future version accessing this option will raise (:issue:`59502`)
 - Deprecated passing non-Index types to :meth:`Index.join`; explicitly convert to Index first (:issue:`62897`)
 - Deprecated silent casting of non-datetime 'other' to datetime in :meth:`Series.combine_first` (:issue:`62931`)
@@ -816,7 +817,6 @@ Other Deprecations
 - Deprecated slicing on a :class:`Series` or :class:`DataFrame` with a :class:`DatetimeIndex` using a ``datetime.date`` object, explicitly cast to :class:`Timestamp` instead (:issue:`35830`)
 - Deprecated support for the Dataframe Interchange Protocol (:issue:`56732`)
 - Deprecated the 'inplace' keyword from :meth:`Resampler.interpolate`, as passing ``True`` raises ``AttributeError`` (:issue:`58690`)
-
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.prior_deprecations:
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -589,6 +589,8 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         return start, end
 
     def _parse_with_reso(self, label: str) -> tuple[Timestamp, Resolution]:
+        parsed, reso = super()._parse_with_reso(label)
+
         # GH#58302 - Deprecate non-ISO string formats in .loc indexing
         if isinstance(label, str) and not _is_iso_format_string(label):
             msg = (
@@ -597,8 +599,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 f"Got '{label}'."
             )
             warnings.warn(msg, Pandas4Warning, stacklevel=find_stack_level())
-
-        parsed, reso = super()._parse_with_reso(label)
 
         parsed = Timestamp(parsed)
 
@@ -733,6 +733,8 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         mask = np.array(True)
         in_index = True
         if start is not None:
+            start_casted = self._maybe_cast_slice_bound(start, "left")
+
             # GH#58302 - Deprecate non-ISO string formats in .loc indexing
             if isinstance(start, str) and not _is_iso_format_string(start):
                 msg = (
@@ -742,11 +744,12 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 )
                 warnings.warn(msg, Pandas4Warning, stacklevel=find_stack_level())
 
-            start_casted = self._maybe_cast_slice_bound(start, "left")
             mask = start_casted <= self
             in_index &= (start_casted == self).any()
 
         if end is not None:
+            end_casted = self._maybe_cast_slice_bound(end, "right")
+
             # GH#58302 - Deprecate non-ISO string formats in .loc indexing
             if isinstance(end, str) and not _is_iso_format_string(end):
                 msg = (
@@ -756,7 +759,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 )
                 warnings.warn(msg, Pandas4Warning, stacklevel=find_stack_level())
 
-            end_casted = self._maybe_cast_slice_bound(end, "right")
             mask = (self <= end_casted) & mask
             in_index &= (end_casted == self).any()
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -720,9 +720,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         def check_str_or_none(point) -> bool:
             return point is not None and not isinstance(point, str)
 
-        # GH#33146 if start and end are combinations of str and None and Index is not
-        # monotonic, we can not use Index.slice_indexer because it does not honor the
-        # actual elements, is only searching for start and end
         # GH#58302 - Deprecate non-ISO string formats in .loc indexing
         if isinstance(start, str) and not _is_iso_format_string(start):
             msg = (
@@ -740,6 +737,9 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             )
             warnings.warn(msg, Pandas4Warning, stacklevel=find_stack_level())
 
+        # GH#33146 if start and end are combinations of str and None and Index is not
+        # monotonic, we can not use Index.slice_indexer because it does not honor the
+        # actual elements, is only searching for start and end
         if (
             check_str_or_none(start)
             or check_str_or_none(end)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -756,7 +756,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
         if end is not None:
             end_casted = self._maybe_cast_slice_bound(end, "right")
-
             mask = (self <= end_casted) & mask
             in_index &= (end_casted == self).any()
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -591,15 +591,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     def _parse_with_reso(self, label: str) -> tuple[Timestamp, Resolution]:
         parsed, reso = super()._parse_with_reso(label)
 
-        # GH#58302 - Deprecate non-ISO string formats in .loc indexing
-        if isinstance(label, str) and not _is_iso_format_string(label):
-            msg = (
-                "Parsing non-ISO datetime strings in .loc is deprecated and will be "
-                "removed in a future version. Use ISO format (YYYY-MM-DD) instead. "
-                f"Got '{label}'."
-            )
-            warnings.warn(msg, Pandas4Warning, stacklevel=find_stack_level())
-
         parsed = Timestamp(parsed)
 
         if self.tz is not None and parsed.tzinfo is None:
@@ -645,6 +636,14 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 parsed, reso = self._parse_with_reso(key)
             except ValueError as err:
                 raise KeyError(key) from err
+            # GH#58302 - Deprecate non-ISO string formats in .loc indexing
+            if not _is_iso_format_string(key):
+                msg = (
+                    "Parsing non-ISO datetime strings in .loc is deprecated "
+                    "and will be removed in a future version. Use ISO format "
+                    f"(YYYY-MM-DD) instead. Got '{key}'."
+                )
+                warnings.warn(msg, Pandas4Warning, stacklevel=find_stack_level())
             self._disallow_mismatched_indexing(parsed)
 
             if self._can_partial_date_slice(reso):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -137,14 +137,10 @@ def _is_iso_format_string(date_str: str) -> bool:
         dt.date.fromisoformat(date_str)
         return True
     except (ValueError, TypeError):
-        # Fallback regex for reduced precision dates not supported by fromisoformat()
-        # Checks if string starts with ISO pattern (YYYY, YYYY-MM, YYYY-MM-DD, etc.)
-        # Pattern: ^\d{4}(?:-|T|$)
-        # - Requires exactly 4 digits at start (year)
-        # - Followed by: hyphen (YYYY-), T (YYYY-T...), or end (YYYY)
-        # Examples that match: "2024", "2024-01", "2024-01-10", "2024-01-10T00:00:00"
-        # Examples that don't: "01/10/2024", "2024 01 10", "1/1/2024"
-        return re.match(r"^\d{4}(?:-|T|$)", date_str) is not None
+        # Fallback for reduced precision dates not supported by fromisoformat()
+        # Match YYYY, YYYY-MM, YYYY-MM-DD with optional time component
+        pattern = r"\d{4}(?:-\d{2})?(?:-\d{2})?(?:T.*)?"
+        return re.fullmatch(pattern, date_str) is not None
 
 
 @inherit_names(

--- a/pandas/tests/groupby/methods/test_value_counts.py
+++ b/pandas/tests/groupby/methods/test_value_counts.py
@@ -72,6 +72,9 @@ def seed_df(seed_nans, n, m):
 @pytest.mark.parametrize("bins", [None, [0, 5]], ids=repr)
 @pytest.mark.parametrize("isort", [True, False])
 @pytest.mark.parametrize("normalize, name", [(True, "proportion"), (False, "count")])
+@pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
 def test_series_groupby_value_counts(
     seed_nans,
     num_rows,

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -28,12 +28,7 @@ import pandas._testing as tm
 from pandas.core.arrays import BooleanArray
 import pandas.core.common as com
 
-pytestmark = [
-    pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning"),
-    pytest.mark.filterwarnings(
-        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-    ),
-]
+pytestmark = pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
 
 
 def test_repr():

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2851,6 +2851,9 @@ def test_groupby_with_Time_Grouper(unit):
     tm.assert_frame_equal(result, expected_output)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
 def test_groupby_series_with_datetimeindex_month_name():
     # GH 48509
     s = Series([0, 1, 0], index=date_range("2022-01-01", periods=3), name="jan")

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -28,7 +28,12 @@ import pandas._testing as tm
 from pandas.core.arrays import BooleanArray
 import pandas.core.common as com
 
-pytestmark = pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning"),
+    pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    ),
+]
 
 
 def test_repr():

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -26,10 +26,6 @@ import pandas._testing as tm
 
 from pandas.tseries.frequencies import to_offset
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 
@@ -493,6 +489,9 @@ class TestGetLoc:
         with pytest.raises(TypeError, match=msg):
             dti.get_loc(key)
 
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_get_loc_reasonable_key_error(self):
         # GH#1062
         index = DatetimeIndex(["1/3/2000"])

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -26,6 +26,10 @@ import pandas._testing as tm
 
 from pandas.tseries.frequencies import to_offset
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -489,14 +489,11 @@ class TestGetLoc:
         with pytest.raises(TypeError, match=msg):
             dti.get_loc(key)
 
-    @pytest.mark.filterwarnings(
-        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-    )
     def test_get_loc_reasonable_key_error(self):
         # GH#1062
-        index = DatetimeIndex(["1/3/2000"])
+        index = DatetimeIndex(["2000-01-03"])
         with pytest.raises(KeyError, match="2000"):
-            index.get_loc("1/1/2000")
+            index.get_loc("2000-01-01")
 
     def test_get_loc_year_str(self):
         rng = date_range("1/1/2000", "1/1/2010")

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -19,6 +19,10 @@ from pandas import (
 )
 import pandas._testing as tm
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 class TestSlicing:
     def test_string_index_series_name_converted(self):

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -561,3 +561,8 @@ class TestDatetimeIndexNonISODeprecation:
         with tm.assert_produces_warning(None):
             result = ser_daily.loc[Timestamp("2024-01-10")]
             assert result == 9
+
+    def test_loc_indexing_invalid_iso_pattern_raises_keyerror(self, ser_daily):
+        # GH#58302 - Malformed date strings fail at parsing, before ISO check
+        with pytest.raises(KeyError, match="2025-ANYTHING-GOES"):
+            ser_daily.loc["2025-ANYTHING-GOES"]

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -501,13 +501,11 @@ class TestDatetimeIndexNonISODeprecation:
     @pytest.mark.parametrize(
         "date_string,expected",
         [
-            ("2024-01-10", 9),  # YYYY-MM-DD (dash)
-            ("2024/01/10", 9),  # YYYY/MM/DD (slash)
-            ("2024 01 10", 9),  # YYYY MM DD (space)
+            ("2024-01-10", 9),  # YYYY-MM-DD (ISO format)
         ],
     )
     def test_loc_indexing_iso_format_no_warning(self, ser_daily, date_string, expected):
-        # GH#58302 - ISO formats should NOT warn
+        # GH#58302 - ISO format (YYYY-MM-DD) should NOT warn
         with tm.assert_produces_warning(None):
             result = ser_daily.loc[date_string]
             assert result == expected

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -19,12 +19,12 @@ from pandas import (
 )
 import pandas._testing as tm
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 class TestSlicing:
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
+
     def test_string_index_series_name_converted(self):
         # GH#1644
         df = DataFrame(

--- a/pandas/tests/indexes/multi/test_partial_indexing.py
+++ b/pandas/tests/indexes/multi/test_partial_indexing.py
@@ -9,10 +9,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 @pytest.fixture
 def df():

--- a/pandas/tests/indexes/multi/test_partial_indexing.py
+++ b/pandas/tests/indexes/multi/test_partial_indexing.py
@@ -9,6 +9,10 @@ from pandas import (
 )
 import pandas._testing as tm
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 @pytest.fixture
 def df():

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -172,22 +172,19 @@ class TestGetItem:
         tm.assert_series_equal(ts[[Period("2012-01-02", freq="D")]], exp)
 
     @pytest.mark.arm_slow
-    @pytest.mark.filterwarnings(
-        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-    )
     def test_getitem_seconds(self):
         # GH#6716
-        didx = date_range(start="2013/01/01 09:00:00", freq="s", periods=4000)
-        pidx = period_range(start="2013/01/01 09:00:00", freq="s", periods=4000)
+        didx = date_range(start="2013-01-01 09:00:00", freq="s", periods=4000)
+        pidx = period_range(start="2013-01-01 09:00:00", freq="s", periods=4000)
 
         for idx in [didx, pidx]:
             # getitem against index should raise ValueError
             values = [
                 "2014",
-                "2013/02",
-                "2013/01/02",
-                "2013/02/01 9h",
-                "2013/02/01 09:00",
+                "2013-02",
+                "2013-01-02",
+                "2013-02-01 9h",
+                "2013-02-01 09:00",
             ]
             for val in values:
                 # GH7116
@@ -197,9 +194,9 @@ class TestGetItem:
                     idx[val]
 
             ser = Series(np.random.default_rng(2).random(len(idx)), index=idx)
-            tm.assert_series_equal(ser["2013/01/01 10:00"], ser[3600:3660])
-            tm.assert_series_equal(ser["2013/01/01 9h"], ser[:3600])
-            for d in ["2013/01/01", "2013/01", "2013"]:
+            tm.assert_series_equal(ser["2013-01-01 10:00"], ser[3600:3660])
+            tm.assert_series_equal(ser["2013-01-01 9h"], ser[:3600])
+            for d in ["2013-01-01", "2013-01", "2013"]:
                 tm.assert_series_equal(ser[d], ser)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -21,10 +21,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 dti4 = date_range("2016-01-01", periods=4)
 dti = dti4[:-1]
 rng = pd.Index(range(3))
@@ -176,6 +172,9 @@ class TestGetItem:
         tm.assert_series_equal(ts[[Period("2012-01-02", freq="D")]], exp)
 
     @pytest.mark.arm_slow
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_getitem_seconds(self):
         # GH#6716
         didx = date_range(start="2013/01/01 09:00:00", freq="s", periods=4000)
@@ -209,6 +208,9 @@ class TestGetItem:
             date_range,
             period_range,
         ],
+    )
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
     )
     def test_getitem_day(self, idx_range):
         # GH#6716

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -21,6 +21,10 @@ from pandas import (
 )
 import pandas._testing as tm
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 dti4 = date_range("2016-01-01", periods=4)
 dti = dti4[:-1]
 rng = pd.Index(range(3))

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -10,6 +10,10 @@ from pandas import (
 )
 import pandas._testing as tm
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 class TestPeriodIndex:
     def test_getitem_periodindex_duplicates_string_slice(self):

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -10,12 +10,12 @@ from pandas import (
 )
 import pandas._testing as tm
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 class TestPeriodIndex:
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
+
     def test_getitem_periodindex_duplicates_string_slice(self):
         # monotonic
         idx = PeriodIndex([2000, 2007, 2007, 2009, 2009], freq="Y-JUN")

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -19,10 +19,6 @@ from pandas import (
 import pandas._testing as tm
 from pandas.tests.indexing.common import _mklbl
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 class TestMultiIndexSlicers:
     def test_per_axis_per_level_getitem(self):

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -308,6 +308,9 @@ class TestMultiIndexSlicers:
         ]
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_multiindex_slicers_edges(self):
         # GH 8132
         # various edge cases

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -19,6 +19,10 @@ from pandas import (
 import pandas._testing as tm
 from pandas.tests.indexing.common import _mklbl
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 class TestMultiIndexSlicers:
     def test_per_axis_per_level_getitem(self):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -44,6 +44,10 @@ from pandas.api.types import is_scalar
 from pandas.core.indexing import _one_ellipsis_message
 from pandas.tests.indexing.common import check_indexing_smoketest_or_raises
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 @pytest.mark.parametrize(
     "series, new_series, expected_ser",

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -44,10 +44,6 @@ from pandas.api.types import is_scalar
 from pandas.core.indexing import _one_ellipsis_message
 from pandas.tests.indexing.common import check_indexing_smoketest_or_raises
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 @pytest.mark.parametrize(
     "series, new_series, expected_ser",

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -280,6 +280,9 @@ class TestLoc:
 
 class TestLocBaseIndependent:
     # Tests for loc that do not depend on subclassing Base
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_loc_npstr(self):
         # GH#45580
         df = DataFrame(index=date_range("2021", "2022"))
@@ -1281,6 +1284,9 @@ class TestLocBaseIndependent:
         expected = DataFrame(col_data, columns=["A"], dtype=float)
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_loc_getitem_time_object(self, frame_or_series):
         rng = date_range("1/1/2000", "1/5/2000", freq="5min")
         mask = (rng.hour == 9) & (rng.minute == 30)
@@ -2434,6 +2440,9 @@ class TestPartialStringSlicing:
 
 
 class TestLabelSlicing:
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_loc_getitem_slicing_datetimes_frame(self):
         # GH#7523
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -38,10 +38,6 @@ from pandas.tseries import offsets
 from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import Minute
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 @pytest.fixture
 def simple_date_range_series():
@@ -331,6 +327,9 @@ def test_resample_rounding(unit):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
 def test_resample_basic_from_daily(unit):
     # from daily
     dti = date_range(
@@ -555,6 +554,9 @@ def test_resample_ohlc(unit):
     assert xs["close"] == s.iloc[4]
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
 def test_resample_ohlc_result(unit):
     # GH 12332
     index = date_range("1-1-2000", "2-15-2000", freq="h").as_unit(unit)
@@ -666,6 +668,9 @@ def test_resample_timestamp_to_period(
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
 def test_ohlc_5min(unit):
     def _ohlc(group):
         if isna(group).all():
@@ -1580,6 +1585,9 @@ def test_resample_dst_anchor(unit):
     )
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
 def test_resample_dst_anchor2(unit):
     dti = date_range(
         "2013-09-30", "2013-11-02", freq="30Min", tz="Europe/Paris"

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -38,6 +38,10 @@ from pandas.tseries import offsets
 from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import Minute
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 @pytest.fixture
 def simple_date_range_series():

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -16,6 +16,10 @@ from pandas import (
 import pandas._testing as tm
 from pandas.core.indexes.datetimes import date_range
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 @pytest.fixture
 def test_frame():

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -16,10 +16,6 @@ from pandas import (
 import pandas._testing as tm
 from pandas.core.indexes.datetimes import date_range
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 @pytest.fixture
 def test_frame():
@@ -138,6 +134,9 @@ def test_groupby_resample_on_api_with_getitem():
     tm.assert_series_equal(result, exp)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
 def test_groupby_with_origin():
     # GH 31809
 

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -27,11 +27,10 @@ from pandas import (
 )
 import pandas._testing as tm
 
-pytestmark = pytest.mark.filterwarnings(
+
+@pytest.mark.filterwarnings(
     "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
 )
-
-
 def test_fancy_getitem():
     dti = date_range(
         freq="WOM-1FRI", start=datetime(2005, 1, 1), end=datetime(2010, 1, 1)
@@ -50,6 +49,9 @@ def test_fancy_getitem():
     )
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
 def test_fancy_setitem():
     dti = date_range(
         freq="WOM-1FRI", start=datetime(2005, 1, 1), end=datetime(2010, 1, 1)

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -27,6 +27,10 @@ from pandas import (
 )
 import pandas._testing as tm
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 def test_fancy_getitem():
     dti = date_range(

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -37,10 +37,6 @@ from pandas.core.indexing import IndexingError
 
 from pandas.tseries.offsets import BDay
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 class TestSeriesGetitemScalars:
     def test_getitem_object_index_float_string(self):
@@ -151,6 +147,9 @@ class TestSeriesGetitemScalars:
         assert ts[time_pandas] == ts[time_datetime]
 
     @pytest.mark.parametrize("tz", ["US/Eastern", "dateutil/US/Eastern"])
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_string_index_alias_tz_aware(self, tz):
         rng = date_range("1/1/2000", periods=10, tz=tz)
         ser = Series(np.random.default_rng(2).standard_normal(len(rng)), index=rng)
@@ -237,6 +236,9 @@ class TestSeriesGetitemSlices:
 
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_getitem_slice_strings_with_datetimeindex(self):
         idx = DatetimeIndex(
             ["1/1/2000", "1/2/2000", "1/2/2000", "1/3/2000", "1/4/2000"]

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -37,6 +37,10 @@ from pandas.core.indexing import IndexingError
 
 from pandas.tseries.offsets import BDay
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 class TestSeriesGetitemScalars:
     def test_getitem_object_index_float_string(self):

--- a/pandas/tests/series/indexing/test_xs.py
+++ b/pandas/tests/series/indexing/test_xs.py
@@ -8,10 +8,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
-)
-
 
 def test_xs_datetimelike_wrapping():
     # GH#31630 a case where we shouldn't wrap datetime64 in Timestamp
@@ -50,6 +46,9 @@ class TestXSWithMultiIndex:
         result = ser.xs("one", level="L2")
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.filterwarnings(
+        "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+    )
     def test_series_getitem_multiindex_xs(self):
         # GH#6258
         dt = list(date_range("20130903", periods=3))

--- a/pandas/tests/series/indexing/test_xs.py
+++ b/pandas/tests/series/indexing/test_xs.py
@@ -8,6 +8,10 @@ from pandas import (
 )
 import pandas._testing as tm
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Parsing non-ISO datetime strings:pandas.errors.Pandas4Warning"
+)
+
 
 def test_xs_datetimelike_wrapping():
     # GH#31630 a case where we shouldn't wrap datetime64 in Timestamp


### PR DESCRIPTION
- [X] closes #58302 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

**Before**:
```
ser.loc["1/10/2024":"1/14/2024"]      # Returns Jan 10-14
ser.loc["1/10/2024":"14/1/2024"]      # Also returns Jan 10-14
ser.loc["10/1/2024":"14/1/2024"]      # Returns empty
```
**After**:
```
ser.loc["1/10/2024":"1/14/2024"]      # Still returns Jan 10-14 + FutureWarning
ser.loc["2024-01-10":"2024-01-14"]    # Use ISO format instead
```

There's no way to know if "1/10/2024" is being parsed as MM/DD or DD/MM until you run it. This deprecation pushes users toward ISO format to avoid the confusion.