### PR TITLE
DOC: improve '10 minutes to pandas' Merge section with join example

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -463,6 +463,10 @@ code snippet below. See more at :ref:`Vectorized String Methods
 
 Merge
 -----
+pandas provides various facilities for combining :class:`Series` and :class:`DataFrame` objects. This includes set-logic for combining indexes and relational algebra functionality for SQL-style join or merge operations.
+
+   * **Concatenation**: Stacks objects along a particular axis using :func:`concat`.
+   * **Database-style joining**: Merges objects based on common keys using :func:`merge`.
 
 Concat
 ~~~~~~
@@ -515,6 +519,14 @@ Join
    left
    right
    pd.merge(left, right, on="key")
+
+:func:`merge` with a left join to preserve all keys from the left :class:`DataFrame`, even if they don't have a match in the right :class:`DataFrame`:
+
+.. ipython:: python
+
+   left = pd.DataFrame({"name": ["Alice", "Bob", "Charlie"], "id": [1, 2, 3]})
+   right = pd.DataFrame({"id": [1, 2, 4], "score": [95, 88, 70]})
+   pd.merge(left, right, on="id", how="left")
 
 Grouping
 --------


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Description
This PR improves the '10 minutes to pandas' guide by clarifying the distinction between concatenation and merging. 

### Motivation
The existing 'foo/bar' examples in this section are tightly coupled to a continuous operation flow. To avoid disrupting this sequence or introducing side effects for subsequent code blocks, I have added a **self-contained** example using a 'Student Scores' scenario. 

This provides two key improvements:
1. **Isolated Logic**: By re-defining the DataFrames within the block, users can experiment with the code independently.
2. **Concept Clarity**: It introduces the `how="left"` parameter and demonstrates explicit `NaN` handling for missing keys—a critical real-world concept that was previously missing from this high-level guide.