### PR TITLE
BUG: Fix for Issue 53028 - Fix DictCursor returning column names

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -163,9 +163,7 @@ def _convert_arrays_to_dataframe(
     coerce_float: bool = True,
     dtype_backend: DtypeBackend | Literal["numpy"] = "numpy",
 ) -> DataFrame:
-    # Fix for GH#53028: DictCursor returns dictionaries which cause
-    # to_object_array_tuples to populate DataFrame with column names instead
-    # of actual values. Convert dictionaries to tuples in column order.
+    # GH#53028 - handle cursors that return dictionaries
     if data and len(data) > 0 and is_dict_like(data[0]):
         data = [tuple(row[col] for col in columns) for row in data]
     content = lib.to_object_array_tuples(data)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -163,6 +163,11 @@ def _convert_arrays_to_dataframe(
     coerce_float: bool = True,
     dtype_backend: DtypeBackend | Literal["numpy"] = "numpy",
 ) -> DataFrame:
+    # Fix for GH#53028: DictCursor returns dictionaries which cause
+    # to_object_array_tuples to populate DataFrame with column names instead
+    # of actual values. Convert dictionaries to tuples in column order.
+    if data and len(data) > 0 and is_dict_like(data[0]):
+        data = [tuple(row[col] for col in columns) for row in data]
     content = lib.to_object_array_tuples(data)
     idx_len = content.shape[0]
     arrays = convert_object_array(

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -46,6 +46,7 @@ from pandas.io.sql import (
     SQLAlchemyEngine,
     SQLDatabase,
     SQLiteDatabase,
+    _convert_arrays_to_dataframe,
     get_engine,
     pandasSQL_builder,
     read_sql_query,
@@ -4392,3 +4393,26 @@ def test_xsqlite_if_exists(sqlite_buildin):
         (5, "E"),
     ]
     drop_table(table_name, sqlite_buildin)
+
+
+def test_convert_arrays_to_dataframe_with_dictcursor():
+    """
+    Test for GH#53028: DictCursor returns dictionaries which cause
+    _convert_arrays_to_dataframe to populate DataFrame with column names
+    instead of actual values.
+    """
+    # Simulate DictCursor output (e.g., from pymysql with DictCursor)
+    dict_data = [
+        {"id": 117, "value": "ABCDEF", "state_id": 5},
+        {"id": 163, "value": "DEFRDC", "state_id": 5},
+    ]
+    columns = ["id", "value", "state_id"]
+
+    result = _convert_arrays_to_dataframe(dict_data, columns)
+
+    expected = DataFrame(
+        [[117, "ABCDEF", 5], [163, "DEFRDC", 5]],
+        columns=columns,
+    )
+
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -4397,20 +4397,17 @@ def test_xsqlite_if_exists(sqlite_buildin):
     drop_table(table_name, sqlite_buildin)
 
 
-def test_read_sql_query_dictcursor():
-    """
-    Test for GH#53028: DictCursor returns dictionaries which cause
-    read_sql_query to populate DataFrame with column names instead of actual values.
-    """
+@pytest.mark.parametrize("conn", ["sqlite_buildin"])
+def test_read_sql_query_dictcursor(conn, request):
+    # GH#53028
+    conn = request.getfixturevalue(conn)
 
     def sqlite3_factory(cursor: Any, row: Any) -> Any:
-        """Convert SQL row into a Dict rather than Tuple"""
         d = {}
         for idx, col in enumerate(cursor.description):
             d[col[0]] = row[idx]
         return d
 
-    conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3_factory
 
     df_input = DataFrame(
@@ -4426,4 +4423,3 @@ def test_read_sql_query_dictcursor():
     )
 
     tm.assert_frame_equal(result, expected)
-    conn.close()


### PR DESCRIPTION
… values in read_sql_query

- [x] closes #53028 closes #52437
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Problem:
When using pymysql with DictCursor (or similar dictionary-returning cursors), pd.read_sql_query() returned a DataFrame where cells contained column names instead of actual values.

RCA:
DictCursor returns rows as dictionaries: [{'id': 117, 'value': 'ABCDEF'}, ...]
read_sql_query() calls _convert_arrays_to_dataframe(), which calls lib.to_object_array_tuples(data)
to_object_array_tuples() expects tuples/lists. 

When it receives dictionaries, it does the following:
- Iterating a dict yields keys, not values
- Converting a dict to a tuple gives tuple({'id': 117, 'value': 'ABCDEF'}) gives ('id', 'value') 
- Result: column names instead of values

Solution:
Check if data contains dictionaries (using is_dict_like() on the first row)
If dictionaries are found, converts each row to a tuple in column order: tuple(row[col] for col in columns)
Then passes the converted data to to_object_array_tuples()