### PR TITLE
BUG: Fix test_assignment_not_inplace incorrect assertion

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1311,7 +1311,6 @@ class TestOperations:
         expected = Series([True], name="a")
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.xfail(reason="Unknown: Omitted test_ in name prior.")
     def test_assignment_not_inplace(self):
         # see gh-9297
         df = DataFrame(
@@ -1323,7 +1322,8 @@ class TestOperations:
 
         expected = df.copy()
         expected["c"] = expected["a"] + expected["b"]
-        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(actual, expected)
+        assert list(df.columns) == ["a", "b"]
 
     def test_multi_line_expression(self):
         # GH 11149


### PR DESCRIPTION
- Remove incorrect xfail marker
- Fix assertion to compare actual result instead of original df
- Add check to verify original DataFrame is unchanged

Closes #64208

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
