### PR TITLE
Fix linkcode_resolve to use versioned GitHub URLs (fixes #58350)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -694,7 +694,6 @@ def linkcode_resolve(domain, info) -> str | None:
 
     fn = os.path.relpath(fn, start=os.path.dirname(pandas.__file__))
 
-    
     return (
         f"https://github.com/pandas-dev/pandas/blob/"
         f"v{pandas.__version__}/pandas/{fn}{linespec}"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -694,13 +694,11 @@ def linkcode_resolve(domain, info) -> str | None:
 
     fn = os.path.relpath(fn, start=os.path.dirname(pandas.__file__))
 
-    if "+" in pandas.__version__:
-        return f"https://github.com/pandas-dev/pandas/blob/main/pandas/{fn}{linespec}"
-    else:
-        return (
-            f"https://github.com/pandas-dev/pandas/blob/"
-            f"v{pandas.__version__}/pandas/{fn}{linespec}"
-        )
+    
+    return (
+        f"https://github.com/pandas-dev/pandas/blob/"
+        f"v{pandas.__version__}/pandas/{fn}{linespec}"
+    )
 
 
 # remove the docstring of the flags attribute (inherited from numpy ndarray)


### PR DESCRIPTION
Fixes #64056 

This PR updates `linkcode_resolve` to always generate GitHub URLs pointing to versioned release tags instead of the `main` branch, ensuring stable and correct source links in the documentation.

