### PR TITLE
CI: Fix docs build env variables

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -51,8 +51,8 @@ jobs:
 
     - name: Show environment variables
       run: |
-        echo "PANDAS_VERSION=${{ env.PANDAS_VERSION }}
-        echo "PANDAS_VERSION_OVERRIDE=${{ env.PANDAS_VERSION_OVERRIDE }}
+        echo "PANDAS_VERSION=${{ env.PANDAS_VERSION }}"
+        echo "PANDAS_VERSION_OVERRIDE=${{ env.PANDAS_VERSION_OVERRIDE }}"
 
 #    - name: Checkout
 #      uses: actions/checkout@v6

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -45,8 +45,7 @@ jobs:
     steps:
     - name: Set pandas version
       run: |
-        ref_name=${{ github.ref_name }}
-        echo "PANDAS_VERSION=${ref_name:1}" >> "$GITHUB_ENV"
+        echo "PANDAS_VERSION=${GITHUB_REF_NAME:1}" >> "$GITHUB_ENV"
       if: github.event_name != 'workflow_dispatch'
 
     - name: Show environment variables

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -22,7 +22,7 @@ env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PANDAS_VERSION: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version }}"
+  PANDAS_VERSION: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || '' }}"
   PANDAS_VERSION_OVERRIDE: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || '' }}"
 
 permissions:

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -22,7 +22,7 @@ env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PANDAS_VERSION: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || ${GITHUB_REF_NAME:1} }}"
+  PANDAS_VERSION: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version }}"
   PANDAS_VERSION_OVERRIDE: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || '' }}"
 
 permissions:
@@ -43,66 +43,77 @@ jobs:
         shell: bash -el {0}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-
-    - name: Set up Conda
-      uses: ./.github/actions/setup-conda
-
-    - name: Build Pandas
-      uses: ./.github/actions/build_pandas
-
-    - name: Extra installs
-      # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
-      run: sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
-
-    - name: Test website
-      run: python -m pytest web/
-
-    - name: Build website
-      run: python web/pandas_web.py web/pandas --target-path=web/build
-
-    - name: Build documentation
-      run: doc/make.py --warnings-are-errors
-
-    - name: Build the interactive terminal
-      working-directory: web/interactive_terminal
-      run: jupyter lite build
-
-    - name: Build documentation zip
-      run: doc/make.py zip_html
-
-    - name: Install ssh key
+    - name: Set pandas version
       run: |
-        mkdir -m 700 -p ~/.ssh
-        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
-      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
+        ref_name=${{ github.ref_name }}
+        echo "PANDAS_VERSION=${ref_name:1}" >> "$GITHUB_ENV"
+      if: github.event_name != 'workflow_dispatch'
 
-    - name: Copy cheatsheets into site directory
-      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
+    - name: Show environment variables
+      run: |
+        echo "PANDAS_VERSION=${{ env.PANDAS_VERSION }}
+        echo "PANDAS_VERSION_OVERRIDE=${{ env.PANDAS_VERSION_OVERRIDE }}
 
-    - name: Upload web
-      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    - name: Upload dev docs
-      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    - name: Upload prod docs
-      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
-      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && env.PANDAS_VERSION_OVERRIDE != '')
-
-    - name: Move docs into site directory
-      run: mv doc/build/html web/build/docs
-
-    - name: Save website as an artifact
-      uses: actions/upload-artifact@v6
-      with:
-        name: website
-        path: web/build
-        retention-days: 14
+#    - name: Checkout
+#      uses: actions/checkout@v6
+#      with:
+#        fetch-depth: 0
+#
+#    - name: Set up Conda
+#      uses: ./.github/actions/setup-conda
+#
+#    - name: Build Pandas
+#      uses: ./.github/actions/build_pandas
+#
+#    - name: Extra installs
+#      # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
+#      run: sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
+#
+#    - name: Test website
+#      run: python -m pytest web/
+#
+#    - name: Build website
+#      run: python web/pandas_web.py web/pandas --target-path=web/build
+#
+#    - name: Build documentation
+#      run: doc/make.py --warnings-are-errors
+#
+#    - name: Build the interactive terminal
+#      working-directory: web/interactive_terminal
+#      run: jupyter lite build
+#
+#    - name: Build documentation zip
+#      run: doc/make.py zip_html
+#
+#    - name: Install ssh key
+#      run: |
+#        mkdir -m 700 -p ~/.ssh
+#        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
+#        chmod 600 ~/.ssh/id_rsa
+#        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
+#      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
+#
+#    - name: Copy cheatsheets into site directory
+#      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
+#
+#    - name: Upload web
+#      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
+#      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+#
+#    - name: Upload dev docs
+#      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
+#      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+#
+#    - name: Upload prod docs
+#      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
+#      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && env.PANDAS_VERSION_OVERRIDE != '')
+#
+#    - name: Move docs into site directory
+#      run: mv doc/build/html web/build/docs
+#
+#    - name: Save website as an artifact
+#      uses: actions/upload-artifact@v6
+#      with:
+#        name: website
+#        path: web/build
+#        retention-days: 14

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -53,66 +53,66 @@ jobs:
         echo "PANDAS_VERSION=${{ env.PANDAS_VERSION }}"
         echo "PANDAS_VERSION_OVERRIDE=${{ env.PANDAS_VERSION_OVERRIDE }}"
 
-#    - name: Checkout
-#      uses: actions/checkout@v6
-#      with:
-#        fetch-depth: 0
-#
-#    - name: Set up Conda
-#      uses: ./.github/actions/setup-conda
-#
-#    - name: Build Pandas
-#      uses: ./.github/actions/build_pandas
-#
-#    - name: Extra installs
-#      # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
-#      run: sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
-#
-#    - name: Test website
-#      run: python -m pytest web/
-#
-#    - name: Build website
-#      run: python web/pandas_web.py web/pandas --target-path=web/build
-#
-#    - name: Build documentation
-#      run: doc/make.py --warnings-are-errors
-#
-#    - name: Build the interactive terminal
-#      working-directory: web/interactive_terminal
-#      run: jupyter lite build
-#
-#    - name: Build documentation zip
-#      run: doc/make.py zip_html
-#
-#    - name: Install ssh key
-#      run: |
-#        mkdir -m 700 -p ~/.ssh
-#        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
-#        chmod 600 ~/.ssh/id_rsa
-#        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
-#      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
-#
-#    - name: Copy cheatsheets into site directory
-#      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
-#
-#    - name: Upload web
-#      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
-#      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-#
-#    - name: Upload dev docs
-#      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
-#      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-#
-#    - name: Upload prod docs
-#      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
-#      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && env.PANDAS_VERSION_OVERRIDE != '')
-#
-#    - name: Move docs into site directory
-#      run: mv doc/build/html web/build/docs
-#
-#    - name: Save website as an artifact
-#      uses: actions/upload-artifact@v6
-#      with:
-#        name: website
-#        path: web/build
-#        retention-days: 14
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Conda
+      uses: ./.github/actions/setup-conda
+
+    - name: Build Pandas
+      uses: ./.github/actions/build_pandas
+
+    - name: Extra installs
+      # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
+      run: sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
+
+    - name: Test website
+      run: python -m pytest web/
+
+    - name: Build website
+      run: python web/pandas_web.py web/pandas --target-path=web/build
+
+    - name: Build documentation
+      run: doc/make.py --warnings-are-errors
+
+    - name: Build the interactive terminal
+      working-directory: web/interactive_terminal
+      run: jupyter lite build
+
+    - name: Build documentation zip
+      run: doc/make.py zip_html
+
+    - name: Install ssh key
+      run: |
+        mkdir -m 700 -p ~/.ssh
+        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
+      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
+
+    - name: Copy cheatsheets into site directory
+      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
+
+    - name: Upload web
+      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    - name: Upload dev docs
+      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    - name: Upload prod docs
+      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
+      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && env.PANDAS_VERSION_OVERRIDE != '')
+
+    - name: Move docs into site directory
+      run: mv doc/build/html web/build/docs
+
+    - name: Save website as an artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: website
+        path: web/build
+        retention-days: 14


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Fix due to #63504. Just making minimal changes here. This can be slightly cleaned up I think and made more safe:

-  Just set `PANDAS_VERSION` unconditionally in the `env:` block
- I think we should have a checkbox on the workflow dispatch page `Publish build` that defaults to False, relying on a text box being  non-empty is too error prone. 
- We should have validation on `inputs.version` that it is actually a valid version (`\d\.\d\.\d`).

It's also not clear to me why using `${GITHUB_REF_NAME:1}` isn't sufficient in all cases - would we republish docs off of a commit that isn't the tagged commit?
