### PR TITLE
PERF: left join fastpath

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -105,8 +105,8 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.__getitem__` when selecting a
   single column by label on a :class:`DataFrame` with duplicate column names.
   (:issue:`64126`).
+- Performance improvement in :func:`merge` with ``how="left"`` (:issue:`64370`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
--
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2923,12 +2923,22 @@ def _factorize_keys(
         lk_data, rk_data = lk, rk  # type: ignore[assignment]
         lk_mask, rk_mask = None, None
 
-    hash_join_available = how == "inner" and not sort and lk.dtype.kind in "iufb"
+    hash_join_available = (
+        how in ("inner", "left") and not sort and lk.dtype.kind in "iufb"
+    )
     if hash_join_available:
         rlab = rizer.factorize(rk_data, mask=rk_mask)
         if rizer.get_count() == len(rlab):
             ridx, lidx = rizer.hash_inner_join(lk_data, lk_mask)
-            return lidx, ridx, -1
+            if how == "inner":
+                return lidx, ridx, -1
+            # left-outer hash join with unique right side.
+            # Preserve original left-row order: one output row per left row,
+            # ridx=-1 for unmatched rows.
+            n_left = len(lk_data)
+            ridx_full = np.full(n_left, -1, dtype=np.intp)
+            ridx_full[lidx] = ridx
+            return np.arange(n_left, dtype=np.intp), ridx_full, -1
         else:
             llab = rizer.factorize(lk_data, mask=lk_mask)
     else:


### PR DESCRIPTION
Written by claude, reviewed manually by me.  But I don't do a ton of joins myself, so I'd like to get @rhshadrach to take a look.

```
rng = np.random.default_rng(42)
N_LEFT, N_RIGHT = 5_000_000, 200_000
left  = pd.DataFrame({"id": rng.integers(0, N_RIGHT, N_LEFT, dtype=np.int64)})
right = pd.DataFrame({"id": np.arange(N_RIGHT, dtype=np.int64), "v": rng.random(N_RIGHT)})

%timeit pd.merge(left, right, on="id", how="left", sort=False)
183 ms ± 6.11 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- main
78.2 ms ± 1.61 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- PR
```