### PR TITLE
CI: Re-enable `-Werror` in Linux and MacOS

### DIFF
--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -6,8 +6,7 @@ inputs:
     default: true
   werror:
     description: Enable werror flag for build
-    # TMP disable werror until we fix all warnings with more recent meson
-    default: false
+    default: true
 runs:
   using: composite
   steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -212,6 +212,11 @@ jobs:
 
       - name: Build Pandas
         uses: ./.github/actions/build_pandas
+        with:
+          # Windows contains a lot of warnings regarding unsafe type conversion.
+          # It's possible to replicate some of them in clang with the `-Wconversion` flag.
+          # Tracking issue: https://github.com/pandas-dev/pandas/issues/63701
+          werror: ${{ runner.os != 'Windows' }}
 
       - name: Test
         uses: ./.github/actions/run-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -166,10 +166,6 @@ jobs:
     - name: Build Pandas
       id: build
       uses: ./.github/actions/build_pandas
-      # TMP disable werror until we fix all warnings with more recent meson
-      # with:
-      #   # xref https://github.com/cython/cython/issues/6870
-      #   werror: ${{ matrix.name != 'Freethreading' }}
 
     - name: Test (not single_cpu)
       uses: ./.github/actions/run-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -166,6 +166,11 @@ jobs:
     - name: Build Pandas
       id: build
       uses: ./.github/actions/build_pandas
+      with:
+        # python3.14t/cpython/pyatomic_gcc.h:63:10:
+        #   error: ‘__atomic_fetch_add_8’
+        #   writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
+        werror: ${{ matrix.name != 'Freethreading' }}
 
     - name: Test (not single_cpu)
       uses: ./.github/actions/run-tests

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -134,7 +134,7 @@ except ImportError:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def memory_usage_of_objects(arr: object[:]) -> int64_t:
+def memory_usage_of_objects(ndarray[object, ndim=1] arr) -> int64_t:
     """
     Return the memory usage of an object array in bytes.
 
@@ -3190,7 +3190,9 @@ def to_object_array_tuples(rows: object) -> np.ndarray:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def fast_multiget(dict mapping, object[:] keys, default=np.nan) -> "ArrayLike":
+def fast_multiget(
+    dict mapping, ndarray[object, ndim=1] keys, default=np.nan
+) -> "ArrayLike":
     cdef:
         Py_ssize_t i, n = len(keys)
         object val

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -60,7 +60,7 @@ def unstack(const numeric_object_t[:, :] values, const uint8_t[:] mask,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def explode(object[:] values):
+def explode(ndarray[object, ndim=1] values):
     """
     transform array list-likes to long form
     preserve non-list entries


### PR DESCRIPTION
- [x] xref #63701 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

This patch also fixes the warning of unused function on linux by changing the type annotation of some functions.