### PR TITLE
PERF: Use lookup table for fast bulk scanning in CSV tokenizer

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -623,11 +623,11 @@ static int parser_buffer_bytes(parser_t *self, size_t nbytes,
 #define IS_QUOTE(c) ((c == self->quotechar && self->quoting != QUOTE_NONE))
 
 // don't parse '\r' with a custom line terminator
-#define IS_CARRIAGE(c) (c == carriage_symbol)
+#define IS_CARRIAGE(c) (has_carriage && c == carriage_symbol)
 
-#define IS_COMMENT_CHAR(c) (c == comment_symbol)
+#define IS_COMMENT_CHAR(c) (has_comment && c == comment_symbol)
 
-#define IS_ESCAPE_CHAR(c) (c == escape_symbol)
+#define IS_ESCAPE_CHAR(c) (has_escape && c == escape_symbol)
 
 #define IS_SKIPPABLE_SPACE(c)                                                  \
   ((!self->delim_whitespace && c == ' ' && self->skipinitialspace))
@@ -680,13 +680,12 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
   const int delim_whitespace = self->delim_whitespace;
   const char delimiter = self->delimiter;
 
-  // 1000 is something that couldn't fit in "char"
-  // thus comparing a char to it would always be "false"
-  const int carriage_symbol = (self->lineterminator == '\0') ? '\r' : 1000;
-  const int comment_symbol =
-      (self->commentchar != '\0') ? self->commentchar : 1000;
-  const int escape_symbol =
-      (self->escapechar != '\0') ? self->escapechar : 1000;
+  const char carriage_symbol = '\r';
+  const int has_carriage = (self->lineterminator == '\0');
+  const char comment_symbol = self->commentchar;
+  const int has_comment = (self->commentchar != '\0');
+  const char escape_symbol = self->escapechar;
+  const int has_escape = (self->escapechar != '\0');
   const int has_skip = (self->skipfunc != NULL || self->skipset != NULL ||
                         self->skip_first_N_rows >= 0);
 
@@ -707,18 +706,15 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
   uint8_t breaks_field_scan[256] = {0};
   uint8_t index;
 
-  // For char-typed values, use memcpy to reinterpret as uint8_t index.
-  // For int-typed sentinels (carriage_symbol, escape_symbol, comment_symbol)
-  // that use 1000 for "disabled", we guard with < 256 and cast instead,
-  // since sizeof(int) != sizeof(uint8_t).
-
   memcpy(&index, &lineterminator, sizeof(lineterminator));
   breaks_field_scan[index] |= 0x1;
-  if (carriage_symbol < 256) {
-    breaks_field_scan[(uint8_t)carriage_symbol] |= 0x1;
+  if (has_carriage) {
+    memcpy(&index, &carriage_symbol, sizeof(carriage_symbol));
+    breaks_field_scan[index] |= 0x1;
   }
-  if (escape_symbol < 256) {
-    breaks_field_scan[(uint8_t)escape_symbol] |= 0x1 | 0x2;
+  if (has_escape) {
+    memcpy(&index, &escape_symbol, sizeof(escape_symbol));
+    breaks_field_scan[index] |= 0x1 | 0x2;
   }
   if (!delim_whitespace) {
     memcpy(&index, &delimiter, sizeof(delimiter));
@@ -731,8 +727,9 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
     memcpy(&index, &tab, sizeof(tab));
     breaks_field_scan[index] |= 0x1;
   }
-  if (comment_symbol < 256) {
-    breaks_field_scan[(uint8_t)comment_symbol] |= 0x1;
+  if (has_comment) {
+    memcpy(&index, &comment_symbol, sizeof(comment_symbol));
+    breaks_field_scan[index] |= 0x1;
   }
   if (self->quoting != QUOTE_NONE) {
     memcpy(&index, &self->quotechar, sizeof(self->quotechar));

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -700,6 +700,31 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
   char *stream = self->stream + self->stream_len;
   uint64_t slen = self->stream_len;
 
+  // Lookup table for fast scanning in IN_FIELD and IN_QUOTED_FIELD states.
+  // Bit 0 (0x1): character is special in an unquoted field.
+  // Bit 1 (0x2): character is special in a quoted field.
+  uint8_t is_special[256] = {0};
+
+  is_special[(uint8_t)lineterminator] |= 0x1;
+  if (carriage_symbol < 256) {
+    is_special[(uint8_t)carriage_symbol] |= 0x1;
+  }
+  if (escape_symbol < 256) {
+    is_special[(uint8_t)escape_symbol] |= 0x1 | 0x2;
+  }
+  if (!delim_whitespace) {
+    is_special[(uint8_t)delimiter] |= 0x1;
+  } else {
+    is_special[(uint8_t)' '] |= 0x1;
+    is_special[(uint8_t)'\t'] |= 0x1;
+  }
+  if (comment_symbol < 256) {
+    is_special[(uint8_t)comment_symbol] |= 0x1;
+  }
+  if (self->quoting != QUOTE_NONE) {
+    is_special[(uint8_t)self->quotechar] |= 0x2;
+  }
+
   TRACE(("%s\n", buf));
 
   if (self->file_lines == 0) {
@@ -948,6 +973,14 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
       } else {
         // normal character - save in field
         PUSH_CHAR(c);
+
+        // Bulk scan: copy remaining ordinary characters directly,
+        // bypassing the per-char state machine overhead.
+        while (i + 1 < self->datalen && !(is_special[(uint8_t)*buf] & 0x1)) {
+          *stream++ = *buf++;
+          slen++;
+          i++;
+        }
       }
       break;
 
@@ -967,6 +1000,14 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
       } else {
         // normal character - save in field
         PUSH_CHAR(c);
+
+        // Bulk scan: copy remaining ordinary characters directly,
+        // bypassing the per-char state machine overhead.
+        while (i + 1 < self->datalen && !(is_special[(uint8_t)*buf] & 0x2)) {
+          *stream++ = *buf++;
+          slen++;
+          i++;
+        }
       }
       break;
 

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -705,8 +705,15 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
   // Bit 0 (0x1): breaks scan in an unquoted field.
   // Bit 1 (0x2): breaks scan in a quoted field.
   uint8_t breaks_field_scan[256] = {0};
+  uint8_t index;
 
-  breaks_field_scan[(uint8_t)lineterminator] |= 0x1;
+  // For char-typed values, use memcpy to reinterpret as uint8_t index.
+  // For int-typed sentinels (carriage_symbol, escape_symbol, comment_symbol)
+  // that use 1000 for "disabled", we guard with < 256 and cast instead,
+  // since sizeof(int) != sizeof(uint8_t).
+
+  memcpy(&index, &lineterminator, sizeof(lineterminator));
+  breaks_field_scan[index] |= 0x1;
   if (carriage_symbol < 256) {
     breaks_field_scan[(uint8_t)carriage_symbol] |= 0x1;
   }
@@ -714,19 +721,22 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
     breaks_field_scan[(uint8_t)escape_symbol] |= 0x1 | 0x2;
   }
   if (!delim_whitespace) {
-    breaks_field_scan[(uint8_t)delimiter] |= 0x1;
+    memcpy(&index, &delimiter, sizeof(delimiter));
+    breaks_field_scan[index] |= 0x1;
   } else {
     // Mirrors IS_DELIMITER's use of isblank(), which matches ' ' and '\t'.
-    breaks_field_scan[(uint8_t)' '] |= 0x1;
-    breaks_field_scan[(uint8_t)'\t'] |= 0x1;
+    char space = ' ', tab = '\t';
+    memcpy(&index, &space, sizeof(space));
+    breaks_field_scan[index] |= 0x1;
+    memcpy(&index, &tab, sizeof(tab));
+    breaks_field_scan[index] |= 0x1;
   }
   if (comment_symbol < 256) {
     breaks_field_scan[(uint8_t)comment_symbol] |= 0x1;
   }
-  // quotechar is a char (always 0-255), unlike the int sentinels above
-  // that use 1000 for "disabled", so no < 256 guard is needed here.
   if (self->quoting != QUOTE_NONE) {
-    breaks_field_scan[(uint8_t)self->quotechar] |= 0x2;
+    memcpy(&index, &self->quotechar, sizeof(self->quotechar));
+    breaks_field_scan[index] |= 0x2;
   }
 
   TRACE(("%s\n", buf));

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -681,13 +681,13 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
   const char delimiter = self->delimiter;
 
   const char carriage_symbol = '\r';
-  const int has_carriage = (self->lineterminator == '\0');
+  const bool has_carriage = (self->lineterminator == '\0');
   const char comment_symbol = self->commentchar;
-  const int has_comment = (self->commentchar != '\0');
+  const bool has_comment = (self->commentchar != '\0');
   const char escape_symbol = self->escapechar;
-  const int has_escape = (self->escapechar != '\0');
-  const int has_skip = (self->skipfunc != NULL || self->skipset != NULL ||
-                        self->skip_first_N_rows >= 0);
+  const bool has_escape = (self->escapechar != '\0');
+  const bool has_skip = (self->skipfunc != NULL || self->skipset != NULL ||
+                         self->skip_first_N_rows >= 0);
 
   if (make_stream_space(self, self->datalen - self->datapos) < 0) {
     const size_t bufsize = 100;

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -700,29 +700,33 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
   char *stream = self->stream + self->stream_len;
   uint64_t slen = self->stream_len;
 
-  // Lookup table for fast scanning in IN_FIELD and IN_QUOTED_FIELD states.
-  // Bit 0 (0x1): character is special in an unquoted field.
-  // Bit 1 (0x2): character is special in a quoted field.
-  uint8_t is_special[256] = {0};
+  // Lookup table marking characters that force a state-machine transition
+  // during bulk scanning in IN_FIELD and IN_QUOTED_FIELD.
+  // Bit 0 (0x1): breaks scan in an unquoted field.
+  // Bit 1 (0x2): breaks scan in a quoted field.
+  uint8_t breaks_field_scan[256] = {0};
 
-  is_special[(uint8_t)lineterminator] |= 0x1;
+  breaks_field_scan[(uint8_t)lineterminator] |= 0x1;
   if (carriage_symbol < 256) {
-    is_special[(uint8_t)carriage_symbol] |= 0x1;
+    breaks_field_scan[(uint8_t)carriage_symbol] |= 0x1;
   }
   if (escape_symbol < 256) {
-    is_special[(uint8_t)escape_symbol] |= 0x1 | 0x2;
+    breaks_field_scan[(uint8_t)escape_symbol] |= 0x1 | 0x2;
   }
   if (!delim_whitespace) {
-    is_special[(uint8_t)delimiter] |= 0x1;
+    breaks_field_scan[(uint8_t)delimiter] |= 0x1;
   } else {
-    is_special[(uint8_t)' '] |= 0x1;
-    is_special[(uint8_t)'\t'] |= 0x1;
+    // Mirrors IS_DELIMITER's use of isblank(), which matches ' ' and '\t'.
+    breaks_field_scan[(uint8_t)' '] |= 0x1;
+    breaks_field_scan[(uint8_t)'\t'] |= 0x1;
   }
   if (comment_symbol < 256) {
-    is_special[(uint8_t)comment_symbol] |= 0x1;
+    breaks_field_scan[(uint8_t)comment_symbol] |= 0x1;
   }
+  // quotechar is a char (always 0-255), unlike the int sentinels above
+  // that use 1000 for "disabled", so no < 256 guard is needed here.
   if (self->quoting != QUOTE_NONE) {
-    is_special[(uint8_t)self->quotechar] |= 0x2;
+    breaks_field_scan[(uint8_t)self->quotechar] |= 0x2;
   }
 
   TRACE(("%s\n", buf));
@@ -976,7 +980,8 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
 
         // Bulk scan: copy remaining ordinary characters directly,
         // bypassing the per-char state machine overhead.
-        while (i + 1 < self->datalen && !(is_special[(uint8_t)*buf] & 0x1)) {
+        while (i + 1 < self->datalen &&
+               !(breaks_field_scan[(uint8_t)*buf] & 0x1)) {
           *stream++ = *buf++;
           slen++;
           i++;
@@ -1003,7 +1008,8 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
 
         // Bulk scan: copy remaining ordinary characters directly,
         // bypassing the per-char state machine overhead.
-        while (i + 1 < self->datalen && !(is_special[(uint8_t)*buf] & 0x2)) {
+        while (i + 1 < self->datalen &&
+               !(breaks_field_scan[(uint8_t)*buf] & 0x2)) {
           *stream++ = *buf++;
           slen++;
           i++;


### PR DESCRIPTION
## Summary

- Build a `uint8_t is_special[256]` lookup table at the top of `tokenize_bytes` that marks which characters are special in unquoted fields (bit 0) and quoted fields (bit 1)
- In the `IN_FIELD` and `IN_QUOTED_FIELD` hot paths, after processing the first ordinary character through the normal state machine, a tight inner loop bulk-copies subsequent ordinary characters directly — bypassing the per-character switch/if-else chain (up to 5 comparisons per byte in `IN_FIELD`)
- The 256-byte table fits in 4 cache lines and stays hot for the duration of parsing

ASV results:

| Change | Before | After | Ratio | Benchmark (Parameter) |
|--------|--------|-------|-------|-----------------------|
| - | 9.35±0.9ms | 5.74±0.3ms | 0.61 | io.csv.ReadCSVThousands.time_thousands('\|', None, 'c') |
| - | 67.9±5ms | 46.2±5ms | 0.68 | io.csv.ReadCSVMemMapUTF8.time_read_memmapped_utf8 |
| - | 7.23±1ms | 5.24±0.6ms | 0.73 | io.csv.ReadCSVThousands.time_thousands(',', None, 'c') |
| - | 419±400μs | 304±2μs | 0.73 | io.csv.ReadCSVFloatPrecision.time_read_csv(';', '.', 'high') |
| - | 5.44G | 4.15G | 0.76 | io.csv.ReadCSVCParserLowMemory.peakmem_over_2gb_input |
| - | 7.21±1ms | 5.98±0.2ms | 0.83 | io.csv.ReadCSVThousands.time_thousands('\|', ',', 'c') |
| - | 572±60μs | 482±30μs | 0.84 | io.csv.ReadCSVFloatPrecision.time_read_csv(';', '_', None) |
| - | 557±30μs | 477±7μs | 0.85 | io.csv.ReadCSVFloatPrecision.time_read_csv(',', '_', None) |
| - | 1.08±0.05ms | 946±30μs | 0.87 | io.csv.ReadCSVFloatPrecision.time_read_csv(';', '.', 'round_trip') |

## Test plan

- [x] Full `pandas/tests/io/parser/` suite passes (4375 passed)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)