### PR TITLE
DOC : Added gs to the list of valid URL schemes in the read_feather

### DIFF
--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -92,7 +92,7 @@ def read_feather(
     path : str, path object, or file-like object
         String, path object (implementing ``os.PathLike[str]``), or file-like
         object implementing a binary ``read()`` function. The string could be a URL.
-        Valid URL schemes include http, ftp, s3, and file. For file URLs, a host is
+        Valid URL schemes include http, ftp, s3, gs and file. For file URLs, a host is
         expected. A local file could be: ``file://localhost/path/to/table.feather``.
     columns : sequence, default None
         If not provided, all columns are read.


### PR DESCRIPTION
- [ ] closes #63240  (Replace xxxx with the GitHub issue number)

- small fix 

@rhshadrach  `Yes, it seems to me that not limited to S3 and GCS makes this clear, no?` 
I feel both points are correct, but if you feel it should be stated explicitly, please let me know and I’ll update it. 