### PR TITLE
PERF: use khash set types in ismember to avoid allocating unused vals array

### DIFF
--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -6,26 +6,77 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 
 {{py:
 
-# name, dtype, ttype, c_type, to_c_type
+# name, dtype, ttype, c_type, to_c_type, set_ttype
 dtypes = [('Complex128', 'complex128', 'complex128',
-                         'khcomplex128_t', 'to_khcomplex128_t'),
+                         'khcomplex128_t', 'to_khcomplex128_t', 'set_complex128'),
           ('Complex64', 'complex64', 'complex64',
-                        'khcomplex64_t', 'to_khcomplex64_t'),
-          ('Float64', 'float64', 'float64', 'float64_t', ''),
-          ('Float32', 'float32', 'float32', 'float32_t', ''),
-          ('UInt64', 'uint64', 'uint64', 'uint64_t', ''),
-          ('UInt32', 'uint32', 'uint32', 'uint32_t', ''),
-          ('UInt16', 'uint16', 'uint16', 'uint16_t', ''),
-          ('UInt8', 'uint8', 'uint8', 'uint8_t', ''),
-          ('Object', 'object', 'pymap', 'object', '<PyObject*>'),
-          ('Int64', 'int64', 'int64', 'int64_t', ''),
-          ('Int32', 'int32', 'int32', 'int32_t', ''),
-          ('Int16', 'int16', 'int16', 'int16_t', ''),
-          ('Int8', 'int8', 'int8', 'int8_t', '')]
+                        'khcomplex64_t', 'to_khcomplex64_t', 'set_complex64'),
+          ('Float64', 'float64', 'float64', 'float64_t', '', 'set_float64'),
+          ('Float32', 'float32', 'float32', 'float32_t', '', 'set_float32'),
+          ('UInt64', 'uint64', 'uint64', 'uint64_t', '', 'set_uint64'),
+          ('UInt32', 'uint32', 'uint32', 'uint32_t', '', 'set_uint32'),
+          ('UInt16', 'uint16', 'uint16', 'uint16_t', '', 'set_uint16'),
+          ('UInt8', 'uint8', 'uint8', 'uint8_t', '', 'set_uint8'),
+          ('Object', 'object', 'pymap', 'object', '<PyObject*>', 'pyset'),
+          ('Int64', 'int64', 'int64', 'int64_t', '', 'set_int64'),
+          ('Int32', 'int32', 'int32', 'int32_t', '', 'set_int32'),
+          ('Int16', 'int16', 'int16', 'int16_t', '', 'set_int16'),
+          ('Int8', 'int8', 'int8', 'int8_t', '', 'set_int8')]
+
+# Primitive set types used by ismember. Declared here (not via cimport) so
+# that their companion functions (kh_init_*, kh_put_*, etc.) are also in
+# scope. kh_pyset_t (object) is handled via khash.pxd / hashtable.pxd.
+# name, c_type
+primitive_set_types_for_ismember = [
+    ('set_complex128', 'khcomplex128_t'),
+    ('set_complex64', 'khcomplex64_t'),
+    ('set_float64', 'float64_t'),
+    ('set_float32', 'float32_t'),
+    ('set_uint64', 'uint64_t'),
+    ('set_uint32', 'uint32_t'),
+    ('set_uint16', 'uint16_t'),
+    ('set_uint8', 'uint8_t'),
+    ('set_int64', 'int64_t'),
+    ('set_int32', 'int32_t'),
+    ('set_int16', 'int16_t'),
+    ('set_int8', 'int8_t'),
+]
 
 }}
 
-{{for name, dtype, ttype, c_type, to_c_type in dtypes}}
+{{for set_name, set_c_type in primitive_set_types_for_ismember}}
+cdef extern from "pandas/vendored/klib/khash_python.h":
+    ctypedef struct kh_{{set_name}}_t:
+        uint32_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        {{set_c_type}} *keys
+        char *vals
+
+    kh_{{set_name}}_t* kh_init_{{set_name}}() nogil
+    void kh_destroy_{{set_name}}(kh_{{set_name}}_t*) nogil
+    uint32_t kh_get_{{set_name}}(kh_{{set_name}}_t*, {{set_c_type}}) nogil
+    void kh_resize_{{set_name}}(kh_{{set_name}}_t*, uint32_t) nogil
+    uint32_t kh_put_{{set_name}}(kh_{{set_name}}_t*, {{set_c_type}}, int*) nogil
+
+{{endfor}}
+
+# kh_pyset_t is the set counterpart to kh_pymap_t (object dtype).
+# Redeclared here so kh_init_pyset / kh_put_pyset / kh_get_pyset are in scope.
+from cpython.object cimport PyObject
+cdef extern from "pandas/vendored/klib/khash_python.h":
+    ctypedef struct kh_pyset_t:
+        uint32_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        PyObject **keys
+        char *vals
+
+    kh_pyset_t* kh_init_pyset()
+    void kh_destroy_pyset(kh_pyset_t*)
+    uint32_t kh_get_pyset(kh_pyset_t*, PyObject*)
+    void kh_resize_pyset(kh_pyset_t*, uint32_t)
+    uint32_t kh_put_pyset(kh_pyset_t*, PyObject*, int*)
+
+{{for name, dtype, ttype, c_type, to_c_type, set_ttype in dtypes}}
 
 
 @cython.wraparound(False)
@@ -243,11 +294,11 @@ cdef ismember_{{dtype}}(const {{dtype}}_t[:] arr, const {{dtype}}_t[:] values):
         {{c_type}} val
         {{endif}}
 
-        kh_{{ttype}}_t *table = kh_init_{{ttype}}()
+        kh_{{set_ttype}}_t *table = kh_init_{{set_ttype}}()
 
     # construct the table
     n = len(values)
-    kh_resize_{{ttype}}(table, n)
+    kh_resize_{{set_ttype}}(table, n)
 
     {{if dtype == 'object'}}
     if True:
@@ -256,7 +307,7 @@ cdef ismember_{{dtype}}(const {{dtype}}_t[:] arr, const {{dtype}}_t[:] values):
     {{endif}}
         for i in range(n):
             val = {{to_c_type}}(values[i])
-            kh_put_{{ttype}}(table, val, &ret)
+            kh_put_{{set_ttype}}(table, val, &ret)
 
     # test membership
     n = len(arr)
@@ -269,10 +320,10 @@ cdef ismember_{{dtype}}(const {{dtype}}_t[:] arr, const {{dtype}}_t[:] values):
     {{endif}}
         for i in range(n):
             val = {{to_c_type}}(arr[i])
-            k = kh_get_{{ttype}}(table, val)
+            k = kh_get_{{set_ttype}}(table, val)
             result[i] = (k != table.n_buckets)
 
-    kh_destroy_{{ttype}}(table)
+    kh_destroy_{{set_ttype}}(table)
     return result.view(np.bool_)
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/include/pandas/vendored/klib/khash.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash.h
@@ -642,6 +642,9 @@ static inline khuint_t __ac_Wang_hash(khuint_t key) {
 #define KHASH_SET_INIT_INT(name)                                               \
   KHASH_INIT(name, khint32_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
 
+#define KHASH_SET_INIT_UINT(name)                                              \
+  KHASH_INIT(name, khuint32_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
+
 /*! @function
   @abstract     Instantiate a hash map containing integer keys
   @param  name  Name of the hash table [symbol]
@@ -687,6 +690,12 @@ static inline khuint_t __ac_Wang_hash(khuint_t key) {
 #define KHASH_MAP_INIT_UINT16(name, khval_t)                                   \
   KHASH_INIT(name, khuint16_t, khval_t, 1, kh_int_hash_func, kh_int_hash_equal)
 
+#define KHASH_SET_INIT_INT16(name)                                             \
+  KHASH_INIT(name, khint16_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
+
+#define KHASH_SET_INIT_UINT16(name)                                            \
+  KHASH_INIT(name, khuint16_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
+
 /*! @function
   @abstract     Instantiate a hash map containing 8bit-integer keys
   @param  name  Name of the hash table [symbol]
@@ -697,6 +706,12 @@ static inline khuint_t __ac_Wang_hash(khuint_t key) {
 
 #define KHASH_MAP_INIT_UINT8(name, khval_t)                                    \
   KHASH_INIT(name, khuint8_t, khval_t, 1, kh_int_hash_func, kh_int_hash_equal)
+
+#define KHASH_SET_INIT_INT8(name)                                              \
+  KHASH_INIT(name, khint8_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
+
+#define KHASH_SET_INIT_UINT8(name)                                             \
+  KHASH_INIT(name, khuint8_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
 
 typedef const char *kh_cstr_t;
 /*! @function
@@ -725,6 +740,14 @@ typedef const char *kh_cstr_t;
 #define kh_exist_uint16(h, k) (kh_exist(h, k))
 #define kh_exist_int8(h, k) (kh_exist(h, k))
 #define kh_exist_uint8(h, k) (kh_exist(h, k))
+#define kh_exist_set_int64(h, k) (kh_exist(h, k))
+#define kh_exist_set_uint64(h, k) (kh_exist(h, k))
+#define kh_exist_set_int32(h, k) (kh_exist(h, k))
+#define kh_exist_set_uint32(h, k) (kh_exist(h, k))
+#define kh_exist_set_int16(h, k) (kh_exist(h, k))
+#define kh_exist_set_uint16(h, k) (kh_exist(h, k))
+#define kh_exist_set_int8(h, k) (kh_exist(h, k))
+#define kh_exist_set_uint8(h, k) (kh_exist(h, k))
 
 KHASH_MAP_INIT_STR(str, size_t)
 KHASH_MAP_INIT_INT(int32, size_t)
@@ -735,5 +758,13 @@ KHASH_MAP_INIT_INT16(int16, size_t)
 KHASH_MAP_INIT_UINT16(uint16, size_t)
 KHASH_MAP_INIT_INT8(int8, size_t)
 KHASH_MAP_INIT_UINT8(uint8, size_t)
+KHASH_SET_INIT_INT64(set_int64)
+KHASH_SET_INIT_UINT64(set_uint64)
+KHASH_SET_INIT_INT(set_int32)
+KHASH_SET_INIT_UINT(set_uint32)
+KHASH_SET_INIT_INT16(set_int16)
+KHASH_SET_INIT_UINT16(set_uint16)
+KHASH_SET_INIT_INT8(set_int8)
+KHASH_SET_INIT_UINT8(set_uint8)
 
 #endif /* __AC_KHASH_H */

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -122,11 +122,23 @@ static inline khuint32_t kh_float32_hash_func(float val) {
 
 KHASH_MAP_INIT_FLOAT64(float64, size_t)
 
+#define KHASH_SET_INIT_FLOAT64(name)                                           \
+  KHASH_INIT(name, khfloat64_t, char, 0, kh_float64_hash_func,                 \
+             kh_floats_hash_equal)
+
+KHASH_SET_INIT_FLOAT64(set_float64)
+
 #define KHASH_MAP_INIT_FLOAT32(name, khval_t)                                  \
   KHASH_INIT(name, khfloat32_t, khval_t, 1, kh_float32_hash_func,              \
              kh_floats_hash_equal)
 
 KHASH_MAP_INIT_FLOAT32(float32, size_t)
+
+#define KHASH_SET_INIT_FLOAT32(name)                                           \
+  KHASH_INIT(name, khfloat32_t, char, 0, kh_float32_hash_func,                 \
+             kh_floats_hash_equal)
+
+KHASH_SET_INIT_FLOAT32(set_float32)
 
 static inline khint32_t kh_complex128_hash_func(khcomplex128_t val) {
   return kh_float64_hash_func(val.real) ^ kh_float64_hash_func(val.imag);
@@ -144,14 +156,30 @@ static inline khint32_t kh_complex64_hash_func(khcomplex64_t val) {
 
 KHASH_MAP_INIT_COMPLEX64(complex64, size_t)
 
+#define KHASH_SET_INIT_COMPLEX64(name)                                         \
+  KHASH_INIT(name, khcomplex64_t, char, 0, kh_complex64_hash_func,             \
+             kh_complex_hash_equal)
+
+KHASH_SET_INIT_COMPLEX64(set_complex64)
+
 #define KHASH_MAP_INIT_COMPLEX128(name, khval_t)                               \
   KHASH_INIT(name, khcomplex128_t, khval_t, 1, kh_complex128_hash_func,        \
              kh_complex_hash_equal)
 
 KHASH_MAP_INIT_COMPLEX128(complex128, size_t)
 
+#define KHASH_SET_INIT_COMPLEX128(name)                                        \
+  KHASH_INIT(name, khcomplex128_t, char, 0, kh_complex128_hash_func,           \
+             kh_complex_hash_equal)
+
+KHASH_SET_INIT_COMPLEX128(set_complex128)
+
 #define kh_exist_complex64(h, k) (kh_exist(h, k))
 #define kh_exist_complex128(h, k) (kh_exist(h, k))
+#define kh_exist_set_float64(h, k) (kh_exist(h, k))
+#define kh_exist_set_float32(h, k) (kh_exist(h, k))
+#define kh_exist_set_complex64(h, k) (kh_exist(h, k))
+#define kh_exist_set_complex128(h, k) (kh_exist(h, k))
 
 // NaN-floats should be in the same equivalency class, see GH 22119
 static inline int floatobject_cmp(PyFloatObject *a, PyFloatObject *b) {

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -64,7 +64,7 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
         khuint_t n_buckets, size, n_occupied, upper_bound
         uint32_t *flags
         PyObject **keys
-        size_t *vals
+        char *vals
 
     kh_pyset_t* kh_init_pyset()
     void kh_destroy_pyset(kh_pyset_t*)

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -64,7 +64,7 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
         khuint_t n_buckets, size, n_occupied, upper_bound
         uint32_t *flags
         PyObject **keys
-        char *vals
+        size_t *vals
 
     kh_pyset_t* kh_init_pyset()
     void kh_destroy_pyset(kh_pyset_t*)

--- a/pandas/_libs/khash_for_primitive_helper.pxi.in
+++ b/pandas/_libs/khash_for_primitive_helper.pxi.in
@@ -20,6 +20,21 @@ primitive_types = [('int64', 'int64_t'),
                    ('complex64', 'khcomplex64_t'),
                    ('complex128', 'khcomplex128_t'),
                   ]
+
+# name, c_type — set (membership-only) counterparts to the map types above
+primitive_set_types = [('set_int64', 'int64_t'),
+                       ('set_uint64', 'uint64_t'),
+                       ('set_float64', 'float64_t'),
+                       ('set_int32', 'int32_t'),
+                       ('set_uint32', 'uint32_t'),
+                       ('set_float32', 'float32_t'),
+                       ('set_int16', 'int16_t'),
+                       ('set_uint16', 'uint16_t'),
+                       ('set_int8', 'int8_t'),
+                       ('set_uint8', 'uint8_t'),
+                       ('set_complex64', 'khcomplex64_t'),
+                       ('set_complex128', 'khcomplex128_t'),
+                      ]
 }}
 
 {{for name, c_type in primitive_types}}
@@ -30,6 +45,27 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
         uint32_t *flags
         {{c_type}} *keys
         size_t *vals
+
+    kh_{{name}}_t* kh_init_{{name}}() nogil
+    void kh_destroy_{{name}}(kh_{{name}}_t*) nogil
+    void kh_clear_{{name}}(kh_{{name}}_t*) nogil
+    khuint_t kh_get_{{name}}(kh_{{name}}_t*, {{c_type}}) nogil
+    void kh_resize_{{name}}(kh_{{name}}_t*, khuint_t) nogil
+    khuint_t kh_put_{{name}}(kh_{{name}}_t*, {{c_type}}, int*) nogil
+    void kh_del_{{name}}(kh_{{name}}_t*, khuint_t) nogil
+
+    bint kh_exist_{{name}}(kh_{{name}}_t*, khiter_t) nogil
+
+{{endfor}}
+
+{{for name, c_type in primitive_set_types}}
+
+cdef extern from "pandas/vendored/klib/khash_python.h":
+    ctypedef struct kh_{{name}}_t:
+        khuint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        {{c_type}} *keys
+        char *vals
 
     kh_{{name}}_t* kh_init_{{name}}() nogil
     void kh_destroy_{{name}}(kh_{{name}}_t*) nogil


### PR DESCRIPTION
*This PR was written by Claude Sonnet 4.6 at the request of @jbrockmendel.*

## Problem

`ismember` (the C-level kernel behind `Series.isin()`) used the same map-type hash tables (`kh_int64_t`, `kh_float64_t`, etc.) as `factorize`. Map types allocate a `vals` array (8 bytes/bucket) alongside the `keys` array. For `ismember` the `vals` array is never written or read — it's pure waste.

Raised in #39799 (set vs map for `isin`). Related: #8524 (khash upgrade).

## Solution

Add khash **set** instantiations for all 12 primitive dtypes (int8/16/32/64, uint8/16/32/64, float32/64, complex64/128) and wire `ismember_*` to use them. Sets skip the `vals` allocation entirely.

Changes:
- `khash.h`: add `KHASH_SET_INIT_UINT`, `KHASH_SET_INIT_INT16/UINT16/INT8/UINT8` macros (were missing) and set instantiations for all integer types
- `khash_python.h`: add `KHASH_SET_INIT_FLOAT64/32`, `KHASH_SET_INIT_COMPLEX128/64` macros and instantiations  
- `khash_for_primitive_helper.pxi.in`: add Cython `cdef extern` declarations for all 12 set types
- `hashtable_func_helper.pxi.in`: re-declare set types inline (required — cimporting a type does not bring its companion C functions into scope in Cython), switch `ismember_*` to use set types
- `khash.pxd`: fix `kh_pyset_t.vals` field type (`char *`, not `size_t *`)

## Performance

Benchmarked with 500 alternating rounds per case in isolated subprocesses (N=1 000 000):

| Case | map (ms) | set (ms) | Δ |
|---|---|---|---|
| `int64` / few unique | 1.94 | 1.51 | **−22%** |
| `int64` / many unique | 10.25 | 9.96 | −3% |
| `int64` / arange | 8.09 | 7.76 | −4% |
| `float64` / few unique | 2.96 | 2.45 | **−17%** |
| `float64` / many unique | 14.69 | 14.58 | −1% |
| `float64` / NaN-heavy | 3.02 | 2.41 | **−20%** |

No regressions observed. Improvements are largest when the lookup set is small (few distinct values) or when most lookups miss (NaN-heavy), consistent with the smaller hash table fitting better in cache.