### PR TITLE
REF: avoid freq in extract_ordinals

### DIFF
--- a/pandas/_libs/tslibs/period.pyi
+++ b/pandas/_libs/tslibs/period.pyi
@@ -38,7 +38,7 @@ def from_ordinals(
 ) -> npt.NDArray[np.int64]: ...
 def extract_ordinals(
     values: npt.NDArray[np.object_],
-    freq: Frequency | int,
+    dtype: PeriodDtypeBase,
 ) -> npt.NDArray[np.int64]: ...
 def extract_freq(
     values: npt.NDArray[np.object_],

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -282,8 +282,8 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):  # type: ignore[misc]
         periods = np.asarray(scalars, dtype=object)
 
         freq = freq or libperiod.extract_freq(periods)
-        ordinals = libperiod.extract_ordinals(periods, freq)
         dtype = PeriodDtype(freq)
+        ordinals = libperiod.extract_ordinals(periods, dtype)
         return cls(ordinals, dtype=dtype)
 
     @classmethod

--- a/pandas/tests/tslibs/test_period.py
+++ b/pandas/tests/tslibs/test_period.py
@@ -5,6 +5,7 @@ from pandas._libs.tslibs import (
     iNaT,
     to_offset,
 )
+from pandas._libs.tslibs.dtypes import PeriodDtypeBase
 from pandas._libs.tslibs.period import (
     extract_ordinals,
     get_period_field_arr,
@@ -104,16 +105,18 @@ class TestExtractOrdinals:
         # with non-object, make sure we raise TypeError, not segfault
         arr = np.arange(5)
         freq = to_offset("D")
+        dtype = PeriodDtypeBase(freq._period_dtype_code, 1)
         with pytest.raises(TypeError, match="values must be object-dtype"):
-            extract_ordinals(arr, freq)
+            extract_ordinals(arr, dtype)
 
     def test_extract_ordinals_2d(self):
         freq = to_offset("D")
+        dtype = PeriodDtypeBase(freq._period_dtype_code, 1)
         arr = np.empty(10, dtype=object)
         arr[:] = iNaT
 
-        res = extract_ordinals(arr, freq)
-        res2 = extract_ordinals(arr.reshape(5, 2), freq)
+        res = extract_ordinals(arr, dtype)
+        res2 = extract_ordinals(arr.reshape(5, 2), dtype)
         tm.assert_numpy_array_equal(res, res2.reshape(-1))
 
 


### PR DESCRIPTION
As discussed in this week's dev call, I'm trying to move the Period code away from using DateOffsets. This makes extract_ordinals use the dtype directly (note PeriodDtype subclasses PeriodDtypeBase)

xref #61897.  Same overarching goal, order of merging does not matter.