### PR TITLE
Add strict=true in zip() in tests\arrays

### DIFF
--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -130,7 +130,7 @@ def test_map_with_dict_or_series(na_action):
     expected = Categorical(new_values, categories=[3.0, 2, "one"])
     tm.assert_categorical_equal(result, expected)
 
-    mapper = dict(zip(orig_values[:-1], new_values[:-1]))
+    mapper = dict(zip(orig_values[:-1], new_values[:-1], strict=True))
     result = cat.map(mapper, na_action=na_action)
     # Order of categories in result can be different
     tm.assert_categorical_equal(result, expected)

--- a/pandas/tests/arrays/integer/test_construction.py
+++ b/pandas/tests/arrays/integer/test_construction.py
@@ -67,7 +67,7 @@ def test_conversions(data_missing):
     expected = np.array([pd.NA, 1], dtype=object)
     tm.assert_numpy_array_equal(result, expected)
 
-    for r, e in zip(result, expected):
+    for r, e in zip(result, expected, strict=True):
         if pd.isnull(r):
             assert pd.isnull(e)
         elif is_integer(r):

--- a/pandas/tests/arrays/integer/test_function.py
+++ b/pandas/tests/arrays/integer/test_function.py
@@ -104,7 +104,7 @@ def test_ufunc_binary_output(using_nan_is_na):
     assert isinstance(result, tuple)
     assert len(result) == 2
 
-    for x, y in zip(result, expected):
+    for x, y in zip(result, expected, strict=True):
         tm.assert_extension_array_equal(x, y)
 
 


### PR DESCRIPTION
Added 'strict=True' parameter to zip calls for better error handling.
- [ ] xref #62434 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
