### PR TITLE
Fix JSON serialization of TimedeltaIndex labels (GH#63236)

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Generic,
     Literal,
+    cast,
     Self,
     TypeVar,
     final,
@@ -73,6 +74,7 @@ from pandas.io.json._table_schema import (
 )
 from pandas.io.parsers.readers import validate_integer
 
+DateUnit = Literal["s", "ms", "us", "ns"]
 if TYPE_CHECKING:
     from collections.abc import (
         Callable,
@@ -238,7 +240,7 @@ def _format_timedelta_labels(index, date_format: str, date_unit: str | None):
         return index
 
     values = index._values  # ndarray[td64]
-    result = []
+    result: list[object] = []
 
     if date_format == "iso":
         for val in values:
@@ -250,7 +252,10 @@ def _format_timedelta_labels(index, date_format: str, date_unit: str | None):
                 result.append(td.isoformat())
 
     else:  # epoch
-        unit = date_unit or "ms"
+        if date_unit is None:
+            unit: DateUnit = "ms"
+        else:
+            unit = cast(DateUnit, date_unit) 
 
         for val in values:
             if isna(val):

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -11,9 +11,9 @@ from typing import (
     Any,
     Generic,
     Literal,
-    cast,
     Self,
     TypeVar,
+    cast,
     final,
     overload,
 )
@@ -255,7 +255,7 @@ def _format_timedelta_labels(index, date_format: str, date_unit: str | None):
         if date_unit is None:
             unit: DateUnit = "ms"
         else:
-            unit = cast(DateUnit, date_unit) 
+            unit = cast(DateUnit, date_unit)
 
         for val in values:
             if isna(val):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1794,9 +1794,9 @@ class TestPandasContainer:
         "date_format,key", [("epoch", 86400000), ("iso", "P1DT0H0M0S")]
     )
     def test_timedelta_as_label(self, date_format, key, unit, request):
-        if unit != "ns":
-            mark = pytest.mark.xfail(reason="GH#63236 failure to round-trip")
-            request.applymarker(mark)
+        # if unit != "ns":
+        #     mark = pytest.mark.xfail(reason="GH#63236 failure to round-trip")
+        #     request.applymarker(mark)
         df = DataFrame([[1]], columns=[pd.Timedelta("1D").as_unit(unit)])
         expected = f'{{"{key}":{{"0":1}}}}'
 


### PR DESCRIPTION
## Summary

Fix JSON serialization of `TimedeltaIndex` labels so that timedelta values are encoded consistently and missing labels are handled correctly. This change ensures correct output for both `date_format="iso"` and `date_format="epoch"` and resolves failures in timedelta label round-tripping tests.

## Problem

When serializing objects with a `TimedeltaIndex` (or Timedelta-like labels), pandas formats axis labels before passing them to the JSON writer. For non-nanosecond resolutions, missing values (`NaT`) in the `TimedeltaIndex` were incorrectly stringified, producing JSON object keys such as:
- `"NaT": null`
- `"None": null`

However, existing pandas behavior and tests expect missing axis labels to be represented using the literal string `"null"` as the JSON object key.

This issue was exposed in:
- `TestPandasContainer::test_timedelta_as_label`
- `TestPandasContainer::test_timedelta_to_json`

## What changed

- Added explicit formatting of `TimedeltaIndex` labels during JSON serialization:
  - valid timedelta labels are formatted as ISO-8601 strings when `date_format="iso"`
  - valid timedelta labels are formatted as integers in the requested `date_unit` when `date_format="epoch"`
  - missing `NaT` labels are encoded as the string `"null"` to match existing pandas JSON expectations
  - labels are returned as an `Index` with `object` dtype to prevent coercion into `"NaT"` or `"None"` string values

## Why this works

JSON object keys cannot be `null`. Pandas historically represents missing axis labels using the literal string `"null"` when serializing to JSON. By explicitly formatting `TimedeltaIndex` labels and preserving missing labels as `"null"`, this change ensures consistent, backward-compatible JSON output across all timedelta resolutions.

## Tests

```bash
python -m pytest pandas/tests/io/json/test_pandas.py
```

Fixes: #63236