### PR TITLE
CI: Re-enable `-Werror` on Windows

### DIFF
--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -7,9 +7,6 @@ inputs:
   werror:
     description: Enable werror flag for build
     default: true
-  extra-args:
-    description: Extra arguments passed to `pip install`
-    default: ""
 runs:
   using: composite
   steps:
@@ -32,11 +29,9 @@ runs:
       run: |
         if [[ ${{ inputs.editable }} == "true" ]]; then
           pip install -e . --no-build-isolation -v --no-deps \
-            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }} \
-            ${{ inputs.extra-args }}
+            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }}
         else
           pip install . --no-build-isolation -v --no-deps \
-            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }} \
-            ${{ inputs.extra-args }}
+            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }}
         fi
       shell: bash -el {0}

--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -7,6 +7,9 @@ inputs:
   werror:
     description: Enable werror flag for build
     default: true
+  extra-args:
+    description: Extra arguments passed to `pip install`
+    default: ""
 runs:
   using: composite
   steps:
@@ -29,9 +32,11 @@ runs:
       run: |
         if [[ ${{ inputs.editable }} == "true" ]]; then
           pip install -e . --no-build-isolation -v --no-deps \
-            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }}
+            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }} \
+            ${{ inputs.extra-args }}
         else
           pip install . --no-build-isolation -v --no-deps \
-            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }}
+            ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }} \
+            ${{ inputs.extra-args }}
         fi
       shell: bash -el {0}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -221,7 +221,10 @@ jobs:
           # Windows contains a lot of warnings regarding unsafe type conversion.
           # It's possible to replicate some of them in clang with the `-Wconversion` flag.
           # Tracking issue: https://github.com/pandas-dev/pandas/issues/63701
-          extra-args: ${{ runner.os == 'Windows' && '-Csetup-args=-Dc_args="-wd4244 -wd4267 -wd4244 -wd4551"' || '' }}
+          extra-args: >-
+            ${{ runner.os == 'Windows'
+              && '-Csetup-args=-Dc_args="-wd4244 -wd4267" -Csetup-args=-Dcpp_args="-wd4244 -wd4551"'
+              || '' }}
 
       - name: Test
         uses: ./.github/actions/run-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -217,14 +217,6 @@ jobs:
 
       - name: Build Pandas
         uses: ./.github/actions/build_pandas
-        with:
-          # Windows contains a lot of warnings regarding unsafe type conversion.
-          # It's possible to replicate some of them in clang with the `-Wconversion` flag.
-          # Tracking issue: https://github.com/pandas-dev/pandas/issues/63701
-          extra-args: >-
-            ${{ runner.os == 'Windows'
-              && '-Csetup-args=-Dc_args="-wd4244 -wd4267" -Csetup-args=-Dcpp_args="-wd4244 -wd4551"'
-              || '' }}
 
       - name: Test
         uses: ./.github/actions/run-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -221,7 +221,7 @@ jobs:
           # Windows contains a lot of warnings regarding unsafe type conversion.
           # It's possible to replicate some of them in clang with the `-Wconversion` flag.
           # Tracking issue: https://github.com/pandas-dev/pandas/issues/63701
-          extra-args: ${{ runner.os == 'Windows' && '-Csetup-args=-Dc_args="-wd4244 -wd4267"' || '' }}
+          extra-args: ${{ runner.os == 'Windows' && '-Csetup-args=-Dc_args="-wd4244 -wd4267 -wd4244 -wd4551"' || '' }}
 
       - name: Test
         uses: ./.github/actions/run-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -221,7 +221,7 @@ jobs:
           # Windows contains a lot of warnings regarding unsafe type conversion.
           # It's possible to replicate some of them in clang with the `-Wconversion` flag.
           # Tracking issue: https://github.com/pandas-dev/pandas/issues/63701
-          extra-args: ${{ runner.os == 'Windows' && '-Csetup-args=-Dc_args=-wd4244' || '' }}
+          extra-args: ${{ runner.os == 'Windows' && '-Csetup-args=-Dc_args="-wd4244 -wd4267"' || '' }}
 
       - name: Test
         uses: ./.github/actions/run-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -221,7 +221,7 @@ jobs:
           # Windows contains a lot of warnings regarding unsafe type conversion.
           # It's possible to replicate some of them in clang with the `-Wconversion` flag.
           # Tracking issue: https://github.com/pandas-dev/pandas/issues/63701
-          werror: ${{ runner.os != 'Windows' }}
+          extra-args: ${{ runner.os == 'Windows' && '-Csetup-args=-Dc_args=-wd4244' || '' }}
 
       - name: Test
         uses: ./.github/actions/run-tests

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ add_project_arguments(
 
 cc = meson.get_compiler('c')
 if cc.get_id() == 'msvc'
+    # Tracking issue: https://github.com/pandas-dev/pandas/issues/63701
     # Ignore some MSVC specific warnings:
     # C4244: possible loss of data in conversion. Reproductible with `-Wconversion`.
     # C4267: conversion from `size_t` to smaller type.

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,18 @@ add_project_arguments(
     language: 'cpp',
 )
 
+cc = meson.get_compiler('c')
+if cc.get_id() == 'msvc'
+    # Ignore some MSVC specific warnings:
+    # C4244: possible loss of data in conversion. Reproductible with `-Wconversion`.
+    # C4267: conversion from `size_t` to smaller type.
+    # C4551: occurs due to Cython generating code with (void)func.
+    #        https://github.com/cython/cython/issues/3579
+    add_project_arguments(
+        ['/wd4244', '/wd4267', '/wd4551'],
+        language: ['c', 'cpp'],
+    )
+endif
 
 if fs.exists('_version_meson.py')
     py.install_sources('_version_meson.py', subdir: 'pandas')


### PR DESCRIPTION
- [x] xref #63701 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

Disabled some windows specific warnings in `meson.build`.