### PR TITLE
DOC: Inline storage_options docstring for OpenpyxlReader

### DIFF
--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -538,7 +538,6 @@ class OpenpyxlWriter(ExcelWriter):
 
 
 class OpenpyxlReader(BaseExcelReader["Workbook"]):
-    @doc(storage_options=_shared_docs["storage_options"])
     def __init__(
         self,
         filepath_or_buffer: FilePath | ReadBuffer[bytes],
@@ -552,7 +551,17 @@ class OpenpyxlReader(BaseExcelReader["Workbook"]):
         ----------
         filepath_or_buffer : str, path object or Workbook
             Object to be parsed.
-        {storage_options}
+
+        storage_options : dict, optional
+            Extra options that make sense for a particular storage connection, e.g.
+            host, port, username, password, etc. For HTTP(S) URLs the key-value pairs
+            are forwarded to ``urllib.request.Request`` as header options. For other
+            URLs (e.g. starting with "s3://", and "gcs://") the key-value pairs are
+            forwarded to ``fsspec.open``. Please see ``fsspec`` and ``urllib`` for more
+            details, and for more examples on storage options refer `here
+            <https://pandas.pydata.org/docs/user_guide/io.html?
+            highlight=storage_options#reading-writing-remote-files>`_.
+
         engine_kwargs : dict, optional
             Arbitrary keyword arguments passed to excel engine.
         """


### PR DESCRIPTION
This PR removes the usage of the @doc decorator in OpenpyxlReader.__init__,
by inlining the storage_options documentation directly in the docstring.

Changes made:
- Removed @doc decorator
- Updated docstrings for clarity

Fixes #62437
