### PR TITLE
BUG: Use compression_method instead of dict in warning message

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -367,7 +367,7 @@ def _get_filepath_or_buffer(
         and encoding in ["utf-16", "utf-32"]
     ):
         warnings.warn(
-            f"{compression} will not write the byte order mark for {encoding}",
+            f"{compression_method} will not write the byte order mark for {encoding}",
             UnicodeWarning,
             stacklevel=find_stack_level(),
         )


### PR DESCRIPTION
The BOM warning in `get_handle()` was formatting the `compression` dict instead of the `compression_method` string, producing an unreadable message like `{'method': 'bz2'} will not write the byte order mark for utf-16` instead of `bz2 will not write the byte order mark for utf-16`.