### PR TITLE
BUG : Fix is_string_dtype returning True for empty object-dtype arrays

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1921,7 +1921,7 @@ def is_all_strings(value: ArrayLike) -> bool:
 
     if isinstance(dtype, np.dtype):
         if len(value) == 0:
-            return dtype == np.dtype("object")
+            return False
         else:
             return dtype == np.dtype("object") and lib.is_string_array(
                 np.asarray(value), skipna=False

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -328,7 +328,7 @@ def test_is_string_dtype(dtype, expected):
 def test_is_string_dtype_empty_object_array_false():
     arr = np.array([], dtype=object)
     assert not com.is_string_dtype(arr)
-    
+
 
 @pytest.mark.parametrize(
     "data",

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -325,6 +325,11 @@ def test_is_string_dtype(dtype, expected):
     assert result is expected
 
 
+def test_is_string_dtype_empty_object_array_false():
+    arr = np.array([], dtype=object)
+    assert not com.is_string_dtype(arr)
+    
+
 @pytest.mark.parametrize(
     "data",
     [[(0, 1), (1, 1)], pd.Categorical([1, 2, 3]), np.array([1, 2], dtype=object)],


### PR DESCRIPTION
is_string_dtype currently returns True for empty NumPy arrays with object dtype. Since the array contains no elements, no string inference can be made, and treating it as string-like is incorrect.

The behavior comes from is_all_strings, which special-cases empty object-dtype arrays and returns True based only on the container dtype. This infers string-ness without examining any values, which is inconsistent with how dtype inference works elsewhere in pandas and contradicts the documented behavior of is_string_dtype.

This change updates is_all_strings so that empty object-dtype arrays are no longer considered string-like. Non-empty object arrays, StringDtype, categoricals, and NumPy string dtypes are unaffected.
