### PR TITLE
BUG: Fix regression in is_list_like for custom sequences).

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1523,6 +1523,7 @@ Other
 - Bug when calling :py:func:`copy.copy` on a :class:`DataFrame` or :class:`Series` which would return a deep copy instead of a shallow copy (:issue:`62971`)
 - Fixed bug in the :meth:`Series.rank` with object dtype and extremely small float values (:issue:`62036`)
 - Fixed bug where the :class:`DataFrame` constructor misclassified array-like objects with a ``.name`` attribute as :class:`Series` or :class:`Index` (:issue:`61443`)
+- Fixed regression in :func:`is_list_like` where custom sequence objects (implementing ``__getitem__`` and ``__len__`` but not ``__iter__``) were incorrectly identified as not list-like (:issue:`42549`)
 - Accessing the underlying NumPy array of a DataFrame or Series will return a read-only
   array if the array shares data with the original DataFrame or Series (:ref:`copy_on_write_read_only_na`).
   This logic is expanded to accessing the underlying pandas ExtensionArray

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1324,7 +1324,11 @@ cdef bint c_is_list_like(object obj, bint allow_sets) except -1:
     # then the generic implementation
     return (
         # equiv: `isinstance(obj, abc.Iterable)`
-        getattr(obj, "__iter__", None) is not None and not isinstance(obj, type)
+        (getattr(obj, "__iter__", None) is not None
+         # equiv: `isinstance(obj, abc.Sequence)`
+         or (getattr(obj, "__len__", None) is not None
+             and getattr(obj, "__getitem__", None) is not None))
+        and not isinstance(obj, type)
         # we do not count strings/unicode/bytes as list-like
         # exclude Generic types that have __iter__
         and not isinstance(obj, (str, bytes, _GenericAlias, GenericAlias))

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -261,6 +261,27 @@ def test_is_list_like_native_container_types():
     assert not inference.is_list_like(tuple[str])
 
 
+def test_is_list_like_sequence_protocol():
+    # GH 42549
+    class SequenceProtocol:
+        def __init__(self, data):
+            self.data = data
+
+        def __getitem__(self, index):
+            return self.data[index]
+
+        def __len__(self):
+            return len(self.data)
+
+    obj = SequenceProtocol([1, 2, 3])
+    assert inference.is_list_like(obj)
+
+    # Verify strict DataFrame construction handling
+    df = DataFrame(index=range(3), data={"a": obj})
+    expected = DataFrame({"a": [1, 2, 3]})
+    tm.assert_frame_equal(df, expected)
+
+
 def test_is_sequence():
     is_seq = inference.is_sequence
     assert is_seq((1, 2))


### PR DESCRIPTION
- [x] closes #42549
- [x] Tests added and passed
- [x] All [code checks passed]
- [ ] Added [type annotations]
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This patch correctly handles containers that contains items, but does not have an interator. The iterator requirement was introduced by accident in the earlier PR.