### PR TITLE
STY: (1/5) enforce b905 for frame tests

### DIFF
--- a/pandas/tests/frame/conftest.py
+++ b/pandas/tests/frame/conftest.py
@@ -50,7 +50,7 @@ def mixed_float_frame():
         {
             col: np.random.default_rng(2).random(30, dtype=dtype)
             for col, dtype in zip(
-                list("ABCD"), ["float32", "float32", "float32", "float64"]
+                list("ABCD"), ["float32", "float32", "float32", "float64"], strict=True
             )
         },
         index=Index([f"foo_{i}" for i in range(30)], dtype=object),
@@ -70,7 +70,9 @@ def mixed_int_frame():
     return DataFrame(
         {
             col: np.ones(30, dtype=dtype)
-            for col, dtype in zip(list("ABCD"), ["int32", "uint64", "uint8", "int64"])
+            for col, dtype in zip(
+                list("ABCD"), ["int32", "uint64", "uint8", "int64"], strict=True
+            )
         },
         index=Index([f"foo_{i}" for i in range(30)], dtype=object),
     )

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -29,7 +29,7 @@ class TestFromDict:
 
         result = DataFrame(data)
         expected = DataFrame.from_dict(
-            dict(zip(range(len(data)), data)), orient="index"
+            dict(zip(range(len(data)), data, strict=True)), orient="index"
         )
         tm.assert_frame_equal(result, expected.reindex(result.index))
 
@@ -37,9 +37,9 @@ class TestFromDict:
         data = [OrderedDict([["a", 1.5], ["b", 3], ["c", 4], ["d", 6]])]
 
         result = DataFrame(data)
-        expected = DataFrame.from_dict(dict(zip([0], data)), orient="index").reindex(
-            result.index
-        )
+        expected = DataFrame.from_dict(
+            dict(zip([0], data, strict=True)), orient="index"
+        ).reindex(result.index)
         tm.assert_frame_equal(result, expected)
 
     def test_constructor_list_of_series(self):
@@ -47,7 +47,7 @@ class TestFromDict:
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 4.0]]),
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 6.0]]),
         ]
-        sdict = OrderedDict(zip(["x", "y"], data))
+        sdict = OrderedDict(zip(["x", "y"], data, strict=True))
         idx = Index(["a", "b", "c"])
 
         # all named
@@ -66,7 +66,7 @@ class TestFromDict:
         ]
         result = DataFrame(data2)
 
-        sdict = OrderedDict(zip(["x", "Unnamed 0"], data))
+        sdict = OrderedDict(zip(["x", "Unnamed 0"], data, strict=True))
         expected = DataFrame.from_dict(sdict, orient="index")
         tm.assert_frame_equal(result, expected)
 
@@ -82,7 +82,7 @@ class TestFromDict:
         data = [Series(d) for d in data]
 
         result = DataFrame(data)
-        sdict = OrderedDict(zip(range(len(data)), data))
+        sdict = OrderedDict(zip(range(len(data)), data, strict=True))
         expected = DataFrame.from_dict(sdict, orient="index")
         tm.assert_frame_equal(result, expected.reindex(result.index))
 
@@ -97,7 +97,7 @@ class TestFromDict:
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 4.0]]),
             OrderedDict([["a", 1.5], ["b", 3.0], ["c", 6.0]]),
         ]
-        sdict = OrderedDict(zip(range(len(data)), data))
+        sdict = OrderedDict(zip(range(len(data)), data, strict=True))
 
         idx = Index(["a", "b", "c"])
         data2 = [Series([1.5, 3, 4], idx, dtype="O"), Series([1.5, 3, 6], idx)]

--- a/pandas/tests/frame/indexing/test_delitem.py
+++ b/pandas/tests/frame/indexing/test_delitem.py
@@ -52,7 +52,7 @@ class TestDataFrameDelItem:
     def test_delitem_col_still_multiindex(self):
         arrays = [["a", "b", "c", "top"], ["", "", "", "OD"], ["", "", "", "wx"]]
 
-        tuples = sorted(zip(*arrays))
+        tuples = sorted(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples)
 
         df = DataFrame(np.random.default_rng(2).standard_normal((3, 4)), columns=index)

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -114,8 +114,8 @@ class TestGetitemListLike:
             iter,
             Index,
             set,
-            lambda keys: dict(zip(keys, range(len(keys)))),
-            lambda keys: dict(zip(keys, range(len(keys)))).keys(),
+            lambda keys: dict(zip(keys, range(len(keys)), strict=True)),
+            lambda keys: dict(zip(keys, range(len(keys)), strict=True)).keys(),
         ],
         ids=["list", "iter", "Index", "set", "dict", "dict_keys"],
     )

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1524,7 +1524,7 @@ class TestDataFrameIndexing:
         # GH#57457
         columns = ["a"]
         data = [np.array([1, 2], dtype=">f8")]
-        df = DataFrame(dict(zip(columns, data)))
+        df = DataFrame(dict(zip(columns, data, strict=True)))
         result = df[df.columns]
         dfexp = DataFrame({"a": [1, 2]}, dtype=">f8")
         expected = dfexp[dfexp.columns]

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -663,7 +663,7 @@ class TestDataFrameSetItem:
         tm.assert_frame_equal(df, expected)
 
     def test_setitem_list_of_tuples(self, float_frame):
-        tuples = list(zip(float_frame["A"], float_frame["B"]))
+        tuples = list(zip(float_frame["A"], float_frame["B"], strict=True))
         float_frame["tuples"] = tuples
 
         result = float_frame["tuples"]

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -137,7 +137,7 @@ class TestXSWithMultiIndex:
             ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
             ["one", "two", "one", "two", "one", "two", "one", "two"],
         ]
-        tuples = list(zip(*arrays))
+        tuples = list(zip(*arrays, strict=True))
 
         index = MultiIndex.from_tuples(tuples, names=["first", "second"])
         df = DataFrame(

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -144,7 +144,8 @@ class TestDataFrameDrop:
 
         # non-unique - wheee!
         nu_df = DataFrame(
-            list(zip(range(3), range(-3, 1), list("abc"))), columns=["a", "a", "b"]
+            list(zip(range(3), range(-3, 0), list("abc"), strict=True)),
+            columns=["a", "a", "b"],
         )
         tm.assert_frame_equal(nu_df.drop("a", axis=1), nu_df[["b"]])
         tm.assert_frame_equal(nu_df.drop("b", axis="columns"), nu_df["a"])
@@ -296,7 +297,7 @@ class TestDataFrameDrop:
             ["", "wx", "wy", "", "", ""],
         ]
 
-        tuples = sorted(zip(*arrays))
+        tuples = sorted(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples)
         df = DataFrame(np.random.default_rng(2).standard_normal((4, 6)), columns=index)
 

--- a/pandas/tests/frame/methods/test_isin.py
+++ b/pandas/tests/frame/methods/test_isin.py
@@ -92,7 +92,7 @@ class TestDataFrameIsIn:
     def test_isin_tuples(self):
         # GH#16394
         df = DataFrame({"A": [1, 2, 3], "B": ["a", "b", "f"]})
-        df["C"] = list(zip(df["A"], df["B"]))
+        df["C"] = list(zip(df["A"], df["B"], strict=True))
         result = df["C"].isin([(1, "a")])
         tm.assert_series_equal(result, Series([True, False, False], name="C"))
 

--- a/pandas/tests/frame/methods/test_pop.py
+++ b/pandas/tests/frame/methods/test_pop.py
@@ -52,7 +52,7 @@ class TestDataFramePop:
             ["", "wx", "wy", "", "", ""],
         ]
 
-        tuples = sorted(zip(*arrays))
+        tuples = sorted(zip(*arrays, strict=True))
         index = MultiIndex.from_tuples(tuples)
         df = DataFrame(np.random.default_rng(2).standard_normal((4, 6)), columns=index)
 

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -885,7 +885,7 @@ class TestDataFrameReplace:
         values = [-2, -1, "missing"]
         result = df.replace(to_rep, values)
         expected = df.copy()
-        for rep, value in zip(to_rep, values):
+        for rep, value in zip(to_rep, values, strict=True):
             result = expected.replace(rep, value, inplace=True)
             assert result is expected
         tm.assert_frame_equal(result, expected)
@@ -1035,8 +1035,8 @@ class TestDataFrameReplace:
         # nested dictionary replacement
         df = DataFrame({"a": list(range(1, 5))})
 
-        result = df.replace({"a": dict(zip(range(1, 5), range(2, 6)))})
-        expected = df.replace(dict(zip(range(1, 5), range(2, 6))))
+        result = df.replace({"a": dict(zip(range(1, 5), range(2, 6), strict=True))})
+        expected = df.replace(dict(zip(range(1, 5), range(2, 6), strict=True)))
         tm.assert_frame_equal(result, expected)
 
     def test_nested_dict_overlapping_keys_replace_str(self):
@@ -1045,8 +1045,8 @@ class TestDataFrameReplace:
         astr = a.astype(str)
         bstr = np.arange(2, 6).astype(str)
         df = DataFrame({"a": astr})
-        result = df.replace(dict(zip(astr, bstr)))
-        expected = df.replace({"a": dict(zip(astr, bstr))})
+        result = df.replace(dict(zip(astr, bstr, strict=True)))
+        expected = df.replace({"a": dict(zip(astr, bstr, strict=True))})
         tm.assert_frame_equal(result, expected)
 
     def test_replace_swapping_bug(self):

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -115,7 +115,7 @@ class TestResetIndex:
         stacked.index.names = names
         deleveled = stacked.reset_index()
         for i, (lev, level_codes) in enumerate(
-            zip(stacked.index.levels, stacked.index.codes)
+            zip(stacked.index.levels, stacked.index.codes, strict=True)
         ):
             values = lev.take(level_codes)
             name = names[i]

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -132,7 +132,7 @@ class TestDataFrameToDict:
         ]
         assert isinstance(recons_data, list)
         assert len(recons_data) == 3
-        for left, right in zip(recons_data, expected_records):
+        for left, right in zip(recons_data, expected_records, strict=True):
             tm.assert_dict_equal(left, right)
 
         # GH#10844

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -78,7 +78,7 @@ class TestDataFrameMisc:
         # them in __dir__.
         df = DataFrame(
             [list("abcd"), list("efgh")],
-            columns=pd.MultiIndex.from_tuples(list(zip("ABCD", "EFGH"))),
+            columns=pd.MultiIndex.from_tuples(list(zip("ABCD", "EFGH", strict=True))),
         )
         for key in list("ABCD"):
             assert key in dir(df)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -374,9 +374,9 @@ class TestDataFrameConstructors:
                 for d in dtypes
             ]
 
-        for d, a in zip(dtypes, arrays):
+        for d, a in zip(dtypes, arrays, strict=True):
             assert a.dtype == d
-        ad.update(dict(zip(dtypes, arrays)))
+        ad.update(dict(zip(dtypes, arrays, strict=True)))
         df = DataFrame(ad)
 
         dtypes = MIXED_FLOAT_DTYPES + MIXED_INT_DTYPES
@@ -491,7 +491,7 @@ class TestDataFrameConstructors:
         nums = list(range(nitems))
         np.random.default_rng(2).shuffle(nums)
         expected = [f"A{i:d}" for i in nums]
-        df = DataFrame(OrderedDict(zip(expected, [[0]] * nitems)))
+        df = DataFrame(OrderedDict(zip(expected, [[0]] * nitems, strict=True)))
         assert expected == list(df.columns)
 
     def test_constructor_dict(self):
@@ -784,8 +784,12 @@ class TestDataFrameConstructors:
     def test_constructor_dict_cast2(self):
         # can't cast to float
         test_data = {
-            "A": dict(zip(range(20), [f"word_{i}" for i in range(20)])),
-            "B": dict(zip(range(15), np.random.default_rng(2).standard_normal(15))),
+            "A": dict(zip(range(20), [f"word_{i}" for i in range(20)], strict=True)),
+            "B": dict(
+                zip(
+                    range(15), np.random.default_rng(2).standard_normal(15), strict=True
+                )
+            ),
         }
         with pytest.raises(ValueError, match="could not convert string"):
             DataFrame(test_data, dtype=float)
@@ -1729,7 +1733,8 @@ class TestDataFrameConstructors:
             Index(["c", "d", "e"], name=name_in3),
         ]
         series = {
-            c: Series([0, 1, 2], index=i) for i, c in zip(indices, ["x", "y", "z"])
+            c: Series([0, 1, 2], index=i)
+            for i, c in zip(indices, ["x", "y", "z"], strict=True)
         }
         result = DataFrame(series)
 

--- a/pandas/tests/frame/test_iteration.py
+++ b/pandas/tests/frame/test_iteration.py
@@ -30,7 +30,7 @@ class TestIteration:
         # GH#17213, GH#13918
         cols = ["a", "b", "c"]
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=cols)
-        for c, (k, v) in zip(cols, df.items()):
+        for c, (k, v) in zip(cols, df.items(), strict=True):
             assert c == k
             assert isinstance(v, Series)
             assert (df[k] == v).all()

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -997,7 +997,7 @@ class TestDataFrameQueryStrings:
             ops = 2 * ([eq, ne])
             msg = r"'(Not)?In' nodes are not implemented"
 
-            for lh, op_, rh in zip(lhs, ops, rhs):
+            for lh, op_, rh in zip(lhs, ops, rhs, strict=True):
                 ex = f"{lh} {op_} {rh}"
                 with pytest.raises(NotImplementedError, match=msg):
                     df.query(
@@ -1038,7 +1038,7 @@ class TestDataFrameQueryStrings:
             ops = 2 * ([eq, ne])
             msg = r"'(Not)?In' nodes are not implemented"
 
-            for lh, ops_, rh in zip(lhs, ops, rhs):
+            for lh, ops_, rh in zip(lhs, ops, rhs, strict=True):
                 ex = f"{lh} {ops_} {rh}"
                 with pytest.raises(NotImplementedError, match=msg):
                     df.query(ex, engine=engine, parser=parser)

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -864,7 +864,7 @@ class TestDataFrameReshape:
         assert udf.notna().values.sum() == len(df)
         mk_list = lambda a: list(a) if isinstance(a, tuple) else [a]
         rows, cols = udf["jolie"].notna().values.nonzero()
-        for i, j in zip(rows, cols):
+        for i, j in zip(rows, cols, strict=True):
             left = sorted(udf["jolie"].iloc[i, j].split("."))
             right = mk_list(udf["jolie"].index[i]) + mk_list(udf["jolie"].columns[j])
             right = sorted(map(cast, right))
@@ -928,7 +928,7 @@ class TestDataFrameReshape:
         assert udf.notna().values.sum() == 2 * len(df)
         mk_list = lambda a: list(a) if isinstance(a, tuple) else [a]
         rows, cols = udf[col].notna().values.nonzero()
-        for i, j in zip(rows, cols):
+        for i, j in zip(rows, cols, strict=True):
             left = sorted(udf[col].iloc[i, j].split("."))
             right = mk_list(udf[col].index[i]) + mk_list(udf[col].columns[j])
             right = sorted(map(cast, right))
@@ -946,7 +946,7 @@ class TestDataFrameReshape:
             [3, 0, 1, 2, np.nan, np.nan, np.nan, np.nan],
             [np.nan, np.nan, np.nan, np.nan, 4, 5, 6, 7],
         ]
-        vals = list(map(list, zip(*vals)))
+        vals = list(map(list, zip(*vals, strict=True)))
         idx = Index([np.nan, 0, 1, 2, 4, 5, 6, 7], name="B")
         cols = MultiIndex(
             levels=[["C"], ["a", "b"]], codes=[[0, 0], [0, 1]], names=[None, "A"]
@@ -1416,7 +1416,7 @@ def test_unstack_sort_false_nan(levels2, expected_columns):
     result = df.unstack(level="level2", sort=False)
     expected_data = [[0, 4], [1, 5], [2, 6], [3, 7]]
     expected = DataFrame(
-        dict(zip(expected_columns, expected_data)),
+        dict(zip(expected_columns, expected_data, strict=True)),
         index=Index(["b", "a"], name="level1"),
         columns=MultiIndex.from_tuples(expected_columns, names=[None, "level2"]),
     )

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -231,10 +231,10 @@ class TestDataFrameSubclassing:
         df = tm.SubclassedDataFrame(
             [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
 
@@ -250,7 +250,14 @@ class TestDataFrameSubclassing:
                 [41, 43],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AAAABBBB"), list("ccddccdd"), list("yzyzyzyz"))),
+                list(
+                    zip(
+                        list("AAAABBBB"),
+                        list("ccddccdd"),
+                        list("yzyzyzyz"),
+                        strict=True,
+                    )
+                ),
                 names=["aaa", "ccc", "yyy"],
             ),
             columns=Index(["W", "X"], name="www"),
@@ -274,7 +281,14 @@ class TestDataFrameSubclassing:
                 [42, 43],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AAAABBBB"), list("ccddccdd"), list("WXWXWXWX"))),
+                list(
+                    zip(
+                        list("AAAABBBB"),
+                        list("ccddccdd"),
+                        list("WXWXWXWX"),
+                        strict=True,
+                    )
+                ),
                 names=["aaa", "ccc", "www"],
             ),
             columns=Index(["y", "z"], name="yyy"),
@@ -293,10 +307,10 @@ class TestDataFrameSubclassing:
                 [40, 41, 42.0, 43.0],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
 
@@ -312,7 +326,14 @@ class TestDataFrameSubclassing:
                 [41, 43.0],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AAAABBBB"), list("ccddccdd"), list("yzyzyzyz"))),
+                list(
+                    zip(
+                        list("AAAABBBB"),
+                        list("ccddccdd"),
+                        list("yzyzyzyz"),
+                        strict=True,
+                    )
+                ),
                 names=["aaa", "ccc", "yyy"],
             ),
             columns=Index(["W", "X"], name="www"),
@@ -336,7 +357,14 @@ class TestDataFrameSubclassing:
                 [42.0, 43.0],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AAAABBBB"), list("ccddccdd"), list("WXWXWXWX"))),
+                list(
+                    zip(
+                        list("AAAABBBB"),
+                        list("ccddccdd"),
+                        list("WXWXWXWX"),
+                        strict=True,
+                    )
+                ),
                 names=["aaa", "ccc", "www"],
             ),
             columns=Index(["y", "z"], name="yyy"),
@@ -365,10 +393,10 @@ class TestDataFrameSubclassing:
         df = tm.SubclassedDataFrame(
             [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
 
@@ -376,7 +404,14 @@ class TestDataFrameSubclassing:
             [[10, 20, 11, 21, 12, 22, 13, 23], [30, 40, 31, 41, 32, 42, 33, 43]],
             index=Index(["A", "B"], name="aaa"),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWWWXXXX"), list("yyzzyyzz"), list("cdcdcdcd"))),
+                list(
+                    zip(
+                        list("WWWWXXXX"),
+                        list("yyzzyyzz"),
+                        list("cdcdcdcd"),
+                        strict=True,
+                    )
+                ),
                 names=["www", "yyy", "ccc"],
             ),
         )
@@ -391,7 +426,14 @@ class TestDataFrameSubclassing:
             [[10, 30, 11, 31, 12, 32, 13, 33], [20, 40, 21, 41, 22, 42, 23, 43]],
             index=Index(["c", "d"], name="ccc"),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWWWXXXX"), list("yyzzyyzz"), list("ABABABAB"))),
+                list(
+                    zip(
+                        list("WWWWXXXX"),
+                        list("yyzzyyzz"),
+                        list("ABABABAB"),
+                        strict=True,
+                    )
+                ),
                 names=["www", "yyy", "aaa"],
             ),
         )
@@ -409,10 +451,10 @@ class TestDataFrameSubclassing:
                 [40, 41, 42.0, 43.0],
             ],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
 
@@ -423,7 +465,14 @@ class TestDataFrameSubclassing:
             ],
             index=Index(["A", "B"], name="aaa"),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWWWXXXX"), list("yyzzyyzz"), list("cdcdcdcd"))),
+                list(
+                    zip(
+                        list("WWWWXXXX"),
+                        list("yyzzyyzz"),
+                        list("cdcdcdcd"),
+                        strict=True,
+                    )
+                ),
                 names=["www", "yyy", "ccc"],
             ),
         )
@@ -441,7 +490,14 @@ class TestDataFrameSubclassing:
             ],
             index=Index(["c", "d"], name="ccc"),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWWWXXXX"), list("yyzzyyzz"), list("ABABABAB"))),
+                list(
+                    zip(
+                        list("WWWWXXXX"),
+                        list("yyzzyyzz"),
+                        list("ABABABAB"),
+                        strict=True,
+                    )
+                ),
                 names=["www", "yyy", "aaa"],
             ),
         )
@@ -507,7 +563,7 @@ class TestDataFrameSubclassing:
                 "A1980": {0: "d", 1: "e", 2: "f"},
                 "B1970": {0: 2.5, 1: 1.2, 2: 0.7},
                 "B1980": {0: 3.2, 1: 1.3, 2: 0.1},
-                "X": dict(zip(range(3), x)),
+                "X": dict(zip(range(3), x, strict=True)),
             }
         )
 
@@ -604,10 +660,10 @@ class TestDataFrameSubclassing:
         df = tm.SubclassedDataFrame(
             [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
-                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+                list(zip(list("AABB"), list("cdcd"), strict=True)), names=["aaa", "ccc"]
             ),
             columns=MultiIndex.from_tuples(
-                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+                list(zip(list("WWXX"), list("yzyz"), strict=True)), names=["www", "yyy"]
             ),
         )
         result = df.count()

--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -44,7 +44,7 @@ def test_unary_binary(request, dtype):
     assert len(result_pandas) == 2
     expected_numpy = np.modf(values)
 
-    for result, b in zip(result_pandas, expected_numpy):
+    for result, b in zip(result_pandas, expected_numpy, strict=True):
         expected = pd.DataFrame(b, index=df.index, columns=df.columns)
         tm.assert_frame_equal(result, expected)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -426,30 +426,6 @@ exclude = [
 # Keep this one enabled
 "pandas/_typing.py" = ["TC"]
 
-# TODO: Fix B905 (zip-without-explicit-strict) - Remove files below as they're fixed
-# For contributors working on this issue:
-# After adding strict={True,False} to zip() calls in a file,
-# remove its line from this section
-"pandas/tests/frame/conftest.py" = ["B905"]
-"pandas/tests/frame/constructors/test_from_dict.py" = ["B905"]
-"pandas/tests/frame/indexing/test_delitem.py" = ["B905"]
-"pandas/tests/frame/indexing/test_getitem.py" = ["B905"]
-"pandas/tests/frame/indexing/test_indexing.py" = ["B905"]
-"pandas/tests/frame/indexing/test_setitem.py" = ["B905"]
-"pandas/tests/frame/indexing/test_xs.py" = ["B905"]
-"pandas/tests/frame/methods/test_drop.py" = ["B905"]
-"pandas/tests/frame/methods/test_isin.py" = ["B905"]
-"pandas/tests/frame/methods/test_pop.py" = ["B905"]
-"pandas/tests/frame/methods/test_replace.py" = ["B905"]
-"pandas/tests/frame/methods/test_reset_index.py" = ["B905"]
-"pandas/tests/frame/methods/test_to_dict.py" = ["B905"]
-"pandas/tests/frame/test_api.py" = ["B905"]
-"pandas/tests/frame/test_constructors.py" = ["B905"]
-"pandas/tests/frame/test_iteration.py" = ["B905"]
-"pandas/tests/frame/test_query_eval.py" = ["B905"]
-"pandas/tests/frame/test_stack_unstack.py" = ["B905"]
-"pandas/tests/frame/test_subclass.py" = ["B905"]
-"pandas/tests/frame/test_ufunc.py" = ["B905"]
 "pandas/tests/groupby/test_groupby_dropna.py" = ["B905"]
 "pandas/tests/groupby/test_groupby.py" = ["B905"]
 "pandas/tests/groupby/test_grouping.py" = ["B905"]


### PR DESCRIPTION
- [ ] xref #62434 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

This is a poor man stacked PR. I split these changes into several commits to facilitate review. The last commit in the trunk is #63999.
