### PR TITLE
TST: Remove Windows ARROW_TIMEZONE_DATABASE xfails for PyArrow>=22

### DIFF
--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -18,6 +18,7 @@ try:
     pa_version_under19p0 = _palv < Version("19.0.0")
     pa_version_under20p0 = _palv < Version("20.0.0")
     pa_version_under21p0 = _palv < Version("21.0.0")
+    pa_version_under22p0 = _palv < Version("22.0.0")
     HAS_PYARROW = _palv >= Version(PYARROW_MIN_VERSION)
 except ImportError:
     pa_version_under14p0 = True

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -30,4 +30,5 @@ except ImportError:
     pa_version_under19p0 = True
     pa_version_under20p0 = True
     pa_version_under21p0 = True
+    pa_version_under22p0 = True
     HAS_PYARROW = False

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -36,6 +36,8 @@ from pandas._libs import lib
 from pandas._libs.tslibs import timezones
 from pandas.compat import (
     PY312,
+    is_ci_environment,
+    is_platform_windows,
     pa_version_under14p0,
     pa_version_under19p0,
     pa_version_under20p0,
@@ -68,6 +70,18 @@ pa = pytest.importorskip("pyarrow")
 
 from pandas.core.arrays.arrow.array import ArrowExtensionArray
 from pandas.core.arrays.arrow.extension_types import ArrowPeriodType
+
+
+def _require_timezone_database(request):
+    if is_platform_windows() and is_ci_environment():
+        mark = pytest.mark.xfail(
+            raises=pa.ArrowInvalid,
+            reason=(
+                "TODO: Set ARROW_TIMEZONE_DATABASE environment variable "
+                "on CI to path to the tzdata for pyarrow."
+            ),
+        )
+        request.applymarker(mark)
 
 
 @pytest.fixture(params=tm.ALL_PYARROW_DTYPES, ids=str)
@@ -349,6 +363,10 @@ class TestArrowArray(base.ExtensionTests):
             ArrowExtensionArray._from_sequence_of_strings(["12-1"], dtype=dtype)
 
     def test_from_sequence_of_strings_pa_array(self, data, request):
+        pa_dtype = data.dtype.pyarrow_dtype
+        if pa.types.is_timestamp(pa_dtype) and pa_dtype.tz is not None:
+            _require_timezone_database(request)
+
         pa_array = data._pa_array.cast(pa.string())
         result = type(data)._from_sequence_of_strings(pa_array, dtype=data.dtype)
         tm.assert_extension_array_equal(result, data)
@@ -2590,6 +2608,8 @@ def test_dt_isocalendar():
 )
 def test_dt_day_month_name(method, exp, request):
     # GH 52388
+    _require_timezone_database(request)
+
     ser = pd.Series([datetime(2023, 1, 1), None], dtype=ArrowDtype(pa.timestamp("ms")))
     result = getattr(ser.dt, method)()
     expected = pd.Series([exp, None], dtype=ArrowDtype(pa.string()))
@@ -2597,6 +2617,8 @@ def test_dt_day_month_name(method, exp, request):
 
 
 def test_dt_strftime(request):
+    _require_timezone_database(request)
+
     ser = pd.Series(
         [datetime(year=2023, month=1, day=2, hour=3), None],
         dtype=ArrowDtype(pa.timestamp("ns")),
@@ -2683,6 +2705,8 @@ def test_dt_tz_localize_unsupported_tz_options():
 
 
 def test_dt_tz_localize_none(request):
+    _require_timezone_database(request)
+
     ser = pd.Series(
         [datetime(year=2023, month=1, day=2, hour=3), None],
         dtype=ArrowDtype(pa.timestamp("ns", tz="US/Pacific")),
@@ -2697,6 +2721,8 @@ def test_dt_tz_localize_none(request):
 
 @pytest.mark.parametrize("unit", ["us", "ns"])
 def test_dt_tz_localize(unit, request):
+    _require_timezone_database(request)
+
     ser = pd.Series(
         [datetime(year=2023, month=1, day=2, hour=3), None],
         dtype=ArrowDtype(pa.timestamp(unit)),
@@ -2718,6 +2744,8 @@ def test_dt_tz_localize(unit, request):
     ],
 )
 def test_dt_tz_localize_nonexistent(nonexistent, exp_date, request):
+    _require_timezone_database(request)
+
     ser = pd.Series(
         [datetime(year=2023, month=3, day=12, hour=2, minute=30), None],
         dtype=ArrowDtype(pa.timestamp("ns")),

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -43,6 +43,7 @@ from pandas.compat import (
     pa_version_under20p0,
     pa_version_under21p0,
 )
+from pandas.compat.pyarrow import pa_version_under22p0
 from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.common import pandas_dtype
@@ -73,7 +74,7 @@ from pandas.core.arrays.arrow.extension_types import ArrowPeriodType
 
 
 def _require_timezone_database(request):
-    if is_platform_windows() and is_ci_environment():
+    if is_platform_windows() and is_ci_environment() and pa_version_under22p0:
         mark = pytest.mark.xfail(
             raises=pa.ArrowInvalid,
             reason=(

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -11,6 +11,7 @@ from pandas.compat import (
     is_ci_environment,
     is_platform_windows,
 )
+from pandas.compat.pyarrow import pa_version_under22p0
 
 import pandas as pd
 import pandas._testing as tm
@@ -385,7 +386,7 @@ def test_interchange_from_non_pandas_tz_aware(request):
     pa = pytest.importorskip("pyarrow", "11.0.0")
     import pyarrow.compute as pc
 
-    if is_platform_windows() and is_ci_environment():
+    if is_platform_windows() and is_ci_environment() and pa_version_under22p0:
         mark = pytest.mark.xfail(
             raises=pa.ArrowInvalid,
             reason=(

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -7,6 +7,10 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import iNaT
+from pandas.compat import (
+    is_ci_environment,
+    is_platform_windows,
+)
 
 import pandas as pd
 import pandas._testing as tm
@@ -376,10 +380,20 @@ def test_datetimetzdtype(tz, unit):
         tm.assert_frame_equal(df, from_dataframe(df.__dataframe__()))
 
 
-def test_interchange_from_non_pandas_tz_aware():
+def test_interchange_from_non_pandas_tz_aware(request):
     # GH 54239, 54287
     pa = pytest.importorskip("pyarrow", "11.0.0")
     import pyarrow.compute as pc
+
+    if is_platform_windows() and is_ci_environment():
+        mark = pytest.mark.xfail(
+            raises=pa.ArrowInvalid,
+            reason=(
+                "TODO: Set ARROW_TIMEZONE_DATABASE environment variable "
+                "on CI to path to the tzdata for pyarrow."
+            ),
+        )
+        request.applymarker(mark)
 
     arr = pa.array([datetime(2020, 1, 1), None, datetime(2020, 1, 2)])
     arr = pc.assume_timezone(arr, "Asia/Kathmandu")

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -9,6 +9,7 @@ from pandas._libs import lib
 from pandas._libs.tslibs import Day
 from pandas._typing import DatetimeNaTType
 from pandas.compat import is_platform_windows
+from pandas.compat.pyarrow import pa_version_under22p0
 from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
@@ -2143,7 +2144,7 @@ def test_resample_b_55282(unit):
         pytest.param(
             "UTC",
             marks=pytest.mark.xfail(
-                condition=is_platform_windows(),
+                condition=is_platform_windows() and pa_version_under22p0,
                 reason="TODO: Set ARROW_TIMEZONE_DATABASE env var in CI",
             ),
         ),

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -8,6 +8,7 @@ import pytest
 from pandas._libs import lib
 from pandas._libs.tslibs import Day
 from pandas._typing import DatetimeNaTType
+from pandas.compat import is_platform_windows
 from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
@@ -2137,7 +2138,16 @@ def test_resample_b_55282(unit):
 @td.skip_if_no("pyarrow")
 @pytest.mark.parametrize(
     "tz",
-    [None, "UTC"],
+    [
+        None,
+        pytest.param(
+            "UTC",
+            marks=pytest.mark.xfail(
+                condition=is_platform_windows(),
+                reason="TODO: Set ARROW_TIMEZONE_DATABASE env var in CI",
+            ),
+        ),
+    ],
 )
 def test_arrow_timestamp_resample(tz):
     # GH 56371


### PR DESCRIPTION
Reverts pandas-dev/pandas#63894, and only xfails when PyArrow<22.

~Still working on confirming PyArrow==22 is the cutoff for Windows.~