### PR TITLE
BUG: fix NaN identity check in Categorical.map

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -227,9 +227,9 @@ Categorical
   preserved (:issue:`64064`)
 
 - Bug in :meth:`Categorical.__repr__` where the values and categories lines could exceed ``display.width`` (:issue:`12066`)
-- Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory ...
-- Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` ...
-- Bug in :meth:`Index.fillna` raising ``TypeError`` ...
+- Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory by using ``dict.get``, causing ``NA`` values to be replaced with ``NaN`` instead of the mapper's default value (:issue:`62710`)
+- Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
+- Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
 -
 
 Datetimelike

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -221,10 +221,15 @@ Bug fixes
 
 Categorical
 ^^^^^^^^^^^
+
+- Fixed ``Categorical.map`` incorrectly returning an ``Index`` instead of a
+  ``Categorical`` when the mapping was one-to-one and missing values were
+  preserved (:issue:`64064`).
+
 - Bug in :meth:`Categorical.__repr__` where the values and categories lines could exceed ``display.width`` (:issue:`12066`)
-- Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory by using ``dict.get``, causing ``NA`` values to be replaced with ``NaN`` instead of the mapper's default value (:issue:`62710`)
-- Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
-- Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
+- Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory ...
+- Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` ...
+- Bug in :meth:`Index.fillna` raising ``TypeError`` ...
 -
 
 Datetimelike

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -224,7 +224,7 @@ Categorical
 
 - Fixed ``Categorical.map`` incorrectly returning an ``Index`` instead of a
   ``Categorical`` when the mapping was one-to-one and missing values were
-  preserved (:issue:`64064`).
+  preserved (:issue:`64064`)
 
 - Bug in :meth:`Categorical.__repr__` where the values and categories lines could exceed ``display.width`` (:issue:`12066`)
 - Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory ...

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1651,7 +1651,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 except KeyError:
                     na_val = np.nan
 
-        if new_categories.is_unique and not new_categories.hasnans and na_val is np.nan:
+        if new_categories.is_unique and not new_categories.hasnans and isna(na_val):
             new_dtype = CategoricalDtype(new_categories, ordered=self.ordered)
             return self.from_codes(self._codes.copy(), dtype=new_dtype, validate=False)
 

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -125,7 +125,7 @@ def test_map_nan_identity_preserves_categorical():
 
     def mapper(x):
         if pd.isna(x):
-            return np.nan
+            return float("nan")
         return x.upper()
 
     result = cat.map(mapper, na_action=None)

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -125,11 +125,13 @@ def test_map_nan_identity_preserves_categorical():
 
     def mapper(x):
         if pd.isna(x):
-            return float("nan")
+            return np.nan
         return x.upper()
 
     result = cat.map(mapper, na_action=None)
-    assert isinstance(result, Categorical)
+
+    expected = Categorical(["A", "B", np.nan], categories=["A", "B"])
+    tm.assert_categorical_equal(result, expected)
 
 
 def test_map_with_dict_or_series(na_action):

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -120,6 +120,18 @@ def test_map_with_nan_ignore(data, f, expected):  # GH 24241
         tm.assert_index_equal(result, expected)
 
 
+def test_map_nan_identity_preserves_categorical():
+    cat = Categorical(["a", "b", np.nan])
+
+    def mapper(x):
+        if pd.isna(x):
+            return float("nan")
+        return x.upper()
+
+    result = cat.map(mapper, na_action=None)
+    assert isinstance(result, Categorical)
+
+
 def test_map_with_dict_or_series(na_action):
     orig_values = ["a", "B", 1, "a"]
     new_values = ["one", 2, 3.0, "one"]


### PR DESCRIPTION
Categorical.map was using na_val is np.nan to detect preserved NaN values.
this is incorrect because NaN is not a singleton and identity comparison can fail.
because of this the categorical fast path was skipped and an Index was returned even when mapping was one to one and NaNs were unchanged.
this change replaces the identity check with isna(na_val) and adds a small regression test covering this case.