### PR TITLE
STY: Add strict=True to zip() calls in pandas/tests/reshape

### DIFF
--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -707,7 +707,7 @@ def test_concat_repeated_keys(keys, integrity):
     # GH: 20816
     series_list = [Series({"a": 1}), Series({"b": 2}), Series({"c": 3})]
     result = concat(series_list, keys=keys, verify_integrity=integrity)
-    tuples = list(zip(keys, ["a", "b", "c"]))
+    tuples = list(zip(keys, ["a", "b", "c"], strict=True))
     expected = Series([1, 2, 3], index=MultiIndex.from_tuples(tuples))
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -60,7 +60,7 @@ class TestIndexConcat:
             Index(["c", "d", "e"], name=name_in3),
         ]
         frames = [
-            DataFrame({c: [0, 1, 2]}, index=i) for i, c in zip(indices, ["x", "y", "z"])
+            DataFrame({c: [0, 1, 2]}, index=i) for i, c in zip(indices, ["x", "y", "z"], strict=True)
         ]
         result = concat(frames, axis=1)
 
@@ -218,7 +218,7 @@ class TestMultiIndexConcat:
         level2 = [1] * 5 + [2] * 2
         level1 = [1] * 7
         no_name = list(range(5)) + list(range(2))
-        tuples = list(zip(level2, level1, no_name))
+        tuples = list(zip(level2, level1, no_name, strict=True))
         index = MultiIndex.from_tuples(tuples, names=["level2", "level1", None])
         expected = DataFrame({"col": no_name}, index=index, dtype=np.int32)
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -801,7 +801,7 @@ class TestWideToLong:
                 "A1980": {0: "d", 1: "e", 2: "f"},
                 "B1970": {0: 2.5, 1: 1.2, 2: 0.7},
                 "B1980": {0: 3.2, 1: 1.3, 2: 0.1},
-                "X": dict(zip(range(3), x)),
+                "X": dict(zip(range(3), x, strict=True)),
             }
         )
         df["id"] = df.index
@@ -837,7 +837,7 @@ class TestWideToLong:
                 "A.1980": {0: "d", 1: "e", 2: "f"},
                 "B.1970": {0: 2.5, 1: 1.2, 2: 0.7},
                 "B.1980": {0: 3.2, 1: 1.3, 2: 0.1},
-                "X": dict(zip(range(3), x)),
+                "X": dict(zip(range(3), x, strict=True)),
             }
         )
         df["id"] = df.index
@@ -861,7 +861,7 @@ class TestWideToLong:
                 "A(quarterly)1980": {0: "d", 1: "e", 2: "f"},
                 "B(quarterly)1970": {0: 2.5, 1: 1.2, 2: 0.7},
                 "B(quarterly)1980": {0: 3.2, 1: 1.3, 2: 0.1},
-                "X": dict(zip(range(3), x)),
+                "X": dict(zip(range(3), x, strict=True)),
             }
         )
         df["id"] = df.index

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -304,5 +304,5 @@ def test_qcut_contains(scale, q, precision):
     arr = (scale * np.arange(q + 1)).round(precision)
     result = qcut(arr, q, precision=precision)
 
-    for value, bucket in zip(arr, result):
+    for value, bucket in zip(arr, result, strict=True):
         assert value in bucket


### PR DESCRIPTION
## STY: Add strict=True to zip() calls in pandas/tests/reshape

### Description
This PR enforces Ruff rule B905 (`zip-without-explicit-strict`) for the `pandas/tests/reshape` directory by adding `strict=True` to all `zip()` calls.

### Changes Made
Modified the following test files to add `strict=True` parameter to `zip()` calls:
- `pandas/tests/reshape/concat/test_concat.py` (1 occurrence)
- `pandas/tests/reshape/concat/test_index.py` (2 occurrences)  
- `pandas/tests/reshape/test_melt.py` (3 occurrences)
- `pandas/tests/reshape/test_qcut.py` (1 occurrence)

**Total: 7 zip() calls updated**

### Rationale
Using `strict=True` makes zip() raise a `ValueError` if the input iterables have different lengths, which helps catch bugs early. Most zip() calls in pandas have an underlying assumption that input arguments are of equal length, and this change makes that assumption explicit and runtime-verified.

### Related Issue
Contributes to #62434

### Testing
All existing tests in the modified files pass with the changes. The `strict=True` parameter was chosen because:
- All modified zip() calls iterate over collections that are expected to have matching lengths
- This is a test file change with no runtime impact on pandas library code
- Enforcing strict equality helps catch test logic errors

### Files Changed
```
pandas/tests/reshape/concat/test_concat.py
pandas/tests/reshape/concat/test_index.py
pandas/tests/reshape/test_melt.py
pandas/tests/reshape/test_qcut.py
```

### Directory Status
This PR completes the enforcement of B905 for the `pandas/tests/reshape` directory. All `zip()` calls in this directory now have explicit `strict` parameters.

### Notes
- This is part of the larger effort to enforce Ruff rule B905 across the entire pandas codebase
- Once all directories are updated, a separate PR will enable the B905 rule in `pyproject.toml`
- Changes are minimal and focused on code style improvement with no functional changes to test logic
