### PR TITLE
FIX: use per-block shape when deciding split behavior in Block.conver…

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -544,7 +544,7 @@ class Block(PandasObject, libinternals.Block):
         for blk in blks:
             # Determine dtype column by column
             sub_blks = (
-                [blk] if blk.ndim == 1 or self.shape[0] == 1 else list(blk._split())
+                [blk] if blk.ndim == 1 or blk.shape[0] == 1 else list(blk._split())
             )
             dtypes = [
                 convert_dtypes(


### PR DESCRIPTION
Block.convert_dtypes decides whether to split blocks “column by column”, but
uses self.shape[0] instead of blk.shape[0] inside the per-block loop.

After self.convert(), blocks in `blks` may differ in shape from the original
block, so consulting `self.shape` can lead to incorrect splitting decisions
and unnecessary block fragmentation.

This change switches the check to blk.shape[0], aligning the logic with the
per-block semantics of the loop and the method’s intent, without affecting
existing behavior when shapes are uniform.