### PR TITLE
ERR: raise ValueError when numeric_only is not a bool in reduction ops (GH#53098)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -87,6 +87,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Other API changes
 ^^^^^^^^^^^^^^^^^
 - APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`64483`).
+- Reduction methods (:meth:`DataFrame.sum`, :meth:`DataFrame.prod`, :meth:`DataFrame.mean`, :meth:`DataFrame.median`, :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`DataFrame.std`, :meth:`DataFrame.var`, :meth:`DataFrame.sem`, :meth:`DataFrame.skew`) now raise a ``ValueError`` when ``numeric_only`` is not a bool (e.g. ``None``) (:issue:`53098`).
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11758,6 +11758,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> Series | float:
         nv.validate_stat_ddof_func((), kwargs, fname=name)
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        validate_bool_kwarg(numeric_only, "numeric_only", none_allowed=False)
 
         return self._reduce(
             func, name, axis=axis, numeric_only=numeric_only, skipna=skipna, ddof=ddof
@@ -11816,6 +11817,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         nv.validate_func(name, (), kwargs)
 
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        validate_bool_kwarg(numeric_only, "numeric_only", none_allowed=False)
 
         return self._reduce(
             func, name=name, axis=axis, skipna=skipna, numeric_only=numeric_only
@@ -11920,6 +11922,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         nv.validate_func(name, (), kwargs)
 
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        validate_bool_kwarg(numeric_only, "numeric_only", none_allowed=False)
 
         return self._reduce(
             func,

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -848,7 +848,7 @@ class TestDataFrameAnalytics:
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("method, unit", [("sum", 0), ("prod", 1)])
-    @pytest.mark.parametrize("numeric_only", [None, True, False])
+    @pytest.mark.parametrize("numeric_only", [True, False])
     def test_sum_prod_nanops(self, method, unit, numeric_only):
         idx = ["a", "b", "c"]
         df = DataFrame({"a": [unit, unit], "b": [unit, np.nan], "c": [np.nan, np.nan]})
@@ -2026,7 +2026,7 @@ def test_mixed_frame_with_integer_sum():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("numeric_only", [True, False, None])
+@pytest.mark.parametrize("numeric_only", [True, False])
 @pytest.mark.parametrize("method", ["min", "max"])
 def test_minmax_extensionarray(method, numeric_only):
     # https://github.com/pandas-dev/pandas/issues/32651
@@ -2040,6 +2040,18 @@ def test_minmax_extensionarray(method, numeric_only):
         index=Index(["Int64"]),
     )
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["sum", "prod", "mean", "median", "min", "max", "std", "var", "sem", "skew"],
+)
+def test_numeric_only_non_bool_raises(method):
+    # GH#53098 numeric_only must be a bool, not None or other non-bool types
+    df = DataFrame({"x": [1], "y": [4]})
+    msg = 'For argument "numeric_only" expected type bool'
+    with pytest.raises(ValueError, match=msg):
+        getattr(df, method)(numeric_only=None)
 
 
 @pytest.mark.parametrize("ts_value", [Timestamp("2000-01-01"), pd.NaT])


### PR DESCRIPTION
## Summary

Closes #53098.

Passing non-bool values to `numeric_only` in DataFrame reduction methods (`sum`, `prod`, `mean`, `median`, `min`, `max`, `std`, `var`, `sem`, `skew`, `kurt`) silently accepted any truthy/falsy value since pandas 2.0. The `None` case is particularly confusing because `None` was the old default in 1.x and users may have code that passes `None` thinking it behaves differently from `False`.

The fix adds `validate_bool_kwarg(numeric_only, "numeric_only", none_allowed=False)` in the three private dispatch methods `_stat_function`, `_stat_function_ddof`, and `_min_count_stat_function` in `NDFrame`. These three methods cover all the affected public reduction methods in one place, consistent with how `skipna` is already validated in those same methods.

## Changes

- `pandas/core/generic.py`: three `validate_bool_kwarg` calls added, one per dispatch method
- `pandas/tests/frame/test_reductions.py`: removed `None` from two existing parametrize lists; added `test_numeric_only_non_bool_raises` covering all affected methods
- `doc/source/whatsnew/v3.1.0.rst`: entry under "Other API changes"

## Test plan

- [ ] `pytest pandas/tests/frame/test_reductions.py -k "test_sum_prod_nanops or test_minmax_extensionarray or test_numeric_only_non_bool_raises"` — 18 passed

The new test `test_numeric_only_non_bool_raises` covers all 10 affected methods with `numeric_only=None` and asserts `ValueError` is raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)