### PR TITLE
ENH: Implement stable parameter behavior in Series.argsort

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4176,6 +4176,15 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             # GH#54257 We allow -1 here so that np.argsort(series) works
             self._get_axis_number(axis)
 
+        if stable is not None:
+            if kind != "quicksort":
+                raise ValueError(
+                    "`kind` and keyword parameters can't be provided at the same time. "
+                    "Use only one of them."
+                )
+            if stable:
+                kind = "stable"
+
         result = self.array.argsort(kind=kind)
 
         res = self._constructor(

--- a/pandas/tests/series/methods/test_argsort.py
+++ b/pandas/tests/series/methods/test_argsort.py
@@ -74,3 +74,21 @@ class TestSeriesArgsort:
     def test_argsort_preserve_name(self, datetime_series):
         result = datetime_series.argsort()
         assert result.name == datetime_series.name
+
+    def test_argsort_stable_behavior():
+        ser = Series([3, 1, 2])
+        arr = np.array([3, 1, 2])
+
+        # 1. stable=True matches NumPy
+        result_stable_true = ser.argsort(stable=True).to_numpy()
+        expected_stable_true = np.argsort(arr, stable=True)
+        tm.assert_numpy_array_equal(result_stable_true, expected_stable_true)
+
+        # 2. stable=False matches NumPy
+        result_stable_false = ser.argsort(stable=False).to_numpy()
+        expected_stable_false = np.argsort(arr, stable=False)
+        tm.assert_numpy_array_equal(result_stable_false, expected_stable_false)
+
+        # 3. Conflicting kind and stable should raise
+        with pytest.raises(ValueError, match="kind.*keyword parameters"):
+            ser.argsort(kind="heapsort", stable=True)

--- a/pandas/tests/series/methods/test_argsort.py
+++ b/pandas/tests/series/methods/test_argsort.py
@@ -75,7 +75,7 @@ class TestSeriesArgsort:
         result = datetime_series.argsort()
         assert result.name == datetime_series.name
 
-    def test_argsort_stable_behavior():
+    def test_argsort_stable_behavior(self):
         ser = Series([3, 1, 2])
         arr = np.array([3, 1, 2])
 


### PR DESCRIPTION
- [x] closes #64255 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Note: Becuase of Python defaults, we cannot detect if `kind="quicksort"` was passed explicitly/. So `"quicksort"` is treated as the default. and try to show exact error and behavior like Numpy