### PR TITLE
BUG: Fix deprecation warnings with option_context have incorrect stacklevel

### DIFF
--- a/pandas/tests/config/test_config.py
+++ b/pandas/tests/config/test_config.py
@@ -1,3 +1,6 @@
+import os
+import warnings
+
 import pytest
 
 from pandas._config import config as cf
@@ -476,6 +479,21 @@ class TestConfig:
 
         # Ensure the current context is reset
         assert cf.get_option(option_name) == original_value
+
+    def test_option_context_deprecated_stacklevel(self):
+        cf.register_option("a", 1)
+        cf.deprecate_option("a", FutureWarning)
+
+        expected = os.path.normcase(os.path.abspath(__file__))
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            with pd.option_context("a", 2):
+                pass
+
+        assert recorded
+        for warning in recorded:
+            assert os.path.normcase(warning.filename) == expected
 
     def test_dictwrapper_getattr(self):
         options = cf.options

--- a/pandas/util/_exceptions.py
+++ b/pandas/util/_exceptions.py
@@ -44,6 +44,10 @@ def find_stack_level() -> int:
 
     pkg_dir = os.path.dirname(pd.__file__)
     test_dir = os.path.join(pkg_dir, "tests")
+    contextlib_file = getattr(contextlib, "__file__", None)
+    contextlib_dir = (
+        os.path.dirname(contextlib_file) if contextlib_file is not None else None
+    )
 
     # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
     frame: FrameType | None = inspect.currentframe()
@@ -52,6 +56,9 @@ def find_stack_level() -> int:
         while frame:
             filename = inspect.getfile(frame)
             if filename.startswith(pkg_dir) and not filename.startswith(test_dir):
+                frame = frame.f_back
+                n += 1
+            elif contextlib_dir and filename.startswith(contextlib_dir):
                 frame = frame.f_back
                 n += 1
             else:


### PR DESCRIPTION
- [X] closes #63235 (Replace xxxx with the GitHub issue number)
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
