### PR TITLE
[backport 3.0.x] BUG: Fix read_hdf failing on generic datetime64 dtype (#64008)

### DIFF
--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -33,6 +33,7 @@ Bug fixes
 - Fixed a bug in the :func:`comparison_op` raising a ``TypeError`` for zerodim
   subclasses of ``np.ndarray`` (:issue:`63205`)
 - Added additional typing aliases in :py:mod:`pandas.api.typing.aliases` (:issue:`64098`)
+- Fixed bug in :func:`read_hdf` reading a file written by pandas <= 2.2 with a datetime64 column (:issue:`64006`)
 - Fixed bug in :meth:`DataFrame.loc` when setting new row and new columns simultaneously filling existing columns with ``b''`` instead of ``NaN`` (:issue:`58316`)
 - Fixed thread safety issues in :class:`DataFrame` internals on the free-threaded build (:issue:`63685`).
 - Prevent buffer overflow in :meth:`Rolling.corr` and :meth:`Rolling.cov` with variable windows when passing ``other`` with a longer index than the original window. This now raises ``ValueError`` (:issue:`62937`)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2700,6 +2700,8 @@ class DataCol(IndexCol):
         # reverse converts
         if dtype.startswith("datetime64"):
             # recreate with tz if indicated
+            if dtype == "datetime64":
+                dtype = "datetime64[ns]"
             converted = _set_tz(converted, tz, dtype)
 
         elif dtype.startswith("timedelta64"):
@@ -3088,6 +3090,8 @@ class GenericFixed(Fixed):
 
             if dtype and dtype.startswith("datetime64"):
                 # reconstruct a timezone if indicated
+                if dtype == "datetime64":
+                    dtype = "datetime64[ns]"
                 tz = getattr(attrs, "tz", None)
                 ret = _set_tz(ret, tz, dtype)
 

--- a/pandas/tests/io/pytables/test_compat.py
+++ b/pandas/tests/io/pytables/test_compat.py
@@ -86,12 +86,6 @@ _legacy_files = list(Path(__file__).parent.parent.glob("data/legacy_hdf/*/*.h5")
 @pytest.mark.parametrize("legacy_file", _legacy_files, ids=lambda x: x.name)
 def test_legacy_files(datapath, legacy_file, using_infer_string, request):
     legacy_version = Version(legacy_file.parent.name)
-    if legacy_version < Version("2.2.0"):
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="HDF5 files from pandas < 2.2 with datetime64 columns"
-            )
-        )
     legacy_file = datapath(legacy_file)
 
     if not np_version_gt2 and legacy_file.endswith("fixed.h5"):


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/64008