### PR TITLE
BUG: Add logical operators to pd.col Expression class

### DIFF
--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -37,6 +37,12 @@ _OP_SYMBOLS = {
     "__lt__": "<",
     "__eq__": "==",
     "__ne__": "!=",
+    "__and__": "&",
+    "__rand__": "&",
+    "__or__": "|",
+    "__ror__": "|",
+    "__xor__": "^",
+    "__rxor__": "^",
 }
 
 
@@ -156,6 +162,28 @@ class Expression:
 
     def __rmod__(self, other: Any) -> Expression:
         return self._with_binary_op("__rmod__", other)
+
+    # Logical ops
+    def __and__(self, other: Any) -> Expression:
+        return self._with_binary_op("__and__", other)
+
+    def __rand__(self, other: Any) -> Expression:
+        return self._with_binary_op("__rand__", other)
+
+    def __or__(self, other: Any) -> Expression:
+        return self._with_binary_op("__or__", other)
+
+    def __ror__(self, other: Any) -> Expression:
+        return self._with_binary_op("__ror__", other)
+
+    def __xor__(self, other: Any) -> Expression:
+        return self._with_binary_op("__xor__", other)
+
+    def __rxor__(self, other: Any) -> Expression:
+        return self._with_binary_op("__rxor__", other)
+
+    def __invert__(self) -> Expression:
+        return Expression(lambda df: ~self(df), f"(~{self._repr_str})")
 
     def __array_ufunc__(
         self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any

--- a/pandas/tests/test_col.py
+++ b/pandas/tests/test_col.py
@@ -142,6 +142,7 @@ def test_custom_accessor() -> None:
 def test_col_logical_ops(
     expr: Expression, expected_values: list[bool], expected_str: str
 ) -> None:
+    # https://github.com/pandas-dev/pandas/issues/63322
     df = pd.DataFrame({"a": [True, False, True, False], "b": [False, True, True, True]})
     result = df.assign(c=expr)
     expected = pd.DataFrame(

--- a/pandas/tests/test_col.py
+++ b/pandas/tests/test_col.py
@@ -102,9 +102,6 @@ def test_custom_accessor() -> None:
 @pytest.mark.parametrize(
     ("expr", "expected_values", "expected_str"),
     [
-        # __and__ and __rand__
-        # a = [True, False, True, False], b = [False, True, True, True]
-        # a & b = [False, False, True, False]
         (
             pd.col("a") & pd.col("b"),
             [False, False, True, False],
@@ -115,7 +112,6 @@ def test_custom_accessor() -> None:
             [True, False, True, False],
             "(col('a') & True)",
         ),
-        # __or__ and __ror__
         (
             pd.col("a") | pd.col("b"),
             [True, True, True, True],
@@ -126,8 +122,6 @@ def test_custom_accessor() -> None:
             [True, False, True, False],
             "(col('a') | False)",
         ),
-        # __xor__ and __rxor__
-        # a ^ b = [True, True, False, True]
         (
             pd.col("a") ^ pd.col("b"),
             [True, True, False, True],
@@ -138,7 +132,6 @@ def test_custom_accessor() -> None:
             [False, True, False, True],
             "(col('a') ^ True)",
         ),
-        # __invert__
         (
             ~pd.col("a"),
             [False, True, False, True],
@@ -147,7 +140,7 @@ def test_custom_accessor() -> None:
     ],
 )
 def test_col_logical_ops(
-    expr: Expression, expected_values: list[object], expected_str: str
+    expr: Expression, expected_values: list[bool], expected_str: str
 ) -> None:
     df = pd.DataFrame({"a": [True, False, True, False], "b": [False, True, True, True]})
     result = df.assign(c=expr)
@@ -161,29 +154,7 @@ def test_col_logical_ops(
     tm.assert_frame_equal(result, expected)
     assert str(expr) == expected_str
 
-
-def test_col_logical_ops_combined() -> None:
-    """Test combining multiple logical operators like in DataFrame.loc[]."""
-    df = pd.DataFrame(
-        {
-            "x": [1, 2, 3, 4, 5],
-            "y": [10, 20, 30, 40, 50],
-        }
-    )
-    # Test combining conditions with & operator
-    expr = (pd.col("x") > 2) & (pd.col("y") < 45)
+    # Test that the expression works with .loc
     result = df.loc[expr]
-    expected = df.loc[(df["x"] > 2) & (df["y"] < 45)]
-    tm.assert_frame_equal(result, expected)
-
-    # Test combining conditions with | operator
-    expr = (pd.col("x") == 1) | (pd.col("x") == 5)
-    result = df.loc[expr]
-    expected = df.loc[(df["x"] == 1) | (df["x"] == 5)]
-    tm.assert_frame_equal(result, expected)
-
-    # Test negation with ~
-    expr = ~(pd.col("x") > 3)
-    result = df.loc[expr]
-    expected = df.loc[~(df["x"] > 3)]
+    expected = df[expected_values]
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary

Add `__and__`, `__rand__`, `__or__`, `__ror__`, `__xor__`, `__rxor__`, `__invert__` methods to `Expression` class to support combining conditions with `&`, `|`, `^`, `~` operators in `pd.col` expressions.

## Example

```python
import pandas as pd
import io

data = '''datetime,cfs
2018-02-28,350
2018-03-15,420
2019-04-10,380
2019-06-01,450
'''
dd = pd.read_csv(io.StringIO(data), parse_dates=['datetime']).set_index('datetime')

# This now works with & operator
result = (dd
 .reset_index()
 .sort_values('datetime')
 .loc[(pd.col('datetime') > '2018-03-01') & (pd.col('datetime') <= '2019-05-31')]
 .assign(cfs=pd.col('cfs').clip(upper=400))
)
```

Closes #63322