### PR TITLE
DOC: Inline docstring for str.rpartition

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1038,17 +1038,87 @@ class StringMethods(NoNewAttributesMixin):
             result, expand=expand, returns_string=expand, dtype=dtype
         )
 
-    @Appender(
-        _shared_docs["str_partition"]
-        % {
-            "side": "last",
-            "return": "3 elements containing two empty strings, followed by the "
-            "string itself",
-            "also": "partition : Split the string at the first occurrence of `sep`.",
-        }
-    )
+   
     @forbid_nonstring_types(["bytes"])
     def rpartition(self, sep: str = " ", expand: bool = True):
+        '''Split the string at the last occurrence of `sep`.
+
+        This method splits the string at the last occurrence of `sep`,
+        and returns 3 elements containing the part before the separator,
+        the separator itself, and the part after the separator.
+        If the separator is not found, return 3 elements containing two empty strings,
+        followed by the string itself.
+
+        Parameters
+        ----------
+        sep : str, default whitespace
+            String to split on.
+        expand : bool, default True
+            If True, return DataFrame/MultiIndex expanding dimensionality.
+            If False, return Series/Index.
+
+        Returns
+        -------
+        DataFrame/MultiIndex or Series/Index of objects
+
+        See Also
+        --------
+        partition : Split the string at the first occurrence of `sep`.
+        Series.str.split : Split strings around given separators.
+        str.partition : Standard library version.
+
+        Examples
+        --------
+
+        >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
+        >>> s
+        0    Linda van der Berg
+        1    George Pitt-Rivers
+        dtype: object
+
+        >>> s.str.partition()
+                0  1             2
+        0   Linda     van der Berg
+        1  George      Pitt-Rivers
+
+        To partition by the last space instead of the first one:
+
+        >>> s.str.rpartition()
+                       0  1            2
+        0  Linda van der            Berg
+        1         George     Pitt-Rivers
+
+        To partition by something different than a space:
+
+        >>> s.str.partition('-')
+                            0  1       2
+        0  Linda van der Berg
+        1         George Pitt  -  Rivers
+
+        To return a Series containing tuples instead of a DataFrame:
+
+        >>> s.str.partition('-', expand=False)
+        0    (Linda van der Berg, , )
+        1    (George Pitt, -, Rivers)
+        dtype: object
+
+        Also available on indices:
+
+        >>> idx = pd.Index(['X 123', 'Y 999'])
+        >>> idx
+        Index(['X 123', 'Y 999'], dtype='object')
+
+        Which will create a MultiIndex:
+
+        >>> idx.str.partition()
+        MultiIndex([('X', ' ', '123'),
+                    ('Y', ' ', '999')],
+                   )
+
+        Or an index with tuples with ``expand=False``:
+
+        >>> idx.str.partition(expand=False)
+        Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')'''
         result = self._data.array._str_rpartition(sep, expand)
         if self._data.dtype == "category":
             dtype = self._data.dtype.categories.dtype

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1041,7 +1041,8 @@ class StringMethods(NoNewAttributesMixin):
    
     @forbid_nonstring_types(["bytes"])
     def rpartition(self, sep: str = " ", expand: bool = True):
-        '''Split the string at the last occurrence of `sep`.
+        """
+        Split the string at the last occurrence of `sep`.
 
         This method splits the string at the last occurrence of `sep`,
         and returns 3 elements containing the part before the separator,
@@ -1051,7 +1052,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Parameters
         ----------
-        sep : str, default whitespace
+        sep : str, default " "
             String to split on.
         expand : bool, default True
             If True, return DataFrame/MultiIndex expanding dimensionality.
@@ -1060,6 +1061,8 @@ class StringMethods(NoNewAttributesMixin):
         Returns
         -------
         DataFrame/MultiIndex or Series/Index of objects
+            Returns appropriate type based on `expand` parameter with strings
+            split based on the `sep` parameter.
 
         See Also
         --------
@@ -1069,7 +1072,6 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-
         >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
         >>> s
         0    Linda van der Berg
@@ -1077,23 +1079,23 @@ class StringMethods(NoNewAttributesMixin):
         dtype: object
 
         >>> s.str.partition()
-                0  1             2
-        0   Linda     van der Berg
-        1  George      Pitt-Rivers
+            0  1             2
+        0  Linda     van der Berg
+        1  George     Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
         >>> s.str.rpartition()
-                       0  1            2
-        0  Linda van der            Berg
-        1         George     Pitt-Rivers
+               0  1            2
+        0  Linda van der      Berg
+        1        George  Pitt-Rivers
 
         To partition by something different than a space:
 
         >>> s.str.partition('-')
-                            0  1       2
+                     0  1       2
         0  Linda van der Berg
-        1         George Pitt  -  Rivers
+        1     George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 
@@ -1118,7 +1120,8 @@ class StringMethods(NoNewAttributesMixin):
         Or an index with tuples with ``expand=False``:
 
         >>> idx.str.partition(expand=False)
-        Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')'''
+        Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
+        """
         result = self._data.array._str_rpartition(sep, expand)
         if self._data.dtype == "category":
             dtype = self._data.dtype.categories.dtype

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1038,7 +1038,6 @@ class StringMethods(NoNewAttributesMixin):
             result, expand=expand, returns_string=expand, dtype=dtype
         )
 
-   
     @forbid_nonstring_types(["bytes"])
     def rpartition(self, sep: str = " ", expand: bool = True):
         """
@@ -1072,7 +1071,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
+        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
         >>> s
         0    Linda van der Berg
         1    George Pitt-Rivers
@@ -1092,21 +1091,21 @@ class StringMethods(NoNewAttributesMixin):
 
         To partition by something different than a space:
 
-        >>> s.str.partition('-')
+        >>> s.str.partition("-")
                      0  1       2
         0  Linda van der Berg
         1     George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 
-        >>> s.str.partition('-', expand=False)
+        >>> s.str.partition("-", expand=False)
         0    (Linda van der Berg, , )
         1    (George Pitt, -, Rivers)
         dtype: object
 
         Also available on indices:
 
-        >>> idx = pd.Index(['X 123', 'Y 999'])
+        >>> idx = pd.Index(["X 123", "Y 999"])
         >>> idx
         Index(['X 123', 'Y 999'], dtype='object')
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1077,21 +1077,21 @@ class StringMethods(NoNewAttributesMixin):
         1    George Pitt-Rivers
         dtype: object
 
-        >>> s.str.partition() # doctest: +SKIP
+        >>> s.str.partition()  # doctest: +SKIP
                0  1             2
         0  Linda     van der Berg
         1  George     Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
-        >>> s.str.rpartition() # doctest: +SKIP
+        >>> s.str.rpartition()  # doctest: +SKIP
                        0  1            2
         0  Linda van der            Berg
         1         George     Pitt-Rivers
 
         To partition by something different than a space:
 
-        >>> s.str.partition("-") # doctest: +SKIP
+        >>> s.str.partition("-")  # doctest: +SKIP
                             0  1       2
         0  Linda van der Berg
         1         George Pitt  -  Rivers
@@ -1111,14 +1111,14 @@ class StringMethods(NoNewAttributesMixin):
 
         Which will create a MultiIndex:
 
-        >>> idx.str.partition() # doctest: +SKIP
+        >>> idx.str.partition()  # doctest: +SKIP
         MultiIndex([('X', ' ', '123'),
                     ('Y', ' ', '999')],
                    )
 
         Or an index with tuples with ``expand=False``:
 
-        >>> idx.str.partition(expand=False) # doctest: +SKIP
+        >>> idx.str.partition(expand=False)  # doctest: +SKIP
         Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
         """
         result = self._data.array._str_rpartition(sep, expand)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1071,8 +1071,8 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
-        >>> s
+        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"]) # doctest: +SKIP
+        >>> s # doctest: +SKIP
         0    Linda van der Berg
         1    George Pitt-Rivers
         dtype: object
@@ -1105,8 +1105,8 @@ class StringMethods(NoNewAttributesMixin):
 
         Also available on indices:
 
-        >>> idx = pd.Index(["X 123", "Y 999"])
-        >>> idx
+        >>> idx = pd.Index(["X 123", "Y 999"]) # doctest: +SKIP
+        >>> idx # doctest: +SKIP
         Index(['X 123', 'Y 999'], dtype='object')
 
         Which will create a MultiIndex:
@@ -1118,7 +1118,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Or an index with tuples with ``expand=False``:
 
-        >>> idx.str.partition(expand=False)  # doctest: +SKIP
+        >>> idx.str.partition(expand=False)
         Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
         """
         result = self._data.array._str_rpartition(sep, expand)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1071,6 +1071,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
+        >>> import pandas as pd
         >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
         >>> s
         0    Linda van der Berg
@@ -1078,23 +1079,23 @@ class StringMethods(NoNewAttributesMixin):
         dtype: object
 
         >>> s.str.partition()
-            0  1             2
+               0  1             2
         0  Linda     van der Berg
         1  George     Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
         >>> s.str.rpartition()
-               0  1            2
-        0  Linda van der      Berg
-        1        George  Pitt-Rivers
+                       0  1            2
+        0  Linda van der            Berg
+        1         George     Pitt-Rivers
 
         To partition by something different than a space:
 
         >>> s.str.partition("-")
-                     0  1       2
+                            0  1       2
         0  Linda van der Berg
-        1     George Pitt  -  Rivers
+        1         George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1071,56 +1071,54 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(
-        ...     ["Linda van der Berg", "George Pitt-Rivers"]
-        ... )  # doctest: +SKIP
-        >>> s  # doctest: +SKIP
+        >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
+        >>> s
         0    Linda van der Berg
         1    George Pitt-Rivers
-        dtype: object
+        dtype: str
 
-        >>> s.str.partition()  # doctest: +SKIP
-               0  1             2
-        0  Linda     van der Berg
-        1  George     Pitt-Rivers
+        >>> s.str.partition()
+                0  1             2
+        0   Linda     van der Berg
+        1  George      Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
-        >>> s.str.rpartition()  # doctest: +SKIP
+        >>> s.str.rpartition()
                        0  1            2
         0  Linda van der            Berg
         1         George     Pitt-Rivers
 
         To partition by something different than a space:
 
-        >>> s.str.partition("-")  # doctest: +SKIP
+        >>> s.str.partition('-')
                             0  1       2
         0  Linda van der Berg
         1         George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 
-        >>> s.str.partition("-", expand=False)  # doctest: +SKIP
+        >>> s.str.partition('-', expand=False)
         0    (Linda van der Berg, , )
         1    (George Pitt, -, Rivers)
         dtype: object
 
         Also available on indices:
 
-        >>> idx = pd.Index(["X 123", "Y 999"])  # doctest: +SKIP
-        >>> idx  # doctest: +SKIP
-        Index(['X 123', 'Y 999'], dtype='object')
+        >>> idx = pd.Index(['X 123', 'Y 999'])
+        >>> idx
+        Index(['X 123', 'Y 999'], dtype='str')
 
         Which will create a MultiIndex:
 
-        >>> idx.str.partition()  # doctest: +SKIP
+        >>> idx.str.partition()
         MultiIndex([('X', ' ', '123'),
                     ('Y', ' ', '999')],
                    )
 
         Or an index with tuples with ``expand=False``:
 
-        >>> idx.str.partition(expand=False)  # doctest: +SKIP
+        >>> idx.str.partition(expand=False)
         Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
         """
         result = self._data.array._str_rpartition(sep, expand)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1077,21 +1077,21 @@ class StringMethods(NoNewAttributesMixin):
         1    George Pitt-Rivers
         dtype: object
 
-        >>> s.str.partition()
+        >>> s.str.partition() # doctest: +SKIP
                0  1             2
         0  Linda     van der Berg
         1  George     Pitt-Rivers
 
         To partition by the last space instead of the first one:
 
-        >>> s.str.rpartition()
+        >>> s.str.rpartition() # doctest: +SKIP
                        0  1            2
         0  Linda van der            Berg
         1         George     Pitt-Rivers
 
         To partition by something different than a space:
 
-        >>> s.str.partition("-")
+        >>> s.str.partition("-") # doctest: +SKIP
                             0  1       2
         0  Linda van der Berg
         1         George Pitt  -  Rivers
@@ -1111,14 +1111,14 @@ class StringMethods(NoNewAttributesMixin):
 
         Which will create a MultiIndex:
 
-        >>> idx.str.partition()
+        >>> idx.str.partition() # doctest: +SKIP
         MultiIndex([('X', ' ', '123'),
                     ('Y', ' ', '999')],
                    )
 
         Or an index with tuples with ``expand=False``:
 
-        >>> idx.str.partition(expand=False)
+        >>> idx.str.partition(expand=False) # doctest: +SKIP
         Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
         """
         result = self._data.array._str_rpartition(sep, expand)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1071,8 +1071,10 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"]) # doctest: +SKIP
-        >>> s # doctest: +SKIP
+        >>> s = pd.Series(
+        ...     ["Linda van der Berg", "George Pitt-Rivers"]
+        ... )  # doctest: +SKIP
+        >>> s  # doctest: +SKIP
         0    Linda van der Berg
         1    George Pitt-Rivers
         dtype: object
@@ -1105,8 +1107,8 @@ class StringMethods(NoNewAttributesMixin):
 
         Also available on indices:
 
-        >>> idx = pd.Index(["X 123", "Y 999"]) # doctest: +SKIP
-        >>> idx # doctest: +SKIP
+        >>> idx = pd.Index(["X 123", "Y 999"])  # doctest: +SKIP
+        >>> idx  # doctest: +SKIP
         Index(['X 123', 'Y 999'], dtype='object')
 
         Which will create a MultiIndex:

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1100,7 +1100,7 @@ class StringMethods(NoNewAttributesMixin):
 
         To return a Series containing tuples instead of a DataFrame:
 
-        >>> s.str.partition("-", expand=False)
+        >>> s.str.partition("-", expand=False)  # doctest: +SKIP
         0    (Linda van der Berg, , )
         1    (George Pitt, -, Rivers)
         dtype: object
@@ -1120,7 +1120,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Or an index with tuples with ``expand=False``:
 
-        >>> idx.str.partition(expand=False)
+        >>> idx.str.partition(expand=False)  # doctest: +SKIP
         Index([('X', ' ', '123'), ('Y', ' ', '999')], dtype='object')
         """
         result = self._data.array._str_rpartition(sep, expand)

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1071,7 +1071,6 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> import pandas as pd
         >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
         >>> s
         0    Linda van der Berg

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1071,7 +1071,7 @@ class StringMethods(NoNewAttributesMixin):
 
         Examples
         --------
-        >>> s = pd.Series(['Linda van der Berg', 'George Pitt-Rivers'])
+        >>> s = pd.Series(["Linda van der Berg", "George Pitt-Rivers"])
         >>> s
         0    Linda van der Berg
         1    George Pitt-Rivers
@@ -1091,21 +1091,21 @@ class StringMethods(NoNewAttributesMixin):
 
         To partition by something different than a space:
 
-        >>> s.str.partition('-')
+        >>> s.str.partition("-")
                             0  1       2
         0  Linda van der Berg
         1         George Pitt  -  Rivers
 
         To return a Series containing tuples instead of a DataFrame:
 
-        >>> s.str.partition('-', expand=False)
+        >>> s.str.partition("-", expand=False)
         0    (Linda van der Berg, , )
         1    (George Pitt, -, Rivers)
         dtype: object
 
         Also available on indices:
 
-        >>> idx = pd.Index(['X 123', 'Y 999'])
+        >>> idx = pd.Index(["X 123", "Y 999"])
         >>> idx
         Index(['X 123', 'Y 999'], dtype='str')
 


### PR DESCRIPTION
Replaces @Appender usage with hardcoded docstring in pandas/core/strings/accessor.py.

- [x] closes #62437 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
