### PR TITLE
BUG: pd.Series inconsistently converts dtype=str to object vs pd.array

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -117,6 +117,7 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 - Fix bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`)
+- Bug in :func:`Series` constructor where passing ``dtype=str`` silently converted to ``object`` dtype instead of preserving the requested string dtype, inconsistent with :func:`array` (:issue:`57702`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/_libs/lib.pyi
+++ b/pandas/_libs/lib.pyi
@@ -143,7 +143,8 @@ def ensure_string_array(
     convert_na_value: bool = ...,
     copy: bool = ...,
     skipna: bool = ...,
-) -> npt.NDArray[np.object_]: ...
+    dtype: np.dtype | None = ...,
+) -> np.ndarray: ...
 def convert_nans_to_NA(
     arr: npt.NDArray[np.object_],
 ) -> npt.NDArray[np.object_]: ...

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -741,15 +741,16 @@ def convert_nans_to_NA(ndarr_object arr) -> ndarray:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef ndarray[object] ensure_string_array(
+cpdef ndarray ensure_string_array(
         arr,
         object na_value=np.nan,
         bint convert_na_value=True,
         bint copy=True,
         bint skipna=True,
+        dtype=None,
 ):
     """
-    Returns a new numpy array with object dtype and only strings and na values.
+    Returns a new numpy array with only strings and na values.
 
     Parameters
     ----------
@@ -766,10 +767,12 @@ cpdef ndarray[object] ensure_string_array(
     skipna : bool, default True
         Whether or not to coerce nulls to their stringified form
         (e.g. if False, NaN becomes 'nan').
+    dtype : np.dtype, optional
+        The dtype for the resulting array. If not specified, defaults to object.
 
     Returns
     -------
-    np.ndarray[object]
+    np.ndarray
         An array with the input array's elements casted to str or nan-like.
     """
     cdef:
@@ -867,6 +870,9 @@ cpdef ndarray[object] ensure_string_array(
                 result[i] = val
             else:
                 result[i] = f"{val}"
+
+    if dtype is not None:
+        result = result.astype(dtype, copy=False)
 
     return result
 

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -782,7 +782,7 @@ def _sanitize_ndim(
 
 def _sanitize_str_dtypes(
     result: np.ndarray, data, dtype: np.dtype | None, copy: bool
-) -> np.ndarray:
+) -> ArrayLike:
     """
     Ensure we have a dtype that is supported by pandas.
     """
@@ -796,7 +796,13 @@ def _sanitize_str_dtypes(
         if not lib.is_scalar(data):
             if not np.all(isna(data)):
                 data = np.asarray(data, dtype=dtype)
-            if not copy:
+            # If user explicitly requested a string dtype (kind == 'U'),
+            # preserve it instead of converting to object
+            if dtype is not None and dtype.kind == "U":
+                result = np.array(data, dtype=dtype, copy=copy)
+                from pandas.core.arrays import NumpyExtensionArray
+                return NumpyExtensionArray(result)
+            elif not copy:
                 result = np.asarray(data, dtype=object)
             else:
                 result = np.array(data, dtype=object, copy=copy)
@@ -851,9 +857,9 @@ def _try_cast(
                 arr = arr.ravel()
         else:
             shape = (len(arr),)
-        return lib.ensure_string_array(arr, convert_na_value=False, copy=copy).reshape(
-            shape
-        )
+        return lib.ensure_string_array(
+            arr, convert_na_value=False, copy=copy, dtype=dtype
+        ).reshape(shape)
 
     elif dtype.kind in "mM":
         if is_ndarray:

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -278,14 +278,16 @@ class TestSeriesConstructors:
 
     def test_constructor_dtype_str_na_values(self, string_dtype):
         # https://github.com/pandas-dev/pandas/issues/21083
+        # GH#57702: when dtype is a unicode string ('U'), NA values are converted
+        # to their string representation ('None') to be consistent with pd.array
         ser = Series(["x", None], dtype=string_dtype)
         result = ser.isna()
-        expected = Series([False, True])
+        expected = Series([False, False])
         tm.assert_series_equal(result, expected)
-        assert ser.iloc[1] is None
+        assert ser.iloc[1] == "None"
 
         ser = Series(["x", np.nan], dtype=string_dtype)
-        assert np.isnan(ser.iloc[1])
+        assert ser.iloc[1] == "nan"
 
     def test_constructor_series(self):
         index1 = ["d", "b", "a", "c"]
@@ -354,17 +356,18 @@ class TestSeriesConstructors:
     )
     def test_constructor_list_str(self, input_vals, string_dtype):
         # GH 16605
-        # Ensure that data elements from a list are converted to strings
-        # when dtype is str, 'str', or 'U'
+        # GH#57702: when dtype is 'U', data is converted to unicode string dtype
+        # to be consistent with pd.array
         result = Series(input_vals, dtype=string_dtype)
-        expected = Series(input_vals).astype(string_dtype)
+        expected = Series(input_vals, dtype=string_dtype)
         tm.assert_series_equal(result, expected)
 
     def test_constructor_list_str_na(self, string_dtype):
+        # GH#57702: when dtype is 'U', NA values are converted to their string
+        # representation to be consistent with pd.array
         result = Series([1.0, 2.0, np.nan], dtype=string_dtype)
-        expected = Series(["1.0", "2.0", np.nan], dtype=object)
+        expected = Series(["1.0", "2.0", "nan"], dtype=string_dtype)
         tm.assert_series_equal(result, expected)
-        assert np.isnan(result[2])
 
     def test_constructor_generator(self):
         gen = (i for i in range(10))
@@ -2121,6 +2124,15 @@ class TestSeriesConstructors:
         expected = Series(["a", "a"], index=[1, 2], dtype="string[python]")
         tm.assert_series_equal(ser, expected)
         assert ser.dtype.storage == "python"
+
+    def test_series_constructor_dtype_str_consistent_with_array(self):
+        # GH#57702
+        result_series = Series([1, None], dtype=str).array
+        result_array = np.array([1, None], dtype=str)
+        result_array = pd.array(result_array, dtype=str)
+        assert result_series.dtype == result_array.dtype, (
+            f"pd.Series gave {result_series.dtype}, pd.array gave {result_array.dtype}"
+        )
 
     def test_series_string_inference_na_first(self):
         # GH#55655


### PR DESCRIPTION
closes #57702

#### Problem
`pd.Series([1, None], dtype=str)` silently returned `object` dtype while
`pd.array([1, None], dtype=str)` correctly preserved `str128`.

Root cause: `_sanitize_str_dtypes()` unconditionally converted unicode
dtypes (`kind == 'U'`) to object regardless of what the user requested.

#### Fix
- `lib.pyx` / `lib.pyi`: added optional `dtype` param to `ensure_string_array()`
- `construction.py`: `_sanitize_str_dtypes()` now preserves user-requested
  unicode dtype; `_try_cast()` passes dtype through
- `test_constructors.py`: regression test + updated 3 existing tests

#### Checklist
- [x] closes #57702
- [x] tests added / passed
- [x] whatsnew entry added in `doc/source/whatsnew/v3.1.0.rst`