### PR TITLE
TST: remove unnecessary check_freq=False in pytables tests

### DIFF
--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -586,8 +586,7 @@ def test_append_with_data_columns(temp_hdfstore):
         & (df_new.A > 0)
         & (df_new.B < 0)
     ]
-    tm.assert_frame_equal(result, expected, check_freq=False)
-    # FIXME: 2020-05-07 freq check randomly fails in the CI
+    tm.assert_frame_equal(result, expected)
 
     # yield an empty frame
     result = temp_hdfstore.select("df", "string='foo' and string2='cool'")
@@ -613,9 +612,7 @@ def test_append_with_data_columns(temp_hdfstore):
 
     result = temp_hdfstore.select("df_dc", ["B > 0", "C > 0", "string == foo"])
     expected = df_dc[(df_dc.B > 0) & (df_dc.C > 0) & (df_dc.string == "foo")]
-    tm.assert_frame_equal(result, expected, check_freq=False)
-    # FIXME: 2020-12-07 intermittent build failures here with freq of
-    #  None instead of BDay(4)
+    tm.assert_frame_equal(result, expected)
 
     # doc example part 2
 

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -886,8 +886,7 @@ def test_select_as_multiple(temp_hdfstore):
     )
     expected = concat([df1, df2], axis=1)
     expected = expected[(expected.A > 0) & (expected.B > 0)]
-    tm.assert_frame_equal(result, expected, check_freq=False)
-    # FIXME: 2021-01-20 this is failing with freq None vs 4B on some builds
+    tm.assert_frame_equal(result, expected)
 
     # multiple (diff selector)
     result = temp_hdfstore.select_as_multiple(

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -708,9 +708,7 @@ def test_coordinates_multiple_tables(temp_hdfstore):
 
     expected = concat([df1, df2], axis=1)
     expected = expected[(expected.A > 0) & (expected.B > 0)]
-    tm.assert_frame_equal(result, expected, check_freq=False)
-    # FIXME: 2021-01-18 on some (mostly windows) builds we get freq=None
-    #  but expect freq="18B"
+    tm.assert_frame_equal(result, expected)
 
 
 def test_coordinates_array_mask(temp_hdfstore):


### PR DESCRIPTION
Remove `check_freq=False` and associated FIXME comments from three pytables test files.

The FIXME comments (from 2020-2021) noted intermittent freq mismatches on some CI builds. These were caused by the tests using the non-deterministic `np.random.randn`, which produced different row selections on different platforms, leading to inconsistent freq inference. Since the tests were migrated to `np.random.default_rng(2)` in #54209 (2023), the results are deterministic and the `check_freq=False` workarounds are no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)