### PR TITLE
DOC: Correct two typos in pandas documentation

### DIFF
--- a/pandas/core/_numba/extensions.py
+++ b/pandas/core/_numba/extensions.py
@@ -44,7 +44,7 @@ from pandas.core.series import Series
 
 # Helper function to hack around fact that Index casts numpy string dtype to object
 #
-# Idea is to set an attribute on a Index called _numba_data
+# Idea is to set an attribute on an Index called _numba_data
 # that is the original data, or the object data casted to numpy string dtype,
 # with a context manager that is unset afterwards
 @contextmanager
@@ -342,12 +342,12 @@ def unbox_series(typ, obj, c):
 @box(IndexType)
 def box_index(typ, val, c):
     """
-    Convert a native index structure to a Index object.
+    Convert a native index structure to an Index object.
 
     If our native index is of a numpy string dtype, we'll cast it to
     object.
     """
-    # First build a Numpy array object, then wrap it in a Index
+    # First build a Numpy array object, then wrap it in an Index
     index = cgutils.create_struct_proxy(typ)(c.context, c.builder, value=val)
 
     res = cgutils.alloca_once_value(c.builder, index.parent)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1306,7 +1306,7 @@ class MultiIndex(Index):
             # The levels would overflow a 16 bit uint - use uint8
             return MultiIndexUInt32Engine(self.levels, self.codes, offsets)
         if lev_bits[0] > 8:
-            # The levels would overflow a 8 bit uint - use uint16
+            # The levels would overflow an 8 bit uint - use uint16
             return MultiIndexUInt16Engine(self.levels, self.codes, offsets)
         # The levels fit in an 8 bit uint - use uint8
         return MultiIndexUInt8Engine(self.levels, self.codes, offsets)


### PR DESCRIPTION
Correct two typos in pandas documentation

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
