### PR TITLE
ENH: use stable sort in value_counts

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -948,7 +948,7 @@ def value_counts_internal(
             result = Series(counts, index=idx, name=name, copy=False)
 
     if sort:
-        result = result.sort_values(ascending=ascending)
+        result = result.sort_values(ascending=ascending, kind="stable")
 
     if normalize:
         result = result / counts.sum()

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -993,7 +993,12 @@ class IndexOpsMixin(OpsMixin):
             If True then the object returned will contain the relative
             frequencies of the unique values.
         sort : bool, default True
-            Sort by frequencies when True. Preserve the order of the data when False.
+            Stable sort by frequencies when True. Preserve the order of the data
+            when False.
+
+            .. versionchanged:: 3.0.0
+
+                Prior to 3.0.0, the sort was unstable.
         ascending : bool, default False
             Sort in ascending order.
         bins : int, optional

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7761,11 +7761,16 @@ class DataFrame(NDFrame, OpsMixin):
         normalize : bool, default False
             Return proportions rather than frequencies.
         sort : bool, default True
-            Sort by frequencies when True. Preserve the order of the data when False.
+            Stable sort by frequencies when True. Preserve the order of the data
+            when False.
 
             .. versionchanged:: 3.0.0
 
                 Prior to 3.0.0, ``sort=False`` would sort by the columns values.
+
+            .. versionchanged:: 3.0.0
+
+                Prior to 3.0.0, the sort was unstable.
         ascending : bool, default False
             Sort in ascending order.
         dropna : bool, default True
@@ -7875,7 +7880,7 @@ class DataFrame(NDFrame, OpsMixin):
         counts.name = name
 
         if sort:
-            counts = counts.sort_values(ascending=ascending)
+            counts = counts.sort_values(ascending=ascending, kind="stable")
         if normalize:
             counts /= counts.sum()
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -2776,8 +2776,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         normalize : bool, default False
             Return proportions rather than frequencies.
         sort : bool, default True
-            Sort by frequencies when True. When False, non-grouping columns will appear
-            in the order they occur in within groups.
+            Stable sort by frequencies when True. When False, non-grouping
+            columns will appear in the order they occur in within groups.
 
             .. versionchanged:: 3.0.0
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1450,8 +1450,13 @@ class TestValueCounts:
         # GH 63155
         arr = np.random.default_rng(2).integers(0, 128, 8192)
         result = algos.value_counts_internal(arr, sort=True)
-        expected = Series(arr).value_counts(sort=False).sort_values(ascending=False, kind="stable")
+        expected = (
+            Series(arr)
+            .value_counts(sort=False)
+            .sort_values(ascending=False, kind="stable")
+        )
         tm.assert_series_equal(result, expected)
+
 
 class TestDuplicated:
     def test_duplicated_with_nas(self):

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1448,7 +1448,7 @@ class TestValueCounts:
 
     def test_value_counts_stability(self):
         # GH 63155
-        arr = np.random.default_rng(2).integers(0, 16, 64)
+        arr = np.random.default_rng(2).integers(0, 32, 64)
         result = algos.value_counts_internal(arr, sort=True)
 
         value_counts = Series(arr).value_counts(sort=False)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1446,6 +1446,12 @@ class TestValueCounts:
         )
         tm.assert_series_equal(result, expected)
 
+    def test_value_counts_stability(self):
+        # GH 63155
+        arr = np.random.default_rng(2).integers(0, 128, 8192)
+        result = algos.value_counts_internal(arr, sort=True)
+        expected = Series(arr).value_counts(sort=False).sort_values(ascending=False, kind="stable")
+        tm.assert_series_equal(result, expected)
 
 class TestDuplicated:
     def test_duplicated_with_nas(self):

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1448,14 +1448,16 @@ class TestValueCounts:
 
     def test_value_counts_stability(self):
         # GH 63155
-        arr = np.random.default_rng(2).integers(0, 128, 8192)
+        arr = np.random.default_rng(2).integers(0, 16, 64)
         result = algos.value_counts_internal(arr, sort=True)
-        expected = (
-            Series(arr)
-            .value_counts(sort=False)
-            .sort_values(ascending=False, kind="stable")
-        )
+
+        value_counts = Series(arr).value_counts(sort=False)
+        expected = value_counts.sort_values(ascending=False, kind="stable")
         tm.assert_series_equal(result, expected)
+
+        unstable_sorted = value_counts.sort_values(ascending=False, kind="quicksort")
+        with pytest.raises(AssertionError):
+            tm.assert_series_equal(result, unstable_sorted)
 
 
 class TestDuplicated:


### PR DESCRIPTION
- [x] closes pandas-dev/pandas#63155
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
  - It is not too clear to me how I can test the stability of sorting.
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
  - The failing parts are not related to this PR.
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
  - Not applicable.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
  - Added in docstring.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
  - Only natual intelligence is involved.