### PR TITLE
TST: Add test for DataFrame.agg with np.size (#42203, #48328)

### DIFF
--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1840,6 +1840,23 @@ def test_agg_std():
     tm.assert_frame_equal(result, expected)
 
 
+def test_agg_np_size():
+    # GH#42203, GH#48328
+    df = DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["A", "B", "C"])
+
+    result = df.agg({"A": [np.size]})
+    expected = DataFrame({"A": [3]}, index=["size"])
+    tm.assert_frame_equal(result, expected)
+
+    result = df.agg({"A": np.size})
+    expected = Series({"A": 3})
+    tm.assert_series_equal(result, expected)
+
+    result = df.agg({"A": [np.mean, np.size]})
+    expected = DataFrame({"A": [4.0, 3.0]}, index=["mean", "size"])
+    tm.assert_frame_equal(result, expected)
+
+
 def test_agg_dist_like_and_nonunique_columns():
     # GH#51099
     df = DataFrame(


### PR DESCRIPTION
  Your PR body should look like:                                                                                                                                                                                                                                                                                            
  - [x] closes #42203                                                                                                                                                                                                                                                                                                       
  - [x] Tests added and passed                                                                                                                                                                                                                                                                                              
  - [x] All code checks passed.                                                                                                                                                                                                                                                                                             
  - [x] Added type annotations to new arguments/methods/functions.                                                                                                                                                                                                                                                          
  - [x] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.                                                                                                                                                                                                           
  - [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.                                                                                                                             
                                                                                                                                                                                                                 
  Adds a regression test for `DataFrame.agg` with `np.size` which was previously                                                                                                                                 
  treated as a transform instead of an aggregation when used in dict form.                                                                                                                                       
                                                                                                                                                                                                                 
  The fix is already on main (confirmed working on 3.0.0rc2). This PR adds tests                                                                                                                                 
  to prevent regression.