### PR TITLE
TST: DataFrame.update preserves mixed dtypes

### DIFF
--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -197,6 +197,7 @@ class TestDataFrameUpdate:
                 np.datetime64("2000-01-02T00:00:00"),
                 np.dtype("datetime64[ns]"),
             ),
+            (1, 2, pd.Int64Dtype()),
         ],
     )
     def test_update_preserve_dtype(self, value_df, value_other, dtype):

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -233,13 +233,13 @@ class TestDataFrameUpdate:
         # GH#44104
         dtype1 = pd.Int64Dtype()
         dtype2 = pd.StringDtype()
-        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        df = DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
         df = df.astype({"a": dtype1, "b": dtype2})
 
-        other = pd.DataFrame({"a": [4, 5], "b": ["a", "b"]})
+        other = DataFrame({"a": [4, 5], "b": ["a", "b"]})
         other = other.astype({"a": dtype1, "b": dtype2})
 
-        expected = pd.DataFrame({"a": [4, 5, 3], "b": ["a", "b", "z"]})
+        expected = DataFrame({"a": [4, 5, 3], "b": ["a", "b", "z"]})
         expected = expected.astype({"a": dtype1, "b": dtype2})
 
         df.update(other)

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -228,3 +228,19 @@ class TestDataFrameUpdate:
         expected = DataFrame({"a": [2, 2, 3]}, index=[1, 1, 2], dtype=np.dtype("intc"))
         df.update(other)
         tm.assert_frame_equal(df, expected)
+
+    def test_update_preserve_mixed_dtypes(self):
+        # GH#44104
+        dtype1 = pd.Int64Dtype()
+        dtype2 = pd.StringDtype()
+        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        df = df.astype({"a": dtype1, "b": dtype2})
+
+        other = pd.DataFrame({"a": [4, 5], "b": ["a", "b"]})
+        other = other.astype({"a": dtype1, "b": dtype2})
+
+        expected = pd.DataFrame({"a": [4, 5, 3], "b": ["a", "b", "z"]})
+        expected = expected.astype({"a": dtype1, "b": dtype2})
+
+        df.update(other)
+        tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
Added a test case with mixed dtypes in a DataFrame and checks dtypes after DataFrame.update
- [] closes #44104  (Replace xxxx with the GitHub issue number)
- [] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
