### PR TITLE
DEP: Remove tzdata as a hard dependency outside of Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ details, see the commit logs at https://github.com/pandas-dev/pandas.
 ## Dependencies
 - [NumPy - Adds support for large, multi-dimensional arrays, matrices and high-level mathematical functions to operate on these arrays](https://www.numpy.org)
 - [python-dateutil - Provides powerful extensions to the standard datetime module](https://dateutil.readthedocs.io/en/stable/index.html)
-- [tzdata - Provides an IANA time zone database](https://tzdata.readthedocs.io/en/latest/)
+- [tzdata - Provides an IANA time zone database](https://tzdata.readthedocs.io/en/latest/) (Only required on Windows)
 
 See the [full installation instructions](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies) for minimum supported versions of required, recommended and optional dependencies.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ details, see the commit logs at https://github.com/pandas-dev/pandas.
 ## Dependencies
 - [NumPy - Adds support for large, multi-dimensional arrays, matrices and high-level mathematical functions to operate on these arrays](https://www.numpy.org)
 - [python-dateutil - Provides powerful extensions to the standard datetime module](https://dateutil.readthedocs.io/en/stable/index.html)
-- [tzdata - Provides an IANA time zone database](https://tzdata.readthedocs.io/en/latest/) (Only required on Windows)
+- [tzdata - Provides an IANA time zone database](https://tzdata.readthedocs.io/en/latest/) (Only required on Windows/Emscripten)
 
 See the [full installation instructions](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies) for minimum supported versions of required, recommended and optional dependencies.
 

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -150,10 +150,12 @@ Package                                                          Minimum support
 ================================================================ ==========================
 `NumPy <https://numpy.org>`__                                    1.26.0
 `python-dateutil <https://dateutil.readthedocs.io/en/stable/>`__ 2.8.2
-`tzdata <https://pypi.org/project/tzdata/>`__                    2023.3
+*`tzdata <https://pypi.org/project/tzdata/>`__                    2023.3
 ================================================================ ==========================
 
 Generally, the minimum supported version is ~2 years old from the release date of a major or minor pandas version.
+
+* ``tzdata`` is only required on Windows.
 
 .. _install.optional_dependencies:
 

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -150,7 +150,7 @@ Package                                                          Minimum support
 ================================================================ ==========================
 `NumPy <https://numpy.org>`__                                    1.26.0
 `python-dateutil <https://dateutil.readthedocs.io/en/stable/>`__ 2.8.2
- `tzdata <https://pypi.org/project/tzdata/>`__ \*                2023.3
+ `tzdata <https://pypi.org/project/tzdata/>`__ \*                /
 ================================================================ ==========================
 
 \* ``tzdata`` is only required on Windows and Pyodide (Emscripten).

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -150,12 +150,12 @@ Package                                                          Minimum support
 ================================================================ ==========================
 `NumPy <https://numpy.org>`__                                    1.26.0
 `python-dateutil <https://dateutil.readthedocs.io/en/stable/>`__ 2.8.2
-*`tzdata <https://pypi.org/project/tzdata/>`__                    2023.3
+ `tzdata <https://pypi.org/project/tzdata/>`__ \*                2023.3
 ================================================================ ==========================
 
-Generally, the minimum supported version is ~2 years old from the release date of a major or minor pandas version.
+\* ``tzdata`` is only required on Windows and Pyodide (Emscripten).
 
-* ``tzdata`` is only required on Windows.
+Generally, the minimum supported version is ~2 years old from the release date of a major or minor pandas version.
 
 .. _install.optional_dependencies:
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -657,8 +657,6 @@ The following required dependencies were updated:
 +=================+======================+
 | numpy           | 1.26.0               |
 +-----------------+----------------------+
-| tzdata          | 2023.3               |
-+-----------------+----------------------+
 
 For `optional libraries <https://pandas.pydata.org/docs/getting_started/install.html>`_ the general recommendation is to use the latest version.
 The following table lists the lowest version per library that is currently being tested throughout the development of pandas.

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -59,9 +59,6 @@ cdef bint is_utc_zoneinfo(tzinfo tz):
             utc_zoneinfo = zoneinfo.ZoneInfo("UTC")
         except zoneinfo.ZoneInfoNotFoundError:
             return False
-        # Warn if tzdata is too old, even if there is a system tzdata to alert
-        # users about the mismatch between local/system tzdata
-        import_optional_dependency("tzdata", errors="warn", min_version="2022.7")
 
     return tz is utc_zoneinfo
 

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -3,6 +3,9 @@ from datetime import (
     timedelta,
     timezone,
 )
+import subprocess
+import sys
+import textwrap
 
 import dateutil.tz
 import pytest
@@ -14,6 +17,24 @@ from pandas._libs.tslibs import (
 from pandas.compat import is_platform_windows
 
 from pandas import Timestamp
+
+
+def test_no_timezone_data():
+    # https://github.com/pandas-dev/pandas/pull/63335
+    # Test error message when timezone data is not available.
+    msg = "'No time zone found with key Europe/Brussels'"
+    code = textwrap.dedent(
+        f"""\
+        import sys, zoneinfo, pandas as pd
+        sys.modules['tzdata'] = None
+        zoneinfo.reset_tzpath(['/path/to/nowhere'])
+        try:
+            pd.to_datetime('2012-01-01').tz_localize('Europe/Brussels')
+        except zoneinfo.ZoneInfoNotFoundError as err:
+            assert str(err) == "{msg}"
+        """
+    )
+    subprocess.check_call([sys.executable, "-c", code])
 
 
 def test_is_utc(utc_fixture):

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -19,6 +19,7 @@ from pandas.compat import is_platform_windows
 from pandas import Timestamp
 
 
+@pytest.mark.single_cpu
 def test_no_timezone_data():
     # https://github.com/pandas-dev/pandas/pull/63335
     # Test error message when timezone data is not available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "python-dateutil>=2.8.2",
   "tzdata>=2023.3; platform_system == 'Windows'",
   # Emscripten is the platform system for Pyodide.
-  "tzdata>=2023.3; platform_system == 'Emscripten'",
+  "tzdata>=2023.3; sys_platform == 'emscripten'",
 ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = '>=3.11'
 dependencies = [
   "numpy>=1.26.0",
   "python-dateutil>=2.8.2",
-  "tzdata>=2023.3"
+  "tzdata>=2023.3; platform_system == 'Windows'",
 ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ requires-python = '>=3.11'
 dependencies = [
   "numpy>=1.26.0",
   "python-dateutil>=2.8.2",
-  "tzdata>=2023.3; platform_system == 'Windows'",
+  "tzdata; platform_system == 'Windows'",
   # Emscripten is the platform system for Pyodide.
-  "tzdata>=2023.3; sys_platform == 'emscripten'",
+  "tzdata; sys_platform == 'emscripten'",
 ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
   "numpy>=1.26.0",
   "python-dateutil>=2.8.2",
   "tzdata>=2023.3; platform_system == 'Windows'",
+  # Emscripten is the platform system for Pyodide.
+  "tzdata>=2023.3; platform_system == 'Emscripten'",
 ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = '>=3.11'
 dependencies = [
   "numpy>=1.26.0",
   "python-dateutil>=2.8.2",
-  "tzdata; platform_system == 'Windows'",
+  "tzdata; sys_platform == 'win32'",
   # Emscripten is the platform system for Pyodide.
   "tzdata; sys_platform == 'emscripten'",
 ]


### PR DESCRIPTION
- [x] closes #63264 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This may still need more discussion.

Docs change:

<img width="350" height="150" alt="image" src="https://github.com/user-attachments/assets/639f8900-2a07-4423-82d7-1001ac0a6abc" />
