### PR TITLE
CLN: move away from numpy.fix in favor of numpy.trunc

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -3492,7 +3492,7 @@ default 'raise'
             year -= 1
             month += 12
         return (day +
-                np.fix((153 * month - 457) / 5) +
+                np.trunc((153 * month - 457) / 5) +
                 365 * year +
                 np.floor(year / 4) -
                 np.floor(year / 100) +

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2287,7 +2287,7 @@ default 'raise'
         month[testarr] += 12
         return (
             day
-            + np.fix((153 * month - 457) / 5)
+            + np.trunc((153 * month - 457) / 5)
             + 365 * year
             + np.floor(year / 4)
             - np.floor(year / 100)


### PR DESCRIPTION
This PR replaces all occurrences of `numpy.fix` with `numpy.trunc`. This is in response to [a currently discussed deprecation of `numpy.fix`](https://mail.python.org/archives/list/numpy-discussion@python.org/thread/LYRHETXPN32S7FNHKNLJFDIYWGQHLODJ/) as well as performance considerations (nice, but secondary).

This change should not change anything in a meaningful way, internally or externally.

It is, however, unclear to me whether this PR should also remove `test_np_fix` in `test_ufunc.py`. I opted to keep it. If desired, I can make this part of the PR. It is worth noting that no corresponding `test_np_trunc` exists (should it?). https://github.com/pandas-dev/pandas/blob/3157d077fd9ecc67d522e68a8e4d5b30f3208cf4/pandas/tests/series/test_ufunc.py#L460-L467

Cheers