### PR TITLE
CLN: Remove redundant .format() on f-strings in _IntArrayFormatter

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1479,9 +1479,9 @@ class FloatArrayFormatter(_GenericArrayFormatter):
 class _IntArrayFormatter(_GenericArrayFormatter):
     def _format_strings(self) -> list[str]:
         if self.leading_space is False:
-            formatter_str = lambda x: f"{x:d}".format(x=x)
+            formatter_str = lambda x: f"{x:d}"
         else:
-            formatter_str = lambda x: f"{x: d}".format(x=x)
+            formatter_str = lambda x: f"{x: d}"
         formatter = self.formatter or formatter_str
         fmt_values = [formatter(x) for x in self.values]
         return fmt_values


### PR DESCRIPTION

The f-strings `f"{x:d}"` and `f"{x: d}"` already produce the formatted result, making the chained `.format(x=x)` calls a no-op. This removes the unnecessary `.format()` calls.
