### PR TITLE
DOC: add note to 3.0.0 whatsnew about removed deprecations

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -6,6 +6,14 @@ What's new in 3.0.0 (Month XX, 2025)
 These are the changes in pandas 3.0.0. See :ref:`release` for a full changelog
 including other versions of pandas.
 
+.. note::
+
+    The pandas 3.0 release removed a lot of functionality that was deprecated
+    in previous releases (see :ref:`below <whatsnew_300.prior_deprecations>`
+    for an overview). It is recommended to first upgrade to pandas 2.3 and to
+    ensure your code is working without warnings, before upgrading to pandas
+    3.0.
+
 {{ header }}
 
 .. ---------------------------------------------------------------------------


### PR DESCRIPTION
I just saw that we had a similar note in the 1.0 release notes, and thought it could be useful to add to 3.0 as well. 
I don't know how common it would be that people are still on 2.2 and would now update directly to 3.0, though?