### PR TITLE
TYP: Update TimeAmbiguous type to include bool

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -479,7 +479,9 @@ MatplotlibColor: TypeAlias = str | Sequence[float]
 TimeGrouperOrigin: TypeAlias = Union[
     "Timestamp", Literal["epoch", "start", "start_day", "end", "end_day"]
 ]
-TimeAmbiguous: TypeAlias = Literal["infer", "NaT", "raise"] | npt.NDArray[np.bool_]
+TimeAmbiguous: TypeAlias = (
+    Literal["infer", "NaT", "raise"] | bool | npt.NDArray[np.bool_]
+)
 TimeNonexistent: TypeAlias = (
     Literal["shift_forward", "shift_backward", "NaT", "raise"] | timedelta
 )


### PR DESCRIPTION
Internally, the `ambiguous` parameter supports a single bool as well as an array of bool (https://github.com/pandas-dev/pandas/blob/2.3.x/pandas/_libs/tslibs/tzconversion.pyx#L206). Passing a single bool is also handled correctly at runtime (https://github.com/pandas-dev/pandas/blob/2.3.x/pandas/_libs/tslibs/tzconversion.pyx#L263-L268). The public API currently enforces an array—which either means unnecessary overhead or ignoring the type hint.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
