### PR TITLE
TST: update test_group_var_large_inputs to work with numpy 2.5

### DIFF
--- a/pandas/tests/groupby/test_libgroupby.py
+++ b/pandas/tests/groupby/test_libgroupby.py
@@ -113,8 +113,7 @@ class TestGroupVarFloat64(GroupVarTestMixin):
 
         out = np.array([[np.nan]], dtype=self.dtype)
         counts = np.array([0], dtype="int64")
-        values = (prng.random(10**6) + 10**12).astype(self.dtype)
-        values.shape = (10**6, 1)
+        values = (prng.random((10**6, 1)) + 10**12).astype(self.dtype)
         labels = np.zeros(10**6, dtype="intp")
 
         self.algo(out, counts, values, labels)


### PR DESCRIPTION
This should fix the currently failing CI about changing the shape of an array by assigning to `.shape` being deprecated