### PR TITLE
BUG: Fix CSV C tokenizer infinite loop with embedded \r + space

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -187,6 +187,7 @@ MultiIndex
 
 I/O
 ^^^
+- Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -785,10 +785,11 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
           do {
             --buf;
             --i;
-          } while (i + 1 > self->datapos && !IS_TERMINATOR(*buf));
+          } while (i + 1 > self->datapos && !IS_TERMINATOR(*buf) &&
+                   !IS_CARRIAGE(*buf));
 
-          // reached a newline rather than the beginning
-          if (IS_TERMINATOR(*buf)) {
+          // reached a newline/carriage return rather than the beginning
+          if (IS_TERMINATOR(*buf) || IS_CARRIAGE(*buf)) {
             ++buf; // move pointer to first char after newline
             ++i;
           }

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -20,7 +20,6 @@ import pytest
 
 from pandas.compat import WASM
 from pandas.errors import (
-    ParserError,
     ParserWarning,
 )
 import pandas.util._test_decorators as td
@@ -33,18 +32,33 @@ import pandas._testing as tm
 
 
 @pytest.mark.parametrize(
-    "malformed",
-    ["1\r1\r1\r 1\r 1\r", "1\r1\r1\r 1\r 1\r11\r", "1\r1\r1\r 1\r 1\r11\r1\r"],
+    "malformed,expected_data",
+    [
+        ("1\r1\r1\r 1\r 1\r", [[1], [1], [1], [1], [1]]),
+        ("1\r1\r1\r 1\r 1\r11\r", [[1], [1], [1], [1], [1], [11]]),
+        ("1\r1\r1\r 1\r 1\r11\r1\r", [[1], [1], [1], [1], [1], [11], [1]]),
+    ],
     ids=["words pointer", "stream pointer", "lines pointer"],
 )
-def test_buffer_overflow(c_parser_only, malformed):
-    # see gh-9205: test certain malformed input files that cause
-    # buffer overflows in tokenizer.c
-    msg = "Buffer overflow caught - possible malformed input file."
+def test_buffer_overflow(c_parser_only, malformed, expected_data):
+    # see gh-9205, gh-51141: test certain malformed input files that
+    # previously caused buffer overflows in tokenizer.c due to
+    # \r characters being treated as line terminators, then triggering
+    # an infinite re-parsing loop in the WHITESPACE_LINE state.
     parser = c_parser_only
+    result = parser.read_csv(StringIO(malformed), header=None)
+    expected = DataFrame(expected_data)
+    tm.assert_frame_equal(result, expected)
 
-    with pytest.raises(ParserError, match=msg):
-        parser.read_csv(StringIO(malformed))
+
+def test_cr_in_field_with_trailing_space(c_parser_only):
+    # GH#51141 - embedded \r followed by space in unquoted field
+    # should not cause infinite re-parsing or buffer overflow
+    parser = c_parser_only
+    data = "a,b,c\n1,2,3\n4,5\r X,6\n"
+    result = parser.read_csv(StringIO(data))
+    assert len(result) == 3
+    assert result.shape == (3, 3)
 
 
 def test_delim_whitespace_custom_terminator(c_parser_only):


### PR DESCRIPTION
## Summary
- Fixes #51141 — a CSV file with an embedded `\r` (carriage return) followed by a space inside an unquoted field causes the C tokenizer to enter an infinite re-parsing loop, producing 131K+ spurious rows or a buffer overflow crash.
- The `WHITESPACE_LINE` backtrack loop only checked for `\n` (`IS_TERMINATOR`) when searching backward for the start of the current line. It didn't check for `\r` (`IS_CARRIAGE`), so it would skip past the `\r` and land at the previous line's `\n`, causing the same line to be re-parsed indefinitely.
- Adds `!IS_CARRIAGE(*buf)` to the backtrack loop condition and `|| IS_CARRIAGE(*buf)` to the boundary check.

## Test plan
- [x] Updated `test_buffer_overflow` (GH#9205) — these inputs now parse correctly instead of overflowing
- [x] Added `test_cr_in_field_with_trailing_space` for the specific GH#51141 pattern
- [x] Full `pandas/tests/io/parser/` suite passes (4,377 tests, 0 failures)
- [x] Verified `\r\n` (Windows) and `\r`-only (old Mac) line endings still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)