### PR TITLE
ENH: Add Vortex file format supportImplements read_vortex() and DataF…

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -166,6 +166,7 @@ from pandas.io.api import (
     read_stata,
     read_sas,
     read_spss,
+    read_vortex, 
     read_iceberg,
 )
 
@@ -336,6 +337,7 @@ __all__ = [
     "read_stata",
     "read_table",
     "read_xml",
+    "read_vortex", 
     "reset_option",
     "set_eng_float_format",
     "set_option",

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3954,8 +3954,33 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             storage_options=storage_options,
         )
 
-    # ----------------------------------------------------------------------
-    # Indexing Methods
+    @final
+    def to_vortex(
+        self,
+        path,
+        *,
+        storage_options=None,
+        **kwargs,
+    ) -> None:
+        """
+        Write object to the Vortex binary format.
+
+        Parameters
+        ----------
+        path : str or path object
+        storage_options : dict, optional
+        **kwargs
+
+        See Also
+        --------
+        read_vortex : Read a Vortex file.
+        """
+        from pandas.io.vortex import to_vortex
+
+        return to_vortex(self, path, storage_options=storage_options, **kwargs)
+
+        # ----------------------------------------------------------------------
+        # Indexing Methods
 
     @final
     def take(self, indices, axis: Axis = 0, **kwargs) -> Self:

--- a/pandas/io/api.py
+++ b/pandas/io/api.py
@@ -36,6 +36,7 @@ from pandas.io.sql import (
 )
 from pandas.io.stata import read_stata
 from pandas.io.xml import read_xml
+from pandas.io.vortex import read_vortex
 
 __all__ = [
     "ExcelFile",
@@ -61,5 +62,6 @@ __all__ = [
     "read_stata",
     "read_table",
     "read_xml",
+    "read_vortex", 
     "to_pickle",
 ]

--- a/pandas/io/vortex.py
+++ b/pandas/io/vortex.py
@@ -1,0 +1,170 @@
+"""
+Vortex format support for pandas.
+"""
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
+
+from pandas.compat._optional import import_optional_dependency
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
+    from pandas._typing import (
+        FilePath,
+        ReadBuffer,
+        StorageOptions,
+        WriteBuffer,
+    )
+
+
+def read_vortex(
+    path: FilePath | ReadBuffer[bytes],
+    columns: list[str] | None = None,
+    storage_options: StorageOptions | None = None,
+    **kwargs: Any,
+) -> DataFrame:
+    """
+    Load a Vortex file from the file path, returning a DataFrame.
+
+    Parameters
+    ----------
+    path : str, path object, or file-like object
+        String or path object (implementing ``os.PathLike[str]``).
+        The string could be a URL. Valid URL schemes include http, ftp, s3, 
+        gs, and file.
+    columns : list, optional
+        If not None, only these columns will be read from the file.
+    storage_options : dict, optional
+        Extra options that make sense for a particular storage connection, e.g.
+        host, port, username, password, etc. Currently not supported for Vortex.
+
+        .. versionadded:: 3.0.0
+    **kwargs
+        Any additional kwargs are passed to ``vortex.open`` and ``scan``.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame containing the data from the Vortex file.
+
+    See Also
+    --------
+    DataFrame.to_vortex : Write a DataFrame to the Vortex format.
+    read_parquet : Read a Parquet file.
+    read_feather : Read a Feather file.
+    read_orc : Read an ORC file.
+
+    Examples
+    --------
+    >>> df = pd.read_vortex("path/to/file.vortex")  # doctest: +SKIP
+
+    Read only certain columns:
+
+    >>> df = pd.read_vortex(
+    ...     "path/to/file.vortex",
+    ...     columns=["col1", "col2"]
+    ... )  # doctest: +SKIP
+    """
+    vortex = import_optional_dependency(
+        "vortex", extra="vortex is required for Vortex support."
+    )
+
+    # Convert Path object to string if necessary
+    from pathlib import Path
+    if isinstance(path, Path):
+        path = str(path)
+
+    # Open the Vortex file
+    v_file = vortex.open(path)
+
+    # Perform scan with optional column projection
+    scan = v_file.scan(projection=columns, **kwargs)
+
+    # Read all data and convert to Arrow format
+    result_array = scan.read_all()
+
+    # Convert Vortex result to Arrow Table
+    if hasattr(result_array, "to_arrow_table"):
+        arrow_table = result_array.to_arrow_table()
+    elif hasattr(result_array, "to_arrow"):
+        import pyarrow as pa
+
+        if isinstance(arrow_obj, pa.Table):
+            arrow_table = arrow_obj
+        else:
+            # Construct Table from batches if needed
+            arrow_table = pa.Table.from_batches([arrow_obj])
+    else:
+        raise ValueError(
+            "Unable to convert Vortex result to Arrow format. "
+            "Please ensure vortex is properly installed."
+        )
+
+    # Convert Arrow Table to pandas DataFrame
+    return arrow_table.to_pandas()
+
+
+def to_vortex(
+    df: DataFrame,
+    path: FilePath | WriteBuffer[bytes],
+    *,
+    storage_options: StorageOptions | None = None,
+    **kwargs: Any,
+) -> None:
+    """
+    Write a DataFrame to the Vortex binary format.
+
+    Parameters
+    ----------
+    df : DataFrame
+        The DataFrame to write.
+    path : str or path object
+        String or path object (implementing ``os.PathLike[str]``).
+    storage_options : dict, optional
+        Extra options that make sense for a particular storage connection, e.g.
+        host, port, username, password, etc. Currently not supported for Vortex.
+
+        .. versionadded:: 3.0.0
+    **kwargs
+        Additional arguments passed to ``vortex.io.write``.
+
+    See Also
+    --------
+    read_vortex : Read a Vortex file.
+    DataFrame.to_parquet : Write a DataFrame to the Parquet format.
+    DataFrame.to_feather : Write a DataFrame to the Feather format.
+    DataFrame.to_orc : Write a DataFrame to the ORC format.
+
+    Notes
+    -----
+    This function writes the DataFrame to the Vortex columnar storage format,
+    which is optimized for analytical workloads.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
+    >>> df.to_vortex("output.vortex")  # doctest: +SKIP
+    """
+    vortex = import_optional_dependency(
+        "vortex", extra="vortex is required for Vortex support."
+    )
+    pa = import_optional_dependency(
+        "pyarrow", extra="pyarrow is required for Vortex support."
+    )
+
+    # Convert Path object to string if necessary
+    from pathlib import Path
+    if isinstance(path, Path):
+        path = str(path)
+
+    # Convert DataFrame to Arrow Table
+    table = pa.Table.from_pandas(df)
+
+    # Convert Arrow Table to Vortex Array
+    v_array = vortex.array(table)
+
+    # Write to file
+    vortex.io.write(v_array, path, **kwargs)

--- a/pandas/tests/io/test_vortex.py
+++ b/pandas/tests/io/test_vortex.py
@@ -1,0 +1,93 @@
+"""
+Tests for Vortex file format support.
+"""
+import numpy as np
+import pytest
+
+from pandas import (
+    DataFrame,
+    read_vortex,
+)
+import pandas._testing as tm
+
+# Only run tests if vortex is installed
+pytest.importorskip("vortex")
+
+
+class TestVortex:
+    """Tests for Vortex I/O operations."""
+
+    def test_basic_roundtrip(self, tmp_path):
+        """Test basic write and read roundtrip."""
+        df = DataFrame({
+            "a": [1, 2, 3],
+            "b": ["x", "y", "z"],
+            "c": [1.1, 2.2, 3.3],
+        })
+        path = tmp_path / "test.vortex"
+
+        df.to_vortex(path)
+        result = read_vortex(path)
+
+        tm.assert_frame_equal(df, result)
+
+    def test_read_column_subset(self, tmp_path):
+        """Test reading only a subset of columns."""
+        df = DataFrame({
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+            "c": [7, 8, 9],
+        })
+        path = tmp_path / "test_cols.vortex"
+
+        df.to_vortex(path)
+        result = read_vortex(path, columns=["a", "c"])
+
+        expected = df[["a", "c"]]
+        tm.assert_frame_equal(result, expected)
+
+    def test_empty_dataframe(self, tmp_path):
+        """Test reading and writing an empty DataFrame."""
+        df = DataFrame({"a": [], "b": []})
+        path = tmp_path / "test_empty.vortex"
+
+        df.to_vortex(path)
+        result = read_vortex(path)
+
+        tm.assert_frame_equal(df, result)
+
+    def test_various_dtypes(self, tmp_path):
+        """Test DataFrame with various data types."""
+        df = DataFrame({
+            "int": np.array([1, 2, 3], dtype="int64"),
+            "float": np.array([1.0, 2.0, 3.0], dtype="float64"),
+            "str": ["a", "b", "c"],
+            "bool": [True, False, True],
+        })
+        path = tmp_path / "test_dtypes.vortex"
+
+        df.to_vortex(path)
+        result = read_vortex(path)
+
+        tm.assert_frame_equal(df, result)
+
+    def test_with_index(self, tmp_path):
+        """Test DataFrame with custom index is preserved as column."""
+        df = DataFrame(
+            {"a": [1, 2, 3], "b": [4, 5, 6]},
+            index=["x", "y", "z"],
+        )
+        path = tmp_path / "test_index.vortex"
+
+        df.to_vortex(path)
+        result = read_vortex(path)
+
+        # Vortex saves index as a column, verify it exists and has correct values
+        assert "__index_level_0__" in result.columns
+        assert list(result["__index_level_0__"]) == list(df.index)
+        
+        # Verify data columns match (reset index for comparison)
+        tm.assert_frame_equal(
+            df.reset_index(drop=True), 
+            result[["a", "b"]].reset_index(drop=True)
+        )


### PR DESCRIPTION
## Description

This PR implements support for the Vortex columnar file format in pandas, addressing issue #63418.

## Changes

- Added `read_vortex()` function to read Vortex files into DataFrames
- Added `DataFrame.to_vortex()` method to write DataFrames to Vortex format
- Comprehensive test suite covering basic I/O, column projection, various dtypes, and index handling

## Tests

All tests pass locally:
