### PR TITLE
Fix excelfile parse dimensions

### DIFF
--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -610,8 +610,6 @@ class OpenpyxlReader(BaseExcelReader["Workbook"]):
     def get_sheet_data(
         self, sheet, file_rows_needed: int | None = None
     ) -> list[list[Scalar]]:
-   #     if self.book.read_only:
-#        sheet.reset_dimensions()
 
         data: list[list[Scalar]] = []
         last_row_with_data = -1

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -610,8 +610,8 @@ class OpenpyxlReader(BaseExcelReader["Workbook"]):
     def get_sheet_data(
         self, sheet, file_rows_needed: int | None = None
     ) -> list[list[Scalar]]:
-        if self.book.read_only:
-            sheet.reset_dimensions()
+   #     if self.book.read_only:
+#        sheet.reset_dimensions()
 
         data: list[list[Scalar]] = []
         last_row_with_data = -1


### PR DESCRIPTION
Closes #63010

Fixes an issue where `ExcelFile.parse()` with openpyxl resets
`Worksheet.max_row` and `Worksheet.max_column` to None.

### Changes
Removed the `sheet.reset_dimensions()` call for read-only sheets,
as it causes unexpected loss of dimension information after parsing.

### Reproducible example
```python
import pandas as pd

with pd.ExcelFile("some_file.xlsx") as excel_file:
    ws = excel_file.book["Sheet1"]
    dim_before = (ws.max_row, ws.max_column)
    excel_file.parse(sheet_name=ws.title)
    dim_after = (ws.max_row, ws.max_column)

assert dim_before == dim_after  # now passes ✅
