### PR TITLE
Type the return of itertuples as an iterable of Any

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -239,6 +239,7 @@ Other enhancements
 - Added a new :meth:`DataFrame.from_arrow` method to import any Arrow-compatible
   tabular data object into a pandas :class:`DataFrame` through the
   `Arrow PyCapsule Protocol <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>`__ (:issue:`59631`)
+- :meth:`DataFrame.itertuples` is now annotated to return an iterable of Any to accommodate dynamic namedtuple types
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1598,9 +1598,17 @@ class DataFrame(NDFrame, OpsMixin):
                 s._mgr.add_references(self._mgr)
             yield k, s
 
+    @overload
+    def itertuples(self, index: bool, name: None) -> Iterable[tuple[Any, ...]]:
+        ...
+
+    @overload
+    def itertuples(self, index: bool, name: str) -> Iterable[Any]:
+        ...
+
     def itertuples(
         self, index: bool = True, name: str | None = "Pandas"
-    ) -> Iterable[tuple[Any, ...]]:
+    ) -> Iterable[tuple[Any, ...]] | Iterable[Any]:
         """
         Iterate over DataFrame rows as namedtuples.
 


### PR DESCRIPTION
This is needed since it is a dynamically created NamedTuple. An overload is added for the case of a plain tuple return value when name is passed as None.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
