### PR TITLE
BUG: Fix segfault in read_csv with extremely large exponents

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1512,12 +1512,13 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     int n = 0;
     // Prevent integer overflow by capping exponent value
     // DBL_MAX_EXP is typically 1024, so we use a safe upper bound
-    const int MAX_EXPONENT_DIGITS = 4;  // Allows up to 9999
+    const int MAX_EXPONENT_DIGITS = 4; // Allows up to 9999
     while (isdigit_ascii(*p)) {
       if (num_digits < MAX_EXPONENT_DIGITS) {
         n = n * 10 + (*p - '0');
       }
-      // Continue consuming digits even after cap to maintain correct parsing position
+      // Continue consuming digits even after cap to maintain correct parsing
+      // position
       num_digits++;
       p++;
     }

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1510,8 +1510,14 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     // Process string of digits.
     num_digits = 0;
     int n = 0;
+    // Prevent integer overflow by capping exponent value
+    // DBL_MAX_EXP is typically 1024, so we use a safe upper bound
+    const int MAX_EXPONENT_DIGITS = 4;  // Allows up to 9999
     while (isdigit_ascii(*p)) {
-      n = n * 10 + (*p - '0');
+      if (num_digits < MAX_EXPONENT_DIGITS) {
+        n = n * 10 + (*p - '0');
+      }
+      // Continue consuming digits even after cap to maintain correct parsing position
       num_digits++;
       p++;
     }

--- a/pandas/tests/io/parser/test_issue_63089.py
+++ b/pandas/tests/io/parser/test_issue_63089.py
@@ -1,9 +1,10 @@
 """
 Test for issue #63089 - read_csv segfault with large exponent
 """
+
 import io
+
 import pandas as pd
-import pytest
 
 
 class TestIssue63089:
@@ -11,27 +12,30 @@ class TestIssue63089:
         """Test that extremely large exponents don't cause segfault."""
         # This previously caused SIGSEGV due to integer overflow
         # when parsing the exponent
-        result = pd.read_csv(io.StringIO("""h
-4e492493924924"""))
-        
+        result = pd.read_csv(
+            io.StringIO("""h
+4e492493924924""")
+        )
+
         # Should parse as infinity or large float, not crash
         assert len(result) == 1
-        assert 'h' in result.columns
+        assert "h" in result.columns
         # The value should be infinity since the exponent is way too large
         import numpy as np
-        assert np.isinf(result['h'].iloc[0]) or result['h'].iloc[0] > 1e308
-    
+
+        assert np.isinf(result["h"].iloc[0]) or result["h"].iloc[0] > 1e308
+
     def test_various_large_exponents(self):
         """Test various edge cases with large exponents."""
         test_cases = [
             "1e999999999",  # Very large positive exponent
-            "1e-999999999",  # Very large negative exponent  
+            "1e-999999999",  # Very large negative exponent
             "2.5e123456789",  # Large exponent with decimal
         ]
-        
+
         for test_val in test_cases:
             csv_data = f"col\n{test_val}"
             result = pd.read_csv(io.StringIO(csv_data))
             # Should not crash, result should be inf, 0, or valid float
             assert len(result) == 1
-            assert not pd.isna(result['col'].iloc[0]) or True  # Just don't crash
+            assert not pd.isna(result["col"].iloc[0]) or True  # Just don't crash

--- a/pandas/tests/io/parser/test_issue_63089.py
+++ b/pandas/tests/io/parser/test_issue_63089.py
@@ -1,0 +1,37 @@
+"""
+Test for issue #63089 - read_csv segfault with large exponent
+"""
+import io
+import pandas as pd
+import pytest
+
+
+class TestIssue63089:
+    def test_large_exponent_no_segfault(self):
+        """Test that extremely large exponents don't cause segfault."""
+        # This previously caused SIGSEGV due to integer overflow
+        # when parsing the exponent
+        result = pd.read_csv(io.StringIO("""h
+4e492493924924"""))
+        
+        # Should parse as infinity or large float, not crash
+        assert len(result) == 1
+        assert 'h' in result.columns
+        # The value should be infinity since the exponent is way too large
+        import numpy as np
+        assert np.isinf(result['h'].iloc[0]) or result['h'].iloc[0] > 1e308
+    
+    def test_various_large_exponents(self):
+        """Test various edge cases with large exponents."""
+        test_cases = [
+            "1e999999999",  # Very large positive exponent
+            "1e-999999999",  # Very large negative exponent  
+            "2.5e123456789",  # Large exponent with decimal
+        ]
+        
+        for test_val in test_cases:
+            csv_data = f"col\n{test_val}"
+            result = pd.read_csv(io.StringIO(csv_data))
+            # Should not crash, result should be inf, 0, or valid float
+            assert len(result) == 1
+            assert not pd.isna(result['col'].iloc[0]) or True  # Just don't crash

--- a/reproduce_issue_63089.py
+++ b/reproduce_issue_63089.py
@@ -1,0 +1,11 @@
+import io
+import pandas as pd
+
+print("Testing issue #63089...")
+try:
+    result = pd.read_csv(io.StringIO("""h
+4e492493924924"""))
+    print("Success! Result:")
+    print(result)
+except Exception as e:
+    print(f"Exception occurred: {type(e).__name__}: {e}")

--- a/reproduce_issue_63089.py
+++ b/reproduce_issue_63089.py
@@ -1,10 +1,13 @@
 import io
+
 import pandas as pd
 
 print("Testing issue #63089...")
 try:
-    result = pd.read_csv(io.StringIO("""h
-4e492493924924"""))
+    result = pd.read_csv(
+        io.StringIO("""h
+4e492493924924""")
+    )
     print("Success! Result:")
     print(result)
 except Exception as e:


### PR DESCRIPTION
Closes #63089

## Description

This PR fixes a segmentation fault that occurs when reading CSV files containing numbers with extremely large exponents in scientific notation (e.g., `4e492493924924`).

## Root Cause

The issue was an integer overflow in the `xstrtod()` function in `pandas/_libs/src/parser/tokenizer.c`. When parsing the exponent portion of scientific notation, the code accumulated digits into an `int` variable without bounds checking:

```c
int n = 0;
while (isdigit_ascii(*p)) {
    n = n * 10 + (*p - '0');  // Integer overflow with large exponents
    num_digits++;
    p++;
}
```

With an exponent like `492493924924`, the variable `n` would overflow, causing undefined behavior that manifests as a segmentation fault.

## Solution

I added a maximum digit cap (`MAX_EXPONENT_DIGITS = 4`) when accumulating the exponent value:

- Only the first 4 digits are used for the actual exponent value (allowing up to 9999)
- Remaining digits are still consumed to maintain correct parsing position
- This is sufficient since valid double-precision exponents are limited to roughly ±308 anyway
- The existing range check (`DBL_MIN_EXP` to `DBL_MAX_EXP`) will properly handle out-of-range values

## Testing

Added `test_issue_63089.py` with test cases covering:
- The exact case from the issue report
- Various edge cases with extremely large positive and negative exponents
- Numbers with decimal points and large exponents

The fix prevents the overflow while maintaining correct parsing behavior for valid scientific notation.

---
**Checklist:**
- [x] Closes #63089
- [x] Added test case
- [x] All existing tests should pass (haven't run full suite locally due to build dependencies)