### PR TITLE
DOC: Fix default value for engine in pandas.eval

### DIFF
--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -243,8 +243,9 @@ def eval(
         The engine used to evaluate the expression. Supported engines are
 
         - None : tries to use ``numexpr``, falls back to ``python``
-        - ``'numexpr'`` : Evaluates pandas objects using
-          numexpr for large speed ups in complex expressions with large frames.
+        - ``'numexpr'`` : This is the default engine when ``numexpr`` is installed.
+          Evaluates pandas objects using numexpr for large speed ups in complex
+          expressions with large frames.
         - ``'python'`` : Performs operations as if you had ``eval``'d in top
           level python. This engine is generally not that useful.
 

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -238,12 +238,12 @@ def eval(
         ``'python'`` parser to retain strict Python semantics.  See the
         :ref:`enhancing performance <enhancingperf.eval>` documentation for
         more details.
-    engine : {'python', 'numexpr'}, default 'numexpr'
+    engine : {'python', 'numexpr'}, optional, default None
 
         The engine used to evaluate the expression. Supported engines are
 
         - None : tries to use ``numexpr``, falls back to ``python``
-        - ``'numexpr'`` : This default engine evaluates pandas objects using
+        - ``'numexpr'`` : Evaluates pandas objects using
           numexpr for large speed ups in complex expressions with large frames.
         - ``'python'`` : Performs operations as if you had ``eval``'d in top
           level python. This engine is generally not that useful.


### PR DESCRIPTION
Update docstring to match signature default of None. Also clarify description of numexpr engine.

- [x] closes #63376
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Description
Updates the docstring for the `engine` parameter in `pandas.eval` (located in `pandas/core/computation/eval.py`) to reflect that the default value in the function signature is `None`.

Previously documented as `default 'numexpr'`, it has been corrected to `optional, default None` to match the signature `engine: str | None = None`.

The description for the `'numexpr'` engine was also updated to remove the phrase "This default engine" to avoid contradiction with the new parameter description.

### Validation
Ran the docstring validation script locally:
`python scripts/validate_docstrings.py pandas.eval`
