### PR TITLE
This PR adds a test demonstrating inconsistent behavior between pd.array and pd.Series when dtype=str and None values are present.  Related issue: pandas-dev/pandas#57702Add test for inconsistent string dtype handling with None

### DIFF
--- a/pandas/tests/arrays/string_/test_string_array.py
+++ b/pandas/tests/arrays/string_/test_string_array.py
@@ -1,0 +1,7 @@
+import pandas as pd
+
+def test_string_array_none_dtype_consistency():
+    arr = pd.array([1, None], dtype=str)
+    ser_arr = pd.Series([1, None], dtype=str).array
+
+    assert arr.dtype == ser_arr.dtype

--- a/pandas/tests/arrays/string_/test_string_array.py
+++ b/pandas/tests/arrays/string_/test_string_array.py
@@ -1,7 +1,9 @@
 import pandas as pd
 
+
 def test_string_array_none_dtype_consistency():
     arr = pd.array([1, None], dtype=str)
     ser_arr = pd.Series([1, None], dtype=str).array
 
     assert arr.dtype == ser_arr.dtype
+


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
