### PR TITLE
BUG: concat with datetime64 columns of differing resolutions results ...

### DIFF
--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -166,9 +166,24 @@ def _get_result_dtype(
         target_dtype = np.dtype(object)
         kinds = {"o"}
     else:
-        # error: Argument 1 to "np_find_common_type" has incompatible type
-        # "*Set[Union[ExtensionDtype, Any]]"; expected "dtype[Any]"
-        target_dtype = np_find_common_type(*dtypes)  # type: ignore[arg-type]
+        # GH#53307: Handle datetime64 and timedelta64 with different resolutions
+        np_dtypes = [dt for dt in dtypes if isinstance(dt, np.dtype)]
+        if len(np_dtypes) == len(dtypes):
+            # All are numpy dtypes
+            if all(lib.is_np_dtype(t, "M") for t in np_dtypes):
+                # All datetime64, take finest resolution
+                target_dtype = np.dtype(max(np_dtypes))
+            elif all(lib.is_np_dtype(t, "m") for t in np_dtypes):
+                # All timedelta64, take finest resolution
+                target_dtype = np.dtype(max(np_dtypes))
+            else:
+                # error: Argument 1 to "np_find_common_type" has incompatible type
+                # "*Set[Union[ExtensionDtype, Any]]"; expected "dtype[Any]"
+                target_dtype = np_find_common_type(*dtypes)  # type: ignore[arg-type]
+        else:
+            # error: Argument 1 to "np_find_common_type" has incompatible type
+            # "*Set[Union[ExtensionDtype, Any]]"; expected "dtype[Any]"
+            target_dtype = np_find_common_type(*dtypes)  # type: ignore[arg-type]
 
     return any_ea, kinds, target_dtype
 

--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -296,6 +296,25 @@ class TestDatetimeConcat:
         result = concat([first, second], ignore_index=True)
         tm.assert_series_equal(result, expected)
 
+    def test_concat_datetime64_different_resolutions(self, unit, unit2):
+        # GH#53307
+        # Concatenating datetime64 columns with different resolutions
+        # should return the finest resolution, not object dtype
+        df = DataFrame(
+            {
+                "ints": range(2),
+                "dates": date_range("2000", periods=2, freq="min", unit=unit),
+            },
+        )
+        df2 = df.copy()
+        df2["dates"] = df.dates.astype(f"M8[{unit2}]")
+
+        result = concat([df, df2])
+
+        exp_unit = tm.get_finest_unit(unit, unit2)
+        assert pd.api.types.is_datetime64_any_dtype(result.dates.dtype)
+        assert result.dates.dtype == np.dtype(f"datetime64[{exp_unit}]")
+
 
 class TestTimezoneConcat:
     def test_concat_tz_series(self):
@@ -563,6 +582,28 @@ def test_concat_timedelta64_block():
     result = concat([df, df])
     tm.assert_frame_equal(result.iloc[:10], df, check_index_type=False)
     tm.assert_frame_equal(result.iloc[10:], df, check_index_type=False)
+
+
+@pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+@pytest.mark.parametrize("unit2", ["s", "ms", "us", "ns"])
+def test_concat_timedelta64_different_resolutions(unit, unit2):
+    # GH#53307
+    # Concatenating timedelta64 columns with different resolutions
+    # should return the finest resolution, not object dtype
+    df = DataFrame(
+        {
+            "ints": range(2),
+            "deltas": to_timedelta(np.arange(2), unit=unit),
+        },
+    )
+    df2 = df.copy()
+    df2["deltas"] = df.deltas.astype(f"m8[{unit2}]")
+
+    result = concat([df, df2])
+
+    exp_unit = tm.get_finest_unit(unit, unit2)
+    assert pd.api.types.is_timedelta64_dtype(result.deltas.dtype)
+    assert result.deltas.dtype == np.dtype(f"timedelta64[{exp_unit}]")
 
 
 def test_concat_multiindex_datetime_nat():


### PR DESCRIPTION
Fixes #53307

Fixed concat to preserve datetime64 dtype when concatenating columns with different resolutions instead of falling back to object dtype.

- [x] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest  file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow .