### PR TITLE
DOC: Fix PR02,SA01 for pandas.tseries.offsets.CDay

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -71,8 +71,6 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         --format=actions \
         -i ES01 `# For now it is ok if docstrings are missing the extended summary` \
         -i "pandas.tseries.offsets.BusinessHour PR02,SA01" \
-        -i "pandas.tseries.offsets.CDay PR02,SA01" \
-        -i "pandas.tseries.offsets.CustomBusinessDay PR02,SA01" \
         -i "pandas.tseries.offsets.CustomBusinessHour PR02,SA01" \
         -i "pandas.tseries.offsets.FY5253Quarter.is_on_offset GL08" \
         -i "pandas.tseries.offsets.LastWeekOfMonth.is_on_offset GL08" \

--- a/doc/source/reference/offset_frequency.rst
+++ b/doc/source/reference/offset_frequency.rst
@@ -160,6 +160,7 @@ Properties
     CustomBusinessDay.weekmask
     CustomBusinessDay.calendar
     CustomBusinessDay.holidays
+    CustomBusinessDay.offset
 
 Methods
 ~~~~~~~

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -6189,7 +6189,7 @@ cdef class CustomBusinessDay(BusinessDay):
 
     In CustomBusinessDay we can use custom weekmask, holidays, and calendar.
 
-    Parameters
+    Attributes
     ----------
     n : int, default 1
         The number of days represented.
@@ -6204,6 +6204,10 @@ cdef class CustomBusinessDay(BusinessDay):
         Calendar to integrate.
     offset : timedelta, default timedelta(0)
         Time offset to apply.
+
+    See Also
+    --------
+    :class:`~pandas.tseries.offsets.DateOffset` : Standard kind of date increment.
 
     Examples
     --------


### PR DESCRIPTION
- [ ] related to #60365

fixes

```
pandas.tseries.offsets.CDay PR02,SA01
pandas.tseries.offsets.CustomBusinessDay PR02,SA01
```

Added `CustomBusinessDay.offset` to the Properties section in `doc/source/reference/offset_frequency.rst`. This ensures autosummary can generate the stub file for the new documented property.