### PR TITLE
BUG: Fix Index.intersection returning same instance when indexes are equal GH#63169

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3286,6 +3286,11 @@ class Index(IndexOpsMixin, PandasObject):
                 result = self.unique()._get_reconciled_name_object(other)
             else:
                 result = self._get_reconciled_name_object(other)
+
+                # Always return a new instance on equality
+                if result is self:
+                    result = self.copy()
+
             if sort is True:
                 result = result.sort_values()
             return result

--- a/pandas/tests/indexes/base_class/test_setops.py
+++ b/pandas/tests/indexes/base_class/test_setops.py
@@ -264,3 +264,13 @@ class TestIndexSetOps:
         result = getattr(idx1, diff_type)(idx2)
         expected = Index(expected)
         tm.assert_index_equal(result, expected)
+    def test_intersection_returns_new_instance(self):
+        idx1 = Index([0, 1])
+        idx2 = Index([0, 1])
+        result = idx1.intersection(idx2)
+
+        # Should be equal but NOT the same reference
+        tm.assert_index_equal(result, idx1)
+        print(idx1)
+        assert result is not idx1
+


### PR DESCRIPTION
Fixes GH#63169.

`Index.intersection` previously returned the original Index instance
when both Index objects were equal and unique:

    idx1 = Index([0, 1])
    idx2 = Index([0, 1])
    result = idx1.intersection(idx2)
    result is idx1   # True (incorrect)

This caused identity issues when downstream code expected a new Index.

This PR ensures that a new Index object is always returned when
intersection is computed, even if both indexes are equal.

A new test has been added:
- test_intersection_returns_new_instance

This confirms:
- the result contains the correct values
- the returned Index is *not* the same object reference.
