### PR TITLE
DOC: Replace @doc decorators in pandas/core/indexing.py #62437

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2607,6 +2607,7 @@ class _AtIndexer(_ScalarAccessIndexer):
     >>> df.loc[5].at["B"]
     np.int64(4)
     """
+
     _takeable = False
 
     def _convert_key(self, key):
@@ -2676,9 +2677,7 @@ class _iAtIndexer(_ScalarAccessIndexer):
 
     Examples
     --------
-    >>> df = pd.DataFrame(
-    ...     [[0, 2, 3], [0, 4, 1], [10, 20, 30]], columns=["A", "B", "C"]
-    ... )
+    >>> df = pd.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]], columns=["A", "B", "C"])
     >>> df
         A   B   C
     0   0   2   3
@@ -2701,6 +2700,7 @@ class _iAtIndexer(_ScalarAccessIndexer):
     >>> df.loc[0].iat[1]
     np.int64(2)
     """
+
     _takeable = True
 
     def _convert_key(self, key):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2542,8 +2542,71 @@ class _ScalarAccessIndexer(NDFrameIndexerBase):
         self.obj._set_value(*key, value=value, takeable=self._takeable)
 
 
-@doc(IndexingMixin.at)
 class _AtIndexer(_ScalarAccessIndexer):
+    """
+    Access a single value for a row/column label pair.
+
+    Similar to ``loc``, in that both provide label-based lookups. Use
+    ``at`` if you only need to get or set a single value in a DataFrame
+    or Series.
+
+    Raises
+    ------
+    KeyError
+        If getting a value and 'label' does not exist in a DataFrame or Series.
+
+    ValueError
+        If row/column label pair is not a tuple or if any label
+        from the pair is not a scalar for DataFrame.
+        If label is list-like (*excluding* NamedTuple) for Series.
+
+    See Also
+    --------
+    DataFrame.at : Access a single value for a row/column pair by label.
+    DataFrame.iat : Access a single value for a row/column pair by integer
+        position.
+    DataFrame.loc : Access a group of rows and columns by label(s).
+    DataFrame.iloc : Access a group of rows and columns by integer
+        position(s).
+    Series.at : Access a single value by label.
+    Series.iat : Access a single value by integer position.
+    Series.loc : Access a group of rows by label(s).
+    Series.iloc : Access a group of rows by integer position(s).
+
+    Notes
+    -----
+    See :ref:`Fast scalar value getting and setting <indexing.basics.get_value>`
+    for more details.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame(
+    ...     [[0, 2, 3], [0, 4, 1], [10, 20, 30]],
+    ...     index=[4, 5, 6],
+    ...     columns=["A", "B", "C"],
+    ... )
+    >>> df
+        A   B   C
+    4   0   2   3
+    5   0   4   1
+    6  10  20  30
+
+    Get value at specified row/column pair
+
+    >>> df.at[4, "B"]
+    np.int64(2)
+
+    Set value at specified row/column pair
+
+    >>> df.at[4, "B"] = 10
+    >>> df.at[4, "B"]
+    np.int64(10)
+
+    Get value within a Series
+
+    >>> df.loc[5].at["B"]
+    np.int64(4)
+    """
     _takeable = False
 
     def _convert_key(self, key):
@@ -2592,8 +2655,52 @@ class _AtIndexer(_ScalarAccessIndexer):
         return super().__setitem__(key, value)
 
 
-@doc(IndexingMixin.iat)
 class _iAtIndexer(_ScalarAccessIndexer):
+    """
+    Access a single value for a row/column pair by integer position.
+
+    Similar to ``iloc``, in that both provide integer-based lookups. Use
+    ``iat`` if you only need to get or set a single value in a DataFrame
+    or Series.
+
+    Raises
+    ------
+    IndexError
+        When integer position is out of bounds.
+
+    See Also
+    --------
+    DataFrame.at : Access a single value for a row/column label pair.
+    DataFrame.loc : Access a group of rows and columns by label(s).
+    DataFrame.iloc : Access a group of rows and columns by integer position(s).
+
+    Examples
+    --------
+    >>> df = pd.DataFrame(
+    ...     [[0, 2, 3], [0, 4, 1], [10, 20, 30]], columns=["A", "B", "C"]
+    ... )
+    >>> df
+        A   B   C
+    0   0   2   3
+    1   0   4   1
+    2  10  20  30
+
+    Get value at specified row/column pair
+
+    >>> df.iat[1, 2]
+    np.int64(1)
+
+    Set value at specified row/column pair
+
+    >>> df.iat[1, 2] = 10
+    >>> df.iat[1, 2]
+    np.int64(10)
+
+    Get value within a series
+
+    >>> df.loc[0].iat[1]
+    np.int64(2)
+    """
     _takeable = True
 
     def _convert_key(self, key):


### PR DESCRIPTION
Replace @doc decorator with inline docstrings for _AtIndexer and _iAtIndexer classes.

- [x] xref #62437 (partial - _AtIndexer and _iAtIndexer only)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
