### PR TITLE
BUG: use our arrow->pandas conversion utility in read_iceberg (correct string dtype)

### DIFF
--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -44,6 +44,8 @@ dependencies:
   - openpyxl>=3.1.5
   - psycopg2>=2.9.10
   - pyarrow>=13.0.0
+  - pydantic<2.12.0  # TMP pin to avoid pyiceberg/pydantic issues
+  - pyiceberg>=0.8.1
   - pymysql>=1.1.1
   - pyreadstat>=1.2.8
   - pytables>=3.10.1

--- a/pandas/io/iceberg.py
+++ b/pandas/io/iceberg.py
@@ -7,6 +7,8 @@ from pandas.util._decorators import set_module
 
 from pandas import DataFrame
 
+from pandas.io._util import arrow_table_to_pandas
+
 
 @set_module("pandas")
 def read_iceberg(
@@ -96,7 +98,7 @@ def read_iceberg(
         options=scan_properties,
         limit=limit,
     )
-    return result.to_pandas()
+    return arrow_table_to_pandas(result.to_arrow())
 
 
 def to_iceberg(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,6 +445,8 @@ filterwarnings = [
   # Ignore 3rd party EncodingWarning but raise on pandas'
   "ignore:.*encoding.* argument not specified:EncodingWarning",
   "error:.*encoding.* argument not specified:EncodingWarning:pandas",
+  # From pyiceberg w/ Python >=3.13: https://github.com/apache/iceberg-python/issues/2530#issuecomment-3712112040
+  "ignore:unclosed database in <sqlite3.Connection object*:ResourceWarning",
   # From fastparquet - test_read_filters_fastparquet
   "ignore:.*FileIO:pytest.PytestUnraisableExceptionWarning",
   # From plotting doctests


### PR DESCRIPTION
cc @mroeschke I think this should fix the iceberg failures you are seeing on the infer_string=0 builds in https://github.com/pandas-dev/pandas/pull/63969