### PR TITLE
CLN: Inline .clang-config in pre-commit-config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,0 @@
-IndentPPDirectives: AfterHash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
     hooks:
     - id: clang-format
       files: ^pandas/_libs/src|^pandas/_libs/include
-      args: [-i]
+      args: ['-i', '--style', '{IndentPPDirectives: AfterHash}']
       types_or: [c, c++]
 -   repo: https://github.com/trim21/pre-commit-mirror-meson
     rev: v1.10.0


### PR DESCRIPTION
Follow up to https://github.com/pandas-dev/pandas/pull/63542, to avoid proliferating tool-specific config files, inlining the configuration added in that PR