### PR TITLE
DOC: Bump pydata-sphinx-theme

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -16,6 +16,7 @@ Version 2.3
 .. toctree::
    :maxdepth: 2
 
+   v2.3.4
    v2.3.3
    v2.3.2
    v2.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -86,7 +86,7 @@ dependencies:
   - google-auth
   - natsort  # DataFrame.sort_values doctest
   - numpydoc
-  - pydata-sphinx-theme=0.14
+  - pydata-sphinx-theme=0.16
   - pytest-cython  # doctest
   - sphinx
   - sphinx-design

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -61,7 +61,7 @@ gitdb
 google-auth
 natsort
 numpydoc
-pydata-sphinx-theme==0.14
+pydata-sphinx-theme==0.16
 pytest-cython
 sphinx
 sphinx-design


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Was seeing warning due to 2.3.x pinned to 0.14, I think we should keep this up to date with the main branch since it requires no other changes. Also gets docs build back to green by adding reference to `v2.3.4`.