### PR TITLE
Fix doc alignment

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10201,11 +10201,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Notes
         -----
-        The where method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``True`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with axis of
-        ``cond`` Series/DataFrame, the values of ``cond`` on misaligned index positions
+        ``other`` is used. If the axis of ``other`` does not align with the caller
+        Series/DataFrame, the values of ``cond`` on misaligned index positions
         will be filled with False.
 
         The signature for :func:`Series.where` or
@@ -10368,8 +10367,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The mask method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``False`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with axis of
-        ``cond`` Series/DataFrame, the values of ``cond`` on misaligned index positions
+        ``other`` is used. If the axis of ``other`` does not align with the caller
+        Series/DataFrame, the values of ``cond`` on misaligned index positions
         will be filled with True.
 
         The signature for :func:`Series.where` or

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10205,9 +10205,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         element in the caller, if ``cond`` is ``True`` the
         element is used; otherwise the corresponding element from
         ``other`` is used. If the axis of ``other`` does not align with
-        the caller Series/DataFrame, the values of ``cond`` on misaligned index
-        positions
-        will be filled with False.
+        the caller Series/DataFrame, the values of ``cond`` on misaligned
+        index positions will be filled with False.
 
         The signature for :func:`Series.where` or
         :func:`DataFrame.where` differs from :func:`numpy.where`.
@@ -10370,9 +10369,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         element in the caller, if ``cond`` is ``False`` the
         element is used; otherwise the corresponding element from
         ``other`` is used. If the axis of ``other`` does not align with
-        the caller Series/DataFrame, the values of ``cond`` on misaligned index
-        positions
-        will be filled with True.
+        the caller Series/DataFrame, the values of ``cond`` on misaligned 
+        index positions will be filled with True.
 
         The signature for :func:`Series.where` or
         :func:`DataFrame.where` differs from :func:`numpy.where`.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10205,7 +10205,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         element in the caller, if ``cond`` is ``True`` the
         element is used; otherwise the corresponding element from
         ``other`` is used. If the axis of ``other`` does not align with
-        the caller Series/DataFrame, the values of ``cond`` on misaligned index positions
+        the caller Series/DataFrame, the values of ``cond`` on misaligned index
+        positions
         will be filled with False.
 
         The signature for :func:`Series.where` or
@@ -10369,7 +10370,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         element in the caller, if ``cond`` is ``False`` the
         element is used; otherwise the corresponding element from
         ``other`` is used. If the axis of ``other`` does not align with
-        the caller Series/DataFrame, the values of ``cond`` on misaligned index positions
+        the caller Series/DataFrame, the values of ``cond`` on misaligned index
+        positions
         will be filled with True.
 
         The signature for :func:`Series.where` or

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10201,6 +10201,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Notes
         -----
+        The where method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``True`` the
         element is used; otherwise the corresponding element from
         ``other`` is used. If the axis of ``other`` does not align with the caller

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10204,8 +10204,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The where method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``True`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with the caller
-        Series/DataFrame, the values of ``cond`` on misaligned index positions
+        ``other`` is used. If the axis of ``other`` does not align with axis of
+        ``cond`` Series/DataFrame, the values of ``cond`` on misaligned index positions
         will be filled with False.
 
         The signature for :func:`Series.where` or
@@ -10368,8 +10368,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The mask method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``False`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with the caller
-        Series/DataFrame, the values of ``cond`` on misaligned index positions
+        ``other`` is used. If the axis of ``other`` does not align with axis of
+        ``cond`` Series/DataFrame, the values of ``cond`` on misaligned index positions
         will be filled with True.
 
         The signature for :func:`Series.where` or

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10369,7 +10369,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         element in the caller, if ``cond`` is ``False`` the
         element is used; otherwise the corresponding element from
         ``other`` is used. If the axis of ``other`` does not align with
-        the caller Series/DataFrame, the values of ``cond`` on misaligned 
+        the caller Series/DataFrame, the values of ``cond`` on misaligned
         index positions will be filled with True.
 
         The signature for :func:`Series.where` or

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10204,8 +10204,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The where method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``True`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with axis of
-        ``cond`` Series/DataFrame, the values of ``cond`` on misaligned index positions
+        ``other`` is used. If the axis of ``other`` does not align with
+        the caller Series/DataFrame, the values of ``cond`` on misaligned index positions
         will be filled with False.
 
         The signature for :func:`Series.where` or
@@ -10368,8 +10368,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The mask method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``False`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with axis of
-        ``cond`` Series/DataFrame, the values of ``cond`` on misaligned index positions
+        ``other`` is used. If the axis of ``other`` does not align with
+        the caller Series/DataFrame, the values of ``cond`` on misaligned index positions
         will be filled with True.
 
         The signature for :func:`Series.where` or

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10204,7 +10204,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The where method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``True`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with
+        ``other`` is used. If the axis of ``cond`` does not align with
         the caller Series/DataFrame, the values of ``cond`` on misaligned
         index positions will be filled with False.
 
@@ -10368,7 +10368,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The mask method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``False`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with
+        ``other`` is used. If the axis of ``cond`` does not align with
         the caller Series/DataFrame, the values of ``cond`` on misaligned
         index positions will be filled with True.
 


### PR DESCRIPTION
This Pull Request addresses issue #61781 by correcting a typo in the NDFrame.where and NDFrame.mask docstrings. The documentation previously stated that alignment for the cond parameter was performed against other, but it actually aligns with the caller (self). I have updated the relevant sections in 
pandas/core/generic.py
 to accurately reflect this behavior and added a corresponding entry in the 
doc/source/whatsnew/v3.1.0.rst
 file under the Documentation section for the upcoming release. I verified these changes locally using a test script which confirmed that cond aligns with the caller even when other is a scalar or an object with a misaligned index.