### PR TITLE
STY: Use strict arg in zip() in pandas/tests/dtypes

### DIFF
--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -188,10 +188,10 @@ ll_params = [
     (np.nan, False, "NaN"),
     (None, False, "None"),
 ]
-objs, expected, ids = zip(*ll_params)
+objs, expected, ids = zip(*ll_params, strict=True)
 
 
-@pytest.fixture(params=zip(objs, expected), ids=ids)
+@pytest.fixture(params=zip(objs, expected, strict=True), ids=ids)
 def maybe_list_like(request):
     return request.param
 


### PR DESCRIPTION
I added the `strict=True` parameter to 2 `zip()` calls in `pandas/tests/dtypes/test_inference.py` to enforce Ruff rule B905.

**Changes made:**
- Line 191: Added `strict=True` to `zip(*ll_params, strict=True)` 
- Line 194: Added `strict=True` to `zip(objs, expected, strict=True)` in the pytest fixture

This ensures that all zipped iterables have equal lengths, making the tests more robust by catching potential bugs early.

---

**Checklist:**

- [x] xref #62434
- [ ] Tests added and passed if fixing a bug or adding a new feature - *N/A: This is a style fix, existing tests will validate the change*
- [x] All code checks passed
- [ ] Added type annotations to new arguments/methods/functions - *N/A: No new code added*
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature - *N/A: Style fix doesn't require whatsnew entry*
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md` - *N/A: Manual code changes*