### PR TITLE
DOC: Fix typos and misleading See Also descriptions in GroupBy docstrings

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9168,7 +9168,7 @@ class DataFrame(NDFrame, OpsMixin):
             and not self.columns.equals(right.columns)
             and fill_value is None
         ):
-            # GH#60498 Reindex if MultiIndexe columns are not matching
+            # GH#60498 Reindex if MultiIndex columns are not matching
             # GH#60903 Don't reindex if fill_value is provided
             return True
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -826,7 +826,7 @@ class SeriesGroupBy(GroupBy[Series]):
         See Also
         --------
         Series.filter: Filter elements of ungrouped Series.
-        DataFrameGroupBy.filter : Filter elements from groups base on criterion.
+        DataFrameGroupBy.filter : Filter elements from groups based on criterion.
 
         Notes
         -----
@@ -2757,7 +2757,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         See Also
         --------
         DataFrame.filter: Filter elements of ungrouped DataFrame.
-        SeriesGroupBy.filter : Filter elements from groups base on criterion.
+        SeriesGroupBy.filter : Filter elements from groups based on criterion.
 
         Notes
         -----

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4189,8 +4189,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         See Also
         --------
-        pad : Returns Series with minimum number of char in object.
-        backfill : Backward fill the missing values in the dataset.
+        pad : Forward fill values within each group.
+        backfill : Backward fill values within each group.
         """
         # Need int value for Cython
         if limit is None:
@@ -4264,8 +4264,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         See Also
         --------
-        Series.ffill: Returns Series with minimum number of char in object.
-        DataFrame.ffill: Object with missing values filled or None if inplace=True.
+        Series.ffill : Forward fill missing values in a Series.
+        DataFrame.ffill : Forward fill missing values in a DataFrame.
         Series.fillna: Fill NaN values of a Series.
         DataFrame.fillna: Fill NaN values of a DataFrame.
 


### PR DESCRIPTION
## Summary

- Fixed "base" → "based" typo in `See Also` sections of `SeriesGroupBy.filter` and `DataFrameGroupBy.filter`
- Fixed misleading `See Also` descriptions for `ffill`/`bfill` in `GroupBy._fill` and `GroupBy.ffill` — the descriptions were copy-pasted from `Series.str.pad` (e.g., "Returns Series with minimum number of char in object") instead of describing forward/backward fill behavior
- Fixed "MultiIndexe" → "MultiIndex" typo in a code comment in `DataFrame._should_reindex_frame_op`

- [ ] No behavioral changes — docstring and comment fixes only

