### PR TITLE
FIX: drop(index=[pd.NA]) fails for Arrow-backed index (#63304)

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1430,8 +1430,9 @@ class ArrowExtensionArray(
 
             if has_pd_na:
                 value_set = value_set.cast(self._pa_array.type)
-             # else: pass-through to pc.is_in below, ensuring legacy behavior (crash or otherwise)
-             # is preserved for non-pd.NA nulls (e.g. [None], [np.nan])
+             # else: pass-through to pc.is_in below, ensuring legacy behavior
+             # (crash or otherwise) is preserved for non-pd.NA nulls (e.g. [None], [np.nan])
+
 
         result = pc.is_in(self._pa_array, value_set=value_set)
         # pyarrow 2.0.0 returned nulls, so we explicitly specify dtype to convert nulls

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -61,7 +61,6 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
-
 from pandas.core import (
     algorithms as algos,
     missing,

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1430,9 +1430,9 @@ class ArrowExtensionArray(
 
             if has_pd_na:
                 value_set = value_set.cast(self._pa_array.type)
-             # else: pass-through to pc.is_in below, ensuring legacy behavior
-             # (crash or otherwise) is preserved for non-pd.NA nulls (e.g. [None], [np.nan])
-
+            # else: pass-through to pc.is_in below, ensuring
+            # legacy behavior (crash or otherwise) is preserved
+            # for non-pd.NA nulls (e.g. [None], [np.nan])
 
         result = pc.is_in(self._pa_array, value_set=value_set)
         # pyarrow 2.0.0 returned nulls, so we explicitly specify dtype to convert nulls

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1430,7 +1430,7 @@ class ArrowExtensionArray(
                 if x is lib.missing.NA:
                     has_pd_na = True
                     break
-            
+
             if has_pd_na:
                 value_set = value_set.cast(self._pa_array.type)
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1427,7 +1427,8 @@ class ArrowExtensionArray(
             # on crashing to trigger fallback (e.g. in parsers).
             has_pd_na = False
             for x in values:
-                if x is lib.missing.NA:
+                # GH#63304: Check for pd.NA (NAType) specifically
+                if isna(x) and not isinstance(x, (float, np.floating, type(None))):
                     has_pd_na = True
                     break
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -60,7 +60,7 @@ from pandas.core.dtypes.common import (
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
-from pandas.core.dtypes.missing import isna
+
 
 from pandas.core import (
     algorithms as algos,
@@ -341,6 +341,8 @@ class ArrowExtensionArray(
         """
         Construct a new ExtensionArray from a sequence of strings.
         """
+        from pandas.core.dtypes.missing import isna
+
         mask = isna(strings)
 
         if isinstance(strings, cls):
@@ -539,6 +541,8 @@ class ArrowExtensionArray(
         -------
         pa.Scalar
         """
+        from pandas.core.dtypes.missing import isna
+
         if isinstance(value, pa.Scalar):
             pa_scalar = value
         elif isna(value) and not (lib.is_float(value) and not is_nan_na()):
@@ -2698,6 +2702,8 @@ class ArrowExtensionArray(
         ]
 
     def _convert_bool_result(self, result, na=lib.no_default, method_name=None):
+        from pandas.core.dtypes.missing import isna
+
         if na is not lib.no_default and not isna(na):  # pyright: ignore [reportGeneralTypeIssues]
             result = result.fill_null(na)
         return self._from_pyarrow_array(result)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -60,6 +60,7 @@ from pandas.core.dtypes.common import (
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
+from pandas.core.dtypes.missing import isna
 
 
 from pandas.core import (

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1418,7 +1418,10 @@ class ArrowExtensionArray(
         if not len(values):
             return np.zeros(len(self), dtype=bool)
 
-        result = pc.is_in(self._pa_array, value_set=pa.array(values))
+        value_set = pa.array(values, from_pandas=True)
+        if pa.types.is_null(value_set.type):
+            value_set = value_set.cast(self._pa_array.type)
+        result = pc.is_in(self._pa_array, value_set=value_set)
         # pyarrow 2.0.0 returned nulls, so we explicitly specify dtype to convert nulls
         # to False
         return np.array(result, dtype=np.bool_)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -62,7 +62,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from pandas.core.dtypes.missing import isna
 
-
 from pandas.core import (
     algorithms as algos,
     missing,

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -585,6 +585,8 @@ class ArrowExtensionArray(
         -------
         pa.Array or pa.ChunkedArray
         """
+        from pandas.core.dtypes.missing import isna
+
         value = extract_array(value, extract_numpy=True)
         if isinstance(value, cls):
             pa_array = value._pa_array
@@ -907,6 +909,8 @@ class ArrowExtensionArray(
         self.__dict__.update(state)
 
     def _cmp_method(self, other, op) -> ArrowExtensionArray:
+        from pandas.core.dtypes.missing import isna
+
         pc_func = ARROW_CMP_FUNCS[op.__name__]
         ltype = self._pa_array.type
 
@@ -1691,6 +1695,8 @@ class ArrowExtensionArray(
         copy: bool = False,
         na_value: object = lib.no_default,
     ) -> np.ndarray:
+        from pandas.core.dtypes.missing import isna
+
         original_na_value = na_value
         dtype, na_value = to_numpy_dtype_inference(self, dtype, na_value, self._hasna)
         pa_type = self._pa_array.type

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1120,6 +1120,8 @@ class ArrowExtensionArray(
         return len(self._pa_array)
 
     def __contains__(self, key) -> bool:
+        from pandas.core.dtypes.missing import isna
+
         # https://github.com/pandas-dev/pandas/pull/51307#issuecomment-1426372604
         if isna(key) and key is not self.dtype.na_value:
             if lib.is_float(key) and is_nan_na():
@@ -1623,6 +1625,8 @@ class ArrowExtensionArray(
             raise IndexError("out of bounds value in 'indices'.")
 
         if allow_fill:
+            from pandas.core.dtypes.missing import isna
+
             fill_mask = indices_array < 0
             if fill_mask.any():
                 validate_indices(indices_array, len(self._pa_array))

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -60,7 +60,7 @@ from pandas.core.dtypes.common import (
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
-from pandas.core.dtypes.missing import isna
+
 
 from pandas.core import (
     algorithms as algos,
@@ -1424,7 +1424,7 @@ class ArrowExtensionArray(
             has_pd_na = False
             for x in values:
                 # GH#63304: Check for pd.NA (NAType) specifically
-                if isna(x) and not isinstance(x, (float, np.floating, type(None))):
+                if is_pdna_or_none(x) and x is not None:
                     has_pd_na = True
                     break
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1427,7 +1427,7 @@ class ArrowExtensionArray(
                 if isna(x) and not isinstance(x, (float, np.floating, type(None))):
                     has_pd_na = True
                     break
-            
+
             if has_pd_na:
                 value_set = value_set.cast(self._pa_array.type)
              # else: pass-through to pc.is_in below, ensuring legacy behavior (crash or otherwise)

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -34,9 +34,7 @@ def test_drop_na_arrow_index():
         df.drop(index=[pd.NA])
 
     # Case where NA IS in the index (should verify it drops correctly)
-    df = pd.DataFrame(
-        {"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]")
-    )
+    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]"))
     result = df.drop(index=[pd.NA])
     expected = pd.DataFrame({"A": [1]}, index=pd.Index([1], dtype="int64[pyarrow]"))
     tm.assert_frame_equal(result, expected)
@@ -45,7 +43,5 @@ def test_drop_na_arrow_index():
         {"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]")
     )
     result = df.drop(index=[pd.NA])
-    expected = pd.DataFrame(
-        {"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]")
-    )
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]"))
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -2,6 +2,8 @@ import pytest
 import pandas as pd
 import pandas._testing as tm
 
+pa = pytest.importorskip("pyarrow", minversion="13.0.0")
+
 def test_drop_na_arrow_index():
     # GH#63304
     # Test that dropping pd.NA from PyArrow-backed Index does not raise ArrowInvalid

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -1,36 +1,51 @@
 import pytest
+
 import pandas as pd
 import pandas._testing as tm
 
 pa = pytest.importorskip("pyarrow", minversion="13.0.0")
 
+
 def test_drop_na_arrow_index():
     # GH#63304
     # Test that dropping pd.NA from PyArrow-backed Index does not raise ArrowInvalid
-    
+
     # integer
-    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([1, 2, 3], dtype="int64[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2, 3]}, index=pd.Index([1, 2, 3], dtype="int64[pyarrow]")
+    )
     # pd.NA is not in index, should raise KeyError, but NOT ArrowInvalid
     with pytest.raises(KeyError, match="not found in axis"):
         df.drop(index=[pd.NA])
 
     # string
-    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index(["a", "b", "c"], dtype="string[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2, 3]}, index=pd.Index(["a", "b", "c"], dtype="string[pyarrow]")
+    )
     with pytest.raises(KeyError, match="not found in axis"):
         df.drop(index=[pd.NA])
 
     # binary
-    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([b"a", b"b", b"c"], dtype="binary[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2, 3]},
+        index=pd.Index([b"a", b"b", b"c"], dtype="binary[pyarrow]"),
+    )
     with pytest.raises(KeyError, match="not found in axis"):
         df.drop(index=[pd.NA])
 
     # Case where NA IS in the index (should verify it drops correctly)
-    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]")
+    )
     result = df.drop(index=[pd.NA])
     expected = pd.DataFrame({"A": [1]}, index=pd.Index([1], dtype="int64[pyarrow]"))
     tm.assert_frame_equal(result, expected)
 
-    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]"))
+    df = pd.DataFrame(
+        {"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]")
+    )
     result = df.drop(index=[pd.NA])
-    expected = pd.DataFrame({"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]"))
+    expected = pd.DataFrame(
+        {"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]")
+    )
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_gh63304.py
+++ b/pandas/tests/indexing/test_gh63304.py
@@ -1,0 +1,34 @@
+import pytest
+import pandas as pd
+import pandas._testing as tm
+
+def test_drop_na_arrow_index():
+    # GH#63304
+    # Test that dropping pd.NA from PyArrow-backed Index does not raise ArrowInvalid
+    
+    # integer
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([1, 2, 3], dtype="int64[pyarrow]"))
+    # pd.NA is not in index, should raise KeyError, but NOT ArrowInvalid
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # string
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index(["a", "b", "c"], dtype="string[pyarrow]"))
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # binary
+    df = pd.DataFrame({"A": [1, 2, 3]}, index=pd.Index([b"a", b"b", b"c"], dtype="binary[pyarrow]"))
+    with pytest.raises(KeyError, match="not found in axis"):
+        df.drop(index=[pd.NA])
+
+    # Case where NA IS in the index (should verify it drops correctly)
+    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index([1, pd.NA], dtype="int64[pyarrow]"))
+    result = df.drop(index=[pd.NA])
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index([1], dtype="int64[pyarrow]"))
+    tm.assert_frame_equal(result, expected)
+
+    df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["a", pd.NA], dtype="string[pyarrow]"))
+    result = df.drop(index=[pd.NA])
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index(["a"], dtype="string[pyarrow]"))
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] Fixes #63304
- [x] All tests passed (including new regression tests)
- [x] Code style (ruff) applied

Description:
This PR resolves an ArrowInvalid error when dropping `pd.NA` from Arrow-backed indices. It ensures the `value_set` in `ArrowExtensionArray.isin` is correctly cast to the array's native type.

Key Verifications:
- Validated `inplace=True` stability.
- Confirmed no type coercion to NumPy.
- Verified data alignment across columns.