### PR TITLE
BUG: Inconsistency of BooleanArray.__and__ with pd.NA and [pd.NA](fix…

### DIFF
--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -397,7 +397,7 @@ class BooleanArray(BaseMaskedArray):
         if isinstance(other, BooleanArray):
             other, mask = other._data, other._mask
         elif is_list_like(other):
-            other = np.asarray(other, dtype="bool")
+            other = np.asarray(other, dtype=object)
             if other.ndim > 1:
                 return NotImplemented
             other, mask = coerce_to_array(other, copy=False)

--- a/pandas/tests/arrays/boolean/test_ops.py
+++ b/pandas/tests/arrays/boolean/test_ops.py
@@ -25,3 +25,9 @@ class TestUnaryOps:
         result = abs(arr)
 
         tm.assert_extension_array_equal(result, arr)
+
+    def test_booleanarray_and_list_with_na(self):
+        b = pd.array([True, False], dtype="boolean")
+        result = b & [pd.NA, False]
+        expected = pd.array([pd.NA, False], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)


### PR DESCRIPTION
This pull request fixes an inconsistency in how `BooleanArray` handles logical operations when the right-hand side is a list-like object containing `pd.NA`.  The root cause is in the implementation of `_logical_method`, where list-like operands are coerced with `np.asarray(other, dtype="bool")`. When `other` contains `pd.NA`, NumPy attempts to evaluate `bool(pd.NA)`, which always raises `TypeError`. This prevents pandas from constructing the appropriate boolean data array and mask that represent missing values in a `BooleanArray`. 

The fix replaces the unsafe boolean casting with a safe conversion that preserves `pd.NA` values. Instead of forcing `dtype="bool"`, the code now converts the input to an object array and passes it through `coerce_to_array`, which correctly constructs both the underlying boolean data and the mask that identifies missing entries. This allows pandas to evaluate expressions like `b & [pd.NA, False]` using its normal element-wise logic and return the correct result. 

- [ ] closes #63095(Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
