### PR TITLE
STY: Enforce Ruff rule B905 in pandas/tests/series/test_constructors.py

### DIFF
--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1401,7 +1401,7 @@ class TestSeriesConstructors:
         values = [42544017.198965244, 1234565, 40512335.181958228, -1]
 
         def create_data(constructor):
-            return dict(zip((constructor(x) for x in dates_as_str), values))
+            return dict(zip((constructor(x) for x in dates_as_str), values, strict=True))
 
         data_datetime64 = create_data(np.datetime64)
         data_datetime = create_data(lambda x: datetime.strptime(x, "%Y-%m-%d"))


### PR DESCRIPTION
Enforced Ruff rule B905 (zip-without-explicit-strict) by adding `strict=True` to `zip` calls in `pandas/tests/series/test_constructors.py`.

- [x] closes #62434
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#running-the-test-suite) if fixing a bug or adding a new feature
- [N/A] [All code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [N/A] [Added an entry in the latest `doc/source/whatsnew/*.rst` file](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#whatsnew) if fixing a bug or adding a new feature.
