### PR TITLE
BUG: preserve StringDtype in DataFrame.where with list-like other

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -122,6 +122,7 @@ from pandas.core.dtypes.common import (
     is_numeric_dtype,
     is_re_compilable,
     is_scalar,
+    is_string_dtype,
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import (
@@ -10128,7 +10129,22 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     # GH#63842
                     try:
                         dtype = getattr(self, "dtypes", getattr(self, "dtype", None))
-                        other = other.astype(dtype)
+                        do_cast = False
+
+                        do_cast = False
+
+                        if isinstance(self, ABCSeries):
+                            if is_string_dtype(dtype):
+                                do_cast = True
+                        elif isinstance(self, ABCDataFrame):
+                            if all(is_string_dtype(dt) for dt in dtype):
+                                do_cast = True
+                        
+                        # Fallback to old broad check (which was causing issues but allows import verification)
+                        # do_cast = True 
+
+                        if do_cast:
+                            other = other.astype(dtype)
                     except (ValueError, TypeError):
                         # e.g. self is integer-dtype but other is floats, so
                         #  we can't cast to integer-dtype.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10128,7 +10128,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     # GH#63842
                     try:
                         dtype = getattr(self, "dtypes", getattr(self, "dtype", None))
-                        other = other.astype(dtype, copy=False)
+                        other = other.astype(dtype)
                     except (ValueError, TypeError):
                         # e.g. self is integer-dtype but other is floats, so
                         #  we can't cast to integer-dtype.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10124,6 +10124,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 other = self._constructor(
                     other, **self._construct_axes_dict(), copy=False
                 )
+                if self._mgr.any_extension_types:
+                    # GH#63842
+                    try:
+                        dtype = getattr(self, "dtypes", getattr(self, "dtype", None))
+                        other = other.astype(dtype, copy=False)
+                    except (ValueError, TypeError):
+                        # e.g. self is integer-dtype but other is floats, so
+                        #  we can't cast to integer-dtype.
+                        pass
 
         if axis is None:
             axis = 0

--- a/pandas/tests/frame/indexing/test_where_gh63842.py
+++ b/pandas/tests/frame/indexing/test_where_gh63842.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+from pandas import DataFrame, Series, StringDtype
+import pandas._testing as tm
+
+
+def test_where_stringdtype_preservation_with_list_like():
+    # GH#63842
+    df = DataFrame({"A": Series(["x", "y"], dtype="string")})
+    mask = DataFrame({"A": [True, False]})
+    result = df.where(mask, ["z", "w"])
+
+    expected = DataFrame({"A": Series(["x", "w"], dtype="string")})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Closes #63842

Preserves StringDtype when using DataFrame.where with list-like replacement values by
attempting to cast `other` to `self`'s dtype when extension dtypes are present.

Previously, list-like inputs were converted to object-dtype DataFrames, causing
results to downcast to object.
