### PR TITLE
TST: add regression test for DataFrame.update with datetime and None …

### DIFF
--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -246,3 +246,16 @@ class TestDataFrameUpdate:
 
         df.update(other)
         tm.assert_frame_equal(df, expected)
+
+    def test_update_datetime_column_after_setting_none(self):
+        # GH#29462
+
+        df = DataFrame({"date": [pd.Timestamp("2026-02-05")]})
+
+        other = df.copy()
+        other["date"] = None
+
+        other.update(df)
+        expected = DataFrame({"date": [pd.Timestamp("2026-02-05")]})
+
+        tm.assert_frame_equal(other, expected, check_dtype=False)

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -256,6 +256,6 @@ class TestDataFrameUpdate:
         other["date"] = None
 
         other.update(df)
-        expected = DataFrame({"date": [pd.Timestamp("2026-02-05")]})
+        expected = DataFrame({"date": [pd.Timestamp("2026-02-05")]}, dtype=object)
 
-        tm.assert_frame_equal(other, expected, check_dtype=False)
+        tm.assert_frame_equal(other, expected)


### PR DESCRIPTION
## Summary
Added regression test for #29462. 

The test uses `check_dtype=False` because after `update()`, the column
dtype remains `object` instead of reverting to the source dtype (e.g.,
`datetime64[us]`, `int64`, `str`). Whether `update()` should infer the
dtype from the source DataFrame is a design question rather than a bug— see my
comment on #29462.

## AI Usage
Used Claude Code for guidance on finding the issue and organizing 
the contribution workflow. Test code was written and reviewed by me.


- [x] closes #29462 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
