### PR TITLE
BUG: Fix to_csv/astype tz-aware datetime formatting inconsistency

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1363,6 +1363,7 @@ I/O
 - Bug in :meth:`MultiIndex.factorize` incorrectly raising on length-0 indexes (:issue:`57517`)
 - Bug in :meth:`read_csv` causing segmentation fault when ``encoding_errors`` is not a string. (:issue:`59059`)
 - Bug in :meth:`read_csv` for the ``c`` and ``python`` engines where parsing numbers with large exponents caused overflows. Now, numbers with large positive exponents are parsed as ``inf`` or ``-inf`` depending on the sign of the mantissa, while those with large negative exponents are parsed as ``0.0`` (:issue:`62617`, :issue:`38794`, :issue:`62740`)
+- Bug in :meth:`DataFrame.to_csv` and :meth:`Series.astype` where timezone-aware datetimes were formatted with inconsistent sub-second precision (:issue:`62111`)
 - Bug in :meth:`DataFrame.to_csv` where ``quotechar`` is not escaped when ``escapechar`` is not ``None`` (:issue:`61407`)
 - Bug in :meth:`read_csv` raising ``TypeError`` when ``index_col`` is specified and ``na_values`` is a dict containing the key ``None``. (:issue:`57547`)
 - Bug in :meth:`read_csv` raising ``TypeError`` when ``nrows`` and ``iterator`` are specified without specifying a ``chunksize``. (:issue:`59079`)

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -202,6 +202,7 @@ def format_array_from_datetime(
         object res
         npy_datetimestruct dts
         Py_ssize_t pos
+        str timespec = "auto"
 
         # Note that `result` (and thus `result_flat`) is C-order and
         #  `it` iterates C-order as well, so the iteration matches
@@ -247,6 +248,19 @@ def format_array_from_datetime(
         elif format == "%Y-%m-%d":
             # Default format for dates
             basic_format_day = True
+
+    else:
+        # GH#62111: detect resolution for consistent formatting
+        if format is None:
+            reso_obj = get_resolution(values, tz=tz, reso=reso)
+            if reso_obj == Resolution.RESO_NS:
+                timespec = "nanoseconds"
+            elif reso_obj == Resolution.RESO_US:
+                timespec = "microseconds"
+            elif reso_obj == Resolution.RESO_MS:
+                timespec = "milliseconds"
+            else:
+                timespec = "seconds"
 
     if format is not None and not basic_format and not basic_format_day:
         fmt_template = _convert_strftime_format(format)
@@ -297,8 +311,8 @@ def format_array_from_datetime(
 
             ts = Timestamp._from_value_and_reso(val, reso=reso, tz=tz)
             if format is None:
-                # Use datetime.str, that returns ts.isoformat(sep=' ')
-                res = str(ts)
+                # GH#62111
+                res = ts.isoformat(sep=" ", timespec=timespec)
             else:
 
                 # invalid format string

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1087,7 +1087,7 @@ default 'raise'
 
         >>> s.dt.tz_localize('Europe/Warsaw', nonexistent='shift_backward')
         0   2015-03-29 01:59:59.999999999+01:00
-        1   2015-03-29 03:30:00+02:00
+        1   2015-03-29 03:30:00.000000000+02:00
         dtype: datetime64[ns, Europe/Warsaw]
 
         >>> s.dt.tz_localize('Europe/Warsaw', nonexistent=pd.Timedelta('1h'))

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11320,7 +11320,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         dtype: int64
         >>> s.tz_localize("Europe/Warsaw", nonexistent="shift_backward")
         2015-03-29 01:59:59.999999999+01:00    0
-        2015-03-29 03:30:00+02:00              1
+        2015-03-29 03:30:00.000000000+02:00    1
         dtype: int64
         >>> s.tz_localize("Europe/Warsaw", nonexistent=pd.Timedelta("1h"))
         2015-03-29 03:30:00+02:00    0

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -722,7 +722,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
         >>> s.dt.tz_localize('Europe/Warsaw', nonexistent='shift_backward')
         0   2015-03-29 01:59:59.999999999+01:00
-        1   2015-03-29 03:30:00+02:00
+        1   2015-03-29 03:30:00.000000000+02:00
         dtype: datetime64[ns, Europe/Warsaw]
 
         >>> s.dt.tz_localize('Europe/Warsaw', nonexistent=pd.Timedelta('1h'))

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -1,4 +1,8 @@
 import csv
+from datetime import (
+    datetime,
+    timezone,
+)
 import io
 import os
 import sys
@@ -997,3 +1001,40 @@ def test_to_csv_categorical_tz_timestamp_with_na_rep():
     )
     result_na = DataFrame({"ct": ser_na}).to_csv(na_rep=r"\N")
     assert r"\N" in result_na
+
+
+def test_to_csv_datetime_tz_consistent_format():
+    # GH#62111
+    df = DataFrame(
+        {
+            "timestamp": [
+                datetime(2025, 8, 14, 12, 34, 56, 0, tzinfo=timezone.utc),
+                datetime(2025, 8, 14, 12, 34, 56, 1, tzinfo=timezone.utc),
+            ]
+        }
+    )
+    result = df.to_csv(index=False)
+    expected_rows = [
+        "timestamp",
+        "2025-08-14 12:34:56.000000+00:00",
+        "2025-08-14 12:34:56.000001+00:00",
+    ]
+    expected = tm.convert_rows_list_to_csv_str(expected_rows)
+    assert result == expected
+
+    df = DataFrame(
+        {
+            "timestamp": [
+                datetime(2025, 8, 14, 12, 34, 56, 0, tzinfo=timezone.utc),
+                datetime(2025, 8, 14, 12, 34, 57, 0, tzinfo=timezone.utc),
+            ]
+        }
+    )
+    result = df.to_csv(index=False)
+    expected_rows = [
+        "timestamp",
+        "2025-08-14 12:34:56+00:00",
+        "2025-08-14 12:34:57+00:00",
+    ]
+    expected = tm.convert_rows_list_to_csv_str(expected_rows)
+    assert result == expected


### PR DESCRIPTION
- [x] closes #62111 
- [x] [Tests added and passed] if fixing a bug or adding a new feature
- [x] All [code checks passed].
- [ ] Added [type annotations] to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

When formatting timezone-aware datetimes via `to_csv`, `astype(str)`, or repr of tz-aware `DatetimeIndex`, values with zero sub-second components were formatted without the fractional part (e.g., 12:34:56+00:00) while values with non-zero sub-seconds included it (e.g., 12:34:56.000001+00:00).

The fix extends the resolution detection logic (already used for tz-naive datetimes) to tz-aware datetimes, applying consistent formatting.