### PR TITLE
BUG: raise ValueError when unit passed to to_datetime with datetime-like input

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -362,6 +362,17 @@ def _convert_listlike_datetimes(
         arg = np.array(arg)
 
     arg_dtype = getattr(arg, "dtype", None)
+    # GH#64012 - raise if unit is passed with datetime-like input,
+    # since unit is only for numeric/epoch conversion
+    if unit is not None and (
+        isinstance(arg_dtype, DatetimeTZDtype)
+        or lib.is_np_dtype(arg_dtype, "M")
+        or (isinstance(arg_dtype, ArrowDtype) and arg_dtype.type is Timestamp)
+    ):
+        raise ValueError(
+            "cannot specify 'unit' when the input is datetime-like. "
+            "Use .as_unit() to convert to a different resolution."
+        )
     # these are shortcutable
     tz = "utc" if utc else None
     if isinstance(arg_dtype, DatetimeTZDtype):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2048,6 +2048,20 @@ class TestToDatetimeUnit:
         with pytest.raises(OutOfBoundsDatetime, match=msg):
             to_datetime(should_fail2, unit="D", errors="raise")
 
+    def test_to_datetime_unit_with_datetimeindex(self):
+        # GH#64012 - unit should not be silently ignored for datetime-like input
+        dti = date_range("2026-01-01", periods=3, freq="D", unit="us")
+        msg = "cannot specify 'unit' when the input is datetime-like"
+        with pytest.raises(ValueError, match=msg):
+            to_datetime(dti, unit="ns")
+
+    def test_to_datetime_unit_with_tz_aware_datetimeindex(self):
+        # GH#64012 - also applies to timezone-aware input
+        dti = date_range("2026-01-01", periods=3, freq="D", tz="US/Eastern")
+        msg = "cannot specify 'unit' when the input is datetime-like"
+        with pytest.raises(ValueError, match=msg):
+            to_datetime(dti, unit="ns")
+
 
 class TestToDatetimeDataFrame:
     @pytest.fixture


### PR DESCRIPTION
`to_datetime` silently ignores the `unit` parameter when the input is already datetime-like (e.g. `DatetimeIndex`, `DatetimeArray`, or Arrow timestamp). Since `unit` is meant for numeric/epoch conversion, this is confusing — the user expects a resolution change but gets the original back unchanged.

This PR adds a check in `_convert_listlike_datetimes` that raises a `ValueError` when `unit` is specified with datetime-like input, directing users to `.as_unit()` instead.

**Before:**
```python
dti = pd.date_range("2026-01-01", periods=3, freq="D", unit="us")
result = pd.to_datetime(dti, unit="ns")
result.dtype  # datetime64[us] — unit="ns" silently ignored
```

**After:**
```python
dti = pd.date_range("2026-01-01", periods=3, freq="D", unit="us")
pd.to_datetime(dti, unit="ns")
# ValueError: cannot specify 'unit' when the input is datetime-like.
# Use .as_unit() to convert to a different resolution.
```

Closes #64012