### PR TITLE
CI: Simplify docs build with workflow_dispatch

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -54,7 +54,9 @@ jobs:
         fi
 
     - name: Test upload prod docs
-      run: echo "Upload prod docs ran!"
+      run: |
+        echo "Upload prod docs ran!"
+        echo "${{ github.event.inputs.publish_prod }}"
       if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event.inputs.publish_prod
 
 #    - name: Checkout

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -53,16 +53,11 @@ jobs:
           echo "PANDAS_VERSION=${GITHUB_REF_NAME:1}" >> "$GITHUB_ENV"
         fi
 
-    - name: Show value
-      run: |
-        echo "${{ github.event.inputs.publish_prod }}
-        echo "${{ inputs.publish_prod }}
-
     - name: Test upload prod docs
       run: |
         echo "Upload prod docs ran!"
         echo "${{ github.event.inputs.publish_prod }}"
-      if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event.inputs.publish_prod == true) }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event.inputs.publish_prod == 'true') }}
 
 #    - name: Checkout
 #      uses: actions/checkout@v6

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -104,7 +104,7 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload prod docs
-      # Revert before merging; making sure this step does not run as intended when putting up this PR.
+      # Revert before merging; allows for testing this PR.
       # run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
       run: echo "Upload prod docs ran!"
       if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event.inputs.publish_prod

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         echo "Upload prod docs ran!"
         echo "${{ github.event.inputs.publish_prod }}"
-      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event.inputs.publish_prod
+      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || ${{ github.event.inputs.publish_prod == true }}
 
 #    - name: Checkout
 #      uses: actions/checkout@v6

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         echo "Upload prod docs ran!"
         echo "${{ github.event.inputs.publish_prod }}"
-      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || ${{ github.event.inputs.publish_prod == true }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event.inputs.publish_prod == true) }}
 
 #    - name: Checkout
 #      uses: actions/checkout@v6

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -53,68 +53,70 @@ jobs:
           echo "PANDAS_VERSION=${GITHUB_REF_NAME:1}" >> "$GITHUB_ENV"
         fi
 
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-
-    - name: Set up Conda
-      uses: ./.github/actions/setup-conda
-
-    - name: Build Pandas
-      uses: ./.github/actions/build_pandas
-
-    - name: Extra installs
-      # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
-      run: sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
-
-    - name: Test website
-      run: python -m pytest web/
-
-    - name: Build website
-      run: python web/pandas_web.py web/pandas --target-path=web/build
-
-    - name: Build documentation
-      run: doc/make.py --warnings-are-errors
-
-    - name: Build the interactive terminal
-      working-directory: web/interactive_terminal
-      run: jupyter lite build
-
-    - name: Build documentation zip
-      run: doc/make.py zip_html
-
-    - name: Install ssh key
-      run: |
-        mkdir -m 700 -p ~/.ssh
-        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
-      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
-
-    - name: Copy cheatsheets into site directory
-      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
-
-    - name: Upload web
-      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    - name: Upload dev docs
-      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    - name: Upload prod docs
-      # Revert before merging; allows for testing this PR.
-      # run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
+    - name: Test upload prod docs
       run: echo "Upload prod docs ran!"
       if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event.inputs.publish_prod
 
-    - name: Move docs into site directory
-      run: mv doc/build/html web/build/docs
-
-    - name: Save website as an artifact
-      uses: actions/upload-artifact@v6
-      with:
-        name: website
-        path: web/build
-        retention-days: 14
+#    - name: Checkout
+#      uses: actions/checkout@v6
+#      with:
+#        fetch-depth: 0
+#
+#    - name: Set up Conda
+#      uses: ./.github/actions/setup-conda
+#
+#    - name: Build Pandas
+#      uses: ./.github/actions/build_pandas
+#
+#    - name: Extra installs
+#      # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
+#      run: sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
+#
+#    - name: Test website
+#      run: python -m pytest web/
+#
+#    - name: Build website
+#      run: python web/pandas_web.py web/pandas --target-path=web/build
+#
+#    - name: Build documentation
+#      run: doc/make.py --warnings-are-errors
+#
+#    - name: Build the interactive terminal
+#      working-directory: web/interactive_terminal
+#      run: jupyter lite build
+#
+#    - name: Build documentation zip
+#      run: doc/make.py zip_html
+#
+#    - name: Install ssh key
+#      run: |
+#        mkdir -m 700 -p ~/.ssh
+#        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
+#        chmod 600 ~/.ssh/id_rsa
+#        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
+#      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
+#
+#    - name: Copy cheatsheets into site directory
+#      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
+#
+#    - name: Upload web
+#      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
+#      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+#
+#    - name: Upload dev docs
+#      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
+#      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+#
+#    - name: Upload prod docs
+#      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
+#      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event.inputs.publish_prod
+#
+#    - name: Move docs into site directory
+#      run: mv doc/build/html web/build/docs
+#
+#    - name: Save website as an artifact
+#      uses: actions/upload-artifact@v6
+#      with:
+#        name: website
+#        path: web/build
+#        retention-days: 14

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -17,13 +17,15 @@ on:
         description: 'The pandas version to override'
         required: false
         type: string
+      publish_prod:
+        description: 'Publish to production'
+        type: boolean
+        default: false
 
 env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PANDAS_VERSION: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || '' }}"
-  PANDAS_VERSION_OVERRIDE: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || '' }}"
 
 permissions:
   contents: read
@@ -45,13 +47,11 @@ jobs:
     steps:
     - name: Set pandas version
       run: |
-        echo "PANDAS_VERSION=${GITHUB_REF_NAME:1}" >> "$GITHUB_ENV"
-      if: github.event_name != 'workflow_dispatch'
-
-    - name: Show environment variables
-      run: |
-        echo "PANDAS_VERSION=${{ env.PANDAS_VERSION }}"
-        echo "PANDAS_VERSION_OVERRIDE=${{ env.PANDAS_VERSION_OVERRIDE }}"
+        if [ -n "${{ github.event.inputs.version }}" ]; then
+          echo "PANDAS_VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+        else
+          echo "PANDAS_VERSION=${GITHUB_REF_NAME:1}" >> "$GITHUB_ENV"
+        fi
 
     - name: Checkout
       uses: actions/checkout@v6
@@ -104,8 +104,10 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload prod docs
-      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
-      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && env.PANDAS_VERSION_OVERRIDE != '')
+      # Revert before merging; making sure this step does not run as intended when putting up this PR.
+      # run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
+      run: echo "Upload prod docs ran!"
+      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event.inputs.publish_prod
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -53,6 +53,11 @@ jobs:
           echo "PANDAS_VERSION=${GITHUB_REF_NAME:1}" >> "$GITHUB_ENV"
         fi
 
+    - name: Show value
+      run: |
+        echo "${{ github.event.inputs.publish_prod }}
+        echo "${{ inputs.publish_prod }}
+
     - name: Test upload prod docs
       run: |
         echo "Upload prod docs ran!"

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -53,72 +53,66 @@ jobs:
           echo "PANDAS_VERSION=${GITHUB_REF_NAME:1}" >> "$GITHUB_ENV"
         fi
 
-    - name: Test upload prod docs
-      run: |
-        echo "Upload prod docs ran!"
-        echo "${{ github.event.inputs.publish_prod }}"
-      if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event.inputs.publish_prod == 'true') }}
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
-#    - name: Checkout
-#      uses: actions/checkout@v6
-#      with:
-#        fetch-depth: 0
-#
-#    - name: Set up Conda
-#      uses: ./.github/actions/setup-conda
-#
-#    - name: Build Pandas
-#      uses: ./.github/actions/build_pandas
-#
-#    - name: Extra installs
-#      # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
-#      run: sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
-#
-#    - name: Test website
-#      run: python -m pytest web/
-#
-#    - name: Build website
-#      run: python web/pandas_web.py web/pandas --target-path=web/build
-#
-#    - name: Build documentation
-#      run: doc/make.py --warnings-are-errors
-#
-#    - name: Build the interactive terminal
-#      working-directory: web/interactive_terminal
-#      run: jupyter lite build
-#
-#    - name: Build documentation zip
-#      run: doc/make.py zip_html
-#
-#    - name: Install ssh key
-#      run: |
-#        mkdir -m 700 -p ~/.ssh
-#        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
-#        chmod 600 ~/.ssh/id_rsa
-#        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
-#      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
-#
-#    - name: Copy cheatsheets into site directory
-#      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
-#
-#    - name: Upload web
-#      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
-#      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-#
-#    - name: Upload dev docs
-#      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
-#      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-#
-#    - name: Upload prod docs
-#      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
-#      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event.inputs.publish_prod
-#
-#    - name: Move docs into site directory
-#      run: mv doc/build/html web/build/docs
-#
-#    - name: Save website as an artifact
-#      uses: actions/upload-artifact@v6
-#      with:
-#        name: website
-#        path: web/build
-#        retention-days: 14
+    - name: Set up Conda
+      uses: ./.github/actions/setup-conda
+
+    - name: Build Pandas
+      uses: ./.github/actions/build_pandas
+
+    - name: Extra installs
+      # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
+      run: sudo apt-get update && sudo apt-get install -y libegl1 libopengl0
+
+    - name: Test website
+      run: python -m pytest web/
+
+    - name: Build website
+      run: python web/pandas_web.py web/pandas --target-path=web/build
+
+    - name: Build documentation
+      run: doc/make.py --warnings-are-errors
+
+    - name: Build the interactive terminal
+      working-directory: web/interactive_terminal
+      run: jupyter lite build
+
+    - name: Build documentation zip
+      run: doc/make.py zip_html
+
+    - name: Install ssh key
+      run: |
+        mkdir -m 700 -p ~/.ssh
+        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
+      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
+
+    - name: Copy cheatsheets into site directory
+      run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
+
+    - name: Upload web
+      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    - name: Upload dev docs
+      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    - name: Upload prod docs
+      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
+      if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (inputs.publish_prod == 'true') }}
+
+    - name: Move docs into site directory
+      run: mv doc/build/html web/build/docs
+
+    - name: Save website as an artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: website
+        path: web/build
+        retention-days: 14

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -174,9 +174,7 @@ copyright = f"{datetime.now().year},"
 import pandas  # isort:skip
 
 # version = '%s r%s' % (pandas.__version__, svn_version())
-version = str(pandas.__version__)
-if version_override := os.environ.get("PANDAS_VERSION_OVERRIDE"):
-    version = version_override
+version = os.environ.get("PANDAS_VERSION", str(pandas.__version__))
 
 # The full version, including alpha/beta/rc tags.
 release = version


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Simplifies the docs workflow to only have `PANDAS_VERSION` as an environment variable. Also introduces a checkbox to ensure we don't publish to prod even if someone specifies the version on the workflow dispatch page.

I setup the penultimate commit to test and ensure the step is skipped properly when the `publish_prod` is checked/unchecked.

unchecked: https://github.com/rhshadrach/pandas/actions/runs/21321663130/job/61372403355
checked: https://github.com/rhshadrach/pandas/actions/runs/21321653346/job/61372378903