### PR TITLE
ENH: Add OpenMP detection for cython.prange support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -284,7 +284,7 @@ jobs:
         run: |
           /opt/python/cp313-cp313/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
+          python -m pip install --no-cache-dir -U pip wheel meson[ninja]==1.5.0 meson-python==0.18.0
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
@@ -324,7 +324,7 @@ jobs:
         run: |
           /opt/python/cp313-cp313/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel meson-python==0.18.0 meson[ninja]==1.2.3
+          python -m pip install --no-cache-dir -U pip wheel meson-python==0.18.0 meson[ninja]==1.5.0
           python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
@@ -395,7 +395,7 @@ jobs:
       - name: Build Environment
         run: |
           python --version
-          python -m pip install --upgrade pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
+          python -m pip install --upgrade pip wheel meson[ninja]==1.5.0 meson-python==0.18.0
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.116.0 pytest>=8.3.4 pytest-xdist>=3.6.1 pytest-cov
           python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"

--- a/ci/deps/actions-311-minimum_versions.yaml
+++ b/ci/deps/actions-311-minimum_versions.yaml
@@ -9,7 +9,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython<4.0.0a0
-  - meson=1.2.3
+  - meson=1.5.0
   - meson-python=0.18.0
 
   # test dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=3.1.0,<4.0.0a0
-  - meson>=1.2.3,<2
+  - meson>=1.5.0,<2
   - meson-python>=0.18.0,<1
 
   # test dependencies

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
     'cython',
     version: run_command(['generate_version.py', '--print'], check: true).stdout().strip(),
     license: 'BSD-3',
-    meson_version: '>=1.2.3',
+    meson_version: '>=1.5.0',
     default_options: [
         'buildtype=release',
         'c_std=c17',
@@ -49,6 +49,12 @@ if cc.get_id() == 'msvc'
         language: ['c', 'cpp'],
     )
 endif
+
+# OpenMP is required for cython.prange parallel loops.
+# On macOS with Apple Clang: brew install libomp
+# Meson >= 1.5.0 auto-detects Homebrew's libomp.
+# If unavailable, prange falls back to sequential range.
+openmp_dep = dependency('OpenMP', language: 'c', required: false)
 
 if fs.exists('_version_meson.py')
     py.install_sources('_version_meson.py', subdir: 'pandas')

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -105,7 +105,7 @@ cdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna, const uint8
     cdef:
         int64_t[::1] result_counts = np.empty(table.size + na_add, dtype=np.int64)
 
-    for i in range(table.size):
+    for i in range(<Py_ssize_t>table.size):
         {{if dtype == 'object'}}
         k = kh_get_{{ttype}}(table, result_keys.data[i])
         {{else}}
@@ -114,7 +114,7 @@ cdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna, const uint8
         result_counts[i] = table.vals[k]
 
     if na_counter > 0:
-        result_counts[table.size] = na_counter
+        result_counts[<Py_ssize_t>table.size] = na_counter
         result_keys.append(val)
 
     kh_destroy_{{ttype}}(table)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 pip
 versioneer[toml]
 cython>=3.1.0,<4.0.0a0
-meson[ninja]>=1.2.3,<2
+meson[ninja]>=1.5.0,<2
 meson-python>=0.18.0,<1
 pytest>=8.3.4
 pytest-cov


### PR DESCRIPTION
## Summary
- Bump meson minimum from 1.2.1 to 1.5.0 (released July 2024)
- Add `openmp_dep = dependency('OpenMP', language: 'c', required: false)` in root `meson.build`

Meson 1.5.0 added native detection of Homebrew's libomp on macOS with Apple Clang ([meson#13350](https://github.com/mesonbuild/meson/pull/13350)), so `brew install libomp; pip install pandas` is sufficient for OpenMP-accelerated builds — no manual `CPPFLAGS`/`LDFLAGS` needed. On Linux (GCC), OpenMP works out of the box. When libomp is not installed, the build succeeds and `prange` silently falls back to sequential `range`.

The `openmp_dep` variable is available in all subdir `meson.build` files via meson's scoping. Individual Cython extensions can opt in by adding `openmp_dep` to their `deps` when they start using `prange`, e.g.:
```meson
'groupby': {'sources': ['groupby.pyx'], 'deps': [m_dep, openmp_dep]},
```

Prior art: scikit-learn uses the same approach (`dependency('OpenMP', language: 'c', required: false)` in `sklearn/meson.build`).

## Test plan
- [x] `pbuild` succeeds, meson output shows `Run-time dependency OpenMP for c found: YES 5.0`
- [x] CI passes (no functional changes, just build infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)