### PR TITLE
TST: remove is_ci_environment antipattern

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -24,7 +24,6 @@ runs:
   steps:
     - name: Test
       env:
-        PANDAS_CI: 1
         PANDAS_FUTURE_INFER_STRING: ${{ inputs.pandas_future_infer_string }}
         PANDAS_FUTURE_PYTHON_SCALARS: ${{ inputs.pandas_future_python_scalars }}
         MESONPY_EDITABLE_VERBOSE: 1

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   ENV_FILE: environment.yml
-  PANDAS_CI: 1
 
 permissions: {}
 

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -24,7 +24,6 @@ on:
 
 env:
   ENV_FILE: environment.yml
-  PANDAS_CI: 1
 
 permissions: {}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -269,7 +269,7 @@ jobs:
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
-          PANDAS_CI=1 python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
+          python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-32bit
@@ -312,7 +312,7 @@ jobs:
       - name: Run Tests
         run: |
           . ~/virtualenvs/pandas-dev/bin/activate
-          PANDAS_CI=1 python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
+          python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-musl
@@ -359,7 +359,6 @@ jobs:
 
     env:
       PYTEST_WORKERS: "auto"
-      PANDAS_CI: 1
       PATTERN: "not slow and not network and not clipboard and not single_cpu"
       PYTEST_TARGET: pandas
 
@@ -441,8 +440,6 @@ jobs:
           pip install dist/*.whl
 
       - name: Test pandas for Pyodide
-        env:
-          PANDAS_CI: 1
         run: |
           source .venv-pyodide/bin/activate
           pip install pytest hypothesis pytest-cov

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,6 +94,7 @@ jobs:
     env:
       LANG: ${{ matrix.lang || 'C.UTF-8' }}
       LC_ALL: ${{ matrix.lc_all || '' }}
+      PANDAS_MOTO_URL: "http://localhost:5000"
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.environment }}-${{ matrix.pytest_marker_expression }}-${{ matrix.extra_apt || '' }}-${{ matrix.pandas_future_infer_string }}-${{ matrix.platform }}

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -10,7 +10,6 @@ Other items:
 
 from __future__ import annotations
 
-import os
 import platform
 import sys
 from typing import TYPE_CHECKING
@@ -136,19 +135,6 @@ def is_platform_riscv64() -> bool:
         True if the running platform uses riscv64 architecture.
     """
     return platform.machine() == "riscv64"
-
-
-def is_ci_environment() -> bool:
-    """
-    Checking if running in a continuous integration environment by checking
-    the PANDAS_CI environment variable.
-
-    Returns
-    -------
-    bool
-        True if the running in a continuous integration environment.
-    """
-    return os.environ.get("PANDAS_CI", "0") == "1"
 
 
 __all__ = [

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -36,7 +36,6 @@ from pandas._libs import lib
 from pandas._libs.tslibs import timezones
 from pandas.compat import (
     PY312,
-    is_ci_environment,
     is_platform_windows,
     pa_version_under14p0,
     pa_version_under19p0,
@@ -74,7 +73,7 @@ from pandas.core.arrays.arrow.extension_types import ArrowPeriodType
 
 
 def _require_timezone_database(request):
-    if is_platform_windows() and is_ci_environment() and pa_version_under22p0:
+    if is_platform_windows() and pa_version_under22p0:
         mark = pytest.mark.xfail(
             raises=pa.ArrowInvalid,
             reason=(

--- a/pandas/tests/interchange/test_impl.py
+++ b/pandas/tests/interchange/test_impl.py
@@ -7,10 +7,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import iNaT
-from pandas.compat import (
-    is_ci_environment,
-    is_platform_windows,
-)
+from pandas.compat import is_platform_windows
 from pandas.compat.pyarrow import pa_version_under22p0
 
 import pandas as pd
@@ -386,7 +383,7 @@ def test_interchange_from_non_pandas_tz_aware(request):
     pa = pytest.importorskip("pyarrow", "11.0.0")
     import pyarrow.compute as pc
 
-    if is_platform_windows() and is_ci_environment() and pa_version_under22p0:
+    if is_platform_windows() and pa_version_under22p0:
         mark = pytest.mark.xfail(
             raises=pa.ArrowInvalid,
             reason=(

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -1,13 +1,8 @@
+import os
 import uuid
 
 import pytest
 
-from pandas.compat import (
-    is_ci_environment,
-    is_platform_arm,
-    is_platform_mac,
-    is_platform_windows,
-)
 import pandas.util._test_decorators as td
 
 import pandas.io.common as icom
@@ -59,11 +54,9 @@ def aws_credentials(monkeysession):
 
 @pytest.fixture(scope="session")
 def moto_server(aws_credentials):
-    # use service container for Linux on GitHub Actions
-    if is_ci_environment() and not (
-        is_platform_mac() or is_platform_arm() or is_platform_windows()
-    ):
-        yield "http://localhost:5000"
+    url = os.environ.get("PANDAS_MOTO_URL")
+    if url:
+        yield url
     else:
         moto_server = pytest.importorskip("moto.server")
         server = moto_server.ThreadedMotoServer(port=0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ build-verbosity = 3
 environment = {LDFLAGS="-Wl,--strip-all"}
 test-extras = "test"
 test-command = """
-  PANDAS_CI='1' python -c 'import pandas as pd; \
+  python -c 'import pandas as pd; \
   pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db", "-n 2", "--no-strict-data-files"]); \
   pd.test(extra_args=["-m not clipboard and single_cpu and not slow and not network and not db", "--no-strict-data-files"]);' \
   """
@@ -153,7 +153,6 @@ before-build = "PACKAGE_DIR={package} bash {package}/scripts/cibw_before_build.s
 environment = {}
 before-build = "pip install delvewheel"
 test-command = """
-  set PANDAS_CI='1' && \
   python -c "import pandas as pd; \
   pd.test(extra_args=['--no-strict-data-files', '-m not clipboard and not single_cpu and not slow and not network and not db']);" \
   """
@@ -162,7 +161,7 @@ repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
 [[tool.cibuildwheel.overrides]]
 select = "*-manylinux_aarch64*"
 test-command = """
-  PANDAS_CI='1' python -c 'import pandas as pd; \
+  python -c 'import pandas as pd; \
   pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db and not fails_arm_wheels", "-n 2", "--no-strict-data-files"]); \
   pd.test(extra_args=["-m not clipboard and single_cpu and not slow and not network and not db", "--no-strict-data-files"]);' \
   """
@@ -186,7 +185,7 @@ repair-wheel-command = ""
 # https://github.com/pyodide/pyodide/issues/5805
 build-verbosity = 1
 test-command = """
-  PANDAS_CI='1' python -c 'import pandas as pd; \
+  python -c 'import pandas as pd; \
   pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db", "--no-strict-data-files"]);' \
   """
 

--- a/scripts/run_stubtest.py
+++ b/scripts/run_stubtest.py
@@ -12,12 +12,8 @@ pd_version = getattr(pd, "__version__", "")
 
 # fail early if pandas is not installed
 if not pd_version:
-    # fail on the CI, soft fail during local development
     warnings.warn("You need to install the development version of pandas", stacklevel=1)
-    if pd.compat.is_ci_environment():
-        sys.exit(1)
-    else:
-        sys.exit(0)
+    sys.exit(1)
 
 # GH 48260
 if "dev" not in pd_version:


### PR DESCRIPTION
- [x] closes #55465

## Summary

- Remove `is_ci_environment()` helper and all its usages, per #55465
- **Arrow timezone xfails** (`test_arrow.py`, `test_impl.py`): Drop the `is_ci_environment()` guard from the xfail condition, matching the pattern already used in `test_datetime_index.py`. The xfail now applies on `is_platform_windows() and pa_version_under22p0` unconditionally.
- **Moto server fixture** (`io/conftest.py`): Replace `is_ci_environment()` + platform checks with an explicit `PANDAS_MOTO_URL` env var (set in the Linux CI workflow where the moto service container runs).
- **Stubtest** (`scripts/run_stubtest.py`): Always exit 1 when pandas is not installed, rather than soft-failing locally. If you're running stubtest without pandas, that's always an error.
- Delete `is_ci_environment()` from `pandas/compat/__init__.py` entirely.

Closes #55465

## Test plan

- [ ] Existing CI tests pass (no behavioral change for arrow timezone xfails on Windows CI)
- [ ] Linux CI moto tests use the service container via `PANDAS_MOTO_URL`
- [ ] macOS/Windows CI moto tests still start a threaded moto server (no `PANDAS_MOTO_URL` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)