### PR TITLE
BUG: Allow is_bool_indexer to recognize NumpyExtensionArray

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -45,6 +45,7 @@ from pandas.core.dtypes.generic import (
     ABCExtensionArray,
     ABCIndex,
     ABCMultiIndex,
+    ABCNumpyExtensionArray,
     ABCSeries,
 )
 from pandas.core.dtypes.inference import iterable_not_string
@@ -128,7 +129,8 @@ def is_bool_indexer(key: Any) -> bool:
         and convert to an ndarray.
     """
     if isinstance(
-        key, (ABCSeries, np.ndarray, ABCIndex, ABCExtensionArray)
+        key,
+        (ABCSeries, np.ndarray, ABCIndex, ABCExtensionArray, ABCNumpyExtensionArray),
     ) and not isinstance(key, ABCMultiIndex):
         if key.dtype == np.object_:
             key_array = np.asarray(key)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -717,6 +717,18 @@ def test__getitem__boolean_numpyextensionarray():
 
 
 @pytest.mark.parametrize(
+    "container",
+    [np.array, pd.Series, lambda x: pd.arrays.NumpyExtensionArray(np.array(x))],
+    ids=["numpy-array", "series", "numpy-extension-array"],
+)
+def test__getitem__boolean_arraylike(container):
+    ri = RangeIndex(5)
+    result = ri[container([True, True, False, False, True])]
+    expected = Index([0, 1, 4], dtype="int64")
+    tm.assert_index_equal(result, expected)
+
+
+@pytest.mark.parametrize(
     "rng, exp_rng",
     [
         [range(5), range(3, 4)],

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -710,6 +710,12 @@ def test_take_return_rangeindex():
     tm.assert_index_equal(result, expected, exact=True)
 
 
+def test__getitem__boolean_numpyextensionarray():
+    ri = RangeIndex(1)
+    result = ri[pd.arrays.NumpyExtensionArray(np.array([True]))]
+    tm.assert_index_equal(ri, result)
+
+
 @pytest.mark.parametrize(
     "rng, exp_rng",
     [

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -236,6 +236,12 @@ class TestIsBoolIndexer:
         expected = df[[]]
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("scalar", [1, True])
+    def test_numpyextensionarray(self, scalar):
+        # GH 63391
+        arr = pd.arrays.NumpyExtensionArray(np.array([scalar]))
+        assert com.is_bool_indexer(arr) is isinstance(scalar, bool)
+
 
 @pytest.mark.parametrize("with_exception", [True, False])
 def test_temp_setattr(with_exception):


### PR DESCRIPTION
- [ ] closes #63391 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Bug in main so no whatsnew needed.

I'm not sure why `ABCExtensionArray` doesn't cover `ABCNumpyExtensionArray`, but that would probably be too large of a change for this issue.
