### PR TITLE
BUG: Fix to_html adding time to datetime columns in transposed DataFrame (GH#10640)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1269,6 +1269,7 @@ I/O
 - Bug in :meth:`DataFrame.to_dict` raises unnecessary ``UserWarning`` when columns are not unique and ``orient='tight'``. (:issue:`58281`)
 - Bug in :meth:`DataFrame.to_excel` when writing empty :class:`DataFrame` with :class:`MultiIndex` on both axes (:issue:`57696`)
 - Bug in :meth:`DataFrame.to_excel` where the :class:`MultiIndex` index with a period level was not a date (:issue:`60099`)
+- Bug in :meth:`DataFrame.to_html` where a :class:`DatetimeIndex` in the columns was including the time even when it was 00:00:00 (:issue:`10640`)
 - Bug in :meth:`DataFrame.to_stata` when exporting a column containing both long strings (Stata strL) and :class:`pd.NA` values (:issue:`23633`)
 - Bug in :meth:`DataFrame.to_stata` when input encoded length and normal length are mismatched (:issue:`61583`)
 - Bug in :meth:`DataFrame.to_stata` when writing :class:`DataFrame` and ``byteorder=`big```. (:issue:`58969`)

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -130,7 +130,7 @@ class HTMLFormatter:
         return 0
 
     def _get_columns_formatted_values(self) -> Iterable:
-        return self.columns
+        return self.columns._format_flat(include_name=False)
 
     @property
     def is_truncated(self) -> bool:

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1165,3 +1165,17 @@ def test_to_html_empty_complex_array():
         "</table>"
     )
     assert result == expected
+
+
+def test_to_html_datetime_columns_no_time():
+    # GH 10640
+    df = DataFrame(
+        np.random.default_rng(2).standard_normal((5, 2)),
+        columns=["a", "b"],
+        index=pd.to_datetime(
+            ["2015-01-05", "2015-01-04", "2015-01-03", "2015-01-02", "2015-01-01"]
+        ),
+    )
+    result = df.T.to_html()
+    assert "2015-01-05 00:00:00" not in result
+    assert "2015-01-05" in result


### PR DESCRIPTION
- Closes #10640

**Description:**
When using `to_html` on a transposed DataFrame with a DatetimeIndex, the column headers were including the time component (e.g., `00:00:00`) even when it should be hidden. This was because `HTMLFormatter` was using the raw column values instead of the formatted values.

**Fix:**
- Updated `HTMLFormatter._get_columns_formatted_values` to use `self.columns._format_flat(include_name=False)`, aligning the behavior with `NotebookFormatter` and respecting display options.

**Verification:**
- Added regression test `test_to_html_datetime_columns_no_time` in `pandas/tests/io/formats/test_to_html.py`.
- Added release note in `doc/source/whatsnew/v3.0.0.rst`.