### PR TITLE
TYP: Silence mypy comparison-overlap in datetimes.py

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2970,7 +2970,7 @@ def _generate_range(
     # Argument 1 to "Timestamp" has incompatible type "Optional[Timestamp]";
     # expected "Union[integer[Any], float, str, date, datetime64]"
     start = Timestamp(start)  # type: ignore[arg-type]
-    if start is not NaT: # type: ignore[comparison-overlap]
+    if start is not NaT:  # type: ignore[comparison-overlap]
         start = start.as_unit(unit)
     else:
         start = None
@@ -2978,7 +2978,7 @@ def _generate_range(
     # Argument 1 to "Timestamp" has incompatible type "Optional[Timestamp]";
     # expected "Union[integer[Any], float, str, date, datetime64]"
     end = Timestamp(end)  # type: ignore[arg-type]
-    if end is not NaT: # type: ignore[comparison-overlap]
+    if end is not NaT:  # type: ignore[comparison-overlap]
         end = end.as_unit(unit)
     else:
         end = None

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2970,7 +2970,7 @@ def _generate_range(
     # Argument 1 to "Timestamp" has incompatible type "Optional[Timestamp]";
     # expected "Union[integer[Any], float, str, date, datetime64]"
     start = Timestamp(start)  # type: ignore[arg-type]
-    if start is not NaT:
+    if start is not NaT: # type: ignore[comparison-overlap]
         start = start.as_unit(unit)
     else:
         start = None
@@ -2978,7 +2978,7 @@ def _generate_range(
     # Argument 1 to "Timestamp" has incompatible type "Optional[Timestamp]";
     # expected "Union[integer[Any], float, str, date, datetime64]"
     end = Timestamp(end)  # type: ignore[arg-type]
-    if end is not NaT:
+    if end is not NaT: # type: ignore[comparison-overlap]
         end = end.as_unit(unit)
     else:
         end = None


### PR DESCRIPTION
- [ ] closes #63721(Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
Resolves local mypy `comparison-overlap` errors in `datetimes.py` where `Timestamp` is checked against `NaT`.

## Verification on Latest Main
I pulled the latest changes (commit `60ff5221`, Jan 17) to verify if this was already fixed.

Running mypy locally on this commit **still flags** the errors:
`pandas/core/arrays/datetimes.py:2973: error: Non-overlapping identity check (left operand type: "Timestamp", right operand type: "NaTType")`

## Reason
While CI is passing (likely due to environment/version differences), the code logically performs a check `if start is not NaT` on a variable typed as `Timestamp`. This creates a conflict in strict environments because `Timestamp` constructors are not typed to return `NaT` (per decision #58475).

## Fix
Since the logic is correct but the typing is too strict, I added `# type: ignore[comparison-overlap]` to suppress the local noise, as suggested by maintainers in the related issue.