### PR TITLE
DOC: Fix meta_prefix and record_prefix parameter descriptions in json_normalize

### DIFF
--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -326,7 +326,7 @@ def json_normalize(
     meta : list of paths (str or list of str), default None
         Fields to use as metadata for each record in resulting table.
     meta_prefix : str, default None
-        String to  prefix records with dotted path, e.g. foo.bar.field if
+        String to prefix records with dotted path, e.g. foo.bar.field if
         meta is ['foo', 'bar'].
     record_prefix : str, default None
         String to prefix records with dotted path, e.g. foo.bar.field if

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -326,10 +326,10 @@ def json_normalize(
     meta : list of paths (str or list of str), default None
         Fields to use as metadata for each record in resulting table.
     meta_prefix : str, default None
-        If True, prefix records with dotted path, e.g. foo.bar.field if
+        String to  prefix records with dotted path, e.g. foo.bar.field if
         meta is ['foo', 'bar'].
     record_prefix : str, default None
-        If True, prefix records with dotted path, e.g. foo.bar.field if
+        String to prefix records with dotted path, e.g. foo.bar.field if
         path to records is ['foo', 'bar'].
     errors : {'raise', 'ignore'}, default 'raise'
         Configures error handling.


### PR DESCRIPTION
## Summary
  - Fixed incorrect parameter descriptions for `meta_prefix` and
  `record_prefix` in `json_normalize` function
  - Changed "If True, prefix records" to "String to prefix
  records" to accurately reflect that these are string
  parameters, not boolean flags

  ## Test plan
  - [x] Ran docstring validation using `uv run python
  scripts/validate_docstrings.py pandas.json_normalize`
  - [x] Validation passes successfully
