### PR TITLE
CI: Upload test coverage to Codecov again

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -40,18 +40,3 @@ runs:
           ${{ inputs.numprocesses }} \
           ${{ inputs.pytest_target }}
       shell: bash -euox pipefail {0}
-
-    - name: Publish test results
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-      with:
-        name: Test results
-        path: test-data.xml
-      if: failure()
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
-      with:
-        flags: unittests
-        name: codecov-pandas
-        fail_ci_if_error: false
-      if: failure()

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,7 +94,6 @@ jobs:
     env:
       LANG: ${{ matrix.lang || 'C.UTF-8' }}
       LC_ALL: ${{ matrix.lc_all || '' }}
-      PANDAS_MOTO_URL: "http://localhost:5000"
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.environment }}-${{ matrix.pytest_marker_expression }}-${{ matrix.extra_apt || '' }}-${{ matrix.pandas_future_infer_string }}-${{ matrix.platform }}
@@ -171,6 +170,9 @@ jobs:
     - name: Test (not single_cpu)
       uses: ./.github/actions/run-tests
       id: test-not-single-cpu
+      env:
+        # Ensure port matches moto service
+        PANDAS_MOTO_URL: "http://localhost:5000"
       with:
         environment: ${{ matrix.environment }}
         numprocesses: 'auto'
@@ -182,6 +184,9 @@ jobs:
     - name: Test (single_cpu)
       id: test-single-cpu
       uses: ./.github/actions/run-tests
+      env:
+        # Ensure port matches moto service
+        PANDAS_MOTO_URL: "http://localhost:5000"
       with:
         environment: ${{ matrix.environment }}
         numprocesses: 0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -197,7 +197,8 @@ jobs:
         name: codecov-pandas-${{ matrix.name }}
         fail_ci_if_error: false
         disable_telem: true
-      # single_cpu + not single_cpu jobs provide most hollistic coverage report
+      # coverage report appended for single_cpu + not single_cpu steps
+      # provide most hollistic coverage report
       if: ${{ steps.test-not-single-cpu.outcome == 'success' && steps.test-single-cpu.outcome == 'success' }}
 
   macos-windows:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -194,7 +194,7 @@ jobs:
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
       with:
         flags: unittests
-        name: codecov-pandas-${{ matrix.name }}
+        name: codecov-pandas-${{ matrix.name || format('{0} {1}', matrix.platform, matrix.environment) }}
         fail_ci_if_error: false
         disable_telem: true
       # coverage report appended for single_cpu + not single_cpu steps

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -169,6 +169,7 @@ jobs:
 
     - name: Test (not single_cpu)
       uses: ./.github/actions/run-tests
+      id: test-not-single-cpu
       with:
         environment: ${{ matrix.environment }}
         numprocesses: 'auto'
@@ -176,7 +177,9 @@ jobs:
         pytest_target: ${{ matrix.pytest_target || 'pandas' }}
         pandas_future_infer_string: ${{ matrix.pandas_future_infer_string || '1' }}
         pandas_future_python_scalars: ${{ matrix.pandas_future_python_scalars || '0' }}
+
     - name: Test (single_cpu)
+      id: test-single-cpu
       uses: ./.github/actions/run-tests
       with:
         environment: ${{ matrix.environment }}
@@ -186,6 +189,16 @@ jobs:
         pandas_future_infer_string: ${{ matrix.pandas_future_infer_string || '1' }}
         pandas_future_python_scalars: ${{ matrix.pandas_future_python_scalars || '0' }}
       if: ${{ matrix.pytest_marker_expression == '' && (always() && steps.build.outcome == 'success')}}
+
+    - name: Upload test coverage to Codecov
+      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+      with:
+        flags: unittests
+        name: codecov-pandas-${{ matrix.name }}
+        fail_ci_if_error: false
+        disable_telem: true
+      # single_cpu + not single_cpu jobs provide most hollistic coverage report
+      if: ${{ steps.test-not-single-cpu.outcome == 'success' && steps.test-single-cpu.outcome == 'success' }}
 
   macos-windows:
     permissions:
@@ -268,7 +281,7 @@ jobs:
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
-          PANDAS_CI=1 python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
+          PANDAS_CI=1 python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-32bit
@@ -311,7 +324,7 @@ jobs:
       - name: Run Tests
         run: |
           . ~/virtualenvs/pandas-dev/bin/activate
-          PANDAS_CI=1 python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas --junitxml=test-data.xml
+          PANDAS_CI=1 python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-musl

--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ asv_bench/env/
 asv_bench/html/
 asv_bench/results/
 asv_bench/pandas/
-test-data.xml
 
 # Documentation generated files #
 #################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,7 +423,7 @@ docstring-code-format = true
 [tool.pytest.ini_options]
 # sync minversion with pyproject.toml & install.rst
 minversion = "8.3.4"
-addopts = "--strict-markers --strict-config --capture=no --durations=30 --junitxml=test-data.xml"
+addopts = "--strict-markers --strict-config --capture=no --durations=30"
 empty_parameter_set_mark = "fail_at_collect"
 xfail_strict = true
 testpaths = "pandas"

--- a/scripts/tests/data/deps_minimum.toml
+++ b/scripts/tests/data/deps_minimum.toml
@@ -227,7 +227,7 @@ exclude = [
 [tool.pytest.ini_options]
 # sync minversion with pyproject.toml & install.rst
 minversion = "7.0"
-addopts = "--strict-data-files --strict-markers --strict-config --capture=no --durations=30 --junitxml=test-data.xml"
+addopts = "--strict-data-files --strict-markers --strict-config --capture=no --durations=30"
 empty_parameter_set_mark = "fail_at_collect"
 xfail_strict = true
 testpaths = "pandas"


### PR DESCRIPTION
I cannot tell when we stopped uploading test coverage data to Codecov, but the prior logic was to upload coverage when the unit tests failed. Now this PR will upload coverage data when the ubuntu single cpu and non single cpu jobs complete (as a "net" coverage report).

Also eliminate generating `test-data.xml`. This was probably needed prior to us using Github Actions.