### PR TITLE
TST: Add test for bug (#64524) that causes `read_html` to parse a nested table incorrectly when using `html5lib` or `bs4` flavors

### DIFF
--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -617,6 +617,53 @@ class TestReadHtml:
 
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.xfail(reason="Known issue: GH-64524", strict=False)
+    def test_nested_table(self, flavor_read_html):
+        """
+        Make sure that read_html parses nested tables correctly. A web page can have a
+        nested table if the developer decided to use a table for layout instead of CSS.
+        The outer table could be used for layout while the inner table contains
+        actual data.
+
+        GH-64524 describes a bug that causes this test to fail.
+        """
+        result = flavor_read_html(
+            StringIO("""
+                <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table id="descendant">
+                                    <thead>
+                                        <tr>
+                                            <th>A</th>
+                                            <th>B</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>1</td>
+                                            <td>2</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            """),
+            attrs={"id": "descendant"},
+        )[0]
+
+        expected = DataFrame(data=[[1, 2]], columns=["A", "B"])
+
+        tm.assert_frame_equal(result, expected)
+
     def test_header_and_one_column(self, flavor_read_html):
         """
         Don't fail with bs4 when there is a header and only one column


### PR DESCRIPTION
- [x] See #64524 for a description of the bug.
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] ~~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~~
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] ~~If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.~~
