### PR TITLE
TST: fix tests failing with exact=True

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1384,13 +1384,23 @@ def assert_equal(left, right, **kwargs) -> None:
     __tracebackhide__ = True
 
     if isinstance(left, Index):
-        assert_index_equal(left, right, **kwargs)
+        exact = kwargs.pop("exact", True)
+        assert_index_equal(left, right, exact=exact, **kwargs)
         if isinstance(left, (DatetimeIndex, TimedeltaIndex)):
             assert left.freq == right.freq, (left.freq, right.freq)
     elif isinstance(left, Series):
-        assert_series_equal(left, right, **kwargs)
+        check_index_type = kwargs.pop("check_index_type", True)
+        assert_series_equal(left, right, check_index_type=check_index_type, **kwargs)
     elif isinstance(left, DataFrame):
-        assert_frame_equal(left, right, **kwargs)
+        check_index_type = kwargs.pop("check_index_type", True)
+        check_column_type = kwargs.pop("check_column_type", True)
+        assert_frame_equal(
+            left,
+            right,
+            check_index_type=check_index_type,
+            check_column_type=check_column_type,
+            **kwargs,
+        )
     elif isinstance(left, IntervalArray):
         assert_interval_array_equal(left, right, **kwargs)
     elif isinstance(left, PeriodArray):

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1384,23 +1384,13 @@ def assert_equal(left, right, **kwargs) -> None:
     __tracebackhide__ = True
 
     if isinstance(left, Index):
-        exact = kwargs.pop("exact", True)
-        assert_index_equal(left, right, exact=exact, **kwargs)
+        assert_index_equal(left, right, **kwargs)
         if isinstance(left, (DatetimeIndex, TimedeltaIndex)):
             assert left.freq == right.freq, (left.freq, right.freq)
     elif isinstance(left, Series):
-        check_index_type = kwargs.pop("check_index_type", True)
-        assert_series_equal(left, right, check_index_type=check_index_type, **kwargs)
+        assert_series_equal(left, right, **kwargs)
     elif isinstance(left, DataFrame):
-        check_index_type = kwargs.pop("check_index_type", True)
-        check_column_type = kwargs.pop("check_column_type", True)
-        assert_frame_equal(
-            left,
-            right,
-            check_index_type=check_index_type,
-            check_column_type=check_column_type,
-            **kwargs,
-        )
+        assert_frame_equal(left, right, **kwargs)
     elif isinstance(left, IntervalArray):
         assert_interval_array_equal(left, right, **kwargs)
     elif isinstance(left, PeriodArray):

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -481,7 +481,9 @@ def test_dropna(fill_value):
     tm.assert_sp_array_equal(arr.dropna(), exp)
 
     df = pd.DataFrame({"a": [0, 1], "b": arr})
-    expected_df = pd.DataFrame({"a": [1], "b": exp}, index=pd.Index([1]))
+    expected_df = pd.DataFrame(
+        {"a": [1], "b": exp}, index=pd.RangeIndex(start=1, stop=2, step=1)
+    )
     tm.assert_equal(df.dropna(), expected_df)
 
 

--- a/pandas/tests/frame/methods/test_asof.py
+++ b/pandas/tests/frame/methods/test_asof.py
@@ -5,6 +5,7 @@ from pandas._libs.tslibs import IncompatibleFrequency
 
 from pandas import (
     DataFrame,
+    Index,
     Period,
     Series,
     Timestamp,
@@ -105,7 +106,7 @@ class TestFrameAsof:
         # GH 15713
         # DataFrame/Series is all nans
         result = frame_or_series([np.nan]).asof([0])
-        expected = frame_or_series([np.nan])
+        expected = frame_or_series([np.nan], index=Index([0]))
         tm.assert_equal(result, expected)
 
     def test_all_nans(self, date_range_frame):

--- a/pandas/tests/groupby/test_all_methods.py
+++ b/pandas/tests/groupby/test_all_methods.py
@@ -91,7 +91,7 @@ def test_not_c_contiguous_mask(groupby_func):
     if groupby_func == "corrwith":
         # corrwith is deprecated
         return
-    df = DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]}, dtype="Int64")
+    df = DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]}, dtype="Int64", index=[0, 1, 2])
     reversed = DataFrame(
         {"a": [2, 1, 1], "b": [5, 4, 3]}, dtype="Int64", index=[2, 1, 0]
     )[::-1]

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1834,6 +1834,7 @@ def test_empty_groupby(columns, keys, values, method, op, dropna, using_infer_st
     if override_dtype is not None:
         expected = expected.astype(override_dtype)
     if len(keys) == 1:
+        expected.index = Index([], dtype=df[keys[0]].dtype, name=keys[0])
         expected.index.name = keys[0]
     tm.assert_equal(result, expected)
 

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -465,7 +465,7 @@ class TestGrouping:
         obj = frame_or_series([1, 2, 3, 4], index=index)
         groups = Series([1, 0, 1, 0], index=index, name=("a", "a"))
         result = obj.groupby(groups).last()
-        expected = frame_or_series([4, 3])
+        expected = frame_or_series([4, 3], index=Index([0, 1]))
         expected.index.name = ("a", "a")
         tm.assert_equal(result, expected)
 

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -13,6 +13,7 @@ import pandas as pd
 from pandas import (
     DataFrame,
     DatetimeIndex,
+    Index,
     Series,
     Timestamp,
     date_range,
@@ -241,7 +242,7 @@ def test_timezones_fixed_format_empty(temp_hdfstore, tz_aware_fixture, frame_or_
 
     dtype = pd.DatetimeTZDtype(tz=tz_aware_fixture)
 
-    obj = Series(dtype=dtype, name="A")
+    obj = Series(dtype=dtype, name="A", index=Index([]))
     if frame_or_series is DataFrame:
         obj = obj.to_frame()
 

--- a/pandas/tests/reshape/concat/test_categorical.py
+++ b/pandas/tests/reshape/concat/test_categorical.py
@@ -183,7 +183,12 @@ class TestCategoricalConcat:
 
         result = pd.concat([df1, df2])
         expected = DataFrame(
-            {"x": Series([datetime(2021, 1, 1), datetime(2021, 1, 2)])}
+            {
+                "x": Series(
+                    [datetime(2021, 1, 1), datetime(2021, 1, 2)],
+                    index=[0, 1],
+                )
+            }
         )
 
         tm.assert_equal(result, expected)


### PR DESCRIPTION
- xref #57436 
- realted to PR #64036

The goal is to change in `assert_index_equal` the parameter `exact` from default "equiv" to `True`.

As a first step, we need to check that the tests pass with `exact=True`. In this PR, the tests that failed as if `exact=True` were already being set are fixed.