### PR TITLE
DOC: minor alignment fixes to `pandas.melt()` docstring

### DIFF
--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -109,19 +109,19 @@ def melt(
     ...     }
     ... )
     >>> df
-    A  B  C
+       A  B  C
     0  a  1  2
     1  b  3  4
     2  c  5  6
 
     >>> pd.melt(df, id_vars=["A"], value_vars=["B"])
-    A variable  value
+       A variable  value
     0  a        B      1
     1  b        B      3
     2  c        B      5
 
     >>> pd.melt(df, id_vars=["A"], value_vars=["B", "C"])
-    A variable  value
+       A variable  value
     0  a        B      1
     1  b        B      3
     2  c        B      5
@@ -138,7 +138,7 @@ def melt(
     ...     var_name="myVarname",
     ...     value_name="myValname",
     ... )
-    A myVarname  myValname
+       A myVarname  myValname
     0  a         B          1
     1  b         B          3
     2  c         B          5
@@ -146,7 +146,7 @@ def melt(
     Original index values can be kept around:
 
     >>> pd.melt(df, id_vars=["A"], value_vars=["B", "C"], ignore_index=False)
-    A variable  value
+       A variable  value
     0  a        B      1
     1  b        B      3
     2  c        B      5
@@ -158,20 +158,20 @@ def melt(
 
     >>> df.columns = [list("ABC"), list("DEF")]
     >>> df
-    A  B  C
-    D  E  F
+       A  B  C
+       D  E  F
     0  a  1  2
     1  b  3  4
     2  c  5  6
 
     >>> pd.melt(df, col_level=0, id_vars=["A"], value_vars=["B"])
-    A variable  value
+       A variable  value
     0  a        B      1
     1  b        B      3
     2  c        B      5
 
     >>> pd.melt(df, id_vars=[("A", "D")], value_vars=[("B", "E")])
-    (A, D) variable_0 variable_1  value
+      (A, D) variable_0 variable_1  value
     0      a          B          E      1
     1      b          B          E      3
     2      c          B          E      5


### PR DESCRIPTION
### Pandas version checks

* [x]  I have checked that the issue still exists on the latest versions of the docs on `main` [here](https://pandas.pydata.org/docs/dev/)


### Location of the documentation

https://pandas.pydata.org/docs/reference/api/pandas.melt.html


### Documentation problem

Dataframe headers that appear in the example docstring for `pandas.melt()` were not properly aligned with their columns. This caused some initial confusion, as the columns in the constructed dataframe example did not visually appear to match the columns in the example output. While the constructed dataframe has column `A` with values `a, b, c`, the printed example in the docstring visually appeared to have values `0, 1, 2`. This similarly applies to all of the other columns.

### Suggested fix for documentation

Adding additional spaces to the headers in the docstring fixes the appearance. It now appears to match what is displayed when re-running the examples in an interpreter.
