### PR TITLE
BUG: Fix dtype inference for tz-aware datetime in .loc assignment

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -567,6 +567,11 @@ def infer_fill_value(val):
     elif val.dtype == object:
         dtype = lib.infer_dtype(ensure_object(val), skipna=False)
         if dtype in ["datetime", "datetime64"]:
+            # Check if any value is timezone-aware
+            tz = _infer_timezone_from_object_array(val)
+            if tz is not None:
+                # Return timezone-aware NaT
+                return np.array("NaT", dtype=DatetimeTZDtype(tz=tz))
             return np.array("NaT", dtype=DT64NS_DTYPE)
         elif dtype in ["timedelta", "timedelta64"]:
             return np.array("NaT", dtype=TD64NS_DTYPE)
@@ -574,6 +579,19 @@ def infer_fill_value(val):
     elif val.dtype.kind == "U":
         return np.array(np.nan, dtype=val.dtype)
     return np.nan
+
+
+def _infer_timezone_from_object_array(val):
+    """
+    Check if the object array contains timezone-aware datetime values.
+    Returns the timezone if found, None otherwise.
+    """
+    import datetime as dt
+
+    for item in val:
+        if isinstance(item, dt.datetime) and item.tzinfo is not None:
+            return item.tzinfo
+    return None
 
 
 def construct_1d_array_from_inferred_fill_value(
@@ -587,6 +605,14 @@ def construct_1d_array_from_inferred_fill_value(
 
     arr = sanitize_array(value, Index(range(1)), copy=False)
     taker = -1 * np.ones(length, dtype=np.intp)
+
+    # If the array is a DatetimeArray with timezone, we need to ensure
+    # the fill value used by take_nd preserves the timezone
+    if isinstance(arr.dtype, DatetimeTZDtype):
+        # Create a timezone-aware NaT for the fill value
+        fill_value = np.array("NaT", dtype=arr.dtype)
+        return take_nd(arr, taker, fill_value=fill_value)
+
     return take_nd(arr, taker)
 
 

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1498,3 +1498,27 @@ def test_setitem_partial_row_multiple_columns():
         }
     )
     tm.assert_frame_equal(df, expected)
+
+
+def test_setitem_loc_tz_aware_datetime_inference():
+    # GH#55423
+    # When adding a tz-aware datetime column to a DataFrame using .loc
+    # assignment, the dtype should be datetime64[ns, UTC] not "object"
+    import datetime as dt
+
+    df = DataFrame([{"id": 1}, {"id": 2}, {"id": 3}])
+    _time = dt.datetime.utcfromtimestamp(1695887042).replace(tzinfo=dt.timezone.utc)
+    df.loc[df.id >= 2, "time"] = _time
+
+    # Check the dtype is datetime64[ns, UTC] not object
+    assert df.dtypes["time"] == DatetimeTZDtype(tz="UTC")
+
+    # Verify the values are correctly set
+    expected = DataFrame(
+        {
+            "id": [1, 2, 3],
+            "time": [NaT, Timestamp(_time), Timestamp(_time)],
+        }
+    )
+    # Compare without the exact type to handle different tz representations
+    tm.assert_frame_equal(df, expected, check_dtype=False)


### PR DESCRIPTION
## Summary

Fixes #55423

When adding a tz-aware datetime column to a DataFrame using `.loc` assignment with a boolean mask, the dtype was becoming "object" instead of "datetime64[ns, UTC]".

## Reproducible Example

```python
import pandas as pd
import datetime as dt

df = pd.DataFrame([{'id': 1}, {'id': 2}, {'id': 3}])
_time = dt.datetime.utcfromtimestamp(1695887042).replace(tzinfo=dt.timezone.utc)
df.loc[df.id >= 2, 'time'] = _time

# Before fix: dtype is 'object'
# After fix: dtype is 'datetime64[ns, UTC]'
print(df.dtypes)
```

## Root Cause

In `pandas/core/dtypes/missing.py`:
- `construct_1d_array_from_inferred_fill_value` creates an array using `sanitize_array`
- Then uses `take_nd` with -1 indices to expand to full length
- The default fill value didn't preserve timezone information for DatetimeTZDtype

## Fix

1. **In `construct_1d_array_from_inferred_fill_value`**: Added explicit handling for DatetimeTZDtype to pass the correct timezone-aware NaT as fill_value to `take_nd`

2. **In `infer_fill_value`**: Added detection of timezone-aware datetimes in object arrays and returns appropriate DatetimeTZDtype NaT

3. **Added helper function `_infer_timezone_from_object_array`**: Detects timezone from datetime objects

## Testing

Added test case `test_setitem_loc_tz_aware_datetime_inference` in `pandas/tests/frame/indexing/test_setitem.py`