### PR TITLE
CI: fix 113 pyright warnings in code checks build

### DIFF
--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -6,10 +6,10 @@ from pandas.core.internals.managers import (
 )
 
 __all__ = [
-    "Block",  # pyright:ignore[reportUnsupportedDunderAll)]
+    "Block",  # pyright:ignore[reportUnsupportedDunderAll]
     "BlockManager",
-    "DatetimeTZBlock",  # pyright:ignore[reportUnsupportedDunderAll)]
-    "ExtensionBlock",  # pyright:ignore[reportUnsupportedDunderAll)]
+    "DatetimeTZBlock",  # pyright:ignore[reportUnsupportedDunderAll]
+    "ExtensionBlock",  # pyright:ignore[reportUnsupportedDunderAll]
     "SingleBlockManager",
     "concatenate_managers",
     "make_block",

--- a/pyright_reportGeneralTypeIssues.json
+++ b/pyright_reportGeneralTypeIssues.json
@@ -9,6 +9,7 @@
     "reportOperatorIssue": true,
     "reportRedeclaration": true,
     "reportReturnType": true,
+    "reportMissingModuleSource": false,
     "useLibraryCodeForTypes": false,
     "analyzeUnannotatedFunctions": false,
     "disableBytesTypePromotions": true,


### PR DESCRIPTION
## Summary
- Fix typo in `pyright:ignore` comments in `pandas/core/internals/__init__.py` — stray `)` prevented suppression of 3 `reportUnsupportedDunderAll` warnings
- Add `reportMissingModuleSource = false` to `pyright_reportGeneralTypeIssues.json` to match the setting already in `pyproject.toml`, suppressing 110 warnings about Cython extension imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)