### PR TITLE
DOC: Fix typo in text data user guide

### DIFF
--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -47,7 +47,7 @@ to significantly increase the performance and lower the memory overhead of
 
    The default when pandas infers the dtype of a collection of
    strings is to use ``dtype='str'``. This will use ``np.nan``
-   as it's NA value and be backed by a PyArrow string array when
+   as its NA value and be backed by a PyArrow string array when
    PyArrow is installed, or backed by NumPy ``object`` array
    when PyArrow is not installed.
 


### PR DESCRIPTION
This PR fixes a small grammatical typo in the text data user guide
("it's NA value" → "its NA value").

No functional changes.
