### PR TITLE
PERF: Hoist skip_this_line check out of tokenizer hot loop

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -687,6 +687,8 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
       (self->commentchar != '\0') ? self->commentchar : 1000;
   const int escape_symbol =
       (self->escapechar != '\0') ? self->escapechar : 1000;
+  const int has_skip = (self->skipfunc != NULL || self->skipset != NULL ||
+                        self->skip_first_N_rows >= 0);
 
   if (make_stream_space(self, self->datalen - self->datapos) < 0) {
     const size_t bufsize = 100;
@@ -817,7 +819,8 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
 
     case START_RECORD: {
       // start of record
-      const int should_skip = skip_this_line(self, self->file_lines);
+      const int should_skip =
+          has_skip ? skip_this_line(self, self->file_lines) : 0;
 
       if (should_skip == -1) {
         goto parsingerror;


### PR DESCRIPTION
## Summary

- Precompute a `has_skip` flag at the top of `tokenize_bytes` that checks whether any skip configuration is active (`skipfunc`, `skipset`, or `skip_first_N_rows`)
- Guard the `skip_this_line()` call in `START_RECORD` with this flag, avoiding the function call entirely in the common case (no `skiprows` argument)

In the common case `skip_this_line` falls through to `return (rownum <= self->skip_first_N_rows)` where `skip_first_N_rows == -1`, so the call always returns false. This change eliminates that per-row overhead.

## Performance

```python
import pandas as pd

# 1M rows x 5 float columns
df = pd.DataFrame(np.random.default_rng(42).standard_normal((1_000_000, 5)))
df.to_csv("/tmp/bench.csv", index=False)

%timeit pd.read_csv("/tmp/bench.csv", engine="c")
334 ms ± 11.9 ms per loop (mean ± std. dev. of 10 runs, 5 loops each)  # <- PR
351 ms ± 26.5 ms per loop (mean ± std. dev. of 10 runs, 5 loops each)  # <- main
```

ASV continuous (`ReadCSV` suite) showed several benchmarks with significant improvement and no regressions:

| ratio | Benchmark |
|---|---|
| 0.90x | `ParallelReadCSV.time_read_csv('object')` |
| 0.86x | `ReadCSVParseSpecialDate.time_read_special_date('mdY', 'c')` |
| 0.84x | `ReadCSVFloatPrecision.time_read_csv(';', '_', None)` |
| 0.83x | `ReadCSVMemMapUTF8.time_read_memmapped_utf8` |
| 0.82x | `ReadCSVFloatPrecision.time_read_csv(';', '_', 'high')` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)