### PR TITLE
TST: remove fixed xfail for PyArrow 23.0.1

### DIFF
--- a/pandas/tests/io/parser/common/test_float.py
+++ b/pandas/tests/io/parser/common/test_float.py
@@ -60,17 +60,9 @@ def test_scientific_no_exponent(all_parsers_all_precisions):
         ("-50060e8007123400", -np.inf),
     ],
 )
-def test_large_exponent(request, all_parsers_all_precisions, value, expected_value):
+def test_large_exponent(all_parsers_all_precisions, value, expected_value):
     # GH#38753; GH#38794; GH#62740
     parser, precision = all_parsers_all_precisions
-
-    if (
-        parser.engine == "pyarrow"
-        and precision is None
-        and value[:2] not in ["0E", "-0"]
-    ):
-        reason = "https://github.com/apache/arrow/issues/49003"
-        request.applymarker(pytest.mark.xfail(reason=reason, raises=AssertionError))
 
     data = f"data\n{value}"
     result = parser.read_csv(StringIO(data), float_precision=precision)


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/63895, since this now has been fixed upstream in pyarrow and just released with pyarrow 23.0.1.

I am removing the xfail all together, instead of keeping it but only for pyarrow ==23.0.0, assuming we should always be testing with the latest bug-fix release of the given version