### PR TITLE
PERF : Speed up `merge(sort=False)` for range-like unique integer join keys (left/right joins)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -131,6 +131,7 @@ Performance improvements
 - Performance improvement in :func:`merge` and :meth:`DataFrame.join` for many-to-many joins with ``sort=False`` (:issue:`56564`)
 - Performance improvement in :func:`merge` with ``how="cross"`` (:issue:`38082`)
 - Performance improvement in :func:`merge` with ``how="left"`` (:issue:`64370`)
+- Performance improvement in :func:`merge` with ``sort=False`` for single-key ``how="left"``/``how="right"`` joins when the opposite join key is sorted, unique, and range-like (:issue:`64146`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading from binary file-like objects (e.g. PyArrow S3 file handles) by avoiding unnecessary ``TextIOWrapper`` wrapping (:issue:`46823`)
 - Performance improvement in :func:`read_html` and the Python CSV parser when ``thousands`` is set, fixing catastrophic regex backtracking on cells with many comma-separated digit groups followed by non-numeric text (:issue:`52619`)
 - Performance improvement in :func:`read_sas` for SAS7BDAT files by pre-computing date/datetime column classification once during metadata parsing instead of per chunk (:issue:`47339`)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2098,76 +2098,52 @@ def get_join_indexers(
     elif not sort and how in ("left", "right"):
         lk: ArrayLike
         rk: ArrayLike
+        if how == "left" and not isinstance(right, RangeIndex):
+            if (
+                right.is_monotonic_increasing
+                and right.is_unique
+                and right.dtype.kind in "iu"
+            ):
+                _rk = right._values
+                if isinstance(_rk, np.ndarray):
+                    r = maybe_sequence_to_range(_rk)
+                    if isinstance(r, range):
+                        right = RangeIndex(r, name=right.name)
+        elif how == "right" and not isinstance(left, RangeIndex):
+            if (
+                left.is_monotonic_increasing
+                and left.is_unique
+                and left.dtype.kind in "iu"
+            ):
+                _lk = left._values
+                if isinstance(_lk, np.ndarray):
+                    r = maybe_sequence_to_range(_lk)
+                    if isinstance(r, range):
+                        left = RangeIndex(r, name=left.name)
         if how == "left":
             lk = left._values
-            if isinstance(lk, np.ndarray):
-                if (
-                    right.is_monotonic_increasing
-                    and right.is_unique
-                    and right.dtype.kind in "iu"
-                ):
-                    if isinstance(right, RangeIndex):
-                        if lk.dtype.kind in "iu":
-                            ridx = right.get_indexer(lk)
-                            lidx = None
-                        else:
-                            rk = right._values
-                            lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
-                    else:
-                        rk = right._values
-                        if isinstance(rk, np.ndarray):
-                            r = maybe_sequence_to_range(rk)
-                            if isinstance(r, range):
-                                right = RangeIndex(
-                                    r.start, r.stop, r.step, name=right.name
-                                )
-                            if isinstance(right, RangeIndex) and lk.dtype.kind in "iu":
-                                ridx = right.get_indexer(lk)
-                                lidx = None
-                            else:
-                                lidx, ridx = get_join_indexers_non_unique(
-                                    lk, rk, sort, how
-                                )
-                        else:
-                            lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
-                else:
-                    rk = right._values
-                    lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+            if (
+                isinstance(lk, np.ndarray)
+                and isinstance(right, RangeIndex)
+                and lk.dtype.kind in "iu"
+            ):
+                ridx = right.get_indexer(lk)
+                lidx = None
             else:
                 rk = right._values
                 lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
-        elif (
-            left.is_monotonic_increasing and left.is_unique and left.dtype.kind in "iu"
-        ):
+        else:
             rk = right._values
-            if isinstance(rk, np.ndarray):
-                if isinstance(left, RangeIndex):
-                    if rk.dtype.kind in "iu":
-                        lidx = left.get_indexer(rk)
-                        ridx = None
-                    else:
-                        lk = left._values
-                        lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
-                else:
-                    lk = left._values
-                    if isinstance(lk, np.ndarray):
-                        r = maybe_sequence_to_range(lk)
-                        if isinstance(r, range):
-                            left = RangeIndex(r.start, r.stop, r.step, name=left.name)
-                        if isinstance(left, RangeIndex) and rk.dtype.kind in "iu":
-                            lidx = left.get_indexer(rk)
-                            ridx = None
-                        else:
-                            lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
-                    else:
-                        lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+            if (
+                isinstance(rk, np.ndarray)
+                and isinstance(left, RangeIndex)
+                and rk.dtype.kind in "iu"
+            ):
+                lidx = left.get_indexer(rk)
+                ridx = None
             else:
                 lk = left._values
                 lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
-        else:
-            lk = left._values
-            rk = right._values
-            lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
     else:
         lk = left._values
         rk = right._values

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -66,6 +66,7 @@ from pandas import (
     Categorical,
     Index,
     MultiIndex,
+    RangeIndex,
     Series,
 )
 import pandas.core.algorithms as algos
@@ -81,6 +82,7 @@ from pandas.core.construction import (
     extract_array,
 )
 from pandas.core.indexes.api import default_index
+from pandas.core.indexes.base import maybe_sequence_to_range
 from pandas.core.sorting import (
     get_group_index,
     is_int64_overflow_possible,
@@ -2027,6 +2029,31 @@ class _MergeOperation:
             )
 
 
+def _maybe_get_rangeindex_indexer(
+    probe: np.ndarray, target_index: Index
+) -> npt.NDArray[np.intp] | None:
+    """
+    Parameters
+    ----------
+    probe : np.ndarray
+        1D integer array to map into ``target_index``.
+    target_index : Index
+        Target index. Fast-path applies only when this is a
+        :class:`~pandas.RangeIndex`.
+
+    Returns
+    -------
+    np.ndarray[np.intp] or None
+        Indexer into ``target_index`` (``-1`` for missing) or ``None`` if the
+        fast-path does not apply.
+    """
+    if not isinstance(target_index, RangeIndex):
+        return None
+    if probe.ndim != 1 or probe.dtype.kind not in "iu":
+        return None
+    return target_index.get_indexer(probe)
+
+
 def get_join_indexers(
     left_keys: list[ArrayLike],
     right_keys: list[ArrayLike],
@@ -2094,9 +2121,56 @@ def get_join_indexers(
     ):
         _, lidx, ridx = left.join(right, how=how, return_indexers=True, sort=sort)
     else:
-        lidx, ridx = get_join_indexers_non_unique(
-            left._values, right._values, sort, how
-        )
+        lk = left._values
+        rk = right._values
+        if (
+            not sort
+            and isinstance(lk, np.ndarray)
+            and isinstance(rk, np.ndarray)
+            and how in ("left", "right")
+        ):
+            if how == "left":
+                if (
+                    right.is_monotonic_increasing
+                    and right.is_unique
+                    and right.dtype.kind in "iu"
+                ):
+                    r = maybe_sequence_to_range(rk)
+                    if isinstance(r, range):
+                        right = RangeIndex(r.start, r.stop, r.step, name=right.name)
+
+                if (
+                    isinstance(right, RangeIndex)
+                    and lk.ndim == 1
+                    and lk.dtype.kind in "iu"
+                ):
+                    ridx = right.get_indexer(lk)
+                    lidx = None
+                else:
+                    lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+
+            else:  # how == "right"
+                if (
+                    left.is_monotonic_increasing
+                    and left.is_unique
+                    and left.dtype.kind in "iu"
+                ):
+                    r = maybe_sequence_to_range(lk)
+                    if isinstance(r, range):
+                        left = RangeIndex(r.start, r.stop, r.step, name=left.name)
+
+                if (
+                    isinstance(left, RangeIndex)
+                    and rk.ndim == 1
+                    and rk.dtype.kind in "iu"
+                ):
+                    lidx = left.get_indexer(rk)
+                    ridx = None
+                else:
+                    lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+
+        else:
+            lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
 
     if lidx is not None and is_range_indexer(lidx, len(left)):
         lidx = None

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2029,6 +2029,16 @@ class _MergeOperation:
             )
 
 
+def _maybe_promote_to_rangeindex(idx: Index) -> Index:
+    if idx.is_monotonic_increasing and idx.is_unique and idx.dtype.kind in "iu":
+        values = idx._values
+        if isinstance(values, np.ndarray):
+            result = maybe_sequence_to_range(values)
+            if isinstance(result, range):
+                return RangeIndex(result, name=idx.name)
+    return idx
+
+
 def get_join_indexers(
     left_keys: list[ArrayLike],
     right_keys: list[ArrayLike],
@@ -2099,27 +2109,9 @@ def get_join_indexers(
         lk: ArrayLike
         rk: ArrayLike
         if how == "left" and not isinstance(right, RangeIndex):
-            if (
-                right.is_monotonic_increasing
-                and right.is_unique
-                and right.dtype.kind in "iu"
-            ):
-                _rk = right._values
-                if isinstance(_rk, np.ndarray):
-                    r = maybe_sequence_to_range(_rk)
-                    if isinstance(r, range):
-                        right = RangeIndex(r, name=right.name)
+            right = _maybe_promote_to_rangeindex(right)
         elif how == "right" and not isinstance(left, RangeIndex):
-            if (
-                left.is_monotonic_increasing
-                and left.is_unique
-                and left.dtype.kind in "iu"
-            ):
-                _lk = left._values
-                if isinstance(_lk, np.ndarray):
-                    r = maybe_sequence_to_range(_lk)
-                    if isinstance(r, range):
-                        left = RangeIndex(r, name=left.name)
+            left = _maybe_promote_to_rangeindex(left)
         if how == "left":
             lk = left._values
             if (

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2096,6 +2096,8 @@ def get_join_indexers(
     ):
         _, lidx, ridx = left.join(right, how=how, return_indexers=True, sort=sort)
     elif not sort and how in ("left", "right"):
+        lk: ArrayLike
+        rk: ArrayLike
         if how == "left":
             lk = left._values
             if isinstance(lk, np.ndarray):

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2095,58 +2095,81 @@ def get_join_indexers(
         and (left.is_unique or right.is_unique)
     ):
         _, lidx, ridx = left.join(right, how=how, return_indexers=True, sort=sort)
-    else:
-        lk = left._values
-        rk = right._values
-        if (
-            not sort
-            and isinstance(lk, np.ndarray)
-            and isinstance(rk, np.ndarray)
-            and how in ("left", "right")
-        ):
-            if how == "left":
+    elif not sort and how in ("left", "right"):
+        if how == "left":
+            lk = left._values
+            if isinstance(lk, np.ndarray):
                 if (
                     right.is_monotonic_increasing
                     and right.is_unique
                     and right.dtype.kind in "iu"
                 ):
-                    r = maybe_sequence_to_range(rk)
-                    if isinstance(r, range):
-                        right = RangeIndex(r.start, r.stop, r.step, name=right.name)
-                    if (
-                        isinstance(right, RangeIndex)
-                        and lk.ndim == 1
-                        and lk.dtype.kind in "iu"
-                    ):
-                        ridx = right.get_indexer(lk)
-                        lidx = None
+                    if isinstance(right, RangeIndex):
+                        if lk.dtype.kind in "iu":
+                            ridx = right.get_indexer(lk)
+                            lidx = None
+                        else:
+                            rk = right._values
+                            lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
                     else:
-                        lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+                        rk = right._values
+                        if isinstance(rk, np.ndarray):
+                            r = maybe_sequence_to_range(rk)
+                            if isinstance(r, range):
+                                right = RangeIndex(
+                                    r.start, r.stop, r.step, name=right.name
+                                )
+                            if isinstance(right, RangeIndex) and lk.dtype.kind in "iu":
+                                ridx = right.get_indexer(lk)
+                                lidx = None
+                            else:
+                                lidx, ridx = get_join_indexers_non_unique(
+                                    lk, rk, sort, how
+                                )
+                        else:
+                            lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
                 else:
-                    lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
-
-            elif (
-                left.is_monotonic_increasing
-                and left.is_unique
-                and left.dtype.kind in "iu"
-            ):
-                r = maybe_sequence_to_range(lk)
-                if isinstance(r, range):
-                    left = RangeIndex(r.start, r.stop, r.step, name=left.name)
-                if (
-                    isinstance(left, RangeIndex)
-                    and rk.ndim == 1
-                    and rk.dtype.kind in "iu"
-                ):
-                    lidx = left.get_indexer(rk)
-                    ridx = None
-                else:
+                    rk = right._values
                     lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
             else:
+                rk = right._values
                 lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
-
+        elif (
+            left.is_monotonic_increasing and left.is_unique and left.dtype.kind in "iu"
+        ):
+            rk = right._values
+            if isinstance(rk, np.ndarray):
+                if isinstance(left, RangeIndex):
+                    if rk.dtype.kind in "iu":
+                        lidx = left.get_indexer(rk)
+                        ridx = None
+                    else:
+                        lk = left._values
+                        lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+                else:
+                    lk = left._values
+                    if isinstance(lk, np.ndarray):
+                        r = maybe_sequence_to_range(lk)
+                        if isinstance(r, range):
+                            left = RangeIndex(r.start, r.stop, r.step, name=left.name)
+                        if isinstance(left, RangeIndex) and rk.dtype.kind in "iu":
+                            lidx = left.get_indexer(rk)
+                            ridx = None
+                        else:
+                            lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+                    else:
+                        lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+            else:
+                lk = left._values
+                lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
         else:
+            lk = left._values
+            rk = right._values
             lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+    else:
+        lk = left._values
+        rk = right._values
+        lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
 
     if lidx is not None and is_range_indexer(lidx, len(left)):
         lidx = None

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2029,31 +2029,6 @@ class _MergeOperation:
             )
 
 
-def _maybe_get_rangeindex_indexer(
-    probe: np.ndarray, target_index: Index
-) -> npt.NDArray[np.intp] | None:
-    """
-    Parameters
-    ----------
-    probe : np.ndarray
-        1D integer array to map into ``target_index``.
-    target_index : Index
-        Target index. Fast-path applies only when this is a
-        :class:`~pandas.RangeIndex`.
-
-    Returns
-    -------
-    np.ndarray[np.intp] or None
-        Indexer into ``target_index`` (``-1`` for missing) or ``None`` if the
-        fast-path does not apply.
-    """
-    if not isinstance(target_index, RangeIndex):
-        return None
-    if probe.ndim != 1 or probe.dtype.kind not in "iu":
-        return None
-    return target_index.get_indexer(probe)
-
-
 def get_join_indexers(
     left_keys: list[ArrayLike],
     right_keys: list[ArrayLike],

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2113,27 +2113,26 @@ def get_join_indexers(
                     r = maybe_sequence_to_range(rk)
                     if isinstance(r, range):
                         right = RangeIndex(r.start, r.stop, r.step, name=right.name)
-
-                if (
-                    isinstance(right, RangeIndex)
-                    and lk.ndim == 1
-                    and lk.dtype.kind in "iu"
-                ):
-                    ridx = right.get_indexer(lk)
-                    lidx = None
+                    if (
+                        isinstance(right, RangeIndex)
+                        and lk.ndim == 1
+                        and lk.dtype.kind in "iu"
+                    ):
+                        ridx = right.get_indexer(lk)
+                        lidx = None
+                    else:
+                        lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
                 else:
                     lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
 
-            else:  # how == "right"
-                if (
-                    left.is_monotonic_increasing
-                    and left.is_unique
-                    and left.dtype.kind in "iu"
-                ):
-                    r = maybe_sequence_to_range(lk)
-                    if isinstance(r, range):
-                        left = RangeIndex(r.start, r.stop, r.step, name=left.name)
-
+            elif (
+                left.is_monotonic_increasing
+                and left.is_unique
+                and left.dtype.kind in "iu"
+            ):
+                r = maybe_sequence_to_range(lk)
+                if isinstance(r, range):
+                    left = RangeIndex(r.start, r.stop, r.step, name=left.name)
                 if (
                     isinstance(left, RangeIndex)
                     and rk.ndim == 1
@@ -2143,6 +2142,8 @@ def get_join_indexers(
                     ridx = None
                 else:
                     lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
+            else:
+                lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)
 
         else:
             lidx, ridx = get_join_indexers_non_unique(lk, rk, sort, how)


### PR DESCRIPTION
* [x] closes #64146
* [x] [[Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
* [x] All [[code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
* [x] Added [[type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints)](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
* [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
* [x] I have reviewed and followed all the [[contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)](https://pandas.pydata.org/docs/dev/development/contributing.html)
* [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

In this PR I try to introduce a deterministic fast-path for `DataFrame.merge(..., sort=False)` **single-key** joins (`how="left"` and `how="right"`) when the opposite-side join key is **integer/unsigned integer**, **sorted**, **unique**, and **range-like** (convertible via `maybe_sequence_to_range`). In this case, we convert the sorted/unique join key to a `RangeIndex` and compute the indexer via `RangeIndex.get_indexer`.
 

The bottleneck in the affected cases is falling back to `get_join_indexers_non_unique(...)`, which must handle the fully general join problem and typically involves factorization/hashing and additional intermediate allocations even when one side’s key is an exact arithmetic progression. This change basically avoids that general path when the range-like conditions hold.

I added ASV coverage in `asv_bench/benchmarks/join_merge.py` via `MergeRangeLikeFastPath`, including:
* sorted baseline (should remain unchanged)
* left join with unsorted left keys (target)
* right join with unsorted right keys (target)
* zero-match unsorted left (miss-heavy)

<details>
<summary><strong>Results</strong></summary>

| Benchmark | Rows (`n`) | Before | After | Speedup |
|---|---:|---:|---:|---:|
| `time_left_join_sorted_baseline` | 1,000,000 | 8.88 ms | 7.92 ms | 1.12× |
| `time_left_join_sorted_baseline` | 200,000 | 2.88 ms | 2.70 ms | 1.07× |
| `time_left_join_sorted_baseline` | 50,000 | 1.77 ms | 1.51 ms | 1.17× |
| `time_left_join_sorted_baseline` | 5,000,000 | 34.8 ms | 32.7 ms | 1.06× |
| `time_left_join_unsorted_left` | 1,000,000 | 87.9 ms | 31.1 ms | 2.83× |
| `time_left_join_unsorted_left` | 200,000 | 16.4 ms | 6.87 ms | 2.39× |
| `time_left_join_unsorted_left` | 50,000 | 5.64 ms | 2.58 ms | 2.19× |
| `time_left_join_unsorted_left` | 5,000,000 | 608 ms | 151 ms | 4.03× |
| `time_left_join_zero_match_unsorted_left` | 1,000,000 | 109 ms | 10.8 ms | 10.09× |
| `time_left_join_zero_match_unsorted_left` | 200,000 | 20.2 ms | 3.13 ms | 6.45× |
| `time_left_join_zero_match_unsorted_left` | 50,000 | 6.68 ms | 1.67 ms | 4.00× |
| `time_left_join_zero_match_unsorted_left` | 5,000,000 | 913 ms | 50.0 ms | 18.26× |
| `time_right_join_unsorted_right` | 1,000,000 | 85.3 ms | 13.5 ms | 6.32× |
| `time_right_join_unsorted_right` | 200,000 | 17.3 ms | 3.94 ms | 4.39× |
| `time_right_join_unsorted_right` | 50,000 | 5.19 ms | 1.69 ms | 3.07× |
| `time_right_join_unsorted_right` | 5,000,000 | 525 ms | 73.6 ms | 7.13× |

</details>
