### PR TITLE
TST: add regression test for tz-aware dtype preservation in loc setitem expansion

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -28,6 +28,7 @@ from pandas import (
     Index,
     IndexSlice,
     MultiIndex,
+    NaT,
     Period,
     PeriodIndex,
     Series,
@@ -2251,6 +2252,28 @@ class TestLocSetitemWithExpansion:
             index=["Bank", "Credit Union", "Total"],
         )
         tm.assert_frame_equal(df, expected)
+
+
+    def test_loc_setitem_with_expansion_preserves_tzaware_datetime_dtype(self):
+        df = DataFrame([{"id": 1}, {"id": 2}, {"id": 3}])
+
+        ts = Timestamp("2023-09-28 07:44:02+00:00")
+        df.loc[df["id"] >= 2, "time"] = ts
+
+        expected = DataFrame(
+            {
+                "id": [1, 2, 3],
+                "time": [
+                    NaT,
+                    Timestamp("2023-09-28 07:44:02+00:00"),
+                    Timestamp("2023-09-28 07:44:02+00:00"),
+                ],
+            }
+        )
+
+        tm.assert_frame_equal(df, expected)
+        assert isinstance(df["time"].dtype, pd.DatetimeTZDtype)
+        assert str(df["time"].dtype).endswith(", UTC]")
 
     def test_loc_setitem_with_expansion_dtype_retention(self):
         # GH#6485

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -28,7 +28,6 @@ from pandas import (
     Index,
     IndexSlice,
     MultiIndex,
-    NaT,
     Period,
     PeriodIndex,
     Series,
@@ -2253,7 +2252,6 @@ class TestLocSetitemWithExpansion:
         )
         tm.assert_frame_equal(df, expected)
 
-
     def test_loc_setitem_with_expansion_preserves_tzaware_datetime_dtype(self):
         df = DataFrame([{"id": 1}, {"id": 2}, {"id": 3}])
 
@@ -2264,7 +2262,7 @@ class TestLocSetitemWithExpansion:
             {
                 "id": [1, 2, 3],
                 "time": [
-                    NaT,
+                    pd.NaT,
                     Timestamp("2023-09-28 07:44:02+00:00"),
                     Timestamp("2023-09-28 07:44:02+00:00"),
                 ],


### PR DESCRIPTION
## Summary
Adds a regression test for `.loc` setitem-with-expansion when assigning a tz-aware scalar into a new column.

## What this covers
The original issue reported that assigning a UTC-aware timestamp with:

```python
df.loc[df["id"] >= 2, "time"] = ts
```

could cause the new `time` column to fall back to `object` dtype.

I checked current `main` locally and the repro now preserves a tz-aware datetime dtype, so this PR adds regression coverage to lock in that behavior.

## Testing

python -m pytest pandas/tests/indexing/test_loc.py -k 
preserves_tzaware_datetime_dtype

## Issue

Closes #55423