### PR TITLE
CLN: Hide Categorical.reshape/swapaxes/transpose from dir()

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -367,7 +367,9 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     # ops, which raise
     __array_priority__ = 1000
     # tolist is not actually deprecated, just suppressed in the __dir__
-    _hidden_attrs = PandasObject._hidden_attrs | frozenset(["tolist"])
+    _hidden_attrs = PandasObject._hidden_attrs | frozenset(
+        ["tolist", "reshape", "swapaxes", "transpose"]
+    )
     _typ = "categorical"
 
     _dtype: CategoricalDtype


### PR DESCRIPTION
## Summary

- Add `reshape`, `swapaxes`, and `transpose` to `Categorical._hidden_attrs`
  so they no longer appear in `dir()` or tab-completion.
- These methods are inherited from the Cython `NDArrayBacked` base class and
  are no-ops on 1-D Categorical data (they just return `self`). They have no
  docstring, are not in the API reference, and would confuse users who discover
  them via autocomplete.
- This matches the existing pattern of suppressing `tolist` on `Categorical`
  via `_hidden_attrs`.
- The methods remain accessible via `getattr()` for backward compatibility.

## Test plan

- [x] `dir(pd.Categorical(['a', 'b']))` no longer includes `reshape`,
  `swapaxes`, or `transpose`
- [x] `pd.Categorical(['a', 'b']).reshape(2, 1)` still works (not removed,
  just hidden)