### PR TITLE
TST: ensure categorical index levels remain categorical in merge

### DIFF
--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2229,13 +2229,21 @@ class TestMergeCategorical:
 
         df3 = df2.iloc[:10, :].groupby(["z", "x"], observed=True).agg({"d": "sum"})
         df4 = df2.iloc[90:, :].groupby(["z", "x", "y"], observed=True).agg({"d": "sum"})
-        result = (
-            merge(df3, df4, left_index=True, right_index=True, how="outer")
-            .index.to_frame()
-            .dtypes
+        result = merge(df3, df4, left_index=True, right_index=True, how="outer")
+
+        cats = list(range(1, 100))
+        z = Categorical(list(range(1, 11)) + list(range(91, 100)), categories=cats)
+        x = Categorical(list(range(1, 11)) + list(range(91, 100)), categories=cats)
+        y = Categorical([np.nan] * 10 + list(range(91, 100)), categories=cats)
+        idx = MultiIndex.from_arrays([z, x, y], names=["z", "x", "y"])
+        expected = DataFrame(
+            {
+                "d_x": list(map(float, range(1, 11))) + [np.nan] * 9,
+                "d_y": [np.nan] * 10 + list(map(float, range(91, 100))),
+            },
+            index=idx,
         )
-        assert isinstance(result["z"], CategoricalDtype)
-        assert isinstance(result["x"], CategoricalDtype)
+        tm.assert_frame_equal(result, expected)
 
 
 class TestMergeOnIndexes:

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2218,28 +2218,28 @@ class TestMergeCategorical:
         # GH#37480
         df1 = DataFrame(
             {
-                "x": list(range(1, 100)),
-                "y": list(range(1, 100)),
-                "z": list(range(1, 100)),
-                "d": list(range(1, 100)),
+                "x": list(range(1, 10)),
+                "y": list(range(1, 10)),
+                "z": list(range(1, 10)),
+                "d": list(range(1, 10)),
             }
         )
 
         df2 = df1.astype({"x": "category", "y": "category", "z": "category"})
 
-        df3 = df2.iloc[:10, :].groupby(["z", "x"], observed=True).agg({"d": "sum"})
-        df4 = df2.iloc[90:, :].groupby(["z", "x", "y"], observed=True).agg({"d": "sum"})
+        df3 = df2.iloc[:4, :].groupby(["z", "x"], observed=True).agg({"d": "sum"})
+        df4 = df2.iloc[7:, :].groupby(["z", "x", "y"], observed=True).agg({"d": "sum"})
         result = merge(df3, df4, left_index=True, right_index=True, how="outer")
 
-        cats = list(range(1, 100))
-        z = Categorical(list(range(1, 11)) + list(range(91, 100)), categories=cats)
-        x = Categorical(list(range(1, 11)) + list(range(91, 100)), categories=cats)
-        y = Categorical([np.nan] * 10 + list(range(91, 100)), categories=cats)
+        cats = list(range(1, 10))
+        z = Categorical(list(range(1, 5)) + list(range(8, 10)), categories=cats)
+        x = Categorical(list(range(1, 5)) + list(range(8, 10)), categories=cats)
+        y = Categorical([np.nan] * 4 + list(range(8, 10)), categories=cats)
         idx = MultiIndex.from_arrays([z, x, y], names=["z", "x", "y"])
         expected = DataFrame(
             {
-                "d_x": list(map(float, range(1, 11))) + [np.nan] * 9,
-                "d_y": [np.nan] * 10 + list(map(float, range(91, 100))),
+                "d_x": list(map(float, range(1, 5))) + [np.nan] * 2,
+                "d_y": [np.nan] * 4 + list(map(float, range(8, 10))),
             },
             index=idx,
         )

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2214,6 +2214,29 @@ class TestMergeCategorical:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_merge_category_index_levels_stay_category(self):
+        # GH#37480
+        df1 = DataFrame(
+            {
+                "x": list(range(1, 100)),
+                "y": list(range(1, 100)),
+                "z": list(range(1, 100)),
+                "d": list(range(1, 100)),
+            }
+        )
+
+        df2 = df1.astype({"x": "category", "y": "category", "z": "category"})
+
+        df3 = df2.iloc[:10, :].groupby(["z", "x"], observed=True).agg({"d": "sum"})
+        df4 = df2.iloc[90:, :].groupby(["z", "x", "y"], observed=True).agg({"d": "sum"})
+        result = (
+            merge(df3, df4, left_index=True, right_index=True, how="outer")
+            .index.to_frame()
+            .dtypes
+        )
+        assert isinstance(result["z"], CategoricalDtype)
+        assert isinstance(result["x"], CategoricalDtype)
+
 
 class TestMergeOnIndexes:
     @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] closes #37480

The reproducible example works correctly on main. Added a test to cover it.