### PR TITLE
DOC: Fix SA01 for pandas.StringDtype.na_value

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -82,7 +82,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.typing.SeriesGroupBy.plot PR02" \
         -i "pandas.api.typing.Resampler.quantile PR01,PR07" \
         -i "pandas.StringDtype.storage SA01" \
-        -i "pandas.StringDtype.na_value SA01" \
         -i "pandas.tseries.offsets.BDay PR02,SA01" \
         -i "pandas.tseries.offsets.BHalfYearBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BHalfYearBegin.n GL08" \

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -157,6 +157,11 @@ class StringDtype(StorageExtensionDtype):
         Returns ``np.nan`` for the default string dtype with NumPy semantics,
         and ``pd.NA`` for the opt-in string dtype with pandas NA semantics.
 
+        See Also
+        --------
+        isna : Detect missing values.
+        NA : Missing value indicator for nullable dtypes.
+
         Examples
         --------
         >>> ser = pd.Series(["a", "b"])


### PR DESCRIPTION
- [ ] closes #63555

Fixes

```
pandas.StringDtype.na_value SA01
```

Added references:
- isna : Detect missing values
- NA : Missing value indicator for nullable dtypes


