### PR TITLE
TST: fix `test_config` to use `pytest.warns()`

### DIFF
--- a/pandas/tests/config/test_config.py
+++ b/pandas/tests/config/test_config.py
@@ -129,7 +129,7 @@ class TestConfig:
 
         cf.deprecate_option("KanBan", category)
         msg = "'kanban' is deprecated, please refrain from using it."
-        with pytest.warns(category, match=msg):
+        with tm.assert_produces_warning(category, match=msg):
             cf.get_option("kAnBaN")
 
     def test_get_option(self):

--- a/pandas/tests/config/test_config.py
+++ b/pandas/tests/config/test_config.py
@@ -129,7 +129,7 @@ class TestConfig:
 
         cf.deprecate_option("KanBan", category)
         msg = "'kanban' is deprecated, please refrain from using it."
-        with pytest.raises(category, match=msg):
+        with pytest.warns(category, match=msg):
             cf.get_option("kAnBaN")
 
     def test_get_option(self):


### PR DESCRIPTION
Fix `pandas/tests/config/test_config.py::TestConfig::test_case_insensitive` to use `pytest.warns()` when checking for warnings instead of incorrect `pytest.raises()`. This fixes running the test suite without `-Werror`.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
