### PR TITLE
API: Timedelta/to_timedelta with round-floats preserve unit

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1152,6 +1152,18 @@ def sequence_to_td64ns(
         else:
             mask = np.isnan(data)
 
+        if unit is not None and unit != "ns":
+            # if all non-NaN entries are round, treat these like ints and give
+            #  back the requested unit (or closest-supported)
+            int_data = data.astype(np.int64)
+            all_round = (mask | (data == int_data)).all()
+            if all_round:
+                result, _ = sequence_to_td64ns(
+                    int_data, copy=False, unit=unit, errors=errors
+                )
+                result[mask] = iNaT
+                return result, inferred_freq
+
         data = cast_from_unit_vectorized(data, unit or "ns")
         data[mask] = iNaT
         data = data.view("m8[ns]")

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -201,6 +201,27 @@ class TestTimedeltaConstructorUnitKeyword:
         with pytest.raises(ValueError, match=msg):
             to_timedelta([1, 2], unit)
 
+    def test_unit_round_float(self):
+        # When the float is round, we give the requested unit
+        #  (or nearest-supported) like we do with integers
+        td = Timedelta(45.0, unit="s")
+        assert td.unit == "s"
+        assert td == Timedelta(45, unit="s")
+
+        td = to_timedelta(45.0, unit="s")
+        assert td.unit == "s"
+        assert td == Timedelta(45, unit="s")
+
+    def test_unit_non_round_float(self):
+        # With non-round floats, we have to give nanosecond
+        td = Timedelta(45.5, unit="s")
+        assert td.unit == "ns"
+        assert td == Timedelta(45_500, unit="ms")
+
+        td = to_timedelta(45.5, unit="s")
+        assert td.unit == "ns"
+        assert td == Timedelta(45_500, unit="ms")
+
 
 def test_construct_from_kwargs_overflow():
     # GH#55503
@@ -218,7 +239,7 @@ def test_construct_with_weeks_unit_overflow():
     with pytest.raises(OutOfBoundsTimedelta, match=msg):
         Timedelta(1000000000000000000, unit="W")
 
-    with pytest.raises(OutOfBoundsTimedelta, match="without overflow"):
+    with pytest.raises(OutOfBoundsTimedelta, match=msg):
         Timedelta(1000000000000000000.0, unit="W")
 
 
@@ -304,7 +325,7 @@ def test_from_tick_reso():
 def test_construction():
     expected = np.timedelta64(10, "D").astype("m8[ns]").view("i8")
     assert Timedelta(10, unit="D")._value == expected // 10**9
-    assert Timedelta(10.0, unit="D")._value == expected
+    assert Timedelta(10.0, unit="D")._value == expected // 10**9
     assert Timedelta("10 days")._value == expected // 1000
     assert Timedelta(days=10)._value == expected // 1000
     assert Timedelta(days=10.0)._value == expected // 1000

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -328,6 +328,28 @@ class TestTimedeltas:
         expected = pd.Timedelta("0 days 00:19:59.999999998")
         assert result == expected
 
+    def test_to_timedelta_unit_round_floats(self):
+        # When the float is round, we give the requested unit
+        #  (or nearest-supported) like we do with integers
+        arr = np.array([45.0], dtype=object)
+        result = to_timedelta(arr, unit="s")
+        expected = to_timedelta([45], unit="s")
+        tm.assert_index_equal(result, expected)
+
+        arr2 = arr.astype(np.float64)
+        result2 = to_timedelta(arr2, unit="s")
+        tm.assert_index_equal(result2, expected)
+
+    def test_to_timedelta_unit_non_round_floats(self):
+        # With non-round floats, we have to give nanosecond
+        arr = np.array([45.5], dtype=object)
+        result = to_timedelta(arr, unit="s")
+        assert result.unit == "ns"
+
+        arr2 = arr.astype(np.float64)
+        result2 = to_timedelta(arr2, unit="s")
+        assert result2.unit == "ns"
+
 
 def test_from_numeric_arrow_dtype(any_numeric_ea_dtype):
     # GH 52425


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Discussed in the last dev call.  Following this I'll do the same for the to_datetime/Timestamp paths.

Context: https://github.com/pandas-dev/pandas/issues/63275