### PR TITLE
DOC: Fix broken external links in debugging C extensions documentation (#64069)

### DIFF
--- a/doc/source/development/debugging_extensions.rst
+++ b/doc/source/development/debugging_extensions.rst
@@ -10,9 +10,9 @@ pandas uses Cython and C/C++ `extension modules <https://docs.python.org/3/exten
 
 For Python developers with limited or no C/C++ experience this can seem a daunting task. Core developer Will Ayd has written a 3 part blog series to help guide you from the standard Python debugger into these other tools:
 
-1. `Fundamental Python Debugging Part 1 - Python <https://willayd.com/fundamental-python-debugging-part-1-python/>`_
-2. `Fundamental Python Debugging Part 2 - Python Extensions <https://willayd.com/fundamental-python-debugging-part-2-python-extensions/>`_
-3. `Fundamental Python Debugging Part 3 - Cython Extensions <https://willayd.com/fundamental-python-debugging-part-3-cython-extensions/>`_
+1. `Fundamental Python Debugging Part 1 - Python <https://willayd.com/fundamental-python-debugging-part-1-python.html>`_
+2. `Fundamental Python Debugging Part 2 - Python Extensions <https://willayd.com/fundamental-python-debugging-part-2-python-extensions.html>`_
+3. `Fundamental Python Debugging Part 3 - Cython Extensions <https://willayd.com/fundamental-python-debugging-part-3-cython-extensions.html>`_
 
 Debugging locally
 -----------------


### PR DESCRIPTION
DOC: Fix broken external links in debugging C extensions documentation (#64069)

- [x] closes #64069
- [ ] Tests added and passed (not required for documentation-only changes)
- [x] All code checks passed.
- [ ] Added type annotations (not required for documentation-only changes)
- [ ] Added an entry in whatsnew (not required for documentation-only changes)
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.