### PR TITLE
BUG: Fix drop(index=[pd.NA]) for PyArrow-backed Index (GH#63304)

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1430,7 +1430,7 @@ class ArrowExtensionArray(
                 if x is lib.missing.NA:
                     has_pd_na = True
                     break
-            
+
             if has_pd_na:
                 value_set = value_set.cast(self._pa_array.type)
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1427,7 +1427,8 @@ class ArrowExtensionArray(
             # on crashing to trigger fallback (e.g. in parsers).
             has_pd_na = False
             for x in values:
-                if x is lib.missing.NA:
+                # GH#63304: Check for pd.NA (NAType) specifically
+                if isna(x) and not isinstance(x, (float, np.floating, type(None))):
                     has_pd_na = True
                     break
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1418,7 +1418,10 @@ class ArrowExtensionArray(
         if not len(values):
             return np.zeros(len(self), dtype=bool)
 
-        result = pc.is_in(self._pa_array, value_set=pa.array(values))
+        value_set = pa.array(values, from_pandas=True)
+        if pa.types.is_null(value_set.type):
+            value_set = value_set.cast(self._pa_array.type)
+        result = pc.is_in(self._pa_array, value_set=value_set)
         # pyarrow 2.0.0 returned nulls, so we explicitly specify dtype to convert nulls
         # to False
         return np.array(result, dtype=np.bool_)

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -34,9 +34,7 @@ def test_drop_na_arrow_index():
         df.drop(index=[pd.NA])
 
     # Case where NA IS in the index (should verify it drops correctly)
-    df = pd.DataFrame(
-        {"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]")
-    )
+    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]"))
     result = df.drop(index=[pd.NA])
     expected = pd.DataFrame({"A": [1]}, index=pd.Index([1], dtype="int64[pyarrow]"))
     tm.assert_frame_equal(result, expected)
@@ -45,7 +43,5 @@ def test_drop_na_arrow_index():
         {"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]")
     )
     result = df.drop(index=[pd.NA])
-    expected = pd.DataFrame(
-        {"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]")
-    )
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]"))
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -2,6 +2,8 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 
+pa = pytest.importorskip("pyarrow", minversion="13.0.0")
+
 def test_drop_na_arrow_index():
     # GH#63304
     # Test that dropping pd.NA from PyArrow-backed Index does not raise ArrowInvalid

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -1,36 +1,51 @@
 import pytest
+
 import pandas as pd
 import pandas._testing as tm
 
 pa = pytest.importorskip("pyarrow", minversion="13.0.0")
 
+
 def test_drop_na_arrow_index():
     # GH#63304
     # Test that dropping pd.NA from PyArrow-backed Index does not raise ArrowInvalid
-    
+
     # integer
-    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([1, 2, 3], dtype="int64[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2, 3]}, index=pd.Index([1, 2, 3], dtype="int64[pyarrow]")
+    )
     # pd.NA is not in index, should raise KeyError, but NOT ArrowInvalid
     with pytest.raises(KeyError, match="not found in axis"):
         df.drop(index=[pd.NA])
 
     # string
-    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index(["a", "b", "c"], dtype="string[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2, 3]}, index=pd.Index(["a", "b", "c"], dtype="string[pyarrow]")
+    )
     with pytest.raises(KeyError, match="not found in axis"):
         df.drop(index=[pd.NA])
 
     # binary
-    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([b"a", b"b", b"c"], dtype="binary[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2, 3]},
+        index=pd.Index([b"a", b"b", b"c"], dtype="binary[pyarrow]"),
+    )
     with pytest.raises(KeyError, match="not found in axis"):
         df.drop(index=[pd.NA])
 
     # Case where NA IS in the index (should verify it drops correctly)
-    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]")
+    )
     result = df.drop(index=[pd.NA])
     expected = pd.DataFrame({"A": [1]}, index=pd.Index([1], dtype="int64[pyarrow]"))
     tm.assert_frame_equal(result, expected)
 
-    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]")
+    )
     result = df.drop(index=[pd.NA])
-    expected = pd.DataFrame({"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]"))
+    expected = pd.DataFrame(
+        {"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]")
+    )
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -1,0 +1,34 @@
+import pytest
+import pandas as pd
+import pandas._testing as tm
+
+def test_drop_na_arrow_index():
+    # GH#63304
+    # Test that dropping pd.NA from PyArrow-backed Index does not raise ArrowInvalid
+    
+    # integer
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([1, 2, 3], dtype="int64[pyarrow]"))
+    # pd.NA is not in index, should raise KeyError, but NOT ArrowInvalid
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # string
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index(["a", "b", "c"], dtype="string[pyarrow]"))
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # binary
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([b"a", b"b", b"c"], dtype="binary[pyarrow]"))
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # Case where NA IS in the index (should verify it drops correctly)
+    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]"))
+    result = df.drop(index=[pd.NA])
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index([1], dtype="int64[pyarrow]"))
+    tm.assert_frame_equal(result, expected)
+
+    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]"))
+    result = df.drop(index=[pd.NA])
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]"))
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] Fixes #63304
- [x] All tests passed (including new regression tests)
- [x] Code style (ruff) applied

**Description:**
This PR resolves an ArrowInvalid error when dropping `pd.NA` from Arrow-backed indices. It ensures the `value_set` in `ArrowExtensionArray.isin` is correctly cast to the array's native type.

**Key Verifications:**
- Validated `inplace=True` stability.
- Confirmed no type coercion to NumPy.
- Verified data alignment across columns.