### PR TITLE
ENH: allow urlopen timeout via storage_options

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -395,8 +395,8 @@ def _get_filepath_or_buffer(
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the
         # server responded with gzipped data
-        
-        # don't mutate user input 
+
+        # don't mutate user input
         storage_options = dict(storage_options or {})
 
         # Reserve "urlopen_timeout" for urllib, don't forward it as an HTTP header

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -332,7 +332,9 @@ def _get_filepath_or_buffer(
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
         host, port, username, password, etc. For HTTP(S) URLs the key-value pairs
-        are forwarded to ``urllib.request.Request`` as header options. For other
+        are forwarded to ``urllib.request.Request`` as header options except for
+        the reserved key ``urlopen_timeout`` which is passed as the ``timeout``
+        argument to ``urllib.request.urlopen`` (socket timeout, in seconds). For other
         URLs (e.g. starting with "s3://", and "gcs://") the key-value pairs are
         forwarded to ``fsspec.open``. Please see ``fsspec`` and ``urllib`` for more
         details, and for more examples on storage options refer `here
@@ -393,7 +395,13 @@ def _get_filepath_or_buffer(
         # TODO: fsspec can also handle HTTP via requests, but leaving this
         # unchanged. using fsspec appears to break the ability to infer if the
         # server responded with gzipped data
-        storage_options = storage_options or {}
+        
+        # don't mutate user input 
+        storage_options = dict(storage_options or {})
+
+        # Reserve "urlopen_timeout" for urllib, don't forward it as an HTTP header
+        timeout = storage_options.pop("urlopen_timeout", None)
+        urlopen_kwargs = {} if timeout is None else {"timeout": timeout}
 
         # waiting until now for importing to match intended lazy logic of
         # urlopen function defined elsewhere in this module
@@ -401,7 +409,7 @@ def _get_filepath_or_buffer(
 
         # assuming storage_options is to be interpreted as headers
         req_info = urllib.request.Request(filepath_or_buffer, headers=storage_options)
-        with urlopen(req_info) as req:
+        with urlopen(req_info, **urlopen_kwargs) as req:
             content_encoding = req.headers.get("Content-Encoding", None)
             if content_encoding == "gzip":
                 # Override compression based on Content-Encoding header

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -491,7 +491,7 @@ def test_urlopen_timeout_from_storage_options(monkeypatch):
         def __init__(self, data: bytes):
             self._data = data
             # pandas checks req.headers.get("Content-Encoding", None)
-            self.headers = {}
+            self.headers: dict[str, str] = {}
 
         def read(self) -> bytes:
             return self._data

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -482,6 +482,51 @@ class TestMMapWrapper:
             pd.read_csv(temp_file, compression=compression_, encoding=encoding)
 
 
+def test_urlopen_timeout_from_storage_options(monkeypatch):
+    import pandas.io.common as icom
+
+    called = {}
+
+    class DummyResponse:
+        def __init__(self, data: bytes):
+            self._data = data
+            # pandas checks req.headers.get("Content-Encoding", None)
+            self.headers = {}
+
+        def read(self) -> bytes:
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(req, **kwargs):
+        # capture timeout passed down into urlopen()
+        called["timeout"] = kwargs.get("timeout", None)
+
+        # req is a urllib.request.Request; its headers are normalized internally
+        # Ensure our reserved key was NOT forwarded as an HTTP header.
+        assert not any(k.lower() == "urlopen_timeout" for k in req.headers)
+
+        return DummyResponse(b"a,b\n1,2\n")
+
+    # Patch the wrapper used by pandas.io.common._get_filepath_or_buffer
+    monkeypatch.setattr(icom, "urlopen", fake_urlopen)
+
+    opts = {"urlopen_timeout": 5, "User-Agent": "foo"}
+
+    ioargs = icom._get_filepath_or_buffer(
+        "http://example.com/test.csv",
+        storage_options=opts,
+    )
+
+    assert called["timeout"] == 5
+    assert opts == {"urlopen_timeout": 5, "User-Agent": "foo"}  # not mutated
+    assert ioargs.filepath_or_buffer.getvalue() == b"a,b\n1,2\n"
+
+
 def test_is_fsspec_url():
     assert icom.is_fsspec_url("gcs://pandas/somethingelse.com")
     assert icom.is_fsspec_url("gs://pandas/somethingelse.com")


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
  - Added a unit test in pandas/tests/io/test_common.py for `storage_options={"urlopen_timeout": ...}` behavior (monkeypatching `pandas.io.common.urlopen`).
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
