### PR TITLE
BUG/API: Series constructor to honor unit of specified timedelta64 dtype

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1167,6 +1167,10 @@ Timedelta
 - Bug in adding or subtracting a :class:`Timedelta` object with non-nanosecond unit to a python ``datetime.datetime`` object giving incorrect results; this now works correctly for Timedeltas inside the ``datetime.timedelta`` implementation bounds (:issue:`53643`)
 - Bug in multiplication operations with ``timedelta64`` dtype failing to raise ``TypeError`` when multiplying by ``bool`` objects or dtypes (:issue:`58054`)
 - Bug in multiplication operations with ``timedelta64`` dtype incorrectly raising when multiplying by numpy-nullable dtypes or pyarrow integer dtypes (:issue:`58054`)
+- Bug in the :class:`Series` constructor not honoring the unit of the ``timedelta64[unit]`` dtype
+  when constructing a timedelta series from integers, e.g. ``pd.Series([0, 1, 2], dtype="timedelta64[s]")``
+  still interpreted the numbers as nanoseconds instead of seconds. Now it will interpret the passed
+  integers according to the unit of the specified dtype (:issue:`48312`, :issue:`52457`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -244,10 +244,13 @@ class TimedeltaArray(dtl.TimelikeOps):
 
     @classmethod
     def _from_sequence(cls, data, *, dtype=None, copy: bool = False) -> Self:
+        unit = None
         if dtype:
             dtype = _validate_td64_dtype(dtype)
+            if lib.infer_dtype(data) == "integer":
+                unit = np.datetime_data(dtype)[0]
 
-        data, freq = sequence_to_td64ns(data, copy=copy, unit=None)
+        data, freq = sequence_to_td64ns(data, copy=copy, unit=unit)
 
         if dtype is not None:
             data = astype_overflowsafe(data, dtype=dtype, copy=False)
@@ -270,6 +273,8 @@ class TimedeltaArray(dtl.TimelikeOps):
         """
         if dtype:
             dtype = _validate_td64_dtype(dtype)
+            if unit is None and lib.infer_dtype(data) == "integer":
+                unit = np.datetime_data(dtype)[0]
 
         assert unit not in ["Y", "y", "M"]  # caller is responsible for checking
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -802,8 +802,7 @@ class TestDataFrameAnalytics:
         if not skipna or all(value is pd.NaT for value in values):
             expected = Series({"a": pd.NaT}, dtype=f"timedelta64[{unit}]")
         else:
-            # 86400000000000ns == 1 day
-            expected = Series({"a": 86400000000000}, dtype=f"timedelta64[{unit}]")
+            expected = Series({"a": "1 days"}, dtype=f"timedelta64[{unit}]")
         tm.assert_series_equal(result, expected)
 
     def test_sum_corner(self):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1978,26 +1978,10 @@ class TestSeriesConstructors:
 
     def test_constructor_dtype_timedelta_alternative_construct(self):
         # GH#35465
-        result = Series([1000000, 200000, 3000000], dtype="timedelta64[ns]")
-        expected = Series(pd.to_timedelta([1000000, 200000, 3000000], unit="ns"))
+        result = Series([1000000, 200000, 3000000], dtype="timedelta64[us]")
+        expected = Series(pd.to_timedelta([1000000, 200000, 3000000], unit="us"))
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.xfail(
-        reason="Not clear what the correct expected behavior should be with "
-        "integers now that we support non-nano. ATM (2022-10-08) we treat ints "
-        "as nanoseconds, then cast to the requested dtype. xref #48312"
-    )
-    def test_constructor_dtype_timedelta_ns_s(self):
-        # GH#35465
-        result = Series([1000000, 200000, 3000000], dtype="timedelta64[ns]")
-        expected = Series([1000000, 200000, 3000000], dtype="timedelta64[s]")
-        tm.assert_series_equal(result, expected)
-
-    @pytest.mark.xfail(
-        reason="Not clear what the correct expected behavior should be with "
-        "integers now that we support non-nano. ATM (2022-10-08) we treat ints "
-        "as nanoseconds, then cast to the requested dtype. xref #48312"
-    )
     def test_constructor_dtype_timedelta_ns_s_astype_int64(self):
         # GH#35465
         result = Series([1000000, 200000, 3000000], dtype="timedelta64[ns]").astype(


### PR DESCRIPTION
~On top of https://github.com/pandas-dev/pandas/pull/63303, so for now only check the last commit to see the changes.~

- [x] closes #48312
- [x] closes #52457 
- [ ] xref https://github.com/pandas-dev/pandas/pull/52463
- [ ] xref https://github.com/pandas-dev/pandas/pull/52476

This is a redo of https://github.com/pandas-dev/pandas/pull/52463, with one additional check for `lib.infer_dtype` of the values being integer. This might not be very robust (and adds a bit of overhead), but the problem is that if we do not do that, `array_to_timedelta64` will complain about a `unit` being passed if encountering string values.

- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
