### PR TITLE
BUG: HDFStore.select(where=...) silently returns empty DataFrame with datetime64[us] index

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -13,6 +13,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
+- Fixed regression in :meth:`HDFStore.select` where the ``where`` clause on a datetime index silently returned empty results when the index had non-nanosecond resolution (:issue:`64310`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_302.bug_fixes:

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -225,7 +225,10 @@ class BinOp(ops.BinOp):
             if isinstance(conv_val, (int, float)):
                 conv_val = stringify(conv_val)
             conv_val = ensure_decoded(conv_val)
-            conv_val = Timestamp(conv_val).as_unit("ns")
+            unit = "ns"
+            if "[" in kind:
+                unit = cast("TimeUnit", kind.split("[")[-1][:-1])
+            conv_val = Timestamp(conv_val).as_unit(unit)
             if conv_val.tz is not None:
                 conv_val = conv_val.tz_convert("UTC")
             return TermValue(conv_val, conv_val._value, kind)

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -225,7 +225,7 @@ class BinOp(ops.BinOp):
             if isinstance(conv_val, (int, float)):
                 conv_val = stringify(conv_val)
             conv_val = ensure_decoded(conv_val)
-            unit = "ns"
+            unit: TimeUnit = "ns"
             if "[" in kind:
                 unit = cast("TimeUnit", kind.split("[")[-1][:-1])
             conv_val = Timestamp(conv_val).as_unit(unit)


### PR DESCRIPTION

- [x] closes #64310  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
