### PR TITLE
PERF: Optimize month_position_check in infer_freq

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -107,6 +107,7 @@ Performance improvements
   (:issue:`64126`).
 - Performance improvement in :func:`merge` with ``how="left"`` (:issue:`64370`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
+- Performance improvement in :func:`infer_freq` (:issue:`??`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -105,9 +105,9 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.__getitem__` when selecting a
   single column by label on a :class:`DataFrame` with duplicate column names.
   (:issue:`64126`).
+- Performance improvement in :func:`infer_freq` (:issue:`64463`)
 - Performance improvement in :func:`merge` with ``how="left"`` (:issue:`64370`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
-- Performance improvement in :func:`infer_freq` (:issue:`??`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -97,9 +97,12 @@ def build_field_sarray(const int64_t[:] dtindex, NPY_DATETIMEUNIT reso):
     return out
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def month_position_check(fields, weekdays) -> str | None:
     cdef:
-        int32_t daysinmonth, y, m, d
+        Py_ssize_t i, count
+        int32_t daysinmonth, y, m, d, wd
         bint calendar_end = True
         bint business_end = True
         bint calendar_start = True
@@ -108,8 +111,16 @@ def month_position_check(fields, weekdays) -> str | None:
         int32_t[:] years = fields["Y"]
         int32_t[:] months = fields["M"]
         int32_t[:] days = fields["D"]
+        int32_t[:] wdays = np.asarray(weekdays, dtype=np.int32)
 
-    for y, m, d, wd in zip(years, months, days, weekdays, strict=True):
+    count = len(years)
+
+    for i in range(count):
+        y = years[i]
+        m = months[i]
+        d = days[i]
+        wd = wdays[i]
+
         if calendar_start:
             calendar_start &= d == 1
         if business_start:


### PR DESCRIPTION
Claude wrote this, I reviewed it manually

```
dti = pd.date_range("2000-01-31", periods=10000, freq="ME")._with_freq(None)

%timeit pd.infer_freq(dti)
5.15 ms ± 692 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # <- main
686 μs ± 91.4 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  # <- PR
```

## Summary
- Replace Python-level `zip()` iteration with C-level indexed `range()` loop in `month_position_check`
- Type the `weekdays` parameter as an `int32_t[:]` memoryview instead of untyped Python object
- Add `@cython.boundscheck(False)` and `@cython.wraparound(False)` decorators
