### PR TITLE
STY: add strict=True to zip() in pandas/tests/series/indexing

### DIFF
--- a/pandas/tests/series/indexing/test_get.py
+++ b/pandas/tests/series/indexing/test_get.py
@@ -149,7 +149,7 @@ def test_get_with_default():
 
     for data, index in ((d0, d1), (d1, d0)):
         s = Series(data, index=index)
-        for i, d in zip(index, data):
+        for i, d in zip(index, data, strict=True):
             assert s.get(i) == d
             assert s.get(i, d) == d
             assert s.get(i, "z") == d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -512,7 +512,6 @@ exclude = [
 "pandas/tests/reshape/test_qcut.py" = ["B905"]
 "pandas/tests/scalar/period/test_asfreq.py" = ["B905"]
 "pandas/tests/series/accessors/test_dt_accessor.py" = ["B905"]
-"pandas/tests/series/indexing/test_get.py" = ["B905"]
 "pandas/tests/series/test_api.py" = ["B905"]
 "pandas/tests/series/test_constructors.py" = ["B905"]
 "pandas/tests/strings/conftest.py" = ["B905"]


### PR DESCRIPTION
- Part of #62434
- Added `strict=True` to `zip()` calls in `pandas/tests/series/indexing/test_get.py`.
- Removed the file from the `B905` ignore list in `pyproject.toml`.

- [x] Part of #62434
- [x] Tests added and passed
- [x] All code checks passed
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.