### PR TITLE
TST: Add regression test for GH#27437

### DIFF
--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -719,3 +719,30 @@ class TestGetitemDeprecatedIndexers:
         ser = Series([1, 2, 3])
         with pytest.raises(TypeError, match="as an indexer is not supported"):
             ser[key] = 1
+
+
+def test_getitem_categorical_index_from_cut():
+    # GH#27437
+    # Ensure indexing works correctly when index is output from pd.cut
+    
+    data = DataFrame(dict(values=range(20), quintiles=pd.cut(range(20), 5)))
+    grouped = data.groupby("quintiles")["values"]
+    
+    # Create Series with categorical index from cut
+    samples = grouped.agg(lambda x: list(x.head(3)))
+    
+    # samples should have a CategoricalIndex
+    assert isinstance(samples.index, pd.CategoricalIndex)
+    
+    # Test indexing with different methods
+    # Integer indexing should use label-based (categorical interval)
+    result0 = samples[0]  # First interval
+    result_last = samples[19]  # Last interval
+    
+    # Both should be lists
+    assert isinstance(result0, list)
+    assert isinstance(result_last, list)
+    
+    # Should be different lists (from different quintiles)
+    # The bug was that indexing with different values returned the same result
+    assert result0 != result_last


### PR DESCRIPTION
Fixes #27437

Add regression test for indexing on Series with CategoricalIndex created from pd.cut.

Background:
The issue reported confusing behavior when indexing a Series with a CategoricalIndex created from pd.cut. Different index values (0, 1, 2.3, 19) all returned the same result, which was incorrect.

Example:
- samples has CategoricalIndex of intervals from pd.cut(range(20), 5)
- samples[0], samples[1], samples[2.3] all returned [3, 2, 1] (first interval)
- Only samples[19] returned the correct last interval

The bug was that integer indexing wasn't properly handled for categorical intervals.

Changes:
- Added test_getitem_categorical_index_from_cut in pandas/tests/series/indexing/test_getitem.py
- Test creates Series with CategoricalIndex from pd.cut
- Test verifies that indexing with different values returns different results
- Test ensures CategoricalIndex type is preserved

This prevents regression of categorical interval indexing behavior.
