### PR TITLE
BUG: avoid object dtype in dataframe.where if possible

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10125,6 +10125,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     other, **self._construct_axes_dict(), copy=False
                 )
 
+        # To avoid the data type always being object (GH#63842)
+        if isinstance(other, (list, tuple)):
+            curr = other
+            while not lib.is_scalar(curr[0]):
+                curr = curr[0]
+            other = curr[0]
+
         if axis is None:
             axis = 0
 

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -150,6 +150,12 @@ class TestDataFrame:
 
         tm.assert_frame_equal(empty_frame_copy, empty_frame)
 
+    def test_data_type(self):
+        pdf = DataFrame({"A": ["a", "bc", "cde", "fghi"]})
+        pdf_mask = DataFrame({"A": [True, False, True, False]})
+        result = pdf.where(pdf_mask, [["xyz"]])
+        assert pdf.dtypes.iloc[0] == result.dtypes.iloc[0]
+
 
 # formerly in Generic but only test DataFrame
 class TestDataFrame2:


### PR DESCRIPTION
- [x] closes #63842 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This PR is to make sure that `dataframe.where` avoids the `object` dtype if possible. 
Though it loops through the collection, it may not be a problem as it is unlikely that the user will work with `lists/tuples` of such high dimensions(even in numpy, the highest dimension allowed is 64).

