### PR TITLE
TST: Add regression test for groupby().apply() external mutation

### DIFF
--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1529,18 +1529,14 @@ def test_groupby_apply_store_copy():
         }
     )
 
-    # Empty dict to hold the chunks
     store = {}
 
     def addstore(x):
         store[len(store)] = x.copy()
 
     df.groupby("B").apply(addstore)
-
-    # Output boolean mask
     out_mask = {0: [True, False, True, False], 1: [False, True, False, True]}
 
-    # The expected output in store dict
     expected_out = {0: df[out_mask[0]], 1: df[out_mask[1]]}
 
     tm.assert_frame_equal(store[0], expected_out[0].drop("B", axis=1))

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1536,8 +1536,8 @@ def test_groupby_apply_store_copy():
 
     df.groupby("B").apply(addstore)
 
-    expected_out_0 = df.iloc[[0, 2], 0]
-    expected_out_1 = df.iloc[[1, 3], 0]
+    expected_out_0 = df.iloc[[0, 2], [0]]
+    expected_out_1 = df.iloc[[1, 3], [0]]
 
-    tm.assert_series_equal(store[0]["A"], expected_out_0)
-    tm.assert_series_equal(store[1]["A"], expected_out_1)
+    tm.assert_frame_equal(store[0], expected_out_0)
+    tm.assert_frame_equal(store[1], expected_out_1)

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1535,9 +1535,9 @@ def test_groupby_apply_store_copy():
         store[len(store)] = x.copy()
 
     df.groupby("B").apply(addstore)
-    out_mask = {0: [True, False, True, False], 1: [False, True, False, True]}
 
-    expected_out = {0: df[out_mask[0]], 1: df[out_mask[1]]}
+    expected_out_0 = df.iloc[[0, 2], 0]
+    expected_out_1 = df.iloc[[1, 3], 0]
 
-    tm.assert_frame_equal(store[0], expected_out[0].drop("B", axis=1))
-    tm.assert_frame_equal(store[1], expected_out[1].drop("B", axis=1))
+    tm.assert_series_equal(store[0]["A"], expected_out_0)
+    tm.assert_series_equal(store[1]["A"], expected_out_1)


### PR DESCRIPTION
GH-40673: Adds a test case to prevent regression of a bug where the internal object reused by apply() would corrupt externally stored DataFrames created with .copy(). This test verifies that store[0] and store[1] correctly contain independent copies of their respective groups.

- [x] closes #40673
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
