### PR TITLE
DOC/BLD: use correct version number for linkcode in case of re-build of docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -694,7 +694,7 @@ def linkcode_resolve(domain, info) -> str | None:
 
     fn = os.path.relpath(fn, start=os.path.dirname(pandas.__file__))
 
-    if "+" in pandas.__version__:
+    if "+" in version:
         return f"https://github.com/pandas-dev/pandas/blob/main/pandas/{fn}{linespec}"
     else:
         return (


### PR DESCRIPTION
Closes #64056

Ensuring we use the potentially overridden version number (when using the mechanism introduced by https://github.com/pandas-dev/pandas/pull/63504)