### PR TITLE
TYP: annotate core.common and core.dtypes.cast

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -444,7 +444,7 @@ class Apply(metaclass=abc.ABCMeta):
         obj = self.obj
 
         results = []
-        keys = []
+        keys: list[Hashable] = []
 
         # degenerate case
         if selected_obj.ndim == 1:
@@ -1987,7 +1987,8 @@ def relabel_result(
         # mean  1.5
         if reorder_mask:
             fun = [
-                com.get_callable_name(f) if not isinstance(f, str) else f for f in fun
+                com.get_callable_name(f) if not isinstance(f, str) else f  # type: ignore[misc]
+                for f in fun
             ]
             col_idx_order = Index(s.index, copy=False).get_indexer(fun)
             valid_idx = col_idx_order != -1

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -63,10 +63,15 @@ if TYPE_CHECKING:
         T,
     )
 
-    from pandas import Index
+    from pandas import (
+        DataFrame,
+        Index,
+        Series,
+    )
+    from pandas.core.generic import NDFrame
 
 
-def flatten(line):
+def flatten(line: Iterable) -> Generator[Any]:
     """
     Flatten an arbitrarily nested sequence.
 
@@ -90,7 +95,7 @@ def flatten(line):
             yield element
 
 
-def consensus_name_attr(objs):
+def consensus_name_attr(objs: list[Series | DataFrame]) -> Hashable | None:
     name = objs[0].name
     for obj in objs[1:]:
         try:
@@ -159,7 +164,7 @@ def is_bool_indexer(key: Any) -> bool:
     return False
 
 
-def cast_scalar_indexer(val):
+def cast_scalar_indexer(val: Any) -> Any:
     """
     Disallow indexing with a float key, even if that key is a round number.
 
@@ -181,42 +186,42 @@ def cast_scalar_indexer(val):
     return val
 
 
-def not_none(*args):
+def not_none(*args: object) -> Generator[object]:
     """
     Returns a generator consisting of the arguments that are not None.
     """
     return (arg for arg in args if arg is not None)
 
 
-def any_none(*args) -> bool:
+def any_none(*args: object) -> bool:
     """
     Returns a boolean indicating if any argument is None.
     """
     return any(arg is None for arg in args)
 
 
-def all_none(*args) -> bool:
+def all_none(*args: object) -> bool:
     """
     Returns a boolean indicating if all arguments are None.
     """
     return all(arg is None for arg in args)
 
 
-def any_not_none(*args) -> bool:
+def any_not_none(*args: object) -> bool:
     """
     Returns a boolean indicating if any argument is not None.
     """
     return any(arg is not None for arg in args)
 
 
-def all_not_none(*args) -> bool:
+def all_not_none(*args: object) -> bool:
     """
     Returns a boolean indicating if all arguments are not None.
     """
     return all(arg is not None for arg in args)
 
 
-def count_not_none(*args) -> int:
+def count_not_none(*args: object) -> int:
     """
     Returns the count of arguments that are not None.
     """
@@ -297,7 +302,7 @@ def index_labels_to_array(
     return rlabels
 
 
-def maybe_make_list(obj):
+def maybe_make_list(obj: Any) -> list | tuple | None:
     if obj is not None and not isinstance(obj, (tuple, list)):
         return [obj]
     return obj
@@ -313,7 +318,7 @@ def maybe_iterable_to_list(obj: Iterable[T] | T) -> Collection[T] | T:
     return obj
 
 
-def is_null_slice(obj) -> bool:
+def is_null_slice(obj: object) -> bool:
     """
     We have a null slice.
     """
@@ -325,7 +330,7 @@ def is_null_slice(obj) -> bool:
     )
 
 
-def is_empty_slice(obj) -> bool:
+def is_empty_slice(obj: object) -> bool:
     """
     We have an empty slice, e.g. no values are selected.
     """
@@ -346,7 +351,7 @@ def is_true_slices(line: abc.Iterable) -> abc.Generator[bool, None, None]:
 
 
 # TODO: used only once in indexing; belongs elsewhere?
-def is_full_slice(obj, line: int) -> bool:
+def is_full_slice(obj: object, line: int) -> bool:
     """
     We have a full length slice.
     """
@@ -358,7 +363,7 @@ def is_full_slice(obj, line: int) -> bool:
     )
 
 
-def get_callable_name(obj):
+def get_callable_name(obj: object) -> str | None:
     # typical case has name
     if hasattr(obj, "__name__"):
         return obj.__name__
@@ -375,7 +380,7 @@ def get_callable_name(obj):
     return None
 
 
-def apply_if_callable(maybe_callable, obj, **kwargs):
+def apply_if_callable(maybe_callable: Any, obj: Any, **kwargs: Any) -> Any:
     """
     Evaluate possibly callable input using obj and kwargs if it is callable,
     otherwise return as it is.
@@ -394,7 +399,7 @@ def apply_if_callable(maybe_callable, obj, **kwargs):
     return maybe_callable
 
 
-def standardize_mapping(into):
+def standardize_mapping(into: type | abc.Mapping) -> type | partial:
     """
     Helper function to standardize a supplied mapping.
 
@@ -436,7 +441,9 @@ def random_state(
 ) -> np.random.RandomState: ...
 
 
-def random_state(state: RandomState | None = None):
+def random_state(
+    state: RandomState | None = None,
+) -> np.random.RandomState | np.random.Generator:
     """
     Helper function for processing random_state arguments.
 
@@ -463,7 +470,7 @@ def random_state(state: RandomState | None = None):
     elif isinstance(state, np.random.Generator):
         return state
     elif state is None:
-        return np.random
+        return np.random  # type: ignore[return-value]
     else:
         raise ValueError(
             "random_state must be an integer, array-like, a BitGenerator, Generator, "
@@ -533,13 +540,13 @@ def pipe(
         return func(obj, *args, **kwargs)
 
 
-def get_rename_function(mapper):
+def get_rename_function(mapper: Any) -> Callable:
     """
     Returns a function that will map names/labels, dependent if mapper
     is a dict, Series or just a function.
     """
 
-    def f(x):
+    def f(x: Hashable) -> Any:
         if x in mapper:
             return mapper[x]
         else:
@@ -564,7 +571,9 @@ def convert_to_list_like(
 
 
 @contextlib.contextmanager
-def temp_setattr(obj, attr: str, value, condition: bool = True) -> Generator[None]:
+def temp_setattr(
+    obj: Any, attr: str, value: Any, condition: bool = True
+) -> Generator[Any]:
     """
     Temporarily set attribute on an object.
 
@@ -594,7 +603,7 @@ def temp_setattr(obj, attr: str, value, condition: bool = True) -> Generator[Non
             setattr(obj, attr, old_value)
 
 
-def require_length_match(data, index: Index) -> None:
+def require_length_match(data: Any, index: Index) -> None:
     """
     Check the length of data matches the length of the index.
     """
@@ -660,7 +669,7 @@ def fill_missing_names(names: Sequence[Hashable | None]) -> list[Hashable]:
     return [f"level_{i}" if name is None else name for i, name in enumerate(names)]
 
 
-def is_local_in_caller_frame(obj):
+def is_local_in_caller_frame(obj: NDFrame) -> bool:
     """
     Helper function used in detecting chained assignment.
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -366,7 +366,7 @@ def is_full_slice(obj: object, line: int) -> bool:
 def get_callable_name(obj: object) -> str | None:
     # typical case has name
     if hasattr(obj, "__name__"):
-        return obj.__name__
+        return obj.__name__  # pyright: ignore[reportAttributeAccessIssue]
     # some objects don't; could recurse
     if isinstance(obj, partial):
         return get_callable_name(obj.func)

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -545,7 +545,6 @@ def sanitize_masked_array(data: ma.MaskedArray) -> np.ndarray:
     mask = ma.getmaskarray(data)
     if mask.any():
         dtype, fill_value = maybe_promote(data.dtype, np.nan)
-        dtype = cast("np.dtype", dtype)
         data = ma.asarray(data.astype(dtype, copy=True))
         data.soften_mask()  # set hardmask False if it was True
         data[mask] = fill_value

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -144,7 +144,7 @@ def maybe_convert_platform(
     return arr
 
 
-def is_nested_object(obj) -> bool:
+def is_nested_object(obj: object) -> bool:
     """
     return a boolean if we have a nested object, e.g. a Series with 1 or
     more Series elements
@@ -234,7 +234,7 @@ def _maybe_unbox_datetimelike(value: Scalar, dtype: DtypeObj) -> Scalar:
     return value
 
 
-def _disallow_mismatched_datetimelike(value, dtype: DtypeObj) -> None:
+def _disallow_mismatched_datetimelike(value: Scalar, dtype: DtypeObj) -> None:
     """
     numpy allows np.array(dt64values, dtype="timedelta64[ns]") and
     vice-versa, but we do not want to allow this, so we need to
@@ -325,7 +325,7 @@ def maybe_downcast_numeric(
         # e.g. SparseDtype has no itemsize attr
         return result
 
-    def trans(x):
+    def trans(x: np.ndarray) -> np.ndarray:
         if do_round:
             return x.round()
         return x
@@ -448,7 +448,7 @@ _canonical_nans = {
 }
 
 
-def maybe_promote(dtype: np.dtype, fill_value=np.nan):
+def maybe_promote(dtype: np.dtype, fill_value: Any = np.nan) -> tuple[np.dtype, Any]:
     """
     Find the minimal dtype that can hold both the given dtype and fill_value.
 
@@ -506,14 +506,16 @@ def maybe_promote(dtype: np.dtype, fill_value=np.nan):
 
 
 @functools.lru_cache
-def _maybe_promote_cached(dtype, fill_value, fill_value_type):
+def _maybe_promote_cached(
+    dtype: np.dtype, fill_value: Any, fill_value_type: type
+) -> tuple[np.dtype, Any]:
     # The cached version of _maybe_promote below
     # This also use fill_value_type as (unused) argument to use this in the
     # cache lookup -> to differentiate 1 and True
     return _maybe_promote(dtype, fill_value)
 
 
-def _maybe_promote(dtype: np.dtype, fill_value=np.nan):
+def _maybe_promote(dtype: np.dtype, fill_value: Any = np.nan) -> tuple[np.dtype, Any]:
     # The actual implementation of the function, use `maybe_promote` above for
     # a cached version.
     if not is_scalar(fill_value):
@@ -554,8 +556,8 @@ def _maybe_promote(dtype: np.dtype, fill_value=np.nan):
 
         dta = DatetimeArray._from_sequence([], dtype="M8[ns]")
         try:
-            fv = dta._validate_setitem_value(fill_value)
-            return dta.dtype, fv
+            fv = dta._validate_setitem_value(fill_value)  # type: ignore[no-untyped-call]
+            return cast("np.dtype", dta.dtype), fv
         except (ValueError, TypeError):
             return _dtype_obj, fill_value
 
@@ -637,7 +639,7 @@ def _maybe_promote(dtype: np.dtype, fill_value=np.nan):
     return dtype, fill_value
 
 
-def _ensure_dtype_type(value, dtype: np.dtype):
+def _ensure_dtype_type(value: Any, dtype: np.dtype) -> Any:
     """
     Ensure that the given value is an instance of the given dtype.
 
@@ -662,7 +664,7 @@ def _ensure_dtype_type(value, dtype: np.dtype):
     return dtype.type(value)
 
 
-def infer_dtype_from(val) -> tuple[DtypeObj, Any]:
+def infer_dtype_from(val: object) -> tuple[DtypeObj, Any]:
     """
     Interpret the dtype from a scalar or array.
 
@@ -675,7 +677,7 @@ def infer_dtype_from(val) -> tuple[DtypeObj, Any]:
     return infer_dtype_from_array(val)
 
 
-def infer_dtype_from_scalar(val) -> tuple[DtypeObj, Any]:
+def infer_dtype_from_scalar(val: object) -> tuple[DtypeObj, Any]:
     """
     Interpret the dtype from a scalar.
 
@@ -779,7 +781,7 @@ def dict_compat(d: dict[Scalar, Scalar]) -> dict[Scalar, Scalar]:
     return {maybe_box_datetimelike(key): value for key, value in d.items()}
 
 
-def infer_dtype_from_array(arr) -> tuple[DtypeObj, ArrayLike]:
+def infer_dtype_from_array(arr: Any) -> tuple[DtypeObj, ArrayLike]:
     """
     Infer the dtype from an array.
 
@@ -822,7 +824,7 @@ def infer_dtype_from_array(arr) -> tuple[DtypeObj, ArrayLike]:
     return arr.dtype, arr
 
 
-def _maybe_infer_dtype_type(element):
+def _maybe_infer_dtype_type(element: object) -> DtypeObj | None:
     """
     Try to infer an object's dtype, for use in arithmetic ops.
 
@@ -875,7 +877,7 @@ def invalidate_string_dtypes(dtype_set: set[DtypeObj]) -> None:
         )
 
 
-def coerce_indexer_dtype(indexer, categories) -> np.ndarray:
+def coerce_indexer_dtype(indexer: np.ndarray, categories: Index) -> np.ndarray:
     """coerce the indexer input array to the smallest dtype possible"""
     length = len(categories)
     if length < _int8_max:
@@ -1068,9 +1070,8 @@ def convert_dtypes(
         # GH 53648
         inferred_dtype = _arrow_dtype_mapping()[inferred_dtype.pyarrow_dtype]
 
-    # error: Incompatible return value type (got "Union[str, Union[dtype[Any],
-    # ExtensionDtype]]", expected "Union[dtype[Any], ExtensionDtype]")
-    return inferred_dtype  # type: ignore[return-value]
+    assert not isinstance(inferred_dtype, str)
+    return inferred_dtype
 
 
 def maybe_cast_to_datetime(
@@ -1303,7 +1304,7 @@ def find_common_type(types: list[ExtensionDtype]) -> DtypeObj: ...
 def find_common_type(types: list[DtypeObj]) -> DtypeObj: ...
 
 
-def find_common_type(types):
+def find_common_type(types: list[DtypeObj]) -> DtypeObj:  # type: ignore[misc]
     """
     Find a common data type among the given dtypes.
 
@@ -1341,21 +1342,24 @@ def find_common_type(types):
                     return res
         return np.dtype("object")
 
+    # At this point, all types are np.dtype (ExtensionDtype was handled above)
+    np_types = cast("list[np.dtype]", types)
+
     # take lowest unit
-    if all(lib.is_np_dtype(t, "M") for t in types):
-        return np.dtype(max(types))
-    if all(lib.is_np_dtype(t, "m") for t in types):
-        return np.dtype(max(types))
+    if all(lib.is_np_dtype(t, "M") for t in np_types):
+        return np.dtype(max(np_types))
+    if all(lib.is_np_dtype(t, "m") for t in np_types):
+        return np.dtype(max(np_types))
 
     # don't mix bool / int or float or complex
     # this is different from numpy, which casts bool with float/int as int
-    has_bools = any(t.kind == "b" for t in types)
+    has_bools = any(t.kind == "b" for t in np_types)
     if has_bools:
-        for t in types:
+        for t in np_types:
             if t.kind in "iufc":
                 return np.dtype("object")
 
-    return np_find_common_type(*types)
+    return np_find_common_type(*np_types)
 
 
 def construct_2d_arraylike_from_scalar(
@@ -1439,7 +1443,7 @@ def construct_1d_arraylike_from_scalar(
     return subarr
 
 
-def maybe_unbox_numpy_scalar(value):
+def maybe_unbox_numpy_scalar(value: Any) -> Any:
     result = value
     if using_python_scalars() and isinstance(value, np.generic):
         if isinstance(result, np.longdouble):
@@ -1455,7 +1459,7 @@ def maybe_unbox_numpy_scalar(value):
     return result
 
 
-def _maybe_box_and_unbox_datetimelike(value: Scalar, dtype: DtypeObj):
+def _maybe_box_and_unbox_datetimelike(value: Scalar, dtype: DtypeObj) -> Scalar:
     # Caller is responsible for checking dtype.kind in "mM"
 
     if isinstance(value, dt.datetime):
@@ -1628,7 +1632,7 @@ def can_hold_element(arr: ArrayLike, element: Any) -> bool:
                 "PeriodArray | DatetimeArray | TimedeltaArray | IntervalArray", arr
             )
             try:
-                arr._validate_setitem_value(element)
+                arr._validate_setitem_value(element)  # type: ignore[no-untyped-call]
                 return True
             except (ValueError, TypeError):
                 return False
@@ -1735,7 +1739,7 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
                     #  itemsize issues there?
                     return casted
                 raise LossySetitemError
-            if dtype.itemsize < tipo.itemsize:
+            if dtype.itemsize < tipo.itemsize:  # type: ignore[union-attr]
                 raise LossySetitemError
             if not isinstance(tipo, np.dtype):
                 # i.e. nullable IntegerDtype; we can put this into an ndarray
@@ -1833,7 +1837,7 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
         # TODO: test tests.frame.methods.test_replace tests get here,
         #  need more targeted tests.  xref phofl has a PR about this
         if tipo is not None:
-            if tipo.kind == "S" and tipo.itemsize <= dtype.itemsize:
+            if tipo.kind == "S" and tipo.itemsize <= dtype.itemsize:  # type: ignore[union-attr]
                 return element
             raise LossySetitemError
         if isinstance(element, bytes) and len(element) <= dtype.itemsize:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -17265,8 +17265,7 @@ class DataFrame(NDFrame, OpsMixin):
             result = result.__finalize__(self, method="kurt")
         return result
 
-    # error: Incompatible types in assignment
-    kurtosis = kurt  # type: ignore[assignment]
+    kurtosis = kurt
     product = prod
 
     def cummin(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -17265,7 +17265,8 @@ class DataFrame(NDFrame, OpsMixin):
             result = result.__finalize__(self, method="kurt")
         return result
 
-    kurtosis = kurt
+    # error: Incompatible types in assignment
+    kurtosis = kurt  # type: ignore[assignment]
     product = prod
 
     def cummin(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1813,7 +1813,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         # Validate keys
         keys = common.maybe_make_list(keys)
         invalid_keys = [
-            k for k in keys if not self._is_label_or_level_reference(k, axis=axis)
+            k
+            for k in keys  # pyright: ignore[reportOptionalIterable]
+            if not self._is_label_or_level_reference(k, axis=axis)
         ]
 
         if invalid_keys:
@@ -1823,9 +1825,17 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             )
 
         # Compute levels and labels to drop
-        levels_to_drop = [k for k in keys if self._is_level_reference(k, axis=axis)]
+        levels_to_drop = [
+            k
+            for k in keys  # pyright: ignore[reportOptionalIterable]
+            if self._is_level_reference(k, axis=axis)
+        ]
 
-        labels_to_drop = [k for k in keys if not self._is_level_reference(k, axis=axis)]
+        labels_to_drop = [
+            k
+            for k in keys  # pyright: ignore[reportOptionalIterable]
+            if not self._is_level_reference(k, axis=axis)
+        ]
 
         # Perform copy upfront and then use inplace operations below.
         # This ensures that we always perform exactly one copy.

--- a/pandas/core/methods/to_dict.py
+++ b/pandas/core/methods/to_dict.py
@@ -152,8 +152,7 @@ def to_dict(
             stacklevel=find_stack_level(),
         )
     # GH16122
-    # error: Call to untyped function "standardize_mapping" in typed context
-    into_c = com.standardize_mapping(into)  # type: ignore[no-untyped-call]
+    into_c = com.standardize_mapping(into)
 
     #  error: Incompatible types in assignment (expression has type "str",
     # variable has type "Literal['dict', 'list', 'series', 'split', 'tight',

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -964,7 +964,7 @@ class _MergeOperation:
         self.right = self.orig_right = _right
         self.how, self.anti_join = self._validate_how(how)
 
-        self.on = com.maybe_make_list(on)
+        self.on = com.maybe_make_list(on)  # type: ignore[assignment]
 
         self.suffixes = suffixes
         self.sort = sort or how == "outer"

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2434,7 +2434,7 @@ class _AsOfMerge(_OrderedMerge):
 
         # GH#29130 Check that merge keys do not have dtype object
         if not self.left_index:
-            left_on_0 = left_on[0]
+            left_on_0 = left_on[0]  # pyright: ignore[reportOptionalSubscript]
             if isinstance(left_on_0, _known):
                 lo_dtype = left_on_0.dtype
             else:
@@ -2447,7 +2447,7 @@ class _AsOfMerge(_OrderedMerge):
             lo_dtype = self.left.index.dtype
 
         if not self.right_index:
-            right_on_0 = right_on[0]
+            right_on_0 = right_on[0]  # pyright: ignore[reportOptionalSubscript]
             if isinstance(right_on_0, _known):
                 ro_dtype = right_on_0.dtype
             else:

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -470,7 +470,7 @@ class MPLPlot(ABC):
 
         if self.style is not None:
             if isinstance(self.style, dict):
-                styles = [self.style[col] for col in self.columns if col in self.style]  # pyright: ignore[reportOptionalIterable]
+                styles = [self.style[col] for col in self.columns if col in self.style]  # type: ignore[union-attr]  # pyright: ignore[reportOptionalIterable]
             elif is_list_like(self.style):
                 styles = self.style
             else:
@@ -504,7 +504,7 @@ class MPLPlot(ABC):
         elif self.by is not None and self._kind == "hist":
             return len(self._grouped)
         elif self.by is not None and self._kind == "box":
-            return len(self.columns)
+            return len(self.columns)  # type: ignore[arg-type]
         else:
             return data.shape[1]
 
@@ -677,7 +677,7 @@ class MPLPlot(ABC):
             else:
                 data = data.to_frame(name=label)
         elif self._kind in ("hist", "box"):
-            cols = self.columns if self.by is None else self.columns + self.by
+            cols = self.columns if self.by is None else self.columns + self.by  # type: ignore[operator]
             data = data.loc[:, cols]
         return data
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -536,7 +536,6 @@ module = [
   "pandas.core.arrays.*", # TODO
   "pandas.core.computation.*", # TODO
   "pandas.core.dtypes.astype", # TODO
-  "pandas.core.dtypes.cast", # TODO
   "pandas.core.dtypes.common", # TODO
   "pandas.core.dtypes.concat", # TODO
   "pandas.core.dtypes.dtypes", # TODO
@@ -569,7 +568,6 @@ module = [
   "pandas.core.apply", # TODO
   "pandas.core.arraylike", # TODO
   "pandas.core.base", # TODO
-  "pandas.core.common", # TODO
   "pandas.core.construction", # TODO
   "pandas.core.flags", # TODO
   "pandas.core.frame", # TODO


### PR DESCRIPTION
## Summary
- Add complete type annotations to all untyped functions in `pandas/core/common.py` (~20 functions) and `pandas/core/dtypes/cast.py` (~15 functions)
- Remove both modules from the mypy override list in `pyproject.toml` (removing `disallow_untyped_defs = false`, `disallow_untyped_calls = false`, `disallow_incomplete_defs = false`)
- Fix downstream type errors exposed by the new annotations in `apply.py`, `construction.py`, `frame.py`, `to_dict.py`, `merge.py`, and `plotting/_matplotlib/core.py`

## Annotation strategy
- `object` for parameters where only identity checks (`is`, `isinstance`) are used
- `Any` for parameters where attributes/methods are accessed dynamically or the type is too broad to narrow (e.g. elements from object-dtype arrays)
- Tightened signatures where callers are few and specific (e.g. `coerce_indexer_dtype(indexer: np.ndarray, categories: Index)`, `consensus_name_attr(objs: list[Series | DataFrame])`)

## Test plan
- [x] `mypy pandas/` passes clean
- [x] `pyright pandas/core/common.py pandas/core/dtypes/cast.py` passes clean
- [x] All tests in `pandas/tests/dtypes/cast/` and `pandas/tests/test_common.py` pass