### PR TITLE
WEB: add pandas 3.0 release candidate announcement blog

### DIFF
--- a/web/pandas/_templates/layout.html
+++ b/web/pandas/_templates/layout.html
@@ -56,9 +56,11 @@
             </nav>
         </header>
         <main role="main">
-            <div class="container">
+            {% block body_container %}
+            <div class="container container-main">
                 {% block body %}{% endblock %}
             </div>
+            {% endblock %}
         </main>
         <footer class="container pt-4 pt-md-5 border-top">
             <ul class="list-inline social-buttons float-end">

--- a/web/pandas/community/blog/pandas-3.0-release-candidate.md
+++ b/web/pandas/community/blog/pandas-3.0-release-candidate.md
@@ -1,4 +1,4 @@
-Title: pandas 3.0.0 release candidate ready for testing
+Title: pandas 3.0.0 release candidate ready for testing!
 Date: 2025-12-12
 
 # pandas 3.0.0 release candidate ready for testing!
@@ -24,7 +24,8 @@ pandas 3.0 introduces several major enhancements:
 - **New `pd.col` syntax**: Initial support for `pd.col()` as a simplified syntax
   for creating callables in `DataFrame.assign`
 
-You can find the complete list of changes in our
+Together with a lot of other improvements and bug fixes. You can find the
+complete list of changes in our
 [release notes](https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html).
 
 ## Important changes requiring code updates
@@ -70,7 +71,8 @@ patterns.
 
 The most impactfull change is that **chained assignment will no longer work**.
 As a result, the `SettingWithCopyWarning` is also removed (since there is no
-longer ambiguity whether it would work or not).
+longer ambiguity whether it would work or not), and defensive `.copy()` calls
+to silence the warning are no longer needed.
 
 **Example:**
 ```python
@@ -103,9 +105,12 @@ How can you best test the release candidate?
 1. **First update to the latest released pandas 2.3** (if you are not already
    running that version) and test it with your codebase. It is recommended to
    resolve any deprecation warning before upgrading to pandas 3.0.
-2. **Install the release candidate** and test it with your codebase
-3. **Run your existing code** to identify any issues or needed updates
-4. **Report any problems** you encounter on our [GitHub repository issue tracker](https://github.com/pandas-dev/pandas/issues)
+2. Optionally, you can already enable the new string dtype and Copy-on-Write
+   mode using pandas 2.3 (`pd.options.future.infer_string = True` and
+   `pd.options.mode.copy_on_write = True`).
+3. **Install the release candidate** (see below) and test it with your codebase
+4. **Run your existing code** to identify any issues or needed updates
+5. **Report any problems** you encounter on our [GitHub repository issue tracker](https://github.com/pandas-dev/pandas/issues)
 
 The more testing we get now, the smoother the final pandas 3.0 release will be
 for everyone. Your feedback is crucial for making this a successful release!

--- a/web/pandas/community/blog/pandas-3.0-release-candidate.md
+++ b/web/pandas/community/blog/pandas-3.0-release-candidate.md
@@ -1,0 +1,114 @@
+Title: pandas 3.0.0 release candidate ready for testing
+Date: 2025-12-12
+
+# pandas 3.0.0 release candidate ready for testing!
+
+We're excited to announce the release candidate for pandas 3.0. This major
+release brings significant improvements to pandas, but also features some
+potentially breaking changes.
+
+## Highlights of pandas 3.0
+
+pandas 3.0 introduces several major enhancements:
+
+- **Dedicated string data type by default**: String columns are now inferred as
+  the new `str` dtype instead of `object`, providing better performance and type
+  safety
+- **Consistent copy/view behaviour with Copy-on-Write (CoW)** (a.k.a. getting
+  rid of the SettingWithCopyWarning): More predictable and consistent behavior
+  for all operations, with improved performance through avoiding unnecessary
+  copies
+- **New `pd.col` syntax**: Initial support for `pd.col()` as a simplified syntax
+  for creating callables in `DataFrame.assign`
+- **Enhanced deprecation policy**: A new 3-stage deprecation process to give
+  downstream packages more time to adapt
+
+You can find the complete list of changes in our
+[release notes](https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html).
+
+## Important changes requiring code updates
+
+As a major release, pandas 3.0 includes some breaking changes that may require
+updates to your code. The two most significant changes are:
+
+### 1. Dedicated string data type by default
+
+Starting with pandas 3.0, string columns are automatically inferred as `str`
+dtype instead of the numpy `object` (which can store any Python object).
+
+**Example of the change:**
+```python
+# Old behavior (pandas < 3.0)
+>>> ser = pd.Series(["a", "b"])
+>>> ser
+0    a
+1    b
+dtype: object  # <-- numpy object dtype
+
+# New behavior (pandas 3.0)
+>>> ser = pd.Series(["a", "b"])
+>>> ser.dtype
+>>> ser
+0    a
+1    b
+dtype: str  # <-- new string dtype
+```
+
+This change improves performance and type safety, but may require code updates.
+For more details, see the
+[String Data Type Migration Guide](https://pandas.pydata.org/docs/dev/user_guide/migration-3-strings.html).
+
+### 2. Consistent copy/view behaviour with Copy-on-Write (CoW)
+
+Copy-on-Write is now the default and only mode in pandas 3.0. This makes
+behavior more consistent and predictable, but requires updates to certain coding
+patterns:
+
+**What you need to update:**
+- **Chained assignment** will no longer work. You'll need to use `.loc` or
+  `.iloc` directly on the DataFrame instead
+- The `SettingWithCopyWarning` is removed (since chained assignment no longer works)
+- Any indexing operation now always behaves as if it were a copy, so
+  modifications won't affect the original DataFrame
+
+**Example of the change:**
+```python
+# Old behavior (pandas < 3.0) - chained assignment
+df[df['A'] > 0]['B'] = 1  # This might modify df (unpredictable)
+
+# New behavior (pandas 3.0) - must use .loc
+df.loc[df['A'] > 0, 'B'] = 1  # This is the correct way
+```
+
+[Copy-on-Write Migration Guide](https://pandas.pydata.org/pandas-docs/version/3.0.0/user_guide/copy_on_write.html)
+
+## Call to Action: Test the Release Candidate
+
+We need your help to ensure a smooth pandas 3.0 release!
+
+Especially if you have pandas code in production or maintain a library with
+pandas as a dependency, it is strongly recommended to run your test suites with
+the release candidate, and report any issue to our issue tracker before the
+official 3.0.0 release.
+
+1. **Install the release candidate** and test it with your codebase
+2. **Run your existing code** to identify any issues or needed updates
+3. **Report any problems** you encounter on our [GitHub repository](https://github.com/pandas-dev/pandas/issues)
+4. **Share your migration experiences** with the community
+
+The more testing we get now, the smoother the final pandas 3.0 release will be
+for everyone. Your feedback is crucial to making this a successful release!
+
+### Getting the Release Candidate
+
+You can install the pandas 3.0 release candidate from PyPI:
+
+```bash
+python -m pip install --upgrade pandas==3.0.0rc0
+```
+
+Or from conda-forge using conda/mamba:
+
+```bash
+conda install -c conda-forge/label/pandas_rc pandas==3.0.0rc0
+```

--- a/web/pandas/community/blog/pandas-3.0-release-candidate.md
+++ b/web/pandas/community/blog/pandas-3.0-release-candidate.md
@@ -7,6 +7,9 @@ We're excited to announce the release candidate for pandas 3.0. This major
 release brings significant improvements to pandas, but also features some
 potentially breaking changes.
 
+To ensure a smooth pandas 3.0 release, we can use your help to [test the
+release candidate now](#call-to-action-test-the-release-candidate).
+
 ## Highlights of pandas 3.0
 
 pandas 3.0 introduces several major enhancements:
@@ -20,8 +23,6 @@ pandas 3.0 introduces several major enhancements:
   copies
 - **New `pd.col` syntax**: Initial support for `pd.col()` as a simplified syntax
   for creating callables in `DataFrame.assign`
-- **Enhanced deprecation policy**: A new 3-stage deprecation process to give
-  downstream packages more time to adapt
 
 You can find the complete list of changes in our
 [release notes](https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html).
@@ -36,7 +37,7 @@ updates to your code. The two most significant changes are:
 Starting with pandas 3.0, string columns are automatically inferred as `str`
 dtype instead of the numpy `object` (which can store any Python object).
 
-**Example of the change:**
+**Example:**
 ```python
 # Old behavior (pandas < 3.0)
 >>> ser = pd.Series(["a", "b"])
@@ -54,35 +55,41 @@ dtype: object  # <-- numpy object dtype
 dtype: str  # <-- new string dtype
 ```
 
-This change improves performance and type safety, but may require code updates.
+This change improves performance and type safety, but may require code updates,
+especially for library code that currently looks for "object" dtype when
+expecting string data.
+
 For more details, see the
-[String Data Type Migration Guide](https://pandas.pydata.org/docs/dev/user_guide/migration-3-strings.html).
+[migration guide for the new string data type](https://pandas.pydata.org/docs/dev/user_guide/migration-3-strings.html).
 
 ### 2. Consistent copy/view behaviour with Copy-on-Write (CoW)
 
 Copy-on-Write is now the default and only mode in pandas 3.0. This makes
 behavior more consistent and predictable, but requires updates to certain coding
-patterns:
+patterns.
 
-**What you need to update:**
-- **Chained assignment** will no longer work. You'll need to use `.loc` or
-  `.iloc` directly on the DataFrame instead
-- The `SettingWithCopyWarning` is removed (since chained assignment no longer works)
-- Any indexing operation now always behaves as if it were a copy, so
-  modifications won't affect the original DataFrame
+The most impactfull change is that **chained assignment will no longer work**.
+As a result, the `SettingWithCopyWarning` is also removed (since there is no
+longer ambiguity whether it would work or not).
 
-**Example of the change:**
+**Example:**
 ```python
 # Old behavior (pandas < 3.0) - chained assignment
-df[df['A'] > 0]['B'] = 1  # This might modify df (unpredictable)
+df["foo"][df["bar"] > 5] =   # This might modify df (unpredictable)
 
-# New behavior (pandas 3.0) - must use .loc
-df.loc[df['A'] > 0, 'B'] = 1  # This is the correct way
+# New behavior (pandas 3.0) - must do the modification in one step (e.g. with .loc)
+df.loc[df["bar"] > 5, "foo"] = 100
 ```
 
-[Copy-on-Write Migration Guide](https://pandas.pydata.org/pandas-docs/version/3.0.0/user_guide/copy_on_write.html)
+In general, any result of an indexing operation or method now always behaves as
+if it were a copy, so modifications of the result won't affect the original
+DataFrame.
 
-## Call to Action: Test the Release Candidate
+For more details, see the
+[Copy-on-Write migration guide](https://pandas.pydata.org/docs/dev/user_guide/copy_on_write.html#migrating-to-copy-on-write).
+
+
+## Call to Action: test the Release Candidate
 
 We need your help to ensure a smooth pandas 3.0 release!
 
@@ -91,13 +98,17 @@ pandas as a dependency, it is strongly recommended to run your test suites with
 the release candidate, and report any issue to our issue tracker before the
 official 3.0.0 release.
 
-1. **Install the release candidate** and test it with your codebase
-2. **Run your existing code** to identify any issues or needed updates
-3. **Report any problems** you encounter on our [GitHub repository](https://github.com/pandas-dev/pandas/issues)
-4. **Share your migration experiences** with the community
+How can you best test the release candidate?
+
+1. **First update to the latest released pandas 2.3** (if you are not already
+   running that version) and test it with your codebase. It is recommended to
+   resolve any deprecation warning before upgrading to pandas 3.0.
+2. **Install the release candidate** and test it with your codebase
+3. **Run your existing code** to identify any issues or needed updates
+4. **Report any problems** you encounter on our [GitHub repository issue tracker](https://github.com/pandas-dev/pandas/issues)
 
 The more testing we get now, the smoother the final pandas 3.0 release will be
-for everyone. Your feedback is crucial to making this a successful release!
+for everyone. Your feedback is crucial for making this a successful release!
 
 ### Getting the Release Candidate
 

--- a/web/pandas/index.html
+++ b/web/pandas/index.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block body %}
+{% block body_container %}
     <div class="container">
         <div class="row">
             <div class="col-md-9">

--- a/web/pandas/static/css/pandas.css
+++ b/web/pandas/static/css/pandas.css
@@ -9,6 +9,7 @@ h1 {
     font-size: 2.4rem;
     font-weight: 700;
     color: #130654;
+    margin: 2.4rem 0 2.4rem;
 }
 h2 {
     font-size: 1.8rem;
@@ -134,6 +135,12 @@ a.headerlink {
 h2:hover a.headerlink, h3:hover a.headerlink {
     opacity: 1;
     transition: opacity 0.5s;
+}
+
+@media (min-width: 992px) {
+  .container-main {
+    max-width: 960px;
+  }
 }
 
 


### PR DESCRIPTION
The idea here is to have a page to link to (e.g. for the banner https://github.com/pandas-dev/pandas/pull/63282) that is a bit more high-level and less overwhelming than the full release notes
