### PR TITLE
DOC: explain read_csv/read_table float_precision behavior

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -736,9 +736,15 @@ def read_csv(
         option can improve performance because there is no longer any I/O overhead.
     float_precision : {{'high', 'legacy', 'round_trip'}}, optional
         Specifies which converter the C engine should use for floating-point
-        values. The options are ``None`` or ``'high'`` for the ordinary converter,
-        ``'legacy'`` for the original lower precision pandas converter, and
-        ``'round_trip'`` for the round-trip converter.
+        values. This affects how text is converted to Python floating-point
+        values.
+
+        - ``None`` or ``'high'``: use the default high-precision converter.
+        - ``'legacy'``: use the original lower precision pandas converter.
+        - ``'round_trip'``: use the round-trip converter.
+
+        ``'round_trip'`` minimizes cases where reading and then writing a value
+        changes its textual representation.
 
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
@@ -1299,9 +1305,15 @@ def read_table(
         option can improve performance because there is no longer any I/O overhead.
     float_precision : {{'high', 'legacy', 'round_trip'}}, optional
         Specifies which converter the C engine should use for floating-point
-        values. The options are ``None`` or ``'high'`` for the ordinary converter,
-        ``'legacy'`` for the original lower precision pandas converter, and
-        ``'round_trip'`` for the round-trip converter.
+        values. This affects how text is converted to Python floating-point
+        values.
+
+        - ``None`` or ``'high'``: use the default high-precision converter.
+        - ``'legacy'``: use the original lower precision pandas converter.
+        - ``'round_trip'``: use the round-trip converter.
+
+        ``'round_trip'`` minimizes cases where reading and then writing a value
+        changes its textual representation.
 
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
@@ -2068,9 +2080,15 @@ def TextParser(*args, **kwds) -> TextFileReader:
         Encoding to use for UTF when reading/writing (ex. 'utf-8')
     float_precision : str, optional
         Specifies which converter the C engine should use for floating-point
-        values. The options are `None` or `high` for the ordinary converter,
-        `legacy` for the original lower precision pandas converter, and
-        `round_trip` for the round-trip converter.
+        values. This affects how text is converted to Python floating-point
+        values.
+
+        - ``None`` or ``high``: use the default high-precision converter.
+        - ``legacy``: use the original lower precision pandas converter.
+        - ``round_trip``: use the round-trip converter.
+
+        ``round_trip`` minimizes cases where reading and then writing a value
+        changes its textual representation.
     """
     kwds["engine"] = "python"
     return TextFileReader(*args, **kwds)


### PR DESCRIPTION
## Problem
`float_precision` in `read_csv` / `read_table` is currently under-explained: users see option names (`high`, `legacy`, `round_trip`) but not the practical behavior/tradeoffs (issue #64094).

## What this PR changes
- clarifies that `float_precision` controls text-to-float conversion behavior in the C parser
- documents each option explicitly:
  - `None` / `high`: default high-precision converter
  - `legacy`: original lower-precision converter
  - `round_trip`: converter focused on round-trip-safe text representation
- explains “round-trip” in practical terms (minimizes representation changes when reading then writing values)

## Scope
- docs-only change in parser docs shared by `read_csv` / `read_table`
- no parser behavior changes

Closes #64094.

## Validation
- `python3 -m compileall pandas/io/parsers/readers.py`
- `git diff --check`
