### PR TITLE
DOC: Add AI contribution guidelines and clarify other contribution policies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,5 @@
 - [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
 - [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
 - [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
+- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
 - [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -266,11 +266,15 @@ and merged into the project to appear in the next release. To submit a pull requ
    * TYP: Type annotations
    * CLN: Code cleanup
 
-#. Write a description of your changes in the ``Preview Discussion`` tab
+#. Complete the checklist template in the body of the pull request and write an additional description below the checklist if necessary.
 #. Click ``Send Pull Request``.
 
 This request then goes to the repository maintainers, and they will review
 the code.
+
+.. note::
+    A pull request should be associated with an open Github issue except if the change is trivial such as fixing a typo.
+    Pull requests that do not abide by all the applicable contribution guidelines may be closed by a maintainer.
 
 .. _contributing.update-pr:
 

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -51,9 +51,9 @@ the `GitHub "issues" tab <https://github.com/pandas-dev/pandas/issues>`_
 to find issues that interest you and are available to work on. Issues available to work on are:
 
 * Issues without the label ``Needs Triage`` or ``Needs Discussion``. These issues require clarification and confirmation
-from a maintainer before proceeding.
+  from a maintainer before proceeding.
 * Issues that have not been started by another contributor. Please check that another contributor has not commented their intent
-to work on the issue or already submitted an open pull request to address the issue before proceeding.
+  to work on the issue or already submitted an open pull request to address the issue before proceeding.
 
 .. tip::
     We recommend issues labeled `Docs

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -274,7 +274,8 @@ the code.
 
 .. note::
     A pull request should be associated with an open Github issue except if the change is trivial such as fixing a typo.
-    Pull requests that do not abide by all the applicable contribution guidelines may be closed by a maintainer.
+    Pull requests that do not abide by all the applicable contribution guidelines may be closed by a maintainer. Contributors
+    who have shown continued, quality pull requests may be exempt from following all guidelines strictly.
 
 .. _contributing.update-pr:
 

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -11,7 +11,25 @@ Contributing to pandas
 
 
 All contributions, bug reports, bug fixes, documentation improvements,
-enhancements, and ideas are welcome.
+enhancements, and ideas are welcome. We ask that contributors follow
+all contribution guidelines when participating with pandas.
+
+.. _contributing.ai:
+
+Automated contributions policy
+==============================
+
+Contributors may use automated tools such as AI coding assistants while contributing
+to pandas as long as it's used **responsibly**. Any use of these tools in a contribution must abide by all of the
+following guidelines:
+
+* You must disclose that you used an automated tool in the contribution.
+* You must fully review and modify the result of the automated tool.
+* You must ensure the contribution fully abides by all documented, contribution conventions in pandas.
+
+This policy applies to any contribution made to pandas, including submitted issues or pull requests. Maintainers
+reserve the right to discern whether automated tooling was used and reject contributions that do not follow all of
+the above guidelines. Maintainers may also ban users from contributing to pandas who violate these guidelines 2 or more times.
 
 .. _contributing.bug_reports:
 
@@ -30,20 +48,27 @@ Finding an issue to contribute to
 
 If you are brand new to pandas or open-source development, we recommend searching
 the `GitHub "issues" tab <https://github.com/pandas-dev/pandas/issues>`_
-to find issues that interest you. Unassigned issues labeled `Docs
-<https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3ADocs+no%3Aassignee>`_
-and `good first issue
-<https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22+no%3Aassignee>`_
-are typically good for newer contributors.
+to find issues that interest you and are available to work on. Issues available to work on are:
 
-Once you've found an interesting issue, leave a comment with your intention
+* Issues without the label ``Needs Triage`` or ``Needs Discussion``. These issues require clarification and confirmation
+from a maintainer before proceeding.
+* Issues that have not been started by another contributor. Please check that another contributor has not commented their intent
+to work on the issue or already submitted an open pull request to address the issue before proceeding.
+
+.. tip::
+    We recommend issues labeled `Docs
+    <https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3ADocs+no%3Aassignee>`_
+    and `good first issue
+    <https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22+no%3Aassignee>`_
+    for newer contributors.
+
+Once you've found an interesting, available issue, leave a comment with your intention
 to start working on it. If somebody else has
 already commented on the issue but they have shown a lack of activity in the issue
 or a pull request in the past 2-3 weeks, you may take it over.
 
 If for whatever reason you are not able to continue working with the issue, please
-leave a comment on an issue, so other people know it's available again. You can check the list of
-assigned issues, since people may not be working on them anymore.
+leave a comment on an issue, so other people know it's available again.
 
 We have several :ref:`contributor community <community>` communication channels, which you are
 welcome to join, and ask questions as you figure things out. Among them are regular meetings for

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -277,6 +277,10 @@ the code.
     Pull requests that do not abide by all the applicable contribution guidelines may be closed by a maintainer. Contributors
     who have shown continued, quality pull requests may be exempt from following all guidelines strictly.
 
+.. warning::
+    pandas will not accept low quality pull requests that do not meaningfully contribute to the project. Maintainers reserve
+    their right to close these pull requests and ban users who repeatedly submit low quality pull requests.
+
 .. _contributing.update-pr:
 
 Updating your pull request


### PR DESCRIPTION
I have noticed an uptick of contributions that [irresponsibly use AI](https://github.com/pandas-dev/pandas/pull/63873) or make [meaningless changes](https://github.com/pandas-dev/pandas/pull/63853). I'd like to have documentation to point to when closing or banning users that engage in this behavior.

* The AI policy I borrowed heavily from [Matplotlib](https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage) and [scikit-learn](https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy)
* I added additional language emphasizing to follow all guidelines and well as clarifying when it should be appropriate to open a pull request.

Would be good to get feedback from those working with newer contributors lately cc @afeld @rhshadrach 