### PR TITLE
DOC: Add missing public APIs to the API reference

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -163,7 +163,10 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.typing.SeriesGroupBy.sum ES01" \
         -i "pandas.api.typing.SeriesGroupBy.value_counts ES01" \
         -i "pandas.api.typing.DataFrameGroupBy.boxplot ES01" \
-        -i "pandas.api.typing.SeriesGroupBy.hist ES01" # no backslash in the last line
+        -i "pandas.api.typing.SeriesGroupBy.hist ES01" \
+        -i "pandas.Timestamp.fromisocalendar GL01,GL02,SS02,SA01,EX01" \
+        -i "pandas.Timestamp.fromisoformat SS02,SS03,ES01,SA01,EX01" \
+        -i "pandas.Timedelta.resolution_string SA01" # no backslash in the last line
 
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/doc/source/reference/arrays.rst
+++ b/doc/source/reference/arrays.rst
@@ -187,6 +187,8 @@ Methods
    Timestamp.day_name
    Timestamp.dst
    Timestamp.floor
+   Timestamp.fromisocalendar
+   Timestamp.fromisoformat
    Timestamp.fromordinal
    Timestamp.fromtimestamp
    Timestamp.isocalendar
@@ -265,6 +267,7 @@ Properties
    Timedelta.min
    Timedelta.nanoseconds
    Timedelta.resolution
+   Timedelta.resolution_string
    Timedelta.seconds
    Timedelta.unit
    Timedelta.value

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -86,6 +86,7 @@ Binary operator functions
    Series.sub
    Series.mul
    Series.div
+   Series.divmod
    Series.truediv
    Series.floordiv
    Series.mod
@@ -94,6 +95,7 @@ Binary operator functions
    Series.rsub
    Series.rmul
    Series.rdiv
+   Series.rdivmod
    Series.rtruediv
    Series.rfloordiv
    Series.rmod


### PR DESCRIPTION
- [x] closes #64446

Series.divmod, Series.rdivmod, Timestamp.fromisocalendar, Timestamp.fromisoformat, and Timedelta.resolution_string were accessible as public APIs but absent from the reference docs.