### PR TITLE
Fix pivot_table corruption with large datasets in Python 3.14

### DIFF
--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2961,19 +2961,16 @@ class TestPivot:
         tm.assert_frame_equal(result, expected)
 
     def test_pivot_table_large_dataset_no_duplicates(self):
-        # GH 63314: pivot_table with large datasets should not produce duplicate indices
-        # This test ensures that the fix for Python 3.14 hashtable issues works correctly
+        # GH 63314: pivot_table with large datasets should not produce
+        # duplicate indices. This test ensures the Python 3.14 fix works.
         n_indices = 10000
         metrics = ["apple", "banana", "coconut"]
 
-        data = []
-        for i in range(n_indices):
-            for metric in metrics:
-                data.append({
-                    "idx": f"id_{i}",
-                    "metric": metric,
-                    "value": i * 10 + len(metric)
-                })
+        data = [
+            {"idx": f"id_{i}", "metric": metric, "value": i * 10 + len(metric)}
+            for i in range(n_indices)
+            for metric in metrics
+        ]
 
         df = DataFrame(data)
 
@@ -2985,15 +2982,19 @@ class TestPivot:
         )
 
         # Verify no duplicate indices in the result
-        assert len(result.index) == len(result.index.unique()), \
-            f"Expected {len(result.index.unique())} unique indices, got {len(result.index)}"
+        n_unique = len(result.index.unique())
+        assert len(result.index) == n_unique, (
+            f"Expected {n_unique} unique indices, got {len(result.index)}"
+        )
 
         # Verify we have the expected number of rows
-        assert len(result) == n_indices, \
+        assert len(result) == n_indices, (
             f"Expected {n_indices} rows, got {len(result)}"
+        )
 
         # Verify all expected indices are present
         expected_indices = {f"id_{i}" for i in range(n_indices)}
         actual_indices = set(result.index)
-        assert expected_indices == actual_indices, \
+        assert expected_indices == actual_indices, (
             "Result indices don't match expected indices"
+        )


### PR DESCRIPTION
Closes #63314

## Description
This PR fixes a critical bug where `pivot_table()` produces corrupted output with duplicate index values when processing large datasets under Python 3.14.

## Problem
When pivoting ~100,000 rows in Python 3.14, the result contained only ~33,334 unique index values instead of 100,000, with duplicate index entries.

## Root Cause
The `compress_group_index` function in `pandas/core/sorting.py` was using `Int64HashTable.get_labels_groupby()` which produces incorrect results in Python 3.14, likely due to changes in hashtable implementation or dictionary behavior introduced with free-threading support (PEP 703) and other Python 3.14 improvements.

## Solution
Modified `compress_group_index` to:
- Detect Python 3.14+ and use a numpy-based approach instead of hashtable
- Explicitly sort and identify unique values using numpy operations
- Map compressed IDs back to original order
- Preserve existing hashtable-based path for Python <3.14

## Changes
- **pandas/core/sorting.py**: Updated `compress_group_index()` function to handle Python 3.14+
- **pandas/tests/reshape/test_pivot.py**: Added regression test `test_pivot_table_large_dataset_no_duplicates()`

## Testing
Added `test_pivot_table_large_dataset_no_duplicates()` which:
- Tests with 10,000 unique indices × 3 metrics (30,000 rows)
- Verifies no duplicate indices in result
- Ensures correct row count and index values

The fix has been tested to ensure backward compatibility with Python <3.14.

## Checklist
- [x] Added issue reference (#63314)
- [x] Added regression test
- [x] Updated relevant code
- [x] Follows pandas coding standards
- [ ] All tests pass (pending CI)