### PR TITLE
DOC: fix dtype dict examples in read_csv/read_table

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -800,7 +800,7 @@ def read_csv(
 
     Column types are inferred but can be explicitly specified using the dtype argument.
 
-    >>> pd.read_csv("data.csv", dtype={{"Value": float}})  # doctest: +SKIP
+    >>> pd.read_csv("data.csv", dtype={"Value": float})  # doctest: +SKIP
        Name  Value
     0   foo    1.0
     1   bar    2.0
@@ -1363,7 +1363,7 @@ def read_table(
 
     Column types are inferred but can be explicitly specified using the dtype argument.
 
-    >>> pd.read_table("data.csv", dtype={{"Value": float}})  # doctest: +SKIP
+    >>> pd.read_table("data.csv", dtype={"Value": float})  # doctest: +SKIP
        Name  Value
     0   foo    1.0
     1   bar    2.0


### PR DESCRIPTION
## Summary
- fixes the `dtype` dict example in `read_csv` docstring
- applies the same fix to the equivalent `read_table` example for consistency

## Details
- changed `dtype={{"Value": float}}` to `dtype={"Value": float}` in:
  - `pandas/io/parsers/readers.py` (`read_csv`)
  - `pandas/io/parsers/readers.py` (`read_table`)

- [x] closes #64394
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.