### PR TITLE
BUG: handle negative overflow in Period conversion from timestamp with millisecond resolution

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1308,7 +1308,7 @@ I/O
 Period
 ^^^^^^
 - Fixed error message when passing invalid period alias to :meth:`PeriodIndex.to_timestamp` (:issue:`58974`)
-- Fixed recoverable overflow for near-minimum timestamps with microsecond resolution (:issue:`63278`)
+- Fixed recoverable overflow for near-minimum timestamps with microsecond and millisecond resolutions (:issue:`63278`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -379,8 +379,8 @@ static bool scale_time_with_underflow_check(int64_t time, int64_t scale_factor,
   if (time < min_scalable_time) {
     const int64_t amount_below_threshold = time - min_scalable_time;
     const int64_t scaled_time = scale_factor * (time - amount_below_threshold);
-    return checked_add(scale_factor * amount_below_threshold, fractional_part,
-                       result) ||
+    return checked_mul(scale_factor, amount_below_threshold, result) ||
+           checked_add(*result, fractional_part, result) ||
            checked_add(scaled_time, *result, result);
   }
 

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -169,10 +169,11 @@ class TestPeriodConstruction:
         rt2 = per2.to_timestamp()
         assert rt2.asm8 == dt64
 
-    def test_construction_from_min_timestamp(self):
+    @pytest.mark.parametrize("freq", ["ms", "us", "ns"])
+    def test_construction_from_min_timestamp(self, freq):
         # GH-63278
-        ts = Timestamp(Timestamp.min.value, unit="us")
-        per = Period(ts, freq="us")
+        ts = Timestamp(Timestamp.min.value, unit=freq)
+        per = Period(ts, freq=freq)
 
         # pandas.errors.OutOfBoundsDatetime: Out of bounds nanosecond timestamp:
         # -290308-12-21 19:59:05


### PR DESCRIPTION
- [x] xref #63278
- [x] extends #63509 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

To avoid code duplication, I created a helper function that performs the verification and used it for millisecond, microsecond and nanosecond resolutions.
