### PR TITLE
DOC: add NaN example to DataFrame.equals

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1459,7 +1459,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         DataFrames with NaN in the same locations compare equal.
 
-        >>> import numpy as np
         >>> df_nan1 = pd.DataFrame({"a": [1, np.nan], "b": [3, np.nan]})
         >>> df_nan2 = pd.DataFrame({"a": [1, np.nan], "b": [3, np.nan]})
         >>> df_nan1.equals(df_nan2)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1456,6 +1456,20 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         0  10.0  20.0
         >>> df.equals(different_data_type)
         False
+
+        DataFrames with NaN in the same locations compare equal.
+
+        >>> import numpy as np
+        >>> df_nan1 = pd.DataFrame({"a": [1, np.nan], "b": [3, np.nan]})
+        >>> df_nan2 = pd.DataFrame({"a": [1, np.nan], "b": [3, np.nan]})
+        >>> df_nan1.equals(df_nan2)
+        True
+
+        If the NaN values are not in the same locations, they compare unequal.
+
+        >>> df_nan3 = pd.DataFrame({"a": [1, np.nan], "b": [3, 4]})
+        >>> df_nan1.equals(df_nan3)
+        False
         """
         if not (isinstance(other, type(self)) or isinstance(self, type(other))):
             return False


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This PR updates the `DataFrame.equals` docstring to include a short example
showing how `NaN` values are handled.

- Adds an example where `NaN` values are in the same locations, which compares `True`.
- Adds an example where the position of `NaN` differs, which compares `False`.

Documentation-only change, no behavior modifications.
