### PR TITLE
DOC: fix --extra-inex-url keyword in install docs for nightly wheels

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -112,7 +112,7 @@ index from the PyPI registry of anaconda.org. You can install it by running.
 
 .. code-block:: shell
 
-    pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+    pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
 
 .. note::
     You might be required to uninstall an existing version of pandas to install the development version.


### PR DESCRIPTION
Changing `--extra-index` to `--extra-index-url`. Didn't verify if pip is actually accepting the former, but the latter is the argument as documented: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url (and also what we use in our CI)