### PR TITLE
DOC: fix Index.to_frame name parameter description

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    drafts: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,0 @@
-reviews:
-  auto_review:
-    drafts: true

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1663,9 +1663,9 @@ class Index(IndexOpsMixin, PandasObject):
         index : bool, default True
             Set the index of the returned DataFrame as the original Index.
 
-        name : Hashable, default lib.no_default
+        name : Hashable, defaults to index.name
             The passed name should substitute for the index name (if it has
-            one). If not specified, the index's own name is used.
+            one).
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1663,9 +1663,9 @@ class Index(IndexOpsMixin, PandasObject):
         index : bool, default True
             Set the index of the returned DataFrame as the original Index.
 
-        name : object, defaults to index.name
+        name : Hashable, default lib.no_default
             The passed name should substitute for the index name (if it has
-            one).
+            one). If not specified, the index's own name is used.
 
         Returns
         -------


### PR DESCRIPTION
Closes #63191.

The `name` parameter in `Index.to_frame` had two inaccuracies in its docstring:

- Type was documented as `object`, but the actual type annotation is `Hashable`
- Default was described as `index.name`, but the actual default is `lib.no_default`

Fixed both and added a clarifying sentence about the fallback behavior.