### PR TITLE
TST: regression test for HDFStore.select with non-sorted Categorical (GH#38131)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -170,6 +170,7 @@ MultiIndex
 I/O
 ^^^
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
+- Fixed bug in :meth:`HDFStore.select` where filtering a ``Categorical`` column with a non-alphabetical category order returned wrong rows (:issue:`38131`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -170,7 +170,6 @@ MultiIndex
 I/O
 ^^^
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
-- Fixed bug in :meth:`HDFStore.select` where filtering a ``Categorical`` column with a non-alphabetical category order returned wrong rows (:issue:`38131`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)

--- a/pandas/tests/io/pytables/test_categorical.py
+++ b/pandas/tests/io/pytables/test_categorical.py
@@ -4,6 +4,7 @@ import pytest
 from pandas import (
     Categorical,
     DataFrame,
+    HDFStore,
     Series,
     _testing as tm,
     concat,
@@ -186,4 +187,18 @@ def test_convert_value(temp_h5_path, where: str, expected):
 
     df.to_hdf(temp_h5_path, key="df", format="table", min_itemsize=max_widths)
     result = read_hdf(temp_h5_path, where=f'col=="{where}"')
+    tm.assert_frame_equal(result, expected)
+
+
+def test_categorical_select_non_sorted_categories(temp_h5_path):
+    # GH#38131 - select() returned wrong rows for non-sorted category order
+    df = DataFrame(
+        {"col1": Categorical(["a", "b", "c", "a"], categories=["c", "b", "a"])}
+    )
+
+    with HDFStore(temp_h5_path) as store:
+        store.append("df", df, data_columns=df.columns)
+        result = store.select("df", "col1='a'")
+
+    expected = df[df["col1"] == "a"]
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #38131

This was fixed by #61225.

Claude wrote this, I reviewed it manually.
