### PR TITLE
DOC: clarify read_fwf filepath_or_buffer semantics

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1498,11 +1498,14 @@ def read_fwf(
     Parameters
     ----------
     filepath_or_buffer : str, path object, or file-like object
-        String, path object (implementing ``os.PathLike[str]``), or file-like
-        object implementing a text ``read()`` function.The string could be a URL.
+        Any valid string path is acceptable. The string could be a URL.
         Valid URL schemes include http, ftp, s3, and file. For file URLs, a host is
-        expected. A local file could be:
-        ``file://localhost/path/to/table.csv``.
+        expected. A local file could be: ``file://localhost/path/to/table.csv``.
+
+        If you want to pass in a path object, pandas accepts any ``os.PathLike``.
+
+        By file-like object, we refer to objects with a ``read()`` method, such as
+        a file handle (e.g. via builtin ``open`` function) or ``StringIO``.
     colspecs : list of tuple (int, int) or 'infer'. optional
         A list of tuples giving the extents of the fixed-width
         fields of each line as half-open intervals (i.e.,  [from, to] ).


### PR DESCRIPTION
## Summary
- clarify `read_fwf(filepath_or_buffer=...)` docs so `str` is clearly documented as a file path/URL
- align wording with `read_csv` docs for path-like and file-like objects
- explicitly mention `StringIO` for in-memory text input

Closes #55790.

## Validation
- `python3 -m compileall pandas/io/parsers/readers.py`
