### PR TITLE
DOC: Replace @doc decorator with inline docstrings in pandas/io/feather_format.py

### DIFF
--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -13,14 +13,10 @@ from pandas._config import using_string_dtype
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
 from pandas.errors import Pandas4Warning
-from pandas.util._decorators import (
-    doc,
-    set_module,
-)
+from pandas.util._decorators import set_module
 from pandas.util._validators import check_dtype_backend
 
 from pandas.core.api import DataFrame
-from pandas.core.shared_docs import _shared_docs
 
 from pandas.io._util import arrow_table_to_pandas
 from pandas.io.common import get_handle
@@ -40,7 +36,6 @@ if TYPE_CHECKING:
     )
 
 
-@doc(storage_options=_shared_docs["storage_options"])
 def to_feather(
     df: DataFrame,
     path: FilePath | WriteBuffer[bytes],
@@ -54,7 +49,15 @@ def to_feather(
     ----------
     df : DataFrame
     path : str, path object, or file-like object
-    {storage_options}
+    storage_options : dict, optional
+        Extra options that make sense for a particular storage connection, e.g.
+        host, port, username, password, etc. For HTTP(S) URLs the key-value pairs
+        are forwarded to ``urllib.request.Request`` as header options. For other
+        URLs (e.g. starting with "s3://", and "gcs://") the key-value pairs are
+        forwarded to ``fsspec.open``. Please see ``fsspec`` and ``urllib`` for more
+        details, and for more examples on storage options refer `here
+        <https://pandas.pydata.org/docs/user_guide/io.html?
+        highlight=storage_options#reading-writing-remote-files>`_.
     **kwargs :
         Additional keywords passed to `pyarrow.feather.write_feather`.
 
@@ -72,7 +75,6 @@ def to_feather(
 
 
 @set_module("pandas")
-@doc(storage_options=_shared_docs["storage_options"])
 def read_feather(
     path: FilePath | ReadBuffer[bytes],
     columns: Sequence[Hashable] | None = None,
@@ -102,7 +104,15 @@ def read_feather(
         If not provided, all columns are read.
     use_threads : bool, default True
         Whether to parallelize reading using multiple threads.
-    {storage_options}
+    storage_options : dict, optional
+        Extra options that make sense for a particular storage connection, e.g.
+        host, port, username, password, etc. For HTTP(S) URLs the key-value pairs
+        are forwarded to ``urllib.request.Request`` as header options. For other
+        URLs (e.g. starting with "s3://", and "gcs://") the key-value pairs are
+        forwarded to ``fsspec.open``. Please see ``fsspec`` and ``urllib`` for more
+        details, and for more examples on storage options refer `here
+        <https://pandas.pydata.org/docs/user_guide/io.html?
+        highlight=storage_options#reading-writing-remote-files>`_.
 
     dtype_backend : {{'numpy_nullable', 'pyarrow'}}
         Back-end data type applied to the resultant :class:`DataFrame`


### PR DESCRIPTION
## Description
Removed `@doc` decorators from `to_feather` and `read_feather` functions in `pandas/io/feather_format.py` and inlined the `storage_options` parameter documentation. This makes docstrings more maintainable and enables proper validation by Ruff.

Part of #62437

## Checklist with Relevant Items
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
