### PR TITLE
BUG: Fix incorrect index length when ignore_index=True in series concat

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -710,7 +710,9 @@ def _get_concat_axis_series(
 ) -> Index:
     """Return result concat axis when concatenating Series objects."""
     if ignore_index:
-        return default_index(len(objs))
+        total_length = sum(len(obj) for obj in objs)
+        return default_index(total_length)
+
     elif bm_axis == 0:
         indexes = [x.index for x in objs]
         if keys is None:


### PR DESCRIPTION
Fix incorrect index length when ignore_index=True in series concat

The concat axis was previously created with length len(objs), which counts input containers rather than concatenated rows. This caused index/data length mismatches for any non-trivial concat.

The concat axis length is now computed as the sum of object lengths, restoring correctness for ignore_index=True.

I am happy to add parametrized test cases if required and given exact file location.


