### PR TITLE
BUG: Fix drop(index=[pd.NA]) for PyArrow-backed Index (GH#63304)

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1418,7 +1418,10 @@ class ArrowExtensionArray(
         if not len(values):
             return np.zeros(len(self), dtype=bool)
 
-        result = pc.is_in(self._pa_array, value_set=pa.array(values))
+        value_set = pa.array(values, from_pandas=True)
+        if pa.types.is_null(value_set.type):
+            value_set = value_set.cast(self._pa_array.type)
+        result = pc.is_in(self._pa_array, value_set=value_set)
         # pyarrow 2.0.0 returned nulls, so we explicitly specify dtype to convert nulls
         # to False
         return np.array(result, dtype=np.bool_)

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -2,6 +2,8 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 
+pa = pytest.importorskip("pyarrow", minversion="13.0.0")
+
 def test_drop_na_arrow_index():
     # GH#63304
     # Test that dropping pd.NA from PyArrow-backed Index does not raise ArrowInvalid

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -1,0 +1,34 @@
+import pytest
+import pandas as pd
+import pandas._testing as tm
+
+def test_drop_na_arrow_index():
+    # GH#63304
+    # Test that dropping pd.NA from PyArrow-backed Index does not raise ArrowInvalid
+    
+    # integer
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([1, 2, 3], dtype="int64[pyarrow]"))
+    # pd.NA is not in index, should raise KeyError, but NOT ArrowInvalid
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # string
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index(["a", "b", "c"], dtype="string[pyarrow]"))
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # binary
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([b"a", b"b", b"c"], dtype="binary[pyarrow]"))
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # Case where NA IS in the index (should verify it drops correctly)
+    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]"))
+    result = df.drop(index=[pd.NA])
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index([1], dtype="int64[pyarrow]"))
+    tm.assert_frame_equal(result, expected)
+
+    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]"))
+    result = df.drop(index=[pd.NA])
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]"))
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
This PR resolves an ArrowInvalid error when dropping pd.NA from Arrow-backed indices. It ensures the value_set in ArrowExtensionArray.isin is correctly cast to the array's native type.

Fix regression in pandas 3.0 where `df.drop(index=[pd.NA])` raises `ArrowInvalid` for PyArrow-backed indexes.

The comparison value set containing `pd.NA` was passed to `pyarrow.compute.is_in` without a concrete Arrow
type. Cast null comparison values to the array’s native Arrow dtype before calling the kernel.

Added regression tests for string, int64, and binary PyArrow-backed index dtypes.

Closes GH#63304
