### PR TITLE
CI: Use external_error_raised for pa.ArrowInvalid

### DIFF
--- a/pandas/tests/series/accessors/test_list_accessor.py
+++ b/pandas/tests/series/accessors/test_list_accessor.py
@@ -97,7 +97,7 @@ def test_list_getitem_slice_invalid():
         [[1, 2, 3], [4, None, 5], None],
         dtype=ArrowDtype(pa.list_(pa.int64())),
     )
-    with pytest.raises(pa.lib.ArrowInvalid, match=re.escape("`step` must be >= 1")):
+    with tm.external_error_raised(pa.ArrowInvalid):
         ser.list[1:None:0]
 
 
@@ -129,9 +129,9 @@ def test_list_getitem_invalid_index(list_dtype):
         [[1, 2, 3], [4, None, 5], None],
         dtype=ArrowDtype(list_dtype),
     )
-    with pytest.raises(pa.lib.ArrowInvalid, match="Index -1 is out of bounds"):
+    with tm.external_error_raised(pa.ArrowInvalid):
         ser.list[-1]
-    with pytest.raises(pa.lib.ArrowInvalid, match="Index 5 is out of bounds"):
+    with tm.external_error_raised(pa.ArrowInvalid):
         ser.list[5]
     with pytest.raises(ValueError, match="key must be an int or slice, got str"):
         ser.list["abc"]


### PR DESCRIPTION
e.g https://github.com/pandas-dev/pandas/actions/runs/21761489382/job/62786030392?pr=64048

Appears the pyarrow exception message changed

```
 
    def test_list_getitem_slice_invalid():
        ser = Series(
            [[1, 2, 3], [4, None, 5], None],
            dtype=ArrowDtype(pa.list_(pa.int64())),
        )
        with pytest.raises(pa.lib.ArrowInvalid, match=re.escape("`step` must be >= 1")):
>           ser.list[1:None:0]

pandas/tests/series/accessors/test_list_accessor.py:101: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pandas/core/arrays/arrow/accessors.py:181: in __getitem__
    sliced = pc.list_slice(self._pa_array, start, stop, step)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../../micromamba/envs/test/lib/python3.13/site-packages/pyarrow/compute.py:271: in wrapper
    return func.call(args, options, memory_pool)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pyarrow/_compute.pyx:399: in pyarrow._compute.Function.call
    ???
pyarrow/error.pxi:155: in pyarrow.lib.pyarrow_internal_check_status
    return check_status(status)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   raise convert_status(status)
E   pyarrow.lib.ArrowInvalid: `step` must be greater than or equal to 1, got: 0

pyarrow/error.pxi:92: ArrowInvalid

During handling of the above exception, another exception occurred:

    def test_list_getitem_slice_invalid():
        ser = Series(
            [[1, 2, 3], [4, None, 5], None],
            dtype=ArrowDtype(pa.list_(pa.int64())),
        )
>       with pytest.raises(pa.lib.ArrowInvalid, match=re.escape("`step` must be >= 1")):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       AssertionError: Regex pattern did not match.
E         Expected regex: '`step`\\ must\\ be\\ >=\\ 1'
E         Actual message: '`step` must be greater than or equal to 1, got: 0'

```