### PR TITLE
REGR/PERF: Fix perf regression in _LocationIndexer._post_expansion_casting

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -955,14 +955,12 @@ class _LocationIndexer(NDFrameIndexerBase):
                     self.obj._mgr = new_ser._mgr
             elif orig_obj.shape[1] == self.obj.shape[1]:
                 # We added rows but not columns
-                for i in range(orig_obj.shape[1]):
-                    new_dtype = self.obj.dtypes.iloc[i]
-                    orig_dtype = orig_obj.dtypes.iloc[i]
-                    if new_dtype != orig_dtype:
-                        new_arr = infer_and_maybe_downcast(
-                            orig_obj.iloc[:, i].array, self.obj.iloc[:, i]._values
-                        )
-                        self.obj.isetitem(i, new_arr)
+                mask = (self.obj.dtypes != orig_obj.dtypes).reset_index(drop=True)
+                for i, same_dtype in mask[mask].items():
+                    new_arr = infer_and_maybe_downcast(
+                        orig_obj.iloc[:, i].array, self.obj.iloc[:, i]._values
+                    )
+                    self.obj.isetitem(i, new_arr)
 
             elif orig_obj.columns.is_unique and self.obj.columns.is_unique:
                 for col in orig_obj.columns:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -958,12 +958,11 @@ class _LocationIndexer(NDFrameIndexerBase):
                 changed_dtypes = (
                     self.obj._mgr.get_dtypes() != orig_obj._mgr.get_dtypes()
                 )
-                for i, changed_dtype in enumerate(changed_dtypes):
-                    if changed_dtype:
-                        new_arr = infer_and_maybe_downcast(
-                            orig_obj.iloc[:, i].array, self.obj.iloc[:, i]._values
-                        )
-                        self.obj.isetitem(i, new_arr)
+                for i in np.flatnonzero(changed_dtypes):
+                    new_arr = infer_and_maybe_downcast(
+                        orig_obj.iloc[:, i].array, self.obj.iloc[:, i]._values
+                    )
+                    self.obj.isetitem(i, new_arr)
 
             elif orig_obj.columns.is_unique and self.obj.columns.is_unique:
                 for col in orig_obj.columns:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -955,12 +955,15 @@ class _LocationIndexer(NDFrameIndexerBase):
                     self.obj._mgr = new_ser._mgr
             elif orig_obj.shape[1] == self.obj.shape[1]:
                 # We added rows but not columns
-                mask = (self.obj.dtypes != orig_obj.dtypes).reset_index(drop=True)
-                for i, same_dtype in mask[mask].items():
-                    new_arr = infer_and_maybe_downcast(
-                        orig_obj.iloc[:, i].array, self.obj.iloc[:, i]._values
-                    )
-                    self.obj.isetitem(i, new_arr)
+                changed_dtypes = (
+                    self.obj._mgr.get_dtypes() != orig_obj._mgr.get_dtypes()
+                )
+                for i, changed_dtype in enumerate(changed_dtypes):
+                    if changed_dtype:
+                        new_arr = infer_and_maybe_downcast(
+                            orig_obj.iloc[:, i].array, self.obj.iloc[:, i]._values
+                        )
+                        self.obj.isetitem(i, new_arr)
 
             elif orig_obj.columns.is_unique and self.obj.columns.is_unique:
                 for col in orig_obj.columns:


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/pandas/pull/62523
Ref: https://github.com/pandas-dev/asv-runner/issues/104

<details>

```python
dtype = "Float64"
inplace = True
N, M = 10000, 100
if dtype in ("datetime64[ns]", "datetime64[ns, tz]", "timedelta64[ns]"):
    data = {
        "datetime64[ns]": date_range("2011-01-01", freq="h", periods=N),
        "datetime64[ns, tz]": date_range(
            "2011-01-01", freq="h", periods=N, tz="Asia/Tokyo"
        ),
        "timedelta64[ns]": timedelta_range(start="1 day", periods=N, freq="1D"),
    }
    df = DataFrame({f"col_{i}": data[dtype] for i in range(M)})
    df[::2] = None
else:
    values = np.random.randn(N, M)
    values[::2] = np.nan
    if dtype == "Int64":
        values = values.round()
        values = values.astype(object)
        values[::2] = NA
    df = DataFrame(values, dtype=dtype)
fill_values = df.iloc[df.first_valid_index()].to_dict()

df.fillna(value=fill_values, inplace=inplace)
# 1.2s <-- main
# 120 ms <-- PR
```

</details>

Still a large regression after this (~25ms -> 120ms), but at a glance doesn't seem easy to clawback the rest.

cc @jbrockmendel