### PR TITLE
Fix issue #63444, sorry first time if I did something wrong

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1453,7 +1453,7 @@ Other
   array if the array shares data with the original DataFrame or Series (:ref:`copy_on_write_read_only_na`).
   This logic is expanded to accessing the underlying pandas ExtensionArray
   through ``.array`` (or ``.values`` depending on the dtype) as well (:issue:`61925`).
-
+- Bug in :meth:`Series.round` where series shows TypeError when passed empty Series (:issue:`63444`)
 .. ***DO NOT USE THIS SECTION***
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2579,11 +2579,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         dtype: float64
         """
         nv.validate_round(args, kwargs)
-        if not self.empty and (self.dtype == "object" or self.dtype=='str'):
+        if not self.empty and (self.dtype == "object" or self.dtype == "str"):
             raise TypeError("Expected numeric dtype, got object instead.")
-        if not self.empty and (self.dtype=='str'):
+        if not self.empty and (self.dtype == "str"):
             raise TypeError("Expected numeric dtype, got string instead.")
-        
+
         new_mgr = self._mgr.round(decimals=decimals)
         return self._constructor_from_mgr(new_mgr, axes=new_mgr.axes).__finalize__(
             self, method="round"

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2579,8 +2579,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         dtype: float64
         """
         nv.validate_round(args, kwargs)
-        if self.dtype == "object":
+        if not self.empty and (self.dtype == "object" or self.dtype=='str'):
             raise TypeError("Expected numeric dtype, got object instead.")
+        if not self.empty and (self.dtype=='str'):
+            raise TypeError("Expected numeric dtype, got string instead.")
+        
         new_mgr = self._mgr.round(decimals=decimals)
         return self._constructor_from_mgr(new_mgr, axes=new_mgr.axes).__finalize__(
             self, method="round"

--- a/pandas/tests/series/methods/test_round_empty.py
+++ b/pandas/tests/series/methods/test_round_empty.py
@@ -1,0 +1,31 @@
+import pytest
+import numpy as np
+import pandas as pd
+import pandas.testing as tm
+
+#GH63444
+
+
+def test_series_round_empty1():
+    result = pd.Series([]).round(2)
+    expected = pd.Series([])
+
+def test_series_round_empty2():
+    result = pd.Series([], dtype='float64').round()
+    expected = pd.Series([], dtype='float64')
+    tm.assert_series_equal(result, expected)
+def test_series_round_numeric():
+    result = pd.Series([1.2345, 2.6789, 3.14159]).round(2)
+    expected = pd.Series([1.23, 2.68, 3.14])
+    tm.assert_series_equal(result, expected)
+def test_series_round_integers():
+    result = pd.Series([1, 2, 3]).round(2)
+    expected = pd.Series([1, 2, 3])
+    tm.assert_series_equal(result, expected)
+
+def test_series_round_str():
+    with pytest.raises(TypeError):
+        pd.Series(['a', 'b', 'c']).round(2)
+def test_series_round_obj():
+    with pytest.raises(TypeError):
+        pd.Series(['123'], dtype='object').round(2)

--- a/pandas/tests/series/methods/test_round_empty.py
+++ b/pandas/tests/series/methods/test_round_empty.py
@@ -1,31 +1,40 @@
 import pytest
-import numpy as np
+
 import pandas as pd
 import pandas.testing as tm
 
-#GH63444
+# GH63444
 
 
 def test_series_round_empty1():
     result = pd.Series([]).round(2)
     expected = pd.Series([])
+    tm.assert_series_equal(result, expected)
+
 
 def test_series_round_empty2():
-    result = pd.Series([], dtype='float64').round()
-    expected = pd.Series([], dtype='float64')
+    result = pd.Series([], dtype="float64").round()
+    expected = pd.Series([], dtype="float64")
     tm.assert_series_equal(result, expected)
+
+
 def test_series_round_numeric():
     result = pd.Series([1.2345, 2.6789, 3.14159]).round(2)
     expected = pd.Series([1.23, 2.68, 3.14])
     tm.assert_series_equal(result, expected)
+
+
 def test_series_round_integers():
     result = pd.Series([1, 2, 3]).round(2)
     expected = pd.Series([1, 2, 3])
     tm.assert_series_equal(result, expected)
 
+
 def test_series_round_str():
     with pytest.raises(TypeError):
-        pd.Series(['a', 'b', 'c']).round(2)
+        pd.Series(["a", "b", "c"]).round(2)
+
+
 def test_series_round_obj():
     with pytest.raises(TypeError):
-        pd.Series(['123'], dtype='object').round(2)
+        pd.Series(["123"], dtype="object").round(2)


### PR DESCRIPTION
Before when you pass an empty series into the pd.Series.round() it would raise a type error because an empty series is an object type. Now it doesn’t raise that error. It will raise that error only when an object or string type is passed. It now checks if it the series is a true string or object before raising error. I also added some new test cases to make sure the fix doesn’t mess up the function and that it handles empty series. Might have made mistakes as it’s my first time contributing!

- [x] closes #63444 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
