### PR TITLE
Keep compatibility for subclasses overriding __finalize__ for concat/merge

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -598,7 +598,7 @@ def _get_result(
             result = sample._constructor_from_mgr(mgr, axes=mgr.axes)
             result._name = name
             return result.__finalize__(
-                types.SimpleNamespace(input_objs=objs), method="concat"
+                types.SimpleNamespace(input_objs=objs, objs=objs), method="concat"
             )
 
         # combine as columns in a frame
@@ -620,7 +620,7 @@ def _get_result(
             df = cons(data, index=index, copy=False)
             df.columns = columns
             return df.__finalize__(
-                types.SimpleNamespace(input_objs=objs), method="concat"
+                types.SimpleNamespace(input_objs=objs, objs=objs), method="concat"
             )
 
     # combine block managers
@@ -660,7 +660,9 @@ def _get_result(
         )
 
         out = sample._constructor_from_mgr(new_data, axes=new_data.axes)
-        return out.__finalize__(types.SimpleNamespace(input_objs=objs), method="concat")
+        return out.__finalize__(
+            types.SimpleNamespace(input_objs=objs, objs=objs), method="concat"
+        )
 
 
 def new_axes(

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1150,7 +1150,10 @@ class _MergeOperation:
         self._maybe_restore_index_levels(result)
 
         return result.__finalize__(
-            types.SimpleNamespace(input_objs=[self.left, self.right]), method="merge"
+            types.SimpleNamespace(
+                input_objs=[self.left, self.right], left=self.left, right=self.right
+            ),
+            method="merge",
         )
 
     @final


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/60357, keeping the existing names for the objects that subclasses might check for in custom logic in `__finalize__`.

We can deprecate accessing those additional names later, but that is not critical for 3.0