### PR TITLE
BUG: fix 1-ULP rounding error in precise_xstrtod via uint64_t mantissa accumulation

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1619,15 +1619,18 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     break;
   }
 
-  double number = 0.;
   long int exponent = 0;
   long int num_digits = 0;
   long int num_decimals = 0;
 
+  // Accumulate mantissa digits as an integer to avoid per-digit FP rounding.
+  // max_digits=17 decimal digits fit safely in uint64_t (max ~9.9e17 < 2^64).
+  uint64_t mantissa = 0;
+
   // Process string of digits.
   while (isdigit_ascii(*p)) {
     if (num_digits < max_digits) {
-      number = number * 10. + (*p - '0');
+      mantissa = mantissa * 10 + (*p - '0');
       num_digits++;
     } else {
       ++exponent;
@@ -1644,7 +1647,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     p++;
 
     while (num_digits < max_digits && isdigit_ascii(*p)) {
-      number = number * 10. + (*p - '0');
+      mantissa = mantissa * 10 + (*p - '0');
       p++;
       num_digits++;
       num_decimals++;
@@ -1661,6 +1664,10 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     *error = ERANGE;
     return 0.0;
   }
+
+  // Single conversion from integer mantissa to double: at most one rounding,
+  // compared to up to max_digits roundings in the old FP accumulation loop.
+  double number = (double)mantissa;
 
   // Correct for sign.
   if (negative)

--- a/pandas/tests/io/parser/common/test_float.py
+++ b/pandas/tests/io/parser/common/test_float.py
@@ -98,6 +98,36 @@ def test_small_int_followed_by_float(
 
 
 @pytest.mark.parametrize(
+    "value",
+    [
+        "90071992547409930.0",
+        "90071992547409931.0",
+        "90071992547409935.0",
+        "90071992547409938.0",
+    ],
+)
+def test_precise_xstrtod_large_mantissa(c_parser_only, value):
+    # GH#XXXXX
+    # When a 17-digit mantissa's 16-digit prefix crosses 2^53
+    # (= 9007199254740992), the old per-digit FP accumulation
+    #   number = number * 10. + digit
+    # introduced a rounding error at step 16 that shifted the final result
+    # by one ULP.  Specifically, the 16-digit prefix 9007199254740993
+    # (= 2^53 + 1) was not representable as a double and rounded down to
+    # 9007199254740992, causing subsequent arithmetic to produce a value
+    # ~10 units below the true mantissa.  With ULP = 16 near 9e16, this
+    # 10-unit error was enough to round to the wrong double.
+    #
+    # The fix accumulates mantissa digits in uint64_t and converts to
+    # double once, so there is at most one rounding instead of up to
+    # max_digits=17.
+    parser = c_parser_only
+    data = f"val\n{value}"
+    result = parser.read_csv(StringIO(data), float_precision="high")["val"][0]
+    assert result == float(value)
+
+
+@pytest.mark.parametrize(
     "value", ["81e31d04049863b72", "d81e31d04049863b72", "81e3104049863b72"]
 )
 def test_invalid_float_number(all_parsers_all_precisions, value):


### PR DESCRIPTION
Claude wrote this, I reviewed it manually.

- In `precise_xstrtod`, mantissa digits were accumulated directly into a `double` via repeated `number = number * 10. + digit` FP multiply-adds. Each operation can round, giving up to `max_digits=17` independent rounding events before the final power-of-10 scaling step.
- The fix accumulates digits into a `uint64_t` instead (17 decimal digits fit safely; max ~9.9×10¹⁷ < 2⁶⁴), then converts to `double` once. This gives at most one rounding for the mantissa.
- Adds a regression test demonstrating the old code returned a result 1 ULP off for mantissas whose 16-digit prefix crosses 2⁵³ (= 9007199254740992). For example, parsing `"90071992547409930.0"` with `float_precision="high"` previously returned `9.007199254740992e+16` instead of the correctly-rounded `9.007199254740994e+16`.

The 16-digit prefix `9007199254740993 = 2⁵³ + 1` is not representable as a `double` (IEEE 754 doubles only represent even integers above 2⁵³), so it rounded down to `9007199254740992`. Subsequent arithmetic then produced a mantissa ~10 integer units below the true value. Near 9×10¹⁶ the ULP is 16, so a 10-unit error is enough to round to the wrong double.
