### PR TITLE
TST: change np.fix test to np.trunc

### DIFF
--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -457,11 +457,12 @@ def test_array_ufuncs_for_many_arguments():
         ufunc(ser, ser, df)
 
 
-@pytest.mark.xfail(reason="see https://github.com/pandas-dev/pandas/pull/51082")
-def test_np_fix():
-    # np.fix is not a ufunc but is composed of several ufunc calls under the hood
-    # with `out` and `where` keywords
+def test_np_trunc():
+    # This used to test np.fix, which is not a ufunc but is composed of
+    # several ufunc calls under the hood with `out` and `where` keywords. But numpy
+    # is deprecating that (or at least discussing deprecating) in favor of np.trunc,
+    # which _is_ a ufunc without the out keyword usage.
     ser = pd.Series([-1.5, -0.5, 0.5, 1.5])
-    result = np.fix(ser)
+    result = np.trunc(ser)
     expected = pd.Series([-1.0, -0.0, 0.0, 1.0])
     tm.assert_series_equal(result, expected)


### PR DESCRIPTION
The np.fix test is currently causing the CI to fail on newer versions of numpy.  I suspect this is related to the discussion I've seen on their mailing list about deprecating np.fix in favor of np.trunc.  So this PR changes that test to use np.trunc instead.