### PR TITLE
BUG: Fixed extra blank row in to_excel for MultiIndex with empty names (#27772)

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -42,6 +42,9 @@ Bug fixes
 - Fixed a bug where :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Fixed a bug where :meth:`DataFrame.div` ignored the ``axis`` argument when used with ``level`` for MultiIndex columns (:issue:`64428`)
 - Fixed a bug where assigning :class:`NA` to a string column could trigger a PyArrow error and corrupt data (:issue:`64320`)
+- :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
+- Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
+- Fixed bug in :meth:`DataFrame.to_excel` where an extra empty row was added when writing a :class:`MultiIndex` with no names (:issue:`27772`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_302.contributors:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -631,7 +631,7 @@ class ExcelFormatter:
             yield ExcelCell(
                 row=lnum,
                 col=coloffset,
-                val=name,
+                val=name if name is not None else "",
                 style=None,
             )
 
@@ -698,7 +698,7 @@ class ExcelFormatter:
 
         gen2: Iterable[ExcelCell] = ()
 
-        if self.df.index.names:
+        if com.any_not_none(*self.df.index.names):
             row = [x if x is not None else "" for x in self.df.index.names] + [
                 ""
             ] * len(self.columns)
@@ -779,7 +779,7 @@ class ExcelFormatter:
             # MultiIndex columns require an extra row
             # with index names (blank if None) for
             # unambiguous round-trip, Issue #11328
-            if isinstance(self.columns, MultiIndex):
+            if isinstance(self.columns, MultiIndex) and com.any_not_none(*self.df.index.names):
                 self.rowcounter += 1
 
             # if index labels are not empty go ahead and dump

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -734,7 +734,9 @@ class ExcelFormatter:
             else:
                 index_label = self.df.index.names[0]
 
-            if isinstance(self.columns, MultiIndex):
+            if isinstance(self.columns, MultiIndex) and com.any_not_none(
+                *self.df.index.names
+            ):
                 self.rowcounter += 1
 
             if index_label and self.header is not False:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -779,7 +779,9 @@ class ExcelFormatter:
             # MultiIndex columns require an extra row
             # with index names (blank if None) for
             # unambiguous round-trip, Issue #11328
-            if isinstance(self.columns, MultiIndex) and com.any_not_none(*self.df.index.names):
+            if isinstance(self.columns, MultiIndex) and com.any_not_none(
+                *self.df.index.names
+            ):
                 self.rowcounter += 1
 
             # if index labels are not empty go ahead and dump

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -631,7 +631,7 @@ class ExcelFormatter:
             yield ExcelCell(
                 row=lnum,
                 col=coloffset,
-                val=name if name is not None else "",
+                val=name,
                 style=None,
             )
 

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -371,34 +371,64 @@ class TestRoundTrip:
 
         tm.assert_frame_equal(result, expected)
 
-    def test_multiindex_no_empty_row(self, tmp_excel):
+    @pytest.mark.parametrize(
+        "index_type, columns_type",
+        [
+            ("multi", "multi"),
+            ("single", "multi"),
+            ("multi", "single"),
+        ],
+    )
+    def test_multiindex_no_empty_row_variations(
+        self, tmp_excel, index_type, columns_type
+    ):
         # GH 27772
-        # Setup: 2-level MultiIndex for rows and columns with names=None
-        row_mi = MultiIndex.from_tuples([("R1", 1), ("R1", 2)], names=[None, None])
-        col_mi = MultiIndex.from_tuples([("C1", "A"), ("C1", "B")], names=[None, None])
-        df = DataFrame([[10, 20], [30, 40]], index=row_mi, columns=col_mi)
+        # Setup row index
+        if index_type == "multi":
+            row_mi = MultiIndex.from_tuples([("R1", 1), ("R1", 2)], names=[None, None])
+        else:
+            row_mi = ["R1", "R2"]
 
+        # Setup column index
+        if columns_type == "multi":
+            col_mi = MultiIndex.from_tuples(
+                [("C1", "A"), ("C1", "B")], names=[None, None]
+            )
+        else:
+            col_mi = ["C1", "C2"]
+
+        df = DataFrame([[10, 20], [30, 40]], index=row_mi, columns=col_mi)
         df.to_excel(tmp_excel)
 
-        # Read the raw grid with no parsing
+        # Read the raw grid
         result = pd.read_excel(tmp_excel, header=None, index_col=None)
-
-        # Standardize: Convert "Unnamed: X" strings or Nones to np.nan
-        # This ensures tm.assert_frame_equal doesn't trip on engine-specific naming
         result = result.map(
             lambda x: np.nan if (pd.isna(x) or str(x).startswith("Unnamed:")) else x
         )
 
-        # Define the reference "physical layout"
-        expected = DataFrame(
-            [
+        # Dynamically build expected physical layout
+        if index_type == "multi" and columns_type == "multi":
+            expected_data = [
                 [np.nan, np.nan, "C1", np.nan],
                 [np.nan, np.nan, "A", "B"],
                 ["R1", 1, 10, 20],
                 [np.nan, 2, 30, 40],
             ]
-        )
+        elif index_type == "single" and columns_type == "multi":
+            expected_data = [
+                [np.nan, "C1", np.nan],
+                [np.nan, "A", "B"],
+                ["R1", 10, 20],
+                ["R2", 30, 40],
+            ]
+        else:  # multi index, single column
+            expected_data = [
+                [np.nan, np.nan, "C1", "C2"],
+                ["R1", 1, 10, 20],
+                [np.nan, 2, 30, 40],
+            ]
 
+        expected = DataFrame(expected_data)
         tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -370,6 +370,32 @@ class TestRoundTrip:
         )
 
         tm.assert_frame_equal(result, expected)
+        
+    def test_multiindex_no_empty_row(self, tmp_excel):
+        # GH 27772
+        # Setup: 2-level MultiIndex for rows and columns with names=None
+        row_mi = MultiIndex.from_tuples([("R1", 1), ("R1", 2)], names=[None, None])
+        col_mi = MultiIndex.from_tuples([("C1", "A"), ("C1", "B")], names=[None, None])
+        df = DataFrame([[10, 20], [30, 40]], index=row_mi, columns=col_mi)
+
+        df.to_excel(tmp_excel)
+        
+        # Read the raw grid with no parsing
+        result = pd.read_excel(tmp_excel, header=None, index_col=None)
+        
+        # Standardize: Convert "Unnamed: X" strings or Nones to np.nan
+        # This ensures tm.assert_frame_equal doesn't trip on engine-specific naming
+        result = result.map(lambda x: np.nan if (pd.isna(x) or str(x).startswith("Unnamed:")) else x)
+
+        # Define the reference "physical layout"
+        expected = DataFrame([
+            [np.nan, np.nan, "C1", np.nan],
+            [np.nan, np.nan, "A",  "B" ],
+            ["R1",   1,      10,    20 ],
+            [np.nan,   2,      30,    40 ]
+        ])
+
+        tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -370,7 +370,7 @@ class TestRoundTrip:
         )
 
         tm.assert_frame_equal(result, expected)
-        
+
     def test_multiindex_no_empty_row(self, tmp_excel):
         # GH 27772
         # Setup: 2-level MultiIndex for rows and columns with names=None
@@ -379,21 +379,25 @@ class TestRoundTrip:
         df = DataFrame([[10, 20], [30, 40]], index=row_mi, columns=col_mi)
 
         df.to_excel(tmp_excel)
-        
+
         # Read the raw grid with no parsing
         result = pd.read_excel(tmp_excel, header=None, index_col=None)
-        
+
         # Standardize: Convert "Unnamed: X" strings or Nones to np.nan
         # This ensures tm.assert_frame_equal doesn't trip on engine-specific naming
-        result = result.map(lambda x: np.nan if (pd.isna(x) or str(x).startswith("Unnamed:")) else x)
+        result = result.map(
+            lambda x: np.nan if (pd.isna(x) or str(x).startswith("Unnamed:")) else x
+        )
 
         # Define the reference "physical layout"
-        expected = DataFrame([
-            [np.nan, np.nan, "C1", np.nan],
-            [np.nan, np.nan, "A",  "B" ],
-            ["R1",   1,      10,    20 ],
-            [np.nan,   2,      30,    40 ]
-        ])
+        expected = DataFrame(
+            [
+                [np.nan, np.nan, "C1", np.nan],
+                [np.nan, np.nan, "A", "B"],
+                ["R1", 1, 10, 20],
+                [np.nan, 2, 30, 40],
+            ]
+        )
 
         tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
This PR resolves an issue where an additional blank row was inserted between the header and the data when exporting a DataFrame with a MultiIndex to Excel, specifically when the index levels have no names (None).

Changes:

Modified ExcelFormatter in _base.py to check if index names are actually present before incrementing the row counter for the "header-index" spacer.

Added a robust test case in test_writers.py that inspects the raw grid layout to ensure no "ghost rows" or literal "None" strings are present.

- [x] closes #27772
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (no new argument)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`. (used Gemini but with a "human in the loop" approach)
