### PR TITLE
PERF: skip unnecessary capitalize() in get_date_name_field

### DIFF
--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -175,8 +175,8 @@ def get_date_name_field(
         else:
             names = np.array(_get_locale_names("f_weekday", locale),
                              dtype=np.object_)
-        for i in range(len(names)):
-            names[i] = names[i].capitalize()
+            for i in range(len(names)):
+                names[i] = names[i].capitalize()
         for i in range(count):
             if dtindex[i] == NPY_NAT:
                 out[i] = np.nan
@@ -192,8 +192,8 @@ def get_date_name_field(
         else:
             names = np.array(_get_locale_names("f_month", locale),
                              dtype=np.object_)
-        for i in range(len(names)):
-            names[i] = names[i].capitalize()
+            for i in range(len(names)):
+                names[i] = names[i].capitalize()
         for i in range(count):
             if dtindex[i] == NPY_NAT:
                 out[i] = np.nan


### PR DESCRIPTION
## Summary
- Fix ~25% regression in `Timestamp.month_name()` and ~14% in `Timestamp.day_name()` introduced by #64462
- `DAYS_FULL` and `MONTHS_FULL` are already properly capitalized, so the `capitalize()` loop is a no-op for the default `locale=None` case. Move it into the `else` (locale) branch only.
- Reported in https://github.com/pandas-dev/asv-runner/issues/109#issuecomment-4038110928

## Test plan
- [x] Existing tests pass (`test_fields.py`, `test_timestamp.py`, `test_scalar_compat.py`)
- [x] Verified `month_name()` and `day_name()` return correct results for scalar Timestamp, NaT, and DatetimeIndex

🤖 Generated with [Claude Code](https://claude.com/claude-code)