### PR TITLE
BUG: Fix broken error message in ExcelFormatter for missing columns

### DIFF
--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -568,7 +568,7 @@ class ExcelFormatter:
         if cols is not None:
             # all missing, raise
             if not len(Index(cols).intersection(df.columns)):
-                raise KeyError("passes columns are not ALL present dataframe")
+                raise KeyError("Passed columns are not all present in the dataframe")
 
             if len(Index(cols).intersection(df.columns)) != len(set(cols)):
                 # Deprecated in GH#17295, enforced in 1.0.0

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1220,7 +1220,7 @@ class TestExcelWriter:
             write_frame.to_excel(tmp_excel, sheet_name="test1", columns=["B", "C"])
 
         with pytest.raises(
-            KeyError, match="'passes columns are not ALL present dataframe'"
+            KeyError, match="Passed columns are not all present in the dataframe"
         ):
             write_frame.to_excel(tmp_excel, sheet_name="test1", columns=["C", "D"])
 


### PR DESCRIPTION
Fix typo and grammar in the `KeyError` message raised by `ExcelFormatter` when none of the specified columns are present in the DataFrame.

**Before:** `"passes columns are not ALL present dataframe"`
**After:** `"Passed columns are not all present in the dataframe"`

Updated the corresponding test match string in `test_writers.py`.