### PR TITLE
DOC: fix subject-verb agreement in merging.rst

### DIFF
--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -977,7 +977,7 @@ with optional filling of missing data with ``fill_method``.
 
 :func:`merge_asof` is similar to an ordered left-join except that matches are on the
 nearest key rather than equal keys. For each row in the ``left`` :class:`DataFrame`,
-the last row in the ``right`` :class:`DataFrame` are selected where the ``on`` key is less
+the last row in the ``right`` :class:`DataFrame` is selected where the ``on`` key is less
 than the left's key. Both :class:`DataFrame` must be sorted by the key.
 
 Optionally :func:`merge_asof` can perform a group-wise merge by matching the


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Description

Fixes a subject-verb agreement error in the `merge_asof` section of the merging documentation.

**Current:**
> "For each row in the `left` DataFrame, the last row in the `right` DataFrame **are** selected..."

**Fixed:**
> "For each row in the `left` DataFrame, the last row in the `right` DataFrame **is** selected..."

The subject "the last row" is singular and requires the singular verb "is" rather than "are".
