### PR TITLE
CI: Use manylinux_2_28 for 32 bit tests job

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -216,7 +216,7 @@ jobs:
   Linux-32-bit:
     runs-on: ubuntu-24.04
     container:
-      image: quay.io/pypa/manylinux2014_i686
+      image: quay.io/pypa/manylinux_2_28_i686
       options: --platform linux/386
     steps:
       - name: Checkout pandas Repo


### PR DESCRIPTION
Testing with a newer image. I'd say we're free to bump since we don't release 32 bit wheels