### PR TITLE
CI: `validate_docstrings.py` breaks in WSL

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -67,7 +67,7 @@ fi
 if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Validate Docstrings' ; echo "$MSG"
-    "$BASE_DIR"/scripts/validate_docstrings.py \
+    python "$BASE_DIR"/scripts/validate_docstrings.py \
         --format=actions \
         -i "pandas.tseries.frequencies.to_offset ES01" \
         -i "pandas.Series.hist ES01" \


### PR DESCRIPTION
- [x] related to #64272
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Analogous issue with `generate_version.py`, which is fixed in #64275 

Evoke `validate_docstrings.py` with the `python` executable rather than by relying on its shebang. The same approach is already used for running other Python scripts in `code_checks.sh`