### PR TITLE
BUG: Support for Expressions with dunders

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -19,6 +19,8 @@ Fixed regressions
 
 Bug fixes
 ^^^^^^^^^
+- :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
+- Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_302.contributors:

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -7,6 +7,7 @@ from collections.abc import (
 from typing import (
     TYPE_CHECKING,
     Any,
+    NoReturn,
 )
 
 from pandas.util._decorators import set_module
@@ -149,6 +150,22 @@ class Expression:
     def __rmul__(self, other: Any) -> Expression:
         self_repr, other_repr = self._maybe_wrap_parentheses(other)
         return self._with_op("__rmul__", other, f"{other_repr} * {self_repr}")
+
+    def __matmul__(self, other: Any) -> Expression:
+        self_repr, other_repr = self._maybe_wrap_parentheses(other)
+        return self._with_op("__matmul__", other, f"{self_repr} @ {other_repr}")
+
+    def __rmatmul__(self, other: Any) -> Expression:
+        self_repr, other_repr = self._maybe_wrap_parentheses(other)
+        return self._with_op("__rmatmul__", other, f"{other_repr} @ {self_repr}")
+
+    def __pow__(self, other: Any) -> Expression:
+        self_repr, other_repr = self._maybe_wrap_parentheses(other)
+        return self._with_op("__pow__", other, f"{self_repr} ** {other_repr}")
+
+    def __rpow__(self, other: Any) -> Expression:
+        self_repr, other_repr = self._maybe_wrap_parentheses(other)
+        return self._with_op("__rpow__", other, f"{other_repr} ** {self_repr}")
 
     def __truediv__(self, other: Any) -> Expression:
         self_repr, other_repr = self._maybe_wrap_parentheses(other)
@@ -306,6 +323,19 @@ class Expression:
 
     def __repr__(self) -> str:
         return self._repr_str or "Expr(...)"
+
+    # Unsupported ops
+    def __bool__(self) -> NoReturn:
+        raise TypeError("boolean value of an expression is ambiguous")
+
+    def __iter__(self) -> NoReturn:
+        raise TypeError("Expression objects are not iterable")
+
+    def __copy__(self) -> NoReturn:
+        raise TypeError("Expression objects are not copiable")
+
+    def __deepcopy__(self, memo) -> NoReturn:
+        raise TypeError("Expression objects are not copiable")
 
 
 @set_module("pandas")

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -334,7 +334,7 @@ class Expression:
     def __copy__(self) -> NoReturn:
         raise TypeError("Expression objects are not copiable")
 
-    def __deepcopy__(self, memo) -> NoReturn:
+    def __deepcopy__(self, memo: dict[int, Any] | None) -> NoReturn:
         raise TypeError("Expression objects are not copiable")
 
 

--- a/pandas/tests/test_col.py
+++ b/pandas/tests/test_col.py
@@ -357,8 +357,10 @@ def test_iter():
 
 
 def test_contains():
+    # Python 3.14 changes the message from "is not iterable" to
+    # "is not a container or iterable"
     with pytest.raises(
-        TypeError, match="argument of type 'Expression' is not iterable"
+        TypeError, match="argument of type 'Expression' is not .* iterable"
     ):
         1 in pd.col("a")
 

--- a/pandas/tests/test_col.py
+++ b/pandas/tests/test_col.py
@@ -360,7 +360,7 @@ def test_contains():
     # Python 3.14 changes the message from "is not iterable" to
     # "is not a container or iterable"
     with pytest.raises(
-        TypeError, match="argument of type 'Expression' is not .* iterable"
+        TypeError, match="argument of type 'Expression' is not .*iterable"
     ):
         1 in pd.col("a")
 


### PR DESCRIPTION
- [x] closes #64267
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Whether or not to support copy/deepcopy seems unclear to me. The one use case I could maybe see users run into is if you have expressions in some object and deepcopy that object, this PR currently makes that raise. The trouble with deepcopy is that an expression contains arguments given to functions, e.g.

```python
ser = pd.Series([1, 1, 2])
expr = pd.col("a").groupby(ser).sum()
```

If we were to support deepcopy, do we deepcopy `ser` if a user does `copy.deepcopy(expr)`? If we decide to support copying, I don't think it needs to be in this PR as it just makes a recursion error into a type error so does no harm.

Another case of operators I could maybe see users expecting for pandas to support is inplace operators where the LHS is not an expression. E.g.

```python
ser = pd.Series([1, 2, 3])
ser *= pd.col("a")
```

I think one would expect `ser` to become the expression `pd.Series([1, 2, 3]) * pd.col("a")`, but currently this raises a TypeError. If we do want to support this, I'd like to tackle it in a separate PR.