### PR TITLE
DOC: Fix duplicates parameter docstring in pandas.cut

### DIFF
--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -108,7 +108,7 @@ def cut(
         The precision at which to store and display the bins labels.
     include_lowest : bool, default False
         Whether the first interval should be left-inclusive or not.
-    duplicates : {default 'raise', 'drop'}, optional
+    duplicates : {'raise', 'drop'}, default 'raise'
         If bin edges are not unique, raise ValueError or drop non-uniques.
     ordered : bool, default True
         Whether the labels are ordered or not. Applies to returned types


### PR DESCRIPTION
- [x] closes #63377
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature (I did not add new tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (no new arguments/methods/functions)
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Description
Updates the docstring for the `duplicates` parameter in `pandas.cut` (located in `pandas/core/reshape/tile.py`) to match the function signature and Numpydoc formatting standards.

The parameter was previously documented as `{default 'raise', 'drop'}, optional`, which incorrectly implied the default might be `None` or was ambiguous. It has been corrected to `{'raise', 'drop'}, default 'raise'`.

### Validation
Ran the docstring validation script locally, which passed for the updated parameter:
`python scripts/validate_docstrings.py pandas.cut`