### PR TITLE
BUG: Fix str.cat losing StringDtype on index during alignment

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -281,6 +281,16 @@ def _maybe_return_indexers(meth: F) -> F:
         sort: bool = False,
     ):
         join_index, lidx, ridx = meth(self, other, how=how, level=level, sort=sort)
+
+        # Preserve StringDtype on left join without overlap
+        if (
+            how == "left"
+            and isinstance(self.dtype, StringDtype)
+            and not isinstance(other.dtype, StringDtype)
+            and join_index.equals(self)
+        ):
+            join_index = join_index.astype(self.dtype)
+
         if not return_indexers:
             return join_index
 

--- a/pandas/tests/indexes/string/test_join.py
+++ b/pandas/tests/indexes/string/test_join.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+
+def test_left_join_preserves_string_index_dtype_no_overlap():
+    left = pd.Index(["1", "2", "3"], dtype="string")
+    right = pd.Index([0, 1, 2])
+
+    result = left.join(right, how="left")
+
+    assert result.dtype == "string"
+    assert result.equals(left)
+
+
+def test_left_join_string_index_with_overlap_upcasts():
+    left = pd.Index(["1", "2", "3"], dtype="string")
+    right = pd.Index(["2", "4"])
+
+    result = left.join(right, how="left")
+
+    assert result.dtype == object
+
+
+def test_str_cat_preserves_string_index_dtype_with_series():
+    s = pd.Series(["a", "b", "c"], index=["1", "2", "3"])
+    other = pd.Series(["A", "B", "C"])
+
+    result = s.str.cat(other, sep=",", na_rep="-")
+
+    assert result.index.dtype == "string"


### PR DESCRIPTION
**Summary**

Fixes a bug where Series.str.cat causes a StringDtype index to be upcast to object during index alignment, even when no actual alignment occurs.

**Changes**

- Avoid upcasting a StringDtype index to object during left joins when the resulting index is identical to the left index

- Apply the fix at the Index.join level so behavior is corrected consistently across alignment-based operations

- Leave existing behavior unchanged for joins with overlapping labels or non-left join types

**Tests**

- test_left_join_preserves_string_index_dtype_no_overlap

- test_left_join_string_index_with_overlap_upcasts

- test_str_cat_preserves_string_index_dtype_with_series

Fixes #63371

Thanks @galipremsagar for reporting and investigating this, and thanks to the
maintainers @rhshadrach @jorisvandenbossche for the discussion around the expected behavior.
