### PR TITLE
STY: Add strict parameter to zip() in pandas/core/reshape/concat

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -419,13 +419,15 @@ def concat(
             or any(not isinstance(index, DatetimeIndex) for index in non_concat_axis)
             or all(
                 prev is curr
-                for prev, curr in zip(non_concat_axis, non_concat_axis[1:], strict=True)
+                for prev, curr in zip(
+                    non_concat_axis, non_concat_axis[1:], strict=False
+                )
             )
             or (
                 all(
                     prev[-1] <= curr[0] and prev.is_monotonic_increasing
                     for prev, curr in zip(
-                        non_concat_axis, non_concat_axis[1:], strict=True
+                        non_concat_axis, non_concat_axis[1:], strict=False
                     )
                     if not prev.empty and not curr.empty
                 )

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -418,12 +418,15 @@ def concat(
             intersect
             or any(not isinstance(index, DatetimeIndex) for index in non_concat_axis)
             or all(
-                prev is curr for prev, curr in zip(non_concat_axis, non_concat_axis[1:])
+                prev is curr
+                for prev, curr in zip(non_concat_axis, non_concat_axis[1:], strict=True)
             )
             or (
                 all(
                     prev[-1] <= curr[0] and prev.is_monotonic_increasing
-                    for prev, curr in zip(non_concat_axis, non_concat_axis[1:])
+                    for prev, curr in zip(
+                        non_concat_axis, non_concat_axis[1:], strict=True
+                    )
                     if not prev.empty and not curr.empty
                 )
                 and non_concat_axis[-1].is_monotonic_increasing

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -5,6 +5,7 @@ Concat routines.
 from __future__ import annotations
 
 from collections import abc
+from itertools import pairwise
 import types
 from typing import (
     TYPE_CHECKING,
@@ -417,18 +418,11 @@ def concat(
         if (
             intersect
             or any(not isinstance(index, DatetimeIndex) for index in non_concat_axis)
-            or all(
-                prev is curr
-                for prev, curr in zip(
-                    non_concat_axis, non_concat_axis[1:], strict=False
-                )
-            )
+            or all(prev is curr for prev, curr in pairwise(non_concat_axis))
             or (
                 all(
                     prev[-1] <= curr[0] and prev.is_monotonic_increasing
-                    for prev, curr in zip(
-                        non_concat_axis, non_concat_axis[1:], strict=False
-                    )
+                    for prev, curr in pairwise(non_concat_axis)
                     if not prev.empty and not curr.empty
                 )
                 and non_concat_axis[-1].is_monotonic_increasing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -453,7 +453,6 @@ exclude = [
 "pandas/core/groupby/grouper.py" = ["B905"]
 "pandas/core/groupby/ops.py" = ["B905"]
 "pandas/core/methods/to_dict.py" = ["B905"]
-"pandas/core/reshape/concat.py" = ["B905"]
 "pandas/core/reshape/encoding.py" = ["B905"]
 "pandas/core/reshape/melt.py" = ["B905"]
 "pandas/core/reshape/merge.py" = ["B905"]


### PR DESCRIPTION
As a result of the addition from #62843, some calls to zip() in pandas/core/reshape/concat.py did not adhere to Ruff rule B905 as outlined in #62434.

Also, I noticed there are a lot of files still listed as "Todo: fix B905" in pyproject.toml even though all of their zip() calls seem to be already fixed to have a "strict" parameter. Shouldn't those files be removed from the todo list or is there something else I'm missing here?