### PR TITLE
DOC: Correct return type for `DataFrame.hist`

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -231,8 +231,8 @@ def hist_frame(
 
     Returns
     -------
-    matplotlib.Axes or numpy.ndarray of them
-        Returns a AxesSubplot object a numpy array of AxesSubplot objects.
+    np.ndarray
+        2D NumPy Array of :class:`matplotlib.axes.Axes`.
 
     See Also
     --------


### PR DESCRIPTION
The current return type that's documented is too broad, I think. It looks to me like it's always a 2D ndarray of `Axes`

Indeed, `make_subplots` is called with `squeeze=False`

https://github.com/pandas-dev/pandas/blob/d18f9a20ff58e39cca70ede022c8fd4981a31d5f/pandas/plotting/_matplotlib/hist.py#L549-L552

and in there there's:

https://github.com/pandas-dev/pandas/blob/edf00e953e6e185345fbc488cd9a963ab2d59d58/pandas/plotting/_matplotlib/tools.py#L319-L321

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
