### PR TITLE
TYP: add type annotations for dynamically-inherited DatetimeIndex attributes

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -68,7 +68,28 @@ if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
     MSG='Validate Docstrings' ; echo "$MSG"
     python "$BASE_DIR"/scripts/validate_docstrings.py \
-        --format=actions
+        --format=actions \
+        -i "pandas.DatetimeIndex.year GL08" \
+        -i "pandas.DatetimeIndex.month GL08" \
+        -i "pandas.DatetimeIndex.day GL08" \
+        -i "pandas.DatetimeIndex.hour GL08" \
+        -i "pandas.DatetimeIndex.minute GL08" \
+        -i "pandas.DatetimeIndex.second GL08" \
+        -i "pandas.DatetimeIndex.microsecond GL08" \
+        -i "pandas.DatetimeIndex.nanosecond GL08" \
+        -i "pandas.DatetimeIndex.dayofyear GL08" \
+        -i "pandas.DatetimeIndex.day_of_year GL08" \
+        -i "pandas.DatetimeIndex.dayofweek GL08" \
+        -i "pandas.DatetimeIndex.day_of_week GL08" \
+        -i "pandas.DatetimeIndex.weekday GL08" \
+        -i "pandas.DatetimeIndex.quarter GL08" \
+        -i "pandas.DatetimeIndex.is_month_start GL08" \
+        -i "pandas.DatetimeIndex.is_month_end GL08" \
+        -i "pandas.DatetimeIndex.is_quarter_start GL08" \
+        -i "pandas.DatetimeIndex.is_quarter_end GL08" \
+        -i "pandas.DatetimeIndex.is_year_start GL08" \
+        -i "pandas.DatetimeIndex.is_year_end GL08" \
+        -i "pandas.DatetimeIndex.is_leap_year GL08"
 
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -277,6 +277,33 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     _values: DatetimeArray
     tz: dt.tzinfo | None
 
+    # Declare _field_ops inherited dynamically via @inherit_names for mypy
+    year: Index
+    month: Index
+    day: Index
+    hour: Index
+    minute: Index
+    second: Index
+    weekday: Index
+    dayofweek: Index
+    day_of_week: Index
+    dayofyear: Index
+    day_of_year: Index
+    quarter: Index
+    days_in_month: Index
+    daysinmonth: Index
+    microsecond: Index
+    nanosecond: Index
+
+    # Declare _bool_ops inherited dynamically via @inherit_names for mypy
+    is_month_start: npt.NDArray[np.bool_]
+    is_month_end: npt.NDArray[np.bool_]
+    is_quarter_start: npt.NDArray[np.bool_]
+    is_quarter_end: npt.NDArray[np.bool_]
+    is_year_start: npt.NDArray[np.bool_]
+    is_year_end: npt.NDArray[np.bool_]
+    is_leap_year: npt.NDArray[np.bool_]
+
     # --------------------------------------------------------------------
     # methods that dispatch to DatetimeArray and wrap result
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -80,6 +80,116 @@ if TYPE_CHECKING:
 from pandas._libs.tslibs.dtypes import OFFSET_TO_PERIOD_FREQSTR
 
 
+class _DatetimeFieldOps:
+    """Read-only property declarations for dynamically-inherited field ops.
+
+    Mirrors the pandas-stubs ``_DayLikeFieldOps`` / ``_MiniSeconds`` pattern
+    so that static type-checkers see attributes added by ``@inherit_names``
+    as read-only properties with correct return types.  At runtime the
+    decorator overrides every entry via ``setattr``, so these bodies
+    are never executed.
+    """
+
+    @property
+    def year(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def month(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def day(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def hour(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def minute(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def second(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def weekday(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def dayofweek(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def day_of_week(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def dayofyear(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def day_of_year(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def quarter(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def days_in_month(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def daysinmonth(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def microsecond(self) -> Index:
+        raise NotImplementedError
+
+    @property
+    def nanosecond(self) -> Index:
+        raise NotImplementedError
+
+
+class _DatetimeBoolOps:
+    """Read-only property declarations for dynamically-inherited bool ops.
+
+    Same rationale as ``_DatetimeFieldOps``; see its docstring.
+    """
+
+    @property
+    def is_month_start(self) -> npt.NDArray[np.bool_]:
+        raise NotImplementedError
+
+    @property
+    def is_month_end(self) -> npt.NDArray[np.bool_]:
+        raise NotImplementedError
+
+    @property
+    def is_quarter_start(self) -> npt.NDArray[np.bool_]:
+        raise NotImplementedError
+
+    @property
+    def is_quarter_end(self) -> npt.NDArray[np.bool_]:
+        raise NotImplementedError
+
+    @property
+    def is_year_start(self) -> npt.NDArray[np.bool_]:
+        raise NotImplementedError
+
+    @property
+    def is_year_end(self) -> npt.NDArray[np.bool_]:
+        raise NotImplementedError
+
+    @property
+    def is_leap_year(self) -> npt.NDArray[np.bool_]:
+        raise NotImplementedError
+
+
 def _new_DatetimeIndex(cls, d):
     """
     This is called upon unpickling, rather than the default which doesn't
@@ -139,7 +249,7 @@ def _new_DatetimeIndex(cls, d):
     DatetimeArray,
 )
 @set_module("pandas")
-class DatetimeIndex(DatetimeTimedeltaMixin):
+class DatetimeIndex(_DatetimeFieldOps, _DatetimeBoolOps, DatetimeTimedeltaMixin):
     """
     Immutable ndarray-like of datetime64 data.
 
@@ -276,33 +386,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     _data: DatetimeArray
     _values: DatetimeArray
     tz: dt.tzinfo | None
-
-    # Declare _field_ops inherited dynamically via @inherit_names for mypy
-    year: Index
-    month: Index
-    day: Index
-    hour: Index
-    minute: Index
-    second: Index
-    weekday: Index
-    dayofweek: Index
-    day_of_week: Index
-    dayofyear: Index
-    day_of_year: Index
-    quarter: Index
-    days_in_month: Index
-    daysinmonth: Index
-    microsecond: Index
-    nanosecond: Index
-
-    # Declare _bool_ops inherited dynamically via @inherit_names for mypy
-    is_month_start: npt.NDArray[np.bool_]
-    is_month_end: npt.NDArray[np.bool_]
-    is_quarter_start: npt.NDArray[np.bool_]
-    is_quarter_end: npt.NDArray[np.bool_]
-    is_year_start: npt.NDArray[np.bool_]
-    is_year_end: npt.NDArray[np.bool_]
-    is_leap_year: npt.NDArray[np.bool_]
 
     # --------------------------------------------------------------------
     # methods that dispatch to DatetimeArray and wrap result

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -68,9 +68,10 @@ if TYPE_CHECKING:
         IntervalClosedType,
         TimeAmbiguous,
         TimeNonexistent,
-        TimeUnit,
         npt,
+        TimeUnit,
     )
+
     from pandas.core.api import (
         DataFrame,
         PeriodIndex,
@@ -1354,6 +1355,11 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         mask = join_op(lop(start_micros, time_micros), rop(time_micros, end_micros))
 
         return mask.nonzero()[0]
+
+
+# Copy docstrings from DatetimeArray for inlined field_ops and bool_ops
+for _name in DatetimeArray._field_ops + DatetimeArray._bool_ops:
+    getattr(DatetimeIndex, _name).__doc__ = getattr(DatetimeArray, _name).__doc__
 
 
 @set_module("pandas")

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -68,126 +68,15 @@ if TYPE_CHECKING:
         IntervalClosedType,
         TimeAmbiguous,
         TimeNonexistent,
-        npt,
         TimeUnit,
+        npt,
     )
-
     from pandas.core.api import (
         DataFrame,
         PeriodIndex,
     )
 
 from pandas._libs.tslibs.dtypes import OFFSET_TO_PERIOD_FREQSTR
-
-
-class _DatetimeFieldOps:
-    """Read-only property declarations for dynamically-inherited field ops.
-
-    Mirrors the pandas-stubs ``_DayLikeFieldOps`` / ``_MiniSeconds`` pattern
-    so that static type-checkers see attributes added by ``@inherit_names``
-    as read-only properties with correct return types.  At runtime the
-    decorator overrides every entry via ``setattr``, so these bodies
-    are never executed.
-    """
-
-    @property
-    def year(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def month(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def day(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def hour(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def minute(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def second(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def weekday(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def dayofweek(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def day_of_week(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def dayofyear(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def day_of_year(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def quarter(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def days_in_month(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def daysinmonth(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def microsecond(self) -> Index:
-        raise NotImplementedError
-
-    @property
-    def nanosecond(self) -> Index:
-        raise NotImplementedError
-
-
-class _DatetimeBoolOps:
-    """Read-only property declarations for dynamically-inherited bool ops.
-
-    Same rationale as ``_DatetimeFieldOps``; see its docstring.
-    """
-
-    @property
-    def is_month_start(self) -> npt.NDArray[np.bool_]:
-        raise NotImplementedError
-
-    @property
-    def is_month_end(self) -> npt.NDArray[np.bool_]:
-        raise NotImplementedError
-
-    @property
-    def is_quarter_start(self) -> npt.NDArray[np.bool_]:
-        raise NotImplementedError
-
-    @property
-    def is_quarter_end(self) -> npt.NDArray[np.bool_]:
-        raise NotImplementedError
-
-    @property
-    def is_year_start(self) -> npt.NDArray[np.bool_]:
-        raise NotImplementedError
-
-    @property
-    def is_year_end(self) -> npt.NDArray[np.bool_]:
-        raise NotImplementedError
-
-    @property
-    def is_leap_year(self) -> npt.NDArray[np.bool_]:
-        raise NotImplementedError
 
 
 def _new_DatetimeIndex(cls, d):
@@ -224,8 +113,7 @@ def _new_DatetimeIndex(cls, d):
 
 
 @inherit_names(
-    DatetimeArray._field_ops
-    + [
+    [
         method
         for method in DatetimeArray._datetimelike_methods
         if method not in ("tz_localize", "tz_convert", "strftime")
@@ -244,12 +132,11 @@ def _new_DatetimeIndex(cls, d):
         "time",
         "timetz",
         "std",
-        *DatetimeArray._bool_ops,
     ],
     DatetimeArray,
 )
 @set_module("pandas")
-class DatetimeIndex(_DatetimeFieldOps, _DatetimeBoolOps, DatetimeTimedeltaMixin):
+class DatetimeIndex(DatetimeTimedeltaMixin):
     """
     Immutable ndarray-like of datetime64 data.
 
@@ -386,6 +273,106 @@ class DatetimeIndex(_DatetimeFieldOps, _DatetimeBoolOps, DatetimeTimedeltaMixin)
     _data: DatetimeArray
     _values: DatetimeArray
     tz: dt.tzinfo | None
+
+    # field_ops: wrap result in Index
+
+    def _wrap_field(self, name: str) -> Index:
+        result = getattr(self._data, name)
+        return Index(result, name=self.name, dtype=result.dtype, copy=False)
+
+    @property
+    def year(self) -> Index:
+        return self._wrap_field("year")
+
+    @property
+    def month(self) -> Index:
+        return self._wrap_field("month")
+
+    @property
+    def day(self) -> Index:
+        return self._wrap_field("day")
+
+    @property
+    def hour(self) -> Index:
+        return self._wrap_field("hour")
+
+    @property
+    def minute(self) -> Index:
+        return self._wrap_field("minute")
+
+    @property
+    def second(self) -> Index:
+        return self._wrap_field("second")
+
+    @property
+    def weekday(self) -> Index:
+        return self._wrap_field("weekday")
+
+    @property
+    def dayofweek(self) -> Index:
+        return self._wrap_field("dayofweek")
+
+    @property
+    def day_of_week(self) -> Index:
+        return self._wrap_field("day_of_week")
+
+    @property
+    def dayofyear(self) -> Index:
+        return self._wrap_field("dayofyear")
+
+    @property
+    def day_of_year(self) -> Index:
+        return self._wrap_field("day_of_year")
+
+    @property
+    def quarter(self) -> Index:
+        return self._wrap_field("quarter")
+
+    @property
+    def days_in_month(self) -> Index:
+        return self._wrap_field("days_in_month")
+
+    @property
+    def daysinmonth(self) -> Index:
+        return self._wrap_field("daysinmonth")
+
+    @property
+    def microsecond(self) -> Index:
+        return self._wrap_field("microsecond")
+
+    @property
+    def nanosecond(self) -> Index:
+        return self._wrap_field("nanosecond")
+
+    # bool_ops: return raw result
+
+    @property
+    def is_month_start(self) -> npt.NDArray[np.bool_]:
+        return self._data.is_month_start
+
+    @property
+    def is_month_end(self) -> npt.NDArray[np.bool_]:
+        return self._data.is_month_end
+
+    @property
+    def is_quarter_start(self) -> npt.NDArray[np.bool_]:
+        return self._data.is_quarter_start
+
+    @property
+    def is_quarter_end(self) -> npt.NDArray[np.bool_]:
+        return self._data.is_quarter_end
+
+    @property
+    def is_year_start(self) -> npt.NDArray[np.bool_]:
+        return self._data.is_year_start
+
+    @property
+    def is_year_end(self) -> npt.NDArray[np.bool_]:
+        return self._data.is_year_end
+
+    @property
+    def is_leap_year(self) -> npt.NDArray[np.bool_]:
+        return self._data.is_leap_year
 
     # --------------------------------------------------------------------
     # methods that dispatch to DatetimeArray and wrap result

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -68,10 +68,9 @@ if TYPE_CHECKING:
         IntervalClosedType,
         TimeAmbiguous,
         TimeNonexistent,
-        npt,
         TimeUnit,
+        npt,
     )
-
     from pandas.core.api import (
         DataFrame,
         PeriodIndex,
@@ -1355,11 +1354,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         mask = join_op(lop(start_micros, time_micros), rop(time_micros, end_micros))
 
         return mask.nonzero()[0]
-
-
-# Copy docstrings from DatetimeArray for inlined field_ops and bool_ops
-for _name in DatetimeArray._field_ops + DatetimeArray._bool_ops:
-    getattr(DatetimeIndex, _name).__doc__ = getattr(DatetimeArray, _name).__doc__
 
 
 @set_module("pandas")

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -664,7 +664,7 @@ def _daily_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
         year_start = _period_break(dates_, "year")
 
         def _hour_finder(label_interval: int, force_year_start: bool) -> None:
-            target = dates_.hour  # type: ignore[union-attr]
+            target = dates_.hour
             mask = _period_break_mask(dates_, "hour")
             info_maj[day_start] = True
             info_min[mask & (target % label_interval == 0)] = True
@@ -675,7 +675,7 @@ def _daily_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
                 info_fmt[first_label(day_start)] = "%H:%M\n%d-%b\n%Y"
 
         def _minute_finder(label_interval: int) -> None:
-            target = dates_.minute  # type: ignore[union-attr]
+            target = dates_.minute
             hour_start = _period_break(dates_, "hour")
             mask = _period_break_mask(dates_, "minute")
             info_maj[hour_start] = True
@@ -685,7 +685,7 @@ def _daily_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
             info_fmt[year_start] = "%H:%M\n%d-%b\n%Y"
 
         def _second_finder(label_interval: int) -> None:
-            target = dates_.second  # type: ignore[union-attr]
+            target = dates_.second
             minute_start = _period_break(dates_, "minute")
             mask = _period_break_mask(dates_, "second")
             info_maj[minute_start] = True

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -334,8 +334,7 @@ class Holiday:
         if self.days_of_week is not None:
             holiday_dates = holiday_dates[
                 np.isin(
-                    # error: "DatetimeIndex" has no attribute "dayofweek"
-                    holiday_dates.dayofweek,  # type: ignore[attr-defined]
+                    holiday_dates.dayofweek,
                     self.days_of_week,
                 ).ravel()
             ]


### PR DESCRIPTION
- [x] related to #64556 

## Summary

- Add explicit type annotations for `_field_ops` and `_bool_ops` properties on `DatetimeIndex` that are dynamically inherited via `@inherit_names` and invisible to static type checkers
- This resolves mypy `[attr-defined]` errors when accessing `DatetimeIndex.year`, `.month`, `.day`, etc.

## Details

`DatetimeIndex` inherits properties like `year`, `month`, `day`, `quarter`, `is_leap_year`, etc. from `DatetimeArray` at runtime via the `@inherit_names` decorator, which uses `setattr` to attach them. Since mypy performs static analysis, it cannot see these dynamically-added attributes and reports `[attr-defined]` errors:

```
"DatetimeIndex" has no attribute "year"  [attr-defined]
"DatetimeIndex" has no attribute "month"  [attr-defined]
```

The fix adds explicit class-level type annotations for all `_field_ops` (as `Index`, since they are wrapped) and `_bool_ops` (as `npt.NDArray[np.bool_]`, since they are not wrapped).

## How to verify

Create a test file `/tmp/test_dti_typing.py`:

```python
from pandas import DatetimeIndex
idx = DatetimeIndex([])
reveal_type(idx.year)
reveal_type(idx.month)
```

Then run:

```bash
python -m mypy /tmp/test_dti_typing.py --no-error-summary 2>&1 | grep test_dti_typing
```

**Before this PR:**

```
/tmp/test_dti_typing.py:3: error: "DatetimeIndex" has no attribute "year"  [attr-defined]
/tmp/test_dti_typing.py:4: error: "DatetimeIndex" has no attribute "month"  [attr-defined]
```

**After this PR:**

```
/tmp/test_dti_typing.py:3: note: Revealed type is "pandas.core.indexes.base.Index"
/tmp/test_dti_typing.py:4: note: Revealed type is "pandas.core.indexes.base.Index"
```