### PR TITLE
TST: Add regression tests for GH#55423 (tz-aware setitem expansion retains dtype)

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2363,6 +2363,46 @@ class TestLocSetitemWithExpansion:
         )
         tm.assert_frame_equal(df, expected)
 
+    def test_loc_setitem_with_expansion_tz_aware_column_retains_dtype(self):
+        # GH#55423 - enlarging a DataFrame by adding an extra column with a
+        # tz-aware datetime scalar should retain datetime64 dtype, not object.
+        import datetime as dt
+
+        df = DataFrame([{"id": 1}, {"id": 2}, {"id": 3}])
+        _time = dt.datetime.utcfromtimestamp(1695887042).replace(
+            tzinfo=dt.timezone.utc
+        )
+
+        # Set a tz-aware datetime on a subset of rows, expanding with a new col
+        df.loc[df["id"] >= 2, "time"] = _time
+
+        # The 'time' column must be datetime64 (tz-aware), not object dtype
+        assert df["time"].dtype != object, (
+            f"Expected datetime64[tz] dtype, got {df['time'].dtype}"
+        )
+        assert pd.api.types.is_datetime64_any_dtype(df["time"]), (
+            f"Expected datetime64 dtype, got {df['time'].dtype}"
+        )
+
+        # Row 0 (not matched) should be NaT; rows 1 & 2 should hold _time
+        assert pd.isna(df.loc[0, "time"])
+        assert df.loc[1, "time"] == Timestamp(_time)
+        assert df.loc[2, "time"] == Timestamp(_time)
+
+    def test_loc_setitem_with_expansion_tz_aware_column_via_timestamp(self):
+        # GH#55423 - same as above but value given as pd.Timestamp
+        ts = Timestamp("2023-09-28 07:44:02", tz="UTC")
+        df = DataFrame({"id": [10, 20, 30]})
+
+        df.loc[df["id"] > 10, "created_at"] = ts
+
+        assert pd.api.types.is_datetime64_any_dtype(df["created_at"]), (
+            f"Expected datetime64 dtype, got {df['created_at'].dtype}"
+        )
+        assert pd.isna(df.loc[0, "created_at"])
+        assert df.loc[1, "created_at"] == ts
+        assert df.loc[2, "created_at"] == ts
+
 
 class TestLocCallable:
     def test_frame_loc_getitem_callable(self):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2376,13 +2376,12 @@ class TestLocSetitemWithExpansion:
         # Set a tz-aware datetime on a subset of rows, expanding with a new col
         df.loc[df["id"] >= 2, "time"] = _time
 
-        # The 'time' column must be datetime64 (tz-aware), not object dtype
-        assert df["time"].dtype != object, (
-            f"Expected datetime64[tz] dtype, got {df['time'].dtype}"
+        # The 'time' column must be tz-aware datetime64 with UTC timezone, not object
+        dtype = df["time"].dtype
+        assert isinstance(dtype, pd.DatetimeTZDtype), (
+            f"Expected DatetimeTZDtype, got {dtype}"
         )
-        assert pd.api.types.is_datetime64_any_dtype(df["time"]), (
-            f"Expected datetime64 dtype, got {df['time'].dtype}"
-        )
+        assert dtype.tz is dt.timezone.utc, f"Expected UTC timezone, got {dtype.tz}"
 
         # Row 0 (not matched) should be NaT; rows 1 & 2 should hold _time
         assert pd.isna(df.loc[0, "time"])
@@ -2396,9 +2395,11 @@ class TestLocSetitemWithExpansion:
 
         df.loc[df["id"] > 10, "created_at"] = ts
 
-        assert pd.api.types.is_datetime64_any_dtype(df["created_at"]), (
-            f"Expected datetime64 dtype, got {df['created_at'].dtype}"
+        dtype = df["created_at"].dtype
+        assert isinstance(dtype, pd.DatetimeTZDtype), (
+            f"Expected tz-aware datetime64 dtype, got {dtype}"
         )
+        assert dtype.tz is ts.tz, f"Expected timezone {ts.tz}, got {dtype.tz}"
         assert pd.isna(df.loc[0, "created_at"])
         assert df.loc[1, "created_at"] == ts
         assert df.loc[2, "created_at"] == ts


### PR DESCRIPTION
## Problem

Closes #55423.

When enlarging a `DataFrame` by assigning a tz-aware `datetime` scalar to a **new column** via `.loc[mask, 'new_col'] = <tz-aware datetime>`, the resulting column had `object` dtype instead of `datetime64[us, UTC]`:

```python
import pandas as pd
import datetime as dt

df = pd.DataFrame([{'id': 1}, {'id': 2}, {'id': 3}])
_time = dt.datetime.utcfromtimestamp(1695887042).replace(tzinfo=dt.timezone.utc)
df.loc[df['id'] >= 2, 'time'] = _time

print(df['time'].dtype)  # object  ← BUG (expected datetime64[us, UTC])
```

## Fix

The underlying bug was fixed in #62523. This PR adds the **missing regression tests** that the maintainer requested:

> _"im seeing the expected behavior on main. could use a test."_ — @jbrockmendel (2025-10-14)

## Changes

`pandas/tests/indexing/test_loc.py` — 2 new tests in `TestLocSetitemWithExpansion`:

| Test | Scenario |
|------|----------|
| `test_loc_setitem_with_expansion_tz_aware_column_retains_dtype` | `dt.datetime` with `tzinfo=timezone.utc` (original reporter's exact pattern) |
| `test_loc_setitem_with_expansion_tz_aware_column_via_timestamp` | `pd.Timestamp(tz='UTC')` (Timestamp code path) |

## Test Results

```
PASSED  test_loc_setitem_with_expansion_tz_aware_column_retains_dtype
PASSED  test_loc_setitem_with_expansion_tz_aware_column_via_timestamp

100 passed, 4 skipped, 1 xfailed  (full TestLocSetitemWithExpansion class)
```

- [x] Tests added for the regression (GH#55423)
- [x] Tests only — no new public API, no whatsnew entry needed (already covered by #62523)