### PR TITLE
Fix PeriodIndex.is_full for duplicate periods

### DIFF
--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -562,7 +562,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         if not self.is_monotonic_increasing:
             raise ValueError("Index is not monotonic")
         values = self.asi8
-        return bool((values[1:] - values[:-1] == 1).all())
+        return bool(((values[1:] - values[:-1]) == 1).all())
 
     @property
     def inferred_type(self) -> str:

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -562,7 +562,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         if not self.is_monotonic_increasing:
             raise ValueError("Index is not monotonic")
         values = self.asi8
-        return bool(((values[1:] - values[:-1]) < 2).all())
+        return bool((values[1:] - values[:-1] == 1).all())
 
     @property
     def inferred_type(self) -> str:

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -137,6 +137,15 @@ class TestPeriodIndex:
         tm.assert_index_equal(idx.unique(), expected)
         assert idx.nunique() == 3
 
+    def test_is_full_false_with_duplicates(self):
+        idx = PeriodIndex(
+            ["2023-01", "2023-02", "2023-02", "2023-03"],
+            freq="M",
+        )
+
+        assert idx.is_monotonic_increasing
+        assert idx.is_full is False
+
     def test_pindex_fieldaccessor_nat(self):
         idx = PeriodIndex(
             ["2011-01", "2011-02", "NaT", "2012-03", "2012-04"], freq="D", name="name"


### PR DESCRIPTION
PeriodIndex.is_full currently returns True for monotonic indexes that contain duplicate period.
for example, a monthly index like ["2023-01", "2023-02", "2023-02", "2023-03"] is monotonic but not rangelike, so is_full should be False per the docstring.
the existing check allows zero-differences between consective values; this change requires a strict step of one period instead.
the fix is small and directly matches the documented behavior, so I put up the pr directly.