### PR TITLE
TST: add regression test for GH #42437

### DIFF
--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -13,7 +13,6 @@ from pandas.compat.numpy import np_version_gt2
 from pandas.errors import IndexingError
 
 from pandas.core.dtypes.common import is_list_like
-from pandas.api.extensions import ExtensionArray, ExtensionDtype
 
 from pandas import (
     NA,
@@ -38,6 +37,10 @@ from pandas import (
     timedelta_range,
 )
 import pandas._testing as tm
+from pandas.api.extensions import (
+    ExtensionArray,
+    ExtensionDtype,
+)
 
 from pandas.tseries.offsets import BDay
 
@@ -698,6 +701,7 @@ class TestSetitemCasting:
         with pytest.raises(TypeError, match="Invalid value"):
             ser[1:] = arr[1:]  # has an NA -> cast to boolean dtype
 
+
 def test_setitem_extension_array_into_object_dtype():
     # GH#42437
     # Ensure assigning an ExtensionArray into an object-dtype
@@ -745,6 +749,7 @@ def test_setitem_extension_array_into_object_dtype():
 
     expected = Series([(1, 2, 3)] * 3, dtype=object)
     tm.assert_series_equal(ser, expected)
+
 
 class SetitemCastingEquivalents:
     """

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -13,6 +13,7 @@ from pandas.compat.numpy import np_version_gt2
 from pandas.errors import IndexingError
 
 from pandas.core.dtypes.common import is_list_like
+from pandas.api.extensions import ExtensionArray, ExtensionDtype
 
 from pandas import (
     NA,
@@ -697,6 +698,53 @@ class TestSetitemCasting:
         with pytest.raises(TypeError, match="Invalid value"):
             ser[1:] = arr[1:]  # has an NA -> cast to boolean dtype
 
+def test_setitem_extension_array_into_object_dtype():
+    # GH#42437
+    # Ensure assigning an ExtensionArray into an object-dtype
+    # Series stores elements individually.
+
+    class SimpleDtype(ExtensionDtype):
+        @property
+        def type(self):
+            return tuple
+
+        @property
+        def name(self):
+            return "simple"
+
+        @classmethod
+        def construct_array_type(cls):
+            return SimpleEA
+
+    class SimpleEA(ExtensionArray):
+        @property
+        def dtype(self):
+            return SimpleDtype()
+
+        def __len__(self):
+            return 3
+
+        def __getitem__(self, item):
+            if isinstance(item, int):
+                return (1, 2, 3)
+            raise NotImplementedError
+
+        def isna(self):
+            return np.zeros(len(self), dtype=bool)
+
+        def copy(self):
+            return SimpleEA()
+
+        def take(self, indices, allow_fill=False, fill_value=None):
+            return SimpleEA()
+
+    data = SimpleEA()
+    ser = Series(index=range(3), dtype=object)
+
+    ser[:] = data
+
+    expected = Series([(1, 2, 3)] * 3, dtype=object)
+    tm.assert_series_equal(ser, expected)
 
 class SetitemCastingEquivalents:
     """


### PR DESCRIPTION
- [x] closes #42437
- [x] tests added
- [ ] whatsnew entry not required

### What does this PR do?

Adds a regression test for GH #42437.

This test ensures that assigning an ExtensionArray whose elements are
array-like (e.g. tuples) into an object-dtype Series stores the elements
individually rather than using `np.asarray` in a way that expands
dimensions.

The behavior is already correct on `main`; this test guards against
future regressions.