### PR TITLE
DOC: Fix typos in comments and docstrings

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -519,7 +519,7 @@ def shares_memory(left, right) -> bool:
             right_buf1 = right_pa_data.chunk(0).buffers()[1]
             return left_buf1.address == right_buf1.address
         else:
-            # if we have one one ArrowExtensionArray and one other array, assume
+            # if we have one ArrowExtensionArray and one other array, assume
             # they can only share memory if they share the same numpy buffer
             return np.shares_memory(left, right)
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1109,7 +1109,7 @@ class _LocationIndexer(NDFrameIndexerBase):
         if self._is_nested_tuple_indexer(tup):
             return self._getitem_nested_tuple(tup)
 
-        # we maybe be using a tuple to represent multiple dimensions here
+        # we may be using a tuple to represent multiple dimensions here
         ax0 = self.obj._get_axis(0)
         # ...but iloc should handle the tuple as simple integer-location
         # instead of checking it as multiindex representation (GH 13797)

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -581,7 +581,7 @@ def _coerce_to_type(x: Index) -> tuple[Index, DtypeObj | None]:
 
 
 def _is_dt_or_td(dtype: DtypeObj) -> bool:
-    # Note: the dtype here comes from an Index.dtype, so we know that that any
+    # Note: the dtype here comes from an Index.dtype, so we know that any
     #  dt64/td64 dtype is of a supported unit.
     return isinstance(dtype, DatetimeTZDtype) or lib.is_np_dtype(dtype, "mM")
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -1117,7 +1117,7 @@ class _IOWrapper:
     # and writable. If we have a read-only buffer, we shouldn't need writable and vice
     # versa. Some buffers, are seek/read/writ-able but they do not have the "-able"
     # methods, e.g., tempfile.SpooledTemporaryFile.
-    # If a buffer does not have the above "-able" methods, we simple assume they are
+    # If a buffer does not have the above "-able" methods, we simply assume they are
     # seek/read/writ-able.
     def __init__(self, buffer: BaseBuffer) -> None:
         self.buffer = buffer
@@ -1243,7 +1243,7 @@ def _is_binary_mode(handle: FilePath | BaseBuffer, mode: str) -> bool:
 
 @functools.lru_cache
 def _get_binary_io_classes() -> tuple[type, ...]:
-    """IO classes that that expect bytes"""
+    """IO classes that expect bytes"""
     binary_classes: tuple[type, ...] = (BufferedIOBase, RawIOBase)
 
     # python-zstandard doesn't use any of the builtin base classes; instead we

--- a/pandas/io/excel/_util.py
+++ b/pandas/io/excel/_util.py
@@ -314,7 +314,7 @@ def combine_kwargs(engine_kwargs: dict[str, Any] | None, kwargs: dict) -> dict:
     engine_kwargs: dict
         kwargs to be passed through to the engine.
     kwargs: dict
-        kwargs to be psased through to the engine (deprecated)
+        kwargs to be passed through to the engine (deprecated)
 
     Returns
     -------

--- a/pandas/io/parsers/python_parser.py
+++ b/pandas/io/parsers/python_parser.py
@@ -830,7 +830,7 @@ class PythonParser(ParserBase):
         the name, not the middle of it.
         """
         # first_row will be a list, so we need to check
-        # that that list is not empty before proceeding.
+        # that the list is not empty before proceeding.
         if not first_row:
             return first_row
 


### PR DESCRIPTION
Fix seven typos in comments and docstrings across the codebase:

- `pandas/io/common.py`: "we **simple** assume" → "we **simply** assume"
- `pandas/io/common.py`: "IO classes **that that** expect bytes" → "IO classes **that** expect bytes"
- `pandas/io/excel/_util.py`: "kwargs to be **psased** through" → "kwargs to be **passed** through"
- `pandas/core/indexing.py`: "we **maybe be** using a tuple" → "we **may be** using a tuple"
- `pandas/core/reshape/tile.py`: "we know **that that** any" → "we know **that** any"
- `pandas/io/parsers/python_parser.py`: "**that that** list is not empty" → "**that the** list is not empty"
- `pandas/_testing/__init__.py`: "if we have **one one** ArrowExtensionArray" → "if we have **one** ArrowExtensionArray"