### PR TITLE
BUG: Suppress unnecessary RuntimeWarning in to_datetime with missing componentsFix runtime warning

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -110,7 +110,7 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
-- Fix bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`) 
+- Fix bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`)
 
 Categorical
 ^^^^^^^^^^^

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -110,6 +110,7 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
+- Fix bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`) 
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1177,7 +1177,8 @@ def sequence_to_td64ns(
         if unit is not None and unit != "ns":
             # if all non-NaN entries are round, treat these like ints and give
             #  back the requested unit (or closest-supported)
-            int_data = data.astype(np.int64)
+            with np.errstate(invalid="ignore"):
+                int_data = data.astype(np.int64)
             all_round = (mask | (data == int_data)).all()
             if all_round:
                 result, _ = sequence_to_td64ns(

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3827,3 +3827,19 @@ def test_to_datetime_lxml_elementunicoderesult_with_format(cache):
 
     out = to_datetime(Series([val]), format="%Y-%m-%d %H:%M:%S", cache=cache)
     assert out.iloc[0] == Timestamp(s)
+
+
+def test_to_datetime_missing_component_no_runtime_warning():
+    df = DataFrame(
+        {
+            "year": [2023, 2023],
+            "month": [12, 2],
+            "day": [1, 2],
+            "hour": [2, np.nan],
+        }
+    )
+
+    with tm.assert_produces_warning(None):
+        result = to_datetime(df)
+
+    assert result.iloc[1] is NaT


### PR DESCRIPTION
- [x] closes #64141
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Summary

Surpress uneccessary `RuntimeWarning`  in `to_datetime` when converting DataFrame with missing datetime value
Ignore NumPy invalid cast warning since missing value are correclt handled as `NaT`

Note: AI is only used to find the correct files related to issue