### PR TITLE
TST: add regression test for Series.combine fill_value with integer label (GH#31142)

### DIFF
--- a/pandas/tests/series/methods/test_combine.py
+++ b/pandas/tests/series/methods/test_combine.py
@@ -24,3 +24,19 @@ class TestCombine:
         result = s1.combine(s2, lambda x, y: x + y)
         expected = Series([-74, NA, 105], dtype="Int8")  # dtype should be preserved
         tm.assert_series_equal(result, expected)
+
+    def test_combine_fill_value_integer_label(self):
+        # GH#31142
+        # When one Series has an integer label (e.g. 0) that does not exist in
+        # the other Series, fill_value should be used for the missing side.
+        # Previously, Series.get(0) fell back to positional access, so key 0
+        # incorrectly retrieved the first element of the other Series instead
+        # of returning fill_value.
+        a = Series([1, 2, 3], index=["a", "b", "c"])
+        b = Series([10, 20, 30], index=[0, "e", "f"])
+        result = b.combine(a, lambda x, y: x + y, fill_value=0)
+        expected = Series(
+            [10, 1, 2, 3, 20, 30],
+            index=[0, "a", "b", "c", "e", "f"],
+        )
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- closes #31142
- [x] Tests added and passed if fixing a bug or adding a new feature
- [ ] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

## Summary

`Series.combine` with `fill_value` gave wrong results when one Series had an integer label (e.g. `0`) absent from the other Series. Inside `combine`, `self.get(idx, fill_value)` was called, and `Series.get(0)` fell back to positional access, returning the first element instead of `fill_value`. The call `func(value, fill_value)` then produced an incorrect result.

The bug was fixed separately when `Series.__getitem__` was made strictly label-based. This PR adds a regression test so the fix is not accidentally reverted.

**Reproducer from the issue:**

```python
a = pd.Series([1, 2, 3], index=["a", "b", "c"])
b = pd.Series([10, 20, 30], index=[0, "e", "f"])
c = b.combine(a, lambda x, y: x + y, fill_value=0)
# Before fix: c[0] == 11  (0 was treated as positional, a[0]=1 was retrieved)
# After fix:  c[0] == 10  (fill_value=0 is used correctly)
```

Note: I used an automated tool (Claude Code) to help write this PR. I have reviewed the code and the test is correct.