### PR TITLE
CLN: Remove dead code in `NumericDtype.__from_arrow__`

### DIFF
--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -95,12 +95,7 @@ class NumericDtype(BaseMaskedDtype):
             array = array.cast(pyarrow_type)
 
         if isinstance(array, pyarrow.ChunkedArray):
-            # TODO this "if" can be removed when requiring pyarrow >= 10.0, which fixed
-            # combine_chunks for empty arrays https://github.com/apache/arrow/pull/13757
-            if array.num_chunks == 0:
-                array = pyarrow.array([], type=array.type)
-            else:
-                array = array.combine_chunks()
+            array = array.combine_chunks()
 
         data, mask = pyarrow_array_to_numpy_and_mask(array, dtype=self.numpy_dtype)
         if data.dtype.kind == "f" and is_nan_na():


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.


https://github.com/pandas-dev/pandas/commit/f6d509474ecf7add51a32eebdf48331426dbc4c5#diff-06c825c7594054fe43f7015a3863aff0013275ab454abc28b12b851bfe463447 bumped the pyarrow minimum version to 13.0, so the if-clause is no longer needed according to the comment