### PR TITLE
DOC: Add note about SQL Server temp table datetime precision loss (#62995)

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5771,6 +5771,32 @@ with respect to the timezone.
 timezone aware or naive. When reading ``TIMESTAMP WITH TIME ZONE`` types, pandas
 will convert the data to UTC.
 
+.. note::
+
+   When using :func:`~pandas.DataFrame.to_sql` with Microsoft SQL Server and pyodbc,
+   datetime precision may be lost when writing to local temporary tables
+   (tables with names starting with ``#``). This is due to a limitation in how
+   the ODBC driver infers parameter types for temporary tables.
+
+   To preserve datetime precision with SQL Server temporary tables, add
+   ``UseFMTONLY=Yes`` to your connection string:
+
+   .. code-block:: python
+
+      from sqlalchemy import create_engine
+
+      connection_string = (
+          "mssql+pyodbc://user:password@server/database"
+          "?driver=ODBC+Driver+17+for+SQL+Server"
+          "&UseFMTONLY=Yes"
+      )
+      engine = create_engine(connection_string)
+
+   Alternatively, use global temporary tables (``##table_name``) instead of
+   local temporary tables (``#table_name``). See the `pyodbc documentation
+   <https://github.com/mkleehammer/pyodbc/wiki/Tips-and-Tricks-by-Database-Platform#using-fast_executemany-with-a-temporary-table>`__
+   for more details.
+
 .. _io.sql.method:
 
 Insertion method

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5773,10 +5773,12 @@ will convert the data to UTC.
 
 .. note::
 
-   When using :func:`~pandas.DataFrame.to_sql` with Microsoft SQL Server and pyodbc,
-   datetime precision may be lost when writing to local temporary tables
-   (tables with names starting with ``#``). This is due to a limitation in how
-   the ODBC driver infers parameter types for temporary tables.
+   When using :func:`~pandas.DataFrame.to_sql` with Microsoft SQL Server and pyodbc
+   with ``fast_executemany=True``, datetime precision may be lost when writing to
+   local temporary tables (tables with names starting with ``#``). This is because
+   that code path binds parameters as arrays and relies on the ODBC driver inferring
+   the temporary table's column types, which it cannot do for temporary tables. The
+   default (per-row) insert path is unaffected.
 
    To preserve datetime precision with SQL Server temporary tables, add
    ``UseFMTONLY=Yes`` to your connection string:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2912,6 +2912,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Not all datastores support ``method="multi"``. Oracle, for example,
         does not support multi-value insert.
 
+        When using SQL Server with pyodbc, datetime precision may be lost when
+        writing to local temporary tables (names starting with ``#``). To avoid
+        this, add ``UseFMTONLY=Yes`` to the connection string. See
+        :ref:`io.sql_datetime_data` for details.
+
         References
         ----------
         .. [1] https://docs.sqlalchemy.org

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2912,10 +2912,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Not all datastores support ``method="multi"``. Oracle, for example,
         does not support multi-value insert.
 
-        When using SQL Server with pyodbc, datetime precision may be lost when
-        writing to local temporary tables (names starting with ``#``). To avoid
-        this, add ``UseFMTONLY=Yes`` to the connection string. See
-        :ref:`io.sql_datetime_data` for details.
+        When using SQL Server with pyodbc and ``fast_executemany=True``, datetime
+        precision may be lost when writing to local temporary tables (names starting
+        with ``#``). To avoid this, add ``UseFMTONLY=Yes`` to the connection string.
+        See :ref:`io.sql_datetime_data` for details.
 
         References
         ----------


### PR DESCRIPTION
Adds documentation warning about potential datetime precision loss when using `DataFrame.to_sql()` with Microsoft SQL Server local temporary tables (table names starting with `#`).

### Background

When using `pyodbc` with `fast_executemany=True`, the ODBC driver relies on `sp_describe_undeclared_parameters` to infer parameter types. This stored procedure does not support local temporary tables, which can cause the driver to fall back to default type inference and truncate datetime precision.

This is a known limitation in the ODBC/pyodbc layer rather than pandas itself. See https://github.com/mkleehammer/pyodbc/issues/295 for more details.


### Changes

- Added a note in the *Datetime data types* section of `doc/source/user_guide/io.rst` describing the issue and a known workaround (`UseFMTONLY=Yes`)
- Added a short note to the `to_sql()` docstring pointing readers to the documentation

### Workaround

Users can add `UseFMTONLY=Yes` to their connection string:

```python
connection_string = (
    "mssql+pyodbc://user:password@server/database"
    "?driver=ODBC+Driver+17+for+SQL+Server"
    "&UseFMTONLY=Yes"
)
```

Closes #62995