### PR TITLE
TST:Replacing all ensure_cleans with pytest fixture in pandas/_testing/_io.py and removing the definition of ensure_clean.

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -68,7 +68,6 @@ from pandas._testing.compat import (
 )
 from pandas._testing.contexts import (
     decompress_file,
-    ensure_clean,
     raises_chained_assignment_error,
     set_timezone,
     with_csv_dialect,
@@ -587,7 +586,6 @@ __all__ = [
     "can_set_locale",
     "convert_rows_list_to_csv_str",
     "decompress_file",
-    "ensure_clean",
     "external_error_raised",
     "get_cython_table_params",
     "get_dtype",

--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gzip
 import io
-import pathlib
 import tarfile
 from typing import (
     TYPE_CHECKING,
@@ -14,7 +13,6 @@ import zipfile
 from pandas.compat._optional import import_optional_dependency
 
 import pandas as pd
-from pandas._testing.contexts import ensure_clean
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -34,7 +32,7 @@ if TYPE_CHECKING:
 
 
 def round_trip_pickle(
-    obj: Any, path: FilePath | ReadPickleBuffer | None = None
+    obj: Any, tmp_path, path: FilePath | ReadPickleBuffer | None = None
 ) -> DataFrame | Series:
     """
     Pickle an object and then read it again.
@@ -54,12 +52,12 @@ def round_trip_pickle(
     _path = path
     if _path is None:
         _path = f"__{uuid.uuid4()}__.pickle"
-    with ensure_clean(_path) as temp_path:
-        pd.to_pickle(obj, temp_path)
-        return pd.read_pickle(temp_path)
+    temp_path = tmp_path / _path
+    pd.to_pickle(obj, temp_path)
+    return pd.read_pickle(temp_path)
 
 
-def round_trip_pathlib(writer, reader, path: str | None = None):
+def round_trip_pathlib(writer, reader, tmp_path, path: str | None = None):
     """
     Write an object to file specified by a pathlib.Path and read it back
 
@@ -77,12 +75,11 @@ def round_trip_pathlib(writer, reader, path: str | None = None):
     pandas object
         The original object that was serialized and then re-read.
     """
-    Path = pathlib.Path
     if path is None:
         path = "___pathlib___"
-    with ensure_clean(path) as path:
-        writer(Path(path))
-        obj = reader(Path(path))
+    path = tmp_path / path
+    writer(path)
+    obj = reader(path)
     return obj
 
 

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -2,15 +2,11 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 import os
-from pathlib import Path
 import sys
-import tempfile
 from typing import (
     IO,
     TYPE_CHECKING,
-    Any,
 )
-import uuid
 
 from pandas.compat import CHAINED_WARNING_DISABLED
 from pandas.errors import ChainedAssignmentError
@@ -92,38 +88,6 @@ def set_timezone(tz: str) -> Generator[None]:
         yield
     finally:
         setTZ(orig_tz)
-
-
-@contextmanager
-def ensure_clean(filename=None) -> Generator[Any]:
-    """
-    Gets a temporary path and agrees to remove on close.
-
-    This implementation does not use tempfile.mkstemp to avoid having a file handle.
-    If the code using the returned path wants to delete the file itself, windows
-    requires that no program has a file handle to it.
-
-    Parameters
-    ----------
-    filename : str (optional)
-        suffix of the created file.
-    """
-    folder = Path(tempfile.gettempdir())
-
-    if filename is None:
-        filename = ""
-    filename = str(uuid.uuid4()) + filename
-    path = folder / filename
-
-    path.touch()
-
-    handle_or_str = str(path)
-
-    try:
-        yield handle_or_str
-    finally:
-        if path.is_file():
-            path.unlink()
 
 
 @contextmanager

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -120,9 +120,9 @@ class TestSparseArray:
         tm.assert_numpy_array_equal(res, vals)
 
     @pytest.mark.parametrize("fix", ["arr", "zarr"])
-    def test_pickle(self, fix, request):
+    def test_pickle(self, fix, request, tmp_path):
         obj = request.getfixturevalue(fix)
-        unpickled = tm.round_trip_pickle(obj)
+        unpickled = tm.round_trip_pickle(obj, tmp_path)
         tm.assert_sp_array_equal(unpickled, obj)
 
     def test_generator_warnings(self):

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -62,7 +62,7 @@ class Base:
         assert not dtype == np.str_
         assert not np.str_ == dtype
 
-    def test_pickle(self, dtype):
+    def test_pickle(self, dtype, tmp_path):
         # make sure our cache is NOT pickled
 
         # clear the cache
@@ -70,7 +70,7 @@ class Base:
         assert not len(dtype._cache_dtypes)
 
         # force back to the cache
-        result = tm.round_trip_pickle(dtype)
+        result = tm.round_trip_pickle(dtype, tmp_path)
         if not isinstance(dtype, PeriodDtype):
             # Because PeriodDtype has a cython class as a base class,
             #  it has different pickle semantics, and its cache is re-populated
@@ -848,7 +848,7 @@ class TestIntervalDtype(Base):
             assert not is_interval_dtype(np.int64)
             assert not is_interval_dtype(np.float64)
 
-    def test_caching(self):
+    def test_caching(self, tmp_path):
         # GH 54184: Caching not shown to improve performance
         IntervalDtype.reset_cache()
         dtype = IntervalDtype("int64", "right")
@@ -858,20 +858,20 @@ class TestIntervalDtype(Base):
         assert len(IntervalDtype._cache_dtypes) == 0
 
         IntervalDtype.reset_cache()
-        tm.round_trip_pickle(dtype)
+        tm.round_trip_pickle(dtype, tmp_path)
         assert len(IntervalDtype._cache_dtypes) == 0
 
     def test_not_string(self):
         # GH30568: though IntervalDtype has object kind, it cannot be string
         assert not is_string_dtype(IntervalDtype())
 
-    def test_unpickling_without_closed(self):
+    def test_unpickling_without_closed(self, tmp_path):
         # GH#38394
         dtype = IntervalDtype("interval")
 
         assert dtype._closed is None
 
-        tm.round_trip_pickle(dtype)
+        tm.round_trip_pickle(dtype, tmp_path)
 
     def test_dont_keep_ref_after_del(self):
         # GH 54184

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -239,20 +239,20 @@ class TestDataFrameBlockInternals:
         with pytest.raises(ValueError, match=msg):
             f("M8[ns]")
 
-    def test_pickle_float_string_frame(self, float_string_frame):
-        unpickled = tm.round_trip_pickle(float_string_frame)
+    def test_pickle_float_string_frame(self, float_string_frame, tmp_path):
+        unpickled = tm.round_trip_pickle(float_string_frame, tmp_path)
         tm.assert_frame_equal(float_string_frame, unpickled)
 
         # buglet
         float_string_frame._mgr.ndim
 
-    def test_pickle_empty(self):
+    def test_pickle_empty(self, tmp_path):
         empty_frame = DataFrame()
-        unpickled = tm.round_trip_pickle(empty_frame)
+        unpickled = tm.round_trip_pickle(empty_frame, tmp_path)
         repr(unpickled)
 
-    def test_pickle_empty_tz_frame(self, timezone_frame):
-        unpickled = tm.round_trip_pickle(timezone_frame)
+    def test_pickle_empty_tz_frame(self, timezone_frame, tmp_path):
+        unpickled = tm.round_trip_pickle(timezone_frame, tmp_path)
         tm.assert_frame_equal(timezone_frame, unpickled)
 
     def test_consolidate_datetime64(self):

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -82,7 +82,7 @@ class TestDataFrameSubclassing:
         cdf_multi2 = CustomDataFrame([[0, 1], [2, 3]], columns=mcol)
         assert isinstance(cdf_multi2["A"], CustomSeries)
 
-    def test_dataframe_metadata(self):
+    def test_dataframe_metadata(self, tmp_path):
         df = tm.SubclassedDataFrame(
             {"X": [1, 2, 3], "Y": [1, 2, 3]}, index=["a", "b", "c"]
         )
@@ -97,7 +97,7 @@ class TestDataFrameSubclassing:
         assert df.iloc[0:1, :].testattr == "XXX"
 
         # see gh-10553
-        unpickled = tm.round_trip_pickle(df)
+        unpickled = tm.round_trip_pickle(df, tmp_path)
         tm.assert_frame_equal(df, unpickled)
         assert df._metadata == unpickled._metadata
         assert df.testattr == unpickled.testattr

--- a/pandas/tests/generic/test_duplicate_labels.py
+++ b/pandas/tests/generic/test_duplicate_labels.py
@@ -380,11 +380,11 @@ def test_inplace_raises(method, frame_only):
             method(s)
 
 
-def test_pickle():
+def test_pickle(tmp_path):
     a = pd.Series([1, 2]).set_flags(allows_duplicate_labels=False)
-    b = tm.round_trip_pickle(a)
+    b = tm.round_trip_pickle(a, tmp_path)
     tm.assert_series_equal(a, b)
 
     a = pd.DataFrame({"A": []}).set_flags(allows_duplicate_labels=False)
-    b = tm.round_trip_pickle(a)
+    b = tm.round_trip_pickle(a, tmp_path)
     tm.assert_frame_equal(a, b)

--- a/pandas/tests/indexes/base_class/test_pickle.py
+++ b/pandas/tests/indexes/base_class/test_pickle.py
@@ -2,10 +2,10 @@ from pandas import Index
 import pandas._testing as tm
 
 
-def test_pickle_preserves_object_dtype():
+def test_pickle_preserves_object_dtype(tmp_path):
     # GH#43188, GH#43155 don't infer numeric dtype
     index = Index([1, 2, 3], dtype=object)
 
-    result = tm.round_trip_pickle(index)
+    result = tm.round_trip_pickle(index, tmp_path)
     assert result.dtype == object
     tm.assert_index_equal(index, result)

--- a/pandas/tests/indexes/datetimes/test_pickle.py
+++ b/pandas/tests/indexes/datetimes/test_pickle.py
@@ -9,37 +9,37 @@ import pandas._testing as tm
 
 
 class TestPickle:
-    def test_pickle(self):
+    def test_pickle(self, tmp_path):
         # GH#4606
         idx = to_datetime(["2013-01-01", NaT, "2014-01-06"])
-        idx_p = tm.round_trip_pickle(idx)
+        idx_p = tm.round_trip_pickle(idx, tmp_path)
         assert idx_p[0] == idx[0]
         assert idx_p[1] is NaT
         assert idx_p[2] == idx[2]
 
-    def test_pickle_dont_infer_freq(self):
+    def test_pickle_dont_infer_freq(self, tmp_path):
         # GH#11002
         # don't infer freq
         idx = date_range("1750-1-1", "2050-1-1", freq="7D")
-        idx_p = tm.round_trip_pickle(idx)
+        idx_p = tm.round_trip_pickle(idx, tmp_path)
         tm.assert_index_equal(idx, idx_p)
 
-    def test_pickle_after_set_freq(self):
+    def test_pickle_after_set_freq(self, tmp_path):
         dti = date_range("20130101", periods=3, tz="US/Eastern", name="foo")
         dti = dti._with_freq(None)
 
-        res = tm.round_trip_pickle(dti)
+        res = tm.round_trip_pickle(dti, tmp_path)
         tm.assert_index_equal(res, dti)
 
-    def test_roundtrip_pickle_with_tz(self):
+    def test_roundtrip_pickle_with_tz(self, tmp_path):
         # GH#8367
         # round-trip of timezone
         index = date_range("20130101", periods=3, tz="US/Eastern", name="foo")
-        unpickled = tm.round_trip_pickle(index)
+        unpickled = tm.round_trip_pickle(index, tmp_path)
         tm.assert_index_equal(index, unpickled)
 
     @pytest.mark.parametrize("freq", ["B", "C"])
-    def test_pickle_unpickle(self, freq):
+    def test_pickle_unpickle(self, freq, tmp_path):
         rng = date_range("2009-01-01", "2010-01-01", freq=freq)
-        unpickled = tm.round_trip_pickle(rng)
+        unpickled = tm.round_trip_pickle(rng, tmp_path)
         assert unpickled.freq == freq

--- a/pandas/tests/indexes/interval/test_pickle.py
+++ b/pandas/tests/indexes/interval/test_pickle.py
@@ -3,8 +3,8 @@ import pandas._testing as tm
 
 
 class TestPickle:
-    def test_pickle_round_trip_closed(self, closed):
+    def test_pickle_round_trip_closed(self, closed, tmp_path):
         # https://github.com/pandas-dev/pandas/issues/35658
         idx = IntervalIndex.from_tuples([(1, 2), (2, 3)], closed=closed)
-        result = tm.round_trip_pickle(idx)
+        result = tm.round_trip_pickle(idx, tmp_path)
         tm.assert_index_equal(result, idx)

--- a/pandas/tests/indexes/period/test_pickle.py
+++ b/pandas/tests/indexes/period/test_pickle.py
@@ -13,14 +13,14 @@ from pandas.tseries import offsets
 
 class TestPickle:
     @pytest.mark.parametrize("freq", ["D", "M", "Y"])
-    def test_pickle_round_trip(self, freq):
+    def test_pickle_round_trip(self, freq, tmp_path):
         idx = PeriodIndex(["2016-05-16", "NaT", NaT, np.nan], freq=freq)
-        result = tm.round_trip_pickle(idx)
+        result = tm.round_trip_pickle(idx, tmp_path)
         tm.assert_index_equal(result, idx)
 
-    def test_pickle_freq(self):
+    def test_pickle_freq(self, tmp_path):
         # GH#2891
         prng = period_range("1/1/2011", "1/1/2012", freq="M")
-        new_prng = tm.round_trip_pickle(prng)
+        new_prng = tm.round_trip_pickle(prng, tmp_path)
         assert new_prng.freq == offsets.MonthEnd()
         assert new_prng.freqstr == "M"

--- a/pandas/tests/indexes/test_any_index.py
+++ b/pandas/tests/indexes/test_any_index.py
@@ -102,16 +102,16 @@ class TestConversion:
 
 
 class TestRoundTrips:
-    def test_pickle_roundtrip(self, index):
-        result = tm.round_trip_pickle(index)
+    def test_pickle_roundtrip(self, index, tmp_path):
+        result = tm.round_trip_pickle(index, tmp_path)
         tm.assert_index_equal(result, index, exact=True)
         if result.nlevels > 1:
             # GH#8367 round-trip with timezone
             assert index.equal_levels(result)
 
-    def test_pickle_preserves_name(self, index):
+    def test_pickle_preserves_name(self, index, tmp_path):
         original_name, index.name = index.name, "foo"
-        unpickled = tm.round_trip_pickle(index)
+        unpickled = tm.round_trip_pickle(index, tmp_path)
         assert index.equals(unpickled)
         index.name = original_name
 

--- a/pandas/tests/indexes/timedeltas/test_pickle.py
+++ b/pandas/tests/indexes/timedeltas/test_pickle.py
@@ -3,9 +3,9 @@ import pandas._testing as tm
 
 
 class TestPickle:
-    def test_pickle_after_set_freq(self):
+    def test_pickle_after_set_freq(self, tmp_path):
         tdi = timedelta_range("1 day", periods=4, freq="s")
         tdi = tdi._with_freq(None)
 
-        res = tm.round_trip_pickle(tdi)
+        res = tm.round_trip_pickle(tdi, tmp_path)
         tm.assert_index_equal(res, tdi)

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -261,9 +261,9 @@ class TestBlock:
             ["bool", [5]],
         ],
     )
-    def test_pickle(self, typ, data):
+    def test_pickle(self, typ, data, tmp_path):
         blk = create_block(typ, data)
-        assert_block_equal(tm.round_trip_pickle(blk), blk)
+        assert_block_equal(tm.round_trip_pickle(blk, tmp_path), blk)
 
     def test_mgr_locs(self, fblock):
         assert isinstance(fblock.mgr_locs, BlockPlacement)
@@ -391,8 +391,8 @@ class TestBlockManager:
         mgr = BlockManager(blocks, axes)
         mgr.iget(1)
 
-    def test_pickle(self, mgr):
-        mgr2 = tm.round_trip_pickle(mgr)
+    def test_pickle(self, mgr, tmp_path):
+        mgr2 = tm.round_trip_pickle(mgr, tmp_path)
         tm.assert_frame_equal(
             DataFrame._from_mgr(mgr, axes=mgr.axes),
             DataFrame._from_mgr(mgr2, axes=mgr2.axes),
@@ -407,24 +407,24 @@ class TestBlockManager:
         assert not mgr2._known_consolidated
 
     @pytest.mark.parametrize("mgr_string", ["a,a,a:f8", "a: f8; a: i8"])
-    def test_non_unique_pickle(self, mgr_string):
+    def test_non_unique_pickle(self, mgr_string, tmp_path):
         mgr = create_mgr(mgr_string)
-        mgr2 = tm.round_trip_pickle(mgr)
+        mgr2 = tm.round_trip_pickle(mgr, tmp_path)
         tm.assert_frame_equal(
             DataFrame._from_mgr(mgr, axes=mgr.axes),
             DataFrame._from_mgr(mgr2, axes=mgr2.axes),
         )
 
-    def test_categorical_block_pickle(self):
+    def test_categorical_block_pickle(self, tmp_path):
         mgr = create_mgr("a: category")
-        mgr2 = tm.round_trip_pickle(mgr)
+        mgr2 = tm.round_trip_pickle(mgr, tmp_path)
         tm.assert_frame_equal(
             DataFrame._from_mgr(mgr, axes=mgr.axes),
             DataFrame._from_mgr(mgr2, axes=mgr2.axes),
         )
 
         smgr = create_single_mgr("category")
-        smgr2 = tm.round_trip_pickle(smgr)
+        smgr2 = tm.round_trip_pickle(smgr, tmp_path)
         tm.assert_series_equal(
             Series()._constructor_from_mgr(smgr, axes=smgr.axes),
             Series()._constructor_from_mgr(smgr2, axes=smgr2.axes),

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1422,7 +1422,7 @@ class TestExcelWriter:
         result = pd.read_excel(tmp_excel, index_col=0)
         tm.assert_frame_equal(result, expected)
 
-    def test_path_path_lib(self, engine, ext):
+    def test_path_path_lib(self, engine, ext, tmp_path):
         df = DataFrame(
             1.1 * np.arange(120).reshape((30, 4)),
             columns=Index(list("ABCD")),
@@ -1431,7 +1431,7 @@ class TestExcelWriter:
         writer = partial(df.to_excel, engine=engine)
 
         reader = partial(pd.read_excel, index_col=0)
-        result = tm.round_trip_pathlib(writer, reader, path=f"foo{ext}")
+        result = tm.round_trip_pathlib(writer, reader, tmp_path, path=f"foo{ext}")
         tm.assert_frame_equal(result, df)
 
     def test_merged_cell_custom_objects(self, tmp_excel):

--- a/pandas/tests/io/parser/common/test_file_buffer_url.py
+++ b/pandas/tests/io/parser/common/test_file_buffer_url.py
@@ -70,14 +70,16 @@ def test_local_file(all_parsers, csv_dir_path):
 
 
 @xfail_pyarrow  # AssertionError: DataFrame.index are different
-def test_path_path_lib(all_parsers):
+def test_path_path_lib(all_parsers, tmp_path):
     parser = all_parsers
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
         columns=Index(list("ABCD")),
         index=Index([f"i-{i}" for i in range(30)]),
     )
-    result = tm.round_trip_pathlib(df.to_csv, lambda p: parser.read_csv(p, index_col=0))
+    result = tm.round_trip_pathlib(
+        df.to_csv, lambda p: parser.read_csv(p, index_col=0), tmp_path
+    )
     tm.assert_frame_equal(df, result)
 
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -907,7 +907,7 @@ def test_select_filter_corner(setup_path, request):
         tm.assert_frame_equal(result, df.loc[:, df.columns[:75:2]])
 
 
-def test_path_pathlib():
+def test_path_pathlib(tmp_path):
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
         columns=Index(list("ABCD")),
@@ -915,7 +915,7 @@ def test_path_pathlib():
     )
 
     result = tm.round_trip_pathlib(
-        lambda p: df.to_hdf(p, key="df"), lambda p: read_hdf(p, "df")
+        lambda p: df.to_hdf(p, key="df"), lambda p: read_hdf(p, "df"), tmp_path
     )
     tm.assert_frame_equal(df, result)
 
@@ -937,7 +937,7 @@ def test_contiguous_mixed_data_table(start, stop, setup_path):
         tm.assert_frame_equal(df[start:stop], result)
 
 
-def test_path_pathlib_hdfstore():
+def test_path_pathlib_hdfstore(tmp_path):
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
         columns=Index(list("ABCD")),
@@ -952,18 +952,18 @@ def test_path_pathlib_hdfstore():
         with HDFStore(path) as store:
             return read_hdf(store, "df")
 
-    result = tm.round_trip_pathlib(writer, reader)
+    result = tm.round_trip_pathlib(writer, reader, tmp_path)
     tm.assert_frame_equal(df, result)
 
 
-def test_pickle_path_localpath():
+def test_pickle_path_localpath(tmp_path):
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
         columns=Index(list("ABCD")),
         index=Index([f"i-{i}" for i in range(30)]),
     )
     result = tm.round_trip_pathlib(
-        lambda p: df.to_hdf(p, key="df"), lambda p: read_hdf(p, "df")
+        lambda p: df.to_hdf(p, key="df"), lambda p: read_hdf(p, "df"), tmp_path
     )
     tm.assert_frame_equal(df, result)
 

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -139,13 +139,13 @@ class TestFeather:
         self.check_round_trip(df, temp_file, use_threads=True)
         self.check_round_trip(df, temp_file, use_threads=False)
 
-    def test_path_pathlib(self):
+    def test_path_pathlib(self, tmp_path):
         df = pd.DataFrame(
             1.1 * np.arange(120).reshape((30, 4)),
             columns=pd.Index(list("ABCD")),
             index=pd.Index([f"i-{i}" for i in range(30)]),
         ).reset_index()
-        result = tm.round_trip_pathlib(df.to_feather, read_feather)
+        result = tm.round_trip_pathlib(df.to_feather, read_feather, tmp_path)
         tm.assert_frame_equal(df, result)
 
     def test_passthrough_keywords(self, temp_file):

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1672,7 +1672,7 @@ The repeated labels are:\n-+\nwolof
             path = temp_file
             df.to_stata(path)
 
-    def test_path_pathlib(self):
+    def test_path_pathlib(self, tmp_path):
         df = DataFrame(
             1.1 * np.arange(120).reshape((30, 4)),
             columns=pd.Index(list("ABCD")),
@@ -1680,7 +1680,7 @@ The repeated labels are:\n-+\nwolof
         )
         df.index.name = "index"
         reader = lambda x: read_stata(x).set_index("index")
-        result = tm.round_trip_pathlib(df.to_stata, reader)
+        result = tm.round_trip_pathlib(df.to_stata, reader, tmp_path)
         tm.assert_frame_equal(df, result)
 
     @pytest.mark.parametrize("write_index", [True, False])

--- a/pandas/tests/libs/test_lib.py
+++ b/pandas/tests/libs/test_lib.py
@@ -281,9 +281,9 @@ def test_cache_readonly_preserve_docstrings():
     assert Index.hasnans.__doc__ is not None
 
 
-def test_no_default_pickle():
+def test_no_default_pickle(tmp_path):
     # GH#40397
-    obj = tm.round_trip_pickle(lib.no_default)
+    obj = tm.round_trip_pickle(lib.no_default, tmp_path)
     assert obj is lib.no_default
 
 

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -645,9 +645,9 @@ class TestPeriodConstruction:
 
 
 class TestPeriodMethods:
-    def test_round_trip(self):
+    def test_round_trip(self, tmp_path):
         p = Period("2000Q1")
-        new_p = tm.round_trip_pickle(p)
+        new_p = tm.round_trip_pickle(p, tmp_path)
         assert new_p == p
 
     def test_hash(self):

--- a/pandas/tests/scalar/test_na_scalar.py
+++ b/pandas/tests/scalar/test_na_scalar.py
@@ -317,8 +317,8 @@ def test_pickle_roundtrip():
     assert result is NA
 
 
-def test_pickle_roundtrip_pandas():
-    result = tm.round_trip_pickle(NA)
+def test_pickle_roundtrip_pandas(tmp_path):
+    result = tm.round_trip_pickle(NA, tmp_path)
     assert result is NA
 
 
@@ -326,9 +326,9 @@ def test_pickle_roundtrip_pandas():
     "values, dtype", [([1, 2, NA], "Int64"), (["A", "B", NA], "string")]
 )
 @pytest.mark.parametrize("as_frame", [True, False])
-def test_pickle_roundtrip_containers(as_frame, values, dtype):
+def test_pickle_roundtrip_containers(as_frame, values, dtype, tmp_path):
     s = pd.Series(pd.array(values, dtype=dtype))
     if as_frame:
         s = s.to_frame(name="A")
-    result = tm.round_trip_pickle(s)
+    result = tm.round_trip_pickle(s, tmp_path)
     tm.assert_equal(result, s)

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -677,7 +677,7 @@ def test_nat_addsub_tdlike_scalar(obj):
     assert NaT - obj is NaT
 
 
-def test_pickle():
+def test_pickle(tmp_path):
     # GH#4606
-    p = tm.round_trip_pickle(NaT)
+    p = tm.round_trip_pickle(NaT, tmp_path)
     assert p is NaT

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -567,9 +567,9 @@ class TestTimedeltas:
         with pytest.raises(ValueError, match=msg):
             Timedelta("- 1days, 00")
 
-    def test_pickle(self):
+    def test_pickle(self, tmp_path):
         v = Timedelta("1 days 10:11:12.0123456")
-        v_p = tm.round_trip_pickle(v)
+        v_p = tm.round_trip_pickle(v, tmp_path)
         assert v == v_p
 
     def test_timedelta_hash_equality(self):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -657,11 +657,11 @@ class TestNonNano:
 
         assert other.asm8 < ts
 
-    def test_pickle(self, ts, tz_aware_fixture):
+    def test_pickle(self, ts, tz_aware_fixture, tmp_path):
         tz = tz_aware_fixture
         tz = maybe_get_tz(tz)
         ts = Timestamp._from_value_and_reso(ts._value, ts._creso, tz)
-        rt = tm.round_trip_pickle(ts)
+        rt = tm.round_trip_pickle(ts, tmp_path)
         assert rt._creso == ts._creso
         assert rt == ts
 

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -199,9 +199,9 @@ def test_version_tag():
 @pytest.mark.parametrize(
     "obj", [(obj,) for obj in pd.__dict__.values() if callable(obj)]
 )
-def test_serializable(obj):
+def test_serializable(obj, tmp_path):
     # GH 35611
-    unpickled = tm.round_trip_pickle(obj)
+    unpickled = tm.round_trip_pickle(obj, tmp_path)
     assert type(obj) == type(unpickled)
 
 

--- a/pandas/tests/tseries/offsets/test_custom_business_day.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_day.py
@@ -82,9 +82,9 @@ class TestCustomBusinessDay:
         dt = datetime(2014, 1, 17)
         assert_offset_equal(CDay(calendar=calendar), dt, datetime(2014, 1, 21))
 
-    def test_roundtrip_pickle(self, offset, offset2):
+    def test_roundtrip_pickle(self, offset, offset2, tmp_path):
         def _check_roundtrip(obj):
-            unpickled = tm.round_trip_pickle(obj)
+            unpickled = tm.round_trip_pickle(obj, tmp_path)
             assert unpickled == obj
 
         _check_roundtrip(offset)

--- a/pandas/tests/tseries/offsets/test_custom_business_month.py
+++ b/pandas/tests/tseries/offsets/test_custom_business_month.py
@@ -46,9 +46,9 @@ class TestCommonCBM:
         assert hash(offset2) == hash(offset2)
 
     @pytest.mark.parametrize("_offset", [CBMonthBegin, CBMonthEnd])
-    def test_roundtrip_pickle(self, _offset):
+    def test_roundtrip_pickle(self, _offset, tmp_path):
         def _check_roundtrip(obj):
-            unpickled = tm.round_trip_pickle(obj)
+            unpickled = tm.round_trip_pickle(obj, tmp_path)
             assert unpickled == obj
 
         _check_roundtrip(_offset())

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -549,9 +549,9 @@ class TestCommon:
             result = offset_s + dta
         tm.assert_equal(result, dta)
 
-    def test_pickle_roundtrip(self, offset_types):
+    def test_pickle_roundtrip(self, offset_types, tmp_path):
         off = _create_offset(offset_types)
-        res = tm.round_trip_pickle(off)
+        res = tm.round_trip_pickle(off, tmp_path)
         assert off == res
         if type(off) is not DateOffset:
             for attr in off._attributes:
@@ -562,10 +562,10 @@ class TestCommon:
                 # Make sure nothings got lost from _params (which __eq__) is based on
                 assert getattr(off, attr) == getattr(res, attr)
 
-    def test_pickle_dateoffset_odd_inputs(self):
+    def test_pickle_dateoffset_odd_inputs(self, tmp_path):
         # GH#34511
         off = DateOffset(months=12)
-        res = tm.round_trip_pickle(off)
+        res = tm.round_trip_pickle(off, tmp_path)
         assert off == res
 
         base_dt = datetime(2020, 1, 1)


### PR DESCRIPTION
- [x] closes #62435 
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Replacing all ensure_cleans with pytest fixture in pandas/_testing/_io.py and removing the definition of ensure_clean.

closes #62435 