### PR TITLE
DOC: Remove stale Categorical side-effects section

### DIFF
--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -1147,34 +1147,3 @@ Setting the index will create a ``CategoricalIndex``:
     df.index
     # This now sorts by the categories order
     df.sort_index()
-
-Side effects
-~~~~~~~~~~~~
-
-Constructing a ``Series`` from a ``Categorical`` will not copy the input
-``Categorical``. This means that changes to the ``Series`` will in most cases
-change the original ``Categorical``:
-
-.. ipython:: python
-
-    cat = pd.Categorical([1, 2, 3, 10], categories=[1, 2, 3, 4, 10])
-    s = pd.Series(cat, name="cat")
-    cat
-    s.iloc[0:2] = 10
-    cat
-
-Use ``copy=True`` to prevent such a behaviour or simply don't reuse ``Categoricals``:
-
-.. ipython:: python
-
-    cat = pd.Categorical([1, 2, 3, 10], categories=[1, 2, 3, 4, 10])
-    s = pd.Series(cat, name="cat", copy=True)
-    cat
-    s.iloc[0:2] = 10
-    cat
-
-.. note::
-
-    This also happens in some cases when you supply a NumPy array instead of a ``Categorical``:
-    using an int array (e.g. ``np.array([1,2,3,4])``) will exhibit the same behavior, while using
-    a string array (e.g. ``np.array(["a","b","c","a"])``) will not.


### PR DESCRIPTION
The "Side effects" section under `doc/source/user_guide/categorical.rst` ([pandas docs](https://pandas.pydata.org/docs/user_guide/categorical.html)) warns that constructing a `Series` from a `Categorical` without `copy=True` allows mutations to propagate back to the original `Categorical`. This is no longer true as of pandas 3.0, where Copy-on-Write is the default behavior ([v3.0.0 release notes](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html)).

Under CoW, the `Series` constructor always behaves as if it produces a copy, so the side effect described in this section cannot occur. Both code examples in the section already produce identical output, confirming the warning is stale.

This PR removes the section entirely.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
