### PR TITLE
BUG: Clarify KeyError for missing groups in GroupBy.get_group

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -882,7 +882,7 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
             if isinstance(name, tuple) and len(name) == 1:
                 name = name[0]
             else:
-                raise KeyError(name)
+                raise KeyError(f"Group {name} not found")
 
         inds = self._get_index(name)
         if not len(inds):

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2887,6 +2887,13 @@ def test_get_group_len_1_list_likes(test_series, kwarg, value, name, warn):
     tm.assert_equal(result, expected)
 
 
+def test_get_group_missing_group_error_message():
+    df = DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    with pytest.raises(KeyError, match="Group 3 not found"):
+        df.groupby("a").get_group(3)
+
+
 def test_groupby_ngroup_with_nan():
     # GH#50100
     df = DataFrame({"a": Categorical([np.nan]), "b": [1]})


### PR DESCRIPTION
- Update the error raised by `GroupBy.get_group` when a requested group
  key is not found.
- Replace the previous bare `KeyError(name)` with a message that clearly
  indicates the missing group.
- Add a regression test for this case.
