### PR TITLE
ENH: Make pd.to_datetime with format parameter more robust to dirty data (#62840)

### DIFF
--- a/pandas/_libs/include/pandas/datetime/pd_datetime.h
+++ b/pandas/_libs/include/pandas/datetime/pd_datetime.h
@@ -48,7 +48,7 @@ typedef struct {
   PyArray_DatetimeMetaData (*get_datetime_metadata_from_dtype)(PyArray_Descr *);
   int (*parse_iso_8601_datetime)(const char *, int, int, npy_datetimestruct *,
                                  NPY_DATETIMEUNIT *, int *, int *, const char *,
-                                 int, FormatRequirement);
+                                 int, FormatRequirement, double);
   int (*get_datetime_iso_8601_strlen)(int, NPY_DATETIMEUNIT);
   int (*make_iso_8601_datetime)(npy_datetimestruct *, char *, size_t, int,
                                 NPY_DATETIMEUNIT);
@@ -94,10 +94,11 @@ static PandasDateTime_CAPI *PandasDateTimeAPI = NULL;
   PandasDateTimeAPI->get_datetime_metadata_from_dtype((dtype))
 #define parse_iso_8601_datetime(str, len, want_exc, out, out_bestunit,         \
                                 out_local, out_tzoffset, format, format_len,   \
-                                format_requirement)                            \
+                                format_requirement, threshold)                 \
   PandasDateTimeAPI->parse_iso_8601_datetime(                                  \
       (str), (len), (want_exc), (out), (out_bestunit), (out_local),            \
-      (out_tzoffset), (format), (format_len), (format_requirement))
+      (out_tzoffset), (format), (format_len), (format_requirement),            \
+      (threshold))
 #define get_datetime_iso_8601_strlen(local, base)                              \
   PandasDateTimeAPI->get_datetime_iso_8601_strlen((local), (base))
 #define make_iso_8601_datetime(dts, outstr, outlen, utc, base)                 \

--- a/pandas/_libs/include/pandas/vendored/numpy/datetime/np_datetime_strings.h
+++ b/pandas/_libs/include/pandas/vendored/numpy/datetime/np_datetime_strings.h
@@ -67,7 +67,8 @@ int parse_iso_8601_datetime(const char *str, int len, int want_exc,
                             NPY_DATETIMEUNIT *out_bestunit, int *out_local,
                             int *out_tzoffset, const char *format,
                             int format_len,
-                            FormatRequirement format_requirement);
+                            FormatRequirement format_requirement,
+                            double threshold);
 
 /*
  * Provides a string length to use for converting datetime

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
@@ -742,6 +742,8 @@ hour:
 
     /* Invalidates the component if there is more than 2 digits */
     if (sublen > 0) {
+      if (substr[0] == 'Z')
+        goto parse_timezone;
       int has_sep = 0;
       int j = 0;
       for (j = 0; j < (sublen > 2 ? 2 : sublen); ++j) {
@@ -894,6 +896,8 @@ minute:
 
     /* Invalidates the component if there is more than 2 digits */
     if (sublen > 0) {
+      if (substr[0] == 'Z')
+        goto parse_timezone;
       int has_sep = 0;
       int j = 0;
       for (j = 0; j < (sublen > 2 ? 2 : sublen); ++j) {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
@@ -114,7 +114,6 @@ int parse_iso_8601_datetime(const char *str, int len, int want_exc,
                             int format_len,
                             FormatRequirement format_requirement,
                             double threshold) {
-  printf("Start %s\n", str);
   if (len < 0 || format_len < 0)
     goto parse_error;
   int year_leap = 0;
@@ -312,7 +311,6 @@ int parse_iso_8601_datetime(const char *str, int len, int want_exc,
   }
 
 year_sep:
-  printf("Now %s\n", substr);
   /* Negate the year if necessary */
   if (str[0] == '-') {
     out->year = -out->year;
@@ -612,14 +610,7 @@ day:
 
     /* Invalidates the component if there is more than 2 digits */
     if (sublen > 0) {
-      int still_more = 1;
-      for (i = 0; i < valid_ymd_sep_len; ++i) {
-        if (*substr == valid_ymd_sep[i]) {
-          still_more = 0;
-          break;
-        }
-      }
-      if (still_more) {
+      if (isdigit(substr[0])) {
         invalid_components++;
         while (sublen > 0 && isdigit(substr[0])) {
           substr++;

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
@@ -441,7 +441,7 @@ month:
     if (sublen > 0) {
       int has_sep = 0;
       int j = 0;
-      for (j = 0; j < (sublen > 2 ? 2 : sublen); ++j) {
+      for (j = 0; j < (sublen > 2 && !has_ymd_sep ? 2 : sublen); ++j) {
         char c = substr[j];
         for (i = 0; i < valid_ymd_sep_len; ++i) {
           if (c == valid_ymd_sep[i]) {

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -90,7 +90,8 @@ cdef int string_to_dts(
     int* out_tzoffset,
     bint want_exc,
     str format = *,
-    bint exact = *
+    bint exact = *,
+    double threshold = *,
 ) except? -1
 
 cdef NPY_DATETIMEUNIT get_unit_from_dtype(cnp.dtype dtype)

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -65,7 +65,7 @@ cdef extern from "pandas/datetime/pd_datetime.h":
                                 NPY_DATETIMEUNIT *out_bestunit,
                                 int *out_local, int *out_tzoffset,
                                 const char *format, int format_len,
-                                FormatRequirement exact)
+                                FormatRequirement exact, double threshold)
 
 # ----------------------------------------------------------------------
 # numpy object inspection
@@ -348,6 +348,7 @@ cdef int string_to_dts(
     bint want_exc,
     str format=None,
     bint exact=True,
+    double threshold = 1.0,
 ) except? -1:
     cdef:
         Py_ssize_t length
@@ -367,7 +368,7 @@ cdef int string_to_dts(
     return parse_iso_8601_datetime(buf, length, want_exc,
                                    dts, out_bestunit, out_local, out_tzoffset,
                                    format_buf, format_length,
-                                   format_requirement)
+                                   format_requirement, threshold)
 
 
 cpdef ndarray astype_overflowsafe(

--- a/pandas/_libs/tslibs/strptime.pyi
+++ b/pandas/_libs/tslibs/strptime.pyi
@@ -9,6 +9,7 @@ def array_strptime(
     errors: str = ...,
     utc: bool = ...,
     creso: int = ...,  # NPY_DATETIMEUNIT
+    threshold: float = ...,
 ) -> tuple[np.ndarray, np.ndarray]: ...
 
 # first ndarray is M8[ns], second is object ndarray of tzinfo | None

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -355,6 +355,7 @@ def array_strptime(
     errors="raise",
     bint utc=False,
     NPY_DATETIMEUNIT creso=NPY_DATETIMEUNIT.NPY_FR_GENERIC,
+    double threshold = 1.0,
 ):
     """
     Calculates the datetime structs represented by the passed array of strings
@@ -367,6 +368,23 @@ def array_strptime(
     errors : string specifying error handling, {'raise', 'coerce'}
     creso : NPY_DATETIMEUNIT, default NPY_FR_GENERIC
         Set to NPY_FR_GENERIC to infer a resolution.
+
+    /// INSERT DOCUMENTATION UPDATE HERE ///
+    ########################
+        ########################
+            ########################
+                ########################
+                    ########################
+                        ########################
+                            ########################
+                                ########################
+                            ########################
+                        ########################
+                    ########################
+                ########################
+            ########################
+        ########################
+    ########################
     """
 
     cdef:
@@ -453,15 +471,23 @@ def array_strptime(
             out_tzoffset = 0
 
             if fmt == "ISO8601":
-                string_to_dts_succeeded = not string_to_dts(
+                res = string_to_dts(
                     val, &dts, &out_bestunit, &out_local,
-                    &out_tzoffset, False, None, False
+                    &out_tzoffset, False, None, False, threshold
                 )
+                if res == -2:  # sentinel for NaT
+                    iresult[i] = NPY_NAT
+                    continue
+                string_to_dts_succeeded = not res
             elif iso_format:
-                string_to_dts_succeeded = not string_to_dts(
+                res = string_to_dts(
                     val, &dts, &out_bestunit, &out_local,
-                    &out_tzoffset, False, fmt, exact
+                    &out_tzoffset, False, fmt, exact, threshold
                 )
+                string_to_dts_succeeded = not res
+                if res == -2:  # sentinel for NaT
+                    iresult[i] = NPY_NAT
+                    continue
             if string_to_dts_succeeded:
                 # No error reported by string_to_dts, pick back up
                 # where we left off

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -368,23 +368,7 @@ def array_strptime(
     errors : string specifying error handling, {'raise', 'coerce'}
     creso : NPY_DATETIMEUNIT, default NPY_FR_GENERIC
         Set to NPY_FR_GENERIC to infer a resolution.
-
-    /// INSERT DOCUMENTATION UPDATE HERE ///
-    ########################
-        ########################
-            ########################
-                ########################
-                    ########################
-                        ########################
-                            ########################
-                                ########################
-                            ########################
-                        ########################
-                    ########################
-                ########################
-            ########################
-        ########################
-    ########################
+    threshold : minimum fraction of valid datetime components required
     """
 
     cdef:

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -808,10 +808,10 @@ def to_datetime(
         parsing.
     threshold : float
         Minimum fraction of valid datetime components required to consider parsing
-        successful. Components include year, month, day, hour, minute, and second
-        if present in the input. An invalid component has too many or too few digits
-        or a number outside the possible range (e.g., month outside [1, 12]). Behavior
-        depends on the threshold:
+        successful. Must be between 0.0 and 1.0. Components include year, month,
+        day, hour, minute, and second if present in the input. An invalid component
+        has too many or too few digits or a number outside the possible range
+        (e.g., month outside [1, 12]). Behavior depends on the threshold:
 
         - 1.0 (default): all components must be valid, else raises error (unless
         ``errors='coerce'``).

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -328,6 +328,7 @@ def _convert_listlike_datetimes(
     dayfirst: bool | None = None,
     yearfirst: bool | None = None,
     exact: bool = True,
+    threshold: float = 1.0,
 ):
     """
     Helper function for to_datetime. Performs the conversions of 1D listlike
@@ -351,6 +352,23 @@ def _convert_listlike_datetimes(
         yearfirst parsing behavior from to_datetime
     exact : bool, default True
         exact format matching behavior from to_datetime
+
+    /// INSERT DOCUMENTATION UPDATE HERE ///
+    ########################
+        ########################
+            ########################
+                ########################
+                    ########################
+                        ########################
+                            ########################
+                                ########################
+                            ########################
+                        ########################
+                    ########################
+                ########################
+            ########################
+        ########################
+    ########################
 
     Returns
     -------
@@ -433,7 +451,9 @@ def _convert_listlike_datetimes(
 
     # `format` could be inferred, or user didn't ask for mixed-format parsing.
     if format is not None and format != "mixed":
-        return _array_strptime_with_fallback(arg, name, utc, format, exact, errors)
+        return _array_strptime_with_fallback(
+            arg, name, utc, format, exact, errors, threshold
+        )
 
     result, tz_parsed = objects_to_datetime64(
         arg,
@@ -464,11 +484,14 @@ def _array_strptime_with_fallback(
     fmt: str,
     exact: bool,
     errors: str,
+    threshold: float = 1.0,
 ) -> Index:
     """
     Call array_strptime, with fallback behavior depending on 'errors'.
     """
-    result, tz_out = array_strptime(arg, fmt, exact=exact, errors=errors, utc=utc)
+    result, tz_out = array_strptime(
+        arg, fmt, exact=exact, errors=errors, utc=utc, threshold=threshold
+    )
     if tz_out is not None:
         unit = np.datetime_data(result.dtype)[0]
         unit = cast("TimeUnit", unit)
@@ -686,6 +709,7 @@ def to_datetime(
     unit: str | None = None,
     origin: str = "unix",
     cache: bool = True,
+    threshold: float = 1.0,
 ) -> DatetimeIndex | Series | DatetimeScalar | NaTType:
     """
     Convert argument to datetime.
@@ -794,6 +818,23 @@ def to_datetime(
         is only used when there are at least 50 values. The presence of
         out-of-bounds values will render the cache unusable and may slow down
         parsing.
+
+    /// INSERT DOCUMENTATION UPDATE HERE ///
+    ########################
+        ########################
+            ########################
+                ########################
+                    ########################
+                        ########################
+                            ########################
+                                ########################
+                            ########################
+                        ########################
+                    ########################
+                ########################
+            ########################
+        ########################
+    ########################
 
     Returns
     -------
@@ -1012,6 +1053,7 @@ def to_datetime(
         yearfirst=yearfirst,
         errors=errors,
         exact=exact,  # type: ignore[arg-type]
+        threshold=threshold,
     )
     result: Timestamp | NaTType | Series | Index
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1033,6 +1033,9 @@ def to_datetime(
     if arg is None:
         return NaT
 
+    if not (0.0 <= threshold <= 1.0):
+        raise ValueError(f"`threshold` must be between 0.0 and 1.0, got {threshold}")
+
     if origin != "unix":
         arg = _adjust_to_origin(arg, origin, unit)
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -814,11 +814,12 @@ def to_datetime(
         (e.g., month outside [1, 12]). Behavior depends on the threshold:
 
         - 1.0 (default): all components must be valid, else raises error (unless
-        ``errors='coerce'``).
+          ``errors='coerce'``).
         - 0.0: any invalid component produces NaT, else returns a valid datetime.
         - Values between 0 and 1: if all components are valid, returns a valid
           datetime; if the fraction of valid components >= threshold, returns NaT;
           otherwise raises error.
+
     Returns
     -------
     datetime

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3830,6 +3830,7 @@ class TestForIncreasedRobustness:
         )
         expected = Timestamp("2018-10-01 12:00:00.0000000011")
         assert res == expected
+
         res = to_datetime(
             "2018-10-01 12:00:00.0000000011",
             format="%Y-%m-%d %H:%M:%S.%f",
@@ -3837,17 +3838,51 @@ class TestForIncreasedRobustness:
         )
         assert res == expected
 
-    def test_parse_with_malformed_year(self):
+    def test_parse_with_five_digit_year(self):
+        res = to_datetime(
+            "20012-10-01 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+    def test_parse_with_three_digit_year(self):
+        res = to_datetime(
+            "212-10-01 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+    def test_parse_with_two_digit_year(self):
         res = to_datetime(
             "12-10-01 12:00:00.0000000011", format="%Y-%m-%d %H:%M:%S.%f", threshold=0.5
         )
         assert isna(res)
 
-    def test_parse_with_malformed_year_iso(self):
+    def test_parse_with_one_digit_year(self):
+        res = to_datetime(
+            "1-10-01 12:00:00.0000000011", format="%Y-%m-%d %H:%M:%S.%f", threshold=0.5
+        )
+        assert isna(res)
+
+    def test_parse_with_five_digit_year_iso(self):
+        res = to_datetime("20012-10-01", format="ISO8601", threshold=0.5)
+        assert isna(res)
+
+    def test_parse_with_three_digit_year_iso(self):
+        res = to_datetime("201-10-01", format="ISO8601", threshold=0.5)
+        assert isna(res)
+
+    def test_parse_with_two_digit_year_iso(self):
         res = to_datetime("12-10-01", format="ISO8601", threshold=0.5)
         assert isna(res)
 
-    """def test_parse_with_malformed_month(self):
+    def test_parse_with_one_digit_year_iso(self):
+        res = to_datetime("1-10-01", format="ISO8601", threshold=0.5)
+        assert isna(res)
+
+    def test_parse_with_three_digit_month(self):
         res = to_datetime(
             "2018-202-01 12:00:00.0000000011",
             format="%Y-%m-%d %H:%M:%S.%f",
@@ -3855,11 +3890,35 @@ class TestForIncreasedRobustness:
         )
         assert isna(res)
 
-    def test_parse_with_malformed_month_iso(self):
+    def test_parse_with_one_digit_month(self):
+        res = to_datetime(
+            "2018-0-01 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+        res = to_datetime(
+            "2018-2-01 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        expected = Timestamp("2018-02-01 12:00:00.0000000011")
+        assert res == expected
+
+    def test_parse_with_three_digit_month_iso(self):
         res = to_datetime("2018-202-01", format="ISO8601", threshold=0.5)
         assert isna(res)
 
-    def test_parse_with_malformed_day(self):
+    def test_parse_with_one_digit_month_iso(self):
+        res = to_datetime("2018-0-01", format="ISO8601", threshold=0.5)
+        assert isna(res)
+
+        res = to_datetime("2018-2-01", format="ISO8601", threshold=0.5)
+        expected = Timestamp("2018-02-01")
+        assert res == expected
+
+    def test_parse_with_three_digit_day(self):
         res = to_datetime(
             "2018-10-202 12:00:00.0000000011",
             format="%Y-%m-%d %H:%M:%S.%f",
@@ -3867,9 +3926,105 @@ class TestForIncreasedRobustness:
         )
         assert isna(res)
 
-    def test_parse_with_malformed_day_iso(self):
+    def test_parse_with_one_digit_day(self):
+        res = to_datetime(
+            "2018-10-0 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+        res = to_datetime(
+            "2018-02-1 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        expected = Timestamp("2018-02-01 12:00:00.0000000011")
+        assert res == expected
+
+    def test_parse_with_three_digit_day_iso(self):
         res = to_datetime("2018-10-202", format="ISO8601", threshold=0.5)
         assert isna(res)
+
+    def test_parse_with_one_digit_day_iso(self):
+        res = to_datetime("2018-10-0", format="ISO8601", threshold=0.5)
+        assert isna(res)
+
+        res = to_datetime("2018-02-1", format="ISO8601", threshold=0.5)
+        expected = Timestamp("2018-02-01")
+        assert res == expected
+
+    def test_parse_with_three_digit_hour(self):
+        res = to_datetime(
+            "2018-07-01 121:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+    def test_parse_with_one_digit_hour(self):
+        res = to_datetime(
+            "2018-10-01 24:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+        res = to_datetime(
+            "2018-02-01 1:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        expected = Timestamp("2018-02-01 01:00:00.0000000011")
+        assert res == expected
+
+    def test_parse_with_three_digit_minute(self):
+        res = to_datetime(
+            "2018-07-01 12:121:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+    def test_parse_with_one_digit_minute(self):
+        res = to_datetime(
+            "2018-10-01 23:60:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+        res = to_datetime(
+            "2018-02-01 10:1:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        expected = Timestamp("2018-02-01 10:01:00.0000000011")
+        assert res == expected
+
+    def test_parse_with_three_digit_second(self):
+        res = to_datetime(
+            "2018-07-01 12:12:121.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+    def test_parse_with_one_digit_second(self):
+        res = to_datetime(
+            "2018-10-01 23:00:60.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+        res = to_datetime(
+            "2018-02-01 10:00:1.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        expected = Timestamp("2018-02-01 10:00:01.0000000011")
+        assert res == expected
 
     def test_parse_with_half_malformed_components(self):
         res = to_datetime(
@@ -3877,22 +4032,118 @@ class TestForIncreasedRobustness:
         )
         assert isna(res)
 
-    def test_parse_with_too_many_malformed_components(self):
+        res = to_datetime(
+            "20118-101-01 23:60:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
         with pytest.raises(ValueError, match="^time data *"):
-            to_datetime(
+            _ = to_datetime(
+                "20118-101-01 23:60:100.0000000011",
+                format="%Y-%m-%d %H:%M:%S.%f",
+                threshold=0.5,
+            )
+
+    def test_parse_with_too_many_malformed_components(self):
+        res = to_datetime(
+            "2018-111-111 10:00:01.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+        with pytest.raises(ValueError, match="^time data *"):
+            _ = to_datetime(
                 "2018-202-202 12:202:202", format="%Y-%m-%d %H:%M:%S", threshold=0.5
             )
 
     def test_parse_with_too_many_malformed_components_all(self):
         with pytest.raises(ValueError, match="^time data *"):
-            to_datetime(
+            _ = to_datetime(
                 "2018-10-202 12:00:00", format="%Y-%m-%d %H:%M:%S", threshold=1.0
             )
 
     def test_parse_with_too_many_malformed_components_iso(self):
-        with pytest.raises(ValueError, match="^time data *"):
-            to_datetime("18-10-202", format="ISO8601", threshold=0.5)
+        res = to_datetime("2018-10-111", format="ISO8601", threshold=0.5)
+        assert isna(res)
+
+        with pytest.raises(
+            ValueError, match="^Time data 18-10-202 is not ISO8601 format"
+        ):
+            _ = to_datetime("18-10-202", format="ISO8601", threshold=0.5)
 
     def test_parse_with_too_many_malformed_components_iso_all(self):
+        with pytest.raises(
+            ValueError, match="^Time data 2018-100-202 is not ISO8601 format"
+        ):
+            _ = to_datetime("2018-100-202", format="ISO8601", threshold=1.0)
+
+    def test_parse_with_all_malformed_components(self):
         with pytest.raises(ValueError, match="^time data *"):
-            to_datetime("2018-10-202", format="ISO8601", threshold=1.0)"""
+            _ = to_datetime(
+                "201-202-202 121:202:202", format="%Y-%m-%d %H:%M:%S", threshold=0.5
+            )
+
+        res = to_datetime(
+            "201-202-202 121:202:202", format="%Y-%m-%d %H:%M:%S", threshold=0.0
+        )
+        assert isna(res)
+
+    def test_series(self):
+        series = Series(["2020", "1999", "2011"])
+        result = to_datetime(series, format="%Y")
+        expected = Series(
+            [
+                Timestamp("2020-01-01"),
+                Timestamp("1999-01-01"),
+                Timestamp("2011-01-01"),
+            ]
+        )
+        tm.assert_series_equal(result, expected)
+
+        series = Series(["199"])
+        result = to_datetime(series, format="%Y", threshold=0.0)
+        assert isna(result[0])
+
+        series = Series(["2020-01-101", "1999-101-01", "211-10-11", "2020-01-01"])
+        result = to_datetime(series, format="ISO8601", threshold=0.5)
+        assert isna(result[0])
+        assert isna(result[1])
+        assert isna(result[2])
+        assert not isna(result[3])
+
+        series = Series(["2020-01-101", "1999-101-01", "2011-101-101"])
+        with pytest.raises(
+            ValueError, match="^Time data 2011-101-101 is not ISO8601 format"
+        ):
+            _ = to_datetime(series, format="ISO8601", threshold=0.5)
+
+    def test_errors_is_coerce(self):
+        series = Series(["2020", "20xx"])
+        result = to_datetime(series, format="%Y", errors="coerce", threshold=1.0)
+        expected = Series([Timestamp("2020-01-01"), NaT])
+        tm.assert_series_equal(result, expected)
+
+    def test_iso_and_format_have_same_threshold_behavior(self):
+        assert isna(to_datetime("2018-202-01", format="ISO8601", threshold=0.5))
+        assert isna(to_datetime("2018-202-01", format="%Y-%m-%d", threshold=0.5))
+
+    def test_microseconds_does_not_count(self):
+        with pytest.raises(ValueError, match="^time data *"):
+            _ = to_datetime(
+                "20181-021-011 111:010:010.0000000011",
+                format="%Y-%m-%d %H:%M:%S.%f",
+                threshold=0.01,
+            )
+
+    def test_one_component(self):
+        res = to_datetime("20181", format="%Y", threshold=0.0)
+        assert isna(res)
+
+    def test_parse_mixed_format_threshold(self):
+        series = Series(["2020-01-01", "01/02/2021", "2021-13-01"])
+        result = to_datetime(series, format="mixed", threshold=0.5, errors="coerce")
+        expected = Series([Timestamp("2020-01-01"), Timestamp("2021-01-02"), NaT])
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -4155,3 +4155,22 @@ class TestForIncreasedRobustness:
             threshold=0.5,
         )
         assert isna(result)
+
+    def test_bad_threshold(self):
+        with pytest.raises(
+            ValueError, match="`threshold` must be between 0.0 and 1.0, got -0.5"
+        ):
+            _ = to_datetime(
+                "2020-01-01 12:20:20",
+                format="%Y-%m-%d %H:%M:%S",
+                threshold=-0.5,
+            )
+
+        with pytest.raises(
+            ValueError, match="`threshold` must be between 0.0 and 1.0, got 2.0"
+        ):
+            _ = to_datetime(
+                "2020-01-01 12:20:20",
+                format="%Y-%m-%d %H:%M:%S",
+                threshold=2.0,
+            )

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3824,28 +3824,75 @@ def test_to_datetime_lxml_elementunicoderesult_with_format(cache):
 class TestForIncreasedRobustness:
     def test_parse_with_no_malformed_components(self):
         res = to_datetime(
-            "2018-10-01 12:00:00.0000000011", format="%Y-%m-%d %H:%M:%S.%f"
+            "2018-10-01 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
         )
         expected = Timestamp("2018-10-01 12:00:00.0000000011")
         assert res == expected
+        res = to_datetime(
+            "2018-10-01 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=1.0,
+        )
+        assert res == expected
+
+    def test_parse_with_malformed_year(self):
+        res = to_datetime(
+            "12-10-01 12:00:00.0000000011", format="%Y-%m-%d %H:%M:%S.%f", threshold=0.5
+        )
+        assert isna(res)
+
+    def test_parse_with_malformed_year_iso(self):
+        res = to_datetime("12-10-01", format="ISO8601", threshold=0.5)
+        assert isna(res)
+
+    """def test_parse_with_malformed_month(self):
+        res = to_datetime(
+            "2018-202-01 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
+        )
+        assert isna(res)
+
+    def test_parse_with_malformed_month_iso(self):
+        res = to_datetime("2018-202-01", format="ISO8601", threshold=0.5)
+        assert isna(res)
 
     def test_parse_with_malformed_day(self):
         res = to_datetime(
-            "2018-10-. 12:00:00.0000000011", format="%Y-%m-%d %H:%M:%S.%f"
+            "2018-10-202 12:00:00.0000000011",
+            format="%Y-%m-%d %H:%M:%S.%f",
+            threshold=0.5,
         )
-        expected = NaT
-        assert res == expected
+        assert isna(res)
 
     def test_parse_with_malformed_day_iso(self):
-        res = to_datetime("2018-10-.", format="ISO8601")
-        expected = NaT
-        assert res == expected
+        res = to_datetime("2018-10-202", format="ISO8601", threshold=0.5)
+        assert isna(res)
 
     def test_parse_with_half_malformed_components(self):
-        res = to_datetime("2018-10-. 12:.:.", format="%Y-%m-%d %H:%M:%S")
-        expected = NaT
-        assert res == expected
+        res = to_datetime(
+            "2018-10-202 12:202:202", format="%Y-%m-%d %H:%M:%S", threshold=0.5
+        )
+        assert isna(res)
 
     def test_parse_with_too_many_malformed_components(self):
         with pytest.raises(ValueError, match="^time data *"):
-            to_datetime("2018-.-. 12:.:.", format="%Y-%m-%d %H:%M:%S")
+            to_datetime(
+                "2018-202-202 12:202:202", format="%Y-%m-%d %H:%M:%S", threshold=0.5
+            )
+
+    def test_parse_with_too_many_malformed_components_all(self):
+        with pytest.raises(ValueError, match="^time data *"):
+            to_datetime(
+                "2018-10-202 12:00:00", format="%Y-%m-%d %H:%M:%S", threshold=1.0
+            )
+
+    def test_parse_with_too_many_malformed_components_iso(self):
+        with pytest.raises(ValueError, match="^time data *"):
+            to_datetime("18-10-202", format="ISO8601", threshold=0.5)
+
+    def test_parse_with_too_many_malformed_components_iso_all(self):
+        with pytest.raises(ValueError, match="^time data *"):
+            to_datetime("2018-10-202", format="ISO8601", threshold=1.0)"""

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -4147,3 +4147,11 @@ class TestForIncreasedRobustness:
         result = to_datetime(series, format="mixed", threshold=0.5, errors="coerce")
         expected = Series([Timestamp("2020-01-01"), Timestamp("2021-01-02"), NaT])
         tm.assert_series_equal(result, expected)
+
+    def test_example(self):
+        result = to_datetime(
+            "2018-100-26 12:00:00",
+            format="%Y-%m-%d %H:%M:%S",
+            threshold=0.5,
+        )
+        assert isna(result)


### PR DESCRIPTION
- Closes #62840 

This PR adds a new `threshold` argument to `to_datetime` that allows users to specify the minimum fraction of valid datetime components required for parsing to succeed. For this feature, "successful" parsing means that the function returns either a valid `Timestamp` or `NaT` (i.e., it does not raise an exception). The threshold determines whether partially-invalid values produce `NaT` or raise an error. This enables more flexible and robust parsing behavior for partially-invalid dates while preserving strict behavior by default (`threshold=1.0`).

### Summary of changes
- Added `threshold` argument to `to_datetime`.
- Implemented validation logic and clamping of threshold values to `[0.0, 1.0]`.
- Updated parsing internals to compute the fraction of valid components.
- Added tests for valid, invalid, and boundary threshold behavior.
- Added documentation: explanation, parameter description, and example.
- Added type annotations across all new argument signatures.
- Ensured all code checks and pre-commit hooks pass.