### PR TITLE
BUG: Fix DataFrame.from_records ignoring exclude when nrows=0 (#63774)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1321,6 +1321,7 @@ MultiIndex
 - Bug in :meth:`MultiIndex.union` raising when indexes have duplicates with differing names (:issue:`62059`)
 - Bug in :meth:`MultiIndex.from_tuples` causing wrong output with input of type tuples having NaN values (:issue:`60695`, :issue:`60988`)
 - Bug in :meth:`DataFrame.__setitem__` where column alignment logic would reindex the assigned value with an empty index, incorrectly setting all values to ``NaN``.(:issue:`61841`)
+  - Bug in :meth:`DataFrame.from_records` where the ``exclude`` parameter was ignored when ``nrows=0`` (:issue:`63774`)
 - Bug in :meth:`DataFrame.reindex` and :meth:`Series.reindex` where reindexing :class:`Index` to a :class:`MultiIndex` would incorrectly set all values to ``NaN``.(:issue:`60923`)
 
 I/O

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2355,6 +2355,16 @@ class DataFrame(NDFrame, OpsMixin):
 
         if is_iterator(data):
             if nrows == 0:
+                if (
+                    columns is None
+                    and hasattr(data, "dtype")
+                    and data.dtype.names is not None
+                ):
+                    columns = list(data.dtype.names)
+
+                if columns is not None and exclude is not None:
+                    columns = Index(columns).drop(exclude).tolist()
+
                 return cls(index=index, columns=columns)
 
             try:


### PR DESCRIPTION
- [x] closes #63774
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file if fixing a bug or adding a new feature.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Ensures that the `exclude` parameter is correctly applied to the resulting columns in `DataFrame.from_records` even when `nrows=0` is specified. Previously, the method would return an empty DataFrame with all columns intact, bypassing the exclusion logic.

Modified pandas/core/frame.py to filter columns before instantiation when nrows is zero. Added a regression test in pandas/tests/frame/constructors/test_from_records.py.