### PR TITLE
TST: Add regression test for GH#31142

### DIFF
--- a/pandas/tests/series/methods/test_combine.py
+++ b/pandas/tests/series/methods/test_combine.py
@@ -24,3 +24,23 @@ class TestCombine:
         result = s1.combine(s2, lambda x, y: x + y)
         expected = Series([-74, NA, 105], dtype="Int8")  # dtype should be preserved
         tm.assert_series_equal(result, expected)
+
+    def test_combine_fill_value_with_mixed_index(self):
+        # GH#31142
+        # Ensure combine with fill_value works correctly with mixed-type indices
+        
+        a = Series([1, 2, 3], index=["a", "b", "c"])
+        b = Series([10, 20, 30], index=[0, "e", "f"])
+        
+        result = b.combine(a, lambda x, y: x + y, fill_value=0)
+        
+        # Index 0 should use fill_value for 'a' value (0 + 10 = 10, not 1 + 10 = 11)
+        # The bug was that it incorrectly added b[0] with a['a'] when they shouldn't align
+        expected = Series([10, 1, 2, 3, 20, 30], index=[0, "a", "b", "c", "e", "f"])
+        tm.assert_series_equal(result, expected)
+        
+        # Test with integer index that doesn't match
+        b2 = Series([10, 20, 30], index=[4, "e", "f"])
+        result2 = b2.combine(a, lambda x, y: x + y, fill_value=0)
+        expected2 = Series([10, 1, 2, 3, 20, 30], index=[4, "a", "b", "c", "e", "f"])
+        tm.assert_series_equal(result2, expected2)


### PR DESCRIPTION
Fixes #31142

Add regression test for Series.combine with fill_value and mixed-type indices.

Background:
The issue reported unexpected results when using combine with fill_value on Series with mixed-type indices. When index 0 (integer) didn't align with index 'a' (string), the function incorrectly combined them as if they matched, instead of using fill_value.

Example:
- b = Series([10, 20, 30], index=[0, 'e', 'f'])
- a = Series([1, 2, 3], index=['a', 'b', 'c'])
- b.combine(a, lambda x,y: x+y, fill_value=0)
- Expected b[0] = 10 (10 + fill_value 0), got 11 (10 + a['a'])

Changes:
- Added test_combine_fill_value_with_mixed_index in pandas/tests/series/methods/test_combine.py
- Test verifies that non-aligning indices use fill_value correctly
- Test includes both the problematic case (index 0) and working case (index 4)

This prevents regression of the combine fill_value behavior with mixed indices.
