### PR TITLE
BUG: fix regression in DataFrame construction from list of dicts with missing value as key

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -14,8 +14,8 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`DataFrame.groupby` and :meth:`Series.groupby` when grouping on categorical data with NA values, ``observed=False``, and ``dropna=True`` (:issue:`52445`)
-- Fixed regression when calling ``numpy.random``'s ``permutation()`` on a (pyarrow-backed) string :class:`Series` (:issue:`63935`)
 - Fixed regression in the :class:`DataFrame` and :meth:`DataFrame.from_records` constructor with a list of dicts with a missing value indicator as key (:issue:`63889`)
+- Fixed regression when calling ``numpy.random``'s ``permutation()`` on a (pyarrow-backed) string :class:`Series` (:issue:`63935`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.bugs:

--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -15,6 +15,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :meth:`DataFrame.groupby` and :meth:`Series.groupby` when grouping on categorical data with NA values, ``observed=False``, and ``dropna=True`` (:issue:`52445`)
 - Fixed regression when calling ``numpy.random``'s ``permutation()`` on a (pyarrow-backed) string :class:`Series` (:issue:`63935`)
+- Fixed regression in the :class:`DataFrame` and :meth:`DataFrame.from_records` constructor with a list of dicts with a missing value indicator as key (:issue:`63889`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.bugs:

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -867,17 +867,22 @@ def _list_of_dict_to_arrays(
     content : np.ndarray[object, ndim=2]
     columns : Index
     """
+    # assure that they are of the base dict class and not of derived
+    # classes
+    data = [d if type(d) is dict else dict(d) for d in data]
+
     if columns is None:
         gen = (list(x.keys()) for x in data)
         sort = not any(isinstance(d, dict) for d in data)
         pre_cols = lib.fast_unique_multiple_list_gen(gen, sort=sort)
         columns = ensure_index(pre_cols)
 
-    # assure that they are of the base dict class and not of derived
-    # classes
-    data = [d if type(d) is dict else dict(d) for d in data]
+        # use pre_cols to preserve exact values that were present as dict keys
+        # (e.g. otherwise missing values might be coerced to the canonical repr)
+        content = lib.dicts_to_array(data, pre_cols)
+    else:
+        content = lib.dicts_to_array(data, list(columns))
 
-    content = lib.dicts_to_array(data, list(columns))
     return content, columns
 
 

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -504,7 +504,7 @@ class TestFromRecords:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("missing_value", [None, np.nan, pd.NA])
-    def test_from_records_missing_value_key(self, missing_value):
+    def test_from_records_missing_value_key(self, missing_value, using_infer_string):
         # https://github.com/pandas-dev/pandas/issues/63889
         # preserve values when None key is converted to NaN column name
         dict_data = [
@@ -512,7 +512,10 @@ class TestFromRecords:
             {"colA": 3, missing_value: 4},
         ]
         result = DataFrame.from_records(dict_data)
-        expected = DataFrame([[1, 2], [3, 4]], columns=["colA", np.nan])
+        expected = DataFrame(
+            [[1, 2], [3, 4]],
+            columns=["colA", np.nan if not using_infer_string else missing_value],
+        )
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("missing_value", [None, np.nan, pd.NA])

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -12,6 +12,7 @@ from pandas._config import using_string_dtype
 
 from pandas.compat import is_platform_little_endian
 
+import pandas as pd
 from pandas import (
     CategoricalIndex,
     DataFrame,
@@ -500,4 +501,26 @@ class TestFromRecords:
             iter(rows), index=[0, 1], columns=["col_1", "Col_2"], nrows=0
         )
         expected = DataFrame([], index=[0, 1], columns=["col_1", "Col_2"])
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("missing_value", [None, np.nan, pd.NA])
+    def test_from_records_missing_value_key(self, missing_value):
+        # https://github.com/pandas-dev/pandas/issues/63889
+        # preserve values when None key is converted to NaN column name
+        dict_data = [
+            {"colA": 1, missing_value: 2},
+            {"colA": 3, missing_value: 4},
+        ]
+        result = DataFrame.from_records(dict_data)
+        expected = DataFrame([[1, 2], [3, 4]], columns=["colA", np.nan])
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("missing_value", [None, np.nan, pd.NA])
+    def test_from_records_missing_value_key_only(self, missing_value):
+        dict_data = [
+            {missing_value: 1},
+            {missing_value: 2},
+        ]
+        result = DataFrame.from_records(dict_data)
+        expected = DataFrame([[1], [2]], columns=Index([missing_value]))
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/constructors/test_from_records.py
+++ b/pandas/tests/frame/constructors/test_from_records.py
@@ -514,7 +514,7 @@ class TestFromRecords:
         result = DataFrame.from_records(dict_data)
         expected = DataFrame(
             [[1, 2], [3, 4]],
-            columns=["colA", np.nan if not using_infer_string else missing_value],
+            columns=["colA", np.nan if using_infer_string else missing_value],
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -642,7 +642,9 @@ class TestDataFrameConstructors:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("missing_value", [None, np.nan, pd.NA])
-    def test_constructor_list_of_dict_with_str_na_key(self, missing_value):
+    def test_constructor_list_of_dict_with_str_na_key(
+        self, missing_value, using_infer_string
+    ):
         # https://github.com/pandas-dev/pandas/issues/63889
         # preserve values when None key is converted to NaN column name
         dict_data = [
@@ -650,15 +652,25 @@ class TestDataFrameConstructors:
             {"colA": 3, missing_value: 4},
         ]
         result = DataFrame(dict_data)
-        expected = DataFrame([[1, 2], [3, 4]], columns=["colA", np.nan])
+        expected = DataFrame(
+            [[1, 2], [3, 4]],
+            columns=["colA", np.nan if using_infer_string else missing_value],
+        )
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("missing_value", [None, np.nan, pd.NA])
-    def test_constructor_dict_of_dict_with_str_na_key(self, missing_value):
+    def test_constructor_dict_of_dict_with_str_na_key(
+        self, missing_value, using_infer_string
+    ):
         # https://github.com/pandas-dev/pandas/issues/63889
         dict_data = {"col": {"row1": 1, missing_value: 2, "row3": 3}}
         result = DataFrame(dict_data)
-        expected = DataFrame({"col": [1, 2, 3]}, index=Index(["row1", np.nan, "row3"]))
+        expected = DataFrame(
+            {"col": [1, 2, 3]},
+            index=Index(
+                ["row1", np.nan if using_infer_string else missing_value, "row3"]
+            ),
+        )
         tm.assert_frame_equal(result, expected)
 
     def test_constructor_multi_index(self):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -641,6 +641,26 @@ class TestDataFrameConstructors:
         expected = DataFrame([[1, 2], [2, 3]], columns=[np.nan, 2])
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("missing_value", [None, np.nan, pd.NA])
+    def test_constructor_list_of_dict_with_str_na_key(self, missing_value):
+        # https://github.com/pandas-dev/pandas/issues/63889
+        # preserve values when None key is converted to NaN column name
+        dict_data = [
+            {"colA": 1, missing_value: 2},
+            {"colA": 3, missing_value: 4},
+        ]
+        result = DataFrame(dict_data)
+        expected = DataFrame([[1, 2], [3, 4]], columns=["colA", np.nan])
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("missing_value", [None, np.nan, pd.NA])
+    def test_constructor_dict_of_dict_with_str_na_key(self, missing_value):
+        # https://github.com/pandas-dev/pandas/issues/63889
+        dict_data = {"col": {"row1": 1, missing_value: 2, "row3": 3}}
+        result = DataFrame(dict_data)
+        expected = DataFrame({"col": [1, 2, 3]}, index=Index(["row1", np.nan, "row3"]))
+        tm.assert_frame_equal(result, expected)
+
     def test_constructor_multi_index(self):
         # GH 4078
         # construction error with mi and all-nan frame


### PR DESCRIPTION
- [x] closes #63889
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) 
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.



Note that this does _not_ fix the corner-case of having more than one missing value indicator in the dictionary (eg entries with both None and pd.NA as key)
