### PR TITLE
PERF: use kth_smallest_c (O(n) quickselect) in group_quantile

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -104,6 +104,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.__getitem__` when selecting a
   single column by label on a :class:`DataFrame` with duplicate column names.
   (:issue:`64126`).
+- Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
 -
 
 .. ---------------------------------------------------------------------------


### PR DESCRIPTION
- [x] closes #55535 (Replace xxxx with the GitHub issue number)

Written by claude, checked manually by me.  Claude's description:

```
Replaces the O(n log n) PyArray_ArgSort in group_quantile with kth_smallest_c, an in-place quickselect already 
used by group_median_float64. NAs are pre-filtered into a malloc'd buffer per group, which also removes the 
need for special datetimelike NaT-ordering during the sort. With PyArray_ArgSort gone the entire group loop 
can now run with nogil.
```

For benchmarks I re-used the ones from #51722:

```
def time_quantile(nrows, ncols, ngroups):
    qs = [0.5, 0.75]
    np.random.seed(342464)
    arr = np.random.randn(nrows, ncols)
    df = pd.DataFrame(arr)
    df["A"] = np.random.randint(ngroups, size=nrows)

    gb = df.groupby("A")

    res = %timeit -o gb.quantile(qs)
    return res.average

timings = {}

for nrows in [10**5, 10**6, 10**7]:
    for ncols in [1, 5, 10]:
        for ngroups in [10, 100, 1000, 10000]:
            key = (nrows, ncols, ngroups)
            timings[key] = time_quantile(nrows, ncols, ngroups)
```

Did this both for the branch and main, with results:

```
                              PR      main     ratio
nrows    ncols ngroups                              
100000   1     10       0.001465  0.004830  3.297218
               100      0.001497  0.003612  2.413878
               1000     0.001699  0.003040  1.789195
               10000    0.002042  0.007548  3.695708
         5     10       0.006008  0.022532  3.750351
               100      0.006162  0.017569  2.851134
               1000     0.007643  0.014530  1.901058
               10000    0.009297  0.037099  3.990209
         10    10       0.011676  0.047364  4.056418
               100      0.012687  0.034440  2.714561
               1000     0.015220  0.028742  1.888461
               10000    0.018570  0.073535  3.959829
1000000  1     10       0.014591  0.061686  4.227789
               100      0.016307  0.052029  3.190653
               1000     0.016382  0.040706  2.484796
               10000    0.019700  0.033109  1.680687
         5     10       0.060962  0.291152  4.775992
               100      0.065525  0.230587  3.519046
               1000     0.068881  0.181701  2.637898
               10000    0.082409  0.147250  1.786815
         10    10       0.117233  0.593391  5.061646
               100      0.125051  0.458625  3.667504
               1000     0.133698  0.348497  2.606601
               10000    0.163415  0.300555  1.839214
10000000 1     10       0.158154  0.753921  4.767015
               100      0.254546  0.687054  2.699132
               1000     0.249855  0.565732  2.264246
               10000    0.247494  0.460997  1.862656
         5     10       0.639675  3.675702  5.746207
               100      0.747488  3.092634  4.137369
               1000     0.802854  2.507813  3.123621
               10000    0.809624  1.882959  2.325719
         10    10       1.402854  7.602455  5.419279
               100      1.508487  6.278624  4.162201
               1000     1.630688  5.056155  3.100627
               10000    1.688307  4.005462  2.372473
```

so perf improvement is from 1.68x to 5.75x.  Biggest impact in small-ngroups cases.