### PR TITLE
DOC: Fix GL08 for pandas.tseries.offsets.FY5253.get_rule_code_suffix

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -154,7 +154,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.Day.n GL08" \
         -i "pandas.tseries.offsets.Easter.is_on_offset GL08" \
         -i "pandas.tseries.offsets.Easter.n GL08" \
-        -i "pandas.tseries.offsets.FY5253.get_rule_code_suffix GL08" \
         -i "pandas.tseries.offsets.FY5253.get_year_end GL08" \
         -i "pandas.tseries.offsets.FY5253.is_on_offset GL08" \
         -i "pandas.tseries.offsets.FY5253.n GL08" \
@@ -162,7 +161,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.FY5253.startingMonth GL08" \
         -i "pandas.tseries.offsets.FY5253.variation GL08" \
         -i "pandas.tseries.offsets.FY5253.weekday GL08" \
-        -i "pandas.tseries.offsets.FY5253Quarter.get_rule_code_suffix GL08" \
         -i "pandas.tseries.offsets.FY5253Quarter.get_weeks GL08" \
         -i "pandas.tseries.offsets.FY5253Quarter.is_on_offset GL08" \
         -i "pandas.tseries.offsets.FY5253Quarter.n GL08" \

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -4199,6 +4199,34 @@ cdef class FY5253Mixin(SingleConstructorOffset):
             return "L"
 
     def get_rule_code_suffix(self) -> str:
+        """
+        Return the suffix component of the rule code.
+
+        The suffix combines the variation prefix, starting month abbreviation,
+        and weekday abbreviation into a string format.
+
+        Returns
+        -------
+        str
+            Suffix string in the format "{variation}-{month}-{weekday}".
+            The variation is "N" for nearest or "L" for last.
+
+        See Also
+        --------
+        FY5253.rule_code : Return the complete rule code string.
+        FY5253Quarter.rule_code : Return the complete rule code string for
+            FY5253Quarter.
+
+        Examples
+        --------
+        >>> offset = pd.offsets.FY5253(weekday=4, startingMonth=12, variation="nearest")
+        >>> offset.get_rule_code_suffix()
+        'N-DEC-FRI'
+
+        >>> offset = pd.offsets.FY5253(weekday=0, startingMonth=1, variation="last")
+        >>> offset.get_rule_code_suffix()
+        'L-JAN-MON'
+        """
         prefix = self._get_suffix_prefix()
         month = MONTH_ALIASES[self.startingMonth]
         weekday = int_to_weekday[self.weekday]


### PR DESCRIPTION
- [ ] related to #60365 

Fixes

```
pandas.tseries.offsets.FY5253.get_rule_code_suffix GL08
pandas.tseries.offsets.FY5253Quarter.get_rule_code_suffix GL08
```