### PR TITLE
Fix #54182: DataFrame.apply min/max NaN first element issue

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1179,8 +1179,13 @@ class FrameApply(NDFrameApply):
 
         results = {}
 
+        func_name = com.get_cython_func(self.func)
+
         for i, v in enumerate(series_gen):
-            results[i] = self.func(v, *self.args, **self.kwargs)
+            if func_name and not self.args and not self.kwargs:
+                results[i] = getattr(v, func_name)()
+            else:
+                results[i] = self.func(v, *self.args, **self.kwargs)
             if isinstance(results[i], ABCSeries):
                 # If we have a view on v, we need to make a copy because
                 #  series_generator will swap out the underlying data

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1182,7 +1182,7 @@ class FrameApply(NDFrameApply):
         func_name = com.get_cython_func(self.func)
 
         for i, v in enumerate(series_gen):
-            if func_name and not self.args and not self.kwargs:
+            if func_name and not self.args and not self.kwargs and func_name in ["min", "max"]:
                 results[i] = getattr(v, func_name)()
             else:
                 results[i] = self.func(v, *self.args, **self.kwargs)

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1873,3 +1873,19 @@ def test_agg_dist_like_and_nonunique_columns():
 def test_wrong_engine(engine_name):
     with pytest.raises(ValueError, match="Unknown engine "):
         DataFrame().apply(lambda x: x, engine=engine_name)
+
+
+def test_apply_min_max_with_nan_first_element():
+    # GH#54182
+    # Case 1: First element is NaN
+    data = {"a": [1, 2, 3, 4], "b": [np.nan, -0.475, 13.795, -574]}
+    df = DataFrame(data)
+
+    result_min = df.apply(min, axis=0)
+    expected_min = df.min(axis=0)
+    tm.assert_series_equal(result_min, expected_min)
+
+    result_max = df.apply(max, axis=0)
+    expected_max = df.max(axis=0)
+    tm.assert_series_equal(result_max, expected_max)
+


### PR DESCRIPTION
Summary:
- Fixed issue #54182 where DataFrame.apply(min/max) returns NaN if the first element is NaN.
- Redirected Python built-in min/max to pandas Series methods to handle NaNs correctly.

Verification:
- Added regression test: test_apply_min_max_with_nan_first_element
- Verified locally with verify_fix_standalone.py
