### PR TITLE
CLN: Enable ruff rule PLR1736 (unnecessary-list-index-lookup)

### DIFF
--- a/pandas/tests/indexes/datetimes/test_iter.py
+++ b/pandas/tests/indexes/datetimes/test_iter.py
@@ -20,7 +20,7 @@ class TestDatetimeIndexIteration:
             ["2018-02-08 15:00:00.168456358", "2018-02-08 15:00:00.168456359"], tz=tz
         )
         for i, ts in enumerate(index):
-            assert ts == index[i]
+            assert ts == index[i]  # noqa: PLR1736 (unnecessary-list-index-lookup)
 
     def test_iter_readonly(self):
         # GH#28055 ints_to_pydatetime with readonly array
@@ -35,7 +35,7 @@ class TestDatetimeIndexIteration:
 
         for i, ts in enumerate(index):
             result = ts
-            expected = index[i]
+            expected = index[i]  # noqa: PLR1736 (unnecessary-list-index-lookup)
             assert result == expected
 
     def test_iteration_preserves_tz2(self):
@@ -45,7 +45,7 @@ class TestDatetimeIndexIteration:
 
         for i, ts in enumerate(index):
             result = ts
-            expected = index[i]
+            expected = index[i]  # noqa: PLR1736 (unnecessary-list-index-lookup)
             assert result._repr_base == expected._repr_base
             assert result == expected
 
@@ -56,7 +56,7 @@ class TestDatetimeIndexIteration:
         )
         for i, ts in enumerate(index):
             result = ts
-            expected = index[i]
+            expected = index[i]  # noqa: PLR1736 (unnecessary-list-index-lookup)
             assert result._repr_base == expected._repr_base
             assert result == expected
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,8 +359,6 @@ ignore = [
   "PLW1641", # 16 errors
   # Bad or misspelled dunder method name
   "PLW3201", # 69 errors, seems to be all false positive
-  # Unnecessary lookup of list item by index
-  "PLR1736", # 4 errors, we're currently having inline pylint ignore
   # Unpacking a dictionary in iteration without calling `.items()`
   "PLE1141", # autofixable
   # import-outside-toplevel


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
