### PR TITLE
Fix Series.clip() failing with 0-d numpy arrays

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6807,7 +6807,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             self._get_axis_number(axis)
 
         res_name = ops.get_op_result_name(self, other)
-
+        if isinstance(other,np.ndarray) and other.ndim == 0:
+            other=other.item()
         if isinstance(other, Series):
             return self._binop(other, op, level=level, fill_value=fill_value)
         elif isinstance(other, (np.ndarray, list, tuple, ExtensionArray)):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6807,8 +6807,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             self._get_axis_number(axis)
 
         res_name = ops.get_op_result_name(self, other)
-        if isinstance(other,np.ndarray) and other.ndim == 0:
-            other=other.item()
+        if isinstance(other, np.ndarray) and other.ndim == 0:
+            other = other.item()
         if isinstance(other, Series):
             return self._binop(other, op, level=level, fill_value=fill_value)
         elif isinstance(other, (np.ndarray, list, tuple, ExtensionArray)):


### PR DESCRIPTION
This PR fixes a Series.clip() failing with 0-d numpy arrays that occurs when passing a 0-dimensional NumPy array (e.g., np.array(0)) as a bound.

The Issue
The current implementation calls len() on the input boundaries. While this works for sequences and multi-dimensional arrays, it causes a TypeError when the input is a 0-d array (scalar-like), as NumPy does not define len() for these objects.
Changes
Added a check to identify if the input is a 0-d array.

Modified the logic to use .item() to extract the scalar value when a 0-d array is detected

This ensures compatibility with scalar-like NumPy objects while maintaining existing behavior for sequences.