### PR TITLE
BUG: pd.Grouper does not retain PyArrow index dtype

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1358,6 +1358,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.Rolling.var` and :meth:`.Rolling.std` computing incorrect results due to numerical instability. (:issue:`47721`, :issue:`52407`, :issue:`54518`, :issue:`55343`)
 - Bug in :meth:`DataFrame.groupby` methods when operating on NumPy-nullable data failing when the NA mask was not C-contiguous (:issue:`61031`)
 - Bug in :meth:`DataFrame.groupby` when grouping by a Series and that Series was modified after calling :meth:`DataFrame.groupby` but prior to the groupby operation (:issue:`63219`)
+- Bug in :meth:`DataFrame.groupby` with a :class:`TimeGrouper` (e.g. ``pd.Grouper(freq="D")``) not retaining PyArrow index dtype (:issue:`63518`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -242,6 +242,8 @@ class Resampler(BaseGroupBy, PandasObject):
         """
         binner, bins, binlabels = self._get_binner_for_time()
         assert len(bins) == len(binlabels)
+        if self._timegrouper._arrow_dtype is not None:
+            binlabels = binlabels.astype(self._timegrouper._arrow_dtype)
         bin_grouper = BinGrouper(bins, binlabels, indexer=self._indexer)
         return binner, bin_grouper
 

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -11,6 +11,8 @@ from datetime import (
 import numpy as np
 import pytest
 
+import pandas.util._test_decorators as td
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -957,6 +959,7 @@ class TestGroupBy:
         expected_df = gb[["Quantity"]].aggregate("mean")
         tm.assert_frame_equal(result_df, expected_df)
 
+    @td.skip_if_no("pyarrow")
     def test_pyarrow_index_retention(self):
         # https://github.com/pandas-dev/pandas/issues/63518
         df = DataFrame(

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -956,3 +956,26 @@ class TestGroupBy:
         )
         expected_df = gb[["Quantity"]].aggregate("mean")
         tm.assert_frame_equal(result_df, expected_df)
+
+    def test_pyarrow_index_retention(self):
+        # https://github.com/pandas-dev/pandas/issues/63518
+        df = DataFrame(
+            {
+                "a": [1, 2, 3],
+            },
+            index=Index(
+                [
+                    Timestamp("2013-01-01"),
+                    Timestamp("2013-01-01"),
+                    Timestamp("2013-01-02"),
+                ],
+                dtype="timestamp[ns, America/Denver][pyarrow]",
+            ),
+        )
+        gb = df.groupby(Grouper(freq="D"))
+        result = gb._grouper.result_index
+        expected = Index(
+            [Timestamp("2013-01-01"), Timestamp("2013-01-02")],
+            dtype="timestamp[ns, America/Denver][pyarrow]",
+        )
+        tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] closes #63518 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
