### PR TITLE
BUG: fix IntervalDtype.__from_arrow__ for nullable subtypes

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1470,20 +1470,41 @@ class IntervalDtype(PandasExtensionDtype):
             chunks = array.chunks
 
         results = []
+        subtype_is_extension = isinstance(self.subtype, ExtensionDtype)
+
         for arr in chunks:
             if isinstance(arr, pyarrow.ExtensionArray):
                 arr = arr.storage
-            left = np.asarray(arr.field("left"), dtype=self.subtype)
-            right = np.asarray(arr.field("right"), dtype=self.subtype)
-            iarr = IntervalArray.from_arrays(left, right, closed=self.closed)
+
+            if subtype_is_extension:
+                left = self.subtype.__from_arrow__(arr.field("left"))
+                right = self.subtype.__from_arrow__(arr.field("right"))
+            else:
+                left = np.asarray(arr.field("left"), dtype=self.subtype)
+                right = np.asarray(arr.field("right"), dtype=self.subtype)
+
+            iarr = IntervalArray.from_arrays(
+                left, right, closed=self.closed, dtype=self
+            )
             results.append(iarr)
 
         if not results:
+            if subtype_is_extension:
+                array_type = self.subtype.construct_array_type()
+                empty_values = array_type._from_sequence([], dtype=self.subtype)
+            else:
+                empty_values = np.array([], dtype=self.subtype)
+
             return IntervalArray.from_arrays(
-                np.array([], dtype=self.subtype),
-                np.array([], dtype=self.subtype),
+                empty_values,
+                empty_values.copy(),
                 closed=self.closed,
+                dtype=self,
             )
+
+        if len(results) == 1:
+            return results[0]
+
         return IntervalArray._concat_same_type(results)
 
     def _get_common_dtype(self, dtypes: list[DtypeObj]) -> DtypeObj | None:

--- a/pandas/tests/arrays/interval/test_interval_pyarrow.py
+++ b/pandas/tests/arrays/interval/test_interval_pyarrow.py
@@ -158,3 +158,27 @@ def test_from_arrow_from_raw_struct_array():
 
     result = dtype.__from_arrow__(pa.chunked_array([arr]))
     tm.assert_extension_array_equal(result, expected)
+
+
+def test_from_arrow_with_nullable_subtype():
+    pa = pytest.importorskip("pyarrow")
+
+    from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
+
+    interval_dtype = pd.IntervalDtype(pd.Int64Dtype(), "right")
+    arr = pa.array(
+        [
+            {"left": 1, "right": 2},
+            {"left": 3, "right": 4},
+        ],
+        type=ArrowIntervalType(pa.int64(), "right"),
+    )
+
+    result = interval_dtype.__from_arrow__(arr)
+    expected = IntervalArray.from_arrays(
+        pd.array([1, 3], dtype="Int64"),
+        pd.array([2, 4], dtype="Int64"),
+        closed="right",
+        dtype=interval_dtype,
+    )
+    tm.assert_extension_array_equal(result, expected)


### PR DESCRIPTION
## Summary
- fix `IntervalDtype.__from_arrow__` to handle extension subtypes via the subtype's own `__from_arrow__` converter instead of `np.asarray(..., dtype=...)`
- preserve the requested interval dtype when constructing interval arrays from Arrow
- avoid an unnecessary concat round-trip for the single-chunk case, which could coerce `interval[Int64]` back to `interval[int64]`
- add a regression test for `IntervalDtype(pd.Int64Dtype(), ...)` Arrow conversion

## Issue
- Closes #64297

## Tests
- `python -m pytest pandas/tests/arrays/interval/test_interval_pyarrow.py -k 'from_arrow'`
- `python -m pytest pandas/tests/arrays/interval/test_interval_pyarrow.py pandas/tests/dtypes/test_dtypes.py -k 'TestIntervalDtype or from_arrow'`
