### PR TITLE
DOC: Add an example for .shift(suffix=)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11188,9 +11188,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             For datetime, timedelta, or period data, etc. :attr:`NaT` is used.
             For extension dtypes, ``self.dtype.na_value`` is used.
         suffix : str, optional
-            If str and periods is an iterable, this is added after the column
+            If str and `periods` is an iterable, this is added after the column
             name and before the shift value for each shifted column name.
-            For example, if `suffix='_shift', periods=[1, -1]`, and the column is
+            For example, if ``suffix='_shift', periods=[1, -1]``, and the column is
             named `n`, the resulting columns will be named `n_shift_1`
             and `n_shift_-1`.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11190,6 +11190,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         suffix : str, optional
             If str and periods is an iterable, this is added after the column
             name and before the shift value for each shifted column name.
+            For example, if `suffix='_shift', periods=[1, -1]`, and the column is
+            named `n`, the resulting columns will be named `n_shift_1`
+            and `n_shift_-1`.
 
         Returns
         -------


### PR DESCRIPTION
I was reading the `.shift()` documentation, looking for something else, and the `suffix` parameter description confused me, especially since I had never heard of `periods` being an iterable before. After digesting it though, it's really simple, so I wanted to add an example to make it clear.

I wrote this for 2.3.x, but it should probably be applied to main as well. I was just confused by [the additional line there](https://github.com/pandas-dev/pandas/blob/main/pandas/core/generic.py#L10070C13-L10070C74), ``For `Series` this parameter is unused and defaults to `None`.`` I'm not sure why that's the case, but I'm sure there's a reasonable explanation.

- ~~[ ] closes #xxxx (Replace xxxx with the GitHub issue number)~~
- ~~[ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature~~
  - I don't think this is applicable, but I'm making part of the API explicit, so maybe it is
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- ~~[ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.~~
- ~~[ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~~
- ~~[ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.~~