### PR TITLE
REGR: Allow RE2 syntax in str.contains and str.replace 

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -18,6 +18,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.reindex` when using a string fill value  (:issue:`63993`)
 - Fixed regression in the :class:`DataFrame` and :meth:`DataFrame.from_records` constructor with a list of dicts with a missing value indicator as key (:issue:`63889`)
 - Fixed regression when calling ``numpy.random``'s ``permutation()`` on a (pyarrow-backed) string :class:`Series` (:issue:`63935`)
+- Fixed regression where :meth:`Series.str.contains` and :meth:`Series.str.replace` on pyarrow-backed strings rejected RE2 unicode escapes like ``\x{...}`` and ``\p{...}`` (:issue:`63901`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_301.bugs:

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -98,7 +98,12 @@ class ArrowStringArrayMixin:
             return False
 
         str_pat = pat.pattern if isinstance(pat, re.Pattern) else pat
-        tokens = regex_parser(str_pat)
+        try:
+            tokens = regex_parser(str_pat)
+        except re.error:
+            # Pattern not valid for Python's re (e.g. RE2 syntax like \x{...} or \p)
+            # Let the pyarrow backend handle it.
+            return False
         return has_unsupported_code(tokens)
 
     def _str_len(self):

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1480,13 +1480,18 @@ class StringMethods(NoNewAttributesMixin):
         4    False
         dtype: bool
         """
-        if regex and re.compile(pat).groups:
-            warnings.warn(
-                "This pattern is interpreted as a regular expression, and has "
-                "match groups. To actually get the groups, use str.extract.",
-                UserWarning,
-                stacklevel=find_stack_level(),
-            )
+        if regex:
+            try:
+                has_groups = re.compile(pat).groups
+            except re.error:
+                has_groups = False
+            if has_groups:
+                warnings.warn(
+                    "This pattern is interpreted as a regular expression, and has "
+                    "match groups. To actually get the groups, use str.extract.",
+                    UserWarning,
+                    stacklevel=find_stack_level(),
+                )
 
         result = self._data.array._str_contains(pat, case, flags, na, regex)
         return self._wrap_result(result, fill_value=na, returns_string=False)

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1782,6 +1782,14 @@ def test_str_contains_flags_unsupported():
         ser.str.contains("a", flags=1)
 
 
+def test_str_contains_re2_unicode_escape():
+    # GH 63901
+    ser = pd.Series(["a", "\u0e01", None], dtype=ArrowDtype(pa.string()))
+    result = ser.str.contains(r"[\x{0e00}-\x{0e7f}]")
+    expected = pd.Series([False, True, None], dtype=ArrowDtype(pa.bool_()))
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "side, pat, na, exp",
     [
@@ -1836,6 +1844,13 @@ def test_str_replace(pat, repl, n, regex, exp):
     ser = pd.Series(["abac", None], dtype=ArrowDtype(pa.string()))
     result = ser.str.replace(pat, repl, n=n, regex=regex)
     expected = pd.Series(exp, dtype=ArrowDtype(pa.string()))
+    tm.assert_series_equal(result, expected)
+
+
+def test_str_replace_re2_unicode_property():
+    ser = pd.Series(["Jan", "Feb", None], dtype=ArrowDtype(pa.string()))
+    result = ser.str.replace(r"\p{Lu}", "U", regex=True)
+    expected = pd.Series(["Uan", "Ueb", None], dtype=ArrowDtype(pa.string()))
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] addresses part of #63901(Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Summary
- Handle RE2-only regex syntax in Arrow string operations by skipping Python `re` compilation checks when they fail.
- Allow RE2 patterns like `\x{...}` and `\p{...}` to flow to the PyArrow backend.
- Add regression tests for RE2 unicode escape and unicode property patterns.

## Testing
- `python -m pytest pandas/tests/extension/test_arrow.py -k "re2_unicode_escape or re2_unicode_property"`

## Notes
- This PR focuses on pyarrow-backed string behavior. We only bypass Python `re` checks when they fail (`try...except re.error`) so valid RE2 patterns can be handled by PyArrow.
- The approach avoids modifying standard regex handling and preserves existing group-warning behavior when `re` can compile.