### PR TITLE
DOC: clarify whatsnew item about updated deprecation policy

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -172,9 +172,9 @@ This includes :meth:`DataFrame.assign`, :meth:`DataFrame.loc`, and getitem/setit
 It is expected that the support for ``pd.col()`` will be expanded to more methods
 in future releases.
 
-New Deprecation Policy
-^^^^^^^^^^^^^^^^^^^^^^
-pandas 3.0.0 introduces a new 3-stage deprecation policy: using ``DeprecationWarning`` initially, then switching to ``FutureWarning`` for broader visibility in the last minor version before the next major release, and then removal of the deprecated functionality in the major release. This was done to give downstream packages more time to adjust to pandas deprecations, which should reduce the amount of warnings that a user gets from code that isn't theirs. See `PDEP 17 <https://pandas.pydata.org/pdeps/0017-backwards-compatibility-and-deprecation-policy.html>`_ for more details.
+Updated deprecation policy
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+pandas 3.0.0 updates the deprecation policy to clarify which deprecation warnings will be issued, using a new 3-stage policy: using ``DeprecationWarning`` initially, then switching to ``FutureWarning`` for broader visibility in the last minor version before the next major release, and then removal of the deprecated functionality in the major release. This was done to give downstream packages more time to adjust to pandas deprecations, which should reduce the amount of warnings that a user gets from code that isn't theirs. See `PDEP 17 <https://pandas.pydata.org/pdeps/0017-backwards-compatibility-and-deprecation-policy.html>`_ for more details.
 
 All warnings for upcoming changes in pandas will have the base class :class:`pandas.errors.PandasChangeWarning`. Users may also use the following subclasses to control warnings.
 
@@ -183,6 +183,9 @@ All warnings for upcoming changes in pandas will have the base class :class:`pan
 - :class:`pandas.errors.PandasPendingDeprecationWarning`: Base class of all warnings which emit a ``PendingDeprecationWarning``, independent of the version they will be enforced.
 - :class:`pandas.errors.PandasDeprecationWarning`: Base class of all warnings which emit a ``DeprecationWarning``, independent of the version they will be enforced.
 - :class:`pandas.errors.PandasFutureWarning`: Base class of all warnings which emit a ``FutureWarning``, independent of the version they will be enforced.
+
+Deprecations added in 3.x using :class:`pandas.errors.Pandas4Warning` will initially inherit from :class:`pandas.errors.PandasDeprecationWarning`.
+In the last minor release of the 3.x series, these deprecations will switch to inherit from :class:`pandas.errors.PandasFutureWarning` for broader visibility.
 
 .. _whatsnew_300.enhancements.other:
 


### PR DESCRIPTION
I reworded a bit the deprecation policy section to clarify that it is a refined policy (since the deprecate in minor + enforce in major release was already the existing policy).

That also reminds me that we should update the text of https://pandas.pydata.org/docs/dev/development/policies.html with the latest content from the PDEP (https://pandas.pydata.org/pdeps/0017-backwards-compatibility-and-deprecation-policy.html)