### PR TITLE
DOC: Remove incorrect parameters from get_window_bounds docstrings

### DIFF
--- a/pandas/core/indexers/objects.py
+++ b/pandas/core/indexers/objects.py
@@ -88,8 +88,6 @@ class BaseIndexer:
         ----------
         num_values : int, default 0
             number of values that will be aggregated over
-        window_size : int, default 0
-            the number of rows in a window
         min_periods : int, default None
             min_periods passed from the top level rolling API
         center : bool, default None
@@ -98,8 +96,6 @@ class BaseIndexer:
             closed passed from the top level rolling API
         step : int, default None
             step passed from the top level rolling API
-        win_type : str, default None
-            win_type passed from the top level rolling API
 
         Returns
         -------
@@ -127,8 +123,6 @@ class FixedWindowIndexer(BaseIndexer):
         ----------
         num_values : int, default 0
             number of values that will be aggregated over
-        window_size : int, default 0
-            the number of rows in a window
         min_periods : int, default None
             min_periods passed from the top level rolling API
         center : bool, default None
@@ -137,8 +131,6 @@ class FixedWindowIndexer(BaseIndexer):
             closed passed from the top level rolling API
         step : int, default None
             step passed from the top level rolling API
-        win_type : str, default None
-            win_type passed from the top level rolling API
 
         Returns
         -------
@@ -181,8 +173,6 @@ class VariableWindowIndexer(BaseIndexer):
         ----------
         num_values : int, default 0
             number of values that will be aggregated over
-        window_size : int, default 0
-            the number of rows in a window
         min_periods : int, default None
             min_periods passed from the top level rolling API
         center : bool, default None
@@ -191,8 +181,6 @@ class VariableWindowIndexer(BaseIndexer):
             closed passed from the top level rolling API
         step : int, default None
             step passed from the top level rolling API
-        win_type : str, default None
-            win_type passed from the top level rolling API
 
         Returns
         -------
@@ -316,8 +304,6 @@ class VariableOffsetWindowIndexer(BaseIndexer):
         ----------
         num_values : int, default 0
             number of values that will be aggregated over
-        window_size : int, default 0
-            the number of rows in a window
         min_periods : int, default None
             min_periods passed from the top level rolling API
         center : bool, default None
@@ -326,8 +312,6 @@ class VariableOffsetWindowIndexer(BaseIndexer):
             closed passed from the top level rolling API
         step : int, default None
             step passed from the top level rolling API
-        win_type : str, default None
-            win_type passed from the top level rolling API
 
         Returns
         -------
@@ -421,8 +405,6 @@ class ExpandingIndexer(BaseIndexer):
         ----------
         num_values : int, default 0
             number of values that will be aggregated over
-        window_size : int, default 0
-            the number of rows in a window
         min_periods : int, default None
             min_periods passed from the top level rolling API
         center : bool, default None
@@ -431,8 +413,6 @@ class ExpandingIndexer(BaseIndexer):
             closed passed from the top level rolling API
         step : int, default None
             step passed from the top level rolling API
-        win_type : str, default None
-            win_type passed from the top level rolling API
 
         Returns
         -------
@@ -510,8 +490,6 @@ class FixedForwardWindowIndexer(BaseIndexer):
         ----------
         num_values : int, default 0
             number of values that will be aggregated over
-        window_size : int, default 0
-            the number of rows in a window
         min_periods : int, default None
             min_periods passed from the top level rolling API
         center : bool, default None
@@ -520,8 +498,6 @@ class FixedForwardWindowIndexer(BaseIndexer):
             closed passed from the top level rolling API
         step : int, default None
             step passed from the top level rolling API
-        win_type : str, default None
-            win_type passed from the top level rolling API
 
         Returns
         -------
@@ -599,8 +575,6 @@ class GroupbyIndexer(BaseIndexer):
         ----------
         num_values : int, default 0
             number of values that will be aggregated over
-        window_size : int, default 0
-            the number of rows in a window
         min_periods : int, default None
             min_periods passed from the top level rolling API
         center : bool, default None
@@ -609,8 +583,6 @@ class GroupbyIndexer(BaseIndexer):
             closed passed from the top level rolling API
         step : int, default None
             step passed from the top level rolling API
-        win_type : str, default None
-            win_type passed from the top level rolling API
 
         Returns
         -------
@@ -680,8 +652,6 @@ class ExponentialMovingWindowIndexer(BaseIndexer):
         ----------
         num_values : int, default 0
             number of values that will be aggregated over
-        window_size : int, default 0
-            the number of rows in a window
         min_periods : int, default None
             min_periods passed from the top level rolling API
         center : bool, default None
@@ -690,8 +660,6 @@ class ExponentialMovingWindowIndexer(BaseIndexer):
             closed passed from the top level rolling API
         step : int, default None
             step passed from the top level rolling API
-        win_type : str, default None
-            win_type passed from the top level rolling API
 
         Returns
         -------


### PR DESCRIPTION
Remove `window_size` and `win_type` from the `get_window_bounds` docstrings in `pandas/core/indexers/objects.py`. These are listed as method parameters but do not exist in the method signature — `window_size` is an instance attribute set via `__init__`, and `win_type` is not used in any `get_window_bounds` implementation.

Affected classes: `BaseIndexer`, `FixedWindowIndexer`, `VariableWindowIndexer`, `VariableOffsetWindowIndexer`, `ExpandingIndexer`, `FixedForwardWindowIndexer`, `GroupbyIndexer`, `ExponentialMovingWindowIndexer`.