### PR TITLE
BUG: handle overflow in `group_sum`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .noseids
 .ipynb_checkpoints
 .tags
+tags
 .cache/
 .vscode/
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1237,6 +1237,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGroupBy.groups` and :meth:`.SeriesGroupby.groups` that would not respect groupby argument ``dropna`` (:issue:`55919`)
 - Bug in :meth:`.DataFrameGroupBy.median` where nat values gave an incorrect result. (:issue:`57926`)
 - Bug in :meth:`.DataFrameGroupBy.quantile` when ``interpolation="nearest"`` is inconsistent with :meth:`DataFrame.quantile` (:issue:`47942`)
+- Bug in :meth:`.DataFrameGroupBy.sum` and :meth:`.SeriesGroupby.groups` returning ``NaN`` on overflow. These methods now returns ``inf`` or ``-inf`` on overflow. (:issue:`60303`)
 - Bug in :meth:`.DataFrameGroupBy` reductions where non-Boolean values were allowed for the ``numeric_only`` argument; passing a non-Boolean value will now raise (:issue:`62778`)
 - Bug in :meth:`.Resampler.interpolate` on a :class:`DataFrame` with non-uniform sampling and/or indices not aligning with the resulting resampled index would result in wrong interpolation (:issue:`21351`)
 - Bug in :meth:`.Series.rolling` when used with a :class:`.BaseIndexer` subclass and computing min/max (:issue:`46726`)

--- a/pandas/tests/groupby/test_libgroupby.py
+++ b/pandas/tests/groupby/test_libgroupby.py
@@ -329,3 +329,40 @@ def test_cython_group_sum_Inf_at_beginning_and_end(values, out):
         actual,
         expected,
     )
+
+
+@pytest.mark.parametrize(
+    "values, expected_values",
+    [
+        (np.finfo(np.float64).max, [[np.inf]]),
+        (np.finfo(np.float64).min, [[-np.inf]]),
+        (
+            np.complex128(np.finfo(np.float64).min, np.finfo(np.float64).max),
+            [[np.complex128(-np.inf, np.inf)]],
+        ),
+        (
+            np.complex128(np.finfo(np.float64).max, np.finfo(np.float64).min),
+            [[np.complex128(np.inf, -np.inf)]],
+        ),
+        (
+            np.complex128(np.finfo(np.float64).max, np.finfo(np.float64).max),
+            [[np.complex128(np.inf, np.inf)]],
+        ),
+        (
+            np.complex128(np.finfo(np.float64).min, np.finfo(np.float64).min),
+            [[np.complex128(-np.inf, -np.inf)]],
+        ),
+    ],
+)
+def test_cython_group_sum_overflow(values, expected_values):
+    # GH-60303
+    data = np.array([[values] for _ in range(3)])
+    labels = np.array([0, 0, 0], dtype=np.intp)
+    counts = np.array([0], dtype="int64")
+
+    expected = np.array(expected_values, dtype=values.dtype)
+    actual = np.zeros_like(expected)
+
+    group_sum(actual, counts, data, labels, None, is_datetimelike=False)
+
+    tm.assert_numpy_array_equal(actual, expected)

--- a/pandas/tests/groupby/test_libgroupby.py
+++ b/pandas/tests/groupby/test_libgroupby.py
@@ -337,20 +337,28 @@ def test_cython_group_sum_Inf_at_beginning_and_end(values, out):
         (np.finfo(np.float64).max, [[np.inf]]),
         (np.finfo(np.float64).min, [[-np.inf]]),
         (
-            np.complex128(np.finfo(np.float64).min, np.finfo(np.float64).max),
-            [[np.complex128(-np.inf, np.inf)]],
+            np.complex128(np.finfo(np.float64).min + np.finfo(np.float64).max * 1j),
+            [[complex(-np.inf, np.inf)]],
         ),
         (
-            np.complex128(np.finfo(np.float64).max, np.finfo(np.float64).min),
-            [[np.complex128(np.inf, -np.inf)]],
+            np.complex128(np.finfo(np.float64).max + np.finfo(np.float64).min * 1j),
+            [[complex(np.inf, -np.inf)]],
         ),
         (
-            np.complex128(np.finfo(np.float64).max, np.finfo(np.float64).max),
-            [[np.complex128(np.inf, np.inf)]],
+            np.complex128(np.finfo(np.float64).max + np.finfo(np.float64).max * 1j),
+            [[complex(np.inf, np.inf)]],
         ),
         (
-            np.complex128(np.finfo(np.float64).min, np.finfo(np.float64).min),
-            [[np.complex128(-np.inf, -np.inf)]],
+            np.complex128(np.finfo(np.float64).min + np.finfo(np.float64).min * 1j),
+            [[complex(-np.inf, -np.inf)]],
+        ),
+        (
+            np.complex128(3.0 + np.finfo(np.float64).min * 1j),
+            [[complex(9.0, -np.inf)]],
+        ),
+        (
+            np.complex128(np.finfo(np.float64).max + 3 * 1j),
+            [[complex(np.inf, 9.0)]],
         ),
     ],
 )


### PR DESCRIPTION
- [x] closes #60303 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

## Implementation

Check if value is finite using the C macro `isfinite` and use special verification for complex types.

## Tests

In the tests, `np.finfo(np.float64).max` is equal to `np.float64(1.7976931348623157e+308)` and `np.finfo(np.float64).min` is equal to `np.float64(-1.7976931348623157e+308)`. It requires 3 values to trigger`NaN`.