### PR TITLE
Remove redundant rule when python>=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,8 +301,6 @@ ignore = [
   "PYI041",
   # incorrect-dict-iterator, flags valid Series.items usage
   "PERF102",
-  # try-except-in-loop, becomes useless in Python 3.11
-  "PERF203",
   # pytest-parametrize-names-wrong-type
   "PT006",
   # pytest-parametrize-values-wrong-type


### PR DESCRIPTION
This rule is only run for Python versions prior to 3.11

https://docs.astral.sh/ruff/rules/try-except-in-loop/