### PR TITLE
TYP: Add type annotations to Index (pandas/core/indexes/base.py)

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1896,7 +1896,7 @@ def normalize_keyword_aggregation(
     uniquified_aggspec = _make_unique_kwarg_list(aggspec_order)
 
     # get the new index of columns by comparison
-    col_idx_order = Index(uniquified_aggspec).get_indexer(uniquified_order)
+    col_idx_order = Index(uniquified_aggspec).get_indexer(uniquified_order)  # type: ignore[arg-type]
     return aggspec, columns, col_idx_order
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4233,7 +4233,7 @@ class DataFrame(NDFrame, OpsMixin):
                 return self._getitem_multilevel(key)
             indexer = self.columns.get_loc(key)
             if is_integer(indexer):
-                indexer = [indexer]
+                indexer = [indexer]  # type: ignore[assignment]
         else:
             if is_iterator(key):
                 key = list(key)
@@ -4241,7 +4241,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         # take() does not accept boolean indexers
         if getattr(indexer, "dtype", None) == bool:
-            indexer = np.where(indexer)[0]
+            indexer = np.where(indexer)[0]  # type: ignore[arg-type, assignment]
 
         if isinstance(indexer, slice):
             return self._slice(indexer, axis=1)
@@ -4673,7 +4673,7 @@ class DataFrame(NDFrame, OpsMixin):
             elif is_scalar(loc):
                 locs = [loc]
             else:
-                locs = loc.nonzero()[0]
+                locs = loc.nonzero()[0]  # type: ignore[union-attr]
 
             return self.isetitem(locs, value)
 
@@ -4763,7 +4763,7 @@ class DataFrame(NDFrame, OpsMixin):
                 iindex = cast("int", index)
             else:
                 icol = self.columns.get_loc(col)
-                iindex = self.index.get_loc(index)
+                iindex = self.index.get_loc(index)  # type: ignore[assignment]
             self._mgr.column_setitem(icol, iindex, value, inplace_only=True)
 
         except (KeyError, TypeError, ValueError, LossySetitemError):
@@ -4821,7 +4821,7 @@ class DataFrame(NDFrame, OpsMixin):
 
     def _get_item(self, item: Hashable) -> Series:
         loc = self.columns.get_loc(item)
-        return self._ixs(loc, axis=1)
+        return self._ixs(loc, axis=1)  # type: ignore[arg-type]
 
     # ----------------------------------------------------------------------
     # Unsorted
@@ -7130,13 +7130,13 @@ class DataFrame(NDFrame, OpsMixin):
                 level = [level]
             level = [self.index._get_level_number(lev) for lev in level]
             if len(level) < self.index.nlevels:
-                new_index = self.index.droplevel(level)
+                new_index = self.index.droplevel(level)  # type: ignore[assignment]
 
         if not drop:
             to_insert: Iterable[tuple[Any, Any | None]]
 
             default = "index" if "index" not in self else "level_0"
-            names = self.index._get_default_index_names(names, default)
+            names = self.index._get_default_index_names(names, default)  # type: ignore[arg-type]
 
             if isinstance(self.index, MultiIndex):
                 to_insert = zip(
@@ -7642,7 +7642,7 @@ class DataFrame(NDFrame, OpsMixin):
             if not is_list_like(subset):
                 subset = [cast("Hashable", subset)]
             ax = self._get_axis(agg_axis)
-            indices = ax.get_indexer_for(subset)
+            indices = ax.get_indexer_for(subset)  # type: ignore[arg-type]
             check = indices == -1
             if check.any():
                 raise KeyError(np.array(subset)[check].tolist())
@@ -13366,7 +13366,7 @@ class DataFrame(NDFrame, OpsMixin):
         if ignore_index:
             result.index = default_index(len(result))
         else:
-            result.index = self.index.take(result.index)
+            result.index = self.index.take(result.index)  # type: ignore[arg-type]
         result = result.reindex(columns=self.columns)
 
         return result.__finalize__(self, method="explode")
@@ -17265,8 +17265,7 @@ class DataFrame(NDFrame, OpsMixin):
             result = result.__finalize__(self, method="kurt")
         return result
 
-    # error: Incompatible types in assignment
-    kurtosis = kurt  # type: ignore[assignment]
+    kurtosis = kurt
     product = prod
 
     def cummin(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -17265,7 +17265,8 @@ class DataFrame(NDFrame, OpsMixin):
             result = result.__finalize__(self, method="kurt")
         return result
 
-    kurtosis = kurt
+    # error: Incompatible types in assignment
+    kurtosis = kurt  # type: ignore[assignment]
     product = prod
 
     def cummin(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1033,9 +1033,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             # GH 13473
             if not callable(replacements):
                 if ax._is_multi and level is not None:
-                    indexer = ax.get_level_values(level).get_indexer_for(replacements)
+                    indexer = ax.get_level_values(level).get_indexer_for(replacements)  # type: ignore[arg-type]
                 else:
-                    indexer = ax.get_indexer_for(replacements)
+                    indexer = ax.get_indexer_for(replacements)  # type: ignore[arg-type]
 
                 if errors == "raise" and len(indexer[indexer == -1]):
                     missing_labels = [

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -363,9 +363,9 @@ class Grouper:
                 if self._indexer is not None:
                     reverse_indexer = self._indexer.argsort()
                     unsorted_ax = self._grouper.take(reverse_indexer)
-                    ax = unsorted_ax.take(obj.index)
+                    ax = unsorted_ax.take(obj.index)  # type: ignore[arg-type]
                 else:
-                    ax = self._grouper.take(obj.index)
+                    ax = self._grouper.take(obj.index)  # type: ignore[arg-type]
             else:
                 if key not in obj._info_axis:
                     raise KeyError(f"The grouper name {key} is not found")
@@ -686,7 +686,7 @@ class Grouping:
     @cache_readonly
     def groups(self) -> dict[Hashable, Index]:
         codes, uniques = self._codes_and_uniques
-        uniques = Index._with_infer(uniques, name=self.name, copy=False)
+        uniques = Index._with_infer(uniques, name=self.name, copy=False)  # type: ignore[assignment]
 
         r, counts = libalgos.groupsort_indexer(ensure_platform_int(codes), len(uniques))
         counts = ensure_int64(counts).cumsum()

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -798,7 +798,7 @@ class BaseGrouper:
         # When passed a categorical grouping, keep all categories
         for k, (ping, level) in enumerate(zip(self.groupings, levels, strict=True)):
             if ping._passed_categorical:
-                levels[k] = level.set_categories(ping._orig_cats)
+                levels[k] = level.set_categories(ping._orig_cats)  # type: ignore[attr-defined]
 
         if len(self.groupings) == 1:
             result_index = levels[0]

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4302,10 +4302,10 @@ class Index(IndexOpsMixin, PandasObject):
             # TODO: tests where passing `keep_order=not self._is_multi`
             #  makes a difference for non-MultiIndex case
             target, indexer, _ = self._join_level(
-                target,
+                target,  # type: ignore[arg-type]
                 level,
                 how="right",
-                keep_order=not self._is_multi,  # type: ignore[arg-type]
+                keep_order=not self._is_multi,
             )
 
         elif self.equals(target):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2607,7 +2607,7 @@ class Index(IndexOpsMixin, PandasObject):
     # Null Handling Methods
 
     @cache_readonly
-    def _na_value(self) -> object:
+    def _na_value(self) -> Hashable:
         """The expected NA value to use with this index."""
         dtype = self.dtype
         if isinstance(dtype, np.dtype):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1814,7 +1814,7 @@ class Index(IndexOpsMixin, PandasObject):
             )
 
         # All items in 'new_names' need to be hashable
-        validate_all_hashable(*new_names, error_name=f"{type(self).__name__}.name")  # pyright: ignore[reportOptionalIterable]
+        validate_all_hashable(*new_names, error_name=f"{type(self).__name__}.name")  # pyright: ignore[reportOptionalIterable, reportGeneralTypeIssues]
 
         return new_names  # pyright: ignore[reportReturnType]
 
@@ -4953,7 +4953,7 @@ class Index(IndexOpsMixin, PandasObject):
                 join_array, lidx, ridx = self._left_indexer(other)  # pyright: ignore[reportArgumentType]
                 join_index, lidx, ridx = self._wrap_join_result(
                     join_array,
-                    other,
+                    other,  # pyright: ignore[reportArgumentType]
                     lidx,
                     ridx,
                     how,  # pyright: ignore[reportArgumentType]
@@ -4968,7 +4968,7 @@ class Index(IndexOpsMixin, PandasObject):
                 join_array, ridx, lidx = other._left_indexer(self)
                 join_index, lidx, ridx = self._wrap_join_result(
                     join_array,
-                    other,
+                    other,  # pyright: ignore[reportArgumentType]
                     lidx,
                     ridx,
                     how,  # pyright: ignore[reportArgumentType]
@@ -4977,7 +4977,7 @@ class Index(IndexOpsMixin, PandasObject):
             join_array, lidx, ridx = self._inner_indexer(other)  # pyright: ignore[reportArgumentType]
             join_index, lidx, ridx = self._wrap_join_result(
                 join_array,
-                other,
+                other,  # pyright: ignore[reportArgumentType]
                 lidx,
                 ridx,
                 how,  # pyright: ignore[reportArgumentType]
@@ -4986,7 +4986,7 @@ class Index(IndexOpsMixin, PandasObject):
             join_array, lidx, ridx = self._outer_indexer(other)  # pyright: ignore[reportArgumentType]
             join_index, lidx, ridx = self._wrap_join_result(
                 join_array,
-                other,
+                other,  # pyright: ignore[reportArgumentType]
                 lidx,
                 ridx,
                 how,  # pyright: ignore[reportArgumentType]
@@ -5914,7 +5914,7 @@ class Index(IndexOpsMixin, PandasObject):
             if isinstance(loc, slice):
                 return self[loc][-1]
 
-        return self[loc]
+        return self[loc]  # pyright: ignore[reportReturnType]
 
     def asof_locs(
         self, where: Index, mask: npt.NDArray[np.bool_]
@@ -6983,7 +6983,8 @@ class Index(IndexOpsMixin, PandasObject):
             # everything for it to work (element ordering, search side and
             # resulting value).
             pos = self[::-1].searchsorted(  # type: ignore[call-overload]
-                label, side="right" if side == "left" else "left"
+                label,
+                side="right" if side == "left" else "left",  # pyright: ignore[reportArgumentType]
             )
             return maybe_unbox_numpy_scalar(len(self) - pos)  # type: ignore[no-untyped-call]
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6983,8 +6983,8 @@ class Index(IndexOpsMixin, PandasObject):
             # everything for it to work (element ordering, search side and
             # resulting value).
             pos = self[::-1].searchsorted(  # type: ignore[call-overload]
-                label,
-                side="right" if side == "left" else "left",  # pyright: ignore[reportArgumentType]
+                label,  # pyright: ignore[reportArgumentType]
+                side="right" if side == "left" else "left",
             )
             return maybe_unbox_numpy_scalar(len(self) - pos)  # type: ignore[no-untyped-call]
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -957,10 +957,10 @@ class Index(IndexOpsMixin, PandasObject):
             return tuple(self.__array_wrap__(x) for x in result)
         elif method == "reduce":
             result = lib.item_from_zerodim(result)
-            return maybe_unbox_numpy_scalar(result)  # type: ignore[no-untyped-call]
+            return maybe_unbox_numpy_scalar(result)
         elif is_scalar(result):
             # e.g. matmul
-            return maybe_unbox_numpy_scalar(result)  # type: ignore[no-untyped-call]
+            return maybe_unbox_numpy_scalar(result)
 
         if result.dtype == np.float16:
             result = result.astype(np.float32)
@@ -5501,7 +5501,7 @@ class Index(IndexOpsMixin, PandasObject):
         key = lib.item_from_zerodim(key)
         if is_integer(key) or is_float(key):
             # GH#44051 exclude bool, which would return a 2d ndarray
-            key = com.cast_scalar_indexer(key)  # type: ignore[no-untyped-call]
+            key = com.cast_scalar_indexer(key)
             return getitem(key)  # pyright: ignore[reportReturnType]
 
         if isinstance(key, slice):
@@ -6986,7 +6986,7 @@ class Index(IndexOpsMixin, PandasObject):
                 label,  # pyright: ignore[reportArgumentType]
                 side="right" if side == "left" else "left",
             )
-            return maybe_unbox_numpy_scalar(len(self) - pos)  # type: ignore[no-untyped-call]
+            return maybe_unbox_numpy_scalar(len(self) - pos)
 
         raise ValueError("index must be monotonic increasing or decreasing")
 
@@ -7179,8 +7179,8 @@ class Index(IndexOpsMixin, PandasObject):
             if start_slice == -1:
                 start_slice -= len(self)
 
-        start_slice = maybe_unbox_numpy_scalar(start_slice)  # type: ignore[no-untyped-call]
-        end_slice = maybe_unbox_numpy_scalar(end_slice)  # type: ignore[no-untyped-call]
+        start_slice = maybe_unbox_numpy_scalar(start_slice)
+        end_slice = maybe_unbox_numpy_scalar(end_slice)
         return start_slice, end_slice
 
     def delete(
@@ -7603,7 +7603,7 @@ class Index(IndexOpsMixin, PandasObject):
             # i.e. EA, call _reduce instead of "any" to get TypeError instead
             #  of AttributeError
             return vals._reduce("any")
-        return maybe_unbox_numpy_scalar(np.any(vals))  # type: ignore[no-untyped-call]
+        return maybe_unbox_numpy_scalar(np.any(vals))
 
     def all(self, *args: Any, **kwargs: Any) -> Any:
         """
@@ -7654,7 +7654,7 @@ class Index(IndexOpsMixin, PandasObject):
             # i.e. EA, call _reduce instead of "all" to get TypeError instead
             #  of AttributeError
             return vals._reduce("all")
-        return maybe_unbox_numpy_scalar(np.all(vals))  # type: ignore[no-untyped-call]
+        return maybe_unbox_numpy_scalar(np.all(vals))
 
     @final
     def _maybe_disable_logical_methods(self, opname: str_t) -> None:
@@ -7850,7 +7850,7 @@ class Index(IndexOpsMixin, PandasObject):
             # quick check
             first = self[0]
             if not isna(first):
-                return maybe_unbox_numpy_scalar(first)  # type: ignore[no-untyped-call]
+                return maybe_unbox_numpy_scalar(first)
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
@@ -7861,7 +7861,7 @@ class Index(IndexOpsMixin, PandasObject):
         if not self._is_multi and not isinstance(self._values, np.ndarray):
             return self._values._reduce(name="min", skipna=skipna)
 
-        return maybe_unbox_numpy_scalar(nanops.nanmin(self._values, skipna=skipna))  # type: ignore[no-untyped-call]
+        return maybe_unbox_numpy_scalar(nanops.nanmin(self._values, skipna=skipna))
 
     def max(
         self,
@@ -7923,18 +7923,18 @@ class Index(IndexOpsMixin, PandasObject):
             # quick check
             last = self[-1]
             if not isna(last):
-                return maybe_unbox_numpy_scalar(last)  # type: ignore[no-untyped-call]
+                return maybe_unbox_numpy_scalar(last)
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
             mask = self._isnan
             if not skipna or mask.all():
-                return maybe_unbox_numpy_scalar(self._na_value)  # type: ignore[no-untyped-call]
+                return maybe_unbox_numpy_scalar(self._na_value)
 
         if not self._is_multi and not isinstance(self._values, np.ndarray):
             return self._values._reduce(name="max", skipna=skipna)
 
-        return maybe_unbox_numpy_scalar(nanops.nanmax(self._values, skipna=skipna))  # type: ignore[no-untyped-call]
+        return maybe_unbox_numpy_scalar(nanops.nanmax(self._values, skipna=skipna))
 
     # --------------------------------------------------------------------
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -12,6 +12,7 @@ from typing import (
     Literal,
     NoReturn,
     Self,
+    SupportsIndex,
     cast,
     final,
     overload,
@@ -194,6 +195,7 @@ if TYPE_CHECKING:
         Dtype,
         DtypeObj,
         F,
+        Frequency,
         IgnoreRaise,
         IndexLabel,
         IndexT,
@@ -260,14 +262,14 @@ def _maybe_return_indexers(meth: F) -> F:
 
     @functools.wraps(meth)
     def join(
-        self,
+        self: Index,
         other: Index,
         *,
         how: JoinHow = "left",
-        level=None,
+        level: Level | None = None,
         return_indexers: bool = False,
         sort: bool = False,
-    ):
+    ) -> Index | tuple[Index, npt.NDArray[np.intp] | None, npt.NDArray[np.intp] | None]:
         join_index, lidx, ridx = meth(self, other, how=how, level=level, sort=sort)
         if not return_indexers:
             return join_index
@@ -281,7 +283,7 @@ def _maybe_return_indexers(meth: F) -> F:
     return cast("F", join)
 
 
-def _new_Index(cls, d):
+def _new_Index(cls: type[Index], d: dict) -> Index:
     """
     This is called upon unpickling, rather than the default which doesn't
     have arguments and breaks __new__.
@@ -292,7 +294,7 @@ def _new_Index(cls, d):
     if issubclass(cls, ABCPeriodIndex):
         from pandas.core.indexes.period import _new_PeriodIndex
 
-        return _new_PeriodIndex(cls, **d)
+        return _new_PeriodIndex(cls, **d)  # type: ignore[no-untyped-call]
 
     if issubclass(cls, ABCMultiIndex):
         if "labels" in d and "codes" not in d:
@@ -307,7 +309,7 @@ def _new_Index(cls, d):
         # Prevent Index.__new__ from conducting inference;
         #  "data" key not in RangeIndex
         d["dtype"] = d["data"].dtype
-    return cls.__new__(cls, **d)
+    return cls.__new__(cls, **d)  # pyright: ignore[reportArgumentType]
 
 
 @set_module("pandas")
@@ -475,10 +477,10 @@ class Index(IndexOpsMixin, PandasObject):
 
     def __new__(
         cls,
-        data=None,
-        dtype=None,
+        data: Any = None,
+        dtype: Dtype | None = None,
         copy: bool | None = None,
-        name=None,
+        name: Hashable = None,
         tupleize_cols: bool = True,
     ) -> Self:
         from pandas.core.indexes.range import RangeIndex
@@ -501,7 +503,7 @@ class Index(IndexOpsMixin, PandasObject):
         if isinstance(data, (range, RangeIndex)):
             result = RangeIndex(start=data, copy=bool(copy), name=name)
             if dtype is not None:
-                return result.astype(dtype, copy=False)
+                return result.astype(dtype, copy=False)  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
             # error: Incompatible return value type (got "MultiIndex",
             # expected "Self")
             return result  # type: ignore[return-value]
@@ -574,15 +576,15 @@ class Index(IndexOpsMixin, PandasObject):
             if "Data must be 1-dimensional" in str(err):
                 raise ValueError("Index data must be 1-dimensional") from err
             raise
-        arr = ensure_wrapped_if_datetimelike(arr)
+        arr = ensure_wrapped_if_datetimelike(arr)  # type: ignore[no-untyped-call]
 
         klass = cls._dtype_to_subclass(arr.dtype)
 
         arr = klass._ensure_array(arr, arr.dtype, copy=False)
-        return klass._simple_new(arr, name, refs=refs)
+        return klass._simple_new(arr, name, refs=refs)  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
 
     @classmethod
-    def _ensure_array(cls, data, dtype, copy: bool):
+    def _ensure_array(cls, data: ArrayLike, dtype: DtypeObj, copy: bool) -> ArrayLike:
         """
         Ensure we have a valid array to pass to _simple_new.
         """
@@ -601,7 +603,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     @classmethod
-    def _dtype_to_subclass(cls, dtype: DtypeObj):
+    def _dtype_to_subclass(cls, dtype: DtypeObj) -> type[Index]:
         # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
 
         if isinstance(dtype, ExtensionDtype):
@@ -668,7 +670,7 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @classmethod
-    def _with_infer(cls, *args, **kwargs):
+    def _with_infer(cls, *args: Any, **kwargs: Any) -> Self:
         """
         Constructor that uses the 1.0.x behavior inferring numeric dtypes
         for ndarray[object] inputs.
@@ -681,7 +683,7 @@ class Index(IndexOpsMixin, PandasObject):
             # "ndarray[Any, Any]"
             values = lib.maybe_convert_objects(result._values)  # type: ignore[arg-type]
             if values.dtype.kind in "iufb":
-                return Index(values, name=result.name, copy=False)
+                return Index(values, name=result.name, copy=False)  # type: ignore[return-value]
 
         return result
 
@@ -749,7 +751,7 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Index Internals Methods
 
-    def _shallow_copy(self, values, name: Hashable = no_default) -> Self:
+    def _shallow_copy(self, values: ArrayLike, name: Hashable = no_default) -> Self:
         """
         Create a new Index with the same class as the caller, don't copy the
         data, use the same object attributes with passed in attributes taking
@@ -785,7 +787,7 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @final
-    def is_(self, other) -> bool:
+    def is_(self, other: Index) -> bool:
         """
         More flexible, faster check like ``is`` but that works through views.
 
@@ -794,8 +796,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        other : object
-            Other object to compare against.
+        other : Index
+            Other Index to compare against.
 
         Returns
         -------
@@ -819,10 +821,10 @@ class Index(IndexOpsMixin, PandasObject):
             return True
         elif not hasattr(other, "_id"):
             return False
-        elif self._id is None or other._id is None:
+        elif self._id is None or other._id is None:  # pyright: ignore[reportAttributeAccessIssue]
             return False
         else:
-            return self._id is other._id
+            return self._id is other._id  # pyright: ignore[reportAttributeAccessIssue]
 
     @final
     def _reset_identity(self) -> None:
@@ -834,7 +836,7 @@ class Index(IndexOpsMixin, PandasObject):
     @final
     def _cleanup(self) -> None:
         if "_engine" in self._cache:
-            self._engine.clear_mapping()
+            self._engine.clear_mapping()  # type: ignore[no-untyped-call]
 
     @cache_readonly
     def _engine(
@@ -911,7 +913,9 @@ class Index(IndexOpsMixin, PandasObject):
         """
         return len(self._data)
 
-    def __array__(self, dtype=None, copy=None) -> np.ndarray:
+    def __array__(
+        self, dtype: npt.DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
         """
         The array interface, return my values.
         """
@@ -921,7 +925,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         return np.array(self._data, dtype=dtype, copy=copy)
 
-    def __array_ufunc__(self, ufunc: np.ufunc, method: str_t, *inputs, **kwargs):
+    def __array_ufunc__(
+        self, ufunc: np.ufunc, method: str_t, *inputs: Any, **kwargs: Any
+    ) -> Any:
         if any(isinstance(other, (ABCSeries, ABCDataFrame)) for other in inputs):
             return NotImplemented
 
@@ -951,10 +957,10 @@ class Index(IndexOpsMixin, PandasObject):
             return tuple(self.__array_wrap__(x) for x in result)
         elif method == "reduce":
             result = lib.item_from_zerodim(result)
-            return maybe_unbox_numpy_scalar(result)
+            return maybe_unbox_numpy_scalar(result)  # type: ignore[no-untyped-call]
         elif is_scalar(result):
             # e.g. matmul
-            return maybe_unbox_numpy_scalar(result)
+            return maybe_unbox_numpy_scalar(result)  # type: ignore[no-untyped-call]
 
         if result.dtype == np.float16:
             result = result.astype(np.float32)
@@ -962,11 +968,16 @@ class Index(IndexOpsMixin, PandasObject):
         return self.__array_wrap__(result)
 
     @final
-    def __array_wrap__(self, result, context=None, return_scalar=False):
+    def __array_wrap__(
+        self,
+        result: np.ndarray,
+        context: tuple | None = None,
+        return_scalar: bool = False,
+    ) -> Any:
         """
         Gets called after a ufunc and other functions e.g. np.split.
         """
-        result = lib.item_from_zerodim(result)
+        result = lib.item_from_zerodim(result)  # type: ignore[assignment]
         if np.ndim(result) > 1:
             # Reached in plotting tests with e.g. np.nonzero(index)
             return result
@@ -1024,9 +1035,9 @@ class Index(IndexOpsMixin, PandasObject):
         >>> s.index.ravel()
         Index(['a', 'b', 'c'], dtype='str')
         """
-        return self[:]
+        return self[:]  # type: ignore[return-value]
 
-    def view(self, cls=None):
+    def view(self, cls: npt.DTypeLike | None = None) -> Index:
         """
         Return a view of the Index with the specified dtype or a new Index instance.
 
@@ -1085,26 +1096,26 @@ class Index(IndexOpsMixin, PandasObject):
         if cls is not None:
             dtype = cls
             if isinstance(cls, str):
-                dtype = pandas_dtype(cls)
+                dtype = pandas_dtype(cls)  # type: ignore[assignment]
 
-            if needs_i8_conversion(dtype):
-                idx_cls = self._dtype_to_subclass(dtype)
-                arr = self.array.view(dtype)
+            if needs_i8_conversion(dtype):  # type: ignore[arg-type]
+                idx_cls = self._dtype_to_subclass(dtype)  # type: ignore[arg-type]
+                arr = self.array.view(dtype)  # type: ignore[arg-type]
                 if isinstance(arr, ExtensionArray):
                     # here we exclude non-supported dt64/td64 dtypes
                     return idx_cls._simple_new(
                         arr, name=self.name, refs=self._references
                     )
-                return arr
+                return arr  # type: ignore[return-value]
 
-            result = self._data.view(cls)
+            result = self._data.view(cls)  # type: ignore[arg-type]
         else:
-            result = self._view()
+            result = self._view()  # type: ignore[assignment]
         if isinstance(result, Index):
             result._id = self._id
-        return result
+        return result  # type: ignore[return-value]
 
-    def astype(self, dtype: Dtype, copy: bool = True):
+    def astype(self, dtype: Dtype, copy: bool = True) -> Index:
         """
         Create an Index with values cast to dtypes.
 
@@ -1175,11 +1186,11 @@ class Index(IndexOpsMixin, PandasObject):
 
     def take(
         self,
-        indices,
+        indices: Sequence[int] | np.ndarray,
         axis: Axis = 0,
         allow_fill: bool = True,
-        fill_value=None,
-        **kwargs,
+        fill_value: object = None,
+        **kwargs: Any,
     ) -> Self:
         """
         Return a new Index of the values selected by the indices.
@@ -1248,10 +1259,12 @@ class Index(IndexOpsMixin, PandasObject):
             taken = values.take(
                 indices, allow_fill=allow_fill, fill_value=self._na_value
             )
-        return self._constructor._simple_new(taken, name=self.name)
+        return self._constructor._simple_new(taken, name=self.name)  # pyright: ignore[reportArgumentType]
 
     @final
-    def _maybe_disallow_fill(self, allow_fill: bool, fill_value, indices) -> bool:
+    def _maybe_disallow_fill(
+        self, allow_fill: bool, fill_value: object, indices: npt.NDArray[np.intp]
+    ) -> bool:
         """
         We only use pandas-style take when allow_fill is True _and_
         fill_value is not None.
@@ -1273,7 +1286,7 @@ class Index(IndexOpsMixin, PandasObject):
             allow_fill = False
         return allow_fill
 
-    def repeat(self, repeats, axis: None = None) -> Self:
+    def repeat(self, repeats: int | Sequence[int], axis: None = None) -> Self:
         """
         Repeat elements of an Index.
 
@@ -1310,9 +1323,9 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx.repeat([1, 2, 3])
         Index(['a', 'b', 'b', 'c', 'c', 'c'], dtype='str')
         """
-        repeats = ensure_platform_int(repeats)
+        repeats = ensure_platform_int(repeats)  # type: ignore[assignment]
         nv.validate_repeat((), {"axis": axis})
-        res_values = self._values.repeat(repeats)
+        res_values = self._values.repeat(repeats)  # pyright: ignore[reportArgumentType]
 
         # _constructor so RangeIndex-> Index with an int64 dtype
         return self._constructor._simple_new(res_values, name=self.name)
@@ -1374,7 +1387,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self.copy(deep=False)
 
     @final
-    def __deepcopy__(self, memo=None) -> Self:
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
         """
         Parameters
         ----------
@@ -1400,14 +1413,14 @@ class Index(IndexOpsMixin, PandasObject):
         return f"{klass_name}({data}{prepr})"
 
     @property
-    def _formatter_func(self):
+    def _formatter_func(self) -> Callable:
         """
         Return the formatter function.
         """
         return default_pprint
 
     @final
-    def _format_data(self, name=None) -> str_t:
+    def _format_data(self, name: str_t | None = None) -> str_t:
         """
         Return the formatted data as a unicode string.
         """
@@ -1457,7 +1470,7 @@ class Index(IndexOpsMixin, PandasObject):
         Return a name or list of names with None replaced by the level number.
         """
         if self._is_multi:
-            return maybe_sequence_to_range(
+            return maybe_sequence_to_range(  # type: ignore[return-value]
                 [
                     level if name is None else name
                     for level, name in enumerate(self.names)
@@ -1471,7 +1484,7 @@ class Index(IndexOpsMixin, PandasObject):
         # how to represent ourselves to matplotlib
         if isinstance(self.dtype, np.dtype) and self.dtype.kind != "M":
             return cast("np.ndarray", self.values)
-        return self.astype(object, copy=False)._values
+        return self.astype(object, copy=False)._values  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
 
     _default_na_rep = "NaN"
 
@@ -1524,9 +1537,9 @@ class Index(IndexOpsMixin, PandasObject):
         *,
         na_rep: str_t = "",
         decimal: str_t = ".",
-        float_format=None,
-        date_format=None,
-        quoting=None,
+        float_format: str_t | None = None,
+        date_format: str_t | None = None,
+        quoting: int | None = None,
     ) -> npt.NDArray[np.object_]:
         return get_values_for_csv(
             self._values,
@@ -1537,7 +1550,7 @@ class Index(IndexOpsMixin, PandasObject):
             quoting=quoting,
         )
 
-    def _summary(self, name=None) -> str_t:
+    def _summary(self, name: str_t | None = None) -> str_t:
         """
         Return a summarized representation.
 
@@ -1553,13 +1566,13 @@ class Index(IndexOpsMixin, PandasObject):
         if len(self) > 0:
             head = self[0]
             if hasattr(head, "format") and not isinstance(head, str):
-                head = head.format()
+                head = head.format()  # pyright: ignore[reportAttributeAccessIssue]
             elif needs_i8_conversion(self.dtype):
                 # e.g. Timedelta, display as values, not quoted
                 head = self._formatter_func(head).replace("'", "")
             tail = self[-1]
             if hasattr(tail, "format") and not isinstance(tail, str):
-                tail = tail.format()
+                tail = tail.format()  # pyright: ignore[reportAttributeAccessIssue]
             elif needs_i8_conversion(self.dtype):
                 # e.g. Timedelta, display as values, not quoted
                 tail = self._formatter_func(tail).replace("'", "")
@@ -1594,7 +1607,9 @@ class Index(IndexOpsMixin, PandasObject):
         return self
 
     @final
-    def to_series(self, index=None, name: Hashable | None = None) -> Series:
+    def to_series(
+        self, index: Axes | None = None, name: Hashable | None = None
+    ) -> Series:
         """
         Create a Series with both index and values equal to the index keys.
 
@@ -1602,7 +1617,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        index : Index, optional
+        index : Index or array-like, optional
             Index of resulting Series. If None, defaults to original index.
         name : str, optional
             Name of resulting Series. If None, defaults to name of original
@@ -1769,7 +1784,10 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     def _validate_names(
-        self, name=None, names=None, deep: bool = False
+        self,
+        name: Hashable = None,
+        names: Sequence[Hashable] | None = None,
+        deep: bool = False,
     ) -> list[Hashable]:
         """
         Handles the quirks of having a singular 'name' parameter for general
@@ -1790,18 +1808,20 @@ class Index(IndexOpsMixin, PandasObject):
         else:
             new_names = name
 
-        if len(new_names) != len(self.names):
+        if len(new_names) != len(self.names):  # pyright: ignore[reportArgumentType]
             raise ValueError(
-                f"Length of new names must be {len(self.names)}, got {len(new_names)}"
+                f"Length of new names must be {len(self.names)}, got {len(new_names)}"  # pyright: ignore[reportArgumentType]
             )
 
         # All items in 'new_names' need to be hashable
         validate_all_hashable(*new_names, error_name=f"{type(self).__name__}.name")  # pyright: ignore[reportOptionalIterable]
 
-        return new_names
+        return new_names  # pyright: ignore[reportReturnType]
 
     def _get_default_index_names(
-        self, names: Hashable | Sequence[Hashable] | None = None, default=None
+        self,
+        names: Sequence[Hashable] | int | str_t | None = None,
+        default: Hashable = None,
     ) -> list[Hashable]:
         """
         Get names of index.
@@ -1833,7 +1853,7 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 names = [default] if self.name is None else [self.name]
 
-        return names
+        return names  # pyright: ignore[reportReturnType]
 
     def _get_names(self) -> FrozenList:
         """
@@ -1870,7 +1890,9 @@ class Index(IndexOpsMixin, PandasObject):
         """
         return FrozenList((self.name,))
 
-    def _set_names(self, values, *, level=None) -> None:
+    def _set_names(
+        self, values: Sequence[Hashable], *, level: int | Sequence[int] | None = None
+    ) -> None:
         """
         Set new names on index. Each name has to be a hashable type.
 
@@ -1900,15 +1922,39 @@ class Index(IndexOpsMixin, PandasObject):
     names = property(fset=_set_names, fget=_get_names)
 
     @overload
-    def set_names(self, names, *, level=..., inplace: Literal[False] = ...) -> Self: ...
+    def set_names(
+        self,
+        names: Hashable | Sequence[Hashable] | dict[Hashable, Hashable],
+        *,
+        level: Hashable | Sequence[Hashable] | None = ...,
+        inplace: Literal[False] = ...,
+    ) -> Self: ...
 
     @overload
-    def set_names(self, names, *, level=..., inplace: Literal[True]) -> None: ...
+    def set_names(
+        self,
+        names: Hashable | Sequence[Hashable] | dict[Hashable, Hashable],
+        *,
+        level: Hashable | Sequence[Hashable] | None = ...,
+        inplace: Literal[True],
+    ) -> None: ...
 
     @overload
-    def set_names(self, names, *, level=..., inplace: bool = ...) -> Self | None: ...
+    def set_names(
+        self,
+        names: Hashable | Sequence[Hashable] | dict[Hashable, Hashable],
+        *,
+        level: Hashable | Sequence[Hashable] | None = ...,
+        inplace: bool = ...,
+    ) -> Self | None: ...
 
-    def set_names(self, names, *, level=None, inplace: bool = False) -> Self | None:
+    def set_names(
+        self,
+        names: Hashable | Sequence[Hashable] | dict[Hashable, Hashable],
+        *,
+        level: Hashable | Sequence[Hashable] | None = None,
+        inplace: bool = False,
+    ) -> Self | None:
         """
         Set Index or MultiIndex name.
 
@@ -1985,15 +2031,17 @@ class Index(IndexOpsMixin, PandasObject):
 
         if isinstance(self, ABCMultiIndex) and is_dict_like(names) and level is None:
             # Transform dict to list of new names and corresponding levels
-            level, names_adjusted = [], []
+            level_list: list[int] = []
+            names_adjusted: list[Hashable] = []
             for i, name in enumerate(self.names):
-                if name in names.keys():
-                    level.append(i)
-                    names_adjusted.append(names[name])
+                if name in names.keys():  # type: ignore[union-attr]
+                    level_list.append(i)
+                    names_adjusted.append(names[name])  # type: ignore[index]
+            level = level_list
             names = names_adjusted
 
         if not is_list_like(names):
-            names = [names]
+            names = [names]  # type: ignore[assignment]
         if level is not None and not is_list_like(level):
             level = [level]
 
@@ -2002,18 +2050,24 @@ class Index(IndexOpsMixin, PandasObject):
         else:
             idx = self._view()
 
-        idx._set_names(names, level=level)
+        idx._set_names(names, level=level)  # type: ignore[arg-type]
         if not inplace:
-            return idx
+            return idx  # pyright: ignore[reportReturnType]
         return None
 
     @overload
-    def rename(self, name, *, inplace: Literal[False] = ...) -> Self: ...
+    def rename(
+        self, name: Hashable | Sequence[Hashable], *, inplace: Literal[False] = ...
+    ) -> Self: ...
 
     @overload
-    def rename(self, name, *, inplace: Literal[True]) -> None: ...
+    def rename(
+        self, name: Hashable | Sequence[Hashable], *, inplace: Literal[True]
+    ) -> None: ...
 
-    def rename(self, name, *, inplace: bool = False) -> Self | None:
+    def rename(
+        self, name: Hashable | Sequence[Hashable], *, inplace: bool = False
+    ) -> Self | None:
         """
         Alter Index or MultiIndex name.
 
@@ -2081,7 +2135,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self
 
     @final
-    def _validate_index_level(self, level) -> None:
+    def _validate_index_level(self, level: Level) -> None:
         """
         Validate index level.
 
@@ -2104,15 +2158,15 @@ class Index(IndexOpsMixin, PandasObject):
                 f"Requested level ({level}) does not match index name ({self.name})"
             )
 
-    def _get_level_number(self, level) -> int:
+    def _get_level_number(self, level: Level) -> int:
         self._validate_index_level(level)
         return 0
 
     def sortlevel(
         self,
-        level=None,
+        level: Level | None = None,
         ascending: bool | list[bool] = True,
-        sort_remaining=None,
+        sort_remaining: bool | None = None,
         na_position: NaPosition = "first",
     ) -> tuple[Self, np.ndarray]:
         """
@@ -2154,7 +2208,7 @@ class Index(IndexOpsMixin, PandasObject):
             return_indexer=True, ascending=ascending, na_position=na_position
         )
 
-    def _get_level_values(self, level) -> Index:
+    def _get_level_values(self, level: Level) -> Index:
         """
         Return an Index of values for requested level.
 
@@ -2196,7 +2250,7 @@ class Index(IndexOpsMixin, PandasObject):
     get_level_values = _get_level_values
 
     @final
-    def droplevel(self, level: IndexLabel = 0):
+    def droplevel(self, level: IndexLabel = 0) -> Index:
         """
         Return index with requested level(s) removed.
 
@@ -2255,7 +2309,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self._drop_level_numbers(levnums)
 
     @final
-    def _drop_level_numbers(self, levnums: list[int]):
+    def _drop_level_numbers(self, levnums: list[int]) -> Index:
         """
         Drop MultiIndex levels by level _number_, not name.
         """
@@ -2545,7 +2599,7 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Pickle Methods
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple:
         d = {"data": self._data, "name": self.name}
         return _new_Index, (type(self), d), None
 
@@ -2553,7 +2607,7 @@ class Index(IndexOpsMixin, PandasObject):
     # Null Handling Methods
 
     @cache_readonly
-    def _na_value(self):
+    def _na_value(self) -> object:
         """The expected NA value to use with this index."""
         dtype = self.dtype
         if isinstance(dtype, np.dtype):
@@ -2712,7 +2766,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     notnull = notna
 
-    def fillna(self, value):
+    def fillna(self, value: object) -> Index:
         """
         Fill NA/NaN values with the specified value.
 
@@ -2826,7 +2880,7 @@ class Index(IndexOpsMixin, PandasObject):
         if self.is_unique:
             return self._view()
 
-        result = super().unique()
+        result = super().unique()  # type: ignore[no-untyped-call]
         return self._shallow_copy(result)
 
     def drop_duplicates(self, *, keep: DropKeep = "first") -> Self:
@@ -2947,7 +3001,7 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Arithmetic & Logical Methods
 
-    def __iadd__(self, other):
+    def __iadd__(self, other: object) -> Self:  # type: ignore[misc]
         # alias for __add__
         return self + other
 
@@ -2961,18 +3015,18 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Set Operation Methods
 
-    def _get_reconciled_name_object(self, other):
+    def _get_reconciled_name_object(self, other: Index) -> Self:
         """
         If the result of a set operation will be self,
         return a shallow copy of self.
         """
-        name = get_op_result_name(self, other)
+        name = get_op_result_name(self, other)  # type: ignore[no-untyped-call]
         if self.name is not name:
             return self.rename(name)
         return self.copy(deep=False)
 
     @final
-    def _validate_sort_keyword(self, sort) -> None:
+    def _validate_sort_keyword(self, sort: bool | None) -> None:
         if sort not in [None, False, True]:
             raise ValueError(
                 "The 'sort' keyword only takes the values of "
@@ -3003,7 +3057,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self, other
 
     @final
-    def union(self, other, sort: bool | None = None):
+    def union(self, other: Axes, sort: bool | None = None) -> Index:
         """
         Form the union of two Index objects.
 
@@ -3130,11 +3184,11 @@ class Index(IndexOpsMixin, PandasObject):
                 return result.sort_values()
             return result
 
-        result = self._union(other, sort=sort)
+        union_result = self._union(other, sort=sort)
 
-        return self._wrap_setop_result(other, result)
+        return self._wrap_setop_result(other, union_result)
 
-    def _union(self, other: Index, sort: bool | None):
+    def _union(self, other: Index, sort: bool | None) -> Index | ArrayLike | MultiIndex:
         """
         Specific union logic should go here. In subclasses, union behavior
         should be overwritten here rather than in `self.union`.
@@ -3152,7 +3206,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        Index
+        Index, MultiIndex, or ArrayLike
         """
         lvals = self._values
         rvals = other._values
@@ -3167,7 +3221,7 @@ class Index(IndexOpsMixin, PandasObject):
             #  (actually don't need either unique, but without this restriction
             #  test_union_same_value_duplicated_in_both fails)
             try:
-                return self._outer_indexer(other)[0]
+                return self._outer_indexer(other)[0]  # pyright: ignore[reportArgumentType]
             except TypeError:
                 # incomparable objects; should only be for object dtype
                 value_list = list(lvals)
@@ -3211,8 +3265,10 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @final
-    def _wrap_setop_result(self, other: Index, result) -> Index:
-        name = get_op_result_name(self, other)
+    def _wrap_setop_result(
+        self, other: Index, result: Index | ArrayLike | MultiIndex
+    ) -> Index:
+        name = get_op_result_name(self, other)  # type: ignore[no-untyped-call]
         if isinstance(result, Index):
             if result.name != name:
                 result = result.rename(name)
@@ -3221,7 +3277,7 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @final
-    def intersection(self, other, sort: bool = False):
+    def intersection(self, other: Axes, sort: bool = False) -> Index:
         # default sort keyword is different here from other setops intentionally
         #  done in GH#25063
         """
@@ -3313,16 +3369,18 @@ class Index(IndexOpsMixin, PandasObject):
             other = other.astype(dtype, copy=False)
             return this.intersection(other, sort=sort)
 
-        result = self._intersection(other, sort=sort)
+        result = self._intersection(other, sort=sort)  # type: ignore[assignment]
         return self._wrap_intersection_result(other, result)
 
-    def _intersection(self, other: Index, sort: bool = False):
+    def _intersection(
+        self, other: Index, sort: bool = False
+    ) -> Index | ArrayLike | MultiIndex:
         """
         intersection specialized to the case with matching dtypes.
         """
         if self._can_use_libjoin and other._can_use_libjoin:
             try:
-                res_indexer, indexer, _ = self._inner_indexer(other)
+                res_indexer, indexer, _ = self._inner_indexer(other)  # pyright: ignore[reportArgumentType]
             except TypeError:
                 # non-comparable; should only be for object dtype
                 pass
@@ -3335,19 +3393,21 @@ class Index(IndexOpsMixin, PandasObject):
                 else:
                     result = self.take(indexer)
                     res = result.drop_duplicates()  # type: ignore[assignment]
-                return ensure_wrapped_if_datetimelike(res)
+                return ensure_wrapped_if_datetimelike(res)  # type: ignore[no-untyped-call]
 
         res_values = self._intersection_via_get_indexer(other, sort=sort)
-        res_values = _maybe_try_sort(res_values, sort)
+        res_values = _maybe_try_sort(res_values, sort)  # type: ignore[assignment]
         return res_values
 
-    def _wrap_intersection_result(self, other, result):
+    def _wrap_intersection_result(
+        self, other: Index, result: Index | ArrayLike | MultiIndex
+    ) -> Index:
         # We will override for MultiIndex to handle empty results
         return self._wrap_setop_result(other, result)
 
     @final
     def _intersection_via_get_indexer(
-        self, other: Index | MultiIndex, sort
+        self, other: Index | MultiIndex, sort: bool | None
     ) -> ArrayLike | MultiIndex:
         """
         Find the intersection of two Indexes using get_indexer.
@@ -3379,7 +3439,7 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @final
-    def difference(self, other, sort: bool | None = None):
+    def difference(self, other: Axes, sort: bool | None = None) -> Index:
         """
         Return a new Index with elements of index not in `other`.
 
@@ -3450,7 +3510,7 @@ class Index(IndexOpsMixin, PandasObject):
         result = self._difference(other, sort=sort)
         return self._wrap_difference_result(other, result)
 
-    def _difference(self, other, sort):
+    def _difference(self, other: Index, sort: bool | None) -> Index:
         # overridden by RangeIndex
         this = self
         if isinstance(self, ABCCategoricalIndex) and self.hasnans and other.hasnans:
@@ -3458,19 +3518,21 @@ class Index(IndexOpsMixin, PandasObject):
         other = other.unique()
         the_diff = this[other.get_indexer_for(this) == -1]
         the_diff = the_diff if this.is_unique else the_diff.unique()
-        the_diff = _maybe_try_sort(the_diff, sort)
+        the_diff = cast("Index", _maybe_try_sort(the_diff, sort))
         return the_diff
 
-    def _wrap_difference_result(self, other, result):
+    def _wrap_difference_result(
+        self, other: Index, result: Index | ArrayLike | MultiIndex
+    ) -> Index:
         # We will override for MultiIndex to handle empty results
         return self._wrap_setop_result(other, result)
 
     def symmetric_difference(
         self,
-        other,
+        other: Axes,
         result_name: abc.Hashable | None = None,
         sort: bool | None = None,
-    ):
+    ) -> Index:
         """
         Compute the symmetric difference of two Index objects.
 
@@ -3548,7 +3610,7 @@ class Index(IndexOpsMixin, PandasObject):
         left_indexer = np.setdiff1d(
             np.arange(this.size), common_indexer, assume_unique=True
         )
-        left_diff = this.take(left_indexer)
+        left_diff = this.take(left_indexer)  # pyright: ignore[reportArgumentType]
 
         # {other} minus {this}
         right_indexer = (indexer == -1).nonzero()[0]
@@ -3564,26 +3626,27 @@ class Index(IndexOpsMixin, PandasObject):
             if len(result) == 0:
                 # result might be an Index, if other was an Index
                 return left_diff.remove_unused_levels().set_names(result_name)
+            result = cast("Index", result)
             return result.set_names(result_name)
 
     @final
-    def _assert_can_do_setop(self, other) -> bool:
+    def _assert_can_do_setop(self, other: Axes) -> bool:
         if not is_list_like(other):
             raise TypeError("Input must be Index or array-like")
         return True
 
-    def _convert_can_do_setop(self, other) -> tuple[Index, Hashable]:
+    def _convert_can_do_setop(self, other: Axes) -> tuple[Index, Hashable]:
         if not isinstance(other, Index):
             other = Index(other, name=self.name)
             result_name = self.name
         else:
-            result_name = get_op_result_name(self, other)
+            result_name = get_op_result_name(self, other)  # type: ignore[no-untyped-call]
         return other, result_name
 
     # --------------------------------------------------------------------
     # Indexing Methods
 
-    def get_loc(self, key):
+    def get_loc(self, key: Hashable) -> int | slice | npt.NDArray[np.bool_]:
         """
         Get integer location, slice or boolean mask for requested label.
 
@@ -3646,10 +3709,10 @@ class Index(IndexOpsMixin, PandasObject):
     @final
     def get_indexer(
         self,
-        target,
+        target: Axes,
         method: ReindexMethod | None = None,
         limit: int | None = None,
-        tolerance=None,
+        tolerance: Any = None,
     ) -> npt.NDArray[np.intp]:
         """
         Compute indexer and mask for new index given the current index.
@@ -3729,6 +3792,7 @@ class Index(IndexOpsMixin, PandasObject):
             # _maybe_cast_listlike_indexer ensures target has our dtype
             #  (could improve perf by doing _should_compare check earlier?)
             assert self.dtype == target.dtype
+            target = cast("CategoricalIndex", target)
 
             indexer = self._engine.get_indexer(target.codes)
             if self.hasnans and target.hasnans:
@@ -3739,7 +3803,7 @@ class Index(IndexOpsMixin, PandasObject):
                 target_nans = isna(orig_target)
                 loc = self.get_loc(np.nan)
                 mask = target.isna()
-                indexer[target_nans] = loc
+                indexer[target_nans] = loc  # type: ignore[assignment]
                 indexer[mask & ~target_nans] = -1
             return indexer
 
@@ -3748,6 +3812,7 @@ class Index(IndexOpsMixin, PandasObject):
             # get an indexer for unique categories then propagate to codes via take_nd
             # get_indexer instead of _get_indexer needed for MultiIndex cases
             #  e.g. test_append_different_columns_types
+            target = cast("CategoricalIndex", target)
             categories_indexer = self.get_indexer(target.categories)
 
             indexer = algos.take_nd(categories_indexer, target.codes, fill_value=-1)
@@ -3758,7 +3823,7 @@ class Index(IndexOpsMixin, PandasObject):
                 # GH#41934
                 loc = self.get_loc(np.nan)
                 mask = target.isna()
-                indexer[mask] = loc
+                indexer[mask] = loc  # type: ignore[assignment]
 
             return ensure_platform_int(indexer)
 
@@ -3790,7 +3855,7 @@ class Index(IndexOpsMixin, PandasObject):
         target: Index,
         method: str_t | None = None,
         limit: int | None = None,
-        tolerance=None,
+        tolerance: Any = None,
     ) -> npt.NDArray[np.intp]:
         if tolerance is not None:
             tolerance = self._convert_tolerance(tolerance, target)
@@ -3810,7 +3875,7 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 tgt_values = target._get_engine_target()
 
-            indexer = self._engine.get_indexer(tgt_values)
+            indexer = self._engine.get_indexer(tgt_values)  # pyright: ignore[reportArgumentType]
 
         return ensure_platform_int(indexer)
 
@@ -3831,7 +3896,7 @@ class Index(IndexOpsMixin, PandasObject):
         self,
         method: str_t | None,
         limit: int | None = None,
-        tolerance=None,
+        tolerance: Any = None,
     ) -> None:
         """
         Raise if we have a get_indexer `method` that is not supported or valid.
@@ -3872,7 +3937,9 @@ class Index(IndexOpsMixin, PandasObject):
                     "backfill or nearest reindexing"
                 )
 
-    def _convert_tolerance(self, tolerance, target: np.ndarray | Index) -> np.ndarray:
+    def _convert_tolerance(
+        self, tolerance: Any, target: np.ndarray | Index
+    ) -> np.ndarray:
         # override this method on subclasses
         tolerance = np.asarray(tolerance)
         if target.size != tolerance.size and tolerance.size > 1:
@@ -3892,7 +3959,11 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     def _get_fill_indexer(
-        self, target: Index, method: str_t, limit: int | None = None, tolerance=None
+        self,
+        target: Index,
+        method: str_t,
+        limit: int | None = None,
+        tolerance: Any = None,
     ) -> npt.NDArray[np.intp]:
         if self._is_multi:
             if not (self.is_monotonic_increasing or self.is_monotonic_decreasing):
@@ -3959,7 +4030,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     def _get_nearest_indexer(
-        self, target: Index, limit: int | None, tolerance
+        self, target: Index, limit: int | None, tolerance: Any
     ) -> npt.NDArray[np.intp]:
         """
         Get the indexer for the nearest index labels; requires an index with
@@ -3994,7 +4065,7 @@ class Index(IndexOpsMixin, PandasObject):
         self,
         target: Index,
         indexer: npt.NDArray[np.intp],
-        tolerance,
+        tolerance: Any,
     ) -> npt.NDArray[np.intp]:
         distance = self._difference_compat(target, indexer)
 
@@ -4031,7 +4102,9 @@ class Index(IndexOpsMixin, PandasObject):
         self._validate_indexer("positional", key.stop, "iloc")
         self._validate_indexer("positional", key.step, "iloc")
 
-    def _convert_slice_indexer(self, key: slice, kind: Literal["loc", "getitem"]):
+    def _convert_slice_indexer(
+        self, key: slice, kind: Literal["loc", "getitem"]
+    ) -> slice:
         """
         Convert a slice indexer.
 
@@ -4100,7 +4173,7 @@ class Index(IndexOpsMixin, PandasObject):
     def _raise_invalid_indexer(
         self,
         form: Literal["slice", "positional"],
-        key,
+        key: object,
         reraise: lib.NoDefault | None | Exception = lib.no_default,
     ) -> None:
         """
@@ -4136,9 +4209,9 @@ class Index(IndexOpsMixin, PandasObject):
 
     def reindex(
         self,
-        target,
+        target: Axes,
         method: ReindexMethod | None = None,
-        level=None,
+        level: Level | None = None,
         limit: int | None = None,
         tolerance: float | None = None,
     ) -> tuple[Index, npt.NDArray[np.intp] | None]:
@@ -4213,7 +4286,6 @@ class Index(IndexOpsMixin, PandasObject):
 
         if not isinstance(target, Index) and len(target) == 0:
             if level is not None and self._is_multi:
-                # "Index" has no attribute "levels"; maybe "nlevels"?
                 idx = self.levels[level]  # type: ignore[attr-defined]
             else:
                 idx = self
@@ -4230,7 +4302,10 @@ class Index(IndexOpsMixin, PandasObject):
             # TODO: tests where passing `keep_order=not self._is_multi`
             #  makes a difference for non-MultiIndex case
             target, indexer, _ = self._join_level(
-                target, level, how="right", keep_order=not self._is_multi
+                target,
+                level,
+                how="right",
+                keep_order=not self._is_multi,  # type: ignore[arg-type]
             )
 
         elif self.equals(target):
@@ -4247,10 +4322,12 @@ class Index(IndexOpsMixin, PandasObject):
         else:
             indexer, _ = self.get_indexer_non_unique(target)
 
-        target = self._wrap_reindex_result(target, indexer, preserve_names)
+        target = self._wrap_reindex_result(target, indexer, preserve_names)  # type: ignore[arg-type]
         return target, indexer
 
-    def _wrap_reindex_result(self, target, indexer, preserve_names: bool):
+    def _wrap_reindex_result(
+        self, target: Index, indexer: npt.NDArray[np.intp] | None, preserve_names: bool
+    ) -> Index:
         target = self._maybe_preserve_names(target, preserve_names)
         return target
 
@@ -4560,26 +4637,28 @@ class Index(IndexOpsMixin, PandasObject):
             except TypeError:
                 join_index = self.union(other)
                 try:
-                    join_index = _maybe_try_sort(join_index, sort)
+                    join_index = _maybe_try_sort(join_index, sort)  # type: ignore[assignment]
                 except TypeError:
                     pass
 
         names = other.names if how == "right" else self.names
-        if join_index.names != names:
-            join_index = join_index.set_names(names)
+        if join_index.names != names:  # pyright: ignore[reportAttributeAccessIssue]
+            join_index = join_index.set_names(names)  # pyright: ignore[reportAttributeAccessIssue]
 
         if join_index is self:
             lindexer = None
         else:
-            lindexer = self.get_indexer_for(join_index)
+            lindexer = self.get_indexer_for(join_index)  # pyright: ignore[reportArgumentType]
         if join_index is other:
             rindexer = None
         else:
-            rindexer = other.get_indexer_for(join_index)
-        return join_index, lindexer, rindexer
+            rindexer = other.get_indexer_for(join_index)  # pyright: ignore[reportArgumentType]
+        return join_index, lindexer, rindexer  # pyright: ignore[reportReturnType]
 
     @final
-    def _join_multi(self, other: Index, how: JoinHow):
+    def _join_multi(
+        self, other: Index, how: JoinHow
+    ) -> tuple[Index, npt.NDArray[np.intp] | None, npt.NDArray[np.intp] | None]:
         from pandas.core.indexes.multi import MultiIndex
         from pandas.core.reshape.merge import restore_dropped_levels_multijoin
 
@@ -4606,8 +4685,8 @@ class Index(IndexOpsMixin, PandasObject):
                 self_jnlevels = self
                 other_jnlevels = other.reorder_levels(self.names)
             else:
-                self_jnlevels = self.droplevel(ldrop_names)
-                other_jnlevels = other.droplevel(rdrop_names)
+                self_jnlevels = self.droplevel(ldrop_names)  # type: ignore[assignment]
+                other_jnlevels = other.droplevel(rdrop_names)  # type: ignore[assignment]
 
             # Join left and right
             # Join on same leveled multi-index frames is supported
@@ -4698,7 +4777,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @final
     def _join_level(
-        self, other: Index, level, how: JoinHow = "left", keep_order: bool = True
+        self, other: Index, level: Level, how: JoinHow = "left", keep_order: bool = True
     ) -> tuple[MultiIndex, npt.NDArray[np.intp] | None, npt.NDArray[np.intp] | None]:
         """
         The join method *only* affects the level of the resulting
@@ -4869,11 +4948,15 @@ class Index(IndexOpsMixin, PandasObject):
                 # We can perform much better than the general case
                 join_index = self
                 lidx = None
-                ridx = self._left_indexer_unique(other)
+                ridx = self._left_indexer_unique(other)  # pyright: ignore[reportArgumentType]
             else:
-                join_array, lidx, ridx = self._left_indexer(other)
+                join_array, lidx, ridx = self._left_indexer(other)  # pyright: ignore[reportArgumentType]
                 join_index, lidx, ridx = self._wrap_join_result(
-                    join_array, other, lidx, ridx, how
+                    join_array,
+                    other,
+                    lidx,
+                    ridx,
+                    how,  # pyright: ignore[reportArgumentType]
                 )
         elif how == "right":
             if self.is_unique:
@@ -4884,17 +4967,29 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 join_array, ridx, lidx = other._left_indexer(self)
                 join_index, lidx, ridx = self._wrap_join_result(
-                    join_array, other, lidx, ridx, how
+                    join_array,
+                    other,
+                    lidx,
+                    ridx,
+                    how,  # pyright: ignore[reportArgumentType]
                 )
         elif how == "inner":
-            join_array, lidx, ridx = self._inner_indexer(other)
+            join_array, lidx, ridx = self._inner_indexer(other)  # pyright: ignore[reportArgumentType]
             join_index, lidx, ridx = self._wrap_join_result(
-                join_array, other, lidx, ridx, how
+                join_array,
+                other,
+                lidx,
+                ridx,
+                how,  # pyright: ignore[reportArgumentType]
             )
         elif how == "outer":
-            join_array, lidx, ridx = self._outer_indexer(other)
+            join_array, lidx, ridx = self._outer_indexer(other)  # pyright: ignore[reportArgumentType]
             join_index, lidx, ridx = self._wrap_join_result(
-                join_array, other, lidx, ridx, how
+                join_array,
+                other,
+                lidx,
+                ridx,
+                how,  # pyright: ignore[reportArgumentType]
             )
 
         lidx = None if lidx is None else ensure_platform_int(lidx)
@@ -5233,7 +5328,7 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @final
-    def where(self, cond, other=None) -> Index:
+    def where(self, cond: np.ndarray, other: object = None) -> Index:
         """
         Replace values where the condition is False.
 
@@ -5275,7 +5370,7 @@ class Index(IndexOpsMixin, PandasObject):
     # construction helpers
     @final
     @classmethod
-    def _raise_scalar_data_error(cls, data):
+    def _raise_scalar_data_error(cls, data: object) -> NoReturn:
         # We return the TypeError so that we can raise it from the constructor
         #  in order to keep mypy happy
         raise TypeError(
@@ -5286,7 +5381,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @classmethod
     def _maybe_copy_array_input(
-        cls, data, copy: bool | None, dtype
+        cls, data: object, copy: bool | None, dtype: Dtype | None
     ) -> tuple[Any, bool]:
         """
         Ensure that the input data is copied if necessary.
@@ -5299,7 +5394,7 @@ class Index(IndexOpsMixin, PandasObject):
                     copy = False
         return data, bool(copy)
 
-    def _validate_fill_value(self, value):
+    def _validate_fill_value(self, value: object) -> object:
         """
         Check if the value can be inserted into our array without casting,
         and convert it to an appropriate native type if necessary.
@@ -5379,10 +5474,18 @@ class Index(IndexOpsMixin, PandasObject):
     __hash__: ClassVar[None]  # type: ignore[assignment]
 
     @final
-    def __setitem__(self, key, value) -> None:
+    def __setitem__(self, key: object, value: object) -> None:
         raise TypeError("Index does not support mutable operations")
 
-    def __getitem__(self, key):
+    @overload
+    def __getitem__(self, key: SupportsIndex) -> Any: ...
+
+    @overload
+    def __getitem__(
+        self, key: slice | np.ndarray | list[int] | list[bool] | Series
+    ) -> Index: ...
+
+    def __getitem__(self, key: Any) -> Any:
         """
         Override numpy.ndarray's __getitem__ method to work as desired.
 
@@ -5398,8 +5501,8 @@ class Index(IndexOpsMixin, PandasObject):
         key = lib.item_from_zerodim(key)
         if is_integer(key) or is_float(key):
             # GH#44051 exclude bool, which would return a 2d ndarray
-            key = com.cast_scalar_indexer(key)
-            return getitem(key)
+            key = com.cast_scalar_indexer(key)  # type: ignore[no-untyped-call]
+            return getitem(key)  # pyright: ignore[reportReturnType]
 
         if isinstance(key, slice):
             # This case is separated from the conditional above to avoid
@@ -5445,7 +5548,7 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @final
-    def _can_hold_identifiers_and_holds_name(self, name) -> bool:
+    def _can_hold_identifiers_and_holds_name(self, name: Hashable) -> bool:
         """
         Faster check for ``name in self`` when we know `name` is a Python
         identifier (e.g. in NDFrame.__getattr__, which hits this to support
@@ -5507,7 +5610,7 @@ class Index(IndexOpsMixin, PandasObject):
         names = {obj.name for obj in to_concat}
         name = None if len(names) > 1 else self.name
 
-        return self._concat(to_concat, name)
+        return self._concat(to_concat, name)  # pyright: ignore[reportArgumentType]
 
     def _concat(self, to_concat: list[Index], name: Hashable) -> Index:
         """
@@ -5519,7 +5622,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return Index._with_infer(result, name=name, copy=False)
 
-    def putmask(self, mask, value) -> Index:
+    def putmask(self, mask: npt.NDArray[np.bool_], value: object) -> Index:
         """
         Return a new Index of the values set with the mask.
 
@@ -5579,7 +5682,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         if isinstance(values, np.ndarray):
             converted = setitem_datetimelike_compat(values, mask.sum(), converted)
-            np.putmask(values, mask, converted)
+            np.putmask(values, mask, converted)  # pyright: ignore[reportArgumentType]
 
         else:
             # Note: we use the original value here, not converted, as
@@ -5691,7 +5794,7 @@ class Index(IndexOpsMixin, PandasObject):
         return array_equivalent(self._values, other._values)
 
     @final
-    def identical(self, other) -> bool:
+    def identical(self, other: Index) -> bool:
         """
         Similar to equals, but checks that object attributes and types are also equal.
 
@@ -5739,7 +5842,7 @@ class Index(IndexOpsMixin, PandasObject):
         )
 
     @final
-    def asof(self, label):
+    def asof(self, label: Hashable) -> Hashable:
         """
         Return the label from the index, or, if not present, the previous one.
 
@@ -5868,7 +5971,7 @@ class Index(IndexOpsMixin, PandasObject):
         # types "Union[ExtensionArray, ndarray[Any, Any]]", "str"
         # TODO: will be fixed when ExtensionArray.searchsorted() is fixed
         locs = self._values[mask].searchsorted(
-            where._values,
+            where._values,  # pyright: ignore[reportArgumentType]
             side="right",  # type: ignore[call-overload]
         )
         locs = np.where(locs > 0, locs - 1, 0)
@@ -5994,11 +6097,11 @@ class Index(IndexOpsMixin, PandasObject):
         sorted_index = self.take(_as)
 
         if return_indexer:
-            return sorted_index, _as
+            return sorted_index, _as  # pyright: ignore[reportReturnType]
         else:
-            return sorted_index
+            return sorted_index  # pyright: ignore[reportReturnType]
 
-    def shift(self, periods: int = 1, freq=None) -> Self:
+    def shift(self, periods: int = 1, freq: Frequency | None = None) -> Self:
         """
         Shift index by desired number of time frequency increments.
 
@@ -6059,7 +6162,7 @@ class Index(IndexOpsMixin, PandasObject):
             f"TimedeltaIndex; Got type {type(self).__name__}"
         )
 
-    def argsort(self, *args, **kwargs) -> npt.NDArray[np.intp]:
+    def argsort(self, *args: Any, **kwargs: Any) -> npt.NDArray[np.intp]:
         """
         Return the integer indices that would sort the index.
 
@@ -6102,7 +6205,7 @@ class Index(IndexOpsMixin, PandasObject):
         #  by RangeIndex, MultIIndex
         return self._data.argsort(*args, **kwargs)
 
-    def _check_indexing_error(self, key) -> None:
+    def _check_indexing_error(self, key: object) -> None:
         if not is_scalar(key):
             # if key is not a scalar, directly raise an error (the code below
             # would convert to numpy arrays and raise later any way) - GH29926
@@ -6121,7 +6224,7 @@ class Index(IndexOpsMixin, PandasObject):
         }
 
     def get_indexer_non_unique(
-        self, target
+        self, target: Axes
     ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
         """
         Compute indexer and mask for new index given the current index.
@@ -6208,11 +6311,11 @@ class Index(IndexOpsMixin, PandasObject):
         else:
             tgt_values = target._get_engine_target()
 
-        indexer, missing = self._engine.get_indexer_non_unique(tgt_values)
+        indexer, missing = self._engine.get_indexer_non_unique(tgt_values)  # pyright: ignore[reportArgumentType]
         return ensure_platform_int(indexer), ensure_platform_int(missing)
 
     @final
-    def get_indexer_for(self, target) -> npt.NDArray[np.intp]:
+    def get_indexer_for(self, target: Axes) -> npt.NDArray[np.intp]:
         """
         Guaranteed return of an indexer even when non-unique.
 
@@ -6247,7 +6350,9 @@ class Index(IndexOpsMixin, PandasObject):
         indexer, _ = self.get_indexer_non_unique(target)
         return indexer
 
-    def _get_indexer_strict(self, key, axis_name: str_t) -> tuple[Index, np.ndarray]:
+    def _get_indexer_strict(
+        self, key: Axes, axis_name: str_t
+    ) -> tuple[Index, np.ndarray]:
         """
         Analogue to get_indexer that raises if any elements are missing.
         """
@@ -6256,10 +6361,10 @@ class Index(IndexOpsMixin, PandasObject):
             keyarr = com.asarray_tuplesafe(keyarr)
 
         if self._index_as_unique:
-            indexer = self.get_indexer_for(keyarr)
-            keyarr = self.reindex(keyarr)[0]
+            indexer = self.get_indexer_for(keyarr)  # pyright: ignore[reportArgumentType]
+            keyarr = self.reindex(keyarr)[0]  # pyright: ignore[reportArgumentType]
         else:
-            keyarr, indexer, new_indexer = self._reindex_non_unique(keyarr)
+            keyarr, indexer, new_indexer = self._reindex_non_unique(keyarr)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
         self._raise_if_missing(keyarr, indexer, axis_name)
 
@@ -6281,7 +6386,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         return keyarr, indexer
 
-    def _raise_if_missing(self, key, indexer, axis_name: str_t) -> None:
+    def _raise_if_missing(
+        self, key: Index, indexer: npt.NDArray[np.intp], axis_name: str_t
+    ) -> None:
         """
         Check that indexer can be used to return a result.
 
@@ -6290,9 +6397,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        key : list-like
+        key : Index
             Targeted labels (only used to show correct error message).
-        indexer: array-like of booleans
+        indexer: np.ndarray[np.intp]
             Indices corresponding to the key,
             (with -1 indicating not found).
         axis_name : str
@@ -6318,22 +6425,22 @@ class Index(IndexOpsMixin, PandasObject):
 
     @overload
     def _get_indexer_non_comparable(
-        self, target: Index, method, unique: Literal[True] = ...
+        self, target: Index, method: str_t | None, unique: Literal[True] = ...
     ) -> npt.NDArray[np.intp]: ...
 
     @overload
     def _get_indexer_non_comparable(
-        self, target: Index, method, unique: Literal[False]
+        self, target: Index, method: str_t | None, unique: Literal[False]
     ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]: ...
 
     @overload
     def _get_indexer_non_comparable(
-        self, target: Index, method, unique: bool = True
+        self, target: Index, method: str_t | None, unique: bool = True
     ) -> npt.NDArray[np.intp] | tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]: ...
 
     @final
     def _get_indexer_non_comparable(
-        self, target: Index, method, unique: bool = True
+        self, target: Index, method: str_t | None, unique: bool = True
     ) -> npt.NDArray[np.intp] | tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
         """
         Called from get_indexer or get_indexer_non_unique when the target
@@ -6410,7 +6517,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         elif self.dtype.kind == "u" and other.dtype.kind == "i":
             # GH#41873
-            if other.min() >= 0:
+            if other.min() >= 0:  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
                 # lookup min as it may be cached
                 # TODO: may need itemsize check if we have non-64-bit Indexes
                 return self, other.astype(self.dtype)
@@ -6430,7 +6537,7 @@ class Index(IndexOpsMixin, PandasObject):
         return self, other
 
     @final
-    def _find_common_type_compat(self, target) -> DtypeObj:
+    def _find_common_type_compat(self, target: Any) -> DtypeObj:
         """
         Implementation of find_common_type that adjusts for Index-specific
         special cases.
@@ -6513,7 +6620,7 @@ class Index(IndexOpsMixin, PandasObject):
         return True
 
     @final
-    def groupby(self, values) -> PrettyDict[Hashable, Index]:
+    def groupby(self, values: Axes) -> PrettyDict[Hashable, Index]:
         """
         Group the index labels by a given array of values.
 
@@ -6535,11 +6642,15 @@ class Index(IndexOpsMixin, PandasObject):
         result = values._reverse_indexer()
 
         # map to the label
-        result = {k: self.take(v) for k, v in result.items()}
+        result = {k: self.take(v) for k, v in result.items()}  # type: ignore[misc]
 
-        return PrettyDict(result)
+        return PrettyDict(result)  # type: ignore[arg-type]
 
-    def map(self, mapper, na_action: Literal["ignore"] | None = None):
+    def map(
+        self,
+        mapper: Callable | dict | Series,
+        na_action: Literal["ignore"] | None = None,
+    ) -> Index:
         """
         Map values using an input mapping or function.
 
@@ -6583,7 +6694,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         from pandas.core.indexes.multi import MultiIndex
 
-        new_values = self._map_values(mapper, na_action=na_action)
+        new_values = self._map_values(mapper, na_action=na_action)  # type: ignore[no-untyped-call]
 
         # we can return a MultiIndex
         if new_values.size and isinstance(new_values[0], tuple):
@@ -6616,7 +6727,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     # TODO: De-duplicate with map, xref GH#32349
     @final
-    def _transform_index(self, func, *, level=None) -> Index:
+    def _transform_index(self, func: Callable, *, level: int | None = None) -> Index:
         """
         Apply function to all values found in index.
 
@@ -6637,7 +6748,9 @@ class Index(IndexOpsMixin, PandasObject):
             items = [func(x) for x in self]
             return Index(items, name=self.name, tupleize_cols=False)
 
-    def isin(self, values, level: str_t | int | None = None) -> npt.NDArray[np.bool_]:
+    def isin(
+        self, values: Axes | set, level: str_t | int | None = None
+    ) -> npt.NDArray[np.bool_]:
         """
         Return a boolean array where the index values are in `values`.
 
@@ -6708,9 +6821,9 @@ class Index(IndexOpsMixin, PandasObject):
         """
         if level is not None:
             self._validate_index_level(level)
-        return algos.isin(self._values, values)
+        return algos.isin(self._values, values)  # type: ignore[arg-type]
 
-    def _get_string_slice(self, key: str_t):
+    def _get_string_slice(self, key: str_t) -> slice:
         # this is for partial string indexing,
         # overridden in DatetimeIndex, TimedeltaIndex and PeriodIndex
         raise NotImplementedError
@@ -6776,7 +6889,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return slice(start_slice, end_slice, step)
 
-    def _maybe_cast_indexer(self, key):
+    def _maybe_cast_indexer(self, key: Hashable) -> Hashable:
         """
         If we have a float key and are not a floating index, then try to cast
         to an int if equivalent.
@@ -6791,7 +6904,7 @@ class Index(IndexOpsMixin, PandasObject):
             key = self.dtype.na_value
         return key
 
-    def _maybe_cast_listlike_indexer(self, target) -> Index:
+    def _maybe_cast_listlike_indexer(self, target: Axes) -> Index:
         """
         Analogue to maybe_cast_indexer for get_indexer instead of get_loc.
         """
@@ -6818,7 +6931,7 @@ class Index(IndexOpsMixin, PandasObject):
     def _validate_indexer(
         self,
         form: Literal["positional", "slice"],
-        key,
+        key: object,
         kind: Literal["getitem", "iloc"],
     ) -> None:
         """
@@ -6828,7 +6941,7 @@ class Index(IndexOpsMixin, PandasObject):
         if not lib.is_int_or_none(key):
             self._raise_invalid_indexer(form, key)
 
-    def _maybe_cast_slice_bound(self, label, side: str_t):
+    def _maybe_cast_slice_bound(self, label: Hashable, side: str_t) -> Hashable:
         """
         This function should be overloaded in subclasses that allow non-trivial
         casting on label-slice bounds, e.g. datetime-like indices allowing
@@ -6860,21 +6973,23 @@ class Index(IndexOpsMixin, PandasObject):
 
         return label
 
-    def _searchsorted_monotonic(self, label, side: Literal["left", "right"] = "left"):
+    def _searchsorted_monotonic(
+        self, label: Hashable, side: Literal["left", "right"] = "left"
+    ) -> int:
         if self.is_monotonic_increasing:
-            return self.searchsorted(label, side=side)
+            return self.searchsorted(label, side=side)  # type: ignore[call-overload]
         elif self.is_monotonic_decreasing:
             # np.searchsorted expects ascending sort order, have to reverse
             # everything for it to work (element ordering, search side and
             # resulting value).
-            pos = self[::-1].searchsorted(
+            pos = self[::-1].searchsorted(  # type: ignore[call-overload]
                 label, side="right" if side == "left" else "left"
             )
-            return maybe_unbox_numpy_scalar(len(self) - pos)
+            return maybe_unbox_numpy_scalar(len(self) - pos)  # type: ignore[no-untyped-call]
 
         raise ValueError("index must be monotonic increasing or decreasing")
 
-    def get_slice_bound(self, label, side: Literal["left", "right"]) -> int:
+    def get_slice_bound(self, label: Hashable, side: Literal["left", "right"]) -> int:
         """
         Calculate slice bound that corresponds to given label.
 
@@ -6945,7 +7060,7 @@ class Index(IndexOpsMixin, PandasObject):
             # get_loc may return a boolean array, which
             # is OK as long as they are representable by a slice.
             assert is_bool_dtype(slc.dtype)
-            slc = lib.maybe_booleans_to_slice(slc.view("u1"))
+            slc = lib.maybe_booleans_to_slice(slc.view("u1"))  # type: ignore[assignment]
             if isinstance(slc, np.ndarray):
                 raise KeyError(
                     f"Cannot get {side} slice bound for non-unique "
@@ -7063,8 +7178,8 @@ class Index(IndexOpsMixin, PandasObject):
             if start_slice == -1:
                 start_slice -= len(self)
 
-        start_slice = maybe_unbox_numpy_scalar(start_slice)
-        end_slice = maybe_unbox_numpy_scalar(end_slice)
+        start_slice = maybe_unbox_numpy_scalar(start_slice)  # type: ignore[no-untyped-call]
+        end_slice = maybe_unbox_numpy_scalar(end_slice)  # type: ignore[no-untyped-call]
         return start_slice, end_slice
 
     def delete(
@@ -7112,7 +7227,7 @@ class Index(IndexOpsMixin, PandasObject):
         # _constructor so RangeIndex-> Index with an int64 dtype
         return self._constructor._simple_new(res_values, name=self.name)
 
-    def insert(self, loc: int, item) -> Index:
+    def insert(self, loc: int, item: Hashable) -> Index:
         """
         Make new Index inserting new item at location.
 
@@ -7354,11 +7469,11 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Generated Arithmetic, Comparison, and Unary Methods
 
-    def _cmp_method(self, other, op):
+    def _cmp_method(self, other: object, op: Callable) -> Any:
         """
         Wrapper used to dispatch comparison operations.
         """
-        if self.is_(other):
+        if isinstance(other, Index) and self.is_(other):
             # fastpath
             if op in {operator.eq, operator.le, operator.ge}:
                 arr = np.ones(len(self), dtype=bool)
@@ -7387,17 +7502,19 @@ class Index(IndexOpsMixin, PandasObject):
         return result
 
     @final
-    def _logical_method(self, other, op):
-        res_name = ops.get_op_result_name(self, other)
+    def _logical_method(self, other: object, op: Callable) -> Index:
+        res_name = ops.get_op_result_name(self, other)  # type: ignore[no-untyped-call]
 
         lvalues = self._values
         rvalues = extract_array(other, extract_numpy=True, extract_range=True)
 
         res_values = ops.logical_op(lvalues, rvalues, op)
-        return self._construct_result(res_values, name=res_name, other=other)
+        return self._construct_result(res_values, name=res_name, other=other)  # type: ignore[return-value]
 
     @final
-    def _construct_result(self, result, name, other):
+    def _construct_result(
+        self, result: ArrayLike, name: Hashable, other: object
+    ) -> Index | tuple[Index, Index]:
         if isinstance(result, tuple):
             return (
                 Index(result[0], name=name, dtype=result[0].dtype, copy=False),
@@ -7405,7 +7522,7 @@ class Index(IndexOpsMixin, PandasObject):
             )
         return Index(result, name=name, dtype=result.dtype, copy=False)
 
-    def _arith_method(self, other, op):
+    def _arith_method(self, other: object, op: Callable) -> Index:
         if (
             isinstance(other, Index)
             and is_object_dtype(other.dtype)
@@ -7416,10 +7533,10 @@ class Index(IndexOpsMixin, PandasObject):
             # See https://github.com/pandas-dev/pandas/issues/31109
             return NotImplemented
 
-        return super()._arith_method(other, op)
+        return super()._arith_method(other, op)  # type: ignore[no-untyped-call]
 
     @final
-    def _unary_method(self, op):
+    def _unary_method(self, op: Callable) -> Index:
         result = op(self._values)
         return Index(result, name=self.name, copy=False)
 
@@ -7439,7 +7556,7 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Reductions
 
-    def any(self, *args, **kwargs):
+    def any(self, *args: Any, **kwargs: Any) -> Any:
         """
         Return whether any element is Truthy.
 
@@ -7485,9 +7602,9 @@ class Index(IndexOpsMixin, PandasObject):
             # i.e. EA, call _reduce instead of "any" to get TypeError instead
             #  of AttributeError
             return vals._reduce("any")
-        return maybe_unbox_numpy_scalar(np.any(vals))
+        return maybe_unbox_numpy_scalar(np.any(vals))  # type: ignore[no-untyped-call]
 
-    def all(self, *args, **kwargs):
+    def all(self, *args: Any, **kwargs: Any) -> Any:
         """
         Return whether all elements are Truthy.
 
@@ -7536,7 +7653,7 @@ class Index(IndexOpsMixin, PandasObject):
             # i.e. EA, call _reduce instead of "all" to get TypeError instead
             #  of AttributeError
             return vals._reduce("all")
-        return maybe_unbox_numpy_scalar(np.all(vals))
+        return maybe_unbox_numpy_scalar(np.all(vals))  # type: ignore[no-untyped-call]
 
     @final
     def _maybe_disable_logical_methods(self, opname: str_t) -> None:
@@ -7547,7 +7664,11 @@ class Index(IndexOpsMixin, PandasObject):
             raise TypeError(f"cannot perform {opname} with {type(self).__name__}")
 
     def argmin(
-        self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs
+        self,
+        axis: AxisInt | None = None,
+        skipna: bool = True,
+        *args: Any,
+        **kwargs: Any,
     ) -> int:
         """
         Return int position of the smallest value in the Index.
@@ -7607,7 +7728,11 @@ class Index(IndexOpsMixin, PandasObject):
         return super().argmin(skipna=skipna)
 
     def argmax(
-        self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs
+        self,
+        axis: AxisInt | None = None,
+        skipna: bool = True,
+        *args: Any,
+        **kwargs: Any,
     ) -> int:
         """
         Return int position of the largest value in the Index.
@@ -7665,7 +7790,13 @@ class Index(IndexOpsMixin, PandasObject):
                 raise ValueError("Encountered all NA values")
         return super().argmax(skipna=skipna)
 
-    def min(self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs):
+    def min(
+        self,
+        axis: AxisInt | None = None,
+        skipna: bool = True,
+        *args: Any,
+        **kwargs: Any,
+    ) -> object:
         """
         Return the minimum value of the Index.
 
@@ -7718,7 +7849,7 @@ class Index(IndexOpsMixin, PandasObject):
             # quick check
             first = self[0]
             if not isna(first):
-                return maybe_unbox_numpy_scalar(first)
+                return maybe_unbox_numpy_scalar(first)  # type: ignore[no-untyped-call]
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
@@ -7729,9 +7860,15 @@ class Index(IndexOpsMixin, PandasObject):
         if not self._is_multi and not isinstance(self._values, np.ndarray):
             return self._values._reduce(name="min", skipna=skipna)
 
-        return maybe_unbox_numpy_scalar(nanops.nanmin(self._values, skipna=skipna))
+        return maybe_unbox_numpy_scalar(nanops.nanmin(self._values, skipna=skipna))  # type: ignore[no-untyped-call]
 
-    def max(self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs):
+    def max(
+        self,
+        axis: AxisInt | None = None,
+        skipna: bool = True,
+        *args: Any,
+        **kwargs: Any,
+    ) -> object:
         """
         Return the maximum value of the Index.
 
@@ -7785,18 +7922,18 @@ class Index(IndexOpsMixin, PandasObject):
             # quick check
             last = self[-1]
             if not isna(last):
-                return maybe_unbox_numpy_scalar(last)
+                return maybe_unbox_numpy_scalar(last)  # type: ignore[no-untyped-call]
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
             mask = self._isnan
             if not skipna or mask.all():
-                return maybe_unbox_numpy_scalar(self._na_value)
+                return maybe_unbox_numpy_scalar(self._na_value)  # type: ignore[no-untyped-call]
 
         if not self._is_multi and not isinstance(self._values, np.ndarray):
             return self._values._reduce(name="max", skipna=skipna)
 
-        return maybe_unbox_numpy_scalar(nanops.nanmax(self._values, skipna=skipna))
+        return maybe_unbox_numpy_scalar(nanops.nanmax(self._values, skipna=skipna))  # type: ignore[no-untyped-call]
 
     # --------------------------------------------------------------------
 
@@ -7828,7 +7965,7 @@ class Index(IndexOpsMixin, PandasObject):
         return (len(self),)
 
 
-def maybe_sequence_to_range(sequence) -> Any | range:
+def maybe_sequence_to_range(sequence: Axes) -> Axes:
     """
     Convert a 1D, non-pandas sequence to a range if possible.
 
@@ -7866,7 +8003,9 @@ def maybe_sequence_to_range(sequence) -> Any | range:
         return sequence
 
 
-def ensure_index_from_sequences(sequences, names=None) -> Index:
+def ensure_index_from_sequences(
+    sequences: Sequence[Axes], names: Sequence[Hashable] | None = None
+) -> Index:
     """
     Construct an index from sequences of data.
 
@@ -7903,7 +8042,7 @@ def ensure_index_from_sequences(sequences, names=None) -> Index:
         return default_index(0)
     elif len(sequences) == 1:
         if names is not None:
-            names = names[0]
+            names = names[0]  # type: ignore[assignment]
         return Index(maybe_sequence_to_range(sequences[0]), name=names)
     else:
         # TODO: Apply maybe_sequence_to_range to sequences?
@@ -7994,7 +8133,7 @@ def _validate_join_method(method: str) -> None:
         raise ValueError(f"do not recognize join method {method}")
 
 
-def maybe_extract_name(name, obj, cls) -> Hashable:
+def maybe_extract_name(name: Hashable, obj: object, cls: type) -> Hashable:
     """
     If no name is passed, then extract it from data, validating hashability.
     """
@@ -8056,7 +8195,7 @@ def _unpack_nested_dtype(other: Index) -> DtypeObj:
     return other.dtype
 
 
-def _maybe_try_sort(result: Index | ArrayLike, sort: bool | None):
+def _maybe_try_sort(result: Index | ArrayLike, sort: bool | None) -> Index | ArrayLike:
     if sort is not False:
         try:
             # error: Incompatible types in assignment (expression has type
@@ -8079,10 +8218,10 @@ def _maybe_try_sort(result: Index | ArrayLike, sort: bool | None):
 def get_values_for_csv(
     values: ArrayLike,
     *,
-    date_format,
+    date_format: str_t | None,
     na_rep: str = "nan",
-    quoting=None,
-    float_format=None,
+    quoting: int | None = None,
+    float_format: str_t | None = None,
     decimal: str = ".",
 ) -> npt.NDArray[np.object_]:
     """
@@ -8097,7 +8236,7 @@ def get_values_for_csv(
             fill_value=na_rep,
         )
 
-    values = ensure_wrapped_if_datetimelike(values)
+    values = ensure_wrapped_if_datetimelike(values)  # type: ignore[no-untyped-call]
 
     if isinstance(values, (DatetimeArray, TimedeltaArray)):
         if values.ndim == 1:

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -329,7 +329,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
         >>> ci_ordered.equals(ci2_ordered)
         False
         """
-        if self.is_(other):
+        if self.is_(other):  # type: ignore[arg-type]
             return True
 
         if not isinstance(other, Index):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -456,7 +456,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         reso = Resolution.from_attrname(reso_str)
         return parsed, reso
 
-    def _get_string_slice(self, key: str) -> slice | npt.NDArray[np.intp]:
+    def _get_string_slice(self, key: str) -> slice | npt.NDArray[np.intp]:  # type: ignore[override]
         # overridden by TimedeltaIndex
         parsed, reso = self._parse_with_reso(key)
         try:
@@ -889,7 +889,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             result = self[:0]
         else:
             lslice = slice(*left.slice_locs(start, end))
-            result = left._values[lslice]
+            result = left._values[lslice]  # type: ignore[assignment]
 
         return result
 
@@ -993,7 +993,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             #  that result.freq == self.freq
             return result
         else:
-            return super()._union(other, sort)._with_freq("infer")
+            return super()._union(other, sort)._with_freq("infer")  # type: ignore[union-attr]
 
     # --------------------------------------------------------------------
     # Join Methods

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -91,6 +91,7 @@ if TYPE_CHECKING:
     from collections.abc import Hashable
 
     from pandas._typing import (
+        Axes,
         Dtype,
         DtypeObj,
         IntervalClosedType,
@@ -868,7 +869,7 @@ class IntervalIndex(ExtensionIndex):
         return ensure_platform_int(indexer)
 
     def get_indexer_non_unique(
-        self, target: Index
+        self, target: Axes
     ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
         """
         Compute indexer and mask for new index given the current index.
@@ -945,7 +946,7 @@ class IntervalIndex(ExtensionIndex):
             # Note: this case behaves differently from other Index subclasses
             #  because IntervalIndex does partial-int indexing
             target = self._maybe_convert_i8(target)
-            indexer, missing = self._engine.get_indexer_non_unique(target.values)
+            indexer, missing = self._engine.get_indexer_non_unique(target.values)  # type: ignore[union-attr]
 
         return ensure_platform_int(indexer), ensure_platform_int(missing)
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1317,7 +1317,7 @@ class MultiIndex(Index):
     def _constructor(self) -> Callable[..., MultiIndex]:  # type: ignore[override]
         return type(self).from_tuples
 
-    def _shallow_copy(self, values: np.ndarray, name=lib.no_default) -> MultiIndex:
+    def _shallow_copy(self, values: np.ndarray, name=lib.no_default) -> MultiIndex:  # type: ignore[override]
         """
         Create a new Index with the same class as the caller, don't copy the
         data, use the same object attributes with passed in attributes taking
@@ -1959,7 +1959,7 @@ class MultiIndex(Index):
         new_codes = [level_codes[~indexer] for level_codes in self.codes]
         return self.set_codes(codes=new_codes)
 
-    def _get_level_values(self, level: int, unique: bool = False) -> Index:
+    def _get_level_values(self, level: int, unique: bool = False) -> Index:  # type: ignore[override]
         """
         Return vector of label values for requested level,
         equal to the length of the index
@@ -2727,7 +2727,7 @@ class MultiIndex(Index):
         keys = [lev.codes for lev in target._get_codes_for_sorting()]
         return lexsort_indexer(keys, na_position=na_position, codes_given=True)
 
-    def repeat(self, repeats: int, axis=None) -> MultiIndex:
+    def repeat(self, repeats: int, axis=None) -> MultiIndex:  # type: ignore[override]
         """
         Repeat elements of a MultiIndex.
 
@@ -3101,7 +3101,7 @@ class MultiIndex(Index):
         self,
         level: IndexLabel = 0,
         ascending: bool | list[bool] = True,
-        sort_remaining: bool = True,
+        sort_remaining: bool = True,  # type: ignore[override]
         na_position: str = "first",
     ) -> tuple[MultiIndex, npt.NDArray[np.intp]]:
         """
@@ -3488,7 +3488,7 @@ class MultiIndex(Index):
             # TODO: need is_valid_na_for_dtype(key, level_index.dtype)
             return -1
         else:
-            return level_index.get_loc(key)
+            return level_index.get_loc(key)  # type: ignore[return-value]
 
     def get_loc(self, key):
         """
@@ -4235,7 +4235,7 @@ class MultiIndex(Index):
         --------
         equal_levels
         """
-        if self.is_(other):
+        if self.is_(other):  # type: ignore[arg-type]
             return True
 
         if not isinstance(other, Index):
@@ -4359,7 +4359,7 @@ class MultiIndex(Index):
         _, result_names = self._convert_can_do_setop(other)
         return result.set_names(result_names)
 
-    def _wrap_difference_result(self, other, result: MultiIndex) -> MultiIndex:
+    def _wrap_difference_result(self, other, result: MultiIndex) -> MultiIndex:  # type: ignore[override]
         _, result_names = self._convert_can_do_setop(other)
 
         if len(result) == 0:
@@ -4459,7 +4459,7 @@ class MultiIndex(Index):
             raise ValueError("Item must have length equal to number of levels.")
         return item
 
-    def putmask(self, mask, value: MultiIndex) -> MultiIndex:
+    def putmask(self, mask, value: MultiIndex) -> MultiIndex:  # type: ignore[override]
         """
         Return a new MultiIndex of the values set with the mask.
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1000,7 +1000,7 @@ class RangeIndex(Index):
 
         first = self._range[::-1] if self.step < 0 else self._range
         overlap = self.intersection(other)
-        if overlap.step < 0:
+        if overlap.step < 0:  # type: ignore[attr-defined]
             overlap = overlap[::-1]
 
         if len(overlap) == 0:
@@ -1027,14 +1027,14 @@ class RangeIndex(Index):
             # e.g. range(-8, 20, 7) and range(13, -9, -3)
             return self[1:-1]
 
-        if overlap.step == first.step:
+        if overlap.step == first.step:  # type: ignore[attr-defined]
             if overlap[0] == first.start:
                 # The difference is everything after the intersection
                 new_rng = range(overlap[-1] + first.step, first.stop, first.step)
             elif overlap[-1] == first[-1]:
                 # The difference is everything before the intersection
                 new_rng = range(first.start, overlap[0], first.step)
-            elif overlap._range == first[1:-1]:
+            elif overlap._range == first[1:-1]:  # type: ignore[attr-defined]
                 # e.g. range(4) and range(1, 3)
                 step = len(first) - 1
                 new_rng = first[::step]
@@ -1048,7 +1048,7 @@ class RangeIndex(Index):
             #  len(overlap) == 0 and len(overlap) == len(self)
             assert len(self) > 1
 
-            if overlap.step == first.step * 2:
+            if overlap.step == first.step * 2:  # type: ignore[attr-defined]
                 if overlap[0] == first[0] and overlap[-1] in (first[-1], first[-2]):
                     # e.g. range(1, 10, 1) and range(1, 10, 2)
                     new_rng = first[1::2]
@@ -1115,11 +1115,11 @@ class RangeIndex(Index):
             lidx = self.get_indexer(join_index)
             ridx = None
         elif how == "inner":
-            join_index = self.intersection(other)
+            join_index = self.intersection(other)  # type: ignore[assignment]
             lidx = self.get_indexer(join_index)
             ridx = other.get_indexer(join_index)
         elif how == "outer":
-            join_index = self.union(other)
+            join_index = self.union(other)  # type: ignore[assignment]
             lidx = self.get_indexer(join_index)
             ridx = other.get_indexer(join_index)
 
@@ -1451,7 +1451,7 @@ class RangeIndex(Index):
             # even if we can represent as a RangeIndex, return
             # as a float64 Index if we have float-like descriptors
             if not all(is_integer(x) for x in [rstart, rstop, rstep]):
-                result = result.astype("float64")
+                result = result.astype("float64")  # type: ignore[assignment]
 
             return result
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -591,7 +591,7 @@ def _homogenize(
                     val = Series(val).reindex(index)._values
                 else:
                     # Fast path: use lib.fast_multiget for dicts without missing keys
-                    val = lib.fast_multiget(val, oindex._values, default=np.nan)
+                    val = lib.fast_multiget(val, oindex._values, default=np.nan)  # type: ignore[arg-type]
 
             val = sanitize_array(val, index, dtype=dtype, copy=False)
             com.require_length_match(val, index)

--- a/pandas/core/methods/selectn.py
+++ b/pandas/core/methods/selectn.py
@@ -127,7 +127,7 @@ class SelectNSeries(SelectN[Series]):
             result = default_index.sort_values(ascending=ascending, kind="stable").head(
                 n
             )
-            result.index = original_index.take(result.index)
+            result.index = original_index.take(result.index)  # type: ignore[arg-type]
             return result
 
         # Fast method used in the general case
@@ -290,7 +290,7 @@ class SelectNFrame(SelectN[DataFrame]):
         frame = frame.take(indexer)
 
         # Restore the index on frame
-        frame.index = original_index.take(indexer)
+        frame.index = original_index.take(indexer)  # type: ignore[arg-type]
 
         # If there is only one column, the frame is already sorted.
         if len(columns) == 1:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2738,13 +2738,13 @@ class TimeGrouper(Grouper):
 
         end_stamps = labels
         if self.closed == "left":
-            end_stamps += self.freq  # type: ignore[misc]
+            end_stamps += self.freq
 
         bins = ax.searchsorted(end_stamps, side=self.closed)
 
         if self.offset:
             # GH 10530 & 31809
-            labels += self.offset  # type: ignore[misc]
+            labels += self.offset
 
         return binner, bins, labels
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2618,8 +2618,8 @@ class TimeGrouper(Grouper):
             return binner, [], labels
 
         first, last = _get_timestamp_range_edges(
-            ax.min(),
-            ax.max(),
+            ax.min(),  # type: ignore[arg-type]
+            ax.max(),  # type: ignore[arg-type]
             self.freq,
             unit=ax.unit,
             closed=self.closed,
@@ -2655,9 +2655,9 @@ class TimeGrouper(Grouper):
         if self.closed == "right":
             labels = binner
             if self.label == "right":
-                labels = labels[1:]
+                labels = labels[1:]  # type: ignore[assignment]
         elif self.label == "right":
-            labels = labels[1:]
+            labels = labels[1:]  # type: ignore[assignment]
 
         if ax.hasnans:
             binner = binner.insert(0, NaT)
@@ -2667,7 +2667,7 @@ class TimeGrouper(Grouper):
         # adjust the labels
         # GH4076
         if len(bins) < len(labels):
-            labels = labels[: len(bins)]
+            labels = labels[: len(bins)]  # type: ignore[assignment]
 
         return binner, bins, labels
 
@@ -2704,7 +2704,7 @@ class TimeGrouper(Grouper):
             # intraday values on last day
             if bin_edges[-2] > ax_values.max():
                 bin_edges = bin_edges[:-1]
-                binner = binner[:-1]
+                binner = binner[:-1]  # type: ignore[assignment]
         else:
             bin_edges = binner.asi8
         return binner, bin_edges
@@ -2730,7 +2730,7 @@ class TimeGrouper(Grouper):
         start, end = ax.min(), ax.max()
 
         if self.closed == "right":
-            end += self.freq
+            end += self.freq  # type: ignore[operator]
 
         labels = binner = timedelta_range(
             start=start, end=end, freq=self.freq, name=ax.name
@@ -2738,13 +2738,13 @@ class TimeGrouper(Grouper):
 
         end_stamps = labels
         if self.closed == "left":
-            end_stamps += self.freq
+            end_stamps += self.freq  # type: ignore[misc]
 
         bins = ax.searchsorted(end_stamps, side=self.closed)
 
         if self.offset:
             # GH 10530 & 31809
-            labels += self.offset
+            labels += self.offset  # type: ignore[misc]
 
         return binner, bins, labels
 
@@ -2800,8 +2800,8 @@ class TimeGrouper(Grouper):
 
         freq_mult = self.freq.n
 
-        start = ax.min().asfreq(self.freq, how=self.convention)
-        end = ax.max().asfreq(self.freq, how="end")
+        start = ax.min().asfreq(self.freq, how=self.convention)  # type: ignore[attr-defined]
+        end = ax.max().asfreq(self.freq, how="end")  # type: ignore[attr-defined]
         bin_shift = 0
 
         if isinstance(self.freq, Tick):

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -351,7 +351,7 @@ def lreshape(data: DataFrame, groups: dict, dropna: bool = True) -> DataFrame:
         pivot_cols.append(target)
         all_cols = all_cols.union(names)
 
-    id_cols = list(data.columns.difference(all_cols))
+    id_cols = list(data.columns.difference(all_cols))  # type: ignore[arg-type]
     for col in id_cols:
         mdata[col] = np.tile(data[col]._values, K)
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -864,7 +864,7 @@ def _stack_multi_columns(
         # but if unsorted can get a boolean
         # indexer
         if not isinstance(loc, slice):
-            slice_len = len(loc)
+            slice_len = len(loc)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
         else:
             slice_len = loc.stop - loc.start
 
@@ -1012,7 +1012,7 @@ def stack_v3(frame: DataFrame, level: list[int]) -> Series | DataFrame:
         assert isinstance(stack_cols, MultiIndex)
         ordered_stack_cols = stack_cols._reorder_ilevels(sorter)
     else:
-        ordered_stack_cols = stack_cols
+        ordered_stack_cols = stack_cols  # type: ignore[assignment]
     ordered_stack_cols_unique = ordered_stack_cols.unique()
     if isinstance(ordered_stack_cols, MultiIndex):
         column_levels = ordered_stack_cols.levels
@@ -1111,7 +1111,7 @@ def stack_reshape(
             # concat column order may be different from dropping the levels
             new_columns = frame.columns._drop_level_numbers(drop_levnums).unique()
         else:
-            new_columns = [0]
+            new_columns = [0]  # type: ignore[assignment]
         result = DataFrame(columns=new_columns, dtype=frame._values.dtype)
 
     if len(level) < frame.columns.nlevels:

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -407,7 +407,7 @@ def _nbins_to_bins(x_idx: Index, nbins: int, right: bool) -> Index:
     rng = (x_idx.min(), x_idx.max())
     mn, mx = rng
 
-    if is_numeric_dtype(x_idx.dtype) and (np.isinf(mn) or np.isinf(mx)):
+    if is_numeric_dtype(x_idx.dtype) and (np.isinf(mn) or np.isinf(mx)):  # type: ignore[call-overload]
         # GH#24314
         raise ValueError(
             "cannot specify integer `bins` when input data contains infinity"
@@ -424,11 +424,15 @@ def _nbins_to_bins(x_idx: Index, nbins: int, right: bool) -> Index:
             # error: Item "ExtensionArray" of "ExtensionArray | ndarray[Any, Any]"
             # has no attribute "_generate_range"
             bins = x_idx._values._generate_range(  # type: ignore[union-attr]
-                start=mn - td, end=mx + td, periods=nbins + 1, freq=None, unit=unit
+                start=mn - td,
+                end=mx + td,
+                periods=nbins + 1,
+                freq=None,
+                unit=unit,  # type: ignore[operator]
             )
         else:
-            mn -= 0.001 * abs(mn) if mn != 0 else 0.001
-            mx += 0.001 * abs(mx) if mx != 0 else 0.001
+            mn -= 0.001 * abs(mn) if mn != 0 else 0.001  # type: ignore[operator, arg-type]
+            mx += 0.001 * abs(mx) if mx != 0 else 0.001  # type: ignore[operator, arg-type]
 
             bins = np.linspace(mn, mx, nbins + 1, endpoint=True)
     else:  # adjust end points after binning
@@ -444,8 +448,8 @@ def _nbins_to_bins(x_idx: Index, nbins: int, right: bool) -> Index:
                 start=mn, end=mx, periods=nbins + 1, freq=None, unit=unit
             )
         else:
-            bins = np.linspace(mn, mx, nbins + 1, endpoint=True)
-        adj = (mx - mn) * 0.001  # 0.1% of the range
+            bins = np.linspace(mn, mx, nbins + 1, endpoint=True)  # type: ignore[call-overload]
+        adj = (mx - mn) * 0.001  # type: ignore[operator]  # 0.1% of the range
         if right:
             bins[0] -= adj
         else:

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -424,11 +424,11 @@ def _nbins_to_bins(x_idx: Index, nbins: int, right: bool) -> Index:
             # error: Item "ExtensionArray" of "ExtensionArray | ndarray[Any, Any]"
             # has no attribute "_generate_range"
             bins = x_idx._values._generate_range(  # type: ignore[union-attr]
-                start=mn - td,
-                end=mx + td,
+                start=mn - td,  # type: ignore[operator]
+                end=mx + td,  # type: ignore[operator]
                 periods=nbins + 1,
                 freq=None,
-                unit=unit,  # type: ignore[operator]
+                unit=unit,
             )
         else:
             mn -= 0.001 * abs(mn) if mn != 0 else 0.001  # type: ignore[operator, arg-type]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1146,7 +1146,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         except (TypeError, ValueError, LossySetitemError):
             # The key was OK, but we cannot set the value losslessly
-            indexer = self.index.get_loc(key)
+            indexer = self.index.get_loc(key)  # type: ignore[assignment]
             self._set_values(indexer, value)
 
         except InvalidIndexError as err:
@@ -1462,7 +1462,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                     level_list = level
                 level_list = [self.index._get_level_number(lev) for lev in level_list]
                 if len(level_list) < self.index.nlevels:
-                    new_index = self.index.droplevel(level_list)
+                    new_index = self.index.droplevel(level_list)  # type: ignore[assignment]
 
             if inplace:
                 self.index = new_index

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -92,7 +92,7 @@ def get_indexer_indexer(
 
     if level is not None:
         _, indexer = target.sortlevel(
-            level,
+            level,  # type: ignore[arg-type]
             ascending=ascending,
             sort_remaining=sort_remaining,
             na_position=na_position,

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -446,7 +446,7 @@ class HTMLFormatter:
                 index_values = self.fmt.tr_frame.index.map(fmt)
             else:
                 # only reached with non-Multi index
-                index_values = self.fmt.tr_frame.index._format_flat(include_name=False)
+                index_values = self.fmt.tr_frame.index._format_flat(include_name=False)  # type: ignore[assignment]
 
         row: list[str] = []
         for i in range(nrows):
@@ -462,7 +462,7 @@ class HTMLFormatter:
 
             row = []
             if self.fmt.index:
-                row.append(index_values[i])
+                row.append(index_values[i])  # pyright: ignore[reportArgumentType]
             # see gh-22579
             # Column misalignment also occurs for
             # a standard index when the columns index is named.

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1802,7 +1802,7 @@ class Styler(StylerRenderer):
                     continue
                 css_list = maybe_convert_css_to_tuples(c)
                 i = self.index.get_loc(rn)
-                self.ctx[(i, j)].extend(css_list)
+                self.ctx[(i, j)].extend(css_list)  # type: ignore[index]
 
     def _update_ctx_header(self, attrs: DataFrame, axis: AxisInt) -> None:
         """
@@ -3106,7 +3106,7 @@ class Styler(StylerRenderer):
         # Returns a boolean mask indicating where `self.data` has numerical columns.
         # Choosing a mask as opposed to the column names also works for
         # boolean column labels (GH47838).
-        return self.data.columns.isin(self.data.select_dtypes(include=np.number))
+        return self.data.columns.isin(self.data.select_dtypes(include=np.number))  # type: ignore[arg-type]
 
     def background_gradient(
         self,

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1881,16 +1881,16 @@ the string values returned are correct."""
             fmtlist = []
             lbllist = []
             for col in columns:
-                i = data.columns.get_loc(col)  # type: ignore[no-untyped-call]
+                i = data.columns.get_loc(col)
                 dtyplist.append(self._dtyplist[i])
                 typlist.append(self._typlist[i])
                 fmtlist.append(self._fmtlist[i])
                 lbllist.append(self._lbllist[i])
 
-            self._dtyplist = dtyplist
-            self._typlist = typlist
-            self._fmtlist = fmtlist
-            self._lbllist = lbllist
+            self._dtyplist = dtyplist  # type: ignore[assignment]
+            self._typlist = typlist  # type: ignore[assignment]
+            self._fmtlist = fmtlist  # type: ignore[assignment]
+            self._lbllist = lbllist  # type: ignore[assignment]
             self._column_selector_set = True
 
         return data[columns]

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -787,7 +787,7 @@ def _daily_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
         info_min[month_start] = True
         info_min[year_start] = False
 
-        month_break = dates_[month_start].month
+        month_break = dates_[month_start].month  # pyright: ignore[reportAttributeAccessIssue]
         jan_or_jul = month_start[(month_break == 1) | (month_break == 7)]
         info_fmt[jan_or_jul] = "%b"
         info_fmt[year_start] = "%b\n%Y"
@@ -802,7 +802,7 @@ def _daily_finder(vmin: float, vmax: float, freq: BaseOffset) -> np.ndarray:
     # Case 6. More than 12 years ................
     else:
         year_start = _period_break(dates_, "year")
-        year_break = dates_[year_start].year
+        year_break = dates_[year_start].year  # pyright: ignore[reportAttributeAccessIssue]
         nyears = span / periodsperyear
         (min_anndef, maj_anndef) = _get_default_annual_spacing(nyears)
         major_idx = year_start[(year_break % maj_anndef == 0)]

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -422,7 +422,7 @@ class MPLPlot(ABC):
                     "When subplots is an iterable, each entry "
                     "should be a list/tuple of column names."
                 )
-            idx_locs = columns.get_indexer_for(group)
+            idx_locs = columns.get_indexer_for(group)  # type: ignore[arg-type]
             if (idx_locs == -1).any():
                 bad_labels = np.extract(idx_locs == -1, group)
                 raise ValueError(
@@ -438,7 +438,7 @@ class MPLPlot(ABC):
             seen_columns = seen_columns.union(unique_columns)
             out.append(tuple(idx_locs))
 
-        unseen_columns = columns.difference(seen_columns)
+        unseen_columns = columns.difference(seen_columns)  # type: ignore[arg-type]
         for column in unseen_columns:
             idx_loc = columns.get_loc(column)
             out.append((idx_loc,))

--- a/pandas/plotting/_matplotlib/groupby.py
+++ b/pandas/plotting/_matplotlib/groupby.py
@@ -138,4 +138,4 @@ def reformat_hist_y_given_by(y: np.ndarray, by: IndexLabel | None) -> np.ndarray
     """
     if by is not None and len(y.shape) > 1:
         return np.array([remove_na_arraylike(col) for col in y.T]).T
-    return remove_na_arraylike(y)
+    return remove_na_arraylike(y)  # pyright: ignore[reportReturnType]

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -274,7 +274,7 @@ class KdePlot(HistPlot):
     ):
         from scipy.stats import gaussian_kde
 
-        y = remove_na_arraylike(y)
+        y = remove_na_arraylike(y)  # pyright: ignore[reportAssignmentType]
         gkde = gaussian_kde(y, bw_method=bw_method, weights=weights)
 
         # gaussian_kde.evaluate(None) raises TypeError, so pyright requires this check

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -254,7 +254,7 @@ def use_dynamic_x(ax: Axes, index: Index) -> bool:
         freq_str = OFFSET_TO_PERIOD_FREQSTR.get(freq_str, freq_str)
         base = to_offset(freq_str, is_period=True)._period_dtype_code  # type: ignore[attr-defined]
         if base <= FreqGroup.FR_DAY.value:
-            return index[:1].is_normalized
+            return index[:1].is_normalized  # type: ignore[attr-defined]
         period = Period(index[0], freq_str)
         assert isinstance(period, Period)
         return period.to_timestamp().tz_localize(index.tz) == index[0]

--- a/pandas/tests/groupby/methods/test_quantile.py
+++ b/pandas/tests/groupby/methods/test_quantile.py
@@ -31,7 +31,7 @@ import pandas._testing as tm
         ),
         (
             pd.date_range("1/1/18", freq="D", periods=5).as_unit("s"),
-            pd.date_range("1/1/18", freq="D", periods=5)[::-1].as_unit("s"),
+            pd.date_range("1/1/18", freq="D", periods=5)[::-1].as_unit("s"),  # type: ignore[attr-defined]
         ),
         # All NA
         ([np.nan] * 5, [np.nan] * 5),

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -29,8 +29,8 @@ rng = pd.Index(range(3))
 @pytest.fixture(
     params=[
         dti,
-        dti.tz_localize("UTC"),
-        dti.to_period("W"),
+        dti.tz_localize("UTC"),  # type: ignore[attr-defined]
+        dti.to_period("W"),  # type: ignore[attr-defined]
         dti - dti[0],
         rng,
         pd.Index([1, 2, 3]),

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -410,7 +410,7 @@ class Holiday:
             return dates.copy()
 
         if self.observance is not None:
-            return dates.map(lambda d: self.observance(d))  # pyright: ignore[reportOptionalCall]
+            return dates.map(lambda d: self.observance(d))  # type: ignore[return-value, misc]  # pyright: ignore[reportOptionalCall]
 
         if self.offset is not None:
             if not isinstance(self.offset, list):
@@ -422,7 +422,7 @@ class Holiday:
                 # ignore the PerformanceWarnings:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", PerformanceWarning)
-                    dates += offset  # type: ignore[misc]
+                    dates += offset
         return dates
 
 

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -422,7 +422,7 @@ class Holiday:
                 # ignore the PerformanceWarnings:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", PerformanceWarning)
-                    dates += offset
+                    dates += offset  # type: ignore[misc]
         return dates
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -546,7 +546,18 @@ module = [
   "pandas.core.groupby.groupby", # TODO
   "pandas.core.groupby.ops", # TODO
   "pandas.core.indexers.*", # TODO
-  "pandas.core.indexes.*", # TODO
+  "pandas.core.indexes.accessors", # TODO
+  "pandas.core.indexes.api", # TODO
+  "pandas.core.indexes.category", # TODO
+  "pandas.core.indexes.datetimelike", # TODO
+  "pandas.core.indexes.datetimes", # TODO
+  "pandas.core.indexes.extension", # TODO
+  "pandas.core.indexes.frozen", # TODO
+  "pandas.core.indexes.interval", # TODO
+  "pandas.core.indexes.multi", # TODO
+  "pandas.core.indexes.period", # TODO
+  "pandas.core.indexes.range", # TODO
+  "pandas.core.indexes.timedeltas", # TODO
   "pandas.core.interchange.column", # TODO
   "pandas.core.interchange.dataframe_protocol", # TODO
   "pandas.core.interchange.from_dataframe", # TODO

--- a/pyright_reportGeneralTypeIssues.json
+++ b/pyright_reportGeneralTypeIssues.json
@@ -62,7 +62,6 @@
         "pandas/core/groupby/grouper.py",
         "pandas/core/groupby/ops.py",
         "pandas/core/indexers/utils.py",
-        "pandas/core/indexes/base.py",
         "pandas/core/indexes/category.py",
         "pandas/core/indexes/datetimelike.py",
         "pandas/core/indexes/datetimes.py",


### PR DESCRIPTION
This one was a slog getting working.

## Summary

- Add parameter and return type annotations throughout `Index` in `pandas/core/indexes/base.py`, enabling both pyright and mypy type checking for the module
- Remove `base.py` from pyright's exclude list in `pyright_reportGeneralTypeIssues.json`
- Expand the `pandas.core.indexes.*` mypy wildcard in `pyproject.toml` into individual module entries, excluding `base` so it gets checked
- Add `__getitem__` overloads (`SupportsIndex -> Any` vs `slice | np.ndarray | list[int] | list[bool] | Series -> Index`) to enable precise return types for callers
- Tighten parameter types where possible (e.g. `Hashable` for label params, `Axes` for index-castable params, `Frequency` for freq params)
- Fix `_raise_if_missing` and `_union` docstrings to match their actual signatures
- Fix spillover `type: ignore` / `pyright: ignore` comments in ~28 other files caused by the newly precise types

## Test plan

- [x] mypy passes with 0 errors on `pandas/core/indexes/base.py` (and all spillover files)
- [x] pyright passes with 0 errors on `pandas/core/indexes/base.py`
- [x] All pre-commit hooks pass (ruff, ruff-format, etc.)
- [ ] CI type checking passes
- [ ] Existing test suite passes (no runtime changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)