### PR TITLE
DOC: Remove 'Show source' button from doc pages for clarity

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -406,7 +406,7 @@ html_use_modindex = True
 # html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-# html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
- [x] closes #48715
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Old view is the following:
<img width="2160" height="928" alt="image" src="https://github.com/user-attachments/assets/ceb44c5b-ef8e-4c2c-9d73-36e10f493a53" />

New view gets rid of the show source button at the top right:
<img width="2160" height="928" alt="image" src="https://github.com/user-attachments/assets/7e791bf6-1df2-46bc-8c05-d020765357df" />
