### PR TITLE
DOC: clarify migration guide for users of existing string dtypes

### DIFF
--- a/doc/source/user_guide/migration-3-strings.rst
+++ b/doc/source/user_guide/migration-3-strings.rst
@@ -20,6 +20,14 @@ enable it with:
 
 This allows you to test your code before the final 3.0 release.
 
+.. note::
+
+   This migration guide focuses on the changes and migration steps needed when
+   you are currently using ``object`` dtype for string data, which is used by
+   default in pandas < 3.0. If you are already using one of the opt-in string
+   dtypes, you can continue to do so without change.
+   See :ref:`string_migration_guide-for_existing_users` for more details.
+
 Background
 ----------
 
@@ -456,6 +464,9 @@ raise an error regardless of the number of strings:
    TypeError                                 Traceback (most recent call last)
    ...
    TypeError: Cannot perform reduction 'prod' with string dtype
+
+
+.. _string_migration_guide-for_existing_users:
 
 For existing users of the nullable ``StringDtype``
 --------------------------------------------------

--- a/doc/source/user_guide/migration-3-strings.rst
+++ b/doc/source/user_guide/migration-3-strings.rst
@@ -457,7 +457,20 @@ raise an error regardless of the number of strings:
    ...
    TypeError: Cannot perform reduction 'prod' with string dtype
 
-.. For existing users of the nullable ``StringDtype``
-.. --------------------------------------------------
+For existing users of the nullable ``StringDtype``
+--------------------------------------------------
 
-.. TODO
+While pandas 3.0 introduces a new _default_ string data type, pandas had an
+opt-in nullable string data type since pandas 1.0, which can be specified using
+``dtype="string"``. This nullable string dtype uses ``pd.NA`` as the missing
+value indicator. In addition, also through :class:`ArrowDtype` (by using
+``dtypes_backend="pyarrow"``) since pandas 1.5, one could already make use of
+a dedicated string dtype.
+
+If you are already using one of the nullable string dtypes, for example by
+specifying ``dtype="string"``, by using :meth:`~DataFrame.convert_dtypes`, or
+by specifying the ``dtype_backend`` argument in IO functions, you can continue
+to do so without change.
+
+The migration guide above applies to code that is currently (< 3.0) using object
+dtype for string data.


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/63279