### PR TITLE
STY: Add strict= to zip() calls in pandas/tests/groupby

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -617,7 +617,7 @@ def test_groupby_as_index_cython(df):
     result = grouped.mean()
     expected = data.groupby(["A", "B"]).mean()
 
-    arrays = list(zip(*expected.index.values))
+    arrays = list(zip(*expected.index.values, strict=True))
     expected.insert(0, "A", arrays[0])
     expected.insert(1, "B", arrays[1])
     expected.index = RangeIndex(len(expected))
@@ -943,7 +943,8 @@ def test_groupby_with_hier_columns():
             *[
                 ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
                 ["one", "two", "one", "two", "one", "two", "one", "two"],
-            ]
+            ],
+            strict=True,
         )
     )
     index = MultiIndex.from_tuples(tuples)
@@ -1223,7 +1224,7 @@ def test_groupby_nat_exclude():
     ]
     keys = sorted(grouped.groups.keys())
     assert len(keys) == 2
-    for k, e in zip(keys, expected):
+    for k, e in zip(keys, expected, strict=True):
         # grouped.groups keys are np.datetime64 with system tz
         # not to be affected by tz, only compare values
         tm.assert_index_equal(grouped.groups[k], e)
@@ -1916,7 +1917,7 @@ def test_groupby_multiindex_nat():
 
 def test_groupby_empty_list_raises():
     # GH 5289
-    values = zip(range(10), range(10))
+    values = zip(range(10), range(10), strict=True)
     df = DataFrame(values, columns=["apple", "b"])
     msg = "Grouper and axis must be same length"
     with pytest.raises(ValueError, match=msg):
@@ -1971,12 +1972,14 @@ def test_groups_sort_dropna(sort, dropna):
     gb = df.groupby([0, 1], sort=sort, dropna=dropna)
     result = gb.groups
 
-    for result_key, expected_key in zip(result.keys(), expected.keys()):
+    for result_key, expected_key in zip(result.keys(), expected.keys(), strict=True):
         # Compare as NumPy arrays to handle np.nan
         result_key = np.array(result_key)
         expected_key = np.array(expected_key)
         tm.assert_numpy_array_equal(result_key, expected_key)
-    for result_value, expected_value in zip(result.values(), expected.values()):
+    for result_value, expected_value in zip(
+        result.values(), expected.values(), strict=True
+    ):
         tm.assert_index_equal(result_value, expected_value)
 
 

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -326,7 +326,7 @@ def test_groupby_apply_with_dropna_for_multi_index(dropna, data, selected_data, 
     gb = df.groupby("groups", dropna=dropna)
     result = gb.apply(lambda grp: pd.DataFrame({"values": range(len(grp))}))
 
-    mi_tuples = tuple(zip(data["groups"], selected_data["values"]))
+    mi_tuples = tuple(zip(data["groups"], selected_data["values"], strict=False))
     mi = pd.MultiIndex.from_tuples(mi_tuples, names=["groups", None])
     # Since right now, by default MI will drop NA from levels when we create MI
     # via `from_*`, so we need to add NA for level manually afterwards.
@@ -379,7 +379,9 @@ def test_groupby_nan_included():
         "g2": np.array([3], dtype=dtype),
         np.nan: np.array([1, 4], dtype=dtype),
     }
-    for result_values, expected_values in zip(result.values(), expected.values()):
+    for result_values, expected_values in zip(
+        result.values(), expected.values(), strict=True
+    ):
         tm.assert_numpy_array_equal(result_values, expected_values)
     assert np.isnan(list(result.keys())[2])
     assert list(result.keys())[0:2] == ["g1", "g2"]
@@ -624,7 +626,9 @@ def test_categorical_transformers(transformation_func, observed, sort, as_index)
     expected = getattr(gb_dropna, transformation_func)(*args)
 
     for iloc, value in zip(
-        df[df["x"].isnull()].index.tolist(), null_group_result.values.ravel()
+        df[df["x"].isnull()].index.tolist(),
+        null_group_result.values.ravel(),
+        strict=True,
     ):
         if expected.ndim == 1:
             expected.iloc[iloc] = value

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -300,7 +300,7 @@ class TestGrouping:
     def test_grouper_returning_tuples(self, func):
         # GH 22257 , both with dict and with callable
         df = DataFrame({"X": ["A", "B", "A", "B"], "Y": [1, 4, 3, 2]})
-        mapping = dict(zip(range(4), [("C", 5), ("D", 6)] * 2))
+        mapping = dict(zip(range(4), [("C", 5), ("D", 6)] * 2, strict=True))
 
         if func:
             gb = df.groupby(by=lambda idx: mapping[idx], sort=False)

--- a/pandas/tests/groupby/test_raises.py
+++ b/pandas/tests/groupby/test_raises.py
@@ -29,7 +29,7 @@ from pandas.tests.groupby import get_groupby_method_args
         lambda x: x % 2,
         [0, 0, 0, 1, 2, 2, 2, 3, 3],
         np.array([0, 0, 0, 1, 2, 2, 2, 3, 3]),
-        dict(zip(range(9), [0, 0, 0, 1, 2, 2, 2, 3, 3])),
+        dict(zip(range(9), [0, 0, 0, 1, 2, 2, 2, 3, 3], strict=True)),
         Series([1, 1, 1, 1, 1, 2, 2, 2, 2]),
         [Series([1, 1, 1, 1, 1, 2, 2, 2, 2]), Series([3, 3, 4, 4, 4, 4, 4, 3, 3])],
     ]

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -433,7 +433,7 @@ class TestGroupBy:
 
         for df in [df_original, df_reordered]:
             grouped = df.groupby(Grouper(freq="ME", key="Date"))
-            for t, expected in zip(dt_list, expected_list):
+            for t, expected in zip(dt_list, expected_list, strict=True):
                 dt = Timestamp(t)
                 result = grouped.get_group(dt)
                 tm.assert_frame_equal(result, expected)
@@ -448,7 +448,7 @@ class TestGroupBy:
 
         for df in [df_original, df_reordered]:
             grouped = df.groupby(["Buyer", Grouper(freq="ME", key="Date")])
-            for (b, t), expected in zip(g_list, expected_list):
+            for (b, t), expected in zip(g_list, expected_list, strict=True):
                 dt = Timestamp(t)
                 result = grouped.get_group((b, dt))
                 tm.assert_frame_equal(result, expected)
@@ -465,7 +465,7 @@ class TestGroupBy:
 
         for df in [df_original, df_reordered]:
             grouped = df.groupby(Grouper(freq="ME"))
-            for t, expected in zip(dt_list, expected_list):
+            for t, expected in zip(dt_list, expected_list, strict=True):
                 dt = Timestamp(t)
                 result = grouped.get_group(dt)
                 tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -953,7 +953,7 @@ def test_ffill_bfill_non_unique_multilevel(func, expected_status):
     result = getattr(df.groupby("symbol")["status"], func)()
 
     index = MultiIndex.from_tuples(
-        tuples=list(zip(*[date, symbol])), names=["date", "symbol"]
+        tuples=list(zip(*[date, symbol], strict=True)), names=["date", "symbol"]
     )
     expected = Series(expected_status, index=index, name="status")
 


### PR DESCRIPTION
Part of #62434

Add ’strict=‘ to all ‘zip()’ calls in ‘pandas/tests/groupby/’ .

Modified files:
- pandas/tests/groupby/test_groupby.py (6 changes)
- pandas/tests/groupby/test_groupby_dropna.py (3 changes)
- pandas/tests/groupby/test_grouping.py (1 change)
- pandas/tests/groupby/test_raises.py (1 change)
- pandas/tests/groupby/test_timegrouper.py (3 changes)
- pandas/tests/groupby/transform/test_transform.py (1 change)
