### PR TITLE
BUG: fix empty suffix and prefix handling in pyarrow string methods

### DIFF
--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -201,22 +201,23 @@ class ArrowStringArrayMixin:
 
     def _str_swapcase(self) -> Self:
         return self._from_pyarrow_array(pc.utf8_swapcase(self._pa_array))
-def _str_removeprefix(self, prefix: str):
-    if prefix == "":
-        return self
-    starts_with = pc.starts_with(self._pa_array, pattern=prefix)
-    removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
-    result = pc.if_else(starts_with, removed, self._pa_array)
-    return self._from_pyarrow_array(result)
+        
+    def _str_removeprefix(self, prefix: str):
+        if prefix == "":
+            return self
+        starts_with = pc.starts_with(self._pa_array, pattern=prefix)
+        removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
+        result = pc.if_else(starts_with, removed, self._pa_array)
+        return self._from_pyarrow_array(result)
 
 
-def _str_removesuffix(self, suffix: str):
-    if suffix == "":
-        return self
-    ends_with = pc.ends_with(self._pa_array, pattern=suffix)
-    removed = pc.utf8_slice_codeunits(self._pa_array, 0, stop=-len(suffix))
-    result = pc.if_else(ends_with, removed, self._pa_array)
-    return self._from_pyarrow_array(result)
+    def _str_removesuffix(self, suffix: str):
+        if suffix == "":
+            return self
+        ends_with = pc.ends_with(self._pa_array, pattern=suffix)
+        removed = pc.utf8_slice_codeunits(self._pa_array, 0, stop=-len(suffix))
+        result = pc.if_else(ends_with, removed, self._pa_array)
+        return self._from_pyarrow_array(result)
 
 
 

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -209,10 +209,13 @@ class ArrowStringArrayMixin:
         return self._from_pyarrow_array(result)
 
     def _str_removesuffix(self, suffix: str):
+        if suffix == "":
+            return self
         ends_with = pc.ends_with(self._pa_array, pattern=suffix)
         removed = pc.utf8_slice_codeunits(self._pa_array, 0, stop=-len(suffix))
         result = pc.if_else(ends_with, removed, self._pa_array)
         return self._from_pyarrow_array(result)
+
 
     def _str_startswith(
         self, pat: str | tuple[str, ...], na: Scalar | lib.NoDefault = lib.no_default

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -201,7 +201,7 @@ class ArrowStringArrayMixin:
 
     def _str_swapcase(self) -> Self:
         return self._from_pyarrow_array(pc.utf8_swapcase(self._pa_array))
-        
+
     def _str_removeprefix(self, prefix: str):
         if prefix == "":
             return self

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -204,7 +204,7 @@ class ArrowStringArrayMixin:
 
     def _str_removeprefix(self, prefix: str):
         if prefix == "":
-            return self.copy()
+            return self._from_pyarrow_array(self._pa_array)
         starts_with = pc.starts_with(self._pa_array, pattern=prefix)
         removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
         result = pc.if_else(starts_with, removed, self._pa_array)
@@ -212,7 +212,7 @@ class ArrowStringArrayMixin:
 
     def _str_removesuffix(self, suffix: str):
         if suffix == "":
-            return self.copy()
+            return self._from_pyarrow_array(self._pa_array)
         ends_with = pc.ends_with(self._pa_array, pattern=suffix)
         removed = pc.utf8_slice_codeunits(self._pa_array, 0, stop=-len(suffix))
         result = pc.if_else(ends_with, removed, self._pa_array)

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -210,7 +210,6 @@ class ArrowStringArrayMixin:
         result = pc.if_else(starts_with, removed, self._pa_array)
         return self._from_pyarrow_array(result)
 
-
     def _str_removesuffix(self, suffix: str):
         if suffix == "":
             return self

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -202,6 +202,8 @@ class ArrowStringArrayMixin:
     def _str_swapcase(self) -> Self:
         return self._from_pyarrow_array(pc.utf8_swapcase(self._pa_array))
 def _str_removeprefix(self, prefix: str):
+    if prefix == "":
+        return self
     starts_with = pc.starts_with(self._pa_array, pattern=prefix)
     removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
     result = pc.if_else(starts_with, removed, self._pa_array)
@@ -209,10 +211,13 @@ def _str_removeprefix(self, prefix: str):
 
 
 def _str_removesuffix(self, suffix: str):
+    if suffix == "":
+        return self
     ends_with = pc.ends_with(self._pa_array, pattern=suffix)
     removed = pc.utf8_slice_codeunits(self._pa_array, 0, stop=-len(suffix))
     result = pc.if_else(ends_with, removed, self._pa_array)
     return self._from_pyarrow_array(result)
+
 
 
 

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -203,6 +203,8 @@ class ArrowStringArrayMixin:
         return self._from_pyarrow_array(pc.utf8_swapcase(self._pa_array))
 
     def _str_removeprefix(self, prefix: str):
+        if prefix == "":
+            return self
         starts_with = pc.starts_with(self._pa_array, pattern=prefix)
         removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
         result = pc.if_else(starts_with, removed, self._pa_array)

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -202,21 +202,37 @@ class ArrowStringArrayMixin:
     def _str_swapcase(self) -> Self:
         return self._from_pyarrow_array(pc.utf8_swapcase(self._pa_array))
 
-    def _str_removeprefix(self, prefix: str):
-        if prefix == "":
-            return self
-        starts_with = pc.starts_with(self._pa_array, pattern=prefix)
-        removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
-        result = pc.if_else(starts_with, removed, self._pa_array)
-        return self._from_pyarrow_array(result)
+def _str_removeprefix(self, prefix: str):
+    if prefix == "":
+        return self
 
-    def _str_removesuffix(self, suffix: str):
-        if suffix == "":
-            return self
-        ends_with = pc.ends_with(self._pa_array, pattern=suffix)
-        removed = pc.utf8_slice_codeunits(self._pa_array, 0, stop=-len(suffix))
-        result = pc.if_else(ends_with, removed, self._pa_array)
-        return self._from_pyarrow_array(result)
+    starts_with = pc.starts_with(self._pa_array, pattern=prefix)
+    removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
+    result = pc.if_else(
+        starts_with,
+        removed,
+        self._pa_array,
+    )
+    return self._from_pyarrow_array(result)
+
+
+def _str_removesuffix(self, suffix: str):
+    if suffix == "":
+        return self
+
+    ends_with = pc.ends_with(self._pa_array, pattern=suffix)
+    removed = pc.utf8_slice_codeunits(
+        self._pa_array,
+        0,
+        stop=-len(suffix),
+    )
+    result = pc.if_else(
+        ends_with,
+        removed,
+        self._pa_array,
+    )
+    return self._from_pyarrow_array(result)
+
 
 
     def _str_startswith(

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -204,7 +204,7 @@ class ArrowStringArrayMixin:
 
     def _str_removeprefix(self, prefix: str):
         if prefix == "":
-            return self
+            return self.copy()
         starts_with = pc.starts_with(self._pa_array, pattern=prefix)
         removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
         result = pc.if_else(starts_with, removed, self._pa_array)
@@ -212,7 +212,7 @@ class ArrowStringArrayMixin:
 
     def _str_removesuffix(self, suffix: str):
         if suffix == "":
-            return self
+            return self.copy()
         ends_with = pc.ends_with(self._pa_array, pattern=suffix)
         removed = pc.utf8_slice_codeunits(self._pa_array, 0, stop=-len(suffix))
         result = pc.if_else(ends_with, removed, self._pa_array)

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -201,37 +201,19 @@ class ArrowStringArrayMixin:
 
     def _str_swapcase(self) -> Self:
         return self._from_pyarrow_array(pc.utf8_swapcase(self._pa_array))
-
 def _str_removeprefix(self, prefix: str):
-    if prefix == "":
-        return self
-
     starts_with = pc.starts_with(self._pa_array, pattern=prefix)
     removed = pc.utf8_slice_codeunits(self._pa_array, len(prefix))
-    result = pc.if_else(
-        starts_with,
-        removed,
-        self._pa_array,
-    )
+    result = pc.if_else(starts_with, removed, self._pa_array)
     return self._from_pyarrow_array(result)
 
 
 def _str_removesuffix(self, suffix: str):
-    if suffix == "":
-        return self
-
     ends_with = pc.ends_with(self._pa_array, pattern=suffix)
-    removed = pc.utf8_slice_codeunits(
-        self._pa_array,
-        0,
-        stop=-len(suffix),
-    )
-    result = pc.if_else(
-        ends_with,
-        removed,
-        self._pa_array,
-    )
+    removed = pc.utf8_slice_codeunits(self._pa_array, 0, stop=-len(suffix))
+    result = pc.if_else(ends_with, removed, self._pa_array)
     return self._from_pyarrow_array(result)
+
 
 
 

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -218,10 +218,6 @@ class ArrowStringArrayMixin:
         result = pc.if_else(ends_with, removed, self._pa_array)
         return self._from_pyarrow_array(result)
 
-
-
-
-
     def _str_startswith(
         self, pat: str | tuple[str, ...], na: Scalar | lib.NoDefault = lib.no_default
     ):

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -574,6 +574,7 @@ def test_removesuffix(any_string_dtype, suffix, expected):
 
 
 
+
 def test_string_slice_get_syntax(any_string_dtype):
     ser = Series(
         ["YYY", "B", "C", "YYYYYYbYYY", "BYYYcYYY", np.nan, "CYYYBYYY", "dog", "cYYYt"],

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -544,7 +544,12 @@ def test_strip_lstrip_rstrip_args(any_string_dtype, method, exp):
 
 
 @pytest.mark.parametrize(
-    "prefix, expected", [("a", ["b", " b c", "bc"]), ("ab", ["", "a b c", "bc"])]
+    "prefix, expected",
+    [
+        ("a", ["b", " b c", "bc"]),
+        ("ab", ["", "a b c", "bc"]),
+        ("", ["ab", "a b c", "bc"]),
+    ],
 )
 def test_removeprefix(any_string_dtype, prefix, expected):
     ser = Series(["ab", "a b c", "bc"], dtype=any_string_dtype)
@@ -554,13 +559,19 @@ def test_removeprefix(any_string_dtype, prefix, expected):
 
 
 @pytest.mark.parametrize(
-    "suffix, expected", [("c", ["ab", "a b ", "b"]), ("bc", ["ab", "a b c", ""])]
+    "suffix, expected",
+    [
+        ("c", ["ab", "a b ", "b"]),
+        ("bc", ["ab", "a b c", ""]),
+        ("", ["ab", "a b c", "bc"]),
+    ],
 )
 def test_removesuffix(any_string_dtype, suffix, expected):
     ser = Series(["ab", "a b c", "bc"], dtype=any_string_dtype)
     result = ser.str.removesuffix(suffix)
     ser_expected = Series(expected, dtype=any_string_dtype)
     tm.assert_series_equal(result, ser_expected)
+
 
 
 def test_string_slice_get_syntax(any_string_dtype):

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -573,8 +573,6 @@ def test_removesuffix(any_string_dtype, suffix, expected):
     tm.assert_series_equal(result, ser_expected)
 
 
-
-
 def test_string_slice_get_syntax(any_string_dtype):
     ser = Series(
         ["YYY", "B", "C", "YYYYYYbYYY", "BYYYcYYY", np.nan, "CYYYBYYY", "dog", "cYYYt"],


### PR DESCRIPTION
Python's `str.removeprefix("")` and `str.removesuffix("")` return the original string.

The current pyarrow-backed implementation slices with `stop=0` or `start=0` when the prefix or suffix is empty, which can result in unexpected behavior instead of preserving the original values.

This PR adds explicit guards for empty prefix and suffix inputs and includes tests to ensure parity with Python semantics.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
