### PR TITLE
[backport 2.3.x]  Minor cleanup: removed mypy inline type comment in _xlsxwriter.py constructor (#62675) 

### DIFF
--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -213,7 +213,7 @@ class XlsxWriter(ExcelWriter):
         )
 
         try:
-            self._book = Workbook(self._handles.handle, **engine_kwargs)  # type: ignore[arg-type]
+            self._book = Workbook(self._handles.handle, **engine_kwargs)
         except TypeError:
             self._handles.handle.close()
             raise


### PR DESCRIPTION
Backport #62675 to fix mypy error in CI