### PR TITLE
BUG: Allow empty interesection in DataFrame.update

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10081,12 +10081,6 @@ class DataFrame(NDFrame, OpsMixin):
             raise ValueError("Update not allowed with duplicate indexes on other.")
 
         index_intersection = other.index.intersection(self.index)
-        if index_intersection.empty:
-            raise ValueError(
-                "Update not allowed when the index on `other` has no intersection "
-                "with this dataframe."
-            )
-
         other = other.reindex(index_intersection)
         this_data = self.loc[index_intersection]
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10081,6 +10081,8 @@ class DataFrame(NDFrame, OpsMixin):
             raise ValueError("Update not allowed with duplicate indexes on other.")
 
         index_intersection = other.index.intersection(self.index)
+        if index_intersection.empty:
+            return
         other = other.reindex(index_intersection)
         this_data = self.loc[index_intersection]
 

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -215,13 +215,6 @@ class TestDataFrameUpdate:
         with pytest.raises(ValueError, match="duplicate index"):
             df.update(other)
 
-    def test_update_raises_without_intersection(self):
-        # GH#55509
-        df = DataFrame({"a": [1]}, index=[1])
-        other = DataFrame({"a": [2]}, index=[2])
-        with pytest.raises(ValueError, match="no intersection"):
-            df.update(other)
-
     def test_update_on_duplicate_frame_unique_argument_index(self):
         # GH#55509
         df = DataFrame({"a": [1, 1, 1]}, index=[1, 1, 2], dtype=np.dtype("intc"))

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -215,7 +215,7 @@ class TestDataFrameUpdate:
         with pytest.raises(ValueError, match="duplicate index"):
             df.update(other)
 
-    def test_update_raises_without_intersection(self):
+    def test_update_without_intersection(self):
         # GH#63452
         orig = DataFrame({"a": [1]}, index=[1])
         df = orig.copy()

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -215,6 +215,14 @@ class TestDataFrameUpdate:
         with pytest.raises(ValueError, match="duplicate index"):
             df.update(other)
 
+    def test_update_raises_without_intersection(self):
+        # GH#63452
+        orig = DataFrame({"a": [1]}, index=[1])
+        df = orig.copy()
+        other = DataFrame({"a": [2]}, index=[2])
+        df.update(other)
+        tm.assert_frame_equal(df, orig)
+
     def test_update_on_duplicate_frame_unique_argument_index(self):
         # GH#55509
         df = DataFrame({"a": [1, 1, 1]}, index=[1, 1, 2], dtype=np.dtype("intc"))


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

#57637 unnecessarily restricted `DataFrame.update` from operating on an empty intersection, which does not match `Series.update` behavior. Since dtypes of the caller remain the same in all cases, it's safe to just return when this occurs.