### PR TITLE
BUG: pd.array now rejects multidimensional arguments

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -151,6 +151,12 @@ class NumpyExtensionArray(
             # e.g. list-of-tuples
             result = construct_1d_object_array_from_listlike(scalars)
 
+        if result.ndim != 1:
+            raise ValueError(
+                "NumpyExtensionArray must be 1-dimensional. "
+                f"Got {result.ndim}-dimensional array instead."
+            )
+
         if copy and result is scalars:
             result = result.copy()
         return cls(result)

--- a/pandas/tests/arrays/numpy_/test_numpy.py
+++ b/pandas/tests/arrays/numpy_/test_numpy.py
@@ -127,6 +127,20 @@ def test_from_sequence_dtype():
     tm.assert_extension_array_equal(result, expected)
 
 
+def test_from_sequence_raises_2d():
+    # GH#64280
+    arr = np.array([[1, 2], [3, 4]], dtype="int64")
+    with pytest.raises(ValueError, match="must be 1-dimensional"):
+        NumpyExtensionArray._from_sequence(arr, dtype="int64")
+
+
+def test_from_sequence_raises_2d_float():
+    # GH#64280
+    arr = np.array([[1, 2], [3, 4]], dtype="float64")
+    with pytest.raises(ValueError, match="must be 1-dimensional"):
+        NumpyExtensionArray._from_sequence(arr, dtype="float64")
+
+
 def test_constructor_copy():
     arr = np.array([0, 1])
     result = NumpyExtensionArray(arr, copy=True)

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -494,6 +494,21 @@ def test_nd_raises(data):
         pd.array(data, dtype="int64")
 
 
+@pytest.mark.parametrize(
+    "data, dtype",
+    [
+        ([[1, 2], [3, 4]], np.float64),
+        ([[1, 2], [3, 4]], np.int64),
+        (np.array([[1, 2], [3, 4]]), np.float64),
+        (np.array([[1, 2], [3, 4]]), np.int64),
+    ],
+)
+def test_nd_raises_2d(data, dtype):
+    # GH#64280
+    with pytest.raises(ValueError, match="NumpyExtensionArray must be 1-dimensional"):
+        pd.array(data, dtype=dtype)
+
+
 def test_scalar_raises():
     with pytest.raises(ValueError, match="Cannot pass scalar '1'"):
         pd.array(1)


### PR DESCRIPTION
## Summary

- Fixes #64280
- Add validation in `NumpyExtensionArray._from_sequence` to reject non-1D input
- Enforces the documented behavior for `pd.array` which states it should raise `ValueError` for non-1D input

## Details

Previously, `pd.array` accepted 2D arrays when a NumPy dtype was specified:

```python
pd.array([[1, 9], [2, 6], [3, 5]], dtype=np.float64)
# Before: returned a 2D NumpyExtensionArray
# After: raises ValueError
```

The fix adds a dimensionality check in `_from_sequence` to raise a `ValueError` when the input is not 1-dimensional. This does not affect internal operations that directly construct `NumpyExtensionArray` with 2D arrays (e.g., `test_np_reduce_2d`), as those bypass `_from_sequence`.

## Test Plan

- Added `test_from_sequence_raises_2d` and `test_from_sequence_raises_2d_float` in `pandas/tests/arrays/numpy_/test_numpy.py`
- Added `test_nd_raises_2d` in `pandas/tests/arrays/test_array.py` to test the `pd.array` function directly