### PR TITLE
PERF: Optimize astype_overflowsafe unit conversion

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -107,6 +107,7 @@ Performance improvements
   (:issue:`64126`).
 - Performance improvement in :func:`merge` with ``how="left"`` (:issue:`64370`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
+- Performance improvement in datetime/timedelta unit conversion (e.g. ``datetime64[s]`` to ``datetime64[ns]``) (:issue:`35025`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -420,18 +420,38 @@ cpdef ndarray astype_overflowsafe(
         )
         return iresult2.view(dtype)
 
+    if from_unit == NPY_FR_Y or from_unit == NPY_FR_M:
+        # Y/M don't have a fixed conversion factor; fall back to
+        # datetimestruct roundtrip.
+        return _astype_overflowsafe_to_larger_unit_via_dts(
+            values, dtype, from_unit, to_unit, is_coerce,
+        )
+
     if (<object>values).dtype.byteorder == ">":
         # GH#29684 we incorrectly get OutOfBoundsDatetime if we dont swap
         values = values.astype(values.dtype.newbyteorder("<"))
 
     cdef:
         ndarray i8values = values.view("i8")
+        int64_t mult = get_conversion_factor(from_unit, to_unit)
+        int64_t overflow_limit = INT64_MAX // mult
+        int64_t i8min, i8max
 
-        # equiv: result = np.empty((<object>values).shape, dtype="i8")
+    # Fast path: if min/max are both within the overflow-safe range, there
+    # are no NATs (NAT == INT64_MIN < -overflow_limit) and no overflow risk,
+    # so we can use numpy's vectorized multiply.  Restricted to ndim >= 1
+    # since 0-d .view(dtype) has edge cases; the slow path handles 0-d fine.
+    if i8values.ndim >= 1 and i8values.size > 0:
+        i8min = i8values.min()
+        i8max = i8values.max()
+        if i8min >= -overflow_limit and i8max <= overflow_limit:
+            return (i8values * mult).view(dtype)
+
+    # Slow path: per-element loop with NAT and overflow handling.
+    cdef:
         ndarray iresult = cnp.PyArray_EMPTY(
             values.ndim, values.shape, cnp.NPY_INT64, 0
         )
-
         cnp.broadcast mi = cnp.PyArray_MultiIterNew2(iresult, i8values)
         Py_ssize_t i, N = values.size
         int64_t value, new_value
@@ -444,26 +464,26 @@ cpdef ndarray astype_overflowsafe(
 
         if value == NPY_DATETIME_NAT:
             new_value = NPY_DATETIME_NAT
-        else:
-            pandas_datetime_to_datetimestruct(value, from_unit, &dts)
-
-            try:
-                check_dts_bounds(&dts, to_unit)
-            except OutOfBoundsDatetime as err:
-                if is_coerce:
-                    new_value = NPY_DATETIME_NAT
-                elif is_td:
-                    from_abbrev = np.datetime_data(values.dtype)[0]
-                    np_val = np.timedelta64(value, from_abbrev)
-                    msg = (
-                        "Cannot convert {np_val} to {dtype} without overflow"
-                        .format(np_val=str(np_val), dtype=str(dtype))
-                    )
-                    raise OutOfBoundsTimedelta(msg) from err
-                else:
-                    raise
+        elif value > overflow_limit or value < -overflow_limit:
+            if is_coerce:
+                new_value = NPY_DATETIME_NAT
+            elif is_td:
+                from_abbrev = np.datetime_data(values.dtype)[0]
+                np_val = np.timedelta64(value, from_abbrev)
+                msg = (
+                    "Cannot convert {np_val} to {dtype} without overflow"
+                    .format(np_val=str(np_val), dtype=str(dtype))
+                )
+                raise OutOfBoundsTimedelta(msg)
             else:
-                new_value = npy_datetimestruct_to_datetime(to_unit, &dts)
+                pandas_datetime_to_datetimestruct(value, from_unit, &dts)
+                fmt = dts_to_iso_string(&dts)
+                attrname = npy_unit_to_attrname[to_unit]
+                raise OutOfBoundsDatetime(
+                    f"Out of bounds {attrname} timestamp: {fmt}"
+                )
+        else:
+            new_value = value * mult
 
         # Analogous to: iresult[i] = new_value
         (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = new_value
@@ -546,6 +566,69 @@ cdef int op_to_op_code(op):
         return Py_GT
 
 
+cdef ndarray _astype_overflowsafe_to_larger_unit_via_dts(
+    ndarray values,
+    cnp.dtype dtype,
+    NPY_DATETIMEUNIT from_unit,
+    NPY_DATETIMEUNIT to_unit,
+    bint is_coerce,
+):
+    """
+    Fallback for Y/M units where a fixed conversion factor doesn't exist.
+    Uses the datetimestruct roundtrip for correctness.
+    """
+    if (<object>values).dtype.byteorder == ">":
+        values = values.astype(values.dtype.newbyteorder("<"))
+
+    cdef:
+        ndarray i8values = values.view("i8")
+        ndarray iresult = cnp.PyArray_EMPTY(
+            values.ndim, values.shape, cnp.NPY_INT64, 0
+        )
+        cnp.broadcast mi = cnp.PyArray_MultiIterNew2(iresult, i8values)
+        Py_ssize_t i, N = values.size
+        int64_t value, new_value
+        npy_datetimestruct dts
+        npy_datetimestruct cmp_lower, cmp_upper
+        bint is_td = dtype.type_num == cnp.NPY_TIMEDELTA
+
+    get_implementation_bounds(to_unit, &cmp_lower, &cmp_upper)
+
+    for i in range(N):
+        value = (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 1))[0]
+
+        if value == NPY_DATETIME_NAT:
+            new_value = NPY_DATETIME_NAT
+        else:
+            pandas_datetime_to_datetimestruct(value, from_unit, &dts)
+
+            if (cmp_npy_datetimestruct(&dts, &cmp_lower) == -1
+                    or cmp_npy_datetimestruct(&dts, &cmp_upper) == 1):
+                if is_coerce:
+                    new_value = NPY_DATETIME_NAT
+                elif is_td:
+                    from_abbrev = np.datetime_data(values.dtype)[0]
+                    np_val = np.timedelta64(value, from_abbrev)
+                    msg = (
+                        "Cannot convert {np_val} to {dtype} without overflow"
+                        .format(np_val=str(np_val), dtype=str(dtype))
+                    )
+                    raise OutOfBoundsTimedelta(msg)
+                else:
+                    fmt = dts_to_iso_string(&dts)
+                    attrname = npy_unit_to_attrname[to_unit]
+                    raise OutOfBoundsDatetime(
+                        f"Out of bounds {attrname} timestamp: {fmt}"
+                    )
+            else:
+                new_value = npy_datetimestruct_to_datetime(to_unit, &dts)
+
+        (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = new_value
+        cnp.PyArray_MultiIter_NEXT(mi)
+
+    return iresult.view(dtype)
+
+
 cdef ndarray _astype_overflowsafe_to_smaller_unit(
     ndarray i8values,
     NPY_DATETIMEUNIT from_unit,
@@ -572,7 +655,7 @@ cdef ndarray _astype_overflowsafe_to_smaller_unit(
         # Note the arguments to_unit, from unit are swapped vs how they
         #  are passed when going to a higher-frequency reso.
         int64_t mult = get_conversion_factor(to_unit, from_unit)
-        int64_t value, mod
+        int64_t value, mod, new_value
 
     for i in range(N):
         # Analogous to: item = i8values[i]
@@ -581,13 +664,16 @@ cdef ndarray _astype_overflowsafe_to_smaller_unit(
         if value == NPY_DATETIME_NAT:
             new_value = NPY_DATETIME_NAT
         else:
-            new_value, mod = divmod(value, mult)
-            if not round_ok and mod != 0:
-                from_abbrev = npy_unit_to_abbrev(from_unit)
-                to_abbrev = npy_unit_to_abbrev(to_unit)
-                raise ValueError(
-                    f"Cannot losslessly cast '{value} {from_abbrev}' to {to_abbrev}"
-                )
+            new_value = value // mult
+            if not round_ok:
+                mod = value % mult
+                if mod != 0:
+                    from_abbrev = npy_unit_to_abbrev(from_unit)
+                    to_abbrev = npy_unit_to_abbrev(to_unit)
+                    raise ValueError(
+                        f"Cannot losslessly cast '{value} {from_abbrev}' "
+                        f"to {to_abbrev}"
+                    )
 
         # Analogous to: iresult[i] = new_value
         (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = new_value


### PR DESCRIPTION
Claude wrote this, I reviewed it manually.

- [x] closes #35025


## Summary
- For the **to-larger-unit path** (e.g. `datetime64[s]` → `datetime64[ns]`), replace the per-element `datetimestruct` roundtrip (`int64 → npy_datetimestruct → bounds check → int64`) with a min/max bounds check followed by numpy's vectorized multiply. This is the hot path reported in #35025.
- For the **to-smaller-unit path** (e.g. `datetime64[ns]` → `datetime64[us]`), fix `new_value` not being C-typed (`int64_t`) and replace Python `divmod()` with C-level `//` and `%`, skipping `%` entirely when `round_ok=True`.
- Y/M units (which lack a fixed conversion factor) are split into a separate helper that preserves the original `datetimestruct` roundtrip logic.

```python
import numpy as np
from pandas._libs.tslibs.np_datetime import astype_overflowsafe

vals_s = np.arange(1_000_000, dtype="i8").view("datetime64[s]")
dtype_ns = np.dtype("datetime64[ns]")

%timeit astype_overflowsafe(vals_s, dtype_ns)
1.05 ms ± 12.3 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  # <- PR
23.4 ms ± 124 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- main
```
