### PR TITLE
BUG: DataFrame.apply(min/max) returns NaN when first element is NaN

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1179,8 +1179,18 @@ class FrameApply(NDFrameApply):
 
         results = {}
 
+        func_name = com.get_cython_func(self.func)
+
         for i, v in enumerate(series_gen):
-            results[i] = self.func(v, *self.args, **self.kwargs)
+            if (
+                func_name
+                and not self.args
+                and not self.kwargs
+                and func_name in ["min", "max"]
+            ):
+                results[i] = getattr(v, func_name)()
+            else:
+                results[i] = self.func(v, *self.args, **self.kwargs)
             if isinstance(results[i], ABCSeries):
                 # If we have a view on v, we need to make a copy because
                 #  series_generator will swap out the underlying data

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1873,3 +1873,18 @@ def test_agg_dist_like_and_nonunique_columns():
 def test_wrong_engine(engine_name):
     with pytest.raises(ValueError, match="Unknown engine "):
         DataFrame().apply(lambda x: x, engine=engine_name)
+
+
+def test_apply_min_max_with_nan_first_element():
+    # GH#54182
+    # Case 1: First element is NaN
+    data = {"a": [1, 2, 3, 4], "b": [np.nan, -0.475, 13.795, -574]}
+    df = DataFrame(data)
+
+    result_min = df.apply(min, axis=0)
+    expected_min = df.min(axis=0)
+    tm.assert_series_equal(result_min, expected_min)
+
+    result_max = df.apply(max, axis=0)
+    expected_max = df.max(axis=0)
+    tm.assert_series_equal(result_max, expected_max)


### PR DESCRIPTION
- Fixes pandas-dev/pandas#54182

### What changed
- Redirect built-in `min` and `max` in `DataFrame.apply` to pandas Series reductions to ensure NaN-aware behavior.
- Prevents incorrect result when first element is NaN.

### Tests
- Added regression test: `test_apply_min_max_with_nan_first_element`

### Notes
- Verified with standalone reproduction script and CI.
