### PR TITLE
DOC: update matching version label for RCs in conf.py for version dropdown

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -237,7 +237,7 @@ html_theme = "pydata_sphinx_theme"
 if ".dev" in version or ("rc" in version and "+" in version):
     switcher_version = "dev"
 elif "rc" in version:
-    switcher_version = version.split("rc", maxsplit=1)[0] + " (rc)"
+    switcher_version = ".".join(version.split(".")[:2]) + " (rc)"
 else:
     # only keep major.minor version number to match versions.json
     switcher_version = ".".join(version.split(".")[:2])


### PR DESCRIPTION
Too late for now, but already fixing in case we use this in the future. This should fix that currently for the rc docs (https://pandas.pydata.org/pandas-docs/version/3.0/index.html), the dropdown use "Choose version" instead of the actual version ("3.0 (rc)") as label for the dropdown button.