### PR TITLE
DEP: Require NumPy 2.3.3 on Python>=3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ license = {file = 'LICENSE'}
 requires-python = '>=3.11'
 dependencies = [
   "numpy>=1.26.0; python_version < '3.14'",
-  # NumPy 1.x is fundamentally broken on 3.14
-  "numpy>=2.0.0; python_version >= '3.14'",
+  # Earlier versions of NumPy are fundamentally broken on 3.14
+  "numpy>=2.3.3; python_version >= '3.14'",
   "python-dateutil>=2.8.2",
   "tzdata; sys_platform == 'win32'",
   # Emscripten is the platform system for Pyodide.


### PR DESCRIPTION
- [x] closes #63735 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

As mentioned in the issue, the patch fixing NumPy for Python 3.14 was merged into 2.3.3 and not earlier.