### PR TITLE
BUG: fix CoW handling of DataFrame(index/series) constructor

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -13,7 +13,8 @@ including other versions of pandas.
 
 Bug fixes
 ^^^^^^^^^
-
+- Fixed a bug in the :class:`DataFrame` constructor when passed a :class:`Series` or
+  :class:`Index` correctly handling Copy-on-Write (:issue:`63899`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.contributors:

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -230,7 +230,7 @@ def ndarray_to_mgr(
         # be copied when consolidating the blocks
         if copy:
             values = [
-                x.copy(deep=True)
+                (x.copy(deep=True) if isinstance(x, Index) else x.copy())
                 if isinstance(x, (ExtensionArray, Index, ABCSeries))
                 and is_1d_only_ea_dtype(x.dtype)
                 else x

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -226,14 +226,29 @@ def ndarray_to_mgr(
         else:
             values = [values]
 
+        # Handle copy semantics: already copy 1d-only EA. Other arrays will
+        # be copied when consolidating the blocks
+        if copy:
+            values = [
+                x.copy(deep=True)
+                if isinstance(x, (ExtensionArray, Index, ABCSeries))
+                and is_1d_only_ea_dtype(x.dtype)
+                else x
+                for x in values
+            ]
+
         if columns is None:
             columns = Index(range(len(values)))
         else:
             columns = ensure_index(columns)
 
-        return arrays_to_mgr(values, columns, index, dtype=dtype)
+        return arrays_to_mgr(values, columns, index, dtype=dtype, consolidate=copy)
 
-    elif isinstance(vdtype, ExtensionDtype):
+    if isinstance(values, (ABCSeries, Index)):
+        if not copy and (dtype is None or astype_is_view(values.dtype, dtype)):
+            refs = values._references
+
+    if isinstance(vdtype, ExtensionDtype):
         # i.e. Datetime64TZ, PeriodDtype; cases with is_1d_only_ea_dtype(vdtype)
         #  are already caught above
         values = extract_array(values, extract_numpy=True)
@@ -243,9 +258,6 @@ def ndarray_to_mgr(
             values = values.reshape(-1, 1)
 
     elif isinstance(values, (ABCSeries, Index)):
-        if not copy and (dtype is None or astype_is_view(values.dtype, dtype)):
-            refs = values._references
-
         if copy:
             values = values._values.copy()
         else:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1257,7 +1257,7 @@ class TestiLocBaseIndependent:
         # GH#45241
         # TODO: make an extension interface test for this?
         arr = interval_range(1, 10.0)._values
-        df = DataFrame(arr)
+        df = DataFrame(arr, copy=False)
 
         # ser should be a *view* on the DataFrame data
         ser = df.iloc[2]


### PR DESCRIPTION
- [x] closes #63899
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

This fixes a few issues in the DataFrame constructor:
- when a Series/Index object with EA was passed with the default `copy=False` path, no references were tracked. By passing `copy=False` as `consolidate` to `arrays_to_mgr` -> `create_block_manager_from_column_arrays`, it ensures to take a code path that extracts the references
- for the same case as above, but for an explicit `copy=True`, we were currently also not actually copying (because the default consolidation only copies in case of 2d blocks, and thus does not copy 1d-only EAs)
- specifically for 2d EAs (eg datetimetz) in a Series/Index, we were not tracking the refs because this case was currently handled separately if an `elif` case before the series/index block. Moved the extraction of the refs for Series/Index before the if/elif block.

And expanded the existing test case to cover the different array types