### PR TITLE
TST: Add regression test for pivot on empty frame with period dtype (GH62705)

### DIFF
--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2942,3 +2942,20 @@ class TestPivot:
         tm.assert_frame_equal(
             df, df_expected, check_dtype=False, check_column_type=False
         )
+
+    @pytest.mark.parametrize("freq", ["D", "M", "Q", "Y"])
+    def test_pivot_empty_dataframe_period_dtype(self, freq):
+        # GH#62705
+
+        dtype = pd.PeriodDtype(freq=freq)
+        df = pd.DataFrame({"index": [], "columns": [], "values": []})
+        df = df.astype({"values": dtype})
+        result = df.pivot(index="index", columns="columns", values="values")
+
+        expected_index = pd.Index([], name="index", dtype="float64")
+        expected_columns = pd.Index([], name="columns", dtype="float64")
+        expected = pd.DataFrame(
+            index=expected_index, columns=expected_columns, dtype=dtype
+        )
+
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2948,13 +2948,13 @@ class TestPivot:
         # GH#62705
 
         dtype = pd.PeriodDtype(freq=freq)
-        df = pd.DataFrame({"index": [], "columns": [], "values": []})
+        df = DataFrame({"index": [], "columns": [], "values": []})
         df = df.astype({"values": dtype})
         result = df.pivot(index="index", columns="columns", values="values")
 
-        expected_index = pd.Index([], name="index", dtype="float64")
-        expected_columns = pd.Index([], name="columns", dtype="float64")
-        expected = pd.DataFrame(
+        expected_index = Index([], name="index", dtype="float64")
+        expected_columns = Index([], name="columns", dtype="float64")
+        expected = DataFrame(
             index=expected_index, columns=expected_columns, dtype=dtype
         )
 


### PR DESCRIPTION
- [X] closes #62705
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
---

This PR adds a regression test for issue #62705.

The original issue reported a `TypeError: Cannot interpret 'period[D]' as a data type` when `.pivot()` was called on an **empty** DataFrame where the `values` column had a `PeriodDtype`.

As noted in the issue, this bug was already fixed on `main`, but it lacked a specific regression test to prevent this from reoccurring.

This new test:
1.  Creates an empty DataFrame: `pd.DataFrame({"index": [], "columns": [], "values": []})`
2.  Casts the `values` column to a `PeriodDtype` (parametrized for "D", "M", "Q", "Y").
3.  Calls `.pivot()` and asserts that the operation completes without an error.
4.  Validates that the resulting empty pivoted DataFrame has the correct empty `float64` index/columns and the original `PeriodDtype` for its data, which matches the behavior of the fixed pivot operation.