### PR TITLE
Period constructed from invalid high-resolution Timestamp should raise OutOfBoundsDatetime

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -849,7 +849,9 @@ cdef int64_t _period_ordinal_safe(npy_datetimestruct *dts, int freq) except? -1:
     except OverflowError as err:
         # Translate low-level overflow into a user-facing OutOfBoundsDatetime.
         fmt = dts_to_iso_string(dts)
-        raise OutOfBoundsDatetime(f"Out of bounds datetime for Period with freq {freq}: {fmt}") from err
+        raise OutOfBoundsDatetime(
+            f"Out of bounds datetime for Period with freq {freq}: {fmt}"
+            ) from err
 
 
 cdef void get_date_info(int64_t ordinal,
@@ -1189,7 +1191,7 @@ cpdef int64_t period_ordinal(int y, int m, int d, int h, int min,
     dts.sec = s
     dts.us = us
     dts.ps = ps
-    #return get_period_ordinal(&dts, freq)
+    # return get_period_ordinal(&dts, freq)
     return _period_ordinal_safe(&dts, freq)
 
 

--- a/pandas/tests/tslibs/test_period.py
+++ b/pandas/tests/tslibs/test_period.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pytest
-
+import pandas as pd
 from pandas._libs.tslibs import (
     iNaT,
     to_offset,
+    OutOfBoundsDatetime,
 )
 from pandas._libs.tslibs.period import (
     extract_ordinals,
@@ -121,3 +122,10 @@ def test_get_period_field_array_raises_on_out_of_range():
     msg = "Buffer dtype mismatch, expected 'const int64_t' but got 'double'"
     with pytest.raises(ValueError, match=msg):
         get_period_field_arr(-1, np.empty(1), 0)
+
+def test_period_from_overflow_timestamp_raises():
+    # Construct a deliberately broken Timestamp
+    ts = pd.Timestamp(pd.Timestamp.min.value, unit="us")
+
+    with pytest.raises(OutOfBoundsDatetime):
+        pd.Period(ts, freq="us")

--- a/pandas/tests/tslibs/test_period.py
+++ b/pandas/tests/tslibs/test_period.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pytest
-import pandas as pd
+
 from pandas._libs.tslibs import (
+    OutOfBoundsDatetime,
     iNaT,
     to_offset,
-    OutOfBoundsDatetime,
 )
 from pandas._libs.tslibs.period import (
     extract_ordinals,
@@ -13,6 +13,7 @@ from pandas._libs.tslibs.period import (
     period_ordinal,
 )
 
+import pandas as pd
 import pandas._testing as tm
 
 
@@ -122,6 +123,7 @@ def test_get_period_field_array_raises_on_out_of_range():
     msg = "Buffer dtype mismatch, expected 'const int64_t' but got 'double'"
     with pytest.raises(ValueError, match=msg):
         get_period_field_arr(-1, np.empty(1), 0)
+
 
 def test_period_from_overflow_timestamp_raises():
     # Construct a deliberately broken Timestamp


### PR DESCRIPTION
### Summary

Constructing a `Period` from a `Timestamp` whose underlying integer becomes out-of-range when interpreted at a higher-resolution frequency (e.g., treating `Timestamp.min.value` as microseconds) previously triggered a low-level `OverflowError` inside `get_period_ordinal`, which is declared `noexcept`.   This resulted in an *unraisable* exception and `Period(...)` silently returning an incorrect ordinal instead of raising `OutOfBoundsDatetime`.

### What this PR changes

A new internal helper `_period_ordinal_safe(...)` is introduced.  It mirrors the logic of `get_period_ordinal` but is allowed to raise Python exceptions.   `cpdef period_ordinal(...)`, which feeds the Python-facing `Period(...)` API, now delegates to this safe helper.

This ensures:

- low-level period arithmetic and internal callers continue using the original `get_period_ordinal` unchanged,
- Python-facing constructions such as `Period(Timestamp, "us")` correctly raise `OutOfBoundsDatetime` when the timestamp cannot be represented at the target frequency,
- no C-level `OverflowError` leaks into pytest as an unraisable exception.

### Test

The regression test:

```python
ts = pd.Timestamp(pd.Timestamp.min.value, unit="us")
with pytest.raises(OutOfBoundsDatetime):
    pd.Period(ts, freq="us")
```
Fixes #63278