### PR TITLE
DOC: fixed code output on copy_on_write.rst line 251

### DIFF
--- a/doc/source/user_guide/copy_on_write.rst
+++ b/doc/source/user_guide/copy_on_write.rst
@@ -249,9 +249,9 @@ two subsequent indexing operations, e.g.
     In [3]: df
     Out[3]:
        foo  bar
-    0  100    4
+    0    1    4
     1    2    5
-    2    3    6
+    2  100    6
 
 The column ``foo`` was updated where the column ``bar`` is greater than 5.
 This violated the CoW principles though, because it would have to modify the


### PR DESCRIPTION
- [ ] closes #63258 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Fixed the output of the code in docs:
`df = pd.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})`
`df["foo"][df["bar"] > 5] = 100`
`df`

To:
`      foo  bar`
`   0    1    4`
`   1    2    5`
`   2  100    6`
