### PR TITLE
CI: Fix location of cibuildwheel wheels for nightly upload

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -164,6 +164,7 @@ jobs:
         uses: pypa/cibuildwheel@v3.2.1
         with:
          package-dir: ./dist/${{ startsWith(matrix.buildplat[1], 'macosx') && env.sdist_name || needs.build_sdist.outputs.sdist_file }}
+         output-dir: ./dist
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
           CIBW_BUILD_FRONTEND: ${{ matrix.cibw_build_frontend || 'pip' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Validate wheel RECORD
         shell: bash -el {0}
-        run: for whl in $(ls ./dist/*.whl); do wheel unpack ./dist/$whl -d /tmp; done
+        run: for whl in $(ls ./dist/*.whl); do wheel unpack $whl -d /tmp; done
 
       - uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -194,18 +194,18 @@ jobs:
 
       - name: Validate wheel RECORD
         shell: bash -el {0}
-        run: for whl in $(ls wheelhouse); do wheel unpack wheelhouse/$whl -d /tmp; done
+        run: for whl in $(ls ./dist/*.whl); do wheel unpack ./dist/$whl -d /tmp; done
 
       - uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
-          path: ./wheelhouse/*.whl
+          path: ./dist/*.whl
 
       - name: Upload wheels & sdist
         if: ${{ success() && env.IS_SCHEDULE_DISPATCH == 'true' }}
         uses: scientific-python/upload-nightly-action@0.6.2
         with:
-          artifacts_path: dist
+          artifacts_path: ./dist
           anaconda_nightly_upload_token: ${{secrets.PANDAS_NIGHTLY_UPLOAD_TOKEN}}
 
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,6 @@ pandas/py.typed
 .ropeproject
 # wheel files
 *.whl
-**/wheelhouse/*
 pip-wheel-metadata
 # coverage
 .coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ setup = ['--vsenv'] # For Windows
 
 [tool.cibuildwheel]
 skip = ["*_i686", "*_ppc64le", "*_s390x"]
+output-dir = "dist"
 build-verbosity = 3
 environment = {LDFLAGS="-Wl,--strip-all"}
 test-extras = "test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ setup = ['--vsenv'] # For Windows
 
 [tool.cibuildwheel]
 skip = ["*_i686", "*_ppc64le", "*_s390x"]
-output-dir = "dist"
 build-verbosity = 3
 environment = {LDFLAGS="-Wl,--strip-all"}
 test-extras = "test"


### PR DESCRIPTION
Follow up to https://github.com/pandas-dev/pandas/pull/63266

cibuildwheel puts the resulting wheels in a default `wheelshouse` directory. Since we create an sdist in a `./dist` directory before, this PR changes the cibuildwheel `output-dir` to `dist` as well so scientific-python/upload-nightly-action uploads the sdist and wheels from the same directory