### PR TITLE
DOC: Add asi8 and unit properties to API reference

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -166,7 +166,12 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
         -i "pandas.api.typing.SeriesGroupBy.hist ES01" \
         -i "pandas.Timestamp.fromisocalendar GL01,GL02,SS02,SA01,EX01" \
         -i "pandas.Timestamp.fromisoformat SS02,SS03,ES01,SA01,EX01" \
-        -i "pandas.Timedelta.resolution_string SA01" # no backslash in the last line
+        -i "pandas.Timedelta.resolution_string SA01" \
+        -i "pandas.DatetimeIndex.asi8 GL08" \
+        -i "pandas.PeriodIndex.asi8 GL08" \
+        -i "pandas.TimedeltaIndex.asi8 GL08" \
+        -i "pandas.DatetimeIndex.unit GL08" \
+        -i "pandas.TimedeltaIndex.unit GL08" # no backslash in the last line
 
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -358,6 +358,8 @@ Time/date components
    DatetimeIndex.is_year_end
    DatetimeIndex.is_leap_year
    DatetimeIndex.inferred_freq
+   DatetimeIndex.asi8
+   DatetimeIndex.unit
 
 Selecting
 ~~~~~~~~~
@@ -423,6 +425,8 @@ Components
    TimedeltaIndex.nanoseconds
    TimedeltaIndex.components
    TimedeltaIndex.inferred_freq
+   TimedeltaIndex.asi8
+   TimedeltaIndex.unit
 
 Conversion
 ~~~~~~~~~~
@@ -481,6 +485,7 @@ Properties
     PeriodIndex.weekday
     PeriodIndex.weekofyear
     PeriodIndex.year
+    PeriodIndex.asi8
 
 Methods
 ~~~~~~~


### PR DESCRIPTION
## Summary
- Add `DatetimeIndex.asi8`, `PeriodIndex.asi8`, `TimedeltaIndex.asi8`,
  `DatetimeIndex.unit`, and `TimedeltaIndex.unit` to
  `doc/source/reference/indexing.rst` so they appear in the rendered API docs.
- Add GL08 ignores in `ci/code_checks.sh` for these 5 properties since their
  thin wrappers in `DatetimeIndexOpsMixin` / `DatetimeTimedeltaMixin` currently
  delegate to `self._data` without a docstring of their own.
These properties were accessible on the public API but absent from the reference
documentation. They were found by comparing `dir()` output against autosummary
entries in the RST files and filtering out aliases and methods already documented
on a parent or sibling class.
## Test plan
- [x] `ci/code_checks.sh docstrings` passes with the new ignore entries
- [x] `doc/source/reference/indexing.rst` renders correctly with the new entries
