### PR TITLE
TST: Add regression test for DatetimeIndex.union across DST boundary (#62915)

### DIFF
--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -757,3 +757,13 @@ def test_intersection_non_nano_rangelike():
         freq="D",
     )
     tm.assert_index_equal(result, expected)
+
+
+def test_union_across_dst_boundary():
+    # GH#62915 union should work when one index ends at DST boundary
+    # and the other extends past it
+    index1 = date_range("2025-10-25", "2025-10-26", freq="D", tz="Europe/Helsinki")
+    index2 = date_range("2025-10-25", "2025-10-28", freq="D", tz="Europe/Helsinki")
+    result = index1.union(index2)
+    expected = date_range("2025-10-25", "2025-10-28", freq="D", tz="Europe/Helsinki")
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] closes #62915
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This PR adds a regression test for #62915.

The bug was that `DatetimeIndex.union` would fail with an `AssertionError` when one index ended at a DST (Daylight Saving Time) boundary and the other extended past it. This was fixed by commit 1bd183007b and this test ensures the fix is not regressed.