### PR TITLE
TYP: enable 7 pyright checks, remove stale mypy overrides

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2205,7 +2205,7 @@ class ArrowExtensionArray(
 
         if name == "sem":
 
-            def pyarrow_meth(data, skip_nulls, **kwargs):
+            def pyarrow_meth(data, skip_nulls, **kwargs):  # pyright: ignore[reportRedeclaration]
                 numerator = pc.stddev(data, skip_nulls=skip_nulls, **kwargs)
                 denominator = pc.sqrt_checked(pc.count(self._pa_array))
                 return pc.divide_checked(numerator, denominator)

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1092,7 +1092,7 @@ class TimedeltaArray(dtl.TimelikeOps):
         hasnans = self._hasna
         if hasnans:
 
-            def f(x):
+            def f(x):  # pyright: ignore[reportRedeclaration]
                 if isna(x):
                     return [np.nan] * len(columns)
                 return x.components

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2362,9 +2362,9 @@ class DataFrame(NDFrame, OpsMixin):
             # columns, whichever is applicable.
             if is_dict_like(dtype_mapping):
                 if name in dtype_mapping:
-                    dtype_mapping = dtype_mapping[name]
+                    dtype_mapping = dtype_mapping[name]  # pyright: ignore[reportOptionalSubscript]
                 elif index_int in dtype_mapping:
-                    dtype_mapping = dtype_mapping[index_int]
+                    dtype_mapping = dtype_mapping[index_int]  # pyright: ignore[reportOptionalSubscript]
                 else:
                     dtype_mapping = None
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1254,7 +1254,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 else:
                     f = common.get_rename_function(v)
                     curnames = self._get_axis(axis).names
-                    newnames = [f(name) for name in curnames]
+                    newnames = [f(name) for name in curnames]  # pyright: ignore[reportOptionalCall]
                 result._set_axis_name(newnames, axis=axis, inplace=True)
             if not inplace:
                 return result
@@ -7791,7 +7791,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     # Note: Checking below for `in foo.keys()` instead of
                     #  `in foo` is needed for when we have a Series and not dict
                     mapping = {
-                        col: (to_replace[col], value[col])
+                        col: (to_replace[col], value[col])  # pyright: ignore[reportOptionalSubscript]
                         for col in to_replace.keys()
                         if col in value.keys() and col in self
                     }

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1796,7 +1796,7 @@ class Index(IndexOpsMixin, PandasObject):
             )
 
         # All items in 'new_names' need to be hashable
-        validate_all_hashable(*new_names, error_name=f"{type(self).__name__}.name")
+        validate_all_hashable(*new_names, error_name=f"{type(self).__name__}.name")  # pyright: ignore[reportOptionalIterable]
 
         return new_names
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1313,7 +1313,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         # categorical/sparse/datetimetz
         if value_is_extension_type:
 
-            def value_getitem(placement):
+            def value_getitem(placement):  # pyright: ignore[reportRedeclaration]
                 return value
 
         else:

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -608,15 +608,15 @@ def _interpolate_scipy_wrapper(
         terp = interpolate.interp1d(
             x, y, kind=kind, fill_value=fill_value, bounds_error=bounds_error
         )
-        new_y = terp(new_x)
+        new_y = terp(new_x)  # pyright: ignore[reportOptionalCall]
     elif method == "spline":
         # GH #10633, #24014
-        if isna(order) or (order <= 0):
+        if isna(order) or (order <= 0):  # pyright: ignore[reportOptionalOperand]
             raise ValueError(
                 f"order needs to be specified and greater than 0; got order: {order}"
             )
         terp = interpolate.UnivariateSpline(x, y, k=order, **kwargs)
-        new_y = terp(new_x)
+        new_y = terp(new_x)  # pyright: ignore[reportOptionalCall]
     else:
         # GH 7295: need to be able to write for some reason
         # in some circumstances: check all three

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -138,7 +138,7 @@ class bottleneck_switch:
                     # `mask` is not recognised by bottleneck, would raise
                     #  TypeError if called
                     kwds.pop("mask", None)
-                    result = bn_func(values, axis=axis, **kwds)
+                    result = bn_func(values, axis=axis, **kwds)  # pyright: ignore[reportOptionalCall]
 
                     # prefer to treat inf/-inf as NA, but must compute the func
                     # twice :(

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1654,14 +1654,14 @@ def get_corr_func(
     if method == "kendall":
         from scipy.stats import kendalltau
 
-        def func(a, b):
+        def func(a, b):  # pyright: ignore[reportRedeclaration]
             return kendalltau(a, b)[0]
 
         return func
     elif method == "spearman":
         from scipy.stats import spearmanr
 
-        def func(a, b):
+        def func(a, b):  # pyright: ignore[reportRedeclaration]
             return spearmanr(a, b)[0]
 
         return func

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2442,7 +2442,7 @@ class _AsOfMerge(_OrderedMerge):
                 raise MergeError("left_by and right_by must be the same length")
 
             left_on = self.left_by + list(left_on)
-            right_on = self.right_by + list(right_on)
+            right_on = self.right_by + list(right_on)  # pyright: ignore[reportOptionalOperand]
 
         return left_on, right_on
 
@@ -2631,7 +2631,7 @@ class _AsOfMerge(_OrderedMerge):
 
             # choose appropriate function by type
             func = _asof_by_function(self.direction)
-            return func(
+            return func(  # pyright: ignore[reportOptionalCall]
                 left_values,
                 right_values,
                 left_by_values,
@@ -2642,7 +2642,7 @@ class _AsOfMerge(_OrderedMerge):
         else:
             # choose appropriate function by type
             func = _asof_by_function(self.direction)
-            return func(
+            return func(  # pyright: ignore[reportOptionalCall]
                 left_values,
                 right_values,
                 None,

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1290,7 +1290,7 @@ class Window(BaseWindow):
         result = ResamplerWindowApply(self, func, args=args, kwargs=kwargs).agg()
         if result is None:
             # these must apply directly
-            result = func(self)
+            result = func(self)  # pyright: ignore[reportOptionalCall]
 
         return result
 

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -99,7 +99,7 @@ def read_clipboard(
     # inspect no more then the 10 first lines, if they
     # all contain an equal number (>0) of tabs, infer
     # that this came from excel and set 'sep' accordingly
-    lines = text[:10000].split("\n")[:-1][:10]
+    lines = text[:10000].split("\n")[:-1][:10]  # pyright: ignore[reportOptionalSubscript]
 
     # Need to remove leading white space, since read_csv
     # accepts:

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -257,7 +257,7 @@ class XlsxWriter(ExcelWriter):
         style_dict = {"null": None}
 
         if validate_freeze_panes(freeze_panes):
-            wks.freeze_panes(*(freeze_panes))
+            wks.freeze_panes(*(freeze_panes))  # pyright: ignore[reportOptionalIterable]
 
         for cell in cells:
             val, fmt = self._value_with_fmt(cell.val)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1303,7 +1303,7 @@ class FloatArrayFormatter(_GenericArrayFormatter):
         # because str(0.0) = '0.0' while '%g' % 0.0 = '0'
         if float_format:
 
-            def base_formatter(v):
+            def base_formatter(v):  # pyright: ignore[reportRedeclaration]
                 assert float_format is not None  # for mypy
                 # error: "str" not callable
                 # error: Unexpected keyword argument "value" for "__call__" of

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -276,7 +276,7 @@ def enable_data_resource_formatter(enable: bool) -> None:
     if "IPython" not in sys.modules:
         # definitely not in IPython
         return
-    from IPython import get_ipython
+    from IPython import get_ipython  # pyright: ignore[reportPrivateImportUsage]
 
     # error: Call to untyped function "get_ipython" in typed context
     ip = get_ipython()  # type: ignore[no-untyped-call]

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2870,7 +2870,7 @@ class Styler(StylerRenderer):
         elif isinstance(table_styles, dict):
             axis = self.data._get_axis_number(axis)
             obj = self.data.index if axis == 1 else self.data.columns
-            idf = f".{self.css['row']}" if axis == 1 else f".{self.css['col']}"
+            idf = f".{self.css['row']}" if axis == 1 else f".{self.css['col']}"  # pyright: ignore[reportOptionalSubscript]
 
             table_styles = [
                 {

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -191,8 +191,8 @@ class CParserWrapper(ParserBase):
         # error: Cannot determine type of 'names'
 
         # much faster than using orig_names.index(x) xref GH#44106
-        names_dict = {x: i for i, x in enumerate(self.orig_names)}
-        col_indices = [names_dict[x] for x in self.names]
+        names_dict = {x: i for i, x in enumerate(self.orig_names)}  # pyright: ignore[reportOptionalIterable]
+        col_indices = [names_dict[x] for x in self.names]  # pyright: ignore[reportOptionalIterable]
         noconvert_columns = self._set_noconvert_dtype_columns(
             col_indices,
             self.names,

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3005,7 +3005,7 @@ class GenericFixed(Fixed):
         kwargs = {}
         if index_class == DatetimeIndex:
 
-            def f(values, freq=None, tz=None):
+            def f(values, freq=None, tz=None):  # pyright: ignore[reportRedeclaration]
                 # data are already in UTC, localize and convert if tz present
                 dta = DatetimeArray._simple_new(
                     values.values, dtype=values.dtype, freq=freq
@@ -3540,7 +3540,7 @@ class Table(Fixed):
     pandas_kind = "wide_table"
     format_type: str = "table"  # GH#30962 needed by dask
     table_type: str
-    levels: int | list[Hashable] = 1
+    levels: int | list[Hashable] = 1  # pyright: ignore[reportRedeclaration]
     is_table = True
 
     metadata: list
@@ -3779,7 +3779,7 @@ class Table(Fixed):
         self.nan_rep = getattr(self.attrs, "nan_rep", None)
         self.encoding = _ensure_encoding(getattr(self.attrs, "encoding", None))
         self.errors = getattr(self.attrs, "errors", "strict")
-        self.levels: list[Hashable] = getattr(self.attrs, "levels", None) or []
+        self.levels: list[Hashable] = getattr(self.attrs, "levels", None) or []  # pyright: ignore[reportRedeclaration]
         self.index_axes = [a for a in self.indexables if a.is_an_indexable]
         self.values_axes = [a for a in self.indexables if not a.is_an_indexable]
 
@@ -4663,7 +4663,7 @@ class AppendableTable(Table):
 
             self.write_data_chunk(
                 rows,
-                indexes=[a[start_i:end_i] for a in indexes],
+                indexes=[a[start_i:end_i] for a in indexes],  # pyright: ignore[reportOptionalSubscript]
                 mask=mask[start_i:end_i] if mask is not None else None,
                 values=[v[start_i:end_i] for v in bvalues],
             )

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1305,6 +1305,7 @@ class SQLTable(PandasObject):
         """
         parse_dates = _process_parse_dates_argument(parse_dates)
 
+        assert self.frame is not None  # caller always sets frame before this
         for sql_col in self.table.columns:
             col_name = sql_col.name
             try:

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -335,7 +335,7 @@ def _grouped_plot_by_column(
     if return_type is None:
         result = axes
 
-    byline = by[0] if len(by) == 1 else by
+    byline = by[0] if len(by) == 1 else by  # pyright: ignore[reportOptionalSubscript]
     fig.suptitle(f"Boxplot grouped by {byline}")
     maybe_adjust_figure(fig, bottom=0.15, top=0.9, left=0.1, right=0.9, wspace=0.2)
 

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -470,7 +470,7 @@ class MPLPlot(ABC):
 
         if self.style is not None:
             if isinstance(self.style, dict):
-                styles = [self.style[col] for col in self.columns if col in self.style]
+                styles = [self.style[col] for col in self.columns if col in self.style]  # pyright: ignore[reportOptionalIterable]
             elif is_list_like(self.style):
                 styles = self.style
             else:
@@ -1380,7 +1380,7 @@ class ScatterPlot(PlanePlot):
         create_colors = not self._are_valid_colors(c_values)
         if create_colors:
             color_mapping = self._get_color_mapping(c_values)
-            c_values = [color_mapping[s] for s in c_values]
+            c_values = [color_mapping[s] for s in c_values]  # pyright: ignore[reportOptionalIterable]
 
             # build legend for labeling custom colors
             ax.legend(

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -29,11 +29,13 @@ def one(request):
 
 
 zeros = [
-    box_cls([0] * 5, dtype=dtype)
+    box_cls([0] * 5, dtype=dtype)  # type: ignore[operator]
     for box_cls in [Index, np.array, pd.array]
     for dtype in [np.int64, np.uint64, np.float64]
 ]
-zeros.extend([box_cls([-0.0] * 5, dtype=np.float64) for box_cls in [Index, np.array]])
+zeros.extend(
+    [box_cls([-0.0] * 5, dtype=np.float64) for box_cls in [Index, np.array]]  # type: ignore[operator]
+)
 zeros.extend([np.array(0, dtype=dtype) for dtype in [np.int64, np.uint64, np.float64]])
 zeros.extend([np.array(-0.0, dtype=np.float64)])
 zeros.extend([0, 0.0, -0.0])

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -586,6 +586,7 @@ def test_is_numeric_dtype():
         def construct_array_type(self):
             raise NotImplementedError
 
+        @property
         def _is_numeric(self) -> bool:
             return True
 

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -410,7 +410,7 @@ class Holiday:
             return dates.copy()
 
         if self.observance is not None:
-            return dates.map(lambda d: self.observance(d))
+            return dates.map(lambda d: self.observance(d))  # pyright: ignore[reportOptionalCall]
 
         if self.offset is not None:
             if not isinstance(self.offset, list):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -627,23 +627,6 @@ module = [
 ]
 check_untyped_defs = false
 
-[[tool.mypy.overrides]]
-module = [
-  "pandas.tests.apply.test_series_apply",
-  "pandas.tests.arithmetic.conftest",
-  "pandas.tests.arrays.sparse.test_combine_concat",
-  "pandas.tests.dtypes.test_common",
-  "pandas.tests.frame.methods.test_to_records",
-  "pandas.tests.groupby.test_rank",
-  "pandas.tests.groupby.transform.test_transform",
-  "pandas.tests.indexes.interval.test_interval",
-  "pandas.tests.indexing.test_categorical",
-  "pandas.tests.io.excel.test_writers",
-  "pandas.tests.reductions.test_reductions",
-  "pandas.tests.test_expressions",
-]
-ignore_errors = true
-
 # To be kept consistent with "Import Formatting" section in contributing.rst
 [tool.isort]
 known_pre_libs = "pandas._config"
@@ -684,15 +667,8 @@ reportGeneralTypeIssues = false
 reportIndexIssue = false
 reportMissingModuleSource = false
 reportOperatorIssue = false
-reportOptionalCall = false
-reportOptionalIterable = false
 reportOptionalMemberAccess = false
-reportOptionalOperand = false
-reportOptionalSubscript = false
-reportPrivateImportUsage = false
-reportRedeclaration = false
 reportReturnType = false
-reportUnboundVariable = false
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Summary

- Enable 7 previously-disabled pyright basic-mode checks that had very few violations (0–15 each): `reportUnboundVariable`, `reportPrivateImportUsage`, `reportOptionalOperand`, `reportOptionalIterable`, `reportRedeclaration`, `reportOptionalCall`, `reportOptionalSubscript`
- Add targeted `# pyright: ignore` comments for the remaining false positives
- Remove the mypy `ignore_errors=true` override block — all 12 test modules now pass cleanly
- Fix 2 underlying type errors: missing `@property` on `_is_numeric` override, missing `assert` for `self.frame`

Reduces disabled pyright basic-mode checks from 17 → 10.

## Test plan

- [x] pyright passes at baseline (32 `reportMissingImports` for optional deps only)
- [x] mypy passes with 0 errors
- [x] Pre-commit hooks pass
- [x] `pandas/tests/arithmetic/` test suite passes (21870 passed)
- [x] `pandas/tests/dtypes/test_common.py::test_is_numeric_dtype` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)