### PR TITLE
DOC: fix redundant phrasing in reshaping.rst

### DIFF
--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -342,7 +342,7 @@ by supplying the ``var_name`` and ``value_name`` parameters.
    cheese.melt(id_vars=["first", "last"], var_name="quantity")
 
 When transforming a DataFrame using :func:`~pandas.melt`, the index will be ignored.
-The original index values can be kept by setting the ``ignore_index=False`` parameter to ``False`` (default is ``True``).
+The original index values can be kept by setting the ``ignore_index`` parameter to ``False`` (default is ``True``).
 ``ignore_index=False`` will however duplicate index values.
 
 .. ipython:: python


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Description

Fixes redundant phrasing in the `melt` section of the reshaping documentation.

**Current:**
> "by setting the `ignore_index=False` parameter to `False`"

**Fixed:**
> "by setting the `ignore_index` parameter to `False`"

The original text redundantly states `ignore_index=False` and then says to set it to `False`.
