### PR TITLE
ERR: Better error message for convert_dtypes without pyarrow (GH#63745)

### DIFF
--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -240,3 +240,18 @@ class TestConvertDtypes:
         )
         result = df.convert_dtypes()
         tm.assert_frame_equal(result, expected)
+
+    def test_convert_dtypes_pyarrow_not_installed_error(self, monkeypatch):
+        # GH#63745
+        # Ensure clear error message when pyarrow is not installed
+        # but dtype_backend="pyarrow" is specified
+        
+        # Simulate pyarrow not being installed
+        import sys
+        monkeypatch.setitem(sys.modules, "pyarrow", None)
+        
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        
+        msg = "dtype_backend='pyarrow' requires the 'pyarrow' package"
+        with pytest.raises(ImportError, match=msg):
+            df.convert_dtypes(dtype_backend="pyarrow")

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -480,3 +480,11 @@ def check_dtype_backend(dtype_backend) -> None:
                 f"dtype_backend {dtype_backend} is invalid, only 'numpy_nullable' and "
                 f"'pyarrow' are allowed.",
             )
+        if dtype_backend == "pyarrow":
+            # GH#63745: Check that pyarrow is installed before proceeding
+            from pandas.compat._optional import import_optional_dependency
+
+            import_optional_dependency(
+                "pyarrow",
+                extra="dtype_backend='pyarrow' requires the 'pyarrow' package.",
+            )


### PR DESCRIPTION
Fixes #63745

## Summary
Provide a clear error message when `convert_dtypes(dtype_backend='pyarrow')` is called without pyarrow installed.

## Background
When pyarrow was not installed, calling `convert_dtypes(dtype_backend='pyarrow')` raised a cryptic error deep in the conversion process:

```python
NameError: name 'ArrowDtype' is not defined
```

This occurred when trying to check `isinstance(dtype, ArrowDtype)`, but `ArrowDtype` wasn't imported because pyarrow was missing.

## Changes
- Added pyarrow availability check in `check_dtype_backend()`
- Now raises a clear `ImportError` early with helpful message:
  ```
  ImportError: dtype_backend='pyarrow' requires the 'pyarrow' package.
  Use pip or conda to install the pyarrow package.
  ```

## Testing
Added `test_convert_dtypes_pyarrow_not_installed_error`:
- Uses monkeypatch to simulate missing pyarrow
- Verifies clear ImportError is raised with helpful message

## Before/After
**Before:**
```python
df.convert_dtypes(dtype_backend="pyarrow")
# NameError: name 'ArrowDtype' is not defined  ❌ Cryptic!
```

**After:**
```python
df.convert_dtypes(dtype_backend="pyarrow")
# ImportError: dtype_backend='pyarrow' requires the 'pyarrow' package.  ✓ Clear!
```
