### PR TITLE
BUG: define `__Pyx_PyUnstable_Object_IsUniqueReferencedTemporary` for python<3.14

### DIFF
--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -1006,8 +1006,11 @@ cdef class BlockValuesRefs:
 
 cdef extern from "Python.h":
     """
+    // python version < 3.14
     #if PY_VERSION_HEX < 0x030E0000
-    int __Pyx_PyUnstable_Object_IsUniqueReferencedTemporary(PyObject *ref);
+    int __Pyx_PyUnstable_Object_IsUniqueReferencedTemporary(PyObject *ref) {
+        return Py_REFCNT(ref) == 1;
+    }
     #else
     #define __Pyx_PyUnstable_Object_IsUniqueReferencedTemporary \
         PyUnstable_Object_IsUniqueReferencedTemporary

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -1008,6 +1008,7 @@ cdef extern from "Python.h":
     """
     // python version < 3.14
     #if PY_VERSION_HEX < 0x030E0000
+    // This function is unused and is declared to avoid a build warning
     int __Pyx_PyUnstable_Object_IsUniqueReferencedTemporary(PyObject *ref) {
         return Py_REFCNT(ref) == 1;
     }


### PR DESCRIPTION
- [x] closes #63128 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

Just want to point out that this definition is somewhat useless because just below this definition we have:

```cython
# Python version compatibility for PyUnstable_Object_IsUniqueReferencedTemporary
cdef inline bint _is_unique_referenced_temporary(object obj) except -1:
    if PY_VERSION_HEX >= 0x030E0000:
        # Python 3.14+ has PyUnstable_Object_IsUniqueReferencedTemporary
        return PyUnstable_Object_IsUniqueReferencedTemporary(obj)
    else:
        # Fallback for older Python versions using sys.getrefcount
        return sys.getrefcount(obj) <= 1
```

The new definition isn't used for Python<3.14, and uses the CPython definition for Python >=3.14. But at least the symbol is defined and won't cause import errors:

```console
$ nm build/cp313d/pandas/_libs/internals.cpython-313d-x86_64-linux-gnu.so | grep Unique
0000000000000d00 t __Pyx_PyUnstable_Object_IsUniqueReferencedTemporary
```