### PR TITLE
DOC: clarify free-threaded wheel availability for Windows

### DIFF
--- a/doc/source/whatsnew/v2.3.3.rst
+++ b/doc/source/whatsnew/v2.3.3.rst
@@ -14,8 +14,10 @@ Pandas 2.3.3 is now compatible with Python 3.14
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pandas 2.3.3 is the first version of pandas that is generally compatible with the upcoming
-Python 3.14, and both wheels for free-threaded and normal Python 3.14 will be uploaded for
-this release.
+Python 3.14. Wheels for both free-threaded and normal Python 3.14 are provided on macOS
+and Linux platforms. Free-threaded Python 3.14 wheels were not published for Windows
+in this release.
+
 
 As usual please report any bugs discovered to our `issue tracker <https://github.com/pandas-dev/pandas/issues/new/choose>`_
 


### PR DESCRIPTION
Fixes #63649

Clarifies that free-threaded Python 3.14 wheels were not published for Windows
in the pandas 2.3.3 release.
