### PR TITLE
TST: xfail PyArrow 23.0 failures

### DIFF
--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -42,7 +42,7 @@ dependencies:
   - pyqt>=5.15.9
   - openpyxl>=3.1.5
   - psycopg2>=2.9.10
-  - pyarrow>=13.0.0,<=22.0.0 # https://github.com/apache/arrow/issues/49003
+  - pyarrow>=13.0.0
   - pyiceberg>=0.8.1
   - pydantic<2.12.0  # TMP pin to avoid pyiceberg/pydantic issues
   - pymysql>=1.1.1

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -42,7 +42,7 @@ dependencies:
   - pyqt>=5.15.9
   - openpyxl>=3.1.5
   - psycopg2>=2.9.10
-  - pyarrow>=13.0.0,<=22.0.0 # https://github.com/apache/arrow/issues/49003
+  - pyarrow>=13.0.0
   - pyiceberg>=0.8.1
   - pydantic<2.12.0  # TMP pin to avoid pyiceberg/pydantic issues
   - pymysql>=1.1.1

--- a/ci/deps/actions-313-downstream_compat.yaml
+++ b/ci/deps/actions-313-downstream_compat.yaml
@@ -41,7 +41,7 @@ dependencies:
   - qtpy>=2.4.2
   - openpyxl>=3.1.5
   - psycopg2>=2.9.10
-  - pyarrow>=13.0.0,<=22.0.0 # https://github.com/apache/arrow/issues/49003
+  - pyarrow>=13.0.0
   - pyiceberg>=0.8.1
   - pymysql>=1.1.1
   - pyqt>=5.15.9

--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -43,7 +43,7 @@ dependencies:
   - pyqt>=5.15.9
   - openpyxl>=3.1.5
   - psycopg2>=2.9.10
-  - pyarrow>=13.0.0,<=22.0.0 # https://github.com/apache/arrow/issues/49003
+  - pyarrow>=13.0.0
   - pymysql>=1.1.1
   - pyreadstat>=1.2.8
   - pytables>=3.10.1

--- a/pandas/tests/io/parser/common/test_float.py
+++ b/pandas/tests/io/parser/common/test_float.py
@@ -60,9 +60,17 @@ def test_scientific_no_exponent(all_parsers_all_precisions):
         ("-50060e8007123400", -np.inf),
     ],
 )
-def test_large_exponent(all_parsers_all_precisions, value, expected_value):
+def test_large_exponent(request, all_parsers_all_precisions, value, expected_value):
     # GH#38753; GH#38794; GH#62740
     parser, precision = all_parsers_all_precisions
+
+    if (
+        parser.engine == "pyarrow"
+        and precision is None
+        and value[:2] not in ["0E", "-0"]
+    ):
+        reason = "https://github.com/apache/arrow/issues/49003"
+        request.applymarker(pytest.mark.xfail(reason=reason, raises=AssertionError))
 
     data = f"data\n{value}"
     result = parser.read_csv(StringIO(data), float_precision=precision)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Reverts #63893 and xfails specific tests as suggested by @mroeschke 