### PR TITLE
BUG: Fix double negative typo in CategoricalDtype error message

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -337,7 +337,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
                     "Cannot specify `categories` or `ordered` together with `dtype`."
                 )
             elif not isinstance(dtype, CategoricalDtype):
-                raise ValueError(f"Cannot not construct CategoricalDtype from {dtype}")
+                raise ValueError(f"Cannot construct CategoricalDtype from {dtype}")
         elif cls.is_dtype(values):
             # If no "dtype" was passed, use the one from "values", but honor
             # the "ordered" and "categories" arguments

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -156,7 +156,7 @@ class TestCategoricalDtype(Base):
             CategoricalDtype._from_values_or_dtype(values, categories, ordered, dtype)
 
     def test_from_values_or_dtype_invalid_dtype(self):
-        msg = "Cannot not construct CategoricalDtype from <class 'object'>"
+        msg = "Cannot construct CategoricalDtype from <class 'object'>"
         with pytest.raises(ValueError, match=msg):
             CategoricalDtype._from_values_or_dtype(None, None, None, object)
 


### PR DESCRIPTION
Fix "Cannot not construct" → "Cannot construct" in the error message raised when an invalid dtype is passed to `CategoricalDtype._from_values_or_dtype`.