### PR TITLE
Timestamp round/ceil/floor allow timedelta argument + allow timedelta strings in `to_offset` 

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -268,6 +268,7 @@ Other enhancements
   data object into a pandas object through the
   `Arrow PyCapsule Protocol <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>`__ (:issue:`59631`)
 - :meth:`Series.round` now supports object dtypes when the underlying Python objects implement ``__round__`` (:issue:`63444`)
+- :meth:`Timestamp.round`, :meth:`Timestamp.floor`, and :meth:`Timestamp.ceil` now officially accept :class:`Timedelta` arguments (:issue:`63687`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_300.notable_bug_fixes:

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -6191,7 +6191,9 @@ cpdef to_offset(freq, bint is_period=False):
     Parameters
     ----------
     freq : str, datetime.timedelta, BaseOffset or None
-        The frequency represented.
+        The frequency represented. If a string, can be either a pandas
+        Timedelta string (e.g., "1 days 2 hours 30 minutes") or an offset
+        string (e.g., "5min", "1D1h", "2W").
     is_period : bool, default False
         Convert string denoting period frequency to corresponding offsets
         frequency if is_period=True.
@@ -6208,6 +6210,7 @@ cpdef to_offset(freq, bint is_period=False):
     See Also
     --------
     BaseOffset : Standard kind of date increment used for a date range.
+    Timedelta : Immutable timedelta object.
 
     Examples
     --------
@@ -6229,6 +6232,14 @@ cpdef to_offset(freq, bint is_period=False):
 
     >>> to_offset(pd.offsets.Hour())
     <Hour>
+
+    String Timedelta arguments are now supported and take precedence:
+
+    >>> to_offset("1 days 2 hours")
+    <26 * Hours>
+
+    >>> to_offset("1h30min")
+    <90 * Minutes>
 
     Passing the parameter ``is_period`` equal to True, you can use a string
     denoting period frequency:
@@ -6258,59 +6269,61 @@ cpdef to_offset(freq, bint is_period=False):
     elif isinstance(freq, str):
         result = None
         stride_sign = None
-
         try:
-            split = opattern.split(freq)
-            if split[-1] != "" and not split[-1].isspace():
-                # the last element must be blank
-                raise ValueError("last element must be blank")
+            result = delta_to_tick(Timedelta(freq))
+        except (ValueError, TypeError) as exc:
+            try:
+                split = opattern.split(freq)
+                if split[-1] != "" and not split[-1].isspace():
+                    # the last element must be blank
+                    raise ValueError("last element must be blank")
 
-            tups = zip(split[0::4], split[1::4], split[2::4], strict=False)
-            for n, (sep, stride, name) in enumerate(tups):
-                name = _warn_about_deprecated_aliases(name, is_period)
-                _validate_to_offset_alias(name, is_period)
-                if is_period:
-                    if name.upper() in c_PERIOD_TO_OFFSET_FREQSTR:
-                        if name.upper() != name:
-                            raise ValueError(
-                                f"\'{name}\' is no longer supported, "
-                                f"please use \'{name.upper()}\' instead.",
-                            )
-                        name = c_PERIOD_TO_OFFSET_FREQSTR[name.upper()]
-                name = _lite_rule_alias.get(name, name)
+                tups = zip(split[0::4], split[1::4], split[2::4], strict=False)
+                for n, (sep, stride, name) in enumerate(tups):
+                    name = _warn_about_deprecated_aliases(name, is_period)
+                    _validate_to_offset_alias(name, is_period)
+                    if is_period:
+                        if name.upper() in c_PERIOD_TO_OFFSET_FREQSTR:
+                            if name.upper() != name:
+                                raise ValueError(
+                                    f"\'{name}\' is no longer supported, "
+                                    f"please use \'{name.upper()}\' instead.",
+                                )
+                            name = c_PERIOD_TO_OFFSET_FREQSTR[name.upper()]
+                    name = _lite_rule_alias.get(name, name)
 
-                if sep != "" and not sep.isspace():
-                    raise ValueError("separator must be spaces")
-                if stride_sign is None:
-                    stride_sign = -1 if stride.startswith("-") else 1
-                if not stride:
-                    stride = 1
+                    if sep != "" and not sep.isspace():
+                        raise ValueError("separator must be spaces")
+                    if stride_sign is None:
+                        stride_sign = -1 if stride.startswith("-") else 1
+                    if not stride:
+                        stride = 1
 
-                if name in {"D", "h", "min", "s", "ms", "us", "ns"}:
-                    # For these prefixes, we have something like "3h" or
-                    #  "2.5min", so we can construct a Timedelta with the
-                    #  matching unit and get our offset from delta_to_tick
-                    td = Timedelta(1, unit=name)
-                    off = delta_to_tick(td)
-                    offset = off * float(stride)
-                    if n != 0:
-                        # If n==0, then stride_sign is already incorporated
-                        #  into the offset
-                        offset *= stride_sign
-                else:
-                    stride = int(stride)
-                    offset = _get_offset(name)
-                    offset = offset * int(np.fabs(stride) * stride_sign)
+                    if name in {"D", "h", "min", "s", "ms", "us", "ns"}:
+                        # For these prefixes, we have something like "3h" or
+                        #  "2.5min", so we can construct a Timedelta with the
+                        #  matching unit and get our offset from delta_to_tick
+                        td = Timedelta(1, unit=name)
+                        off = delta_to_tick(td)
+                        offset = off * float(stride)
+                        if n != 0:
+                            # If n==0, then stride_sign is already incorporated
+                            #  into the offset
+                            offset *= stride_sign
+                    else:
+                        stride = int(stride)
+                        offset = _get_offset(name)
+                        offset = offset * int(np.fabs(stride) * stride_sign)
 
-                if result is None:
-                    result = offset
-                else:
-                    result = result + offset
-        except (ValueError, TypeError) as err:
-            raise_invalid_freq(
-                freq=freq,
-                extra_message=f"Failed to parse with error message: {repr(err)}"
-            )
+                    if result is None:
+                        result = offset
+                    else:
+                        result = result + offset
+            except (ValueError, TypeError) as err:
+                raise_invalid_freq(
+                    freq=freq,
+                    extra_message=f"Failed to parse with error message: {repr(err)}"
+                )
 
         # TODO(3.0?) once deprecation of "d" is enforced, the check for it here
         #  can be removed

--- a/pandas/_libs/tslibs/timestamps.pyi
+++ b/pandas/_libs/tslibs/timestamps.pyi
@@ -198,19 +198,19 @@ class Timestamp(datetime):
     # TODO: round/floor/ceil could return NaT?
     def round(
         self,
-        freq: str,
+        freq: str | Timedelta,
         ambiguous: bool | Literal["raise", "NaT"] = ...,
         nonexistent: TimestampNonexistent = ...,
     ) -> Self: ...
     def floor(
         self,
-        freq: str,
+        freq: str | Timedelta,
         ambiguous: bool | Literal["raise", "NaT"] = ...,
         nonexistent: TimestampNonexistent = ...,
     ) -> Self: ...
     def ceil(
         self,
-        freq: str,
+        freq: str | Timedelta,
         ambiguous: bool | Literal["raise", "NaT"] = ...,
         nonexistent: TimestampNonexistent = ...,
     ) -> Self: ...

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2794,8 +2794,8 @@ class Timestamp(_Timestamp):
 
         Parameters
         ----------
-        freq : str
-            Frequency string indicating the rounding resolution.
+        freq : str or Timedelta
+            Frequency string indicating the rounding resolution or a Timedelta object.
         ambiguous : bool or {'raise', 'NaT'}, default 'raise'
             The behavior is as follows:
 
@@ -2871,6 +2871,11 @@ timedelta}, default 'raise'
         >>> ts.round(freq='1h30min')
         Timestamp('2020-03-14 15:00:00')
 
+        ``freq`` can also be a Timedelta object:
+
+        >>> ts.round(freq=pd.Timedelta('1h30min'))
+        Timestamp('2020-03-14 15:00:00')
+
         Analogous for ``pd.NaT``:
 
         >>> pd.NaT.round()
@@ -2897,8 +2902,8 @@ timedelta}, default 'raise'
 
         Parameters
         ----------
-        freq : str
-            Frequency string indicating the flooring resolution.
+        freq : str or Timedelta
+            Frequency string indicating the flooring resolution or a Timedelta object.
         ambiguous : bool or {'raise', 'NaT'}, default 'raise'
             The behavior is as follows:
 
@@ -2968,6 +2973,11 @@ timedelta}, default 'raise'
         >>> ts.floor(freq='1h30min')
         Timestamp('2020-03-14 15:00:00')
 
+        ``freq`` can also be a Timedelta object:
+
+        >>> ts.floor(freq=pd.Timedelta('1h30min'))
+        Timestamp('2020-03-14 15:00:00')
+
         Analogous for ``pd.NaT``:
 
         >>> pd.NaT.floor()
@@ -2992,8 +3002,8 @@ timedelta}, default 'raise'
 
         Parameters
         ----------
-        freq : str
-            Frequency string indicating the ceiling resolution.
+        freq : str or Timedelta
+            Frequency string indicating the ceiling resolution or a Timedelta object.
         ambiguous : bool or {'raise', 'NaT'}, default 'raise'
             The behavior is as follows:
 
@@ -3061,6 +3071,11 @@ timedelta}, default 'raise'
         or a combination of multiple units, like '1h30min' (i.e. 1 hour and 30 minutes):
 
         >>> ts.ceil(freq='1h30min')
+        Timestamp('2020-03-14 16:30:00')
+
+        ``freq`` can also be a Timedelta object:
+
+        >>> ts.ceil(freq=pd.Timedelta('1h30min'))
         Timestamp('2020-03-14 16:30:00')
 
         Analogous for ``pd.NaT``:

--- a/pandas/tests/scalar/timestamp/methods/test_round.py
+++ b/pandas/tests/scalar/timestamp/methods/test_round.py
@@ -91,6 +91,96 @@ class TestTimestampRound:
             stamp.round("foo")
 
     @pytest.mark.parametrize(
+        "timestamp, freq_td, expected",
+        [
+            ("20130101 09:10:11", Timedelta("1 day"), "20130101"),
+            ("20130101 19:10:11", Timedelta("1 day"), "20130102"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 day"), "2000-01-05 00:00:00"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 hour"), "2000-01-05 05:00:00"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 second"), "2000-01-05 05:09:15"),
+            (
+                "2000-01-05 05:09:15.13",
+                Timedelta("1 hour 30 min"),
+                "2000-01-05 04:30:00",
+            ),
+        ],
+    )
+    def test_round_timedelta_freq(self, timestamp, freq_td, expected):
+        # GH#63687 - Timestamp.round accepts Timedelta arguments
+        dt = Timestamp(timestamp)
+        result = dt.round(freq_td)
+        expected = Timestamp(expected)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "timestamp, freq_td, expected",
+        [
+            ("20130101 09:10:11", Timedelta("1 day"), "20130101"),
+            ("20130101 19:10:11", Timedelta("1 day"), "20130101"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 day"), "2000-01-05 00:00:00"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 hour"), "2000-01-05 05:00:00"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 second"), "2000-01-05 05:09:15"),
+            (
+                "2000-01-05 05:09:15.13",
+                Timedelta("1 hour 30 min"),
+                "2000-01-05 04:30:00",
+            ),
+            # Edge cases
+            ("2117-01-01 00:00:45", Timedelta("15s"), "2117-01-01 00:00:45"),
+            (
+                "2117-01-01 00:00:45.000000012",
+                Timedelta("10ns"),
+                "2117-01-01 00:00:45.000000010",
+            ),
+            ("1823-01-01 00:00:01", Timedelta("1s"), "1823-01-01 00:00:01"),
+            ("NaT", Timedelta("1s"), "NaT"),
+        ],
+    )
+    def test_floor_timedelta_freq(self, timestamp, freq_td, expected):
+        # GH#63687 - Timestamp.floor accepts Timedelta arguments (including edge cases)
+        dt = Timestamp(timestamp)
+        if dt is NaT:
+            assert dt.floor(freq_td) is NaT
+        else:
+            result = dt.floor(freq_td)
+            expected = Timestamp(expected)
+            assert result == expected
+
+    @pytest.mark.parametrize(
+        "timestamp, freq_td, expected",
+        [
+            ("20130101 09:10:11", Timedelta("1 day"), "20130102"),
+            ("20130101 19:10:11", Timedelta("1 day"), "20130102"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 day"), "2000-01-06 00:00:00"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 hour"), "2000-01-05 06:00:00"),
+            ("2000-01-05 05:09:15.13", Timedelta("1 second"), "2000-01-05 05:09:16"),
+            (
+                "2000-01-05 05:09:15.13",
+                Timedelta("1 hour 30 min"),
+                "2000-01-05 06:00:00",
+            ),
+            # Edge cases
+            ("2117-01-01 00:00:45", Timedelta("15s"), "2117-01-01 00:00:45"),
+            (
+                "1823-01-01 00:00:01.000000012",
+                Timedelta("10ns"),
+                "1823-01-01 00:00:01.000000020",
+            ),
+            ("1823-01-01 00:00:01", Timedelta("1s"), "1823-01-01 00:00:01"),
+            ("NaT", Timedelta("1s"), "NaT"),
+        ],
+    )
+    def test_ceil_timedelta_freq(self, timestamp, freq_td, expected):
+        # GH#63687 - Timestamp.ceil accepts Timedelta arguments (including edge cases)
+        dt = Timestamp(timestamp)
+        if dt is NaT:
+            assert dt.ceil(freq_td) is NaT
+        else:
+            result = dt.ceil(freq_td)
+            expected = Timestamp(expected)
+            assert result == expected
+
+    @pytest.mark.parametrize(
         "test_input, rounder, freq, expected",
         [
             ("2117-01-01 00:00:45", "floor", "15s", "2117-01-01 00:00:45"),


### PR DESCRIPTION
- [x] closes #63687 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
