### PR TITLE
DOC: clarify loc slice step behavior with example closes #63311

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -431,22 +431,34 @@ an error will be raised. For instance, in the above example, ``s.loc[2:5]`` woul
 For more information about duplicate labels, see
 :ref:`Duplicate Labels <duplicates>`.
 
-Also, when using a slice with a step, such as ``.loc[start:stop:step]``, note that
+When using a slice with a step, such as ``.loc[start:stop:step]``, note that
 *start* and *stop* are interpreted as **labels**, while *step* is applied over
 the **positional index** within that label range. This means a stepped slice
-may return different labels than selecting an explicit list, even when they
-appear similar.
+will behave differently than using the labels ``range(start, stop, step)`` when
+the index is not contiguous integers.
 
 For example, in a ``Series`` with a non-contiguous integer index:
 
 .. ipython:: python
 
-   s = pd.Series(range(10), index=[0, 5, 10, 15, 20, 25, 30, 35, 40, 45])
-   s.loc[10:50:5]              # (10), then skip 3 positions → 35 only
-   s.loc[[10, 15, 20, 25]]     # explicit label selection
+    s = pd.Series(range(10), index=[0, 5, 10, 15, 20, 25, 30, 35, 40, 45])
+    s.loc[10:50:5]              # (10), then skip 3 positions → 35 only
+    s.loc[[10, 15, 20, 25]]     # explicit label selection
 
 The first applies *step* across **positional locations** between the start/stop
 labels. The second selects each label directly.
+
+Similarly, with a string-based index, the behavior is identical:
+
+.. ipython:: python
+
+    s = pd.Series(range(10), index=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])
+    s.loc['b':'i':2]            # Start at 'b' (position 1), stop at 'i' (position 8), step 2 positions → 'b', 'd', 'f', 'h'
+    s.loc[['b', 'd', 'f', 'h']] # explicit label selection
+
+In both cases, *start* and *stop* determine the label boundaries (inclusive),
+while *step* skips positions within that range, regardless of the index type.
+
 
 
 .. _indexing.integer:

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -431,6 +431,24 @@ an error will be raised. For instance, in the above example, ``s.loc[2:5]`` woul
 For more information about duplicate labels, see
 :ref:`Duplicate Labels <duplicates>`.
 
+Also, when using a slice with a step, such as ``.loc[start:stop:step]``, note that
+*start* and *stop* are interpreted as **labels**, while *step* is applied over
+the **positional index** within that label range. This means a stepped slice
+may return different labels than selecting an explicit list, even when they
+appear similar.
+
+For example, in a ``Series`` with a non-contiguous integer index:
+
+.. ipython:: python
+
+   s = pd.Series(range(10), index=[0, 5, 10, 15, 20, 25, 30, 35, 40, 45])
+   s.loc[10:50:5]              # (10), then skip 3 positions → 35 only
+   s.loc[[10, 15, 20, 25]]     # explicit label selection
+
+The first applies *step* across **positional locations** between the start/stop
+labels. The second selects each label directly.
+
+
 .. _indexing.integer:
 
 Selection by position


### PR DESCRIPTION
When using .loc[start:stop:step], start/stop use label semantics but step is positional within that range. Added example showing difference from explicit label selection.

<img width="987" height="702" alt="image" src="https://github.com/user-attachments/assets/33df1c5c-528b-4b4b-a183-b4fbba6e38fe" />


Closes #63311

- [x] closes #63311
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
