### PR TITLE
CLN: Enable ruff rule PLR1733 (unnecessary-dict-value-lookup)

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2282,7 +2282,7 @@ def _convert_datetime_to_stata_type(fmt: str) -> np.dtype:
 def _maybe_convert_to_int_keys(convert_dates: dict, varlist: list[Hashable]) -> dict:
     new_dict = {}
     for key, value in convert_dates.items():
-        if not convert_dates[key].startswith("%"):  # make sure proper fmts
+        if not value.startswith("%"):  # make sure proper fmts
             convert_dates[key] = "%" + value
         if key in varlist:
             new_dict[varlist.index(key)] = convert_dates[key]

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -89,7 +89,7 @@ def test_pickles(datapath):
 
         for typ, dv in data.items():
             for dt, result in dv.items():
-                expected = data[typ][dt]
+                expected = result
 
                 if typ == "series" and dt == "ts":
                     # GH 7748

--- a/pandas/tests/series/test_iteration.py
+++ b/pandas/tests/series/test_iteration.py
@@ -12,22 +12,22 @@ class TestIteration:
 
     def test_iteritems_datetimes(self, datetime_series):
         for idx, val in datetime_series.items():
-            assert val == datetime_series[idx]
+            assert val == datetime_series[idx]  # noqa: PLR1733
 
     def test_iteritems_strings(self, string_series):
         for idx, val in string_series.items():
-            assert val == string_series[idx]
+            assert val == string_series[idx]  # noqa: PLR1733
 
         # assert is lazy (generators don't define reverse, lists do)
         assert not hasattr(string_series.items(), "reverse")
 
     def test_items_datetimes(self, datetime_series):
         for idx, val in datetime_series.items():
-            assert val == datetime_series[idx]
+            assert val == datetime_series[idx]  # noqa: PLR1733
 
     def test_items_strings(self, string_series):
         for idx, val in string_series.items():
-            assert val == string_series[idx]
+            assert val == string_series[idx]  # noqa: PLR1733
 
         # assert is lazy (generators don't define reverse, lists do)
         assert not hasattr(string_series.items(), "reverse")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,8 +359,6 @@ ignore = [
   "PLW1641", # 16 errors
   # Bad or misspelled dunder method name
   "PLW3201", # 69 errors, seems to be all false positive
-  # Unnecessary lookup of dictionary value by key
-  "PLR1733", # 5 errors, it seems like we wannt to ignore these
   # Unnecessary lookup of list item by index
   "PLR1736", # 4 errors, we're currently having inline pylint ignore
   # Unpacking a dictionary in iteration without calling `.items()`


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
