### PR TITLE
BUG: ensure we still honor copy=True in Series constructor in all cases

### DIFF
--- a/pandas/tests/copy_view/test_constructors.py
+++ b/pandas/tests/copy_view/test_constructors.py
@@ -47,6 +47,16 @@ def test_series_from_series(dtype):
     ser.iloc[0] = 0
     assert result.iloc[0] == 1
 
+    # forcing copy=False still gives a CoW shallow copy
+    result = Series(ser, dtype=dtype, copy=False)
+    assert np.shares_memory(get_array(ser), get_array(result))
+    assert result._mgr.blocks[0].refs.has_reference()
+
+    # forcing copy=True still results in an actual hard copy up front
+    result = Series(ser, dtype=dtype, copy=True)
+    assert not np.shares_memory(get_array(ser), get_array(result))
+    assert ser._mgr._has_no_reference(0)
+
 
 def test_series_from_series_with_reindex():
     # Case: constructing a Series from another Series with specifying an index
@@ -54,7 +64,7 @@ def test_series_from_series_with_reindex():
     ser = Series([1, 2, 3], name="name")
 
     # passing an index that doesn't actually require a reindex of the values
-    # -> without CoW we get an actual mutating view
+    # -> still getting a CoW shallow copy
     for index in [
         ser.index,
         ser.index.copy(),
@@ -65,6 +75,11 @@ def test_series_from_series_with_reindex():
         assert np.shares_memory(ser.values, result.values)
         result.iloc[0] = 0
         assert ser.iloc[0] == 1
+
+        # forcing copy=True still results in an actual hard copy up front
+        result = Series(ser, index=index, copy=True)
+        assert not np.shares_memory(ser.values, result.values)
+        assert not result._mgr.blocks[0].refs.has_reference()
 
     # ensure that if an actual reindex is needed, we don't have any refs
     # (mutating the result wouldn't trigger CoW)
@@ -86,6 +101,13 @@ def test_series_from_array(idx, dtype, arr):
 
     arr[0] = 100
     tm.assert_series_equal(ser, ser_orig)
+
+    # if the user explicitly passes copy=False, we get an actual view
+    # not protected by CoW
+    ser = Series(arr, dtype=dtype, index=idx, copy=False)
+    assert np.shares_memory(get_array(ser), data)
+    arr[0] = 50
+    assert ser.iloc[0] == 50
 
 
 @pytest.mark.parametrize("copy", [True, False, None])
@@ -112,9 +134,22 @@ def test_series_from_index(idx):
     ser.iloc[0] = ser.iloc[1]
     tm.assert_index_equal(idx, expected)
 
+    # forcing copy=False still gives a CoW shallow copy
+    ser = Series(idx, copy=False)
+    assert np.shares_memory(get_array(ser), get_array(idx))
+    assert not ser._mgr._has_no_reference(0)
+    ser.iloc[0] = ser.iloc[1]
+    tm.assert_index_equal(idx, expected)
 
-def test_series_from_index_different_dtypes():
-    idx = Index([1, 2, 3], dtype="int64")
+    # forcing copy=True still results in a copy
+    ser = Series(idx, copy=True)
+    assert not np.shares_memory(get_array(ser), get_array(idx))
+    assert ser._mgr._has_no_reference(0)
+
+
+@pytest.mark.parametrize("copy", [True, False, None])
+def test_series_from_index_different_dtypes(copy):
+    idx = Index([1, 2, 3], dtype="int64", copy=copy)
     ser = Series(idx, dtype="int32")
     assert not np.shares_memory(get_array(ser), get_array(idx))
     assert ser._mgr._has_no_reference(0)


### PR DESCRIPTION
Expanding the `Series(..)` constructor tests to cover all cases for copy=True vs False vs default None, and ensure we still honor `copy=True` when passing a Series or Index.

Triggered by checking the exact behaviour to describe that in the docstring for https://github.com/pandas-dev/pandas/pull/63341