### PR TITLE
COMPAT: Fix OverflowError in nanops with numpy 2.5

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -202,9 +202,12 @@ def _get_fill_value(
             return -np.inf
     elif fill_value_typ == "+inf":
         # need the max int here
-        return lib.i8max
+        # Return as np.int64 so that np.where promotes the dtype
+        # instead of raising OverflowError (numpy 2.5+) when the
+        # value doesn't fit in the array's dtype (e.g. int8).
+        return np.int64(lib.i8max)
     else:
-        return iNaT
+        return np.int64(iNaT)
 
 
 def _maybe_get_mask(


### PR DESCRIPTION
Claude wrote this, I reviewed it manually.

NumPy 2.5 made np.where strict about Python integer scalars that overflow the array's dtype. Wrap fill_value as np.int64 before passing to np.where so dtype promotion works correctly.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
