### PR TITLE
BUG: str methods failing on PyArrow data with regex using backreferences

### DIFF
--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -49,9 +49,12 @@ class ArrowStringArrayMixin:
         raise NotImplementedError
 
     @staticmethod
-    def _has_regex_lookaround(pat: str | re.Pattern) -> bool:
+    def _has_unsupported_regex(pat: str | re.Pattern) -> bool:
         """
-        Determine if regex pattern contains a lookahead or lookbehind.
+        Determine if regex pattern contains features not supported by RE2 / pyarrow.
+
+        This includes lookaround (lookahead or lookbehind) assertions and
+        backreferences.
 
         Parameters
         ----------
@@ -74,23 +77,29 @@ class ArrowStringArrayMixin:
                 "or downgrade Python"
             ) from err
 
-        def has_assert(tokens):
+        def has_unsupported_code(tokens):
             # For certain op codes we need to recurse.
             for op_code, argument in tokens:
                 if (
-                    (op_code == _parser.SUBPATTERN and has_assert(argument[3]))
+                    (
+                        op_code == _parser.SUBPATTERN
+                        and has_unsupported_code(argument[3])
+                    )
                     or (
                         op_code == _parser.BRANCH
-                        and any(has_assert(tokens) for tokens in argument[1])
+                        and any(has_unsupported_code(tokens) for tokens in argument[1])
                     )
-                    or (op_code in [_parser.ASSERT_NOT, _parser.ASSERT])
+                    or (
+                        op_code
+                        in [_parser.ASSERT_NOT, _parser.ASSERT, _parser.GROUPREF]
+                    )
                 ):
                     return True
             return False
 
         str_pat = pat.pattern if isinstance(pat, re.Pattern) else pat
         tokens = regex_parser(str_pat)
-        return has_assert(tokens)
+        return has_unsupported_code(tokens)
 
     def _str_len(self):
         result = pc.utf8_length(self._pa_array)

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -395,7 +395,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
         if (
             flags
             or self._is_re_pattern_with_flags(pat)
-            or (regex and self._has_regex_lookaround(pat))
+            or (regex and self._has_unsupported_regex(pat))
         ):
             return super()._str_contains(pat, case, flags, na, regex)
         if isinstance(pat, re.Pattern):
@@ -414,7 +414,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
         if (
             flags
             or self._is_re_pattern_with_flags(pat)
-            or self._has_regex_lookaround(pat)
+            or self._has_unsupported_regex(pat)
         ):
             return super()._str_match(pat, case, flags, na)
         if isinstance(pat, re.Pattern):
@@ -454,7 +454,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
                 # https://docs.python.org/3/library/re.html
                 isinstance(repl, str) and r"\g<" in repl
             )
-            or (regex and self._has_regex_lookaround(pat))
+            or (regex and self._has_unsupported_regex(pat))
         ):
             return super()._str_replace(pat, repl, n, case, flags, regex)
 
@@ -469,7 +469,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
             return ArrowExtensionArray._str_repeat(self, repeats=repeats)
 
     def _str_count(self, pat: str, flags: int = 0):
-        if flags or self._has_regex_lookaround(pat):
+        if flags or self._has_unsupported_regex(pat):
             return super()._str_count(pat, flags)
         result = pc.count_substring_regex(self._pa_array, pat)
         return self._convert_int_result(result)

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -885,6 +885,7 @@ def test_setitem_with_different_string_storage():
 @pytest.mark.parametrize(
     "pat, expected",
     [
+        # lookaround assertions
         (r"(?=abc)", True),
         (r"(?<=123)", True),
         (r"(?!xyz)", True),
@@ -910,8 +911,12 @@ def test_setitem_with_different_string_storage():
         (r"(?=test)?", False),
         (r"abc|(?=test)", True),
         (r"^(?=test)$", True),
+        # backreferences
+        (r"(abc)\1", True),
+        (r"\b(\w+)\s+\1\b", True),
+        (r"\b(?P<word>\w+)\s+(?P=word)\b", True),
     ],
 )
-def test_has_regex_lookaround(pat, expected):
+def test_has_regex_unsupported_code(pat, expected):
     # https://github.com/pandas-dev/pandas/issues/60833
-    assert ArrowStringArrayMixin._has_regex_lookaround(pat) == expected
+    assert ArrowStringArrayMixin._has_unsupported_regex(pat) == expected


### PR DESCRIPTION
Part of #63683

Small follow-up on https://github.com/pandas-dev/pandas/pull/63613 generalizing the check to also check for backreferences (which also raise with pyarrow)

Didn't yet add a end-to-end test, just a unit test for the helper method to ensure it catches a few cases.