### PR TITLE
DOC: update dropdown logic to use 'dev' version for commits after the rc

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -232,7 +232,7 @@ html_theme = "pydata_sphinx_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 
-if ".dev" in version:
+if ".dev" in version or ("rc" in version and "+" in version):
     switcher_version = "dev"
 elif "rc" in version:
     switcher_version = version.split("rc", maxsplit=1)[0] + " (rc)"


### PR DESCRIPTION
This should fix the fact that the dev version currently doesn't show up in the dropdown button label, _when_ you are on the dev docs (it currently shows "Choose version")