### PR TITLE
TST: add regression test for to_numeric with large exponent

### DIFF
--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -902,3 +902,11 @@ def test_coerce_pyarrow_backend():
     result = to_numeric(ser, errors="coerce", dtype_backend="pyarrow")
     expected = Series([1, 2, None], dtype=ArrowDtype(pa.int64()))
     tm.assert_series_equal(result, expected)
+
+
+def test_large_exponent_coerce():
+    # GH#63650 - exponent overflow in precise_xstrtod should not segfault
+    ser = Series(["1E3000000000"])
+    result = to_numeric(ser, errors="coerce")
+    expected = Series([np.inf])
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #63650

## Summary
- Adds a regression test for GH#63650 where `pd.to_numeric(pd.Series(["1E3000000000"]), errors="coerce")` caused a segfault due to signed integer overflow in `precise_xstrtod`
- The underlying bug was already fixed on main (commit 4228e61bdf), but no test covered this specific case
- The test verifies the string parses to `inf` without crashing

## Test plan
- [x] `pytest pandas/tests/tools/test_to_numeric.py::test_large_exponent_coerce` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)