### PR TITLE
ENH: Add remove_prefix and remove_suffix to NDFrame

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4829,6 +4829,64 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2       3       5
         3       4       6
         """
+
+    @final
+    def remove_prefix(self, prefix: str) -> Self:
+        """
+        Remove a prefix from labels.
+
+        For Series, the row labels are processed.
+        For DataFrame, the column labels are processed.
+
+        Parameters
+        ----------
+        prefix : str
+            The string to remove from the start of each label.
+
+        Returns
+        -------
+        Series or DataFrame
+            New Series or DataFrame with updated labels.
+
+        See Also
+        --------
+        add_prefix : Add a prefix to labels.
+        """
+        f = lambda x: str(x).removeprefix(prefix)
+
+        if self.ndim == 1:
+            return self.rename(index=f)
+        else:
+            return self.rename(columns=f)
+
+    @final
+    def remove_suffix(self, suffix: str) -> Self:
+        """
+        Remove a suffix from labels.
+
+        For Series, the row labels are processed.
+        For DataFrame, the column labels are processed.
+
+        Parameters
+        ----------
+        suffix : str
+            The string to remove from the end of each label.
+
+        Returns
+        -------
+        Series or DataFrame
+            New Series or DataFrame with updated labels.
+
+        See Also
+        --------
+        add_suffix : Add a suffix to labels.
+        """
+        f = lambda x: str(x).removesuffix(suffix)
+
+        if self.ndim == 1:
+            return self.rename(index=f)
+        else:
+            return self.rename(columns=f)
         f = lambda x: f"{x}{suffix}"
 
         axis_name = self._info_axis_name


### PR DESCRIPTION
Added methods to remove prefixes and suffixes from labels in Series and DataFrame.

### Description
This PR adds `remove_prefix` and `remove_suffix` methods to `NDFrame` (Series/DataFrame).

These are the logical inverses of the existing `add_prefix` and `add_suffix` methods. Currently, users have to use lambda functions to achieve this:
`df.rename(columns=lambda x: x.removeprefix('prefix'))`

This addition simplifies this common data cleaning task to:
`df.remove_prefix('prefix')`

### Dependencies
This change relies on the standard library `str.removeprefix` and `str.removesuffix`.


- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
