### PR TITLE
ENH: Support axis parameter in BaseMaskedArray.any/all for 2D

### DIFF
--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1920,9 +1920,9 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             return self._maybe_mask_result(result, mask)
 
         if skipna:
-            return result  # type: ignore[return-value]
+            return result
         elif not result or len(self) == 0 or not self._mask.any():
-            return result  # type: ignore[return-value]
+            return result
         else:
             return self.dtype.na_value
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1815,7 +1815,16 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
         values = self._data.copy()
         np.putmask(values, self._mask, self.dtype._falsey_value)
-        result = values.any()
+        result = values.any(axis=axis)
+
+        if isinstance(result, np.ndarray):
+            if skipna:
+                mask = np.zeros(result.shape, dtype=bool)
+            else:
+                # Kleene logic: False | NA = NA, True | NA = True
+                mask = ~result & self._mask.any(axis=axis)
+            return self._maybe_mask_result(result, mask)
+
         if skipna:
             return result
         elif result or len(self) == 0 or not self._mask.any():
@@ -1901,6 +1910,14 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         values = self._data.copy()
         np.putmask(values, self._mask, self.dtype._truthy_value)
         result = values.all(axis=axis)
+
+        if isinstance(result, np.ndarray):
+            if skipna:
+                mask = np.zeros(result.shape, dtype=bool)
+            else:
+                # Kleene logic: True & NA = NA, False & NA = False
+                mask = result & self._mask.any(axis=axis)
+            return self._maybe_mask_result(result, mask)
 
         if skipna:
             return result  # type: ignore[return-value]

--- a/pandas/tests/arrays/masked/test_function.py
+++ b/pandas/tests/arrays/masked/test_function.py
@@ -73,3 +73,86 @@ def test_to_numpy():
     result = arr.to_numpy()
     expected = np.array(["a", pd.NA, "c"])
     tm.assert_numpy_array_equal(result, expected)
+
+
+class TestAnyAll2D:
+    """Tests for any/all on 2D masked arrays with axis parameter."""
+
+    @pytest.fixture
+    def arr2d(self):
+        # [[True,  False],
+        #  [True,  <NA> ]]
+        from pandas.core.arrays import BooleanArray
+
+        data = np.array([[True, False], [True, True]], dtype=bool)
+        mask = np.array([[False, False], [False, True]], dtype=bool)
+        return BooleanArray._simple_new(data, mask)
+
+    @pytest.mark.parametrize("method", ["any", "all"])
+    def test_axis_none(self, arr2d, method):
+        # axis=None reduces to scalar; should match flattened 1D result
+        result = getattr(arr2d, method)(axis=None)
+        expected = getattr(arr2d.ravel(), method)()
+        assert result == expected
+
+    def test_any_axis0(self, arr2d):
+        result = arr2d.any(axis=0)
+        expected = pd.array([True, False], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_any_axis1(self, arr2d):
+        result = arr2d.any(axis=1)
+        expected = pd.array([True, True], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_all_axis0(self, arr2d):
+        result = arr2d.all(axis=0)
+        expected = pd.array([True, False], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_all_axis1(self, arr2d):
+        result = arr2d.all(axis=1)
+        expected = pd.array([False, True], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_any_skipna_false_axis0(self, arr2d):
+        # col0: True, True -> True; col1: False, NA -> NA (Kleene: False|NA=NA)
+        result = arr2d.any(axis=0, skipna=False)
+        expected = pd.array([True, pd.NA], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_any_skipna_false_axis1(self, arr2d):
+        # row0: True, False -> True; row1: True, NA -> True (Kleene: True|NA=True)
+        result = arr2d.any(axis=1, skipna=False)
+        expected = pd.array([True, True], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_all_skipna_false_axis0(self, arr2d):
+        # col0: True, True -> True (no NAs); col1: False, NA -> False (Kleene)
+        result = arr2d.all(axis=0, skipna=False)
+        expected = pd.array([True, False], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_all_skipna_false_axis1(self, arr2d):
+        # row0: True, False -> False; row1: True, NA -> NA (Kleene: True&NA=NA)
+        result = arr2d.all(axis=1, skipna=False)
+        expected = pd.array([False, pd.NA], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)
+
+    @pytest.mark.parametrize("method", ["any", "all"])
+    def test_all_na_column(self, method):
+        # Column that is all-NA should return falsey/truthy for skipna=True
+        from pandas.core.arrays import IntegerArray
+
+        data = np.array([[1, 2], [3, 4]], dtype=np.int64)
+        mask = np.array([[False, True], [False, True]], dtype=bool)
+        arr = IntegerArray._simple_new(data, mask)
+
+        result = getattr(arr, method)(axis=0)
+        if method == "any":
+            # col0: 1,3 -> True; col1: all-NA -> False
+            expected = pd.array([True, False], dtype="boolean")
+        else:
+            # col0: 1,3 -> True; col1: all-NA -> True
+            expected = pd.array([True, True], dtype="boolean")
+        tm.assert_extension_array_equal(result, expected)

--- a/pandas/tests/arrays/masked/test_function.py
+++ b/pandas/tests/arrays/masked/test_function.py
@@ -5,7 +5,11 @@ from pandas.core.dtypes.common import is_integer_dtype
 
 import pandas as pd
 import pandas._testing as tm
-from pandas.core.arrays import BaseMaskedArray
+from pandas.core.arrays import (
+    BaseMaskedArray,
+    BooleanArray,
+    IntegerArray,
+)
 
 arrays = [pd.array([1, 2, 3, None], dtype=dtype) for dtype in tm.ALL_INT_EA_DTYPES]
 arrays += [
@@ -82,8 +86,6 @@ class TestAnyAll2D:
     def arr2d(self):
         # [[True,  False],
         #  [True,  <NA> ]]
-        from pandas.core.arrays import BooleanArray
-
         data = np.array([[True, False], [True, True]], dtype=bool)
         mask = np.array([[False, False], [False, True]], dtype=bool)
         return BooleanArray._simple_new(data, mask)
@@ -142,8 +144,6 @@ class TestAnyAll2D:
     @pytest.mark.parametrize("method", ["any", "all"])
     def test_all_na_column(self, method):
         # Column that is all-NA should return falsey/truthy for skipna=True
-        from pandas.core.arrays import IntegerArray
-
         data = np.array([[1, 2], [3, 4]], dtype=np.int64)
         mask = np.array([[False, True], [False, True]], dtype=bool)
         arr = IntegerArray._simple_new(data, mask)

--- a/pandas/tests/arrays/masked/test_function.py
+++ b/pandas/tests/arrays/masked/test_function.py
@@ -84,6 +84,7 @@ class TestAnyAll2D:
 
     @pytest.fixture
     def arr2d(self):
+        # GH#64510
         # [[True,  False],
         #  [True,  <NA> ]]
         data = np.array([[True, False], [True, True]], dtype=bool)


### PR DESCRIPTION
## Summary
- Fix `BaseMaskedArray.any()` missing `axis=` parameter in its call to `ndarray.any()` (the `all()` method already passed it correctly).
- Add 2D array result handling in both `any()` and `all()` with proper Kleene logic for `skipna=False`.
- Part of incremental work toward 2D support for masked arrays (IntegerArray, FloatingArray, BooleanArray).

## Test plan
- [x] Added `TestAnyAll2D` class with 12 tests covering axis=0, axis=1, axis=None, skipna=False with Kleene logic, and all-NA columns
- [x] Existing masked extension tests pass (6385 passed)
- [x] Existing reduction tests pass (537 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)