### PR TITLE
DOC: Correct many grammatical issues

### DIFF
--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -1070,7 +1070,7 @@ cdef class StringHashTable(HashTable):
             val = values[i]
 
             if isinstance(val, str):
-                # GH#31499 if we have a np.str_ PyUnicode_AsUTF8 won't recognize
+                # GH#31499 if we have an np.str_ PyUnicode_AsUTF8 won't recognize
                 #  it as a str, even though isinstance does.
                 v = PyUnicode_AsUTF8(<str>val)
             else:
@@ -1108,7 +1108,7 @@ cdef class StringHashTable(HashTable):
             val = values[i]
 
             if isinstance(val, str):
-                # GH#31499 if we have a np.str_ PyUnicode_AsUTF8 won't recognize
+                # GH#31499 if we have an np.str_ PyUnicode_AsUTF8 won't recognize
                 #  it as a str, even though isinstance does.
                 v = PyUnicode_AsUTF8(<str>val)
             else:

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -58,7 +58,7 @@ cdef bint is_definitely_invalid_key(object val):
 
 cdef ndarray _get_bool_indexer(ndarray values, object val, ndarray mask = None):
     """
-    Return a ndarray[bool] of locations where val matches self.values.
+    Return an ndarray[bool] of locations where val matches self.values.
 
     If val is not NA, this is equivalent to `self.values == val`
     """

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -120,7 +120,7 @@ def format_array_from_datetime(
     NPY_DATETIMEUNIT reso=NPY_FR_ns,
 ) -> np.ndarray:
     """
-    return a np object array of the string formatted values
+    return an np object array of the string formatted values
 
     Parameters
     ----------

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -276,7 +276,7 @@ cdef (int64_t, int) precision_from_unit(
 
 cdef int64_t get_datetime64_nanos(object val, NPY_DATETIMEUNIT reso) except? -1:
     """
-    Extract the value and unit from a np.datetime64 object, then convert the
+    Extract the value and unit from an np.datetime64 object, then convert the
     value to nanoseconds if necessary.
     """
     cdef:

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -1885,7 +1885,7 @@ cdef bint checknull_with_nat(object val):
 
 cdef bint is_dt64nat(object val):
     """
-    Is this a np.datetime64 object np.datetime64("NaT").
+    Is this an np.datetime64 object np.datetime64("NaT").
     """
     if cnp.is_datetime64_object(val):
         return cnp.get_datetime64_value(val) == NPY_NAT
@@ -1894,7 +1894,7 @@ cdef bint is_dt64nat(object val):
 
 cdef bint is_td64nat(object val):
     """
-    Is this a np.timedelta64 object np.timedelta64("NaT").
+    Is this an np.timedelta64 object np.timedelta64("NaT").
     """
     if cnp.is_timedelta64_object(val):
         return cnp.get_timedelta64_value(val) == NPY_NAT

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -818,7 +818,7 @@ cdef class BaseOffset:
         state["normalize"] = self.normalize
 
         # we don't want to actually pickle the calendar object
-        # as its a np.busyday; we recreate on deserialization
+        # as its an np.busyday; we recreate on deserialization
         state.pop("calendar", None)
         if "kwds" in state:
             state["kwds"].pop("calendar", None)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1489,7 +1489,7 @@ cdef class _Timedelta(timedelta):
         """
         cdef:
             str abbrev = npy_unit_to_abbrev(self._creso)
-        # TODO: way to create a np.timedelta64 obj with the reso directly
+        # TODO: way to create an np.timedelta64 obj with the reso directly
         #  instead of having to get the abbrev?
         return np.timedelta64(self._value, abbrev)
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -412,7 +412,7 @@ cdef class _Timestamp(ABCTimestamp):
 
     @classmethod
     def _from_dt64(cls, dt64: np.datetime64):
-        # construct a Timestamp from a np.datetime64 object, keeping the
+        # construct a Timestamp from an np.datetime64 object, keeping the
         #  resolution of the input.
         # This is here mainly so we can incrementally implement non-nano
         #  (e.g. only tznaive at first)

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -402,7 +402,7 @@ def get_cython_table_params(ndframe, func_names_and_expected):
     ----------
     ndframe : DataFrame or Series
     func_names_and_expected : Sequence of two items
-        The first item is a name of a NDFrame method ('sum', 'prod') etc.
+        The first item is a name of an NDFrame method ('sum', 'prod') etc.
         The second item is the expected return value.
 
     Returns

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -803,7 +803,7 @@ def assert_extension_array_equal(
             ):
                 return
         # Avoid slow object-dtype comparisons
-        # np.asarray for case where we have a np.MaskedArray
+        # np.asarray for case where we have an np.MaskedArray
         assert_numpy_array_equal(
             np.asarray(left.asi8),
             np.asarray(right.asi8),

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1161,7 +1161,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             raise TypeError(f"cannot subtract a datelike from a {type(self).__name__}")
 
         self = cast("DatetimeArray", self)
-        # subtract a datetime from myself, yielding a ndarray[timedelta64[ns]]
+        # subtract a datetime from myself, yielding an ndarray[timedelta64[ns]]
 
         if isna(other):
             # i.e. np.datetime64("NaT")

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1977,7 +1977,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         axis: AxisInt | None = None,
     ) -> Self:
         """
-        Repeat elements of a IntervalArray.
+        Repeat elements of an IntervalArray.
 
         Returns a new IntervalArray where each element of the current IntervalArray
         is repeated consecutively a given number of times.

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -393,7 +393,7 @@ def maybe_downcast_numeric(
 
 def maybe_upcast_numeric_to_64bit(arr: NumpyIndexT) -> NumpyIndexT:
     """
-    If array is a int/uint/float bit size lower than 64 bit, upcast it to 64 bit.
+    If array is an int/uint/float bit size lower than 64 bit, upcast it to 64 bit.
 
     Parameters
     ----------
@@ -1393,7 +1393,7 @@ def construct_1d_arraylike_from_scalar(
     value: Scalar, length: int, dtype: DtypeObj | None
 ) -> ArrayLike:
     """
-    create a np.ndarray / pandas type of specified shape and dtype
+    create an np.ndarray / pandas type of specified shape and dtype
     filled with values
 
     Parameters

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -602,7 +602,7 @@ def is_categorical_dtype(arr_or_dtype) -> bool:
 
 def is_string_or_object_np_dtype(dtype: np.dtype) -> bool:
     """
-    Faster alternative to is_string_dtype, assumes we have a np.dtype object.
+    Faster alternative to is_string_dtype, assumes we have an np.dtype object.
     """
     return dtype == object or dtype.kind in "SU"
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -113,7 +113,7 @@ str_type = str
 
 class PandasExtensionDtype(ExtensionDtype):
     """
-    A np.dtype duck-typed class, suitable for holding a custom dtype.
+    An np.dtype duck-typed class, suitable for holding a custom dtype.
 
     THIS IS NOT A REAL NUMPY DTYPE
     """
@@ -503,7 +503,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
             # assumes if any individual category is a tuple, then all our. ATM
             # I don't really want to support just some of the categories being
             # tuples.
-            cat_list = list(categories)  # breaks if a np.array of categories
+            cat_list = list(categories)  # breaks if an np.array of categories
             cat_array = hash_tuples(cat_list)
         else:
             if categories.dtype == "O" and len({type(x) for x in categories}) != 1:

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -593,7 +593,7 @@ def construct_1d_array_from_inferred_fill_value(
 
 def maybe_fill(arr: np.ndarray) -> np.ndarray:
     """
-    Fill numpy.ndarray with NaN, unless we have a integer or boolean dtype.
+    Fill numpy.ndarray with NaN, unless we have an integer or boolean dtype.
     """
     if arr.dtype.kind not in "iub":
         arr.fill(np.nan)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -645,7 +645,7 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
 
         def get_converter(s):
             # possibly convert to the actual key types
-            # in the indices, could be a Timestamp or a np.datetime64
+            # in the indices, could be a Timestamp or an np.datetime64
             if isinstance(s, datetime.datetime):
                 return lambda key: Timestamp(key)
             elif isinstance(s, np.datetime64):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1319,7 +1319,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def repeat(self, repeats, axis: None = None) -> Self:
         """
-        Repeat elements of a Index.
+        Repeat elements of an Index.
 
         Returns a new Index where each element of the current Index
         is repeated consecutively a given number of times.
@@ -4937,7 +4937,7 @@ class Index(IndexOpsMixin, PandasObject):
         Whether we can use the fastpaths implemented in _libs.join.
 
         This is driven by whether (in monotonic increasing cases that are
-        guaranteed not to have NAs) we can convert to a np.ndarray without
+        guaranteed not to have NAs) we can convert to an np.ndarray without
         making a copy. If we cannot, this negates the performance benefit
         of using libjoin.
         """

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -921,7 +921,7 @@ class RangeIndex(Index):
         sort : bool or None, default None
             Whether to sort (monotonically increasing) the resulting index.
             ``sort=None|True`` returns a ``RangeIndex`` if possible or a sorted
-            ``Index`` with a int64 dtype if not.
+            ``Index`` with an int64 dtype if not.
             ``sort=False`` can return a ``RangeIndex`` if self is monotonically
             increasing and other is fully contained in self. Otherwise, returns
             an unsorted ``Index`` with an int64 dtype.
@@ -1184,7 +1184,7 @@ class RangeIndex(Index):
         Overriding parent method for the case of all RangeIndex instances.
 
         When all members of "indexes" are of type RangeIndex: result will be
-        RangeIndex if possible, Index with a int64 dtype otherwise. E.g.:
+        RangeIndex if possible, Index with an int64 dtype otherwise. E.g.:
         indexes = [RangeIndex(3), RangeIndex(3, 6)] -> RangeIndex(6)
         indexes = [RangeIndex(3), RangeIndex(4, 6)] -> Index([0,1,2,4,5], dtype='int64')
         """

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1480,7 +1480,7 @@ class _LocIndexer(_LocationIndexer):
     def _convert_to_indexer(self, key, axis: AxisInt):
         """
         Convert indexing key into something we can use to do actual fancy
-        indexing on a ndarray.
+        indexing on an ndarray.
 
         Examples
         ix[:5] -> slice(0, 5)
@@ -1991,7 +1991,7 @@ class _iLocIndexer(_LocationIndexer):
         lplane_indexer = length_of_indexer(pi, self.obj.index)
         # lplane_indexer gives the expected length of obj[indexer[0]]
 
-        # we need an iterable, with a ndim of at least 1
+        # we need an iterable, with an ndim of at least 1
         # eg. don't pass through np.array(0)
         if is_list_like_indexer(value) and getattr(value, "ndim", 1) > 0:
             if isinstance(value, ABCDataFrame):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1151,7 +1151,7 @@ class Block(PandasObject, libinternals.Block):
         Parameters
         ----------
         mask : np.ndarray[bool], SparseArray[bool], or BooleanArray
-        new : a ndarray/object
+        new : an ndarray/object
 
         Returns
         -------
@@ -1214,7 +1214,7 @@ class Block(PandasObject, libinternals.Block):
 
         Parameters
         ----------
-        other : a ndarray/object
+        other : an ndarray/object
         cond : np.ndarray[bool], SparseArray[bool], or BooleanArray
 
         Returns

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -193,7 +193,7 @@ def ndarray_to_mgr(
     values, index, columns, dtype: DtypeObj | None, copy: bool
 ) -> Manager:
     # used in DataFrame.__init__
-    # input must be a ndarray, list, Series, Index, ExtensionArray
+    # input must be an ndarray, list, Series, Index, ExtensionArray
     infer_object = not isinstance(values, (ABCSeries, Index, ExtensionArray))
 
     if isinstance(values, ABCSeries):

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -807,7 +807,7 @@ class BaseBlockManager(PandasObject):
         only_slice : bool, default False
             Whether to take views, not copies, along columns.
         use_na_proxy : bool, default False
-            Whether to use a np.void ndarray for newly introduced columns.
+            Whether to use an np.void ndarray for newly introduced columns.
 
         pandas-indexer with -1's only.
         """
@@ -883,7 +883,7 @@ class BaseBlockManager(PandasObject):
             If True, we always return views on existing arrays, never copies.
             This is used when called from ops.blockwise.operate_blockwise.
         use_na_proxy : bool, default False
-            Whether to use a np.void ndarray for newly introduced columns.
+            Whether to use an np.void ndarray for newly introduced columns.
         ref_inplace_op: bool, default False
             Don't track refs if True because we operate inplace
 

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -851,7 +851,7 @@ def pad_or_backfill_inplace(
     # reshape a 1 dim if needed
     if values.ndim == 1:
         if axis != 0:  # pragma: no cover
-            raise AssertionError("cannot interpolate on a ndim == 1 with axis != 0")
+            raise AssertionError("cannot interpolate on an ndim == 1 with axis != 0")
         values = values.reshape(tuple((1,) + values.shape))
 
     method = clean_fill_method(method)

--- a/pandas/core/ops/mask_ops.py
+++ b/pandas/core/ops/mask_ops.py
@@ -49,7 +49,7 @@ def kleene_or(
         return kleene_or(right, left, right_mask, left_mask)
 
     if not isinstance(left, np.ndarray):
-        raise TypeError("Either `left` or `right` need to be a np.ndarray.")
+        raise TypeError("Either `left` or `right` need to be an np.ndarray.")
 
     raise_for_nan(right, method="or")
 
@@ -113,7 +113,7 @@ def kleene_xor(
         return kleene_xor(right, left, right_mask, left_mask)
 
     if not isinstance(left, np.ndarray):
-        raise TypeError("Either `left` or `right` need to be a np.ndarray.")
+        raise TypeError("Either `left` or `right` need to be an np.ndarray.")
 
     raise_for_nan(right, method="xor")
     if right is libmissing.NA:
@@ -163,7 +163,7 @@ def kleene_and(
         return kleene_and(right, left, right_mask, left_mask)
 
     if not isinstance(left, np.ndarray):
-        raise TypeError("Either `left` or `right` need to be a np.ndarray.")
+        raise TypeError("Either `left` or `right` need to be an np.ndarray.")
     raise_for_nan(right, method="and")
 
     if right is libmissing.NA:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4293,7 +4293,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         This routine will explode list-likes including lists, tuples, sets,
         Series, and np.ndarray. The result dtype of the subset rows will
         be object. Scalars will be returned unchanged, and empty list-likes will
-        result in a np.nan for that row. In addition, the ordering of elements in
+        result in an np.nan for that row. In addition, the ordering of elements in
         the output will be non-deterministic when exploding sets.
 
         Reference :ref:`the user guide <reshaping.explode>` for more examples.

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -270,7 +270,7 @@ def hash_array(
       dtype=uint64)
     """
     if not hasattr(vals, "dtype"):
-        raise TypeError("must pass a ndarray-like")
+        raise TypeError("must pass an ndarray-like")
 
     if isinstance(vals, ABCExtensionArray):
         return vals._hash_pandas_object(

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -991,7 +991,7 @@ class InvalidColumnName(Warning):
 
 class CategoricalConversionWarning(Warning):
     """
-    Warning is raised when reading a partial labeled Stata file using a iterator.
+    Warning is raised when reading a partial labeled Stata file using an iterator.
 
     This warning helps ensure data integrity and alerts users to potential issues
     during the incremental reading of Stata files with labeled data, allowing for

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -1280,7 +1280,7 @@ class Parser:
     @final
     def _try_convert_to_date(self, data: Series) -> Series:
         """
-        Try to parse a ndarray like into a date column.
+        Try to parse an ndarray like into a date column.
 
         Try to coerce object in epoch/iso formats and integer/float in epoch
         formats.

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1126,16 +1126,16 @@ class MPLPlot(ABC):
         Error bars can be specified in several ways:
             Series: the user provides a pandas.Series object of the same
                     length as the data
-            ndarray: provides a np.ndarray of the same length as the data
+            ndarray: provides an np.ndarray of the same length as the data
             DataFrame/dict: error values are paired with keys matching the
                     key in the plotted DataFrame
             str: the name of the column within the plotted DataFrame
 
         Asymmetrical error bars are also supported, however raw error values
-        must be provided in this case. For a ``N`` length :class:`Series`, a
+        must be provided in this case. For an ``N`` length :class:`Series`, a
         ``2xN`` array should be provided indicating lower and upper (or left
-        and right) errors. For a ``MxN`` :class:`DataFrame`, asymmetrical errors
-        should be in a ``Mx2xN`` array.
+        and right) errors. For an ``MxN`` :class:`DataFrame`, asymmetrical errors
+        should be in an ``Mx2xN`` array.
         """
         if err is None:
             return None, data

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1830,7 +1830,7 @@ class TestTimedeltaArraylikeMulDivOps:
             expected = expected.to_numpy()
         tm.assert_equal(res, expected)
         if box_with_array is DataFrame:
-            # We have a np.timedelta64(NaT), not pd.NaT
+            # We have an np.timedelta64(NaT), not pd.NaT
             assert isinstance(res.iloc[1, 0], np.timedelta64)
 
         res = tdi // other
@@ -1841,7 +1841,7 @@ class TestTimedeltaArraylikeMulDivOps:
             expected = expected.to_numpy()
         tm.assert_equal(res, expected)
         if box_with_array is DataFrame:
-            # We have a np.timedelta64(NaT), not pd.NaT
+            # We have an np.timedelta64(NaT), not pd.NaT
             assert isinstance(res.iloc[1, 0], np.timedelta64)
 
     # ------------------------------------------------------------------

--- a/pandas/tests/arrays/boolean/test_logical.py
+++ b/pandas/tests/arrays/boolean/test_logical.py
@@ -249,7 +249,7 @@ class TestLogicalOps(BaseOpsUtil):
 
 @pytest.mark.parametrize("operation", [kleene_or, kleene_xor, kleene_and])
 def test_error_both_scalar(operation):
-    msg = r"Either `left` or `right` need to be a np\.ndarray."
+    msg = r"Either `left` or `right` need to be an np\.ndarray."
     with pytest.raises(TypeError, match=msg):
         # masks need to be non-None, otherwise it ends up in an infinite recursion
         operation(True, True, np.zeros(1), np.zeros(1))

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -444,7 +444,7 @@ class TestFrameFlexComparisons:
         df = DataFrame([pd.NaT])
 
         result = df == pd.NaT
-        # result.iloc[0, 0] is a np.bool_ object
+        # result.iloc[0, 0] is an np.bool_ object
         assert result.iloc[0, 0].item() is False
 
         result = df.eq(pd.NaT)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1869,7 +1869,7 @@ class TestDataFrameConstructors:
         )
         tm.assert_series_equal(result, expected)
 
-        # check with ndarray construction ndim==0 (e.g. we are passing a ndim 0
+        # check with ndarray construction ndim==0 (e.g. we are passing an ndim 0
         # ndarray with a dtype specified)
         df = DataFrame(
             {

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -762,7 +762,7 @@ def test_index_equal_empty_iterable():
 
 
 def test_raise_invalid_sortorder():
-    # Test that the MultiIndex constructor raise when a incorrect sortorder is given
+    # Test that the MultiIndex constructor raise when an incorrect sortorder is given
     # GH#28518
 
     levels = [[0, 1], [0, 1, 2]]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -333,7 +333,7 @@ class TestLocBaseIndependent:
 
     def test_loc_getitem_dups(self):
         # GH 5678
-        # repeated getitems on a dup index returning a ndarray
+        # repeated getitems on a dup index returning an ndarray
         df = DataFrame(
             np.random.default_rng(2).random((20, 5)),
             index=["ABCDE"[x % 5] for x in range(20)],
@@ -1431,7 +1431,7 @@ class TestLocBaseIndependent:
         tm.assert_frame_equal(expected, df)
 
     def test_loc_setitem_categorical_values_partial_column_slice(self):
-        # Assigning a Category to parts of a int/... column uses the values of
+        # Assigning a Category to parts of an int/... column uses the values of
         # the Categorical
         df = DataFrame({"a": [1, 1, 1, 1, 1], "b": list("aaaaa")})
         with pytest.raises(TypeError, match="Invalid value"):

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -251,7 +251,7 @@ def test_select_dtypes(setup_path, request):
         tm.assert_frame_equal(expected, result)
 
         # https://github.com/PyTables/PyTables/issues/282
-        # bug in selection when 0th row has a np.nan and an index
+        # bug in selection when 0th row has an np.nan and an index
         # store.append('df3',df,data_columns=True)
         # result = store.select(
         #    'df3', where='values>2.0')

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -229,7 +229,7 @@ class TestReductions:
 
 class TestIndexReductions:
     # Note: the name TestIndexReductions indicates these tests
-    #  were moved from a Index-specific test file, _not_ that these tests are
+    #  were moved from an Index-specific test file, _not_ that these tests are
     #  intended long-term to be Index-specific
 
     @pytest.mark.parametrize(

--- a/pandas/tests/reshape/concat/test_invalid.py
+++ b/pandas/tests/reshape/concat/test_invalid.py
@@ -14,7 +14,7 @@ import pandas._testing as tm
 class TestInvalidConcat:
     @pytest.mark.parametrize("obj", [1, {}, [1, 2], (1, 2)])
     def test_concat_invalid(self, obj):
-        # trying to concat a ndframe with a non-ndframe
+        # trying to concat an ndframe with a non-ndframe
         df1 = DataFrame(range(2))
         msg = (
             f"cannot concatenate object of type '{type(obj)}'; "

--- a/pandas/tests/reshape/test_from_dummies.py
+++ b/pandas/tests/reshape/test_from_dummies.py
@@ -304,7 +304,7 @@ def test_no_prefix_string_cats_contains_get_dummies_NaN_column():
         pytest.param(
             1,
             {"": ["a", "b", 1]},
-            id="default_category is a int",
+            id="default_category is an int",
         ),
         pytest.param(
             1.25,

--- a/pandas/tests/series/methods/test_rank.py
+++ b/pandas/tests/series/methods/test_rank.py
@@ -92,7 +92,7 @@ class TestSeriesRank:
         mask = np.isnan(datetime_series)
         filled = datetime_series.fillna(np.inf)
 
-        # rankdata returns a ndarray
+        # rankdata returns an ndarray
         exp = Series(sp_stats.rankdata(filled), index=filled.index, name="ts")
         exp[mask] = np.nan
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -673,7 +673,7 @@ class TestToDatetime:
         # https://github.com/pandas-dev/pandas/issues/49298
         # https://github.com/pandas-dev/pandas/issues/50254
         # note: ISO8601 formats go down a fastpath, so we need to check both
-        # a ISO8601 format and a non-ISO8601 one
+        # an ISO8601 format and a non-ISO8601 one
         ts1 = constructor(args[0])
         ts2 = args[1]
         result = to_datetime([ts1, ts2], format=fmt, utc=utc)
@@ -697,7 +697,7 @@ class TestToDatetime:
         # https://github.com/pandas-dev/pandas/issues/50254
         # GH#57275
         # note: ISO8601 formats go down a fastpath, so we need to check both
-        # a ISO8601 format and a non-ISO8601 one
+        # an ISO8601 format and a non-ISO8601 one
         args = ["2000-01-01 01:00:00", "2000-01-01 02:00:00+00:00"]
         ts1 = constructor(args[0])
         ts2 = args[1]
@@ -796,7 +796,7 @@ class TestToDatetime:
     ):
         # https://github.com/pandas-dev/pandas/issues/49298
         # note: ISO8601 formats go down a fastpath, so we need to check both
-        # a ISO8601 format and a non-ISO8601 one
+        # an ISO8601 format and a non-ISO8601 one
         ts1 = constructor(args[0])
         ts2 = constructor(args[1])
         with pytest.raises(

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -68,7 +68,7 @@ def test_hash_array_mixed(dtype):
 
 @pytest.mark.parametrize("val", [5, "foo", pd.Timestamp("20130101")])
 def test_hash_array_errors(val):
-    msg = "must pass a ndarray-like"
+    msg = "must pass an ndarray-like"
     with pytest.raises(TypeError, match=msg):
         hash_array(val)
 


### PR DESCRIPTION
Correct grammar issues about a/an usage.

I searched for patterns such as `" a np"` and `" a nd"` in the GitHub codebase, because they are most likely to contain grammatical mistakes. Then I manually reviewed which ones needed to be changed. These patterns are not exhaustive, so a few issues of ("a" vs "an") still remain.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
