### PR TITLE
TYP: enable mypy checks for pandas.errors

### DIFF
--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -530,7 +530,9 @@ class AbstractMethodError(NotImplementedError):
     AbstractMethodError: This classmethod must be defined in the concrete class Foo
     """
 
-    def __init__(self, class_instance, methodtype: str = "method") -> None:
+    def __init__(
+        self, class_instance: type | object, methodtype: str = "method"
+    ) -> None:
         types = {"method", "classmethod", "staticmethod", "property"}
         if methodtype not in types:
             raise ValueError(
@@ -540,7 +542,7 @@ class AbstractMethodError(NotImplementedError):
         self.class_instance = class_instance
 
     def __str__(self) -> str:
-        if self.methodtype == "classmethod":
+        if isinstance(self.class_instance, type):
             name = self.class_instance.__name__
         else:
             name = type(self.class_instance).__name__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -593,7 +593,6 @@ module = [
   "pandas.core.sample", # TODO
   "pandas.core.series", # TODO
   "pandas.core.sorting", # TODO
-  "pandas.errors", # TODO
   "pandas.io.clipboard", # TODO
   "pandas.io.excel._base", # TODO
   "pandas.io.excel._odfreader", # TODO


### PR DESCRIPTION
## Summary
- Remove `pandas.errors` from the mypy override block that disables `disallow_untyped_defs` and related checks
- Add `type | object` annotation to `AbstractMethodError.__init__`'s `class_instance` parameter
- Use `isinstance(self.class_instance, type)` narrowing in `__str__` instead of checking `self.methodtype == "classmethod"`, so mypy can verify the `.__name__` attribute access

## Test plan
- [x] `mypy pandas/errors/` passes with no errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)