### PR TITLE
STY: Add explicit strict= to zip() calls in pandas/tests/strings

### DIFF
--- a/pandas/tests/strings/conftest.py
+++ b/pandas/tests/strings/conftest.py
@@ -94,9 +94,10 @@ _any_string_method = [
         ],
         [()] * 100,
         [{}] * 100,
+        strict=False,
     )
 )
-ids, _, _ = zip(*_any_string_method)  # use method name as fixture-id
+ids, _, _ = zip(*_any_string_method, strict=True)  # use method name as fixture-id
 missing_methods = {f for f in dir(StringMethods) if not f.startswith("_")} - set(ids)
 
 # test that the above list captures all methods of StringMethods

--- a/pandas/tests/strings/test_api.py
+++ b/pandas/tests/strings/test_api.py
@@ -21,7 +21,7 @@ _any_allowed_skipna_inferred_dtype = [
     ("empty", []),
     ("mixed-integer", ["a", np.nan, 2]),
 ]
-ids, _ = zip(*_any_allowed_skipna_inferred_dtype)  # use inferred type as id
+ids, _ = zip(*_any_allowed_skipna_inferred_dtype, strict=True)  # use inferred type as id
 
 
 @pytest.fixture(params=_any_allowed_skipna_inferred_dtype, ids=ids)

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -757,7 +757,7 @@ def test_cat_on_bytes_raises():
 
 def test_str_accessor_in_apply_func():
     # https://github.com/pandas-dev/pandas/issues/38979
-    df = DataFrame(zip("abc", "def"))
+    df = DataFrame(zip("abc", "def", strict=True))
     expected = Series(["A/D", "B/E", "C/F"])
     result = df.apply(lambda f: "/".join(f.str.upper()), axis=1)
     tm.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary

Add `strict=True` or `strict=False` to all `zip()` calls in `pandas/tests/strings/` directory to comply with Ruff rule B905 (zip-without-explicit-strict).

## Changes

| File | Changes |
|------|---------|
| `conftest.py` | Add `strict=False` for intentionally unequal length zip, `strict=True` for equal length unpack |
| `test_api.py` | Add `strict=True` for equal length unpack |
| `test_strings.py` | Add `strict=True` for equal length strings |

## Details

- **`conftest.py` line 97**: Uses `strict=False` because the zip intentionally combines a list of ~27 methods with `[()] * 100` and `[{}] * 100` (unequal lengths by design)
- **`conftest.py` line 100**: Uses `strict=True` because unpacking `_any_string_method` where each element is a 3-tuple
- **`test_api.py` line 24**: Uses `strict=True` because unpacking `_any_allowed_skipna_inferred_dtype` where each element is a 2-tuple
- **`test_strings.py` line 760**: Uses `strict=True` because `zip("abc", "def")` combines two equal-length strings

Partial fix for #62434

🤖 Generated with [Claude Code](https://claude.com/claude-code)