### PR TITLE
ENH: Improve error message for integer dtype interpolation

### DIFF
--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -189,7 +189,18 @@ def clean_fill_method(
         valid_methods.append("nearest")
         expecting = "pad (ffill), backfill (bfill) or nearest"
     if method not in valid_methods:
-        raise ValueError(f"Invalid fill method. Expecting {expecting}. Got {method}")
+        msg = f"Invalid fill method. Expecting {expecting}. Got {method}"
+        if method in ("linear", "time", "index", "values", "nearest", "zero", 
+                      "slinear", "quadratic", "cubic", "barycentric", "krogh",
+                      "spline", "polynomial", "from_derivatives", 
+                      "piecewise_polynomial", "pchip", "akima", "cubicspline"):
+            msg += (
+                ". Note: interpolation methods like 'linear' are not supported "
+                "for integer dtypes. Integer columns only support 'pad' (ffill) "
+                "and 'backfill' (bfill) methods. Consider converting to float dtype "
+                "if you need to use interpolation."
+            )
+        raise ValueError(msg)
     return method
 
 

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -806,3 +806,18 @@ class TestSeriesInterpolateData:
         result = ser.interpolate(method="nearest", fill_value=0)
         expected = Series([np.nan, 0, 1, 1, 3, 0])
         tm.assert_series_equal(result, expected)
+
+    def test_interpolate_integer_dtype_error_message(self):
+        # GH#41565
+        # Test that interpolating an integer Series with method='linear' provides
+        # a helpful error message suggesting the limitation and workaround
+        s = Series([1, None, 3], dtype=pd.Int64Dtype())
+        msg = (
+            r"Invalid fill method\. Expecting pad \(ffill\) or backfill \(bfill\)\. "
+            r"Got linear\. Note: interpolation methods like 'linear' are not supported "
+            r"for integer dtypes\. Integer columns only support 'pad' \(ffill\) and "
+            r"'backfill' \(bfill\) methods\. Consider converting to float dtype "
+            r"if you need to use interpolation\."
+        )
+        with pytest.raises(ValueError, match=msg):
+            s.interpolate(method="linear")


### PR DESCRIPTION
- Add helpful hint when trying to interpolate integer columns with unsupported methods like 'linear'
- Explain that integer dtypes only support 'pad' and 'backfill'
- Suggest converting to float dtype as workaround
- Add test to verify improved error message

Fixes #41565