### PR TITLE
PERF: faster many:many join with sort=False

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -109,6 +109,7 @@ Performance improvements
   single column by label on a :class:`DataFrame` with duplicate column names.
   (:issue:`64126`).
 - Performance improvement in :func:`infer_freq` (:issue:`64463`)
+- Performance improvement in :func:`merge` and :meth:`DataFrame.join` for many-to-many joins with ``sort=False`` (:issue:`56564`)
 - Performance improvement in :func:`merge` with ``how="cross"`` (:issue:`38082`)
 - Performance improvement in :func:`merge` with ``how="left"`` (:issue:`64370`)
 - Performance improvement in :meth:`GroupBy.first` and :meth:`GroupBy.last` for Extension Array dtypes, which no longer fall back to a slow ``apply``-based implementation (:issue:`57591`)

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -31,6 +31,9 @@ def inner_join(const intp_t[:] left, const intp_t[:] right,
         intp_t lc, rc
         Py_ssize_t left_pos = 0, right_pos = 0, position = 0
         Py_ssize_t offset
+        intp_t[::1] group_of, right_start
+        intp_t group
+        Py_ssize_t p
 
     left_sorter, left_count = groupsort_indexer(left, max_groups)
     right_sorter, right_count = groupsort_indexer(right, max_groups)
@@ -47,42 +50,64 @@ def inner_join(const intp_t[:] left, const intp_t[:] right,
     left_indexer = np.empty(count, dtype=np.intp)
     right_indexer = np.empty(count, dtype=np.intp)
 
-    with nogil:
-        # exclude the NA group
-        left_pos = left_count[0]
-        right_pos = right_count[0]
-        for i in range(1, max_groups + 1):
-            lc = left_count[i]
-            rc = right_count[i]
+    if sort:
+        with nogil:
+            # exclude the NA group
+            left_pos = left_count[0]
+            right_pos = right_count[0]
+            for i in range(1, max_groups + 1):
+                lc = left_count[i]
+                rc = right_count[i]
 
-            if rc > 0 and lc > 0:
-                for j in range(lc):
-                    offset = position + j * rc
-                    for k in range(rc):
-                        left_indexer[offset + k] = left_pos + j
-                        right_indexer[offset + k] = right_pos + k
-                position += lc * rc
-            left_pos += lc
-            right_pos += rc
+                if rc > 0 and lc > 0:
+                    for j in range(lc):
+                        offset = position + j * rc
+                        for k in range(rc):
+                            left_indexer[offset + k] = left_pos + j
+                            right_indexer[offset + k] = right_pos + k
+                    position += lc * rc
+                left_pos += lc
+                right_pos += rc
 
-        # Will overwrite left/right indexer with the result
-        _get_result_indexer(left_sorter, left_indexer)
-        _get_result_indexer(right_sorter, right_indexer)
-
-    if not sort:
-        # if not asked to sort, revert to original order
-        if len(left) == len(left_indexer):
-            # no multiple matches for any row on the left
-            # this is a short-cut to avoid groupsort_indexer
-            # otherwise, the `else` path also works in this case
-            rev = np.empty(len(left), dtype=np.intp)
-            rev.put(np.asarray(left_sorter), np.arange(len(left)))
-        else:
-            rev, _ = groupsort_indexer(left_indexer, len(left))
-
-        return np.asarray(left_indexer).take(rev), np.asarray(right_indexer).take(rev)
+            # Will overwrite left/right indexer with the result
+            _get_result_indexer(left_sorter, left_indexer)
+            _get_result_indexer(right_sorter, right_indexer)
     else:
-        return np.asarray(left_indexer), np.asarray(right_indexer)
+        # For sort=False, generate output directly in original left order
+        # to avoid expensive post-hoc reordering of the (potentially huge)
+        # output arrays.
+        group_of = np.zeros(len(left), dtype=np.intp)
+        right_start = np.empty(max_groups + 1, dtype=np.intp)
+
+        with nogil:
+            # Build group_of: maps original left position -> group number
+            left_pos = left_count[0]
+            for i in range(1, max_groups + 1):
+                lc = left_count[i]
+                for j in range(lc):
+                    group_of[left_sorter[left_pos + j]] = i
+                left_pos += lc
+
+            # Build right_start: starting offset in right_sorter per group
+            right_pos = right_count[0]
+            for i in range(1, max_groups + 1):
+                right_start[i] = right_pos
+                right_pos += right_count[i]
+
+            # Fill output in original left order
+            for p in range(len(left)):
+                group = group_of[p]
+                if group > 0:
+                    rc = right_count[group]
+                    if rc > 0:
+                        for k in range(rc):
+                            left_indexer[position + k] = p
+                            right_indexer[position + k] = (
+                                right_sorter[right_start[group] + k]
+                            )
+                        position += rc
+
+    return np.asarray(left_indexer), np.asarray(right_indexer)
 
 
 @cython.wraparound(False)
@@ -91,13 +116,15 @@ def left_outer_join(const intp_t[:] left, const intp_t[:] right,
                     Py_ssize_t max_groups, bint sort=True):
     cdef:
         Py_ssize_t i, j, k, count = 0
-        ndarray[intp_t] rev
         intp_t[::1] left_count, right_count
         intp_t[::1] left_sorter, right_sorter
         intp_t[::1] left_indexer, right_indexer
         intp_t lc, rc
         Py_ssize_t left_pos = 0, right_pos = 0, position = 0
         Py_ssize_t offset
+        intp_t[::1] group_of, right_start
+        intp_t group
+        Py_ssize_t p
 
     left_sorter, left_count = groupsort_indexer(left, max_groups)
     right_sorter, right_count = groupsort_indexer(right, max_groups)
@@ -116,46 +143,73 @@ def left_outer_join(const intp_t[:] left, const intp_t[:] right,
     left_indexer = np.empty(count, dtype=np.intp)
     right_indexer = np.empty(count, dtype=np.intp)
 
-    with nogil:
-        # exclude the NA group
-        left_pos = left_count[0]
-        right_pos = right_count[0]
-        for i in range(1, max_groups + 1):
-            lc = left_count[i]
-            rc = right_count[i]
+    if sort:
+        with nogil:
+            # exclude the NA group
+            left_pos = left_count[0]
+            right_pos = right_count[0]
+            for i in range(1, max_groups + 1):
+                lc = left_count[i]
+                rc = right_count[i]
 
-            if rc == 0:
-                for j in range(lc):
-                    left_indexer[position + j] = left_pos + j
-                    right_indexer[position + j] = -1
-                position += lc
-            else:
-                for j in range(lc):
-                    offset = position + j * rc
-                    for k in range(rc):
-                        left_indexer[offset + k] = left_pos + j
-                        right_indexer[offset + k] = right_pos + k
-                position += lc * rc
-            left_pos += lc
-            right_pos += rc
+                if rc == 0:
+                    for j in range(lc):
+                        left_indexer[position + j] = left_pos + j
+                        right_indexer[position + j] = -1
+                    position += lc
+                else:
+                    for j in range(lc):
+                        offset = position + j * rc
+                        for k in range(rc):
+                            left_indexer[offset + k] = left_pos + j
+                            right_indexer[offset + k] = right_pos + k
+                    position += lc * rc
+                left_pos += lc
+                right_pos += rc
 
-        # Will overwrite left/right indexer with the result
-        _get_result_indexer(left_sorter, left_indexer)
-        _get_result_indexer(right_sorter, right_indexer)
-
-    if not sort:  # if not asked to sort, revert to original order
-        if len(left) == len(left_indexer):
-            # no multiple matches for any row on the left
-            # this is a short-cut to avoid groupsort_indexer
-            # otherwise, the `else` path also works in this case
-            rev = np.empty(len(left), dtype=np.intp)
-            rev.put(np.asarray(left_sorter), np.arange(len(left)))
-        else:
-            rev, _ = groupsort_indexer(left_indexer, len(left))
-
-        return np.asarray(left_indexer).take(rev), np.asarray(right_indexer).take(rev)
+            # Will overwrite left/right indexer with the result
+            _get_result_indexer(left_sorter, left_indexer)
+            _get_result_indexer(right_sorter, right_indexer)
     else:
-        return np.asarray(left_indexer), np.asarray(right_indexer)
+        # For sort=False, generate output directly in original left order
+        # to avoid expensive post-hoc reordering of the (potentially huge)
+        # output arrays.
+        group_of = np.zeros(len(left), dtype=np.intp)
+        right_start = np.empty(max_groups + 1, dtype=np.intp)
+
+        with nogil:
+            # Build group_of: maps original left position -> group number
+            left_pos = left_count[0]
+            for i in range(1, max_groups + 1):
+                lc = left_count[i]
+                for j in range(lc):
+                    group_of[left_sorter[left_pos + j]] = i
+                left_pos += lc
+
+            # Build right_start: starting offset in right_sorter per group
+            right_pos = right_count[0]
+            for i in range(1, max_groups + 1):
+                right_start[i] = right_pos
+                right_pos += right_count[i]
+
+            # Fill output in original left order
+            for p in range(len(left)):
+                group = group_of[p]
+                if group > 0:
+                    rc = right_count[group]
+                    if rc > 0:
+                        for k in range(rc):
+                            left_indexer[position + k] = p
+                            right_indexer[position + k] = (
+                                right_sorter[right_start[group] + k]
+                            )
+                        position += rc
+                    else:
+                        left_indexer[position] = p
+                        right_indexer[position] = -1
+                        position += 1
+
+    return np.asarray(left_indexer), np.asarray(right_indexer)
 
 
 @cython.wraparound(False)


### PR DESCRIPTION
Written by claude, reviewed manually (WIP) by me.

- [x] closes #56564

For `sort=False` (the default), `inner_join` and `left_outer_join` in `join.pyx` generated output in sorted order and then expensively reordered via `groupsort_indexer` + two `.take(rev)` calls on the full output array. For many:many joins this output can be orders of magnitude larger than the inputs (e.g. 1M × 600K → 60M rows), making the reordering dominant.

Generate output directly in original left order instead, eliminating ~5 extra O(n_output) passes and a large temporary allocation.

Benchmark from #56564 (1M left × 600K right, 60M result rows):

```
import pandas as pd

df1 = pd.DataFrame({
    "key": [x // 100 for x in range(1_000_000)],
    "val1": 10
}).set_index("key")

df2 = pd.DataFrame({
    "key": [x // 100 for x in range(200_000, 800_000)],
    "val2": 20
}).set_index("key")

%timeit pd.merge(df1, df2, left_index=True, right_index=True, how="inner")
988 ms ± 74.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- main
595 ms ± 32.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- PR
 
%timeit pd.merge(df1, df2, on=["key"], how="inner")
1.19 s ± 84.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- main
781 ms ± 84.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- PR
```
