### PR TITLE
DOC: Fix spelling mistakes and incomplete sentences in Timestamp docstrings

### DIFF
--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -716,7 +716,7 @@ cdef datetime dateutil_parse(
             # e.g. "1994 Jan 15 05:16 FOO" where FOO is not recognized
             # GH#18702, # GH 50235 enforced in 3.0
             raise ValueError(
-                f'Parsed string "{timestr}" included an un-recognized timezone '
+                f'Parsed string "{timestr}" included an unrecognized timezone '
                 f'"{res.tzname}".'
             )
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1602,7 +1602,7 @@ cdef class _Timestamp(ABCTimestamp):
         """
         Convert a Timestamp object to a native Python datetime object.
 
-        This method is useful when you need to utilize a pandas Timestamp.
+        This method is useful for when you need to utilize a pandas Timestamp
         object in contexts where native Python datetime objects are expected
         or required. The conversion discards the nanoseconds component, and a
         warning can be issued in such cases if desired.

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1602,7 +1602,7 @@ cdef class _Timestamp(ABCTimestamp):
         """
         Convert a Timestamp object to a native Python datetime object.
 
-        This method is useful for when you need to utilize a pandas Timestamp
+        This method is useful when you need to utilize a pandas Timestamp.
         object in contexts where native Python datetime objects are expected
         or required. The conversion discards the nanoseconds component, and a
         warning can be issued in such cases if desired.
@@ -3117,7 +3117,7 @@ timedelta}, default 'raise'
         """
         Localize the Timestamp to a timezone.
 
-        Convert naive Timestamp to local time zone or remove
+        Convert a naive Timestamp to the local time zone or remove the time zone information.
         timezone from timezone-aware Timestamp.
 
         Parameters
@@ -3475,7 +3475,7 @@ default 'raise'
 
     def to_julian_date(self) -> np.float64:
         """
-        Convert TimeStamp to a Julian Date.
+        Convert Timestamp to a Julian Date.
 
         This method returns the number of days as a float since
         0 Julian date, which is noon January 1, 4713 BC.

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -3117,7 +3117,7 @@ timedelta}, default 'raise'
         """
         Localize the Timestamp to a timezone.
 
-        Convert a naive Timestamp to the local time zone or remove the time zone information.
+        Convert naive Timestamp to local time zone or remove
         timezone from timezone-aware Timestamp.
 
         Parameters

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2260,7 +2260,7 @@ default 'raise'
 
     def to_julian_date(self) -> npt.NDArray[np.float64]:
         """
-        Convert TimeStamp to a Julian Date.
+        Convert Timestamp to a Julian Date.
 
         This method returns the number of days as a float since noon January 1, 4713 BC.
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -601,7 +601,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     def to_julian_date(self) -> Index:
         """
-        Convert TimeStamp to a Julian Date.
+        Convert Timestamp to a Julian Date.
 
         This method returns the number of days as a float since noon January 1, 4713 BC.
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3611,7 +3611,7 @@ def test_to_datetime_iso8601_utc_mixed_both_offsets():
 def test_unknown_tz_raises():
     # GH#18702, GH#51476
     dtstr = "2014 Jan 9 05:15 FAKE"
-    msg = '.*un-recognized timezone "FAKE".'
+    msg = '.*unrecognized timezone "FAKE".'
     with pytest.raises(ValueError, match=msg):
         Timestamp(dtstr)
 

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -43,7 +43,7 @@ def test_parsing_tzlocal_deprecated():
             r"Parsing 'EST' as tzlocal \(dependent on system timezone\) "
             r"is no longer supported\. "
             "Pass the 'tz' keyword or call tz_localize after construction instead",
-            ".*included an un-recognized timezone",
+            ".*included an unrecognized timezone",
         ]
     )
     dtstr = "Jan 15 2004 03:00 EST"


### PR DESCRIPTION
This PR fixes a couple of clear spelling mistakes and a few incomplete or
awkwardly phrased sentences in Timestamp-related docstrings.
These are documentation-only changes and do not affect any behavior or logic.



 