### PR TITLE
TST/CLN: remove unnecessary left-over usage of using_infer_string in pytables tests

### DIFF
--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -718,7 +718,7 @@ def test_append_misc_empty_frame(temp_hdfstore):
     tm.assert_frame_equal(temp_hdfstore.select("df2"), df)
 
 
-def test_append_raise(temp_hdfstore, using_infer_string):
+def test_append_raise(temp_hdfstore):
     # test append with invalid input to get good error messages
 
     # list in column

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -182,7 +182,7 @@ def test_put_compression_blosc(temp_hdfstore):
     tm.assert_frame_equal(temp_hdfstore["c"], df)
 
 
-def test_put_datetime_ser(temp_hdfstore, performance_warning, using_infer_string):
+def test_put_datetime_ser(temp_hdfstore, performance_warning):
     # https://github.com/pandas-dev/pandas/pull/60663
     ser = Series(3 * [Timestamp("20010102").as_unit("ns")])
     temp_hdfstore.put("ser", ser)
@@ -266,7 +266,7 @@ def test_store_index_types(temp_hdfstore, format, index):
     tm.assert_frame_equal(df, temp_hdfstore["df"])
 
 
-def test_column_multiindex(temp_hdfstore, using_infer_string):
+def test_column_multiindex(temp_hdfstore):
     # GH 4710
     # recreate multi-indexes properly
 
@@ -294,7 +294,7 @@ def test_column_multiindex(temp_hdfstore, using_infer_string):
         temp_hdfstore.put("df3", df, format="table", data_columns=True)
 
 
-def test_column_multiindex_existing(temp_hdfstore, using_infer_string):
+def test_column_multiindex_existing(temp_hdfstore):
     # appending multi-column on existing table (see GH 6167)
 
     index = MultiIndex.from_tuples(
@@ -307,7 +307,7 @@ def test_column_multiindex_existing(temp_hdfstore, using_infer_string):
     tm.assert_frame_equal(temp_hdfstore["df2"], concat((df, df)))
 
 
-def test_column_multiindex_non_index_axes(temp_hdfstore, using_infer_string):
+def test_column_multiindex_non_index_axes(temp_hdfstore):
     df = DataFrame(np.arange(12).reshape(3, 4), columns=Index(list("ABCD"), name="foo"))
     expected = df.set_axis(df.index.to_numpy())
 

--- a/pandas/tests/io/pytables/test_read.py
+++ b/pandas/tests/io/pytables/test_read.py
@@ -159,7 +159,7 @@ def test_pytables_native2_read(datapath):
     assert isinstance(d1, DataFrame)
 
 
-def test_read_hdf_open_store(temp_h5_path, using_infer_string):
+def test_read_hdf_open_store(temp_h5_path):
     # GH10330
     # No check for non-string path_or-buf, and no test of open store
     df = DataFrame(

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -423,9 +423,7 @@ def test_can_serialize_dates(temp_h5_path):
     _check_roundtrip(frame, tm.assert_frame_equal, path=temp_h5_path)
 
 
-def test_store_hierarchical(
-    temp_h5_path, using_infer_string, multiindex_dataframe_random_data
-):
+def test_store_hierarchical(temp_h5_path, multiindex_dataframe_random_data):
     frame = multiindex_dataframe_random_data
 
     _check_roundtrip(frame, tm.assert_frame_equal, path=temp_h5_path)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -110,14 +110,14 @@ def test_repr(temp_hdfstore, performance_warning, using_infer_string):
     store["b"] = Series(range(10), dtype="float64", index=[f"i_{i}" for i in range(10)])
     store["c"] = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
-        columns=Index(list("ABCD"), dtype=object),
-        index=Index([f"i-{i}" for i in range(30)], dtype=object),
+        columns=Index(list("ABCD")),
+        index=Index([f"i-{i}" for i in range(30)]),
     )
 
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
-        columns=Index(list("ABCD"), dtype=object),
-        index=Index([f"i-{i}" for i in range(30)], dtype=object),
+        columns=Index(list("ABCD")),
+        index=Index([f"i-{i}" for i in range(30)]),
     )
     df["obj1"] = "foo"
     df["obj2"] = "bar"
@@ -150,8 +150,8 @@ def test_repr_get_storer(temp_hdfstore):
     # storers
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
-        columns=Index(list("ABCD"), dtype=object),
-        index=Index([f"i-{i}" for i in range(30)], dtype=object),
+        columns=Index(list("ABCD")),
+        index=Index([f"i-{i}" for i in range(30)]),
     )
     temp_hdfstore.append("df", df)
 
@@ -167,13 +167,13 @@ def test_contains(temp_hdfstore):
     )
     store["b"] = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
-        columns=Index(list("ABCD"), dtype=object),
-        index=Index([f"i-{i}" for i in range(30)], dtype=object),
+        columns=Index(list("ABCD")),
+        index=Index([f"i-{i}" for i in range(30)]),
     )
     store["foo/bar"] = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
-        columns=Index(list("ABCD"), dtype=object),
-        index=Index([f"i-{i}" for i in range(30)], dtype=object),
+        columns=Index(list("ABCD")),
+        index=Index([f"i-{i}" for i in range(30)]),
     )
     assert "a" in store
     assert "b" in store
@@ -187,8 +187,8 @@ def test_contains(temp_hdfstore):
     with tm.assert_produces_warning(tables.NaturalNameWarning, check_stacklevel=False):
         store["node())"] = DataFrame(
             1.1 * np.arange(120).reshape((30, 4)),
-            columns=Index(list("ABCD"), dtype=object),
-            index=Index([f"i-{i}" for i in range(30)], dtype=object),
+            columns=Index(list("ABCD")),
+            index=Index([f"i-{i}" for i in range(30)]),
         )
     assert "node())" in store
 
@@ -200,12 +200,12 @@ def test_versioning(temp_hdfstore):
     )
     store["b"] = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
-        columns=Index(list("ABCD"), dtype=object),
-        index=Index([f"i-{i}" for i in range(30)], dtype=object),
+        columns=Index(list("ABCD")),
+        index=Index([f"i-{i}" for i in range(30)]),
     )
     df = DataFrame(
         np.random.default_rng(2).standard_normal((20, 4)),
-        columns=Index(list("ABCD"), dtype=object),
+        columns=Index(list("ABCD")),
         index=date_range("2000-01-01", periods=20, freq="B"),
     )
     store.append("df1", df[:10])


### PR DESCRIPTION
While working on the HDF IO tests, I noticed some no-longer-needed usage of `using_infer_string`, cleaning that up a bit in this PR (this is probably something that can also be done in other places). 
And removed some more explicit `dtype=object` cases that are not needed.