### PR TITLE
CLN: Replace get_option(infer_string) with using_string_dtype

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -12,7 +12,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas._typing import (
@@ -2123,7 +2123,7 @@ class StringMethods(NoNewAttributesMixin):
         """
         if dtype is not None and not is_string_dtype(dtype):
             raise ValueError(f"dtype must be string or object, got {dtype=}")
-        if dtype is None and get_option("future.infer_string"):
+        if dtype is None and using_string_dtype():
             dtype = "str"
         # TODO: Add a similar _bytes interface.
         if encoding in _cpython_optimized_decoders:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2278,7 +2278,7 @@ class IndexCol:
         except UnicodeEncodeError as err:
             if (
                 errors == "surrogatepass"
-                and get_option("future.infer_string")
+                and using_string_dtype()
                 and str(err).endswith("surrogates not allowed")
                 and HAS_PYARROW
             ):
@@ -3214,7 +3214,7 @@ class GenericFixed(Fixed):
             except UnicodeEncodeError as err:
                 if (
                     self.errors == "surrogatepass"
-                    and get_option("future.infer_string")
+                    and using_string_dtype()
                     and str(err).endswith("surrogates not allowed")
                     and HAS_PYARROW
                 ):
@@ -3365,7 +3365,7 @@ class SeriesFixed(GenericFixed):
         except UnicodeEncodeError as err:
             if (
                 self.errors == "surrogatepass"
-                and get_option("future.infer_string")
+                and using_string_dtype()
                 and str(err).endswith("surrogates not allowed")
                 and HAS_PYARROW
             ):
@@ -4829,7 +4829,7 @@ class AppendableFrameTable(AppendableTable):
                 except UnicodeEncodeError as err:
                     if (
                         self.errors == "surrogatepass"
-                        and get_option("future.infer_string")
+                        and using_string_dtype()
                         and str(err).endswith("surrogates not allowed")
                         and HAS_PYARROW
                     ):

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config import using_string_dtype
 
 from pandas._libs.byteswap import (
     read_double_with_byteswap,
@@ -699,7 +699,7 @@ class SAS7BDATReader(SASReader):
         rslt = {}
 
         js, jb = 0, 0
-        infer_string = get_option("future.infer_string")
+        infer_string = using_string_dtype()
         for j in range(self.column_count):
             name = self.column_names[j]
 


### PR DESCRIPTION
It appears this is the option we're using more consistently