### PR TITLE
DOC: For `is_string_dtype` replace self-reference under See Also

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -627,8 +627,8 @@ def is_string_dtype(arr_or_dtype) -> bool:
 
     See Also
     --------
-    api.types.is_string_dtype : Check whether the provided array or dtype
-                                is of the string dtype.
+    api.types.is_object_dtype : Check whether an array-like or dtype is of the
+        object dtype.
 
     Examples
     --------


### PR DESCRIPTION
The docstring of `is_string_dtype` referenced itself under See Also. I replaced this with a reference to `is_object_dtype`, as that also references `is_string_dtype` (I didn't spot any other related functions).