### PR TITLE
DOC: clarify .str behaviour on mixed-type Series

### DIFF
--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -355,7 +355,7 @@ Missing values on either side will result in missing values in the result as wel
 Concatenating a Series and something array-like into a Series
 -------------------------------------------------------------
 
-The parameter ``others`` can also be two-dimensional. In this case, the number or rows must match the lengths of the calling ``Series`` (or ``Index``).
+The parameter ``others`` can also be two-dimensional. In this case, the number of rows must match the lengths of the calling ``Series`` (or ``Index``).
 
 .. ipython:: python
 

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -110,19 +110,7 @@ the equivalent (scalar) built-in string methods:
    s.str.upper()
    s.str.len()
 
-.. note::
 
-   String methods are applied element-wise. If a value is not a string,
-   the result for that element will be ``NaN`` rather than raising an error.
-
-   For example:
-
-   .. ipython:: python
-
-      pd.Series(["a", 1]).str.upper()
-
-   returns ``NaN`` for the non-string value. This behavior is intentional
-   and allows vectorized string operations on data containing mixed types.
 
 
 .. ipython:: python
@@ -176,6 +164,20 @@ and replacing any remaining whitespaces with underscores:
     each other: ``s + " " + s`` won't work if ``s`` is a ``Series`` of type ``category``). Also,
     ``.str`` methods which operate on elements of type ``list`` are not available on such a
     ``Series``.
+
+.. note::
+
+   For object-dtype Series, string methods are applied element-wise.
+   If a value is not a string, the result for that element will be ``NaN``
+   rather than raising an error.
+
+   For example:
+
+   .. ipython:: python
+
+      pd.Series(["a", 1]).str.upper()
+
+   returns ``NaN`` for the non-string value.
 
 .. _text.warn_types:
 

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -110,6 +110,21 @@ the equivalent (scalar) built-in string methods:
    s.str.upper()
    s.str.len()
 
+.. note::
+
+   String methods are applied element-wise. If a value is not a string,
+   the result for that element will be ``NaN`` rather than raising an error.
+
+   For example:
+
+   .. ipython:: python
+
+      pd.Series(["a", 1]).str.upper()
+
+   returns ``NaN`` for the non-string value. This behavior is intentional
+   and allows vectorized string operations on data containing mixed types.
+
+
 .. ipython:: python
 
    idx = pd.Index([" jack", "jill ", " jesse ", "frank"])


### PR DESCRIPTION
**What does this PR do?**

Adds a short clarification to the user guide explaining the behaviour of
pandas string methods on mixed-type Series.

In particular, it documents that `.str` methods are applied element-wise
and that non-string values result in `NaN` rather than raising an error.
An example is included to illustrate this behaviour.

**Why is this needed?**

This behaviour is intentional but can be surprising to new users.
It commonly leads to confusion when working with mixed-type data,
especially around `NaN` propagation and output dtypes.

This change improves discoverability and understanding without changing
any existing behaviour.
