### PR TITLE
replaced all @doc in core/arrays/arrow/array.py with inline docstrings

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1631,7 +1631,7 @@ class ArrowExtensionArray(
 
         Examples
         --------
-        >>> arr = pd.array([1, 2, 3, 5])
+        >>> arr = pd.array([1, 2, 3, 5], dtype="int64[pyarrow]")
         >>> arr.searchsorted([4])
         array([3])
         """

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1389,10 +1389,9 @@ class ArrowExtensionArray(
         limit : int, default None
             The maximum number of entries where NA values will be filled.
         copy : bool, default True
-            Whether to make a copy of the data before filling. If False, then
-            the original should be modified and no new memory should be allocated.
-            For ExtensionArray subclasses that cannot do this, it is at the
-            author's discretion whether to ignore "copy=False" or to raise.
+            Whether to make a copy of the data before filling. This parameter
+            is inherited from pandas.ExtensionArray and should be left at its
+            default value (Arrow arrays cannot be altered in place).
 
         Returns
         -------

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1515,7 +1515,8 @@ class ArrowExtensionArray(
         Examples
         --------
         >>> arr = pd.array(
-        ...     [['Ant', 'Badger', 'Cobra','Cobra', 'Deer', 'Ant'], dtype=str)
+        ...     ["Ant", "Badger", "Cobra", "Cobra", "Deer", "Ant"], dtype=str
+        ... )
         >>> arr_codes, arr_uniques = arr.factorize()
         >>> arr_codes
         array([0, 1, 2, 2, 3, 0])

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1908,7 +1908,7 @@ class ArrowExtensionArray(
 
         Examples
         --------
-        >>> pd.array([1, 1, 2, 3, 3], dtype="Int64").duplicated()
+        >>> pd.array([1, 1, 2, 3, 3], dtype="int64[pyarrow]").duplicated()
         array([False,  True, False, False,  True])
         """
         pa_type = self._pa_array.type

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1408,11 +1408,13 @@ class ArrowExtensionArray(
 
         Examples
         --------
-        >>> arr = pd.array([np.nan, np.nan, 2, 3, np.nan, np.nan])
+        >>> arr = pd.array(
+        ...     [np.nan, np.nan, 2, 3, np.nan, np.nan], dtype="int64[pyarrow]"
+        ... )
         >>> arr.fillna(0)
-        <IntegerArray>
+        <ArrowExtensionArray>
         [0, 0, 2, 3, 0, 0]
-        Length: 6, dtype: Int64
+        Length: 6, dtype: int64[pyarrow]
         """
         if not self._hasna:
             return self.copy()
@@ -1480,7 +1482,7 @@ class ArrowExtensionArray(
         use_na_sentinel: bool = True,
     ) -> tuple[np.ndarray, ExtensionArray]:
         """
-        Encode the extension array as an enumerated type.
+        Encode the arrow array as an enumerated type.
 
         Parameters
         ----------
@@ -1493,14 +1495,14 @@ class ArrowExtensionArray(
         -------
         codes : ndarray
             An integer NumPy array that's an indexer into the original
-            ExtensionArray.
-        uniques : ExtensionArray
-            An ExtensionArray containing the unique values of `self`.
+            ArrowArray.
+        uniques : ArrowArray
+            An ArrowArray containing the unique values of `self`.
 
             .. note::
 
                uniques will *not* contain an entry for the NA value of
-               the ExtensionArray if there are any missing values present
+               the ArrowArray if there are any missing values present
                in `self`.
 
         See Also

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1514,15 +1514,15 @@ class ArrowExtensionArray(
 
         Examples
         --------
-        >>> idx1 = pd.PeriodIndex(
-        ...     ["2014-01", "2014-01", "2014-02", "2014-02", "2014-03", "2014-03"],
-        ...     freq="M",
-        ... )
-        >>> arr, idx = idx1.factorize()
-        >>> arr
-        array([0, 0, 1, 1, 2, 2])
-        >>> idx
-        PeriodIndex(['2014-01', '2014-02', '2014-03'], dtype='period[M]')
+        >>> arr = pd.array(
+        ...     [['Ant', 'Badger', 'Cobra','Cobra', 'Deer', 'Ant'], dtype=str)
+        >>> arr_codes, arr_uniques = arr.factorize()
+        >>> arr_codes
+        array([0, 1, 2, 2, 3, 0])
+        >>> arr_uniques
+        <ArrowStringArray>
+        ['Ant', 'Badger', 'Cobra', 'Deer']
+        Length: 4, dtype: str
         """
         null_encoding = "mask" if use_na_sentinel else "encode"
 


### PR DESCRIPTION
- [x] xref #62437 (partially)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

@doc replaced with direct copies of method docstring from core/arrays/base.py (to which the @doc decorators referred). Modified the docstring of the fillna method to reflect that the return type is ArrowExtensionArray rather than generic ExtensionArray.