### PR TITLE
TST: Replace ensure_clean_store with tmp_path in io/pytables/test_categorical.py

### DIFF
--- a/pandas/tests/io/pytables/test_categorical.py
+++ b/pandas/tests/io/pytables/test_categorical.py
@@ -4,6 +4,7 @@ import pytest
 from pandas import (
     Categorical,
     DataFrame,
+    HDFStore,
     Series,
     _testing as tm,
     concat,
@@ -11,14 +12,14 @@ from pandas import (
 )
 from pandas.tests.io.pytables.common import (
     _maybe_remove,
-    ensure_clean_store,
 )
 
 pytestmark = [pytest.mark.single_cpu]
 
 
-def test_categorical(setup_path):
-    with ensure_clean_store(setup_path) as store:
+def test_categorical(tmp_path):
+    path = tmp_path / "test_categorical.h5"
+    with HDFStore(path) as store:
         # Basic
         _maybe_remove(store, "s")
         s = Series(


### PR DESCRIPTION
### What does this PR do?
* Update `pandas/tests/io/pytables/test_categorical.py` from using the custom `ensure_clean_store` utility to the standard pytest `tmp_path` fixture.

### Why is this change needed?
* Issue #62435 

### Testing
* All existing tests pass
* No behavioral changes to the tests

