### PR TITLE
 TST: Add regression test for groupby.var/std arrow dtype retention

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2775,9 +2775,6 @@ class ArrowExtensionArray(
             na_value = 1
         elif pa.types.is_boolean(pa_dtype):
             na_value = True
-        elif pa.types.is_decimal(pa_dtype):
-            # GH#54627
-            return type(self)(self._pa_array.cast(pa.float64()))._to_masked()
         else:
             raise NotImplementedError
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2775,6 +2775,9 @@ class ArrowExtensionArray(
             na_value = 1
         elif pa.types.is_boolean(pa_dtype):
             na_value = True
+        elif pa.types.is_decimal(pa_dtype):
+            # GH#54627
+            return type(self)(self._pa_array.cast(pa.float64()))._to_masked()
         else:
             raise NotImplementedError
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3387,64 +3387,6 @@ def test_groupby_std_returns_arrow_dtype():
     assert result.dtypes["B"] == ArrowDtype(pa.float64())
 
 
-def test_groupby_var_returns_arrow_dtype_float32():
-    # GH#54627
-    df = pd.DataFrame(
-        {
-            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
-            "B": pd.Series([123.0, 12.0, 50.0, 75.0], dtype="float32[pyarrow]"),
-        }
-    )
-    result = df.groupby("A").var()
-    assert result.dtypes["B"] == ArrowDtype(pa.float32())
-
-
-def test_groupby_std_returns_arrow_dtype_float32():
-    # GH#54627
-    df = pd.DataFrame(
-        {
-            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
-            "B": pd.Series([123.0, 12.0, 50.0, 75.0], dtype="float32[pyarrow]"),
-        }
-    )
-    result = df.groupby("A").std()
-    assert result.dtypes["B"] == ArrowDtype(pa.float32())
-
-
-def test_groupby_var_returns_arrow_dtype_decimal():
-    # GH#54627
-    from decimal import Decimal
-
-    df = pd.DataFrame(
-        {
-            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
-            "B": pd.Series(
-                [Decimal("123.0"), Decimal("12.0"), Decimal("50.0"), Decimal("75.0")],
-                dtype=ArrowDtype(pa.decimal128(6, 3)),
-            ),
-        }
-    )
-    result = df.groupby("A").var()
-    assert result.dtypes["B"] == ArrowDtype(pa.float64())
-
-
-def test_groupby_std_returns_arrow_dtype_decimal():
-    # GH#54627
-    from decimal import Decimal
-
-    df = pd.DataFrame(
-        {
-            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
-            "B": pd.Series(
-                [Decimal("123.0"), Decimal("12.0"), Decimal("50.0"), Decimal("75.0")],
-                dtype=ArrowDtype(pa.decimal128(6, 3)),
-            ),
-        }
-    )
-    result = df.groupby("A").std()
-    assert result.dtypes["B"] == ArrowDtype(pa.float64())
-
-
 def test_fixed_size_list():
     # GH#55000
     ser = pd.Series(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3363,6 +3363,30 @@ def test_groupby_count_return_arrow_dtype(data_missing):
     tm.assert_frame_equal(result, expected)
 
 
+def test_groupby_var_returns_arrow_dtype():
+    # GH#54627
+    df = pd.DataFrame(
+        {
+            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
+            "B": pd.Series([123, 12, 50, 75], dtype="int64[pyarrow]"),
+        }
+    )
+    result = df.groupby("A").var()
+    assert result.dtypes["B"] == ArrowDtype(pa.float64())
+
+
+def test_groupby_std_returns_arrow_dtype():
+    # GH#54627
+    df = pd.DataFrame(
+        {
+            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
+            "B": pd.Series([123, 12, 50, 75], dtype="int64[pyarrow]"),
+        }
+    )
+    result = df.groupby("A").std()
+    assert result.dtypes["B"] == ArrowDtype(pa.float64())
+
+
 def test_fixed_size_list():
     # GH#55000
     ser = pd.Series(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3387,6 +3387,66 @@ def test_groupby_std_returns_arrow_dtype():
     assert result.dtypes["B"] == ArrowDtype(pa.float64())
 
 
+def test_groupby_var_returns_arrow_dtype_float32():
+    # GH#54627
+    df = pd.DataFrame(
+        {
+            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
+            "B": pd.Series([123.0, 12.0, 50.0, 75.0], dtype="float32[pyarrow]"),
+        }
+    )
+    result = df.groupby("A").var()
+    # Pandas preserves float32 precision for float32 inputs
+    assert result.dtypes["B"] == ArrowDtype(pa.float32())
+
+
+def test_groupby_std_returns_arrow_dtype_float32():
+    # GH#54627
+    df = pd.DataFrame(
+        {
+            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
+            "B": pd.Series([123.0, 12.0, 50.0, 75.0], dtype="float32[pyarrow]"),
+        }
+    )
+    result = df.groupby("A").std()
+    # Pandas preserves float32 precision for float32 inputs
+    assert result.dtypes["B"] == ArrowDtype(pa.float32())
+
+
+def test_groupby_var_returns_arrow_dtype_decimal():
+    # GH#54627
+    from decimal import Decimal
+    df = pd.DataFrame(
+        {
+            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
+            "B": pd.Series(
+                [Decimal("123.0"), Decimal("12.0"), Decimal("50.0"), Decimal("75.0")], 
+                dtype=ArrowDtype(pa.decimal128(6, 3))
+            ),
+        }
+    )
+    result = df.groupby("A").var()
+    # Decimals are cast to float64, so result should be float64
+    assert result.dtypes["B"] == ArrowDtype(pa.float64())
+
+
+def test_groupby_std_returns_arrow_dtype_decimal():
+    # GH#54627
+    from decimal import Decimal
+    df = pd.DataFrame(
+        {
+            "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
+            "B": pd.Series(
+                [Decimal("123.0"), Decimal("12.0"), Decimal("50.0"), Decimal("75.0")], 
+                dtype=ArrowDtype(pa.decimal128(6, 3))
+            ),
+        }
+    )
+    result = df.groupby("A").std()
+    # Decimals are cast to float64, so result should be float64
+    assert result.dtypes["B"] == ArrowDtype(pa.float64())
+
+
 def test_fixed_size_list():
     # GH#55000
     ser = pd.Series(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3414,12 +3414,13 @@ def test_groupby_std_returns_arrow_dtype_float32():
 def test_groupby_var_returns_arrow_dtype_decimal():
     # GH#54627
     from decimal import Decimal
+
     df = pd.DataFrame(
         {
             "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
             "B": pd.Series(
-                [Decimal("123.0"), Decimal("12.0"), Decimal("50.0"), Decimal("75.0")], 
-                dtype=ArrowDtype(pa.decimal128(6, 3))
+                [Decimal("123.0"), Decimal("12.0"), Decimal("50.0"), Decimal("75.0")],
+                dtype=ArrowDtype(pa.decimal128(6, 3)),
             ),
         }
     )
@@ -3430,12 +3431,13 @@ def test_groupby_var_returns_arrow_dtype_decimal():
 def test_groupby_std_returns_arrow_dtype_decimal():
     # GH#54627
     from decimal import Decimal
+
     df = pd.DataFrame(
         {
             "A": pd.Series([True, True, False, False], dtype="bool[pyarrow]"),
             "B": pd.Series(
-                [Decimal("123.0"), Decimal("12.0"), Decimal("50.0"), Decimal("75.0")], 
-                dtype=ArrowDtype(pa.decimal128(6, 3))
+                [Decimal("123.0"), Decimal("12.0"), Decimal("50.0"), Decimal("75.0")],
+                dtype=ArrowDtype(pa.decimal128(6, 3)),
             ),
         }
     )

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3396,7 +3396,6 @@ def test_groupby_var_returns_arrow_dtype_float32():
         }
     )
     result = df.groupby("A").var()
-    # Pandas preserves float32 precision for float32 inputs
     assert result.dtypes["B"] == ArrowDtype(pa.float32())
 
 
@@ -3409,7 +3408,6 @@ def test_groupby_std_returns_arrow_dtype_float32():
         }
     )
     result = df.groupby("A").std()
-    # Pandas preserves float32 precision for float32 inputs
     assert result.dtypes["B"] == ArrowDtype(pa.float32())
 
 
@@ -3426,7 +3424,6 @@ def test_groupby_var_returns_arrow_dtype_decimal():
         }
     )
     result = df.groupby("A").var()
-    # Decimals are cast to float64, so result should be float64
     assert result.dtypes["B"] == ArrowDtype(pa.float64())
 
 
@@ -3443,7 +3440,6 @@ def test_groupby_std_returns_arrow_dtype_decimal():
         }
     )
     result = df.groupby("A").std()
-    # Decimals are cast to float64, so result should be float64
     assert result.dtypes["B"] == ArrowDtype(pa.float64())
 
 


### PR DESCRIPTION
- [x] closes #54627
- [x] Tests added / passed
- [x] Ensure all linting tests pass

#### Implementation:
Test that `int64[pyarrow]` inputs correctly return `float64[pyarrow]` instead of falling back to NumPy `float64`.

Added the following tests to `pandas/tests/extension/test_arrow.py`:
- `test_groupby_var_returns_arrow_dtype`: Verifies `int64` -> `float64[pyarrow]` (Fixes GH#54627).
- `test_groupby_std_returns_arrow_dtype`: Same for std.

Both tests follow the existing pattern in `test_arrow.py`