### PR TITLE
API: Period.to_timestamp default to microsecond unit

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -797,6 +797,7 @@ Other API changes
 ^^^^^^^^^^^^^^^^^
 - 3rd party ``py.path`` objects are no longer explicitly supported in IO methods. Use :py:class:`pathlib.Path` objects instead (:issue:`57091`)
 - :func:`read_table`'s ``parse_dates`` argument defaults to ``None`` to improve consistency with :func:`read_csv` (:issue:`57476`)
+- :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` now give microsecond-unit objects when possible, and nanosecond-unit objects in other cases. This affects the actual value of :meth:`Period.end_time` and :meth:`PeriodIndex.end_time` (:issue:`56164`)
 - All classes inheriting from builtin ``tuple`` (including types created with :func:`collections.namedtuple`) are now hashed and compared as builtin ``tuple`` during indexing operations (:issue:`57922`)
 - Made ``dtype`` a required argument in :meth:`ExtensionArray._from_sequence_of_strings` (:issue:`56519`)
 - Passing a :class:`Series` input to :func:`json_normalize` will now retain the :class:`Series` :class:`Index`, previously output had a new :class:`RangeIndex` (:issue:`51452`)

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1688,7 +1688,7 @@ cdef class PeriodMixin:
         Timestamp('2012-01-01 00:00:00')
 
         >>> period.end_time
-        Timestamp('2012-01-01 23:59:59.999999999')
+        Timestamp('2012-01-01 23:59:59.999999')
         """
         return self.to_timestamp(how="start")
 
@@ -1725,19 +1725,19 @@ cdef class PeriodMixin:
         2   2020-03
         dtype: period[M]
         >>> s.dt.end_time
-        0   2020-01-31 23:59:59.999999999
-        1   2020-02-29 23:59:59.999999999
-        2   2020-03-31 23:59:59.999999999
-        dtype: datetime64[ns]
+        0   2020-01-31 23:59:59.999999
+        1   2020-02-29 23:59:59.999999
+        2   2020-03-31 23:59:59.999999
+        dtype: datetime64[us]
 
         For PeriodIndex:
 
         >>> idx = pd.PeriodIndex(["2023-01", "2023-02", "2023-03"], freq="M")
         >>> idx.end_time
-        DatetimeIndex(['2023-01-31 23:59:59.999999999',
-                       '2023-02-28 23:59:59.999999999',
-                       '2023-03-31 23:59:59.999999999'],
-                       dtype='datetime64[ns]', freq=None)
+        DatetimeIndex(['2023-01-31 23:59:59.999999',
+                       '2023-02-28 23:59:59.999999',
+                       '2023-03-31 23:59:59.999999'],
+                       dtype='datetime64[us]', freq=None)
         """
         return self.to_timestamp(how="end")
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -993,7 +993,7 @@ def periodarr_to_dt64arr(const int64_t[:] periodarr, int freq):
             dta = periodarr.base.view("M8[h]")
         elif freq == FR_DAY:
             dta = periodarr.base.view("M8[D]")
-        # GH#??? give microseconds for everything other than freq="ns"
+        # GH#63760 give microseconds for everything other than freq="ns"
         return astype_overflowsafe(dta, dtype=np.dtype("M8[us]"))
 
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1713,7 +1713,7 @@ cdef class PeriodMixin:
         For Period:
 
         >>> pd.Period('2020-01', 'D').end_time
-        Timestamp('2020-01-01 23:59:59.999999999')
+        Timestamp('2020-01-01 23:59:59.999999')
 
         For Series:
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -38,7 +38,10 @@ from libc.time cimport (
     tm,
 )
 
-from pandas._libs.tslibs.dtypes cimport c_OFFSET_TO_PERIOD_FREQSTR
+from pandas._libs.tslibs.dtypes cimport (
+    PeriodDtypeCode,
+    c_OFFSET_TO_PERIOD_FREQSTR,
+)
 
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 
@@ -69,13 +72,6 @@ from pandas._libs.tslibs.ccalendar cimport (
     get_week_of_year,
     is_leapyear,
 )
-from pandas._libs.tslibs.timedeltas cimport (
-    delta_to_nanoseconds,
-    is_any_td_scalar,
-)
-
-from pandas._libs.tslibs.conversion import DT64NS_DTYPE
-
 from pandas._libs.tslibs.dtypes cimport (
     FR_ANN,
     FR_BUS,
@@ -95,6 +91,10 @@ from pandas._libs.tslibs.dtypes cimport (
     freq_group_code_to_npy_unit,
 )
 from pandas._libs.tslibs.parsing cimport quarter_to_myear
+from pandas._libs.tslibs.timedeltas cimport (
+    delta_to_nanoseconds,
+    is_any_td_scalar,
+)
 
 from pandas._libs.tslibs.parsing import parse_datetime_string_with_reso
 
@@ -973,13 +973,13 @@ def periodarr_to_dt64arr(const int64_t[:] periodarr, int freq):
         for i in range(N):
             out[i] = period_ordinal_to_dt64(periodarr[i], freq)
 
-        return out.base  # .base to access underlying np.ndarray
+        return out.base.view("M8[us]")  # .base to access underlying np.ndarray
 
     else:
         # Short-circuit for performance
         if freq == FR_NS:
             # TODO: copy?
-            return periodarr.base
+            return periodarr.base.view("M8[ns]")
 
         if freq == FR_US:
             dta = periodarr.base.view("M8[us]")
@@ -993,7 +993,8 @@ def periodarr_to_dt64arr(const int64_t[:] periodarr, int freq):
             dta = periodarr.base.view("M8[h]")
         elif freq == FR_DAY:
             dta = periodarr.base.view("M8[D]")
-        return astype_overflowsafe(dta, dtype=DT64NS_DTYPE)
+        # GH#??? give microseconds for everything other than freq="ns"
+        return astype_overflowsafe(dta, dtype=np.dtype("M8[us]"))
 
 
 cdef void get_asfreq_info(int from_freq, int to_freq,
@@ -1161,13 +1162,19 @@ cdef int64_t period_ordinal_to_dt64(int64_t ordinal, int freq) except? -1:
     if ordinal == NPY_NAT:
         return NPY_NAT
 
+    if freq == PeriodDtypeCode.N:
+        # We have to return nanosecond unit, but this is a no-op
+        return ordinal
+
     get_date_info(ordinal, freq, &dts)
 
     try:
-        result = npy_datetimestruct_to_datetime(NPY_DATETIMEUNIT.NPY_FR_ns, &dts)
+        result = npy_datetimestruct_to_datetime(NPY_DATETIMEUNIT.NPY_FR_us, &dts)
     except OverflowError as err:
         fmt = dts_to_iso_string(&dts)
-        raise OutOfBoundsDatetime(f"Out of bounds nanosecond timestamp: {fmt}") from err
+        raise OutOfBoundsDatetime(
+            f"Out of bounds microsecond timestamp: {fmt}"
+        ) from err
 
     return result
 
@@ -2061,6 +2068,9 @@ cdef class _Period(PeriodMixin):
         Uses the target frequency specified at the part of the period specified
         by `how`, which is either `Start` or `Finish`.
 
+        If possible, gives microsecond-unit Timestamp. Otherwise gives nanosecond
+        unit.
+
         Parameters
         ----------
         freq : str or DateOffset
@@ -2089,14 +2099,19 @@ cdef class _Period(PeriodMixin):
         """
         how = validate_end_alias(how)
 
+        if self._dtype._dtype_code == PeriodDtypeCode.N or freq == "ns":
+            unit = "ns"
+        else:
+            unit = "us"
+
         end = how == "E"
         if end:
             if freq == "B" or self._freq == "B":
                 # roll forward to ensure we land on B date
-                adjust = np.timedelta64(1, "D") - np.timedelta64(1, "ns")
+                adjust = np.timedelta64(1, "D") - np.timedelta64(1, unit)
                 return self.to_timestamp(how="start") + adjust
             endpoint = (self + self._freq).to_timestamp(how="start")
-            return endpoint - np.timedelta64(1, "ns")
+            return endpoint - np.timedelta64(1, unit)
 
         if freq is None:
             freq_code = self._dtype._get_to_timestamp_base()
@@ -2110,7 +2125,7 @@ cdef class _Period(PeriodMixin):
         val = self.asfreq(freq, how)
 
         dt64 = period_ordinal_to_dt64(val.ordinal, base)
-        return Timestamp(dt64)
+        return Timestamp(dt64, unit=unit)
 
     @property
     def year(self) -> int:

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -821,7 +821,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         if end:
             if freq == "B" or self.freq == "B":
                 # roll forward to ensure we land on B date
-                adjust = np.timedelta64(1, "D") - np.timedelta64(1, unit)
+                adjust = Timedelta(1, unit="D") - Timedelta(1, unit=unit)
                 return self.to_timestamp(how="start") + adjust
             else:
                 adjust = Timedelta(1, unit=unit)

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -759,6 +759,9 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         """
         Cast to DatetimeArray/Index.
 
+        If possible, gives microsecond-unit DatetimeArray/Index. Otherwise
+        gives nanosecond unit.
+
         Parameters
         ----------
         freq : str or DateOffset, optional
@@ -789,34 +792,39 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         >>> idx = pd.PeriodIndex(["2023-01", "2023-02", "2023-03"], freq="M")
         >>> idx.to_timestamp()
         DatetimeIndex(['2023-01-01', '2023-02-01', '2023-03-01'],
-        dtype='datetime64[ns]', freq='MS')
+        dtype='datetime64[us]', freq='MS')
 
         The frequency will not be inferred if the index contains less than
         three elements, or if the values of index are not strictly monotonic:
 
         >>> idx = pd.PeriodIndex(["2023-01", "2023-02"], freq="M")
         >>> idx.to_timestamp()
-        DatetimeIndex(['2023-01-01', '2023-02-01'], dtype='datetime64[ns]', freq=None)
+        DatetimeIndex(['2023-01-01', '2023-02-01'], dtype='datetime64[us]', freq=None)
 
         >>> idx = pd.PeriodIndex(
         ...     ["2023-01", "2023-02", "2023-02", "2023-03"], freq="2M"
         ... )
         >>> idx.to_timestamp()
         DatetimeIndex(['2023-01-01', '2023-02-01', '2023-02-01', '2023-03-01'],
-        dtype='datetime64[ns]', freq=None)
+        dtype='datetime64[us]', freq=None)
         """
         from pandas.core.arrays import DatetimeArray
 
         how = libperiod.validate_end_alias(how)
 
+        if self.freq.base == "ns" or freq == "ns":
+            unit = "ns"
+        else:
+            unit = "us"
+
         end = how == "E"
         if end:
             if freq == "B" or self.freq == "B":
                 # roll forward to ensure we land on B date
-                adjust = Timedelta(1, "D") - Timedelta(1, "ns")
+                adjust = np.timedelta64(1, "D") - np.timedelta64(1, unit)
                 return self.to_timestamp(how="start") + adjust
             else:
-                adjust = Timedelta(1, "ns")
+                adjust = Timedelta(1, unit=unit).as_unit(unit)
                 return (self + self.freq).to_timestamp(how="start") - adjust
 
         if freq is None:
@@ -831,7 +839,8 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         new_parr = self.asfreq(freq, how=how)
 
         new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
-        dta = DatetimeArray._from_sequence(new_data, dtype=np.dtype("M8[ns]"))
+        dta = DatetimeArray._from_sequence(new_data, dtype=new_data.dtype)
+        assert dta.unit == unit
 
         if self.freq.name == "B":
             # See if we can retain BDay instead of Day in cases where

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -824,7 +824,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
                 adjust = np.timedelta64(1, "D") - np.timedelta64(1, unit)
                 return self.to_timestamp(how="start") + adjust
             else:
-                adjust = Timedelta(1, unit=unit).as_unit(unit)
+                adjust = Timedelta(1, unit=unit)
                 return (self + self.freq).to_timestamp(how="start") - adjust
 
         if freq is None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -15604,7 +15604,7 @@ class DataFrame(NDFrame, OpsMixin):
         2023-01-01     1      3
         2024-01-01     2      4
         >>> df1.index
-        DatetimeIndex(['2023-01-01', '2024-01-01'], dtype='datetime64[ns]', freq=None)
+        DatetimeIndex(['2023-01-01', '2024-01-01'], dtype='datetime64[us]', freq=None)
 
         Using `freq` which is the offset that the Timestamps will have
 
@@ -15615,7 +15615,7 @@ class DataFrame(NDFrame, OpsMixin):
         2023-01-31     1      3
         2024-01-31     2      4
         >>> df2.index
-        DatetimeIndex(['2023-01-31', '2024-01-31'], dtype='datetime64[ns]', freq=None)
+        DatetimeIndex(['2023-01-31', '2024-01-31'], dtype='datetime64[us]', freq=None)
         """
         self._check_copy_deprecation(copy)
         new_obj = self.copy(deep=False)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -896,7 +896,10 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         """
         freq = OFFSET_TO_PERIOD_FREQSTR.get(reso.attr_abbrev, reso.attr_abbrev)
         per = Period(parsed, freq=freq)
-        start, end = per.start_time, per.end_time
+        start = per.start_time
+        # Can't use end_time here bc that will subtract a microsecond
+        #  instead of a nanosecond
+        end = (per + 1).start_time - np.timedelta64(1, "ns")
         start = start.as_unit(self.unit)
         end = end.as_unit(self.unit)
 

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -8,7 +8,6 @@ import pytest
 
 from pandas._libs import (
     NaT,
-    OutOfBoundsDatetime,
     Timestamp,
 )
 from pandas._libs.tslibs import to_offset
@@ -1110,28 +1109,25 @@ class TestPeriodArray(SharedTests):
         parr = dta.to_period()
         result = parr.to_timestamp()
         assert result.freq == "B"
-        tm.assert_extension_array_equal(result, dta)
+        tm.assert_extension_array_equal(result, dta.as_unit("us"))
 
         dta2 = dta[::2]
         parr2 = dta2.to_period()
         result2 = parr2.to_timestamp()
         assert result2.freq == "2B"
-        tm.assert_extension_array_equal(result2, dta2)
+        tm.assert_extension_array_equal(result2, dta2.as_unit("us"))
 
         parr3 = dta.to_period("2B")
         result3 = parr3.to_timestamp()
         assert result3.freq == "B"
-        tm.assert_extension_array_equal(result3, dta)
+        tm.assert_extension_array_equal(result3, dta.as_unit("us"))
 
     def test_to_timestamp_out_of_bounds(self):
         # GH#19643 previously overflowed silently
         pi = pd.period_range("1500", freq="Y", periods=3)
-        msg = "Out of bounds nanosecond timestamp: 1500-01-01 00:00:00"
-        with pytest.raises(OutOfBoundsDatetime, match=msg):
-            pi.to_timestamp()
-
-        with pytest.raises(OutOfBoundsDatetime, match=msg):
-            pi._data.to_timestamp()
+        pi.to_timestamp()
+        dta = pi._data.to_timestamp()
+        assert dta[0] == Timestamp(1500, 1, 1)
 
     @pytest.mark.parametrize("propname", PeriodArray._bool_ops)
     def test_bool_properties(self, arr1d, propname):

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -393,11 +393,11 @@ class TestDataFrameToCSV:
         if r_idx_type == "dt":
             expected.index = expected.index.astype("M8[us]")
         elif r_idx_type == "p":
-            expected.index = expected.index.astype("M8[ns]")
+            expected.index = expected.index.astype("M8[us]")
         if c_idx_type == "dt":
             expected.columns = expected.columns.astype("M8[us]")
         elif c_idx_type == "p":
-            expected.columns = expected.columns.astype("M8[ns]")
+            expected.columns = expected.columns.astype("M8[us]")
         tm.assert_frame_equal(result, expected, check_names=False)
 
     @pytest.mark.slow

--- a/pandas/tests/frame/methods/test_to_timestamp.py
+++ b/pandas/tests/frame/methods/test_to_timestamp.py
@@ -102,7 +102,6 @@ class TestToTimestamp:
         result = df.to_timestamp("min", "end", axis=1)
         exp_index = _get_with_delta(delta)
         exp_index = exp_index + Timedelta(1, "m") - Timedelta(1, "us")
-
         tm.assert_index_equal(result.columns, exp_index)
 
         result = df.to_timestamp("S", "end", axis=1)

--- a/pandas/tests/frame/methods/test_to_timestamp.py
+++ b/pandas/tests/frame/methods/test_to_timestamp.py
@@ -83,7 +83,7 @@ class TestToTimestamp:
         df = df.T
 
         exp_index = date_range("1/1/2001", end="12/31/2009", freq="YE-DEC")
-        exp_index = exp_index + np.timedelta64(1, "D") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "D") - Timedelta(1, "us")
         result = df.to_timestamp("D", "end", axis=1)
         tm.assert_index_equal(result.columns, exp_index)
         tm.assert_numpy_array_equal(result.values, df.values)
@@ -95,19 +95,20 @@ class TestToTimestamp:
         delta = timedelta(hours=23)
         result = df.to_timestamp("H", "end", axis=1)
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + np.timedelta64(1, "h") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "h") - Timedelta(1, "us")
         tm.assert_index_equal(result.columns, exp_index)
 
         delta = timedelta(hours=23, minutes=59)
         result = df.to_timestamp("min", "end", axis=1)
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + np.timedelta64(1, "m") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "m") - Timedelta(1, "us")
+
         tm.assert_index_equal(result.columns, exp_index)
 
         result = df.to_timestamp("S", "end", axis=1)
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + np.timedelta64(1, "s") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "s") - Timedelta(1, "us")
         tm.assert_index_equal(result.columns, exp_index)
 
         result1 = df.to_timestamp("5min", axis=1)
@@ -139,7 +140,7 @@ class TestToTimestamp:
 
         exp_index = date_range("1/1/2001 00:59:59", end="1/2/2001 00:59:59", freq="h")
         result = obj.to_timestamp(how="end")
-        exp_index = exp_index + np.timedelta64(1, "s") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "s") - Timedelta(1, "us")
         tm.assert_index_equal(result.index, exp_index)
         if frame_or_series is Series:
             assert result.name == "foo"

--- a/pandas/tests/frame/methods/test_to_timestamp.py
+++ b/pandas/tests/frame/methods/test_to_timestamp.py
@@ -8,7 +8,6 @@ from pandas import (
     DatetimeIndex,
     PeriodIndex,
     Series,
-    Timedelta,
     date_range,
     period_range,
     to_datetime,
@@ -21,7 +20,6 @@ def _get_with_delta(delta, freq="YE-DEC"):
         to_datetime("1/1/2001") + delta,
         to_datetime("12/31/2009") + delta,
         freq=freq,
-        unit="ns",
     )
 
 
@@ -37,15 +35,15 @@ class TestToTimestamp:
         obj["mix"] = "a"
         obj = tm.get_obj(obj, frame_or_series)
 
-        exp_index = date_range("1/1/2001", end="12/31/2009", freq="YE-DEC", unit="ns")
-        exp_index = exp_index + Timedelta(1, "D") - Timedelta(1, "ns")
+        exp_index = date_range("1/1/2001", end="12/31/2009", freq="YE-DEC")
+        exp_index = exp_index + np.timedelta64(1, "D") - np.timedelta64(1, "us")
         result = obj.to_timestamp("D", "end")
         tm.assert_index_equal(result.index, exp_index)
         tm.assert_numpy_array_equal(result.values, obj.values)
         if frame_or_series is Series:
             assert result.name == "A"
 
-        exp_index = date_range("1/1/2001", end="1/1/2009", freq="YS-JAN", unit="ns")
+        exp_index = date_range("1/1/2001", end="1/1/2009", freq="YS-JAN")
         result = obj.to_timestamp("D", "start")
         tm.assert_index_equal(result.index, exp_index)
 
@@ -55,19 +53,19 @@ class TestToTimestamp:
         delta = timedelta(hours=23)
         result = obj.to_timestamp("H", "end")
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + Timedelta(1, "h") - Timedelta(1, "ns")
+        exp_index = exp_index + np.timedelta64(1, "h") - np.timedelta64(1, "us")
         tm.assert_index_equal(result.index, exp_index)
 
         delta = timedelta(hours=23, minutes=59)
         result = obj.to_timestamp("T", "end")
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + Timedelta(1, "m") - Timedelta(1, "ns")
+        exp_index = exp_index + np.timedelta64(1, "m") - np.timedelta64(1, "us")
         tm.assert_index_equal(result.index, exp_index)
 
         result = obj.to_timestamp("S", "end")
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + Timedelta(1, "s") - Timedelta(1, "ns")
+        exp_index = exp_index + np.timedelta64(1, "s") - np.timedelta64(1, "us")
         tm.assert_index_equal(result.index, exp_index)
 
     def test_to_timestamp_columns(self):
@@ -83,37 +81,37 @@ class TestToTimestamp:
         # columns
         df = df.T
 
-        exp_index = date_range("1/1/2001", end="12/31/2009", freq="YE-DEC", unit="ns")
-        exp_index = exp_index + Timedelta(1, "D") - Timedelta(1, "ns")
+        exp_index = date_range("1/1/2001", end="12/31/2009", freq="YE-DEC")
+        exp_index = exp_index + np.timedelta64(1, "D") - np.timedelta64(1, "us")
         result = df.to_timestamp("D", "end", axis=1)
         tm.assert_index_equal(result.columns, exp_index)
         tm.assert_numpy_array_equal(result.values, df.values)
 
-        exp_index = date_range("1/1/2001", end="1/1/2009", freq="YS-JAN", unit="ns")
+        exp_index = date_range("1/1/2001", end="1/1/2009", freq="YS-JAN")
         result = df.to_timestamp("D", "start", axis=1)
         tm.assert_index_equal(result.columns, exp_index)
 
         delta = timedelta(hours=23)
         result = df.to_timestamp("H", "end", axis=1)
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + Timedelta(1, "h") - Timedelta(1, "ns")
+        exp_index = exp_index + np.timedelta64(1, "h") - np.timedelta64(1, "us")
         tm.assert_index_equal(result.columns, exp_index)
 
         delta = timedelta(hours=23, minutes=59)
         result = df.to_timestamp("min", "end", axis=1)
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + Timedelta(1, "m") - Timedelta(1, "ns")
+        exp_index = exp_index + np.timedelta64(1, "m") - np.timedelta64(1, "us")
         tm.assert_index_equal(result.columns, exp_index)
 
         result = df.to_timestamp("S", "end", axis=1)
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + Timedelta(1, "s") - Timedelta(1, "ns")
+        exp_index = exp_index + np.timedelta64(1, "s") - np.timedelta64(1, "us")
         tm.assert_index_equal(result.columns, exp_index)
 
         result1 = df.to_timestamp("5min", axis=1)
         result2 = df.to_timestamp("min", axis=1)
-        expected = date_range("2001-01-01", "2009-01-01", freq="YS", unit="ns")
+        expected = date_range("2001-01-01", "2009-01-01", freq="YS")
         assert isinstance(result1.columns, DatetimeIndex)
         assert isinstance(result2.columns, DatetimeIndex)
         tm.assert_numpy_array_equal(result1.columns.asi8, expected.asi8)
@@ -138,11 +136,9 @@ class TestToTimestamp:
         if frame_or_series is not Series:
             obj = obj.to_frame()
 
-        exp_index = date_range(
-            "1/1/2001 00:59:59", end="1/2/2001 00:59:59", freq="h", unit="ns"
-        )
+        exp_index = date_range("1/1/2001 00:59:59", end="1/2/2001 00:59:59", freq="h")
         result = obj.to_timestamp(how="end")
-        exp_index = exp_index + Timedelta(1, "s") - Timedelta(1, "ns")
+        exp_index = exp_index + np.timedelta64(1, "s") - np.timedelta64(1, "us")
         tm.assert_index_equal(result.index, exp_index)
         if frame_or_series is Series:
             assert result.name == "foo"

--- a/pandas/tests/frame/methods/test_to_timestamp.py
+++ b/pandas/tests/frame/methods/test_to_timestamp.py
@@ -8,6 +8,7 @@ from pandas import (
     DatetimeIndex,
     PeriodIndex,
     Series,
+    Timedelta,
     date_range,
     period_range,
     to_datetime,
@@ -36,7 +37,7 @@ class TestToTimestamp:
         obj = tm.get_obj(obj, frame_or_series)
 
         exp_index = date_range("1/1/2001", end="12/31/2009", freq="YE-DEC")
-        exp_index = exp_index + np.timedelta64(1, "D") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "D") - Timedelta(1, "us")
         result = obj.to_timestamp("D", "end")
         tm.assert_index_equal(result.index, exp_index)
         tm.assert_numpy_array_equal(result.values, obj.values)
@@ -53,19 +54,19 @@ class TestToTimestamp:
         delta = timedelta(hours=23)
         result = obj.to_timestamp("H", "end")
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + np.timedelta64(1, "h") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "h") - Timedelta(1, "us")
         tm.assert_index_equal(result.index, exp_index)
 
         delta = timedelta(hours=23, minutes=59)
         result = obj.to_timestamp("T", "end")
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + np.timedelta64(1, "m") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "m") - Timedelta(1, "us")
         tm.assert_index_equal(result.index, exp_index)
 
         result = obj.to_timestamp("S", "end")
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
-        exp_index = exp_index + np.timedelta64(1, "s") - np.timedelta64(1, "us")
+        exp_index = exp_index + Timedelta(1, "s") - Timedelta(1, "us")
         tm.assert_index_equal(result.index, exp_index)
 
     def test_to_timestamp_columns(self):

--- a/pandas/tests/indexes/datetimes/methods/test_to_period.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_period.py
@@ -120,11 +120,11 @@ class TestToPeriod:
     def test_period_dt64_round_trip(self):
         dti = date_range("1/1/2000", "1/7/2002", freq="B", unit="ns")
         pi = dti.to_period()
-        tm.assert_index_equal(pi.to_timestamp(), dti)
+        tm.assert_index_equal(pi.to_timestamp(), dti.as_unit("us"))
 
         dti = date_range("1/1/2000", "1/7/2002", freq="B", unit="ns")
         pi = dti.to_period(freq="h")
-        tm.assert_index_equal(pi.to_timestamp(), dti)
+        tm.assert_index_equal(pi.to_timestamp(), dti.as_unit("us"))
 
     def test_to_period_millisecond(self):
         index = DatetimeIndex(

--- a/pandas/tests/indexes/period/methods/test_to_timestamp.py
+++ b/pandas/tests/indexes/period/methods/test_to_timestamp.py
@@ -7,7 +7,6 @@ from pandas import (
     DatetimeIndex,
     NaT,
     PeriodIndex,
-    Timedelta,
     Timestamp,
     date_range,
     period_range,
@@ -22,34 +21,34 @@ class TestToTimestamp:
         pi = dti.to_period()
 
         result = pi[::2].to_timestamp()
-        expected = dti[::2]
+        expected = dti[::2].as_unit("us")
         tm.assert_index_equal(result, expected)
 
         result = pi._data[::2].to_timestamp()
-        expected = dti._data[::2]
+        expected = dti._data[::2].as_unit("us")
         # TODO: can we get the freq to round-trip?
         tm.assert_datetime_array_equal(result, expected, check_freq=False)
 
         result = pi[::-1].to_timestamp()
-        expected = dti[::-1]
+        expected = dti[::-1].as_unit("us")
         tm.assert_index_equal(result, expected)
 
         result = pi._data[::-1].to_timestamp()
-        expected = dti._data[::-1]
+        expected = dti._data[::-1].as_unit("us")
         tm.assert_datetime_array_equal(result, expected, check_freq=False)
 
         result = pi[::2][::-1].to_timestamp()
-        expected = dti[::2][::-1]
+        expected = dti[::2][::-1].as_unit("us")
         tm.assert_index_equal(result, expected)
 
         result = pi._data[::2][::-1].to_timestamp()
-        expected = dti._data[::2][::-1]
+        expected = dti._data[::2][::-1].as_unit("us")
         tm.assert_datetime_array_equal(result, expected, check_freq=False)
 
     def test_to_timestamp_freq(self):
         idx = period_range("2017", periods=12, freq="Y-DEC")
         result = idx.to_timestamp()
-        expected = date_range("2017", periods=12, freq="YS-JAN", unit="ns")
+        expected = date_range("2017", periods=12, freq="YS-JAN")
         tm.assert_index_equal(result, expected)
 
     def test_to_timestamp_pi_nat(self):
@@ -59,7 +58,7 @@ class TestToTimestamp:
         result = index.to_timestamp("D")
         expected = DatetimeIndex(
             [NaT, datetime(2011, 1, 1), datetime(2011, 2, 1)],
-            dtype="M8[ns]",
+            dtype="M8[us]",
             name="idx",
         )
         tm.assert_index_equal(result, expected)
@@ -101,15 +100,15 @@ class TestToTimestamp:
 
         result = idx.to_timestamp()
         expected = DatetimeIndex(
-            ["2011-01-01", "NaT", "2011-02-01"], dtype="M8[ns]", name="idx"
+            ["2011-01-01", "NaT", "2011-02-01"], dtype="M8[us]", name="idx"
         )
         tm.assert_index_equal(result, expected)
 
         result = idx.to_timestamp(how="E")
         expected = DatetimeIndex(
-            ["2011-02-28", "NaT", "2011-03-31"], dtype="M8[ns]", name="idx"
+            ["2011-02-28", "NaT", "2011-03-31"], dtype="M8[us]", name="idx"
         )
-        expected = expected + Timedelta(1, "D") - Timedelta(1, "ns")
+        expected = expected + np.timedelta64(1, "D") - np.timedelta64(1, "us")
         tm.assert_index_equal(result, expected)
 
     def test_to_timestamp_pi_combined(self):
@@ -117,22 +116,22 @@ class TestToTimestamp:
 
         result = idx.to_timestamp()
         expected = DatetimeIndex(
-            ["2011-01-01 00:00", "2011-01-02 01:00"], dtype="M8[ns]", name="idx"
+            ["2011-01-01 00:00", "2011-01-02 01:00"], dtype="M8[us]", name="idx"
         )
         tm.assert_index_equal(result, expected)
 
         result = idx.to_timestamp(how="E")
         expected = DatetimeIndex(
-            ["2011-01-02 00:59:59", "2011-01-03 01:59:59"], name="idx", dtype="M8[ns]"
+            ["2011-01-02 00:59:59", "2011-01-03 01:59:59"], name="idx", dtype="M8[us]"
         )
-        expected = expected + Timedelta(1, "s") - Timedelta(1, "ns")
+        expected = expected + np.timedelta64(1, "s") - np.timedelta64(1, "us")
         tm.assert_index_equal(result, expected)
 
         result = idx.to_timestamp(how="E", freq="h")
         expected = DatetimeIndex(
-            ["2011-01-02 00:00", "2011-01-03 01:00"], dtype="M8[ns]", name="idx"
+            ["2011-01-02 00:00", "2011-01-03 01:00"], dtype="M8[us]", name="idx"
         )
-        expected = expected + Timedelta(1, "h") - Timedelta(1, "ns")
+        expected = expected + np.timedelta64(1, "h") - np.timedelta64(1, "us")
         tm.assert_index_equal(result, expected)
 
     def test_to_timestamp_1703(self):

--- a/pandas/tests/indexes/period/methods/test_to_timestamp.py
+++ b/pandas/tests/indexes/period/methods/test_to_timestamp.py
@@ -7,6 +7,7 @@ from pandas import (
     DatetimeIndex,
     NaT,
     PeriodIndex,
+    Timedelta,
     Timestamp,
     date_range,
     period_range,
@@ -108,7 +109,7 @@ class TestToTimestamp:
         expected = DatetimeIndex(
             ["2011-02-28", "NaT", "2011-03-31"], dtype="M8[us]", name="idx"
         )
-        expected = expected + np.timedelta64(1, "D") - np.timedelta64(1, "us")
+        expected = expected + Timedelta(1, "D") - Timedelta(1, "us")
         tm.assert_index_equal(result, expected)
 
     def test_to_timestamp_pi_combined(self):
@@ -124,14 +125,14 @@ class TestToTimestamp:
         expected = DatetimeIndex(
             ["2011-01-02 00:59:59", "2011-01-03 01:59:59"], name="idx", dtype="M8[us]"
         )
-        expected = expected + np.timedelta64(1, "s") - np.timedelta64(1, "us")
+        expected = expected + Timedelta(1, "s") - Timedelta(1, "us")
         tm.assert_index_equal(result, expected)
 
         result = idx.to_timestamp(how="E", freq="h")
         expected = DatetimeIndex(
             ["2011-01-02 00:00", "2011-01-03 01:00"], dtype="M8[us]", name="idx"
         )
-        expected = expected + np.timedelta64(1, "h") - np.timedelta64(1, "us")
+        expected = expected + Timedelta(1, "h") - Timedelta(1, "us")
         tm.assert_index_equal(result, expected)
 
     def test_to_timestamp_1703(self):

--- a/pandas/tests/indexes/period/test_scalar_compat.py
+++ b/pandas/tests/indexes/period/test_scalar_compat.py
@@ -1,9 +1,9 @@
 """Tests for PeriodIndex behaving like a vectorized Period scalar"""
 
-import numpy as np
 import pytest
 
 from pandas import (
+    Timedelta,
     date_range,
     period_range,
 )
@@ -21,7 +21,7 @@ class TestPeriodIndexOps:
         # GH#17157
         index = period_range(freq="M", start="2016-01-01", end="2016-05-31")
         expected_index = date_range("2016-01-01", end="2016-05-31", freq="ME")
-        expected_index += np.timedelta64(1, "D") - np.timedelta64(1, "us")
+        expected_index += Timedelta(1, "D") - Timedelta(1, "us")
         tm.assert_index_equal(index.end_time, expected_index)
 
     @pytest.mark.filterwarnings(r"ignore:PeriodDtype\[B\] is deprecated:FutureWarning")
@@ -34,5 +34,5 @@ class TestPeriodIndexOps:
         result = pi.end_time
 
         dti = date_range("1990-01-05", freq="D", periods=1)._with_freq(None)
-        expected = dti + np.timedelta64(1, "D") - np.timedelta64(1, "us")
+        expected = dti + Timedelta(1, "D") - Timedelta(1, "us")
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/period/test_scalar_compat.py
+++ b/pandas/tests/indexes/period/test_scalar_compat.py
@@ -1,9 +1,9 @@
 """Tests for PeriodIndex behaving like a vectorized Period scalar"""
 
+import numpy as np
 import pytest
 
 from pandas import (
-    Timedelta,
     date_range,
     period_range,
 )
@@ -14,16 +14,14 @@ class TestPeriodIndexOps:
     def test_start_time(self):
         # GH#17157
         index = period_range(freq="M", start="2016-01-01", end="2016-05-31")
-        expected_index = date_range(
-            "2016-01-01", end="2016-05-31", freq="MS", unit="ns"
-        )
+        expected_index = date_range("2016-01-01", end="2016-05-31", freq="MS")
         tm.assert_index_equal(index.start_time, expected_index)
 
     def test_end_time(self):
         # GH#17157
         index = period_range(freq="M", start="2016-01-01", end="2016-05-31")
         expected_index = date_range("2016-01-01", end="2016-05-31", freq="ME")
-        expected_index += Timedelta(1, "D") - Timedelta(1, "ns")
+        expected_index += np.timedelta64(1, "D") - np.timedelta64(1, "us")
         tm.assert_index_equal(index.end_time, expected_index)
 
     @pytest.mark.filterwarnings(r"ignore:PeriodDtype\[B\] is deprecated:FutureWarning")
@@ -36,5 +34,5 @@ class TestPeriodIndexOps:
         result = pi.end_time
 
         dti = date_range("1990-01-05", freq="D", periods=1)._with_freq(None)
-        expected = dti + Timedelta(days=1, nanoseconds=-1)
+        expected = dti + np.timedelta64(1, "D") - np.timedelta64(1, "us")
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -682,6 +682,7 @@ class TestTSPlot:
         axes = fig.get_axes()
         line = ax.get_lines()[0]
         xp = Series(line.get_ydata(), line.get_xdata()).to_timestamp()
+        xp.index = xp.index.as_unit("ns")
         tm.assert_series_equal(ser, xp)
         assert ax.get_yaxis().get_ticks_position() == "right"
         assert not axes[0].get_yaxis().get_visible()

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1112,7 +1112,7 @@ def test_resample_anchored_intraday(unit):
     result = df.resample("ME").mean()
     expected = df.resample("ME").mean().to_period()
     expected = expected.to_timestamp(how="end")
-    expected.index += Timedelta(1, "ns") - Timedelta(1, "D")
+    expected.index += np.timedelta64(1, "us") - np.timedelta64(1, "D")
     expected.index = expected.index.as_unit(unit)._with_freq("infer")
     assert expected.index.freq == "ME"
     tm.assert_frame_equal(result, expected)
@@ -1121,7 +1121,7 @@ def test_resample_anchored_intraday(unit):
     exp = df.shift(1, freq="D").resample("ME").mean().to_period()
     exp = exp.to_timestamp(how="end")
 
-    exp.index = exp.index + Timedelta(1, "ns") - Timedelta(1, "D")
+    exp.index = exp.index + np.timedelta64(1, "us") - np.timedelta64(1, "D")
     exp.index = exp.index.as_unit(unit)._with_freq("infer")
     assert exp.index.freq == "ME"
     tm.assert_frame_equal(result, exp)
@@ -1134,7 +1134,7 @@ def test_resample_anchored_intraday2(unit):
     result = df.resample("QE").mean()
     expected = df.resample("QE").mean().to_period()
     expected = expected.to_timestamp(how="end")
-    expected.index += Timedelta(1, "ns") - Timedelta(1, "D")
+    expected.index += np.timedelta64(1, "us") - np.timedelta64(1, "D")
     expected.index._data.freq = "QE"
     expected.index._freq = lib.no_default
     expected.index = expected.index.as_unit(unit)
@@ -1144,7 +1144,7 @@ def test_resample_anchored_intraday2(unit):
     expected = df.shift(1, freq="D").resample("QE").mean()
     expected = expected.to_period()
     expected = expected.to_timestamp(how="end")
-    expected.index += Timedelta(1, "ns") - Timedelta(1, "D")
+    expected.index += np.timedelta64(1, "us") - np.timedelta64(1, "D")
     expected.index._data.freq = "QE"
     expected.index._freq = lib.no_default
     expected.index = expected.index.as_unit(unit)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1112,7 +1112,7 @@ def test_resample_anchored_intraday(unit):
     result = df.resample("ME").mean()
     expected = df.resample("ME").mean().to_period()
     expected = expected.to_timestamp(how="end")
-    expected.index += np.timedelta64(1, "us") - np.timedelta64(1, "D")
+    expected.index += Timedelta(1, unit="us") - Timedelta(1, unit="D")
     expected.index = expected.index.as_unit(unit)._with_freq("infer")
     assert expected.index.freq == "ME"
     tm.assert_frame_equal(result, expected)
@@ -1121,7 +1121,7 @@ def test_resample_anchored_intraday(unit):
     exp = df.shift(1, freq="D").resample("ME").mean().to_period()
     exp = exp.to_timestamp(how="end")
 
-    exp.index = exp.index + np.timedelta64(1, "us") - np.timedelta64(1, "D")
+    exp.index = exp.index + Timedelta(1, unit="us") - Timedelta(1, unit="D")
     exp.index = exp.index.as_unit(unit)._with_freq("infer")
     assert exp.index.freq == "ME"
     tm.assert_frame_equal(result, exp)
@@ -1134,7 +1134,7 @@ def test_resample_anchored_intraday2(unit):
     result = df.resample("QE").mean()
     expected = df.resample("QE").mean().to_period()
     expected = expected.to_timestamp(how="end")
-    expected.index += np.timedelta64(1, "us") - np.timedelta64(1, "D")
+    expected.index += Timedelta(1, unit="us") - Timedelta(1, unit="D")
     expected.index._data.freq = "QE"
     expected.index._freq = lib.no_default
     expected.index = expected.index.as_unit(unit)
@@ -1144,7 +1144,7 @@ def test_resample_anchored_intraday2(unit):
     expected = df.shift(1, freq="D").resample("QE").mean()
     expected = expected.to_period()
     expected = expected.to_timestamp(how="end")
-    expected.index += np.timedelta64(1, "us") - np.timedelta64(1, "D")
+    expected.index += Timedelta(1, unit="us") - Timedelta(1, unit="D")
     expected.index._data.freq = "QE"
     expected.index._freq = lib.no_default
     expected.index = expected.index.as_unit(unit)

--- a/pandas/tests/scalar/period/test_asfreq.py
+++ b/pandas/tests/scalar/period/test_asfreq.py
@@ -1,7 +1,6 @@
 import pytest
 
 from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
-from pandas.errors import OutOfBoundsDatetime
 
 from pandas import (
     Period,
@@ -42,10 +41,8 @@ class TestFreqConversion:
         # GH#19643, used to incorrectly give Timestamp in 1754
         with tm.assert_produces_warning(FutureWarning, match=bday_msg):
             per = Period("0001-01-01", freq="B")
-        msg = "Out of bounds nanosecond timestamp"
-        with pytest.raises(OutOfBoundsDatetime, match=msg):
-            with tm.assert_produces_warning(FutureWarning, match=bday_msg):
-                per.to_timestamp()
+        with tm.assert_produces_warning(FutureWarning, match=bday_msg):
+            per.to_timestamp()
 
     def test_asfreq_corner(self):
         val = Period(freq="Y", year=2007)
@@ -694,14 +691,7 @@ class TestFreqConversion:
         start = per.start_time
         expected = Timestamp("2020-01-30 15:57:27.576166")
         assert start == expected
-        assert start._value == per.ordinal * 1000
-
-        per2 = Period("2300-01-01", "us")
-        msg = "2300-01-01"
-        with pytest.raises(OutOfBoundsDatetime, match=msg):
-            per2.start_time
-        with pytest.raises(OutOfBoundsDatetime, match=msg):
-            per2.end_time
+        assert start._value == per.ordinal
 
     def test_asfreq_mult(self):
         # normal freq to mult freq

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -8,16 +8,21 @@ import re
 import numpy as np
 import pytest
 
-from pandas._libs.tslibs import iNaT
+from pandas._libs.tslibs import (
+    iNaT,
+    to_offset,
+)
 from pandas._libs.tslibs.ccalendar import (
     DAYS,
     MONTHS,
 )
-from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 from pandas._libs.tslibs.parsing import DateParseError
 from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
 from pandas.compat import PY314
-from pandas.errors import Pandas4Warning
+from pandas.errors import (
+    OutOfBoundsDatetime,
+    Pandas4Warning,
+)
 
 from pandas import (
     NaT,
@@ -682,12 +687,12 @@ class TestPeriodMethods:
     def test_to_timestamp_mult(self):
         p = Period("2011-01", freq="M")
         assert p.to_timestamp(how="S") == Timestamp("2011-01-01")
-        expected = Timestamp("2011-02-01") - Timedelta(1, "ns")
+        expected = Timestamp("2011-02-01") - np.timedelta64(1, "us")
         assert p.to_timestamp(how="E") == expected
 
         p = Period("2011-01", freq="3M")
         assert p.to_timestamp(how="S") == Timestamp("2011-01-01")
-        expected = Timestamp("2011-04-01") - Timedelta(1, "ns")
+        expected = Timestamp("2011-04-01") - np.timedelta64(1, "us")
         assert p.to_timestamp(how="E") == expected
 
     @pytest.mark.filterwarnings(
@@ -712,8 +717,8 @@ class TestPeriodMethods:
 
         def _ex(p):
             if p.freq == "B":
-                return p.start_time + Timedelta(days=1, nanoseconds=-1)
-            return Timestamp((p + p.freq).start_time._value - 1)
+                return p.start_time + np.timedelta64(1, "D") - np.timedelta64(1, "us")
+            return Timestamp((p + p.freq).start_time._value - 1, unit="us")
 
         for fcode in from_lst:
             p = Period("1982", freq=fcode)
@@ -729,19 +734,19 @@ class TestPeriodMethods:
         p = Period("1985", freq="Y")
 
         result = p.to_timestamp("h", how="end")
-        expected = Timestamp(1986, 1, 1) - Timedelta(1, "ns")
+        expected = Timestamp(1986, 1, 1) - np.timedelta64(1, "us")
         assert result == expected
         result = p.to_timestamp("3h", how="end")
         assert result == expected
 
         result = p.to_timestamp("min", how="end")
-        expected = Timestamp(1986, 1, 1) - Timedelta(1, "ns")
+        expected = Timestamp(1986, 1, 1) - np.timedelta64(1, "us")
         assert result == expected
         result = p.to_timestamp("2min", how="end")
         assert result == expected
 
         result = p.to_timestamp(how="end")
-        expected = Timestamp(1986, 1, 1) - Timedelta(1, "ns")
+        expected = Timestamp(1986, 1, 1) - np.timedelta64(1, "us")
         assert result == expected
 
         expected = datetime(1985, 1, 1)
@@ -761,7 +766,7 @@ class TestPeriodMethods:
             per = Period("1990-01-05", "B")  # Friday
             result = per.to_timestamp("B", how="E")
 
-        expected = Timestamp("1990-01-06") - Timedelta(nanoseconds=1)
+        expected = Timestamp("1990-01-06") - np.timedelta64(1, "us")
         assert result == expected
 
     @pytest.mark.parametrize(
@@ -920,8 +925,21 @@ class TestPeriodProperties:
     def test_outer_bounds_start_and_end_time(self, bound, offset, period_property):
         # GH #13346
         period = TestPeriodProperties._period_constructor(bound, offset)
-        with pytest.raises(OutOfBoundsDatetime, match="Out of bounds nanosecond"):
-            getattr(period, period_property)
+        # post-GH#??? this no longer raises OutOfBoundsDatetime
+        getattr(period, period_property)
+
+        per = Period._from_ordinal(bound.value, freq=to_offset("ms"))
+
+        if period_property == "end_time" and offset == 1:
+            err = OverflowError
+            msg = "value too large"
+        else:
+            err = OutOfBoundsDatetime
+            msg = "Out of bounds microsecond"
+        # But if we do the same thing with a much-more-remote date, we still
+        #  raise OutOfBoundsDatetime (as opposed to silently giving a wrong result)
+        with pytest.raises(err, match=msg):
+            getattr(per, period_property)
 
     @pytest.mark.parametrize("bound, offset", [(Timestamp.min, -1), (Timestamp.max, 1)])
     @pytest.mark.parametrize("period_property", ["start_time", "end_time"])
@@ -946,49 +964,46 @@ class TestPeriodProperties:
     def test_end_time(self):
         p = Period("2012", freq="Y")
 
-        def _ex(*args):
-            return Timestamp(Timestamp(datetime(*args)).as_unit("ns")._value - 1)
-
-        xp = _ex(2013, 1, 1)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 12, 31, 23, 59, 59, 999999)
+        assert p.end_time == exp
 
         p = Period("2012", freq="Q")
-        xp = _ex(2012, 4, 1)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 3, 31, 23, 59, 59, 999999)
+        assert p.end_time == exp
 
         p = Period("2012", freq="M")
-        xp = _ex(2012, 2, 1)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 1, 31, 23, 59, 59, 999999)
+        assert p.end_time == exp
 
         p = Period("2012", freq="D")
-        xp = _ex(2012, 1, 2)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 1, 1, 23, 59, 59, 999999)
+        assert p.end_time == exp
 
         p = Period("2012", freq="h")
-        xp = _ex(2012, 1, 1, 1)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 1, 1, 0, 59, 59, 999999)
+        assert p.end_time == exp
 
         with tm.assert_produces_warning(FutureWarning, match=bday_msg):
             p = Period("2012", freq="B")
-            xp = _ex(2012, 1, 3)
-            assert xp == p.end_time
+            exp = Timestamp(2012, 1, 2, 23, 59, 59, 999999)
+            assert p.end_time == exp
 
         p = Period("2012", freq="W")
-        xp = _ex(2012, 1, 2)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 1, 1, 23, 59, 59, 999999)
+        assert p.end_time == exp
 
         # Test for GH 11738
         p = Period("2012", freq="15D")
-        xp = _ex(2012, 1, 16)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 1, 15, 23, 59, 59, 999999)
+        assert p.end_time == exp
 
         p = Period("2012", freq="1D1h")
-        xp = _ex(2012, 1, 2, 1)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 1, 2, 0, 59, 59, 999999)
+        assert p.end_time == exp
 
         p = Period("2012", freq="1h1D")
-        xp = _ex(2012, 1, 2, 1)
-        assert xp == p.end_time
+        exp = Timestamp(2012, 1, 2, 0, 59, 59, 999999)
+        assert p.end_time == exp
 
     def test_end_time_business_friday(self):
         # GH#34449
@@ -996,16 +1011,13 @@ class TestPeriodProperties:
             per = Period("1990-01-05", "B")
             result = per.end_time
 
-        expected = Timestamp("1990-01-06") - Timedelta(nanoseconds=1)
+        expected = Timestamp("1990-01-06") - np.timedelta64(1, "us")
         assert result == expected
 
     def test_anchor_week_end_time(self):
-        def _ex(*args):
-            return Timestamp(Timestamp(datetime(*args)).as_unit("ns")._value - 1)
-
         p = Period("2013-1-1", "W-SAT")
-        xp = _ex(2013, 1, 6)
-        assert p.end_time == xp
+        exp = Timestamp(2013, 1, 5, 23, 59, 59, 999999)
+        assert p.end_time == exp
 
     def test_properties_annually(self):
         # Test properties on Periods with annually frequency.

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -687,12 +687,12 @@ class TestPeriodMethods:
     def test_to_timestamp_mult(self):
         p = Period("2011-01", freq="M")
         assert p.to_timestamp(how="S") == Timestamp("2011-01-01")
-        expected = Timestamp("2011-02-01") - np.timedelta64(1, "us")
+        expected = Timestamp("2011-02-01") - Timedelta(1, unit="us")
         assert p.to_timestamp(how="E") == expected
 
         p = Period("2011-01", freq="3M")
         assert p.to_timestamp(how="S") == Timestamp("2011-01-01")
-        expected = Timestamp("2011-04-01") - np.timedelta64(1, "us")
+        expected = Timestamp("2011-04-01") - Timedelta(1, unit="us")
         assert p.to_timestamp(how="E") == expected
 
     @pytest.mark.filterwarnings(
@@ -734,19 +734,19 @@ class TestPeriodMethods:
         p = Period("1985", freq="Y")
 
         result = p.to_timestamp("h", how="end")
-        expected = Timestamp(1986, 1, 1) - np.timedelta64(1, "us")
+        expected = Timestamp(1986, 1, 1) - Timedelta(1, unit="us")
         assert result == expected
         result = p.to_timestamp("3h", how="end")
         assert result == expected
 
         result = p.to_timestamp("min", how="end")
-        expected = Timestamp(1986, 1, 1) - np.timedelta64(1, "us")
+        expected = Timestamp(1986, 1, 1) - Timedelta(1, unit="us")
         assert result == expected
         result = p.to_timestamp("2min", how="end")
         assert result == expected
 
         result = p.to_timestamp(how="end")
-        expected = Timestamp(1986, 1, 1) - np.timedelta64(1, "us")
+        expected = Timestamp(1986, 1, 1) - Timedelta(1, unit="us")
         assert result == expected
 
         expected = datetime(1985, 1, 1)
@@ -766,7 +766,7 @@ class TestPeriodMethods:
             per = Period("1990-01-05", "B")  # Friday
             result = per.to_timestamp("B", how="E")
 
-        expected = Timestamp("1990-01-06") - np.timedelta64(1, "us")
+        expected = Timestamp("1990-01-06") - Timedelta(1, unit="us")
         assert result == expected
 
     @pytest.mark.parametrize(
@@ -1011,7 +1011,7 @@ class TestPeriodProperties:
             per = Period("1990-01-05", "B")
             result = per.end_time
 
-        expected = Timestamp("1990-01-06") - np.timedelta64(1, "us")
+        expected = Timestamp("1990-01-06") - Timedelta(1, unit="us")
         assert result == expected
 
     def test_anchor_week_end_time(self):

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -717,7 +717,7 @@ class TestPeriodMethods:
 
         def _ex(p):
             if p.freq == "B":
-                return p.start_time + np.timedelta64(1, "D") - np.timedelta64(1, "us")
+                return p.start_time + Timedelta(days=1) - Timedelta(microseconds=1)
             return Timestamp((p + p.freq).start_time._value - 1, unit="us")
 
         for fcode in from_lst:
@@ -925,7 +925,7 @@ class TestPeriodProperties:
     def test_outer_bounds_start_and_end_time(self, bound, offset, period_property):
         # GH #13346
         period = TestPeriodProperties._period_constructor(bound, offset)
-        # post-GH#??? this no longer raises OutOfBoundsDatetime
+        # post-GH#63760 this no longer raises OutOfBoundsDatetime
         getattr(period, period_property)
 
         per = Period._from_ordinal(bound.value, freq=to_offset("ms"))


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

cc @jorisvandenbossche do we want to get this in under the wire?