### PR TITLE
STY: Enforce Ruff rule zip-without-explicit-strict in pandas/tests/apply and pandas/tests/computation

### DIFF
--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -545,7 +545,9 @@ def test_apply_to_timedelta(by_row):
 )
 def test_apply_listlike_reducer(string_series, ops, names, how, kwargs):
     # GH 39140
-    expected = Series({name: op(string_series) for name, op in zip(names, ops)})
+    expected = Series(
+        {name: op(string_series) for name, op in zip(names, ops, strict=True)}
+    )
     expected.name = "series"
     result = getattr(string_series, how)(ops, **kwargs)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1197,7 +1197,7 @@ class TestOperations:
         expec3 = df.a + df.b + df.c[df.b < 0]
         exprs = expr1, expr2, expr3
         expecs = expec1, expec2, expec3
-        for e, expec in zip(exprs, expecs):
+        for e, expec in zip(exprs, expecs, strict=True):
             tm.assert_series_equal(expec, self.eval(e, local_dict={"df": df}))
 
     def test_assignment_fails(self):


### PR DESCRIPTION
## Description
This PR adds `strict=True` to `zip()` calls in:
- `pandas/tests/apply/test_series_apply.py` 
- `pandas/tests/computation/test_eval.py` 

All modified `zip()` calls pair sequences that are expected to have equal length, so `strict=True` is appropriate to catch potential bugs if the lengths differ.

Part of #62434 

## Checklist with Relevant Items
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
