### PR TITLE
DOC: add Google Colab data loading section

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -6520,3 +6520,45 @@ The files ``test.pkl.compress``, ``test.parquet`` and ``test.feather`` took the 
     24009288 Oct 10 06:43 test_fixed_compress.hdf
     24458940 Oct 10 06:44 test_table.hdf
     24458940 Oct 10 06:44 test_table_compress.hdf
+
+Loading data in Google Colab
+'''''''''''''''''''''''''''
+
+Google Colab is a hosted Jupyter notebook environment. Since it runs remotely,
+files must be explicitly uploaded or mounted before they can be read by pandas.
+
+Uploading local files
+~~~~~~~~~~~~~~~~~~~~~
+
+Files can be uploaded directly to the Colab runtime using ``google.colab.files``:
+
+.. code-block:: python
+
+   from google.colab import files
+   uploaded = files.upload()
+
+   import pandas as pd
+   df = pd.read_csv("data.csv")
+
+Using Google Drive
+~~~~~~~~~~~~~~~~~~
+
+Google Drive can be mounted to make files available to the runtime:
+
+.. code-block:: python
+
+   from google.colab import drive
+   drive.mount("/content/drive")
+
+   import pandas as pd
+   df = pd.read_csv("/content/drive/MyDrive/data.csv")
+
+Loading data from a URL
+~~~~~~~~~~~~~~~~~~~~~~
+
+Data hosted remotely can be read directly using a URL:
+
+.. code-block:: python
+
+   import pandas as pd
+   df = pd.read_csv("https://example.com/data.csv")

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -6521,8 +6521,9 @@ The files ``test.pkl.compress``, ``test.parquet`` and ``test.feather`` took the 
     24458940 Oct 10 06:44 test_table.hdf
     24458940 Oct 10 06:44 test_table_compress.hdf
 
-Loading data in Google Colab
-'''''''''''''''''''''''''''
+Loading data in Google Colab notebooks
+'''''''''''''''''''''''''''''''''''''''
+
 
 Google Colab is a hosted Jupyter notebook environment. Since it runs remotely,
 files must be explicitly uploaded or mounted before they can be read by pandas.
@@ -6539,6 +6540,7 @@ Files can be uploaded directly to the Colab runtime using ``google.colab.files``
 
    import pandas as pd
    df = pd.read_csv("data.csv")
+
 
 Using Google Drive
 ~~~~~~~~~~~~~~~~~~
@@ -6561,4 +6563,5 @@ Data hosted remotely can be read directly using a URL:
 .. code-block:: python
 
    import pandas as pd
-   df = pd.read_csv("https://example.com/data.csv")
+   df = pd.read_csv("https://raw.githubusercontent.com/pandas-dev/pandas/main/doc/data/air_quality_no2.csv")
+

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -6564,4 +6564,3 @@ Data hosted remotely can be read directly using a URL:
 
    import pandas as pd
    df = pd.read_csv("https://raw.githubusercontent.com/pandas-dev/pandas/main/doc/data/air_quality_no2.csv")
-


### PR DESCRIPTION
- Adds a section to the IO user guide describing how to load data in Google Colab
- Covers file uploads, Google Drive mounting, and URL-based workflows
- Fixes #62708
