### PR TITLE
ENH: Add `replace` method to `index`

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -268,6 +268,7 @@ Other enhancements
   data object into a pandas object through the
   `Arrow PyCapsule Protocol <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>`__ (:issue:`59631`)
 - :meth:`Series.round` now supports object dtypes when the underlying Python objects implement ``__round__`` (:issue:`63444`)
+- Added :meth:`Index.replace` and :meth:`MultiIndex.replace` methods, providing functionality consistent with :meth:`Series.replace`. (:issue:`19495`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2119,6 +2119,60 @@ class Index(IndexOpsMixin, PandasObject):
         *,
         regex=False,
     ) -> Index:
+        """
+        Replace values in the Index.
+
+        Return a new Index with values replaced according to ``to_replace`` and
+        ``value``. This method mirrors :meth:`Series.replace` but preserves the
+        immutability and type of the Index.
+
+        Parameters
+        ----------
+        to_replace : scalar, list-like, dict, or None
+            How to find the values to replace.
+
+            * scalar: values equal to ``to_replace`` will be replaced
+            * list-like: values in the list will be replaced
+            * dict: keys are replaced by values
+            * None: only valid if ``value`` is dict-like
+
+        value : scalar, dict, list-like, or lib.no_default
+            Replacement value(s). If ``to_replace`` is dict-like, ``value`` must
+            be ``lib.no_default``.
+
+        regex : bool, default False
+            Whether to interpret ``to_replace`` as a regular expression.
+
+        Returns
+        -------
+        Index
+            A new Index with replaced values.
+
+        See Also
+        --------
+        Series.replace : Replace values in a Series.
+        Index.map : Map values using a function or mapping.
+        Index.where : Replace values conditionally.
+
+        Notes
+        -----
+        This method converts the Index to a Series internally and applies
+        :meth:`Series.replace`, then reconstructs an Index from the result.
+        The original Index is not modified.
+
+        Examples
+        --------
+        >>> idx = pd.Index(["a", "b", "c", "b"])
+        >>> idx.replace("b", "x")
+        Index(['a', 'x', 'c', 'x'], dtype='str')
+
+        >>> idx.replace({"a": "foo", "c": "bar"})
+        Index(['foo', 'b', 'bar', 'b'], dtype='str')
+
+        >>> idx = pd.Index(["cat", "dog", "cow"])
+        >>> idx.replace("c.*", "animal", regex=True)
+        Index(['animal', 'dog', 'animal'], dtype='str')
+        """
         result = self.to_series().replace(
             to_replace=to_replace, value=value, regex=regex
         )

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2118,7 +2118,7 @@ class Index(IndexOpsMixin, PandasObject):
         value=lib.no_default,
         *,
         regex=False,
-    ) -> Self:
+    ) -> Index:
         result = self.to_series().replace(
             to_replace=to_replace, value=value, regex=regex
         )

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2117,7 +2117,7 @@ class Index(IndexOpsMixin, PandasObject):
         to_replace=None,
         value=lib.no_default,
         regex=False,
-    ):
+    ) -> Self:
         result = self.to_series().replace(
             to_replace=to_replace, value=value, regex=regex
         )

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2116,12 +2116,13 @@ class Index(IndexOpsMixin, PandasObject):
         self,
         to_replace=None,
         value=lib.no_default,
+        *,
         regex=False,
     ) -> Self:
         result = self.to_series().replace(
             to_replace=to_replace, value=value, regex=regex
         )
-        return Index(result)
+        return self._constructor(result)
 
     # --------------------------------------------------------------------
     # Level-Centric Methods

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2117,7 +2117,7 @@ class Index(IndexOpsMixin, PandasObject):
         to_replace=None,
         value=lib.no_default,
         *,
-        regex=False,
+        regex: bool = False,
     ) -> Index:
         """
         Replace values in the Index.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2116,11 +2116,10 @@ class Index(IndexOpsMixin, PandasObject):
         self,
         to_replace=None,
         value=lib.no_default,
-        limit=None,
         regex=False,
     ):
         result = self.to_series().replace(
-            to_replace=to_replace, value=value, limit=limit, regex=regex
+            to_replace=to_replace, value=value, regex=regex
         )
         return Index(result)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2112,6 +2112,18 @@ class Index(IndexOpsMixin, PandasObject):
         """
         return self.set_names([name], inplace=inplace)
 
+    def replace(
+        self,
+        to_replace=None,
+        value=lib.no_default,
+        limit=None,
+        regex=False,
+    ):
+        result = self.to_series().replace(
+            to_replace=to_replace, value=value, limit=limit, regex=regex
+        )
+        return Index(result)
+
     # --------------------------------------------------------------------
     # Level-Centric Methods
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -524,6 +524,6 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
         to_replace=None,
         value=None,
         *,
-        regex=False,
+        regex: bool = False,
     ) -> CategoricalIndex:
         raise NotImplementedError("CategoricalIndex.replace is not supported")

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -526,4 +526,25 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
         *,
         regex: bool = False,
     ) -> CategoricalIndex:
+        """
+        Replace values in a CategoricalIndex.
+
+        This method is not supported for ``CategoricalIndex`` and will always
+        raise ``NotImplementedError``.
+
+        Parameters
+        ----------
+        to_replace : scalar, list-like, dict, or None
+            Values to replace.
+        value : scalar, list-like, dict, or None
+            Replacement value(s).
+        regex : bool, default False
+            Whether to interpret ``to_replace`` as a regular expression.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised. Use ``CategoricalIndex.rename_categories`` or
+            ``CategoricalIndex.map`` to modify category values.
+        """
         raise NotImplementedError("CategoricalIndex.replace is not supported")

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -518,3 +518,12 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
         """
         mapped = self._values.map(mapper, na_action=na_action)
         return Index(mapped, name=self.name, copy=False)
+
+    def replace(
+        self,
+        to_replace=None,
+        value=None,
+        *,
+        regex=False,
+    ) -> Self:
+        raise NotImplementedError("CategoricalIndex.replace is not supported")

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -525,5 +525,5 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
         value=None,
         *,
         regex=False,
-    ) -> Self:
+    ) -> CategoricalIndex:
         raise NotImplementedError("CategoricalIndex.replace is not supported")

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3958,7 +3958,7 @@ class MultiIndex(Index):
         to_replace=None,
         value=lib.no_default,
         *,
-        regex=False,
+        regex: bool = False,
     ) -> MultiIndex:
         """
         Replace values in a MultiIndex.

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3953,6 +3953,20 @@ class MultiIndex(Index):
         ind = np.lexsort(keys)
         return indexer[ind]
 
+    def replace(
+        self,
+        to_replace=None,
+        value=lib.no_default,
+        regex=False,
+    ) -> Self:
+        names = self.names
+
+        result = self.to_frame().replace(
+            to_replace=to_replace, value=value, regex=regex
+        )
+
+        return self.from_frame(result, names=names)
+
     def truncate(self, before=None, after=None) -> MultiIndex:
         """
         Slice index between two labels / tuples, return new MultiIndex.

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3960,6 +3960,66 @@ class MultiIndex(Index):
         *,
         regex=False,
     ) -> MultiIndex:
+        """
+        Replace values in a MultiIndex.
+
+        Return a new MultiIndex with values replaced according to
+        ``to_replace`` and ``value``. Replacement is applied elementwise
+        across all levels of the MultiIndex.
+
+        Parameters
+        ----------
+        to_replace : scalar, list-like, dict, or None
+            How to find the values to replace.
+
+            * scalar: values equal to ``to_replace`` will be replaced
+            * list-like: values in the list will be replaced
+            * dict: keys are replaced by values
+            * None: only valid if ``value`` is dict-like
+
+        value : scalar, dict, list-like, or lib.no_default
+            Replacement value(s). If ``to_replace`` is dict-like, ``value`` must
+            be ``lib.no_default``.
+
+        regex : bool, default False
+            Whether to interpret ``to_replace`` as a regular expression.
+
+        Returns
+        -------
+        MultiIndex
+            A new MultiIndex with replaced values.
+
+        See Also
+        --------
+        Series.replace : Replace values in a Series.
+        Index.replace : Replace values in an Index.
+        MultiIndex.map : Map values using a function or mapping.
+
+        Notes
+        -----
+        This method operates by converting the MultiIndex to a DataFrame,
+        applying :meth:`DataFrame.replace`, and reconstructing the MultiIndex
+        while preserving level names. The original MultiIndex is not modified.
+
+        Examples
+        --------
+        >>> idx = pd.MultiIndex.from_product(
+        ...     [["a", "b"], [1, 2]], names=["letter", "number"]
+        ... )
+        >>> idx.replace("a", "x")
+        MultiIndex([('x', 1),
+                    ('x', 2),
+                    ('b', 1),
+                    ('b', 2)],
+                   names=['letter', 'number'])
+
+        >>> idx.replace({1: 10})
+        MultiIndex([('a', 10),
+                    ('a', 2),
+                    ('b', 10),
+                    ('b', 2)],
+                   names=['letter', 'number'])
+        """
         names = self.names
 
         result = self.to_frame().replace(

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3959,7 +3959,7 @@ class MultiIndex(Index):
         value=lib.no_default,
         *,
         regex=False,
-    ) -> Self:
+    ) -> MultiIndex:
         names = self.names
 
         result = self.to_frame().replace(

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3957,6 +3957,7 @@ class MultiIndex(Index):
         self,
         to_replace=None,
         value=lib.no_default,
+        *,
         regex=False,
     ) -> Self:
         names = self.names

--- a/pandas/tests/indexes/base_class/test_replace.py
+++ b/pandas/tests/indexes/base_class/test_replace.py
@@ -1,0 +1,58 @@
+import pytest
+
+from pandas import (
+    DatetimeIndex,
+    Index,
+    to_datetime,
+)
+import pandas._testing as tm
+
+
+class TestReplace:
+    def test_index_replace_scalar(self):
+        idx = Index([1, 2, 3])
+        result = idx.replace(2, 9)
+        expected = Index([1, 9, 3])
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "index, to_replace, value, expected",
+        [
+            ([1, 2, 3], [1, 3], ["a", "c"], ["a", 2, "c"]),
+            ([1, 2, 3], 1, "a", ["a", 2, 3]),
+            ([1, None, 2], [1, 2], "a", ["a", None, "a"]),
+        ],
+    )
+    def test_index_replace_list_and_scalar(self, index, to_replace, value, expected):
+        index = Index(index)
+        expected = Index(expected, dtype="object")
+
+        result = index.replace(to_replace=to_replace, value=value)
+
+        tm.assert_index_equal(result, expected)
+
+    def test_index_replace_dict(self):
+        idx = Index(["a", "b", "c"])
+        result = idx.replace({"b": "x"})
+        expected = Index(["a", "x", "c"])
+        tm.assert_index_equal(result, expected)
+
+    def test_index_replace_dict_and_value_raises(self):
+        idx = Index([1, 2, 3])
+
+        with pytest.raises(ValueError, match="dict-like"):
+            idx.replace({1: "a", 3: "c"}, "x")
+
+    def test_index_name_preserved(self):
+        idx = Index([0, 1], name="foo")
+        result = idx.replace(1, 0)
+        expected = Index([0, 0], name="foo")
+        tm.assert_index_equal(result, expected)
+
+    def test_index_replace_preserves_specialized_types(self):
+        idx = to_datetime(["2020-01-01", "2020-01-02"])
+        result = idx.replace("2020-01-01", "2020-01-03")
+        expected = to_datetime(["2020-01-03", "2020-01-02"])
+
+        tm.assert_index_equal(result, expected)
+        assert isinstance(result, DatetimeIndex)

--- a/pandas/tests/indexes/base_class/test_replace.py
+++ b/pandas/tests/indexes/base_class/test_replace.py
@@ -56,3 +56,9 @@ class TestReplace:
 
         tm.assert_index_equal(result, expected)
         assert isinstance(result, DatetimeIndex)
+
+    def test_index_replace_preserves_subclass(self):
+        idx = DatetimeIndex(["2020-01-01", "2020-01-02"])
+        result = idx.replace("2020", "2021")
+
+        assert isinstance(result, DatetimeIndex)

--- a/pandas/tests/indexes/base_class/test_replace.py
+++ b/pandas/tests/indexes/base_class/test_replace.py
@@ -8,57 +8,89 @@ from pandas import (
 import pandas._testing as tm
 
 
-class TestReplace:
-    def test_index_replace_scalar(self):
+class TestIndexReplace:
+    def test_replace_scalar(self):
         idx = Index([1, 2, 3])
+
         result = idx.replace(2, 9)
         expected = Index([1, 9, 3])
+
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "index, to_replace, value, expected",
+        "data, to_replace, value, expected",
         [
             ([1, 2, 3], [1, 3], ["a", "c"], ["a", 2, "c"]),
             ([1, 2, 3], 1, "a", ["a", 2, 3]),
             ([1, None, 2], [1, 2], "a", ["a", None, "a"]),
         ],
     )
-    def test_index_replace_list_and_scalar(self, index, to_replace, value, expected):
-        index = Index(index)
+    def test_replace_list_and_scalar(self, data, to_replace, value, expected):
+        idx = Index(data)
         expected = Index(expected, dtype="object")
 
-        result = index.replace(to_replace=to_replace, value=value)
+        result = idx.replace(to_replace=to_replace, value=value)
 
         tm.assert_index_equal(result, expected)
 
-    def test_index_replace_dict(self):
+    def test_replace_dict(self):
         idx = Index(["a", "b", "c"])
+
         result = idx.replace({"b": "x"})
         expected = Index(["a", "x", "c"])
+
         tm.assert_index_equal(result, expected)
 
-    def test_index_replace_dict_and_value_raises(self):
+    def test_replace_dict_and_value_raises(self):
         idx = Index([1, 2, 3])
 
         with pytest.raises(ValueError, match="dict-like"):
             idx.replace({1: "a", 3: "c"}, "x")
 
-    def test_index_name_preserved(self):
+    def test_name_preserved(self):
         idx = Index([0, 1], name="foo")
+
         result = idx.replace(1, 0)
         expected = Index([0, 0], name="foo")
+
         tm.assert_index_equal(result, expected)
 
-    def test_index_replace_preserves_specialized_types(self):
+    def test_preserves_subclass(self):
+        idx = DatetimeIndex(["2020-01-01", "2020-01-02"])
+
+        result = idx.replace("2020", "2021")
+
+        assert isinstance(result, DatetimeIndex)
+
+    def test_preserves_specialized_dtype(self):
         idx = to_datetime(["2020-01-01", "2020-01-02"])
+
         result = idx.replace("2020-01-01", "2020-01-03")
         expected = to_datetime(["2020-01-03", "2020-01-02"])
 
         tm.assert_index_equal(result, expected)
         assert isinstance(result, DatetimeIndex)
 
-    def test_index_replace_preserves_subclass(self):
-        idx = DatetimeIndex(["2020-01-01", "2020-01-02"])
-        result = idx.replace("2020", "2021")
+    def test_doc_example_scalar(self):
+        idx = Index(["a", "b", "c", "b"])
 
-        assert isinstance(result, DatetimeIndex)
+        result = idx.replace("b", "x")
+        expected = Index(["a", "x", "c", "x"])
+
+        tm.assert_index_equal(result, expected)
+
+    def test_doc_example_dict(self):
+        idx = Index(["a", "b", "c", "b"])
+
+        result = idx.replace({"a": "foo", "c": "bar"})
+        expected = Index(["foo", "b", "bar", "b"])
+
+        tm.assert_index_equal(result, expected)
+
+    def test_doc_example_regex(self):
+        idx = Index(["cat", "dog", "cow"])
+
+        result = idx.replace("c.*", "animal", regex=True)
+        expected = Index(["animal", "dog", "animal"])
+
+        tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_replace.py
+++ b/pandas/tests/indexes/multi/test_replace.py
@@ -1,34 +1,23 @@
-import pandas as pd
+from pandas import MultiIndex
 import pandas._testing as tm
 
 
 class TestMultiIndexReplace:
     def test_multiindex_replace_elementwise(self):
-        idx = pd.MultiIndex.from_tuples([("a", 1), ("b", 2), ("a", 3)])
+        idx = MultiIndex.from_tuples([("a", 1), ("b", 2), ("a", 3)])
 
         result = idx.replace("a", "x")
 
-        expected = pd.MultiIndex.from_tuples([("x", 1), ("b", 2), ("x", 3)])
-
-        tm.assert_index_equal(result, expected)
-
-    def test_multiindex_replace_partial_tuple(self):
-        idx = pd.MultiIndex.from_tuples([("a", 1), ("b", 2), ("a", 3)])
-
-        result = idx.replace("a", "x")
-
-        expected = pd.MultiIndex.from_tuples([("x", 1), ("b", 2), ("x", 3)])
+        expected = MultiIndex.from_tuples([("x", 1), ("b", 2), ("x", 3)])
 
         tm.assert_index_equal(result, expected)
 
     def test_multiindex_name_preserved(self):
-        idx = pd.MultiIndex.from_tuples(
-            [("a", 1), ("b", 2)], names=["letter", "number"]
-        )
+        idx = MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["letter", "number"])
 
         result = idx.replace("a", "x")
 
-        expected = pd.MultiIndex.from_tuples(
+        expected = MultiIndex.from_tuples(
             [("x", 1), ("b", 2)], names=["letter", "number"]
         )
 

--- a/pandas/tests/indexes/multi/test_replace.py
+++ b/pandas/tests/indexes/multi/test_replace.py
@@ -22,3 +22,43 @@ class TestMultiIndexReplace:
         )
 
         tm.assert_index_equal(result, expected)
+
+    def test_multiindex_replace_scalar(self):
+        idx = MultiIndex.from_product(
+            [["a", "b"], [1, 2]],
+            names=["letter", "number"],
+        )
+
+        result = idx.replace("a", "x")
+
+        expected = MultiIndex.from_tuples(
+            [("x", 1), ("x", 2), ("b", 1), ("b", 2)],
+            names=["letter", "number"],
+        )
+
+        tm.assert_index_equal(result, expected)
+
+    def test_multiindex_replace_dict(self):
+        idx = MultiIndex.from_product(
+            [["a", "b"], [1, 2]],
+            names=["letter", "number"],
+        )
+
+        result = idx.replace({1: 10})
+
+        expected = MultiIndex.from_tuples(
+            [("a", 10), ("a", 2), ("b", 10), ("b", 2)],
+            names=["letter", "number"],
+        )
+
+        tm.assert_index_equal(result, expected)
+
+    def test_multiindex_replace_preserves_names(self):
+        idx = MultiIndex.from_product(
+            [["foo", "bar"], [0, 1]],
+            names=["level_1", "level_2"],
+        )
+
+        result = idx.replace("foo", "baz")
+
+        assert result.names == ["level_1", "level_2"]

--- a/pandas/tests/indexes/multi/test_replace.py
+++ b/pandas/tests/indexes/multi/test_replace.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pandas._testing as tm
+
+
+class TestMultiIndexReplace:
+    def test_multiindex_replace_elementwise(self):
+        idx = pd.MultiIndex.from_tuples([("a", 1), ("b", 2), ("a", 3)])
+
+        result = idx.replace("a", "x")
+
+        expected = pd.MultiIndex.from_tuples([("x", 1), ("b", 2), ("x", 3)])
+
+        tm.assert_index_equal(result, expected)
+
+    def test_multiindex_replace_partial_tuple(self):
+        idx = pd.MultiIndex.from_tuples([("a", 1), ("b", 2), ("a", 3)])
+
+        result = idx.replace("a", "x")
+
+        expected = pd.MultiIndex.from_tuples([("x", 1), ("b", 2), ("x", 3)])
+
+        tm.assert_index_equal(result, expected)
+
+    def test_multiindex_name_preserved(self):
+        idx = pd.MultiIndex.from_tuples(
+            [("a", 1), ("b", 2)], names=["letter", "number"]
+        )
+
+        result = idx.replace("a", "x")
+
+        expected = pd.MultiIndex.from_tuples(
+            [("x", 1), ("b", 2)], names=["letter", "number"]
+        )
+
+        tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] closes #19495 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.



Using the closed PR [here](https://github.com/pandas-dev/pandas/pull/32542) I was able to make a similar PR. But for the categorical Index I wanted to ask for what is the best thing to do with it. For now Categorical Index replace method throws a not implemented error.