### PR TITLE
API: Change assert_index_equal(exact=) default from equiv to True

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -251,21 +251,21 @@ def assert_index_equal(
     if obj is None:
         obj = "MultiIndex" if isinstance(left, MultiIndex) else "Index"
 
-    if exact is lib.no_default and exact == "equiv":  # type: ignore[comparison-overlap]
+    if exact is lib.no_default:
         warnings.warn(
-            "The default value of 'equiv' for the `exact` parameter in is deprecated "
+            "The default value of 'equiv' for the `exact` parameter is deprecated "
             "and will be changed to 'True' in a future version. Please set exact "
             "to the desired value to avoid seeing this warning",
             Pandas4Warning,
             stacklevel=find_stack_level(),
         )
-        exact = True
+        exact = "equiv"
 
     def _check_types(left, right, obj: str = "Index") -> None:
         if not exact:
             return
 
-        assert_class_equal(left, right, exact=exact, obj=obj)  # type: ignore[arg-type]
+        assert_class_equal(left, right, exact=exact, obj=obj)
         assert_attr_equal("inferred_type", left, right, obj=obj)
 
         # Skip exact dtype checking when `check_categorical` is False

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -21,6 +21,7 @@ from pandas.util._decorators import (
     deprecate_kwarg,
     set_module,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_bool,
@@ -188,7 +189,7 @@ def assert_dict_equal(left, right, compare_keys: bool = True) -> None:
 def assert_index_equal(
     left: Index,
     right: Index,
-    exact: bool | str = True,
+    exact: bool | str | lib.NoDefault = lib.no_default,
     check_names: bool = True,
     check_exact: bool = True,
     check_categorical: bool = True,
@@ -244,6 +245,16 @@ def assert_index_equal(
 
     if obj is None:
         obj = "MultiIndex" if isinstance(left, MultiIndex) else "Index"
+
+    if exact is lib.no_default and exact == "equiv":
+        warnings.warn(
+            "The default value of 'equiv' for the `exact` parameter in is deprecated "
+            "and will be changed to 'True' in a future version. Please set exact "
+            "to the desired value to avoid seeing this warning",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+        exact = True
 
     def _check_types(left, right, obj: str = "Index") -> None:
         if not exact:

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -246,7 +246,7 @@ def assert_index_equal(
     if obj is None:
         obj = "MultiIndex" if isinstance(left, MultiIndex) else "Index"
 
-    if exact is lib.no_default and exact == "equiv":
+    if exact is lib.no_default and exact == "equiv":  # type: ignore[comparison-overlap]
         warnings.warn(
             "The default value of 'equiv' for the `exact` parameter in is deprecated "
             "and will be changed to 'True' in a future version. Please set exact "
@@ -260,7 +260,7 @@ def assert_index_equal(
         if not exact:
             return
 
-        assert_class_equal(left, right, exact=exact, obj=obj)
+        assert_class_equal(left, right, exact=exact, obj=obj)  # type: ignore[arg-type]
         assert_attr_equal("inferred_type", left, right, obj=obj)
 
         # Skip exact dtype checking when `check_categorical` is False

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -207,10 +207,15 @@ def assert_index_equal(
         The first index to compare.
     right : Index
         The second index to compare.
-    exact : bool or {'equiv'}, default True
+    exact : bool or {'equiv'}, default 'equiv'
         Whether to check the Index class, dtype and inferred_type
         are identical. If 'equiv', then RangeIndex can be substituted for
         Index with an int64 dtype as well.
+
+        .. deprecated:: 3.1.0
+            The default value of 'equiv' has been deprecated and will be changed to
+            True in the future.
+
     check_names : bool, default True
         Whether to check the names attribute.
     check_exact : bool, default True

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -188,7 +188,7 @@ def assert_dict_equal(left, right, compare_keys: bool = True) -> None:
 def assert_index_equal(
     left: Index,
     right: Index,
-    exact: bool | str = "equiv",
+    exact: bool | str = True,
     check_names: bool = True,
     check_exact: bool = True,
     check_categorical: bool = True,
@@ -206,7 +206,7 @@ def assert_index_equal(
         The first index to compare.
     right : Index
         The second index to compare.
-    exact : bool or {'equiv'}, default 'equiv'
+    exact : bool or {'equiv'}, default True
         Whether to check the Index class, dtype and inferred_type
         are identical. If 'equiv', then RangeIndex can be substituted for
         Index with an int64 dtype as well.

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1392,13 +1392,23 @@ def assert_equal(left, right, **kwargs) -> None:
     __tracebackhide__ = True
 
     if isinstance(left, Index):
-        assert_index_equal(left, right, **kwargs)
+        exact = kwargs.pop("exact", True)
+        assert_index_equal(left, right, exact=exact, **kwargs)
         if isinstance(left, (DatetimeIndex, TimedeltaIndex)):
             assert left.freq == right.freq, (left.freq, right.freq)
     elif isinstance(left, Series):
-        assert_series_equal(left, right, **kwargs)
+        check_index_type = kwargs.pop("check_index_type", True)
+        assert_series_equal(left, right, check_index_type=check_index_type, **kwargs)
     elif isinstance(left, DataFrame):
-        assert_frame_equal(left, right, **kwargs)
+        check_index_type = kwargs.pop("check_index_type", True)
+        check_column_type = kwargs.pop("check_column_type", True)
+        assert_frame_equal(
+            left,
+            right,
+            check_index_type=check_index_type,
+            check_column_type=check_column_type,
+            **kwargs,
+        )
     elif isinstance(left, IntervalArray):
         assert_interval_array_equal(left, right, **kwargs)
     elif isinstance(left, PeriodArray):

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -842,13 +842,34 @@ class TestDatetime64Arithmetic:
         expected = tm.box_expected(expected, box_with_array)
 
         result = rng + two_hours
-        tm.assert_equal(result, expected)
+        if isinstance(result, pd.DataFrame):
+            tm.assert_frame_equal(result, expected, check_index_type=True)
+        elif isinstance(result, Series):
+            tm.assert_series_equal(result, expected, check_index_type=True)
+        elif isinstance(result, pd.Index):
+            tm.assert_index_equal(result, expected, exact=True)
+        else:
+            tm.assert_equal(result, expected)
 
         result = two_hours + rng
-        tm.assert_equal(result, expected)
+        if isinstance(result, pd.DataFrame):
+            tm.assert_frame_equal(result, expected, check_index_type=True)
+        elif isinstance(result, Series):
+            tm.assert_series_equal(result, expected, check_index_type=True)
+        elif isinstance(result, pd.Index):
+            tm.assert_index_equal(result, expected, exact=True)
+        else:
+            tm.assert_equal(result, expected)
 
         rng += two_hours
-        tm.assert_equal(rng, expected)
+        if isinstance(result, pd.DataFrame):
+            tm.assert_frame_equal(result, expected, check_index_type=True)
+        elif isinstance(result, Series):
+            tm.assert_series_equal(result, expected, check_index_type=True)
+        elif isinstance(result, pd.Index):
+            tm.assert_index_equal(result, expected, exact=True)
+        else:
+            tm.assert_equal(result, expected)
 
     def test_dt64arr_sub_timedeltalike_scalar(
         self, tz_naive_fixture, two_hours, box_with_array

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -842,34 +842,13 @@ class TestDatetime64Arithmetic:
         expected = tm.box_expected(expected, box_with_array)
 
         result = rng + two_hours
-        if isinstance(result, pd.DataFrame):
-            tm.assert_frame_equal(result, expected, check_index_type=True)
-        elif isinstance(result, Series):
-            tm.assert_series_equal(result, expected, check_index_type=True)
-        elif isinstance(result, pd.Index):
-            tm.assert_index_equal(result, expected, exact=True)
-        else:
-            tm.assert_equal(result, expected)
+        tm.assert_equal(result, expected)
 
         result = two_hours + rng
-        if isinstance(result, pd.DataFrame):
-            tm.assert_frame_equal(result, expected, check_index_type=True)
-        elif isinstance(result, Series):
-            tm.assert_series_equal(result, expected, check_index_type=True)
-        elif isinstance(result, pd.Index):
-            tm.assert_index_equal(result, expected, exact=True)
-        else:
-            tm.assert_equal(result, expected)
+        tm.assert_equal(result, expected)
 
         rng += two_hours
-        if isinstance(result, pd.DataFrame):
-            tm.assert_frame_equal(result, expected, check_index_type=True)
-        elif isinstance(result, Series):
-            tm.assert_series_equal(result, expected, check_index_type=True)
-        elif isinstance(result, pd.Index):
-            tm.assert_index_equal(result, expected, exact=True)
-        else:
-            tm.assert_equal(result, expected)
+        tm.assert_equal(result, expected)
 
     def test_dt64arr_sub_timedeltalike_scalar(
         self, tz_naive_fixture, two_hours, box_with_array

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1635,7 +1635,7 @@ class TestDatetime64DateOffsetArithmetic:
             ],
             dtype="datetime64[ns]",
         )
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dti + DateOffset(days=1, milliseconds=4)
         expected = DatetimeIndex(
@@ -1646,7 +1646,7 @@ class TestDatetime64DateOffsetArithmetic:
             ],
             dtype="datetime64[ns]",
         )
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
 
 class TestDatetime64OverflowHandling:
@@ -2048,17 +2048,17 @@ class TestDatetimeIndexArithmetic:
 
         # add with TimedeltaIndex
         result = dti + tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = tdi + dti
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # add with timedelta64 array
         result = dti + tdi.values
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = tdi.values + dti
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_dti_iadd_tdi(self, tz_naive_fixture):
         # GH#17558
@@ -2071,20 +2071,20 @@ class TestDatetimeIndexArithmetic:
         # iadd with TimedeltaIndex
         result = DatetimeIndex([Timestamp("2017-01-01", tz=tz)] * 10)
         result += tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = pd.timedelta_range("0 days", periods=10)
         result += dti
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # iadd with timedelta64 array
         result = DatetimeIndex([Timestamp("2017-01-01", tz=tz)] * 10)
         result += tdi.values
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = pd.timedelta_range("0 days", periods=10)
         result += dti
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_dti_sub_tdi(self, tz_naive_fixture):
         # GH#17558
@@ -2096,7 +2096,7 @@ class TestDatetimeIndexArithmetic:
 
         # sub with TimedeltaIndex
         result = dti - tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         msg = "cannot subtract .*TimedeltaArray"
         with pytest.raises(TypeError, match=msg):
@@ -2104,7 +2104,7 @@ class TestDatetimeIndexArithmetic:
 
         # sub with timedelta64 array
         result = dti - tdi.values
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         msg = "cannot subtract a datelike from a TimedeltaArray"
         with pytest.raises(TypeError, match=msg):
@@ -2121,7 +2121,7 @@ class TestDatetimeIndexArithmetic:
         # isub with TimedeltaIndex
         result = DatetimeIndex([Timestamp("2017-01-01", tz=tz)] * 10).as_unit(unit)
         result -= tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # DTA.__isub__ GH#43904
         dta = dti._data.copy()
@@ -2139,7 +2139,7 @@ class TestDatetimeIndexArithmetic:
         # isub with timedelta64 array
         result = DatetimeIndex([Timestamp("2017-01-01", tz=tz)] * 10).as_unit(unit)
         result -= tdi.values
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         with pytest.raises(TypeError, match=msg):
             tdi.values -= dti
@@ -2160,16 +2160,16 @@ class TestDatetimeIndexArithmetic:
         dta = dti.array
         result = dta - dti
         expected = dti - dti
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         tdi = result
         result = dta + tdi
         expected = dti + tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dta - tdi
         expected = dti - tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_sub_dti_dti(self, unit):
         # previously performed setop (deprecated in 0.16.0), now changed to
@@ -2180,10 +2180,10 @@ class TestDatetimeIndexArithmetic:
         expected = TimedeltaIndex([0, 0, 0]).as_unit(unit)
 
         result = dti - dti
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dti_tz - dti_tz
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         msg = "Cannot subtract tz-naive and tz-aware datetime-like objects"
         with pytest.raises(TypeError, match=msg):
             dti_tz - dti
@@ -2193,7 +2193,7 @@ class TestDatetimeIndexArithmetic:
 
         # isub
         dti -= dti
-        tm.assert_index_equal(dti, expected)
+        tm.assert_index_equal(dti, expected, exact=True)
 
         # different length raises ValueError
         dti1 = date_range("20130101", periods=3, unit=unit)
@@ -2207,7 +2207,7 @@ class TestDatetimeIndexArithmetic:
         dti2 = DatetimeIndex(["2012-01-02", "2012-01-03", np.nan]).as_unit(unit)
         expected = TimedeltaIndex(["1 days", np.nan, np.nan]).as_unit(unit)
         result = dti2 - dti1
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     # -------------------------------------------------------------------
     # TODO: Most of this block is moved from series or frame tests, needs
@@ -2315,14 +2315,14 @@ class TestDatetimeIndexArithmetic:
         exp = date_range("2011-01-02", periods=3, freq="2D", name="x", unit=unit)
         for result in [idx + delta, np.add(idx, delta)]:
             assert isinstance(result, DatetimeIndex)
-            tm.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp, exact=True)
             assert result.freq == "2D"
 
         exp = date_range("2010-12-31", periods=3, freq="2D", name="x", unit=unit)
 
         for result in [idx - delta, np.subtract(idx, delta)]:
             assert isinstance(result, DatetimeIndex)
-            tm.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp, exact=True)
             assert result.freq == "2D"
 
         # When adding/subtracting an ndarray (which has no .freq), the result
@@ -2336,7 +2336,7 @@ class TestDatetimeIndexArithmetic:
         ).as_unit(unit)
 
         for result in [idx + delta, np.add(idx, delta)]:
-            tm.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp, exact=True)
             assert result.freq == exp.freq
 
         exp = DatetimeIndex(
@@ -2344,7 +2344,7 @@ class TestDatetimeIndexArithmetic:
         ).as_unit(unit)
         for result in [idx - delta, np.subtract(idx, delta)]:
             assert isinstance(result, DatetimeIndex)
-            tm.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp, exact=True)
             assert result.freq == exp.freq
 
     def test_dti_add_series(self, tz_naive_fixture, names):
@@ -2366,9 +2366,9 @@ class TestDatetimeIndexArithmetic:
 
         expected = index + Timedelta(seconds=5)
         result3 = ser.values + index
-        tm.assert_index_equal(result3, expected)
+        tm.assert_index_equal(result3, expected, exact=True)
         result4 = index + ser.values
-        tm.assert_index_equal(result4, expected)
+        tm.assert_index_equal(result4, expected, exact=True)
 
     @pytest.mark.parametrize("op", [operator.add, roperator.radd, operator.sub])
     def test_dti_addsub_offset_arraylike(
@@ -2436,7 +2436,7 @@ def test_shift_months(years, months, unit):
 
     raw = [x + pd.offsets.DateOffset(years=years, months=months) for x in dti]
     expected = DatetimeIndex(raw).as_unit(dti.unit)
-    tm.assert_index_equal(actual, expected)
+    tm.assert_index_equal(actual, expected, exact=True)
 
 
 def test_dt64arr_addsub_object_dtype_2d(performance_warning):

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -386,7 +386,7 @@ class TestDivisionByZero:
         expected2 = adjust_negative_zero(zero, expected)
 
         result = idx / zero
-        tm.assert_index_equal(result, expected2)
+        tm.assert_index_equal(result, expected2, exact=True)
         ser_compat = Series(idx).astype("i8") / np.array(zero).astype("i8")
         tm.assert_series_equal(ser_compat, Series(expected))
 
@@ -399,7 +399,7 @@ class TestDivisionByZero:
         expected2 = adjust_negative_zero(zero, expected)
 
         result = idx // zero
-        tm.assert_index_equal(result, expected2)
+        tm.assert_index_equal(result, expected2, exact=True)
         ser_compat = Series(idx).astype("i8") // np.array(zero).astype("i8")
         tm.assert_series_equal(ser_compat, Series(expected))
 
@@ -408,7 +408,7 @@ class TestDivisionByZero:
 
         expected = Index([np.nan, np.nan, np.nan, np.nan, np.nan], dtype=np.float64)
         result = idx % zero
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         ser_compat = Series(idx).astype("i8") % np.array(zero).astype("i8")
         tm.assert_series_equal(ser_compat, Series(result))
 
@@ -420,8 +420,8 @@ class TestDivisionByZero:
         exleft = adjust_negative_zero(zero, exleft)
 
         result = divmod(idx, zero)
-        tm.assert_index_equal(result[0], exleft)
-        tm.assert_index_equal(result[1], exright)
+        tm.assert_index_equal(result[0], exleft, exact=True)
+        tm.assert_index_equal(result[1], exright, exact=True)
 
     @pytest.mark.parametrize("op", [operator.truediv, operator.floordiv])
     def test_div_negative_zero(self, zero, numeric_idx, op):
@@ -434,7 +434,7 @@ class TestDivisionByZero:
         expected = adjust_negative_zero(zero, expected)
 
         result = op(idx, zero)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     # ------------------------------------------------------------------
 
@@ -693,11 +693,11 @@ class TestMultiplicationDivision:
         idx = numeric_idx
         result = idx / 1
         expected = idx.astype("float64")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = idx / 2
         expected = Index(idx.values / 2)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.parametrize("op", [operator.mul, ops.rmul, operator.floordiv])
     def test_mul_int_identity(self, op, numeric_idx, box_with_array):
@@ -712,11 +712,11 @@ class TestMultiplicationDivision:
         didx = idx * idx
 
         result = idx * np.array(5, dtype="int64")
-        tm.assert_index_equal(result, idx * 5)
+        tm.assert_index_equal(result, idx * 5, exact=True)
 
         arr_dtype = "uint64" if idx.dtype == np.uint64 else "int64"
         result = idx * np.arange(5, dtype=arr_dtype)
-        tm.assert_index_equal(result, didx)
+        tm.assert_index_equal(result, didx, exact=True)
 
     def test_mul_int_series(self, numeric_idx):
         idx = numeric_idx
@@ -738,7 +738,7 @@ class TestMultiplicationDivision:
         idx = numeric_idx
 
         result = idx * idx
-        tm.assert_index_equal(result, idx**2)
+        tm.assert_index_equal(result, idx**2, exact=True)
 
     def test_mul_datelike_raises(self, numeric_idx):
         idx = numeric_idx
@@ -788,7 +788,7 @@ class TestMultiplicationDivision:
 
         expected = Index(div), Index(mod)
         for r, e in zip(result, expected, strict=True):
-            tm.assert_index_equal(r, e)
+            tm.assert_index_equal(r, e, exact=True)
 
     def test_divmod_ndarray(self, numeric_idx):
         idx = numeric_idx
@@ -800,7 +800,7 @@ class TestMultiplicationDivision:
 
         expected = Index(div), Index(mod)
         for r, e in zip(result, expected, strict=True):
-            tm.assert_index_equal(r, e)
+            tm.assert_index_equal(r, e, exact=True)
 
     def test_divmod_series(self, numeric_idx):
         idx = numeric_idx
@@ -1114,7 +1114,9 @@ class TestAdditionSubtraction:
             tm.assert_almost_equal(np.asarray(result), expected)
 
             assert result.name == series.name
-            tm.assert_index_equal(result.index, series.index._with_freq(None))
+            tm.assert_index_equal(
+                result.index, series.index._with_freq(None), exact=True
+            )
 
     def test_series_divmod_zero(self):
         # Check that divmod uses pandas convention for division by zero,
@@ -1456,15 +1458,15 @@ class TestNumericArithmeticUnsorted:
         index = Index([10, 11, 12], dtype=dtype)
         result = index + delta
         expected = Index(index.values + delta, dtype=dtype)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # this subtraction used to fail
         result = index - delta
         expected = Index(index.values - delta, dtype=dtype)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
-        tm.assert_index_equal(index + index, 2 * index)
-        tm.assert_index_equal(index - index, 0 * index)
+        tm.assert_index_equal(index + index, 2 * index, exact=True)
+        tm.assert_index_equal(index - index, 0 * index, exact=True)
         assert not (index - index).empty
 
     def test_pow_nan_with_zero(self, box_with_array):

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -88,10 +88,10 @@ class TestArithmetic:
 
         expected = pd.Index([x + per for x in idx], dtype=object)
         result = idx + per
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = per + idx
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     # TODO: parametrize
     def test_pow_ops_object(self):
@@ -304,16 +304,16 @@ class TestArithmetic:
     def test_add(self):
         index = pd.Index([str(i) for i in range(10)])
         expected = pd.Index(index.values * 2)
-        tm.assert_index_equal(index + index, expected)
-        tm.assert_index_equal(index + index.tolist(), expected)
-        tm.assert_index_equal(index.tolist() + index, expected)
+        tm.assert_index_equal(index + index, expected, exact=True)
+        tm.assert_index_equal(index + index.tolist(), expected, exact=True)
+        tm.assert_index_equal(index.tolist() + index, expected, exact=True)
 
         # test add and radd
         index = pd.Index(list("abc"))
         expected = pd.Index(["a1", "b1", "c1"])
-        tm.assert_index_equal(index + "1", expected)
+        tm.assert_index_equal(index + "1", expected, exact=True)
         expected = pd.Index(["1a", "1b", "1c"])
-        tm.assert_index_equal("1" + index, expected)
+        tm.assert_index_equal("1" + index, expected, exact=True)
 
     def test_sub_fail(self):
         index = pd.Index([str(i) for i in range(10)])
@@ -334,10 +334,10 @@ class TestArithmetic:
         expected = pd.Index([Decimal(0), Decimal(1)])
 
         result = index - Decimal(1)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = index - pd.Index([Decimal(1), Decimal(1)])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         msg = "unsupported operand type"
         with pytest.raises(TypeError, match=msg):
@@ -352,10 +352,10 @@ class TestArithmetic:
         expected = pd.Index([Decimal(1), Decimal(0)])
 
         result = Decimal(2) - index
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = np.array([Decimal(2), Decimal(2)]) - index
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         msg = "unsupported operand type"
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -658,10 +658,10 @@ class TestPeriodIndexArithmetic:
         off = rng.freq
         expected = pd.Index([-5 * off] * 5)
         result = rng - other
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         rng -= other
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     def test_pi_sub_pi_with_nat(self):
         rng = period_range("1/1/2000", freq="D", periods=5)
@@ -671,7 +671,7 @@ class TestPeriodIndexArithmetic:
         result = rng - other
         off = rng.freq
         expected = pd.Index([pd.NaT, 0 * off, 0 * off, 0 * off, 0 * off])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_parr_sub_pi_mismatched_freq(self, box_with_array, box_with_array2):
         rng = period_range("1/1/2000", freq="D", periods=5)
@@ -695,7 +695,7 @@ class TestPeriodIndexArithmetic:
             [p1_d], freq=p1.freq.base
         )
 
-        tm.assert_index_equal((p2 - p1), expected)
+        tm.assert_index_equal((p2 - p1), expected, exact=True)
 
     @pytest.mark.parametrize("n", [1, 2, 3, 4])
     @pytest.mark.parametrize(
@@ -721,7 +721,7 @@ class TestPeriodIndexArithmetic:
             [p1_d], freq=freq.base
         )
 
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     # -------------------------------------------------------------
     # Invalid Operations
@@ -795,20 +795,20 @@ class TestPeriodIndexArithmetic:
 
         expected = period_range("12/31/1999", freq="90D", periods=3)
         result = rng + tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         result = rng + tdarr
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         result = tdi + rng
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         result = tdarr + rng
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         expected = period_range("1/2/2000", freq="90D", periods=3)
 
         result = rng - tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         result = rng - tdarr
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         msg = r"cannot subtract .* from .*"
         with pytest.raises(TypeError, match=msg):
@@ -880,11 +880,11 @@ class TestPeriodIndexArithmetic:
 
         with tm.assert_produces_warning(performance_warning):
             res = pi + offs
-        tm.assert_index_equal(res, expected)
+        tm.assert_index_equal(res, expected, exact=True)
 
         with tm.assert_produces_warning(performance_warning):
             res2 = offs + pi
-        tm.assert_index_equal(res2, expected)
+        tm.assert_index_equal(res2, expected, exact=True)
 
         unanchored = np.array([pd.offsets.Hour(n=1), pd.offsets.Minute(n=-2)])
         # addition/subtraction ops with incompatible offsets should issue
@@ -913,7 +913,7 @@ class TestPeriodIndexArithmetic:
 
         with tm.assert_produces_warning(performance_warning):
             res = pi - other
-        tm.assert_index_equal(res, expected)
+        tm.assert_index_equal(res, expected, exact=True)
 
         anchored = box([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)])
 
@@ -932,9 +932,9 @@ class TestPeriodIndexArithmetic:
         rng = period_range("2000-01-01 09:00", freq="h", periods=10)
         result = rng + one
         expected = period_range("2000-01-01 10:00", freq="h", periods=10)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         rng += one
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     def test_pi_sub_isub_int(self, one):
         """
@@ -944,9 +944,9 @@ class TestPeriodIndexArithmetic:
         rng = period_range("2000-01-01 09:00", freq="h", periods=10)
         result = rng - one
         expected = period_range("2000-01-01 08:00", freq="h", periods=10)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         rng -= one
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     @pytest.mark.parametrize("five", [5, np.array(5, dtype=np.int64)])
     def test_pi_sub_intlike(self, five):
@@ -954,7 +954,7 @@ class TestPeriodIndexArithmetic:
 
         result = rng - five
         exp = rng + (-five)
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
     def test_pi_add_sub_int_array_freqn_gt1(self):
         # GH#47209 test adding array of ints when freq.n > 1 matches
@@ -963,11 +963,11 @@ class TestPeriodIndexArithmetic:
         arr = np.arange(10)
         result = pi + arr
         expected = pd.Index([x + y for x, y in zip(pi, arr, strict=True)])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = pi - arr
         expected = pd.Index([x - y for x, y in zip(pi, arr, strict=True)])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_pi_sub_isub_offset(self):
         # offset
@@ -975,17 +975,17 @@ class TestPeriodIndexArithmetic:
         rng = period_range("2014", "2024", freq="Y")
         result = rng - pd.offsets.YearEnd(5)
         expected = period_range("2009", "2019", freq="Y")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         rng -= pd.offsets.YearEnd(5)
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
         rng = period_range("2014-01", "2016-12", freq="M")
         result = rng - pd.offsets.MonthEnd(5)
         expected = period_range("2013-08", "2016-07", freq="M")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         rng -= pd.offsets.MonthEnd(5)
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     @pytest.mark.parametrize("transpose", [True, False])
     def test_pi_add_offset_n_gt1(self, box_with_array, transpose):
@@ -1033,7 +1033,7 @@ class TestPeriodIndexArithmetic:
 
         result = op(pi, other)
         expected = PeriodIndex([Period("2016Q1"), Period("NaT")])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.parametrize("int_holder", [np.array, pd.Index])
     def test_pi_sub_intarray(self, int_holder):
@@ -1043,7 +1043,7 @@ class TestPeriodIndexArithmetic:
 
         result = pi - other
         expected = PeriodIndex([Period("2014Q1"), Period("NaT")])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         msg = r"bad operand type for unary -: 'PeriodArray'"
         with pytest.raises(TypeError, match=msg):
@@ -1125,10 +1125,10 @@ class TestPeriodIndexArithmetic:
         expected = period_range("2014-05-04", "2014-05-18", freq="D")
 
         result = rng + other
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         rng += other
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     def test_pi_sub_isub_timedeltalike_daily(self, three_days):
         # Tick-like 3 Days
@@ -1137,10 +1137,10 @@ class TestPeriodIndexArithmetic:
         expected = period_range("2014-04-28", "2014-05-12", freq="D")
 
         result = rng - other
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         rng -= other
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     def test_parr_add_sub_timedeltalike_freq_mismatch_daily(
         self, not_daily, box_with_array
@@ -1173,10 +1173,10 @@ class TestPeriodIndexArithmetic:
         expected = period_range("2014-01-01 12:00", "2014-01-05 12:00", freq="h")
 
         result = rng + other
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         rng += other
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     def test_parr_add_timedeltalike_mismatched_freq_hourly(
         self, not_hourly, box_with_array
@@ -1206,10 +1206,10 @@ class TestPeriodIndexArithmetic:
         expected = period_range("2014-01-01 08:00", "2014-01-05 08:00", freq="h")
 
         result = rng - other
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         rng -= other
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     def test_add_iadd_timedeltalike_annual(self):
         # offset
@@ -1217,9 +1217,9 @@ class TestPeriodIndexArithmetic:
         rng = period_range("2014", "2024", freq="Y")
         result = rng + pd.offsets.YearEnd(5)
         expected = period_range("2019", "2029", freq="Y")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
         rng += pd.offsets.YearEnd(5)
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     def test_pi_add_sub_timedeltalike_freq_mismatch_annual(self, mismatched_freq):
         other = mismatched_freq
@@ -1239,10 +1239,10 @@ class TestPeriodIndexArithmetic:
         expected = period_range("2014-06", "2017-05", freq="M")
 
         result = rng + pd.offsets.MonthEnd(5)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         rng += pd.offsets.MonthEnd(5)
-        tm.assert_index_equal(rng, expected)
+        tm.assert_index_equal(rng, expected, exact=True)
 
     def test_pi_add_sub_timedeltalike_freq_mismatch_monthly(self, mismatched_freq):
         other = mismatched_freq
@@ -1326,7 +1326,7 @@ class TestPeriodIndexArithmetic:
 
         result = parr - pi
         expected = pi - pi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_parr_add_sub_object_array(self, performance_warning):
         pi = period_range("2000-12-31", periods=3, freq="D")
@@ -1469,11 +1469,11 @@ class TestPeriodIndexSeriesMethods:
         result = idx - Period("2011-01", freq="M")
         off = idx.freq
         exp = pd.Index([0 * off, 1 * off, 2 * off, 3 * off], name="idx")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         result = Period("2011-01", freq="M") - idx
         exp = pd.Index([0 * off, -1 * off, -2 * off, -3 * off], name="idx")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
     @pytest.mark.parametrize("ng", ["str", 1.5])
     @pytest.mark.parametrize(
@@ -1625,27 +1625,27 @@ class TestPeriodIndexSeriesMethods:
         result = idx - Period("2012-01", freq="M")
         off = idx.freq
         exp = pd.Index([-12 * off, -11 * off, -10 * off, -9 * off], name="idx")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         result = np.subtract(idx, Period("2012-01", freq="M"))
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         result = Period("2012-01", freq="M") - idx
         exp = pd.Index([12 * off, 11 * off, 10 * off, 9 * off], name="idx")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         result = np.subtract(Period("2012-01", freq="M"), idx)
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         exp = TimedeltaIndex(
             [np.nan, np.nan, np.nan, np.nan], name="idx", dtype="m8[ns]"
         )
         result = idx - Period("NaT", freq="M")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
         assert result.freq == exp.freq
 
         result = Period("NaT", freq="M") - idx
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
         assert result.freq == exp.freq
 
     def test_pi_sub_pdnat(self):
@@ -1654,8 +1654,8 @@ class TestPeriodIndexSeriesMethods:
             ["2011-01", "2011-02", "NaT", "2011-04"], freq="M", name="idx"
         )
         exp = TimedeltaIndex([pd.NaT] * 4, name="idx", dtype="m8[ns]")
-        tm.assert_index_equal(pd.NaT - idx, exp)
-        tm.assert_index_equal(idx - pd.NaT, exp)
+        tm.assert_index_equal(pd.NaT - idx, exp, exact=True)
+        tm.assert_index_equal(idx - pd.NaT, exp, exact=True)
 
     def test_pi_sub_period_nat(self):
         # GH#13071
@@ -1666,14 +1666,14 @@ class TestPeriodIndexSeriesMethods:
         result = idx - Period("2012-01", freq="M")
         off = idx.freq
         exp = pd.Index([-12 * off, pd.NaT, -10 * off, -9 * off], name="idx")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         result = Period("2012-01", freq="M") - idx
         exp = pd.Index([12 * off, pd.NaT, 10 * off, 9 * off], name="idx")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         exp = TimedeltaIndex(
             [np.nan, np.nan, np.nan, np.nan], name="idx", dtype="m8[ns]"
         )
-        tm.assert_index_equal(idx - Period("NaT", freq="M"), exp)
-        tm.assert_index_equal(Period("NaT", freq="M") - idx, exp)
+        tm.assert_index_equal(idx - Period("NaT", freq="M"), exp, exact=True)
+        tm.assert_index_equal(Period("NaT", freq="M") - idx, exp, exact=True)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -298,13 +298,13 @@ class TestTimedelta64ArithmeticUnsorted:
         for result in [idx * 2, np.multiply(idx, 2)]:
             assert isinstance(result, TimedeltaIndex)
             exp = TimedeltaIndex(["4h", "8h", "12h", "16h", "20h"], freq="4h", name="x")
-            tm.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp, exact=True)
             assert result.freq == "4h"
 
         for result in [idx / 2, np.divide(idx, 2)]:
             assert isinstance(result, TimedeltaIndex)
             exp = TimedeltaIndex(["1h", "2h", "3h", "4h", "5h"], freq="h", name="x")
-            tm.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp, exact=True)
             assert result.freq == "h"
 
         for result in [-idx, np.negative(idx)]:
@@ -312,14 +312,14 @@ class TestTimedelta64ArithmeticUnsorted:
             exp = TimedeltaIndex(
                 ["-2h", "-4h", "-6h", "-8h", "-10h"], freq="-2h", name="x"
             )
-            tm.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp, exact=True)
             assert result.freq == "-2h"
 
         idx = TimedeltaIndex(["-2h", "-1h", "0h", "1h", "2h"], freq="h", name="x")
         for result in [abs(idx), np.absolute(idx)]:
             assert isinstance(result, TimedeltaIndex)
             exp = TimedeltaIndex(["2h", "1h", "0h", "1h", "2h"], freq=None, name="x")
-            tm.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp, exact=True)
             assert result.freq is None
 
     def test_subtraction_ops(self):
@@ -345,31 +345,31 @@ class TestTimedelta64ArithmeticUnsorted:
 
         result = dt - dti
         expected = TimedeltaIndex(["0 days", "-1 days", "-2 days"], name="bar")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dti - dt
         expected = TimedeltaIndex(["0 days", "1 days", "2 days"], name="bar")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = tdi - td
         expected = TimedeltaIndex(["0 days", NaT, "1 days"], name="foo")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = td - tdi
         expected = TimedeltaIndex(["0 days", NaT, "-1 days"], name="foo")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dti - td
         expected = DatetimeIndex(
             ["20121231", "20130101", "20130102"], dtype="M8[us]", freq="D", name="bar"
         )
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dt - tdi
         expected = DatetimeIndex(
             ["20121231", NaT, "20121230"], dtype="M8[us]", name="foo"
         )
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_subtraction_ops_with_tz(self, box_with_array):
         # check that dt/dti subtraction ops with tz are validated
@@ -462,15 +462,15 @@ class TestTimedelta64ArithmeticUnsorted:
 
         result = tdi - tdi
         expected = TimedeltaIndex(["0 days", NaT, "0 days"], name="foo")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = tdi + tdi
         expected = TimedeltaIndex(["2 days", NaT, "4 days"], name="foo")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dti - tdi  # name will be reset
         expected = DatetimeIndex(["20121231", NaT, "20130101"], dtype="M8[us]")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_addition_ops(self):
         # with datetimes/timedelta and tdi/dti
@@ -483,21 +483,21 @@ class TestTimedelta64ArithmeticUnsorted:
         expected = DatetimeIndex(
             ["20130102", NaT, "20130103"], dtype="M8[us]", name="foo"
         )
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dt + tdi
         expected = DatetimeIndex(
             ["20130102", NaT, "20130103"], dtype="M8[us]", name="foo"
         )
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = td + tdi
         expected = TimedeltaIndex(["2 days", NaT, "3 days"], name="foo")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = tdi + td
         expected = TimedeltaIndex(["2 days", NaT, "3 days"], name="foo")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # unequal length
         msg = "cannot add indices of unequal length"
@@ -517,11 +517,11 @@ class TestTimedelta64ArithmeticUnsorted:
 
         result = tdi + dti  # name will be reset
         expected = DatetimeIndex(["20130102", NaT, "20130105"], dtype="M8[us]")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dti + tdi  # name will be reset
         expected = DatetimeIndex(["20130102", NaT, "20130105"], dtype="M8[us]")
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = dt + td
         expected = Timestamp("20130102")
@@ -540,7 +540,7 @@ class TestTimedelta64ArithmeticUnsorted:
         shifted = index + timedelta(1)
         back = shifted + timedelta(-1)
         back = back._with_freq("infer")
-        tm.assert_index_equal(index, back)
+        tm.assert_index_equal(index, back, exact=True)
 
         if freq == "D":
             expected = pd.tseries.offsets.Day(1)
@@ -554,7 +554,7 @@ class TestTimedelta64ArithmeticUnsorted:
 
         result = index - timedelta(1)
         expected = index + timedelta(-1)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_timedelta_tick_arithmetic(self):
         # GH#4134, buggy with timedeltas
@@ -567,11 +567,11 @@ class TestTimedelta64ArithmeticUnsorted:
 
         assert result1.freq == rng.freq
         result1 = result1._with_freq(None)
-        tm.assert_index_equal(result1, result4)
+        tm.assert_index_equal(result1, result4, exact=True)
 
         assert result3.freq == rng.freq
         result3 = result3._with_freq(None)
-        tm.assert_index_equal(result2, result3)
+        tm.assert_index_equal(result2, result3, exact=True)
 
     def test_tda_add_sub_index(self):
         # Check that TimedeltaArray defers to Index on arithmetic ops
@@ -582,15 +582,15 @@ class TestTimedelta64ArithmeticUnsorted:
 
         result = tda + dti
         expected = tdi + dti
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = tda + tdi
         expected = tdi + tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = tda - tdi
         expected = tdi - tdi
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_tda_add_dt64_object_array(
         self, performance_warning, box_with_array, tz_naive_fixture
@@ -667,27 +667,27 @@ class TestTimedelta64ArithmeticUnsorted:
 
         result = rng + 1 * rng.freq
         exp = timedelta_range("4 days", periods=5, freq="2D", name="x")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
         assert result.freq == "2D"
 
         result = rng - 2 * rng.freq
         exp = timedelta_range("-2 days", periods=5, freq="2D", name="x")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
         assert result.freq == "2D"
 
         result = rng * 2
         exp = timedelta_range("4 days", periods=5, freq="4D", name="x")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
         assert result.freq == "4D"
 
         result = rng / 2
         exp = timedelta_range("1 days", periods=5, freq="D", name="x")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
         assert result.freq == "D"
 
         result = -rng
         exp = timedelta_range("-2 days", periods=5, freq="-2D", name="x")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
         assert result.freq == "-2D"
 
         rng = timedelta_range("-2 days", periods=5, freq="D", name="x")
@@ -696,7 +696,7 @@ class TestTimedelta64ArithmeticUnsorted:
         exp = TimedeltaIndex(
             ["2 days", "1 days", "0 days", "1 days", "2 days"], name="x"
         )
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
         assert result.freq is None
 
 
@@ -754,17 +754,17 @@ class TestAddSubNaTMasking:
         # These should not overflow!
         exp = TimedeltaIndex([NaT], dtype="m8[us]")
         result = pd.to_timedelta([NaT]) - Timedelta("1 days")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         exp = TimedeltaIndex(["4 days", NaT])
         result = pd.to_timedelta(["5 days", NaT]) - Timedelta("1 days")
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
         exp = TimedeltaIndex([NaT, NaT, "5 hours"])
         result = pd.to_timedelta([NaT, "5 days", "1 hours"]) + pd.to_timedelta(
             ["7 seconds", NaT, "4 hours"]
         )
-        tm.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp, exact=True)
 
 
 class TestTimedeltaArraylikeAddSubOps:
@@ -2328,4 +2328,4 @@ def test_add_timestamp_to_timedelta():
             for i in range(31)
         ]
     )
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -259,13 +259,13 @@ class TestCategoricalAnalytics:
         exp = Categorical([3, 1, 2], dtype=dtype)
         tm.assert_categorical_equal(c.unique(), exp)
 
-        tm.assert_index_equal(Index(c).unique(), Index(exp))
+        tm.assert_index_equal(Index(c).unique(), Index(exp), exact=True)
         tm.assert_categorical_equal(Series(c).unique(), exp)
 
         c = Categorical([1, 1, 2, 2], dtype=dtype)
         exp = Categorical([1, 2], dtype=dtype)
         tm.assert_categorical_equal(c.unique(), exp)
-        tm.assert_index_equal(Index(c).unique(), Index(exp))
+        tm.assert_index_equal(Index(c).unique(), Index(exp), exact=True)
         tm.assert_categorical_equal(Series(c).unique(), exp)
 
     def test_shift(self):
@@ -329,7 +329,9 @@ class TestCategoricalAnalytics:
 
         result = c.map(lambda x: 1, na_action=None)
         # GH 12766: Return an index not an array
-        tm.assert_index_equal(result, Index(np.array([1] * 5, dtype=np.int64)))
+        tm.assert_index_equal(
+            result, Index(np.array([1] * 5, dtype=np.int64)), exact=True
+        )
 
     @pytest.mark.parametrize("value", [1, "True", [1, 2, 3], 5.0])
     def test_validate_inplace_raises(self, value):

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -21,19 +21,19 @@ class TestCategoricalAPI:
     def test_ordered_api(self):
         # GH 9347
         cat1 = Categorical(list("acb"), ordered=False)
-        tm.assert_index_equal(cat1.categories, Index(["a", "b", "c"]))
+        tm.assert_index_equal(cat1.categories, Index(["a", "b", "c"]), exact=True)
         assert not cat1.ordered
 
         cat2 = Categorical(list("acb"), categories=list("bca"), ordered=False)
-        tm.assert_index_equal(cat2.categories, Index(["b", "c", "a"]))
+        tm.assert_index_equal(cat2.categories, Index(["b", "c", "a"]), exact=True)
         assert not cat2.ordered
 
         cat3 = Categorical(list("acb"), ordered=True)
-        tm.assert_index_equal(cat3.categories, Index(["a", "b", "c"]))
+        tm.assert_index_equal(cat3.categories, Index(["a", "b", "c"]), exact=True)
         assert cat3.ordered
 
         cat4 = Categorical(list("acb"), categories=list("bca"), ordered=True)
-        tm.assert_index_equal(cat4.categories, Index(["b", "c", "a"]))
+        tm.assert_index_equal(cat4.categories, Index(["b", "c", "a"]), exact=True)
         assert cat4.ordered
 
     def test_set_ordered(self):
@@ -61,13 +61,13 @@ class TestCategoricalAPI:
         tm.assert_numpy_array_equal(
             res.__array__(), np.array([1, 2, 3, 1], dtype=np.int64)
         )
-        tm.assert_index_equal(res.categories, Index([1, 2, 3]))
+        tm.assert_index_equal(res.categories, Index([1, 2, 3]), exact=True)
 
         exp_cat = np.array(["a", "b", "c", "a"], dtype=np.object_)
         tm.assert_numpy_array_equal(cat.__array__(), exp_cat)
 
         exp_cat = Index(["a", "b", "c"])
-        tm.assert_index_equal(cat.categories, exp_cat)
+        tm.assert_index_equal(cat.categories, exp_cat, exact=True)
 
         # GH18862 (let rename_categories take callables)
         result = cat.rename_categories(lambda x: x.upper())
@@ -96,27 +96,27 @@ class TestCategoricalAPI:
         cat = Categorical(["a", "b", "c", "d"])
         res = cat.rename_categories({"a": 4, "b": 3, "c": 2, "d": 1})
         expected = Index([4, 3, 2, 1])
-        tm.assert_index_equal(res.categories, expected)
+        tm.assert_index_equal(res.categories, expected, exact=True)
 
         # Test for dicts of smaller length
         cat = Categorical(["a", "b", "c", "d"])
         res = cat.rename_categories({"a": 1, "c": 3})
 
         expected = Index([1, "b", 3, "d"])
-        tm.assert_index_equal(res.categories, expected)
+        tm.assert_index_equal(res.categories, expected, exact=True)
 
         # Test for dicts with bigger length
         cat = Categorical(["a", "b", "c", "d"])
         res = cat.rename_categories({"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6})
         expected = Index([1, 2, 3, 4])
-        tm.assert_index_equal(res.categories, expected)
+        tm.assert_index_equal(res.categories, expected, exact=True)
 
         # Test for dicts with no items from old categories
         cat = Categorical(["a", "b", "c", "d"])
         res = cat.rename_categories({"f": 1, "g": 3})
 
         expected = Index(["a", "b", "c", "d"])
-        tm.assert_index_equal(res.categories, expected)
+        tm.assert_index_equal(res.categories, expected, exact=True)
 
     def test_reorder_categories(self):
         cat = Categorical(["a", "b", "c", "a"], ordered=True)
@@ -207,11 +207,11 @@ class TestCategoricalAPI:
         cat = cat.set_categories(["c", "b", "a"])
         res = cat.set_categories(["a", "b", "c"])
         # cat must be the same as before
-        tm.assert_index_equal(cat.categories, exp_categories)
+        tm.assert_index_equal(cat.categories, exp_categories, exact=True)
         tm.assert_numpy_array_equal(cat.__array__(), exp_values)
         # only res is changed
         exp_categories_back = Index(["a", "b", "c"])
-        tm.assert_index_equal(res.categories, exp_categories_back)
+        tm.assert_index_equal(res.categories, exp_categories_back, exact=True)
         tm.assert_numpy_array_equal(res.__array__(), exp_values)
 
         # not all "old" included in "new" -> all not included ones are now
@@ -223,17 +223,17 @@ class TestCategoricalAPI:
         # still not all "old" in "new"
         res = cat.set_categories(["a", "b", "d"])
         tm.assert_numpy_array_equal(res.codes, np.array([0, 1, -1, 0], dtype=np.int8))
-        tm.assert_index_equal(res.categories, Index(["a", "b", "d"]))
+        tm.assert_index_equal(res.categories, Index(["a", "b", "d"]), exact=True)
 
         # all "old" included in "new"
         cat = cat.set_categories(["a", "b", "c", "d"])
         exp_categories = Index(["a", "b", "c", "d"])
-        tm.assert_index_equal(cat.categories, exp_categories)
+        tm.assert_index_equal(cat.categories, exp_categories, exact=True)
 
         # internals...
         c = Categorical([1, 2, 3, 4, 1], categories=[1, 2, 3, 4], ordered=True)
         tm.assert_numpy_array_equal(c._codes, np.array([0, 1, 2, 3, 0], dtype=np.int8))
-        tm.assert_index_equal(c.categories, Index([1, 2, 3, 4]))
+        tm.assert_index_equal(c.categories, Index([1, 2, 3, 4]), exact=True)
 
         exp = np.array([1, 2, 3, 4, 1], dtype=np.int64)
         tm.assert_numpy_array_equal(np.asarray(c), exp)
@@ -245,7 +245,7 @@ class TestCategoricalAPI:
         tm.assert_numpy_array_equal(c._codes, np.array([3, 2, 1, 0, 3], dtype=np.int8))
 
         # categories are now in new order
-        tm.assert_index_equal(c.categories, Index([4, 3, 2, 1]))
+        tm.assert_index_equal(c.categories, Index([4, 3, 2, 1]), exact=True)
 
         # output is the same
         exp = np.array([1, 2, 3, 4, 1], dtype=np.int64)
@@ -349,24 +349,26 @@ class TestCategoricalAPI:
         exp_categories_all = Index(["a", "b", "c", "d", "e"])
         exp_categories_dropped = Index(["a", "b", "c", "d"])
 
-        tm.assert_index_equal(c.categories, exp_categories_all)
+        tm.assert_index_equal(c.categories, exp_categories_all, exact=True)
 
         res = c.remove_unused_categories()
-        tm.assert_index_equal(res.categories, exp_categories_dropped)
-        tm.assert_index_equal(c.categories, exp_categories_all)
+        tm.assert_index_equal(res.categories, exp_categories_dropped, exact=True)
+        tm.assert_index_equal(c.categories, exp_categories_all, exact=True)
 
         # with NaN values (GH11599)
         c = Categorical(["a", "b", "c", np.nan], categories=["a", "b", "c", "d", "e"])
         res = c.remove_unused_categories()
-        tm.assert_index_equal(res.categories, Index(np.array(["a", "b", "c"])))
+        tm.assert_index_equal(
+            res.categories, Index(np.array(["a", "b", "c"])), exact=True
+        )
         exp_codes = np.array([0, 1, 2, -1], dtype=np.int8)
         tm.assert_numpy_array_equal(res.codes, exp_codes)
-        tm.assert_index_equal(c.categories, exp_categories_all)
+        tm.assert_index_equal(c.categories, exp_categories_all, exact=True)
 
         val = ["F", np.nan, "D", "B", "D", "F", np.nan]
         cat = Categorical(values=val, categories=list("ABCDEFG"))
         out = cat.remove_unused_categories()
-        tm.assert_index_equal(out.categories, Index(["B", "D", "F"]))
+        tm.assert_index_equal(out.categories, Index(["B", "D", "F"]), exact=True)
         exp_codes = np.array([2, -1, 1, 0, 1, 2, -1], dtype=np.int8)
         tm.assert_numpy_array_equal(out.codes, exp_codes)
         assert out.tolist() == val

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -73,11 +73,11 @@ class TestCategoricalConstructors:
         # GH 17248
         c = Categorical([])
         expected = Index([])
-        tm.assert_index_equal(c.categories, expected)
+        tm.assert_index_equal(c.categories, expected, exact=True)
 
         c = Categorical([], categories=[1, 2, 3])
         expected = Index([1, 2, 3], dtype=np.int64)
-        tm.assert_index_equal(c.categories, expected)
+        tm.assert_index_equal(c.categories, expected, exact=True)
 
     def test_constructor_empty_boolean(self):
         # see gh-22702
@@ -89,7 +89,7 @@ class TestCategoricalConstructors:
         values = np.array([(1,), (1, 2), (1,), (1, 2)], dtype=object)
         result = Categorical(values)
         expected = Index([(1,), (1, 2)], tupleize_cols=False)
-        tm.assert_index_equal(result.categories, expected)
+        tm.assert_index_equal(result.categories, expected, exact=True)
         assert result.ordered is False
 
     def test_constructor_tuples_datetimes(self):
@@ -110,7 +110,7 @@ class TestCategoricalConstructors:
             [(Timestamp("2010-01-01"),), (Timestamp("2010-01-02"),)],
             tupleize_cols=False,
         )
-        tm.assert_index_equal(result.categories, expected)
+        tm.assert_index_equal(result.categories, expected, exact=True)
 
     def test_constructor_unsortable(self):
         # it works!
@@ -133,7 +133,7 @@ class TestCategoricalConstructors:
         ii = IntervalIndex([Interval(1, 2), Interval(2, 3), Interval(3, 6)])
         exp = Categorical(ii, ordered=True)
         tm.assert_categorical_equal(result, exp)
-        tm.assert_index_equal(result.categories, ii)
+        tm.assert_index_equal(result.categories, ii, exact=True)
 
     def test_constructor(self):
         exp_arr = np.array(["a", "b", "c", "a", "b", "c"], dtype=np.object_)
@@ -172,7 +172,7 @@ class TestCategoricalConstructors:
         c1 = Categorical(["a", "b", "c", "a"], categories=["a", "c", "b"])
         c2 = Categorical(c1, categories=["a", "b", "c"])
         tm.assert_numpy_array_equal(c1.__array__(), c2.__array__())
-        tm.assert_index_equal(c2.categories, Index(["a", "b", "c"]))
+        tm.assert_index_equal(c2.categories, Index(["a", "b", "c"]), exact=True)
 
         # Series of dtype category
         c1 = Categorical(["a", "b", "c", "a"], categories=["a", "b", "c", "d"])
@@ -338,7 +338,7 @@ class TestCategoricalConstructors:
         expected = type(dtl)(s)
         expected._data.freq = None
 
-        tm.assert_index_equal(c.categories, expected)
+        tm.assert_index_equal(c.categories, expected, exact=True)
         tm.assert_numpy_array_equal(c.codes, np.arange(5, dtype="int8"))
 
         # with NaT
@@ -349,7 +349,7 @@ class TestCategoricalConstructors:
         expected = type(dtl)(s2.dropna())
         expected._data.freq = None
 
-        tm.assert_index_equal(c.categories, expected)
+        tm.assert_index_equal(c.categories, expected, exact=True)
 
         exp = np.array([0, 1, 2, 3, -1], dtype=np.int8)
         tm.assert_numpy_array_equal(c.codes, exp)
@@ -361,10 +361,10 @@ class TestCategoricalConstructors:
         idx = date_range("2015-01-01 10:00", freq="D", periods=3, tz="US/Eastern")
         idx = idx._with_freq(None)  # freq not preserved in result.categories
         result = Categorical(idx)
-        tm.assert_index_equal(result.categories, idx)
+        tm.assert_index_equal(result.categories, idx, exact=True)
 
         result = Categorical(Series(idx))
-        tm.assert_index_equal(result.categories, idx)
+        tm.assert_index_equal(result.categories, idx, exact=True)
 
     def test_constructor_date_objects(self):
         # we dont cast date objects to timestamps, matching Index constructor
@@ -378,18 +378,18 @@ class TestCategoricalConstructors:
         idx = timedelta_range("1 days", freq="D", periods=3)
         idx = idx._with_freq(None)  # freq not preserved in result.categories
         result = Categorical(idx)
-        tm.assert_index_equal(result.categories, idx)
+        tm.assert_index_equal(result.categories, idx, exact=True)
 
         result = Categorical(Series(idx))
-        tm.assert_index_equal(result.categories, idx)
+        tm.assert_index_equal(result.categories, idx, exact=True)
 
     def test_constructor_from_index_series_period(self):
         idx = period_range("2015-01-01", freq="D", periods=3)
         result = Categorical(idx)
-        tm.assert_index_equal(result.categories, idx)
+        tm.assert_index_equal(result.categories, idx, exact=True)
 
         result = Categorical(Series(idx))
-        tm.assert_index_equal(result.categories, idx)
+        tm.assert_index_equal(result.categories, idx, exact=True)
 
     @pytest.mark.parametrize(
         "values",
@@ -527,7 +527,7 @@ class TestCategoricalConstructors:
         dtype = CategoricalDtype(cats)
         arr = Categorical.from_codes(codes, dtype=dtype, validate=validate)
         assert arr.categories.dtype == cats.dtype
-        tm.assert_index_equal(arr.categories, Index(cats))
+        tm.assert_index_equal(arr.categories, Index(cats), exact=True)
 
     def test_from_codes_empty(self):
         cat = ["a", "b", "c"]
@@ -706,7 +706,7 @@ class TestCategoricalConstructors:
     def test_constructor_imaginary(self):
         values = [1, 2, 3 + 1j]
         c1 = Categorical(values)
-        tm.assert_index_equal(c1.categories, Index(values))
+        tm.assert_index_equal(c1.categories, Index(values), exact=True)
         tm.assert_numpy_array_equal(np.array(c1), np.array(values))
 
     def test_constructor_string_and_tuples(self):
@@ -720,28 +720,28 @@ class TestCategoricalConstructors:
         cat = Categorical(idx, categories=idx)
         expected_codes = np.arange(10, dtype="int8")
         tm.assert_numpy_array_equal(cat.codes, expected_codes)
-        tm.assert_index_equal(cat.categories, idx)
+        tm.assert_index_equal(cat.categories, idx, exact=True)
 
         # infer categories
         cat = Categorical(idx)
         tm.assert_numpy_array_equal(cat.codes, expected_codes)
-        tm.assert_index_equal(cat.categories, idx)
+        tm.assert_index_equal(cat.categories, idx, exact=True)
 
         # list values
         cat = Categorical(list(idx))
         tm.assert_numpy_array_equal(cat.codes, expected_codes)
-        tm.assert_index_equal(cat.categories, idx)
+        tm.assert_index_equal(cat.categories, idx, exact=True)
 
         # list values, categories
         cat = Categorical(list(idx), categories=list(idx))
         tm.assert_numpy_array_equal(cat.codes, expected_codes)
-        tm.assert_index_equal(cat.categories, idx)
+        tm.assert_index_equal(cat.categories, idx, exact=True)
 
         # shuffled
         values = idx.take([1, 2, 0])
         cat = Categorical(values, categories=idx)
         tm.assert_numpy_array_equal(cat.codes, np.array([1, 2, 0], dtype="int8"))
-        tm.assert_index_equal(cat.categories, idx)
+        tm.assert_index_equal(cat.categories, idx, exact=True)
 
         # extra
         values = pd.interval_range(8, 11, periods=3)
@@ -750,14 +750,14 @@ class TestCategoricalConstructors:
             cat = Categorical(values, categories=idx)
         expected_codes = np.array([8, 9, -1], dtype="int8")
         tm.assert_numpy_array_equal(cat.codes, expected_codes)
-        tm.assert_index_equal(cat.categories, idx)
+        tm.assert_index_equal(cat.categories, idx, exact=True)
 
         # overlapping
         idx = IntervalIndex([Interval(0, 2), Interval(0, 1)])
         cat = Categorical(idx, categories=idx)
         expected_codes = np.array([0, 1], dtype="int8")
         tm.assert_numpy_array_equal(cat.codes, expected_codes)
-        tm.assert_index_equal(cat.categories, idx)
+        tm.assert_index_equal(cat.categories, idx, exact=True)
 
     def test_categorical_extension_array_nullable(self, nulls_fixture):
         # GH:

--- a/pandas/tests/arrays/categorical/test_dtypes.py
+++ b/pandas/tests/arrays/categorical/test_dtypes.py
@@ -58,7 +58,7 @@ class TestCategoricalDtypes:
         c = Categorical(["a", "b", "c"])
         result = c._set_dtype(CategoricalDtype(list("abcd")), copy=True)
         tm.assert_numpy_array_equal(result.codes, c.codes)
-        tm.assert_index_equal(result.dtype.categories, Index(list("abcd")))
+        tm.assert_index_equal(result.dtype.categories, Index(list("abcd")), exact=True)
 
     @pytest.mark.parametrize(
         "values, categories, new_categories, warn",
@@ -144,4 +144,4 @@ class TestCategoricalDtypes:
         expected = IntervalIndex.from_arrays(
             [0, 1], [1, 2], dtype="interval[uint64, right]"
         )
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -150,7 +150,7 @@ class TestCategoricalIndexing:
         exp_arr = np.array([0, 0, 1, 1, 2, 2], dtype=np.int8)
         exp_idx = PeriodIndex(["2014-01", "2014-02", "2014-03"], freq="M")
         tm.assert_numpy_array_equal(cat1._codes, exp_arr)
-        tm.assert_index_equal(cat1.categories, exp_idx)
+        tm.assert_index_equal(cat1.categories, exp_idx, exact=True)
 
         idx2 = PeriodIndex(
             ["2014-03", "2014-03", "2014-02", "2014-01", "2014-03", "2014-01"],
@@ -161,7 +161,7 @@ class TestCategoricalIndexing:
         exp_arr = np.array([2, 2, 1, 0, 2, 0], dtype=np.int8)
         exp_idx2 = PeriodIndex(["2014-01", "2014-02", "2014-03"], freq="M")
         tm.assert_numpy_array_equal(cat2._codes, exp_arr)
-        tm.assert_index_equal(cat2.categories, exp_idx2)
+        tm.assert_index_equal(cat2.categories, exp_idx2, exact=True)
 
         idx3 = PeriodIndex(
             [
@@ -190,7 +190,7 @@ class TestCategoricalIndexing:
             freq="M",
         )
         tm.assert_numpy_array_equal(cat3._codes, exp_arr)
-        tm.assert_index_equal(cat3.categories, exp_idx)
+        tm.assert_index_equal(cat3.categories, exp_idx, exact=True)
 
     @pytest.mark.parametrize(
         "null_val",
@@ -201,7 +201,7 @@ class TestCategoricalIndexing:
         result = PeriodIndex(["2022-04-06", "2022-04-07", null_val], freq="D")
         expected = PeriodIndex(["2022-04-06", "2022-04-07", "NaT"], dtype="period[D]")
         assert result[2] is NaT
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.parametrize("new_categories", [[1, 2, 3, 4], [1, 2]])
     def test_categories_assignments_wrong_length_raises(self, new_categories):

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -42,7 +42,7 @@ def test_map(na_action):
     # GH 12766: Return an index not an array
     result = cat.map(lambda x: 1, na_action=na_action)
     exp = Index(np.array([1] * 5, dtype=np.int64))
-    tm.assert_index_equal(result, exp)
+    tm.assert_index_equal(result, exp, exact=True)
 
     # change categories dtype
     cat = Categorical(list("ABABC"), categories=list("BAC"), ordered=False)
@@ -87,7 +87,7 @@ def test_map_with_nan_none(data, f, expected):  # GH 24241
     if isinstance(expected, Categorical):
         tm.assert_categorical_equal(result, expected)
     else:
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
 
 @pytest.mark.parametrize(
@@ -115,7 +115,7 @@ def test_map_with_nan_ignore(data, f, expected):  # GH 24241
     if data[1] == 1:
         tm.assert_categorical_equal(result, expected)
     else:
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
 
 def test_map_with_dict_or_series(na_action):

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -41,16 +41,16 @@ class TestCategoricalMissing:
     def test_nan_handling(self):
         # Nans are represented as -1 in codes
         c = Categorical(["a", "b", np.nan, "a"])
-        tm.assert_index_equal(c.categories, Index(["a", "b"]))
+        tm.assert_index_equal(c.categories, Index(["a", "b"]), exact=True)
         tm.assert_numpy_array_equal(c._codes, np.array([0, 1, -1, 0], dtype=np.int8))
         c[1] = np.nan
-        tm.assert_index_equal(c.categories, Index(["a", "b"]))
+        tm.assert_index_equal(c.categories, Index(["a", "b"]), exact=True)
         tm.assert_numpy_array_equal(c._codes, np.array([0, -1, -1, 0], dtype=np.int8))
 
         # Adding nan to categories should make assigned nan point to the
         # category!
         c = Categorical(["a", "b", np.nan, "a"])
-        tm.assert_index_equal(c.categories, Index(["a", "b"]))
+        tm.assert_index_equal(c.categories, Index(["a", "b"]), exact=True)
         tm.assert_numpy_array_equal(c._codes, np.array([0, 1, -1, 0], dtype=np.int8))
 
     def test_set_dtype_nans(self):
@@ -133,4 +133,4 @@ class TestCategoricalMissing:
     def test_categorical_only_missing_values_no_cast(self, na_value, dtype):
         # GH#44900
         result = Categorical([na_value, na_value])
-        tm.assert_index_equal(result.categories, Index([], dtype=dtype))
+        tm.assert_index_equal(result.categories, Index([], dtype=dtype), exact=True)

--- a/pandas/tests/arrays/categorical/test_sorting.py
+++ b/pandas/tests/arrays/categorical/test_sorting.py
@@ -51,7 +51,7 @@ class TestCategoricalSort:
         res = cat.sort_values()
         exp = np.array(["a", "b", "c", "d"], dtype=object)
         tm.assert_numpy_array_equal(res.__array__(), exp)
-        tm.assert_index_equal(res.categories, cat.categories)
+        tm.assert_index_equal(res.categories, cat.categories, exact=True)
 
         cat = Categorical(
             ["a", "c", "b", "d"], categories=["a", "b", "c", "d"], ordered=True
@@ -59,12 +59,12 @@ class TestCategoricalSort:
         res = cat.sort_values()
         exp = np.array(["a", "b", "c", "d"], dtype=object)
         tm.assert_numpy_array_equal(res.__array__(), exp)
-        tm.assert_index_equal(res.categories, cat.categories)
+        tm.assert_index_equal(res.categories, cat.categories, exact=True)
 
         res = cat.sort_values(ascending=False)
         exp = np.array(["d", "c", "b", "a"], dtype=object)
         tm.assert_numpy_array_equal(res.__array__(), exp)
-        tm.assert_index_equal(res.categories, cat.categories)
+        tm.assert_index_equal(res.categories, cat.categories, exact=True)
 
         # sort (inplace order)
         cat1 = cat.copy()
@@ -73,7 +73,7 @@ class TestCategoricalSort:
         assert cat1._codes is orig_codes
         exp = np.array(["a", "b", "c", "d"], dtype=object)
         tm.assert_numpy_array_equal(cat1.__array__(), exp)
-        tm.assert_index_equal(res.categories, cat.categories)
+        tm.assert_index_equal(res.categories, cat.categories, exact=True)
 
         # reverse
         cat = Categorical(["a", "c", "c", "b", "d"], ordered=True)
@@ -81,7 +81,7 @@ class TestCategoricalSort:
         exp_val = np.array(["d", "c", "c", "b", "a"], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
         tm.assert_numpy_array_equal(res.__array__(), exp_val)
-        tm.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories, exact=True)
 
     def test_sort_values_na_position(self):
         # see gh-12882
@@ -91,38 +91,38 @@ class TestCategoricalSort:
         exp = np.array([2.0, 2.0, 5.0, np.nan, np.nan])
         res = cat.sort_values()  # default arguments
         tm.assert_numpy_array_equal(res.__array__(), exp)
-        tm.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories, exact=True)
 
         exp = np.array([np.nan, np.nan, 2.0, 2.0, 5.0])
         res = cat.sort_values(ascending=True, na_position="first")
         tm.assert_numpy_array_equal(res.__array__(), exp)
-        tm.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories, exact=True)
 
         exp = np.array([np.nan, np.nan, 5.0, 2.0, 2.0])
         res = cat.sort_values(ascending=False, na_position="first")
         tm.assert_numpy_array_equal(res.__array__(), exp)
-        tm.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories, exact=True)
 
         exp = np.array([2.0, 2.0, 5.0, np.nan, np.nan])
         res = cat.sort_values(ascending=True, na_position="last")
         tm.assert_numpy_array_equal(res.__array__(), exp)
-        tm.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories, exact=True)
 
         exp = np.array([5.0, 2.0, 2.0, np.nan, np.nan])
         res = cat.sort_values(ascending=False, na_position="last")
         tm.assert_numpy_array_equal(res.__array__(), exp)
-        tm.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories, exact=True)
 
         cat = Categorical(["a", "c", "b", "d", np.nan], ordered=True)
         res = cat.sort_values(ascending=False, na_position="last")
         exp_val = np.array(["d", "c", "b", "a", np.nan], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
         tm.assert_numpy_array_equal(res.__array__(), exp_val)
-        tm.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories, exact=True)
 
         cat = Categorical(["a", "c", "b", "d", np.nan], ordered=True)
         res = cat.sort_values(ascending=False, na_position="first")
         exp_val = np.array([np.nan, "d", "c", "b", "a"], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
         tm.assert_numpy_array_equal(res.__array__(), exp_val)
-        tm.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories, exact=True)

--- a/pandas/tests/arrays/integer/test_dtypes.py
+++ b/pandas/tests/arrays/integer/test_dtypes.py
@@ -72,7 +72,7 @@ def test_construct_index(all_data, dropna):
     expected = pd.Index(other, dtype=all_data.dtype)
     assert all_data.dtype == expected.dtype  # dont coerce to object
 
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
 
 def test_astype_index(all_data, dropna):
@@ -90,7 +90,7 @@ def test_astype_index(all_data, dropna):
 
     result = idx.astype(dtype)
     expected = idx.astype(object).astype(dtype)
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
 
 def test_astype(all_data):

--- a/pandas/tests/arrays/interval/test_astype.py
+++ b/pandas/tests/arrays/interval/test_astype.py
@@ -25,4 +25,4 @@ class TestAstype:
         # test IntervalIndex.astype while we're at it.
         result = index.astype(dtype)
         expected = Index(expected)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/construction/test_extract_array.py
+++ b/pandas/tests/construction/test_extract_array.py
@@ -13,6 +13,6 @@ def test_extract_array_rangeindex():
     tm.assert_numpy_array_equal(res, expected)
 
     res = extract_array(ri, extract_numpy=True, extract_range=False)
-    tm.assert_index_equal(res, ri)
+    tm.assert_index_equal(res, ri, exact=True)
     res = extract_array(ri, extract_numpy=False, extract_range=False)
-    tm.assert_index_equal(res, ri)
+    tm.assert_index_equal(res, ri, exact=True)

--- a/pandas/tests/copy_view/index/test_datetimeindex.py
+++ b/pandas/tests/copy_view/index/test_datetimeindex.py
@@ -23,7 +23,7 @@ def test_datetimeindex(box):
     idx = box(DatetimeIndex(ser))
     expected = idx.copy(deep=True)
     ser.iloc[0] = Timestamp("2020-12-31")
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
 
 def test_datetimeindex_tz_convert():
@@ -32,7 +32,7 @@ def test_datetimeindex_tz_convert():
     idx = DatetimeIndex(ser).tz_convert("US/Eastern")
     expected = idx.copy(deep=True)
     ser.iloc[0] = Timestamp("2020-12-31", tz="Europe/Berlin")
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
 
 def test_datetimeindex_tz_localize():
@@ -41,7 +41,7 @@ def test_datetimeindex_tz_localize():
     idx = DatetimeIndex(ser).tz_localize("Europe/Berlin")
     expected = idx.copy(deep=True)
     ser.iloc[0] = Timestamp("2020-12-31")
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
 
 def test_datetimeindex_isocalendar():
@@ -50,7 +50,7 @@ def test_datetimeindex_isocalendar():
     df = DatetimeIndex(ser).isocalendar()
     expected = df.index.copy(deep=True)
     ser.iloc[0] = Timestamp("2020-12-31")
-    tm.assert_index_equal(df.index, expected)
+    tm.assert_index_equal(df.index, expected, exact=True)
 
 
 def test_index_values():

--- a/pandas/tests/copy_view/index/test_index.py
+++ b/pandas/tests/copy_view/index/test_index.py
@@ -123,6 +123,8 @@ def test_index_ops(func, request):
     expected = idx.copy(deep=True)
     if "astype" in request.node.callspec.id:
         expected = expected.astype("Int64")
+    if "repeat" in request.node.callspec.id:
+        expected = expected.repeat([1, 1])
     idx = func(idx)
     view_.iloc[0, 0] = 100
     tm.assert_index_equal(idx, expected, check_names=False)

--- a/pandas/tests/copy_view/index/test_index.py
+++ b/pandas/tests/copy_view/index/test_index.py
@@ -25,7 +25,7 @@ def test_set_index_update_column():
     df = df.set_index("a", drop=False)
     expected = df.index.copy(deep=True)
     df.iloc[0, 0] = 100
-    tm.assert_index_equal(df.index, expected)
+    tm.assert_index_equal(df.index, expected, exact=True)
 
 
 def test_set_index_drop_update_column():
@@ -34,7 +34,7 @@ def test_set_index_drop_update_column():
     df = df.set_index("a", drop=True)
     expected = df.index.copy(deep=True)
     view.iloc[0, 0] = 100
-    tm.assert_index_equal(df.index, expected)
+    tm.assert_index_equal(df.index, expected, exact=True)
 
 
 def test_set_index_series():
@@ -43,7 +43,7 @@ def test_set_index_series():
     df = df.set_index(ser)
     expected = df.index.copy(deep=True)
     ser.iloc[0] = 100
-    tm.assert_index_equal(df.index, expected)
+    tm.assert_index_equal(df.index, expected, exact=True)
 
 
 def test_assign_index_as_series():
@@ -52,7 +52,7 @@ def test_assign_index_as_series():
     df.index = ser
     expected = df.index.copy(deep=True)
     ser.iloc[0] = 100
-    tm.assert_index_equal(df.index, expected)
+    tm.assert_index_equal(df.index, expected, exact=True)
 
 
 def test_assign_index_as_index():
@@ -63,7 +63,7 @@ def test_assign_index_as_index():
     rhs_index = None  # overwrite to clear reference
     expected = df.index.copy(deep=True)
     ser.iloc[0] = 100
-    tm.assert_index_equal(df.index, expected)
+    tm.assert_index_equal(df.index, expected, exact=True)
 
 
 def test_index_from_series():
@@ -71,7 +71,7 @@ def test_index_from_series():
     idx = Index(ser)
     expected = idx.copy(deep=True)
     ser.iloc[0] = 100
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
 
 def test_index_from_series_copy():
@@ -88,7 +88,7 @@ def test_index_from_index():
     idx = Index(idx)
     expected = idx.copy(deep=True)
     ser.iloc[0] = 100
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
 
 @pytest.mark.parametrize(
@@ -127,7 +127,7 @@ def test_index_ops(func, request):
         expected = expected.repeat([1, 1])
     idx = func(idx)
     view_.iloc[0, 0] = 100
-    tm.assert_index_equal(idx, expected, check_names=False)
+    tm.assert_index_equal(idx, expected, exact=True, check_names=False)
 
 
 def test_infer_objects():
@@ -135,7 +135,7 @@ def test_infer_objects():
     expected = idx.copy(deep=True)
     idx = idx.infer_objects(copy=False)
     view_.iloc[0, 0] = "aaaa"
-    tm.assert_index_equal(idx, expected, check_names=False)
+    tm.assert_index_equal(idx, expected, exact=True, check_names=False)
 
 
 def test_index_to_frame():
@@ -146,7 +146,7 @@ def test_index_to_frame():
     assert not df._mgr._has_no_reference(0)
 
     df.iloc[0, 0] = 100
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
 
 def test_index_values():

--- a/pandas/tests/copy_view/index/test_periodindex.py
+++ b/pandas/tests/copy_view/index/test_periodindex.py
@@ -23,7 +23,7 @@ def test_periodindex(box):
     idx = box(PeriodIndex(ser))
     expected = idx.copy(deep=True)
     ser.iloc[0] = Period("2020-12-31")
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
 
 def test_constructor_copy_input_period_ea_default():

--- a/pandas/tests/copy_view/index/test_timedeltaindex.py
+++ b/pandas/tests/copy_view/index/test_timedeltaindex.py
@@ -29,7 +29,7 @@ def test_timedeltaindex(cons):
     idx = cons(ser)
     expected = idx.copy(deep=True)
     ser.iloc[0] = Timedelta("5 days")
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
 
 def test_constructor_copy_input_timedelta_ndarray_default():

--- a/pandas/tests/copy_view/test_constructors.py
+++ b/pandas/tests/copy_view/test_constructors.py
@@ -134,14 +134,14 @@ def test_series_from_index(idx):
     assert np.shares_memory(get_array(ser), get_array(idx))
     assert not ser._mgr._has_no_reference(0)
     ser.iloc[0] = ser.iloc[1]
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
     # forcing copy=False still gives a CoW shallow copy
     ser = Series(idx, copy=False)
     assert np.shares_memory(get_array(ser), get_array(idx))
     assert not ser._mgr._has_no_reference(0)
     ser.iloc[0] = ser.iloc[1]
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)
 
     # forcing copy=True still results in a copy
     ser = Series(idx, copy=True)
@@ -379,4 +379,4 @@ def test_frame_from_dict_of_index():
     assert not df._mgr._has_no_reference(0)
 
     df.iloc[0, 0] = 100
-    tm.assert_index_equal(idx, expected)
+    tm.assert_index_equal(idx, expected, exact=True)

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -894,7 +894,7 @@ class TestCategoricalDtypeParametrized:
     )
     def test_basic(self, categories, ordered):
         c1 = CategoricalDtype(categories, ordered=ordered)
-        tm.assert_index_equal(c1.categories, pd.Index(categories))
+        tm.assert_index_equal(c1.categories, pd.Index(categories), exact=True)
         assert c1.ordered is ordered
 
     def test_order_matters(self):
@@ -913,7 +913,7 @@ class TestCategoricalDtypeParametrized:
 
     def test_categories(self):
         result = CategoricalDtype(["a", "b", "c"])
-        tm.assert_index_equal(result.categories, pd.Index(["a", "b", "c"]))
+        tm.assert_index_equal(result.categories, pd.Index(["a", "b", "c"]), exact=True)
         assert result.ordered is False
 
     def test_equal_but_different(self):
@@ -1072,9 +1072,9 @@ class TestCategoricalDtypeParametrized:
     def test_categorical_categories(self):
         # GH17884
         c1 = CategoricalDtype(Categorical(["a", "b"]))
-        tm.assert_index_equal(c1.categories, pd.Index(["a", "b"]))
+        tm.assert_index_equal(c1.categories, pd.Index(["a", "b"]), exact=True)
         c1 = CategoricalDtype(CategoricalIndex(["a", "b"]))
-        tm.assert_index_equal(c1.categories, pd.Index(["a", "b"]))
+        tm.assert_index_equal(c1.categories, pd.Index(["a", "b"]), exact=True)
 
     @pytest.mark.parametrize(
         "new_categories", [list("abc"), list("cba"), list("wxyz"), None]
@@ -1089,7 +1089,7 @@ class TestCategoricalDtypeParametrized:
         expected_categories = pd.Index(new_categories or original_categories)
         expected_ordered = new_ordered if new_ordered is not None else dtype.ordered
 
-        tm.assert_index_equal(result.categories, expected_categories)
+        tm.assert_index_equal(result.categories, expected_categories, exact=True)
         assert result.ordered is expected_ordered
 
     def test_update_dtype_string(self, ordered):
@@ -1097,7 +1097,7 @@ class TestCategoricalDtypeParametrized:
         expected_categories = dtype.categories
         expected_ordered = dtype.ordered
         result = dtype.update_dtype("category")
-        tm.assert_index_equal(result.categories, expected_categories)
+        tm.assert_index_equal(result.categories, expected_categories, exact=True)
         assert result.ordered is expected_ordered
 
     @pytest.mark.parametrize("bad_dtype", ["foo", object, np.int64, PeriodDtype("Q")])

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -169,4 +169,4 @@ class BaseGroupbyTests:
             with pytest.raises(TypeError, match=msg):
                 df.groupby("A").sum()
             result = df.groupby("A").sum(numeric_only=True).columns
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3440,7 +3440,7 @@ def test_factorize_chunked_dictionary():
     exp_indices = np.array([0, 1], dtype=np.intp)
     exp_uniques = pd.Index(ArrowExtensionArray(pa_array.combine_chunks()))
     tm.assert_numpy_array_equal(res_indices, exp_indices)
-    tm.assert_index_equal(res_uniques, exp_uniques)
+    tm.assert_index_equal(res_uniques, exp_uniques, exact=True)
 
 
 def test_factorize_dictionary_with_na():

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -173,7 +173,7 @@ class TestFromDict:
         # GH#16769
         df = DataFrame.from_dict(data_dict, orient)
         result = df.columns
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_frame_dict_constructor_empty_series(self):
         s1 = Series(

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -140,7 +140,7 @@ class TestFromRecords:
         # empty case
         result = DataFrame.from_records([], columns=["foo", "bar", "baz"])
         assert len(result) == 0
-        tm.assert_index_equal(result.columns, Index(["foo", "bar", "baz"]))
+        tm.assert_index_equal(result.columns, Index(["foo", "bar", "baz"]), exact=True)
 
         result = DataFrame.from_records([])
         assert len(result) == 0
@@ -223,7 +223,7 @@ class TestFromRecords:
 
         assert len(result) == 0
         assert result.index.name == "foo"
-        tm.assert_index_equal(result.columns, expected)
+        tm.assert_index_equal(result.columns, expected, exact=True)
 
     def test_from_records_series_list_dict(self):
         # GH#27358
@@ -259,7 +259,7 @@ class TestFromRecords:
 
         index = Index(np.arange(len(arr))[::-1])
         indexed_frame = DataFrame.from_records(arr, index=index)
-        tm.assert_index_equal(indexed_frame.index, index)
+        tm.assert_index_equal(indexed_frame.index, index, exact=True)
 
         # without names, it should go to last ditch
         arr2 = np.zeros((2, 3))

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -42,7 +42,7 @@ class TestDataFrameIndexing:
         # Column access
         for _, series in sl.items():
             assert len(series.index) == 20
-            tm.assert_index_equal(series.index, sl.index)
+            tm.assert_index_equal(series.index, sl.index, exact=True)
 
         for key, _ in float_frame._series.items():
             assert float_frame[key] is not None
@@ -124,7 +124,7 @@ class TestDataFrameIndexing:
         subindex = datetime_frame.index[indexer]
         subframe = datetime_frame[indexer]
 
-        tm.assert_index_equal(subindex, subframe.index)
+        tm.assert_index_equal(subindex, subframe.index, exact=True)
         with pytest.raises(ValueError, match="Item wrong length"):
             datetime_frame[indexer[:-1]]
 

--- a/pandas/tests/frame/indexing/test_insert.py
+++ b/pandas/tests/frame/indexing/test_insert.py
@@ -26,11 +26,13 @@ class TestDataFrameInsert:
         )
 
         df.insert(0, "foo", df["a"])
-        tm.assert_index_equal(df.columns, Index(["foo", "c", "b", "a"]))
+        tm.assert_index_equal(df.columns, Index(["foo", "c", "b", "a"]), exact=True)
         tm.assert_series_equal(df["a"], df["foo"], check_names=False)
 
         df.insert(2, "bar", df["c"])
-        tm.assert_index_equal(df.columns, Index(["foo", "c", "bar", "b", "a"]))
+        tm.assert_index_equal(
+            df.columns, Index(["foo", "c", "bar", "b", "a"]), exact=True
+        )
         tm.assert_almost_equal(df["c"], df["bar"], check_names=False)
 
         with pytest.raises(ValueError, match="already exists"):

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -379,13 +379,13 @@ class TestDataFrameSetItem:
 
         df["Index"] = rng
         rs = Index(df["Index"])
-        tm.assert_index_equal(rs, rng, check_names=False)
+        tm.assert_index_equal(rs, rng, exact=True, check_names=False)
         assert rs.name == "Index"
         assert rng.name == "index"
 
         rs = df.reset_index().set_index("index")
         assert isinstance(rs.index, PeriodIndex)
-        tm.assert_index_equal(rs.index, rng)
+        tm.assert_index_equal(rs.index, rng, exact=True)
 
     def test_setitem_complete_column_with_array(self):
         # GH#37954
@@ -429,7 +429,7 @@ class TestDataFrameSetItem:
         if dtype == "f8":
             expected_cols = Index([1.0, 2.0, 3.0, False], dtype=object)
 
-        tm.assert_index_equal(df.columns, expected_cols)
+        tm.assert_index_equal(df.columns, expected_cols, exact=True)
 
     @pytest.mark.parametrize("indexer", ["B", ["B"]])
     def test_setitem_frame_length_0_str_key(self, indexer):
@@ -535,10 +535,10 @@ class TestDataFrameSetItem:
         # they compare equal as Index
         # when converted to numpy objects
         c = lambda x: Index(np.array(x))
-        tm.assert_index_equal(c(df.B), c(df.B))
-        tm.assert_index_equal(c(df.B), c(df.C), check_names=False)
-        tm.assert_index_equal(c(df.B), c(df.D), check_names=False)
-        tm.assert_index_equal(c(df.C), c(df.D), check_names=False)
+        tm.assert_index_equal(c(df.B), c(df.B), exact=True)
+        tm.assert_index_equal(c(df.B), c(df.C), exact=True, check_names=False)
+        tm.assert_index_equal(c(df.B), c(df.D), exact=True, check_names=False)
+        tm.assert_index_equal(c(df.C), c(df.D), exact=True, check_names=False)
 
         # B & D are the same Series
         tm.assert_series_equal(df["B"], df["B"])
@@ -563,7 +563,7 @@ class TestDataFrameSetItem:
         result = DataFrame(columns=["A"], index=index)
         result["A"] = []
         expected = DataFrame(columns=["A"], index=index)
-        tm.assert_index_equal(result.index, expected.index)
+        tm.assert_index_equal(result.index, expected.index, exact=True)
 
     @pytest.mark.parametrize(
         "cols, values, expected",

--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -19,6 +19,7 @@ from pandas import (
     DatetimeIndex,
     Index,
     MultiIndex,
+    RangeIndex,
     Series,
     date_range,
     period_range,
@@ -150,7 +151,7 @@ class TestSetIndex:
 
     def test_set_index(self, float_string_frame):
         df = float_string_frame
-        idx = Index(np.arange(len(df) - 1, -1, -1, dtype=np.int64))
+        idx = RangeIndex(start=29, stop=-1, step=-1)
 
         df = df.set_index(idx)
         tm.assert_index_equal(df.index, idx)

--- a/pandas/tests/groupby/test_all_methods.py
+++ b/pandas/tests/groupby/test_all_methods.py
@@ -36,7 +36,7 @@ def test_multiindex_group_all_columns_when_empty(groupby_func):
     with tm.assert_produces_warning(warn, match=warn_msg):
         result = method(*args).index
     expected = df.index
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
 
 def test_duplicate_columns(request, groupby_func, as_index):
@@ -83,7 +83,7 @@ def test_dup_labels_output_shape(groupby_func, idx):
         result = getattr(grp_by, groupby_func)(*args)
 
     assert result.shape == (1, 2)
-    tm.assert_index_equal(result.columns, idx)
+    tm.assert_index_equal(result.columns, idx, exact=True)
 
 
 def test_not_c_contiguous_mask(groupby_func):
@@ -91,7 +91,7 @@ def test_not_c_contiguous_mask(groupby_func):
     if groupby_func == "corrwith":
         # corrwith is deprecated
         return
-    df = DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]}, dtype="Int64")
+    df = DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]}, dtype="Int64", index=[0, 1, 2])
     reversed = DataFrame(
         {"a": [2, 1, 1], "b": [5, 4, 3]}, dtype="Int64", index=[2, 1, 0]
     )[::-1]

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -329,7 +329,7 @@ def test_groupby_as_index_apply_str():
     ind = Index(list("abcde"))
     df = DataFrame([[1, 2], [2, 3], [1, 4], [1, 5], [2, 6]], index=ind)
     res = df.groupby(0, as_index=False, group_keys=False).apply(lambda x: x).index
-    tm.assert_index_equal(res, ind)
+    tm.assert_index_equal(res, ind, exact=True)
 
 
 def test_apply_concat_preserve_names(three_group):
@@ -383,7 +383,7 @@ def test_apply_series_to_frame():
 
     assert isinstance(result, DataFrame)
     assert not hasattr(result, "name")  # GH49907
-    tm.assert_index_equal(result.index, ts.index)
+    tm.assert_index_equal(result.index, ts.index, exact=True)
 
 
 def test_apply_series_yield_constant(df):
@@ -406,7 +406,7 @@ def test_apply_frame_to_series(df):
     grouped = df.groupby(["A", "B"])
     result = grouped.apply(len)
     expected = grouped.count()["C"]
-    tm.assert_index_equal(result.index, expected.index)
+    tm.assert_index_equal(result.index, expected.index, exact=True)
     tm.assert_numpy_array_equal(result.values, expected.values)
 
 
@@ -416,7 +416,7 @@ def test_apply_frame_not_as_index_column_name(df):
     result = grouped.apply(len)
     expected = grouped.count().rename(columns={"C": np.nan}).drop(columns="D")
     # TODO(GH#34306): Use assert_frame_equal when column name is not np.nan
-    tm.assert_index_equal(result.index, expected.index)
+    tm.assert_index_equal(result.index, expected.index, exact=True)
     tm.assert_numpy_array_equal(result.values, expected.values)
 
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -242,9 +242,13 @@ def test_more_basic():
     # GH 10460
     expc = Categorical.from_codes(np.arange(4).repeat(8), levels, ordered=True)
     exp = CategoricalIndex(expc)
-    tm.assert_index_equal(desc_result.stack().index.get_level_values(0), exp)
+    tm.assert_index_equal(
+        desc_result.stack().index.get_level_values(0), exp, exact=True
+    )
     exp = Index(["count", "mean", "std", "min", "25%", "50%", "75%", "max"] * 4)
-    tm.assert_index_equal(desc_result.stack().index.get_level_values(1), exp)
+    tm.assert_index_equal(
+        desc_result.stack().index.get_level_values(1), exp, exact=True
+    )
 
 
 def test_level_get_group(observed):
@@ -697,17 +701,23 @@ def test_datetime():
     ord_data = data.take(idx)
     expected = ord_data.groupby(ord_labels, observed=False).describe()
     tm.assert_frame_equal(desc_result, expected)
-    tm.assert_index_equal(desc_result.index, expected.index)
+    tm.assert_index_equal(desc_result.index, expected.index, exact=True)
     tm.assert_index_equal(
-        desc_result.index.get_level_values(0), expected.index.get_level_values(0)
+        desc_result.index.get_level_values(0),
+        expected.index.get_level_values(0),
+        exact=True,
     )
 
     # GH 10460
     expc = Categorical.from_codes(np.arange(4).repeat(8), levels, ordered=True)
     exp = CategoricalIndex(expc)
-    tm.assert_index_equal((desc_result.stack().index.get_level_values(0)), exp)
+    tm.assert_index_equal(
+        (desc_result.stack().index.get_level_values(0)), exp, exact=True
+    )
     exp = Index(["count", "mean", "std", "min", "25%", "50%", "75%", "max"] * 4)
-    tm.assert_index_equal((desc_result.stack().index.get_level_values(1)), exp)
+    tm.assert_index_equal(
+        (desc_result.stack().index.get_level_values(1)), exp, exact=True
+    )
 
 
 def test_categorical_index():
@@ -745,7 +755,7 @@ def test_describe_categorical_columns():
     df = DataFrame(np.random.default_rng(2).standard_normal((20, 4)), columns=cats)
     result = df.groupby([1, 2, 3, 4] * 5).describe()
 
-    tm.assert_index_equal(result.stack().columns, cats)
+    tm.assert_index_equal(result.stack().columns, cats, exact=True)
     tm.assert_categorical_equal(result.stack().columns.values, cats.values)
 
 
@@ -760,7 +770,7 @@ def test_unstack_categorical():
     result = gcat.describe()
 
     exp_columns = CategoricalIndex(["A", "B"], ordered=False, name="medium")
-    tm.assert_index_equal(result.columns, exp_columns)
+    tm.assert_index_equal(result.columns, exp_columns, exact=True)
     tm.assert_categorical_equal(result.columns.values, exp_columns.values)
 
     result = gcat["A"] + gcat["B"]
@@ -872,11 +882,13 @@ def test_preserve_categories():
     sort_index = CategoricalIndex(categories, categories, ordered=True, name="A")
     nosort_index = CategoricalIndex(list("bac"), categories, ordered=True, name="A")
     tm.assert_index_equal(
-        df.groupby("A", sort=True, observed=False).first().index, sort_index
+        df.groupby("A", sort=True, observed=False).first().index, sort_index, exact=True
     )
     # GH#42482 - don't sort result when sort=False, even when ordered=True
     tm.assert_index_equal(
-        df.groupby("A", sort=False, observed=False).first().index, nosort_index
+        df.groupby("A", sort=False, observed=False).first().index,
+        nosort_index,
+        exact=True,
     )
 
 
@@ -889,10 +901,12 @@ def test_preserve_categories_ordered_false():
     # GH#42482 - don't sort result when sort=False, even when ordered=True
     nosort_index = CategoricalIndex(list("bac"), list("abc"), ordered=False, name="A")
     tm.assert_index_equal(
-        df.groupby("A", sort=True, observed=False).first().index, sort_index
+        df.groupby("A", sort=True, observed=False).first().index, sort_index, exact=True
     )
     tm.assert_index_equal(
-        df.groupby("A", sort=False, observed=False).first().index, nosort_index
+        df.groupby("A", sort=False, observed=False).first().index,
+        nosort_index,
+        exact=True,
     )
 
 
@@ -1956,11 +1970,11 @@ def test_category_order_reducer(
     else:
         result = op_result["a"].cat.categories
     expected = Index([1, 4, 3, 2])
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
     if index_kind == "multi":
         result = op_result.index.get_level_values("a2").categories
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
 
 @pytest.mark.parametrize("index_kind", ["single", "multi"])
@@ -1987,11 +2001,11 @@ def test_category_order_transformer(
     op_result = getattr(gb, transformation_func)(*args)
     result = op_result.index.get_level_values("a").categories
     expected = Index([1, 4, 3, 2])
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
     if index_kind == "multi":
         result = op_result.index.get_level_values("a2").categories
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
 
 @pytest.mark.parametrize("index_kind", ["range", "single", "multi"])
@@ -2023,11 +2037,11 @@ def test_category_order_head_tail(
     else:
         result = op_result.index.get_level_values("a").categories
     expected = Index([1, 4, 3, 2])
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
     if index_kind == "multi":
         result = op_result.index.get_level_values("a2").categories
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
 
 @pytest.mark.parametrize("index_kind", ["range", "single", "multi"])
@@ -2061,11 +2075,11 @@ def test_category_order_apply(as_index, sort, observed, method, index_kind, orde
     else:
         result = op_result.index.get_level_values("a").categories
     expected = Index([1, 4, 3, 2])
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
     if index_kind == "multi":
         result = op_result.index.get_level_values("a2").categories
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
 
 @pytest.mark.parametrize("index_kind", ["range", "single", "multi"])

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -956,19 +956,19 @@ def test_groupby_with_hier_columns():
     )
 
     result = df.groupby(level=0).mean()
-    tm.assert_index_equal(result.columns, columns)
+    tm.assert_index_equal(result.columns, columns, exact=True)
 
     result = df.groupby(level=0).agg("mean")
-    tm.assert_index_equal(result.columns, columns)
+    tm.assert_index_equal(result.columns, columns, exact=True)
 
     result = df.groupby(level=0).apply(lambda x: x.mean())
-    tm.assert_index_equal(result.columns, columns)
+    tm.assert_index_equal(result.columns, columns, exact=True)
 
     # add a nuisance column
     sorted_columns, _ = columns.sortlevel(0)
     df["A", "foo"] = "bar"
     result = df.groupby(level=0).mean(numeric_only=True)
-    tm.assert_index_equal(result.columns, df.columns[:-1])
+    tm.assert_index_equal(result.columns, df.columns[:-1], exact=True)
 
 
 def test_grouping_ndarray(df):
@@ -1227,7 +1227,7 @@ def test_groupby_nat_exclude():
     for k, e in zip(keys, expected, strict=True):
         # grouped.groups keys are np.datetime64 with system tz
         # not to be affected by tz, only compare values
-        tm.assert_index_equal(grouped.groups[k], e)
+        tm.assert_index_equal(grouped.groups[k], e, exact=True)
 
     # confirm obj is not filtered
     tm.assert_frame_equal(grouped._grouper.groupings[0].obj, df)
@@ -1279,7 +1279,7 @@ def test_groupby_2d_malformed():
     d["label"] = ["l1", "l2"]
     tmp = d.groupby(["group"]).mean(numeric_only=True)
     res_values = np.array([[0.0, 1.0], [0.0, 1.0]])
-    tm.assert_index_equal(tmp.columns, Index(["zeros", "ones"]))
+    tm.assert_index_equal(tmp.columns, Index(["zeros", "ones"]), exact=True)
     tm.assert_numpy_array_equal(tmp.values, res_values)
 
 
@@ -1980,7 +1980,7 @@ def test_groups_sort_dropna(sort, dropna):
     for result_value, expected_value in zip(
         result.values(), expected.values(), strict=True
     ):
-        tm.assert_index_equal(result_value, expected_value)
+        tm.assert_index_equal(result_value, expected_value, exact=True)
 
 
 @pytest.mark.parametrize(
@@ -2194,7 +2194,7 @@ def test_groupby_column_index_name_lost(func):
     df = DataFrame([[1]], columns=expected)
     df_grouped = df.groupby([1])
     result = getattr(df_grouped, func)().columns
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
 
 @pytest.mark.parametrize(
@@ -2921,7 +2921,7 @@ def test_decimal_na_sort(test_series):
         gb = gb["value"]
     result = gb._grouper.result_index
     expected = Index([Decimal(1), None], name="key")
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
 
 def test_groupby_dropna_with_nunique_unique():
@@ -2983,7 +2983,7 @@ def test_groupby_multi_index_codes():
     df_grouped = df.groupby(["A", "B"], dropna=False).sum()
 
     index = df_grouped.index
-    tm.assert_index_equal(index, MultiIndex.from_frame(index.to_frame()))
+    tm.assert_index_equal(index, MultiIndex.from_frame(index.to_frame()), exact=True)
 
 
 def test_groupby_datetime_with_nat():

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -466,7 +466,7 @@ class TestGrouping:
         groups = Series([1, 0, 1, 0], index=index, name=("a", "a"))
         result = obj.groupby(groups).last()
         expected = frame_or_series([4, 3])
-        expected.index.name = ("a", "a")
+        expected.index = Index([0, 1], dtype="int64", name=("a", "a"))
         tm.assert_equal(result, expected)
 
     def test_groupby_grouper_f_sanity_checked(self):

--- a/pandas/tests/groupby/test_indexing.py
+++ b/pandas/tests/groupby/test_indexing.py
@@ -273,7 +273,7 @@ def test_columns_on_iter():
     # Group-by and select columns
     cols = ["A", "B"]
     for _, dg in df.groupby(df.A < 4)[cols]:
-        tm.assert_index_equal(dg.columns, pd.Index(cols))
+        tm.assert_index_equal(dg.columns, pd.Index(cols), exact=True)
         assert "C" not in dg.columns
 
 

--- a/pandas/tests/groupby/test_missing.py
+++ b/pandas/tests/groupby/test_missing.py
@@ -19,7 +19,7 @@ def test_groupby_column_index_name_lost_fill_funcs(func):
     df_grouped = df.groupby(["type"])[["a", "b"]]
     result = getattr(df_grouped, func)().columns
     expected = Index(["a", "b"], name="idx")
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
 
 @pytest.mark.parametrize("func", ["ffill", "bfill"])

--- a/pandas/tests/groupby/test_numeric_only.py
+++ b/pandas/tests/groupby/test_numeric_only.py
@@ -194,7 +194,7 @@ class TestNumericOnly:
                 getattr(gb, method)()
         else:
             result = getattr(gb, method)()
-            tm.assert_index_equal(result.columns, expected_columns_numeric)
+            tm.assert_index_equal(result.columns, expected_columns_numeric, exact=True)
 
         if method not in ("first", "last"):
             msg = "|".join(
@@ -212,7 +212,7 @@ class TestNumericOnly:
                 getattr(gb, method)(numeric_only=False)
         else:
             result = getattr(gb, method)(numeric_only=False)
-            tm.assert_index_equal(result.columns, expected_columns)
+            tm.assert_index_equal(result.columns, expected_columns, exact=True)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -981,4 +981,4 @@ class TestGroupBy:
             [Timestamp("2013-01-01"), Timestamp("2013-01-02")],
             dtype="timestamp[ns, America/Denver][pyarrow]",
         )
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -151,13 +151,13 @@ def test_transform_broadcast(tsframe, ts):
     grouped = ts.groupby(lambda x: x.month)
     result = grouped.transform(np.mean)
 
-    tm.assert_index_equal(result.index, ts.index)
+    tm.assert_index_equal(result.index, ts.index, exact=True)
     for _, gp in grouped:
         assert_fp_equal(result.reindex(gp.index), gp.mean())
 
     grouped = tsframe.groupby(lambda x: x.month)
     result = grouped.transform(np.mean)
-    tm.assert_index_equal(result.index, tsframe.index)
+    tm.assert_index_equal(result.index, tsframe.index, exact=True)
     for _, gp in grouped:
         agged = gp.mean(axis=0)
         res = result.reindex(gp.index)
@@ -1116,11 +1116,11 @@ def test_transform_agg_by_name(request, reduction_func, frame_or_series):
         result = g.transform(func, *args)
 
     # this is the *definition* of a transformation
-    tm.assert_index_equal(result.index, obj.index)
+    tm.assert_index_equal(result.index, obj.index, exact=True)
 
     if func not in ("ngroup", "size") and obj.ndim == 2:
         # size/ngroup return a Series, unlike other transforms
-        tm.assert_index_equal(result.columns, obj.columns)
+        tm.assert_index_equal(result.columns, obj.columns, exact=True)
 
     # verify that values were broadcasted across each group
     assert len(set(DataFrame(result).iloc[-4:, -1])) == 1

--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -7,6 +7,7 @@ import pandas as pd
 from pandas import (
     Index,
     NaT,
+    RangeIndex,
 )
 import pandas._testing as tm
 
@@ -100,5 +101,5 @@ def test_getitem_boolean_ea_indexer():
     # GH#45806
     ser = pd.Series([True, False, pd.NA], dtype="boolean")
     result = ser.index[ser]
-    expected = Index([0])
+    expected = RangeIndex(start=0, stop=1, step=1)
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/methods/test_map.py
+++ b/pandas/tests/indexes/datetimes/methods/test_map.py
@@ -43,5 +43,8 @@ class TestMap:
         index = date_range("2018-01-01", periods=count, freq="ME", name=name).map(
             lambda x: (x.year, x.month)
         )
-        exp_index = MultiIndex.from_product(((2018,), range(1, 7)), names=[name, name])
+        exp_index = MultiIndex.from_product(
+            ((2018,), Index([1, 2, 3, 4, 5, 6])),
+            names=[name, name],
+        )
         tm.assert_index_equal(index, exp_index)

--- a/pandas/tests/indexes/numeric/test_join.py
+++ b/pandas/tests/indexes/numeric/test_join.py
@@ -2,7 +2,10 @@ import numpy as np
 import pytest
 
 import pandas._testing as tm
-from pandas.core.indexes.api import Index
+from pandas.core.indexes.api import (
+    Index,
+    RangeIndex,
+)
 
 
 class TestJoinInt64Index:
@@ -28,11 +31,11 @@ class TestJoinInt64Index:
         # not monotonic
         res, lidx, ridx = index.join(other, how="inner", return_indexers=True)
 
-        eres = Index([2, 12], dtype=np.int64, name="lhs")
+        eres = RangeIndex(start=2, stop=22, step=10, name="lhs")
         elidx = np.array([1, 6], dtype=np.intp)
         eridx = np.array([4, 1], dtype=np.intp)
 
-        assert isinstance(res, Index) and res.dtype == np.int64
+        assert isinstance(res, RangeIndex) and res.dtype == np.int64
         tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
@@ -41,8 +44,9 @@ class TestJoinInt64Index:
         res, lidx, ridx = index.join(other_mono, how="inner", return_indexers=True)
 
         res2 = index.intersection(other_mono).set_names(["lhs"])
-        tm.assert_index_equal(res, res2)
+        tm.assert_index_equal(res, res2, exact="equiv")
 
+        eres = Index([2, 12], dtype=np.int64, name="lhs")
         elidx = np.array([1, 6], dtype=np.intp)
         eridx = np.array([1, 4], dtype=np.intp)
         assert isinstance(res, Index) and res.dtype == np.int64

--- a/pandas/tests/indexes/ranges/test_indexing.py
+++ b/pandas/tests/indexes/ranges/test_indexing.py
@@ -100,25 +100,25 @@ class TestTake:
 
         # no errors
         result = idx.take(np.array([1, -3]))
-        expected = Index([2, 1], dtype=np.int64, name="xxx")
+        expected = RangeIndex(start=2, stop=0, step=-1, name="xxx")
         tm.assert_index_equal(result, expected)
 
     def test_take_accepts_empty_array(self):
         idx = RangeIndex(1, 4, name="foo")
         result = idx.take(np.array([]))
-        expected = Index([], dtype=np.int64, name="foo")
+        expected = RangeIndex(start=0, stop=0, step=1, name="foo")
         tm.assert_index_equal(result, expected)
 
         # empty index
         idx = RangeIndex(0, name="foo")
         result = idx.take(np.array([]))
-        expected = Index([], dtype=np.int64, name="foo")
+        expected = RangeIndex(start=0, stop=0, step=1, name="foo")
         tm.assert_index_equal(result, expected)
 
     def test_take_accepts_non_int64_array(self):
         idx = RangeIndex(1, 4, name="foo")
         result = idx.take(np.array([2, 1], dtype=np.uint32))
-        expected = Index([3, 2], dtype=np.int64, name="foo")
+        expected = RangeIndex(start=3, stop=1, step=-1, name="foo")
         tm.assert_index_equal(result, expected)
 
     def test_take_when_index_has_step(self):

--- a/pandas/tests/indexes/ranges/test_join.py
+++ b/pandas/tests/indexes/ranges/test_join.py
@@ -62,7 +62,7 @@ class TestJoin:
         lidx = lidx.take(ind)
         ridx = ridx.take(ind)
 
-        eres = Index([16, 18])
+        eres = RangeIndex(start=16, stop=20, step=2)
         elidx = np.array([8, 9], dtype=np.intp)
         eridx = np.array([9, 7], dtype=np.intp)
 

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -64,9 +64,6 @@ class TestRangeIndexSetOps:
         # intersect with Index with dtype int64
         index = RangeIndex(start=0, stop=20, step=2)
         other = Index(np.arange(1, 6))
-        result = index.intersection(other, sort=sort)
-        expected = Index(np.sort(np.intersect1d(index.values, other.values)))
-        tm.assert_index_equal(result, expected)
 
         result = other.intersection(index, sort=sort)
         expected = Index(

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -9,7 +9,10 @@ import numpy as np
 import pytest
 
 from pandas.compat import IS64
-from pandas.errors import InvalidIndexError
+from pandas.errors import (
+    InvalidIndexError,
+    Pandas4Warning,
+)
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import (
@@ -1357,6 +1360,15 @@ class TestIndex:
         expected = Index(expected_results)
 
         tm.assert_index_equal(result, expected)
+
+    def test_assert_index_equal_exact_equiv_default_deprecated(self):
+        # GH#57436
+        result = Index([0, 1, 2, 3], dtype=np.int64)
+        expected = RangeIndex(0, 4)
+        msg = "The default value of 'equiv' for the `exact` parameter is deprecated "
+
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            tm.assert_index_equal(result, expected)
 
 
 class TestMixedIntIndex:

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -845,9 +845,7 @@ class TestBase:
         idx = simple_index
 
         if idx.dtype.kind in ["i", "u"]:
-            res = ~idx
             expected = Index(~idx.values, name=idx.name)
-            tm.assert_index_equal(res, expected)
 
             # check that we are matching Series behavior
             res2 = ~Series(idx)

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -144,7 +144,7 @@ class TestInsertIndexCoercion(CoercionBase):
         """test coercion triggered by insert"""
         target = original.copy()
         res = target.insert(1, value)
-        tm.assert_index_equal(res, expected)
+        tm.assert_index_equal(res, expected, exact=True)
         assert res.dtype == expected_dtype
 
     @pytest.mark.parametrize(
@@ -244,14 +244,14 @@ class TestInsertIndexCoercion(CoercionBase):
             result = obj.insert(1, ts)
             expected = obj.astype(object).insert(1, ts)
             assert expected.dtype == object
-            tm.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected, exact=True)
 
             ts = pd.Timestamp("2012-01-01", tz="Asia/Tokyo").as_unit("s")
             result = obj.insert(1, ts)
             # once deprecation is enforced:
             expected = obj.insert(1, ts.tz_convert(obj.dtype.tz))
             assert expected.dtype == obj.dtype
-            tm.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected, exact=True)
 
         else:
             # mismatched tzawareness
@@ -259,14 +259,14 @@ class TestInsertIndexCoercion(CoercionBase):
             result = obj.insert(1, ts)
             expected = obj.astype(object).insert(1, ts)
             assert expected.dtype == object
-            tm.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected, exact=True)
 
         item = 1
         result = obj.insert(1, item)
         expected = obj.astype(object).insert(1, item)
         assert expected[1] == item
         assert expected.dtype == object
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_insert_index_timedelta64(self):
         obj = pd.TimedeltaIndex(["1 day", "2 day", "3 day", "4 day"])
@@ -282,7 +282,7 @@ class TestInsertIndexCoercion(CoercionBase):
             result = obj.insert(1, item)
             expected = obj.astype(object).insert(1, item)
             assert expected.dtype == object
-            tm.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.parametrize(
         "insert, coerced_val, coerced_dtype",
@@ -318,7 +318,7 @@ class TestInsertIndexCoercion(CoercionBase):
         else:
             result = obj.insert(0, insert)
             expected = obj.astype(object).insert(0, insert)
-            tm.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected, exact=True)
 
             # TODO: ATM inserting '2012-01-01 00:00:00' when we have obj.freq=="M"
             #  casts that string to Period[M], not clear that is desirable
@@ -326,7 +326,7 @@ class TestInsertIndexCoercion(CoercionBase):
                 # non-castable string
                 result = obj.insert(0, str(insert))
                 expected = obj.astype(object).insert(0, str(insert))
-                tm.assert_index_equal(result, expected)
+                tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.xfail(reason="Test not implemented")
     def test_insert_index_complex128(self):
@@ -479,7 +479,7 @@ class TestWhereCoercion(CoercionBase):
 
         expected = pd.TimedeltaIndex(["1 Day", value, value, "4 Days"])
         result = tdi.where(cond, value)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # wrong-dtyped NaT
         dtnat = np.datetime64("NaT", "ns")
@@ -487,7 +487,7 @@ class TestWhereCoercion(CoercionBase):
         assert expected[1] is dtnat
 
         result = tdi.where(cond, dtnat)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_where_index_period(self):
         dti = pd.date_range("2016-01-01", periods=3, freq="QS")
@@ -499,24 +499,24 @@ class TestWhereCoercion(CoercionBase):
         value = pi[-1] + pi.freq * 10
         expected = pd.PeriodIndex([value, pi[1], value])
         result = pi.where(cond, value)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # Case passing ndarray[object] of Periods
         other = np.asarray(pi + pi.freq * 10, dtype=object)
         result = pi.where(cond, other)
         expected = pd.PeriodIndex([other[0], pi[1], other[2]])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # Passing a mismatched scalar -> casts to object
         td = pd.Timedelta(days=4)
         expected = pd.Index([td, pi[1], td], dtype=object)
         result = pi.where(cond, td)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         per = pd.Period("2020-04-21", "D")
         expected = pd.Index([per, pi[1], per], dtype=object)
         result = pi.where(cond, per)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
 
 class TestFillnaSeriesCoercion(CoercionBase):

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -170,7 +170,7 @@ class TestFancy:
 
         result = df.index
         expected = Index([1, 2, np.inf], dtype=np.float64)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_setitem_dtype_upcast(self):
         # GH3216
@@ -209,7 +209,7 @@ class TestFancy:
         df = DataFrame(np.eye(3), columns=["a", "a", "b"])
         result = df[["b", "a"]].columns
         expected = Index(["b", "a", "a"])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_dups_fancy_indexing_across_dtypes(self):
         # across dtypes
@@ -600,7 +600,7 @@ class TestFancy:
             exp = s.index
             if 0 not in s:
                 exp = Index([*s.index.tolist(), 0])
-            tm.assert_index_equal(s2.index, exp)
+            tm.assert_index_equal(s2.index, exp, exact=True)
 
             s2 = s.copy()
             indexer(s2)["0"] = 0
@@ -616,7 +616,7 @@ class TestFancy:
 
             s2 = s.copy()
             indexer(s2)[0.0] = 0
-            tm.assert_index_equal(s2.index, s.index)
+            tm.assert_index_equal(s2.index, s.index, exact=True)
 
             s2 = s.copy()
             indexer(s2)["0"] = 0

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1768,10 +1768,10 @@ class TestLocWithMultiIndex:
         exp_index = MultiIndex.from_arrays(expected)
         if dim == "index":
             res = df.loc[keys, :]
-            tm.assert_index_equal(res.index, exp_index)
+            tm.assert_index_equal(res.index, exp_index, exact=True)
         elif dim == "columns":
             res = df.loc[:, keys]
-            tm.assert_index_equal(res.columns, exp_index)
+            tm.assert_index_equal(res.columns, exp_index, exact=True)
 
     def test_loc_preserve_names(self, multiindex_year_month_day_dataframe_random_data):
         ymd = multiindex_year_month_day_dataframe_random_data
@@ -1956,10 +1956,10 @@ class TestLocWithMultiIndex:
         )
 
         result = df.index.levels[0]
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = df.loc[["a"]].index.levels[0]
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.parametrize("lt_value", [30, 10])
     def test_loc_multiindex_levels_contain_values_not_in_index_anymore(self, lt_value):
@@ -1990,7 +1990,7 @@ class TestLocWithMultiIndex:
 
         loc_result = ser.loc["a", :, :]
         expected = ser.index.droplevel(0)[:4]
-        tm.assert_index_equal(loc_result.index, expected)
+        tm.assert_index_equal(loc_result.index, expected, exact=True)
 
 
 class TestLocSetitemWithExpansion:
@@ -2004,11 +2004,11 @@ class TestLocSetitemWithExpansion:
         df.loc[item] = 1
 
         exp_index = Index([idx[0], item], dtype=idx.dtype)
-        tm.assert_index_equal(df.index, exp_index)
+        tm.assert_index_equal(df.index, exp_index, exact=True)
 
         ser = df["A"].iloc[:-1]
         ser.loc[item] = 1
-        tm.assert_index_equal(ser.index, exp_index)
+        tm.assert_index_equal(ser.index, exp_index, exact=True)
 
     def test_loc_setitem_with_expansion_large_dataframe(self, monkeypatch):
         # GH#10692
@@ -2145,7 +2145,7 @@ class TestLocSetitemWithExpansion:
 
         result = df.columns
         expected = Index([0, 1, np.inf], dtype=np.float64)
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     @pytest.mark.filterwarnings("ignore:indexing past lexsort depth")
     @pytest.mark.parametrize("has_ref", [True, False])

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -138,7 +138,7 @@ class TestEmptyFrameSetitemExpansion:
 
     def test_partial_set_empty_frame5(self):
         df = DataFrame()
-        tm.assert_index_equal(df.columns, pd.RangeIndex(0))
+        tm.assert_index_equal(df.columns, pd.RangeIndex(0), exact=True)
         df2 = DataFrame()
         df2[1] = Series([1], index=["foo"])
         df.loc[:, 1] = Series([1], index=["foo"])
@@ -558,7 +558,7 @@ class TestPartialSetting:
         ser = Series(df.iloc[0], name="a")
         exp = pd.concat([orig, DataFrame(ser).T.infer_objects()])
         tm.assert_frame_equal(df, exp)
-        tm.assert_index_equal(df.index, Index([*orig.index.tolist(), "a"]))
+        tm.assert_index_equal(df.index, Index([*orig.index.tolist(), "a"]), exact=True)
         assert df.index.dtype == "object"
 
     @pytest.mark.parametrize(

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -226,7 +226,7 @@ def test_resample_empty_series(freq, index, resample_method):
         expected.index = _asfreq_compat(ser.index, freq)
         tm.assert_series_equal(result, expected, check_dtype=False)
 
-    tm.assert_index_equal(result.index, expected.index)
+    tm.assert_index_equal(result.index, expected.index, exact=True)
     assert result.index.freq == expected.index.freq
 
 
@@ -279,7 +279,7 @@ def test_resample_nat_index_series(freq, resample_method):
     else:
         expected = ser[:0].copy()
         tm.assert_series_equal(result, expected, check_dtype=False)
-    tm.assert_index_equal(result.index, expected.index)
+    tm.assert_index_equal(result.index, expected.index, exact=True)
     assert result.index.freq == expected.index.freq
 
 
@@ -353,7 +353,7 @@ def test_resample_empty_dataframe(index, freq, resample_method):
 
     expected.index = _asfreq_compat(df.index, freq)
 
-    tm.assert_index_equal(result.index, expected.index)
+    tm.assert_index_equal(result.index, expected.index, exact=True)
     assert result.index.freq == expected.index.freq
     tm.assert_almost_equal(result, expected)
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -755,7 +755,7 @@ def test_resample_offset(unit):
     exp_rng = date_range("12/31/1999 23:57:00", "1/1/2000 01:57", freq="5min").as_unit(
         unit
     )
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
 
 @pytest.mark.parametrize(
@@ -779,7 +779,7 @@ def test_resample_origin(kwargs, unit):
     ).as_unit(unit)
 
     resampled = ts.resample("5min", **kwargs).mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
 
 @pytest.mark.parametrize(
@@ -816,31 +816,31 @@ def test_resample_origin_prime_freq(unit):
         "2000-10-01 23:14:00", "2000-10-02 00:22:00", freq="17min"
     ).as_unit(unit)
     resampled = ts.resample("17min").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
     resampled = ts.resample("17min", origin="start_day").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
     exp_rng = date_range(
         "2000-10-01 23:30:00", "2000-10-02 00:21:00", freq="17min"
     ).as_unit(unit)
     resampled = ts.resample("17min", origin="start").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
     resampled = ts.resample("17min", offset="23h30min").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
     resampled = ts.resample("17min", origin="start_day", offset="23h30min").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
     exp_rng = date_range(
         "2000-10-01 23:18:00", "2000-10-02 00:26:00", freq="17min"
     ).as_unit(unit)
     resampled = ts.resample("17min", origin="epoch").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
     exp_rng = date_range(
         "2000-10-01 23:24:00", "2000-10-02 00:15:00", freq="17min"
     ).as_unit(unit)
     resampled = ts.resample("17min", origin="2000-01-01").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
 
 def test_resample_origin_with_tz(unit):
@@ -857,14 +857,14 @@ def test_resample_origin_with_tz(unit):
         "1999-12-31 23:57:00", "2000-01-01 01:57", freq="5min", tz=tz
     ).as_unit(unit)
     resampled = ts.resample("5min", origin="1999-12-31 23:57:00+00:00").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
     # origin of '1999-31-12 12:02:00+03:00' should be equivalent for this case
     resampled = ts.resample("5min", origin="1999-12-31 12:02:00+03:00").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
     resampled = ts.resample("5min", origin="epoch", offset="2m").mean()
-    tm.assert_index_equal(resampled.index, exp_rng)
+    tm.assert_index_equal(resampled.index, exp_rng, exact=True)
 
     with pytest.raises(ValueError, match=msg):
         ts.resample("5min", origin="12/31/1999 23:57:00").mean()
@@ -1000,7 +1000,7 @@ def test_resample_to_period_monthly_buglet(unit):
 
     result = ts.resample("ME").mean().to_period()
     exp_index = period_range("Jan-2000", "Dec-2000", freq="M")
-    tm.assert_index_equal(result.index, exp_index)
+    tm.assert_index_equal(result.index, exp_index, exact=True)
 
 
 def test_period_with_agg():
@@ -1193,7 +1193,7 @@ def test_corner_cases(unit):
 
     result = ts.resample("5min", closed="right", label="left").mean()
     ex_index = date_range("1999-12-31 23:55", periods=4, freq="5min").as_unit(unit)
-    tm.assert_index_equal(result.index, ex_index)
+    tm.assert_index_equal(result.index, ex_index, exact=True)
 
 
 def test_corner_cases_date(simple_date_range_series, unit):
@@ -1428,7 +1428,7 @@ def test_resample_nunique_preserves_column_level_names(unit):
         [df.columns.tolist()] * 2, names=["lev0", "lev1"]
     )
     result = df.resample("1h").nunique()
-    tm.assert_index_equal(df.columns, result.columns)
+    tm.assert_index_equal(df.columns, result.columns, exact=True)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -367,7 +367,7 @@ class TestPeriodIndex:
             nonexistent="shift_forward",
             inclusive="left",
         )
-        tm.assert_index_equal(result.index, expected)
+        tm.assert_index_equal(result.index, expected, exact=True)
 
     def test_resample_ambiguous_time_bin_edge(self):
         # GH 10117
@@ -589,7 +589,7 @@ class TestPeriodIndex:
 
         ex_index = date_range(start="1/1/2012 9:30", freq="10min", periods=3)
 
-        tm.assert_index_equal(result.index, ex_index)
+        tm.assert_index_equal(result.index, ex_index, exact=True)
         tm.assert_series_equal(result, exp)
 
     def test_quarterly_resampling(self):

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -142,17 +142,21 @@ def test_pipe(test_frame, _test_series):
 
 def test_getitem(test_frame):
     r = test_frame.resample("h")
-    tm.assert_index_equal(r._selected_obj.columns, test_frame.columns)
+    tm.assert_index_equal(r._selected_obj.columns, test_frame.columns, exact=True)
 
     r = test_frame.resample("h")["B"]
     assert r._selected_obj.name == test_frame.columns[1]
 
     # technically this is allowed
     r = test_frame.resample("h")["A", "B"]
-    tm.assert_index_equal(r._selected_obj.columns, test_frame.columns[[0, 1]])
+    tm.assert_index_equal(
+        r._selected_obj.columns, test_frame.columns[[0, 1]], exact=True
+    )
 
     r = test_frame.resample("h")["A", "B"]
-    tm.assert_index_equal(r._selected_obj.columns, test_frame.columns[[0, 1]])
+    tm.assert_index_equal(
+        r._selected_obj.columns, test_frame.columns[[0, 1]], exact=True
+    )
 
 
 @pytest.mark.parametrize("key", [["D"], ["A", "D"]])

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -152,7 +152,7 @@ def test_groupby_with_origin():
     count_ts = count_ts[middle:end]
     count_ts2 = ts2.groupby(simple_grouper).agg("count")
     with pytest.raises(AssertionError, match="Index are different"):
-        tm.assert_index_equal(count_ts.index, count_ts2.index)
+        tm.assert_index_equal(count_ts.index, count_ts2.index, exact=True)
 
     # test origin on 1970-01-01 00:00:00
     origin = Timestamp(0)
@@ -352,11 +352,11 @@ def test_consistency_with_window(test_frame):
     expected = Index([1, 2, 3], name="A")
     result = df.groupby("A").resample("2s").mean()
     assert result.index.nlevels == 2
-    tm.assert_index_equal(result.index.levels[0], expected)
+    tm.assert_index_equal(result.index.levels[0], expected, exact=True)
 
     result = df.groupby("A").rolling(20).mean()
     assert result.index.nlevels == 2
-    tm.assert_index_equal(result.index.levels[0], expected)
+    tm.assert_index_equal(result.index.levels[0], expected, exact=True)
 
 
 def test_median_duplicate_columns():

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -79,7 +79,7 @@ def test_apply_iteration():
 
     # it works!
     result = grouped.apply(f)
-    tm.assert_index_equal(result.index, df.index)
+    tm.assert_index_equal(result.index, df.index, exact=True)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -92,8 +92,8 @@ def test_resample_offset_with_timedeltaindex():
     exp_without_base = timedelta_range(start="0s", end="25s", freq="2s")
     exp_with_base = timedelta_range(start="5s", end="29s", freq="2s")
 
-    tm.assert_index_equal(without_base.index, exp_without_base)
-    tm.assert_index_equal(with_base.index, exp_with_base)
+    tm.assert_index_equal(without_base.index, exp_without_base, exact=True)
+    tm.assert_index_equal(with_base.index, exp_with_base, exact=True)
 
 
 def test_resample_categorical_data_with_timedeltaindex():
@@ -149,7 +149,7 @@ def test_resample_timedelta_edge_case(start, end, freq, resample_freq):
     s = Series(np.arange(len(idx)), index=idx)
     result = s.resample(resample_freq).min()
     expected_index = timedelta_range(freq=resample_freq, start=start, end=end)
-    tm.assert_index_equal(result.index, expected_index)
+    tm.assert_index_equal(result.index, expected_index, exact=True)
     assert result.index.freq == expected_index.freq
     assert not np.isnan(result.iloc[-1])
 

--- a/pandas/tests/reshape/concat/test_append_common.py
+++ b/pandas/tests/reshape/concat/test_append_common.py
@@ -92,26 +92,26 @@ class TestConcatAppendCommon:
         # index.append
         res = Index(vals1).append(Index(vals2))
         exp = Index(exp_data)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         # 3 elements
         res = Index(vals1).append([Index(vals2), Index(vals3)])
         exp = Index(exp_data3)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         # index.append name mismatch
         i1 = Index(vals1, name="x")
         i2 = Index(vals2, name="y")
         res = i1.append(i2)
         exp = Index(exp_data)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         # index.append name match
         i1 = Index(vals1, name="x")
         i2 = Index(vals2, name="x")
         res = i1.append(i2)
         exp = Index(exp_data, name="x")
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         # cannot append non-index
         with pytest.raises(TypeError, match="all inputs must be Index"):
@@ -213,12 +213,12 @@ class TestConcatAppendCommon:
         # GH#39817
         res = Index(vals1).append(Index(vals2))
         exp = Index(exp_data, dtype=exp_index_dtype)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         # 3 elements
         res = Index(vals1).append([Index(vals2), Index(vals3)])
         exp = Index(exp_data3, dtype=exp_index_dtype)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         # ----- Series ----- #
 
@@ -258,7 +258,7 @@ class TestConcatAppendCommon:
         )
 
         res = dti.append(tdi)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
         assert isinstance(res[0], pd.Timestamp)
         assert isinstance(res[-1], pd.Timedelta)
 
@@ -285,7 +285,7 @@ class TestConcatAppendCommon:
         )
 
         res = dti1.append(dti2)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         dts1 = Series(dti1)
         dts2 = Series(dti2)
@@ -332,7 +332,7 @@ class TestConcatAppendCommon:
         )
 
         res = dti1.append(dti2)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         dts1 = Series(dti1)
         dts2 = Series(dti2)
@@ -357,7 +357,7 @@ class TestConcatAppendCommon:
         )
 
         res = dti1.append(dti3)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         dts1 = Series(dti1)
         dts3 = Series(dti3)
@@ -375,7 +375,7 @@ class TestConcatAppendCommon:
         exp = pd.PeriodIndex(["2011-01", "2011-02", "2012-01", "2012-02"], freq="M")
 
         res = pi1.append(pi2)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         ps1 = Series(pi1)
         ps2 = Series(pi2)
@@ -401,7 +401,7 @@ class TestConcatAppendCommon:
         )
 
         res = pi1.append(pi2)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         ps1 = Series(pi1)
         ps2 = Series(pi2)
@@ -427,7 +427,7 @@ class TestConcatAppendCommon:
         )
 
         res = pi1.append(tdi)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         ps1 = Series(pi1)
         tds = Series(tdi)
@@ -449,7 +449,7 @@ class TestConcatAppendCommon:
         )
 
         res = tdi.append(pi1)
-        tm.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp, exact=True)
 
         ps1 = Series(pi1)
         tds = Series(tdi)

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -183,7 +183,7 @@ class TestCategoricalConcat:
 
         result = pd.concat([df1, df2])
         expected = DataFrame(
-            {"x": Series([datetime(2021, 1, 1), datetime(2021, 1, 2)])}
+            {"x": Series([datetime(2021, 1, 1), datetime(2021, 1, 2)])}, index=[0, 1]
         )
 
         tm.assert_equal(result, expected)
@@ -213,11 +213,17 @@ class TestCategoricalConcat:
         df1 = df[0:3]
         df2 = df[3:]
 
-        tm.assert_index_equal(df["grade"].cat.categories, df1["grade"].cat.categories)
-        tm.assert_index_equal(df["grade"].cat.categories, df2["grade"].cat.categories)
+        tm.assert_index_equal(
+            df["grade"].cat.categories, df1["grade"].cat.categories, exact=True
+        )
+        tm.assert_index_equal(
+            df["grade"].cat.categories, df2["grade"].cat.categories, exact=True
+        )
 
         dfx = pd.concat([df1, df2])
-        tm.assert_index_equal(df["grade"].cat.categories, dfx["grade"].cat.categories)
+        tm.assert_index_equal(
+            df["grade"].cat.categories, dfx["grade"].cat.categories, exact=True
+        )
 
     def test_categorical_index_upcast(self):
         # GH 17629

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -127,7 +127,9 @@ class TestConcatenate:
         )
 
         tm.assert_index_equal(result.columns.levels[0], Index(level, name="group_key"))
-        tm.assert_index_equal(result.columns.levels[1], Index([0, 1, 2, 3]))
+        tm.assert_index_equal(
+            result.columns.levels[1], RangeIndex(start=0, stop=4, step=1)
+        )
 
         assert result.columns.names == ["group_key", None]
 

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -126,9 +126,11 @@ class TestConcatenate:
             names=["group_key"],
         )
 
-        tm.assert_index_equal(result.columns.levels[0], Index(level, name="group_key"))
         tm.assert_index_equal(
-            result.columns.levels[1], RangeIndex(start=0, stop=4, step=1)
+            result.columns.levels[0], Index(level, name="group_key"), exact=True
+        )
+        tm.assert_index_equal(
+            result.columns.levels[1], RangeIndex(start=0, stop=4, step=1), exact=True
         )
 
         assert result.columns.names == ["group_key", None]
@@ -198,7 +200,7 @@ class TestConcatenate:
         )
         assert result.index.names == ("first", "second", None)
         tm.assert_index_equal(
-            result.index.levels[0], Index(["baz", "foo"], name="first")
+            result.index.levels[0], Index(["baz", "foo"], name="first"), exact=True
         )
 
     def test_concat_keys_levels_no_overlap(self):
@@ -519,7 +521,7 @@ class TestConcatenate:
 
         result = concat(dfs, sort=True).columns
         expected = Index([1, "a", None])
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_concat_different_extension_dtypes_upcasts(self):
         a = Series(pd.array([1, 2], dtype="Int64"))

--- a/pandas/tests/reshape/concat/test_dataframe.py
+++ b/pandas/tests/reshape/concat/test_dataframe.py
@@ -212,7 +212,9 @@ class TestDataFrameConcat:
         mi = pd.MultiIndex.from_product([["A"], index], names=["ID", "date"])
         expected = DataFrame(data=data, index=mi)
         tm.assert_frame_equal(result, expected)
-        tm.assert_index_equal(result.index.levels[1], Index([1, 3], name="date"))
+        tm.assert_index_equal(
+            result.index.levels[1], Index([1, 3], name="date"), exact=True
+        )
 
     def test_outer_sort_columns(self):
         # GH#47127

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -317,7 +317,7 @@ class TestMultiIndexConcat:
         result_index = df.index
         expected_index = MultiIndex.from_product(iterables)
 
-        tm.assert_index_equal(result_index, expected_index)
+        tm.assert_index_equal(result_index, expected_index, exact=True)
 
         result_df = df
         expected_df = DataFrame(

--- a/pandas/tests/reshape/concat/test_series.py
+++ b/pandas/tests/reshape/concat/test_series.py
@@ -85,7 +85,9 @@ class TestSeriesConcat:
 
         s2.name = None
         result = concat([s, s2], axis=1)
-        tm.assert_index_equal(result.columns, Index(["A", 0], dtype="object"))
+        tm.assert_index_equal(
+            result.columns, Index(["A", 0], dtype="object"), exact=True
+        )
 
     def test_concat_series_axis1_with_reindex(self, sort):
         # must reindex, #2603

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -252,7 +252,7 @@ class TestJoin:
             assert merged[col].isna().all()
 
         merged2 = target.join(source.reindex([]), on="C", how="inner")
-        tm.assert_index_equal(merged2.columns, merged.columns)
+        tm.assert_index_equal(merged2.columns, merged.columns, exact=True)
         assert len(merged2) == 0
 
     def test_join_on_inner(self):
@@ -265,7 +265,7 @@ class TestJoin:
         expected = expected[expected["value"].notna()]
         tm.assert_series_equal(joined["key"], expected["key"])
         tm.assert_series_equal(joined["value"], expected["value"], check_dtype=False)
-        tm.assert_index_equal(joined.index, expected.index)
+        tm.assert_index_equal(joined.index, expected.index, exact=True)
 
     def test_join_on_singlekey_list(self):
         df = DataFrame({"key": ["a", "a", "b", "b", "c"]})

--- a/pandas/tests/reshape/test_crosstab.py
+++ b/pandas/tests/reshape/test_crosstab.py
@@ -234,7 +234,7 @@ class TestCrosstab:
             [("one", "dull"), ("one", "shiny"), ("two", "dull"), ("two", "shiny")],
             names=["b", "c"],
         )
-        tm.assert_index_equal(res.columns, m)
+        tm.assert_index_equal(res.columns, m, exact=True)
 
     def test_crosstab_no_overlap(self):
         # GS 10291

--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -88,10 +88,10 @@ def test_bins_from_interval_index_doc_example():
     ages = np.array([10, 15, 13, 12, 23, 25, 28, 59, 60])
     c = cut(ages, bins=[0, 18, 35, 70])
     expected = IntervalIndex.from_tuples([(0, 18), (18, 35), (35, 70)])
-    tm.assert_index_equal(c.categories, expected)
+    tm.assert_index_equal(c.categories, expected, exact=True)
 
     result = cut([25, 20, 50], bins=c.categories)
-    tm.assert_index_equal(result.categories, expected)
+    tm.assert_index_equal(result.categories, expected, exact=True)
     tm.assert_numpy_array_equal(result.codes, np.array([1, 1, 2], dtype="int8"))
 
 
@@ -165,7 +165,7 @@ def test_bins_not_monotonic():
 def test_bins_monotonic_not_overflowing(x, bins, expected):
     # GH 26045
     result = cut(x, bins)
-    tm.assert_index_equal(result.categories, expected)
+    tm.assert_index_equal(result.categories, expected, exact=True)
 
 
 def test_wrong_num_labels():
@@ -234,7 +234,7 @@ def test_labels(right, breaks, closed):
 
     result, bins = cut(arr, 4, retbins=True, right=right)
     ex_levels = IntervalIndex.from_breaks(breaks, closed=closed)
-    tm.assert_index_equal(result.categories, ex_levels)
+    tm.assert_index_equal(result.categories, ex_levels, exact=True)
 
 
 def test_cut_pass_series_name_to_factor():
@@ -250,7 +250,7 @@ def test_label_precision():
     result = cut(arr, 4, precision=2)
 
     ex_levels = IntervalIndex.from_breaks([-0.00072, 0.18, 0.36, 0.54, 0.72])
-    tm.assert_index_equal(result.categories, ex_levels)
+    tm.assert_index_equal(result.categories, ex_levels, exact=True)
 
 
 @pytest.mark.parametrize("labels", [None, False])
@@ -274,7 +274,7 @@ def test_inf_handling():
     result_ser = cut(data_ser, bins)
 
     ex_uniques = IntervalIndex.from_breaks(bins)
-    tm.assert_index_equal(result.categories, ex_uniques)
+    tm.assert_index_equal(result.categories, ex_uniques, exact=True)
 
     assert result[5] == Interval(4, np.inf)
     assert result[0] == Interval(-np.inf, 2)
@@ -620,7 +620,7 @@ def test_datetime_cut_roundtrip(tz, unit):
             dtype=f"M8[{unit}]",
         )
     expected_bins = expected_bins.tz_localize(tz)
-    tm.assert_index_equal(result_bins, expected_bins)
+    tm.assert_index_equal(result_bins, expected_bins, exact=True)
 
 
 def test_timedelta_cut_roundtrip():
@@ -634,7 +634,7 @@ def test_timedelta_cut_roundtrip():
     expected_bins = TimedeltaIndex(
         ["0 days 23:57:07.200000", "2 days 00:00:00", "3 days 00:00:00"]
     )
-    tm.assert_index_equal(result_bins, expected_bins)
+    tm.assert_index_equal(result_bins, expected_bins, exact=True)
 
 
 @pytest.mark.parametrize("bins", [6, 7])

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -180,8 +180,8 @@ class TestPivotTable:
             ],
             names=["customer", "product"],
         )
-        tm.assert_index_equal(pv_col.columns, m)
-        tm.assert_index_equal(pv_ind.index, m)
+        tm.assert_index_equal(pv_col.columns, m, exact=True)
+        tm.assert_index_equal(pv_ind.index, m, exact=True)
 
     def test_pivot_table_categorical(self):
         cat1 = Categorical(
@@ -2785,7 +2785,7 @@ class TestPivot:
 
         result = df.pivot(index=1, columns=0, values=2)
         expected_columns = Index(["A", "B"], name=0, dtype=any_string_dtype)
-        tm.assert_index_equal(result.columns, expected_columns)
+        tm.assert_index_equal(result.columns, expected_columns, exact=True)
 
     def test_pivot_index_none(self):
         # GH#3962
@@ -2929,7 +2929,7 @@ class TestPivot:
         pivot = df.pivot_table(index="a", columns="b", values="value", aggfunc="count")
 
         expected = Index([], dtype="object", name="b")
-        tm.assert_index_equal(pivot.columns, expected)
+        tm.assert_index_equal(pivot.columns, expected, exact=True)
 
     def test_pivot_table_handles_explicit_datetime_types(self):
         # GH#43574
@@ -2956,7 +2956,7 @@ class TestPivot:
             ],
             names=["a", "date"],
         )
-        tm.assert_index_equal(pivot.index, expected)
+        tm.assert_index_equal(pivot.index, expected, exact=True)
 
     def test_pivot_table_with_margins_and_numeric_column_names(self):
         # GH#26568

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -76,7 +76,7 @@ def test_qcut_include_lowest():
             Interval(6.75, 9),
         ]
     )
-    tm.assert_index_equal(ii.categories, ex_levels)
+    tm.assert_index_equal(ii.categories, ex_levels, exact=True)
 
 
 def test_qcut_nas():
@@ -172,7 +172,7 @@ def test_qcut_duplicates_bin(kwargs, msg):
     else:
         result = qcut(values, 3, **kwargs)
         expected = IntervalIndex([Interval(-0.001, 1), Interval(1, 3)])
-        tm.assert_index_equal(result.categories, expected)
+        tm.assert_index_equal(result.categories, expected, exact=True)
 
 
 @pytest.mark.parametrize(
@@ -264,7 +264,7 @@ def test_date_like_qcut_bins(arg, expected_bins, unit):
     expected_bins = expected_bins.as_unit(unit)
     ser = Series(arg)
     result, result_bins = qcut(ser, 2, retbins=True)
-    tm.assert_index_equal(result_bins, expected_bins)
+    tm.assert_index_equal(result_bins, expected_bins, exact=True)
 
 
 @pytest.mark.parametrize("bins", [6, 7])

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -281,7 +281,7 @@ def test_from_obscure_array(dtype, box):
     idx_cls = {"M8[ns]": DatetimeIndex, "m8[ns]": TimedeltaIndex}[dtype]
     result = idx_cls(arr)
     expected = idx_cls(data)
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)
 
 
 def test_xarray_coerce_unit():
@@ -299,4 +299,4 @@ def test_xarray_coerce_unit():
         dtype="datetime64[ns]",
         freq=None,
     )
-    tm.assert_index_equal(result, expected)
+    tm.assert_index_equal(result, expected, exact=True)


### PR DESCRIPTION
- [x] closes #57436

Changed in `assert_index_equal` the parameter `exact` from default `equiv` to `True`