### PR TITLE
TYP: Add __class_getitem__ to Index and Series

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -28,6 +28,7 @@ enhancement2
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
+- :class:`Index` and :class:`Series` now support runtime subscript syntax (e.g. ``Index[np.int64]``, ``Series[np.float64]``) for use in type annotations without requiring ``from __future__ import annotations`` (:issue:`36708`)
 - :meth:`.DataFrameGroupBy.agg` now allows for the provided ``func`` to return a NumPy array (:issue:`63957`)
 - Added :meth:`ExtensionArray.count` (:issue:`64450`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -322,6 +322,9 @@ class Index(IndexOpsMixin, PandasObject):
        Index can hold all numpy numeric dtypes (except float16). Previously only
        int64/uint64/float64 dtypes were accepted.
 
+    This class is generic and can be parameterized in type annotations,
+    e.g. ``Index[np.int64]``.
+
     Parameters
     ----------
     data : array-like (1-dimensional)
@@ -373,6 +376,12 @@ class Index(IndexOpsMixin, PandasObject):
     # similar to __array_priority__, positions Index after Series and DataFrame
     #  but before ExtensionArray.  Should NOT be overridden by subclasses.
     __pandas_priority__ = 2000
+
+    @classmethod
+    def __class_getitem__(cls, item: Any) -> type:
+        # Allow subscript syntax (e.g. Index[np.int64]) for type annotations
+        # without requiring quoting or `from __future__ import annotations`.
+        return cls
 
     # Cython methods; see github.com/cython/cython/issues/2647
     #  for why we need to wrap these instead of making them class attributes

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -218,6 +218,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     methods from ndarray have been overridden to automatically exclude
     missing data (currently represented as NaN).
 
+    This class is generic and can be parameterized in type annotations,
+    e.g. ``Series[np.int64]``.
+
     Operations between Series (+, -, /, \\*, \\*\\*) align values based on their
     associated index values-- they need not be the same length. The result
     index will be the sorted union of the two indexes.
@@ -322,6 +325,13 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
     _name: Hashable
     _metadata: list[str] = ["_name"]
+
+    @classmethod
+    def __class_getitem__(cls, item: Any) -> type:
+        # Allow subscript syntax (e.g. Series[np.int64]) for type annotations
+        # without requiring quoting or `from __future__ import annotations`.
+        return cls
+
     _internal_names_set = {"index", "name"} | NDFrame._internal_names_set
     _accessors = {"dt", "cat", "str", "sparse"}
     _hidden_attrs = (


### PR DESCRIPTION
## Summary
- Add `__class_getitem__` to `Index` and `Series` so that runtime subscript syntax (e.g. `Index[np.int64]`, `Series[np.float64]`) works without requiring quoting or `from __future__ import annotations`
- Complements the existing generic support in [pandas-stubs](https://github.com/pandas-dev/pandas-stubs), which already makes `Index` and `Series` generic via `IndexOpsMixin` but relies on annotations being deferred
- Zero performance overhead — `__class_getitem__` is only invoked when the subscript expression is evaluated, not during construction or `isinstance` checks

xref #36708, #34248

## Test plan
- [x] Verified `Index[np.int64]`, `Series[np.float64]`, and subclass subscripts (`RangeIndex[np.int64]`) work at runtime
- [x] Verified no impact on construction or `isinstance` performance
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)