### PR TITLE
BUG: Fix polluted window in rolling var

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1260,6 +1260,7 @@ Groupby/resample/rolling
 - Bug in :meth:`Rolling.skew` incorrectly computing skewness for windows following outliers due to numerical instability. The calculation now properly handles catastrophic cancellation by recomputing affected windows (:issue:`47461`)
 - Bug in :meth:`Series.resample` could raise when the date range ended shortly before a non-existent time. (:issue:`58380`)
 - Bug in :meth:`Series.resample` raising error when resampling non-nanosecond resolutions out of bounds for nanosecond precision (:issue:`57427`)
+- Bug in :meth:`Series.rolling.var` and :meth:`Series.rolling.std` computing incorrect results due to numerical instability. (:issue:`47721`, :issue:`52407`, :issue:`54518`, :issue:`55343`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -449,7 +449,7 @@ def roll_var(const float64_t[:] values, ndarray[int64_t] start,
 
             # Over the first window, observations can only be added
             # never removed
-            if i == 0 or not is_monotonic_increasing_bounds or s >= end[i - 1]:
+            if i == 0 or not is_monotonic_increasing_bounds or s < end[i]:
 
                 prev_value = values[s]
                 num_consecutive_same_value = 0

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -8,9 +8,6 @@ import pytest
 
 from pandas.compat import (
     IS64,
-    is_platform_arm,
-    is_platform_power,
-    is_platform_riscv64,
 )
 from pandas.errors import Pandas4Warning
 
@@ -1085,27 +1082,91 @@ def test_rolling_sem(frame_or_series):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    is_platform_arm() or is_platform_power() or is_platform_riscv64(),
-    reason="GH 38921",
-)
 @pytest.mark.parametrize(
-    ("func", "third_value", "values"),
+    ("func", "values", "window", "ddof", "expected_values"),
     [
-        ("var", 1, [5e33, 0, 0.5, 0.5, 2, 0]),
-        ("std", 1, [7.071068e16, 0, 0.7071068, 0.7071068, 1.414214, 0]),
-        ("var", 2, [5e33, 0.5, 0, 0.5, 2, 0]),
-        ("std", 2, [7.071068e16, 0.7071068, 0, 0.7071068, 1.414214, 0]),
+        ("var", [99999999999999999, 1, 1, 2, 3, 1, 1], 2, 1, [5e33, 0, 0.5, 0.5, 2, 0]),
+        (
+            "std",
+            [99999999999999999, 1, 1, 2, 3, 1, 1],
+            2,
+            1,
+            [7.071068e16, 0, 0.7071068, 0.7071068, 1.414214, 0],
+        ),
+        ("var", [99999999999999999, 1, 2, 2, 3, 1, 1], 2, 1, [5e33, 0.5, 0, 0.5, 2, 0]),
+        (
+            "std",
+            [99999999999999999, 1, 2, 2, 3, 1, 1],
+            2,
+            1,
+            [7.071068e16, 0.7071068, 0, 0.7071068, 1.414214, 0],
+        ),
+        (
+            "std",
+            [1.2e03, 1.3e17, 1.5e17, 1.995e03, 1.990e03],
+            2,
+            1,
+            [9.192388e16, 1.414214e16, 1.060660e17, 3.535534e00],
+        ),
+        (
+            "var",
+            [
+                0.00000000e00,
+                0.00000000e00,
+                3.16188252e-18,
+                2.95781651e-16,
+                2.23153542e-51,
+                0.00000000e00,
+                0.00000000e00,
+                5.39943432e-48,
+                1.38206260e-73,
+                0.00000000e00,
+            ],
+            3,
+            1,
+            [
+                3.33250036e-036,
+                2.88538519e-032,
+                2.88538519e-032,
+                2.91622617e-032,
+                1.65991678e-102,
+                9.71796366e-096,
+                9.71796366e-096,
+                9.71796366e-096,
+            ],
+        ),
+        (
+            "std",
+            [1, -1, 0, 1, 3, 2, -2, 10000000000, 1, 2, 0, -2, 1, 3, 0, 1],
+            6,
+            1,
+            [
+                1.41421356e00,
+                1.87082869e00,
+                4.08248290e09,
+                4.08248290e09,
+                4.08248290e09,
+                4.08248290e09,
+                4.08248290e09,
+                4.08248290e09,
+                1.72240142e00,
+                1.75119007e00,
+                1.64316767e00,
+            ],
+        ),
     ],
 )
-def test_rolling_var_numerical_issues(func, third_value, values):
-    # GH: 37051
-    ds = Series([99999999999999999, 1, third_value, 2, 3, 1, 1])
-    result = getattr(ds.rolling(2), func)()
-    expected = Series([np.nan] + values)
-    tm.assert_series_equal(result, expected)
+def test_rolling_var_correctness(func, values, window, ddof, expected_values):
+    # GH: 37051, 42064, 54518, 52407, 47721
+    ts = Series(values)
+    result = getattr(ts.rolling(window=window), func)(ddof=ddof)
+    if result.last_valid_index():
+        result = result[
+            result.first_valid_index() : result.last_valid_index() + 1
+        ].reset_index(drop=True)
+    expected = Series(expected_values)
+    tm.assert_series_equal(result, expected, atol=1e-55)
     # GH 42064
-    # new `roll_var` will output 0.0 correctly
     tm.assert_series_equal(result == 0, expected == 0)
 
 


### PR DESCRIPTION
- [x] closes #52407 (Replace xxxx with the GitHub issue number)
- [x] closes #55343
- [x] closes #54518
- [x] closes #47721
- [x] closes #38921
- [x] closes #41740
- [x] closes #37398
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

---

I took the tests from #62514.

The solution here is similar to the one in #62863, where I recompute the window if it detects numerical instability due to catastrophic cancellation.

Another point, is that I removed the consecutive value counts, because, for me, it's unnecessary, since I will recompute the window anyway if it detects severe loss of significant digits. Variance dropping to 0, or very close to, is a severe loss in significant digits which will trigger the recomputation.

The performance increase seen here must be because it is no longer counting consecutive values.

## Benchmarks

`asv continuous -f 1.1 -E virtualenv:3.13 upstream/main HEAD -b rolling.Methods`

| Change   | Before [f4851e50] <main>   | After [f0519a33] <fix/rolling-var-stability>   |   Ratio | Benchmark (Parameter)                                                       |
|----------|----------------------------|------------------------------------------------|---------|-----------------------------------------------------------------------------|
| -        | 1.90±0ms                   | 1.69±0ms                                       |    0.89 | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'std')    |
| -        | 2.05±0.01ms                | 1.81±0.02ms                                    |    0.88 | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'std')      |
| -        | 2.12±0.01ms                | 1.85±0.01ms                                    |    0.87 | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'std')   |
| -        | 2.01±0.02ms                | 1.74±0.01ms                                    |    0.86 | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'std') |

<details><summary>ASV Compare</summary>
<p>

```
| Change   | Before [f4851e50] <main>   | After [f0519a33] <fix/rolling-var-stability>   | Ratio   | Benchmark (Parameter)                                                                          |
|----------|----------------------------|------------------------------------------------|---------|------------------------------------------------------------------------------------------------|
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'count')               |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'kurt')                |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'max')                 |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'mean')                |
|          | 237M                       | 237M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'median')              |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'min')                 |
|          | 230M                       | 230M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'nunique')             |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'sem')                 |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'skew')                |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'std')                 |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'float', 'sum')                 |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'count')                 |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'kurt')                  |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'max')                   |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'mean')                  |
|          | 237M                       | 237M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'median')                |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'min')                   |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'nunique')               |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'sem')                   |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'skew')                  |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'std')                   |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('expanding', {}), 'int', 'sum')                   |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'count')   |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'kurt')    |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'max')     |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'mean')    |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'median')  |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'min')     |
|          | 226M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'nunique') |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'sem')     |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'skew')    |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'std')     |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'sum')     |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'count')     |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'kurt')      |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'max')       |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'mean')      |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'median')    |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'min')       |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'nunique')   |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'sem')       |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'skew')      |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'std')       |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'sum')       |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'count')     |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'kurt')      |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'max')       |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'mean')      |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'median')    |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'min')       |
|          | 226M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'nunique')   |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'sem')       |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'skew')      |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'std')       |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'float', 'sum')       |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'count')       |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'kurt')        |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'max')         |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'mean')        |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'median')      |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'min')         |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'nunique')     |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'sem')         |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'skew')        |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'std')         |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('DataFrame', ('rolling', {'window': 10}), 'int', 'sum')         |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'count')                  |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'kurt')                   |
|          | 224M                       | 224M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'max')                    |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'mean')                   |
|          | 236M                       | 236M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'median')                 |
|          | 224M                       | 224M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'min')                    |
|          | 229M                       | 229M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'nunique')                |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'sem')                    |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'skew')                   |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'std')                    |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'float', 'sum')                    |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'count')                    |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'kurt')                     |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'max')                      |
|          | 226M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'mean')                     |
|          | 237M                       | 237M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'median')                   |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'min')                      |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'nunique')                  |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'sem')                      |
|          | 226M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'skew')                     |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'std')                      |
|          | 226M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('expanding', {}), 'int', 'sum')                      |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'count')      |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'kurt')       |
|          | 224M                       | 224M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'max')        |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'mean')       |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'median')     |
|          | 224M                       | 224M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'min')        |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'nunique')    |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'sem')        |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'skew')       |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'std')        |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'float', 'sum')        |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'count')        |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'kurt')         |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'max')          |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'mean')         |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'median')       |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'min')          |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'nunique')      |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'sem')          |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'skew')         |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'std')          |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 1000}), 'int', 'sum')          |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'count')        |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'kurt')         |
|          | 224M                       | 224M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'max')          |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'mean')         |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'median')       |
|          | 224M                       | 224M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'min')          |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'nunique')      |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'sem')          |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'skew')         |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'std')          |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'float', 'sum')          |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'count')          |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'kurt')           |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'max')            |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'mean')           |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'median')         |
|          | 225M                       | 225M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'min')            |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'nunique')        |
|          | 228M                       | 228M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'sem')            |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'skew')           |
|          | 227M                       | 227M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'std')            |
|          | 226M                       | 226M                                           | 1.00    | rolling.Methods.peakmem_method('Series', ('rolling', {'window': 10}), 'int', 'sum')            |
|          | 1.92±0ms                   | 1.91±0.05ms                                    | 0.99    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'count')                  |
|          | 3.17±0.03ms                | 3.20±0.03ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'kurt')                   |
|          | 3.01±0.03ms                | 2.98±0.02ms                                    | 0.99    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'max')                    |
|          | 1.43±0.01ms                | 1.42±0.02ms                                    | 0.99    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'mean')                   |
|          | 138±3ms                    | 139±4ms                                        | 1.01    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'median')                 |
|          | 2.87±0.02ms                | 2.87±0.01ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'min')                    |
|          | 27.9±2ms                   | 28.4±0.3ms                                     | 1.02    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'nunique')                |
|          | 4.62±0.04ms                | 4.41±0.03ms                                    | 0.95    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'sem')                    |
|          | 1.96±0.01ms                | 1.98±0.02ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'skew')                   |
| -        | 2.01±0.02ms                | 1.74±0.01ms                                    | 0.86    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'std')                    |
|          | 1.41±0.01ms                | 1.41±0.01ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'sum')                    |
|          | 1.88±0.02ms                | 1.84±0.01ms                                    | 0.98    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'count')                    |
|          | 3.32±0.01ms                | 3.32±0.02ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'kurt')                     |
|          | 3.06±0.01ms                | 3.07±0.01ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'max')                      |
|          | 1.51±0.02ms                | 1.53±0.01ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'mean')                     |
|          | 110±3ms                    | 110±2ms                                        | 1.00    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'median')                   |
|          | 2.97±0.03ms                | 3.01±0.06ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'min')                      |
|          | 8.40±0.1ms                 | 8.53±0.2ms                                     | 1.02    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'nunique')                  |
|          | 4.69±0.02ms                | 4.46±0.05ms                                    | 0.95    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'sem')                      |
|          | 2.07±0.01ms                | 2.09±0.01ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'skew')                     |
| -        | 2.12±0.01ms                | 1.85±0.01ms                                    | 0.87    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'std')                      |
|          | 1.52±0.01ms                | 1.52±0.01ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'sum')                      |
|          | 2.40±0.2ms                 | 2.30±0.03ms                                    | 0.96    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'count')      |
|          | 3.98±0.02ms                | 3.99±0.03ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'kurt')       |
|          | 3.30±0.01ms                | 3.33±0.04ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'max')        |
|          | 1.83±0.01ms                | 1.79±0.01ms                                    | 0.97    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'mean')       |
|          | 79.9±0.6ms                 | 79.7±0.8ms                                     | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'median')     |
|          | 3.21±0.07ms                | 3.18±0.03ms                                    | 0.99    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'min')        |
|          | 29.5±0.1ms                 | 29.6±0.07ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'nunique')    |
|          | 5.82±0.02ms                | 5.87±0.02ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'sem')        |
|          | 2.94±0.03ms                | 2.94±0.02ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'skew')       |
|          | 2.79±0.01ms                | 2.78±0.01ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'std')        |
|          | 1.75±0.01ms                | 1.75±0.01ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'sum')        |
|          | 2.25±0.01ms                | 2.25±0.02ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'count')        |
|          | 4.14±0.2ms                 | 4.14±0.03ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'kurt')         |
|          | 3.37±0.09ms                | 3.39±0.05ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'max')          |
|          | 1.99±0.01ms                | 1.91±0.01ms                                    | 0.96    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'mean')         |
|          | 79.7±0.6ms                 | 80.6±5ms                                       | 1.01    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'median')       |
|          | 3.22±0.01ms                | 3.23±0.01ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'min')          |
|          | 19.0±0.2ms                 | 18.4±0.1ms                                     | 0.97    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'nunique')      |
|          | 5.89±0.03ms                | 5.90±0.02ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'sem')          |
|          | 3.08±0.04ms                | 3.05±0.01ms                                    | 0.99    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'skew')         |
|          | 2.91±0.01ms                | 2.88±0.01ms                                    | 0.99    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'std')          |
|          | 1.90±0.02ms                | 1.90±0.01ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'sum')          |
|          | 2.30±0.01ms                | 2.33±0.01ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'count')        |
|          | 4.01±0.02ms                | 4.02±0.02ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'kurt')         |
|          | 3.34±0.04ms                | 3.37±0.05ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'max')          |
|          | 1.84±0.05ms                | 1.83±0.02ms                                    | 0.99    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'mean')         |
|          | 33.7±0.6ms                 | 33.7±0.2ms                                     | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'median')       |
|          | 3.26±0.04ms                | 3.27±0.03ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'min')          |
|          | 26.5±0.6ms                 | 26.5±0.4ms                                     | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'nunique')      |
|          | 5.88±0.1ms                 | 5.86±0.04ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'sem')          |
|          | 2.95±0.03ms                | 2.96±0.09ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'skew')         |
|          | 2.79±0.01ms                | 2.80±0.03ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'std')          |
|          | 1.78±0.2ms                 | 1.81±0.05ms                                    | 1.02    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'sum')          |
|          | 2.25±0.01ms                | 2.27±0.02ms                                    | 1.01    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'count')          |
|          | 4.14±0.04ms                | 4.15±0.02ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'kurt')           |
|          | 3.46±0.05ms                | 3.41±0.01ms                                    | 0.99    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'max')            |
|          | 1.98±0.01ms                | 1.94±0.02ms                                    | 0.98    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'mean')           |
|          | 34.2±0.3ms                 | 34.2±0.5ms                                     | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'median')         |
|          | 3.37±0.05ms                | 3.37±0.03ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'min')            |
|          | 25.4±0.5ms                 | 25.3±0.3ms                                     | 0.99    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'nunique')        |
|          | 5.97±0.03ms                | 6.10±0.1ms                                     | 1.02    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'sem')            |
|          | 3.07±0.02ms                | 3.16±0.02ms                                    | 1.03    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'skew')           |
|          | 2.94±0.08ms                | 2.98±0.1ms                                     | 1.02    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'std')            |
|          | 1.89±0.01ms                | 1.90±0.03ms                                    | 1.00    | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'int', 'sum')            |
|          | 1.85±0.03ms                | 1.81±0.02ms                                    | 0.98    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'count')                     |
|          | 3.15±0.03ms                | 3.16±0.02ms                                    | 1.00    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'kurt')                      |
|          | 2.95±0.01ms                | 2.95±0.02ms                                    | 1.00    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'max')                       |
|          | 1.36±0.01ms                | 1.37±0.01ms                                    | 1.01    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'mean')                      |
|          | 139±5ms                    | 138±5ms                                        | 0.99    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'median')                    |
|          | 2.81±0.01ms                | 2.86±0.03ms                                    | 1.02    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'min')                       |
|          | 27.7±0.1ms                 | 28.1±0.3ms                                     | 1.01    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'nunique')                   |
|          | 4.38±0.09ms                | 4.08±0.1ms                                     | 0.93    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'sem')                       |
|          | 1.95±0.02ms                | 1.94±0.03ms                                    | 0.99    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'skew')                      |
| -        | 1.90±0ms                   | 1.69±0ms                                       | 0.89    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'std')                       |
|          | 1.39±0.06ms                | 1.36±0.01ms                                    | 0.98    | rolling.Methods.time_method('Series', ('expanding', {}), 'float', 'sum')                       |
|          | 1.77±0.03ms                | 1.75±0.01ms                                    | 0.99    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'count')                       |
|          | 3.24±0.03ms                | 3.23±0.03ms                                    | 1.00    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'kurt')                        |
|          | 3.04±0.06ms                | 3.02±0.02ms                                    | 1.00    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'max')                         |
|          | 1.46±0.01ms                | 1.48±0.01ms                                    | 1.01    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'mean')                        |
|          | 111±4ms                    | 110±2ms                                        | 0.99    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'median')                      |
|          | 2.92±0.08ms                | 2.92±0.03ms                                    | 1.00    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'min')                         |
|          | 8.26±0.1ms                 | 8.59±0.1ms                                     | 1.04    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'nunique')                     |
|          | 4.38±0.02ms                | 4.13±0.03ms                                    | 0.94    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'sem')                         |
|          | 2.00±0.02ms                | 2.01±0.03ms                                    | 1.01    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'skew')                        |
| -        | 2.05±0.01ms                | 1.81±0.02ms                                    | 0.88    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'std')                         |
|          | 1.47±0ms                   | 1.47±0.01ms                                    | 1.00    | rolling.Methods.time_method('Series', ('expanding', {}), 'int', 'sum')                         |
|          | 2.19±0.01ms                | 2.21±0.01ms                                    | 1.01    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'count')         |
|          | 3.95±0.02ms                | 3.95±0.04ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'kurt')          |
|          | 3.24±0.01ms                | 3.23±0.01ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'max')           |
|          | 1.79±0.01ms                | 1.70±0.01ms                                    | 0.95    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'mean')          |
|          | 79.5±0.5ms                 | 79.2±0.5ms                                     | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'median')        |
|          | 3.12±0.03ms                | 3.14±0.01ms                                    | 1.01    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'min')           |
|          | 29.5±3ms                   | 30.7±0.2ms                                     | 1.04    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'nunique')       |
|          | 5.66±0.4ms                 | 5.61±0.05ms                                    | 0.99    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'sem')           |
|          | 2.88±0.01ms                | 2.90±0.01ms                                    | 1.01    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'skew')          |
|          | 2.70±0.01ms                | 2.70±0.02ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'std')           |
|          | 1.73±0.06ms                | 1.71±0.01ms                                    | 0.98    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'float', 'sum')           |
|          | 2.13±0.01ms                | 2.14±0.01ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'count')           |
|          | 4.05±0.01ms                | 4.10±0.01ms                                    | 1.01    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'kurt')            |
|          | 3.30±0.01ms                | 3.30±0.02ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'max')             |
|          | 2.01±0.2ms                 | 1.86±0.02ms                                    | 0.93    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'mean')            |
|          | 80.1±0.8ms                 | 78.9±0.7ms                                     | 0.99    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'median')          |
|          | 3.20±0.03ms                | 3.18±0.02ms                                    | 0.99    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'min')             |
|          | 19.1±0.2ms                 | 18.6±0.2ms                                     | 0.97    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'nunique')         |
|          | 5.60±0.01ms                | 5.61±0.01ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'sem')             |
|          | 2.98±0.03ms                | 2.99±0.01ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'skew')            |
|          | 2.83±0.02ms                | 2.85±0.01ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'std')             |
|          | 1.85±0.03ms                | 1.83±0.01ms                                    | 0.99    | rolling.Methods.time_method('Series', ('rolling', {'window': 1000}), 'int', 'sum')             |
|          | 2.23±0.02ms                | 2.23±0.01ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'count')           |
|          | 3.94±0.03ms                | 3.95±0.03ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'kurt')            |
|          | 3.30±0.02ms                | 3.76±0.3ms                                     | ~1.14   | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'max')             |
|          | 1.81±0.02ms                | 1.71±0.01ms                                    | 0.94    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'mean')            |
|          | 33.6±0.2ms                 | 33.4±0.4ms                                     | 0.99    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'median')          |
|          | 3.20±0.01ms                | 3.21±0.02ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'min')             |
|          | 26.1±0.1ms                 | 27.1±0.5ms                                     | 1.04    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'nunique')         |
|          | 6.08±0.5ms                 | 5.59±0.03ms                                    | 0.92    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'sem')             |
|          | 2.91±0.02ms                | 2.90±0.05ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'skew')            |
|          | 2.71±0.01ms                | 2.72±0.01ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'std')             |
|          | 1.71±0.1ms                 | 1.70±0.02ms                                    | 0.99    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'sum')             |
|          | 2.17±0.01ms                | 2.14±0.01ms                                    | 0.99    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'count')             |
|          | 4.07±0.01ms                | 4.11±0.08ms                                    | 1.01    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'kurt')              |
|          | 3.40±0.02ms                | 3.34±0.01ms                                    | 0.98    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'max')               |
|          | 1.94±0.01ms                | 1.85±0.01ms                                    | 0.95    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'mean')              |
|          | 34.2±0.2ms                 | 33.5±0.3ms                                     | 0.98    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'median')            |
|          | 3.30±0.01ms                | 3.31±0.04ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'min')               |
|          | 25.2±0.2ms                 | 25.1±0.3ms                                     | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'nunique')           |
|          | 5.63±0.03ms                | 5.60±0.02ms                                    | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'sem')               |
|          | 3.02±0.01ms                | 2.96±0.06ms                                    | 0.98    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'skew')              |
|          | 2.92±0.08ms                | 2.83±0.02ms                                    | 0.97    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'std')               |
|          | 1.84±0.01ms                | 1.85±0ms                                       | 1.00    | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'int', 'sum')               |
```

</p>
</details> 