### PR TITLE
DOC: Correct grammar issues about a/an usage

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2712,7 +2712,7 @@ def maybe_convert_objects(ndarray[object] objects,
                 break
         elif PyDateTime_Check(val) or cnp.is_datetime64_object(val):
 
-            # if we have an tz's attached then return the objects
+            # if we have a tz's attached then return the objects
             if convert_non_numeric:
                 if getattr(val, "tzinfo", None) is not None:
                     seen.datetimetz_ = True

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -1168,7 +1168,7 @@ class NaTType(_NaT):
     fromordinal = _make_error_func(
         "fromordinal",
         """
-        Construct a timestamp from a a proleptic Gregorian ordinal.
+        Construct a timestamp from a proleptic Gregorian ordinal.
 
         This method creates a `Timestamp` object corresponding to the given
         proleptic Gregorian ordinal, which is a count of days from January 1,

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1803,7 +1803,7 @@ class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
     See Also
     --------
     dateutil.relativedelta.relativedelta : The relativedelta type is designed
-        to be applied to an existing datetime an can replace specific components of
+        to be applied to an existing datetime and can replace specific components of
         that datetime, or represents an interval of time.
 
     Examples

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1869,7 +1869,7 @@ class Timestamp(_Timestamp):
     @classmethod
     def fromordinal(cls, ordinal, tz=None):
         """
-        Construct a timestamp from a a proleptic Gregorian ordinal.
+        Construct a timestamp from a proleptic Gregorian ordinal.
 
         This method creates a `Timestamp` object corresponding to the given
         proleptic Gregorian ordinal, which is a count of days from January 1,

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1703,7 +1703,7 @@ def map_array(
             ]
         else:
             # Dictionary does not have a default. Thus it's safe to
-            # convert to an Series for efficiency.
+            # convert to a Series for efficiency.
             # we specify the keys here to handle the
             # possibility that they are tuples
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1335,7 +1335,7 @@ def dt64arr_to_periodarr(
     data, freq, tz=None
 ) -> tuple[npt.NDArray[np.int64], BaseOffset]:
     """
-    Convert an datetime-like array to values Period ordinals.
+    Convert a datetime-like array to values Period ordinals.
 
     Parameters
     ----------

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -107,10 +107,10 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
     See Also
     --------
     :func:`array`
-        The recommended function for creating a ArrowStringArray.
+        The recommended function for creating an ArrowStringArray.
     Series.str
         The string methods are available on Series backed by
-        a ArrowStringArray.
+        an ArrowStringArray.
 
     Notes
     -----

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -882,7 +882,7 @@ def is_unsigned_integer_dtype(arr_or_dtype) -> bool:
     See Also
     --------
     api.types.is_signed_integer_dtype : Check whether the provided array
-        or dtype is of an signed integer dtype.
+        or dtype is of a signed integer dtype.
     api.types.is_integer_dtype : Check whether the provided array or dtype
         is of an integer dtype.
     api.types.is_numeric_dtype : Check whether the provided array or dtype
@@ -1264,7 +1264,7 @@ def is_numeric_dtype(arr_or_dtype) -> bool:
     api.types.is_unsigned_integer_dtype: Check whether the provided array
         or dtype is of an unsigned integer dtype.
     api.types.is_signed_integer_dtype: Check whether the provided array
-        or dtype is of an signed integer dtype.
+        or dtype is of a signed integer dtype.
 
     Examples
     --------

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -2913,7 +2913,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         Returns
         -------
         DataFrame
-            An DataFrame containing the elements taken from each group.
+            A DataFrame containing the elements taken from each group.
 
         See Also
         --------

--- a/pandas/core/indexers/utils.py
+++ b/pandas/core/indexers/utils.py
@@ -126,7 +126,7 @@ def check_setitem_lengths(indexer, value, values) -> bool:
     """
     Validate that value and indexer are the same length.
 
-    An special-case is allowed for when the indexer is a boolean array
+    A special-case is allowed for when the indexer is a boolean array
     and the number of true values equals the length of ``value``. In
     this case, no exception is raised.
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2024,7 +2024,7 @@ class _iLocIndexer(_LocationIndexer):
                 )
 
             elif lplane_indexer == 0 and len(value) == len(self.obj.index):
-                # We get here in one case via .loc with a all-False mask
+                # We get here in one case via .loc with an all-False mask
                 pass
 
             elif self._is_scalar_access(indexer) and is_object_dtype(

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -158,7 +158,7 @@ class _Unstacker:
             # Bug fix GH 20601
             # If the data frame is too big, the number of unique index combination
             # will cause int32 overflow on windows environments.
-            # We want to check and raise an warning before this happens
+            # We want to check and raise a warning before this happens
             num_rows = max(index_level.size for index_level in self.new_index_levels)
             num_columns = self.removed_level.size
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2142,7 +2142,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         ['2016-01-01 00:00:00-05:00']
         Length: 1, dtype: datetime64[s, US/Eastern]
 
-        An Categorical will return categories in the order of
+        A Categorical will return categories in the order of
         appearance and with the same dtype.
 
         >>> pd.Series(pd.Categorical(list("baabc"))).unique()

--- a/web/pandas/community/blog/extension-arrays.md
+++ b/web/pandas/community/blog/extension-arrays.md
@@ -151,7 +151,7 @@ array(['a', 'b', 'a'], dtype=object)
 
 To summarize:
 
-- `.array` will *always* be a an ExtensionArray, and is always a zero-copy
+- `.array` will *always* be an ExtensionArray, and is always a zero-copy
    reference back to the data.
 - `.to_numpy()` is *always* a NumPy array, so you can reliably call
    ndarray-specific methods on it.


### PR DESCRIPTION
Correct grammar issues about a/an usage.   

I searched for patterns such as ``" a a"`` and ``" an c"`` in the GitHub codebase, because they are most likely to contain grammatical mistakes. Then I manually reviewed which ones needed to be changed.  These patterns are not exhaustive, so a few issues of ("a" vs "an") still remain.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
