### PR TITLE
BUG: indexing a MultiIndex-ed DataFrame (only) with a scalar on a lev…

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -9,11 +9,11 @@ including other versions of pandas.
 {{ header }}
 
 .. ---------------------------------------------------------------------------
-.. _whatsnew_301.bugs:
+.. _whatsnew_301.bug_fixes:
 
 Bug fixes
 ^^^^^^^^^
-
+- Bug in indexing a MultiIndex-ed DataFrame (only) with a scalar on a level and a slice on another doesn't drop a level (:issue:`62926`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.contributors:

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1406,7 +1406,7 @@ class TestDataFrameIndexing:
             )
         )
         indexer_tuple = namedtuple("Indexer", df.index.names)
-        idxr = indexer_tuple(first="A", second=["a", "b"])
+        idxr = indexer_tuple(first=["A"], second=["a", "b"])
         result = df.loc[idxr, :]
         expected = DataFrame(
             index=MultiIndex.from_tuples(

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1330,7 +1330,7 @@ class TestFrameArithmeticUnsorted:
         result = getattr(df, op)(x, level="third", axis=0)
 
         expected = pd.concat(
-            [opa(df.loc[idx[:, :, i], :], v) for i, v in x.items()]
+            [opa(df.loc[idx[:, :, [i]], :], v) for i, v in x.items()]
         ).sort_index()
         tm.assert_frame_equal(result, expected)
 
@@ -1338,7 +1338,7 @@ class TestFrameArithmeticUnsorted:
         result = getattr(df, op)(x, level="second", axis=0)
 
         expected = (
-            pd.concat([opa(df.loc[idx[:, i], :], v) for i, v in x.items()])
+            pd.concat([opa(df.loc[idx[:, [i]], :], v) for i, v in x.items()])
             .reindex_like(df)
             .sort_index()
         )

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -775,7 +775,7 @@ class TestDataFrameReshape:
         df = DataFrame([[2010, "a", "I"], [2011, "b", "II"]], columns=["A", "B", "C"])
 
         ind = df.set_index(["A", "B", "C"], drop=False)
-        selection = ind.loc[(slice(None), slice(None), "I"), cols]
+        selection = ind.loc[(slice(None), slice(None), ["I"]), cols]
         result = selection.unstack()
 
         expected = ind.iloc[[0]][cols]

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -871,7 +871,7 @@ def test_timestamp_multiindex_indexer():
         ]
     )
     df = DataFrame({"foo": np.arange(len(idx))}, idx)
-    result = df.loc[pd.IndexSlice["2019-1-2":, "x", :], "foo"]
+    result = df.loc[pd.IndexSlice["2019-1-2":, ["x"], :], "foo"]
     qidx = MultiIndex.from_product(
         [
             date_range(

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -182,18 +182,18 @@ def test_large_multiindex_error(monkeypatch):
             index=MultiIndex.from_product([[1, 2], range(size_cutoff - 1)]),
             columns=["dest"],
         )
-        with pytest.raises(KeyError, match=r"^\(-1, 0\)$"):
+        with pytest.raises(KeyError, match=r"-1"):
             df_below_cutoff.loc[(-1, 0), "dest"]
-        with pytest.raises(KeyError, match=r"^\(3, 0\)$"):
+        with pytest.raises(KeyError, match=r"3"):
             df_below_cutoff.loc[(3, 0), "dest"]
         df_above_cutoff = pd.DataFrame(
             1,
             index=MultiIndex.from_product([[1, 2], range(size_cutoff + 1)]),
             columns=["dest"],
         )
-        with pytest.raises(KeyError, match=r"^\(-1, 0\)$"):
+        with pytest.raises(KeyError, match=r"-1"):
             df_above_cutoff.loc[(-1, 0), "dest"]
-        with pytest.raises(KeyError, match=r"^\(3, 0\)$"):
+        with pytest.raises(KeyError, match=r"3"):
             df_above_cutoff.loc[(3, 0), "dest"]
 
 

--- a/pandas/tests/indexes/multi/test_partial_indexing.py
+++ b/pandas/tests/indexes/multi/test_partial_indexing.py
@@ -42,7 +42,6 @@ def test_partial_string_matching_single_index(df):
         just_a = df_swap.loc["a"]
         result = just_a.loc["2016-01-01"]
         expected = df.loc[IndexSlice[:, "a"], :].iloc[0:2]
-        expected.index = expected.index.droplevel(1)
         tm.assert_frame_equal(result, expected)
 
 
@@ -122,7 +121,6 @@ def test_partial_string_timestamp_multiindex(df):
     # tuple selector with partial string match on date
     # "2016-01-01" has daily resolution, so _is_ a slice on the first level.
     result = df.loc[("2016-01-01", "a"), :]
-    expected = df.iloc[[0, 3]]
     expected = df.iloc[[0, 3]].droplevel(1)
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -655,7 +655,7 @@ def test_loc_datetime_mask_slicing():
     df = DataFrame(
         data=[[1, 2], [3, 4], [5, 6], [7, 6]], index=m_idx, columns=["C1", "C2"]
     )
-    result = df.loc[(dt_idx[0], (df.index.get_level_values(1) > "2017-05-04")), "C1"]
+    result = df.loc[([dt_idx[0]], (df.index.get_level_values(1) > "2017-05-04")), "C1"]
     expected = Series(
         [3],
         name="C1",
@@ -726,19 +726,19 @@ def test_getitem_str_slice():
     # GH#15928
     df = DataFrame(
         [
-            ["20160525 13:30:00.023", "MSFT", "51.95", "51.95"],
-            ["20160525 13:30:00.048", "GOOG", "720.50", "720.93"],
-            ["20160525 13:30:00.076", "AAPL", "98.55", "98.56"],
-            ["20160525 13:30:00.131", "AAPL", "98.61", "98.62"],
-            ["20160525 13:30:00.135", "MSFT", "51.92", "51.95"],
-            ["20160525 13:30:00.135", "AAPL", "98.61", "98.62"],
+            ["2016-05-25 13:30:00.023", "MSFT", "51.95", "51.95"],
+            ["2016-05-25 13:30:00.048", "GOOG", "720.50", "720.93"],
+            ["2016-05-25 13:30:00.076", "AAPL", "98.55", "98.56"],
+            ["2016-05-25 13:30:00.131", "AAPL", "98.61", "98.62"],
+            ["2016-05-25 13:30:00.135", "MSFT", "51.92", "51.95"],
+            ["2016-05-25 13:30:00.135", "AAPL", "98.61", "98.62"],
         ],
-        columns="time,ticker,bid,ask".split(","),
+        columns=["time", "ticker", "bid", "ask"],
     )
     df2 = df.set_index(["ticker", "time"]).sort_index()
 
-    res = df2.loc[("AAPL", slice("2016-05-25 13:30:00")), :].droplevel(0)
-    expected = df2.loc["AAPL"].loc[slice("2016-05-25 13:30:00"), :]
+    res = df2.loc[("AAPL", slice("2016-05-25 13:30:00.134")), :]
+    expected = df2.loc["AAPL"].loc[slice("2016-05-25 13:30:00.134"), :]
     tm.assert_frame_equal(res, expected)
 
 

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -113,7 +113,7 @@ class TestMultiIndexPartial:
         expected = df.loc[("a", "y")][[1, 0]]
         tm.assert_frame_equal(result, expected)
 
-        with pytest.raises(KeyError, match=r"\('a', 'foo'\)"):
+        with pytest.raises(KeyError, match=r"'foo'"):
             df.loc[("a", "foo"), :]
 
     def test_partial_set(

--- a/pandas/tests/io/formats/style/test_style.py
+++ b/pandas/tests/io/formats/style/test_style.py
@@ -709,7 +709,7 @@ class TestStyler:
             IndexSlice[:, IndexSlice[:, "A"]],
             IndexSlice[:, IndexSlice[:, ["A", "C"]]],  # missing col element
             IndexSlice[IndexSlice["a", 1], :],
-            IndexSlice[IndexSlice[:, 1], :],
+            IndexSlice[IndexSlice[:, [1]], :],
             IndexSlice[IndexSlice[:, [1, 3]], :],  # missing row element
             IndexSlice[:, ("x", "A")],
             IndexSlice[("a", 1), :],
@@ -738,7 +738,8 @@ class TestStyler:
         df = DataFrame(np.random.default_rng(2).random((4, 4)), columns=col, index=idx)
 
         with ctx:
-            df.style.map(lambda x: "color: red;", subset=slice_).to_html()
+            html = df.style.map(lambda x: "color: red;", subset=slice_).to_html()
+            assert "color: red" in html
 
     def test_map_subset_multiindex_code(self):
         # https://github.com/pandas-dev/pandas/issues/25858

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -649,7 +649,6 @@ def test_ewm_alpha_arg(series):
 def test_ewm_pairwise_cov_corr(func, frame):
     result = getattr(frame.ewm(span=10, min_periods=5), func)()
     result = result.loc[(slice(None), 1), 5]
-    result.index = result.index.droplevel(1)
     expected = getattr(frame[1].ewm(span=10, min_periods=5), func)(frame[5])
     tm.assert_series_equal(result, expected, check_names=False)
 

--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -80,7 +80,6 @@ def test_rolling_corr_bias_correction():
 def test_rolling_pairwise_cov_corr(func, frame):
     result = getattr(frame.rolling(window=10, min_periods=5), func)()
     result = result.loc[(slice(None), 1), 5]
-    result.index = result.index.droplevel(1)
     expected = getattr(frame[1].rolling(window=10, min_periods=5), func)(frame[5])
     tm.assert_series_equal(result, expected, check_names=False)
 


### PR DESCRIPTION
…el and a slice on another doesn't drop a level (#62926)

- [x] closes #62926
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
