### PR TITLE
DOC: clarify Index.union behavior with duplicates

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3022,8 +3022,12 @@ class Index(IndexOpsMixin, PandasObject):
         Returns
         -------
         Index
-            Returns a new Index object with all unique elements from both the original
+            Returns a new Index object with elements from both the original
             Index and the `other` Index.
+
+            If an element is duplicated in either input Index, the result
+            includes that element with the highest multiplicity from either
+            input.
 
         See Also
         --------
@@ -3046,6 +3050,13 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx2 = pd.Index([1, 2, 3, 4])
         >>> idx1.union(idx2)
         Index(['a', 'b', 'c', 'd', 1, 2, 3, 4], dtype='object')
+
+        Union with duplicates
+
+        >>> idx1 = pd.Index([1, 1, 2, 3])
+        >>> idx2 = pd.Index([1, 2, 2, 4])
+        >>> idx1.union(idx2)
+        Index([1, 1, 2, 2, 3, 4], dtype='int64')
 
         MultiIndex case
 


### PR DESCRIPTION
## Summary
- clarify `Index.union` return description for indexes with duplicate labels
- add an explicit example showing duplicate-preserving (max multiplicity) behavior

## Why
The previous docstring said union returns all unique elements, which is misleading when either input index contains duplicates. `Index.union` keeps duplicates up to the maximum multiplicity seen across the two inputs.

Closes #56137
