### PR TITLE
BUG: Fix ValueError when subtracting Series with MultiIndex containin…

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -161,7 +161,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
--
+- Bug in :meth:`Series` arithmetic operations raising ``ValueError`` when a :class:`MultiIndex` contains NaN values and is aligned with a regular :class:`Index` (:issue:`60908`)
 -
 
 I/O

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4729,8 +4729,13 @@ class Index(IndexOpsMixin, PandasObject):
             rev_indexer = lib.get_reverse_indexer(left_lev_indexer, len(old_level))
             old_codes = left.codes[level]
 
-            taker = old_codes[old_codes != -1]
+            # GH#60908: preserve NaN entries (-1 codes) instead of
+            # dropping them; only drop rows not found in the join
+            nan_mask = old_codes == -1
+            taker = old_codes.copy()
+            taker[nan_mask] = 0  # safe placeholder for .take()
             new_lev_codes = rev_indexer.take(taker)
+            new_lev_codes[nan_mask] = -1  # restore NaN codes
 
             new_codes = list(left.codes)
             new_codes[level] = new_lev_codes
@@ -4741,7 +4746,7 @@ class Index(IndexOpsMixin, PandasObject):
             if keep_order:  # just drop missing values. o.w. keep order
                 left_indexer = np.arange(len(left), dtype=np.intp)
                 left_indexer = cast("np.ndarray", left_indexer)
-                mask = new_lev_codes != -1
+                mask = (new_lev_codes != -1) | nan_mask
                 if not mask.all():
                     new_codes = [lab[mask] for lab in new_codes]
                     left_indexer = left_indexer[mask]

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -268,3 +268,29 @@ def test_join_index_levels():
     )
     tm.assert_index_equal(result.levels[1], expected.levels[1])
     tm.assert_index_equal(result, expected)
+
+
+def test_join_level_with_nan_in_multiindex():
+    # GH#60908
+    import pandas as pd
+
+    ix1 = MultiIndex.from_arrays(
+        [
+            [np.nan, 81, 81, 82, 82],
+            [np.nan, np.nan, np.nan, np.nan, np.nan],
+            pd.to_datetime(
+                [np.nan, "2018-06-01", "2018-07-01", "2018-07-01", "2018-08-01"]
+            ),
+        ],
+        names=["foo", "bar", "date"],
+    )
+    s1 = Series([np.nan, 25.058969, 22.519751, 20.847981, 21.625236], index=ix1)
+    ix2 = Index([81, 82, 83, 84, 85, 86, 87], name="foo")
+    s2 = Series([28.28, 25.25, 22.22, 16.766, 14.0087, 14.948, 29.29], index=ix2)
+
+    result = s1 - s2
+    expected = Series(
+        [np.nan, -3.221031, -5.760249, -4.402019, -3.624764],
+        index=ix1,
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
…g NaN values (#60908)

- [x] closes #60908 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Summary

Subtracting two Series that share a level crashes with `ValueError` when the MultiIndex has NaN values in one of its rows.

The root cause is in `Index._join_level` — it filters out `-1` codes (NaN), which shortens one code array while the others stay full length. This creates an inconsistent MultiIndex.

The fix uses a safe placeholder for `.take()` to restore `-1`, then adjusting the mask to keep original NaN rows.
