### PR TITLE
BUG: fix false matches in DatetimeArray/TimedeltaArray.isin with mismatched resolutions

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -23,6 +23,7 @@ Bug fixes
 ^^^^^^^^^
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Assigning :attr:`pd.NA` to a string column could trigger a PyArrow error and corrupt data (:issue:`64320`)
+- Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`60607`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -23,7 +23,6 @@ Bug fixes
 ^^^^^^^^^
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Assigning :attr:`pd.NA` to a string column could trigger a PyArrow error and corrupt data (:issue:`64320`)
-- Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`60607`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -126,7 +126,7 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)
--
+- Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -810,8 +810,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         if self.dtype.kind in "mM":
             self = cast("DatetimeArray | TimedeltaArray", self)
-            # error: "DatetimeLikeArrayMixin" has no attribute "as_unit"
-            values = values.as_unit(self.unit)  # type: ignore[attr-defined]
+            # Cast to the higher resolution to avoid silently truncating
+            #  finer-resolution values, which could lead to false matches.
+            self, values = self._ensure_matching_resos(values)
 
         try:
             # error: Argument 1 to "_check_compatible_with" of "DatetimeLikeArrayMixin"

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -1388,3 +1388,40 @@ def test_from_pandas_array(dtype):
     result = idx_cls(arr)
     expected = idx_cls(data)
     tm.assert_index_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "self_unit,val_unit",
+    [("s", "ns"), ("ms", "us"), ("us", "ns"), ("ns", "s")],
+)
+@pytest.mark.parametrize("dtype_kind", ["M", "m"])
+def test_isin_mismatched_reso(dtype_kind, self_unit, val_unit):
+    # GH#????? - isin should not silently truncate finer-resolution values
+    #  when converting to self's resolution, which leads to false matches.
+    if dtype_kind == "M":
+        # DatetimeArray
+        arr = DatetimeArray._from_sequence(
+            np.array([0, 1], dtype=f"M8[{self_unit}]"),
+            dtype=np.dtype(f"M8[{self_unit}]"),
+        )
+        vals = DatetimeArray._from_sequence(
+            np.array([1], dtype=f"M8[{val_unit}]"),
+            dtype=np.dtype(f"M8[{val_unit}]"),
+        )
+    else:
+        # TimedeltaArray
+        arr = TimedeltaArray._from_sequence(
+            np.array([0, 1], dtype=f"m8[{self_unit}]"),
+            dtype=np.dtype(f"m8[{self_unit}]"),
+        )
+        vals = TimedeltaArray._from_sequence(
+            np.array([1], dtype=f"m8[{val_unit}]"),
+            dtype=np.dtype(f"m8[{val_unit}]"),
+        )
+
+    result = arr.isin(vals)
+
+    # 1 in self_unit != 1 in val_unit (unless they happen to be the same
+    # unit, which our parametrization avoids), so isin should be [False, False].
+    expected = np.array([False, False])
+    tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -1396,7 +1396,7 @@ def test_from_pandas_array(dtype):
 )
 @pytest.mark.parametrize("dtype_kind", ["M", "m"])
 def test_isin_mismatched_reso(dtype_kind, self_unit, val_unit):
-    # GH#????? - isin should not silently truncate finer-resolution values
+    # GH64545 - isin should not silently truncate finer-resolution values
     #  when converting to self's resolution, which leads to false matches.
     if dtype_kind == "M":
         # DatetimeArray


### PR DESCRIPTION
## Summary
- `DatetimeLikeArrayMixin.isin` called `values.as_unit(self.unit)` with `round_ok=True` (the default), which silently truncated finer-resolution values when converting down (e.g. ns → s). This caused values that differed at sub-unit precision to incorrectly match.
- Fix replaces the lossy downcast with `_ensure_matching_resos`, which casts both arrays up to the finer resolution (no information loss), consistent with how mismatched resolutions are handled elsewhere in the file.

```python
dta = pd.array(pd.to_datetime(["2020-01-01"]).as_unit("s"))
vals = pd.array(pd.to_datetime(["2020-01-01 00:00:00.000000001"]).as_unit("ns"))

dta.isin(vals)
# Before: [True]  (wrong — silently rounded ns value to match)
# After:  [False] (correct — values differ at nanosecond precision)
```

## Test plan
- [x] Added `test_isin_mismatched_reso` covering both `DatetimeArray` and `TimedeltaArray` across 4 resolution pairs
- [x] Existing test suite passes (`test_datetimelike.py`, `test_isin.py`, extension tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)