### PR TITLE
TST: Add regression test for GH#55423

### DIFF
--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1498,3 +1498,26 @@ def test_setitem_partial_row_multiple_columns():
         }
     )
     tm.assert_frame_equal(df, expected)
+
+
+def test_enlarge_frame_with_tz_aware_datetime():
+    # GH#55423
+    # Ensure that enlarging a DataFrame by adding a new column with a tz-aware
+    # datetime scalar results in datetime64[ns, UTC] dtype, not object dtype
+    import datetime as dt
+    
+    df = DataFrame([{"id": 1}, {"id": 2}, {"id": 3}])
+    _time = dt.datetime.utcfromtimestamp(1695887042)
+    _time = _time.replace(tzinfo=dt.timezone.utc)
+    
+    df.loc[df.id >= 2, "time"] = _time
+    
+    # Check that the dtype is datetime64[ns, UTC], not object
+    expected_dtype = DatetimeTZDtype(tz="UTC")
+    assert isinstance(df["time"].dtype, DatetimeTZDtype)
+    assert df["time"].dtype == expected_dtype
+    
+    # Check values
+    assert pd.isna(df.loc[0, "time"])
+    assert df.loc[1, "time"] == Timestamp("2023-09-28 07:44:02", tz="UTC")
+    assert df.loc[2, "time"] == Timestamp("2023-09-28 07:44:02", tz="UTC")


### PR DESCRIPTION
Fixes #55423

Add regression test to ensure that enlarging a DataFrame by adding a new column with a tz-aware datetime scalar results in datetime64[ns, UTC] dtype rather than object dtype.

The bug was already fixed on the main branch (as noted by maintainers in the issue discussion). This PR adds a regression test to prevent regression.

Changes:
- Added test_enlarge_frame_with_tz_aware_datetime in pandas/tests/frame/indexing/test_setitem.py
- Test verifies both dtype and values after enlarging with tz-aware datetime

Testing:
- Test covers the exact scenario from the issue
- Creates DataFrame and uses .loc with condition to add tz-aware datetime
- Verifies resulting dtype is DatetimeTZDtype(tz='UTC')
- Verifies NaT for unset rows and correct timestamps for set rows
