### PR TITLE
PERF: Period.__repr__

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2767,8 +2767,7 @@ cdef class _Period(PeriodMixin):
         >>> pd.Period('2020-01', 'D').freqstr
         'D'
         """
-        freqstr = PeriodDtypeBase(self._freq._period_dtype_code, self._freq.n)._freqstr
-        return freqstr
+        return self._dtype._freqstr
 
     def __repr__(self) -> str:
         base = self._dtype._dtype_code


### PR DESCRIPTION
```
per = pd.Period("2012-06-01", "M")

%timeit repr(per)
151 ns ± 2.06 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)  # <- branch
303 ns ± 6.29 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  # <- main
```

Addresses https://github.com/pandas-dev/asv-runner/issues/103#issuecomment-3931494237, before which I estimate this would be about 251ns locally.

The time_plot_regular goes from 131ms to 20.3ms.