### PR TITLE
CLN: Add IndentPPDirectives AfterHash to clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+IndentPPDirectives: AfterHash

--- a/pandas/_libs/include/pandas/datetime/pd_datetime.h
+++ b/pandas/_libs/include/pandas/datetime/pd_datetime.h
@@ -18,7 +18,7 @@ See NUMPY_LICENSE.txt for the license.
 #pragma once
 
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif // NPY_NO_DEPRECATED_API
 
 #include "pandas/datetime/date_conversions.h"
@@ -63,48 +63,48 @@ typedef struct {
 #ifndef _PANDAS_DATETIME_IMPL
 static PandasDateTime_CAPI *PandasDateTimeAPI = NULL;
 
-#define PandasDateTime_IMPORT                                                  \
-  PandasDateTimeAPI =                                                          \
-      (PandasDateTime_CAPI *)PyCapsule_Import(PandasDateTime_CAPSULE_NAME, 0)
+#  define PandasDateTime_IMPORT                                                \
+    PandasDateTimeAPI = (PandasDateTime_CAPI *)PyCapsule_Import(               \
+        PandasDateTime_CAPSULE_NAME, 0)
 
-#define npy_datetimestruct_to_datetime(NPY_DATETIMEUNIT, npy_datetimestruct)   \
-  PandasDateTimeAPI->npy_datetimestruct_to_datetime((NPY_DATETIMEUNIT),        \
-                                                    (npy_datetimestruct))
-#define scaleNanosecToUnit(value, unit)                                        \
-  PandasDateTimeAPI->scaleNanosecToUnit((value), (unit))
-#define int64ToIso(value, valueUnit, base, len)                                \
-  PandasDateTimeAPI->int64ToIso((value), (valueUnit), (base), (len))
-#define NpyDateTimeToEpoch(dt, base)                                           \
-  PandasDateTimeAPI->NpyDateTimeToEpoch((dt), (base))
-#define PyDateTimeToIso(obj, base, len)                                        \
-  PandasDateTimeAPI->PyDateTimeToIso((obj), (base), (len))
-#define PyDateTimeToEpoch(dt, base)                                            \
-  PandasDateTimeAPI->PyDateTimeToEpoch((dt), (base))
-#define int64ToIsoDuration(value, len)                                         \
-  PandasDateTimeAPI->int64ToIsoDuration((value), (len))
-#define pandas_datetime_to_datetimestruct(dt, base, out)                       \
-  PandasDateTimeAPI->pandas_datetime_to_datetimestruct((dt), (base), (out))
-#define pandas_timedelta_to_timedeltastruct(td, base, out)                     \
-  PandasDateTimeAPI->pandas_timedelta_to_timedeltastruct((td), (base), (out))
-#define convert_pydatetime_to_datetimestruct(dtobj, out)                       \
-  PandasDateTimeAPI->convert_pydatetime_to_datetimestruct((dtobj), (out))
-#define cmp_npy_datetimestruct(a, b)                                           \
-  PandasDateTimeAPI->cmp_npy_datetimestruct((a), (b))
-#define get_datetime_metadata_from_dtype(dtype)                                \
-  PandasDateTimeAPI->get_datetime_metadata_from_dtype((dtype))
-#define parse_iso_8601_datetime(str, len, want_exc, out, out_bestunit,         \
-                                out_local, out_tzoffset, format, format_len,   \
-                                format_requirement)                            \
-  PandasDateTimeAPI->parse_iso_8601_datetime(                                  \
-      (str), (len), (want_exc), (out), (out_bestunit), (out_local),            \
-      (out_tzoffset), (format), (format_len), (format_requirement))
-#define get_datetime_iso_8601_strlen(local, base)                              \
-  PandasDateTimeAPI->get_datetime_iso_8601_strlen((local), (base))
-#define make_iso_8601_datetime(dts, outstr, outlen, utc, base)                 \
-  PandasDateTimeAPI->make_iso_8601_datetime((dts), (outstr), (outlen), (utc),  \
-                                            (base))
-#define make_iso_8601_timedelta(tds, outstr, outlen)                           \
-  PandasDateTimeAPI->make_iso_8601_timedelta((tds), (outstr), (outlen))
+#  define npy_datetimestruct_to_datetime(NPY_DATETIMEUNIT, npy_datetimestruct) \
+    PandasDateTimeAPI->npy_datetimestruct_to_datetime((NPY_DATETIMEUNIT),      \
+                                                      (npy_datetimestruct))
+#  define scaleNanosecToUnit(value, unit)                                      \
+    PandasDateTimeAPI->scaleNanosecToUnit((value), (unit))
+#  define int64ToIso(value, valueUnit, base, len)                              \
+    PandasDateTimeAPI->int64ToIso((value), (valueUnit), (base), (len))
+#  define NpyDateTimeToEpoch(dt, base)                                         \
+    PandasDateTimeAPI->NpyDateTimeToEpoch((dt), (base))
+#  define PyDateTimeToIso(obj, base, len)                                      \
+    PandasDateTimeAPI->PyDateTimeToIso((obj), (base), (len))
+#  define PyDateTimeToEpoch(dt, base)                                          \
+    PandasDateTimeAPI->PyDateTimeToEpoch((dt), (base))
+#  define int64ToIsoDuration(value, len)                                       \
+    PandasDateTimeAPI->int64ToIsoDuration((value), (len))
+#  define pandas_datetime_to_datetimestruct(dt, base, out)                     \
+    PandasDateTimeAPI->pandas_datetime_to_datetimestruct((dt), (base), (out))
+#  define pandas_timedelta_to_timedeltastruct(td, base, out)                   \
+    PandasDateTimeAPI->pandas_timedelta_to_timedeltastruct((td), (base), (out))
+#  define convert_pydatetime_to_datetimestruct(dtobj, out)                     \
+    PandasDateTimeAPI->convert_pydatetime_to_datetimestruct((dtobj), (out))
+#  define cmp_npy_datetimestruct(a, b)                                         \
+    PandasDateTimeAPI->cmp_npy_datetimestruct((a), (b))
+#  define get_datetime_metadata_from_dtype(dtype)                              \
+    PandasDateTimeAPI->get_datetime_metadata_from_dtype((dtype))
+#  define parse_iso_8601_datetime(str, len, want_exc, out, out_bestunit,       \
+                                  out_local, out_tzoffset, format, format_len, \
+                                  format_requirement)                          \
+    PandasDateTimeAPI->parse_iso_8601_datetime(                                \
+        (str), (len), (want_exc), (out), (out_bestunit), (out_local),          \
+        (out_tzoffset), (format), (format_len), (format_requirement))
+#  define get_datetime_iso_8601_strlen(local, base)                            \
+    PandasDateTimeAPI->get_datetime_iso_8601_strlen((local), (base))
+#  define make_iso_8601_datetime(dts, outstr, outlen, utc, base)               \
+    PandasDateTimeAPI->make_iso_8601_datetime((dts), (outstr), (outlen),       \
+                                              (utc), (base))
+#  define make_iso_8601_timedelta(tds, outstr, outlen)                         \
+    PandasDateTimeAPI->make_iso_8601_timedelta((tds), (outstr), (outlen))
 #endif /* !defined(_PANDAS_DATETIME_IMPL) */
 
 #ifdef __cplusplus

--- a/pandas/_libs/include/pandas/parser/pd_parser.h
+++ b/pandas/_libs/include/pandas/parser/pd_parser.h
@@ -52,55 +52,56 @@ typedef struct {
 #ifndef _PANDAS_PARSER_IMPL
 static PandasParser_CAPI *PandasParserAPI = NULL;
 
-#define PandasParser_IMPORT                                                    \
-  PandasParserAPI =                                                            \
-      (PandasParser_CAPI *)PyCapsule_Import(PandasParser_CAPSULE_NAME, 0)
+#  define PandasParser_IMPORT                                                  \
+    PandasParserAPI =                                                          \
+        (PandasParser_CAPI *)PyCapsule_Import(PandasParser_CAPSULE_NAME, 0)
 
-#define to_double(item, p_value, sci, decimal, maybe_int)                      \
-  PandasParserAPI->to_double((item), (p_value), (sci), (decimal), (maybe_int))
-#define floatify(str, result, maybe_int)                                       \
-  PandasParserAPI->floatify((str), (result), (maybe_int))
-#define new_rd_source(obj) PandasParserAPI->new_rd_source((obj))
-#define del_rd_source(src) PandasParserAPI->del_rd_source((src))
-#define buffer_rd_bytes(source, nbytes, bytes_read, status, encoding_errors)   \
-  PandasParserAPI->buffer_rd_bytes((source), (nbytes), (bytes_read), (status), \
-                                   (encoding_errors))
-#define uint_state_init(self) PandasParserAPI->uint_state_init((self))
-#define uint64_conflict(self) PandasParserAPI->uint64_conflict((self))
-#define coliter_setup(self, parser, i, start)                                  \
-  PandasParserAPI->coliter_setup((self), (parser), (i), (start))
-#define parser_new PandasParserAPI->parser_new
-#define parser_init(self) PandasParserAPI->parser_init((self))
-#define parser_free(self) PandasParserAPI->parser_free((self))
-#define parser_del(self) PandasParserAPI->parser_del((self))
-#define parser_add_skiprow(self, row)                                          \
-  PandasParserAPI->parser_add_skiprow((self), (row))
-#define parser_set_skipfirstnrows(self, nrows)                                 \
-  PandasParserAPI->parser_set_skipfirstnrows((self), (nrows))
-#define parser_set_default_options(self)                                       \
-  PandasParserAPI->parser_set_default_options((self))
-#define parser_consume_rows(self, nrows)                                       \
-  PandasParserAPI->parser_consume_rows((self), (nrows))
-#define parser_trim_buffers(self) PandasParserAPI->parser_trim_buffers((self))
-#define tokenize_all_rows(self, encoding_errors)                               \
-  PandasParserAPI->tokenize_all_rows((self), (encoding_errors))
-#define tokenize_nrows(self, nrows, encoding_errors)                           \
-  PandasParserAPI->tokenize_nrows((self), (nrows), (encoding_errors))
-#define str_to_int64(p_item, error, t_sep)                                     \
-  PandasParserAPI->str_to_int64((p_item), (error), (t_sep))
-#define str_to_uint64(state, p_item, error, t_sep)                             \
-  PandasParserAPI->str_to_uint64((state), (p_item), (error), (t_sep))
-#define xstrtod(p, q, decimal, sci, tsep, skip_trailing, error, maybe_int)     \
-  PandasParserAPI->xstrtod((p), (q), (decimal), (sci), (tsep),                 \
-                           (skip_trailing), (error), (maybe_int))
-#define precise_xstrtod(p, q, decimal, sci, tsep, skip_trailing, error,        \
-                        maybe_int)                                             \
-  PandasParserAPI->precise_xstrtod((p), (q), (decimal), (sci), (tsep),         \
-                                   (skip_trailing), (error), (maybe_int))
-#define round_trip(p, q, decimal, sci, tsep, skip_trailing, error, maybe_int)  \
-  PandasParserAPI->round_trip((p), (q), (decimal), (sci), (tsep),              \
-                              (skip_trailing), (error), (maybe_int))
-#define to_boolean(item, val) PandasParserAPI->to_boolean((item), (val))
+#  define to_double(item, p_value, sci, decimal, maybe_int)                    \
+    PandasParserAPI->to_double((item), (p_value), (sci), (decimal), (maybe_int))
+#  define floatify(str, result, maybe_int)                                     \
+    PandasParserAPI->floatify((str), (result), (maybe_int))
+#  define new_rd_source(obj) PandasParserAPI->new_rd_source((obj))
+#  define del_rd_source(src) PandasParserAPI->del_rd_source((src))
+#  define buffer_rd_bytes(source, nbytes, bytes_read, status, encoding_errors) \
+    PandasParserAPI->buffer_rd_bytes((source), (nbytes), (bytes_read),         \
+                                     (status), (encoding_errors))
+#  define uint_state_init(self) PandasParserAPI->uint_state_init((self))
+#  define uint64_conflict(self) PandasParserAPI->uint64_conflict((self))
+#  define coliter_setup(self, parser, i, start)                                \
+    PandasParserAPI->coliter_setup((self), (parser), (i), (start))
+#  define parser_new PandasParserAPI->parser_new
+#  define parser_init(self) PandasParserAPI->parser_init((self))
+#  define parser_free(self) PandasParserAPI->parser_free((self))
+#  define parser_del(self) PandasParserAPI->parser_del((self))
+#  define parser_add_skiprow(self, row)                                        \
+    PandasParserAPI->parser_add_skiprow((self), (row))
+#  define parser_set_skipfirstnrows(self, nrows)                               \
+    PandasParserAPI->parser_set_skipfirstnrows((self), (nrows))
+#  define parser_set_default_options(self)                                     \
+    PandasParserAPI->parser_set_default_options((self))
+#  define parser_consume_rows(self, nrows)                                     \
+    PandasParserAPI->parser_consume_rows((self), (nrows))
+#  define parser_trim_buffers(self) PandasParserAPI->parser_trim_buffers((self))
+#  define tokenize_all_rows(self, encoding_errors)                             \
+    PandasParserAPI->tokenize_all_rows((self), (encoding_errors))
+#  define tokenize_nrows(self, nrows, encoding_errors)                         \
+    PandasParserAPI->tokenize_nrows((self), (nrows), (encoding_errors))
+#  define str_to_int64(p_item, error, t_sep)                                   \
+    PandasParserAPI->str_to_int64((p_item), (error), (t_sep))
+#  define str_to_uint64(state, p_item, error, t_sep)                           \
+    PandasParserAPI->str_to_uint64((state), (p_item), (error), (t_sep))
+#  define xstrtod(p, q, decimal, sci, tsep, skip_trailing, error, maybe_int)   \
+    PandasParserAPI->xstrtod((p), (q), (decimal), (sci), (tsep),               \
+                             (skip_trailing), (error), (maybe_int))
+#  define precise_xstrtod(p, q, decimal, sci, tsep, skip_trailing, error,      \
+                          maybe_int)                                           \
+    PandasParserAPI->precise_xstrtod((p), (q), (decimal), (sci), (tsep),       \
+                                     (skip_trailing), (error), (maybe_int))
+#  define round_trip(p, q, decimal, sci, tsep, skip_trailing, error,           \
+                     maybe_int)                                                \
+    PandasParserAPI->round_trip((p), (q), (decimal), (sci), (tsep),            \
+                                (skip_trailing), (error), (maybe_int))
+#  define to_boolean(item, val) PandasParserAPI->to_boolean((item), (val))
 #endif /* !defined(_PANDAS_PARSER_IMPL) */
 
 #ifdef __cplusplus

--- a/pandas/_libs/include/pandas/parser/tokenizer.h
+++ b/pandas/_libs/include/pandas/parser/tokenizer.h
@@ -38,9 +38,9 @@ See LICENSE for the license
 
 // #define VERBOSE
 #if defined(VERBOSE)
-#define TRACE(X) printf X;
+#  define TRACE(X) printf X;
 #else
-#define TRACE(X)
+#  define TRACE(X)
 #endif // VERBOSE
 
 #define PARSER_OUT_OF_MEMORY -1

--- a/pandas/_libs/include/pandas/portable.h
+++ b/pandas/_libs/include/pandas/portable.h
@@ -12,7 +12,7 @@ The full license is in the LICENSE file, distributed with this software.
 #include <string.h>
 
 #if defined(_MSC_VER)
-#define strcasecmp(s1, s2) _stricmp(s1, s2)
+#  define strcasecmp(s1, s2) _stricmp(s1, s2)
 #endif
 
 // GH-23516 - works around locale perf issues
@@ -25,60 +25,60 @@ The full license is in the LICENSE file, distributed with this software.
 #define tolower_ascii(c) ((((unsigned)(c) - 'A') < 26) ? ((c) | 0x20) : (c))
 
 #if defined(_WIN32)
-#define PD_FALLTHROUGH                                                         \
-  do {                                                                         \
-  } while (0) /* fallthrough */
+#  define PD_FALLTHROUGH                                                       \
+    do {                                                                       \
+    } while (0) /* fallthrough */
 #elif __has_attribute(__fallthrough__)
-#define PD_FALLTHROUGH __attribute__((__fallthrough__))
+#  define PD_FALLTHROUGH __attribute__((__fallthrough__))
 #else
-#define PD_FALLTHROUGH                                                         \
-  do {                                                                         \
-  } while (0) /* fallthrough */
+#  define PD_FALLTHROUGH                                                       \
+    do {                                                                       \
+    } while (0) /* fallthrough */
 #endif
 
 #if defined(_WIN32)
-#ifndef ENABLE_INTSAFE_SIGNED_FUNCTIONS
-#define ENABLE_INTSAFE_SIGNED_FUNCTIONS
-#endif
-#include <intsafe.h>
-#define checked_add(a, b, res)                                                 \
-  _Generic((res),                                                              \
-      int *: IntAdd,                                                           \
-      unsigned int *: UIntAdd,                                                 \
-      long *: LongAdd,                                                         \
-      unsigned long *: ULongAdd,                                               \
-      long long *: LongLongAdd,                                                \
-      unsigned long long *: ULongLongAdd,                                      \
-      short *: ShortAdd,                                                       \
-      unsigned short *: UShortAdd)(a, b, res)
+#  ifndef ENABLE_INTSAFE_SIGNED_FUNCTIONS
+#    define ENABLE_INTSAFE_SIGNED_FUNCTIONS
+#  endif
+#  include <intsafe.h>
+#  define checked_add(a, b, res)                                               \
+    _Generic((res),                                                            \
+        int *: IntAdd,                                                         \
+        unsigned int *: UIntAdd,                                               \
+        long *: LongAdd,                                                       \
+        unsigned long *: ULongAdd,                                             \
+        long long *: LongLongAdd,                                              \
+        unsigned long long *: ULongLongAdd,                                    \
+        short *: ShortAdd,                                                     \
+        unsigned short *: UShortAdd)(a, b, res)
 
-#define checked_sub(a, b, res)                                                 \
-  _Generic((res),                                                              \
-      int *: IntSub,                                                           \
-      unsigned int *: UIntSub,                                                 \
-      long *: LongSub,                                                         \
-      unsigned long *: ULongSub,                                               \
-      long long *: LongLongSub,                                                \
-      unsigned long long *: ULongLongSub,                                      \
-      short *: ShortSub,                                                       \
-      unsigned short *: UShortSub)(a, b, res)
+#  define checked_sub(a, b, res)                                               \
+    _Generic((res),                                                            \
+        int *: IntSub,                                                         \
+        unsigned int *: UIntSub,                                               \
+        long *: LongSub,                                                       \
+        unsigned long *: ULongSub,                                             \
+        long long *: LongLongSub,                                              \
+        unsigned long long *: ULongLongSub,                                    \
+        short *: ShortSub,                                                     \
+        unsigned short *: UShortSub)(a, b, res)
 
-#define checked_mul(a, b, res)                                                 \
-  _Generic((res),                                                              \
-      int *: IntMult,                                                          \
-      unsigned int *: UIntMult,                                                \
-      long *: LongMult,                                                        \
-      unsigned long *: ULongMult,                                              \
-      long long *: LongLongMult,                                               \
-      unsigned long long *: ULongLongMult,                                     \
-      short *: ShortMult,                                                      \
-      unsigned short *: UShortMult)(a, b, res)
+#  define checked_mul(a, b, res)                                               \
+    _Generic((res),                                                            \
+        int *: IntMult,                                                        \
+        unsigned int *: UIntMult,                                              \
+        long *: LongMult,                                                      \
+        unsigned long *: ULongMult,                                            \
+        long long *: LongLongMult,                                             \
+        unsigned long long *: ULongLongMult,                                   \
+        short *: ShortMult,                                                    \
+        unsigned short *: UShortMult)(a, b, res)
 
 #elif (defined(__has_builtin) && __has_builtin(__builtin_add_overflow)) ||     \
     __GNUC__ > 7
-#define checked_add(a, b, res) __builtin_add_overflow(a, b, res)
-#define checked_sub(a, b, res) __builtin_sub_overflow(a, b, res)
-#define checked_mul(a, b, res) __builtin_mul_overflow(a, b, res)
+#  define checked_add(a, b, res) __builtin_add_overflow(a, b, res)
+#  define checked_sub(a, b, res) __builtin_sub_overflow(a, b, res)
+#  define checked_mul(a, b, res) __builtin_mul_overflow(a, b, res)
 #else
 _Static_assert(0,
                "Overflow checking not detected; please try a newer compiler");

--- a/pandas/_libs/include/pandas/vendored/klib/khash.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash.h
@@ -91,19 +91,19 @@ int main() {
 
 // hooks for memory allocator, C-runtime allocator used per default
 #ifndef KHASH_MALLOC
-#define KHASH_MALLOC malloc
+#  define KHASH_MALLOC malloc
 #endif
 
 #ifndef KHASH_REALLOC
-#define KHASH_REALLOC realloc
+#  define KHASH_REALLOC realloc
 #endif
 
 #ifndef KHASH_CALLOC
-#define KHASH_CALLOC calloc
+#  define KHASH_CALLOC calloc
 #endif
 
 #ifndef KHASH_FREE
-#define KHASH_FREE free
+#  define KHASH_FREE free
 #endif
 
 #if UINT_MAX == 0xffffffffu
@@ -227,17 +227,17 @@ static inline khuint32_t murmur2_64to32(khuint64_t k) {
 }
 
 #ifdef KHASH_LINEAR
-#define __ac_inc(k, m) 1
+#  define __ac_inc(k, m) 1
 #else
-#define __ac_inc(k, m) (murmur2_32to32(k) | 1) & (m)
+#  define __ac_inc(k, m) (murmur2_32to32(k) | 1) & (m)
 #endif
 
 #define __ac_fsize(m) ((m) < 32 ? 1 : (m) >> 5)
 
 #ifndef kroundup32
-#define kroundup32(x)                                                          \
-  (--(x), (x) |= (x) >> 1, (x) |= (x) >> 2, (x) |= (x) >> 4, (x) |= (x) >> 8,  \
-   (x) |= (x) >> 16, ++(x))
+#  define kroundup32(x)                                                        \
+    (--(x), (x) |= (x) >> 1, (x) |= (x) >> 2, (x) |= (x) >> 4,                 \
+     (x) |= (x) >> 8, (x) |= (x) >> 16, ++(x))
 #endif
 
 static const double __ac_HASH_UPPER = 0.77;

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -254,17 +254,17 @@ static inline khuint32_t kh_python_hash_func(PyObject *key);
 // we could use any hashing algorithm, this is the original CPython's for tuples
 
 #if SIZEOF_PY_UHASH_T > 4
-#define _PandasHASH_XXPRIME_1 ((Py_uhash_t)11400714785074694791ULL)
-#define _PandasHASH_XXPRIME_2 ((Py_uhash_t)14029467366897019727ULL)
-#define _PandasHASH_XXPRIME_5 ((Py_uhash_t)2870177450012600261ULL)
-#define _PandasHASH_XXROTATE(x)                                                \
-  ((x << 31) | (x >> 33)) /* Rotate left 31 bits */
+#  define _PandasHASH_XXPRIME_1 ((Py_uhash_t)11400714785074694791ULL)
+#  define _PandasHASH_XXPRIME_2 ((Py_uhash_t)14029467366897019727ULL)
+#  define _PandasHASH_XXPRIME_5 ((Py_uhash_t)2870177450012600261ULL)
+#  define _PandasHASH_XXROTATE(x)                                              \
+    ((x << 31) | (x >> 33)) /* Rotate left 31 bits */
 #else
-#define _PandasHASH_XXPRIME_1 ((Py_uhash_t)2654435761UL)
-#define _PandasHASH_XXPRIME_2 ((Py_uhash_t)2246822519UL)
-#define _PandasHASH_XXPRIME_5 ((Py_uhash_t)374761393UL)
-#define _PandasHASH_XXROTATE(x)                                                \
-  ((x << 13) | (x >> 19)) /* Rotate left 13 bits */
+#  define _PandasHASH_XXPRIME_1 ((Py_uhash_t)2654435761UL)
+#  define _PandasHASH_XXPRIME_2 ((Py_uhash_t)2246822519UL)
+#  define _PandasHASH_XXPRIME_5 ((Py_uhash_t)374761393UL)
+#  define _PandasHASH_XXROTATE(x)                                              \
+    ((x << 13) | (x >> 19)) /* Rotate left 13 bits */
 #endif
 
 static inline Py_hash_t tupleobject_hash(PyTupleObject *key) {

--- a/pandas/_libs/include/pandas/vendored/numpy/datetime/np_datetime.h
+++ b/pandas/_libs/include/pandas/vendored/numpy/datetime/np_datetime.h
@@ -17,7 +17,7 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 #pragma once
 
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif // NPY_NO_DEPRECATED_API
 
 #include <numpy/ndarraytypes.h>

--- a/pandas/_libs/include/pandas/vendored/numpy/datetime/np_datetime_strings.h
+++ b/pandas/_libs/include/pandas/vendored/numpy/datetime/np_datetime_strings.h
@@ -22,7 +22,7 @@ This file implements string parsing and creation for NumPy datetime.
 #pragma once
 
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif // NPY_NO_DEPRECATED_API
 
 /* 'format_requirement' can be one of three values:

--- a/pandas/_libs/include/pandas/vendored/ujson/lib/ultrajson.h
+++ b/pandas/_libs/include/pandas/vendored/ujson/lib/ultrajson.h
@@ -61,24 +61,24 @@ tree doesn't have cyclic references.
 
 // Max decimals to encode double floating point numbers with
 #ifndef JSON_DOUBLE_MAX_DECIMALS
-#define JSON_DOUBLE_MAX_DECIMALS 15
+#  define JSON_DOUBLE_MAX_DECIMALS 15
 #endif
 
 // Max recursion depth, default for encoder
 #ifndef JSON_MAX_RECURSION_DEPTH
-#define JSON_MAX_RECURSION_DEPTH 1024
+#  define JSON_MAX_RECURSION_DEPTH 1024
 #endif
 
 // Max recursion depth, default for decoder
 #ifndef JSON_MAX_OBJECT_DEPTH
-#define JSON_MAX_OBJECT_DEPTH 1024
+#  define JSON_MAX_OBJECT_DEPTH 1024
 #endif
 
 /*
 Dictates and limits how much stack space for buffers UltraJSON will use before
 resorting to provided heap functions */
 #ifndef JSON_MAX_STACK_BUFFER_SIZE
-#define JSON_MAX_STACK_BUFFER_SIZE 131072
+#  define JSON_MAX_STACK_BUFFER_SIZE 131072
 #endif
 
 #ifdef _WIN32
@@ -93,24 +93,24 @@ typedef unsigned __int16 JSUTF16;
 typedef unsigned __int32 JSUTF32;
 typedef __int64 JSLONG;
 
-#define EXPORTFUNCTION __declspec(dllexport)
+#  define EXPORTFUNCTION __declspec(dllexport)
 
-#define FASTCALL_MSVC __fastcall
+#  define FASTCALL_MSVC __fastcall
 
-#define INLINE_PREFIX static __inline
+#  define INLINE_PREFIX static __inline
 
 #else
 
-#include <stdint.h>
+#  include <stdint.h>
 typedef int64_t JSINT64;
 typedef uint64_t JSUINT64;
 
 typedef int32_t JSINT32;
 typedef uint32_t JSUINT32;
 
-#define FASTCALL_MSVC
+#  define FASTCALL_MSVC
 
-#define INLINE_PREFIX static inline
+#  define INLINE_PREFIX static inline
 
 typedef uint8_t JSUINT8;
 typedef uint16_t JSUTF16;
@@ -118,25 +118,25 @@ typedef uint32_t JSUTF32;
 
 typedef int64_t JSLONG;
 
-#define EXPORTFUNCTION
+#  define EXPORTFUNCTION
 #endif
 
 #if !(defined(__LITTLE_ENDIAN__) || defined(__BIG_ENDIAN__))
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define __LITTLE_ENDIAN__
-#else
+#  if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#    define __LITTLE_ENDIAN__
+#  else
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define __BIG_ENDIAN__
-#endif
+#    if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#      define __BIG_ENDIAN__
+#    endif
 
-#endif
+#  endif
 
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
-#error "Endianness not supported"
+#  error "Endianness not supported"
 #endif
 
 enum JSTYPES {

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -17,7 +17,7 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 // Licence at LICENSES/NUMPY_LICENSE
 
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif // NPY_NO_DEPRECATED_API
 
 #include "pandas/vendored/numpy/datetime/np_datetime.h"
@@ -830,7 +830,7 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta td,
 PyArray_DatetimeMetaData
 get_datetime_metadata_from_dtype(PyArray_Descr *dtype) {
 #if NPY_ABI_VERSION < 0x02000000
-#define PyDataType_C_METADATA(dtype) ((dtype)->c_metadata)
+#  define PyDataType_C_METADATA(dtype) ((dtype)->c_metadata)
 #endif
   return ((PyArray_DatetimeDTypeMetaData *)PyDataType_C_METADATA(dtype))->meta;
 }

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
@@ -25,7 +25,7 @@ This file implements string parsing and creation for NumPy datetime.
 #define NO_IMPORT
 
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif // NPY_NO_DEPRECATED_API
 
 #include <Python.h>

--- a/pandas/_libs/src/vendored/ujson/lib/ultrajsondec.c
+++ b/pandas/_libs/src/vendored/ujson/lib/ultrajsondec.c
@@ -50,11 +50,11 @@ https://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #include <wchar.h>
 
 #ifndef TRUE
-#define TRUE 1
-#define FALSE 0
+#  define TRUE 1
+#  define FALSE 0
 #endif
 #ifndef NULL
-#define NULL 0
+#  define NULL 0
 #endif
 
 struct DecoderState {

--- a/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
@@ -50,10 +50,10 @@ https://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #include <string.h>
 
 #ifndef TRUE
-#define TRUE 1
+#  define TRUE 1
 #endif
 #ifndef FALSE
-#define FALSE 0
+#  define FALSE 0
 #endif
 
 /*


### PR DESCRIPTION
Add IndentPPDirectives: AfterHash to clang-format configuration.
This makes preprocessor directives easier to read by indenting after the `#`, similar to what the Arrow project does.
Changes:
- Add .clang-format configuration file with IndentPPDirectives: AfterHash
- Apply formatting to all C/C++ source files in pandas/_libs/src and pandas/_libs/include

- [x] closes #62693 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
