### PR TITLE
DOC: Add See Also links to User Guide in API reference

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -9,6 +9,10 @@ DataFrame
 
 Constructor
 ~~~~~~~~~~~
+
+.. note::
+
+   For an introduction to DataFrame, see the :ref:`User Guide <basics.dataframe>`.
 .. autosummary::
    :toctree: api/
 

--- a/doc/source/reference/groupby.rst
+++ b/doc/source/reference/groupby.rst
@@ -11,6 +11,10 @@ GroupBy
 instances are returned by groupby calls :func:`pandas.DataFrame.groupby` and
 :func:`pandas.Series.groupby` respectively.
 
+.. note::
+
+   For more information on GroupBy, see the :ref:`User Guide <groupby>`.
+
 Indexing, iteration
 -------------------
 .. autosummary::

--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -10,6 +10,10 @@ Index
 -----
 .. currentmodule:: pandas
 
+.. note::
+
+   For more information on indexing, see the :ref:`User Guide <indexing>`.
+
 **Many of these methods or variants thereof are available on the objects
 that contain an index (Series/DataFrame) and those should most likely be
 used before calling these methods directly.**

--- a/doc/source/reference/io.rst
+++ b/doc/source/reference/io.rst
@@ -7,6 +7,10 @@ Input/output
 ============
 .. currentmodule:: pandas
 
+.. note::
+
+   For more information on IO tools, see the :ref:`User Guide <io>`.
+
 Pickling
 ~~~~~~~~
 .. autosummary::

--- a/doc/source/reference/missing_value.rst
+++ b/doc/source/reference/missing_value.rst
@@ -7,6 +7,10 @@ Missing values
 ==============
 .. currentmodule:: pandas
 
+.. note::
+
+   For more information on missing data, see the :ref:`User Guide <missing_data>`.
+
 NA is the way to represent missing values for nullable dtypes (see below):
 
 .. autosummary::

--- a/doc/source/reference/plotting.rst
+++ b/doc/source/reference/plotting.rst
@@ -7,6 +7,10 @@ Plotting
 ========
 .. currentmodule:: pandas.plotting
 
+.. note::
+
+   For more information on plotting, see the :ref:`User Guide <visualization>`.
+
 The following functions are contained in the ``pandas.plotting`` module.
 
 .. autosummary::

--- a/doc/source/reference/resampling.rst
+++ b/doc/source/reference/resampling.rst
@@ -7,6 +7,10 @@ Resampling
 ==========
 .. currentmodule:: pandas.api.typing
 
+.. note::
+
+   For more information on resampling, see the :ref:`User Guide <timeseries>`.
+
 :class:`pandas.api.typing.Resampler` instances are returned by
 resample calls: :func:`pandas.DataFrame.resample`, :func:`pandas.Series.resample`.
 

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -9,6 +9,10 @@ Series
 
 Constructor
 -----------
+
+.. note::
+
+   For an introduction to Series, see the :ref:`User Guide <basics.series>`.
 .. autosummary::
    :toctree: api/
 

--- a/doc/source/reference/style.rst
+++ b/doc/source/reference/style.rst
@@ -7,6 +7,10 @@ Style
 =====
 .. currentmodule:: pandas.io.formats.style
 
+.. note::
+
+   For more information on styling, see the :ref:`User Guide <style>`.
+
 ``Styler`` objects are returned by :attr:`pandas.DataFrame.style`.
 
 Styler constructor

--- a/doc/source/reference/window.rst
+++ b/doc/source/reference/window.rst
@@ -6,6 +6,10 @@
 Window
 ======
 
+.. note::
+
+   For more information on window functions, see the :ref:`User Guide <window>`.
+
 :class:`pandas.api.typing.Rolling` instances are returned by ``.rolling`` calls:
 :func:`pandas.DataFrame.rolling` and :func:`pandas.Series.rolling`.
 :class:`pandas.api.typing.Expanding` instances are returned by ``.expanding`` calls:


### PR DESCRIPTION
Closes #62357. Adds .. note:: blocks linking to relevant User Guide sections in the following API reference pages: Series, DataFrame, Indexing, GroupBy, IO, Window, Plotting, Missing Data, Resampling, and Style.