### PR TITLE
Bug: Strings in Excel number fomat do not preserve case(fixes #6317)

### DIFF
--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -21,18 +21,21 @@ if TYPE_CHECKING:
 
 
 def _normalize_number_format_value(value: str) -> str:
-    value = value.strip()
-    out: list[str] = []
-    in_string = False
+    out = []
+    in_single = False
+    in_double = False
 
-    for ch in value:
-        if ch == '"':
+    for ch in value.strip():
+        if ch == "'" and not in_double:
+            in_single = not in_single
             out.append(ch)
-            in_string = not in_string
-        elif in_string:
-            out.append(ch)  # preserve case inside string literals
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+            out.append(ch)
+        elif in_single or in_double:
+            out.append(ch)
         else:
-            out.append(ch.lower())  # normalize outside literals
+            out.append(ch.lower())
     return "".join(out)
 
 

--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -391,7 +391,10 @@ class CSSResolver:
     def atomize(self, declarations: Iterable) -> Generator[tuple[str, str]]:
         for prop, value in declarations:
             prop = prop.lower()
-            value = value.lower()
+            if prop == "number-format":
+                value = value.strip()
+            else:
+                value = value.lower()
             if prop in self.CSS_EXPANSIONS:
                 expand = self.CSS_EXPANSIONS[prop]
                 yield from expand(self, prop, value)
@@ -414,7 +417,10 @@ class CSSResolver:
             prop, sep, val = decl.partition(":")
             prop = prop.strip().lower()
             # TODO: don't lowercase case sensitive parts of values (strings)
-            val = val.strip().lower()
+            if prop == "number-format":
+                val = val.strip()
+            else:
+                val = val.strip().lower()
             if sep:
                 yield prop, val
             else:

--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -19,13 +19,8 @@ if TYPE_CHECKING:
         Iterator,
     )
 
-def _normalize_number_format_value(value: str) -> str:
-    """
-    Lowercase number-format value except for text inside double quotes.
 
-    This preserves case for string literals (e.g. "M") while still
-    normalizing things like [Red] -> [red].
-    """
+def _normalize_number_format_value(value: str) -> str:
     value = value.strip()
     out: list[str] = []
     in_string = False
@@ -34,11 +29,10 @@ def _normalize_number_format_value(value: str) -> str:
         if ch == '"':
             out.append(ch)
             in_string = not in_string
+        elif in_string:
+            out.append(ch)  # preserve case inside string literals
         else:
-            if in_string:
-                out.append(ch)       # preserve case inside string literals
-            else:
-                out.append(ch.lower())  # normalize outside literals
+            out.append(ch.lower())  # normalize outside literals
     return "".join(out)
 
 

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -96,6 +96,7 @@ shared_style_params = [
     ("font-style: italic;", ["font", "i"], True),
     ("text-decoration: underline;", ["font", "u"], "single"),
     ("number-format: $??,???.00;", ["number_format"], "$??,???.00"),
+    ("number-format: #,,"'"M";', ["number_format"], '#,,"M"'),
     ("text-align: left;", ["alignment", "horizontal"], "left"),
     (
         "vertical-align: bottom;",

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -96,7 +96,7 @@ shared_style_params = [
     ("font-style: italic;", ["font", "i"], True),
     ("text-decoration: underline;", ["font", "u"], "single"),
     ("number-format: $??,???.00;", ["number_format"], "$??,???.00"),
-    ("number-format: #,,"'"M";', ["number_format"], '#,,"M"'),
+    ('number-format: #,,"M";', ["number_format"], '#,,"M"'),
     ("text-align: left;", ["alignment", "horizontal"], "left"),
     (
         "vertical-align: bottom;",

--- a/pandas/tests/io/formats/test_css.py
+++ b/pandas/tests/io/formats/test_css.py
@@ -286,3 +286,21 @@ def test_css_relative_font_size(size, relative_to, resolved):
     else:
         inherited = {"font-size": relative_to}
     assert_resolves(f"font-size: {size}", {"font-size": resolved}, inherited=inherited)
+
+def test_css_atomize_preserves_number_format_case():
+    resolver = CSSResolver()
+    declarations = [("NUMBER-FORMAT", '#,,"M"')]
+
+    props = dict(resolver.atomize(declarations))
+
+    assert "number-format" in props
+    assert props["number-format"] == '#,,"M"'
+
+def test_css_parse_preserves_number_format_case():
+    resolver = CSSResolver()
+
+    css = 'NUMBER-FORMAT: #,,"M"; COLOR: Red'
+    result = dict(resolver.parse(css))
+
+    assert result["number-format"] == '#,,"M"'
+    assert result["color"] == "red"

--- a/pandas/tests/io/formats/test_css.py
+++ b/pandas/tests/io/formats/test_css.py
@@ -287,6 +287,7 @@ def test_css_relative_font_size(size, relative_to, resolved):
         inherited = {"font-size": relative_to}
     assert_resolves(f"font-size: {size}", {"font-size": resolved}, inherited=inherited)
 
+
 def test_css_atomize_preserves_number_format_case():
     resolver = CSSResolver()
     declarations = [("NUMBER-FORMAT", '#,,"M"')]
@@ -295,6 +296,7 @@ def test_css_atomize_preserves_number_format_case():
 
     assert "number-format" in props
     assert props["number-format"] == '#,,"M"'
+
 
 def test_css_parse_preserves_number_format_case():
     resolver = CSSResolver()


### PR DESCRIPTION
This PR fixes incorrect lowercasing of Excel number-format string literals during CSS parsing and atomization. Pandas previously lowercased all CSS values, which corrupted custom number formats (e.g., "M" → "m").

The fix treats number-format as a special case in both parse() and atomize(), preserving user-provided casing. Additional unit tests verify this behavior and ensure compatibility with existing CSS resolution behavior

- [ ] closes #63101(Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
