### PR TITLE
DOC: clarify .loc Series-assignment alignment behavior

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -621,7 +621,8 @@ class IndexingMixin:
         **Assignment with Series**
 
         When assigning a Series to .loc[row_indexer, col_indexer], pandas aligns
-        the Series by index labels, not by order or position.
+        the Series by index labels, not by order or position. The same alignment
+        behavior applies to ``df[col] = series``.
 
         Series assignment with .loc and index alignment:
 
@@ -633,6 +634,17 @@ class IndexingMixin:
         0  1  20.0
         1  2  10.0
         2  3 NaN
+
+        This label-based alignment also applies when setting a subset of rows.
+
+        >>> df = pd.DataFrame({"A": [1, 2, 3]}, index=[0, 1, 2])
+        >>> s = pd.Series([100, 200], index=[2, 1])
+        >>> df.loc[[0, 2], "C"] = s
+        >>> df
+           A      C
+        0  1    NaN
+        1  2    NaN
+        2  3  100.0
         """
         return _LocIndexer("loc", self)
 
@@ -1582,7 +1594,8 @@ class _LocIndexer(_LocationIndexer):
     **Assignment with Series**
 
     When assigning a Series to .loc[row_indexer, col_indexer], pandas aligns
-    the Series by index labels, not by order or position.
+    the Series by index labels, not by order or position. The same alignment
+    behavior applies to ``df[col] = series``.
 
     Series assignment with .loc and index alignment:
 
@@ -1594,6 +1607,17 @@ class _LocIndexer(_LocationIndexer):
     0  1  20.0
     1  2  10.0
     2  3 NaN
+
+    This label-based alignment also applies when setting a subset of rows.
+
+    >>> df = pd.DataFrame({"A": [1, 2, 3]}, index=[0, 1, 2])
+    >>> s = pd.Series([100, 200], index=[2, 1])
+    >>> df.loc[[0, 2], "C"] = s
+    >>> df
+       A      C
+    0  1    NaN
+    1  2    NaN
+    2  3  100.0
     """
 
     _takeable: bool = False


### PR DESCRIPTION
## Summary
- clarify in `.loc` docs that Series assignment aligns by label and that the same alignment behavior applies to `df[col] = series`
- add an explicit `.loc` subset-row assignment example showing label alignment and resulting `NaN` for missing labels
- mirror the same additions in both `IndexingMixin.loc` and `_LocIndexer` docstrings to keep generated docs consistent

Closes #39845.

## Validation
- `python3 -m compileall pandas/core/indexing.py`
