### PR TITLE
DOC: clarify list-like conversion in DataFrame broadcasting behavior

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -210,13 +210,12 @@ either match on the *index* or *columns* via the **axis** keyword:
    df.sub(column, axis=0)
 
 List-like inputs are first converted to a ``Series`` and then aligned to columns
-by position. For example, if list elements are ``ndarray`` objects, each column
-is matched with one array object:
+by position:
 
 .. ipython:: python
 
    df2 = pd.DataFrame({"a": [0, 1, 2], "b": [10, 11, 12]})
-   rhs = [np.array([1, 1, 1]), np.array([2, 2, 2])]
+   rhs = [1, 2]
    df2 + rhs
 
 Furthermore you can align a level of a MultiIndexed DataFrame with a Series.

--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -209,6 +209,16 @@ either match on the *index* or *columns* via the **axis** keyword:
    df.sub(column, axis="index")
    df.sub(column, axis=0)
 
+List-like inputs are first converted to a ``Series`` and then aligned to columns
+by position. For example, if list elements are ``ndarray`` objects, each column
+is matched with one array object:
+
+.. ipython:: python
+
+   df2 = pd.DataFrame({"a": [0, 1, 2], "b": [10, 11, 12]})
+   rhs = [np.array([1, 1, 1]), np.array([2, 2, 2])]
+   df2 + rhs
+
 Furthermore you can align a level of a MultiIndexed DataFrame with a Series.
 
 .. ipython:: python


### PR DESCRIPTION
## Summary
- clarify that list-like RHS inputs in DataFrame binary ops are converted to `Series`
- document that this conversion aligns by column position
- add a short example where list elements are `ndarray` objects, showing why object-valued cells can appear

## Issue
Closes #18857

## Notes
This is a docs-only clarification in `user_guide/basics.rst` under the existing "Matching / broadcasting behavior" section.
