### PR TITLE
TST: adjust tests for the deprecation default `exact` in `assert_index_equal` from "equiv" to True

### DIFF
--- a/pandas/tests/copy_view/index/test_index.py
+++ b/pandas/tests/copy_view/index/test_index.py
@@ -125,7 +125,7 @@ def test_index_ops(func, request):
         expected = expected.astype("Int64")
     idx = func(idx)
     view_.iloc[0, 0] = 100
-    tm.assert_index_equal(idx, expected, check_names=False)
+    tm.assert_index_equal(idx, expected, exact="equiv", check_names=False)
 
 
 def test_infer_objects():

--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -19,6 +19,7 @@ from pandas import (
     DatetimeIndex,
     Index,
     MultiIndex,
+    RangeIndex,
     Series,
     date_range,
     period_range,
@@ -150,7 +151,7 @@ class TestSetIndex:
 
     def test_set_index(self, float_string_frame):
         df = float_string_frame
-        idx = Index(np.arange(len(df) - 1, -1, -1, dtype=np.int64))
+        idx = RangeIndex(start=29, stop=-1, step=-1)
 
         df = df.set_index(idx)
         tm.assert_index_equal(df.index, idx)

--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -7,6 +7,7 @@ import pandas as pd
 from pandas import (
     Index,
     NaT,
+    RangeIndex,
 )
 import pandas._testing as tm
 
@@ -100,5 +101,5 @@ def test_getitem_boolean_ea_indexer():
     # GH#45806
     ser = pd.Series([True, False, pd.NA], dtype="boolean")
     result = ser.index[ser]
-    expected = Index([0])
-    tm.assert_index_equal(result, expected)
+    expected = RangeIndex(start=0, stop=1, step=1)
+    tm.assert_index_equal(result, expected, exact=True)

--- a/pandas/tests/indexes/numeric/test_join.py
+++ b/pandas/tests/indexes/numeric/test_join.py
@@ -33,7 +33,7 @@ class TestJoinInt64Index:
         eridx = np.array([4, 1], dtype=np.intp)
 
         assert isinstance(res, Index) and res.dtype == np.int64
-        tm.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres, exact="equiv")
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -41,12 +41,12 @@ class TestJoinInt64Index:
         res, lidx, ridx = index.join(other_mono, how="inner", return_indexers=True)
 
         res2 = index.intersection(other_mono).set_names(["lhs"])
-        tm.assert_index_equal(res, res2)
+        tm.assert_index_equal(res, res2, exact="equiv")
 
         elidx = np.array([1, 6], dtype=np.intp)
         eridx = np.array([1, 4], dtype=np.intp)
         assert isinstance(res, Index) and res.dtype == np.int64
-        tm.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres, exact="equiv")
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 

--- a/pandas/tests/indexes/ranges/test_indexing.py
+++ b/pandas/tests/indexes/ranges/test_indexing.py
@@ -100,26 +100,26 @@ class TestTake:
 
         # no errors
         result = idx.take(np.array([1, -3]))
-        expected = Index([2, 1], dtype=np.int64, name="xxx")
-        tm.assert_index_equal(result, expected)
+        expected = RangeIndex(start=2, stop=0, step=-1, name="xxx")
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_take_accepts_empty_array(self):
         idx = RangeIndex(1, 4, name="foo")
         result = idx.take(np.array([]))
-        expected = Index([], dtype=np.int64, name="foo")
-        tm.assert_index_equal(result, expected)
+        expected = RangeIndex(start=0, stop=0, step=1, name="foo")
+        tm.assert_index_equal(result, expected, exact=True)
 
         # empty index
         idx = RangeIndex(0, name="foo")
         result = idx.take(np.array([]))
-        expected = Index([], dtype=np.int64, name="foo")
-        tm.assert_index_equal(result, expected)
+        expected = RangeIndex(start=0, stop=0, step=1, name="foo")
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_take_accepts_non_int64_array(self):
         idx = RangeIndex(1, 4, name="foo")
         result = idx.take(np.array([2, 1], dtype=np.uint32))
-        expected = Index([3, 2], dtype=np.int64, name="foo")
-        tm.assert_index_equal(result, expected)
+        expected = RangeIndex(start=3, stop=1, step=-1, name="foo")
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_take_when_index_has_step(self):
         idx = RangeIndex(1, 11, 3, name="foo")  # [1, 4, 7, 10]

--- a/pandas/tests/indexes/ranges/test_join.py
+++ b/pandas/tests/indexes/ranges/test_join.py
@@ -67,7 +67,7 @@ class TestJoin:
         eridx = np.array([9, 7], dtype=np.intp)
 
         assert isinstance(res, Index) and res.dtype == np.int64
-        tm.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres, exact="equiv")
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -66,7 +66,7 @@ class TestRangeIndexSetOps:
         other = Index(np.arange(1, 6))
         result = index.intersection(other, sort=sort)
         expected = Index(np.sort(np.intersect1d(index.values, other.values)))
-        tm.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected, exact="equiv")
 
         result = other.intersection(index, sort=sort)
         expected = Index(

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -847,7 +847,7 @@ class TestBase:
         if idx.dtype.kind in ["i", "u"]:
             res = ~idx
             expected = Index(~idx.values, name=idx.name)
-            tm.assert_index_equal(res, expected)
+            tm.assert_index_equal(res, expected, exact="equiv")
 
             # check that we are matching Series behavior
             res2 = ~Series(idx)

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -127,7 +127,9 @@ class TestConcatenate:
         )
 
         tm.assert_index_equal(result.columns.levels[0], Index(level, name="group_key"))
-        tm.assert_index_equal(result.columns.levels[1], Index([0, 1, 2, 3]))
+        tm.assert_index_equal(
+            result.columns.levels[1], RangeIndex(start=0, stop=4, step=1), exact=True
+        )
 
         assert result.columns.names == ["group_key", None]
 


### PR DESCRIPTION
xref #57436
xref #64542

Updated tests for upcoming `assert_index_equal `default `exact `change.