### PR TITLE
REF: No longer pass through nopython in numba APIs

### DIFF
--- a/doc/source/user_guide/enhancingperf.rst
+++ b/doc/source/user_guide/enhancingperf.rst
@@ -287,8 +287,8 @@ pandas Numba Engine
 
 If Numba is installed, one can specify ``engine="numba"`` in select pandas methods to execute the method using Numba.
 Methods that support ``engine="numba"`` will also have an ``engine_kwargs`` keyword that accepts a dictionary that allows one to specify
-``"nogil"``, ``"nopython"`` and ``"parallel"`` keys with boolean values to pass into the ``@jit`` decorator.
-If ``engine_kwargs`` is not specified, it defaults to ``{"nogil": False, "nopython": True, "parallel": False}`` unless otherwise specified.
+``"nogil"`` and ``"parallel"`` keys with boolean values to pass into the ``@jit`` decorator.
+If ``engine_kwargs`` is not specified, it defaults to ``{"nogil": False, "parallel": False}`` unless otherwise specified.
 
 .. note::
 
@@ -424,10 +424,7 @@ Numba is best at accelerating functions that apply numerical functions to NumPy
 arrays. If you try to ``@jit`` a function that contains unsupported `Python <https://numba.readthedocs.io/en/stable/reference/pysupported.html>`__
 or `NumPy <https://numba.readthedocs.io/en/stable/reference/numpysupported.html>`__
 code, compilation will revert `object mode <https://numba.readthedocs.io/en/stable/glossary.html#term-object-mode>`__ which
-will mostly likely not speed up your function. If you would
-prefer that Numba throw an error if it cannot compile a function in a way that
-speeds up your code, pass Numba the argument
-``nopython=True`` (e.g.  ``@jit(nopython=True)``). For more on
+will mostly likely not speed up your function. For more on
 troubleshooting Numba modes, see the `Numba troubleshooting page
 <https://numba.readthedocs.io/en/stable/user/troubleshoot.html>`__.
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -84,7 +84,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 
 Other API changes
 ^^^^^^^^^^^^^^^^^
--
+- APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`?`).
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -84,7 +84,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 
 Other API changes
 ^^^^^^^^^^^^^^^^^
-- APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`?`).
+- APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`64483`).
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -471,7 +471,7 @@ def parallel(request):
     return request.param
 
 
-# Can parameterize nogil & nopython over True | False, but limiting per
+# Can parameterize nogil over True | False, but limiting per
 # https://github.com/pandas-dev/pandas/pull/41971#issuecomment-860607472
 
 
@@ -479,14 +479,6 @@ def parallel(request):
 def nogil(request):
     """
     Fixture for nogil keyword argument for numba.jit.
-    """
-    return request.param
-
-
-@pytest.fixture(params=[True])
-def nopython(request):
-    """
-    Fixture for nopython keyword argument for numba.jit.
     """
     return request.param
 

--- a/pandas/core/_numba/executor.py
+++ b/pandas/core/_numba/executor.py
@@ -67,7 +67,7 @@ def make_looper(func, result_dtype, is_grouped_kernel, nogil: bool, parallel: bo
     if is_grouped_kernel:
 
         @numba.jit(nogil=nogil, parallel=parallel)
-        def column_looper(
+        def column_looper(  # pyright: ignore[reportRedeclaration]
             values: np.ndarray,
             labels: np.ndarray,
             ngroups: int,
@@ -216,11 +216,19 @@ def generate_shared_aggregator(
         # Need to unpack kwargs since numba only supports *args
         if is_grouped_kernel:
             result, na_positions = column_looper(
-                values, labels, ngroups, min_periods, *kwargs.values()
+                values,
+                labels,  # pyright: ignore[reportArgumentType]
+                ngroups,  # pyright: ignore[reportArgumentType]
+                min_periods,
+                *kwargs.values(),
             )
         else:
             result, na_positions = column_looper(
-                values, start, end, min_periods, *kwargs.values()
+                values,
+                start,  # pyright: ignore[reportArgumentType]
+                end,  # pyright: ignore[reportArgumentType]
+                min_periods,
+                *kwargs.values(),
             )
         if result.dtype.kind == "i":
             # Look if na_positions is not empty

--- a/pandas/core/_numba/executor.py
+++ b/pandas/core/_numba/executor.py
@@ -18,14 +18,14 @@ from pandas.core.util.numba_ import jit_user_function
 
 
 @functools.cache
-def generate_apply_looper(func, nopython=True, nogil=True, parallel=False):
+def generate_apply_looper(func, nogil: bool = True, parallel: bool = False):
     if TYPE_CHECKING:
         import numba
     else:
         numba = import_optional_dependency("numba")
     nb_compat_func = jit_user_function(func)
 
-    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    @numba.jit(nogil=nogil, parallel=parallel)
     def nb_looper(values, axis, *args):
         # Operate on the first row/col in order to get
         # the output shape
@@ -58,7 +58,7 @@ def generate_apply_looper(func, nopython=True, nogil=True, parallel=False):
 
 
 @functools.cache
-def make_looper(func, result_dtype, is_grouped_kernel, nopython, nogil, parallel):
+def make_looper(func, result_dtype, is_grouped_kernel, nogil: bool, parallel: bool):
     if TYPE_CHECKING:
         import numba
     else:
@@ -66,7 +66,7 @@ def make_looper(func, result_dtype, is_grouped_kernel, nopython, nogil, parallel
 
     if is_grouped_kernel:
 
-        @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+        @numba.jit(nogil=nogil, parallel=parallel)
         def column_looper(
             values: np.ndarray,
             labels: np.ndarray,
@@ -87,7 +87,7 @@ def make_looper(func, result_dtype, is_grouped_kernel, nopython, nogil, parallel
 
     else:
 
-        @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+        @numba.jit(nogil=nogil, parallel=parallel)
         # error: Incompatible redefinition (redefinition with type
         # "Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any],
         # int, VarArg(Any)], Any]", original type "Callable[[ndarray[Any, Any],
@@ -166,7 +166,6 @@ def generate_shared_aggregator(
     func: Callable[..., Scalar],
     dtype_mapping: dict[np.dtype, np.dtype],
     is_grouped_kernel: bool,
-    nopython: bool,
     nogil: bool,
     parallel: bool,
 ):
@@ -186,8 +185,6 @@ def generate_shared_aggregator(
         or using starts/ends arrays
 
         If true, you also need to pass the number of groups to this function
-    nopython : bool
-        nopython to be passed into numba.jit
     nogil : bool
         nogil to be passed into numba.jit
     parallel : bool
@@ -199,12 +196,10 @@ def generate_shared_aggregator(
     """
 
     # A wrapper around the looper function,
-    # to dispatch based on dtype since numba is unable to do that in nopython mode
+    # to dispatch based on dtype
 
     # It also post-processes the values by inserting nans where number of observations
     # is less than min_periods
-    # Cannot do this in numba nopython mode
-    # (you'll run into type-unification error when you cast int -> float)
     def looper_wrapper(
         values,
         start=None,
@@ -216,7 +211,7 @@ def generate_shared_aggregator(
     ):
         result_dtype = dtype_mapping[values.dtype]
         column_looper = make_looper(
-            func, result_dtype, is_grouped_kernel, nopython, nogil, parallel
+            func, result_dtype, is_grouped_kernel, nogil, parallel
         )
         # Need to unpack kwargs since numba only supports *args
         if is_grouped_kernel:

--- a/pandas/core/_numba/kernels/mean_.py
+++ b/pandas/core/_numba/kernels/mean_.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from pandas._typing import npt
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def add_mean(
     val: float,
     nobs: int,
@@ -49,7 +49,7 @@ def add_mean(
     return nobs, sum_x, neg_ct, compensation, num_consecutive_same_value, prev_value
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def remove_mean(
     val: float, nobs: int, sum_x: float, neg_ct: int, compensation: float
 ) -> tuple[int, float, int, float]:
@@ -64,7 +64,7 @@ def remove_mean(
     return nobs, sum_x, neg_ct, compensation
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def sliding_mean(
     values: np.ndarray,
     result_dtype: np.dtype,
@@ -162,7 +162,7 @@ def sliding_mean(
     return output, na_pos
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def grouped_mean(
     values: np.ndarray,
     result_dtype: np.dtype,

--- a/pandas/core/_numba/kernels/min_max_.py
+++ b/pandas/core/_numba/kernels/min_max_.py
@@ -35,7 +35,7 @@ def bisect_left(a: list[Any], x: Any, lo: int = 0, hi: int = -1) -> int:
     return lo
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def sliding_min_max(
     values: np.ndarray,
     result_dtype: np.dtype,
@@ -129,7 +129,7 @@ def sliding_min_max(
     return output, na_pos
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def grouped_min_max(
     values: np.ndarray,
     result_dtype: np.dtype,

--- a/pandas/core/_numba/kernels/shared.py
+++ b/pandas/core/_numba/kernels/shared.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 @numba.jit(
     # error: Any? not callable
     numba.boolean(numba.int64[:]),  # type: ignore[misc]
-    nopython=True,
     nogil=True,
     parallel=False,
 )

--- a/pandas/core/_numba/kernels/sum_.py
+++ b/pandas/core/_numba/kernels/sum_.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 from pandas.core._numba.kernels.shared import is_monotonic_increasing
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def add_sum(
     val: Any,
     nobs: int,
@@ -49,7 +49,7 @@ def add_sum(
     return nobs, sum_x, compensation, num_consecutive_same_value, prev_value
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def remove_sum(
     val: Any, nobs: int, sum_x: Any, compensation: Any
 ) -> tuple[int, Any, Any]:
@@ -62,7 +62,7 @@ def remove_sum(
     return nobs, sum_x, compensation
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def sliding_sum(
     values: np.ndarray,
     result_dtype: np.dtype,
@@ -221,7 +221,7 @@ def grouped_kahan_sum(
     return output, nobs_arr, comp_arr, consecutive_counts, prev_vals
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def grouped_sum(
     values: np.ndarray,
     result_dtype: np.dtype,

--- a/pandas/core/_numba/kernels/var_.py
+++ b/pandas/core/_numba/kernels/var_.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 from pandas.core._numba.kernels.shared import is_monotonic_increasing
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def add_var(
     val: float,
     nobs: int,
@@ -51,7 +51,7 @@ def add_var(
     return nobs, mean_x, ssqdm_x, compensation, num_consecutive_same_value, prev_value
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def remove_var(
     val: float, nobs: int, mean_x: float, ssqdm_x: float, compensation: float
 ) -> tuple[int, float, float, float]:
@@ -71,7 +71,7 @@ def remove_var(
     return nobs, mean_x, ssqdm_x, compensation
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def sliding_var(
     values: np.ndarray,
     result_dtype: np.dtype,
@@ -168,7 +168,7 @@ def sliding_var(
     return output, na_pos
 
 
-@numba.jit(nopython=True, nogil=True, parallel=False)
+@numba.jit(nogil=True, parallel=False)
 def grouped_var(
     values: np.ndarray,
     result_dtype: np.dtype,

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -919,7 +919,7 @@ class FrameApply(NDFrameApply):
     @functools.cache
     @abc.abstractmethod
     def generate_numba_apply_func(
-        func, nogil=True, nopython=True, parallel=False
+        func, nogil: bool = True, parallel: bool = False
     ) -> Callable[[npt.NDArray, Index, Index], dict[int, Any]]:
         pass
 
@@ -1244,7 +1244,7 @@ class FrameRowApply(FrameApply):
     @staticmethod
     @functools.cache
     def generate_numba_apply_func(
-        func, nogil=True, nopython=True, parallel=False
+        func, nogil: bool = True, parallel: bool = False
     ) -> Callable[[npt.NDArray, Index, Index], dict[int, Any]]:
         numba = import_optional_dependency("numba")
         from pandas import Series
@@ -1257,7 +1257,7 @@ class FrameRowApply(FrameApply):
 
         # Currently the parallel argument doesn't get passed through here
         # (it's disabled) since the dicts in numba aren't thread-safe.
-        @numba.jit(nogil=nogil, nopython=nopython, parallel=parallel)
+        @numba.jit(nogil=nogil, parallel=parallel)
         def numba_func(values, col_names, df_index, *args):
             results = {}
             for j in range(values.shape[1]):
@@ -1386,7 +1386,7 @@ class FrameColumnApply(FrameApply):
     @staticmethod
     @functools.cache
     def generate_numba_apply_func(
-        func, nogil=True, nopython=True, parallel=False
+        func, nogil: bool = True, parallel: bool = False
     ) -> Callable[[npt.NDArray, Index, Index], dict[int, Any]]:
         numba = import_optional_dependency("numba")
         from pandas import Series
@@ -1394,7 +1394,7 @@ class FrameColumnApply(FrameApply):
 
         jitted_udf = numba.extending.register_jitable(func)
 
-        @numba.jit(nogil=nogil, nopython=nopython, parallel=parallel)
+        @numba.jit(nogil=nogil, parallel=parallel)
         def numba_func(values, col_names_index, index, *args):
             results = {}
             # Currently the parallel argument doesn't get passed through here

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -355,10 +355,10 @@ class SeriesGroupBy(GroupBy[Series]):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+              ``{'nogil': False, 'parallel': False}`` and will be
               applied to the function
 
         **kwargs
@@ -648,10 +648,10 @@ class SeriesGroupBy(GroupBy[Series]):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+              ``{'nogil': False, 'parallel': False}`` and will be
               applied to the function
 
         **kwargs
@@ -2117,10 +2117,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+              ``{'nogil': False, 'parallel': False}`` and will be
               applied to the function
 
         **kwargs
@@ -2545,10 +2545,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+              ``{'nogil': False, 'parallel': False}`` and will be
               applied to the function
 
         **kwargs

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1973,10 +1973,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------
@@ -2173,10 +2173,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         numeric_only : bool, default False
             Include only `float`, `int` or `boolean` data.
@@ -2288,10 +2288,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         numeric_only : bool, default False
             Include only `float`, `int` or `boolean` data.
@@ -2743,10 +2743,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         engine_kwargs : dict, default None None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
                 and ``parallel`` dictionary keys. The values must either be ``True`` or
                 ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-                ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+                ``{'nogil': False, 'parallel': False}`` and will be
                 applied to both the ``func`` and the ``apply`` groupby aggregation.
 
         Returns
@@ -2945,10 +2945,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         engine_kwargs : dict, default None None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
                 and ``parallel`` dictionary keys. The values must either be ``True`` or
                 ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-                ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+                ``{'nogil': False, 'parallel': False}`` and will be
                 applied to both the ``func`` and the ``apply`` groupby aggregation.
 
         Returns
@@ -3062,10 +3062,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         engine_kwargs : dict, default None None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
                 and ``parallel`` dictionary keys. The values must either be ``True`` or
                 ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-                ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+                ``{'nogil': False, 'parallel': False}`` and will be
                 applied to both the ``func`` and the ``apply`` groupby aggregation.
 
         Returns

--- a/pandas/core/groupby/numba_.py
+++ b/pandas/core/groupby/numba_.py
@@ -66,7 +66,6 @@ def validate_udf(func: Callable) -> None:
 @functools.cache
 def generate_numba_agg_func(
     func: Callable[..., Scalar],
-    nopython: bool,
     nogil: bool,
     parallel: bool,
 ) -> Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, Any], np.ndarray]:
@@ -83,8 +82,6 @@ def generate_numba_agg_func(
     ----------
     func : function
         function to be applied to each group and will be JITed
-    nopython : bool
-        nopython to be passed into numba.jit
     nogil : bool
         nogil to be passed into numba.jit
     parallel : bool
@@ -100,7 +97,7 @@ def generate_numba_agg_func(
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    @numba.jit(nogil=nogil, parallel=parallel)
     def group_agg(
         values: np.ndarray,
         index: np.ndarray,
@@ -126,7 +123,6 @@ def generate_numba_agg_func(
 @functools.cache
 def generate_numba_transform_func(
     func: Callable[..., np.ndarray],
-    nopython: bool,
     nogil: bool,
     parallel: bool,
 ) -> Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, Any], np.ndarray]:
@@ -143,8 +139,6 @@ def generate_numba_transform_func(
     ----------
     func : function
         function to be applied to each window and will be JITed
-    nopython : bool
-        nopython to be passed into numba.jit
     nogil : bool
         nogil to be passed into numba.jit
     parallel : bool
@@ -160,7 +154,7 @@ def generate_numba_transform_func(
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    @numba.jit(nogil=nogil, parallel=parallel)
     def group_transform(
         values: np.ndarray,
         index: np.ndarray,

--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -41,7 +41,7 @@ def get_jit_arguments(engine_kwargs: dict[str, bool] | None = None) -> dict[str,
     Returns
     -------
     dict[str, bool]
-        nopython, nogil, parallel
+        nogil, parallel
 
     Raises
     ------
@@ -50,10 +50,9 @@ def get_jit_arguments(engine_kwargs: dict[str, bool] | None = None) -> dict[str,
     if engine_kwargs is None:
         engine_kwargs = {}
 
-    nopython = engine_kwargs.get("nopython", True)
     nogil = engine_kwargs.get("nogil", False)
     parallel = engine_kwargs.get("parallel", False)
-    return {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    return {"nogil": nogil, "parallel": parallel}
 
 
 def jit_user_function(func: Callable) -> Callable:

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -426,10 +426,10 @@ class ExponentialMovingWindow(BaseWindow):
         engine_kwargs : dict, default None
             Applies to all supported aggregation methods.
 
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+              ``{'nogil': False, 'parallel': False}`` and will be
               applied to the function
 
         Returns
@@ -551,10 +551,10 @@ class ExponentialMovingWindow(BaseWindow):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------
@@ -638,10 +638,10 @@ class ExponentialMovingWindow(BaseWindow):
               ``compute.use_numba``
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -280,10 +280,10 @@ class Expanding(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+              ``{'nogil': False, 'parallel': False}`` and will be
               applied to both the ``func`` and the ``apply`` rolling aggregation.
 
         args : tuple, default None
@@ -447,10 +447,10 @@ class Expanding(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------
@@ -507,10 +507,10 @@ class Expanding(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------
@@ -567,10 +567,10 @@ class Expanding(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------
@@ -627,10 +627,10 @@ class Expanding(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------
@@ -687,10 +687,10 @@ class Expanding(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------
@@ -752,10 +752,10 @@ class Expanding(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------
@@ -825,10 +825,10 @@ class Expanding(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``
+              ``{'nogil': False, 'parallel': False}``
 
         Returns
         -------

--- a/pandas/core/window/numba_.py
+++ b/pandas/core/window/numba_.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 @functools.cache
 def generate_numba_apply_func(
     func: Callable[..., Scalar],
-    nopython: bool,
     nogil: bool,
     parallel: bool,
 ):
@@ -38,8 +37,6 @@ def generate_numba_apply_func(
     ----------
     func : function
         function to be applied to each window and will be JITed
-    nopython : bool
-        nopython to be passed into numba.jit
     nogil : bool
         nogil to be passed into numba.jit
     parallel : bool
@@ -55,7 +52,7 @@ def generate_numba_apply_func(
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    @numba.jit(nogil=nogil, parallel=parallel)
     def roll_apply(
         values: np.ndarray,
         begin: np.ndarray,
@@ -80,7 +77,6 @@ def generate_numba_apply_func(
 
 @functools.cache
 def generate_numba_ewm_func(
-    nopython: bool,
     nogil: bool,
     parallel: bool,
     com: float,
@@ -95,8 +91,6 @@ def generate_numba_ewm_func(
 
     Parameters
     ----------
-    nopython : bool
-        nopython to be passed into numba.jit
     nogil : bool
         nogil to be passed into numba.jit
     parallel : bool
@@ -116,7 +110,7 @@ def generate_numba_ewm_func(
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    @numba.jit(nogil=nogil, parallel=parallel)
     def ewm(
         values: np.ndarray,
         begin: np.ndarray,
@@ -182,7 +176,6 @@ def generate_numba_ewm_func(
 @functools.cache
 def generate_numba_table_func(
     func: Callable[..., np.ndarray],
-    nopython: bool,
     nogil: bool,
     parallel: bool,
 ):
@@ -199,8 +192,6 @@ def generate_numba_table_func(
     ----------
     func : function
         function to be applied to each window and will be JITed
-    nopython : bool
-        nopython to be passed into numba.jit
     nogil : bool
         nogil to be passed into numba.jit
     parallel : bool
@@ -216,7 +207,7 @@ def generate_numba_table_func(
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    @numba.jit(nogil=nogil, parallel=parallel)
     def roll_table(
         values: np.ndarray,
         begin: np.ndarray,
@@ -251,7 +242,7 @@ def generate_manual_numpy_nan_agg_with_axis(nan_func):
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nopython=True, nogil=True, parallel=True)
+    @numba.jit(nogil=True, parallel=True)
     def nan_agg_with_axis(table):
         result = np.empty(table.shape[1])
         for i in numba.prange(table.shape[1]):
@@ -264,7 +255,6 @@ def generate_manual_numpy_nan_agg_with_axis(nan_func):
 
 @functools.cache
 def generate_numba_ewm_table_func(
-    nopython: bool,
     nogil: bool,
     parallel: bool,
     com: float,
@@ -279,8 +269,6 @@ def generate_numba_ewm_table_func(
 
     Parameters
     ----------
-    nopython : bool
-        nopython to be passed into numba.jit
     nogil : bool
         nogil to be passed into numba.jit
     parallel : bool
@@ -300,7 +288,7 @@ def generate_numba_ewm_table_func(
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    @numba.jit(nogil=nogil, parallel=parallel)
     def ewm_table(
         values: np.ndarray,
         begin: np.ndarray,

--- a/pandas/core/window/online.py
+++ b/pandas/core/window/online.py
@@ -8,7 +8,6 @@ from pandas.compat._optional import import_optional_dependency
 
 
 def generate_online_numba_ewma_func(
-    nopython: bool,
     nogil: bool,
     parallel: bool,
 ):
@@ -18,8 +17,6 @@ def generate_online_numba_ewma_func(
 
     Parameters
     ----------
-    nopython : bool
-        nopython to be passed into numba.jit
     nogil : bool
         nogil to be passed into numba.jit
     parallel : bool
@@ -34,7 +31,7 @@ def generate_online_numba_ewma_func(
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    @numba.jit(nogil=nogil, parallel=parallel)
     def online_ewma(
         values: np.ndarray,
         deltas: np.ndarray,

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2227,12 +2227,12 @@ class Rolling(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``.
 
             The default ``engine_kwargs`` for the ``'numba'`` engine is
-            ``{'nopython': True, 'nogil': False, 'parallel': False}`` and will be
+            ``{'nogil': False, 'parallel': False}`` and will be
             applied to both the ``func`` and the ``apply`` rolling aggregation.
 
         args : tuple, default None
@@ -2400,10 +2400,10 @@ class Rolling(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
-              ``{'nopython': True, 'nogil': False, 'parallel': False}``.
+              ``{'nogil': False, 'parallel': False}``.
 
         Returns
         -------
@@ -2504,12 +2504,12 @@ class Rolling(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``.
 
             The default ``engine_kwargs`` for the ``'numba'`` engine is
-            ``{'nopython': True, 'nogil': False, 'parallel': False}``.
+            ``{'nogil': False, 'parallel': False}``.
 
         **kwargs : mapping, optional
             A dictionary of keyword arguments passed into ``func``.
@@ -2572,12 +2572,12 @@ class Rolling(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``.
 
             The default ``engine_kwargs`` for the ``'numba'`` engine is
-            ``{'nopython': True, 'nogil': False, 'parallel': False}``.
+            ``{'nogil': False, 'parallel': False}``.
 
         Returns
         -------
@@ -2640,12 +2640,12 @@ class Rolling(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``.
 
             The default ``engine_kwargs`` for the ``'numba'`` engine is
-            ``{'nopython': True, 'nogil': False, 'parallel': False}``.
+            ``{'nogil': False, 'parallel': False}``.
 
         Returns
         -------
@@ -2716,12 +2716,12 @@ class Rolling(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``.
 
             The default ``engine_kwargs`` for the ``'numba'`` engine is
-            ``{'nopython': True, 'nogil': False, 'parallel': False}``.
+            ``{'nogil': False, 'parallel': False}``.
 
         Returns
         -------
@@ -2790,12 +2790,12 @@ class Rolling(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``.
 
             The default ``engine_kwargs`` for the ``'numba'`` engine is
-            ``{'nopython': True, 'nogil': False, 'parallel': False}``.
+            ``{'nogil': False, 'parallel': False}``.
 
         Returns
         -------
@@ -2867,12 +2867,12 @@ class Rolling(RollingAndExpandingMixin):
 
         engine_kwargs : dict, default None
             * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
-            * For ``'numba'`` engine, the engine can accept ``nopython``, ``nogil``
+            * For ``'numba'`` engine, the engine can accept  ``nogil``
               and ``parallel`` dictionary keys. The values must either be ``True`` or
               ``False``.
 
             The default ``engine_kwargs`` for the ``'numba'`` engine is
-            ``{'nopython': True, 'nogil': False, 'parallel': False}``.
+            ``{'nogil': False, 'parallel': False}``.
 
         Returns
         -------

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -73,8 +73,7 @@ def test_apply(float_frame, engine, request):
 
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("raw", [True, False])
-@pytest.mark.parametrize("nopython", [True, False])
-def test_apply_args(float_frame, axis, raw, engine, nopython):
+def test_apply_args(float_frame, axis, raw, engine):
     numba = pytest.importorskip("numba")
     if (
         engine == "numba"
@@ -82,14 +81,12 @@ def test_apply_args(float_frame, axis, raw, engine, nopython):
         and is_platform_arm()
     ):
         pytest.skip(f"Segfaults on ARM platforms with numba {numba.__version__}")
-    engine_kwargs = {"nopython": nopython}
     result = float_frame.apply(
         lambda x, y: x + y,
         axis,
         args=(1,),
         raw=raw,
         engine=engine,
-        engine_kwargs=engine_kwargs,
     )
     expected = float_frame + 1
     tm.assert_frame_equal(result, expected)
@@ -101,7 +98,6 @@ def test_apply_args(float_frame, axis, raw, engine, nopython):
         b=2,
         raw=raw,
         engine=engine,
-        engine_kwargs=engine_kwargs,
     )
     expected = float_frame + 3
     tm.assert_frame_equal(result, expected)
@@ -114,7 +110,6 @@ def test_apply_args(float_frame, axis, raw, engine, nopython):
                 b=2,
                 raw=raw,
                 engine=engine,
-                engine_kwargs=engine_kwargs,
             )
 
         # keyword-only arguments are not supported in numba
@@ -128,7 +123,6 @@ def test_apply_args(float_frame, axis, raw, engine, nopython):
                 b=2,
                 raw=raw,
                 engine=engine,
-                engine_kwargs=engine_kwargs,
             )
 
         with pytest.raises(
@@ -141,7 +135,6 @@ def test_apply_args(float_frame, axis, raw, engine, nopython):
                 b=2,
                 raw=raw,
                 engine=engine,
-                engine_kwargs=engine_kwargs,
             )
 
 

--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -87,7 +87,7 @@ def test_check_nopython_kwargs():
 @pytest.mark.filterwarnings("ignore")
 # Filter warnings when parallel=True and the function can't be parallelized by Numba
 @pytest.mark.parametrize("jit", [True, False])
-def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, nopython, as_index):
+def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, as_index):
     pytest.importorskip("numba")
 
     def func_numba(values, index):
@@ -102,7 +102,10 @@ def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, nopython, as_ind
     data = DataFrame(
         {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
-    engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+    engine_kwargs = {
+        "nogil": nogil,
+        "parallel": parallel,
+    }
     grouped = data.groupby(0, as_index=as_index)
     if frame_or_series is Series:
         grouped = grouped[1]
@@ -116,7 +119,7 @@ def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, nopython, as_ind
 @pytest.mark.filterwarnings("ignore")
 # Filter warnings when parallel=True and the function can't be parallelized by Numba
 @pytest.mark.parametrize("jit", [True, False])
-def test_cache(jit, frame_or_series, nogil, parallel, nopython):
+def test_cache(jit, frame_or_series, nogil, parallel):
     # Test that the functions are cached correctly if we switch functions
     pytest.importorskip("numba")
 
@@ -135,7 +138,10 @@ def test_cache(jit, frame_or_series, nogil, parallel, nopython):
     data = DataFrame(
         {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
-    engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+    engine_kwargs = {
+        "nogil": nogil,
+        "parallel": parallel,
+    }
     grouped = data.groupby(0)
     if frame_or_series is Series:
         grouped = grouped[1]
@@ -352,12 +358,11 @@ def test_engine_kwargs_not_cached():
     pytest.importorskip("numba")
     nogil = True
     parallel = False
-    nopython = True
 
     def func_kwargs(values, index):
-        return nogil + parallel + nopython
+        return nogil + parallel
 
-    engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     df = DataFrame({"value": [0, 0, 0]})
     result = df.groupby(level=0).aggregate(
         func_kwargs, engine="numba", engine_kwargs=engine_kwargs
@@ -366,7 +371,7 @@ def test_engine_kwargs_not_cached():
     tm.assert_frame_equal(result, expected)
 
     nogil = False
-    engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     result = df.groupby(level=0).aggregate(
         func_kwargs, engine="numba", engine_kwargs=engine_kwargs
     )
@@ -375,14 +380,14 @@ def test_engine_kwargs_not_cached():
 
 
 @pytest.mark.filterwarnings("ignore")
-def test_multiindex_one_key(nogil, parallel, nopython):
+def test_multiindex_one_key(nogil, parallel):
     pytest.importorskip("numba")
 
     def numba_func(values, index):
         return 1
 
     df = DataFrame([{"A": 1, "B": 2, "C": 3}]).set_index(["A", "B"])
-    engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     result = df.groupby("A").agg(
         numba_func, engine="numba", engine_kwargs=engine_kwargs
     )
@@ -390,14 +395,14 @@ def test_multiindex_one_key(nogil, parallel, nopython):
     tm.assert_frame_equal(result, expected)
 
 
-def test_multiindex_multi_key_not_supported(nogil, parallel, nopython):
+def test_multiindex_multi_key_not_supported(nogil, parallel):
     pytest.importorskip("numba")
 
     def numba_func(values, index):
         return 1
 
     df = DataFrame([{"A": 1, "B": 2, "C": 3}]).set_index(["A", "B"])
-    engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     with pytest.raises(NotImplementedError, match="more than 1 grouping labels"):
         df.groupby(["A", "B"]).agg(
             numba_func, engine="numba", engine_kwargs=engine_kwargs

--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -276,9 +276,7 @@ def test_multifunc_numba_vs_cython_series(agg_kwargs):
 
 
 @pytest.mark.single_cpu
-@pytest.mark.filterwarnings(
-    "ignore:unsafe cast from uint64 to int64:numba.NumbaTypeSafetyWarning"
-)
+@pytest.mark.filterwarnings("ignore:unsafe cast from uint64 to int64")
 @pytest.mark.parametrize(
     "data,agg_kwargs",
     [
@@ -370,7 +368,7 @@ def test_engine_kwargs_not_cached():
     result = df.groupby(level=0).aggregate(
         func_kwargs, engine="numba", engine_kwargs=engine_kwargs
     )
-    expected = DataFrame({"value": [2.0, 2.0, 2.0]})
+    expected = DataFrame({"value": [1.0, 1.0, 1.0]})
     tm.assert_frame_equal(result, expected)
 
     nogil = False
@@ -378,7 +376,7 @@ def test_engine_kwargs_not_cached():
     result = df.groupby(level=0).aggregate(
         func_kwargs, engine="numba", engine_kwargs=engine_kwargs
     )
-    expected = DataFrame({"value": [1.0, 1.0, 1.0]})
+    expected = DataFrame({"value": [0.0, 0.0, 0.0]})
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -276,6 +276,9 @@ def test_multifunc_numba_vs_cython_series(agg_kwargs):
 
 
 @pytest.mark.single_cpu
+@pytest.mark.filterwarnings(
+    "ignore:unsafe cast from uint64 to int64:numba.NumbaTypeSafetyWarning"
+)
 @pytest.mark.parametrize(
     "data,agg_kwargs",
     [

--- a/pandas/tests/groupby/test_numba.py
+++ b/pandas/tests/groupby/test_numba.py
@@ -25,11 +25,11 @@ pytestmark.append(
 # Filter warnings when parallel=True and the function can't be parallelized by Numba
 class TestEngine:
     def test_cython_vs_numba_frame(
-        self, sort, nogil, parallel, nopython, numba_supported_reductions
+        self, sort, nogil, parallel, numba_supported_reductions
     ):
         func, kwargs = numba_supported_reductions
         df = DataFrame({"a": [3, 2, 3, 2], "b": range(4), "c": range(1, 5)})
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         gb = df.groupby("a", sort=sort)
         result = getattr(gb, func)(
             engine="numba", engine_kwargs=engine_kwargs, **kwargs
@@ -38,11 +38,11 @@ class TestEngine:
         tm.assert_frame_equal(result, expected)
 
     def test_cython_vs_numba_getitem(
-        self, sort, nogil, parallel, nopython, numba_supported_reductions
+        self, sort, nogil, parallel, numba_supported_reductions
     ):
         func, kwargs = numba_supported_reductions
         df = DataFrame({"a": [3, 2, 3, 2], "b": range(4), "c": range(1, 5)})
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         gb = df.groupby("a", sort=sort)["c"]
         result = getattr(gb, func)(
             engine="numba", engine_kwargs=engine_kwargs, **kwargs
@@ -51,11 +51,11 @@ class TestEngine:
         tm.assert_series_equal(result, expected)
 
     def test_cython_vs_numba_series(
-        self, sort, nogil, parallel, nopython, numba_supported_reductions
+        self, sort, nogil, parallel, numba_supported_reductions
     ):
         func, kwargs = numba_supported_reductions
         ser = Series(range(3), index=[1, 2, 1], name="foo")
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         gb = ser.groupby(level=0, sort=sort)
         result = getattr(gb, func)(
             engine="numba", engine_kwargs=engine_kwargs, **kwargs

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -85,7 +85,7 @@ def test_check_nopython_kwargs():
 @pytest.mark.filterwarnings("ignore")
 # Filter warnings when parallel=True and the function can't be parallelized by Numba
 @pytest.mark.parametrize("jit", [True, False])
-def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, nopython, as_index):
+def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, as_index):
     pytest.importorskip("numba")
 
     def func(values, index):
@@ -100,7 +100,7 @@ def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, nopython, as_ind
     data = DataFrame(
         {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
-    engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     grouped = data.groupby(0, as_index=as_index)
     if frame_or_series is Series:
         grouped = grouped[1]
@@ -114,7 +114,7 @@ def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, nopython, as_ind
 @pytest.mark.filterwarnings("ignore")
 # Filter warnings when parallel=True and the function can't be parallelized by Numba
 @pytest.mark.parametrize("jit", [True, False])
-def test_cache(jit, frame_or_series, nogil, parallel, nopython):
+def test_cache(jit, frame_or_series, nogil, parallel):
     # Test that the functions are cached correctly if we switch functions
     pytest.importorskip("numba")
 
@@ -133,7 +133,7 @@ def test_cache(jit, frame_or_series, nogil, parallel, nopython):
     data = DataFrame(
         {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
-    engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     grouped = data.groupby(0)
     if frame_or_series is Series:
         grouped = grouped[1]
@@ -241,12 +241,11 @@ def test_engine_kwargs_not_cached():
     pytest.importorskip("numba")
     nogil = True
     parallel = False
-    nopython = True
 
     def func_kwargs(values, index):
-        return nogil + parallel + nopython
+        return nogil + parallel
 
-    engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     df = DataFrame({"value": [0, 0, 0]})
     result = df.groupby(level=0).transform(
         func_kwargs, engine="numba", engine_kwargs=engine_kwargs
@@ -255,7 +254,7 @@ def test_engine_kwargs_not_cached():
     tm.assert_frame_equal(result, expected)
 
     nogil = False
-    engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     result = df.groupby(level=0).transform(
         func_kwargs, engine="numba", engine_kwargs=engine_kwargs
     )
@@ -264,14 +263,14 @@ def test_engine_kwargs_not_cached():
 
 
 @pytest.mark.filterwarnings("ignore")
-def test_multiindex_one_key(nogil, parallel, nopython):
+def test_multiindex_one_key(nogil, parallel):
     pytest.importorskip("numba")
 
     def numba_func(values, index):
         return 1
 
     df = DataFrame([{"A": 1, "B": 2, "C": 3}]).set_index(["A", "B"])
-    engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     result = df.groupby("A").transform(
         numba_func, engine="numba", engine_kwargs=engine_kwargs
     )
@@ -279,14 +278,14 @@ def test_multiindex_one_key(nogil, parallel, nopython):
     tm.assert_frame_equal(result, expected)
 
 
-def test_multiindex_multi_key_not_supported(nogil, parallel, nopython):
+def test_multiindex_multi_key_not_supported(nogil, parallel):
     pytest.importorskip("numba")
 
     def numba_func(values, index):
         return 1
 
     df = DataFrame([{"A": 1, "B": 2, "C": 3}]).set_index(["A", "B"])
-    engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+    engine_kwargs = {"nogil": nogil, "parallel": parallel}
     with pytest.raises(NotImplementedError, match="more than 1 grouping labels"):
         df.groupby(["A", "B"]).transform(
             numba_func, engine="numba", engine_kwargs=engine_kwargs

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -250,7 +250,7 @@ def test_engine_kwargs_not_cached():
     result = df.groupby(level=0).transform(
         func_kwargs, engine="numba", engine_kwargs=engine_kwargs
     )
-    expected = DataFrame({"value": [2.0, 2.0, 2.0]})
+    expected = DataFrame({"value": [1.0, 1.0, 1.0]})
     tm.assert_frame_equal(result, expected)
 
     nogil = False
@@ -258,7 +258,7 @@ def test_engine_kwargs_not_cached():
     result = df.groupby(level=0).transform(
         func_kwargs, engine="numba", engine_kwargs=engine_kwargs
     )
-    expected = DataFrame({"value": [1.0, 1.0, 1.0]})
+    expected = DataFrame({"value": [0.0, 0.0, 0.0]})
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/window/test_apply.py
+++ b/pandas/tests/window/test_apply.py
@@ -148,7 +148,7 @@ def test_invalid_engine():
 def test_invalid_engine_kwargs_cython():
     with pytest.raises(ValueError, match="cython engine does not accept engine_kwargs"):
         Series(range(1)).rolling(1).apply(
-            lambda x: x, engine="cython", engine_kwargs={"nopython": False}
+            lambda x: x, engine="cython", engine_kwargs={"parallel": False}
         )
 
 

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -284,7 +284,7 @@ class TestEngine:
         result = df.rolling(1).apply(
             func, raw=True, engine="numba", engine_kwargs=engine_kwargs
         )
-        expected = DataFrame({"value": [2.0, 2.0, 2.0]})
+        expected = DataFrame({"value": [1.0, 1.0, 1.0]})
         tm.assert_frame_equal(result, expected)
 
         parallel = False
@@ -292,7 +292,7 @@ class TestEngine:
         result = df.rolling(1).apply(
             func, raw=True, engine="numba", engine_kwargs=engine_kwargs
         )
-        expected = DataFrame({"value": [1.0, 1.0, 1.0]})
+        expected = DataFrame({"value": [0.0, 0.0, 0.0]})
         tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -59,7 +59,7 @@ def roll_frame():
 # Filter warnings when parallel=True and the function can't be parallelized by Numba
 class TestEngine:
     @pytest.mark.parametrize("jit", [True, False])
-    def test_numba_vs_cython_apply(self, jit, nogil, parallel, nopython, center, step):
+    def test_numba_vs_cython_apply(self, jit, nogil, parallel, center, step):
         def f(x, *args):
             arg_sum = 0
             for arg in args:
@@ -71,7 +71,7 @@ class TestEngine:
 
             f = numba.jit(f)
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         args = (2,)
 
         s = Series(range(10))
@@ -175,13 +175,12 @@ class TestEngine:
         data,
         nogil,
         parallel,
-        nopython,
         arithmetic_numba_supported_operators,
         step,
     ):
         method, kwargs = arithmetic_numba_supported_operators
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
 
         roll = data.rolling(3, step=step)
         result = getattr(roll, method)(
@@ -194,11 +193,11 @@ class TestEngine:
         "data", [DataFrame(np.eye(5)), Series(range(5), name="foo")]
     )
     def test_numba_vs_cython_expanding_methods(
-        self, data, nogil, parallel, nopython, arithmetic_numba_supported_operators
+        self, data, nogil, parallel, arithmetic_numba_supported_operators
     ):
         method, kwargs = arithmetic_numba_supported_operators
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
 
         data = DataFrame(np.eye(5))
         expand = data.expanding()
@@ -209,7 +208,7 @@ class TestEngine:
         tm.assert_equal(result, expected)
 
     @pytest.mark.parametrize("jit", [True, False])
-    def test_cache_apply(self, jit, nogil, parallel, nopython, step):
+    def test_cache_apply(self, jit, nogil, parallel, step):
         # Test that the functions are cached correctly if we switch functions
         def func_1(x):
             return np.mean(x) + 4
@@ -223,7 +222,7 @@ class TestEngine:
             func_1 = numba.jit(func_1)
             func_2 = numba.jit(func_2)
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
 
         roll = Series(range(10)).rolling(2, step=step)
         result = roll.apply(
@@ -251,15 +250,13 @@ class TestEngine:
             ["expanding", {}],
         ],
     )
-    def test_dont_cache_args(
-        self, window, window_kwargs, nogil, parallel, nopython, method
-    ):
+    def test_dont_cache_args(self, window, window_kwargs, nogil, parallel, method):
         # GH 42287
 
         def add(values, x):
             return np.sum(values) + x
 
-        engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         df = DataFrame({"value": [0, 0, 0]})
         result = getattr(df, window)(method=method, **window_kwargs).apply(
             add, raw=True, engine="numba", engine_kwargs=engine_kwargs, args=(1,)
@@ -278,12 +275,11 @@ class TestEngine:
         # jitted function
         nogil = False
         parallel = True
-        nopython = True
 
         def func(x):
-            return nogil + parallel + nopython
+            return nogil + parallel
 
-        engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         df = DataFrame({"value": [0, 0, 0]})
         result = df.rolling(1).apply(
             func, raw=True, engine="numba", engine_kwargs=engine_kwargs
@@ -292,7 +288,7 @@ class TestEngine:
         tm.assert_frame_equal(result, expected)
 
         parallel = False
-        engine_kwargs = {"nopython": nopython, "nogil": nogil, "parallel": parallel}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         result = df.rolling(1).apply(
             func, raw=True, engine="numba", engine_kwargs=engine_kwargs
         )
@@ -319,14 +315,12 @@ class TestEWM:
         df = DataFrame({"A": ["a", "b", "a", "b"], "B": range(4)})
         with pytest.raises(ValueError, match="cython engine does not"):
             getattr(grouper(df).ewm(com=1.0), method)(
-                engine="cython", engine_kwargs={"nopython": True}
+                engine="cython", engine_kwargs={"parallel": True}
             )
 
     @pytest.mark.parametrize("grouper", ["None", "groupby"])
     @pytest.mark.parametrize("method", ["mean", "sum"])
-    def test_cython_vs_numba(
-        self, grouper, method, nogil, parallel, nopython, ignore_na, adjust
-    ):
+    def test_cython_vs_numba(self, grouper, method, nogil, parallel, ignore_na, adjust):
         df = DataFrame({"B": range(4)})
         if grouper == "None":
             grouper = lambda x: x
@@ -337,14 +331,14 @@ class TestEWM:
             adjust = True
         ewm = grouper(df).ewm(com=1.0, adjust=adjust, ignore_na=ignore_na)
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         result = getattr(ewm, method)(engine="numba", engine_kwargs=engine_kwargs)
         expected = getattr(ewm, method)(engine="cython")
 
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("grouper", ["None", "groupby"])
-    def test_cython_vs_numba_times(self, grouper, nogil, parallel, nopython, ignore_na):
+    def test_cython_vs_numba_times(self, grouper, nogil, parallel, ignore_na):
         # GH 40951
 
         df = DataFrame({"B": [0, 0, 1, 1, 2, 2]})
@@ -369,7 +363,7 @@ class TestEWM:
             halflife=halflife, adjust=True, ignore_na=ignore_na, times=times
         )
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
 
         result = ewm.mean(engine="numba", engine_kwargs=engine_kwargs)
         expected = ewm.mean(engine="cython")
@@ -430,13 +424,12 @@ class TestTableMethod:
         self,
         nogil,
         parallel,
-        nopython,
         arithmetic_numba_supported_operators,
         step,
     ):
         method, kwargs = arithmetic_numba_supported_operators
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
 
         df = DataFrame(np.eye(3))
         roll_table = df.rolling(2, method="table", min_periods=0, step=step)
@@ -455,8 +448,8 @@ class TestTableMethod:
             )
             tm.assert_frame_equal(result, expected)
 
-    def test_table_method_rolling_apply(self, nogil, parallel, nopython, step):
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+    def test_table_method_rolling_apply(self, nogil, parallel, step):
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
 
         def f(x):
             return np.sum(x, axis=0) + 1
@@ -522,8 +515,11 @@ class TestTableMethod:
         )[::step]
         tm.assert_frame_equal(result, expected)
 
-    def test_table_method_expanding_apply(self, nogil, parallel, nopython):
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+    def test_table_method_expanding_apply(self, nogil, parallel):
+        engine_kwargs = {
+            "nogil": nogil,
+            "parallel": parallel,
+        }
 
         def f(x):
             return np.sum(x, axis=0) + 1
@@ -538,11 +534,14 @@ class TestTableMethod:
         tm.assert_frame_equal(result, expected)
 
     def test_table_method_expanding_methods(
-        self, nogil, parallel, nopython, arithmetic_numba_supported_operators
+        self, nogil, parallel, arithmetic_numba_supported_operators
     ):
         method, kwargs = arithmetic_numba_supported_operators
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {
+            "nogil": nogil,
+            "parallel": parallel,
+        }
 
         df = DataFrame(np.eye(3))
         expand_table = df.expanding(method="table")
@@ -563,8 +562,8 @@ class TestTableMethod:
 
     @pytest.mark.parametrize("data", [np.eye(3), np.ones((2, 3)), np.ones((3, 2))])
     @pytest.mark.parametrize("method", ["mean", "sum"])
-    def test_table_method_ewm(self, data, method, nogil, parallel, nopython):
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+    def test_table_method_ewm(self, data, method, nogil, parallel):
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
 
         df = DataFrame(data)
 

--- a/pandas/tests/window/test_online.py
+++ b/pandas/tests/window/test_online.py
@@ -37,11 +37,9 @@ class TestEWM:
     @pytest.mark.parametrize(
         "obj", [DataFrame({"a": range(5), "b": range(5)}), Series(range(5), name="foo")]
     )
-    def test_online_vs_non_online_mean(
-        self, obj, nogil, parallel, nopython, adjust, ignore_na
-    ):
+    def test_online_vs_non_online_mean(self, obj, nogil, parallel, adjust, ignore_na):
         expected = obj.ewm(0.5, adjust=adjust, ignore_na=ignore_na).mean()
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
 
         online_ewm = (
             obj.head(2)
@@ -63,7 +61,7 @@ class TestEWM:
         "obj", [DataFrame({"a": range(5), "b": range(5)}), Series(range(5), name="foo")]
     )
     def test_update_times_mean(
-        self, obj, nogil, parallel, nopython, adjust, ignore_na, halflife_with_times
+        self, obj, nogil, parallel, adjust, ignore_na, halflife_with_times
     ):
         times = Series(
             np.array(
@@ -79,7 +77,7 @@ class TestEWM:
             halflife=halflife_with_times,
         ).mean()
 
-        engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
+        engine_kwargs = {"nogil": nogil, "parallel": parallel}
         online_ewm = (
             obj.head(2)
             .ewm(

--- a/typings/numba.pyi
+++ b/typings/numba.pyi
@@ -24,7 +24,6 @@ def jit(
     pipeline_class: numba.compiler.CompilerBase = ...,
     boundscheck: bool | None = ...,
     *,
-    nopython: bool = ...,
     forceobj: bool = ...,
     looplift: bool = ...,
     error_model: Literal["python", "numpy"] = ...,


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.


It appears we've been getting this NumbaDeprecationWarning in our logs for a while

```
numba.core.errors.NumbaDeprecationWarning: The keyword argument 'nopython=False' was supplied. From Numba 0.59.0 the default is True and supplying this argument has no effect.
```

Since our minimum supported Numba version is 0.60.0, I think we might as well just stop passing this option in `engine_kwarg` arguments all together. A formal deprecation on the pandas side for `engine_kwargs` containing `nopython` might be more trouble than it's worth since Numba is already supplying a warning and we cannot control when Numba further enforces this deprecation.