### PR TITLE
DOC: Use more representative food items in MultiIndex query example

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1206,7 +1206,7 @@ You can also use the levels of a ``DataFrame`` with a
 
    n = 10
    colors = np.random.choice(['red', 'green'], size=n)
-   foods = np.random.choice(['eggs', 'ham'], size=n)
+   foods = np.random.choice(['rice', 'lentils'], size=n)
    colors
    foods
 


### PR DESCRIPTION
Replace `['eggs', 'ham']` with `['rice', 'lentils']` in the MultiIndex query example in `doc/source/user_guide/indexing.rst`.

The example demonstrates `.query()` filtering on a MultiIndex — the choice of food items is arbitrary. Plant-based staples (rice, lentils) are equally representative for this use case and reflect a broader range of common foods in real-world datasets.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.