### PR TITLE
DEPR: groupby.agg unpacking arrays of 1 element

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -92,7 +92,7 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
--
+- Deprecated :meth:`.DataFrameGroupBy.agg` unpacking a scalar when the provided ``func`` returns a Series or array of length 1; in the future this will result in the Series or array being in the result. Users should unpack the scalar in ``func`` itself (:issue:`64014`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -92,7 +92,7 @@ Other API changes
 
 Deprecations
 ~~~~~~~~~~~~
-- Deprecated :meth:`.DataFrameGroupBy.agg` unpacking a scalar when the provided ``func`` returns a Series or array of length 1; in the future this will result in the Series or array being in the result. Users should unpack the scalar in ``func`` itself (:issue:`64014`)
+- Deprecated :meth:`.DataFrameGroupBy.agg` and :meth:`.Resampler.agg` unpacking a scalar when the provided ``func`` returns a Series or array of length 1; in the future this will result in the Series or array being in the result. Users should unpack the scalar in ``func`` itself (:issue:`64014`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -94,7 +94,7 @@ def check_result_array(obj, dtype) -> None:
             raise ValueError("Must produce aggregated value")
 
 
-def extract_result(res, warn: bool):
+def extract_result(res):
     """
     Extract the result object, it might be a 0-dim ndarray
     or a len-1 0-dim, or a scalar
@@ -103,14 +103,13 @@ def extract_result(res, warn: bool):
         # Preserve EA
         res = res._values
         if res.ndim == 1 and len(res) == 1:
-            if warn:
-                warnings.warn(
-                    "Converting a Series or array of length 1 into a scalar is "
-                    "deprecated and will be removed in a future version. If you wish "
-                    "to preserve the current behavior, have ``func`` return scalars.",
-                    category=Pandas4Warning,
-                    stacklevel=find_stack_level(),
-                )
+            warnings.warn(
+                "Converting a Series or array of length 1 into a scalar is "
+                "deprecated and will be removed in a future version. If you wish "
+                "to preserve the current behavior, have ``func`` return scalars.",
+                category=Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
             # see test_agg_lambda_with_timezone, test_resampler_grouper.py::test_apply
             res = res[0]
     return res
@@ -613,7 +612,6 @@ class BaseGrouper:
         self._groupings = groupings
         self._sort = sort
         self.dropna = dropna
-        self._is_resample = False
 
     @property
     def groupings(self) -> list[grouper.Grouping]:
@@ -1013,7 +1011,7 @@ class BaseGrouper:
 
         for i, group in enumerate(splitter):
             res = func(group)
-            res = extract_result(res, warn=not self._is_resample)
+            res = extract_result(res)
 
             if not initialized:
                 # We only do this validation on the first iteration

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -16,6 +16,7 @@ from typing import (
     Generic,
     final,
 )
+import warnings
 
 import numpy as np
 
@@ -31,8 +32,12 @@ from pandas._typing import (
     Shape,
     npt,
 )
-from pandas.errors import AbstractMethodError
+from pandas.errors import (
+    AbstractMethodError,
+    Pandas4Warning,
+)
 from pandas.util._decorators import cache_readonly
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.cast import (
     maybe_downcast_to_dtype,
@@ -89,7 +94,7 @@ def check_result_array(obj, dtype) -> None:
             raise ValueError("Must produce aggregated value")
 
 
-def extract_result(res):
+def extract_result(res, warn: bool):
     """
     Extract the result object, it might be a 0-dim ndarray
     or a len-1 0-dim, or a scalar
@@ -98,6 +103,14 @@ def extract_result(res):
         # Preserve EA
         res = res._values
         if res.ndim == 1 and len(res) == 1:
+            if warn:
+                warnings.warn(
+                    "Converting a Series or array of length 1 into a scalar is "
+                    "deprecated and will be removed in a future version. If you wish "
+                    "to preserve the current behavior, have ``func`` return scalars.",
+                    category=Pandas4Warning,
+                    stacklevel=find_stack_level(),
+                )
             # see test_agg_lambda_with_timezone, test_resampler_grouper.py::test_apply
             res = res[0]
     return res
@@ -600,6 +613,7 @@ class BaseGrouper:
         self._groupings = groupings
         self._sort = sort
         self.dropna = dropna
+        self._is_resample = False
 
     @property
     def groupings(self) -> list[grouper.Grouping]:
@@ -999,7 +1013,7 @@ class BaseGrouper:
 
         for i, group in enumerate(splitter):
             res = func(group)
-            res = extract_result(res)
+            res = extract_result(res, warn=not self._is_resample)
 
             if not initialized:
                 # We only do this validation on the first iteration

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -243,6 +243,7 @@ class Resampler(BaseGroupBy, PandasObject):
         if self._timegrouper._arrow_dtype is not None:
             binlabels = binlabels.astype(self._timegrouper._arrow_dtype)
         bin_grouper = BinGrouper(bins, binlabels, indexer=self._indexer)
+        bin_grouper._is_resample = True
         return binner, bin_grouper
 
     @overload

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -243,7 +243,6 @@ class Resampler(BaseGroupBy, PandasObject):
         if self._timegrouper._arrow_dtype is not None:
             binlabels = binlabels.astype(self._timegrouper._arrow_dtype)
         bin_grouper = BinGrouper(bins, binlabels, indexer=self._indexer)
-        bin_grouper._is_resample = True
         return binner, bin_grouper
 
     @overload

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -9,7 +9,10 @@ from functools import partial
 import numpy as np
 import pytest
 
-from pandas.errors import SpecificationError
+from pandas.errors import (
+    Pandas4Warning,
+    SpecificationError,
+)
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import is_integer_dtype
@@ -1555,7 +1558,9 @@ def test_groupby_agg_precision(any_real_numeric_dtype):
     expected = DataFrame(
         {"key3": pd.array([max_value], dtype=any_real_numeric_dtype)}, index=index
     )
-    result = df.groupby(["key1", "key2"]).agg(lambda x: x)
+    msg = "Converting a Series or array of length 1 into a scalar"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = df.groupby(["key1", "key2"]).agg(lambda x: x)
     tm.assert_frame_equal(result, expected)
 
 
@@ -1649,7 +1654,9 @@ def test_groupby_complex_raises(func):
 def test_agg_of_mode_list(test, constant):
     # GH#25581
     df1 = DataFrame(test)
-    result = df1.groupby(0).agg(Series.mode)
+    msg = "Converting a Series or array of length 1 into a scalar"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = df1.groupby(0).agg(Series.mode)
     # Mode usually only returns 1 value, but can return a list in the case of a tie.
 
     expected = DataFrame(constant)

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -8,7 +8,10 @@ from functools import partial
 import numpy as np
 import pytest
 
-from pandas.errors import SpecificationError
+from pandas.errors import (
+    Pandas4Warning,
+    SpecificationError,
+)
 
 import pandas as pd
 from pandas import (
@@ -616,7 +619,9 @@ def test_agg_lambda_with_timezone():
             ],
         }
     )
-    result = df.groupby("tag").agg({"date": lambda e: e.head(1)})
+    msg = "Converting a Series or array of length 1 into a scalar"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = df.groupby("tag").agg({"date": lambda e: e.head(1)})
     expected = DataFrame(
         [pd.Timestamp("2018-01-01", tz="UTC")],
         index=Index([1], name="tag"),

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -6,7 +6,10 @@ import re
 import numpy as np
 import pytest
 
-from pandas.errors import SpecificationError
+from pandas.errors import (
+    Pandas4Warning,
+    SpecificationError,
+)
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -2457,7 +2460,9 @@ def test_by_column_values_with_same_starting_value(any_string_dtype):
     )
     aggregate_details = {"Mood": Series.mode, "Credit": "sum"}
 
-    result = df.groupby(["Name"]).agg(aggregate_details)
+    msg = "Converting a Series or array of length 1 into a scalar"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = df.groupby(["Name"]).agg(aggregate_details)
     expected = DataFrame(
         {
             "Mood": [["happy", "sad"], "happy"],

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -6,6 +6,7 @@ import pytest
 
 from pandas._libs import lib
 from pandas._libs.tslibs import Day
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 from pandas import (
@@ -653,7 +654,9 @@ def test_agg_list_like_func_with_args():
     with pytest.raises(TypeError, match=msg):
         df.resample("D").agg([foo1, foo2], 3, b=3, c=4)
 
-    result = df.resample("D").agg([foo1, foo2], 3, c=4)
+    msg = "Converting a Series or array of length 1 into a scalar"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = df.resample("D").agg([foo1, foo2], 3, c=4)
     expected = DataFrame(
         [[8, 8], [9, 9], [10, 10]],
         index=date_range("2020-01-01", periods=3, freq="D"),

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import is_platform_windows
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 from pandas import (
@@ -257,7 +258,9 @@ def test_apply(test_frame):
     def f_0(x):
         return x.resample("2s").sum()
 
-    result = r.apply(f_0)
+    msg = "Converting a Series or array of length 1 into a scalar"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = r.apply(f_0)
     tm.assert_frame_equal(result, expected)
 
     def f_1(x):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

It seems likely users can be depending on this behavior. However, it is unreliable - e.g. when used with `mode` if there is a unique mode you get scalars whereas if there not you get Series. If users want to get scalars, they should be unpacking it themselves; unpacking arrays / Series of length one gives a surprising value-dependent edge case.