### PR TITLE
DOC: Fix docstring of DataFrame.eq ('Equal', not 'Not equal')

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9425,7 +9425,7 @@ class DataFrame(NDFrame, OpsMixin):
 
     def eq(self, other, axis: Axis = "columns", level=None) -> DataFrame:
         """
-        Get Not equal to of dataframe and other, element-wise (binary operator `eq`).
+        Get Equal to of dataframe and other, element-wise (binary operator `eq`).
 
         Among flexible wrappers (`eq`, `ne`, `le`, `lt`, `ge`, `gt`) to comparison
         operators.


### PR DESCRIPTION
Originally introduced in 39ac242cb9 (#63384).

- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
