### PR TITLE
CI: CI/CD hardening

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash -el {0}
 
     - name: Publish test results
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: Test results
         path: test-data.xml

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -7,14 +7,14 @@ runs:
       shell: bash -el {0}
 
     - name: Publish test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: Test results
         path: test-data.xml
       if: failure()
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
       with:
         flags: unittests
         name: codecov-pandas

--- a/.github/actions/setup-conda/action.yml
+++ b/.github/actions/setup-conda/action.yml
@@ -7,7 +7,7 @@ runs:
   using: composite
   steps:
     - name: Install ${{ inputs.environment-file }}
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2
       with:
         environment-file: ${{ inputs.environment-file }}
         environment-name: test

--- a/.github/workflows/cache-cleanup-daily.yml
+++ b/.github/workflows/cache-cleanup-daily.yml
@@ -4,6 +4,8 @@ on:
     # 4:10 UTC daily
     - cron: "10 4 * * *"
 
+permissions: {}
+
 jobs:
   cleanup:
     runs-on: ubuntu-24.04

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -4,9 +4,13 @@ on:
     types:
       - closed
 
+permissions: {}
+
 jobs:
   cleanup:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
     if: github.repository_owner == 'pandas-dev'
     steps:
       - name: Clean Cache

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -14,14 +14,15 @@ env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
 
-permissions:
-  contents: read
+permissions: {}
 
 # pre-commit run by https://pre-commit.ci/
 jobs:
   docstring_typing_manual_hooks:
     name: Docstring validation, typing, and other manual pre-commit hooks
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     defaults:
       run:
         shell: bash -el {0}
@@ -89,6 +90,8 @@ jobs:
   asv-benchmarks:
     name: ASV Benchmarks
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     defaults:
       run:
         shell: bash -el {0}
@@ -120,6 +123,8 @@ jobs:
   requirements-dev-text-installable:
     name: Test install requirements-dev.txt
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
       if: ${{ steps.build.outcome == 'success' && always() }}
 
     - name: Typing
-      uses: pre-commit/action@v3.0.1
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       with:
         extra_args: --verbose --hook-stage manual --all-files
       if: ${{ steps.build.outcome == 'success' && always() }}
@@ -103,7 +103,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
 
@@ -133,13 +133,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
         id: setup_python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,9 @@ jobs:
           - python
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162 # v4
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v4
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/autobuild@c793b717bc78562f491db7b0e93a3a178b099162 # v4
+      - uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,8 +8,7 @@ concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analyze:

--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -16,7 +16,7 @@ jobs:
     concurrency:
       group: ${{ github.actor }}-preview-docs
     steps:
-      - uses: pandas-dev/github-doc-previewer@v0.3.2
+      - uses: pandas-dev/github-doc-previewer@7a1ea7e96d1a24578ec35eedd4256a7d80c3fef8 # v0.3.2
         with:
           previewer-server: "https://pandas.pydata.org/preview"
           artifact-job: "Doc Build and Upload"

--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -3,14 +3,15 @@ on:
   issue_comment:
     types: created
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   preview_docs:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     if: github.event.issue.pull_request && github.event.comment.body == '/preview'
     concurrency:
       group: ${{ github.actor }}-preview-docs

--- a/.github/workflows/deprecation-tracking-bot.yml
+++ b/.github/workflows/deprecation-tracking-bot.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       DEPRECATION_TRACKER_ISSUE: 56596
     steps:
-    - uses: actions/github-script@v8
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       id: update-deprecation-issue
       with:
         script: |

--- a/.github/workflows/deprecation-tracking-bot.yml
+++ b/.github/workflows/deprecation-tracking-bot.yml
@@ -10,12 +10,12 @@ on:
       - main
 
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   deprecation_update:
     permissions:
+      contents: read
       issues: write
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -25,7 +25,6 @@ on:
 env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
   contents: read
@@ -100,6 +99,8 @@ jobs:
 
     - name: Build website
       run: python web/pandas_web.py web/pandas --target-path=web/build
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build documentation
       run: doc/make.py --warnings-are-errors

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -81,7 +81,7 @@ jobs:
         fi
 
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
 
@@ -140,7 +140,7 @@ jobs:
       run: mv doc/build/html web/build/docs
 
     - name: Save website as an artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: website
         path: web/build

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -46,23 +46,27 @@ jobs:
 
     steps:
     - name: Set pandas version
+      env:
+        INPUT_VERSION: ${{ github.event.inputs.version }}
+        EVENT_NAME: ${{ github.event_name }}
+        INPUT_PUBLISH_PROD: ${{ github.event.inputs.publish_prod }}
       run: |
         # tags include a `v` prefix.
         tag_version_pat="^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$"
         version_pat="^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$"
 
-        if [[ -n "${{ github.event.inputs.version }}" ]]; then
-          PANDAS_VERSION="${{ github.event.inputs.version }}"
-        elif [[ "${{ github.event_name }}" == "push" && "$GITHUB_REF_NAME" =~ $tag_version_pat ]]; then
+        if [[ -n "$INPUT_VERSION" ]]; then
+          PANDAS_VERSION="$INPUT_VERSION"
+        elif [[ "$EVENT_NAME" == "push" && "$GITHUB_REF_NAME" =~ $tag_version_pat ]]; then
           PANDAS_VERSION="${GITHUB_REF_NAME:1}"
         else
           PANDAS_VERSION=""
         fi
         echo "PANDAS_VERSION=$PANDAS_VERSION" >> "$GITHUB_ENV"
 
-        if [[ "${{ github.event_name }}" == "push" && -n "$PANDAS_VERSION" ]]; then
+        if [[ "$EVENT_NAME" == "push" && -n "$PANDAS_VERSION" ]]; then
           PUBLISH_PROD="true"
-        elif [[ "${{ github.event.inputs.publish_prod }}" == "true" ]]; then
+        elif [[ "$INPUT_PUBLISH_PROD" == "true" ]]; then
           PUBLISH_PROD="true"
         else
           PUBLISH_PROD="false"

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -26,13 +26,14 @@ env:
   ENV_FILE: environment.yml
   PANDAS_CI: 1
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   web_and_docs:
     name: Doc Build and Upload
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7

--- a/.github/workflows/package-checks.yml
+++ b/.github/workflows/package-checks.yml
@@ -11,8 +11,7 @@ on:
       - 3.0.x
     types: [ labeled, opened, synchronize, reopened ]
 
-permissions:
-  contents: read
+permissions: {}
 
 defaults:
   run:
@@ -22,6 +21,8 @@ jobs:
   pip:
     if: ${{ github.event.label.name == 'Build' || contains(github.event.pull_request.labels.*.name, 'Build') || github.event_name == 'push'}}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         extra: ["test", "pyarrow", "performance", "computation", "fss", "aws", "gcp", "excel", "parquet", "feather", "hdf5", "spss", "postgresql", "mysql", "sql-other", "html", "xml", "plot", "output-formatting", "clipboard", "compression", "all"]
@@ -51,6 +52,8 @@ jobs:
   conda_forge_recipe:
     if: ${{ github.event.label.name == 'Build' || contains(github.event.pull_request.labels.*.name, 'Build') || github.event_name == 'push'}}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     name: Test Conda Forge Recipe
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7

--- a/.github/workflows/package-checks.yml
+++ b/.github/workflows/package-checks.yml
@@ -35,13 +35,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
         id: setup_python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
@@ -61,12 +61,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2
         with:
           environment-name: recipe-test
           create-args: >-

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'pandas-dev'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity. Please [update](https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#updating-your-pull-request) and respond to this comment if you're still interested in working on this."

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -4,8 +4,7 @@ on:
   # * is a special character in YAML so you have to quote this string
   - cron: "0 0 * * *"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   stale:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,8 +13,7 @@ on:
       - "doc/**"
       - "web/**"
 
-permissions:
-  contents: read
+permissions: {}
 
 defaults:
   run:
@@ -23,6 +22,8 @@ defaults:
 jobs:
   ubuntu:
     runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: read
     timeout-minutes: 90
     strategy:
       matrix:
@@ -186,6 +187,8 @@ jobs:
       if: ${{ matrix.pattern == '' && (always() && steps.build.outcome == 'success')}}
 
   macos-windows:
+    permissions:
+      contents: read
     timeout-minutes: 90
     strategy:
       matrix:
@@ -223,6 +226,8 @@ jobs:
 
   Linux-32-bit:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     container:
       image: quay.io/pypa/manylinux_2_28_i686
       options: --platform linux/386
@@ -259,6 +264,8 @@ jobs:
 
   Linux-Musl:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     container:
       image: quay.io/pypa/musllinux_1_2_x86_64
     steps:
@@ -319,6 +326,8 @@ jobs:
     #    to the corresponding posix/windows-macos/sdist etc. workflows.
     # Feel free to modify this comment as necessary.
     if: false
+    permissions:
+      contents: read
     defaults:
       run:
         shell: bash -eou pipefail {0}
@@ -373,6 +382,8 @@ jobs:
     # https://pyodide.org/en/stable/usage/index.html#node-js
     name: Pyodide build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-wasm

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -146,7 +146,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
 
@@ -209,7 +209,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -351,12 +351,12 @@ jobs:
       PYTEST_TARGET: pandas
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python Dev Version
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.15-dev'
 
@@ -390,18 +390,18 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout pandas Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python for pyodide-build
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 
       - name: Set up Emscripten toolchain
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
         with:
           version: '3.1.58'
           actions-cache-folder: emsdk-cache
@@ -414,7 +414,7 @@ jobs:
           pyodide build
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '20'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,12 +30,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build_sdist:
     name: Build sdist
+    permissions:
+      contents: read
     if: >-
       (github.event_name == 'schedule') ||
       github.event_name == 'workflow_dispatch' ||
@@ -78,6 +79,8 @@ jobs:
 
   build_wheels:
     needs: build_sdist
+    permissions:
+      contents: read
     name: Build wheel for ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
     if: >-
       (github.event_name == 'schedule') ||
@@ -205,6 +208,8 @@ jobs:
     # trigger an upload to https://anaconda.org/scientific-python-nightly-wheels/pandas
     # for cron jobs or "Run workflow" (restricted to main branch).
     name: Upload nightly packages to Anaconda
+    permissions:
+      contents: read
     if: >
       github.repository == 'pandas-dev/pandas' &&
       (github.event_name == 'schedule' ||

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,12 +49,12 @@ jobs:
       sdist_file: ${{ steps.save-path.outputs.sdist_name }}
     steps:
       - name: Checkout pandas
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
@@ -63,7 +63,7 @@ jobs:
           python -m pip install build
           python -m build --sdist
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: sdist
           path: ./dist/*
@@ -123,13 +123,13 @@ jobs:
 
     steps:
       - name: Checkout pandas
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up MSVC environment for ARM64
         if: matrix.buildplat[1] == 'win_arm64'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: arm64
 
@@ -141,7 +141,7 @@ jobs:
       # removes unnecessary files from the release
       - name: Download sdist (not macOS)
         #if: ${{ matrix.buildplat[1] != 'macosx_*' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:
           name: sdist
           path: ./dist
@@ -164,7 +164,7 @@ jobs:
         run: echo "sdist_name=$(cd ./dist && ls -d */)" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
         with:
          package-dir: ./dist/${{ startsWith(matrix.buildplat[1], 'macosx') && env.sdist_name || needs.build_sdist.outputs.sdist_file }}
         env:
@@ -177,7 +177,7 @@ jobs:
       - name: Set up Python for validation/upload (non-ARM64 Windows & other OS)
         # micromamba is not available for ARM64 Windows
         if: matrix.buildplat[1] != 'win_arm64'
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2
         with:
           environment-name: wheel-env
           # Use a fixed Python, since we might have an unreleased Python not
@@ -199,7 +199,7 @@ jobs:
         shell: bash -el {0}
         run: for whl in $(ls wheelhouse); do wheel unpack wheelhouse/$whl -d /tmp; done
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
@@ -221,7 +221,7 @@ jobs:
 
     steps:
       - name: Download all artefacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:
           path: dist
           merge-multiple: true
@@ -252,11 +252,11 @@ jobs:
 
     steps:
       - name: Download all artefacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:
           path: dist          # everything lands in ./dist/**
 
-      # TODO: This step can be probably be achieved by actions/download-artifact@v8
+      # TODO: This step can be probably be achieved by actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
       # by specifying merge-multiple: true, and a glob pattern
       - name: Collect files
         run: |
@@ -267,7 +267,7 @@ jobs:
           find dist -name '*.tar.gz' -exec mv {} upload/ \;
 
       - name: Publish to **PyPI** (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: upload
           skip-existing: true


### PR DESCRIPTION
Inspired by recent CI attacks: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation

This hardens CI with a few changes:
* All actions are now pinned with SHA rather than version tags. There was one `upload-artifact@v4` which was up-revved to `v7` to match other usage
* In `docbuild-and-upload.yml` it would have been possible to break out of the quotes and inject code into the script (albeit only through a workflow_dispatch input, so would have to be a maintainer). This moves these to env vars that cast as strings and prevent this attack surface
* Reduce the scope of `GITHUB_TOKEN` in `docbuild-and-upload.yml`
* Default to no permissions for runners, and scope them per job

Table of SHA/version equivalency for verification:

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v6 | [`de0fac2e4500dabe0009e67214ff5f5447ce83dd`](https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd) |
| `actions/setup-python` | v6 | [`a309ff8b426b58ec0e2a45f0f869d46889d02405`](https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405) |
| `actions/upload-artifact` | v7 | [`bbbca2ddaa5d8feaa63e36b76fdaad77386f024f`](https://github.com/actions/upload-artifact/commit/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f) |
| `actions/download-artifact` | v8 | [`70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3`](https://github.com/actions/download-artifact/commit/70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3) |
| `actions/setup-node` | v6 | [`53b83947a5a98c8d113130e565377fae1a50d02f`](https://github.com/actions/setup-node/commit/53b83947a5a98c8d113130e565377fae1a50d02f) |
| `actions/stale` | v10 | [`b5d41d4e1d5dceea10e7104786b73624c18a190f`](https://github.com/actions/stale/commit/b5d41d4e1d5dceea10e7104786b73624c18a190f) |
| `actions/github-script` | v8 | [`ed597411d8f924073f98dfc5c65a23a2325f34cd`](https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd) |
| `pre-commit/action` | v3.0.1 | [`2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd`](https://github.com/pre-commit/action/commit/2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd) |
| `pandas-dev/github-doc-previewer` | v0.3.2 | [`7a1ea7e96d1a24578ec35eedd4256a7d80c3fef8`](https://github.com/pandas-dev/github-doc-previewer/commit/7a1ea7e96d1a24578ec35eedd4256a7d80c3fef8) |
| `ilammy/msvc-dev-cmd` | v1 | [`0b201ec74fa43914dc39ae48a89fd1d8cb592756`](https://github.com/ilammy/msvc-dev-cmd/commit/0b201ec74fa43914dc39ae48a89fd1d8cb592756) |
| `pypa/cibuildwheel` | v3.2.1 | [`9c00cb4f6b517705a3794b22395aedc36257242c`](https://github.com/pypa/cibuildwheel/commit/9c00cb4f6b517705a3794b22395aedc36257242c) |
| `pypa/gh-action-pypi-publish` | v1.13.0 | [`ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e`](https://github.com/pypa/gh-action-pypi-publish/commit/ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e) |
| `mamba-org/setup-micromamba` | v2 | [`add3a49764cedee8ee24e82dfde87f5bc2914462`](https://github.com/mamba-org/setup-micromamba/commit/add3a49764cedee8ee24e82dfde87f5bc2914462) |
| `mymindstorm/setup-emsdk` | v14 | [`6ab9eb1bda2574c4ddb79809fc9247783eaf9021`](https://github.com/mymindstorm/setup-emsdk/commit/6ab9eb1bda2574c4ddb79809fc9247783eaf9021) |
| `github/codeql-action` | v4 | [`c793b717bc78562f491db7b0e93a3a178b099162`](https://github.com/github/codeql-action/commit/c793b717bc78562f491db7b0e93a3a178b099162) |
| `codecov/codecov-action` | v5 | [`671740ac38dd9b0130fbe1cec585b89eea48d3de`](https://github.com/codecov/codecov-action/commit/671740ac38dd9b0130fbe1cec585b89eea48d3de) |
| `scientific-python/upload-nightly-action` | 0.6.3 | [`5748273c71e2d8d3a61f3a11a16421c8954f9ecf`](https://github.com/scientific-python/upload-nightly-action/commit/5748273c71e2d8d3a61f3a11a16421c8954f9ecf) |


- [n/a] closes #xxxx (Replace xxxx with the GitHub issue number)
- [n/a] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [n/a] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [n/a] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
