### PR TITLE
BUG: 3.0.0 Regression - can no longer shuffle Series[string] with numpy (issue#63935)

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -27,6 +27,7 @@ Bug fixes
 - Fixed a bug in :func:`col` where unary operators (``-``, ``+``, ``abs``) were not supported (:issue:`63939`)
 - Fixed a bug in the :func:`comparison_op` raising a ``TypeError`` for zerodim
   subclasses of ``np.ndarray`` (:issue:`63205`)
+- Fixed a bug in :func:`numpy.random.Generator.permutation` would fail with ``ValueError`` when called on :class:`Series` with PyArrow-backed dtypes (:issue:`63935`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.contributors:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -854,11 +854,10 @@ class ArrowExtensionArray(
             raise ValueError(
                 "Unable to avoid copy while creating an array as requested."
             )
-        elif copy is None:
-            # `to_numpy(copy=False)` has the meaning of NumPy `copy=None`.
-            copy = False
-
-        return self.to_numpy(dtype=dtype, copy=copy)
+        result = self.to_numpy(dtype=dtype, copy=copy if copy else False)
+        if copy is None and not result.flags.writeable:
+            result = result.copy()
+        return result
 
     def __invert__(self) -> Self:
         # This is a bit wise op for integer types

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -945,7 +945,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         if copy is True:
             return arr
-        if copy is False or astype_is_view(values.dtype, arr.dtype):
+        if np.shares_memory(arr, values):
             arr = arr.view()
             arr.flags.writeable = False
         return arr

--- a/pandas/tests/series/test_arrow_interface.py
+++ b/pandas/tests/series/test_arrow_interface.py
@@ -128,7 +128,7 @@ def test_dataframe_from_arrow():
 )
 def test_numpy_permutation_pyarrow_dtypes(dtype, data):
     # GH#63935
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(42)
     s = pd.Series(data, dtype=dtype)
     result = rng.permutation(s)
     assert len(result) == len(data)

--- a/pandas/tests/series/test_arrow_interface.py
+++ b/pandas/tests/series/test_arrow_interface.py
@@ -1,5 +1,6 @@
 import ctypes
 
+import numpy as np
 import pytest
 
 import pandas.util._test_decorators as td
@@ -115,3 +116,20 @@ def test_dataframe_from_arrow():
         TypeError, match="Expected an Arrow-compatible array-like object"
     ):
         pd.Series.from_arrow([1, 2, 3])
+
+
+@pytest.mark.parametrize(
+    "dtype,data",
+    [
+        ("string[pyarrow]", ["foo", "bar", "baz"]),
+        ("int64[pyarrow]", [1, 2, 3]),
+        ("float64[pyarrow]", [1.0, 2.0, 3.0]),
+    ],
+)
+def test_numpy_permutation_pyarrow_dtypes(dtype, data):
+    # GH#63935
+    rng = np.random.default_rng()
+    s = pd.Series(data, dtype=dtype)
+    result = rng.permutation(s)
+    assert len(result) == len(data)
+    assert set(result) == set(data)


### PR DESCRIPTION
…py #63935

- [x] closes #63935 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
