### PR TITLE
BUG: prevent segfault with mismatching lengths in variable rolling window correlation and covariance

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -29,6 +29,7 @@ Bug fixes
 - Fixed a bug in the :func:`comparison_op` raising a ``TypeError`` for zerodim
   subclasses of ``np.ndarray`` (:issue:`63205`)
 - Fixed thread safety issues in :class:`DataFrame` internals on the free-threaded build (:issue:`63685`).
+- Prevent buffer overflow in :meth:`Rolling.corr` and :meth:`Rolling.cov` with variable windows when passing ``other`` with a longer index than the original window. This now raises ``ValueError`` (:issue:`62937`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.contributors:

--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -195,17 +195,23 @@ class VariableWindowIndexer(BaseIndexer):
         A tuple of ndarray[int64]s, indicating the boundaries of each
         window
         """
+        assert self.index_array is not None
+        if (index_length := len(self.index_array)) < num_values:
+            raise ValueError(
+                "Variable rolling window requires the index to be at least as long "
+                f"as the 'other' index. Got {index_length} < {num_values}. "
+                "Please align 'other' to the rolling object's index using "
+                "reindex_like() or similar method."
+            )
         # error: Argument 4 to "calculate_variable_window_bounds" has incompatible
         # type "Optional[bool]"; expected "bool"
-        # error: Argument 6 to "calculate_variable_window_bounds" has incompatible
-        # type "Optional[ndarray]"; expected "ndarray"
         return calculate_variable_window_bounds(
             num_values,
             self.window_size,
             min_periods,
             center,  # type: ignore[arg-type]
             closed,
-            self.index_array,  # type: ignore[arg-type]
+            self.index_array,
         )
 
 

--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -168,6 +168,18 @@ def test_rolling_corr_diff_length():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("func", ["cov", "corr"])
+def test_time_based_rolling_other_longer_raises(func):
+    # GH#62937
+    idx_short = date_range("2020-01-01", periods=3, freq="D")
+    idx_long = date_range("2020-01-01", periods=5, freq="D")
+    s = Series([1, 2, 3], index=idx_short)
+    other = Series([1, 2, 3, 4, 5], index=idx_long)
+    msg = "Variable rolling window requires .* Got 3 < 5"
+    with pytest.raises(ValueError, match=msg):
+        getattr(s.rolling("2D"), func)(other)
+
+
 @pytest.mark.parametrize(
     "f",
     [


### PR DESCRIPTION
- [x] xref #62937 Just referencing, since I don't know if we should have a defined behavior for this case.
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`. Asked copilot to write the error message.

---

I don't know what would be the correct behavior when we have a size mismatch in a variable rolling window. So this PR is just a safe measure to prevent memory corruption.

### Steps to check the patch

Setup: 

```console
$ meson configure build/cp313 -Dbuildtype=debugoptimized -Db_sanitize='address,undefined'
$ meson compile -C build/cp313
$ export LD_PRELOAD=/usr/lib64/libasan.so.8:/usr/lib64/libubsan.so.1
$ export ASAN_OPTIONS=detect_leaks=0
```

With Patch:

```console
$ pytest pandas/tests/window/test_pairwise.py::test_time_based_rolling_other_longer_raises
... # some unrelated cython specific errors, e.g.:
pandas/tests/window/test_pairwise.py pandas/_libs/index.cpython-313-x86_64-linux-gnu.so.p/pandas/_libs/index.pyx.c:15870:23: runtime error: call to function __pyx_f_6pandas_5_libs_5index_11In
t64Engine__make_hash_table through pointer to incorrect function type 'struct _object *(*)(struct __pyx_obj_6pandas_5_libs_5index_IndexEngine *, long)'
```

<details><summary>Without Patch:</summary>
<p>

```console
$ pytest pandas/tests/window/test_pairwise.py::test_time_based_rolling_other_longer_raises
...
==75634==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b658d0b7b50 at pc 0x7b3554e1b6b8 bp 0x7fff94103d10 sp 0x7fff94103d08
READ of size 8 at 0x7b658d0b7b50 thread T0
    #0 0x7b3554e1b6b7 in __pyx_pf_6pandas_5_libs_6window_8indexers_calculate_variable_window_bounds /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/window/indexers.cpython-313-x8
6_64-linux-gnu.so.p/pandas/_libs/window/indexers.pyx.c:19200
    #1 0x7b3554e15619 in __pyx_pw_6pandas_5_libs_6window_8indexers_1calculate_variable_window_bounds /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/window/indexers.cpython-313-x
86_64-linux-gnu.so.p/pandas/_libs/window/indexers.pyx.c:18839
    #2 0x7b3554e130d6 in __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/window/indexers.cpython-313-x86_64-linux-gnu.so.p/pandas/_l
ibs/window/indexers.pyx.c:27891
    #3 0x000001823185 in _PyEval_EvalFrameDefault (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1823185)
    #4 0x0000018e7fa4 in _PyObject_Call_Prepend (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7fa4)
    #5 0x0000018e7e50 in slot_tp_call (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7e50)
    #6 0x000001ac6c0c in _PyEval_EvalFrameDefault.warm (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1ac6c0c)
    #7 0x0000018e7fa4 in _PyObject_Call_Prepend (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7fa4)
    #8 0x0000018e7e50 in slot_tp_call (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7e50)
    #9 0x00000182ac4b in _PyEval_EvalFrameDefault (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x182ac4b)
    #10 0x0000018e7fa4 in _PyObject_Call_Prepend (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7fa4)
    #11 0x0000018e7e50 in slot_tp_call (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7e50)
    #12 0x000001ac6c0c in _PyEval_EvalFrameDefault.warm (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1ac6c0c)
    #13 0x0000018e7fa4 in _PyObject_Call_Prepend (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7fa4)
    #14 0x0000018e7e50 in slot_tp_call (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7e50)
    #15 0x000001ac6c0c in _PyEval_EvalFrameDefault.warm (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1ac6c0c)
    #16 0x0000018e7fa4 in _PyObject_Call_Prepend (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7fa4)
    #17 0x0000018e7e50 in slot_tp_call (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18e7e50)
    #18 0x000001ac6c0c in _PyEval_EvalFrameDefault.warm (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1ac6c0c)
    #19 0x0000018aa113 in PyEval_EvalCode (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18aa113)
    #20 0x0000018a5239 in run_eval_code_obj (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18a5239)
    #21 0x0000018dc182 in run_mod.llvm.12468226955389376524 (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x18dc182)
    #22 0x000001a08446 in pyrun_file (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1a08446)
    #23 0x000001a07b36 in _PyRun_SimpleFileObject (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1a07b36)
    #24 0x000001a0764f in _PyRun_AnyFileObject (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1a0764f)
    #25 0x000001a075f5 in pymain_run_file_obj (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1a075f5)
    #26 0x000001a074d9 in pymain_run_file (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1a074d9)
    #27 0x000001997e91 in Py_RunMain (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1997e91)
    #28 0x000001997b44 in pymain_main.llvm.12760885333831575200 (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x1997b44)
    #29 0x00000199792c in main (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x199792c)
    #30 0x7f358e0105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: 2b5beec0fd24fe9c9f43eddfdd5facf0b8a1b805)
    #31 0x7f358e010667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: 2b5beec0fd24fe9c9f43eddfdd5facf0b8a1b805)
    #32 0x0000019fff68 in _start (/home/alvaro/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/bin/python3.13+0x19fff68)

0x7b658d0b7b50 is located 8 bytes after 24-byte region [0x7b658d0b7b30,0x7b658d0b7b48)
allocated by thread T0 here:
    #0 0x7f358eae6f2b in malloc (/usr/lib64/libasan.so.8+0xe6f2b) (BuildId: 25975f766867e9e604dc5a71a8befeaed3301942)
    #1 0x7b357bb4a00d in PyDataMem_UserNEW (/home/alvaro/projects/oss/pandas/.venv/lib/python3.13/site-packages/numpy/_core/_multiarray_umath.cpython-313-x86_64-linux-gnu.so+0x14a00d) (Bui
ldId: 3c525c004c550be8bcf0b280d4e253b7c49a2048)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/alvaro/projects/oss/pandas/build/cp313/pandas/_libs/window/indexers.cpython-313-x86_64-linux-gnu.so.p/pandas/_libs/window/indexers.pyx
.c:19200 in __pyx_pf_6pandas_5_libs_6window_8indexers_calculate_variable_window_bounds
Shadow bytes around the buggy address:
  0x7b658d0b7880: fa fa fd fd fd fa fa fa 00 00 00 fa fa fa 00 00
  0x7b658d0b7900: 04 fa fa fa 00 00 00 fa fa fa fd fd fd fa fa fa
  0x7b658d0b7980: fd fd fd fa fa fa 00 00 00 fa fa fa 00 00 00 00
  0x7b658d0b7a00: fa fa 00 00 00 fa fa fa 00 00 00 00 fa fa 00 00
  0x7b658d0b7a80: 00 00 fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa
=>0x7b658d0b7b00: 00 00 00 fa fa fa 00 00 00 fa[fa]fa fd fd fd fa
  0x7b658d0b7b80: fa fa fd fd fd fd fa fa 00 00 00 fa fa fa 00 00
  0x7b658d0b7c00: 00 fa fa fa fd fd fd fd fa fa 00 00 00 fa fa fa
  0x7b658d0b7c80: fd fd fd fd fa fa fd fd fd fd fa fa fd fd fd fa
  0x7b658d0b7d00: fa fa fd fd fd fa fa fa fd fd fd fa fa fa fd fd
  0x7b658d0b7d80: fd fa fa fa fd fd fd fa fa fa fd fd fd fd fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==75634==ABORTING
```


</p>
</details> 

