### PR TITLE
DEPR: Series.round and Series.clip on non-numeric dtypes

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -879,6 +879,7 @@ Other Deprecations
 - Deprecated the keyword ``check_datetimelike_compat`` in :meth:`testing.assert_frame_equal` and :meth:`testing.assert_series_equal` (:issue:`55638`)
 - Deprecated using ``epoch`` date format in :meth:`DataFrame.to_json` and :meth:`Series.to_json`, use ``iso`` instead. (:issue:`57063`)
 - Deprecated allowing ``fill_value`` that cannot be held in the original dtype (excepting NA values for integer and bool dtypes) in :meth:`Series.unstack` and :meth:`DataFrame.unstack` (:issue:`12189`, :issue:`53868`)
+- Deprecated :meth:`Series.round` and :meth:`Series.clip` with non-numeric dtypes; these will raise in a future version of pandas (:issue:`63559`)
 - Deprecated allowing ``fill_value`` that cannot be held in the original dtype (excepting NA values for integer and bool dtypes) in :meth:`Series.shift` and :meth:`DataFrame.shift` (:issue:`53802`)
 - Deprecated allowing strings representing full dates in :meth:`DataFrame.at_time` and :meth:`Series.at_time` (:issue:`50839`)
 - Deprecated backward-compatibility behavior for :meth:`DataFrame.select_dtypes` matching ``str`` dtype when ``np.object_`` is specified (:issue:`61916`)
@@ -889,7 +890,6 @@ Other Deprecations
 - Deprecated slicing on a :class:`Series` or :class:`DataFrame` with a :class:`DatetimeIndex` using a ``datetime.date`` object, explicitly cast to :class:`Timestamp` instead (:issue:`35830`)
 - Deprecated support for the Dataframe Interchange Protocol (:issue:`56732`)
 - Deprecated the ``inplace`` keyword from :meth:`Resampler.interpolate`, as passing ``True`` raises ``AttributeError`` (:issue:`58690`)
-
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.prior_deprecations:
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2576,38 +2576,43 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         3    1.0
         4    3.0
         dtype: float64
+
+        .. deprecated:: 3.0.0
+            Series.round with non-numeric dtype is deprecated and will raise
+            in a future version of pandas.
         """
         nv.validate_round(args, kwargs)
-        
-        from pandas.util._exceptions import find_stack_level
-        import warnings
-        
-        if not (self.dtype.kind in "iufcb"):
+
+        if self.dtype.kind not in "iufcb":
             warnings.warn(
                 f"{type(self).__name__}.round with non-numeric dtype is deprecated "
-                "and will raise in a future version.",
-                FutureWarning,
+                "and will raise in a future version of pandas.",
+                FutureWarning,  # pdlint: ignore[warning_class]
                 stacklevel=find_stack_level(),
             )
-        
+
         new_mgr = self._mgr.round(decimals=decimals)
         return self._constructor_from_mgr(new_mgr, axes=new_mgr.axes).__finalize__(
             self, method="round"
         )
 
     def clip(self, lower=None, upper=None, *args, **kwargs) -> Series:
-        from pandas.util._exceptions import find_stack_level
-        import warnings
+        """
+        Trim values at input threshold(s).
 
-        if not (self.dtype.kind in "iufcb"):
+        .. deprecated:: 3.0.0
+            Series.clip with non-numeric dtype is deprecated and will raise
+            in a future version of pandas.
+        """
+        if self.dtype.kind not in "iufcb":
             warnings.warn(
                 f"{type(self).__name__}.clip with non-numeric dtype is deprecated "
-                "and will raise in a future version.",
-                FutureWarning,
+                "and will raise in a future version of pandas.",
+                FutureWarning,  # pdlint: ignore[warning_class]
                 stacklevel=find_stack_level(),
             )
-        return super().clip(lower=lower, upper=upper, *args, **kwargs)
-    
+        return super().clip(*args, lower=lower, upper=upper, **kwargs)
+
     @overload
     def quantile(
         self, q: float = ..., interpolation: QuantileInterpolation = ...

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2578,13 +2578,36 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         dtype: float64
         """
         nv.validate_round(args, kwargs)
-        if self.dtype == "object":
-            raise TypeError("Expected numeric dtype, got object instead.")
+        
+        from pandas.util._exceptions import find_stack_level
+        import warnings
+        
+        if not (self.dtype.kind in "iufcb"):
+            warnings.warn(
+                f"{type(self).__name__}.round with non-numeric dtype is deprecated "
+                "and will raise in a future version.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        
         new_mgr = self._mgr.round(decimals=decimals)
         return self._constructor_from_mgr(new_mgr, axes=new_mgr.axes).__finalize__(
             self, method="round"
         )
 
+    def clip(self, lower=None, upper=None, *args, **kwargs) -> Series:
+        from pandas.util._exceptions import find_stack_level
+        import warnings
+
+        if not (self.dtype.kind in "iufcb"):
+            warnings.warn(
+                f"{type(self).__name__}.clip with non-numeric dtype is deprecated "
+                "and will raise in a future version.",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+        return super().clip(lower=lower, upper=upper, *args, **kwargs)
+    
     @overload
     def quantile(
         self, q: float = ..., interpolation: QuantileInterpolation = ...


### PR DESCRIPTION
- [x] closes #63559 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
