### PR TITLE
BUG: Fix `read_html` parsing a nested inner table incorrectly with html5lib/bs4

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -304,6 +304,7 @@ I/O
 ^^^
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
+- Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - Bug in :meth:`DataFrame.__repr__` where horizontally truncated output could exceed the terminal width by up to 4 characters (:issue:`32461`)

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -636,16 +636,16 @@ class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
         return row.find_all(("td", "th"), recursive=False)
 
     def _parse_thead_tr(self, table):
-        return table.select("thead tr")
+        return table.select(":scope thead tr")
 
     def _parse_tbody_tr(self, table):
-        from_tbody = table.select("tbody tr")
+        from_tbody = table.select(":scope tbody tr")
         from_root = table.find_all("tr", recursive=False)
         # HTML spec: at most one of these lists has content
         return from_tbody + from_root
 
     def _parse_tfoot_tr(self, table):
-        return table.select("tfoot tr")
+        return table.select(":scope tfoot tr")
 
     def _setup_build_doc(self):
         raw_text = _read(self.io, self.encoding, self.storage_options)

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -617,6 +617,48 @@ class TestReadHtml:
 
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.xfail(reason="Known issue: GH-64524", strict=False)
+    def test_nested_table(self, flavor_read_html):
+        # GH-64524
+        tables = flavor_read_html(
+            StringIO("""
+                <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table id="descendant">
+                                    <thead>
+                                        <tr>
+                                            <th>A</th>
+                                            <th>B</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>1</td>
+                                            <td>2</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            """),
+            attrs={"id": "descendant"},
+        )
+        assert len(tables) == 1
+        result = tables[0]
+
+        expected = DataFrame(data=[[1, 2]], columns=["A", "B"])
+
+        tm.assert_frame_equal(result, expected)
+
     def test_header_and_one_column(self, flavor_read_html):
         """
         Don't fail with bs4 when there is a header and only one column

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -617,7 +617,6 @@ class TestReadHtml:
 
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(reason="Known issue: GH-64524", strict=False)
     def test_nested_table(self, flavor_read_html):
         # GH-64524
         tables = flavor_read_html(


### PR DESCRIPTION
- [x] Closes #64524
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] ~~If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`~~
