### PR TITLE
TST: mark plotting backend tests as single-threaded

### DIFF
--- a/pandas/tests/plotting/test_backend.py
+++ b/pandas/tests/plotting/test_backend.py
@@ -7,6 +7,8 @@ import pandas.util._test_decorators as td
 
 import pandas
 
+pytestmark = pytest.mark.single_cpu
+
 
 @pytest.fixture
 def dummy_backend():


### PR DESCRIPTION
One of those tests regularly fail (see eg https://github.com/pandas-dev/pandas/actions/runs/21430135255/job/61707338981 or https://github.com/pandas-dev/pandas/actions/runs/21408615658/job/61639317716 for two recent failures on main). This also seems to happen specifically on the build without pyarrow (although I can't directly see any possible relation to that).

Looking at the tests, they are setting the option and use monkeypatching, which seems not very robust if those tests would be run in parallel? 
(on the other hand, we also have many other tests using those things that are not marked as single_cpu

I don't know if this is the "proper" fix for the spurious failure on CI (in theory, not having pyarrow will influence which tests are run and so can change which are typically run in parallel?), but regardless it might be a good change anyhow?

(in practice, it will also avoid having the failure in the "Without pyarrow" test build, because that build doesn't run the tests with `single_cpu`)