### PR TITLE
[backport 3.0.x] TST: Remove Windows ARROW_TIMEZONE_DATABASE xfails for PyArrow>=22 (#63905)

### DIFF
--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -18,6 +18,7 @@ try:
     pa_version_under19p0 = _palv < Version("19.0.0")
     pa_version_under20p0 = _palv < Version("20.0.0")
     pa_version_under21p0 = _palv < Version("21.0.0")
+    pa_version_under22p0 = _palv < Version("22.0.0")
     HAS_PYARROW = _palv >= Version(PYARROW_MIN_VERSION)
 except ImportError:
     pa_version_under14p0 = True
@@ -29,4 +30,5 @@ except ImportError:
     pa_version_under19p0 = True
     pa_version_under20p0 = True
     pa_version_under21p0 = True
+    pa_version_under22p0 = True
     HAS_PYARROW = False

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -43,6 +43,7 @@ from pandas.compat import (
     pa_version_under20p0,
     pa_version_under21p0,
 )
+from pandas.compat.pyarrow import pa_version_under22p0
 from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.common import pandas_dtype
@@ -73,7 +74,7 @@ from pandas.core.arrays.arrow.extension_types import ArrowPeriodType
 
 
 def _require_timezone_database(request):
-    if is_platform_windows() and is_ci_environment():
+    if is_platform_windows() and is_ci_environment() and pa_version_under22p0:
         mark = pytest.mark.xfail(
             raises=pa.ArrowInvalid,
             reason=(

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -11,6 +11,7 @@ from pandas.compat import (
     is_ci_environment,
     is_platform_windows,
 )
+from pandas.compat.pyarrow import pa_version_under22p0
 
 import pandas as pd
 import pandas._testing as tm
@@ -385,7 +386,7 @@ def test_interchange_from_non_pandas_tz_aware(request):
     pa = pytest.importorskip("pyarrow", "11.0.0")
     import pyarrow.compute as pc
 
-    if is_platform_windows() and is_ci_environment():
+    if is_platform_windows() and is_ci_environment() and pa_version_under22p0:
         mark = pytest.mark.xfail(
             raises=pa.ArrowInvalid,
             reason=(

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -9,6 +9,7 @@ from pandas._libs import lib
 from pandas._libs.tslibs import Day
 from pandas._typing import DatetimeNaTType
 from pandas.compat import is_platform_windows
+from pandas.compat.pyarrow import pa_version_under22p0
 from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
@@ -2143,7 +2144,7 @@ def test_resample_b_55282(unit):
         pytest.param(
             "UTC",
             marks=pytest.mark.xfail(
-                condition=is_platform_windows(),
+                condition=is_platform_windows() and pa_version_under22p0,
                 reason="TODO: Set ARROW_TIMEZONE_DATABASE env var in CI",
             ),
         ),


### PR DESCRIPTION

(cherry picked from commit 8e7ed0f165277c49b8ce27230cc57c6392dfbfdc)

Backport of https://github.com/pandas-dev/pandas/pull/63905