### PR TITLE
REF: inline array_to_datetime64 cases, update tests

### DIFF
--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1011,7 +1011,9 @@ class TestDatetime64Arithmetic:
 
         ser = tm.box_expected(ser, box_with_array)
 
-        delta_series = Series([np.timedelta64(0, "D"), np.timedelta64(1, "D")])
+        delta_series = Series(
+            [np.timedelta64(0, "D"), np.timedelta64(1, "D")], dtype="m8[ns]"
+        )
         expected = tm.box_expected(delta_series, box_with_array)
 
         tm.assert_equal(ser - ts, expected)

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -1641,7 +1641,9 @@ class TestPeriodIndexSeriesMethods:
         result = np.subtract(Period("2012-01", freq="M"), idx)
         tm.assert_index_equal(result, exp)
 
-        exp = TimedeltaIndex([np.nan, np.nan, np.nan, np.nan], name="idx")
+        exp = TimedeltaIndex(
+            [np.nan, np.nan, np.nan, np.nan], name="idx", dtype="m8[ns]"
+        )
         result = idx - Period("NaT", freq="M")
         tm.assert_index_equal(result, exp)
         assert result.freq == exp.freq
@@ -1655,7 +1657,7 @@ class TestPeriodIndexSeriesMethods:
         idx = PeriodIndex(
             ["2011-01", "2011-02", "NaT", "2011-04"], freq="M", name="idx"
         )
-        exp = TimedeltaIndex([pd.NaT] * 4, name="idx")
+        exp = TimedeltaIndex([pd.NaT] * 4, name="idx", dtype="m8[ns]")
         tm.assert_index_equal(pd.NaT - idx, exp)
         tm.assert_index_equal(idx - pd.NaT, exp)
 
@@ -1674,6 +1676,8 @@ class TestPeriodIndexSeriesMethods:
         exp = pd.Index([12 * off, pd.NaT, 10 * off, 9 * off], name="idx")
         tm.assert_index_equal(result, exp)
 
-        exp = TimedeltaIndex([np.nan, np.nan, np.nan, np.nan], name="idx")
+        exp = TimedeltaIndex(
+            [np.nan, np.nan, np.nan, np.nan], name="idx", dtype="m8[ns]"
+        )
         tm.assert_index_equal(idx - Period("NaT", freq="M"), exp)
         tm.assert_index_equal(Period("NaT", freq="M") - idx, exp)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -850,7 +850,7 @@ class TestTimedeltaArraylikeAddSubOps:
         assert rs.dtype == "timedelta64[ns]"
 
         df = DataFrame({"A": v1})
-        td = Series([timedelta(days=i) for i in range(3)])
+        td = Series([timedelta(days=i) for i in range(3)], dtype="m8[ns]")
         assert td.dtype == "timedelta64[ns]"
 
         # series on the rhs
@@ -875,7 +875,9 @@ class TestTimedeltaArraylikeAddSubOps:
 
         # datetimes on rhs
         result = df["A"] - datetime(2001, 1, 1)
-        expected = Series([timedelta(days=4017 + i) for i in range(3)], name="A")
+        expected = Series(
+            [timedelta(days=4017 + i) for i in range(3)], name="A", dtype="m8[ns]"
+        )
         tm.assert_series_equal(result, expected)
         assert result.dtype == "m8[ns]"
 
@@ -1559,7 +1561,7 @@ class TestTimedeltaArraylikeMulDivOps:
 
     def test_td64arr_mul_bool_scalar_raises(self, box_with_array):
         # GH#58054
-        ser = Series(np.arange(5) * timedelta(hours=1))
+        ser = Series(np.arange(5) * timedelta(hours=1), dtype="m8[ns]")
         obj = tm.box_expected(ser, box_with_array)
 
         msg = r"Cannot multiply 'timedelta64\[ns\]' by bool"
@@ -1582,7 +1584,7 @@ class TestTimedeltaArraylikeMulDivOps:
     )
     def test_td64arr_mul_bool_raises(self, dtype, box_with_array):
         # GH#58054
-        ser = Series(np.arange(5) * timedelta(hours=1))
+        ser = Series(np.arange(5) * timedelta(hours=1), dtype="m8[ns]")
         obj = tm.box_expected(ser, box_with_array)
 
         other = Series(np.arange(5) < 0.5, dtype=dtype)
@@ -1611,7 +1613,7 @@ class TestTimedeltaArraylikeMulDivOps:
         ],
     )
     def test_td64arr_mul_masked(self, dtype, box_with_array):
-        ser = Series(np.arange(5) * timedelta(hours=1))
+        ser = Series(np.arange(5) * timedelta(hours=1), dtype="m8[ns]")
         obj = tm.box_expected(ser, box_with_array)
 
         other = Series(np.arange(5), dtype=dtype)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -747,12 +747,14 @@ class TestDataFrameAnalytics:
 
         # works when only those columns are selected
         result = mixed[["A", "B"]].min(axis=1)
-        expected = Series([timedelta(days=-1)] * 3)
+        expected = Series([timedelta(days=-1)] * 3, dtype="m8[ns]")
         tm.assert_series_equal(result, expected)
 
         result = mixed[["A", "B"]].min()
         expected = Series(
-            [timedelta(seconds=5 * 60 + 5), timedelta(days=-1)], index=["A", "B"]
+            [timedelta(seconds=5 * 60 + 5), timedelta(days=-1)],
+            index=["A", "B"],
+            dtype="m8[ns]",
         )
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/indexes/timedeltas/test_formats.py
+++ b/pandas/tests/indexes/timedeltas/test_formats.py
@@ -22,7 +22,7 @@ class TestTimedeltaIndexRendering:
 
     @pytest.mark.parametrize("method", ["__repr__", "__str__"])
     def test_representation(self, method):
-        idx1 = TimedeltaIndex([], freq="D")
+        idx1 = TimedeltaIndex([], freq="D", dtype="m8[ns]")
         idx2 = TimedeltaIndex(["1 days"], freq="D")
         idx3 = TimedeltaIndex(["1 days", "2 days"], freq="D")
         idx4 = TimedeltaIndex(["1 days", "2 days", "3 days"], freq="D")
@@ -53,7 +53,7 @@ class TestTimedeltaIndexRendering:
 
     # TODO: this is a Series.__repr__ test
     def test_representation_to_series(self):
-        idx1 = TimedeltaIndex([], freq="D")
+        idx1 = TimedeltaIndex([], freq="D", dtype="m8[ns]")
         idx2 = TimedeltaIndex(["1 days"], freq="D")
         idx3 = TimedeltaIndex(["1 days", "2 days"], freq="D")
         idx4 = TimedeltaIndex(["1 days", "2 days", "3 days"], freq="D")
@@ -83,7 +83,7 @@ class TestTimedeltaIndexRendering:
 
     def test_summary(self):
         # GH#9116
-        idx1 = TimedeltaIndex([], freq="D")
+        idx1 = TimedeltaIndex([], freq="D", dtype="m8[ns]")
         idx2 = TimedeltaIndex(["1 days"], freq="D")
         idx3 = TimedeltaIndex(["1 days", "2 days"], freq="D")
         idx4 = TimedeltaIndex(["1 days", "2 days", "3 days"], freq="D")

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -160,7 +160,7 @@ class TestTimedeltaIndex:
             # if no overlap exists return empty index
             (
                 timedelta_range("1 day", periods=10, freq="h", name="idx")[5:],
-                TimedeltaIndex([], freq="h", name="idx"),
+                TimedeltaIndex([], freq="h", name="idx", dtype="m8[ns]"),
             ),
         ],
     )

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1131,7 +1131,7 @@ class TestPandasContainer:
     def test_timedelta(self):
         converter = lambda x: pd.to_timedelta(x, unit="ms")
 
-        ser = Series([timedelta(23), timedelta(seconds=5)])
+        ser = Series([timedelta(23), timedelta(seconds=5)], dtype="m8[ns]")
         assert ser.dtype == "timedelta64[ns]"
 
         msg = (
@@ -1148,7 +1148,7 @@ class TestPandasContainer:
             result = read_json(StringIO(ser.to_json()), typ="series").apply(converter)
         tm.assert_series_equal(result, ser)
 
-        frame = DataFrame([timedelta(23), timedelta(seconds=5)])
+        frame = DataFrame([timedelta(23), timedelta(seconds=5)], dtype="m8[ns]")
         assert frame[0].dtype == "timedelta64[ns]"
 
         with tm.assert_produces_warning(Pandas4Warning, match=msg):

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -307,7 +307,7 @@ class TestSeriesArithmetic:
         dt.iloc[2] = np.nan
         dt2 = dt[::-1]
 
-        expected = Series([timedelta(0), timedelta(0), pd.NaT])
+        expected = Series([timedelta(0), timedelta(0), pd.NaT], dtype="m8[ns]")
         # name is reset
         result = dt2 - dt
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -62,7 +62,9 @@ class TestTimedeltas:
 
     def test_to_timedelta_series(self):
         # Series
-        expected = Series([timedelta(days=1), timedelta(days=1, seconds=1)])
+        expected = Series(
+            [timedelta(days=1), timedelta(days=1, seconds=1)], dtype="m8[ns]"
+        )
 
         msg = "'d' is deprecated and will be removed in a future version."
         with tm.assert_produces_warning(Pandas4Warning, match=msg):
@@ -185,7 +187,7 @@ class TestTimedeltas:
 
     def test_to_timedelta_via_apply(self):
         # GH 5458
-        expected = Series([np.timedelta64(1, "s")])
+        expected = Series([np.timedelta64(1, "s")], dtype="m8[ns]")
         result = Series(["00:00:01"]).apply(to_timedelta)
         tm.assert_series_equal(result, expected)
 
@@ -247,7 +249,7 @@ class TestTimedeltas:
     )
     def test_to_timedelta_nullable_int64_dtype(self, expected_val, result_val):
         # GH 35574
-        expected = Series([timedelta(days=1), expected_val])
+        expected = Series([timedelta(days=1), expected_val], dtype="m8[ns]")
         result = to_timedelta(Series([1, result_val], dtype="Int64"), unit="days")
 
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
This is a logic-neutral refactor to trim the diff in an upcoming PR implementing resolution inference in array_to_timedelta64.