### PR TITLE
TST: Replace ensure_clean_store with tmp_path in test_complex.py, test_file_handling.py

### DIFF
--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -9,9 +9,6 @@ from pandas import (
     read_hdf,
 )
 import pandas._testing as tm
-from pandas.tests.io.pytables.common import tables 
-
-_ = tables
 
 
 def test_complex_fixed(tmp_path, setup_path):

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -10,8 +10,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-tables = pytest.importorskip("tables")
-
 
 def test_complex_fixed(tmp_path, setup_path):
     df = DataFrame(

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -9,7 +9,7 @@ from pandas import (
     read_hdf,
 )
 import pandas._testing as tm
-from pandas.tests.io.pytables.common import tables
+from pandas.tests.io.pytables.common import tables 
 
 _ = tables
 

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -8,7 +8,7 @@ from pandas import (
     Series,
     read_hdf,
 )
-import pandas._testing as tm
+import pandas._testing as tm 
 
 
 def test_complex_fixed(tmp_path, setup_path):

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -2,16 +2,13 @@ import numpy as np
 import pytest
 
 import pandas as pd
+import pandas._testing as tm
 from pandas import (
     DataFrame,
-    Series,
-)
-import pandas._testing as tm
-from pandas.io.pytables import (
     HDFStore,
+    Series,
     read_hdf,
 )
-
 
 
 def test_complex_fixed(tmp_path, setup_path):

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -7,7 +7,6 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-
 from pandas.tests.io.pytables.common import ensure_clean_store
 
 from pandas.io.pytables import read_hdf

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -8,7 +8,10 @@ from pandas import (
     Series,
     read_hdf,
 )
-import pandas._testing as tm 
+import pandas._testing as tm
+from pandas.tests.io.pytables.common import tables
+
+_ = tables
 
 
 def test_complex_fixed(tmp_path, setup_path):

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -7,9 +7,11 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
-from pandas.tests.io.pytables.common import ensure_clean_store
+from pandas.io.pytables import (
+    HDFStore,
+    read_hdf,
+)
 
-from pandas.io.pytables import read_hdf
 
 
 def test_complex_fixed(tmp_path, setup_path):
@@ -103,10 +105,12 @@ def test_complex_mixed_table(tmp_path, setup_path):
         index=list("abcd"),
     )
 
-    with ensure_clean_store(setup_path) as store:
+    path = tmp_path / setup_path
+    with HDFStore(path) as store:
         store.append("df", df, data_columns=["A", "B"])
         result = store.select("df", where="A>2")
         tm.assert_frame_equal(df.loc[df.A > 2], result)
+
 
     path = tmp_path / setup_path
     df.to_hdf(path, key="df", format="table")
@@ -139,7 +143,7 @@ def test_complex_across_dimensions(tmp_path, setup_path):
     tm.assert_frame_equal(df, reread)
 
 
-def test_complex_indexing_error(setup_path):
+def test_complex_indexing_error(tmp_path, setup_path):
     complex128 = np.array(
         [1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j], dtype=np.complex128
     )
@@ -156,9 +160,11 @@ def test_complex_indexing_error(setup_path):
         "values to data_columns when initializing the table."
     )
 
-    with ensure_clean_store(setup_path) as store:
+    path = tmp_path / setup_path
+    with HDFStore(path) as store:
         with pytest.raises(TypeError, match=msg):
             store.append("df", df, data_columns=["C"])
+
 
 
 def test_complex_series_error(tmp_path, setup_path):
@@ -183,7 +189,7 @@ def test_complex_series_error(tmp_path, setup_path):
     tm.assert_series_equal(s, reread)
 
 
-def test_complex_append(setup_path):
+def test_complex_append(tmp_path, setup_path):
     df = DataFrame(
         {
             "a": np.random.default_rng(2).standard_normal(100).astype(np.complex128),
@@ -191,8 +197,10 @@ def test_complex_append(setup_path):
         }
     )
 
-    with ensure_clean_store(setup_path) as store:
+    path = tmp_path / setup_path
+    with HDFStore(path, mode="a") as store:
         store.append("df", df, data_columns=["b"])
         store.append("df", df)
         result = store.select("df")
         tm.assert_frame_equal(pd.concat([df, df], axis=0), result)
+

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -1,16 +1,17 @@
 import numpy as np
 import pytest
-import tables
-
 
 import pandas as pd
+import pandas._testing as tm
 from pandas import (
     DataFrame,
     HDFStore,
     Series,
     read_hdf,
 )
-import pandas._testing as tm
+
+
+tables = pytest.importorskip("tables")
 
 
 def test_complex_fixed(tmp_path, setup_path):

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -1,14 +1,16 @@
 import numpy as np
 import pytest
+import tables
+
 
 import pandas as pd
-import pandas._testing as tm
 from pandas import (
     DataFrame,
     HDFStore,
     Series,
     read_hdf,
 )
+import pandas._testing as tm
 
 
 def test_complex_fixed(tmp_path, setup_path):
@@ -108,7 +110,6 @@ def test_complex_mixed_table(tmp_path, setup_path):
         result = store.select("df", where="A>2")
         tm.assert_frame_equal(df.loc[df.A > 2], result)
 
-
     path = tmp_path / setup_path
     df.to_hdf(path, key="df", format="table")
     reread = read_hdf(path, "df")
@@ -163,7 +164,6 @@ def test_complex_indexing_error(tmp_path, setup_path):
             store.append("df", df, data_columns=["C"])
 
 
-
 def test_complex_series_error(tmp_path, setup_path):
     complex128 = np.array([1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])
     s = Series(complex128, index=list("abcd"))
@@ -200,4 +200,3 @@ def test_complex_append(tmp_path, setup_path):
         store.append("df", df)
         result = store.select("df")
         tm.assert_frame_equal(pd.concat([df, df], axis=0), result)
-

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -7,6 +7,7 @@ from pandas import (
     Series,
 )
 import pandas._testing as tm
+
 from pandas.tests.io.pytables.common import ensure_clean_store
 
 from pandas.io.pytables import read_hdf

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -2,14 +2,13 @@ import numpy as np
 import pytest
 
 import pandas as pd
-import pandas._testing as tm
 from pandas import (
     DataFrame,
     HDFStore,
     Series,
     read_hdf,
 )
-
+import pandas._testing as tm
 
 tables = pytest.importorskip("tables")
 

--- a/pandas/tests/io/pytables/test_file_handling.py
+++ b/pandas/tests/io/pytables/test_file_handling.py
@@ -24,7 +24,6 @@ from pandas import (
 )
 from pandas.tests.io.pytables.common import (
     _maybe_remove,
-    ensure_clean_store,
     tables,
 )
 
@@ -188,8 +187,8 @@ def test_open_args(tmp_path, setup_path, using_infer_string):
     assert not os.path.exists(path)
 
 
-def test_flush(setup_path):
-    with ensure_clean_store(setup_path) as store:
+def test_flush(tmp_path, setup_path):
+    with HDFStore(tmp_path / setup_path) as store:
         store["a"] = Series(range(5))
         store.flush()
         store.flush(fsync=True)
@@ -316,8 +315,8 @@ def test_complibs(tmp_path, lvl, lib, request):
 @pytest.mark.skipif(
     not is_platform_little_endian(), reason="reason platform is not little endian"
 )
-def test_encoding(setup_path):
-    with ensure_clean_store(setup_path) as store:
+def test_encoding(tmp_path, setup_path):
+    with HDFStore(tmp_path / setup_path) as store:
         df = DataFrame({"A": "foo", "B": "bar"}, index=range(5))
         df.loc[2, "A"] = np.nan
         df.loc[3, "B"] = np.nan


### PR DESCRIPTION
- [x] Contributes to #62435 

Replace ensure_clean_store with tmp_path fixture in the following files:
* `pandas/tests/io/pytables/test_keys.py`
* `pandas/tests/io/pytables/test_complex.py`
* ~~`pandas/tests/io/pytables/test_file_handling.py`~~

Specifically,
* Replace all occurrences of `ensure_clean_store` with  + `HDFStore(tmp_path / setup_path)`
* Removed ensure_clean_store imports (no longer used)
* Added `tmp_path` parameter to modified test functions

=====
- [ ] Code fixes #xxx
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
