### PR TITLE
BUG: Fix regression in to_hdf with MultiIndex and StringDtype (GH#63412)

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3147,14 +3147,12 @@ class GenericFixed(Fixed):
             zip(index.levels, index.codes, index.names, strict=True)
         ):
             # write the level
-            if isinstance(lev.dtype, ExtensionDtype):
-                # GH 63412
-                if isinstance(lev.dtype, StringDtype):
-                    pass
-                else:
-                    raise NotImplementedError(
-                        "Saving a MultiIndex with an extension dtype is not supported."
-                    )
+            if isinstance(lev.dtype, ExtensionDtype) and not isinstance(
+                lev.dtype, StringDtype
+            ):
+                raise NotImplementedError(
+                    "Saving a MultiIndex with an extension dtype is not supported."
+                )
             level_key = f"{key}_level{i}"
             conv_level = _convert_index(level_key, lev, self.encoding, self.errors)
             self.write_array(level_key, conv_level.values)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3148,9 +3148,13 @@ class GenericFixed(Fixed):
         ):
             # write the level
             if isinstance(lev.dtype, ExtensionDtype):
-                raise NotImplementedError(
-                    "Saving a MultiIndex with an extension dtype is not supported."
-                )
+                # GH 63412
+                if isinstance(lev.dtype, StringDtype):
+                    lev = lev.astype(object)
+                else:
+                    raise NotImplementedError(
+                        "Saving a MultiIndex with an extension dtype is not supported."
+                    )
             level_key = f"{key}_level{i}"
             conv_level = _convert_index(level_key, lev, self.encoding, self.errors)
             self.write_array(level_key, conv_level.values)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3150,7 +3150,7 @@ class GenericFixed(Fixed):
             if isinstance(lev.dtype, ExtensionDtype):
                 # GH 63412
                 if isinstance(lev.dtype, StringDtype):
-                    lev = lev.astype(object)
+                    pass
                 else:
                     raise NotImplementedError(
                         "Saving a MultiIndex with an extension dtype is not supported."

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -314,12 +314,6 @@ def test_column_multiindex(tmp_path, setup_path, using_infer_string):
 
     path = tmp_path / setup_path
     with HDFStore(path) as store:
-        if using_infer_string:
-            # TODO(infer_string) make this work for string dtype
-            msg = "Saving a MultiIndex with an extension dtype is not supported."
-            with pytest.raises(NotImplementedError, match=msg):
-                store.put("df", df)
-            return
         store.put("df", df)
         tm.assert_frame_equal(
             store["df"], expected, check_index_type=True, check_column_type=True

--- a/pandas/tests/io/pytables/test_read.py
+++ b/pandas/tests/io/pytables/test_read.py
@@ -181,12 +181,6 @@ def test_read_hdf_open_store(tmp_path, setup_path, using_infer_string):
     df = df.set_index(keys="E", append=True)
 
     path = tmp_path / setup_path
-    if using_infer_string:
-        # TODO(infer_string) make this work for string dtype
-        msg = "Saving a MultiIndex with an extension dtype is not supported."
-        with pytest.raises(NotImplementedError, match=msg):
-            df.to_hdf(path, key="df", mode="w")
-        return
     df.to_hdf(path, key="df", mode="w")
     direct = read_hdf(path, "df")
     with HDFStore(path, mode="r") as store:

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -434,12 +434,6 @@ def test_store_hierarchical(
 ):
     frame = multiindex_dataframe_random_data
 
-    if using_infer_string:
-        # TODO(infer_string) make this work for string dtype
-        msg = "Saving a MultiIndex with an extension dtype is not supported."
-        with pytest.raises(NotImplementedError, match=msg):
-            _check_roundtrip(frame, tm.assert_frame_equal, path=temp_file)
-        return
     _check_roundtrip(frame, tm.assert_frame_equal, path=temp_file)
     _check_roundtrip(frame.T, tm.assert_frame_equal, path=temp_file)
     _check_roundtrip(frame["A"], tm.assert_series_equal, path=temp_file)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -1129,3 +1129,16 @@ def test_select_categorical_string_columns(tmp_path, model):
         result = store.select("df", "modelId == model")
         expected = df[df["modelId"] == model]
         tm.assert_frame_equal(result, expected)
+
+
+def test_to_hdf_multiindex_string_dtype_crash(tmp_path):
+    # GH#63412
+    path = tmp_path / "test.h5"
+    index = MultiIndex.from_tuples(
+        [("a", "x"), ("b", "y")], 
+        names=["level1", "level2"]
+    )
+    df = DataFrame({"value": [1, 2]}, index=index)
+    df.to_hdf(path, key="test")
+    result = read_hdf(path, key="test")
+    tm.assert_frame_equal(df, result, check_dtype=False)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -1134,10 +1134,7 @@ def test_select_categorical_string_columns(tmp_path, model):
 def test_to_hdf_multiindex_string_dtype_crash(tmp_path):
     # GH#63412
     path = tmp_path / "test.h5"
-    index = MultiIndex.from_tuples(
-        [("a", "x"), ("b", "y")], 
-        names=["level1", "level2"]
-    )
+    index = MultiIndex.from_tuples([("a", "x"), ("b", "y")], names=["level1", "level2"])
     df = DataFrame({"value": [1, 2]}, index=index)
     df.to_hdf(path, key="test")
     result = read_hdf(path, key="test")


### PR DESCRIPTION
- [x] closes #63412
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Summary
- Fixed `NotImplementedError` when saving `MultiIndex` with `StringDtype` to HDF5.
- Added regression test in `pandas/tests/io/pytables/test_store.py`.
- Enabled existing tests in `test_put.py`, `test_read.py`, and `test_round_trip.py` that were previously skipped for `StringDtype`.