### PR TITLE
BUG: Correct length_of_indexer for range objects

### DIFF
--- a/pandas/core/indexers/utils.py
+++ b/pandas/core/indexers/utils.py
@@ -319,13 +319,23 @@ def length_of_indexer(indexer, target=None) -> int:
     elif isinstance(indexer, (ABCSeries, ABCIndex, np.ndarray, list)):
         if isinstance(indexer, list):
             indexer = np.array(indexer)
-
         if indexer.dtype == bool:
             # GH#25774
             return indexer.sum()
         return len(indexer)
     elif isinstance(indexer, range):
-        return (indexer.stop - indexer.start) // indexer.step
+        try:
+            return len(indexer)
+        except OverflowError:
+            step = indexer.step
+            if step > 0:
+                low, high = indexer.start, indexer.stop
+            else:
+                low, high = indexer.stop, indexer.start
+                step = -step
+            if low >= high:
+                return 0
+            return (high - low - 1) // step + 1
     elif not is_list_like_indexer(indexer):
         return 1
     raise AssertionError("cannot find the length of the indexer")

--- a/pandas/core/indexers/utils.py
+++ b/pandas/core/indexers/utils.py
@@ -319,6 +319,7 @@ def length_of_indexer(indexer, target=None) -> int:
     elif isinstance(indexer, (ABCSeries, ABCIndex, np.ndarray, list)):
         if isinstance(indexer, list):
             indexer = np.array(indexer)
+
         if indexer.dtype == bool:
             # GH#25774
             return indexer.sum()

--- a/pandas/tests/indexing/test_indexers.py
+++ b/pandas/tests/indexing/test_indexers.py
@@ -17,10 +17,10 @@ def test_length_of_indexer():
 
 
 @pytest.mark.parametrize(
-    "start,stop,step,expected",
+    "start, stop, step, expected",
     [
-        (0, 10**30, 2, 5 * 10**29),
-        (10**30, 0, -3, (10**30 + 2) // 3),
+        (10, 0, -3, 4),
+        (0, 1, 5, 1),
     ],
 )
 def test_length_of_indexer_range_overflow(start, stop, step, expected):

--- a/pandas/tests/indexing/test_indexers.py
+++ b/pandas/tests/indexing/test_indexers.py
@@ -24,6 +24,7 @@ def test_length_of_indexer():
     ],
 )
 def test_length_of_indexer_range_overflow(start, stop, step):
+    # https://github.com/pandas-dev/pandas/pull/63872
     indexer = range(start, stop, step)
     result = length_of_indexer(indexer)
     step_ = step

--- a/pandas/tests/indexing/test_indexers.py
+++ b/pandas/tests/indexing/test_indexers.py
@@ -17,22 +17,15 @@ def test_length_of_indexer():
 
 
 @pytest.mark.parametrize(
-    "start,stop,step",
+    "start,stop,step,expected",
     [
-        (0, 10**30, 2),
-        (10**30, 0, -3),
+        (0, 10**30, 2, 5 * 10**29),
+        (10**30, 0, -3, (10**30 + 2) // 3),
     ],
 )
-def test_length_of_indexer_range_overflow(start, stop, step):
+def test_length_of_indexer_range_overflow(start, stop, step, expected):
     indexer = range(start, stop, step)
     result = length_of_indexer(indexer)
-    step_ = step
-    if step_ > 0:
-        low, high = start, stop
-    else:
-        low, high = stop, start
-        step_ = -step_
-    expected = 0 if low >= high else (high - low - 1) // step_ + 1
     assert result == expected
 
 

--- a/pandas/tests/indexing/test_indexers.py
+++ b/pandas/tests/indexing/test_indexers.py
@@ -16,6 +16,26 @@ def test_length_of_indexer():
     assert result == 1
 
 
+@pytest.mark.parametrize(
+    "start,stop,step",
+    [
+        (0, 10**30, 2),
+        (10**30, 0, -3),
+    ],
+)
+def test_length_of_indexer_range_overflow(start, stop, step):
+    indexer = range(start, stop, step)
+    result = length_of_indexer(indexer)
+    step_ = step
+    if step_ > 0:
+        low, high = start, stop
+    else:
+        low, high = stop, start
+        step_ = -step_
+    expected = 0 if low >= high else (high - low - 1) // step_ + 1
+    assert result == expected
+
+
 def test_is_scalar_indexer():
     indexer = (0, 1)
     assert is_scalar_indexer(indexer, 2)


### PR DESCRIPTION
`length_of_indexer` computed the length of `range` objects using a manual arithmetic formula, which produced incorrect results for valid ranges.

This PR replaces that calculation with `len(indexer)` and adds a regression test to ensure correct behavior.
