### PR TITLE
PERF: Skip normalization of named aggregations in groupby.agg when possible

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1802,6 +1802,8 @@ def reconstruct_func(
             func = {
                 column: aggfunc for key, (column, aggfunc) in converted_kwargs.items()
             }
+            # Normalization is skipped if all kwargs keys are the same as their
+            # corresponding column name.
             relabeling = False
 
     assert func is not None

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1770,6 +1770,7 @@ def reconstruct_func(
             raise TypeError("Must provide 'func' or tuples of '(column, aggfunc).")
 
     if relabeling:
+        normalization_needed = False
         # error: Incompatible types in assignment (expression has type
         # "MutableMapping[Hashable, list[Callable[..., Any] | str]]", variable has type
         # "Callable[..., Any] | str | list[Callable[..., Any] | str] |
@@ -1778,18 +1779,31 @@ def reconstruct_func(
         converted_kwargs = {}
         for key, val in kwargs.items():
             if isinstance(val, NamedAgg):
+                column = val.column
                 aggfunc = val.aggfunc
                 if val.args or val.kwargs:
                     aggfunc = lambda x, func=aggfunc, a=val.args, kw=val.kwargs: func(
                         x, *a, **kw
                     )
-                converted_kwargs[key] = (val.column, aggfunc)
             else:
-                converted_kwargs[key] = val
+                column, aggfunc = val
 
-        func, columns, order = normalize_keyword_aggregation(  # type: ignore[assignment]
-            converted_kwargs
-        )
+            if column != key:
+                normalization_needed = True
+            converted_kwargs[key] = column, aggfunc
+
+        if normalization_needed:
+            func, columns, order = normalize_keyword_aggregation(  # type: ignore[assignment]
+                converted_kwargs
+            )
+        else:
+            # When names match, convert to dict format {column: aggfunc}
+            # and disable relabeling since no reordering is needed
+            func = {
+                column: aggfunc
+                for key, (column, aggfunc) in converted_kwargs.items()
+            }
+            relabeling = False
 
     assert func is not None
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1800,8 +1800,7 @@ def reconstruct_func(
             # When names match, convert to dict format {column: aggfunc}
             # and disable relabeling since no reordering is needed
             func = {
-                column: aggfunc
-                for key, (column, aggfunc) in converted_kwargs.items()
+                column: aggfunc for key, (column, aggfunc) in converted_kwargs.items()
             }
             relabeling = False
 

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -2011,4 +2011,3 @@ def test_agg_relabel_with_name_match_and_namedagg():
 
     expected = DataFrame({"B": [3, 7]}, index=Index([0, 1], name="A"))
     tm.assert_frame_equal(result, expected)
-

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -1982,3 +1982,33 @@ def test_groupby_aggregate_empty_udf():
     result = df.groupby(["Group"], as_index=False)["Data"].agg(func)
     expected = DataFrame(columns=["Group", "Data"])
     tm.assert_frame_equal(result, expected)
+
+
+def test_agg_relabel_with_name_match():
+    # GH-63742
+    df = DataFrame(
+        {
+            "group": ["a", "a", "b", "b"],
+            "value": [1, 2, 3, 4],
+            "count": [10, 20, 30, 40],
+        }
+    )
+
+    # Test with tuple format where output names match column names
+    result = df.groupby("group").agg(value=("value", "sum"), count=("count", "max"))
+
+    # Should produce same result as dict format
+    expected = df.groupby("group").agg({"value": "sum", "count": "max"})
+
+    tm.assert_frame_equal(result, expected)
+
+
+def test_agg_relabel_with_name_match_and_namedagg():
+    # GH-63742
+    df = DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
+
+    result = df.groupby("A").agg(B=pd.NamedAgg("B", "sum"))
+
+    expected = DataFrame({"B": [3, 7]}, index=Index([0, 1], name="A"))
+    tm.assert_frame_equal(result, expected)
+


### PR DESCRIPTION
- [x] closes #63742
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.




This improves the named aggregation performance to be similar to un named (around 3X faster)


```python
In [1]: import numpy as np
   ...: import pandas as pd
   ...:
   ...:
   ...: def generate_data(n_rows: int) -> pd.DataFrame:
   ...:     # Random date range within 2024
   ...:     date_range = pd.date_range(start="2024-01-01", end="2024-12-31", freq="D")
   ...:     dates = np.random.choice(date_range, size=n_rows)
   ...:
   ...:     # Random number of users and values
   ...:     num_users = np.random.randint(1, 100, size=n_rows)
   ...:     values = np.random.uniform(1.0, 1000.0, size=n_rows)
   ...:
   ...:     # Create DataFrame
   ...:     df = pd.DataFrame({"date": dates, "num_users": num_users, "value": values})
   ...:     return df
   ...:
   ...:
   ...: def named(df: pd.DataFrame):
   ...:     return df.groupby("date").agg(
   ...:         **{"num_users": ("num_users", "sum"), "value": ("value", "sum")}
   ...:     )
   ...:
   ...:
   ...: def unnamed(df: pd.DataFrame):
   ...:     return df.groupby("date").agg({"num_users": "sum", "value": "sum"})
   ...:

In [2]: df = generate_data(10**3)

In [3]: %timeit named(df)
359 μs ± 4.67 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [4]: %timeit unnamed(df)
362 μs ± 5.03 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
