### PR TITLE
ENH: Add support for universal-pathlib via pathlib-abc

### DIFF
--- a/ci/deps/actions-311-minimum_versions.yaml
+++ b/ci/deps/actions-311-minimum_versions.yaml
@@ -56,6 +56,7 @@ dependencies:
   - scipy=1.14.1
   - sqlalchemy=2.0.36
   - tabulate=0.9.0
+  - universal-pathlib=0.3.9
   - xarray=2024.10.0
   - xlrd=2.0.1
   - xlsxwriter=3.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -55,6 +55,7 @@ dependencies:
   - scipy>=1.14.1
   - sqlalchemy>=2.0.36
   - tabulate>=0.9.0
+  - universal-pathlib>=0.3.9
   - xarray>=2024.10.0
   - xlrd>=2.0.1
   - xlsxwriter>=3.2.0

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -50,6 +50,7 @@ VERSIONS = {
     "sqlalchemy": "2.0.36",
     "tables": "3.10.1",
     "tabulate": "0.9.0",
+    "universal-pathlib": "0.3.9",
     "xarray": "2024.10.0",
     "xlrd": "2.0.1",
     "xlsxwriter": "3.2.0",

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -34,6 +34,7 @@ from pandas.io.common import (
     IOHandles,
     get_handle,
     is_fsspec_url,
+    is_pathlib_abc_path,
     is_url,
     stringify_path,
 )
@@ -93,7 +94,12 @@ def _get_path_or_handle(
     FilePath | ReadBuffer[bytes] | WriteBuffer[bytes], IOHandles[bytes] | None, Any
 ]:
     """File handling for PyArrow."""
-    path_or_handle = stringify_path(path)
+    if is_pathlib_abc_path(path):
+        from pathlib_abc import vfsopen
+
+        path_or_handle = vfsopen(path, mode)
+    else:
+        path_or_handle = stringify_path(path)
     if fs is not None:
         pa_fs = import_optional_dependency("pyarrow.fs", errors="ignore")
         fsspec = import_optional_dependency("fsspec", errors="ignore")

--- a/pandas/tests/io/test_pathlib_abc.py
+++ b/pandas/tests/io/test_pathlib_abc.py
@@ -1,0 +1,425 @@
+"""
+Tests for pathlib-abc ReadablePath/WritablePath support.
+Testing support via UPath.
+
+These tests verify that pandas IO functions accept pathlib_abc compatible
+path objects such as UPath from universal_pathlib.
+"""
+
+import numpy as np
+import pytest
+
+from pandas._config import using_string_dtype
+
+from pandas.compat import HAS_PYARROW
+from pandas.compat.pyarrow import pa_version_under14p0
+
+from pandas import (
+    DataFrame,
+    date_range,
+    read_csv,
+    read_excel,
+    read_feather,
+    read_json,
+    read_parquet,
+    read_pickle,
+    read_stata,
+    read_table,
+)
+import pandas._testing as tm
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Passing a BlockManager to DataFrame:DeprecationWarning"
+)
+
+
+@pytest.fixture
+def upath():
+    """Import and return UPath, skipping if not available."""
+    upath_module = pytest.importorskip("upath")
+    return upath_module.UPath
+
+
+@pytest.fixture
+def cleared_fs():
+    """Provide a cleared memory filesystem."""
+    fsspec = pytest.importorskip("fsspec")
+    memfs = fsspec.filesystem("memory")
+    yield memfs
+    memfs.store.clear()
+
+
+@pytest.fixture
+def df1():
+    """Standard test DataFrame."""
+    return DataFrame(
+        {
+            "int": [1, 3],
+            "float": [2.0, np.nan],
+            "str": ["t", "s"],
+            "dt": date_range("2018-06-18", periods=2),
+        }
+    )
+
+
+class TestUPathReadable:
+    """Tests for reading data using UPath (ReadablePath subclass)."""
+
+    def test_read_csv(self, cleared_fs, df1, upath):
+        # Write test data using fsspec directly
+        text = str(df1.to_csv(index=False)).encode()
+        with cleared_fs.open("test/test.csv", "wb") as w:
+            w.write(text)
+
+        # Read using UPath object
+        path = upath("memory://test/test.csv")
+        df2 = read_csv(path, parse_dates=["dt"])
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_read_table(self, cleared_fs, df1, upath):
+        # Write test data using fsspec directly
+        text = str(df1.to_csv(index=False)).encode()
+        with cleared_fs.open("test/test.csv", "wb") as w:
+            w.write(text)
+
+        # Read using UPath object
+        path = upath("memory://test/test.csv")
+        df2 = read_table(path, sep=",", parse_dates=["dt"])
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_read_json(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+
+        # Write JSON using fsspec directly
+        json_bytes = df.to_json().encode()
+        with cleared_fs.open("test/test.json", "wb") as w:
+            w.write(json_bytes)
+
+        # Read using UPath object
+        path = upath("memory://test/test.json")
+        out = read_json(path)
+        tm.assert_frame_equal(df, out)
+
+    @pytest.mark.xfail(
+        using_string_dtype() and HAS_PYARROW and not pa_version_under14p0,
+        reason="TODO(infer_string) fastparquet",
+    )
+    def test_read_parquet_fastparquet(self, cleared_fs, df1, upath):
+        pytest.importorskip("fastparquet")
+
+        # Write parquet file using string path (known to work)
+        df1.to_parquet(
+            "memory://test/test.parquet",
+            index=False,
+            engine="fastparquet",
+            compression=None,
+        )
+
+        # Read using UPath object
+        path = upath("memory://test/test.parquet")
+        df2 = read_parquet(path, engine="fastparquet")
+        tm.assert_frame_equal(df1, df2)
+
+    def test_read_parquet_pyarrow(self, cleared_fs, df1, upath):
+        pytest.importorskip("pyarrow")
+
+        # Write parquet file using string path
+        df1.to_parquet(
+            "memory://test/test.parquet",
+            index=False,
+            engine="pyarrow",
+            compression=None,
+        )
+
+        # Read using UPath object
+        path = upath("memory://test/test.parquet")
+        df2 = read_parquet(path, engine="pyarrow")
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_read_feather(self, cleared_fs, upath):
+        pytest.importorskip("pyarrow")
+        df = DataFrame({"a": [0]})
+
+        # Write feather using string path
+        df.to_feather("memory://test/test.feather")
+
+        # Read using UPath object
+        path = upath("memory://test/test.feather")
+        out = read_feather(path)
+        tm.assert_frame_equal(df, out)
+
+    def test_read_pickle(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+
+        # Write pickle using string path
+        df.to_pickle("memory://test/test.pkl")
+
+        # Read using UPath object
+        path = upath("memory://test/test.pkl")
+        out = read_pickle(path)
+        tm.assert_frame_equal(df, out)
+
+    def test_read_stata(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+
+        # Write stata using string path
+        df.to_stata("memory://test/test.dta", write_index=False)
+
+        # Read using UPath object
+        path = upath("memory://test/test.dta")
+        out = read_stata(path)
+        tm.assert_frame_equal(df, out.astype("int64"))
+
+    def test_read_excel(self, cleared_fs, df1, upath):
+        pytest.importorskip("openpyxl")
+
+        # Write excel using string path
+        df1.to_excel("memory://test/test.xlsx", index=True)
+
+        # Read using UPath object
+        path = upath("memory://test/test.xlsx")
+        df2 = read_excel(path, parse_dates=["dt"], index_col=0)
+
+        tm.assert_frame_equal(df2, df1)
+
+
+class TestUPathWritable:
+    """Tests for writing data using UPath (WritablePath subclass)."""
+
+    def test_to_csv(self, cleared_fs, df1, upath):
+        path = upath("memory://test/test.csv")
+
+        # Write using UPath object
+        df1.to_csv(path, index=True)
+
+        # Read back using string URL to verify
+        df2 = read_csv("memory://test/test.csv", parse_dates=["dt"], index_col=0)
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_to_json(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.json")
+
+        # Write using UPath object
+        df.to_json(path)
+
+        # Read back using string URL
+        out = read_json("memory://test/test.json")
+        tm.assert_frame_equal(df, out)
+
+    @pytest.mark.xfail(
+        using_string_dtype() and HAS_PYARROW and not pa_version_under14p0,
+        reason="TODO(infer_string) fastparquet",
+    )
+    def test_to_parquet_fastparquet(self, cleared_fs, df1, upath):
+        pytest.importorskip("fastparquet")
+        path = upath("memory://test/test.parquet")
+
+        # Write using UPath object
+        df1.to_parquet(path, index=False, engine="fastparquet", compression=None)
+
+        # Read back using string URL
+        df2 = read_parquet("memory://test/test.parquet", engine="fastparquet")
+        tm.assert_frame_equal(df1, df2)
+
+    def test_to_parquet_pyarrow(self, cleared_fs, df1, upath):
+        pytest.importorskip("pyarrow")
+        path = upath("memory://test/test.parquet")
+
+        # Write using UPath object
+        df1.to_parquet(path, index=False, engine="pyarrow", compression=None)
+
+        # Read back using string URL
+        df2 = read_parquet("memory://test/test.parquet", engine="pyarrow")
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_to_feather(self, cleared_fs, upath):
+        pytest.importorskip("pyarrow")
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.feather")
+
+        # Write using UPath object
+        df.to_feather(path)
+
+        # Read back using string URL
+        out = read_feather("memory://test/test.feather")
+        tm.assert_frame_equal(df, out)
+
+    def test_to_pickle(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.pkl")
+
+        # Write using UPath object
+        df.to_pickle(path)
+
+        # Read back using string URL
+        out = read_pickle("memory://test/test.pkl")
+        tm.assert_frame_equal(df, out)
+
+    def test_to_stata(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.dta")
+
+        # Write using UPath object
+        df.to_stata(path, write_index=False)
+
+        # Read back using string URL
+        out = read_stata("memory://test/test.dta")
+        tm.assert_frame_equal(df, out.astype("int64"))
+
+    def test_to_excel(self, cleared_fs, df1, upath):
+        pytest.importorskip("openpyxl")
+        path = upath("memory://test/test.xlsx")
+
+        # Write using UPath object
+        df1.to_excel(path, index=True)
+
+        # Read back using string URL
+        df2 = read_excel("memory://test/test.xlsx", parse_dates=["dt"], index_col=0)
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_to_markdown(self, cleared_fs, upath):
+        pytest.importorskip("tabulate")
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.md")
+
+        # Write using UPath object
+        df.to_markdown(path)
+
+        # Verify file exists and has content
+        assert cleared_fs.cat("test/test.md")
+
+
+class TestUPathRoundtrip:
+    """Tests for round-trip read/write using UPath objects."""
+
+    def test_csv_roundtrip(self, cleared_fs, df1, upath):
+        path = upath("memory://test/test.csv")
+
+        # Write using UPath
+        df1.to_csv(path, index=False)
+
+        # Read using UPath
+        df2 = read_csv(path, parse_dates=["dt"])
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_json_roundtrip(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.json")
+
+        # Write and read using UPath
+        df.to_json(path)
+        out = read_json(path)
+        tm.assert_frame_equal(df, out)
+
+    def test_parquet_roundtrip_pyarrow(self, cleared_fs, df1, upath):
+        pytest.importorskip("pyarrow")
+        path = upath("memory://test/test.parquet")
+
+        # Write and read using UPath
+        df1.to_parquet(path, index=False, engine="pyarrow", compression=None)
+        df2 = read_parquet(path, engine="pyarrow")
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_pickle_roundtrip(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.pkl")
+
+        # Write and read using UPath
+        df.to_pickle(path)
+        out = read_pickle(path)
+        tm.assert_frame_equal(df, out)
+
+    def test_feather_roundtrip(self, cleared_fs, upath):
+        pytest.importorskip("pyarrow")
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.feather")
+
+        # Write and read using UPath
+        df.to_feather(path)
+        out = read_feather(path)
+        tm.assert_frame_equal(df, out)
+
+    def test_excel_roundtrip(self, cleared_fs, df1, upath):
+        pytest.importorskip("openpyxl")
+        path = upath("memory://test/test.xlsx")
+
+        # Write and read using UPath
+        df1.to_excel(path, index=True)
+        df2 = read_excel(path, parse_dates=["dt"], index_col=0)
+
+        tm.assert_frame_equal(df2, df1)
+
+    def test_stata_roundtrip(self, cleared_fs, upath):
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.dta")
+
+        # Write and read using UPath
+        df.to_stata(path, write_index=False)
+        out = read_stata(path)
+        tm.assert_frame_equal(df, out.astype("int64"))
+
+
+class TestUPathWithCompression:
+    """Tests for UPath with various compression options."""
+
+    @pytest.mark.parametrize("compression", ["gzip", "bz2", "xz"])
+    def test_csv_compression_roundtrip(self, cleared_fs, df1, upath, compression):
+        ext_map = {"gzip": ".gz", "bz2": ".bz2", "xz": ".xz"}
+        ext = ext_map.get(compression, "")
+        path = upath(f"memory://test/test.csv{ext}")
+
+        # Write and read using UPath with compression
+        df1.to_csv(path, index=False, compression=compression)
+        df2 = read_csv(path, parse_dates=["dt"], compression=compression)
+
+        tm.assert_frame_equal(df2, df1)
+
+    @pytest.mark.parametrize("compression", [None, "gzip", "bz2"])
+    def test_json_compression_roundtrip(self, cleared_fs, upath, compression):
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.json")
+
+        # Write and read using UPath with compression
+        df.to_json(path, compression=compression)
+        out = read_json(path, compression=compression)
+        tm.assert_frame_equal(df, out)
+
+    @pytest.mark.parametrize("compression", [None, "gzip"])
+    def test_pickle_compression_roundtrip(self, cleared_fs, upath, compression):
+        df = DataFrame({"a": [0]})
+        path = upath("memory://test/test.pkl")
+
+        # Write and read using UPath with compression
+        df.to_pickle(path, compression=compression)
+        out = read_pickle(path, compression=compression)
+        tm.assert_frame_equal(df, out)
+
+
+class TestUPathErrorHandling:
+    """Tests for error handling with UPath objects."""
+
+    def test_read_nonexistent_file(self, cleared_fs, upath):
+        path = upath("memory://nonexistent/file.csv")
+        with pytest.raises((FileNotFoundError, OSError)):
+            read_csv(path)
+
+    def test_write_creates_parent_dirs(self, cleared_fs, df1, upath):
+        # UPath should be able to create parent directories
+        path = upath("memory://deep/nested/path/test.csv")
+
+        # This should work if parent creation is supported
+        path.parent.mkdir(parents=True, exist_ok=True)
+        df1.to_csv(path, index=False)
+
+        # Verify the file was written
+        df2 = read_csv("memory://deep/nested/path/test.csv", parse_dates=["dt"])
+        tm.assert_frame_equal(df2, df1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ output-formatting = ['jinja2>=3.1.5', 'tabulate>=0.9.0']
 clipboard = ['PyQt5>=5.15.9', 'qtpy>=2.4.2']
 compression = ['zstandard>=0.23.0']
 timezone = ['pytz>=2024.2']
+universal-pathlib = ['universal-pathlib>=0.3.9']
 all = ['adbc-driver-postgresql>=1.2.0',
        'adbc-driver-sqlite>=1.2.0',
        'beautifulsoup4>=4.12.3',
@@ -117,6 +118,7 @@ all = ['adbc-driver-postgresql>=1.2.0',
        'SQLAlchemy>=2.0.36',
        'tables>=3.10.1',
        'tabulate>=0.9.0',
+       'universal-pathlib>=0.3.9',
        'xarray>=2024.10.0',
        'xlrd>=2.0.1',
        'xlsxwriter>=3.2.0',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,6 +44,7 @@ s3fs>=2024.10.0
 scipy>=1.14.1
 SQLAlchemy>=2.0.36
 tabulate>=0.9.0
+universal-pathlib>=0.3.9
 xarray>=2024.10.0
 xlrd>=2.0.1
 xlsxwriter>=3.2.0


### PR DESCRIPTION
- [x] closes #60618
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This draft PR is a minimally invasive change to support [universal-pathlib](https://github.com/fsspec/universal_pathlib) in pandas. This allows users to provide fsspec urlpaths together with storage_options in a single object via a pathlib-like interface.

To have more broad support, this goes via the [pathlib-abc](https://github.com/barneygale/pathlib-abc) base classes `ReadablePath` and `WritablePath`. This will enable pandas to also be used conveniently with other packages that provide a pathlib-style interface based on pathlib-abc.

Before continuing with implementing the typing adjustments and bubble up the pathlib_abc.ReadablePath and pathlib_abc.WritablePath type annotations, I wanted to confirm if this is a reasonable implementation for pandas, or if I should re-design.

disclaimer: I am the universal-pathlib core maintainer. I used copilot to assist in templating the test suite. The implementation in pandas was written by me.

#### Additional items for discussion:

I could approach this differently, and just add support for universal-pathlib directly. This would allow to use the fsspec implementation in pandas more directly. The differences are:

(1) This PR goes via `pathlib_abc.vfsopen` to create an io buffer from a `UPath` that is then handed down to the readers/writers. (It's basically calling `fsspec.open(...)` and returning the corresponding `AbstractBufferedFile` instance)

(2) Alternatively `UPath` exposes a `.storage_options` property containing the fsspec storage options, and can provide the fsspec urlpath as a string via `.as_uri()`.

The advantage of (1) is that other implementations that just subclass pathlib-abc will be supported too. The advantage of (2) is that some writers might be more performant when they can directly act on the fsspec filesystem instead of going through the fsspec AbstractBufferedFile.

Of course both could be implemented.

Let me know what you think,
Andreas 
