### PR TITLE
DOC: clarify subset example using temporary column 'TestColumn' (#63767)

### DIFF
--- a/doc/source/getting_started/intro_tutorials/03_subset_data.rst
+++ b/doc/source/getting_started/intro_tutorials/03_subset_data.rst
@@ -337,9 +337,9 @@ the name ``anonymous`` to the first 3 elements of the fourth column:
 .. ipython:: python
 
     # Create a temporary column to clearly show assignment
-    titanic['TestColumn'] = titanic['Pclass']
-    titanic.iloc[0:3, titanic.columns.get_loc('TestColumn')] = "anonymous"
-    titanic.iloc[:5, titanic.columns.get_loc('TestColumn')]
+    titanic["TestColumn"] = titanic["Pclass"]
+    titanic.loc[0:2, "TestColumn"] = "anonymous"
+    titanic.loc[:4, "TestColumn"]
 
 .. raw:: html
 

--- a/doc/source/getting_started/intro_tutorials/03_subset_data.rst
+++ b/doc/source/getting_started/intro_tutorials/03_subset_data.rst
@@ -336,8 +336,10 @@ the name ``anonymous`` to the first 3 elements of the fourth column:
 
 .. ipython:: python
 
-    titanic.iloc[0:3, 3] = "anonymous"
-    titanic.iloc[:5, 3]
+    # Create a temporary column to clearly show assignment
+    titanic['TestColumn'] = titanic['Pclass']
+    titanic.iloc[0:3, titanic.columns.get_loc('TestColumn')] = "anonymous"
+    titanic.iloc[:5, titanic.columns.get_loc('TestColumn')]
 
 .. raw:: html
 

--- a/doc/source/getting_started/intro_tutorials/03_subset_data.rst
+++ b/doc/source/getting_started/intro_tutorials/03_subset_data.rst
@@ -336,10 +336,9 @@ the name ``anonymous`` to the first 3 elements of the fourth column:
 
 .. ipython:: python
 
-    # Create a temporary column to clearly show assignment
-    titanic["TestColumn"] = titanic["Pclass"]
-    titanic.loc[0:2, "TestColumn"] = "anonymous"
-    titanic.loc[:4, "TestColumn"]
+    titanic["TestColumn"] = titanic["Pclass"].astype("string")
+    titanic.iloc[0:3, titanic.columns.get_loc("TestColumn")] = "anonymous"
+    titanic.iloc[:5, titanic.columns.get_loc("TestColumn")]
 
 .. raw:: html
 


### PR DESCRIPTION
This PR clarifies the example in 03_subset_data tutorial (#63767)
by using a temporary column 'TestColumn' to clearly show assignment
of "anonymous" to a subset of rows.