### PR TITLE
PERF: floatify

### DIFF
--- a/pandas/_libs/src/parser/pd_parser.c
+++ b/pandas/_libs/src/parser/pd_parser.c
@@ -25,25 +25,25 @@ static int to_double(char *item, double *p_value, char sci, char decimal,
 }
 
 static int floatify(PyObject *str, double *result, int *maybe_int) {
-  char *data;
-  PyObject *tmp = NULL;
+  const char *data;
   const char sci = 'E';
   const char dec = '.';
 
   if (PyBytes_Check(str)) {
     data = PyBytes_AS_STRING(str);
   } else if (PyUnicode_Check(str)) {
-    tmp = PyUnicode_AsUTF8String(str);
-    if (tmp == NULL) {
+    // PyUnicode_AsUTF8 returns a pointer to the string's internal UTF-8
+    // buffer (caching it on the object), avoiding a heap allocation.
+    data = PyUnicode_AsUTF8(str);
+    if (data == NULL) {
       return -1;
     }
-    data = PyBytes_AS_STRING(tmp);
   } else {
     PyErr_SetString(PyExc_TypeError, "Invalid object type");
     return -1;
   }
 
-  const int status = to_double(data, result, sci, dec, maybe_int);
+  const int status = to_double((char *)data, result, sci, dec, maybe_int);
 
   if (!status) {
     /* handle inf/-inf infinity/-infinity */
@@ -86,12 +86,10 @@ static int floatify(PyObject *str, double *result, int *maybe_int) {
     }
   }
 
-  Py_XDECREF(tmp);
   return 0;
 
 parsingerror:
   PyErr_Format(PyExc_ValueError, "Unable to parse string \"%s\"", data);
-  Py_XDECREF(tmp);
   return -1;
 }
 


### PR DESCRIPTION
claude says this avoids an allocation, but I'd like to get @willayd's thoughts.

9-10% speedup in pd.to_numeric on floaty strings:

```
N = 200_000
rng = np.random.default_rng(0)

shorts = pd.array([f"{v:.4f}" for v in rng.uniform(0, 1e4, N)], dtype=object)
longs = pd.array([f"{v:.17g}" for v in rng.uniform(0, 1e15, N)], dtype=object)

%timeit pd.to_numeric(shorts)
26 ms ± 203 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)    # <- main
23.8 ms ± 284 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR

%timeit pd.to_numeric(longs)
29.5 ms ± 306 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- main
26.7 ms ± 527 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR
```