### PR TITLE
TST: Use EA scalar instead of python scalar in `test_compare_scalar`

### DIFF
--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -238,7 +238,7 @@ class BaseComparisonOpsTests(BaseOpsUtil):
 
     def test_compare_scalar(self, data, comparison_op):
         ser = pd.Series(data)
-        self._compare_other(ser, data, comparison_op, 0)
+        self._compare_other(ser, data, comparison_op, data[0])
 
     def test_compare_array(self, data, comparison_op):
         ser = pd.Series(data)

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -288,6 +288,12 @@ class TestJSONArray(base.ExtensionTests):
             request.applymarker(mark)
         super().test_arith_frame_with_scalar(data, all_arithmetic_operators)
 
+    def test_compare_scalar(self, data, comparison_op, request):
+        if comparison_op.__name__ in ["eq", "ne"]:
+            mark = pytest.mark.xfail(reason="Comparison methods not implemented")
+            request.applymarker(mark)
+        super().test_compare_scalar(data, comparison_op)
+
     def test_compare_array(self, data, comparison_op, request):
         if comparison_op.__name__ in ["eq", "ne"]:
             mark = pytest.mark.xfail(reason="Comparison methods not implemented")


### PR DESCRIPTION
The test `BaseComparisonOpsTests::test_compare_scalar` is supposed to test comparison operations of a Series containing an Extension Array with a scalar element. The test here uses the python scalar `0` as the `other` object of the comparison whereas the similar test `BaseComparisonOpsTests::test_compare_array` uses `data[0] * len(data)` to create the `other` object:
https://github.com/pandas-dev/pandas/blob/8130978f1babeb6c87382ae1698f96706c71c532/pandas/tests/extension/base/ops.py#L239-L246

With this PR I propose to also use `data[0]` in the `test_compare_scalar` tests as it seems more logical to me to test comparison between the EA and a scalar of the EA type instead of a python native scalar. For the astropy EA I am working on this caused issues for the `le`, `lt`, `ge`, and `gt` operators, see: [Issue #6](https://github.com/Julian-Harbeck/pandas-units-extension/issues/6).