### PR TITLE
DOC: Update outdated getting_started links in whatsnew files

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -6,7 +6,7 @@ whatsnew,whatsnew/index
 release,whatsnew/index
 
 # getting started
-install,getting_started/install
+install,getting_started/installation
 comparison_with_r,getting_started/comparison/comparison_with_r
 comparison_with_sql,getting_started/comparison/comparison_with_sql
 comparison_with_sas,getting_started/comparison/comparison_with_sas

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -835,7 +835,7 @@ If installed, we now require:
 | pytest (dev)    | 4.0.2           |          |
 +-----------------+-----------------+----------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.
 Optional libraries below the lowest tested version may still work, but are not considered supported.
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -716,7 +716,7 @@ If installed, we now require:
 | pytest (dev)    | 4.0.2           |          |         |
 +-----------------+-----------------+----------+---------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.
 Optional libraries below the lowest tested version may still work, but are not considered supported.
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -758,7 +758,7 @@ If installed, we now require:
 | pytest (dev)    | 4.0.2           |          |         |
 +-----------------+-----------------+----------+---------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.
 Optional libraries below the lowest tested version may still work, but are not considered supported.
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -459,7 +459,7 @@ If installed, we now require:
 | mypy (dev)      | 0.782           |          |    X    |
 +-----------------+-----------------+----------+---------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.
 Optional libraries below the lowest tested version may still work, but are not considered supported.
 

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -661,7 +661,7 @@ If installed, we now require:
 | setuptools      | 38.6.0          |          |    X    |
 +-----------------+-----------------+----------+---------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.
 Optional libraries below the lowest tested version may still work, but are not considered supported.
 

--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -520,7 +520,7 @@ If installed, we now require:
 +-----------------+-----------------+----------+---------+
 
 For `optional libraries
-<https://pandas.pydata.org/docs/getting_started/install.html>`_ the general
+<https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general
 recommendation is to use the latest version. The following table lists the
 lowest version per library that is currently being tested throughout the
 development of pandas. Optional libraries below the lowest tested version may

--- a/doc/source/whatsnew/v1.5.0.rst
+++ b/doc/source/whatsnew/v1.5.0.rst
@@ -622,7 +622,7 @@ If installed, we now require:
 | xlsxwriter      | 1.4.3           |          |    X    |
 +-----------------+-----------------+----------+---------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.
 Optional libraries below the lowest tested version may still work, but are not considered supported.
 

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -673,7 +673,7 @@ If installed, we now require:
 | tzdata            | 2022.1          |    X     |    X    |
 +-------------------+-----------------+----------+---------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.
 Optional libraries below the lowest tested version may still work, but are not considered supported.
 

--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -357,7 +357,7 @@ If installed, we now require:
 | zstandard            | 0.17.0          |          |    X    |
 +----------------------+-----------------+----------+---------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 
 See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for more.
 

--- a/doc/source/whatsnew/v2.2.0.rst
+++ b/doc/source/whatsnew/v2.2.0.rst
@@ -440,7 +440,7 @@ index levels when joining on two indexes with different levels (:issue:`34133`).
 
 Increased minimum versions for dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For `optional dependencies <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional dependencies <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 Optional dependencies below the lowest tested version may still work but are not considered supported.
 The following table lists the optional dependencies that have had their minimum tested version increased.
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -627,7 +627,7 @@ The following required dependencies were updated:
 | tzdata          | 2023.3               |
 +-----------------+----------------------+
 
-For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
+For `optional libraries <https://pandas.pydata.org/docs/getting_started/installation.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.
 Optional libraries below the lowest tested version may still work, but are not considered supported.
 


### PR DESCRIPTION
This PR updates several outdated hyperlinks in the documentation that still referenced the old getting_started/install.html page. The Pandas documentation has since reorganized the Getting Started section, and the correct page is now located at getting_started/installation.html.

Summary of changes

Updated all occurrences of getting_started/install.html in the whatsnew/ documentation files to point to getting_started/installation.html.

Corrected the corresponding redirect entry in doc/redirects.csv so that older references route to the correct modern page.

Verified that the remaining occurrences of “getting_started” in other files (CSS references, image paths, and section anchors) were not hyperlinks and therefore did not require modification.

Why this change is needed

Several parts of the documentation contained hard-coded links to pages that no longer exist due to restructuring of the Getting Started section. These outdated URLs:

caused broken links on the live documentation website,

produced unnecessary Sphinx warnings during builds,

made navigation more difficult for new users.

Updating these links ensures users are directed to the correct installation guide and maintains the integrity of the documentation.

Validation

All affected files were updated manually and verified through a filesystem search. Only actual hyperlinks were modified; non-link references such as CSS files, images, and internal anchors were left unchanged.

