### PR TITLE
BUG: Fix inconsistent construction results between pd.array and pd.Series for dtype=str

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -136,6 +136,7 @@ Numeric
 
 Conversion
 ^^^^^^^^^^
+- Bug in :func:`pd.array` where ``dtype=str`` would convert ``None`` values to the string ``"None"``, inconsistent with :class:`Series` construction which preserves ``None`` values. Now ``pd.array`` with ``dtype=str`` consistently preserves NA values like ``None`` and ``np.nan`` (:issue:`57702`)
 -
 -
 

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -397,6 +397,13 @@ def array(
             r"'s', 'ms', 'us', and 'ns' are no longer supported."
         )
 
+    # GH#57702: Handle string dtype consistently with Series construction.
+    # Use ensure_string_array to preserve NA values (None, np.nan) instead
+    # of converting them to string representation (e.g., "None", "nan").
+    if lib.is_np_dtype(dtype, "U"):
+        result = lib.ensure_string_array(data, convert_na_value=False, copy=copy)
+        return NumpyExtensionArray._from_sequence(result, dtype=object, copy=False)
+
     return NumpyExtensionArray._from_sequence(data, dtype=dtype, copy=copy)
 
 

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -560,7 +560,7 @@ def test_array_dtype_str_preserves_na(data, expected_values, expected_dtype):
     assert result.dtype.numpy_dtype == expected_dtype
 
     # Check values - None/np.nan should be preserved, not converted to strings
-    for i, (res_val, exp_val) in enumerate(zip(result, expected_values)):
+    for i, (res_val, exp_val) in enumerate(zip(result, expected_values, strict=False)):
         if exp_val is None or (isinstance(exp_val, float) and np.isnan(exp_val)):
             assert pd.isna(res_val)
         else:


### PR DESCRIPTION
## Description

Closes #57702

This PR fixes the inconsistent behavior between  and  when using  with data containing  values.

### Problem

Previously:
-  would convert  to the string  with dtype 
-  would preserve  with dtype 

This inconsistency was confusing for users.

### Solution

Modified  to handle numpy unicode string dtypes ( or any ) by using  with , which preserves NA values like  and  instead of converting them to their string representations.

### Changes

1. **pandas/core/construction.py**: Added handling for string dtypes before the final  call
2. **pandas/tests/arrays/test_array.py**: Added  test to verify consistent behavior
3. **doc/source/whatsnew/v3.1.0.rst**: Added bug fix entry

### Example



- [x] closes #57702
- [x] tests added / passed
- [x] whatsnew entry added