### PR TITLE
DOC: clarify note about optimized indexing methods

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -94,6 +94,10 @@ well). Any of the axes accessors may be the null slice ``:``. Axes left out of
 the specification are assumed to be ``:``, e.g. ``p.loc['a']`` is equivalent to
 ``p.loc['a', :]``.
 
+For performance-critical or production code, we recommend using the optimized
+pandas data access methods (such as ``.loc`` and ``.iloc``) described in this
+chapter.
+
 
 .. ipython:: python
 

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -99,9 +99,11 @@ Depending on the configuration and installed dependencies,
 string data may be stored using either a Python object-based
 implementation or a pyarrow-backed implementation.
 
-In general, the pyarrow-backed string storage is recommended
-for most users, as it provides better performance and a more
-compact memory representation.
+In general, a PyArrow-backed string storage can offer performance or memory
+benefits for certain workloads, particularly when working with large string
+arrays. However, the performance and memory characteristics depend on the data
+and operations being performed, and Python-backed string storage may be more
+efficient in some cases.
 
 **pyarrow-backed string storage**
 

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -91,6 +91,41 @@ See :ref:`text.four_string_variants` section below for details.
 
 .. _text.string_methods:
 
+String storage: pyarrow vs python
+---------------------------------
+
+Pandas supports different storage backends for string data.
+Depending on the configuration and installed dependencies,
+string data may be stored using either a Python object-based
+implementation or a pyarrow-backed implementation.
+
+In general, the pyarrow-backed string storage is recommended
+for most users, as it provides better performance and a more
+compact memory representation.
+
+**pyarrow-backed string storage**
+
+- Pros:
+  - More compact memory footprint
+  - Faster vectorized string operations
+- Cons:
+  - Strings are immutable; modifying values results in new arrays
+  - Some edge-case behavior differences compared to Python strings
+
+**Python object string storage**
+
+- Pros:
+  - Uses Python string objects (mutable at the array level)
+  - Behavior consistent with standard Python string semantics
+- Cons:
+  - Higher memory usage
+  - Slower performance due to lack of vectorization
+
+While pandas aims to provide identical results regardless of
+the underlying string storage, some behavior differences may
+exist in edge cases (for example, certain Unicode operations).
+These differences are documented where relevant.
+
 String methods
 ==============
 


### PR DESCRIPTION
This PR improves clarity in the indexing user guide by expanding a note that
distinguishes standard indexing operators from optimized pandas indexing
methods. This is a documentation-only change.
