### PR TITLE
DOC: Fix GL08 for pandas.Series.dt

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -70,7 +70,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
     "$BASE_DIR"/scripts/validate_docstrings.py \
         --format=actions \
         -i ES01 `# For now it is ok if docstrings are missing the extended summary` \
-        -i "pandas.Series.dt PR01" `# Accessors are implemented as classes, but we do not document the Parameters section` \
         -i "pandas.tseries.offsets.BDay PR02,SA01" \
         -i "pandas.tseries.offsets.BusinessDay PR02,SA01" \
         -i "pandas.tseries.offsets.BusinessHour PR02,SA01" \

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -628,6 +628,15 @@ class CombinedDatetimelikeProperties(
     """
     Accessor object for Series values' datetime-like, timedelta and period properties.
 
+    This accessor provides access to properties and methods for datetime-like,
+    timedelta, and period data types. It can be used with Series containing
+    datetime64, timedelta64, or period data.
+
+    Parameters
+    ----------
+    data : Series
+        Series with datetime-like, timedelta, or period dtype.
+
     See Also
     --------
     DatetimeIndex : Index of datetime64 data.


### PR DESCRIPTION
- [ ] related to #60365

Fixes

```
pandas.Series.dt PR01
```


- `pandas.Series.str` passes has Parameters documented
- `pandas.Series.cat` fails has Parameters documented

This confirms that pandas accessors do document the Parameters section. 
