### PR TITLE
BUG: .quantile with empty temporal data

### DIFF
--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -512,7 +512,9 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
         else:
             # e.g. test_quantile_empty we are empty integer dtype and res_values
             #  has floating dtype
-            return type(self)._from_sequence(res_values)  # type: ignore[call-arg]
+            # TODO: technically __init__ isn't defined here.
+            #  Should we raise NotImplementedError and handle this on NumpyEA?
+            return type(self)(res_values)  # type: ignore[call-arg]
 
     # ------------------------------------------------------------------------
     # numpy-like methods

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -512,9 +512,7 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
         else:
             # e.g. test_quantile_empty we are empty integer dtype and res_values
             #  has floating dtype
-            # TODO: technically __init__ isn't defined here.
-            #  Should we raise NotImplementedError and handle this on NumpyEA?
-            return type(self)(res_values)  # type: ignore[call-arg]
+            return type(self)._from_sequence(res_values)  # type: ignore[call-arg]
 
     # ------------------------------------------------------------------------
     # numpy-like methods

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -226,12 +226,15 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     """
 
     _typ = "datetimearray"
-    _internal_fill_value = np.datetime64("NaT", "ns")
     _recognized_scalars = (datetime, np.datetime64)
     _is_recognized_dtype: Callable[[DtypeObj], bool] = lambda x: lib.is_np_dtype(
         x, "M"
     ) or isinstance(x, DatetimeTZDtype)
     _infer_matches = ("datetime", "datetime64", "date")
+
+    @property
+    def _internal_fill_value(self) -> np.datetime64:
+        return np.datetime64("NaT", self.unit)
 
     @property
     def _scalar_type(self) -> type[Timestamp]:

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -154,10 +154,13 @@ class TimedeltaArray(dtl.TimelikeOps):
     """
 
     _typ = "timedeltaarray"
-    _internal_fill_value = np.timedelta64("NaT", "ns")
     _recognized_scalars = (timedelta, np.timedelta64, Tick)
     _is_recognized_dtype: Callable[[DtypeObj], bool] = lambda x: lib.is_np_dtype(x, "m")
     _infer_matches = ("timedelta", "timedelta64")
+
+    @property
+    def _internal_fill_value(self) -> np.timedelta64:
+        return np.timedelta64("NaT", self.unit)
 
     @property
     def _scalar_type(self) -> type[Timedelta]:

--- a/pandas/tests/frame/methods/test_quantile.py
+++ b/pandas/tests/frame/methods/test_quantile.py
@@ -928,3 +928,12 @@ def test_multi_quantile_numeric_only_retains_columns():
     tm.assert_frame_equal(
         result, expected, check_index_type=True, check_column_type=True
     )
+
+
+@pytest.mark.parametrize("typ", ["datetime64", "timedelta64"])
+def test_quantile_empty_datetimelike(typ, unit):
+    dtype = f"{typ}[{unit}]"
+    df = DataFrame(np.array([], dtype=dtype))
+    result = df.quantile()
+    expected = Series([pd.NaT], name=0.5, dtype=dtype)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_quantile.py
+++ b/pandas/tests/series/methods/test_quantile.py
@@ -245,3 +245,10 @@ class TestSeriesQuantile:
         result = ser.quantile([0.1, 0.5])
         expected = Series([1, 1], dtype=any_int_ea_dtype, index=[0.1, 0.5])
         tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("typ", ["datetime64", "timedelta64"])
+def test_quantile_empty_datetimelike(typ, unit):
+    ser = Series([], dtype=f"{typ}[{unit}]")
+    result = ser.quantile()
+    assert result is pd.NaT


### PR DESCRIPTION
- [x] closes #63404 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
