### PR TITLE
BUG: Fix inconsistent datetime types between calamine and openpyxl readers (#59186)

### DIFF
--- a/pandas/io/excel/_calamine.py
+++ b/pandas/io/excel/_calamine.py
@@ -15,7 +15,6 @@ from typing import (
 from pandas.compat._optional import import_optional_dependency
 from pandas.util._decorators import doc
 
-import pandas as pd
 from pandas.core.shared_docs import _shared_docs
 
 from pandas.io.excel._base import BaseExcelReader
@@ -107,10 +106,16 @@ class CalamineReader(BaseExcelReader["CalamineWorkbook"]):
                     return val
                 else:
                     return value
+            elif isinstance(value, datetime):
+                # Return datetime.datetime as-is to match openpyxl behavior (GH#59186)
+                return value
             elif isinstance(value, date):
-                return pd.Timestamp(value)
+                # Convert date to datetime to match openpyxl behavior (GH#59186)
+                return datetime(value.year, value.month, value.day)
             elif isinstance(value, timedelta):
-                return pd.Timedelta(value)
+                # Return datetime.timedelta as-is to match openpyxl behavior (GH#59186)
+                # (previously returned pd.Timedelta)
+                return value
             elif isinstance(value, time):
                 return value
 

--- a/pandas/io/excel/_calamine.py
+++ b/pandas/io/excel/_calamine.py
@@ -106,16 +106,12 @@ class CalamineReader(BaseExcelReader["CalamineWorkbook"]):
                     return val
                 else:
                     return value
-            elif isinstance(value, datetime):
-                # Return datetime.datetime as-is to match openpyxl behavior (GH#59186)
+            elif isinstance(value, (datetime, timedelta)):
+                # Return as-is to match openpyxl behavior (GH#59186)
                 return value
             elif isinstance(value, date):
                 # Convert date to datetime to match openpyxl behavior (GH#59186)
                 return datetime(value.year, value.month, value.day)
-            elif isinstance(value, timedelta):
-                # Return datetime.timedelta as-is to match openpyxl behavior (GH#59186)
-                # (previously returned pd.Timedelta)
-                return value
             elif isinstance(value, time):
                 return value
 

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -135,12 +135,7 @@ def df_ref(datapath):
 
 
 def get_exp_unit(read_ext: str, engine: str | None) -> str:
-    unit = "us"
-    if read_ext == ".ods" and engine == "odf":
-        pass
-    elif (read_ext == ".ods") ^ (engine == "calamine"):
-        unit = "s"
-    return unit
+    return "us"
 
 
 def adjust_expected(expected: DataFrame, read_ext: str, engine: str | None) -> None:


### PR DESCRIPTION
closes #59186

When reading Excel files with mixed data types (strings, dates, numbers in the same column), the calamine and openpyxl engines returned different Python types for datetime values:

| Engine | Returned type |
|--------|---------------|
| openpyxl | `datetime.datetime` |
| calamine | `pd.Timestamp` |

This is confusing for users who expect consistent behavior regardless of which engine they use.

This PR Changes the calamine reader to return standard library types (`datetime.datetime`, `datetime.timedelta`) instead of pandas types (`pd.Timestamp`, `pd.Timedelta`), matching openpyxl's behavior.

Testing:
All existing Excel reader tests pass (1467 passed)
Manual testing confirms both engines now return the same types