### PR TITLE
BUG: Arrow-backed duration/timestamp reductions return stdlib types for non-nanosecond units

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1401,6 +1401,7 @@ ExtensionArray
 - Bug in :meth:`ArrowExtensionArray.factorize` where NA values were dropped when input was dictionary-encoded even when dropna was set to False(:issue:`60567`)
 - Bug in :meth:`NDArrayBackedExtensionArray.take` which produced arrays whose dtypes didn't match their underlying data, when called with integer arrays (:issue:`62448`)
 - Bug in :meth:`api.types.is_datetime64_any_dtype` where a custom :class:`ExtensionDtype` would return ``False`` for array-likes (:issue:`57055`)
+- Bug in Arrow-backed duration and timestamp reductions (e.g. ``sum``, ``min``, ``max``, ``median``, ``mean``) incorrectly returning stdlib ``datetime`` objects instead of :class:`Timedelta` and :class:`Timestamp` for resolutions other than nanoseconds (:issue:`63170`)
 - Bug in comparison between object with :class:`ArrowDtype` and incompatible-dtyped (e.g. string vs bool) incorrectly raising instead of returning all-``False`` (for ``==``) or all-``True`` (for ``!=``) (:issue:`59505`)
 - Bug in constructing pandas data structures when passing into ``dtype`` a string of the type followed by ``[pyarrow]`` while PyArrow is not installed would raise ``NameError`` rather than ``ImportError`` (:issue:`57928`)
 - Bug in various :class:`DataFrame` reductions for pyarrow temporal dtypes returning incorrect dtype when result was null (:issue:`59234`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2152,7 +2152,11 @@ class ArrowExtensionArray(
         if pc.is_null(pa_result).as_py():
             return self.dtype.na_value
         elif isinstance(pa_result, pa.Scalar):
-            return pa_result.as_py()
+            result = pa_result.as_py()
+            pa_type = pa_result.type
+            if pa.types.is_duration(pa_type) and pa_type.unit != "ns":
+                return Timedelta(result).as_unit(pa_type.unit)
+            return result
         else:
             return pa_result
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2156,6 +2156,8 @@ class ArrowExtensionArray(
             pa_type = pa_result.type
             if pa.types.is_duration(pa_type) and pa_type.unit != "ns":
                 return Timedelta(result).as_unit(pa_type.unit)
+            elif pa.types.is_timestamp(pa_type) and pa_type.unit != "ns":
+                return Timestamp(result).as_unit(pa_type.unit)
             return result
         else:
             return pa_result

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3819,61 +3819,25 @@ def test_ufunc_retains_missing():
     tm.assert_series_equal(result, expected)
 
 
-def test_duration_reduction_consistency():
+@pytest.mark.parametrize("method", ["sum", "min", "max", "mean", "median"])
+def test_duration_reduction_consistency(unit, method):
     # GH#63170
-    for unit in ["ns", "us", "ms", "s"]:
-        dtype = f"duration[{unit}][pyarrow]"
-        ser = pd.Series([timedelta(seconds=1)], dtype=dtype)
-        result = ser.sum()
-        assert isinstance(result, pd.Timedelta), (
-            f"sum for {unit} returned {type(result)}"
-        )
-        assert result.unit == unit
-
-        result = ser.min()
-        assert isinstance(result, pd.Timedelta), (
-            f"min for {unit} returned {type(result)}"
-        )
-        assert result.unit == unit
-
-        result = ser.max()
-        assert isinstance(result, pd.Timedelta), (
-            f"max for {unit} returned {type(result)}"
-        )
-        assert result.unit == unit
-
-        result = ser.mean()
-        assert isinstance(result, pd.Timedelta), (
-            f"mean for {unit} returned {type(result)}"
-        )
-        assert result.unit == unit
-
-        result = ser.median()
-        assert isinstance(result, pd.Timedelta), (
-            f"median for {unit} returned {type(result)}"
-        )
-        assert result.unit == unit
+    dtype = f"duration[{unit}][pyarrow]"
+    ser = pd.Series([timedelta(seconds=1), timedelta(seconds=2)], dtype=dtype)
+    result = getattr(ser, method)()
+    assert isinstance(result, pd.Timedelta), (
+        f"{method} for {unit} returned {type(result)}"
+    )
+    assert result.unit == unit
 
 
-def test_timestamp_reduction_consistency():
+@pytest.mark.parametrize("method", ["min", "max", "median"])
+def test_timestamp_reduction_consistency(unit, method):
     # GH#63170
-    for unit in ["ns", "us", "ms", "s"]:
-        dtype = f"timestamp[{unit}][pyarrow]"
-        ser = pd.Series([datetime(2024, 1, 1), datetime(2024, 1, 3)], dtype=dtype)
-        result = ser.min()
-        assert isinstance(result, pd.Timestamp), (
-            f"min for {unit} returned {type(result)}"
-        )
-        assert result.unit == unit
-
-        result = ser.max()
-        assert isinstance(result, pd.Timestamp), (
-            f"max for {unit} returned {type(result)}"
-        )
-        assert result.unit == unit
-
-        result = ser.median()
-        assert isinstance(result, pd.Timestamp), (
-            f"median for {unit} returned {type(result)}"
-        )
-        assert result.unit == unit
+    dtype = f"timestamp[{unit}][pyarrow]"
+    ser = pd.Series([datetime(2024, 1, 1), datetime(2024, 1, 3)], dtype=dtype)
+    result = getattr(ser, method)()
+    assert isinstance(result, pd.Timestamp), (
+        f"{method} for {unit} returned {type(result)}"
+    )
+    assert result.unit == unit

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3817,3 +3817,63 @@ def test_ufunc_retains_missing():
 
     expected = pd.Series([np.sin(0.1), pd.NA], dtype="float64[pyarrow]")
     tm.assert_series_equal(result, expected)
+
+
+def test_duration_reduction_consistency():
+    # GH#63170
+    for unit in ["ns", "us", "ms", "s"]:
+        dtype = f"duration[{unit}][pyarrow]"
+        ser = pd.Series([timedelta(seconds=1)], dtype=dtype)
+        result = ser.sum()
+        assert isinstance(result, pd.Timedelta), (
+            f"sum for {unit} returned {type(result)}"
+        )
+        assert result.unit == unit
+
+        result = ser.min()
+        assert isinstance(result, pd.Timedelta), (
+            f"min for {unit} returned {type(result)}"
+        )
+        assert result.unit == unit
+
+        result = ser.max()
+        assert isinstance(result, pd.Timedelta), (
+            f"max for {unit} returned {type(result)}"
+        )
+        assert result.unit == unit
+
+        result = ser.mean()
+        assert isinstance(result, pd.Timedelta), (
+            f"mean for {unit} returned {type(result)}"
+        )
+        assert result.unit == unit
+
+        result = ser.median()
+        assert isinstance(result, pd.Timedelta), (
+            f"median for {unit} returned {type(result)}"
+        )
+        assert result.unit == unit
+
+
+def test_timestamp_reduction_consistency():
+    # GH#63170
+    for unit in ["ns", "us", "ms", "s"]:
+        dtype = f"timestamp[{unit}][pyarrow]"
+        ser = pd.Series([datetime(2024, 1, 1), datetime(2024, 1, 3)], dtype=dtype)
+        result = ser.min()
+        assert isinstance(result, pd.Timestamp), (
+            f"min for {unit} returned {type(result)}"
+        )
+        assert result.unit == unit
+
+        result = ser.max()
+        assert isinstance(result, pd.Timestamp), (
+            f"max for {unit} returned {type(result)}"
+        )
+        assert result.unit == unit
+
+        result = ser.median()
+        assert isinstance(result, pd.Timestamp), (
+            f"median for {unit} returned {type(result)}"
+        )
+        assert result.unit == unit


### PR DESCRIPTION
- [x] closes #63170 
- [x] [Tests added and passed] if fixing a bug or adding a new feature
- [x] All [code checks passed].
- [ ] Added [type annotations] to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Previously, reduction operations (`sum`, `min`, `max`, `mean`, `median`) on Arrow-backed duration and timestamp arrays returned inconsistent scalar types depending on unit resolution. PyArrow's `as_py()` returns `pd.Timedelta/pd.Timestamp` for nanosecond data but stdlib `datetime.timedelta/datetime.datetime` for microsecond, millisecond, and second resolutions.
This change adds explicit wrapping in `_reduce_calc` for duration and timestamp results, using the pattern already established for[`__getitem__`](https://github.com/pandas-dev/pandas/blob/91514c363604506f447e53380d3aa00520f1037b/pandas/core/arrays/arrow/array.py#L807-L814) and [`__iter__`](https://github.com/pandas-dev/pandas/blob/91514c363604506f447e53380d3aa00520f1037b/pandas/core/arrays/arrow/array.py#L823-L834). This ensures these reductions consistently return pandas scalar types while preserving the original unit resolution via `.as_unit()`.