### PR TITLE
BUG: Fix data races in block internals

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -27,6 +27,7 @@ Bug fixes
 - Fixed a bug in :func:`col` where unary operators (``-``, ``+``, ``abs``) were not supported (:issue:`63939`)
 - Fixed a bug in the :func:`comparison_op` raising a ``TypeError`` for zerodim
   subclasses of ``np.ndarray`` (:issue:`63205`)
+- Fixed thread safety issues in :class:`DataFrame` internals on the free-threaded build (:issue:`63685`).
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.contributors:

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - cython<4.0.0a0
+  - cython>=3.1.0,<4.0.0a0
   - meson>=1.2.1,<2
   - meson-python>=0.17.1,<1
 

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -272,6 +272,7 @@ cdef class IndexEngine:
                 self.monotonic_dec = 1
 
     @property
+    @cython.critical_section
     def is_unique(self) -> bool:
         # for why we check is_monotonic_increasing here, see
         # https://github.com/pandas-dev/pandas/pull/55342#discussion_r1361405781
@@ -286,6 +287,7 @@ cdef class IndexEngine:
         self._ensure_mapping_populated()
 
     @property
+    @cython.critical_section
     def is_monotonic_increasing(self) -> bool:
         if self.need_monotonic_check:
             self._do_monotonic_check()
@@ -293,6 +295,7 @@ cdef class IndexEngine:
         return self.monotonic_inc == 1
 
     @property
+    @cython.critical_section
     def is_monotonic_decreasing(self) -> bool:
         if self.need_monotonic_check:
             self._do_monotonic_check()
@@ -336,6 +339,7 @@ cdef class IndexEngine:
         return val
 
     @property
+    @cython.critical_section
     def is_mapping_populated(self) -> bool:
         return self.mapping is not None
 

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -736,7 +736,7 @@ cdef class BlockManager:
         public tuple blocks
         public list axes
         public bint _known_consolidated, _is_consolidated
-        public ndarray _blknos, _blklocs
+        ndarray __blknos, __blklocs
 
     def __cinit__(
         self,
@@ -764,6 +764,25 @@ cdef class BlockManager:
 
     # -------------------------------------------------------------------
     # Block Placement
+    @property
+    @cython.critical_section
+    def _blknos(self):
+        return self.__blknos
+
+    @_blknos.setter
+    @cython.critical_section
+    def _blknos(self, ndarray val):
+        self.__blknos = val
+
+    @property
+    @cython.critical_section
+    def _blklocs(self):
+        return self.__blklocs
+
+    @_blklocs.setter
+    @cython.critical_section
+    def _blklocs(self, ndarray val):
+        self.__blklocs = val
 
     @cython.critical_section
     cpdef _rebuild_blknos_and_blklocs(self):
@@ -803,8 +822,8 @@ cdef class BlockManager:
             if blkno == -1:
                 raise AssertionError("Gaps in blk ref_locs")
 
-        self._blknos = new_blknos
-        self._blklocs = new_blklocs
+        self.__blknos = new_blknos
+        self.__blklocs = new_blklocs
 
     # -------------------------------------------------------------------
     # Pickle
@@ -877,8 +896,8 @@ cdef class BlockManager:
 
         # We can avoid having to rebuild blklocs/blknos
         with cython.critical_section(self):
-            blklocs = self._blklocs
-            blknos = self._blknos
+            blklocs = self.__blklocs
+            blknos = self.__blknos
         if blknos is not None:
             mgr._blknos = blknos.copy()
             mgr._blklocs = blklocs.copy()

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -777,8 +777,6 @@ cdef class BlockManager:
             BlockPlacement bp
             ndarray[intp_t, ndim=1] new_blknos, new_blklocs
 
-        if self._blknos is not None:
-            return
         # equiv: np.empty(length, dtype=np.intp)
         new_blknos = cnp.PyArray_EMPTY(1, &length, cnp.NPY_INTP, 0)
         new_blklocs = cnp.PyArray_EMPTY(1, &length, cnp.NPY_INTP, 0)
@@ -805,9 +803,8 @@ cdef class BlockManager:
             if blkno == -1:
                 raise AssertionError("Gaps in blk ref_locs")
 
-        if self._blknos is None:
-            self._blknos = new_blknos
-            self._blklocs = new_blklocs
+        self._blknos = new_blknos
+        self._blklocs = new_blklocs
 
     # -------------------------------------------------------------------
     # Pickle

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -879,8 +879,9 @@ cdef class BlockManager:
         mgr = type(self)(tuple(nbs), new_axes, verify_integrity=False)
 
         # We can avoid having to rebuild blklocs/blknos
-        blklocs = self._blklocs
-        blknos = self._blknos
+        with cython.critical_section(self):
+            blklocs = self._blklocs
+            blknos = self._blknos
         if blknos is not None:
             mgr._blknos = blknos.copy()
             mgr._blklocs = blklocs.copy()

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -148,8 +148,10 @@ cdef class BlockPlacement:
             start, stop, step, _ = slice_get_indices_ex(self._as_slice)
             # NOTE: this is the C-optimized equivalent of
             #  `np.arange(start, stop, step, dtype=np.intp)`
-            self._as_array = cnp.PyArray_Arange(start, stop, step, NPY_INTP)
-            self._has_array = True
+            as_array = cnp.PyArray_Arange(start, stop, step, NPY_INTP)
+            if not self._has_array:
+                self._as_array = as_array
+                self._has_array = True
 
         return self._as_array
 
@@ -775,6 +777,8 @@ cdef class BlockManager:
             BlockPlacement bp
             ndarray[intp_t, ndim=1] new_blknos, new_blklocs
 
+        if self._blknos is not None:
+            return
         # equiv: np.empty(length, dtype=np.intp)
         new_blknos = cnp.PyArray_EMPTY(1, &length, cnp.NPY_INTP, 0)
         new_blklocs = cnp.PyArray_EMPTY(1, &length, cnp.NPY_INTP, 0)

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -139,6 +139,7 @@ cdef class BlockPlacement:
             return self._as_array
 
     @property
+    @cython.critical_section
     def as_array(self) -> np.ndarray:
         cdef:
             Py_ssize_t start, stop, _
@@ -221,11 +222,14 @@ cdef class BlockPlacement:
         # We can get here with int or ndarray
         return self.iadd(other)
 
+    @cython.critical_section
     cdef slice _ensure_has_slice(self):
         if not self._has_slice:
-            self._as_slice = indexer_as_slice(self._as_array)
-            self._has_slice = True
-
+            as_slice = indexer_as_slice(self._as_array)
+            # check again after indexer_as_slice call
+            if not self._has_slice:
+                self._as_slice = as_slice
+                self._has_slice = True
         return self._as_slice
 
     cpdef BlockPlacement increment_above(self, Py_ssize_t loc):
@@ -759,6 +763,7 @@ cdef class BlockManager:
     # -------------------------------------------------------------------
     # Block Placement
 
+    @cython.critical_section
     cpdef _rebuild_blknos_and_blklocs(self):
         """
         Update mgr._blknos / mgr._blklocs.
@@ -796,8 +801,9 @@ cdef class BlockManager:
             if blkno == -1:
                 raise AssertionError("Gaps in blk ref_locs")
 
-        self._blknos = new_blknos
-        self._blklocs = new_blklocs
+        if self._blknos is None:
+            self._blknos = new_blknos
+            self._blklocs = new_blklocs
 
     # -------------------------------------------------------------------
     # Pickle

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1518,6 +1518,7 @@ cdef class _Timedelta(timedelta):
         self._ensure_components()
         return -999999999 <= self._d and self._d <= 999999999
 
+    @cython.critical_section
     cdef _ensure_components(_Timedelta self):
         """
         compute the components
@@ -1529,6 +1530,8 @@ cdef class _Timedelta(timedelta):
             pandas_timedeltastruct tds
 
         pandas_timedelta_to_timedeltastruct(self._value, self._creso, &tds)
+        if self._is_populated:
+            return
         self._d = tds.days
         self._h = tds.hrs
         self._m = tds.min

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -537,16 +537,21 @@ def shares_memory(left, right) -> bool:
     raise NotImplementedError(type(left), type(right))
 
 
-def run_multithreaded(closure, max_workers, pass_barrier=False):
+def run_multithreaded(closure, max_workers, arguments=None, pass_barrier=False):
     with ThreadPoolExecutor(max_workers=max_workers) as tpe:
-        args = []
+        if arguments is None:
+            arguments = []
+        else:
+            arguments = list(arguments)
+
         if pass_barrier:
             barrier = threading.Barrier(max_workers)
-            args.append(barrier)
+            arguments.append(barrier)
+
         try:
             futures = []
             for _ in range(max_workers):
-                futures.append(tpe.submit(closure, *args))
+                futures.append(tpe.submit(closure, *arguments))
         except RuntimeError as e:
             import pytest
             pytest.skip(f"Spawning {max_workers} threads failed with "

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -551,12 +551,15 @@ def run_multithreaded(closure, max_workers, arguments=None, pass_barrier=False):
         try:
             futures = []
             for _ in range(max_workers):
-                futures.append(tpe.submit(closure, *arguments))
+                futures.append(tpe.submit(closure, *arguments))  # noqa: PERF401
         except RuntimeError as e:
             import pytest
-            pytest.skip(f"Spawning {max_workers} threads failed with "
-                        f"error {e!r} (likely due to resource limits on the "
-                        "system running the tests)")
+
+            pytest.skip(
+                f"Spawning {max_workers} threads failed with "
+                f"error {e!r} (likely due to resource limits on the "
+                "system running the tests)"
+            )
         finally:
             if len(futures) < max_workers and pass_barrier:
                 barrier.abort()

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -389,8 +389,11 @@ def test_multithreaded_reading(float_frame):
     def numpy_assert(b):
         b.wait()
         # See gh-63685, numpy asserts led to data races under TSan
-        np.testing.assert_array_equal(float_frame, float_frame)
-        np.testing.assert_array_almost_equal((float_frame + 1) - 1, float_frame)
+        tm.assert_almost_equal(np.array(float_frame), np.array(float_frame))
+        tm.assert_almost_equal(
+            np.array((float_frame + 1) - 1),
+            np.array(float_frame)
+        )
 
     tm.run_multithreaded(numpy_assert, max_workers=8, pass_barrier=True)
 
@@ -411,6 +414,6 @@ def test_multithreaded_reading(float_frame):
         trendarr = pd.DataFrame(trendarr, index=x.index, columns=['const'])
         x = [trendarr, x]
         x = pd.concat(x[::1], axis=1)
-        np.testing.assert_array_equal(x, x)
+        tm.assert_almost_equal(np.array(x), np.array(x))
 
     tm.run_multithreaded(concat, max_workers=8, pass_barrier=True)

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from pandas.errors import Pandas4Warning
+import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -21,7 +22,6 @@ from pandas import (
     option_context,
 )
 import pandas._testing as tm
-import pandas.util._test_decorators as td
 from pandas.core.internals.blocks import NumpyBlock
 
 # Segregated collection of methods that require the BlockManager internal data

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -21,6 +21,7 @@ from pandas import (
     option_context,
 )
 import pandas._testing as tm
+import pandas.util._test_decorators as td
 from pandas.core.internals.blocks import NumpyBlock
 
 # Segregated collection of methods that require the BlockManager internal data
@@ -417,6 +418,7 @@ def get_longley_data():
     return pd.read_csv(longley_csv).iloc[:, [1, 2, 3, 4, 5, 6]].astype(float)
 
 
+@td.skip_if_warnings_arent_thread_safe
 def test_multithreaded_reading():
     def numpy_assert(data, b):
         b.wait()

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -2,8 +2,8 @@ from datetime import (
     datetime,
     timedelta,
 )
-import itertools
 from io import StringIO
+import itertools
 from textwrap import dedent
 
 import numpy as np
@@ -416,6 +416,7 @@ def get_longley_data():
 
     return pd.read_csv(longley_csv).iloc[:, [1, 2, 3, 4, 5, 6]].astype(float)
 
+
 def test_multithreaded_reading():
     def numpy_assert(data, b):
         b.wait()
@@ -423,10 +424,7 @@ def test_multithreaded_reading():
         tm.assert_almost_equal((data + 1) - 1, data.copy())
 
     tm.run_multithreaded(
-        numpy_assert,
-        max_workers=8,
-        arguments=(get_longley_data(),),
-        pass_barrier=True
+        numpy_assert, max_workers=8, arguments=(get_longley_data(),), pass_barrier=True
     )
 
     def safe_is_const(s):
@@ -442,15 +440,12 @@ def test_multithreaded_reading():
         x = data.copy()
         nobs = len(x)
         trendarr = np.fliplr(np.vander(np.arange(1, nobs + 1, dtype=np.float64), 1))
-        col_const = x.apply(safe_is_const, 0)
-        trendarr = pd.DataFrame(trendarr, index=x.index, columns=['const'])
+        x.apply(safe_is_const, 0)
+        trendarr = DataFrame(trendarr, index=x.index, columns=["const"])
         x = [trendarr, x]
         x = pd.concat(x[::1], axis=1)
         tm.assert_frame_equal(x, x)
 
     tm.run_multithreaded(
-        concat,
-        max_workers=8,
-        arguments=(get_longley_data(),),
-        pass_barrier=True
+        concat, max_workers=8, arguments=(get_longley_data(),), pass_barrier=True
     )

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -422,7 +422,7 @@ def get_longley_data():
 #
 # This test spawns a thread pool, so it shouldn't run under xdist.
 # It generates warnings, so it needs warnings to be thread-safe as well
-@td.skip_if_warnings_arent_thread_safe
+@td.skip_if_thread_unsafe_warnings
 @pytest.mark.single_cpu
 def test_multithreaded_reading():
     def numpy_assert(data, b):

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -419,6 +419,7 @@ def get_longley_data():
 
 
 @td.skip_if_warnings_arent_thread_safe
+@pytest.mark.single_cpu
 def test_multithreaded_reading():
     def numpy_assert(data, b):
         b.wait()

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -119,7 +119,7 @@ skip_if_wasm = pytest.mark.skipif(
     WASM,
     reason="does not support wasm",
 )
-skip_if_warnings_arent_thread_safe = pytest.mark.skipif(
+skip_if_thread_unsafe_warnings = pytest.mark.skipif(
     not getattr(sys.flags, "context_aware_warnings", 0),
     reason="Python warnings must be thread-safe for consistent results",
 )

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -27,6 +27,7 @@ For more information, refer to the ``pytest`` documentation on ``skipif``.
 from __future__ import annotations
 
 import locale
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -117,6 +118,10 @@ skip_if_not_us_locale = pytest.mark.skipif(
 skip_if_wasm = pytest.mark.skipif(
     WASM,
     reason="does not support wasm",
+)
+skip_if_warnings_arent_thread_safe = pytest.mark.skipif(
+    not getattr(sys.flags, "context_aware_warnings", 0),
+    reason="Python warnings must be thread-safe for consistent results",
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "meson-python>=0.17.1,<1",
     "meson>=1.2.1,<2",
     "wheel",
-    "Cython<4.0.0a0",  # Note: sync with setup.py, environment.yml and asv.conf.json
+    "Cython>3.1.0;<4.0.0a0",  # Note: sync with setup.py, environment.yml and asv.conf.json
     # Force numpy higher than 2.0, so that built wheels are compatible
     # with both numpy 1 and 2
     "numpy>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "meson-python>=0.17.1,<1",
     "meson>=1.2.1,<2",
     "wheel",
-    "Cython>3.1.0;<4.0.0a0",  # Note: sync with setup.py, environment.yml and asv.conf.json
+    "Cython>3.1.0,<4.0.0a0",  # Note: sync with setup.py, environment.yml and asv.conf.json
     # Force numpy higher than 2.0, so that built wheels are compatible
     # with both numpy 1 and 2
     "numpy>=2.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 
 pip
 versioneer[toml]
-cython<4.0.0a0
+cython>=3.1.0,<4.0.0a0
 meson[ninja]>=1.2.1,<2
 meson-python>=0.17.1,<1
 pytest>=8.3.4

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def is_platform_mac():
 
 
 # note: sync with pyproject.toml, environment.yml and asv.conf.json
-min_cython_ver = "3.0"
+min_cython_ver = "3.1"
 
 try:
     from Cython import (


### PR DESCRIPTION
This PR fixes several thread safety issues in Pandas internals on the free-threaded build. We found all of them using thread sanitizer testing.

I also added a multithreaded test based on the original test in statsmodels we used to find these issues. There's probably lots more room to add more multithreaded tests, but a real-world example that triggered real issues seems as good a place to start as any to me.

You can read more about critical sections in [the CPython docs](https://docs.python.org/3/howto/free-threading-extensions.html#critical-sections), the [cython docs](https://cython.readthedocs.io/en/latest/src/userguide/freethreading.html#critical-sections), and the [free-threading guide](https://py-free-threading.github.io/porting-extensions/#critical-sections).

- [x] closes #63685
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
