### PR TITLE
DOC: Clarify float_precision behavior in read_csv and read_table docs

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -944,10 +944,17 @@ Specifying method for floating-point conversion
 '''''''''''''''''''''''''''''''''''''''''''''''
 
 The parameter ``float_precision`` can be specified in order to use
-a specific floating-point converter during parsing with the C engine.
-The options are the ordinary converter, the high-precision converter, and
-the round-trip converter (which is guaranteed to round-trip values after
-writing to a file). For example:
+a specific floating-point converter during parsing with the C engine:
+
+- ``None`` or ``"high"`` use the default high-precision converter.
+- ``"legacy"`` uses the original pandas converter (lower precision).
+- ``"round_trip"`` uses the round-trip converter.
+
+In this context, round-trip means parsing text to ``float`` and then
+converting that value back to text and parsing again returns the same
+``float`` value.
+
+For example:
 
 .. ipython:: python
 
@@ -965,6 +972,13 @@ writing to a file). For example:
            StringIO(data),
            engine="c",
            float_precision="high",
+       )["c"][0] - float(val)
+   )
+   abs(
+       pd.read_csv(
+           StringIO(data),
+           engine="c",
+           float_precision="legacy",
        )["c"][0] - float(val)
    )
    abs(

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -954,37 +954,33 @@ In this context, round-trip means parsing text to ``float`` and then
 converting that value back to text and parsing again returns the same
 ``float`` value.
 
-For example:
+The following example uses a near-zero value with many decimal places
+to show how each option affects the result. Reading the parsed scalar
+and formatting it with a fixed precision makes the differences visible:
 
 .. ipython:: python
 
-   val = "0.3066101993807095471566981359501369297504425048828125"
-   data = "a,b,c\n1,2,{0}".format(val)
-   abs(
-       pd.read_csv(
-           StringIO(data),
-           engine="c",
-           float_precision=None,
-       )["c"][0] - float(val)
-   )
-   abs(
-       pd.read_csv(
-           StringIO(data),
-           engine="c",
-           float_precision="high",
-       )["c"][0] - float(val)
-   )
-   abs(
-       pd.read_csv(
-           StringIO(data),
-           engine="c",
-           float_precision="legacy",
-       )["c"][0] - float(val)
-   )
-   abs(
-       pd.read_csv(StringIO(data), engine="c", float_precision="round_trip")["c"][0]
-       - float(val)
-   )
+   from io import StringIO
+
+   data = "value\n0.00000000000000012\n"
+
+   high = pd.read_csv(
+       StringIO(data), engine="c", float_precision="high"
+   ).loc[0, "value"]
+   legacy = pd.read_csv(
+       StringIO(data), engine="c", float_precision="legacy"
+   ).loc[0, "value"]
+   rt = pd.read_csv(
+       StringIO(data), engine="c", float_precision="round_trip"
+   ).loc[0, "value"]
+
+   format(high, ".20g"), format(legacy, ".20g"), format(rt, ".20g")
+
+The formatted output shows that ``"round_trip"`` preserves the textual
+representation of the value more closely than ``"high"`` or ``"legacy"``.
+Use ``float_precision="round_trip"`` when minimizing rounding introduced
+by parsing matters (for example, when the CSV was exported from another
+tool).
 
 
 .. _io.thousands:

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -736,9 +736,17 @@ def read_csv(
         option can improve performance because there is no longer any I/O overhead.
     float_precision : {{'high', 'legacy', 'round_trip'}}, optional
         Specifies which converter the C engine should use for floating-point
-        values. The options are ``None`` or ``'high'`` for the ordinary converter,
-        ``'legacy'`` for the original lower precision pandas converter, and
-        ``'round_trip'`` for the round-trip converter.
+        values.
+
+        - ``None`` or ``'high'``: use the default high-precision converter.
+        - ``'legacy'``: use the original pandas converter (lower precision).
+        - ``'round_trip'``: use the round-trip converter.
+
+        In this context, "round-trip" means parsing text to ``float`` and then
+        converting that value back to text and parsing again returns the same
+        ``float`` value.
+
+        See :ref:`io.float_precision` for examples.
 
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
@@ -1299,9 +1307,17 @@ def read_table(
         option can improve performance because there is no longer any I/O overhead.
     float_precision : {{'high', 'legacy', 'round_trip'}}, optional
         Specifies which converter the C engine should use for floating-point
-        values. The options are ``None`` or ``'high'`` for the ordinary converter,
-        ``'legacy'`` for the original lower precision pandas converter, and
-        ``'round_trip'`` for the round-trip converter.
+        values.
+
+        - ``None`` or ``'high'``: use the default high-precision converter.
+        - ``'legacy'``: use the original pandas converter (lower precision).
+        - ``'round_trip'``: use the round-trip converter.
+
+        In this context, "round-trip" means parsing text to ``float`` and then
+        converting that value back to text and parsing again returns the same
+        ``float`` value.
+
+        See :ref:`io.float_precision` for examples.
 
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
@@ -2068,9 +2084,9 @@ def TextParser(*args, **kwds) -> TextFileReader:
         Encoding to use for UTF when reading/writing (ex. 'utf-8')
     float_precision : str, optional
         Specifies which converter the C engine should use for floating-point
-        values. The options are `None` or `high` for the ordinary converter,
-        `legacy` for the original lower precision pandas converter, and
-        `round_trip` for the round-trip converter.
+        values. The options are ``None`` or ``'high'`` for the default
+        high-precision converter, ``'legacy'`` for the original lower precision
+        pandas converter, and ``'round_trip'`` for the round-trip converter.
     """
     kwds["engine"] = "python"
     return TextFileReader(*args, **kwds)


### PR DESCRIPTION
Improves the user guide documentation for the `float_precision` parameter used when reading CSV and other text files (e.g. `read_csv`, `read_table`).
- [x] closes #64094
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.