### PR TITLE
DOC: Fix subject-verb agreement in error messages

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1264,7 +1264,7 @@ cdef class Tick(SingleConstructorOffset):
         if normalize:
             # GH#21427
             raise ValueError(
-                "Tick offset with `normalize=True` are not allowed."
+                "Tick offset with `normalize=True` is not allowed."
             )
 
     # Note: Without making this cpdef, we get AttributeError when calling
@@ -1501,7 +1501,7 @@ cdef class Day(SingleConstructorOffset):
         if normalize:
             # GH#21427
             raise ValueError(
-                "Day offset with `normalize=True` are not allowed."
+                "Day offset with `normalize=True` is not allowed."
             )
 
     def is_on_offset(self, dt) -> bool:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1091,7 +1091,7 @@ def rank(
             pct=pct,
         )
     else:
-        raise TypeError("Array with ndim > 2 are not supported.")
+        raise TypeError("Array with ndim > 2 is not supported.")
 
     return ranks
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -344,7 +344,7 @@ class BaseWindow(SelectionMixin):
         if needs_i8_conversion(values.dtype):
             raise NotImplementedError(
                 f"ops for {type(self).__name__} for this "
-                f"dtype {values.dtype} are not implemented"
+                f"dtype {values.dtype} is not implemented"
             )
         # GH #12373 : rolling functions error on float32 data
         # make sure the data is coerced to float64

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1846,7 +1846,7 @@ class TestRank:
 
     def test_too_many_ndims(self):
         arr = np.array([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]])
-        msg = "Array with ndim > 2 are not supported"
+        msg = "Array with ndim > 2 is not supported"
 
         with pytest.raises(TypeError, match=msg):
             algos.rank(arr)

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -1013,7 +1013,7 @@ def test_tick_normalize_raises(tick_classes):
     # check that trying to create a Tick object with normalize=True raises
     # GH#21427
     cls = tick_classes
-    msg = "Tick offset with `normalize=True` are not allowed."
+    msg = "Tick offset with `normalize=True` is not allowed."
     with pytest.raises(ValueError, match=msg):
         cls(n=3, normalize=True)
 


### PR DESCRIPTION
Fix subject-verb agreement in four user-facing error messages where a singular subject was paired with "are" instead of "is":

- `pandas/core/algorithms.py`: "Array with ndim > 2 **are** not supported" → "**is** not supported"
- `pandas/core/window/rolling.py`: "dtype {dtype} **are** not implemented" → "**is** not implemented"
- `pandas/_libs/tslibs/offsets.pyx`: "Tick offset with `normalize=True` **are** not allowed" → "**is** not allowed"
- `pandas/_libs/tslibs/offsets.pyx`: "Day offset with `normalize=True` **are** not allowed" → "**is** not allowed"

Updated corresponding test match strings in `test_algos.py` and `test_offsets.py`.