### PR TITLE
BUG: Fix loss of precision when exporting doubles to JSON

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -23,6 +23,8 @@ Bug fixes
 ^^^^^^^^^
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
+- Fix bug in the ujson library that would cause floats between 1e-2 and 1e-15 to lose precision or be rounded to zero when exporting to JSON (:issue:`59313`, :issue:`23328`)
+
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_302.contributors:

--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -23,8 +23,6 @@ Bug fixes
 ^^^^^^^^^
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
-- Fix bug in the ujson library that would cause floats between 1e-2 and 1e-15 to lose precision or be rounded to zero when exporting to JSON (:issue:`59313`, :issue:`23328`)
-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_302.contributors:

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -176,6 +176,7 @@ I/O
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
+- Added ``force_scientific_notation`` keyword argument to :func:`DataFrame.to_json`, enabling floats to always be exported in scientific notation instead of being converted to fixed-point decimals (:issue:`59313`, :issue:`23328`)
 
 Period
 ^^^^^^

--- a/pandas/_libs/include/pandas/vendored/ujson/lib/ultrajson.h
+++ b/pandas/_libs/include/pandas/vendored/ujson/lib/ultrajson.h
@@ -244,6 +244,11 @@ typedef struct __JSONObjectEncoder {
   int doublePrecision;
 
   /*
+  Set whether we want to use scientific notation for doubles
+  If false, use old logic. If true, always use exponential notation. */
+  int forceScientific;
+
+  /*
   If true output will be ASCII with all characters above 127 encoded as \uXXXX.
   If false output will be UTF-8 or what ever charset strings are brought as */
   int forceASCII;

--- a/pandas/_libs/json.pyi
+++ b/pandas/_libs/json.pyi
@@ -7,6 +7,7 @@ def ujson_dumps(
     obj: Any,
     ensure_ascii: bool = ...,
     double_precision: int = ...,
+    force_scientific_notation: bool = ...,
     indent: int = ...,
     orient: str = ...,
     date_unit: str = ...,

--- a/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
@@ -73,22 +73,6 @@ The extra 2 bytes are for the quotes around the string
 */
 #define RESERVE_STRING(_len) (2 + ((_len) * 6))
 
-static const double g_pow10[] = {1,
-                                 10,
-                                 100,
-                                 1000,
-                                 10000,
-                                 100000,
-                                 1000000,
-                                 10000000,
-                                 100000000,
-                                 1000000000,
-                                 10000000000,
-                                 100000000000,
-                                 1000000000000,
-                                 10000000000000,
-                                 100000000000000,
-                                 1000000000000000};
 static const char g_hexChars[] = "0123456789abcdef";
 static const char g_escapeChars[] = "0123456789\\b\\t\\n\\f\\r\\\"\\\\\\/";
 
@@ -780,19 +764,9 @@ void Buffer_AppendLongUnchecked(JSONObjectEncoder *enc, JSINT64 value) {
 
 int Buffer_AppendDoubleUnchecked(JSOBJ obj, JSONObjectEncoder *enc,
                                  double value) {
-  /* if input is beyond the thresholds, revert to exponential */
-  const double thres_max = (double)1e16 - 1;
-  const double thres_min = (double)1e-15;
   char precision_str[20];
-  int count;
-  double diff = 0.0;
   char *str = enc->offset;
-  char *wstr = str;
-  unsigned long long whole;
-  double tmp;
-  unsigned long long frac;
   int neg;
-  double pow10;
 
   if (value == HUGE_VAL || value == -HUGE_VAL) {
     SetError(obj, enc, "Invalid Inf value when encoding double");
@@ -812,100 +786,21 @@ int Buffer_AppendDoubleUnchecked(JSOBJ obj, JSONObjectEncoder *enc,
     value = -value;
   }
 
-  /*
-  for very large or small numbers switch back to native sprintf for
-  exponentials.  anyone want to write code to replace this? */
-  if (value > thres_max || (value != 0.0 && fabs(value) < thres_min)) {
-    precision_str[0] = '%';
-    precision_str[1] = '.';
+  /* Always use sprintf, regardless of float size
+   * to preserve precision*/
+  precision_str[0] = '%';
+  precision_str[1] = '.';
 #if defined(_WIN32) && defined(_MSC_VER)
-    sprintf_s(precision_str + 2, sizeof(precision_str) - 2, "%ug",
-              enc->doublePrecision);
-    enc->offset += sprintf_s(str, enc->end - enc->offset, precision_str,
-                             neg ? -value : value);
+  sprintf_s(precision_str + 2, sizeof(precision_str) - 2, "%ue",
+            enc->doublePrecision);
+  enc->offset += sprintf_s(str, enc->end - enc->offset, precision_str,
+                           neg ? -value : value);
 #else
-    snprintf(precision_str + 2, sizeof(precision_str) - 2, "%ug",
-             enc->doublePrecision);
-    enc->offset += snprintf(str, enc->end - enc->offset, precision_str,
-                            neg ? -value : value);
+  snprintf(precision_str + 2, sizeof(precision_str) - 2, "%ue",
+           enc->doublePrecision);
+  enc->offset += snprintf(str, enc->end - enc->offset, precision_str,
+                          neg ? -value : value);
 #endif
-    return TRUE;
-  }
-
-  pow10 = g_pow10[enc->doublePrecision];
-
-  whole = (unsigned long long)value;
-  tmp = (value - whole) * pow10;
-  frac = (unsigned long long)(tmp);
-  diff = tmp - frac;
-
-  if (diff > 0.5) {
-    ++frac;
-  } else if (diff == 0.5 && ((frac == 0) || (frac & 1))) {
-    /* if halfway, round up if odd, OR
-    if last digit is 0.  That last part is strange */
-    ++frac;
-  }
-
-  // handle rollover, e.g.
-  // case 0.99 with prec 1 is 1.0 and case 0.95 with prec is 1.0 as well
-  if (frac >= pow10) {
-    frac = 0;
-    ++whole;
-  }
-
-  if (enc->doublePrecision == 0) {
-    diff = value - whole;
-
-    if (diff > 0.5) {
-      /* greater than 0.5, round up, e.g. 1.6 -> 2 */
-      ++whole;
-    } else if (diff == 0.5 && (whole & 1)) {
-      /* exactly 0.5 and ODD, then round up */
-      /* 1.5 -> 2, but 2.5 -> 2 */
-      ++whole;
-    }
-
-    // vvvvvvvvvvvvvvvvvvv  Diff from modp_dto2
-  } else if (frac) {
-    count = enc->doublePrecision;
-    // now do fractional part, as an unsigned number
-    // we know it is not 0 but we can have leading zeros, these
-    // should be removed
-    while (!(frac % 10)) {
-      --count;
-      frac /= 10;
-    }
-    //^^^^^^^^^^^^^^^^^^^  Diff from modp_dto2
-
-    // now do fractional part, as an unsigned number
-    do {
-      --count;
-      *wstr++ = (char)(48 + (frac % 10));
-    } while (frac /= 10);
-    // add extra 0s
-    while (count-- > 0) {
-      *wstr++ = '0';
-    }
-    // add decimal
-    *wstr++ = '.';
-  } else {
-    *wstr++ = '0';
-    *wstr++ = '.';
-  }
-
-  // Do whole part. Take care of sign
-  // conversion. Number is reversed.
-  do {
-    *wstr++ = (char)(48 + (whole % 10));
-  } while (whole /= 10);
-
-  if (neg) {
-    *wstr++ = '-';
-  }
-  strreverse(str, wstr - 1);
-  enc->offset += (wstr - (enc->offset));
-
   return TRUE;
 }
 

--- a/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
@@ -73,6 +73,22 @@ The extra 2 bytes are for the quotes around the string
 */
 #define RESERVE_STRING(_len) (2 + ((_len) * 6))
 
+static const double g_pow10[] = {1,
+                                 10,
+                                 100,
+                                 1000,
+                                 10000,
+                                 100000,
+                                 1000000,
+                                 10000000,
+                                 100000000,
+                                 1000000000,
+                                 10000000000,
+                                 100000000000,
+                                 1000000000000,
+                                 10000000000000,
+                                 100000000000000,
+                                 1000000000000000};
 static const char g_hexChars[] = "0123456789abcdef";
 static const char g_escapeChars[] = "0123456789\\b\\t\\n\\f\\r\\\"\\\\\\/";
 
@@ -764,9 +780,19 @@ void Buffer_AppendLongUnchecked(JSONObjectEncoder *enc, JSINT64 value) {
 
 int Buffer_AppendDoubleUnchecked(JSOBJ obj, JSONObjectEncoder *enc,
                                  double value) {
+  /* if input is beyond the thresholds, revert to exponential */
+  const double thres_max = (double)1e16 - 1;
+  const double thres_min = (double)1e-15;
   char precision_str[20];
+  int count;
+  double diff = 0.0;
   char *str = enc->offset;
+  char *wstr = str;
+  unsigned long long whole;
+  double tmp;
+  unsigned long long frac;
   int neg;
+  double pow10;
 
   if (value == HUGE_VAL || value == -HUGE_VAL) {
     SetError(obj, enc, "Invalid Inf value when encoding double");
@@ -778,6 +804,22 @@ int Buffer_AppendDoubleUnchecked(JSOBJ obj, JSONObjectEncoder *enc,
     return FALSE;
   }
 
+  /* Check if forced scientific notation is required */
+  if (enc->forceScientific) {
+    precision_str[0] = '%';
+    precision_str[1] = '.';
+#if defined(_WIN32) && defined(_MSC_VER)
+    sprintf_s(precision_str + 2, sizeof(precision_str) - 2, "%ue",
+              enc->doublePrecision);
+    enc->offset += sprintf_s(str, enc->end - enc->offset, precision_str, value);
+#else
+    snprintf(precision_str + 2, sizeof(precision_str) - 2, "%ue",
+             enc->doublePrecision);
+    enc->offset += snprintf(str, enc->end - enc->offset, precision_str, value);
+#endif
+    return TRUE;
+  }
+
   /* we'll work in positive values and deal with the
   negative sign issue later */
   neg = 0;
@@ -786,21 +828,100 @@ int Buffer_AppendDoubleUnchecked(JSOBJ obj, JSONObjectEncoder *enc,
     value = -value;
   }
 
-  /* Always use sprintf, regardless of float size
-   * to preserve precision*/
-  precision_str[0] = '%';
-  precision_str[1] = '.';
+  /*
+  for very large or small numbers switch back to native sprintf for
+  exponentials.  anyone want to write code to replace this? */
+  if (value > thres_max || (value != 0.0 && fabs(value) < thres_min)) {
+    precision_str[0] = '%';
+    precision_str[1] = '.';
 #if defined(_WIN32) && defined(_MSC_VER)
-  sprintf_s(precision_str + 2, sizeof(precision_str) - 2, "%ue",
-            enc->doublePrecision);
-  enc->offset += sprintf_s(str, enc->end - enc->offset, precision_str,
-                           neg ? -value : value);
+    sprintf_s(precision_str + 2, sizeof(precision_str) - 2, "%ug",
+              enc->doublePrecision);
+    enc->offset += sprintf_s(str, enc->end - enc->offset, precision_str,
+                             neg ? -value : value);
 #else
-  snprintf(precision_str + 2, sizeof(precision_str) - 2, "%ue",
-           enc->doublePrecision);
-  enc->offset += snprintf(str, enc->end - enc->offset, precision_str,
-                          neg ? -value : value);
+    snprintf(precision_str + 2, sizeof(precision_str) - 2, "%ug",
+             enc->doublePrecision);
+    enc->offset += snprintf(str, enc->end - enc->offset, precision_str,
+                            neg ? -value : value);
 #endif
+    return TRUE;
+  }
+
+  pow10 = g_pow10[enc->doublePrecision];
+
+  whole = (unsigned long long)value;
+  tmp = (value - whole) * pow10;
+  frac = (unsigned long long)(tmp);
+  diff = tmp - frac;
+
+  if (diff > 0.5) {
+    ++frac;
+  } else if (diff == 0.5 && ((frac == 0) || (frac & 1))) {
+    /* if halfway, round up if odd, OR
+    if last digit is 0.  That last part is strange */
+    ++frac;
+  }
+
+  // handle rollover, e.g.
+  // case 0.99 with prec 1 is 1.0 and case 0.95 with prec is 1.0 as well
+  if (frac >= pow10) {
+    frac = 0;
+    ++whole;
+  }
+
+  if (enc->doublePrecision == 0) {
+    diff = value - whole;
+
+    if (diff > 0.5) {
+      /* greater than 0.5, round up, e.g. 1.6 -> 2 */
+      ++whole;
+    } else if (diff == 0.5 && (whole & 1)) {
+      /* exactly 0.5 and ODD, then round up */
+      /* 1.5 -> 2, but 2.5 -> 2 */
+      ++whole;
+    }
+
+    // vvvvvvvvvvvvvvvvvvv  Diff from modp_dto2
+  } else if (frac) {
+    count = enc->doublePrecision;
+    // now do fractional part, as an unsigned number
+    // we know it is not 0 but we can have leading zeros, these
+    // should be removed
+    while (!(frac % 10)) {
+      --count;
+      frac /= 10;
+    }
+    //^^^^^^^^^^^^^^^^^^^  Diff from modp_dto2
+
+    // now do fractional part, as an unsigned number
+    do {
+      --count;
+      *wstr++ = (char)(48 + (frac % 10));
+    } while (frac /= 10);
+    // add extra 0s
+    while (count-- > 0) {
+      *wstr++ = '0';
+    }
+    // add decimal
+    *wstr++ = '.';
+  } else {
+    *wstr++ = '0';
+    *wstr++ = '.';
+  }
+
+  // Do whole part. Take care of sign
+  // conversion. Number is reversed.
+  do {
+    *wstr++ = (char)(48 + (whole % 10));
+  } while (whole /= 10);
+
+  if (neg) {
+    *wstr++ = '-';
+  }
+  strreverse(str, wstr - 1);
+  enc->offset += (wstr - (enc->offset));
+
   return TRUE;
 }
 

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -1989,6 +1989,7 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
   static char *kwlist[] = {"obj",
                            "ensure_ascii",
                            "double_precision",
+                           "force_scientific_notation",
                            "encode_html_chars",
                            "orient",
                            "date_unit",
@@ -2000,6 +2001,7 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
   PyObject *oinput = NULL;
   PyObject *oensureAscii = NULL;
   int idoublePrecision = 10; // default double precision setting
+  PyObject *oforceScientific = NULL;
   PyObject *oencodeHTMLChars = NULL;
   char *sOrient = NULL;
   char *sdateFormat = NULL;
@@ -2027,6 +2029,7 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
           .free = PyObject_Free,
           .recursionMax = -1,
           .doublePrecision = idoublePrecision,
+          .forceScientific = 0,
           .forceASCII = 1,
           .encodeHTMLChars = 0,
           .indent = indent,
@@ -2043,15 +2046,19 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
   };
   JSONObjectEncoder *encoder = (JSONObjectEncoder *)&pyEncoder;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiOssOOi", kwlist, &oinput,
-                                   &oensureAscii, &idoublePrecision,
-                                   &oencodeHTMLChars, &sOrient, &sdateFormat,
-                                   &oisoDates, &odefHandler, &indent)) {
+  if (!PyArg_ParseTupleAndKeywords(
+          args, kwargs, "O|OiOOssOOi", kwlist, &oinput, &oensureAscii,
+          &idoublePrecision, &oforceScientific, &oencodeHTMLChars, &sOrient,
+          &sdateFormat, &oisoDates, &odefHandler, &indent)) {
     return NULL;
   }
 
   if (oensureAscii != NULL && !PyObject_IsTrue(oensureAscii)) {
     encoder->forceASCII = 0;
+  }
+
+  if (oforceScientific != NULL && PyObject_IsTrue(oforceScientific)) {
+    encoder->forceScientific = 1;
   }
 
   if (oencodeHTMLChars != NULL && PyObject_IsTrue(oencodeHTMLChars)) {

--- a/pandas/_libs/src/vendored/ujson/python/ujson.c
+++ b/pandas/_libs/src/vendored/ujson/python/ujson.c
@@ -54,7 +54,9 @@ PyObject *JSONToObj(PyObject *self, PyObject *args, PyObject *kwargs);
 #define ENCODER_HELP_TEXT                                                      \
   "Use ensure_ascii=false to output UTF-8. Pass in double_precision to "       \
   "alter the maximum digit precision of doubles. Set "                         \
-  "encode_html_chars=True to encode < > & as unicode escape sequences."
+  "encode_html_chars=True to encode < > & as unicode escape sequences."        \
+  "Use force_scientific_notation=true to always use scientific notation"       \
+  "for floats."
 
 static PyMethodDef ujsonMethods[] = {
     {"ujson_dumps", (PyCFunction)(void (*)(void))objToJSON,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2319,6 +2319,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         | None = None,
         date_format: str | None = None,
         double_precision: int = 10,
+        force_scientific_notation: bool = False,
         force_ascii: bool = True,
         date_unit: TimeUnit = "ms",
         default_handler: Callable[[Any], JSONSerializable] | None = None,
@@ -2381,6 +2382,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             The number of decimal places to use when encoding
             floating point values. The possible maximal value is 15.
             Passing double_precision greater than 15 will raise a ValueError.
+        force_scientific_notation: bool, default False
+            Force scientific notation for all doubles regardless of size. This
+            makes output precision consistent regardless of the exponent.
         force_ascii : bool, default True
             Force encoded string to be ASCII.
         date_unit : str, default 'ms' (milliseconds)
@@ -2628,6 +2632,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             orient=orient,
             date_format=date_format,
             double_precision=double_precision,
+            force_scientific_notation=force_scientific_notation,
             force_ascii=force_ascii,
             date_unit=date_unit,
             default_handler=default_handler,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2382,7 +2382,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             The number of decimal places to use when encoding
             floating point values. The possible maximal value is 15.
             Passing double_precision greater than 15 will raise a ValueError.
-        force_scientific_notation: bool, default False
+        force_scientific_notation : bool, default False
             Force scientific notation for all doubles regardless of size. This
             makes output precision consistent regardless of the exponent.
         force_ascii : bool, default True

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -105,6 +105,7 @@ def to_json(
     orient: str | None = ...,
     date_format: str = ...,
     double_precision: int = ...,
+    force_scientific_notation: bool = ...,
     force_ascii: bool = ...,
     date_unit: str = ...,
     default_handler: Callable[[Any], JSONSerializable] | None = ...,
@@ -124,6 +125,7 @@ def to_json(
     orient: str | None = ...,
     date_format: str = ...,
     double_precision: int = ...,
+    force_scientific_notation: bool = ...,
     force_ascii: bool = ...,
     date_unit: str = ...,
     default_handler: Callable[[Any], JSONSerializable] | None = ...,
@@ -142,6 +144,7 @@ def to_json(
     orient: str | None = None,
     date_format: str = "epoch",
     double_precision: int = 10,
+    force_scientific_notation: bool = False,
     force_ascii: bool = True,
     date_unit: str = "ms",
     default_handler: Callable[[Any], JSONSerializable] | None = None,
@@ -233,6 +236,7 @@ def to_json(
         orient=orient,
         date_format=date_format,
         double_precision=double_precision,
+        force_scientific_notation=force_scientific_notation,
         ensure_ascii=force_ascii,
         date_unit=date_unit,
         default_handler=default_handler,
@@ -263,6 +267,7 @@ class Writer(ABC):
         orient: str | None,
         date_format: str,
         double_precision: int,
+        force_scientific_notation: bool,
         ensure_ascii: bool,
         date_unit: str,
         index: bool,
@@ -277,6 +282,7 @@ class Writer(ABC):
         self.orient = orient
         self.date_format = date_format
         self.double_precision = double_precision
+        self.force_scientific_notation = force_scientific_notation
         self.ensure_ascii = ensure_ascii
         self.date_unit = date_unit
         self.default_handler = default_handler
@@ -293,6 +299,7 @@ class Writer(ABC):
             self.obj_to_write,
             orient=self.orient,
             double_precision=self.double_precision,
+            force_scientific_notation=self.force_scientific_notation,
             ensure_ascii=self.ensure_ascii,
             date_unit=self.date_unit,
             iso_dates=iso_dates,
@@ -360,6 +367,7 @@ class JSONTableWriter(FrameWriter):
         orient: str | None,
         date_format: str,
         double_precision: int,
+        force_scientific_notation: bool,
         ensure_ascii: bool,
         date_unit: str,
         index: bool,
@@ -377,6 +385,7 @@ class JSONTableWriter(FrameWriter):
             orient,
             date_format,
             double_precision,
+            force_scientific_notation,
             ensure_ascii,
             date_unit,
             index,

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -425,13 +425,12 @@ class TestPandasContainer:
     @pytest.mark.parametrize(
         "value,precision,expected_val",
         [
-            (0.95, 1, "9.5e-01"),
-            (0.9951, 1, "1.0e+00"),
-            (1.96, 1, "2.0e+00"),
-            (-1.96, 1, "-2.0e+00"),
-            (0.9996, 2, "1.00e+00"),
-            (0.99996, 3, "1.000e+00"),
-            (0.999999999999999644, 14, "1.00000000000000e+00"),
+            (0.95, 1, 1.0),
+            (1.95, 1, 2.0),
+            (-1.95, 1, -2.0),
+            (0.995, 2, 1.0),
+            (0.9995, 3, 1.0),
+            (0.99999999999999944, 15, 1.0),
         ],
     )
     def test_frame_to_json_float_precision(self, value, precision, expected_val):
@@ -1312,13 +1311,10 @@ class TestPandasContainer:
         ]
         expected = (
             '[9,[[1,null],["STR",null],[[["mathjs","Complex"],'
-            '["re",4.000e+00],["im",-5.000e+00]],"N\\/A"]]]'
+            '["re",4.0],["im",-5.0]],"N\\/A"]]]'
         )
         assert (
-            ujson_dumps(
-                df_list, default_handler=default, double_precision=3, orient="values"
-            )
-            == expected
+            ujson_dumps(df_list, default_handler=default, orient="values") == expected
         )
 
     def test_default_handler_numpy_unsupported_dtype(self):
@@ -2162,37 +2158,37 @@ class TestPandasContainer:
         [
             (
                 Series({0: -6 + 8j, 1: 0 + 1j, 2: 9 - 5j}),
-                '{"0":{"imag":8.00e+00,"real":-6.00e+00},'
-                '"1":{"imag":1.00e+00,"real":0.00e+00},'
-                '"2":{"imag":-5.00e+00,"real":9.00e+00}}',
+                '{"0":{"imag":8.0,"real":-6.0},'
+                '"1":{"imag":1.0,"real":0.0},'
+                '"2":{"imag":-5.0,"real":9.0}}',
             ),
             (
                 Series({0: -9.39 + 0.66j, 1: 3.95 + 9.32j, 2: 4.03 - 0.17j}),
-                '{"0":{"imag":6.60e-01,"real":-9.39e+00},'
-                '"1":{"imag":9.32e+00,"real":3.95e+00},'
-                '"2":{"imag":-1.70e-01,"real":4.03e+00}}',
+                '{"0":{"imag":0.66,"real":-9.39},'
+                '"1":{"imag":9.32,"real":3.95},'
+                '"2":{"imag":-0.17,"real":4.03}}',
             ),
             (
                 DataFrame([[-2 + 3j, -1 - 0j], [4 - 3j, -0 - 10j]]),
-                '{"0":{"0":{"imag":3.00e+00,"real":-2.00e+00},'
-                '"1":{"imag":-3.00e+00,"real":4.00e+00}},'
-                '"1":{"0":{"imag":0.00e+00,"real":-1.00e+00},'
-                '"1":{"imag":-1.00e+01,"real":0.00e+00}}}',
+                '{"0":{"0":{"imag":3.0,"real":-2.0},'
+                '"1":{"imag":-3.0,"real":4.0}},'
+                '"1":{"0":{"imag":0.0,"real":-1.0},'
+                '"1":{"imag":-10.0,"real":0.0}}}',
             ),
             (
                 DataFrame(
                     [[-0.28 + 0.34j, -1.08 - 0.39j], [0.41 - 0.34j, -0.78 - 1.35j]]
                 ),
-                '{"0":{"0":{"imag":3.40e-01,"real":-2.80e-01},'
-                '"1":{"imag":-3.40e-01,"real":4.10e-01}},'
-                '"1":{"0":{"imag":-3.90e-01,"real":-1.08e+00},'
-                '"1":{"imag":-1.35e+00,"real":-7.80e-01}}}',
+                '{"0":{"0":{"imag":0.34,"real":-0.28},'
+                '"1":{"imag":-0.34,"real":0.41}},'
+                '"1":{"0":{"imag":-0.39,"real":-1.08},'
+                '"1":{"imag":-1.35,"real":-0.78}}}',
             ),
         ],
     )
     def test_complex_data_tojson(self, data, expected):
         # GH41174
-        result = data.to_json(double_precision=2)
+        result = data.to_json()
         assert result == expected
 
     def test_json_uint64(self):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -425,12 +425,13 @@ class TestPandasContainer:
     @pytest.mark.parametrize(
         "value,precision,expected_val",
         [
-            (0.95, 1, 1.0),
-            (1.95, 1, 2.0),
-            (-1.95, 1, -2.0),
-            (0.995, 2, 1.0),
-            (0.9995, 3, 1.0),
-            (0.99999999999999944, 15, 1.0),
+            (0.95, 1, "9.5e-01"),
+            (0.9951, 1, "1.0e+00"),
+            (1.96, 1, "2.0e+00"),
+            (-1.96, 1, "-2.0e+00"),
+            (0.9996, 2, "1.00e+00"),
+            (0.99996, 3, "1.000e+00"),
+            (0.999999999999999644, 14, "1.00000000000000e+00"),
         ],
     )
     def test_frame_to_json_float_precision(self, value, precision, expected_val):
@@ -1311,10 +1312,13 @@ class TestPandasContainer:
         ]
         expected = (
             '[9,[[1,null],["STR",null],[[["mathjs","Complex"],'
-            '["re",4.0],["im",-5.0]],"N\\/A"]]]'
+            '["re",4.000e+00],["im",-5.000e+00]],"N\\/A"]]]'
         )
         assert (
-            ujson_dumps(df_list, default_handler=default, orient="values") == expected
+            ujson_dumps(
+                df_list, default_handler=default, double_precision=3, orient="values"
+            )
+            == expected
         )
 
     def test_default_handler_numpy_unsupported_dtype(self):
@@ -2158,37 +2162,37 @@ class TestPandasContainer:
         [
             (
                 Series({0: -6 + 8j, 1: 0 + 1j, 2: 9 - 5j}),
-                '{"0":{"imag":8.0,"real":-6.0},'
-                '"1":{"imag":1.0,"real":0.0},'
-                '"2":{"imag":-5.0,"real":9.0}}',
+                '{"0":{"imag":8.00e+00,"real":-6.00e+00},'
+                '"1":{"imag":1.00e+00,"real":0.00e+00},'
+                '"2":{"imag":-5.00e+00,"real":9.00e+00}}',
             ),
             (
                 Series({0: -9.39 + 0.66j, 1: 3.95 + 9.32j, 2: 4.03 - 0.17j}),
-                '{"0":{"imag":0.66,"real":-9.39},'
-                '"1":{"imag":9.32,"real":3.95},'
-                '"2":{"imag":-0.17,"real":4.03}}',
+                '{"0":{"imag":6.60e-01,"real":-9.39e+00},'
+                '"1":{"imag":9.32e+00,"real":3.95e+00},'
+                '"2":{"imag":-1.70e-01,"real":4.03e+00}}',
             ),
             (
                 DataFrame([[-2 + 3j, -1 - 0j], [4 - 3j, -0 - 10j]]),
-                '{"0":{"0":{"imag":3.0,"real":-2.0},'
-                '"1":{"imag":-3.0,"real":4.0}},'
-                '"1":{"0":{"imag":0.0,"real":-1.0},'
-                '"1":{"imag":-10.0,"real":0.0}}}',
+                '{"0":{"0":{"imag":3.00e+00,"real":-2.00e+00},'
+                '"1":{"imag":-3.00e+00,"real":4.00e+00}},'
+                '"1":{"0":{"imag":0.00e+00,"real":-1.00e+00},'
+                '"1":{"imag":-1.00e+01,"real":0.00e+00}}}',
             ),
             (
                 DataFrame(
                     [[-0.28 + 0.34j, -1.08 - 0.39j], [0.41 - 0.34j, -0.78 - 1.35j]]
                 ),
-                '{"0":{"0":{"imag":0.34,"real":-0.28},'
-                '"1":{"imag":-0.34,"real":0.41}},'
-                '"1":{"0":{"imag":-0.39,"real":-1.08},'
-                '"1":{"imag":-1.35,"real":-0.78}}}',
+                '{"0":{"0":{"imag":3.40e-01,"real":-2.80e-01},'
+                '"1":{"imag":-3.40e-01,"real":4.10e-01}},'
+                '"1":{"0":{"imag":-3.90e-01,"real":-1.08e+00},'
+                '"1":{"imag":-1.35e+00,"real":-7.80e-01}}}',
             ),
         ],
     )
     def test_complex_data_tojson(self, data, expected):
         # GH41174
-        result = data.to_json()
+        result = data.to_json(double_precision=2)
         assert result == expected
 
     def test_json_uint64(self):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -438,6 +438,26 @@ class TestPandasContainer:
         encoded = df.to_json(double_precision=precision)
         assert encoded == f'{{"a_float":{{"0":{expected_val}}}}}'
 
+    @pytest.mark.skipif(not IS64, reason="not compliant on 32-bit, xref #15865")
+    @pytest.mark.parametrize(
+        "value,precision,expected_val",
+        [
+            (0.95, 1, "9.5e-01"),
+            (0.9951, 1, "1.0e+00"),
+            (1.96, 1, "2.0e+00"),
+            (-1.96, 1, "-2.0e+00"),
+            (0.9996, 2, "1.00e+00"),
+            (0.99996, 3, "1.000e+00"),
+            (0.999999999999999644, 14, "1.00000000000000e+00"),
+        ],
+    )
+    def test_frame_to_json_float_scientific_precision(
+        self, value, precision, expected_val
+    ):
+        df = DataFrame([{"a_float": value}])
+        encoded = df.to_json(double_precision=precision, force_scientific_notation=True)
+        assert encoded == f'{{"a_float":{{"0":{expected_val}}}}}'
+
     def test_frame_to_json_except(self):
         df = DataFrame([1, 2, 3])
         msg = "Invalid value 'garbage' for option 'orient'"

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -99,7 +99,7 @@ class TestUltraJSONTests:
         helper(html_encoded, encode_html_chars=True)
 
     @pytest.mark.parametrize(
-        "long_number", [-434296973418351, -12345678901234.5, -528656961.439938]
+        "long_number", [-4342969734183514, -12345678901234.56789012, -528656961.4399388]
     )
     def test_double_long_numbers(self, long_number):
         sut = {"a": long_number}
@@ -148,9 +148,9 @@ class TestUltraJSONTests:
 
     def test_encode_with_decimal(self):
         decimal_input = 1.0
-        output = ujson.ujson_dumps(decimal_input, double_precision=3)
+        output = ujson.ujson_dumps(decimal_input)
 
-        assert output == "1.000e+00"
+        assert output == "1.0"
 
     def test_encode_array_of_nested_arrays(self):
         nested_input = [[[[]]]] * 20
@@ -167,7 +167,7 @@ class TestUltraJSONTests:
         assert doubles_input == ujson.ujson_loads(output)
 
     def test_double_precision(self):
-        double_input = 30.01234567890123
+        double_input = 30.012345678901234
         output = ujson.ujson_dumps(double_input, double_precision=15)
 
         assert double_input == json.loads(output)
@@ -175,15 +175,17 @@ class TestUltraJSONTests:
 
         for double_precision in (3, 9):
             output = ujson.ujson_dumps(double_input, double_precision=double_precision)
-            rounded_input = float(f"%.{double_precision}e" % double_input)
+            rounded_input = round(double_input, double_precision)
 
             assert rounded_input == json.loads(output)
-            assert math.isclose(rounded_input, ujson.ujson_loads(output))
+            assert rounded_input == ujson.ujson_loads(output)
 
-    def test_double_magnitude(self):
-        for i in range(-20, 20):
+    def test_scientific_double_range(self):
+        for i in range(-100, 100):
             double_input = float(f"1.234567890123456e{i}")
-            output = ujson.ujson_dumps(double_input, double_precision=15)
+            output = ujson.ujson_dumps(
+                double_input, double_precision=15, force_scientific_notation=True
+            )
             assert double_input == json.loads(output)
             assert math.isclose(double_input, ujson.ujson_loads(output))
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -177,8 +177,15 @@ class TestUltraJSONTests:
             output = ujson.ujson_dumps(double_input, double_precision=double_precision)
             rounded_input = float(f"%.{double_precision}e" % double_input)
 
-            assert math.isclose(rounded_input, json.loads(output))
+            assert rounded_input == json.loads(output)
             assert math.isclose(rounded_input, ujson.ujson_loads(output))
+
+    def test_double_magnitude(self):
+        for i in range(-20, 20):
+            double_input = float(f"1.234567890123456e{i}")
+            output = ujson.ujson_dumps(double_input, double_precision=15)
+            assert double_input == json.loads(output)
+            assert math.isclose(double_input, ujson.ujson_loads(output))
 
     @pytest.mark.parametrize(
         "invalid_val",

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -99,7 +99,7 @@ class TestUltraJSONTests:
         helper(html_encoded, encode_html_chars=True)
 
     @pytest.mark.parametrize(
-        "long_number", [-4342969734183514, -12345678901234.56789012, -528656961.4399388]
+        "long_number", [-434296973418351, -12345678901234.5, -528656961.439938]
     )
     def test_double_long_numbers(self, long_number):
         sut = {"a": long_number}
@@ -148,9 +148,9 @@ class TestUltraJSONTests:
 
     def test_encode_with_decimal(self):
         decimal_input = 1.0
-        output = ujson.ujson_dumps(decimal_input)
+        output = ujson.ujson_dumps(decimal_input, double_precision=3)
 
-        assert output == "1.0"
+        assert output == "1.000e+00"
 
     def test_encode_array_of_nested_arrays(self):
         nested_input = [[[[]]]] * 20
@@ -167,7 +167,7 @@ class TestUltraJSONTests:
         assert doubles_input == ujson.ujson_loads(output)
 
     def test_double_precision(self):
-        double_input = 30.012345678901234
+        double_input = 30.01234567890123
         output = ujson.ujson_dumps(double_input, double_precision=15)
 
         assert double_input == json.loads(output)
@@ -175,10 +175,10 @@ class TestUltraJSONTests:
 
         for double_precision in (3, 9):
             output = ujson.ujson_dumps(double_input, double_precision=double_precision)
-            rounded_input = round(double_input, double_precision)
+            rounded_input = float(f"%.{double_precision}e" % double_input)
 
-            assert rounded_input == json.loads(output)
-            assert rounded_input == ujson.ujson_loads(output)
+            assert math.isclose(rounded_input, json.loads(output))
+            assert math.isclose(rounded_input, ujson.ujson_loads(output))
 
     @pytest.mark.parametrize(
         "invalid_val",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -723,5 +723,5 @@ exclude_lines = [
 directory = "coverage_html_report"
 
 [tool.codespell]
-ignore-words-list = "blocs, coo, hist, nd, sav, ser, recuse, nin, timere, expec, expecs, indext, SME, NotIn, tructures, tru, indx, abd, ABD"
+ignore-words-list = "blocs, coo, hist, nd, sav, ser, recuse, nin, timere, expec, expecs, indext, SME, NotIn, tructures, tru, indx, abd, ABD, ue"
 ignore-regex = 'https://([\w/\.])+'


### PR DESCRIPTION
- [x] closes #59313 and #23328
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

The current behavior of DataFrame.to_json() is to use decimal notation for floats larger than 1e-16, rounding them to `double_precision` (dp) decimal digits. This results in a loss of precision for anything between 1e-2 and 1e-dp, while completely zeroing out everything between 1e-dp and 1e-15.

My proposed fix is to force the ultrajson encoder to always use scientific notation (accordingly, I have ripped out all the custom formatting logic that became unreachable). This has the following consequences:

- Numbers between 1e-2 and 1e-16 are now properly represented with the set amount of significant figures and are no longer erroneously zeroed out.
- Certain numbers which were allowed to have much more significant digits than `double_precision` are now rounded to `double_precision` digits. For example, the old method would export -12345678901234.568359375 precisely (within reason for floats), while now it will be represented as -1.234567890123457e+13. Keeping in mind that precisions over 15 digits are unnecessary for doubles, I consider this a worthwhile tradeoff.
- Numbers which can be adequately expressed with less digits are padded with zeros, i.e. 1.0 becomes 1.000e+00. This does slightly inflate output file sizes, but compression is available for cases where that matters. I also consider it a positive that the exact precision is now indicated, removing ambiguities about rounding (i.e. 1.300 and a rounded 1.301 are now distinguishable).

I have added new test cases and modified the old ones for the new behavior. However, as I am not familiar with the codebase, I cannot be sure that I did not introduce any new bugs into dependent code.

Known issues:

 - The actual number of  significant digits in one larger than specified in the `double_precision` argument. Subtracting one in the ultrajson encoder could work, but it may be required to add some checks so we don't try to print -1 digits. It should be noted that this issue was already present when the code path was reached under normal conditions.
 - Rounding is not always perfect. For instance, 0.995 is rounded to 0.99, while 0.9951 is correctly rounded up to 1.0