### PR TITLE
DOC: Add Google Colab data loading guide

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -6333,10 +6333,10 @@ To access files stored in your Google Drive:
 
     from google.colab import drive
     import pandas as pd
-    
+
     # Mount your Google Drive
     drive.mount('/content/drive')
-    
+
     # Read file from Drive
     df = pd.read_csv('/content/drive/MyDrive/your_file.csv')
 
@@ -6350,10 +6350,10 @@ To upload files from your local machine:
     from google.colab import files
     import pandas as pd
     import io
-    
+
     # Upload file (opens file picker dialog)
     uploaded = files.upload()
-    
+
     # Read the uploaded file
     for filename in uploaded.keys():
         df = pd.read_csv(io.BytesIO(uploaded[filename]))
@@ -6366,7 +6366,7 @@ Direct URL loading works the same as in standard pandas:
 .. code-block:: python
 
     import pandas as pd
-    
+
     # Read from any public URL
     url = 'https://raw.githubusercontent.com/example/repo/main/data.csv'
     df = pd.read_csv(url)
@@ -6379,23 +6379,23 @@ To read data from Google Sheets:
 .. code-block:: python
 
     import pandas as pd
-    
+
     # Option 1: Export as CSV (sheet must be publicly accessible)
     sheet_id = 'your-spreadsheet-id'
     sheet_name = 'Sheet1'
     url = f'https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&sheet={sheet_name}'
     df = pd.read_csv(url)
-    
+
     # Option 2: Using authentication for private sheets
     # Note: Requires gspread library (pip install gspread)
     from google.colab import auth
     import gspread
     from google.auth import default
-    
+
     auth.authenticate_user()
     creds, _ = default()
     gc = gspread.authorize(creds)
-    
+
     worksheet = gc.open('Your Spreadsheet Name').sheet1
     data = worksheet.get_all_values()
     df = pd.DataFrame(data[1:], columns=data[0])

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -6387,6 +6387,7 @@ To read data from Google Sheets:
     df = pd.read_csv(url)
     
     # Option 2: Using authentication for private sheets
+    # Note: Requires gspread library (pip install gspread)
     from google.colab import auth
     import gspread
     from google.auth import default

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -6316,6 +6316,91 @@ More information about the SAV and ZSAV file formats is available here_.
 
 .. _here: https://www.ibm.com/docs/en/spss-statistics/22.0.0
 
+
+.. _io.colab:
+
+Loading Data in Google Colab
+-----------------------------
+
+Google Colab is a popular cloud-based Jupyter notebook environment. pandas works seamlessly in Colab, and there are several ways to load data:
+
+From Google Drive
+~~~~~~~~~~~~~~~~~
+
+To access files stored in your Google Drive:
+
+.. code-block:: python
+
+    from google.colab import drive
+    import pandas as pd
+    
+    # Mount your Google Drive
+    drive.mount('/content/drive')
+    
+    # Read file from Drive
+    df = pd.read_csv('/content/drive/MyDrive/your_file.csv')
+
+From Local Computer
+~~~~~~~~~~~~~~~~~~~
+
+To upload files from your local machine:
+
+.. code-block:: python
+
+    from google.colab import files
+    import pandas as pd
+    import io
+    
+    # Upload file (opens file picker dialog)
+    uploaded = files.upload()
+    
+    # Read the uploaded file
+    for filename in uploaded.keys():
+        df = pd.read_csv(io.BytesIO(uploaded[filename]))
+
+From URL
+~~~~~~~~
+
+Direct URL loading works the same as in standard pandas:
+
+.. code-block:: python
+
+    import pandas as pd
+    
+    # Read from any public URL
+    url = 'https://raw.githubusercontent.com/example/repo/main/data.csv'
+    df = pd.read_csv(url)
+
+From Google Sheets
+~~~~~~~~~~~~~~~~~~
+
+To read data from Google Sheets:
+
+.. code-block:: python
+
+    import pandas as pd
+    
+    # Option 1: Export as CSV (sheet must be publicly accessible)
+    sheet_id = 'your-spreadsheet-id'
+    sheet_name = 'Sheet1'
+    url = f'https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&sheet={sheet_name}'
+    df = pd.read_csv(url)
+    
+    # Option 2: Using authentication for private sheets
+    from google.colab import auth
+    import gspread
+    from google.auth import default
+    
+    auth.authenticate_user()
+    creds, _ = default()
+    gc = gspread.authorize(creds)
+    
+    worksheet = gc.open('Your Spreadsheet Name').sheet1
+    data = worksheet.get_all_values()
+    df = pd.DataFrame(data[1:], columns=data[0])
+
+For more details on Colab-specific I/O operations, see the `official Google Colab I/O guide <https://colab.research.google.com/notebooks/io.ipynb>`_.
+
 .. _io.other:
 
 Other file formats


### PR DESCRIPTION
## Description
Adds a comprehensive documentation section explaining how to load data into pandas when using Google Colab.

## Changes
- Added new section `.. _io.colab:` to `doc/source/user_guide/io.rst`
- Covers 4 common data loading methods in Colab:
  - From Google Drive (with drive mounting)
  - From local computer upload
  - From URL (standard pandas behavior)
  - From Google Sheets (with and without authentication)
- Includes working code examples for each method
- Added link to official Google Colab I/O guide

## Related Issue
Closes #62708

## Testing
- [x] Verified RST syntax
- [x] Tested all code examples in actual Google Colab environment
- [x] Documentation builds without errors

This addresses the gap identified in the issue where there's no cohesive pandas documentation for Colab users, who represent a significant portion of pandas users in educational and research contexts.