### PR TITLE
TST: Add regression test for GH#55136

### DIFF
--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -832,3 +832,26 @@ def test_day_attribute_non_nano_beyond_int32():
     result = ser.dt.days
     expected = Series([1579371003, 1559453522, 2839645203, 2586, 27, 42066, 0])
     tm.assert_series_equal(result, expected)
+
+
+def test_to_pydatetime_conversion():
+    # GH#55136
+    # Ensure that dt.to_pydatetime() correctly converts datetime64[ns] to object dtype
+    # containing Python datetime objects
+    
+    ser = pd.Series(pd.date_range("2020-01-01", periods=5))
+    assert ser.dtype == "datetime64[ns]"
+    
+    result = ser.dt.to_pydatetime()
+    
+    # Result should be object dtype (array of Python datetime objects)
+    assert result.dtype == object
+    
+    # Verify that elements are Python datetime objects
+    from datetime import datetime
+    for elem in result:
+        assert isinstance(elem, datetime)
+    
+    # Verify values are correct
+    expected_values = pd.date_range("2020-01-01", periods=5).to_pydatetime()
+    tm.assert_numpy_array_equal(result.values, expected_values)


### PR DESCRIPTION
Fixes #55136

Add regression test for dt.to_pydatetime() conversion from datetime64[ns] to Python datetime objects.

Background:
The issue reported that dt.to_pydatetime() didn't appear to change the dtype shown in .info(). The behavior has been fixed on main (to_pydatetime() now correctly returns object dtype), this PR adds a regression test.

Changes:
- Added test_to_pydatetime_conversion in pandas/tests/series/accessors/test_dt_accessor.py
- Test verifies that dt.to_pydatetime() converts datetime64[ns] to object dtype
- Test verifies that the result contains actual Python datetime.datetime objects
- Test verifies the values are correctly preserved

This prevents regression of the conversion behavior.
