### PR TITLE
DOC: Replace pig with deer in Series.to_markdown docstring example

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1718,12 +1718,12 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Examples
             --------
-            >>> s = pd.Series(["elk", "pig", "dog", "quetzal"], name="animal")
+            >>> s = pd.Series(["elk", "deer", "dog", "quetzal"], name="animal")
             >>> print(s.to_markdown())
             |    | animal   |
             |---:|:---------|
             |  0 | elk      |
-            |  1 | pig      |
+            |  1 | deer     |
             |  2 | dog      |
             |  3 | quetzal  |
 
@@ -1735,7 +1735,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             +====+==========+
             |  0 | elk      |
             +----+----------+
-            |  1 | pig      |
+            |  1 | deer     |
             +----+----------+
             |  2 | dog      |
             +----+----------+


### PR DESCRIPTION
Replace `"pig"` with `"deer"` in the `Series.to_markdown` docstring example in `pandas/core/series.py`.

The example illustrates markdown table output — the specific animal names are arbitrary. This updates all three affected lines: the Series constructor and both rendered table outputs (pipe and grid formats). No functional change; the column widths in the rendered output are unchanged since both "pig" and "deer" are shorter than "quetzal", which sets the column width.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.