### PR TITLE
PERF: compute kurtosis for ExtensionArray using groupby method

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12148,8 +12148,7 @@ class DataFrame(SetitemMixin, NDFrame, OpsMixin):
                 result.index = df.index
                 return result
 
-            # kurtosis excluded since groupby does not implement it
-            if df.shape[1] and name != "kurt":
+            if df.shape[1]:
                 dtype = find_common_type(
                     [block.values.dtype for block in df._mgr.blocks]
                 )


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`. 

---

Uses `group_kurt` to compute the kurtosis for extended arrays. It increases performance in asv benchmark from 6 seconds to 25 milliseconds.

```console
$ asv continuous -E virtualenv:3.13 upstream/main HEAD -b kurt --show-stderr

| Change   | Before [7bf66609] <main>   | After [a2f1de11] <perf/kurt>   |   Ratio | Benchmark (Parameter)                                                                    |
|----------|----------------------------|--------------------------------|---------|------------------------------------------------------------------------------------------|
| +        | 2.48±0.01ms                | 2.96±0.2ms                     |    1.19 | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'float', 'kurt')             |
| +        | 3.14±0.01ms                | 3.67±0.4ms                     |    1.17 | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'float', 'kurt') |
| +        | 3.71±0.4ms                 | 4.18±0.2ms                     |    1.13 | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 1000}), 'int', 'kurt')   |
| +        | 2.95±0.03ms                | 3.31±0.2ms                     |    1.12 | stat_ops.FrameOps.time_op('kurt', 'float', 0)                                            |
| -        | 4.30±0.01ms                | 3.78±0.4ms                     |    0.88 | rolling.VariableWindowMethods.time_method('Series', '1d', 'float', 'kurt')               |
| -        | 6.89±0.03s                 | 25.2±3ms                       |    0    | stat_ops.FrameOps.time_op('kurt', 'Int64', 1)                                            |
```
