### PR TITLE
DOC: clarify description of GroupBy.groups attribute

### DIFF
--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -237,9 +237,9 @@ The default setting of ``dropna`` argument is ``True`` which means ``NA`` are no
 GroupBy object attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``groups`` attribute is a dictionary whose keys are the computed unique groups
-and corresponding values are the index labels belonging to each group. In the
-above example we have:
+The ``groups`` attribute of a GroupBy object is a dictionary that maps each
+unique group key to the index labels belonging to that group. In the above
+example:
 
 .. ipython:: python
 


### PR DESCRIPTION
This PR clarifies the description of the GroupBy.groups attribute.

The previous wording was slightly ambiguous about the relationship between
group keys and index labels. This change rephrases the sentence to make the
mapping more explicit, without changing behavior or examples.