### PR TITLE
TST: test concat_compat for datetime-EA with non-ns

### DIFF
--- a/pandas/tests/dtypes/test_concat.py
+++ b/pandas/tests/dtypes/test_concat.py
@@ -1,3 +1,6 @@
+import datetime as dt
+
+import numpy as np
 import pytest
 
 import pandas.core.dtypes.concat as _concat
@@ -64,3 +67,13 @@ def test_concat_series_between_empty_and_tzaware_series(using_infer_string):
         dtype=float,
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_concat_compat_on_non_ns_datetime_EA():
+    # GH#33331
+    np_datetimes = np.array([dt.date(2010, 1, 1)], dtype="datetime64[D]")
+    other = pd.array(["a", "b"], dtype="category")
+
+    result = _concat.concat_compat([np_datetimes, other])
+    expected = np.array([pd.Timestamp("2010-01-01 00:00:00"), "a", "b"], dtype=object)
+    tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/dtypes/test_concat.py
+++ b/pandas/tests/dtypes/test_concat.py
@@ -1,6 +1,3 @@
-import datetime as dt
-
-import numpy as np
 import pytest
 
 import pandas.core.dtypes.concat as _concat
@@ -67,13 +64,3 @@ def test_concat_series_between_empty_and_tzaware_series(using_infer_string):
         dtype=float,
     )
     tm.assert_frame_equal(result, expected)
-
-
-def test_concat_compat_on_non_ns_datetime_EA():
-    # GH#33331
-    np_datetimes = np.array([dt.date(2010, 1, 1)], dtype="datetime64[D]")
-    other = pd.array(["a", "b"], dtype="category")
-
-    result = _concat.concat_compat([np_datetimes, other])
-    expected = np.array([pd.Timestamp("2010-01-01 00:00:00"), "a", "b"], dtype=object)
-    tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -286,6 +286,16 @@ class TestDatetimeConcat:
         result = concat([first, second])
         tm.assert_frame_equal(result, expected)
 
+    def test_concat_compat_on_non_ns_datetime_EA(self):
+        # GH#33331
+        first = Series(np.array([datetime(2010, 1, 1)], dtype="datetime64[D]"))
+        second = Series(pd.array(["a", "b"], dtype="category"))
+
+        expected = Series([Timestamp("2010-01-01 00:00:00"), "a", "b"])
+
+        result = concat([first, second], ignore_index=True)
+        tm.assert_series_equal(result, expected)
+
 
 class TestTimezoneConcat:
     def test_concat_tz_series(self):


### PR DESCRIPTION
- [x] closes #33331

The reproducible example works correctly on main. Added a test to cover it.


