### PR TITLE
Add FutureWarning for converting Series with NaN to bool dtype

### DIFF
--- a/doc/source/whatsnew/v2.3.4.rst
+++ b/doc/source/whatsnew/v2.3.4.rst
@@ -10,6 +10,11 @@ including other versions of pandas.
 
 .. ---------------------------------------------------------------------------
 
+Deprecations
+~~~~~~~~~~~~
+
+- :meth:`Series.astype` and :meth:`DataFrame.astype` now raise a ``FutureWarning`` when converting data containing NaN values to ``bool`` dtype. In a future version, this will raise a ``ValueError``.
+
 Bug fixes
 ^^^^^^^^^
 - Bug in :meth:`DataFrame.__getitem__` returning modified columns when called with ``slice`` in Python 3.12 (:issue:`57500`)

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -16,7 +16,10 @@ import numpy as np
 
 from pandas._libs import lib
 from pandas._libs.tslibs.timedeltas import array_to_timedelta64
-from pandas.errors import IntCastingNaNError
+from pandas.errors import (
+    IntCastingNaNError,
+    PandasFutureWarning,
+)
 from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
@@ -32,7 +35,6 @@ from pandas.core.dtypes.dtypes import (
     NumpyEADtype,
     PeriodDtype,
 )
-
 from pandas.core.dtypes.missing import isna
 
 if TYPE_CHECKING:
@@ -105,7 +107,7 @@ def _astype_nansafe(
         warnings.warn(
             "Converting a Series with NaN values to bool will raise a ValueError "
             "in a future version. Remove NaN values before converting to bool.",
-            FutureWarning,
+            PandasFutureWarning,
             stacklevel=find_stack_level(),
         )
         # Uncomment in future version (3.0+):

--- a/pandas/tests/arrays/sparse/test_astype.py
+++ b/pandas/tests/arrays/sparse/test_astype.py
@@ -5,7 +5,7 @@ from pandas._libs.sparse import IntIndex
 
 from pandas import (
     SparseDtype,
-    Timestamp,
+    Timestamp, Series,
 )
 import pandas._testing as tm
 from pandas.core.arrays.sparse import SparseArray
@@ -131,3 +131,12 @@ class TestAstype:
         arr3 = SparseArray(values, dtype=dtype)
         result3 = arr3.astype("int64")
         tm.assert_numpy_array_equal(result3, expected)
+
+    def test_astype_bool_with_nan_warning(self):
+        ser = Series([1.0, 2.0, np.nan])
+
+        with tm.assert_produces_warning(FutureWarning, match="Converting a Series with NaN values to bool"):
+            result = ser.astype(np.bool_)
+
+        expected = Series([True, True, True])
+        tm.assert_series_equal(expected, result)

--- a/pandas/tests/arrays/sparse/test_astype.py
+++ b/pandas/tests/arrays/sparse/test_astype.py
@@ -2,10 +2,12 @@ import numpy as np
 import pytest
 
 from pandas._libs.sparse import IntIndex
+from pandas.errors import PandasFutureWarning
 
 from pandas import (
+    Series,
     SparseDtype,
-    Timestamp, Series,
+    Timestamp,
 )
 import pandas._testing as tm
 from pandas.core.arrays.sparse import SparseArray
@@ -135,7 +137,10 @@ class TestAstype:
     def test_astype_bool_with_nan_warning(self):
         ser = Series([1.0, 2.0, np.nan])
 
-        with tm.assert_produces_warning(FutureWarning, match="Converting a Series with NaN values to bool"):
+        with tm.assert_produces_warning(
+            PandasFutureWarning,
+            match="Converting a Series with NaN values to bool",
+        ):
             result = ser.astype(np.bool_)
 
         expected = Series([True, True, True])


### PR DESCRIPTION
**Related to #62687**

This PR adds a `FutureWarning` when using `astype()` to convert data containing NaN values to `bool` dtype. In pandas 3.0, this will raise a `ValueError` instead.

Changes:
- Added warning in `_astype_nansafe()` that triggers when converting to `np.bool_` with NaN present
- Added test `test_astype_bool_with_nan_warning()` to verify the warning behavior
- Updated `doc/source/whatsnew/v2.3.4.rst`

Example:
```python
ser = pd.Series([1.0, 2.0, np.nan])
ser.astype(bool)  # FutureWarning: Converting a Series with NaN values to bool...
```