### PR TITLE
DOC: Add User Guide links to GroupBy aggregate, transform, and apply methods

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -380,6 +380,8 @@ class SeriesGroupBy(GroupBy[Series]):
             based on the given function.
         Series.aggregate : Aggregate using one or more operations.
 
+        :ref:`User Guide <groupby.aggregate>` for more details and examples.
+
         Notes
         -----
         When using ``engine='numba'``, there will be no "fall back" behavior internally.
@@ -2177,6 +2179,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         DataFrame.groupby.transform : Transforms the Series on each group
             based on the given function.
         DataFrame.aggregate : Aggregate using one or more operations.
+
+        :ref:`User Guide <groupby.aggregate>` for more details and examples.
 
         Notes
         -----

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -380,10 +380,11 @@ class SeriesGroupBy(GroupBy[Series]):
             based on the given function.
         Series.aggregate : Aggregate using one or more operations.
 
-        :ref:`User Guide <groupby.aggregate>` for more details and examples.
-
         Notes
         -----
+        See :ref:`groupby.aggregate` in the User Guide for more details
+        and examples.
+
         When using ``engine='numba'``, there will be no "fall back" behavior internally.
         The group data and group index will be passed as numpy arrays to the JITed
         user defined function, and no alternative execution attempts will be tried.
@@ -2180,10 +2181,11 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             based on the given function.
         DataFrame.aggregate : Aggregate using one or more operations.
 
-        :ref:`User Guide <groupby.aggregate>` for more details and examples.
-
         Notes
         -----
+        See :ref:`groupby.aggregate` in the User Guide for more details
+        and examples.
+
         When using ``engine='numba'``, there will be no "fall back" behavior internally.
         The group data and group index will be passed as numpy arrays to the JITed
         user defined function, and no alternative execution attempts will be tried.

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -251,6 +251,8 @@ class SeriesGroupBy(GroupBy[Series]):
 
         Notes
         -----
+        See :ref:`groupby.apply` in the User Guide for more details and examples.
+
         The resulting dtype will reflect the return value of the passed ``func``,
         see the examples below.
 
@@ -714,6 +716,8 @@ class SeriesGroupBy(GroupBy[Series]):
 
         Notes
         -----
+        See :ref:`groupby.transform` in the User Guide for more details and examples.
+
         Each group is endowed the attribute 'name' in case you need to know
         which group you are working on.
 
@@ -2712,6 +2716,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         Notes
         -----
+        See :ref:`groupby.transform` in the User Guide for more details and examples.
+
         Each group is endowed the attribute 'name' in case you need to know
         which group you are working on.
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -373,6 +373,8 @@ See Also
 %(klass)s.transform : Call ``func`` on self producing a %(klass)s with the
     same axis shape as self.
 
+:ref:`User Guide <groupby.transform>` for more details and examples.
+
 Notes
 -----
 Each group is endowed the attribute 'name' in case you need to know
@@ -1538,6 +1540,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         transform : Apply function column-by-column to the GroupBy object.
         Series.apply : Apply a function to a Series.
         DataFrame.apply : Apply a function to each row or column of a DataFrame.
+
+        :ref:`User Guide <groupby.apply>` for more details and examples.
 
         Notes
         -----

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -375,8 +375,6 @@ See Also
 
 Notes
 -----
-See :ref:`groupby.transform` in the User Guide for more details and examples.
-
 Each group is endowed the attribute 'name' in case you need to know
 which group you are working on.
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -373,10 +373,10 @@ See Also
 %(klass)s.transform : Call ``func`` on self producing a %(klass)s with the
     same axis shape as self.
 
-:ref:`User Guide <groupby.transform>` for more details and examples.
-
 Notes
 -----
+See :ref:`groupby.transform` in the User Guide for more details and examples.
+
 Each group is endowed the attribute 'name' in case you need to know
 which group you are working on.
 
@@ -1541,10 +1541,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Series.apply : Apply a function to a Series.
         DataFrame.apply : Apply a function to each row or column of a DataFrame.
 
-        :ref:`User Guide <groupby.apply>` for more details and examples.
-
         Notes
         -----
+        See :ref:`groupby.apply` in the User Guide for more details and examples.
+
         The resulting dtype will reflect the return value of the passed ``func``,
         see the examples below.
 


### PR DESCRIPTION
## Description

This PR adds cross-references from the GroupBy API documentation back to the User Guide, addressing #62357.

## Changes

Added `:ref:` links to the User Guide in the `See Also` sections of:

| Method | User Guide Link |
|--------|-----------------|
| `SeriesGroupBy.aggregate` | `groupby.aggregate` |
| `DataFrameGroupBy.aggregate` | `groupby.aggregate` |
| `transform` (via `_transform_template`) | `groupby.transform` |
| `GroupBy.apply` | `groupby.apply` |

Also added a note in the API reference (`doc/source/reference/groupby.rst`) with links to relevant User Guide sections.

## Motivation

As noted in the issue, users navigating from the User Guide to API docs couldn't easily navigate back. This improves discoverability of the comprehensive User Guide sections on groupby operations.

## Files Changed

- `pandas/core/groupby/generic.py` - Added User Guide links to aggregate docstrings
- `pandas/core/groupby/groupby.py` - Added User Guide links to apply and transform docstrings
- `doc/source/reference/groupby.rst` - Added User Guide references in Function application section

Closes #62357