### PR TITLE
STY: Add strict=True in zip() in \core

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -422,15 +422,12 @@ def concat(
             intersect
             or any(not isinstance(index, DatetimeIndex) for index in non_concat_axis)
             or all(
-                prev is curr
-                for prev, curr in zip(non_concat_axis, non_concat_axis[1:], strict=True)
+                prev is curr for prev, curr in zip(non_concat_axis, non_concat_axis[1:])
             )
             or (
                 all(
                     prev[-1] <= curr[0] and prev.is_monotonic_increasing
-                    for prev, curr in zip(
-                        non_concat_axis, non_concat_axis[1:], strict=True
-                    )
+                    for prev, curr in zip(non_concat_axis, non_concat_axis[1:])
                     if not prev.empty and not curr.empty
                 )
                 and non_concat_axis[-1].is_monotonic_increasing

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -422,12 +422,15 @@ def concat(
             intersect
             or any(not isinstance(index, DatetimeIndex) for index in non_concat_axis)
             or all(
-                prev is curr for prev, curr in zip(non_concat_axis, non_concat_axis[1:])
+                prev is curr
+                for prev, curr in zip(non_concat_axis, non_concat_axis[1:], strict=True)
             )
             or (
                 all(
                     prev[-1] <= curr[0] and prev.is_monotonic_increasing
-                    for prev, curr in zip(non_concat_axis, non_concat_axis[1:])
+                    for prev, curr in zip(
+                        non_concat_axis, non_concat_axis[1:], strict=True
+                    )
                     if not prev.empty and not curr.empty
                 )
                 and non_concat_axis[-1].is_monotonic_increasing

--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -212,7 +212,7 @@ def get_dummies(
             with_dummies = [data.select_dtypes(exclude=dtypes_to_encode)]
 
         for col, pre, sep in zip(
-            data_to_encode.items(), prefix, prefix_sep, strict=True
+            data_to_encode.items(), prefix, prefix_sep, strict=False
         ):
             # col is (column_name, column), use just column data here
             dummy = _get_dummies_1d(

--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -5,6 +5,7 @@ from collections.abc import (
     Hashable,
     Iterable,
 )
+import itertools
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -184,7 +185,7 @@ def get_dummies(
         check_len(prefix_sep, "prefix_sep")
 
         if isinstance(prefix, str):
-            prefix = [prefix] * len(data_to_encode.columns)
+            prefix = itertools.repeat(prefix, len(data_to_encode.columns))
         if isinstance(prefix, dict):
             prefix = [prefix[col] for col in data_to_encode.columns]
 
@@ -193,7 +194,7 @@ def get_dummies(
 
         # validate separators
         if isinstance(prefix_sep, str):
-            prefix_sep = [prefix_sep] * len(data_to_encode.columns)
+            prefix_sep = itertools.repeat(prefix_sep, len(data_to_encode.columns))
         elif isinstance(prefix_sep, dict):
             prefix_sep = [prefix_sep[col] for col in data_to_encode.columns]
 

--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -5,7 +5,6 @@ from collections.abc import (
     Hashable,
     Iterable,
 )
-import itertools
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -185,7 +184,7 @@ def get_dummies(
         check_len(prefix_sep, "prefix_sep")
 
         if isinstance(prefix, str):
-            prefix = itertools.cycle([prefix])
+            prefix = [prefix] * len(data_to_encode.columns)
         if isinstance(prefix, dict):
             prefix = [prefix[col] for col in data_to_encode.columns]
 
@@ -194,7 +193,7 @@ def get_dummies(
 
         # validate separators
         if isinstance(prefix_sep, str):
-            prefix_sep = itertools.cycle([prefix_sep])
+            prefix_sep = [prefix_sep] * len(data_to_encode.columns)
         elif isinstance(prefix_sep, dict):
             prefix_sep = [prefix_sep[col] for col in data_to_encode.columns]
 
@@ -212,7 +211,7 @@ def get_dummies(
             with_dummies = [data.select_dtypes(exclude=dtypes_to_encode)]
 
         for col, pre, sep in zip(
-            data_to_encode.items(), prefix, prefix_sep, strict=False
+            data_to_encode.items(), prefix, prefix_sep, strict=True
         ):
             # col is (column_name, column), use just column data here
             dummy = _get_dummies_1d(

--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -211,7 +211,9 @@ def get_dummies(
             # columns to prepend to result.
             with_dummies = [data.select_dtypes(exclude=dtypes_to_encode)]
 
-        for col, pre, sep in zip(data_to_encode.items(), prefix, prefix_sep):
+        for col, pre, sep in zip(
+            data_to_encode.items(), prefix, prefix_sep, strict=True
+        ):
             # col is (column_name, column), use just column data here
             dummy = _get_dummies_1d(
                 col[1],

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -199,7 +199,7 @@ def melt(
         missing = idx == -1
         if missing.any():
             missing_labels = [
-                lab for lab, not_found in zip(labels, missing) if not_found
+                lab for lab, not_found in zip(labels, missing, strict=True) if not_found
             ]
             raise KeyError(
                 "The following id_vars or value_vars are not present in "

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -1098,8 +1098,8 @@ def crosstab(
     from pandas import DataFrame
 
     data = {
-        **dict(zip(unique_rownames, index)),
-        **dict(zip(unique_colnames, columns)),
+        **dict(zip(unique_rownames, index, strict=True)),
+        **dict(zip(unique_colnames, columns, strict=True)),
     }
     df = DataFrame(data, index=common_idx)
 


### PR DESCRIPTION
This PR applies the ruff B905 rule to the files in  \core.

## Modified Files
1. pandas/core/reshape/concat.py
2. pandas/core/reshape/encoding.py
3. pandas/core/reshape/melt.py
4. pandas/core/reshape/pivot.py
