### PR TITLE
DOC: use correct version for stable source links in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -699,7 +699,7 @@ def linkcode_resolve(domain, info) -> str | None:
     else:
         return (
             f"https://github.com/pandas-dev/pandas/blob/"
-            f"v{pandas.__version__}/pandas/{fn}{linespec}"
+            f"v{version}/pandas/{fn}{linespec}"
         )
 
 


### PR DESCRIPTION
## Summary
- use `version` instead of `pandas.__version__` when building the non-dev GitHub source link in `linkcode_resolve`
- this ensures stable docs point to an existing tag (for example `v3.0.1`) instead of a local version string like `v3.0.1+1.g...`

Closes #64223

- [x] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed (docs config only)
- [ ] All code checks passed (not run locally)
- [ ] Added type annotations to new arguments/methods/functions (N/A)
- [ ] Added an entry in `doc/source/whatsnew/vX.X.X.rst` (N/A)
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.