### PR TITLE
TST: add fillna test for filling with Categorical (GH#56329)

### DIFF
--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -256,6 +256,21 @@ class TestFillNA:
         idx = TimedeltaIndex(["1 days", "2 days", "1 days", NaT, NaT])
         df = DataFrame({"a": Categorical(idx)})
         tm.assert_frame_equal(df.fillna(value=NaT), df)
+        
+    def test_fillna_with_categorical_series(self):
+        df = DataFrame({
+            'cats': Categorical(['A', 'B', 'C']),
+            'ints': [1.0, 2.0, np.nan]
+        })
+       
+        filler = Series(Categorical([10.0, 20.0, 30.0]))
+        df.fillna({'ints': filler}, inplace=True)
+        
+        expected = DataFrame({
+            'cats': Categorical(['A', 'B', 'C']),
+            'ints': [1.0, 2.0, 30.0]
+        })
+        tm.assert_frame_equal(df, expected)
 
     def test_fillna_no_downcast(self, frame_or_series):
         # GH#45603 preserve object dtype

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -256,20 +256,18 @@ class TestFillNA:
         idx = TimedeltaIndex(["1 days", "2 days", "1 days", NaT, NaT])
         df = DataFrame({"a": Categorical(idx)})
         tm.assert_frame_equal(df.fillna(value=NaT), df)
-        
+
     def test_fillna_with_categorical_series(self):
-        df = DataFrame({
-            'cats': Categorical(['A', 'B', 'C']),
-            'ints': [1.0, 2.0, np.nan]
-        })
-       
+        df = DataFrame(
+            {"cats": Categorical(["A", "B", "C"]), "ints": [1.0, 2.0, np.nan]}
+        )
+
         filler = Series(Categorical([10.0, 20.0, 30.0]))
-        df.fillna({'ints': filler}, inplace=True)
-        
-        expected = DataFrame({
-            'cats': Categorical(['A', 'B', 'C']),
-            'ints': [1.0, 2.0, 30.0]
-        })
+        df.fillna({"ints": filler}, inplace=True)
+
+        expected = DataFrame(
+            {"cats": Categorical(["A", "B", "C"]), "ints": [1.0, 2.0, 30.0]}
+        )
         tm.assert_frame_equal(df, expected)
 
     def test_fillna_no_downcast(self, frame_or_series):

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -258,17 +258,18 @@ class TestFillNA:
         tm.assert_frame_equal(df.fillna(value=NaT), df)
 
     def test_fillna_with_categorical_series(self):
+        # https://github.com/pandas-dev/pandas/issues/56329
         df = DataFrame(
             {"cats": Categorical(["A", "B", "C"]), "ints": [1.0, 2.0, np.nan]}
         )
 
         filler = Series(Categorical([10.0, 20.0, 30.0]))
-        df.fillna({"ints": filler}, inplace=True)
+        result = df.fillna({"ints": filler})
 
         expected = DataFrame(
             {"cats": Categorical(["A", "B", "C"]), "ints": [1.0, 2.0, 30.0]}
         )
-        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_fillna_no_downcast(self, frame_or_series):
         # GH#45603 preserve object dtype


### PR DESCRIPTION
- [x] closes #56329 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This PR reintroduces the test originally proposed in #62319, updated to address review feedback:
*  avoid in-place mutation to preserve before/after state
*  test reference GH#56329.
