### PR TITLE
STY: Add strict parameter to zip() calls in core/reshape/reshape.py

### DIFF
--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -696,7 +696,9 @@ def stack(
             levels=new_levels, codes=new_codes, names=new_names, verify_integrity=False
         )
     else:
-        levels, (ilab, clab) = zip(*map(stack_factorize, (frame.index, frame.columns)))
+        levels, (ilab, clab) = zip(
+            *map(stack_factorize, (frame.index, frame.columns)), strict=True
+        )
         codes = ilab.repeat(K), np.tile(clab, N).ravel()
         new_index = MultiIndex(
             levels=levels,
@@ -782,9 +784,9 @@ def _stack_multi_column_index(columns: MultiIndex) -> MultiIndex | Index:
     )
 
     # Remove duplicate tuples in the MultiIndex.
-    tuples = zip(*levs)
+    tuples = zip(*levs, strict=True)
     unique_tuples = (key for key, _ in itertools.groupby(tuples))
-    new_levs = zip(*unique_tuples)
+    new_levs = zip(*unique_tuples, strict=False)
 
     # The dtype of each level must be explicitly set to avoid inferring the wrong type.
     # See GH-36991.
@@ -792,7 +794,7 @@ def _stack_multi_column_index(columns: MultiIndex) -> MultiIndex | Index:
         [
             # Not all indices can accept None values.
             Index(new_lev, dtype=lev.dtype) if None not in new_lev else new_lev
-            for new_lev, lev in zip(new_levs, columns.levels)
+            for new_lev, lev in zip(new_levs, columns.levels, strict=True)
         ],
         names=columns.names[:-1],
     )


### PR DESCRIPTION
Contributes to #62434

## Summary
Added explicit `strict` parameter to all `zip()` calls in `pandas/core/reshape/reshape.py` as part of enforcing Ruff rule B905 (zip-without-explicit-strict).

## Changes
- Line 699-701: Added `strict=True` to `zip()` when unpacking `stack_factorize` results for frame.index and frame.columns
- Line 787: Added `strict=True` to `zip()` when creating tuples from levels (levs should have uniform length)
- Line 789: Added `strict=False` to `zip()` when unpacking unique_tuples (length may differ after deduplication via groupby)
- Line 797: Added `strict=True` to `zip()` when pairing new_levs with columns.levels (should have matching lengths)

## Rationale for strict values
- `strict=True`: Used where the iterables are expected to have equal length and a mismatch would indicate a bug
- `strict=False`: Used at line 789 where `unique_tuples` may have fewer elements than the original after deduplication

## Testing
Existing tests continue to pass, verifying that the strict parameters are set correctly for the expected data flows.