### PR TITLE
REF: remove axis keyword from array_algos.transforms.shift

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1353,8 +1353,6 @@ def diff(arr, n: int | float | np.integer | np.floating, axis: AxisInt = 0):
     if not isinstance(arr, np.ndarray):
         # i.e ExtensionArray
         if hasattr(arr, f"__{op.__name__}__"):
-            if axis != 0:
-                raise ValueError(f"cannot diff {type(arr).__name__} on axis={axis}")
             return op(arr, arr.shift(n))
         else:
             raise TypeError(

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1353,6 +1353,8 @@ def diff(arr, n: int | float | np.integer | np.floating, axis: AxisInt = 0):
     if not isinstance(arr, np.ndarray):
         # i.e ExtensionArray
         if hasattr(arr, f"__{op.__name__}__"):
+            if axis >= arr.ndim:
+                raise ValueError(f"cannot diff {type(arr).__name__} on axis={axis}")
             return op(arr, arr.shift(n))
         else:
             raise TypeError(

--- a/pandas/core/array_algos/transforms.py
+++ b/pandas/core/array_algos/transforms.py
@@ -9,25 +9,23 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from pandas._typing import (
-        AxisInt,
-        Scalar,
-    )
+    from pandas._typing import Scalar
 
 
-def shift(
-    values: np.ndarray, periods: int, axis: AxisInt, fill_value: Scalar
-) -> np.ndarray:
+def shift(values: np.ndarray, periods: int, fill_value: Scalar) -> np.ndarray:
     new_values = values
 
     if periods == 0 or values.size == 0:
         return new_values.copy()
 
+    # Always shift along the last axis.
+    axis = new_values.ndim - 1
+
     # make sure array sent to np.roll is c_contiguous
     f_ordered = values.flags.f_contiguous
     if f_ordered:
         new_values = new_values.T
-        axis = new_values.ndim - axis - 1
+        axis = 0
 
     if new_values.size:
         new_values = np.roll(

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -332,10 +332,9 @@ class NDArrayBackedExtensionArray(NDArrayBacked, ExtensionArray):
         len(self) is returned, with all values filled with
         ``self.dtype.na_value``.
         """
-        # NB: shift is always along axis=0
-        axis = 0
+        # NB: shift is always along axis=self.ndim-1
         fill_value = self._validate_scalar(fill_value)
-        new_values = shift(self._ndarray, periods, axis, fill_value)
+        new_values = shift(self._ndarray, periods, fill_value)
 
         return self._from_backing_data(new_values)
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -448,14 +448,13 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         return type(self)(data, mask)
 
     def shift(self, periods: int = 1, fill_value=None) -> Self:
-        # NB: shift is always along axis=0
-        axis = 0
+        # NB: shift is always along axis=self.ndim-1
         if fill_value is None:
-            new_data = shift(self._data, periods, axis, 0)
-            new_mask = shift(self._mask, periods, axis, True)
+            new_data = shift(self._data, periods, 0)
+            new_mask = shift(self._mask, periods, True)
         else:
-            new_data = shift(self._data, periods, axis, fill_value)
-            new_mask = shift(self._mask, periods, axis, False)
+            new_data = shift(self._data, periods, fill_value)
+            new_mask = shift(self._mask, periods, False)
         return type(self)(new_data, new_mask)
 
     @property

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1412,7 +1412,6 @@ class Block(PandasObject, libinternals.Block):
         """shift the block by periods, possibly upcast"""
         # convert integer to float if necessary. need to do a lot more than
         # that, handle boolean etc also
-        axis = self.ndim - 1
 
         # Note: periods is never 0 here, as that is handled at the top of
         #  NDFrame.shift.  If that ever changes, we can do a check for periods=0
@@ -1451,7 +1450,7 @@ class Block(PandasObject, libinternals.Block):
 
         else:
             values = cast("np.ndarray", self.values)
-            new_values = shift(values, periods, axis, casted)
+            new_values = shift(values, periods, casted)
             return [self.make_block_same_class(new_values)]
 
     @final
@@ -1607,9 +1606,7 @@ class EABackedBlock(Block):
         Dispatches to underlying ExtensionArray and re-boxes in an
         ExtensionBlock.
         """
-        # Transpose since EA.shift is always along axis=0, while we want to shift
-        #  along rows.
-        new_values = self.values.T.shift(periods=periods, fill_value=fill_value).T
+        new_values = self.values.shift(periods=periods, fill_value=fill_value)
         return [self.make_block_same_class(new_values)]
 
     @final

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1404,7 +1404,7 @@ class Block(PandasObject, libinternals.Block):
     def diff(self, n: int) -> list[Block]:
         """return block for the diff of the values"""
         # only reached with ndim == 2
-        new_values = algos.diff(self.values, n, axis=self.ndim - 1)
+        new_values = algos.diff(self.values, n, axis=self.values.ndim - 1)
         return [self.make_block(values=new_values)]
 
     def shift(self, periods: int, fill_value: Any = None) -> list[Block]:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1404,8 +1404,7 @@ class Block(PandasObject, libinternals.Block):
     def diff(self, n: int) -> list[Block]:
         """return block for the diff of the values"""
         # only reached with ndim == 2
-        # TODO(EA2D): transpose will be unnecessary with 2D EAs
-        new_values = algos.diff(self.values.T, n, axis=0).T
+        new_values = algos.diff(self.values, n, axis=self.ndim - 1)
         return [self.make_block(values=new_values)]
 
     def shift(self, periods: int, fill_value: Any = None) -> list[Block]:

--- a/pandas/tests/extension/base/dim2.py
+++ b/pandas/tests/extension/base/dim2.py
@@ -33,14 +33,15 @@ class Dim2CompatTests:
                 pytest.skip(f"{dtype} does not support 2D.")
 
     def test_shift_2d(self, data):
-        arr2d = data.repeat(2).reshape(-1, 2)
+        # shift operates along the last axis
+        arr2d = data.repeat(2).reshape(-1, 2).T
 
         for n in [1, -2]:
             for fill_value in [None, data[0]]:
                 result = arr2d.shift(n, fill_value=fill_value)
-                expected_col = data.shift(n, fill_value=fill_value)
-                tm.assert_extension_array_equal(result[:, 0], expected_col)
-                tm.assert_extension_array_equal(result[:, 1], expected_col)
+                expected_row = data.shift(n, fill_value=fill_value)
+                tm.assert_extension_array_equal(result[0, :], expected_row)
+                tm.assert_extension_array_equal(result[1, :], expected_row)
 
     def test_transpose(self, data):
         arr2d = data.repeat(2).reshape(-1, 2)

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -175,6 +175,35 @@ class TestDataFrameShift:
         tm.assert_equal(res, exp)
         assert tm.get_dtype(res) == "datetime64[ns, US/Eastern]"
 
+    def test_shift_2d_dta_block(self):
+        # Ensure shift works correctly with a multi-row 2D DatetimeArray block,
+        #  which does not arise via normal consolidation.
+        dta = date_range("2016-01-01", periods=9)._values.reshape(3, 3)
+        df = DataFrame(dta)
+
+        # Verify we actually have a 2D EA block
+        assert df._mgr.blocks[0].values.shape == (3, 3)
+
+        result = df.shift(1)
+        expected = DataFrame(
+            {
+                0: [NaT, dta[0, 0], dta[1, 0]],
+                1: [NaT, dta[0, 1], dta[1, 1]],
+                2: [NaT, dta[0, 2], dta[1, 2]],
+            }
+        )
+        tm.assert_frame_equal(result, expected)
+
+        result = df.shift(-2)
+        expected = DataFrame(
+            {
+                0: [dta[2, 0], NaT, NaT],
+                1: [dta[2, 1], NaT, NaT],
+                2: [dta[2, 2], NaT, NaT],
+            }
+        )
+        tm.assert_frame_equal(result, expected)
+
     @pytest.mark.parametrize("ex", [10, -10, 20, -20])
     def test_shift_dst_beyond(self, frame_or_series, ex):
         # GH#13926


### PR DESCRIPTION
## Summary
- Remove the `axis` parameter from `array_algos.transforms.shift`, hard-coding `axis=values.ndim-1` (last axis)
- Remove the double-transpose from `EABackedBlock.shift` — previously needed because EA.shift hard-coded axis=0
- Add test for DataFrame.shift with a multi-row 2D DatetimeArray block, which doesn't arise via normal consolidation

## Test plan
- [x] `pandas/tests/frame/methods/test_shift.py` — all pass (including new `test_shift_2d_dta_block`)
- [x] `pandas/tests/extension/ -k shift` — all pass (including updated `test_shift_2d`)
- [x] `pandas/tests/internals/` — all pass
- [x] `pandas/tests/groupby/methods/test_groupby_shift_diff.py` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)