### PR TITLE
BUG: Fix clip failing with scalar numpy array (GH-59053)

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6861,7 +6861,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         if isinstance(other, Series):
             return self._binop(other, op, level=level, fill_value=fill_value)
-        elif isinstance(other, (np.ndarray, list, tuple, ExtensionArray)):
+        elif isinstance(other, (list, tuple)) or (isinstance(other, np.ndarray) and other.ndim > 0):
             if len(other) != len(self):
                 raise ValueError("Lengths must be equal")
             other = self._constructor(other, self.index, copy=False)

--- a/pandas/tests/series/methods/test_clip.py
+++ b/pandas/tests/series/methods/test_clip.py
@@ -155,3 +155,11 @@ class TestSeriesClip:
         expected = Series([lower, upper], dtype=dtype)
 
         tm.assert_series_equal(result, expected)
+
+    def test_clip_with_scalar_array_lower(self):
+        # GH#59053
+        ser = Series([-1, 2, 3])
+        lower = np.array(0)
+        result = ser.clip(lower=lower)
+        expected = Series([0, 2, 3])
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #59053
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Description
Fixed a bug where passing a zero-dimensional numpy array (e.g., `np.array(0)`) to the `clip` method caused a `TypeError: len() of unsized object`.

The issue occurred because the code attempted to check the length of the numpy array without verifying if it had dimensions. This PR updates the logic to treat 0-d arrays as scalars, ensuring they are not iterated over.

I have verified the fix locally and added a regression test case to `pandas/tests/series/methods/test_clip.py`.