### PR TITLE
PERF: Add missing boundscheck/wraparound decorators in _libs

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1223,6 +1223,8 @@ cdef void rank_sorted_1d(
                 out[i] = out[i] / grp_sizes[i]
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def rank_2d(
     ndarray[numeric_object_t, ndim=2] in_arr,
     int axis=0,

--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -21,6 +21,7 @@ import_array()
 from pandas._libs.util cimport is_nan
 
 
+@cython.wraparound(False)
 @cython.boundscheck(False)
 def hash_object_array(
     ndarray[object, ndim=1] arr, str key, str encoding="utf8"

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -510,6 +510,7 @@ cdef class {{name}}HashTable(HashTable):
     {{if dtype == "int64" }}
     # We only use this for int64, can reduce build size and make .pyi
     #  more accurate by only implementing it for int64
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     def map_keys_to_values(
         self, const {{dtype}}_t[:] keys, const int64_t[:] values
@@ -527,6 +528,7 @@ cdef class {{name}}HashTable(HashTable):
                 self.table.vals[k] = <Py_ssize_t>values[i]
     {{endif}}
 
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     def map_locations(self, const {{dtype}}_t[:] values, const uint8_t[:] mask = None) -> None:
         # Used in libindex, safe_sort
@@ -599,6 +601,7 @@ cdef class {{name}}HashTable(HashTable):
 
         return self_locs.to_array(), locs.to_array()
 
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     def lookup(self, const {{dtype}}_t[:] values, const uint8_t[:] mask = None) -> ndarray:
         # -> np.ndarray[np.intp]
@@ -868,6 +871,7 @@ cdef class {{name}}HashTable(HashTable):
         return labels
 
     {{if dtype == 'int64'}}
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     def get_labels_groupby(
         self, const {{dtype}}_t[:] values
@@ -1019,6 +1023,7 @@ cdef class StringHashTable(HashTable):
         else:
             raise KeyError(key)
 
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     def get_indexer(self, ndarray[object] values) -> ndarray:
         # -> np.ndarray[np.intp]
@@ -1050,6 +1055,7 @@ cdef class StringHashTable(HashTable):
         free(vecs)
         return labels
 
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     def lookup(self, ndarray[object] values, object mask = None) -> ndarray:
         # -> np.ndarray[np.intp]
@@ -1089,6 +1095,7 @@ cdef class StringHashTable(HashTable):
         free(vecs)
         return np.asarray(locs)
 
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     def map_locations(self, ndarray[object] values, object mask = None) -> None:
         # mask not yet implemented
@@ -1376,6 +1383,8 @@ cdef class PyObjectHashTable(HashTable):
         else:
             raise KeyError(key)
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     def map_locations(self, ndarray[object] values, object mask = None) -> None:
         # mask not yet implemented
         cdef:
@@ -1391,6 +1400,8 @@ cdef class PyObjectHashTable(HashTable):
             k = kh_put_pymap(self.table, <PyObject*>val, &ret)
             self.table.vals[k] = i
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     def lookup(self, ndarray[object] values, object mask = None) -> ndarray:
         # -> np.ndarray[np.intp]
         # mask not yet implemented

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -56,6 +56,8 @@ cdef bint is_definitely_invalid_key(object val):
     return False
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef ndarray _get_bool_indexer(ndarray values, object val, ndarray mask = None):
     """
     Return an ndarray[bool] of locations where val matches self.values.
@@ -115,6 +117,8 @@ cdef _maybe_resize_array(ndarray values, Py_ssize_t loc, Py_ssize_t max_length):
 _SIZE_CUTOFF = 1_000_000
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef _unpack_bool_indexer(ndarray[uint8_t, ndim=1, cast=True] indexer, object val):
     """
     Possibly unpack a boolean mask to a single indexer.
@@ -373,6 +377,8 @@ cdef class IndexEngine:
         self._ensure_mapping_populated()
         return self.mapping.lookup(values)
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     def get_indexer_non_unique(self, ndarray targets):
         """
         Return an indexer suitable for taking from a non unique index
@@ -1210,6 +1216,8 @@ cdef class MaskedIndexEngine(IndexEngine):
         self._ensure_mapping_populated()
         return self.mapping.lookup(self._get_data(values), self._get_mask(values))
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     def get_indexer_non_unique(self, object targets):
         """
         Return an indexer suitable for taking from a non unique index

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -785,6 +785,8 @@ cdef class BlockManager:
         self.__blklocs = val
 
     @cython.critical_section
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cpdef _rebuild_blknos_and_blklocs(self):
         """
         Update mgr._blknos / mgr._blklocs.

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -684,6 +684,8 @@ def outer_join_indexer(ndarray[numeric_object_t] left, ndarray[numeric_object_t]
 from pandas._libs.hashtable cimport Int64HashTable
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def asof_join_backward_on_X_by_Y(const numeric_t[:] left_values,
                                  const numeric_t[:] right_values,
                                  const int64_t[:] left_by_values,
@@ -755,6 +757,8 @@ def asof_join_backward_on_X_by_Y(const numeric_t[:] left_values,
     return left_indexer, right_indexer
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def asof_join_forward_on_X_by_Y(const numeric_t[:] left_values,
                                 const numeric_t[:] right_values,
                                 const int64_t[:] left_by_values,
@@ -827,6 +831,8 @@ def asof_join_forward_on_X_by_Y(const numeric_t[:] left_values,
     return left_indexer, right_indexer
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def asof_join_nearest_on_X_by_Y(const numeric_t[:] left_values,
                                 const numeric_t[:] right_values,
                                 const int64_t[:] left_by_values,

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -396,6 +396,8 @@ def dicts_to_array(dicts: list, columns: list):
     return result
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def fast_zip(list ndarrays) -> ndarray[object]:
     """
     For zipping multiple ndarrays into an ndarray of tuples.
@@ -438,6 +440,8 @@ def fast_zip(list ndarrays) -> ndarray[object]:
     return result
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def get_reverse_indexer(const intp_t[:] indexer, Py_ssize_t length) -> ndarray:
     """
     Reverse indexing operation.
@@ -509,6 +513,8 @@ def has_only_ints_or_nan(const floating[:] arr) -> bool:
     return True
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def maybe_indices_to_slice(ndarray[intp_t, ndim=1] indices, intp_t max_len):
     cdef:
         Py_ssize_t i, n = len(indices)
@@ -2135,6 +2141,8 @@ cdef bint is_datetime_or_datetime64_array(ndarray values, bint skipna=True):
 
 
 # Note: only python-exposed for tests
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def is_datetime_with_singletz_array(values: ndarray) -> bool:
     """
     Check values have the same tzinfo attribute.
@@ -2262,6 +2270,8 @@ cdef bint is_period_array(ndarray values, bint skipna=True):
 
 
 # Note: only python-exposed for tests
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cpdef bint is_interval_array(ndarray values):
     """
     Is this an ndarray of Interval (or np.nan) with a single dtype?
@@ -3093,6 +3103,8 @@ def map_infer(
         return result
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def to_object_array(rows: object, min_width: int = 0) -> ndarray:
     """
     Convert a list of lists into an object array.
@@ -3153,6 +3165,8 @@ def tuples_to_object_array(ndarray[object] tuples):
     return result
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def to_object_array_tuples(rows: object) -> np.ndarray:
     """
     Convert a list of tuples into an object array. Any subclass of
@@ -3261,6 +3275,8 @@ def is_bool_list(obj: list) -> bool:
     return True
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cpdef ndarray eq_NA_compat(ndarray[object] arr, object key):
     """
     Check for `arr == key`, treating all values as not-equal to pd.NA.

--- a/pandas/_libs/ops.pyx
+++ b/pandas/_libs/ops.pyx
@@ -254,6 +254,8 @@ def vec_binop(ndarray[object] left, ndarray[object] right, object op) -> ndarray
     return maybe_convert_bool(result.base)[0]  # `.base` to access np.ndarray
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def maybe_convert_bool(ndarray[object] arr,
                        true_values=None,
                        false_values=None,

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1482,6 +1482,8 @@ def _maybe_upcast(
 
 
 # -> tuple[ndarray[object], int]
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef _string_box_utf8(parser_t *parser, int64_t col,
                       int64_t line_start, int64_t line_end,
                       bint na_filter, kh_str_starts_t *na_hashset,
@@ -1536,6 +1538,7 @@ cdef _string_box_utf8(parser_t *parser, int64_t col,
     return result, na_count
 
 
+@cython.wraparound(False)
 @cython.boundscheck(False)
 cdef _categorical_convert(parser_t *parser, int64_t col,
                           int64_t line_start, int64_t line_end,
@@ -1875,6 +1878,9 @@ cdef int _try_int64_nogil(parser_t *parser, int64_t col,
 
     return 0
 
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef _try_pylong(parser_t *parser, Py_ssize_t col,
                  int64_t line_start, int64_t line_end,
                  bint na_filter, kh_str_starts_t *na_hashset):
@@ -2119,6 +2125,8 @@ for k in list(na_values):
 
 
 # -> ArrayLike
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef _apply_converter(object f, parser_t *parser, int64_t col,
                       int64_t line_start, int64_t line_end):
     cdef:
@@ -2147,6 +2155,8 @@ cdef list _maybe_encode(list values):
     return [x.encode("utf-8") if isinstance(x, str) else x for x in values]
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def sanitize_objects(ndarray[object] values, set na_values) -> int:
     """
     Convert specified values, including the given set na_values to np.nan.

--- a/pandas/_libs/sas.pyx
+++ b/pandas/_libs/sas.pyx
@@ -1,5 +1,6 @@
 # cython: language_level=3, initializedcheck=False
 # cython: warn.maybe_uninitialized=True, warn.unused=True
+cimport cython
 from cython cimport Py_ssize_t
 from libc.stddef cimport size_t
 from libc.stdint cimport (
@@ -327,6 +328,8 @@ cdef class Parser:
         int (*decompress)(Buffer, Buffer) except? 0
         object parser
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     def __init__(self, object parser):
         cdef:
             int j
@@ -477,6 +480,8 @@ cdef class Parser:
             else:
                 raise ValueError(f"unknown page type: {self.current_page_type}")
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cdef void process_byte_array_with_data(self, int offset, int length) except *:
 
         cdef:

--- a/pandas/_libs/sparse.pyx
+++ b/pandas/_libs/sparse.pyx
@@ -122,6 +122,8 @@ cdef class IntIndex(SparseIndex):
         locs, lens = get_blocks(self.indices)
         return BlockIndex(self.length, locs, lens)
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cpdef IntIndex intersect(self, SparseIndex y_):
         cdef:
             Py_ssize_t xi, yi = 0, result_indexer = 0
@@ -173,6 +175,7 @@ cdef class IntIndex(SparseIndex):
         return IntIndex(self.length, new_indices)
 
     @cython.wraparound(False)
+    @cython.boundscheck(False)
     cpdef int32_t lookup(self, Py_ssize_t index):
         """
         Return the internal location if value exists on given index.
@@ -197,6 +200,7 @@ cdef class IntIndex(SparseIndex):
             return -1
 
     @cython.wraparound(False)
+    @cython.boundscheck(False)
     cpdef ndarray[int32_t] lookup_array(self, ndarray[int32_t, ndim=1] indexer):
         """
         Vectorized lookup, returns ndarray[int32_t]
@@ -227,6 +231,8 @@ cdef class IntIndex(SparseIndex):
         return results
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cpdef get_blocks(ndarray[int32_t, ndim=1] indices):
     cdef:
         Py_ssize_t i, npoints, result_indexer = 0
@@ -321,6 +327,8 @@ cdef class BlockIndex(SparseIndex):
     def ngaps(self) -> int:
         return self.length - self.npoints
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cdef check_integrity(self):
         """
         Check:
@@ -369,6 +377,8 @@ cdef class BlockIndex(SparseIndex):
     def to_block_index(self):
         return self
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cpdef to_int_index(self):
         cdef:
             int32_t i = 0, j, b
@@ -390,6 +400,8 @@ cdef class BlockIndex(SparseIndex):
     def indices(self):
         return self.to_int_index().indices
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cpdef BlockIndex intersect(self, SparseIndex other):
         """
         Intersect two BlockIndex objects
@@ -489,6 +501,8 @@ cdef class BlockIndex(SparseIndex):
         """
         return BlockUnion(self, y.to_block_index()).result
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cpdef Py_ssize_t lookup(self, Py_ssize_t index):
         """
         Return the internal location if value exists on given index.
@@ -515,6 +529,7 @@ cdef class BlockIndex(SparseIndex):
         return -1
 
     @cython.wraparound(False)
+    @cython.boundscheck(False)
     cpdef ndarray[int32_t] lookup_array(self, ndarray[int32_t, ndim=1] indexer):
         """
         Vectorized lookup, returns ndarray[int32_t]
@@ -596,6 +611,8 @@ cdef class BlockUnion(BlockMerge):
     lot easier and reduces code duplication
     """
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cdef _make_merged_blocks(self):
         cdef:
             ndarray[int32_t, ndim=1] xstart, xend, ystart
@@ -644,6 +661,8 @@ cdef class BlockUnion(BlockMerge):
 
         return BlockIndex(self.x.length, out_bloc, out_blen)
 
+    @cython.wraparound(False)
+    @cython.boundscheck(False)
     cdef int32_t _find_next_block_end(self, bint mode) except -1:
         """
         Wow, this got complicated in a hurry
@@ -715,6 +734,8 @@ include "sparse_op_helper.pxi"
 # -----------------------------------------------------------------------------
 # SparseArray mask create operations
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def make_mask_object_ndarray(ndarray[object, ndim=1] arr, object fill_value):
     cdef:
         object value

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -722,6 +722,8 @@ class RoundTo:
         return 4
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef ndarray[int64_t] _floor_int64(const int64_t[:] values, int64_t unit):
     cdef:
         Py_ssize_t i, n = len(values)
@@ -740,6 +742,8 @@ cdef ndarray[int64_t] _floor_int64(const int64_t[:] values, int64_t unit):
     return result
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef ndarray[int64_t] _ceil_int64(const int64_t[:] values, int64_t unit):
     cdef:
         Py_ssize_t i, n = len(values)
@@ -764,6 +768,8 @@ cdef ndarray[int64_t] _ceil_int64(const int64_t[:] values, int64_t unit):
     return result
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef ndarray[int64_t] _rounddown_int64(const int64_t[:] values, int64_t unit):
     cdef:
         Py_ssize_t i, n = len(values)
@@ -796,6 +802,8 @@ cdef ndarray[int64_t] _roundup_int64(values, int64_t unit):
     return _floor_int64(values + unit // 2, unit)
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef ndarray[int64_t] _round_nearest_int64(const int64_t[:] values, int64_t unit):
     cdef:
         Py_ssize_t i, n = len(values)

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -17,6 +17,7 @@ from cpython.datetime cimport (
 
 from datetime import timezone
 
+cimport cython
 from cpython.unicode cimport PyUnicode_AsUTF8AndSize
 from cython cimport Py_ssize_t
 from libc.string cimport strchr
@@ -760,6 +761,8 @@ cdef _find_subsecond_reso(str timestr, int64_t* nanos):
 # Parsing for type-inference
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def try_parse_dates(object[:] values, parser) -> np.ndarray:
     cdef:
         Py_ssize_t i, n

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1330,6 +1330,8 @@ cdef str _period_strftime(int64_t value, int freq, bytes fmt, npy_datetimestruct
     return result
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def period_array_strftime(
     ndarray values, int dtype_code, object na_rep, str date_format
 ):
@@ -1612,6 +1614,8 @@ cdef int64_t _extract_ordinal(object item, PeriodDtypeBase dtype) except? -1:
     return ordinal
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def extract_period_unit(ndarray[object] values) -> PeriodDtypeBase:
     # TODO: Change type to const object[:] when Cython supports that.
 

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -15,6 +15,7 @@ FUNCTIONS:
     _getlang -- Figure out what language is being used for the locale
     strptime -- Calculates the time struct represented by the passed-in string
 """
+cimport cython
 from datetime import timezone
 import zoneinfo
 
@@ -348,6 +349,8 @@ cdef class DatetimeParseState:
         return tz_out
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def array_strptime(
     ndarray[object] values,
     str fmt,

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -687,6 +687,7 @@ cdef class _Timestamp(ABCTimestamp):
             val = self._value
         return val
 
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     cdef bint _get_start_end_field(self, str field, freq):
         cdef:
@@ -883,6 +884,7 @@ cdef class _Timestamp(ABCTimestamp):
         """
         return self.month == 12 and self.day == 31
 
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     cdef _get_date_name_field(self, str field, object locale):
         cdef:

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -1,3 +1,4 @@
+cimport cython
 from datetime import (
     timedelta,
     timezone,
@@ -256,6 +257,8 @@ cdef object _get_utc_trans_times_from_dateutil_tz(tzinfo tz):
     return new_trans
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef int64_t[::1] unbox_utcoffsets(object transinfo):
     cdef:
         Py_ssize_t i

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -68,6 +68,7 @@ cdef class Localizer:
     #    int64_t* tdata
 
     @cython.initializedcheck(False)
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     def __cinit__(self, tzinfo tz, NPY_DATETIMEUNIT creso):
         self.tz = tz
@@ -118,6 +119,7 @@ cdef class Localizer:
                     self.use_pytz = True
                 self.tdata = <int64_t*>cnp.PyArray_DATA(trans)
 
+    @cython.wraparound(False)
     @cython.boundscheck(False)
     cdef int64_t utc_val_to_local_val(
         self, int64_t utc_val, Py_ssize_t* pos, bint* fold=NULL
@@ -475,6 +477,8 @@ cdef str _render_tstamp(int64_t val, NPY_DATETIMEUNIT creso):
     return str(ts)
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef _get_utc_bounds(
     ndarray[int64_t] vals,
     const int64_t* tdata,
@@ -530,6 +534,8 @@ cdef _get_utc_bounds(
     return result_a, result_b
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef _get_utc_bounds_zoneinfo(ndarray vals, tz, NPY_DATETIMEUNIT creso):
     """
     For each point in 'vals', find the UTC time that it corresponds to if
@@ -596,6 +602,7 @@ cdef _get_utc_bounds_zoneinfo(ndarray vals, tz, NPY_DATETIMEUNIT creso):
     return result_a, result_b
 
 
+@cython.wraparound(False)
 @cython.boundscheck(False)
 cdef ndarray[int64_t] _get_dst_hours(
     # vals, creso only needed here to potential render an exception message


### PR DESCRIPTION
## Summary

- Add missing `@cython.boundscheck(False)` and `@cython.wraparound(False)` to ~55 functions across 18 `.pyx` files in `pandas/_libs` that perform typed array/memoryview indexing but were missing one or both decorators
- Add `cimport cython` where needed (sas.pyx, strptime.pyx, parsing.pyx, timezones.pyx)

**Benchmarks** (Apple M3):

```python
arr = np.arange(2_000_000, dtype=np.intp)

%timeit get_reverse_indexer(arr, 2_000_000)
934 µs ± 7.13 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- PR
1.46 ms ± 13.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- main
```

```python
arr = np.arange(2_000_000, dtype=np.intp)

%timeit maybe_indices_to_slice(arr, 5_000_000)
709 µs ± 5.92 µs per loop (mean ± std. dev. of 7 runs, 2000 loops each)  # <- PR
925 µs ± 8.14 µs per loop (mean ± std. dev. of 7 runs, 2000 loops each)  # <- main
```

```python
dti = pd.date_range("2000", periods=5_000_000, freq="s")

%timeit dti.floor("min")
11.2 ms ± 89.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # <- PR
12.4 ms ± 95.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # <- main
```

Files changed: algos.pyx, hashing.pyx, hashtable_class_helper.pxi.in, index.pyx, internals.pyx, join.pyx, lib.pyx, ops.pyx, parsers.pyx, sas.pyx, sparse.pyx, tslibs/fields.pyx, tslibs/parsing.pyx, tslibs/period.pyx, tslibs/strptime.pyx, tslibs/timestamps.pyx, tslibs/timezones.pyx, tslibs/tzconversion.pyx

## Test plan
- [x] Full test suite passes (including `test_append_index` which exposed a `tuples_to_object_array` issue — intentionally left undecorated since callers rely on `IndexError` from mismatched tuple lengths)
- [x] Verified no negative indexing patterns in any decorated function

🤖 Generated with [Claude Code](https://claude.com/claude-code)