### PR TITLE
added a regression test for issue 57702 (StringDtype consistency)

### DIFF
--- a/pandas/tests/construction/test_array.py
+++ b/pandas/tests/construction/test_array.py
@@ -1,6 +1,8 @@
 import pytest
+
 import pandas as pd
 import pandas._testing as tm
+
 
 @pytest.mark.parametrize("data", [
     ["a", None],        # Original case
@@ -12,7 +14,7 @@ def test_string_array_construction_consistency_with_series(data):
     # GH#57702: Ensure pd.array and pd.Series(data).values are consistent
     # for StringDtype(storage="python")
     dtype = pd.StringDtype(storage="python")
- 
+
     result_array = pd.array(data, dtype=dtype)
     result_series_array = pd.Series(data, dtype=dtype).values
 

--- a/pandas/tests/construction/test_array.py
+++ b/pandas/tests/construction/test_array.py
@@ -12,9 +12,8 @@ def test_string_array_construction_consistency_with_series(data):
     # GH#57702: Ensure pd.array and pd.Series(data).values are consistent
     # for StringDtype(storage="python")
     dtype = pd.StringDtype(storage="python")
-    
+ 
     result_array = pd.array(data, dtype=dtype)
     result_series_array = pd.Series(data, dtype=dtype).values
-    
+
     tm.assert_extension_array_equal(result_array, result_series_array)
-    

--- a/pandas/tests/construction/test_array.py
+++ b/pandas/tests/construction/test_array.py
@@ -1,0 +1,19 @@
+import pytest
+import pandas as pd
+import pandas._testing as tm
+
+@pytest.mark.parametrize("data", [
+    ["a", None],        # Original case
+    [None, None],       # All nulls
+    [],                 # Empty list
+    ["", None],         # Empty string and null
+])
+def test_string_array_construction_consistency_with_series(data):
+    # GH#57702: Ensure pd.array and pd.Series(data).values are consistent
+    # for StringDtype(storage="python")
+    dtype = pd.StringDtype(storage="python")
+    
+    result_array = pd.array(data, dtype=dtype)
+    result_series_array = pd.Series(data, dtype=dtype).values
+    
+    tm.assert_extension_array_equal(result_array, result_series_array)

--- a/pandas/tests/construction/test_array.py
+++ b/pandas/tests/construction/test_array.py
@@ -17,3 +17,4 @@ def test_string_array_construction_consistency_with_series(data):
     result_series_array = pd.Series(data, dtype=dtype).values
     
     tm.assert_extension_array_equal(result_array, result_series_array)
+    

--- a/pandas/tests/construction/test_array.py
+++ b/pandas/tests/construction/test_array.py
@@ -4,12 +4,15 @@ import pandas as pd
 import pandas._testing as tm
 
 
-@pytest.mark.parametrize("data", [
-    ["a", None],        # Original case
-    [None, None],       # All nulls
-    [],                 # Empty list
-    ["", None],         # Empty string and null
-])
+@pytest.mark.parametrize(
+    "data",
+    [
+        ["a", None],  # Original case
+        [None, None],  # All nulls
+        [],  # Empty list
+        ["", None],  # Empty string and null
+    ],
+)
 def test_string_array_construction_consistency_with_series(data):
     # GH#57702: Ensure pd.array and pd.Series(data).values are consistent
     # for StringDtype(storage="python")


### PR DESCRIPTION
Issue #57702
<img width="633" height="435" alt="test_array" src="https://github.com/user-attachments/assets/77028e67-cd27-42bb-8345-2174c815fb47" />


This PR adds regression tests for pd.array and pd.Series construction consistency when using StringDtype(storage="python").  While investigating #57702, the reported inconsistency (where pd.array was allegedly behaving differently than pd.Series) was not reproducible on the current main branch. It looked like the issue had already been fixed. However, to ensure this remains stable and to prevent future regressions, I have added parameterized tests in pandas/tests/construction/test_array.py covering: Standard string/None data, All null sequences, Empty sequences, and Empty string/null mixes.