### PR TITLE
CLN: remove redundant type check in test_na_values_scalar

### DIFF
--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -499,15 +499,10 @@ def test_na_values_scalar(all_parsers, na_values, row_data):
     data = "1,2\n2,1"
 
     if parser.engine == "pyarrow" and isinstance(na_values, dict):
-        if isinstance(na_values, dict):
-            err = ValueError
-            msg = "The pyarrow engine doesn't support passing a dict for na_values"
-        else:
-            err = TypeError
-            msg = "The 'pyarrow' engine requires all na_values to be strings"
-        with pytest.raises(err, match=msg):
+        msg = "The pyarrow engine doesn't support passing a dict for na_values"
+        with pytest.raises(ValueError, match=msg):
             parser.read_csv(StringIO(data), names=names, na_values=na_values)
-        return
+        return 
     elif parser.engine == "pyarrow":
         msg = "The 'pyarrow' engine requires all na_values to be strings"
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -502,7 +502,7 @@ def test_na_values_scalar(all_parsers, na_values, row_data):
         msg = "The pyarrow engine doesn't support passing a dict for na_values"
         with pytest.raises(ValueError, match=msg):
             parser.read_csv(StringIO(data), names=names, na_values=na_values)
-        return 
+        return
     elif parser.engine == "pyarrow":
         msg = "The 'pyarrow' engine requires all na_values to be strings"
         with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
### What does this PR changes?

This PR cleans up a redundant nested `isinstance(na_values, dict)` check in `test_na_values_scaler` for the `"pyarrow"` engine.
The inner check was always true and the `else` branch was unreachable.

### Behavior after this PR 

- When `parser.engine == "pyarrow"` and `na_values` is a dict:
    - `ValueError` is still expected.
- When `parser.engine == "pyarrow"` and `na_values` is invalid (non-string types):
    - `TypeError` is still expected.

### Issue reference 

Closes #63119 

### Checklist
- [x] Tests pass locally (`233 passed, 1 skipped, 18 xfailed`)
- [x] Code cleanup only - no behavior changes
- [x]  Follows pandas contribution guidelines 