### PR TITLE
BUG: assert_series_equal failing when comparing two series of null-like values of different types when using the parameter check_dtype=False

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1466,6 +1466,7 @@ Other
   array if the array shares data with the original DataFrame or Series (:ref:`copy_on_write_read_only_na`).
   This logic is expanded to accessing the underlying pandas ExtensionArray
   through ``.array`` (or ``.values`` depending on the dtype) as well (:issue:`61925`).
+- Bug in :func:`.testing.assert_series_equal` failing when comparing two series of null-like values of different types when using parameter ``check_dtype=False`` (:issue:`61473`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1045,9 +1045,9 @@ def assert_series_equal(
             # convert both to NumPy if not, check_dtype would raise earlier
             lv, rv = left_values, right_values
             if isinstance(left_values, ExtensionArray):
-                lv = left_values.to_numpy()
+                lv = left_values.to_numpy(dtype="object")
             if isinstance(right_values, ExtensionArray):
-                rv = right_values.to_numpy()
+                rv = right_values.to_numpy(dtype="object")
             assert_numpy_array_equal(
                 lv,
                 rv,

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1044,10 +1044,11 @@ def assert_series_equal(
         else:
             # convert both to NumPy if not, check_dtype would raise earlier
             lv, rv = left_values, right_values
+            dtype = object if not check_dtype else None
             if isinstance(left_values, ExtensionArray):
-                lv = left_values.to_numpy(dtype="object")
+                lv = left_values.to_numpy(dtype=dtype)
             if isinstance(right_values, ExtensionArray):
-                rv = right_values.to_numpy(dtype="object")
+                rv = right_values.to_numpy(dtype=dtype)
             assert_numpy_array_equal(
                 lv,
                 rv,

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -507,3 +507,10 @@ def test_assert_series_equal_check_exact_index_default(left_idx, right_idx):
     ser2 = Series(np.zeros(6, dtype=int), right_idx)
     tm.assert_series_equal(ser1, ser2)
     tm.assert_frame_equal(ser1.to_frame(), ser2.to_frame())
+
+def test_assert_series_equal_na_values_different_dtype():
+    # GH#61473
+    ser1 = Series([pd.NA], dtype="Int32")
+    ser2 = Series([pd.NA], dtype="object")
+
+    tm.assert_series_equal(ser1, ser2, check_dtype=False)

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -508,6 +508,7 @@ def test_assert_series_equal_check_exact_index_default(left_idx, right_idx):
     tm.assert_series_equal(ser1, ser2)
     tm.assert_frame_equal(ser1.to_frame(), ser2.to_frame())
 
+
 def test_assert_series_equal_na_values_different_dtype():
     # GH#61473
     ser1 = Series([pd.NA], dtype="Int32")


### PR DESCRIPTION
- [X] closes #61473 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Based off the discussion in the issue 61473 I have updated the assert_series_equal to numpy arrays with the dtype 'object'

This prevents the series with null like values failing when check_dtype=False