### PR TITLE
API: DatetimeIndex.equals with mismatched units

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -272,11 +272,11 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
             return False
         elif self.dtype == other.dtype:
             return np.array_equal(self.asi8, other.asi8)
-        elif (self.dtype.kind == "M" and self.tz == other.tz) or self.dtype.kind == "m":
+        elif (self.dtype.kind == "M" and self.tz == other.tz) or self.dtype.kind == "m":  # type: ignore[attr-defined]
             # different units, otherwise matching
             try:
                 # TODO: do this at the EA level?
-                left, right = self._data._ensure_matching_resos(other._data)
+                left, right = self._data._ensure_matching_resos(other._data)  # type: ignore[union-attr]
             except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
                 return False
             else:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -37,6 +37,8 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import (
     InvalidIndexError,
     NullFrequencyError,
+    OutOfBoundsDatetime,
+    OutOfBoundsTimedelta,
 )
 from pandas.util._decorators import (
     cache_readonly,
@@ -266,11 +268,20 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
                     #  OverflowError -> Index([very_large_timedeltas])
                     return False
 
-        if self.dtype != other.dtype:
-            # have different timezone
+        if type(self) != type(other):
             return False
-
-        return np.array_equal(self.asi8, other.asi8)
+        elif self.dtype == other.dtype:
+            return np.array_equal(self.asi8, other.asi8)
+        elif (self.dtype.kind == "M" and self.tz == other.tz) or self.dtype.kind == "m":
+            # different units, otherwise matching
+            try:
+                # TODO: do this at the EA level?
+                left, right = self._data._ensure_matching_resos(other._data)
+            except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
+                return False
+            else:
+                return np.array_equal(left.view("i8"), right.view("i8"))
+        return False
 
     def __contains__(self, key: Any) -> bool:
         """

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -245,8 +245,12 @@ class TestDatetimeIndexSetOps:
 
         # Test intersection
         result = idx1.intersection(idx2)
-        expected = date_range("2000-01-01", periods=3, tz=tz).as_unit("ns")
+        expected = date_range("2000-01-01", periods=3, tz=tz)
         tm.assert_index_equal(result, expected)
+
+        # Intersection dtype is not commutative
+        result2 = idx2.intersection(idx1)
+        tm.assert_index_equal(result2, expected.as_unit("ns"))
 
     def test_symmetric_difference_same_timezone_different_units(self):
         # GH 60080 - fix timezone being changed to UTC when units differ

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -1060,3 +1060,19 @@ def test_rmod_consistent_large_series():
     expected = Series([1] * 10001)
 
     tm.assert_series_equal(result, expected)
+
+
+def test_comparison_mismatched_datetime_units():
+    # GH#63459
+
+    dti = date_range("2016-01-01", periods=3)
+    ser = Series(1, index=dti)
+    ser2 = Series(1, index=dti.as_unit("ns"))
+
+    result = ser == ser2
+    expected = Series([True, True, True], index=ser.index)
+    tm.assert_series_equal(result, expected)
+
+    result2 = ser2 < ser
+    expected2 = Series([False, False, False], index=ser2.index)
+    tm.assert_series_equal(result2, expected2)

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -1062,12 +1062,19 @@ def test_rmod_consistent_large_series():
     tm.assert_series_equal(result, expected)
 
 
-def test_comparison_mismatched_datetime_units():
+@pytest.mark.parametrize(
+    "index",
+    [
+        date_range("2016-01-01", periods=3),
+        date_range("2016-01-01", tz="US/Pacific", periods=3),
+        pd.timedelta_range("1 Day", periods=3),
+    ],
+)
+def test_comparison_mismatched_datetime_units(index):
     # GH#63459
 
-    dti = date_range("2016-01-01", periods=3)
-    ser = Series(1, index=dti)
-    ser2 = Series(1, index=dti.as_unit("ns"))
+    ser = Series(1, index=index)
+    ser2 = Series(1, index=index.as_unit("ns"))
 
     result = ser == ser2
     expected = Series([True, True, True], index=ser.index)


### PR DESCRIPTION
- [x] closes #63459 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
