### PR TITLE
TST: add categorical tests for DataFrame.equals

### DIFF
--- a/pandas/tests/frame/methods/test_equals.py
+++ b/pandas/tests/frame/methods/test_equals.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pandas import (
+    Categorical,
     DataFrame,
     date_range,
 )
@@ -83,3 +84,16 @@ class TestEquals:
         df3 = df1.set_index(["floats"], append=True)
         df2 = df1.set_index(["floats"], append=True)
         assert df3.equals(df2)
+
+    def test_equals_categorical_categories_order(self):
+        cat1 = Categorical(["a", "b", "a"], categories=["a", "b"])
+        cat2 = Categorical(["a", "b", "a"], categories=["b", "a"])
+        df1 = DataFrame({"c": cat1})
+        df2 = DataFrame({"c": cat2})
+
+        assert df1.equals(df2)
+
+        cat3 = Categorical(["a", "b", "a"], categories=["a", "b", "c"])
+        df3 = DataFrame({"c": cat3})
+
+        assert not df1.equals(df3)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### What changes are proposed in this pull request?

This PR adds tests for `DataFrame.equals` with Categorical columns:

- Verifies that DataFrames are considered equal when values and categories are the same, even if the category order differs.
- Verifies that DataFrames are not equal when the category set differs.

This helps improve test coverage for `equals` on Categorical data.

### How is this PR tested?

- New test in `pandas/tests/frame/methods/test_equals.py`