### PR TITLE
TST: fix xfailed plotting tests

### DIFF
--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -112,11 +112,10 @@ class TestDataFramePlots:
         _check_ticks_props(axes, xrot=0)
         _check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
-    @pytest.mark.xfail(reason="Api changed in 3.6.0")
     @pytest.mark.slow
     def test_plot_invalid_arg(self):
         df = DataFrame({"x": [1, 2], "y": [3, 4]})
-        msg = "'Line2D' object has no property 'blarg'"
+        msg = r"Line2D.set\(\) got an unexpected keyword argument 'blarg'"
         with pytest.raises(AttributeError, match=msg):
             df.plot.line(blarg=True)
 

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -201,17 +201,11 @@ class TestSeriesPlots:
         ax = ts.plot.hist(bins=5, ax=ax)
         ax = ts.plot.hist(align="left", stacked=True, ax=ax)
 
-    @pytest.mark.xfail(reason="Api changed in 3.6.0")
     def test_hist_kde(self, ts):
         pytest.importorskip("scipy")
         _, ax = mpl.pyplot.subplots()
         ax = ts.plot.hist(logy=True, ax=ax)
         _check_ax_scales(ax, yaxis="log")
-        xlabels = ax.get_xticklabels()
-        # ticks are values, thus ticklabels are blank
-        _check_text_labels(xlabels, [""] * len(xlabels))
-        ylabels = ax.get_yticklabels()
-        _check_text_labels(ylabels, [""] * len(ylabels))
 
     def test_hist_kde_plot_works(self, ts):
         pytest.importorskip("scipy")
@@ -221,16 +215,11 @@ class TestSeriesPlots:
         pytest.importorskip("scipy")
         _check_plot_works(ts.plot.density)
 
-    @pytest.mark.xfail(reason="Api changed in 3.6.0")
     def test_hist_kde_logy(self, ts):
         pytest.importorskip("scipy")
         _, ax = mpl.pyplot.subplots()
         ax = ts.plot.kde(logy=True, ax=ax)
         _check_ax_scales(ax, yaxis="log")
-        xlabels = ax.get_xticklabels()
-        _check_text_labels(xlabels, [""] * len(xlabels))
-        ylabels = ax.get_yticklabels()
-        _check_text_labels(ylabels, [""] * len(ylabels))
 
     def test_hist_kde_color_bins(self, ts):
         pytest.importorskip("scipy")

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -584,15 +584,12 @@ class TestSeriesPlots:
         # gh-14821: check if the values have any missing values
         assert any(~np.isnan(axes.lines[0].get_xdata()))
 
-    @pytest.mark.xfail(reason="Api changed in 3.6.0")
     def test_boxplot_series(self, ts):
         _, ax = mpl.pyplot.subplots()
         ax = ts.plot.box(logy=True, ax=ax)
         _check_ax_scales(ax, yaxis="log")
         xlabels = ax.get_xticklabels()
         _check_text_labels(xlabels, [ts.name])
-        ylabels = ax.get_yticklabels()
-        _check_text_labels(ylabels, [""] * len(ylabels))
 
     @pytest.mark.parametrize(
         "kind",


### PR DESCRIPTION
test_plot_invalid_arg just needed an updated exception message.

For the other three, claude says that the removed assertions are about "a matpotlib pre-render artifact".  I manually checked that the image produced looks correct.  (it looks like something that is dumb to make a histogram of bc the data being passed is unique.  I suspect that the original test data was larger and random but we smallified it to make the tests faster.)