### PR TITLE
BUG: Conversion from datetime64[ns] to datetime does not effect .info...

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -150,6 +150,7 @@ Conversion
 ^^^^^^^^^^
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`).
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
+- Fixed bug in :meth:`DataFrame.__setitem__` where assigning an object array (e.g., from :meth:`.dt.to_pydatetime`) would incorrectly infer the dtype and convert Python datetime objects back to ``datetime64[ns]`` instead of preserving the ``object`` dtype (:issue:`55136`)
 -
 
 Strings

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5596,6 +5596,14 @@ class DataFrame(NDFrame, OpsMixin):
 
         if is_list_like(value):
             com.require_length_match(value, self.index)
+
+        # GH#55136: preserve dtype for object arrays to prevent unwanted inference
+        # e.g., converting Python datetime objects back to datetime64[ns]
+        dtype = getattr(value, "dtype", None) if hasattr(value, "dtype") else None
+        if dtype is not None and dtype == np.dtype("object"):
+            # Explicitly pass dtype=object to prevent inference in sanitize_array
+            return sanitize_array(value, self.index, dtype=dtype, copy=True, allow_2d=True), None
+
         return sanitize_array(value, self.index, copy=True, allow_2d=True), None
 
     @property

--- a/pandas/tests/frame/methods/test_info.py
+++ b/pandas/tests/frame/methods/test_info.py
@@ -584,3 +584,21 @@ def test_info_show_counts(row, columns, show_counts, result):
         with StringIO() as buf:
             df.info(buf=buf, show_counts=show_counts)
             assert ("non-null" in buf.getvalue()) is result
+
+
+def test_info_after_to_pydatetime():
+    # GH#55136
+    df = DataFrame({"datetime": date_range("2020-01-01", periods=5), "value": range(5)})
+
+    # Convert datetime64 to Python datetime objects
+    df["datetime"] = df["datetime"].dt.to_pydatetime()
+
+    # Check that info() shows dtype as object, not datetime64
+    buf = StringIO()
+    df.info(buf=buf)
+    result = buf.getvalue()
+
+    # The dtype should be 'object', not 'datetime64[ns]'
+    assert "object" in result
+    assert "datetime64" not in result
+    assert df["datetime"].dtype == object


### PR DESCRIPTION
Fixes #55136

Fixed DataFrame column assignment to preserve object dtype when assigning Python datetime objects from dt.to_pydatetime().

- [x] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest  file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow .