### PR TITLE
TST: add test for GH#55423 loc setitem preserving tz-aware datetime

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -7,6 +7,7 @@ from datetime import (
     datetime,
     time,
     timedelta,
+    timezone,
 )
 import re
 
@@ -2360,6 +2361,20 @@ class TestLocSetitemWithExpansion:
                 "D": [np.nan, np.nan, np.nan, 91.0],
             },
             index=Index([0, 1, 2, "x"]),
+        )
+        tm.assert_frame_equal(df, expected)
+
+    def test_loc_setitem_with_expansion_preserves_tzaware_datetime_dtype(self):
+        # GH#55423
+        df = DataFrame([{"id": 1}, {"id": 2}, {"id": 3}])
+        _time = datetime.fromtimestamp(1695887042).replace(tzinfo=timezone.utc)
+        df.loc[df.id >= 2, "time"] = _time
+
+        expected = DataFrame(
+            {
+                "id": [1, 2, 3],
+                "time": [pd.NaT, _time, _time],
+            }
         )
         tm.assert_frame_equal(df, expected)
 


### PR DESCRIPTION
- [x] closes #55423
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
