### PR TITLE
DOC: Inline docstrings in generic.py for ewm (GH#62437)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -95,9 +95,7 @@ from pandas.errors import (
     Pandas4Warning,
 )
 from pandas.errors.cow import _chained_assignment_method_msg
-from pandas.util._decorators import (
-    deprecate_kwarg
-)
+from pandas.util._decorators import deprecate_kwarg
 from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import (
     check_dtype_backend,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12342,8 +12342,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         halflife : float, str, timedelta, optional
             Specify decay in terms of half-life
 
-            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\right)`, for
-            :math:`halflife > 0`.
+            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\right)`,
+            for :math:`halflife > 0`.
 
             If ``times`` is specified, a timedelta convertible unit over which an
             observation decays to half its value. Only applicable to ``mean()``,
@@ -12385,9 +12385,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
             - When ``ignore_na=False`` (default), weights are based on absolute
               positions.
-              For example, the weights of :math:`x_0` and :math:`x_2` used in
-              calculating the final weighted average of [:math:`x_0`, None, :math:`x_2`]
-              are :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+              For example, the weights of :math:`x_0` and :math:`x_2`
+              used in calculating the final weighted average of
+              [:math:`x_0`, None, :math:`x_2`] are
+              :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
               :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
 
             - When ``ignore_na=True``, weights are based
@@ -12493,8 +12494,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         **times**
 
-        Exponentially weighted mean with weights calculated with a timedelta
-        ``halflife`` relative to ``times``.
+        Exponentially weighted mean with weights calculated with a
+        timedelta ``halflife`` relative to ``times``.
 
         >>> times = ['2020-01-01', '2020-01-03', '2020-01-10', '2020-01-15',
         ...         '2020-01-17']

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -96,8 +96,7 @@ from pandas.errors import (
 )
 from pandas.errors.cow import _chained_assignment_method_msg
 from pandas.util._decorators import (
-    deprecate_kwarg,
-    doc,
+    deprecate_kwarg
 )
 from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import (
@@ -12308,7 +12307,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         return Expanding(self, min_periods=min_periods, method=method)
 
     @final
-    @doc(ExponentialMovingWindow)
     def ewm(
         self,
         com: float | None = None,
@@ -12321,6 +12319,189 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         times: np.ndarray | DataFrame | Series | None = None,
         method: Literal["single", "table"] = "single",
     ) -> ExponentialMovingWindow:
+        """  
+        Provide exponentially weighted (EW) calculations.
+
+        Exactly one of ``com``, ``span``, ``halflife``, or ``alpha`` must be
+        provided if ``times`` is not provided. If ``times`` is provided and ``adjust=True``,
+        ``halflife`` and one of ``com``, ``span`` or ``alpha`` may be provided.
+        If ``times`` is provided and ``adjust=False``, ``halflife`` must be the only
+        provided decay-specification parameter.
+
+        Parameters
+        ----------
+        com : float, optional
+            Specify decay in terms of center of mass
+
+            :math:`\alpha = 1 / (1 + com)`, for :math:`com \geq 0`.
+
+        span : float, optional
+            Specify decay in terms of span
+
+            :math:`\alpha = 2 / (span + 1)`, for :math:`span \geq 1`.
+
+        halflife : float, str, timedelta, optional
+            Specify decay in terms of half-life
+
+            :math:`\alpha = 1 - \exp\left(-\ln(2) / halflife\right)`, for
+            :math:`halflife > 0`.
+
+            If ``times`` is specified, a timedelta convertible unit over which an
+            observation decays to half its value. Only applicable to ``mean()``,
+            and halflife value will not apply to the other functions.
+
+        alpha : float, optional
+            Specify smoothing factor :math:`\alpha` directly
+
+            :math:`0 < \alpha \leq 1`.
+
+        min_periods : int, default 0
+            Minimum number of observations in window required to have a value;
+            otherwise, result is ``np.nan``.
+
+        adjust : bool, default True
+            Divide by decaying adjustment factor in beginning periods to account
+            for imbalance in relative weightings (viewing EWMA as a moving average).
+
+            - When ``adjust=True`` (default), the EW function is calculated using weights
+              :math:`w_i = (1 - \alpha)^i`. For example, the EW moving average of the series
+              [:math:`x_0, x_1, ..., x_t`] would be:
+
+            .. math::
+                y_t = \frac{x_t + (1 - \alpha)x_{t-1} + (1 - \alpha)^2 x_{t-2} + ... + (1 -
+                \alpha)^t x_0}{1 + (1 - \alpha) + (1 - \alpha)^2 + ... + (1 - \alpha)^t}
+
+            - When ``adjust=False``, the exponentially weighted function is calculated
+              recursively:
+
+            .. math::
+                \begin{split}
+                    y_0 &= x_0\\
+                    y_t &= (1 - \alpha) y_{t-1} + \alpha x_t,
+                \end{split}
+        ignore_na : bool, default False
+            Ignore missing values when calculating weights.
+
+            - When ``ignore_na=False`` (default), weights are based on absolute positions.
+              For example, the weights of :math:`x_0` and :math:`x_2` used in calculating
+              the final weighted average of [:math:`x_0`, None, :math:`x_2`] are
+              :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+              :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
+
+            - When ``ignore_na=True``, weights are based
+              on relative positions. For example, the weights of :math:`x_0` and :math:`x_2`
+              used in calculating the final weighted average of
+              [:math:`x_0`, None, :math:`x_2`] are :math:`1-\alpha` and :math:`1` if
+              ``adjust=True``, and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
+
+        times : np.ndarray, Series, default None
+
+            Only applicable to ``mean()``.
+
+            Times corresponding to the observations. Must be monotonically increasing and
+            ``datetime64[ns]`` dtype.
+
+            If 1-D array like, a sequence with the same shape as the observations.
+
+        method : str {'single', 'table'}, default 'single'
+            Execute the rolling operation per single column or row (``'single'``)
+            or over the entire object (``'table'``).
+
+            This argument is only implemented when specifying ``engine='numba'``
+            in the method call.
+
+            Only applicable to ``mean()``
+
+        Returns
+        -------
+        pandas.api.typing.ExponentialMovingWindow
+            An instance of ExponentialMovingWindow for further exponentially weighted (EW)
+            calculations, e.g. using the ``mean`` method.
+
+        See Also
+        --------
+        rolling : Provides rolling window calculations.
+        expanding : Provides expanding transformations.
+
+        Notes
+        -----
+        See :ref:`Windowing Operations <window.exponentially_weighted>`
+        for further usage details and examples.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'B': [0, 1, 2, np.nan, 4]})
+        >>> df
+             B
+        0  0.0
+        1  1.0
+        2  2.0
+        3  NaN
+        4  4.0
+
+        >>> df.ewm(com=0.5).mean()
+                  B
+        0  0.000000
+        1  0.750000
+        2  1.615385
+        3  1.615385
+        4  3.670213
+        >>> df.ewm(alpha=2 / 3).mean()
+                  B
+        0  0.000000
+        1  0.750000
+        2  1.615385
+        3  1.615385
+        4  3.670213
+
+        **adjust**
+
+        >>> df.ewm(com=0.5, adjust=True).mean()
+                  B
+        0  0.000000
+        1  0.750000
+        2  1.615385
+        3  1.615385
+        4  3.670213
+        >>> df.ewm(com=0.5, adjust=False).mean()
+                  B
+        0  0.000000
+        1  0.666667
+        2  1.555556
+        3  1.555556
+        4  3.650794
+
+        **ignore_na**
+
+        >>> df.ewm(com=0.5, ignore_na=True).mean()
+                  B
+        0  0.000000
+        1  0.750000
+        2  1.615385
+        3  1.615385
+        4  3.225000
+        >>> df.ewm(com=0.5, ignore_na=False).mean()
+                  B
+        0  0.000000
+        1  0.750000
+        2  1.615385
+        3  1.615385
+        4  3.670213
+
+        **times**
+
+        Exponentially weighted mean with weights calculated with a timedelta ``halflife``
+        relative to ``times``.
+
+        >>> times = ['2020-01-01', '2020-01-03', '2020-01-10', '2020-01-15', '2020-01-17']
+        >>> df.ewm(halflife='4 days', times=pd.DatetimeIndex(times)).mean()
+                  B
+        0  0.000000
+        1  0.585786
+        2  1.523889
+        3  1.523889
+        4  3.233686
+        """
         return ExponentialMovingWindow(
             self,
             com=com,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12317,7 +12317,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         times: np.ndarray | DataFrame | Series | None = None,
         method: Literal["single", "table"] = "single",
     ) -> ExponentialMovingWindow:
-        """
+        r"""
         Provide exponentially weighted (EW) calculations.
 
         Exactly one of ``com``, ``span``, ``halflife``, or ``alpha`` must be
@@ -12380,6 +12380,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     y_0 &= x_0\\
                     y_t &= (1 - \alpha) y_{t-1} + \alpha x_t,
                 \\end{split}
+
         ignore_na : bool, default False
             Ignore missing values when calculating weights.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12332,17 +12332,17 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         com : float, optional
             Specify decay in terms of center of mass
 
-            :math:`\alpha = 1 / (1 + com)`, for :math:`com \geq 0`.
+            :math:`\alpha = 1 / (1 + com)`, for :math:`com \\geq 0`.
 
         span : float, optional
             Specify decay in terms of span
 
-            :math:`\alpha = 2 / (span + 1)`, for :math:`span \geq 1`.
+            :math:`\alpha = 2 / (span + 1)`, for :math:`span \\geq 1`.
 
         halflife : float, str, timedelta, optional
             Specify decay in terms of half-life
 
-            :math:`\alpha = 1 - \exp\left(-\ln(2) / halflife\right)`, for
+            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\right)`, for
             :math:`halflife > 0`.
 
             If ``times`` is specified, a timedelta convertible unit over which an
@@ -12352,7 +12352,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         alpha : float, optional
             Specify smoothing factor :math:`\alpha` directly
 
-            :math:`0 < \alpha \leq 1`.
+            :math:`0 < \alpha \\leq 1`.
 
         min_periods : int, default 0
             Minimum number of observations in window required to have a value;
@@ -12379,7 +12379,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 \begin{split}
                     y_0 &= x_0\\
                     y_t &= (1 - \alpha) y_{t-1} + \alpha x_t,
-                \end{split}
+                \\end{split}
         ignore_na : bool, default False
             Ignore missing values when calculating weights.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12323,10 +12323,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Provide exponentially weighted (EW) calculations.
 
         Exactly one of ``com``, ``span``, ``halflife``, or ``alpha`` must be
-        provided if ``times`` is not provided. If ``times`` is provided and ``adjust=True``,
-        ``halflife`` and one of ``com``, ``span`` or ``alpha`` may be provided.
-        If ``times`` is provided and ``adjust=False``, ``halflife`` must be the only
-        provided decay-specification parameter.
+        provided if ``times`` is not provided. If ``times`` is provided and 
+        ``adjust=True``, ``halflife`` and one of ``com``, ``span`` or ``alpha`` 
+        may be provided.
+        If ``times`` is provided and ``adjust=False``, ``halflife`` 
+        must be the only provided decay-specification parameter.
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12385,7 +12385,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         ignore_na : bool, default False
             Ignore missing values when calculating weights.
 
-            - When ``ignore_na=False`` (default), weights are based on absolute positions.
+            - When ``ignore_na=False`` (default), weights are based on absolute
+              positions.
               For example, the weights of :math:`x_0` and :math:`x_2` used in
               calculating the final weighted average of [:math:`x_0`, None, :math:`x_2`]
               are :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
@@ -12395,7 +12396,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
               on relative positions. For example, the weights of :math:`x_0` and
               :math:`x_2` used in calculating the final weighted average of
               [:math:`x_0`, None, :math:`x_2`] are :math:`1-\alpha` and :math:`1` if
-              ``adjust=True``, and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
+              ``adjust=True``, and :math:`1-\alpha` and :math:`\alpha`
+              if ``adjust=False``.
 
         times : np.ndarray, Series, default None
 
@@ -12496,7 +12498,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Exponentially weighted mean with weights calculated with a timedelta
         ``halflife`` relative to ``times``.
 
-        >>> times = ['2020-01-01', '2020-01-03', '2020-01-10', '2020-01-15', 
+        >>> times = ['2020-01-01', '2020-01-03', '2020-01-10', '2020-01-15',
         ...         '2020-01-17']
         >>> df.ewm(halflife='4 days', times=pd.DatetimeIndex(times)).mean()
                   B

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12319,14 +12319,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         times: np.ndarray | DataFrame | Series | None = None,
         method: Literal["single", "table"] = "single",
     ) -> ExponentialMovingWindow:
-        """  
+        """
         Provide exponentially weighted (EW) calculations.
 
         Exactly one of ``com``, ``span``, ``halflife``, or ``alpha`` must be
-        provided if ``times`` is not provided. If ``times`` is provided and 
-        ``adjust=True``, ``halflife`` and one of ``com``, ``span`` or ``alpha`` 
+        provided if ``times`` is not provided. If ``times`` is provided and
+        ``adjust=True``, ``halflife`` and one of ``com``, ``span`` or ``alpha``
         may be provided.
-        If ``times`` is provided and ``adjust=False``, ``halflife`` 
+        If ``times`` is provided and ``adjust=False``, ``halflife``
         must be the only provided decay-specification parameter.
 
         Parameters
@@ -12364,13 +12364,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Divide by decaying adjustment factor in beginning periods to account
             for imbalance in relative weightings (viewing EWMA as a moving average).
 
-            - When ``adjust=True`` (default), the EW function is calculated using weights
-              :math:`w_i = (1 - \alpha)^i`. For example, the EW moving average of the series
-              [:math:`x_0, x_1, ..., x_t`] would be:
+            - When ``adjust=True`` (default), the EW function is calculated
+              using weights
+              :math:`w_i = (1 - \alpha)^i`. For example, the EW moving
+              average of the series [:math:`x_0, x_1, ..., x_t`] would be:
 
             .. math::
-                y_t = \frac{x_t + (1 - \alpha)x_{t-1} + (1 - \alpha)^2 x_{t-2} + ... + (1 -
-                \alpha)^t x_0}{1 + (1 - \alpha) + (1 - \alpha)^2 + ... + (1 - \alpha)^t}
+                y_t = \frac{x_t + (1 - \alpha)x_{t-1} + (1 - \alpha)^2 x_{t-2} + ... +
+                (1 - \alpha)^t x_0}{1 + (1 - \alpha) + (1 - \alpha)^2 + ... +
+                (1 - \alpha)^t}
 
             - When ``adjust=False``, the exponentially weighted function is calculated
               recursively:
@@ -12384,14 +12386,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Ignore missing values when calculating weights.
 
             - When ``ignore_na=False`` (default), weights are based on absolute positions.
-              For example, the weights of :math:`x_0` and :math:`x_2` used in calculating
-              the final weighted average of [:math:`x_0`, None, :math:`x_2`] are
-              :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+              For example, the weights of :math:`x_0` and :math:`x_2` used in
+              calculating the final weighted average of [:math:`x_0`, None, :math:`x_2`]
+              are :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
               :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
 
             - When ``ignore_na=True``, weights are based
-              on relative positions. For example, the weights of :math:`x_0` and :math:`x_2`
-              used in calculating the final weighted average of
+              on relative positions. For example, the weights of :math:`x_0` and
+              :math:`x_2` used in calculating the final weighted average of
               [:math:`x_0`, None, :math:`x_2`] are :math:`1-\alpha` and :math:`1` if
               ``adjust=True``, and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
 
@@ -12399,8 +12401,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
             Only applicable to ``mean()``.
 
-            Times corresponding to the observations. Must be monotonically increasing and
-            ``datetime64[ns]`` dtype.
+            Times corresponding to the observations. Must be monotonically
+            increasing and ``datetime64[ns]`` dtype.
 
             If 1-D array like, a sequence with the same shape as the observations.
 
@@ -12416,8 +12418,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Returns
         -------
         pandas.api.typing.ExponentialMovingWindow
-            An instance of ExponentialMovingWindow for further exponentially weighted (EW)
-            calculations, e.g. using the ``mean`` method.
+            An instance of ExponentialMovingWindow for further exponentially weighted
+            (EW) calculations, e.g. using the ``mean`` method.
 
         See Also
         --------
@@ -12491,10 +12493,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         **times**
 
-        Exponentially weighted mean with weights calculated with a timedelta ``halflife``
-        relative to ``times``.
+        Exponentially weighted mean with weights calculated with a timedelta
+        ``halflife`` relative to ``times``.
 
-        >>> times = ['2020-01-01', '2020-01-03', '2020-01-10', '2020-01-15', '2020-01-17']
+        >>> times = ['2020-01-01', '2020-01-03', '2020-01-10', '2020-01-15', 
+        ...         '2020-01-17']
         >>> df.ewm(halflife='4 days', times=pd.DatetimeIndex(times)).mean()
                   B
         0  0.000000


### PR DESCRIPTION
- [x] xref #62437
- [x] All code checks passed.
- [x] I have reviewed and followed all the contribution guidelines.

Inlined the docstring for `DataFrame.ewm` and `Series.ewm` in `pandas/core/generic.py` to replace the `@doc` decorator usage.

**Steps taken:**
1. Extracted the rendered docstring from `pd.DataFrame.ewm.__doc__`.
2. Replaced `@doc(ExponentialMovingWindow)` with the static docstring.
3. Removed the unused `doc` import from `pandas.util._decorators`.

This appears to be the last usage of `@doc` in `pandas/core/generic.py`.