### PR TITLE
REF: remove unused mask from _Unstacker.get_new_values

### DIFF
--- a/pandas/_libs/reshape.pyi
+++ b/pandas/_libs/reshape.pyi
@@ -9,7 +9,6 @@ def unstack(
     length: int,
     width: int,
     new_values: np.ndarray,  # reshape_t[:, :]
-    new_mask: np.ndarray,  # uint8_t[:, :]
 ) -> None: ...
 def explode(
     values: npt.NDArray[np.object_],

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -21,7 +21,7 @@ from pandas._libs.lib cimport c_is_list_like
 @cython.boundscheck(False)
 def unstack(const numeric_object_t[:, :] values, const uint8_t[:] mask,
             Py_ssize_t stride, Py_ssize_t length, Py_ssize_t width,
-            numeric_object_t[:, :] new_values, uint8_t[:, :] new_mask) -> None:
+            numeric_object_t[:, :] new_values) -> None:
     """
     Transform long values to wide new_values.
 
@@ -32,10 +32,8 @@ def unstack(const numeric_object_t[:, :] values, const uint8_t[:] mask,
     stride : int
     length : int
     width : int
-    new_values : np.ndarray[bool]
+    new_values : typed ndarray
         result array
-    new_mask : np.ndarray[bool]
-        result mask
     """
     cdef:
         Py_ssize_t i, j, w, nulls, s, offset
@@ -53,7 +51,6 @@ def unstack(const numeric_object_t[:, :] values, const uint8_t[:] mask,
                     if mask[offset]:
                         s = i * width + w
                         new_values[j, s] = values[offset - nulls, i]
-                        new_mask[j, s] = 1
                     else:
                         nulls += 1
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1048,33 +1048,19 @@ class Block(PandasObject, libinternals.Block):
         fill_value : int
             Only used in ExtensionBlock._unstack
         new_placement : np.ndarray[np.intp]
-        allow_fill : bool
         needs_masking : np.ndarray[bool]
+            Only used in ExtensionBlock._unstack
 
         Returns
         -------
         blocks : list of Block
             New blocks of unstacked values.
-        mask : array-like of bool
-            The mask of columns of `blocks` we should keep.
         """
-        new_values, mask = unstacker.get_new_values(
-            self.values.T, fill_value=fill_value
-        )
-
-        mask = mask.any(0)
-        # TODO: in all tests we have mask.all(); can we rely on that?
-
-        # Note: these next two lines ensure that
-        #  mask.sum() == sum(len(nb.mgr_locs) for nb in blocks)
-        #  which the calling function needs in order to pass verify_integrity=False
-        #  to the BlockManager constructor
-        new_values = new_values.T[mask]
-        new_placement = new_placement[mask]
+        new_values = unstacker.get_new_values(self.values.T, fill_value=fill_value)
 
         bp = BlockPlacement(new_placement)
-        blocks = [new_block_2d(new_values, placement=bp)]
-        return blocks, mask
+        blocks = [new_block_2d(new_values.T, placement=bp)]
+        return blocks
 
     # ---------------------------------------------------------------------
 
@@ -2103,14 +2089,7 @@ class ExtensionBlock(EABackedBlock):
         # a `take` on the actual values.
 
         # Caller is responsible for ensuring self.shape[-1] == len(unstacker.index)
-        new_values, mask = unstacker.arange_result
-
-        # Note: these next two lines ensure that
-        #  mask.sum() == sum(len(nb.mgr_locs) for nb in blocks)
-        #  which the calling function needs in order to pass verify_integrity=False
-        #  to the BlockManager constructor
-        new_values = new_values.T[mask]
-        new_placement = new_placement[mask]
+        new_values = unstacker.arange_result
 
         # needs_masking[i] calculated once in BlockManager.unstack tells
         #  us if there are any -1s in the relevant indices.  When False,
@@ -2126,10 +2105,10 @@ class ExtensionBlock(EABackedBlock):
                 ndim=2,
             )
             for i, (indices, place) in enumerate(
-                zip(new_values, new_placement, strict=True)
+                zip(new_values.T, new_placement, strict=True)
             )
         ]
-        return blocks, mask
+        return blocks
 
 
 class NumpyBlock(Block):

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1741,17 +1741,16 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         new_columns = unstacker.get_new_columns(self.items)
         new_index = unstacker.new_index
 
-        allow_fill = not unstacker.mask_all
-        if allow_fill:
-            # calculating the full mask once and passing it to Block._unstack is
-            #  faster than letting calculating it in each repeated call
+        if not unstacker.mask_all:
+            # calculating the full mask once and passing it to
+            #  ExtensionBlock._unstack is faster than calculating
+            #  it in each repeated call
             new_mask2D = (~unstacker.mask).reshape(*unstacker.full_shape)
             needs_masking = new_mask2D.any(axis=0)
         else:
             needs_masking = np.zeros(unstacker.full_shape[1], dtype=bool)
 
         new_blocks: list[Block] = []
-        columns_mask: list[np.ndarray] = []
 
         if len(self.items) == 0:
             factor = 1
@@ -1764,7 +1763,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             mgr_locs = blk.mgr_locs
             new_placement = mgr_locs.tile_for_unstack(factor)
 
-            blocks, mask = blk._unstack(
+            blocks = blk._unstack(
                 unstacker,
                 fill_value,
                 new_placement=new_placement,
@@ -1772,15 +1771,6 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             )
 
             new_blocks.extend(blocks)
-            columns_mask.extend(mask)
-
-            # Block._unstack should ensure this holds,
-            assert mask.sum() == sum(len(nb._mgr_locs) for nb in blocks)
-            # In turn this ensures that in the BlockManager call below
-            #  we have len(new_columns) == sum(x.shape[0] for x in new_blocks)
-            #  which suffices to allow us to pass verify_inegrity=False
-
-        new_columns = new_columns[columns_mask]
 
         bm = BlockManager(new_blocks, [new_columns, new_index], verify_integrity=False)
         return bm

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -124,6 +124,10 @@ class _Unstacker:
         self.constructor = constructor
         self.sort = sort
 
+        # remove_unused_levels ensures every value in the unstacked level
+        # has at least one entry, which guarantees that the mask returned by
+        # get_new_values satisfies mask.any(0).all() i.e. no column in the
+        # unstacked result is entirely empty.
         self.index = index.remove_unused_levels()
 
         self.level = self.index._get_level_number(level)
@@ -243,12 +247,10 @@ class _Unstacker:
         return bool(self.mask.all())
 
     @cache_readonly
-    def arange_result(self) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.bool_]]:
+    def arange_result(self) -> npt.NDArray[np.intp]:
         # We cache this for reuse in ExtensionBlock._unstack
         dummy_arr = np.arange(len(self.index), dtype=np.intp)
-        new_values, mask = self.get_new_values(dummy_arr, fill_value=-1)
-        return new_values, mask.any(0)
-        # TODO: in all tests we have mask.any(0).all(); can we rely on that?
+        return self.get_new_values(dummy_arr, fill_value=-1)
 
     def get_result(self, obj, value_columns, fill_value) -> DataFrame:
         values = obj._values
@@ -258,7 +260,7 @@ class _Unstacker:
         if value_columns is None and values.shape[1] != 1:  # pragma: no cover
             raise ValueError("must pass column labels for multi-column data")
 
-        new_values, _ = self.get_new_values(values, fill_value)
+        new_values = self.get_new_values(values, fill_value)
         columns = self.get_new_columns(value_columns)
         index = self.new_index
 
@@ -300,8 +302,7 @@ class _Unstacker:
                 .swapaxes(1, 2)
                 .reshape(result_shape)
             )
-            new_mask = np.ones(result_shape, dtype=bool)
-            return new_values, new_mask
+            return new_values
 
         dtype = values.dtype
 
@@ -339,7 +340,6 @@ class _Unstacker:
                 new_values.fill(fill_value)
 
         name = dtype.name
-        new_mask = np.zeros(result_shape, dtype=bool)
 
         # we need to convert to a basic dtype
         # and possibly coerce an input to our output dtype
@@ -350,7 +350,7 @@ class _Unstacker:
         else:
             sorted_values = sorted_values.astype(name, copy=False)
 
-        # fill in our values & mask
+        # fill in our values
         libreshape.unstack(
             sorted_values,
             mask.view("u1"),
@@ -358,7 +358,6 @@ class _Unstacker:
             length,
             width,
             new_values,
-            new_mask.view("u1"),
         )
 
         # reconstruct dtype if needed
@@ -369,7 +368,7 @@ class _Unstacker:
             new_values = ensure_wrapped_if_datetimelike(new_values)
             new_values = new_values.view(values.dtype)
 
-        return new_values, new_mask
+        return new_values
 
     def get_new_columns(self, value_columns: Index | None):
         if value_columns is None:


### PR DESCRIPTION
There is a years-old comment in Block._unstack about mask.all() always being True. Claude convinced me this will always hold, so we can simplify things a bit.

## Summary

- `remove_unused_levels()` in `_Unstacker.__init__` guarantees every value in the unstacked level appears in at least one row, which means the mask returned by `get_new_values` always satisfies `mask.any(0).all()` — no column in the unstacked result is ever entirely empty.
- This makes the `new_mask` output from `get_new_values` and `libreshape.unstack` unused, along with the mask-based column filtering in `Block._unstack`, `ExtensionBlock._unstack`, and `BlockManager.unstack`.
- Remove all of the above dead code.

## Test plan

- [x] `pandas/tests/frame/test_stack_unstack.py` (1031 passed)
- [x] `pandas/tests/series/methods/test_unstack.py`
- [x] `pandas/tests/reshape/test_pivot.py`
- [x] `pandas/tests/extension/` (41173 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)