### PR TITLE
BLD: unpin meson(-python) in environment.yml, bump minimum meson-python in build-system requires

### DIFF
--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -6,7 +6,8 @@ inputs:
     default: true
   werror:
     description: Enable werror flag for build
-    default: true
+    # TMP disable werror until we fix all warnings with more recent meson
+    default: false
 runs:
   using: composite
   steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -167,8 +167,10 @@ jobs:
       id: build
       uses: ./.github/actions/build_pandas
       with:
-        # xref https://github.com/cython/cython/issues/6870
-        werror: ${{ matrix.name != 'Freethreading' }}
+        # TMP disable werror until we fix all warnings with more recent meson
+        werror: false
+        # # xref https://github.com/cython/cython/issues/6870
+        # werror: ${{ matrix.name != 'Freethreading' }}
 
     - name: Test (not single_cpu)
       uses: ./.github/actions/run-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -166,11 +166,10 @@ jobs:
     - name: Build Pandas
       id: build
       uses: ./.github/actions/build_pandas
-      with:
-        # TMP disable werror until we fix all warnings with more recent meson
-        werror: false
-        # # xref https://github.com/cython/cython/issues/6870
-        # werror: ${{ matrix.name != 'Freethreading' }}
+      # TMP disable werror until we fix all warnings with more recent meson
+      # with:
+      #   # xref https://github.com/cython/cython/issues/6870
+      #   werror: ${{ matrix.name != 'Freethreading' }}
 
     - name: Test (not single_cpu)
       uses: ./.github/actions/run-tests

--- a/ci/deps/actions-311-minimum_versions.yaml
+++ b/ci/deps/actions-311-minimum_versions.yaml
@@ -10,7 +10,7 @@ dependencies:
   - versioneer
   - cython<4.0.0a0
   - meson=1.2.1
-  - meson-python=0.13.1
+  - meson-python=0.17.1
 
   # test dependencies
   - pytest>=8.3.4

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython<4.0.0a0
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson=1.10.0
+  - meson-python=0.18.0
 
   # test dependencies
   - pytest>=8.3.4

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython<4.0.0a0
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson=1.10.0
+  - meson-python=0.18.0
 
   # test dependencies
   - pytest>=8.3.4

--- a/ci/deps/actions-313-downstream_compat.yaml
+++ b/ci/deps/actions-313-downstream_compat.yaml
@@ -8,8 +8,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython<4.0.0a0
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson=1.10.0
+  - meson-python=0.18.0
 
   # test dependencies
   - pytest>=8.3.4

--- a/ci/deps/actions-313-freethreading.yaml
+++ b/ci/deps/actions-313-freethreading.yaml
@@ -8,7 +8,7 @@ dependencies:
   - setuptools
   - versioneer
   - cython<4.0.0a0
-  - meson=1.8.0
+  - meson=1.10.0
   - meson-python=0.18.0
 
   # test dependencies

--- a/ci/deps/actions-313-numpydev.yaml
+++ b/ci/deps/actions-313-numpydev.yaml
@@ -6,8 +6,8 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson=1.10.0
+  - meson-python=0.18.0
   - cython<4.0.0a0
 
   # test dependencies

--- a/ci/deps/actions-313-pyarrownightly.yaml
+++ b/ci/deps/actions-313-pyarrownightly.yaml
@@ -6,9 +6,9 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - meson=1.2.1
   - cython<4.0.0a0
-  - meson-python=0.13.1
+  - meson=1.10.0
+  - meson-python=0.18.0
 
   # test dependencies
   - pytest>=8.3.4

--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -7,8 +7,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython<4.0.0a0
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson=1.10.0
+  - meson-python=0.18.0
 
   # test dependencies
   - pytest>=8.3.4

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   # build dependencies
   - versioneer
   - cython<4.0.0a0
-  - meson=1.2.1
-  - meson-python=0.13.1
+  - meson>=1.2.1,<2
+  - meson-python>=0.17.1,<1
 
   # test dependencies
   - pytest>=8.3.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,13 @@
 # Minimum requirements for the build system to execute.
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
-    "meson-python>=0.13.1",
+    "meson-python>=0.17.1,<1",
     "meson>=1.2.1,<2",
     "wheel",
     "Cython<4.0.0a0",  # Note: sync with setup.py, environment.yml and asv.conf.json
-    # Force numpy higher than 2.0rc1, so that built wheels are compatible
+    # Force numpy higher than 2.0, so that built wheels are compatible
     # with both numpy 1 and 2
-    "numpy>=2.0.0rc1",
+    "numpy>=2.0.0",
     "versioneer[toml]"
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@
 pip
 versioneer[toml]
 cython<4.0.0a0
-meson[ninja]==1.2.1
-meson-python==0.13.1
+meson[ninja]>=1.2.1,<2
+meson-python>=0.17.1,<1
 pytest>=8.3.4
 pytest-cov
 pytest-xdist>=3.6.1


### PR DESCRIPTION
Partial redo of https://github.com/pandas-dev/pandas/pull/62086 (and https://github.com/pandas-dev/pandas/pull/60681), seeing how this goes now without the additional changes (although I assume we will have to add some of those build config updates to get the builds passing)

While the temporary suppressing of `-Werror` is not ideal (for new warnings), in practice we already have all those warnings anyway (there are present in the wheels builds which already use newer meson, and just don't bubble up in most CI with the older versions).

Closes #63686