### PR TITLE
BUG: still use object dtype for pyarrow-backed IO methods with infer_strings disabled

### DIFF
--- a/pandas/io/_util.py
+++ b/pandas/io/_util.py
@@ -176,8 +176,8 @@ def _post_convert_dtypes(
         for col, dtype in zip(df.columns, df.dtypes, strict=True):
             if isinstance(dtype, pd.StringDtype) and dtype.na_value is np.nan:
                 df[col] = df[col].astype("object").fillna(None)
-            if dtype == "category":
-                cat_dtype = dtype.categories.dtype  # type: ignore[union-attr]
+            if isinstance(dtype, pd.CategoricalDtype):
+                cat_dtype = dtype.categories.dtype
                 if (
                     isinstance(cat_dtype, pd.StringDtype)
                     and cat_dtype.na_value is np.nan

--- a/pandas/io/_util.py
+++ b/pandas/io/_util.py
@@ -177,7 +177,7 @@ def _post_convert_dtypes(
             if isinstance(dtype, pd.StringDtype) and dtype.na_value is np.nan:
                 df[col] = df[col].astype("object").fillna(None)
             if dtype == "category":
-                cat_dtype = dtype.categories.dtype
+                cat_dtype = dtype.categories.dtype  # type: ignore[union-attr]
                 if (
                     isinstance(cat_dtype, pd.StringDtype)
                     and cat_dtype.na_value is np.nan

--- a/pandas/io/_util.py
+++ b/pandas/io/_util.py
@@ -166,4 +166,26 @@ def _post_convert_dtypes(
             # GH#44901 reraise to keep api consistent
             raise ValueError(str(err)) from err
 
+    if (
+        not using_string_dtype()
+        and dtype != "str"
+        and (dtype_backend is lib.no_default or dtype_backend == "numpy")
+    ):
+        # Convert any StringDtype columns back to object dtype (pyarrow always
+        # uses string dtype even when the infer_string option is False)
+        for col, dtype in zip(df.columns, df.dtypes, strict=True):
+            if isinstance(dtype, pd.StringDtype) and dtype.na_value is np.nan:
+                df[col] = df[col].astype("object").fillna(None)
+            if dtype == "category":
+                cat_dtype = dtype.categories.dtype
+                if (
+                    isinstance(cat_dtype, pd.StringDtype)
+                    and cat_dtype.na_value is np.nan
+                ):
+                    cat_dtype = pd.CategoricalDtype(
+                        categories=dtype.categories.astype("object"),
+                        ordered=dtype.ordered,
+                    )
+                    df[col] = df[col].astype(cat_dtype)
+
     return df

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -6,8 +6,6 @@ Tests for the str accessors are in pandas/tests/strings/test_string_array.py
 import numpy as np
 import pytest
 
-from pandas._config import using_string_dtype
-
 from pandas.compat.pyarrow import pa_version_under19p0
 
 from pandas.core.dtypes.common import is_dtype_equal
@@ -351,18 +349,16 @@ def test_arrow_roundtrip(dtype, string_storage, using_infer_string):
         assert table.field("a").type == "large_string"
     with pd.option_context("string_storage", string_storage):
         result = table.to_pandas()
-    if dtype.na_value is np.nan and not using_infer_string:
-        assert result["a"].dtype == "object"
-    else:
-        assert isinstance(result["a"].dtype, pd.StringDtype)
-        expected = df.astype(pd.StringDtype(string_storage, na_value=dtype.na_value))
-        if using_infer_string:
-            expected.columns = expected.columns.astype(
-                pd.StringDtype(string_storage, na_value=np.nan)
-            )
-        tm.assert_frame_equal(result, expected)
-        # ensure the missing value is represented by NA and not np.nan or None
-        assert result.loc[2, "a"] is result["a"].dtype.na_value
+
+    assert isinstance(result["a"].dtype, pd.StringDtype)
+    expected = df.astype(pd.StringDtype(string_storage, na_value=dtype.na_value))
+    if using_infer_string:
+        expected.columns = expected.columns.astype(
+            pd.StringDtype(string_storage, na_value=np.nan)
+        )
+    tm.assert_frame_equal(result, expected)
+    # ensure the missing value is represented by NA and not np.nan or None
+    assert result.loc[2, "a"] is result["a"].dtype.na_value
 
 
 @pytest.mark.filterwarnings("ignore:Passing a BlockManager:DeprecationWarning")
@@ -373,10 +369,17 @@ def test_arrow_from_string(using_infer_string):
 
     result = table.to_pandas()
 
-    if using_infer_string and not pa_version_under19p0:
-        expected = pd.DataFrame({"a": ["a", "b", None]}, dtype="str")
-    else:
+    if not using_infer_string:
+        if pa_version_under19p0:
+            expected = pd.DataFrame({"a": ["a", "b", None]}, dtype="object")
+        else:
+            expected = pd.DataFrame(
+                {"a": ["a", "b", None]}, dtype=pd.StringDtype(na_value=np.nan)
+            )
+    elif pa_version_under19p0:
         expected = pd.DataFrame({"a": ["a", "b", None]}, dtype="object")
+    else:
+        expected = pd.DataFrame({"a": ["a", "b", None]}, dtype="str")
     tm.assert_frame_equal(result, expected)
 
 
@@ -397,16 +400,13 @@ def test_arrow_load_from_zero_chunks(dtype, string_storage, using_infer_string):
     with pd.option_context("string_storage", string_storage):
         result = table.to_pandas()
 
-    if dtype.na_value is np.nan and not using_string_dtype():
-        assert result["a"].dtype == "object"
-    else:
-        assert isinstance(result["a"].dtype, pd.StringDtype)
-        expected = df.astype(pd.StringDtype(string_storage, na_value=dtype.na_value))
-        if using_infer_string:
-            expected.columns = expected.columns.astype(
-                pd.StringDtype(string_storage, na_value=np.nan)
-            )
-        tm.assert_frame_equal(result, expected)
+    assert isinstance(result["a"].dtype, pd.StringDtype)
+    expected = df.astype(pd.StringDtype(string_storage, na_value=dtype.na_value))
+    if using_infer_string:
+        expected.columns = expected.columns.astype(
+            pd.StringDtype(string_storage, na_value=np.nan)
+        )
+    tm.assert_frame_equal(result, expected)
 
 
 def test_value_counts_na(dtype):

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -64,7 +64,9 @@ class TestDataFrameInterpolate:
         assert orig.squeeze()[1] == 1.5
 
     @pytest.mark.parametrize("dtype", ["str", "object"])
-    def test_interp_with_non_numeric(self, dtype):
+    def test_interp_with_non_numeric(self, dtype, using_infer_string):
+        if not using_infer_string:
+            dtype = "object"
         df = DataFrame(
             {
                 "A": [1, 2, np.nan, 4],

--- a/pandas/tests/frame/test_arrow_interface.py
+++ b/pandas/tests/frame/test_arrow_interface.py
@@ -1,5 +1,6 @@
 import ctypes
 
+import numpy as np
 import pytest
 
 import pandas.util._test_decorators as td
@@ -65,12 +66,14 @@ class ArrowStreamWrapper:
 
 
 @td.skip_if_no("pyarrow", min_version="14.0")
-def test_dataframe_from_arrow():
+def test_dataframe_from_arrow(using_infer_string):
     # objects with __arrow_c_stream__
     table = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]})
 
     result = pd.DataFrame.from_arrow(table)
     expected = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
+    if not using_infer_string:
+        expected["b"] = expected["b"].astype(pd.StringDtype(na_value=np.nan))
     tm.assert_frame_equal(result, expected)
 
     # not only pyarrow object are supported

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -138,7 +138,7 @@ Look,a snake,🐍"""
             assert result == data.encode("utf-8")
 
     # Test that pyarrow can handle a file opened with get_handle
-    def test_get_handle_pyarrow_compat(self):
+    def test_get_handle_pyarrow_compat(sel, using_infer_string):
         pa_csv = pytest.importorskip("pyarrow.csv")
 
         # Test latin1, ucs-2, and ucs-4 chars
@@ -154,6 +154,8 @@ Look,a snake,🐍"""
             df = pa_csv.read_csv(handles.handle).to_pandas()
             if pa_version_under19p0:
                 expected = expected.astype("object")
+            elif not using_infer_string:
+                expected = expected.astype(pd.StringDtype(na_value=np.nan))
             tm.assert_frame_equal(df, expected)
             assert not s.closed
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/63803

This actually "fixes" the behaviour, not necessarily because I think it is important to fix, but it was easier to do it this way than to update all the tests to change the expected result for those specific circumstances.