### PR TITLE
DOC: allow rebuilding versioned docs through workflow_dispatch

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -11,11 +11,19 @@ on:
     branches:
       - main
       - 2.3.x
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The pandas version to override'
+        required: false
+        type: string
 
 env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PANDAS_VERSION: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || ${GITHUB_REF_NAME:1} }}"
+  PANDAS_VERSION_OVERRIDE: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || '' }}"
 
 permissions:
   contents: read
@@ -72,7 +80,7 @@ jobs:
         echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
         echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
-      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
 
     - name: Copy cheatsheets into site directory
       run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
@@ -86,8 +94,8 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload prod docs
-      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${GITHUB_REF_NAME:1}
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
+      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && env.PANDAS_VERSION_OVERRIDE != '')
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -175,6 +175,8 @@ import pandas  # isort:skip
 
 # version = '%s r%s' % (pandas.__version__, svn_version())
 version = str(pandas.__version__)
+if version_override := os.environ.get("PANDAS_VERSION_OVERRIDE"):
+    version = version_override
 
 # The full version, including alpha/beta/rc tags.
 release = version


### PR DESCRIPTION
Testing a workflow to allow rebuilding the docs for a released version (without making a new release, when the docs get automatically uploaded), by:

- allowing to specify an override version as an env variable, by having sphinx conf.py check for that
- adding a `workflow_dispatch` event to `.github/workflows/docbuild-and-upload.yml` (only people with write access can trigger that) and when specifying the override version, then the built docs from that commit get uploaded