### PR TITLE
Set up ty in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ ci:
     autofix_prs: false
     autoupdate_schedule: monthly
     # manual stage hooks
-    skip: [pyright, mypy]
+    skip: [pyright, mypy, ty]
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10
@@ -146,6 +146,14 @@ repos:
         pass_filenames: false
         types: [pyi]
         args: [scripts/run_stubtest.py]
+        stages: [manual]
+    -   id: ty
+        # note: assumes python env is setup and activated
+        name: ty
+        entry: ty check
+        language: system
+        pass_filenames: false
+        types: [python]
         stages: [manual]
     -   id: inconsistent-namespace-usage
         name: 'Check for inconsistent use of pandas namespace'

--- a/environment.yml
+++ b/environment.yml
@@ -78,6 +78,7 @@ dependencies:
   # code checks
   - flake8=7.1.0  # run in subprocess over docstring examples
   - mypy=1.17.1  # pre-commit uses locally installed mypy
+  - ty=0.0.9 # pre-commit uses locally installed ty
   - tokenize-rt  # scripts/check_for_inconsistent_pandas_namespace.py
   - pre-commit>=4.2.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -761,6 +761,34 @@ module = [
 ]
 ignore_errors = true
 
+[tool.ty.src]
+include = ["pandas"]
+
+### TODO: Enable gradually
+[tool.ty.rules]
+unresolved-attribute = "ignore"
+invalid-return-type = "ignore"
+unsupported-operator = "ignore"
+invalid-assignment = "ignore"
+invalid-argument-type = "ignore"
+unresolved-import = "ignore"
+no-matching-overload = "ignore"
+call-non-callable = "ignore"
+missing-argument = "ignore"
+not-subscriptable = "ignore"
+unknown-argument = "ignore"
+not-iterable = "ignore"
+unresolved-reference = "ignore"
+invalid-context-manager = "ignore"
+too-many-positional-arguments = "ignore"
+invalid-type-form = "ignore"
+parameter-already-assigned = "ignore"
+possibly-missing-attribute = "ignore"
+invalid-method-override = "ignore"
+unresolved-global = "ignore"
+redundant-cast = "ignore"
+index-out-of-bounds = "ignore"
+
 # To be kept consistent with "Import Formatting" section in contributing.rst
 [tool.isort]
 known_pre_libs = "pandas._config"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -55,6 +55,7 @@ moto
 asv>=0.6.1
 flake8==7.1.0
 mypy==1.17.1
+ty=0.0.9
 tokenize-rt
 pre-commit>=4.2.0
 gitpython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -55,7 +55,7 @@ moto
 asv>=0.6.1
 flake8==7.1.0
 mypy==1.17.1
-ty=0.0.9
+ty==0.0.9
 tokenize-rt
 pre-commit>=4.2.0
 gitpython


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Hello, I add `ty` to the CI after it's released in beta. After updating the environment, its usage is similar to `mypy`: `pre-commit run --hook-stage manual --all-files ty`

