### PR TITLE
DOC: Clarify how skiprows interacts with header in read_csv

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -448,8 +448,8 @@ def read_csv(
         specify row locations for a :class:`~pandas.MultiIndex` on the columns
         e.g. ``[0, 1, 3]``. Intervening rows that are not specified will be
         skipped (e.g. 2 in this example is skipped). Note that this
-        parameter ignores commented lines and empty lines if
-        ``skip_blank_lines=True``, so ``header=0`` denotes the first line of
+        parameter ignores commented lines, empty lines if
+        ``skip_blank_lines=True``, and skipped rows if ``skiprows > 0``, so ``header=0`` denotes the first line of
         data rather than the first line of the file.
 
         When inferred from the file contents, headers are kept distinct from
@@ -545,6 +545,7 @@ def read_csv(
 
         * To read rows 1,000,000 through 1,999,999:
           ``read_csv(..., skiprows=1000000, nrows=999999)``
+          Note that you'll need to specify column names for this call to avoid interpreting line 1,000,000 as a header row.
 
     na_values : Hashable, Iterable of Hashable or dict of {{Hashable : Iterable}},
         optional


### PR DESCRIPTION
This caught me off guard and will hopefully save the next person some of the hours I just wasted. Skiprows applies before the header parameter, despite what the listed example for nrows would lead you to believe.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
