### PR TITLE
BUG: unary operators not supported with pd.col (issue#63939)

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -15,7 +15,7 @@ Bug fixes
 ^^^^^^^^^
 - Fixed a bug in the :class:`DataFrame` constructor when passed a :class:`Series` or
   :class:`Index` correctly handling Copy-on-Write (:issue:`63899`)
-- Fixed a bug in :func:`col` where unary operators (``-`` and ``+``) were not supported (:issue:`63939`)
+- Fixed a bug in :func:`col` where unary operators (``-``, ``+``, ``abs``) were not supported (:issue:`63939`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.contributors:

--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -15,6 +15,7 @@ Bug fixes
 ^^^^^^^^^
 - Fixed a bug in the :class:`DataFrame` constructor when passed a :class:`Series` or
   :class:`Index` correctly handling Copy-on-Write (:issue:`63899`)
+- Fixed a bug in :func:`col` where unary operators (``-`` and ``+``) were not supported (:issue:`63939`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.contributors:

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -252,6 +252,13 @@ class Expression:
             needs_parenthese=True,
         )
 
+    def __abs__(self) -> Expression:
+        return Expression(
+            lambda df: abs(self._eval_expression(df)),
+            f"abs({self._repr_str})",
+            needs_parenthese=True,
+        )
+
     def __array_ufunc__(
         self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any
     ) -> Expression:

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -230,6 +230,20 @@ class Expression:
             needs_parenthese=True,
         )
 
+    def __neg__(self) -> Expression:
+        return Expression(
+            lambda df: -self._eval_expression(df),
+            f"-{self._repr_str}",
+            needs_parenthese=True,
+        )
+
+    def __pos__(self) -> Expression:
+        return Expression(
+            lambda df: +self._eval_expression(df),
+            f"+{self._repr_str}",
+            needs_parenthese=True,
+        )
+
     def __array_ufunc__(
         self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any
     ) -> Expression:

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -231,16 +231,24 @@ class Expression:
         )
 
     def __neg__(self) -> Expression:
+        if self._needs_parentheses:
+            repr_str = f"-({self._repr_str})"
+        else:
+            repr_str = f"-{self._repr_str}"
         return Expression(
             lambda df: -self._eval_expression(df),
-            f"-{self._repr_str}",
+            repr_str,
             needs_parenthese=True,
         )
 
     def __pos__(self) -> Expression:
+        if self._needs_parentheses:
+            repr_str = f"+({self._repr_str})"
+        else:
+            repr_str = f"+{self._repr_str}"
         return Expression(
             lambda df: +self._eval_expression(df),
-            f"+{self._repr_str}",
+            repr_str,
             needs_parenthese=True,
         )
 

--- a/pandas/tests/test_col.py
+++ b/pandas/tests/test_col.py
@@ -51,6 +51,8 @@ from pandas.tests.test_register_accessor import ensure_removed
         (+pd.col("a"), [1, 2], "+col('a')"),
         (-(pd.col("a") + 1), [-2, -3], "-(col('a') + 1)"),
         (-pd.col("a") * 2, [-2, -4], "(-col('a')) * 2"),
+        (abs(pd.col("a")), [1, 2], "abs(col('a'))"),
+        (abs(pd.col("a") - 2), [1, 0], "abs(col('a') - 2)"),
     ],
 )
 def test_col_simple(

--- a/pandas/tests/test_col.py
+++ b/pandas/tests/test_col.py
@@ -46,6 +46,11 @@ from pandas.tests.test_register_accessor import ensure_removed
             [False, True],
             "(col('a') - 1).astype('bool')",
         ),
+        # Unary operators
+        (-pd.col("a"), [-1, -2], "-col('a')"),
+        (+pd.col("a"), [1, 2], "+col('a')"),
+        (-(pd.col("a") + 1), [-2, -3], "-(col('a') + 1)"),
+        (-pd.col("a") * 2, [-2, -4], "-col('a') * 2"),
     ],
 )
 def test_col_simple(

--- a/pandas/tests/test_col.py
+++ b/pandas/tests/test_col.py
@@ -50,7 +50,7 @@ from pandas.tests.test_register_accessor import ensure_removed
         (-pd.col("a"), [-1, -2], "-col('a')"),
         (+pd.col("a"), [1, 2], "+col('a')"),
         (-(pd.col("a") + 1), [-2, -3], "-(col('a') + 1)"),
-        (-pd.col("a") * 2, [-2, -4], "-col('a') * 2"),
+        (-pd.col("a") * 2, [-2, -4], "(-col('a')) * 2"),
     ],
 )
 def test_col_simple(


### PR DESCRIPTION
- [x] closes #63939 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.


### issue
pd.col() does not support unary operator.
``` python
-1 * pd.col("A") # OK
-pd.col("A") # error
+pd.col("A") # error
```

### implement
pd.col() support unary operator
``` python
-pd.col("A") # OK
+pd.col("A") # OK
```
