### PR TITLE
BUG: raising clear error for hist/box with duplicate column names

### DIFF
--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -187,6 +187,8 @@ class MPLPlot(ABC):
         # while column is not, only need `columns` in hist/box plot when it's DF
         # TODO: Might deprecate `column` argument in future PR (#28373)
         if isinstance(data, ABCDataFrame):
+            if self._kind in ("hist", "box") and not data.columns.is_unique:
+                raise ValueError("plotting requires unique column names")
             if column:
                 self.columns = com.maybe_make_list(column)
             elif self.by is None:

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1519,6 +1519,15 @@ class TestDataFramePlots:
         with pytest.raises(TypeError, match=msg):
             df.plot(kind=kind)
 
+    @pytest.mark.parametrize("kind", ["hist", "box"])
+    def test_plot_hist_box_non_unique_columns_raises(self, kind):
+        df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        df.columns = ["a", "a"]
+
+        msg = "plotting requires unique column names"
+        with pytest.raises(ValueError, match=msg):
+            getattr(df.plot, kind)()
+
     @pytest.mark.parametrize(
         "kind", [*list(plotting.PlotAccessor._common_kinds), "area"]
     )


### PR DESCRIPTION
Raise a clear error for `DataFrame.plot.hist()` / `DataFrame.plot.box()` when column labels are non-unique, avoiding the misleading `"no numeric data to plot"` error. Add a regression test covering both kinds.

- [x] closes #64546
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.