### PR TITLE
TYP: enable mypy for array_algos.putmask

### DIFF
--- a/pandas/core/array_algos/putmask.py
+++ b/pandas/core/array_algos/putmask.py
@@ -127,7 +127,7 @@ def extract_bool_array(mask: ArrayLike) -> npt.NDArray[np.bool_]:
     return mask
 
 
-def setitem_datetimelike_compat(values: np.ndarray, num_set: int, other):
+def setitem_datetimelike_compat(values: np.ndarray, num_set: int, other: Any) -> Any:
     """
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -531,7 +531,6 @@ module = [
   "pandas.compat.numpy.function", # TODO
   "pandas.core._numba.executor", # TODO
   "pandas.core.array_algos.masked_reductions", # TODO
-  "pandas.core.array_algos.putmask", # TODO
   "pandas.core.array_algos.quantile", # TODO
   "pandas.core.array_algos.replace", # TODO
   "pandas.core.array_algos.take", # TODO


### PR DESCRIPTION
## Summary
- Remove `pandas.core.array_algos.putmask` from the mypy override exclusion list in `pyproject.toml`
- Add type annotations to `setitem_datetimelike_compat` (`other: Any`, `-> Any`)

## Test plan
- [x] `mypy pandas/core/array_algos/putmask.py` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)