### PR TITLE
DOC: Fix PR02 docstring validation errors for groupby.plot

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -78,8 +78,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.errors.ChainedAssignmentError SA01" \
         -i "pandas.errors.IncompatibleFrequency SA01,SS06,EX01" \
         -i "pandas.api.extensions.ExtensionArray.value_counts EX01,RT03,SA01" \
-        -i "pandas.api.typing.DataFrameGroupBy.plot PR02" \
-        -i "pandas.api.typing.SeriesGroupBy.plot PR02" \
         -i "pandas.api.typing.Resampler.quantile PR01,PR07" \
         -i "pandas.StringDtype.storage SA01" \
         -i "pandas.StringDtype.na_value SA01" \

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1529,6 +1529,12 @@ class SeriesGroupBy(GroupBy[Series]):
         See Also
         --------
         Series.plot : Make plots of Series.
+
+        Examples
+        --------
+        >>> ser = pd.Series([1, 2, 3, 4, 5], index=['a', 'a', 'b', 'b', 'c'])
+        >>> g = ser.groupby(level=0)
+        >>> g.plot()  # doctest: +SKIP
         """
         result = GroupByPlot(self)
         return result
@@ -3557,6 +3563,13 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         See Also
         --------
         DataFrame.plot : Make plots of DataFrame.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [5, 6, 7, 8]},
+        ...                   index=['a', 'a', 'b', 'b'])
+        >>> g = df.groupby(level=0)
+        >>> g.plot()  # doctest: +SKIP
         """
         result = GroupByPlot(self)
         return result

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1516,7 +1516,7 @@ class SeriesGroupBy(GroupBy[Series]):
     @property
     def plot(self) -> GroupByPlot:
         """
-        Make plots of SeriesGroupBy.
+        Make plots of groups from a Series.
 
         Uses the backend specified by the option ``plotting.backend``.
         By default, matplotlib is used.
@@ -3550,7 +3550,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
     @property
     def plot(self) -> GroupByPlot:
         """
-        Make plots of DataFrameGroupBy.
+        Make plots of groups from a DataFrame.
 
         Uses the backend specified by the option ``plotting.backend``.
         By default, matplotlib is used.

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1532,7 +1532,7 @@ class SeriesGroupBy(GroupBy[Series]):
 
         Examples
         --------
-        >>> ser = pd.Series([1, 2, 3, 4, 5], index=['a', 'a', 'b', 'b', 'c'])
+        >>> ser = pd.Series([1, 2, 3, 4, 5], index=["a", "a", "b", "b", "c"])
         >>> g = ser.groupby(level=0)
         >>> g.plot()  # doctest: +SKIP
         """
@@ -3566,8 +3566,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         Examples
         --------
-        >>> df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [5, 6, 7, 8]},
-        ...                   index=['a', 'a', 'b', 'b'])
+        >>> df = pd.DataFrame(
+        ...     {"A": [1, 2, 3, 4], "B": [5, 6, 7, 8]}, index=["a", "a", "b", "b"]
+        ... )
         >>> g = df.groupby(level=0)
         >>> g.plot()  # doctest: +SKIP
         """

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1514,8 +1514,22 @@ class SeriesGroupBy(GroupBy[Series]):
         )
 
     @property
-    @doc(Series.plot.__doc__)
     def plot(self) -> GroupByPlot:
+        """
+        Make plots of SeriesGroupBy.
+
+        Uses the backend specified by the option ``plotting.backend``.
+        By default, matplotlib is used.
+
+        Returns
+        -------
+        GroupByPlot
+            A plotting object that can be used to create plots for each group.
+
+        See Also
+        --------
+        Series.plot : Make plots of Series.
+        """
         result = GroupByPlot(self)
         return result
 
@@ -3528,8 +3542,22 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         )
 
     @property
-    @doc(DataFrame.plot.__doc__)
     def plot(self) -> GroupByPlot:
+        """
+        Make plots of DataFrameGroupBy.
+
+        Uses the backend specified by the option ``plotting.backend``.
+        By default, matplotlib is used.
+
+        Returns
+        -------
+        GroupByPlot
+            A plotting object that can be used to create plots for each group.
+
+        See Also
+        --------
+        DataFrame.plot : Make plots of DataFrame.
+        """
         result = GroupByPlot(self)
         return result
 


### PR DESCRIPTION
- Remove `@doc()` decorator from SeriesGroupBy.plot and DataFrameGroupBy.plot
- Add explicit docstrings with Returns and See Also sections
- Remove PR02 ignore entries from code_checks.sh

```
-i "pandas.api.typing.DataFrameGroupBy.plot PR02" \
-i "pandas.api.typing.SeriesGroupBy.plot PR02" \
```

Part of #60365
 
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
