### PR TITLE
DOC: Replace @doc decorators with inline docstrings in indexing.py #62437

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -25,9 +25,6 @@ from pandas.errors import (
     LossySetitemError,
 )
 from pandas.errors.cow import _chained_assignment_msg
-from pandas.util._decorators import (
-    doc,
-)
 
 from pandas.core.dtypes.cast import (
     can_hold_element,
@@ -1320,9 +1317,7 @@ class _LocIndexer(_LocationIndexer):
 
     Alignable boolean Series:
 
-    >>> df.loc[
-    ...     pd.Series([False, True, False], index=["viper", "sidewinder", "cobra"])
-    ... ]
+    >>> df.loc[pd.Series([False, True, False], index=["viper", "sidewinder", "cobra"])]
                          max_speed  shield
     sidewinder          7       8
 
@@ -1554,6 +1549,7 @@ class _LocIndexer(_LocationIndexer):
     1  2  10.0
     2  3 NaN
     """
+
     _takeable: bool = False
     _valid_types = (
         "labels (MUST BE IN THE INDEX), slices of labels (BOTH "
@@ -2064,6 +2060,7 @@ class _iLocIndexer(_LocationIndexer):
     1   100   300
     2  1000  3000
     """
+
     _valid_types = (
         "integer, integer slice (START point is INCLUDED, END "
         "point is EXCLUDED), listlike of integers, boolean array"

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1227,8 +1227,333 @@ class _LocationIndexer(NDFrameIndexerBase):
         return self.obj.take(inds, axis=axis)
 
 
-@doc(IndexingMixin.loc)
 class _LocIndexer(_LocationIndexer):
+    """
+    Access a group of rows and columns by label(s) or a boolean array.
+
+    ``.loc[]`` is primarily label based, but may also be used with a
+    boolean array.
+
+    Allowed inputs are:
+
+    - A single label, e.g. ``5`` or ``'a'``, (note that ``5`` is
+      interpreted as a *label* of the index, and **never** as an
+      integer position along the index).
+    - A list or array of labels, e.g. ``['a', 'b', 'c']``.
+    - A slice object with labels, e.g. ``'a':'f'``.
+
+      .. warning:: Note that contrary to usual python slices, **both** the
+          start and the stop are included
+
+    - A boolean array of the same length as the axis being sliced,
+      e.g. ``[True, False, True]``.
+    - An alignable boolean Series. The index of the key will be aligned before
+      masking.
+    - An alignable Index. The Index of the returned selection will be the input.
+    - A ``callable`` function with one argument (the calling Series or
+      DataFrame) and that returns valid output for indexing (one of the above)
+
+    See more at :ref:`Selection by Label <indexing.label>`.
+
+    Raises
+    ------
+    KeyError
+        If any items are not found.
+    IndexingError
+        If an indexed key is passed and its index is unalignable to the frame index.
+
+    See Also
+    --------
+    DataFrame.at : Access a single value for a row/column label pair.
+    DataFrame.iloc : Access group of rows and columns by integer position(s).
+    DataFrame.xs : Returns a cross-section (row(s) or column(s)) from the
+                   Series/DataFrame.
+    Series.loc : Access group of values using labels.
+
+    Examples
+    --------
+    **Getting values**
+
+    >>> df = pd.DataFrame(
+    ...     [[1, 2], [4, 5], [7, 8]],
+    ...     index=["cobra", "viper", "sidewinder"],
+    ...     columns=["max_speed", "shield"],
+    ... )
+    >>> df
+                max_speed  shield
+    cobra               1       2
+    viper               4       5
+    sidewinder          7       8
+
+    Single label. Note this returns the row as a Series.
+
+    >>> df.loc["viper"]
+    max_speed    4
+    shield       5
+    Name: viper, dtype: int64
+
+    List of labels. Note using ``[[]]`` returns a DataFrame.
+
+    >>> df.loc[["viper", "sidewinder"]]
+                max_speed  shield
+    viper               4       5
+    sidewinder          7       8
+
+    Single label for row and column
+
+    >>> df.loc["cobra", "shield"]
+    np.int64(2)
+
+    Slice with labels for row and single label for column. As mentioned
+    above, note that both the start and stop of the slice are included.
+
+    >>> df.loc["cobra":"viper", "max_speed"]
+    cobra    1
+    viper    4
+    Name: max_speed, dtype: int64
+
+    Boolean list with the same length as the row axis
+
+    >>> df.loc[[False, False, True]]
+                max_speed  shield
+    sidewinder          7       8
+
+    Alignable boolean Series:
+
+    >>> df.loc[
+    ...     pd.Series([False, True, False], index=["viper", "sidewinder", "cobra"])
+    ... ]
+                         max_speed  shield
+    sidewinder          7       8
+
+    Index (same behavior as ``df.reindex``)
+
+    >>> df.loc[pd.Index(["cobra", "viper"], name="foo")]
+           max_speed  shield
+    foo
+    cobra          1       2
+    viper          4       5
+
+    Conditional that returns a boolean Series
+
+    >>> df.loc[df["shield"] > 6]
+                max_speed  shield
+    sidewinder          7       8
+
+    Conditional that returns a boolean Series with column labels specified
+
+    >>> df.loc[df["shield"] > 6, ["max_speed"]]
+                max_speed
+    sidewinder          7
+
+    Multiple conditional using ``&`` that returns a boolean Series
+
+    >>> df.loc[(df["max_speed"] > 1) & (df["shield"] < 8)]
+                max_speed  shield
+    viper          4       5
+
+    Multiple conditional using ``|`` that returns a boolean Series
+
+    >>> df.loc[(df["max_speed"] > 4) | (df["shield"] < 5)]
+                max_speed  shield
+    cobra               1       2
+    sidewinder          7       8
+
+    Please ensure that each condition is wrapped in parentheses ``()``.
+    See the :ref:`user guide<indexing.boolean>`
+    for more details and explanations of Boolean indexing.
+
+    .. note::
+        If you find yourself using 3 or more conditionals in ``.loc[]``,
+        consider using :ref:`advanced indexing<advanced.advanced_hierarchical>`.
+
+        See below for using ``.loc[]`` on MultiIndex DataFrames.
+
+    Callable that returns a boolean Series
+
+    >>> df.loc[lambda df: df["shield"] == 8]
+                max_speed  shield
+    sidewinder          7       8
+
+    **Setting values**
+
+    Set value for all items matching the list of labels
+
+    >>> df.loc[["viper", "sidewinder"], ["shield"]] = 50
+    >>> df
+                max_speed  shield
+    cobra               1       2
+    viper               4      50
+    sidewinder          7      50
+
+    Set value for an entire row
+
+    >>> df.loc["cobra"] = 10
+    >>> df
+                max_speed  shield
+    cobra              10      10
+    viper               4      50
+    sidewinder          7      50
+
+    Set value for an entire column
+
+    >>> df.loc[:, "max_speed"] = 30
+    >>> df
+                max_speed  shield
+    cobra              30      10
+    viper              30      50
+    sidewinder         30      50
+
+    Set value for rows matching callable condition
+
+    >>> df.loc[df["shield"] > 35] = 0
+    >>> df
+                max_speed  shield
+    cobra              30      10
+    viper               0       0
+    sidewinder          0       0
+
+    Add value matching location
+
+    >>> df.loc["viper", "shield"] += 5
+    >>> df
+                max_speed  shield
+    cobra              30      10
+    viper               0       5
+    sidewinder          0       0
+
+    Setting using a ``Series`` or a ``DataFrame`` sets the values matching the
+    index labels, not the index positions.
+
+    >>> shuffled_df = df.loc[["viper", "cobra", "sidewinder"]]
+    >>> df.loc[:] += shuffled_df
+    >>> df
+                max_speed  shield
+    cobra              60      20
+    viper               0      10
+    sidewinder          0       0
+
+    **Getting values on a DataFrame with an index that has integer labels**
+
+    Another example using integers for the index
+
+    >>> df = pd.DataFrame(
+    ...     [[1, 2], [4, 5], [7, 8]],
+    ...     index=[7, 8, 9],
+    ...     columns=["max_speed", "shield"],
+    ... )
+    >>> df
+       max_speed  shield
+    7          1       2
+    8          4       5
+    9          7       8
+
+    Slice with integer labels for rows. As mentioned above, note that both
+    the start and stop of the slice are included.
+
+    >>> df.loc[7:9]
+       max_speed  shield
+    7          1       2
+    8          4       5
+    9          7       8
+
+    **Getting values with a MultiIndex**
+
+    A number of examples using a DataFrame with a MultiIndex
+
+    >>> tuples = [
+    ...     ("cobra", "mark i"),
+    ...     ("cobra", "mark ii"),
+    ...     ("sidewinder", "mark i"),
+    ...     ("sidewinder", "mark ii"),
+    ...     ("viper", "mark ii"),
+    ...     ("viper", "mark iii"),
+    ... ]
+    >>> index = pd.MultiIndex.from_tuples(tuples)
+    >>> values = [[12, 2], [0, 4], [10, 20], [1, 4], [7, 1], [16, 36]]
+    >>> df = pd.DataFrame(values, columns=["max_speed", "shield"], index=index)
+    >>> df
+                         max_speed  shield
+    cobra      mark i           12       2
+               mark ii           0       4
+    sidewinder mark i           10      20
+               mark ii           1       4
+    viper      mark ii           7       1
+               mark iii         16      36
+
+    Single label. Note this returns a DataFrame with a single index.
+
+    >>> df.loc["cobra"]
+             max_speed  shield
+    mark i          12       2
+    mark ii          0       4
+
+    Single index tuple. Note this returns a Series.
+
+    >>> df.loc[("cobra", "mark ii")]
+    max_speed    0
+    shield       4
+    Name: (cobra, mark ii), dtype: int64
+
+    Single label for row and column. Similar to passing in a tuple, this
+    returns a Series.
+
+    >>> df.loc["cobra", "mark i"]
+    max_speed    12
+    shield        2
+    Name: (cobra, mark i), dtype: int64
+
+    Single tuple. Note using ``[[]]`` returns a DataFrame.
+
+    >>> df.loc[[("cobra", "mark ii")]]
+                   max_speed  shield
+    cobra mark ii          0       4
+
+    Single tuple for the index with a single label for the column
+
+    >>> df.loc[("cobra", "mark i"), "shield"]
+    np.int64(2)
+
+    Slice from index tuple to single label
+
+    >>> df.loc[("cobra", "mark i") : "viper"]
+                         max_speed  shield
+    cobra      mark i           12       2
+               mark ii           0       4
+    sidewinder mark i           10      20
+               mark ii           1       4
+    viper      mark ii           7       1
+               mark iii         16      36
+
+    Slice from index tuple to index tuple
+
+    >>> df.loc[("cobra", "mark i") : ("viper", "mark ii")]
+                        max_speed  shield
+    cobra      mark i          12       2
+               mark ii          0       4
+    sidewinder mark i          10      20
+               mark ii          1       4
+    viper      mark ii          7       1
+
+    Please see the :ref:`user guide<advanced.advanced_hierarchical>`
+    for more details and explanations of advanced indexing.
+
+    **Assignment with Series**
+
+    When assigning a Series to .loc[row_indexer, col_indexer], pandas aligns
+    the Series by index labels, not by order or position.
+
+    Series assignment with .loc and index alignment:
+
+    >>> df = pd.DataFrame({"A": [1, 2, 3]}, index=[0, 1, 2])
+    >>> s = pd.Series([10, 20], index=[1, 0])  # Note reversed order
+    >>> df.loc[:, "B"] = s  # Aligns by index, not order
+    >>> df
+       A   B
+    0  1  20.0
+    1  2  10.0
+    2  3 NaN
+    """
     _takeable: bool = False
     _valid_types = (
         "labels (MUST BE IN THE INDEX), slices of labels (BOTH "
@@ -1239,8 +1564,26 @@ class _LocIndexer(_LocationIndexer):
     # -------------------------------------------------------------------
     # Key Checks
 
-    @doc(_LocationIndexer._validate_key)
     def _validate_key(self, key, axis: Axis) -> None:
+        """
+        Ensure that key is valid for current indexer.
+
+        Parameters
+        ----------
+        key : scalar, slice or list-like
+            Key requested.
+        axis : int
+            Dimension on which the indexing is being made.
+
+        Raises
+        ------
+        TypeError
+            If the key (or some element of it) has wrong type.
+        IndexError
+            If the key (or some element of it) is out of bounds.
+        KeyError
+            If the key was not found.
+        """
         # valid for a collection of labels (we check their presence later)
         # slice of labels (where start-end in labels)
         # slice of integers (only if in the labels)
@@ -1578,8 +1921,149 @@ class _LocIndexer(_LocationIndexer):
         return keyarr, indexer
 
 
-@doc(IndexingMixin.iloc)
 class _iLocIndexer(_LocationIndexer):
+    """
+    Purely integer-location based indexing for selection by position.
+
+    .. versionchanged:: 3.0
+
+       Callables which return a tuple are deprecated as input.
+
+    ``.iloc[]`` is primarily integer position based (from ``0`` to
+    ``length-1`` of the axis), but may also be used with a boolean
+    array.
+
+    Allowed inputs are:
+
+    - An integer, e.g. ``5``.
+    - A list or array of integers, e.g. ``[4, 3, 0]``.
+    - A slice object with ints, e.g. ``1:7``.
+    - A boolean array.
+    - A ``callable`` function with one argument (the calling Series or
+      DataFrame) and that returns valid output for indexing (one of the above).
+      This is useful in method chains, when you don't have a reference to the
+      calling object, but would like to base your selection on
+      some value.
+    - A tuple of row and column indexes. The tuple elements consist of one of the
+      above inputs, e.g. ``(0, 1)``.
+
+    ``.iloc`` will raise ``IndexError`` if a requested indexer is
+    out-of-bounds, except *slice* indexers which allow out-of-bounds
+    indexing (this conforms with python/numpy *slice* semantics).
+
+    See more at :ref:`Selection by Position <indexing.integer>`.
+
+    See Also
+    --------
+    DataFrame.iat : Fast integer location scalar accessor.
+    DataFrame.loc : Purely label-location based indexer for selection by label.
+    Series.iloc : Purely integer-location based indexing for
+                   selection by position.
+
+    Examples
+    --------
+    >>> mydict = [
+    ...     {"a": 1, "b": 2, "c": 3, "d": 4},
+    ...     {"a": 100, "b": 200, "c": 300, "d": 400},
+    ...     {"a": 1000, "b": 2000, "c": 3000, "d": 4000},
+    ... ]
+    >>> df = pd.DataFrame(mydict)
+    >>> df
+          a     b     c     d
+    0     1     2     3     4
+    1   100   200   300   400
+    2  1000  2000  3000  4000
+
+    **Indexing just the rows**
+
+    With a scalar integer.
+
+    >>> type(df.iloc[0])
+    <class 'pandas.Series'>
+    >>> df.iloc[0]
+    a    1
+    b    2
+    c    3
+    d    4
+    Name: 0, dtype: int64
+
+    With a list of integers.
+
+    >>> df.iloc[[0]]
+       a  b  c  d
+    0  1  2  3  4
+    >>> type(df.iloc[[0]])
+    <class 'pandas.DataFrame'>
+
+    >>> df.iloc[[0, 1]]
+         a    b    c    d
+    0    1    2    3    4
+    1  100  200  300  400
+
+    With a `slice` object.
+
+    >>> df.iloc[:3]
+          a     b     c     d
+    0     1     2     3     4
+    1   100   200   300   400
+    2  1000  2000  3000  4000
+
+    With a boolean mask the same length as the index.
+
+    >>> df.iloc[[True, False, True]]
+          a     b     c     d
+    0     1     2     3     4
+    2  1000  2000  3000  4000
+
+    With a callable, useful in method chains. The `x` passed
+    to the ``lambda`` is the DataFrame being sliced. This selects
+    the rows whose index label even.
+
+    >>> df.iloc[lambda x: x.index % 2 == 0]
+          a     b     c     d
+    0     1     2     3     4
+    2  1000  2000  3000  4000
+
+    **Indexing both axes**
+
+    You can mix the indexer types for the index and columns. Use ``:`` to
+    select the entire axis.
+
+    With scalar integers.
+
+    >>> df.iloc[0, 1]
+    np.int64(2)
+
+    With lists of integers.
+
+    >>> df.iloc[[0, 2], [1, 3]]
+          b     d
+    0     2     4
+    2  2000  4000
+
+    With `slice` objects.
+
+    >>> df.iloc[1:3, 0:3]
+          a     b     c
+    1   100   200   300
+    2  1000  2000  3000
+
+    With a boolean array whose length matches the columns.
+
+    >>> df.iloc[:, [True, False, True, False]]
+          a     c
+    0     1     3
+    1   100   300
+    2  1000  3000
+
+    With a callable function that expects the Series or DataFrame.
+
+    >>> df.iloc[:, lambda df: [0, 2]]
+          a     c
+    0     1     3
+    1   100   300
+    2  1000  3000
+    """
     _valid_types = (
         "integer, integer slice (START point is INCLUDED, END "
         "point is EXCLUDED), listlike of integers, boolean array"

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2542,8 +2542,71 @@ class _ScalarAccessIndexer(NDFrameIndexerBase):
         self.obj._set_value(*key, value=value, takeable=self._takeable)
 
 
-@doc(IndexingMixin.at)
 class _AtIndexer(_ScalarAccessIndexer):
+    """
+    Access a single value for a row/column label pair.
+
+    Similar to ``loc``, in that both provide label-based lookups. Use
+    ``at`` if you only need to get or set a single value in a DataFrame
+    or Series.
+
+    Raises
+    ------
+    KeyError
+        If getting a value and 'label' does not exist in a DataFrame or Series.
+
+    ValueError
+        If row/column label pair is not a tuple or if any label
+        from the pair is not a scalar for DataFrame.
+        If label is list-like (*excluding* NamedTuple) for Series.
+
+    See Also
+    --------
+    DataFrame.at : Access a single value for a row/column pair by label.
+    DataFrame.iat : Access a single value for a row/column pair by integer
+        position.
+    DataFrame.loc : Access a group of rows and columns by label(s).
+    DataFrame.iloc : Access a group of rows and columns by integer
+        position(s).
+    Series.at : Access a single value by label.
+    Series.iat : Access a single value by integer position.
+    Series.loc : Access a group of rows by label(s).
+    Series.iloc : Access a group of rows by integer position(s).
+
+    Notes
+    -----
+    See :ref:`Fast scalar value getting and setting <indexing.basics.get_value>`
+    for more details.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame(
+    ...     [[0, 2, 3], [0, 4, 1], [10, 20, 30]],
+    ...     index=[4, 5, 6],
+    ...     columns=["A", "B", "C"],
+    ... )
+    >>> df
+        A   B   C
+    4   0   2   3
+    5   0   4   1
+    6  10  20  30
+
+    Get value at specified row/column pair
+
+    >>> df.at[4, "B"]
+    np.int64(2)
+
+    Set value at specified row/column pair
+
+    >>> df.at[4, "B"] = 10
+    >>> df.at[4, "B"]
+    np.int64(10)
+
+    Get value within a Series
+
+    >>> df.loc[5].at["B"]
+    np.int64(4)
+    """
     _takeable = False
 
     def _convert_key(self, key):
@@ -2592,8 +2655,52 @@ class _AtIndexer(_ScalarAccessIndexer):
         return super().__setitem__(key, value)
 
 
-@doc(IndexingMixin.iat)
 class _iAtIndexer(_ScalarAccessIndexer):
+    """
+    Access a single value for a row/column pair by integer position.
+
+    Similar to ``iloc``, in that both provide integer-based lookups. Use
+    ``iat`` if you only need to get or set a single value in a DataFrame
+    or Series.
+
+    Raises
+    ------
+    IndexError
+        When integer position is out of bounds.
+
+    See Also
+    --------
+    DataFrame.at : Access a single value for a row/column label pair.
+    DataFrame.loc : Access a group of rows and columns by label(s).
+    DataFrame.iloc : Access a group of rows and columns by integer position(s).
+
+    Examples
+    --------
+    >>> df = pd.DataFrame(
+    ...     [[0, 2, 3], [0, 4, 1], [10, 20, 30]], columns=["A", "B", "C"]
+    ... )
+    >>> df
+        A   B   C
+    0   0   2   3
+    1   0   4   1
+    2  10  20  30
+
+    Get value at specified row/column pair
+
+    >>> df.iat[1, 2]
+    np.int64(1)
+
+    Set value at specified row/column pair
+
+    >>> df.iat[1, 2] = 10
+    >>> df.iat[1, 2]
+    np.int64(10)
+
+    Get value within a series
+
+    >>> df.loc[0].iat[1]
+    np.int64(2)
+    """
     _takeable = True
 
     def _convert_key(self, key):


### PR DESCRIPTION
Replace @doc decorators with inline docstrings for _LocIndexer, _LocIndexer._validate_key, and _iLocIndexer.

- [x] xref #62437 (partial - _LocIndexer, _LocIndexer._validate_key, and _iLocIndexer only)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.