### PR TITLE
RLS: 3.0.0

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1476,4 +1476,4 @@ Other
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v2.3.3..v3.0.0
+.. contributors:: v2.3.3..v3.0.0|HEAD

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1,7 +1,7 @@
 .. _whatsnew_300:
 
-What's new in 3.0.0 (Month XX, 2025)
-------------------------------------
+What's new in 3.0.0 (January 21, 2026)
+--------------------------------------
 
 These are the changes in pandas 3.0.0. See :ref:`release` for a full changelog
 including other versions of pandas.
@@ -1475,3 +1475,5 @@ Other
 
 Contributors
 ~~~~~~~~~~~~
+
+.. contributors:: v2.3.3..v3.0.0

--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -5,15 +5,15 @@
         "url": "https://pandas.pydata.org/docs/dev/"
     },
     {
-        "name": "3.0 (rc)",
+        "name": "3.0 (stable)",
         "version": "3.0",
-        "url": "https://pandas.pydata.org/pandas-docs/version/3.0/"
-    },
-    {
-        "name": "2.3 (stable)",
-        "version": "2.3",
         "url": "https://pandas.pydata.org/docs/",
         "preferred": true
+    },
+    {
+        "name": "2.3",
+        "version": "2.3",
+        "url": "https://pandas.pydata.org/pandas-docs/version/2.3/"
     },
     {
         "name": "2.2",


### PR DESCRIPTION
(to be merged as last PR before releasing, to tag the merge commit)

This also updates the date in the release notes and the versions.json for the doc website