### PR TITLE
BUG: validate numeric_only is bool in NDFrame reductions

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -106,6 +106,7 @@ Deprecations
 - Deprecated passing a ``dict`` to :meth:`DataFrame.from_records`, use the :class:`DataFrame` constructor or :meth:`DataFrame.from_dict` instead (:issue:`22025`)
 - Deprecated passing a non-dict (e.g. a list of dicts) to :meth:`DataFrame.from_dict`. Use the :class:`DataFrame` constructor instead (:issue:`58862`)
 - Deprecated passing unnecessary ``*args`` and ``**kwargs`` to :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.cummax`, :meth:`.SeriesGroupBy.skew`, :meth:`.DataFrameGroupBy.skew`, :meth:`.SeriesGroupBy.take`, and :meth:`.DataFrameGroupBy.take`. The ``skipna`` parameter for the cum* methods is now an explicit keyword argument (:issue:`50407`)
+- Deprecated passing non-bool values for ``numeric_only`` in :class:`DataFrame` and :class:`Series` reduction methods (``sum``, ``mean``, ``min``, ``max``, etc.). Pass ``True`` or ``False`` instead (:issue:`53098`)
 - Deprecated setting values with :meth:`DataFrame.at` and :meth:`Series.at` when the key does not exist in the index, which previously expanded the object. Use ``.loc`` instead (:issue:`48323`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
 - Deprecated the ``dropna`` keyword in :meth:`DataFrame.to_hdf`, :meth:`HDFStore.put`, :meth:`HDFStore.append`, and :meth:`HDFStore.append_to_multiple`, and the ``io.hdf.dropna_table`` option. Use :meth:`DataFrame.dropna` before writing instead (:issue:`32038`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11787,6 +11787,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> Series | float:
         nv.validate_stat_ddof_func((), kwargs, fname=name)
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        numeric_only = validate_bool_kwarg(
+            numeric_only, "numeric_only", none_allowed=False, deprecated=True
+        )
 
         return self._reduce(
             func, name, axis=axis, numeric_only=numeric_only, skipna=skipna, ddof=ddof
@@ -11845,6 +11848,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         nv.validate_func(name, (), kwargs)
 
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        numeric_only = validate_bool_kwarg(
+            numeric_only, "numeric_only", none_allowed=False, deprecated=True
+        )
 
         return self._reduce(
             func, name=name, axis=axis, skipna=skipna, numeric_only=numeric_only
@@ -11949,6 +11955,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         nv.validate_func(name, (), kwargs)
 
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        numeric_only = validate_bool_kwarg(
+            numeric_only, "numeric_only", none_allowed=False, deprecated=True
+        )
 
         return self._reduce(
             func,

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -11,6 +11,7 @@ from pandas.compat import (
     is_platform_windows,
 )
 from pandas.compat.numpy import np_version_gt2
+from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -848,7 +849,7 @@ class TestDataFrameAnalytics:
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("method, unit", [("sum", 0), ("prod", 1)])
-    @pytest.mark.parametrize("numeric_only", [None, True, False])
+    @pytest.mark.parametrize("numeric_only", [True, False])
     def test_sum_prod_nanops(self, method, unit, numeric_only):
         idx = ["a", "b", "c"]
         df = DataFrame({"a": [unit, unit], "b": [unit, np.nan], "c": [np.nan, np.nan]})
@@ -1747,6 +1748,41 @@ class TestDataFrameReductions:
         with pytest.raises(ValueError, match=msg):
             getattr(obj, all_reductions)(skipna=None)
 
+    @pytest.mark.parametrize(
+        "method",
+        ["sum", "prod", "min", "max", "mean", "median", "std", "var", "sem"],
+    )
+    @pytest.mark.parametrize(
+        "numeric_only",
+        [None, "True", 1],
+    )
+    def test_reductions_numeric_only_non_bool_deprecated(
+        self, frame_or_series, method, numeric_only
+    ):
+        obj = frame_or_series([1, 2, 3])
+        expected = getattr(obj, method)(numeric_only=bool(numeric_only))
+        msg = (
+            "Passing a non-bool value for numeric_only is deprecated and will "
+            "raise in a future version. Pass True or False instead."
+        )
+        with tm.assert_produces_warning(Pandas4Warning, match=re.escape(msg)):
+            result = getattr(obj, method)(numeric_only=numeric_only)
+        tm.assert_equal(result, expected)
+
+    @pytest.mark.parametrize("numeric_only", [None, "True", 1])
+    def test_reductions_numeric_only_non_bool_preserves_current_sum_behavior(
+        self, numeric_only
+    ):
+        df = DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        expected = df.sum(numeric_only=bool(numeric_only))
+        msg = (
+            "Passing a non-bool value for numeric_only is deprecated and will "
+            "raise in a future version. Pass True or False instead."
+        )
+        with tm.assert_produces_warning(Pandas4Warning, match=re.escape(msg)):
+            result = df.sum(numeric_only=numeric_only)
+        tm.assert_series_equal(result, expected)
+
     def test_reduction_timestamp_smallest_unit(self):
         # GH#52524
         df = DataFrame(
@@ -2029,7 +2065,7 @@ def test_mixed_frame_with_integer_sum():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("numeric_only", [True, False, None])
+@pytest.mark.parametrize("numeric_only", [True, False])
 @pytest.mark.parametrize("method", ["min", "max"])
 def test_minmax_extensionarray(method, numeric_only):
     # https://github.com/pandas-dev/pandas/issues/32651

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -230,6 +230,7 @@ def validate_bool_kwarg(
     arg_name: str,
     none_allowed: bool = True,
     int_allowed: bool = False,
+    deprecated: bool = False,
 ) -> BoolishNoneT:
     """
     Ensure that argument passed in arg_name can be interpreted as boolean.
@@ -244,6 +245,9 @@ def validate_bool_kwarg(
         Whether to consider None to be a valid boolean.
     int_allowed : bool, default False
         Whether to consider integer value to be a valid boolean.
+    deprecated : bool, default False
+        If True, non-bool values emit a deprecation warning and are
+        coerced to bool instead of raising immediately.
 
     Returns
     -------
@@ -263,6 +267,20 @@ def validate_bool_kwarg(
         good_value = good_value or isinstance(value, int)
 
     if not good_value:
+        if deprecated:
+            import warnings
+
+            from pandas.errors import Pandas4Warning
+            from pandas.util._exceptions import find_stack_level
+
+            warnings.warn(
+                f"Passing a non-bool value for {arg_name} is deprecated and "
+                "will raise in a future version. "
+                "Pass True or False instead.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
+            return bool(value)  # type: ignore[return-value]
         raise ValueError(
             f'For argument "{arg_name}" expected type bool, received '
             f"type {type(value).__name__}."

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -13,11 +13,14 @@ from typing import (
     TypeVar,
     overload,
 )
+import warnings
 
 import numpy as np
 
 from pandas._libs import lib
 from pandas._libs.missing import NA
+from pandas.errors import Pandas4Warning
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_bool,
@@ -268,11 +271,6 @@ def validate_bool_kwarg(
 
     if not good_value:
         if deprecated:
-            import warnings
-
-            from pandas.errors import Pandas4Warning
-            from pandas.util._exceptions import find_stack_level
-
             warnings.warn(
                 f"Passing a non-bool value for {arg_name} is deprecated and "
                 "will raise in a future version. "


### PR DESCRIPTION
## What does this PR do?

Fixes reduction operations to require `numeric_only` to be explicitly boolean (`True`/`False`).

- Add `validate_bool_kwarg(..., none_allowed=False)` in NDFrame reduction helper paths used by `sum`, `prod`, `min`, `max`, `mean`, `median`, `std`, `var`, and `sem`.
- Add regression tests asserting `ValueError` for `numeric_only=None`, `"True"`, and `1`.
- Update existing frame tests that previously parameterized `numeric_only=None` to align with the intended contract.

Closes #53098

## Test command

- `python -m pytest pandas/tests/frame/test_reductions.py -k "numeric_only or sum_prod_nanops or minmax_extensionarray"`
- `python -m pytest pandas/tests/series/test_reductions.py`
