### PR TITLE
BUG: MergeError not raised when both right_on and right_index are specified

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1309,6 +1309,7 @@ Reshaping
 - Bug in :meth:`DataFrame.unstack` producing incorrect results when manipulating empty :class:`DataFrame` with an :class:`ExtentionDtype` (:issue:`59123`)
 - Bug in :meth:`concat` where concatenating DataFrame and Series with ``ignore_index = True`` drops the series name (:issue:`60723`, :issue:`56257`)
 - Bug in :func:`melt` where calling with duplicate column names in ``id_vars`` raised a misleading ``AttributeError`` (:issue:`61475`)
+- Bug in :meth:`DataFrame.merge` where specifying both ``right_on`` and ``right_index`` did not raise a ``MergeError`` if ``left_on`` is also specified. Now raises a ``MergeError`` in such cases. (:issue:`63242`)
 - Bug in :meth:`DataFrame.merge` where user-provided suffixes could result in duplicate column names if the resulting names matched existing columns. Now raises a :class:`MergeError` in such cases. (:issue:`61402`)
 - Bug in :meth:`DataFrame.merge` with :class:`CategoricalDtype` columns incorrectly raising ``RecursionError`` (:issue:`56376`)
 - Bug in :meth:`DataFrame.merge` with a ``float32`` index incorrectly casting the index to ``float64`` (:issue:`41626`)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1928,10 +1928,10 @@ class _MergeOperation:
                 )
             if not self.right_index and right_on is None:
                 raise MergeError('Must pass "right_on" OR "right_index".')
-            # if self.right_index and right_on is not None:
-            #     raise MergeError(
-            #         'Can only pass argument "right_on" OR "right_index" not both.'
-            #     )
+            if self.right_index and right_on is not None:
+                raise MergeError(
+                    'Can only pass argument "right_on" OR "right_index" not both.'
+                )
             n = len(left_on)
             if self.right_index:
                 if len(left_on) != self.right.index.nlevels:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1928,6 +1928,10 @@ class _MergeOperation:
                 )
             if not self.right_index and right_on is None:
                 raise MergeError('Must pass "right_on" OR "right_index".')
+            # if self.right_index and right_on is not None:
+            #     raise MergeError(
+            #         'Can only pass argument "right_on" OR "right_index" not both.'
+            #     )
             n = len(left_on)
             if self.right_index:
                 if len(left_on) != self.right.index.nlevels:

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -3149,3 +3149,11 @@ def test_merge_pyarrow_datetime_duplicates():
     )
     expected = expected.convert_dtypes(dtype_backend="pyarrow")
     tm.assert_frame_equal(result, expected)
+
+
+def test_merge_right_on_and_right_index():
+    df1 = pd.DataFrame({"col": [1, 2, 3]})
+    df2 = pd.DataFrame({"col": [2, 3, 4]})
+
+    with pytest.raises(pd.errors.MergeError):
+        df1.merge(df2, left_on="col", right_on="col", right_index=True)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -3152,8 +3152,8 @@ def test_merge_pyarrow_datetime_duplicates():
 
 
 def test_merge_right_on_and_right_index():
-    df1 = pd.DataFrame({"col": [1, 2, 3]})
-    df2 = pd.DataFrame({"col": [2, 3, 4]})
+    df1 = DataFrame({"col": [1, 2, 3]})
+    df2 = DataFrame({"col": [2, 3, 4]})
 
     with pytest.raises(pd.errors.MergeError):
         df1.merge(df2, left_on="col", right_on="col", right_index=True)


### PR DESCRIPTION
- [x] closes #63242 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This PR addresses issue #63242. 

Issue:
In merge.py, if `left_on` is specified, and **both** `right_on` and `right_index` are also specified, a merge error is not raised. This bug is due to this conditional branch: https://github.com/pandas-dev/pandas/blob/main/pandas/core/reshape/merge.py#L1924. 

If `left_on is not None`, the validation never checks `if self.right_index and right_on is not None`. 

Solution:
My minimal fix was adding the following condition in the `elif left_on is not None` conditional branch of the `_validate_left_right_on()` method in pandas/core/reshape/merge.py:

```python
            if self.right_index and right_on is not None:
                raise MergeError(
                    'Can only pass argument "right_on" OR "right_index" not both.'
                )
```

I also added a unit test in test_merge.py that validates my fix:

```python
def test_merge_right_on_and_right_index():
    df1 = DataFrame({"col": [1, 2, 3]})
    df2 = DataFrame({"col": [2, 3, 4]})

    with pytest.raises(pd.errors.MergeError):
        df1.merge(df2, left_on="col", right_on="col", right_index=True)
```

