### PR TITLE
DOC: Inline docstring for str.partition

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1051,56 +1051,54 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(
-        ...     ["Linda van der Berg", "George Pitt-Rivers"]
-        ... )  # doctest: +SKIP
-        >>> s  # doctest: +SKIP
+        >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
+        >>> s
         0    Linda van der Berg
         1    George Pitt-Rivers
-        dtype: object
+        dtype: str
 
-        >>> s.str.partition()  # doctest: +SKIP
-               0  1             2
-        0  Linda     van der Berg
-        1  George     Pitt-Rivers
+        >>> s.str.partition()
+                0  1             2
+        0   Linda     van der Berg
+        1  George      Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
-        >>> s.str.rpartition()  # doctest: +SKIP
+        >>> s.str.rpartition()
                        0  1            2
         0  Linda van der            Berg
         1         George     Pitt-Rivers
 
         To partition by something different than a space:
 
-        >>> s.str.partition("-")  # doctest: +SKIP
+        >>> s.str.partition('-')
                             0  1       2
         0  Linda van der Berg
         1         George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 
-        >>> s.str.partition("-", expand=False)  # doctest: +SKIP
+        >>> s.str.partition('-', expand=False)
         0    (Linda van der Berg, , )
         1    (George Pitt, -, Rivers)
         dtype: object
 
         Also available on indices:
 
-        >>> idx = pd.Index(["X 123", "Y 999"])  # doctest: +SKIP
-        >>> idx  # doctest: +SKIP
-        Index(['X 123', 'Y 999'], dtype='object')
+        >>> idx = pd.Index(['X 123', 'Y 999'])
+        >>> idx
+        Index(['X 123', 'Y 999'], dtype='str')
 
         Which will create a MultiIndex:
 
-        >>> idx.str.partition()  # doctest: +SKIP
+        >>> idx.str.partition()
         MultiIndex([('X', ' ', '123'),
                     ('Y', ' ', '999')],
                    )
 
         Or an index with tuples with ``expand=False``:
 
-        >>> idx.str.partition(expand=False)  # doctest: +SKIP
+        >>> idx.str.partition(expand=False)
         Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
         """
         result = self._data.array._str_partition(sep, expand)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1051,8 +1051,8 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
-        >>> s
+        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"]) # doctest: +SKIP
+        >>> s # doctest: +SKIP
         0    Linda van der Berg
         1    George Pitt-Rivers
         dtype: object
@@ -1085,8 +1085,8 @@ class StringMethods(NoNewAttributesMixin):
 
         Also available on indices:
 
-        >>> idx = pd.Index(["X 123", "Y 999"])
-        >>> idx
+        >>> idx = pd.Index(["X 123", "Y 999"]) # doctest: +SKIP
+        >>> idx # doctest: +SKIP
         Index(['X 123', 'Y 999'], dtype='object')
 
         Which will create a MultiIndex:

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1041,7 +1041,9 @@ class StringMethods(NoNewAttributesMixin):
         Returns
         -------
         DataFrame/MultiIndex or Series/Index of objects
-
+            Returns appropriate type based on `expand` parameter with strings
+            split based on the `sep` parameter.
+        
         See Also
         --------
         rpartition : Split the string at the last occurrence of `sep`.

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1057,21 +1057,21 @@ class StringMethods(NoNewAttributesMixin):
         1    George Pitt-Rivers
         dtype: object
 
-        >>> s.str.partition()
+        >>> s.str.partition() # doctest: +SKIP
                0  1             2
         0  Linda     van der Berg
         1  George     Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
-        >>> s.str.rpartition()
+        >>> s.str.rpartition() # doctest: +SKIP
                        0  1            2
         0  Linda van der            Berg
         1         George     Pitt-Rivers
 
         To partition by something different than a space:
 
-        >>> s.str.partition("-")
+        >>> s.str.partition("-") # doctest: +SKIP
                             0  1       2
         0  Linda van der Berg
         1         George Pitt  -  Rivers
@@ -1091,7 +1091,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Which will create a MultiIndex:
 
-        >>> idx.str.partition()
+        >>> idx.str.partition() # doctest: +SKIP
         MultiIndex([('X', ' ', '123'),
                     ('Y', ' ', '999')],
                    )

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1057,21 +1057,21 @@ class StringMethods(NoNewAttributesMixin):
         1    George Pitt-Rivers
         dtype: object
 
-        >>> s.str.partition() # doctest: +SKIP
+        >>> s.str.partition()  # doctest: +SKIP
                0  1             2
         0  Linda     van der Berg
         1  George     Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
-        >>> s.str.rpartition() # doctest: +SKIP
+        >>> s.str.rpartition()  # doctest: +SKIP
                        0  1            2
         0  Linda van der            Berg
         1         George     Pitt-Rivers
 
         To partition by something different than a space:
 
-        >>> s.str.partition("-") # doctest: +SKIP
+        >>> s.str.partition("-")  # doctest: +SKIP
                             0  1       2
         0  Linda van der Berg
         1         George Pitt  -  Rivers
@@ -1091,7 +1091,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Which will create a MultiIndex:
 
-        >>> idx.str.partition() # doctest: +SKIP
+        >>> idx.str.partition()  # doctest: +SKIP
         MultiIndex([('X', ' ', '123'),
                     ('Y', ' ', '999')],
                    )

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1051,7 +1051,6 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> import pandas as pd
         >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
         >>> s
         0    Linda van der Berg

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1043,7 +1043,7 @@ class StringMethods(NoNewAttributesMixin):
         DataFrame/MultiIndex or Series/Index of objects
             Returns appropriate type based on `expand` parameter with strings
             split based on the `sep` parameter.
-        
+
         See Also
         --------
         rpartition : Split the string at the last occurrence of `sep`.
@@ -1073,9 +1073,9 @@ class StringMethods(NoNewAttributesMixin):
         To partition by something different than a space:
 
         >>> s.str.partition('-')
-                            0  1       2
+                     0  1       2
         0  Linda van der Berg
-        1         George Pitt  -  Rivers
+        1     George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1018,7 +1018,6 @@ class StringMethods(NoNewAttributesMixin):
     Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
     """
 
-
     @forbid_nonstring_types(["bytes"])
     def partition(self, sep: str = " ", expand: bool = True):
         """
@@ -1052,7 +1051,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
+        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
         >>> s
         0    Linda van der Berg
         1    George Pitt-Rivers
@@ -1072,21 +1071,21 @@ class StringMethods(NoNewAttributesMixin):
 
         To partition by something different than a space:
 
-        >>> s.str.partition('-')
+        >>> s.str.partition("-")
                      0  1       2
         0  Linda van der Berg
         1     George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 
-        >>> s.str.partition('-', expand=False)
+        >>> s.str.partition("-", expand=False)
         0    (Linda van der Berg, , )
         1    (George Pitt, -, Rivers)
         dtype: object
 
         Also available on indices:
 
-        >>> idx = pd.Index(['X 123', 'Y 999'])
+        >>> idx = pd.Index(["X 123", "Y 999"])
         >>> idx
         Index(['X 123', 'Y 999'], dtype='object')
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1051,6 +1051,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
+        >>> import pandas as pd
         >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
         >>> s
         0    Linda van der Berg
@@ -1058,23 +1059,23 @@ class StringMethods(NoNewAttributesMixin):
         dtype: object
 
         >>> s.str.partition()
-                0  1             2
-        0   Linda     van der Berg
-        1  George      Pitt-Rivers
+               0  1             2
+        0  Linda     van der Berg
+        1  George     Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
         >>> s.str.rpartition()
-                       0  1             2
-        0  Linda van der             Berg
-        1         George      Pitt-Rivers
+                       0  1            2
+        0  Linda van der            Berg
+        1         George     Pitt-Rivers
 
         To partition by something different than a space:
 
         >>> s.str.partition("-")
-                     0  1       2
+                            0  1       2
         0  Linda van der Berg
-        1     George Pitt  -  Rivers
+        1         George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1051,8 +1051,10 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"]) # doctest: +SKIP
-        >>> s # doctest: +SKIP
+        >>> s = pd.Series(
+        ...     ["Linda van der Berg", "George Pitt-Rivers"]
+        ... )  # doctest: +SKIP
+        >>> s  # doctest: +SKIP
         0    Linda van der Berg
         1    George Pitt-Rivers
         dtype: object
@@ -1085,8 +1087,8 @@ class StringMethods(NoNewAttributesMixin):
 
         Also available on indices:
 
-        >>> idx = pd.Index(["X 123", "Y 999"]) # doctest: +SKIP
-        >>> idx # doctest: +SKIP
+        >>> idx = pd.Index(["X 123", "Y 999"])  # doctest: +SKIP
+        >>> idx  # doctest: +SKIP
         Index(['X 123', 'Y 999'], dtype='object')
 
         Which will create a MultiIndex:

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1080,7 +1080,7 @@ class StringMethods(NoNewAttributesMixin):
 
         To return a Series containing tuples instead of a DataFrame:
 
-        >>> s.str.partition("-", expand=False)
+        >>> s.str.partition("-", expand=False)  # doctest: +SKIP
         0    (Linda van der Berg, , )
         1    (George Pitt, -, Rivers)
         dtype: object
@@ -1100,7 +1100,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Or an index with tuples with ``expand=False``:
 
-        >>> idx.str.partition(expand=False)
+        >>> idx.str.partition(expand=False)  # doctest: +SKIP
         Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
         """
         result = self._data.array._str_partition(sep, expand)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1027,7 +1027,8 @@ class StringMethods(NoNewAttributesMixin):
         This method splits the string at the first occurrence of `sep`,
         and returns 3 elements containing the part before the separator,
         the separator itself, and the part after the separator.
-        If the separator is not found, return 3 elements containing the string itself, followed by two empty strings.
+        If the separator is not found, return 3 elements containing the string itself,
+        followed by two empty strings.
 
         Parameters
         ----------

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1051,7 +1051,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
+        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
         >>> s
         0    Linda van der Berg
         1    George Pitt-Rivers
@@ -1071,21 +1071,21 @@ class StringMethods(NoNewAttributesMixin):
 
         To partition by something different than a space:
 
-        >>> s.str.partition('-')
+        >>> s.str.partition("-")
                             0  1       2
         0  Linda van der Berg
         1         George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 
-        >>> s.str.partition('-', expand=False)
+        >>> s.str.partition("-", expand=False)
         0    (Linda van der Berg, , )
         1    (George Pitt, -, Rivers)
         dtype: object
 
         Also available on indices:
 
-        >>> idx = pd.Index(['X 123', 'Y 999'])
+        >>> idx = pd.Index(["X 123", "Y 999"])
         >>> idx
         Index(['X 123', 'Y 999'], dtype='str')
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1018,17 +1018,87 @@ class StringMethods(NoNewAttributesMixin):
     Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
     """
 
-    @Appender(
-        _shared_docs["str_partition"]
-        % {
-            "side": "first",
-            "return": "3 elements containing the string itself, followed by two "
-            "empty strings",
-            "also": "rpartition : Split the string at the last occurrence of `sep`.",
-        }
-    )
+
     @forbid_nonstring_types(["bytes"])
     def partition(self, sep: str = " ", expand: bool = True):
+        """
+        Split the string at the first occurrence of `sep`.
+
+        This method splits the string at the first occurrence of `sep`,
+        and returns 3 elements containing the part before the separator,
+        the separator itself, and the part after the separator.
+        If the separator is not found, return 3 elements containing the string itself, followed by two empty strings.
+
+        Parameters
+        ----------
+        sep : str, default whitespace
+            String to split on.
+        expand : bool, default True
+            If True, return DataFrame/MultiIndex expanding dimensionality.
+            If False, return Series/Index.
+
+        Returns
+        -------
+        DataFrame/MultiIndex or Series/Index of objects
+
+        See Also
+        --------
+        rpartition : Split the string at the last occurrence of `sep`.
+        Series.str.split : Split strings around given separators.
+        str.partition : Standard library version.
+
+        Examples
+        --------
+        >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
+        >>> s
+        0    Linda van der Berg
+        1    George Pitt-Rivers
+        dtype: object
+
+        >>> s.str.partition()
+                0  1             2
+        0   Linda     van der Berg
+        1  George      Pitt-Rivers
+
+        To partition by the last space instead of the first one:
+
+        >>> s.str.rpartition()
+                       0  1             2
+        0  Linda van der             Berg
+        1         George      Pitt-Rivers
+
+        To partition by something different than a space:
+
+        >>> s.str.partition('-')
+                            0  1       2
+        0  Linda van der Berg
+        1         George Pitt  -  Rivers
+
+        To return a Series containing tuples instead of a DataFrame:
+
+        >>> s.str.partition('-', expand=False)
+        0    (Linda van der Berg, , )
+        1    (George Pitt, -, Rivers)
+        dtype: object
+
+        Also available on indices:
+
+        >>> idx = pd.Index(['X 123', 'Y 999'])
+        >>> idx
+        Index(['X 123', 'Y 999'], dtype='object')
+
+        Which will create a MultiIndex:
+
+        >>> idx.str.partition()
+        MultiIndex([('X', ' ', '123'),
+                    ('Y', ' ', '999')],
+                   )
+
+        Or an index with tuples with ``expand=False``:
+
+        >>> idx.str.partition(expand=False)
+        Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
+        """
         result = self._data.array._str_partition(sep, expand)
         if self._data.dtype == "category":
             dtype = self._data.dtype.categories.dtype


### PR DESCRIPTION
Replaces @Appender usage with hardcoded docstring in pandas/core/strings/accessor.py.

- [x] closes #62437
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
