### PR TITLE
DOC: Fix ES01 for pandas.Period.year

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2132,6 +2132,9 @@ cdef class _Period(PeriodMixin):
         """
         Return the year this Period falls on.
 
+        The year is derived from the internal representation of the Period
+        based on its ordinal value and frequency.
+
         Returns
         -------
         int


### PR DESCRIPTION
- [ ] related to #60365

Fixes

```
pandas.Period.year ES01
```