### PR TITLE
PERF: Improve take_2d Cython helpers

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -7,7 +7,7 @@ from libc.stdlib cimport (
     free,
     malloc,
 )
-from libc.string cimport memmove
+from libc.string cimport memcpy
 
 import numpy as np
 

--- a/pandas/_libs/algos_take_helper.pxi.in
+++ b/pandas/_libs/algos_take_helper.pxi.in
@@ -128,7 +128,7 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
         # GH#3130
         if (values.strides[1] == out.strides[1] and
             values.strides[1] == sizeof({{c_type_out}}) and
-            sizeof({{c_type_out}}) * n >= 256):
+            sizeof({{c_type_out}}) * k >= 256):
 
             for i in range(n):
                 idx = indexer[i]
@@ -138,7 +138,7 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
                 else:
                     v = &values[idx, 0]
                     o = &out[i, 0]
-                    memmove(o, v, <size_t>(sizeof({{c_type_out}}) * k))
+                    memcpy(o, v, <size_t>(sizeof({{c_type_out}}) * k))
         else:
             for i in range(n):
                 idx = indexer[i]

--- a/pandas/_libs/algos_take_helper.pxi.in
+++ b/pandas/_libs/algos_take_helper.pxi.in
@@ -122,9 +122,10 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
 
     fv = fill_value
 
-    {{if c_type_in == c_type_out != "object"}}
-    # GH#3130
+    {{if c_type_in != "object" and c_type_out != "object"}}
     with nogil:
+        {{if c_type_in == c_type_out}}
+        # GH#3130
         if (values.strides[1] == out.strides[1] and
             values.strides[1] == sizeof({{c_type_out}}) and
             sizeof({{c_type_out}}) * n >= 256):
@@ -147,6 +148,16 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
                 else:
                     for j in range(k):
                         out[i, j] = values[idx, j]
+        {{else}}
+        for i in range(n):
+            idx = indexer[i]
+            if idx == -1:
+                for j in range(k):
+                    out[i, j] = fv
+            else:
+                for j in range(k):
+                    out[i, j] = values[idx, j]
+        {{endif}}
     {{else}}
 
     for i in range(n):
@@ -187,7 +198,7 @@ def take_2d_axis1_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
 
     fv = fill_value
 
-    {{if c_type_in == c_type_out != "object"}}
+    {{if c_type_in != "object" and c_type_out != "object"}}
     with nogil:
         for i in range(n):
             for j in range(k):
@@ -228,6 +239,20 @@ def take_2d_multi_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
     k = len(idx1)
 
     fv = fill_value
+    {{if c_type_in != "object" and c_type_out != "object"}}
+    with nogil:
+        for i in range(n):
+            idx = idx0[i]
+            if idx == -1:
+                for j in range(k):
+                    out[i, j] = fv
+            else:
+                for j in range(k):
+                    if idx1[j] == -1:
+                        out[i, j] = fv
+                    else:
+                        out[i, j] = values[idx, idx1[j]]
+    {{else}}
     for i in range(n):
         idx = idx0[i]
         if idx == -1:
@@ -243,5 +268,6 @@ def take_2d_multi_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
                     {{else}}
                     out[i, j] = values[idx, idx1[j]]
                     {{endif}}
+    {{endif}}
 
 {{endfor}}


### PR DESCRIPTION
## Summary

Three small fixes to `algos_take_helper.pxi.in`, created at @jbrockmendel's request:

- **Release GIL for cross-type numeric 2D take functions.** `take_2d_axis0`, `take_2d_axis1`, and `take_2d_multi` only used `nogil` when `c_type_in == c_type_out`. All non-object numeric paths are pure C operations and can safely release the GIL. (`take_1d` already did this correctly.) `take_2d_multi` had no `nogil` at all.
- **Fix `memcpy` threshold in `take_2d_axis0`.** The threshold checked `sizeof(type) * n` (number of rows) instead of `sizeof(type) * k` (columns per row). This caused narrow arrays to incorrectly use `memcpy` for tiny copies, and wide arrays to incorrectly skip it.
- **Use `memcpy` instead of `memmove`.** Source and destination are separate arrays and cannot overlap.

## Test plan

- [x] `pytest pandas/tests/test_take.py` (82/82 passed)
- [x] Manual verification of cross-type and multi take paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)