### PR TITLE
BUG: Fix searchsorted with NA values in masked arrays

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -151,7 +151,7 @@ Interval
 
 Indexing
 ^^^^^^^^
--
+- Bug in :meth:`Series.searchsorted` and :meth:`Index.searchsorted` with nullable integer arrays containing ``NA`` values in the ``value`` parameter returning incorrect insertion positions (:issue:`63938`)
 -
 
 Missing

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1269,8 +1269,34 @@ def searchsorted(
     --------
     numpy.searchsorted : Similar method from NumPy.
     """
+    from pandas.core.arrays.masked import BaseMaskedArray
+    
     if sorter is not None:
         sorter = ensure_platform_int(sorter)
+
+    # Handle masked arrays with NA values (e.g., IntegerArray, FloatArray)
+    if isinstance(value, BaseMaskedArray):
+        if value._mask.any():
+            # Extract valid (non-NA) values and their positions
+            valid_mask = ~value._mask
+            valid_values = value._data[valid_mask]
+            
+            # Search using only valid values
+            result_valid = searchsorted(arr, valid_values, side=side, sorter=sorter)
+            
+            # Handle scalar NA case
+            if np.ndim(value) == 0:
+                return len(arr)
+            
+            # Reconstruct result array, placing NAs at the end
+            result = np.empty(len(value), dtype=np.intp)
+            result[valid_mask] = result_valid
+            result[~valid_mask] = len(arr)
+            
+            return result
+        else:
+            # No NA values present, extract underlying data
+            value = value._data
 
     if (
         isinstance(arr, np.ndarray)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1286,7 +1286,7 @@ def searchsorted(
 
             # Handle scalar NA case
             if np.ndim(value) == 0:
-                return len(arr)
+                return np.intp(len(arr))
 
             # Reconstruct result array, placing NAs at the end
             result = np.empty(len(value), dtype=np.intp)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1270,7 +1270,7 @@ def searchsorted(
     numpy.searchsorted : Similar method from NumPy.
     """
     from pandas.core.arrays.masked import BaseMaskedArray
-    
+
     if sorter is not None:
         sorter = ensure_platform_int(sorter)
 
@@ -1280,19 +1280,19 @@ def searchsorted(
             # Extract valid (non-NA) values and their positions
             valid_mask = ~value._mask
             valid_values = value._data[valid_mask]
-            
+
             # Search using only valid values
             result_valid = searchsorted(arr, valid_values, side=side, sorter=sorter)
-            
+
             # Handle scalar NA case
             if np.ndim(value) == 0:
                 return len(arr)
-            
+
             # Reconstruct result array, placing NAs at the end
             result = np.empty(len(value), dtype=np.intp)
             result[valid_mask] = result_valid
             result[~valid_mask] = len(arr)
-            
+
             return result
         else:
             # No NA values present, extract underlying data

--- a/pandas/tests/series/methods/test_searchsorted.py
+++ b/pandas/tests/series/methods/test_searchsorted.py
@@ -79,10 +79,11 @@ class TestSeriesSearchSorted:
 
 class TestSearchsortedWithNullableIntegers:
     """Comprehensive tests for searchsorted with nullable integer arrays."""
+
     def test_series_searchsorted_nullable_int_common_dtype(self):
         base = 2**53
-        s = Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
-        value = pd.array([base+1, pd.NA], dtype="Int64")
+        s = Series(np.array([base, base + 1, base + 2, base + 3], dtype=np.int64))
+        value = pd.array([base + 1, pd.NA], dtype="Int64")
 
         result = s.searchsorted(value)
         assert result.tolist() == [1, 4]
@@ -90,9 +91,9 @@ class TestSearchsortedWithNullableIntegers:
     def test_searchsorted_int64_with_single_na(self):
         """Test searchsorted with Int64 array containing one NA."""
         base = 2**53
-        s = Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
-        value = pd.array([base+1, pd.NA], dtype="Int64")
-        
+        s = Series(np.array([base, base + 1, base + 2, base + 3], dtype=np.int64))
+        value = pd.array([base + 1, pd.NA], dtype="Int64")
+
         result = s.searchsorted(value, side="left")
         expected = np.array([1, 4], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -100,9 +101,9 @@ class TestSearchsortedWithNullableIntegers:
     def test_searchsorted_int64_with_single_na_right(self):
         """Test searchsorted with side='right'."""
         base = 2**53
-        s = Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
-        value = pd.array([base+1, pd.NA], dtype="Int64")
-        
+        s = Series(np.array([base, base + 1, base + 2, base + 3], dtype=np.int64))
+        value = pd.array([base + 1, pd.NA], dtype="Int64")
+
         result = s.searchsorted(value, side="right")
         expected = np.array([2, 4], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -111,7 +112,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted when all values are NA."""
         s = Series([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([pd.NA, pd.NA, pd.NA], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([5, 5, 5], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -120,7 +121,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with Int64 array but no NA values."""
         s = Series([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([2, 4], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([1, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -129,7 +130,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with mixture of valid values and NAs."""
         s = Series([10, 20, 30, 40, 50], dtype="int64")
         value = pd.array([15, pd.NA, 25, pd.NA, 35], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([1, 5, 2, 5, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -138,7 +139,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with NA at the beginning."""
         s = Series([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([pd.NA, 2, 3], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([5, 1, 2], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -147,7 +148,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with NA at the end."""
         s = Series([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([2, 3, pd.NA], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([1, 2, 5], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -156,7 +157,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted on empty array with NA values."""
         s = Series([], dtype="int64")
         value = pd.array([pd.NA, 1, pd.NA], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([0, 0, 0], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -165,7 +166,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted on single element array."""
         s = Series([5], dtype="int64")
         value = pd.array([pd.NA, 3, 5, 7], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([1, 0, 0, 1], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -174,7 +175,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with Int32 dtype."""
         s = Series([1, 2, 3, 4, 5], dtype="int32")
         value = pd.array([2, pd.NA, 4], dtype="Int32")
-        
+
         result = s.searchsorted(value)
         expected = np.array([1, 5, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -183,7 +184,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with Int8 dtype."""
         s = Series([1, 2, 3, 4, 5], dtype="int8")
         value = pd.array([pd.NA, 3], dtype="Int8")
-        
+
         result = s.searchsorted(value)
         expected = np.array([5, 2], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -192,12 +193,12 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with duplicate values in array."""
         s = Series([1, 2, 2, 3, 3, 3, 4], dtype="int64")
         value = pd.array([2, pd.NA, 3], dtype="Int64")
-        
+
         # side='left'
         result_left = s.searchsorted(value, side="left")
         expected_left = np.array([1, 7, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result_left, expected_left)
-        
+
         # side='right'
         result_right = s.searchsorted(value, side="right")
         expected_right = np.array([3, 7, 6], dtype=np.intp)
@@ -207,7 +208,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with UInt64 dtype."""
         s = Series([1, 2, 3, 4, 5], dtype="uint64")
         value = pd.array([2, pd.NA], dtype="UInt64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([1, 5], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -216,7 +217,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with larger array."""
         s = Series(range(1000), dtype="int64")
         value = pd.array([100, pd.NA, 500, pd.NA, 999], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([100, 1000, 500, 1000, 999], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -225,7 +226,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with values at boundaries."""
         s = Series([10, 20, 30, 40, 50], dtype="int64")
         value = pd.array([0, pd.NA, 10, 50, 60, pd.NA], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([0, 5, 0, 4, 5, 5], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -234,7 +235,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted with negative values."""
         s = Series([-50, -30, -10, 0, 10, 30, 50], dtype="int64")
         value = pd.array([-40, pd.NA, 0, pd.NA, 20], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([1, 7, 3, 7, 5], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -242,17 +243,17 @@ class TestSearchsortedWithNullableIntegers:
     def test_searchsorted_preserves_regular_behavior(self):
         """Ensure regular searchsorted still works without NA."""
         s = Series([1, 2, 3, 4, 5], dtype="int64")
-        
+
         # Regular list
         result = s.searchsorted([2, 4])
         expected = np.array([1, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
-        
+
         # Regular numpy array
         result = s.searchsorted(np.array([2, 4]))
         expected = np.array([1, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
-        
+
         # Scalar
         result = s.searchsorted(3)
         assert result == 2
@@ -261,15 +262,16 @@ class TestSearchsortedWithNullableIntegers:
         """Test that Float64 arrays with NA also work."""
         s = Series([1.5, 2.5, 3.5, 4.5, 5.5], dtype="float64")
         value = pd.array([2.5, pd.NA, 4.0], dtype="Float64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([1, 5, 3], dtype=np.intp)  # Changed from [1, 5, 2]
         tm.assert_numpy_array_equal(result, expected)
+
     def test_searchsorted_series_with_int64_array(self):
         """Test on Series (not just arrays)."""
         s = Series([10, 20, 30, 40, 50])
         value = pd.array([25, pd.NA, 35], dtype="Int64")
-        
+
         result = s.searchsorted(value)
         expected = np.array([2, 5, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
@@ -278,7 +280,7 @@ class TestSearchsortedWithNullableIntegers:
         """Test searchsorted on Index."""
         idx = pd.Index([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([2, pd.NA, 4], dtype="Int64")
-        
+
         result = idx.searchsorted(value)
         expected = np.array([1, 5, 3], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/series/methods/test_searchsorted.py
+++ b/pandas/tests/series/methods/test_searchsorted.py
@@ -81,7 +81,7 @@ class TestSearchsortedWithNullableIntegers:
     """Comprehensive tests for searchsorted with nullable integer arrays."""
     def test_series_searchsorted_nullable_int_common_dtype(self):
         base = 2**53
-        s = pd.Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
+        s = Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
         value = pd.array([base+1, pd.NA], dtype="Int64")
 
         result = s.searchsorted(value)
@@ -90,7 +90,7 @@ class TestSearchsortedWithNullableIntegers:
     def test_searchsorted_int64_with_single_na(self):
         """Test searchsorted with Int64 array containing one NA."""
         base = 2**53
-        s = pd.Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
+        s = Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
         value = pd.array([base+1, pd.NA], dtype="Int64")
         
         result = s.searchsorted(value, side="left")
@@ -100,7 +100,7 @@ class TestSearchsortedWithNullableIntegers:
     def test_searchsorted_int64_with_single_na_right(self):
         """Test searchsorted with side='right'."""
         base = 2**53
-        s = pd.Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
+        s = Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
         value = pd.array([base+1, pd.NA], dtype="Int64")
         
         result = s.searchsorted(value, side="right")
@@ -109,7 +109,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_all_na_values(self):
         """Test searchsorted when all values are NA."""
-        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        s = Series([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([pd.NA, pd.NA, pd.NA], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -118,7 +118,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_no_na_values(self):
         """Test searchsorted with Int64 array but no NA values."""
-        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        s = Series([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([2, 4], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -127,7 +127,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_mixed_valid_and_na(self):
         """Test searchsorted with mixture of valid values and NAs."""
-        s = pd.Series([10, 20, 30, 40, 50], dtype="int64")
+        s = Series([10, 20, 30, 40, 50], dtype="int64")
         value = pd.array([15, pd.NA, 25, pd.NA, 35], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -136,7 +136,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_na_at_start(self):
         """Test searchsorted with NA at the beginning."""
-        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        s = Series([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([pd.NA, 2, 3], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -145,7 +145,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_na_at_end(self):
         """Test searchsorted with NA at the end."""
-        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        s = Series([1, 2, 3, 4, 5], dtype="int64")
         value = pd.array([2, 3, pd.NA], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -154,7 +154,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_empty_array_with_na(self):
         """Test searchsorted on empty array with NA values."""
-        s = pd.Series([], dtype="int64")
+        s = Series([], dtype="int64")
         value = pd.array([pd.NA, 1, pd.NA], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -163,7 +163,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_single_element_with_na(self):
         """Test searchsorted on single element array."""
-        s = pd.Series([5], dtype="int64")
+        s = Series([5], dtype="int64")
         value = pd.array([pd.NA, 3, 5, 7], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -172,7 +172,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_int32_with_na(self):
         """Test searchsorted with Int32 dtype."""
-        s = pd.Series([1, 2, 3, 4, 5], dtype="int32")
+        s = Series([1, 2, 3, 4, 5], dtype="int32")
         value = pd.array([2, pd.NA, 4], dtype="Int32")
         
         result = s.searchsorted(value)
@@ -181,7 +181,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_int8_with_na(self):
         """Test searchsorted with Int8 dtype."""
-        s = pd.Series([1, 2, 3, 4, 5], dtype="int8")
+        s = Series([1, 2, 3, 4, 5], dtype="int8")
         value = pd.array([pd.NA, 3], dtype="Int8")
         
         result = s.searchsorted(value)
@@ -190,7 +190,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_duplicates_with_na(self):
         """Test searchsorted with duplicate values in array."""
-        s = pd.Series([1, 2, 2, 3, 3, 3, 4], dtype="int64")
+        s = Series([1, 2, 2, 3, 3, 3, 4], dtype="int64")
         value = pd.array([2, pd.NA, 3], dtype="Int64")
         
         # side='left'
@@ -205,7 +205,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_uint64_with_na(self):
         """Test searchsorted with UInt64 dtype."""
-        s = pd.Series([1, 2, 3, 4, 5], dtype="uint64")
+        s = Series([1, 2, 3, 4, 5], dtype="uint64")
         value = pd.array([2, pd.NA], dtype="UInt64")
         
         result = s.searchsorted(value)
@@ -214,7 +214,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_large_array_with_na(self):
         """Test searchsorted with larger array."""
-        s = pd.Series(range(1000), dtype="int64")
+        s = Series(range(1000), dtype="int64")
         value = pd.array([100, pd.NA, 500, pd.NA, 999], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -223,7 +223,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_boundary_values_with_na(self):
         """Test searchsorted with values at boundaries."""
-        s = pd.Series([10, 20, 30, 40, 50], dtype="int64")
+        s = Series([10, 20, 30, 40, 50], dtype="int64")
         value = pd.array([0, pd.NA, 10, 50, 60, pd.NA], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -232,7 +232,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_negative_values_with_na(self):
         """Test searchsorted with negative values."""
-        s = pd.Series([-50, -30, -10, 0, 10, 30, 50], dtype="int64")
+        s = Series([-50, -30, -10, 0, 10, 30, 50], dtype="int64")
         value = pd.array([-40, pd.NA, 0, pd.NA, 20], dtype="Int64")
         
         result = s.searchsorted(value)
@@ -241,7 +241,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_preserves_regular_behavior(self):
         """Ensure regular searchsorted still works without NA."""
-        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        s = Series([1, 2, 3, 4, 5], dtype="int64")
         
         # Regular list
         result = s.searchsorted([2, 4])
@@ -259,7 +259,7 @@ class TestSearchsortedWithNullableIntegers:
 
     def test_searchsorted_float_array_with_na(self):
         """Test that Float64 arrays with NA also work."""
-        s = pd.Series([1.5, 2.5, 3.5, 4.5, 5.5], dtype="float64")
+        s = Series([1.5, 2.5, 3.5, 4.5, 5.5], dtype="float64")
         value = pd.array([2.5, pd.NA, 4.0], dtype="Float64")
         
         result = s.searchsorted(value)
@@ -267,7 +267,7 @@ class TestSearchsortedWithNullableIntegers:
         tm.assert_numpy_array_equal(result, expected)
     def test_searchsorted_series_with_int64_array(self):
         """Test on Series (not just arrays)."""
-        s = pd.Series([10, 20, 30, 40, 50])
+        s = Series([10, 20, 30, 40, 50])
         value = pd.array([25, pd.NA, 35], dtype="Int64")
         
         result = s.searchsorted(value)

--- a/pandas/tests/series/methods/test_searchsorted.py
+++ b/pandas/tests/series/methods/test_searchsorted.py
@@ -75,3 +75,210 @@ class TestSeriesSearchSorted:
         msg = "Value must be 1-D array-like or scalar, DataFrame is not supported"
         with pytest.raises(ValueError, match=msg):
             ser.searchsorted(vals)
+
+
+class TestSearchsortedWithNullableIntegers:
+    """Comprehensive tests for searchsorted with nullable integer arrays."""
+    def test_series_searchsorted_nullable_int_common_dtype(self):
+        base = 2**53
+        s = pd.Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
+        value = pd.array([base+1, pd.NA], dtype="Int64")
+
+        result = s.searchsorted(value)
+        assert result.tolist() == [1, 4]
+
+    def test_searchsorted_int64_with_single_na(self):
+        """Test searchsorted with Int64 array containing one NA."""
+        base = 2**53
+        s = pd.Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
+        value = pd.array([base+1, pd.NA], dtype="Int64")
+        
+        result = s.searchsorted(value, side="left")
+        expected = np.array([1, 4], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_int64_with_single_na_right(self):
+        """Test searchsorted with side='right'."""
+        base = 2**53
+        s = pd.Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
+        value = pd.array([base+1, pd.NA], dtype="Int64")
+        
+        result = s.searchsorted(value, side="right")
+        expected = np.array([2, 4], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_all_na_values(self):
+        """Test searchsorted when all values are NA."""
+        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        value = pd.array([pd.NA, pd.NA, pd.NA], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([5, 5, 5], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_no_na_values(self):
+        """Test searchsorted with Int64 array but no NA values."""
+        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        value = pd.array([2, 4], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([1, 3], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_mixed_valid_and_na(self):
+        """Test searchsorted with mixture of valid values and NAs."""
+        s = pd.Series([10, 20, 30, 40, 50], dtype="int64")
+        value = pd.array([15, pd.NA, 25, pd.NA, 35], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([1, 5, 2, 5, 3], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_na_at_start(self):
+        """Test searchsorted with NA at the beginning."""
+        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        value = pd.array([pd.NA, 2, 3], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([5, 1, 2], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_na_at_end(self):
+        """Test searchsorted with NA at the end."""
+        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        value = pd.array([2, 3, pd.NA], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([1, 2, 5], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_empty_array_with_na(self):
+        """Test searchsorted on empty array with NA values."""
+        s = pd.Series([], dtype="int64")
+        value = pd.array([pd.NA, 1, pd.NA], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([0, 0, 0], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_single_element_with_na(self):
+        """Test searchsorted on single element array."""
+        s = pd.Series([5], dtype="int64")
+        value = pd.array([pd.NA, 3, 5, 7], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([1, 0, 0, 1], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_int32_with_na(self):
+        """Test searchsorted with Int32 dtype."""
+        s = pd.Series([1, 2, 3, 4, 5], dtype="int32")
+        value = pd.array([2, pd.NA, 4], dtype="Int32")
+        
+        result = s.searchsorted(value)
+        expected = np.array([1, 5, 3], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_int8_with_na(self):
+        """Test searchsorted with Int8 dtype."""
+        s = pd.Series([1, 2, 3, 4, 5], dtype="int8")
+        value = pd.array([pd.NA, 3], dtype="Int8")
+        
+        result = s.searchsorted(value)
+        expected = np.array([5, 2], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_duplicates_with_na(self):
+        """Test searchsorted with duplicate values in array."""
+        s = pd.Series([1, 2, 2, 3, 3, 3, 4], dtype="int64")
+        value = pd.array([2, pd.NA, 3], dtype="Int64")
+        
+        # side='left'
+        result_left = s.searchsorted(value, side="left")
+        expected_left = np.array([1, 7, 3], dtype=np.intp)
+        tm.assert_numpy_array_equal(result_left, expected_left)
+        
+        # side='right'
+        result_right = s.searchsorted(value, side="right")
+        expected_right = np.array([3, 7, 6], dtype=np.intp)
+        tm.assert_numpy_array_equal(result_right, expected_right)
+
+    def test_searchsorted_uint64_with_na(self):
+        """Test searchsorted with UInt64 dtype."""
+        s = pd.Series([1, 2, 3, 4, 5], dtype="uint64")
+        value = pd.array([2, pd.NA], dtype="UInt64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([1, 5], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_large_array_with_na(self):
+        """Test searchsorted with larger array."""
+        s = pd.Series(range(1000), dtype="int64")
+        value = pd.array([100, pd.NA, 500, pd.NA, 999], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([100, 1000, 500, 1000, 999], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_boundary_values_with_na(self):
+        """Test searchsorted with values at boundaries."""
+        s = pd.Series([10, 20, 30, 40, 50], dtype="int64")
+        value = pd.array([0, pd.NA, 10, 50, 60, pd.NA], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([0, 5, 0, 4, 5, 5], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_negative_values_with_na(self):
+        """Test searchsorted with negative values."""
+        s = pd.Series([-50, -30, -10, 0, 10, 30, 50], dtype="int64")
+        value = pd.array([-40, pd.NA, 0, pd.NA, 20], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([1, 7, 3, 7, 5], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_preserves_regular_behavior(self):
+        """Ensure regular searchsorted still works without NA."""
+        s = pd.Series([1, 2, 3, 4, 5], dtype="int64")
+        
+        # Regular list
+        result = s.searchsorted([2, 4])
+        expected = np.array([1, 3], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+        
+        # Regular numpy array
+        result = s.searchsorted(np.array([2, 4]))
+        expected = np.array([1, 3], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+        
+        # Scalar
+        result = s.searchsorted(3)
+        assert result == 2
+
+    def test_searchsorted_float_array_with_na(self):
+        """Test that Float64 arrays with NA also work."""
+        s = pd.Series([1.5, 2.5, 3.5, 4.5, 5.5], dtype="float64")
+        value = pd.array([2.5, pd.NA, 4.0], dtype="Float64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([1, 5, 3], dtype=np.intp)  # Changed from [1, 5, 2]
+        tm.assert_numpy_array_equal(result, expected)
+    def test_searchsorted_series_with_int64_array(self):
+        """Test on Series (not just arrays)."""
+        s = pd.Series([10, 20, 30, 40, 50])
+        value = pd.array([25, pd.NA, 35], dtype="Int64")
+        
+        result = s.searchsorted(value)
+        expected = np.array([2, 5, 3], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_searchsorted_index_with_na(self):
+        """Test searchsorted on Index."""
+        idx = pd.Index([1, 2, 3, 4, 5], dtype="int64")
+        value = pd.array([2, pd.NA, 4], dtype="Int64")
+        
+        result = idx.searchsorted(value)
+        expected = np.array([1, 5, 3], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
Fixes incorrect behavior when `searchsorted` is called with masked arrays (e.g `IntegerArray`, `FloatArray`) containing `NA` values in the `value` parameter

Previously, `NA` values would either return incorrect insertion positions or raise `TypeError: boolean value of NA is ambiguous`. This fix treats `NA` values as larger than all valid values, assigning them insertion position `len(arr)`.

**example (same used in issue #63938):**
```python
import numpy as np
import pandas as pd

base = 2**53
s = pd.Series(np.array([base, base+1, base+2, base+3], dtype=np.int64))
value = pd.array([base+1, pd.NA], dtype="Int64")

# Before: [0, 4] (incorrect)
# After:  [1, 4] (correct)
result = s.searchsorted(value, side="left")
```

**Changes:**
- Modified `pandas.core.algorithms.searchsorted()` to handle `BaseMaskedArray` with  `NA`  values
- Added comprehensive test coverage for various masked array types and `NA` patterns

---

**Checklist:**
- [x] closes #63938 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.