### PR TITLE
DOC: Fix GL08 for pandas.tseries.offsets.BHalfYearEnd.rule_code

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -75,9 +75,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.extensions.ExtensionArray.value_counts EX01,RT03,SA01" \
         -i "pandas.api.typing.Resampler.quantile PR01,PR07" \
         -i "pandas.tseries.offsets.BDay PR02,SA01" \
-        -i "pandas.tseries.offsets.BHalfYearBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.BHalfYearBegin.startingMonth GL08" \
-        -i "pandas.tseries.offsets.BHalfYearEnd.rule_code GL08" \
         -i "pandas.tseries.offsets.BHalfYearEnd.startingMonth GL08" \
         -i "pandas.tseries.offsets.BQuarterBegin.is_on_offset GL08" \
         -i "pandas.tseries.offsets.BQuarterBegin.rule_code GL08" \
@@ -143,9 +141,7 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.tseries.offsets.FY5253Quarter.variation GL08" \
         -i "pandas.tseries.offsets.FY5253Quarter.weekday GL08" \
         -i "pandas.tseries.offsets.FY5253Quarter.year_has_extra_week GL08" \
-        -i "pandas.tseries.offsets.HalfYearBegin.rule_code GL08" \
         -i "pandas.tseries.offsets.HalfYearBegin.startingMonth GL08" \
-        -i "pandas.tseries.offsets.HalfYearEnd.rule_code GL08" \
         -i "pandas.tseries.offsets.HalfYearEnd.startingMonth GL08" \
         -i "pandas.tseries.offsets.Hour.is_on_offset GL08" \
         -i "pandas.tseries.offsets.LastWeekOfMonth.is_on_offset GL08" \

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -3224,6 +3224,25 @@ cdef class HalfYearOffset(SingleConstructorOffset):
 
     @property
     def rule_code(self) -> str:
+        """
+        Return a string representing the frequency with month suffix.
+
+        This property generates a rule code string that combines the offset's
+        prefix with the abbreviated month name of the starting month.
+
+        See Also
+        --------
+        FY5253Quarter.get_rule_code_suffix : Return the suffix component of the rule
+            code for FY5253Quarter.
+        FY5253.get_rule_code_suffix : Return the suffix component of the rule code for
+            FY5253.
+
+        Examples
+        --------
+        >>> offset = pd.offsets.BHalfYearEnd(startingMonth=6)
+        >>> offset.rule_code
+        'BHYE-JUN'
+        """
         month = MONTH_ALIASES[self.startingMonth]
         return f"{self._prefix}-{month}"
 


### PR DESCRIPTION
- [ ] relates to #60365

Fixes

```
pandas.tseries.offsets.BHalfYearBegin.rule_code GL08
pandas.tseries.offsets.BHalfYearEnd.rule_code GL08
pandas.tseries.offsets.HalfYearBegin.rule_code GL08
pandas.tseries.offsets.HalfYearEnd.rule_code GL08
```