### PR TITLE
BUG: ensure to always return new objects in Index set operations (avoid metadata mutation)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1153,9 +1153,9 @@ Indexing
 - Bug in :meth:`DataFrame.loc.__getitem__` and :meth:`DataFrame.iloc.__getitem__` with a :class:`CategoricalDtype` column with integer categories raising when trying to index a row containing a ``NaN`` entry (:issue:`58954`)
 - Bug in :meth:`Index.__getitem__` incorrectly raising with a 0-dim ``np.ndarray`` key (:issue:`55601`)
 - Bug in :meth:`Index.get_indexer` not casting missing values correctly for new string datatype (:issue:`55833`)
+- Bug in :meth:`Index.intersection`, :meth:`Index.union`, :meth:`MultiIndex.intersection`, and :meth:`MultiIndex.union` returning a reference to the original Index instead of a new instance when operating on identical indexes, which could cause metadata corruption when modifying the result (:issue:`63169`)
 - Bug in adding new rows with :meth:`DataFrame.loc.__setitem__` or :class:`Series.loc.__setitem__` which failed to retain dtype on the object's index in some cases (:issue:`41626`)
 - Bug in indexing on a :class:`DatetimeIndex` with a ``timestamp[pyarrow]`` dtype or on a :class:`TimedeltaIndex` with a ``duration[pyarrow]`` dtype (:issue:`62277`)
-- Bug in :meth:`Index.intersection`, :meth:`Index.union`, :meth:`MultiIndex.intersection`, and :meth:`MultiIndex.union` returning a reference to the original Index instead of a new instance when operating on identical indexes, which could cause metadata corruption when modifying the result (:issue:`63169`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1155,6 +1155,7 @@ Indexing
 - Bug in :meth:`Index.get_indexer` not casting missing values correctly for new string datatype (:issue:`55833`)
 - Bug in adding new rows with :meth:`DataFrame.loc.__setitem__` or :class:`Series.loc.__setitem__` which failed to retain dtype on the object's index in some cases (:issue:`41626`)
 - Bug in indexing on a :class:`DatetimeIndex` with a ``timestamp[pyarrow]`` dtype or on a :class:`TimedeltaIndex` with a ``duration[pyarrow]`` dtype (:issue:`62277`)
+- Bug in :meth:`Index.intersection`, :meth:`Index.union`, :meth:`MultiIndex.intersection`, and :meth:`MultiIndex.union` returning a reference to the original Index instead of a new instance when operating on identical indexes, which could cause metadata corruption when modifying the result (:issue:`63169`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2975,13 +2975,12 @@ class Index(IndexOpsMixin, PandasObject):
     def _get_reconciled_name_object(self, other):
         """
         If the result of a set operation will be self,
-        return self, unless the name changes, in which
-        case make a shallow copy of self.
+        return a shallow copy of self.
         """
         name = get_op_result_name(self, other)
         if self.name is not name:
             return self.rename(name)
-        return self
+        return self.copy()
 
     @final
     def _validate_sort_keyword(self, sort) -> None:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2980,7 +2980,7 @@ class Index(IndexOpsMixin, PandasObject):
         name = get_op_result_name(self, other)
         if self.name is not name:
             return self.rename(name)
-        return self.copy()
+        return self.copy(deep=False)
 
     @final
     def _validate_sort_keyword(self, sort) -> None:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4082,13 +4082,12 @@ class MultiIndex(Index):
     def _get_reconciled_name_object(self, other) -> MultiIndex:
         """
         If the result of a set operation will be self,
-        return self, unless the names change, in which
-        case make a shallow copy of self.
+        return a shallow copy of self.
         """
         names = self._maybe_match_names(other)
         if self.names != names:
             return self.rename(names)
-        return self
+        return self.copy()
 
     def _maybe_match_names(self, other):
         """

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4087,7 +4087,7 @@ class MultiIndex(Index):
         names = self._maybe_match_names(other)
         if self.names != names:
             return self.rename(names)
-        return self.copy()
+        return self.copy(deep=False)
 
     def _maybe_match_names(self, other):
         """

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -986,78 +986,81 @@ class TestSetOpsUnsorted:
         tm.assert_index_equal(res, expected)
 
 
-class TestSetOpsMutation:
-    def test_intersection_mutation_safety(self):
-        # GH#63169
-        index1 = Index([0, 1], name="original")
-        index2 = Index([0, 1], name="original")
+def test_intersection_mutation_safety():
+    # GH#63169
+    index1 = Index([0, 1], name="original")
+    index2 = Index([0, 1], name="original")
 
-        result = index1.intersection(index2)
+    result = index1.intersection(index2)
 
-        assert result is not index1
-        assert result is not index2
+    assert result is not index1
+    assert result is not index2
 
-        tm.assert_index_equal(result, index1)
-        assert result.name == "original"
+    tm.assert_index_equal(result, index1)
+    assert result.name == "original"
 
-        index1.name = "changed"
+    index1.name = "changed"
 
-        assert result.name == "original"
-        assert index1.name == "changed"
+    assert result.name == "original"
+    assert index1.name == "changed"
 
-    def test_union_mutation_safety(self):
-        # GH#63169
-        index1 = Index([0, 1], name="original")
-        index2 = Index([0, 1], name="original")
 
-        result = index1.union(index2)
+def test_union_mutation_safety():
+    # GH#63169
+    index1 = Index([0, 1], name="original")
+    index2 = Index([0, 1], name="original")
 
-        assert result is not index1
-        assert result is not index2
+    result = index1.union(index2)
 
-        tm.assert_index_equal(result, index1)
-        assert result.name == "original"
+    assert result is not index1
+    assert result is not index2
 
-        index1.name = "changed"
+    tm.assert_index_equal(result, index1)
+    assert result.name == "original"
 
-        assert result.name == "original"
-        assert index1.name == "changed"
+    index1.name = "changed"
 
-    def test_union_mutation_safety_other(self):
-        # GH#63169
-        index1 = Index([0, 1], name="original")
-        index2 = Index([0, 1], name="original")
+    assert result.name == "original"
+    assert index1.name == "changed"
 
-        result = index1.union(index2)
 
-        assert result is not index2
+def test_union_mutation_safety_other():
+    # GH#63169
+    index1 = Index([0, 1], name="original")
+    index2 = Index([0, 1], name="original")
 
-        tm.assert_index_equal(result, index2)
-        assert result.name == "original"
+    result = index1.union(index2)
 
-        index2.name = "changed"
+    assert result is not index2
 
-        assert result.name == "original"
-        assert index2.name == "changed"
+    tm.assert_index_equal(result, index2)
+    assert result.name == "original"
 
-    def test_multiindex_intersection_mutation_safety(self):
-        # GH#63169
-        mi1 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
-        mi2 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+    index2.name = "changed"
 
-        result = mi1.intersection(mi2)
-        assert result is not mi1
+    assert result.name == "original"
+    assert index2.name == "changed"
 
-        mi1.names = ["changed1", "changed2"]
-        assert result.names == ["x", "y"]
 
-    def test_multiindex_union_mutation_safety(self):
-        # GH#63169
-        mi1 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
-        mi2 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+def test_multiindex_intersection_mutation_safety():
+    # GH#63169
+    mi1 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+    mi2 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
 
-        result = mi1.union(mi2)
-        assert result is not mi1
+    result = mi1.intersection(mi2)
+    assert result is not mi1
 
-        mi1.names = ["changed1", "changed2"]
-        assert result.names == ["x", "y"]
+    mi1.names = ["changed1", "changed2"]
+    assert result.names == ["x", "y"]
+
+
+def test_multiindex_union_mutation_safety():
+    # GH#63169
+    mi1 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+    mi2 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+
+    result = mi1.union(mi2)
+    assert result is not mi1
+
+    mi1.names = ["changed1", "changed2"]
+    assert result.names == ["x", "y"]

--- a/pandas/tests/indexes/test_setops.py
+++ b/pandas/tests/indexes/test_setops.py
@@ -812,7 +812,7 @@ class TestSetOpsUnsorted:
         first = index[5:20]
 
         union = first.union(first, sort=sort)
-        # GH#63169 - identity is never preserved now
+        # GH#63169 - identity is not preserved to prevent shared mutable state
         assert union is not first
 
         # This should no longer be the same object, since [] is not consistent,
@@ -1025,7 +1025,7 @@ class TestSetOpsMutation:
 
     def test_union_mutation_safety_other(self):
         # GH#63169
-        index1 = Index([], name="original")
+        index1 = Index([0, 1], name="original")
         index2 = Index([0, 1], name="original")
 
         result = index1.union(index2)
@@ -1039,3 +1039,25 @@ class TestSetOpsMutation:
 
         assert result.name == "original"
         assert index2.name == "changed"
+
+    def test_multiindex_intersection_mutation_safety(self):
+        # GH#63169
+        mi1 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+        mi2 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+
+        result = mi1.intersection(mi2)
+        assert result is not mi1
+
+        mi1.names = ["changed1", "changed2"]
+        assert result.names == ["x", "y"]
+
+    def test_multiindex_union_mutation_safety(self):
+        # GH#63169
+        mi1 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+        mi2 = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["x", "y"])
+
+        result = mi1.union(mi2)
+        assert result is not mi1
+
+        mi1.names = ["changed1", "changed2"]
+        assert result.names == ["x", "y"]

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -125,7 +125,7 @@ class TestTimedeltaIndex:
         # Corner cases
         inter = first.intersection(first, sort=sort)
         assert inter is not first
-        tm.assert_index_equal(inter, first)  
+        tm.assert_index_equal(inter, first)
 
     @pytest.mark.parametrize("period_1, period_2", [(0, 4), (4, 0)])
     def test_intersection_zero_length(self, period_1, period_2, sort):

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -114,7 +114,7 @@ class TestTimedeltaIndex:
 
     def test_intersection_equal(self, sort):
         # GH 24471 Test intersection outcome given the sort keyword
-        # for equal indices intersection should return the original index
+        # GH#63169 intersection returns a copy to prevent shared mutable state
         first = timedelta_range("1 day", periods=4, freq="h")
         second = timedelta_range("1 day", periods=4, freq="h")
         intersect = first.intersection(second, sort=sort)
@@ -124,7 +124,7 @@ class TestTimedeltaIndex:
 
         # Corner cases
         inter = first.intersection(first, sort=sort)
-        assert inter is first
+        assert inter is not first
 
     @pytest.mark.parametrize("period_1, period_2", [(0, 4), (4, 0)])
     def test_intersection_zero_length(self, period_1, period_2, sort):

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -125,6 +125,7 @@ class TestTimedeltaIndex:
         # Corner cases
         inter = first.intersection(first, sort=sort)
         assert inter is not first
+        tm.assert_index_equal(inter, first)  
 
     @pytest.mark.parametrize("period_1, period_2", [(0, 4), (4, 0)])
     def test_intersection_zero_length(self, period_1, period_2, sort):


### PR DESCRIPTION
…n) (#63169)

- [x] closes #63169 
- [x] [Tests added and passed]
- [x] All [code checks passed]
- [ ] Added [type annotations]
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Previously, `Index.intersection` and `Index.union` (including `MultiIndex` implementations) would return a direct reference to `self` (or `other`) if the result was identical to the input. This allowed side effects where mutating the metadata (e.g. `.name`) of the result would corrupt the original index.

This change forces a shallow copy (`deep=False`) in these cases. This preserves the performance benefit of sharing the underlying data array while ensuring the Index container itself is a distinct object with independent metadata.