### PR TITLE
REGR: Fix IntervalArray.nunique with infinity

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -2128,7 +2128,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             )
             comb = comb.view("complex128")[:, 0]
         else:
-            comb = np.array(left.ravel(), dtype="complex128")
+            comb = np.asarray(left.ravel(), dtype="complex128")
             comb.imag = right.ravel()
         return comb
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -2128,9 +2128,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             )
             comb = comb.view("complex128")[:, 0]
         else:
-            comb = (np.array(left.ravel(), dtype="complex128")) + (
-                1j * np.array(right.ravel(), dtype="complex128")
-            )
+            comb = np.array(left.ravel(), dtype="complex128")
+            comb.imag = right.ravel()
         return comb
 
     def _from_combined(self, combined: np.ndarray) -> IntervalArray:

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -136,6 +136,20 @@ class TestMethods:
         )
         tm.assert_index_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "data",
+        [
+            [Interval(-np.inf, 0), Interval(-np.inf, 1)],
+            [Interval(0, np.inf), Interval(1, np.inf)],
+        ],
+    )
+    def test_unique_with_infinty(self, data):
+        # https://github.com/pandas-dev/pandas/issues/63218
+        s = pd.Series(data)
+        tm.assert_interval_array_equal(s.unique(), s.array)
+        assert s.nunique() == 2
+        tm.assert_series_equal(s.drop_duplicates(), s)
+
 
 class TestSetitem:
     def test_set_na(self, left_right_dtypes):


### PR DESCRIPTION
- [x] closes #63218 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

No whatsnew as this regression was introduced as part of 3.0 development.

The issue is multiplication with complex numbers and infinities can be surprising:

```python
print(1j * float("inf"))
# (nan+infj)
```

The NaN comes from `inf` being interpreted as `inf + 0j`. Then `(inf + 0j) * (0 + 1j)` makes the real part consist of `inf * 0 + 0j * 1j` with `inf*0` giving `nan`. We therefore need to avoid multiplication.