### PR TITLE
GH#57702: Fix inconsistent None handling in pd.array with string dtype

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -137,12 +137,17 @@ class NumpyExtensionArray(
         if isinstance(dtype, NumpyEADtype):
             dtype = dtype._dtype
 
-        # error: Argument "dtype" to "asarray" has incompatible type
-        # "Union[ExtensionDtype, str, dtype[Any], dtype[floating[_64Bit]], Type[object],
-        # None]"; expected "Union[dtype[Any], None, type, _SupportsDType, str,
-        # Union[Tuple[Any, int], Tuple[Any, Union[int, Sequence[int]]], List[Any],
-        # _DTypeDict, Tuple[Any, Any]]]"
-        result = np.asarray(scalars, dtype=dtype)  # type: ignore[arg-type]
+        # GH#57702: Handle string dtypes specially to preserve None values
+        # Use lib.ensure_string_array to match behavior of pd.Series construction
+        if dtype is not None and getattr(dtype, "kind", None) == "U":
+            result = lib.ensure_string_array(scalars, convert_na_value=False, copy=copy)
+        else:
+            # error: Argument "dtype" to "asarray" has incompatible type
+            # "Union[ExtensionDtype, str, dtype[Any], dtype[floating[_64Bit]], Type[object],
+            # None]"; expected "Union[dtype[Any], None, type, _SupportsDType, str,
+            # Union[Tuple[Any, int], Tuple[Any, Union[int, Sequence[int]]], List[Any],
+            # _DTypeDict, Tuple[Any, Any]]]"
+            result = np.asarray(scalars, dtype=dtype)  # type: ignore[arg-type]
         if (
             result.ndim > 1
             and not hasattr(scalars, "dtype")

--- a/pandas/tests/arrays/numpy_/test_numpy.py
+++ b/pandas/tests/arrays/numpy_/test_numpy.py
@@ -409,3 +409,24 @@ def test_array_repr(any_numpy_array):
     expected = f"<NumpyExtensionArray>\n{values}\nLength: 2, dtype: {nparray.dtype}"
     result = repr(arr)
     assert result == expected, f"{result} vs {expected}"
+
+
+def test_string_dtype_preserves_none():
+    # GH#57702 - Ensure pd.array with string dtype preserves None like pd.Series
+    # Test with numpy string dtype
+    result_array = pd.array([1, None], dtype=np.dtype("U10"))
+    result_series = pd.Series([1, None], dtype=np.dtype("U10")).array
+
+    # Both should preserve None as None, not convert to "None" string
+    # Both should have object dtype to preserve None
+    assert result_array.dtype == object
+    assert result_series.dtype == object
+
+    # Check values match
+    tm.assert_extension_array_equal(result_array, result_series)
+
+    # Explicitly check that None is preserved
+    assert result_array[0] == "1"
+    assert result_array[1] is None
+    assert result_series[0] == "1"
+    assert result_series[1] is None


### PR DESCRIPTION
## Description

Fixes #57702

This PR addresses inconsistent behavior between `pd.array()` and `pd.Series()` when constructing arrays with numpy string dtype and None values.

### Before
- `pd.array([1, None], dtype=np.dtype('U10'))` → `['1', 'None']` (converted None to string)
- `pd.Series([1, None], dtype=np.dtype('U10')).array` → `['1', None]` (preserved None)

### After
- Both now preserve None as None and use object dtype for consistency

## Changes

- **Modified** `pandas/core/arrays/numpy_.py`: Added special handling in `_from_sequence` for string dtypes (dtype.kind == 'U') to use `lib.ensure_string_array()` which preserves None values
- **Added** test `test_string_dtype_preserves_none()` in `pandas/tests/arrays/numpy_/test_numpy.py` to verify consistent behavior

## Root Cause

The issue was in `NumpyExtensionArray._from_sequence()` which directly called `np.asarray(scalars, dtype=dtype)`. When dtype is a numpy string type, numpy converts None to the string "None". Meanwhile, `pd.Series` construction uses `lib.ensure_string_array()` (via `_try_cast()`), which preserves None by using object dtype.

## Solution

Detect string dtypes and route through `lib.ensure_string_array()` to match `pd.Series` behavior:
```python
if dtype is not None and getattr(dtype, "kind", None) == "U":
    result = lib.ensure_string_array(scalars, convert_na_value=False, copy=copy)
else:
    result = np.asarray(scalars, dtype=dtype)
```

## AI Tool Disclosure

This contribution was created with the assistance of Claude Code (AI coding assistant). All code has been fully reviewed, tested, and modified to comply with pandas contribution guidelines.