### PR TITLE
CLN: Fix typo :meth and :class:CategoricalIndex

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -199,7 +199,7 @@ def contains(cat, key, container) -> bool:
     """
     Helper for membership check for ``key`` in ``cat``.
 
-    This is a helper method for :method:`__contains__`
+    This is a helper method for :meth:`__contains__`
     and :class:`CategoricalIndex.__contains__`.
 
     Returns True if ``key`` is in ``cat.categories`` and the
@@ -207,7 +207,7 @@ def contains(cat, key, container) -> bool:
 
     Parameters
     ----------
-    cat : :class:`Categorical`or :class:`categoricalIndex`
+    cat : :class:`Categorical`or :class:`CategoricalIndex`
     key : a hashable object
         The key to check membership for.
     container : Container (e.g. list-like or mapping)


### PR DESCRIPTION

Fix minor docstring issues in the internal `contains()` helper function in `pandas/core/arrays/categorical.py`:

- Fix invalid Sphinx role `:method:` → `:meth:`
- Fix incorrect class name `categoricalIndex` → `CategoricalIndex`