### PR TITLE
DOC: clarify Series.case_when condition-order semantics

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6369,6 +6369,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         caselist : A list of tuples of conditions and expected replacements
             Takes the form:  ``(condition0, replacement0)``,
             ``(condition1, replacement1)``, ... .
+            Entries are evaluated in order. For each element, the first
+            matching condition in ``caselist`` is used, and later conditions
+            are ignored for that element.
+            Elements that do not match any condition retain their original
+            value.
             ``condition`` should be a 1-D boolean array-like object
             or a callable. If ``condition`` is a callable,
             it is computed on the Series
@@ -6398,8 +6403,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         >>> c.case_when(
         ...     caselist=[
-        ...         (a.gt(0), a),  # condition, replacement
-        ...         (b.gt(0), b),
+        ...         (a.gt(0), a),  # first matching condition wins
+        ...         (b.gt(0), b),  # used only where a.gt(0) is False
         ...     ]
         ... )
         0    6


### PR DESCRIPTION
## Problem
`Series.case_when` docs do not make evaluation order explicit enough for non-SQL users (issue #64144). The current example can be misread as “last match wins”.

## What this PR changes
- explicitly documents that conditions are evaluated in order
- clarifies per-element behavior: first matching condition wins; later conditions are ignored for that element
- clarifies that unmatched elements retain original values
- updates example comments to make precedence behavior visible at a glance

## Scope
- docstring clarification only
- no behavior change

Closes #64144.

## Validation
- `python3 -m compileall pandas/core/series.py`
- `git diff --check`
