### PR TITLE
API: partial revert of returning read-only EAs from .array/.values

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5023,8 +5023,8 @@ class Index(IndexOpsMixin, PandasObject):
             from pandas.core.arrays.numpy_ import NumpyExtensionArray
 
             array = NumpyExtensionArray(array)
-        array = array.view()
-        array._readonly = True
+        # array = array.view()
+        # array._readonly = True
         return array
 
     @property

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5023,6 +5023,7 @@ class Index(IndexOpsMixin, PandasObject):
             from pandas.core.arrays.numpy_ import NumpyExtensionArray
 
             array = NumpyExtensionArray(array)
+        # TODO decide on read-only https://github.com/pandas-dev/pandas/issues/63099
         # array = array.view()
         # array._readonly = True
         return array

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2387,7 +2387,8 @@ def external_values(values: ArrayLike) -> ArrayLike:
         values.flags.writeable = False
     else:
         # ExtensionArrays
-        values = values.view()
-        values._readonly = True
+        # values = values.view()
+        # values._readonly = True
+        pass
 
     return values

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2387,6 +2387,7 @@ def external_values(values: ArrayLike) -> ArrayLike:
         values.flags.writeable = False
     else:
         # ExtensionArrays
+        # TODO decide on read-only https://github.com/pandas-dev/pandas/issues/63099
         # values = values.view()
         # values._readonly = True
         pass

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -819,8 +819,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     @property
     def array(self) -> ExtensionArray:
         arr = self._mgr.array_values()
-        arr = arr.view()
-        arr._readonly = True
+        # arr = arr.view()
+        # arr._readonly = True
         return arr
 
     def __len__(self) -> int:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -821,6 +821,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     @property
     def array(self) -> ExtensionArray:
         arr = self._mgr.array_values()
+        # TODO decide on read-only https://github.com/pandas-dev/pandas/issues/63099
         # arr = arr.view()
         # arr._readonly = True
         return arr

--- a/pandas/tests/copy_view/test_array.py
+++ b/pandas/tests/copy_view/test_array.py
@@ -19,11 +19,11 @@ from pandas.tests.copy_view.util import get_array
     "method",
     [
         lambda ser: ser.values,
-        lambda ser: np.asarray(ser.array),
+        # lambda ser: np.asarray(ser.array),
         lambda ser: np.asarray(ser),
         lambda ser: np.array(ser, copy=False),
     ],
-    ids=["values", "array", "np.asarray", "np.array"],
+    ids=["values", "np.asarray", "np.array"],
 )
 def test_series_values(method):
     ser = Series([1, 2, 3], name="name")
@@ -109,12 +109,12 @@ def test_series_to_numpy():
 @pytest.mark.parametrize(
     "method",
     [
-        lambda ser: np.asarray(ser.array),
+        # lambda ser: np.asarray(ser.array),
         lambda ser: np.asarray(ser),
         lambda ser: np.asarray(ser, dtype="int64"),
         lambda ser: np.array(ser, copy=False),
     ],
-    ids=["array", "np.asarray", "np.asarray-dtype", "np.array"],
+    ids=["np.asarray", "np.asarray-dtype", "np.array"],
 )
 def test_series_values_ea_dtypes(method):
     ser = Series([1, 2, 3], dtype="Int64")

--- a/pandas/tests/copy_view/test_array.py
+++ b/pandas/tests/copy_view/test_array.py
@@ -19,17 +19,26 @@ from pandas.tests.copy_view.util import get_array
     "method",
     [
         lambda ser: ser.values,
-        # lambda ser: np.asarray(ser.array),
+        lambda ser: np.asarray(ser.array),
         lambda ser: np.asarray(ser),
         lambda ser: np.array(ser, copy=False),
     ],
-    ids=["values", "np.asarray", "np.array"],
+    ids=["values", "array", "np.asarray", "np.array"],
 )
-def test_series_values(method):
+def test_series_values(request, method):
     ser = Series([1, 2, 3], name="name")
     ser_orig = ser.copy()
 
     arr = method(ser)
+
+    if request.node.callspec.id == "array":
+        # https://github.com/pandas-dev/pandas/issues/63099
+        # .array for now does not return a read-only view
+        assert arr.flags.writeable is True
+        # updating the array updates the series
+        arr[0] = 0
+        assert ser.iloc[0] == 0
+        return
 
     # .values still gives a view but is read-only
     assert np.shares_memory(arr, get_array(ser, "name"))
@@ -109,19 +118,41 @@ def test_series_to_numpy():
 @pytest.mark.parametrize(
     "method",
     [
-        # lambda ser: np.asarray(ser.array),
+        lambda ser: np.asarray(ser.values),
+        lambda ser: np.asarray(ser.array),
         lambda ser: np.asarray(ser),
         lambda ser: np.asarray(ser, dtype="int64"),
         lambda ser: np.array(ser, copy=False),
     ],
-    ids=["np.asarray", "np.asarray-dtype", "np.array"],
+    ids=["values", "array", "np.asarray", "np.asarray-dtype", "np.array"],
 )
-def test_series_values_ea_dtypes(method):
+def test_series_values_ea_dtypes(request, method):
     ser = Series([1, 2, 3], dtype="Int64")
+    ser_orig = ser.copy()
+
     arr = method(ser)
 
+    if request.node.callspec.id in ("values", "array"):
+        # https://github.com/pandas-dev/pandas/issues/63099
+        # .array/values for now does not return a read-only view
+        assert arr.flags.writeable is True
+        # updating the array updates the series
+        arr[0] = 0
+        assert ser.iloc[0] == 0
+        return
+
+    # conversion to ndarray gives a view but is read-only
     assert np.shares_memory(arr, get_array(ser))
     assert arr.flags.writeable is False
+
+    # mutating series through arr therefore doesn't work
+    with pytest.raises(ValueError, match="read-only"):
+        arr[0] = 0
+    tm.assert_series_equal(ser, ser_orig)
+
+    # mutating the series itself still works
+    ser.iloc[0] = 0
+    assert ser.values[0] == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/issues/63099 for context.

This reverts the behaviour change of https://github.com/pandas-dev/pandas/pull/61925 partially, to at least ensure that `.array` and `.values` still returns the underlying ExtensionArray (if the Series is backed by an extension dtype). Other ways to get a numpy array are still left to return a read-only ndarray for now.