### PR TITLE
BLD: newer versions of meson are pickier about types

### DIFF
--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -160,7 +160,7 @@ foreach ext_name, ext_dict : libs_sources
         ext_dict.get('sources'),
         cython_args: cython_args,
         include_directories: [inc_np, inc_pd],
-        dependencies: ext_dict.get('deps', ''),
+        dependencies: ext_dict.get('deps', []),
         subdir: 'pandas/_libs',
         install: true,
     )

--- a/pandas/_libs/tslibs/meson.build
+++ b/pandas/_libs/tslibs/meson.build
@@ -40,7 +40,7 @@ foreach ext_name, ext_dict : tslibs_sources
         ext_dict.get('sources'),
         cython_args: cython_args,
         include_directories: [inc_np, inc_pd],
-        dependencies: ext_dict.get('deps', ''),
+        dependencies: ext_dict.get('deps', []),
         subdir: 'pandas/_libs/tslibs',
         install: true,
     )


### PR DESCRIPTION
The development branch of meson fails to build pandas with the following error:

```
Processing ./.
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'

  Running command Preparing metadata (pyproject.toml)
  + meson setup /home/tcaswell/source/p/pandas-dev/pandas /home/tcaswell/source/p/pandas-dev/pandas/.mesonpy-zgm31ru6 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --vsenv --native-file=/home/tcaswell/source/p/pandas-dev/pandas/.mesonpy-zgm31ru6/meson-python-native-file.ini
  The Meson build system
  Version: 1.10.99
  Source dir: /home/tcaswell/source/p/pandas-dev/pandas
  Build dir: /home/tcaswell/source/p/pandas-dev/pandas/.mesonpy-zgm31ru6
  Build type: native build
  Project name: pandas
  Project version: 3.0.0rc0+56.ga682616387.dirty
  C compiler for the host machine: /usr/bin/ccache cc (gcc 15.2.1 "cc (GCC) 15.2.1 20251112")
  C linker for the host machine: cc ld.bfd 2.45.1
  C++ compiler for the host machine: /usr/bin/ccache c++ (gcc 15.2.1 "c++ (GCC) 15.2.1 20251112")
  C++ linker for the host machine: c++ ld.bfd 2.45.1
  Cython compiler for the host machine: cython (cython 3.3.0)
  Host machine cpu family: x86_64
  Host machine cpu: x86_64
  Program python found: YES (/home/tcaswell/.virtualenvs/cp315-clang/bin/python3)
  Program cython found: YES (/home/tcaswell/.virtualenvs/cp315-clang/bin/cython)
  Found pkg-config: YES (/usr/bin/pkg-config) 2.5.1
  Run-time dependency python found: YES 3.15
  Configuring free_threading_config.pxi using configuration

  ../pandas/_libs/meson.build:158:7: ERROR: python.extension_module keyword argument 'dependencies' was of type array[str] but should have been array[Dependency | InternalDependency]

  A full log can be found at /home/tcaswell/source/p/pandas-dev/pandas/.mesonpy-zgm31ru6/meson-logs/meson-log.txt
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> No available output.

  note: This error originates from a subprocess, and is likely not a problem with pip.
```


Switching the default dependency list to [] rather than '' fixes the build.

This is likely due to https://github.com/mesonbuild/meson/commit/bde1c23b4f3eb9eb63e835b722bb9bbcccc4c8c1 based on the commit message, but I have not bisected this to be sure.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
