### PR TITLE
TST: Add regression test for infer_freq stateful behavior (#55794)

### DIFF
--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -565,7 +565,7 @@ def test_infer_freq_no_stateful_behavior():
     assert frequencies.infer_freq(times[:3]) == "D"
 
     # Call on full index (which has duplicates, so returns None)
-    frequencies.infer_freq(times)
+    assert frequencies.infer_freq(times) is None
 
     # After calling on full index, slice should still return "D"
     assert frequencies.infer_freq(times[:3]) == "D"

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -553,3 +553,19 @@ def test_infer_freq_pyarrow():
     assert frequencies.infer_freq(pd_series.values) == "30s"
     assert frequencies.infer_freq(pd_index) == "30s"
     assert frequencies.infer_freq(pd_series) == "30s"
+
+
+def test_infer_freq_no_stateful_behavior():
+    # GH#55794 infer_freq should not have stateful behavior
+    # calling infer_freq on a full index with duplicates should not
+    # affect the result of calling it on a slice without duplicates
+    times = to_datetime(["2019-01-01", "2019-01-02", "2019-01-03", "2019-01-03"])
+
+    # Before calling infer_freq on full index
+    assert frequencies.infer_freq(times[:3]) == "D"
+
+    # Call on full index (which has duplicates, so returns None)
+    frequencies.infer_freq(times)
+
+    # After calling on full index, slice should still return "D"
+    assert frequencies.infer_freq(times[:3]) == "D"


### PR DESCRIPTION
- [x] closes #55794
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This PR adds a regression test for #55794.

The bug was that `infer_freq` had stateful behavior - calling it on a full index with duplicates would affect the result of subsequent calls on slices without duplicates. This has been fixed on main and this test ensures the fix is not regressed.