### PR TITLE
BUG: Always raise TypeError in `pandas_dtype` when `np.dtype(dtype)` fails (GH#63484)

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1886,7 +1886,6 @@ def pandas_dtype(dtype) -> DtypeObj:
     except TypeError:
         raise
     except Exception as err:
-        # np.dtype uses `eval` which can raise SyntaxError
         raise TypeError(f"data type '{dtype}' not understood") from err
 
     # Any invalid dtype (such as pd.Timestamp) should raise an error.

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1883,7 +1883,9 @@ def pandas_dtype(dtype) -> DtypeObj:
             # Hence enabling DeprecationWarning
             warnings.simplefilter("always", DeprecationWarning)
             npdtype = np.dtype(dtype)
-    except (ValueError, TypeError) as err:
+    except TypeError:
+        raise
+    except ValueError as err:
         raise TypeError(f"data type '{dtype}' not understood") from err
 
     # Any invalid dtype (such as pd.Timestamp) should raise an error.

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1883,7 +1883,9 @@ def pandas_dtype(dtype) -> DtypeObj:
             # Hence enabling DeprecationWarning
             warnings.simplefilter("always", DeprecationWarning)
             npdtype = np.dtype(dtype)
-    except (SyntaxError, ValueError) as err:
+    except TypeError:
+        raise
+    except Exception as err:
         # np.dtype uses `eval` which can raise SyntaxError
         raise TypeError(f"data type '{dtype}' not understood") from err
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1883,7 +1883,7 @@ def pandas_dtype(dtype) -> DtypeObj:
             # Hence enabling DeprecationWarning
             warnings.simplefilter("always", DeprecationWarning)
             npdtype = np.dtype(dtype)
-    except SyntaxError as err:
+    except (SyntaxError, ValueError) as err:
         # np.dtype uses `eval` which can raise SyntaxError
         raise TypeError(f"data type '{dtype}' not understood") from err
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1883,9 +1883,7 @@ def pandas_dtype(dtype) -> DtypeObj:
             # Hence enabling DeprecationWarning
             warnings.simplefilter("always", DeprecationWarning)
             npdtype = np.dtype(dtype)
-    except TypeError:
-        raise
-    except Exception as err:
+    except (ValueError, TypeError) as err:
         raise TypeError(f"data type '{dtype}' not understood") from err
 
     # Any invalid dtype (such as pd.Timestamp) should raise an error.

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -711,10 +711,7 @@ def test_get_dtype(input_param, result):
         # numpy dev changed from double-quotes to single quotes
         ("random string", "data type [\"']random string[\"'] not understood"),
         (pd.DataFrame([1, 2]), "data type not understood"),
-        (
-            np.typing.NDArray[np.float32],
-            "data type not understood|Cannot interpret.*numpy.*as a data type",
-        ),
+        (np.typing.NDArray[np.float32], "data type not understood"),
     ],
 )
 def test_get_dtype_fails(input_param, expected_error_message):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -711,7 +711,10 @@ def test_get_dtype(input_param, result):
         # numpy dev changed from double-quotes to single quotes
         ("random string", "data type [\"']random string[\"'] not understood"),
         (pd.DataFrame([1, 2]), "data type not understood"),
-        (np.typing.NDArray[np.float32], "data type not understood"),
+        (
+            np.typing.NDArray[np.float32],
+            "data type not understood|Cannot interpret.*numpy.ndarray.*as a data type",
+        ),
     ],
 )
 def test_get_dtype_fails(input_param, expected_error_message):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -713,7 +713,7 @@ def test_get_dtype(input_param, result):
         (pd.DataFrame([1, 2]), "data type not understood"),
         (
             np.typing.NDArray[np.float32],
-            "data type not understood|Cannot interpret.*numpy.ndarray.*as a data type",
+            "data type not understood|Cannot interpret.*NDArray.*as a data type",
         ),
     ],
 )

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -711,7 +711,10 @@ def test_get_dtype(input_param, result):
         # numpy dev changed from double-quotes to single quotes
         ("random string", "data type [\"']random string[\"'] not understood"),
         (pd.DataFrame([1, 2]), "data type not understood"),
-        (np.typing.NDArray[np.float32], "data type not understood"),
+        (
+            np.typing.NDArray[np.float32],
+            "data type not understood|Cannot interpret.*numpy.*as a data type",
+        ),
     ],
 )
 def test_get_dtype_fails(input_param, expected_error_message):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -711,6 +711,7 @@ def test_get_dtype(input_param, result):
         # numpy dev changed from double-quotes to single quotes
         ("random string", "data type [\"']random string[\"'] not understood"),
         (pd.DataFrame([1, 2]), "data type not understood"),
+        (np.typing.NDArray[np.float32], "data type not understood"),
     ],
 )
 def test_get_dtype_fails(input_param, expected_error_message):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -713,7 +713,7 @@ def test_get_dtype(input_param, result):
         (pd.DataFrame([1, 2]), "data type not understood"),
         (
             np.typing.NDArray[np.float32],
-            "data type not understood|Cannot interpret.*NDArray.*as a data type",
+            "data type not understood|Cannot interpret.*numpy.*as a data type",
         ),
     ],
 )


### PR DESCRIPTION
- [x] closes #63484 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

