### PR TITLE
BUG: enforce 1-dimensional input in pandas.array

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -139,6 +139,9 @@ Numeric
 Conversion
 ^^^^^^^^^^
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`).
+- Fixed bug in :func:`pandas.array` where passing multidimensional input with some
+  dtypes incorrectly returned a 2-dimensional array instead of raising a
+  ``ValueError`` (:issue:`64280`).
 -
 
 Strings

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -151,6 +151,12 @@ class NumpyExtensionArray(
             # e.g. list-of-tuples
             result = construct_1d_object_array_from_listlike(scalars)
 
+        if result.ndim > 1:
+            raise ValueError(
+                "Data must be 1-dimensional, "
+                f"got ndarray of shape {result.shape} instead"
+            )
+
         if copy and result is scalars:
             result = result.copy()
         return cls(result)

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -151,7 +151,8 @@ class NumpyExtensionArray(
             # e.g. list-of-tuples
             result = construct_1d_object_array_from_listlike(scalars)
 
-        if result.ndim > 1:
+        if result.ndim > 1 and result.dtype.kind not in "SU":
+            # Keep the established behavior for dtype="str", see GH#64138.
             raise ValueError(
                 "Data must be 1-dimensional, "
                 f"got ndarray of shape {result.shape} instead"

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -341,15 +341,6 @@ def array(
     if dtype is not None:
         dtype = pandas_dtype(dtype)
 
-    if getattr(data, "ndim", 1) > 1:
-        shape = getattr(data, "shape", None)
-        if shape is None:
-            raise ValueError("Data must be 1-dimensional.")
-        raise ValueError(
-            "Data must be 1-dimensional, "
-            f"got {type(data).__name__} of shape {shape} instead"
-        )
-
     if isinstance(data, ExtensionArray) and (dtype is None or data.dtype == dtype):
         # e.g. TimedeltaArray[s], avoid casting to NumpyExtensionArray
         if copy:

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -341,6 +341,15 @@ def array(
     if dtype is not None:
         dtype = pandas_dtype(dtype)
 
+    if getattr(data, "ndim", 1) > 1:
+        shape = getattr(data, "shape", None)
+        if shape is None:
+            raise ValueError("Data must be 1-dimensional.")
+        raise ValueError(
+            "Data must be 1-dimensional, "
+            f"got {type(data).__name__} of shape {shape} instead"
+        )
+
     if isinstance(data, ExtensionArray) and (dtype is None or data.dtype == dtype):
         # e.g. TimedeltaArray[s], avoid casting to NumpyExtensionArray
         if copy:

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -494,6 +494,28 @@ def test_nd_raises(data):
         pd.array(data, dtype="int64")
 
 
+@pytest.mark.parametrize(
+    "data, dtype",
+    [
+        (np.array([[1, 2], [3, 4]]), None),
+        (np.array([[1, 2], [3, 4]]), "int64"),
+        (np.array([[1, 2], [3, 4]]), "float64"),
+        (np.array([[1, 2], [3, 4]]), "Int64"),
+        (np.array([["2000-01-01", "2000-01-02"]], dtype="datetime64[ns]"), None),
+        (
+            np.array([["2000-01-01", "2000-01-02"]], dtype="datetime64[ns]"),
+            "datetime64[ns]",
+        ),
+        (np.array([[1, 2], [3, 4]], dtype="timedelta64[s]"), None),
+        (np.array([[1, 2], [3, 4]], dtype="timedelta64[s]"), "timedelta64[s]"),
+    ],
+)
+def test_ndim_gt_1_raises(data, dtype):
+    msg = "Data must be 1-dimensional"
+    with pytest.raises(ValueError, match=msg):
+        pd.array(data, dtype=dtype)
+
+
 def test_scalar_raises():
     with pytest.raises(ValueError, match="Cannot pass scalar '1'"):
         pd.array(1)

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -497,17 +497,10 @@ def test_nd_raises(data):
 @pytest.mark.parametrize(
     "data, dtype",
     [
-        (np.array([[1, 2], [3, 4]]), None),
         (np.array([[1, 2], [3, 4]]), "int64"),
         (np.array([[1, 2], [3, 4]]), "float64"),
-        (np.array([[1, 2], [3, 4]]), "Int64"),
-        (np.array([["2000-01-01", "2000-01-02"]], dtype="datetime64[ns]"), None),
-        (
-            np.array([["2000-01-01", "2000-01-02"]], dtype="datetime64[ns]"),
-            "datetime64[ns]",
-        ),
-        (np.array([[1, 2], [3, 4]], dtype="timedelta64[s]"), None),
-        (np.array([[1, 2], [3, 4]], dtype="timedelta64[s]"), "timedelta64[s]"),
+        (np.array([[1, 2], [3, 4]]), object),
+        (np.array([[1, 2], [3, 4]]), "object"),
     ],
 )
 def test_ndim_gt_1_raises(data, dtype):


### PR DESCRIPTION
- [x] closes #64280
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (N/A: no new arguments/methods/functions)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

`pandas.array` documents 1-dimensional input, but NumPy-backed dtype paths (e.g. `int64`, `float64`) accepted multidimensional input and returned 2D `NumpyExtensionArray`.

This PR validates dimensionality in `NumpyExtensionArray._from_sequence` for multidimensional `ndarray` results, so NumPy-backed `pandas.array(...)` construction now raises `ValueError` for 2D input. This keeps existing internal 2D datetimelike operations (used by where/comparison internals) unaffected.

Tests were added in `pandas/tests/arrays/test_array.py` to cover multidimensional inputs for NumPy-backed dtype construction. A whatsnew entry was also added in `v3.1.0`.

Validation run:
- `python -m ruff check pandas/core/construction.py pandas/core/arrays/numpy_.py pandas/tests/arrays/test_array.py`
- `python -m pytest pandas/tests/arrays/test_array.py -n 0`
- `python -m pytest pandas/tests/series/indexing/test_where.py -k "where_datetimelike_categorical" -n 0`
- `python -m pytest pandas/tests/frame/indexing/test_indexing.py::TestDataFrameIndexing::test_set_2d_casting_date_to_int -n 0`
- `python -m pytest pandas/tests/indexes/datetimes/test_date_range.py::TestDateRanges::test_date_range_index_comparison -n 0`
- `python -m pytest 'pandas/tests/arrays/floating/test_construction.py::test_to_array_error[values8]' -n 0`
