### PR TITLE
TST: Add regression test for concat with datetime64 columns of different resolutions

### DIFF
--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -618,16 +618,13 @@ def test_concat_datetime64_different_resolutions():
     df = DataFrame(
         {
             "ints": range(2),
-            "dates": pd.date_range("2000", periods=2, freq="min"),
+            "dates": date_range("2000", periods=2, freq="min"),
         },
     )
     df2 = df.copy()
     df2["dates"] = df.dates.astype("M8[s]")
-    
+
     combined = concat([df, df2])
-    
+
     # The result should be a datetime64 dtype, not object
-    assert pd.api.types.is_datetime64_any_dtype(combined.dates.dtype)
-    # The resolution should be the most precise (nanoseconds in this case)
-    # or at least maintain datetime64 functionality
     assert combined.dates.dtype.kind == "M"

--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -609,3 +609,25 @@ def test_concat_float_datetime64():
 
     result = concat([df_time, df_float.iloc[:0]])
     tm.assert_frame_equal(result, expected)
+
+
+def test_concat_datetime64_different_resolutions():
+    # GH#53307
+    # Concatenating datetime64 columns with different resolutions
+    # should preserve datetime64 dtype (not convert to object)
+    df = DataFrame(
+        {
+            "ints": range(2),
+            "dates": pd.date_range("2000", periods=2, freq="min"),
+        },
+    )
+    df2 = df.copy()
+    df2["dates"] = df.dates.astype("M8[s]")
+    
+    combined = concat([df, df2])
+    
+    # The result should be a datetime64 dtype, not object
+    assert pd.api.types.is_datetime64_any_dtype(combined.dates.dtype)
+    # The resolution should be the most precise (nanoseconds in this case)
+    # or at least maintain datetime64 functionality
+    assert combined.dates.dtype.kind == "M"


### PR DESCRIPTION
Closes #53307

## Summary
This PR adds a regression test for the bug where concatenating datetime64 columns with different resolutions (e.g., datetime64[ns] and datetime64[s]) resulted in object dtype instead of preserving the datetime64 dtype.

## What's being tested
The test verifies that:
- Concatenating DataFrames with datetime64 columns of different resolutions preserves datetime64 dtype
- The result is not converted to object dtype
- The datetime64 functionality is maintained

## Context
This is a 'Needs Tests' issue - the bug has already been fixed in main, but the fix lacked a regression test to prevent future regressions. This test ensures the fix stays in place.