### PR TITLE
PERF: avoid if_else operation for simple full slice in ArrowExtensionArray.__setitem__

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2420,7 +2420,14 @@ class ArrowExtensionArray(
 
         if com.is_null_slice(key):
             # fast path (GH50248)
-            data = self._if_else(True, value, self._pa_array)
+            if (
+                isinstance(value, (pa.Array, pa.ChunkedArray))
+                and value.type == self._pa_array.type
+                and len(value) == len(self)
+            ):
+                data = value
+            else:
+                data = self._if_else(True, value, self._pa_array)
 
         elif is_integer(key):
             # fast path


### PR DESCRIPTION
This only gives a modest improvement, something like a 5-15% on the simple setitem like:

```python
df = pd.DataFrame({"col1": ["a", "b", "c"], "col2": [1, 2, 3]})
df.loc[[0], "col1"] = "A"
df.loc[0, "col1"] = "A"
```

but since many assignments go through this (somewhere in the internals, we end up doing `block.values[:] = values` after doing the actual setitem on the `values`; this is a separate issue that this might be avoidable), it's nice to avoid an extra unnecessary pyarrow compute operation on the data (for which we know the result should be identical\*)

\* Triggered by looking into https://github.com/pandas-dev/pandas/issues/64320 and which code paths we were taking there. The bug in `if_else` we saw there would also be avoided with this PR by not using if_else in this case