### PR TITLE
PERF: avoid wasteful array round-trip in loc/iloc setitem with list-of-lists

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -581,4 +581,21 @@ class Block:
         self.df.loc[start:end, :] = True
 
 
+class LocSetitem2dValue:
+    def setup(self):
+        nrows = 10_000_000
+        # Mixed dtypes so the setitem takes the split path.
+        self.df = DataFrame(
+            {
+                "a": np.zeros(nrows),
+                "b": np.zeros(nrows, dtype=int),
+                "c": np.zeros(nrows),
+            }
+        )
+        self.value = np.random.randn(nrows, 2).tolist()
+
+    def time_loc_setitem_2d(self):
+        self.df.loc[:, ["a", "c"]] = self.value
+
+
 from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -124,6 +124,9 @@ Performance improvements
 - Performance improvement in indexing a :class:`DataFrame` with a :class:`CategoricalIndex` of :class:`Interval` categories (:issue:`61928`)
 - Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)
 - Performance improvement in repr of :class:`Series` and :class:`DataFrame` containing third-party array-like objects (e.g. xarray ``DataArray``) in object dtype columns (:issue:`61809`)
+- Performance improvement in :meth:`DataFrame.loc` and :meth:`DataFrame.iloc`
+  setitem with a 2D list-of-lists value by avoiding a wasteful round-trip
+  through an intermediate object array (:issue:`64229`).
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2581,8 +2581,12 @@ class _iLocIndexer(_LocationIndexer):
         if not isinstance(value, list) and not is_array_like(value):
             value = np.asarray(value)
 
-        ncols = len(value[0]) if isinstance(value, list) else value.shape[1]
-        if len(ilocs) != ncols:
+        if isinstance(value, list):
+            if any(len(row) != len(ilocs) for row in value):
+                raise ValueError(
+                    "Must have equal len keys and value when setting with an ndarray"
+                )
+        elif value.shape[1] != len(ilocs):
             raise ValueError(
                 "Must have equal len keys and value when setting with an ndarray"
             )

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2573,6 +2573,8 @@ class _iLocIndexer(_LocationIndexer):
                 self._setitem_single_column(loc, value, pi)
 
     def _setitem_with_indexer_2d_value(self, indexer, value) -> None:
+        # We get here with a 2D value (array-like or list-of-lists),
+        # excluding DataFrame which goes through _setitem_with_indexer_frame_value
         pi = indexer[0]
         ilocs = self._ensure_iterable_column_indexer(indexer[1])
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2573,26 +2573,20 @@ class _iLocIndexer(_LocationIndexer):
                 self._setitem_single_column(loc, value, pi)
 
     def _setitem_with_indexer_2d_value(self, indexer, value) -> None:
-        # We get here with 2D value, excluding DataFrame,
-        #  which goes through _setitem_with_indexer_frame_value
         pi = indexer[0]
-
         ilocs = self._ensure_iterable_column_indexer(indexer[1])
 
-        is_list = isinstance(value, list)
-        if is_list:
-            ncols = len(value[0])
-        else:
-            if not is_array_like(value):
-                value = np.asarray(value)
-            ncols = value.shape[1]
+        if not isinstance(value, list) and not is_array_like(value):
+            value = np.asarray(value)
 
+        ncols = len(value[0]) if isinstance(value, list) else value.shape[1]
         if len(ilocs) != ncols:
             raise ValueError(
                 "Must have equal len keys and value when setting with an ndarray"
             )
+
         for i, loc in enumerate(ilocs):
-            if is_list:
+            if isinstance(value, list):
                 value_col = [row[i] for row in value]
             else:
                 value_col = value[:, i]
@@ -3246,30 +3240,9 @@ class _iAtIndexer(_ScalarAccessIndexer):
 
 
 def _is_2d_value(value) -> bool:
-    """
-    Check if *value* is 2-dimensional without converting lists to an ndarray.
-
-    ``np.ndim`` tries the ``.ndim`` attribute first, but for objects that
-    lack it (e.g. plain lists) it falls back to ``np.asarray(a).ndim``,
-    which materialises an ndarray just to check dimensionality.  When the
-    caller subsequently extracts columns directly from the list (avoiding
-    array construction altogether), that conversion is pure overhead.
-
-    This helper short-circuits for homogeneous list-of-lists with a cheap
-    structural check (O(R) row-length scan, no array allocation) and
-    delegates to ``np.ndim`` for everything else.  Ragged lists
-    intentionally fall through so that ``np.ndim`` raises the standard
-    ``ValueError`` for inhomogeneous shapes.
-    """
-    if (
-        isinstance(value, list)
-        and len(value) > 0
-        and isinstance(value[0], (list, tuple))
-    ):
-        first_len = len(value[0])
-        if all(len(row) == first_len for row in value[1:]):
-            return True
-        # Ragged: fall through to np.ndim which raises ValueError
+    """Check if value is 2-dimensional, avoiding np.asarray for plain lists."""
+    if isinstance(value, list):
+        return len(value) > 0 and isinstance(value[0], (list, tuple))
     return np.ndim(value) == 2
 
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2518,9 +2518,7 @@ class _iLocIndexer(_LocationIndexer):
             if isinstance(value, ABCDataFrame):
                 self._setitem_with_indexer_frame_value(indexer, value, name)
 
-            elif np.ndim(value) == 2:
-                # TODO: avoid np.ndim call in case it isn't an ndarray, since
-                #  that will construct an ndarray, which will be wasteful
+            elif _is_2d_value(value):
                 self._setitem_with_indexer_2d_value(indexer, value)
 
             elif len(ilocs) == 1 and lplane_indexer == len(value) and not is_scalar(pi):
@@ -2575,25 +2573,31 @@ class _iLocIndexer(_LocationIndexer):
                 self._setitem_single_column(loc, value, pi)
 
     def _setitem_with_indexer_2d_value(self, indexer, value) -> None:
-        # We get here with np.ndim(value) == 2, excluding DataFrame,
+        # We get here with 2D value, excluding DataFrame,
         #  which goes through _setitem_with_indexer_frame_value
         pi = indexer[0]
 
         ilocs = self._ensure_iterable_column_indexer(indexer[1])
 
-        if not is_array_like(value):
-            # cast lists to array
-            value = np.array(value, dtype=object)
-        if len(ilocs) != value.shape[1]:
+        is_list = isinstance(value, list)
+        if is_list:
+            ncols = len(value[0])
+        else:
+            if not is_array_like(value):
+                value = np.asarray(value)
+            ncols = value.shape[1]
+
+        if len(ilocs) != ncols:
             raise ValueError(
                 "Must have equal len keys and value when setting with an ndarray"
             )
-
         for i, loc in enumerate(ilocs):
-            value_col = value[:, i]
-            if is_object_dtype(value_col.dtype):
-                # casting to list so that we do type inference in setitem_single_column
-                value_col = value_col.tolist()
+            if is_list:
+                value_col = [row[i] for row in value]
+            else:
+                value_col = value[:, i]
+                if is_object_dtype(value_col.dtype):
+                    value_col = value_col.tolist()
             self._setitem_single_column(loc, value_col, pi)
 
     def _setitem_with_indexer_frame_value(
@@ -3239,6 +3243,34 @@ class _iAtIndexer(_ScalarAccessIndexer):
                 )
 
         return super().__setitem__(key, value)
+
+
+def _is_2d_value(value) -> bool:
+    """
+    Check if *value* is 2-dimensional without converting lists to an ndarray.
+
+    ``np.ndim`` tries the ``.ndim`` attribute first, but for objects that
+    lack it (e.g. plain lists) it falls back to ``np.asarray(a).ndim``,
+    which materialises an ndarray just to check dimensionality.  When the
+    caller subsequently extracts columns directly from the list (avoiding
+    array construction altogether), that conversion is pure overhead.
+
+    This helper short-circuits for homogeneous list-of-lists with a cheap
+    structural check (O(R) row-length scan, no array allocation) and
+    delegates to ``np.ndim`` for everything else.  Ragged lists
+    intentionally fall through so that ``np.ndim`` raises the standard
+    ``ValueError`` for inhomogeneous shapes.
+    """
+    if (
+        isinstance(value, list)
+        and len(value) > 0
+        and isinstance(value[0], (list, tuple))
+    ):
+        first_len = len(value[0])
+        if all(len(row) == first_len for row in value[1:]):
+            return True
+        # Ragged: fall through to np.ndim which raises ValueError
+    return np.ndim(value) == 2
 
 
 def _tuplify(ndim: int, loc: Hashable) -> tuple[Hashable | slice, ...]:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -741,6 +741,16 @@ class TestiLocBaseIndependent:
         expected = DataFrame({"A": ["a", "b", "x", "y", "e"], "B": [5, 6, 11, 13, 9]})
         tm.assert_frame_equal(df, expected)
 
+    @pytest.mark.parametrize("indexer", ["loc", "iloc"])
+    def test_setitem_ragged_list_of_lists_raises(self, indexer):
+        # GH#64229
+        df = DataFrame({"a": [0.0, 0.0], "b": [0, 0], "c": [0.0, 0.0]})
+        with pytest.raises(ValueError, match="inhomogeneous shape"):
+            if indexer == "loc":
+                df.loc[:, ["a", "c"]] = [[1], [2, 3]]
+            else:
+                df.iloc[:, [0, 2]] = [[1], [2, 3]]
+
     @pytest.mark.parametrize("has_ref", [True, False])
     @pytest.mark.parametrize("indexer", [[0], slice(None, 1, None), np.array([0])])
     @pytest.mark.parametrize("value", [["Z"], np.array(["Z"])])
@@ -1548,3 +1558,31 @@ class TestILocSeries:
 
         expected = Series([7, 8, 3], dtype="int64[pyarrow]")
         tm.assert_series_equal(ser, expected)
+
+    @pytest.mark.parametrize("indexer", ["loc", "iloc"])
+    def test_setitem_2d_list_of_lists_mixed_dtypes(self, indexer):
+        # GH#64229 — list-of-lists on mixed-dtype DataFrame should
+        # produce the same result as setting with an ndarray.
+        df_list = DataFrame(
+            {"a": [0.0, 0.0, 0.0], "b": [0, 0, 0], "c": [0.0, 0.0, 0.0]}
+        )
+        df_arr = df_list.copy()
+
+        val_list = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+        val_arr = np.array(val_list)
+
+        if indexer == "loc":
+            df_list.loc[:, ["a", "c"]] = val_list
+            df_arr.loc[:, ["a", "c"]] = val_arr
+        else:
+            df_list.iloc[:, [0, 2]] = val_list
+            df_arr.iloc[:, [0, 2]] = val_arr
+
+        tm.assert_frame_equal(df_list, df_arr)
+
+    def test_setitem_2d_list_of_lists_shape_mismatch(self):
+        # GH#64229 —  Column count in value must match
+        # the number of columns being set.
+        df = DataFrame({"a": [0.0, 0.0], "b": [0, 0], "c": [0.0, 0.0]})
+        with pytest.raises(ValueError, match="Must have equal len keys"):
+            df.loc[:, ["a", "c"]] = [[1, 2, 3], [4, 5, 6]]

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1558,31 +1558,3 @@ class TestILocSeries:
 
         expected = Series([7, 8, 3], dtype="int64[pyarrow]")
         tm.assert_series_equal(ser, expected)
-
-    @pytest.mark.parametrize("indexer", ["loc", "iloc"])
-    def test_setitem_2d_list_of_lists_mixed_dtypes(self, indexer):
-        # GH#64229 — list-of-lists on mixed-dtype DataFrame should
-        # produce the same result as setting with an ndarray.
-        df_list = DataFrame(
-            {"a": [0.0, 0.0, 0.0], "b": [0, 0, 0], "c": [0.0, 0.0, 0.0]}
-        )
-        df_arr = df_list.copy()
-
-        val_list = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
-        val_arr = np.array(val_list)
-
-        if indexer == "loc":
-            df_list.loc[:, ["a", "c"]] = val_list
-            df_arr.loc[:, ["a", "c"]] = val_arr
-        else:
-            df_list.iloc[:, [0, 2]] = val_list
-            df_arr.iloc[:, [0, 2]] = val_arr
-
-        tm.assert_frame_equal(df_list, df_arr)
-
-    def test_setitem_2d_list_of_lists_shape_mismatch(self):
-        # GH#64229 —  Column count in value must match
-        # the number of columns being set.
-        df = DataFrame({"a": [0.0, 0.0], "b": [0, 0], "c": [0.0, 0.0]})
-        with pytest.raises(ValueError, match="Must have equal len keys"):
-            df.loc[:, ["a", "c"]] = [[1, 2, 3], [4, 5, 6]]

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -745,7 +745,7 @@ class TestiLocBaseIndependent:
     def test_setitem_ragged_list_of_lists_raises(self, indexer):
         # GH#64229
         df = DataFrame({"a": [0.0, 0.0], "b": [0, 0], "c": [0.0, 0.0]})
-        with pytest.raises(ValueError, match="inhomogeneous shape"):
+        with pytest.raises(ValueError, match="Must have equal len keys"):
             if indexer == "loc":
                 df.loc[:, ["a", "c"]] = [[1], [2, 3]]
             else:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -742,14 +742,15 @@ class TestiLocBaseIndependent:
         tm.assert_frame_equal(df, expected)
 
     @pytest.mark.parametrize("indexer", ["loc", "iloc"])
-    def test_setitem_ragged_list_of_lists_raises(self, indexer):
+    @pytest.mark.parametrize("value", [[[1], [2, 3]], [[2, 3], [1]]])
+    def test_setitem_ragged_list_of_lists_raises(self, indexer, value):
         # GH#64229
         df = DataFrame({"a": [0.0, 0.0], "b": [0, 0], "c": [0.0, 0.0]})
         with pytest.raises(ValueError, match="Must have equal len keys"):
             if indexer == "loc":
-                df.loc[:, ["a", "c"]] = [[1], [2, 3]]
+                df.loc[:, ["a", "c"]] = value
             else:
-                df.iloc[:, [0, 2]] = [[1], [2, 3]]
+                df.iloc[:, [0, 2]] = value
 
     @pytest.mark.parametrize("has_ref", [True, False])
     @pytest.mark.parametrize("indexer", [[0], slice(None, 1, None), np.array([0])])


### PR DESCRIPTION
- [x] closes #64229
