### PR TITLE
DOC: Fix ES01 for pandas.tseries.offsets.DateOffset.is_month_start

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -938,6 +938,9 @@ cdef class BaseOffset:
         """
         Return boolean whether a timestamp occurs on the month start.
 
+        This method determines if a given timestamp falls on the first day
+        of a month, considering the frequency of the offset.
+
         Parameters
         ----------
         ts : Timestamp


### PR DESCRIPTION
- [ ] related to #60365 

fixes

```
pandas.tseries.offsets.DateOffset.is_month_start ES01
```
