### PR TITLE
DOC: Fix SA01,ES01,PR07 for pandas.util.hash_pandas_object

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -278,8 +278,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.YearEnd.is_on_offset GL08" \
         -i "pandas.tseries.offsets.YearEnd.month GL08" \
         -i "pandas.tseries.offsets.YearEnd.n GL08" \
-        -i "pandas.tseries.offsets.YearEnd.normalize GL08" \
-        -i "pandas.util.hash_pandas_object PR07,SA01" # There should be no backslash in the final line, please keep this comment in the last ignored function
+        -i "pandas.tseries.offsets.YearEnd.normalize GL08" # There should be no backslash in the final line, please keep this comment in the last ignored function
 
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -91,9 +91,13 @@ def hash_pandas_object(
     """
     Return a data hash of the Index/Series/DataFrame.
 
+    The hash is computed element-wise using the underlying data values,
+    and optionally includes the index when hashing a Series or DataFrame.
+
     Parameters
     ----------
     obj : Index, Series, or DataFrame
+        The pandas object to hash.
     index : bool, default True
         Include the index in the hash (if Series/DataFrame).
     encoding : str, default 'utf8'
@@ -108,6 +112,11 @@ def hash_pandas_object(
     -------
     Series of uint64
         Same length as the object.
+
+    See Also
+    --------
+    util.hash_array : Return a hash of the given array.
+    util.hash_tuples : Hash a MultiIndex or listlike-of-tuples efficiently.
 
     Examples
     --------


### PR DESCRIPTION
- [ ] closes #63553

Fixes

```
pandas.util.hash_pandas_object PR07,SA01
```

The changes I made to `pandas/core/util/hashing.py`:

- Added extended summary: "The hash is computed element-wise using the underlying data values, and optionally includes the index when hashing a Series or DataFrame."
- Added description for obj parameter: "The pandas object to hash."
- Added See Also section referencing util.hash_array and util.hash_tuples
