### PR TITLE
DOC: clarifying min_itemsize in HDFStore.append and HDFStore.put documentation

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1186,7 +1186,11 @@ class HDFStore:
             Specifies a compression level for data.
             A value of 0 or None disables compression.
         min_itemsize : int, dict, or None
-            Dict of columns that specify minimum str sizes.
+            Minimum number of bytes reserved for object columns.
+            If int, every object column reserves at least 'min_itemsize' bytes per stored value.
+            If dict, specific object columns reserve at least 'min_itemsize' bytes per stored value.
+            Strings are stored as encoded bytes (utf-8), since some characters require multiple
+            bytes, required size may be larger than the number of characters in a string.
         nan_rep : str
             Str to use as str nan representation.
         data_columns : list of columns or True, default None
@@ -1346,7 +1350,11 @@ class HDFStore:
         columns : default None
             This parameter is currently not accepted, try data_columns.
         min_itemsize : int, dict, or None
-            Dict of columns that specify minimum str sizes.
+            Minimum number of bytes reserved for object columns.
+            If int, every object column reserves at least 'min_itemsize' bytes per stored value.
+            If dict, specific object columns reserve at least 'min_itemsize' bytes per stored value.
+            Strings are stored as encoded bytes (utf-8), since some characters require multiple
+            bytes, required size may be larger than the number of characters in a string.
         nan_rep : str
             Str to use as str nan representation.
         chunksize : int or None

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1187,8 +1187,8 @@ class HDFStore:
             A value of 0 or None disables compression.
         min_itemsize : int, dict, or None
             Minimum number of bytes reserved for object columns.
-            If int, every object column reserves at least 'min_itemsize' bytes per stored value.
-            If dict, specific object columns reserve at least 'min_itemsize' bytes per stored value.
+            If int, all columns reserve 'min_itemsize' bytes per stored value.
+            If dict, specific columns reserve 'min_itemsize' bytes per stored value.
             Strings are stored as encoded bytes. Since some characters require multiple
             bytes, required size may be larger than string length.
         nan_rep : str
@@ -1351,8 +1351,8 @@ class HDFStore:
             This parameter is currently not accepted, try data_columns.
         min_itemsize : int, dict, or None
             Minimum number of bytes reserved for object columns.
-            If int, every object column reserves at least 'min_itemsize' bytes per stored value.
-            If dict, specific object columns reserve at least 'min_itemsize' bytes per stored value.
+            If int, all columns reserve 'min_itemsize' bytes per stored value.
+            If dict, specific columns reserve 'min_itemsize' bytes per stored value.
             Strings are stored as encoded bytes. Since some characters require multiple
             bytes, required size may be larger than string length.
         nan_rep : str

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1189,8 +1189,8 @@ class HDFStore:
             Minimum number of bytes reserved for object columns.
             If int, every object column reserves at least 'min_itemsize' bytes per stored value.
             If dict, specific object columns reserve at least 'min_itemsize' bytes per stored value.
-            Strings are stored as encoded bytes (utf-8), since some characters require multiple
-            bytes, required size may be larger than the number of characters in a string.
+            Strings are stored as encoded bytes. Since some characters require multiple
+            bytes, required size may be larger than string length.
         nan_rep : str
             Str to use as str nan representation.
         data_columns : list of columns or True, default None
@@ -1353,8 +1353,8 @@ class HDFStore:
             Minimum number of bytes reserved for object columns.
             If int, every object column reserves at least 'min_itemsize' bytes per stored value.
             If dict, specific object columns reserve at least 'min_itemsize' bytes per stored value.
-            Strings are stored as encoded bytes (utf-8), since some characters require multiple
-            bytes, required size may be larger than the number of characters in a string.
+            Strings are stored as encoded bytes. Since some characters require multiple
+            bytes, required size may be larger than string length.
         nan_rep : str
             Str to use as str nan representation.
         chunksize : int or None


### PR DESCRIPTION
- [X] closes #14601
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature.
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] N/A. Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] N/A. Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [X] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`. (No AI).

**Changes**
- changed the documentation for min_itemsize in HDFStore.put and HDFStore.append to clarify variable type (accepts both int and dict).
- emphasized that min_itemsize reserves bytes per value rather than characters to prevent confusion with UTF-8 and Non-ASCII characters.

Please let me know if all's good and if anything's missing I'll commit the changes ASAP.

Thank you! Very happy to contribute!


