### PR TITLE
DOC: add myself as CODEOWNER for Getting Started and the User Guide

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@ ci/                               @mroeschke
 # docs
 doc/cheatsheet                    @Dr-Irv
 doc/source/development            @noatamir
+doc/source/getting_started        @afeld
+doc/source/user_guide             @afeld
 
 # pandas
 pandas/_typing.py                 @Dr-Irv


### PR DESCRIPTION
- [ ] ~~closes #xxxx~~
- [ ] ~~[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~~
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] ~~Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~~
- [ ] ~~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~~
- [ ] ~~If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.~~

As a member of the Triage team, I have been helping review pull requests around the docs when I can, particularly those that are beginner-oriented. While I wouldn't claim to "own" the Getting Started and User Guide sections, I am more than happy to be an initial review when things come in. This change will help ensure that I see pull requests when I come in, so that they don't linger.