### PR TITLE
DOC: add py:type targets for typing aliases

### DIFF
--- a/doc/source/reference/aliases.rst
+++ b/doc/source/reference/aliases.rst
@@ -32,6 +32,85 @@ own python code that calls pandas or expects certain results.
 
     Note that the definitions and use cases of these aliases are subject to change without notice in any major, minor, or patch release of pandas.
 
+.. raw:: html
+
+    <div style="display:none">
+
+.. py:type:: AggFuncType
+.. py:type:: AlignJoin
+.. py:type:: AnyAll
+.. py:type:: AnyArrayLike
+.. py:type:: ArrayLike
+.. py:type:: AstypeArg
+.. py:type:: Axes
+.. py:type:: Axis
+.. py:type:: CSVEngine
+.. py:type:: ColspaceArgType
+.. py:type:: CompressionOptions
+.. py:type:: CorrelationMethod
+.. py:type:: DropKeep
+.. py:type:: Dtype
+.. py:type:: DtypeArg
+.. py:type:: DtypeBackend
+.. py:type:: DtypeObj
+.. py:type:: ExcelWriterIfSheetExists
+.. py:type:: ExcelWriterMergeCells
+.. py:type:: FilePath
+.. py:type:: FillnaOptions
+.. py:type:: FloatFormatType
+.. py:type:: FormattersType
+.. py:type:: FromDictOrient
+.. py:type:: HTMLFlavors
+.. py:type:: IgnoreRaise
+.. py:type:: IndexLabel
+.. py:type:: InterpolateOptions
+.. py:type:: IntervalClosedType
+.. py:type:: IntervalLeftRight
+.. py:type:: JSONEngine
+.. py:type:: JSONSerializable
+.. py:type:: JoinHow
+.. py:type:: JoinValidate
+.. py:type:: ListLike
+.. py:type:: MergeHow
+.. py:type:: MergeValidate
+.. py:type:: NaPosition
+.. py:type:: NsmallestNlargestKeep
+.. py:type:: OpenFileErrors
+.. py:type:: Ordered
+.. py:type:: ParquetCompressionOptions
+.. py:type:: QuantileInterpolation
+.. py:type:: ReadBuffer
+.. py:type:: ReadCsvBuffer
+.. py:type:: ReadPickleBuffer
+.. py:type:: ReindexMethod
+.. py:type:: Scalar
+.. py:type:: ScalarIndexer
+.. py:type:: SequenceIndexer
+.. py:type:: SequenceNotStr
+.. py:type:: SliceType
+.. py:type:: SortKind
+.. py:type:: StorageOptions
+.. py:type:: Suffixes
+.. py:type:: TakeIndexer
+.. py:type:: TimeAmbiguous
+.. py:type:: TimeGrouperOrigin
+.. py:type:: TimeNonexistent
+.. py:type:: TimeUnit
+.. py:type:: TimedeltaConvertibleTypes
+.. py:type:: TimestampConvertibleTypes
+.. py:type:: ToStataByteorder
+.. py:type:: ToTimestampHow
+.. py:type:: UpdateJoin
+.. py:type:: UsecolsArgType
+.. py:type:: WindowingRankType
+.. py:type:: WriteBuffer
+.. py:type:: WriteExcelBuffer
+.. py:type:: XMLParsers
+
+.. raw:: html
+
+    </div>
+
 Each of these aliases listed in the table below can be found by importing them from :py:mod:`pandas.api.typing.aliases`.
 
 .. list-table::


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
Closes #63810

This PR adds py:type reference targets for each entry in pandas.api.typing.aliases so the aliases have stable, linkable targets in the documentation.