### PR TITLE
Doc: Fix copy parameter type in astype docstring Fixes #63144

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6692,7 +6692,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Parameters
         ----------
-        copy : bool, default False
+        copy : bool or lib.NoDefault, default lib.no_default
             Whether to make a copy for non-object or non-inferable columns
             or Series.
 


### PR DESCRIPTION
Fixes #63144

## Summary
Corrects the type annotation and default value for the `copy` parameter in the `astype()` docstring to match the actual function signature.

## Changes
- Updated `copy` parameter from `bool, default False` to `bool or lib.NoDefault, default lib.no_default`
- Location: `pandas/core/generic.py`, line ~6508


**Before:**  
`copy : bool, default False`

**After:**  
`copy : bool or lib.NoDefault, default lib.no_default`