### PR TITLE
TST: remove strict=False xfail from plotting test

### DIFF
--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -645,11 +645,6 @@ class TestDataFramePlots:
             assert xmin <= lines[0].get_data()[0][0]
             assert xmax >= lines[0].get_data()[0][-1]
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason="2020-12-01 this has been failing periodically on the "
-        "ymin==0 assertion for a week or so.",
-    )
     @pytest.mark.parametrize("stacked", [True, False])
     def test_area_lim(self, stacked):
         df = DataFrame(


### PR DESCRIPTION
#54209 made the np.random data deterministic, which _should_ prevent this test from being flaky.