### PR TITLE
PERF: groupby first/last no longer falls back to apply for ExtensionArrays

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -110,6 +110,7 @@ Performance improvements
 - Performance improvement in :func:`infer_freq` (:issue:`64463`)
 - Performance improvement in :func:`merge` with ``how="cross"`` (:issue:`38082`)
 - Performance improvement in :func:`merge` with ``how="left"`` (:issue:`64370`)
+- Performance improvement in :meth:`GroupBy.first` and :meth:`GroupBy.last` for Extension Array dtypes, which no longer fall back to a slow ``apply``-based implementation (:issue:`57591`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
 - Performance improvement in datetime/timedelta unit conversion (e.g. ``datetime64[s]`` to ``datetime64[ns]``) (:issue:`35025`)
 

--- a/pandas/_libs/groupby.pyi
+++ b/pandas/_libs/groupby.pyi
@@ -166,6 +166,13 @@ def group_nth(
     is_datetimelike: bool = ...,
     skipna: bool = ...,
 ) -> None: ...
+def group_first_last_indexer(
+    labels: npt.NDArray[np.intp],
+    mask: npt.NDArray[np.uint8],
+    ngroups: int,
+    skipna: bool,
+    is_last: bool,
+) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.uint8]]: ...
 def group_rank(
     out: np.ndarray,  # float64_t[:, ::1]
     values: np.ndarray,  # ndarray[rank_t, ndim=2]

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1761,6 +1761,72 @@ def group_nth(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
+def group_first_last_indexer(
+    const intp_t[::1] labels,
+    const uint8_t[::1] mask,
+    Py_ssize_t ngroups,
+    bint skipna,
+    bint is_last,
+):
+    """
+    Compute the index of the first or last (non-NA) element per group.
+
+    Parameters
+    ----------
+    labels : np.ndarray[np.intp]
+        Group labels for each element. Negative values mean the element
+        is not assigned to any group.
+    mask : np.ndarray[np.uint8]
+        Boolean mask where 1 indicates NA.
+    ngroups : int
+        Number of groups.
+    skipna : bool
+        If True, skip NA values when searching for the first/last.
+    is_last : bool
+        If True, find the last valid element; if False, find the first.
+
+    Returns
+    -------
+    result_indices : np.ndarray[np.intp]
+        Index of the first/last element per group. -1 if no valid element found.
+    result_mask : np.ndarray[np.uint8]
+        1 if the group result should be NA, 0 otherwise.
+    """
+    cdef:
+        Py_ssize_t i, N = len(labels)
+        intp_t lab
+        intp_t[::1] result = np.full(ngroups, -1, dtype=np.intp)
+        uint8_t[::1] rmask = np.ones(ngroups, dtype=np.uint8)
+        uint8_t[::1] found = np.zeros(ngroups, dtype=np.uint8)
+
+    with nogil:
+        if is_last:
+            for i in range(N):
+                lab = labels[i]
+                if lab < 0:
+                    continue
+                if skipna and mask[i]:
+                    continue
+                result[lab] = i
+                rmask[lab] = mask[i] if not skipna else 0
+        else:
+            for i in range(N):
+                lab = labels[i]
+                if lab < 0:
+                    continue
+                if found[lab]:
+                    continue
+                if skipna and mask[i]:
+                    continue
+                result[lab] = i
+                found[lab] = 1
+                rmask[lab] = mask[i] if not skipna else 0
+
+    return np.asarray(result), np.asarray(rmask)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def group_rank(
     float64_t[:, ::1] out,
     ndarray[numeric_object_t, ndim=2] values,

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2868,6 +2868,15 @@ class ArrowExtensionArray(
                 **kwargs,
             )
 
+        if how in ["first", "last"]:
+            return self._groupby_first_last(
+                how=how,
+                min_count=min_count,
+                ngroups=ngroups,
+                ids=ids,
+                skipna=kwargs.get("skipna", True),
+            )
+
         # maybe convert to a compatible dtype optimized for groupby
         values: ExtensionArray
         pa_type = self._pa_array.type

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from pandas._libs import (
     algos as libalgos,
+    groupby as libgroupby,
     lib,
 )
 from pandas.compat import set_function_name
@@ -2860,6 +2861,15 @@ class ExtensionArray:
         -------
         np.ndarray or ExtensionArray
         """
+        if how in ["first", "last"]:
+            return self._groupby_first_last(
+                how=how,
+                min_count=min_count,
+                ngroups=ngroups,
+                ids=ids,
+                skipna=kwargs.get("skipna", True),
+            )
+
         from pandas.core.arrays.string_ import StringDtype
         from pandas.core.groupby.ops import WrappedCythonOp
 
@@ -2925,6 +2935,49 @@ class ExtensionArray:
 
         else:
             raise NotImplementedError
+
+    def _groupby_first_last(
+        self,
+        *,
+        how: str,
+        min_count: int,
+        ngroups: int,
+        ids: npt.NDArray[np.intp],
+        skipna: bool = True,
+    ) -> Self:
+        """
+        Optimized implementation of groupby first/last for ExtensionArrays.
+
+        Uses an index-based approach: computes the index of the first/last
+        non-NA element per group, then gathers results via take(). This avoids
+        any dtype conversion and works for all EA types.
+        """
+        if self.ndim != 1:
+            raise NotImplementedError(
+                "groupby first/last only supports 1D ExtensionArrays"
+            )
+        isna_mask = np.asarray(self.isna(), dtype=np.uint8)
+
+        result_indices, result_mask = libgroupby.group_first_last_indexer(
+            labels=ids,
+            mask=isna_mask,
+            ngroups=ngroups,
+            skipna=skipna,
+            is_last=(how == "last"),
+        )
+
+        # Apply min_count: require at least min_count non-NA observations.
+        # For first/last, the natural minimum is 1 (need at least one value).
+        if min_count > 1:
+            nobs = np.zeros(ngroups, dtype=np.int64)
+            non_na_indices = np.where((~isna_mask.view(bool)) & (ids >= 0))[0]
+            np.add.at(nobs, ids[non_na_indices], 1)
+            below = nobs < min_count
+            result_mask[below] = 1
+            result_indices[below] = -1
+
+        # take() with allow_fill=True treats -1 as "fill with NA"
+        return self.take(result_indices, allow_fill=True)
 
 
 class ExtensionArrayNaResult(ExtensionArray):

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -71,6 +71,18 @@ class BaseGroupbyTests:
         result = df.groupby("A").first()
         tm.assert_frame_equal(result, expected)
 
+        expected_last = df.iloc[[1, 3, 5, 7]]
+        expected_last = expected_last.set_index("A")
+
+        result = df.groupby("A").agg({"B": "last"})
+        tm.assert_frame_equal(result, expected_last)
+
+        result = df.groupby("A").agg("last")
+        tm.assert_frame_equal(result, expected_last)
+
+        result = df.groupby("A").last()
+        tm.assert_frame_equal(result, expected_last)
+
     def test_groupby_extension_no_sort(self, data_for_grouping):
         df = pd.DataFrame({"A": [1, 1, 2, 2, 3, 3, 1, 4], "B": data_for_grouping})
 

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -409,6 +409,97 @@ def test_first_last_skipna(any_real_nullable_dtype, sort, skipna, how):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("how", ["first", "last"])
+def test_first_last_ea_min_count(any_real_nullable_dtype, how):
+    # GH#57591
+    na_val = na_value_for_dtype(pandas_dtype(any_real_nullable_dtype))
+    df = DataFrame(
+        {
+            "a": [1, 1, 2, 2, 3],
+            "b": pd.array([1, 2, na_val, na_val, 5], dtype=any_real_nullable_dtype),
+        },
+    )
+    gb = df.groupby("a")
+    result = getattr(gb, how)(min_count=2)
+
+    # Group 1 has 2 valid values -> passes min_count=2
+    # Group 2 has 0 valid values -> fails min_count=2
+    # Group 3 has 1 valid value -> fails min_count=2
+    if how == "first":
+        expected_vals = pd.array([1, na_val, na_val], dtype=any_real_nullable_dtype)
+    else:
+        expected_vals = pd.array([2, na_val, na_val], dtype=any_real_nullable_dtype)
+    expected = DataFrame(
+        {"b": expected_vals},
+        index=pd.Index([1, 2, 3], name="a"),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("how", ["first", "last"])
+def test_first_last_ea_all_na_group(how):
+    # GH#57591
+    df = DataFrame(
+        {
+            "a": [1, 1, 2, 2],
+            "b": pd.array([pd.NA, pd.NA, 3, 4], dtype="Int64"),
+        },
+    )
+    result = getattr(df.groupby("a"), how)()
+    if how == "first":
+        expected_vals = pd.array([pd.NA, 3], dtype="Int64")
+    else:
+        expected_vals = pd.array([pd.NA, 4], dtype="Int64")
+    expected = DataFrame(
+        {"b": expected_vals},
+        index=pd.Index([1, 2], name="a"),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("how", ["first", "last"])
+@pytest.mark.parametrize("skipna", [True, False])
+def test_first_last_skipna_ea_types(how, skipna):
+    # GH#57591 - test skipna with various non-numeric EA types
+    intervals = pd.arrays.IntervalArray.from_breaks([0, 1, 2, 3])
+    cat_dtype = pd.CategoricalDtype(categories=["b", "c"])
+    df = DataFrame(
+        {
+            "g": [1, 1, 2],
+            "cat": pd.Categorical([pd.NA, "b", "c"], dtype=cat_dtype),
+            "interval": intervals,
+        },
+    )
+    result = getattr(df.groupby("g"), how)(skipna=skipna)
+
+    if how == "first" and not skipna:
+        # cat column: first element is NA, skipna=False keeps it
+        expected = DataFrame(
+            {
+                "cat": pd.Categorical([pd.NA, "c"], dtype=cat_dtype),
+                "interval": intervals[[0, 2]],
+            },
+            index=pd.Index([1, 2], name="g"),
+        )
+    elif how == "first":
+        expected = DataFrame(
+            {
+                "cat": pd.Categorical(["b", "c"], dtype=cat_dtype),
+                "interval": intervals[[0, 2]],
+            },
+            index=pd.Index([1, 2], name="g"),
+        )
+    elif how == "last":
+        expected = DataFrame(
+            {
+                "cat": pd.Categorical(["b", "c"], dtype=cat_dtype),
+                "interval": intervals[[1, 2]],
+            },
+            index=pd.Index([1, 2], name="g"),
+        )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_groupby_mean_no_overflow():
     # Regression test for (#22487)
     df = DataFrame(


### PR DESCRIPTION
- [x] closes #57591

## Summary
- Adds a Cython `group_first_last_indexer` function that computes the index of the first/last non-NA element per group using only group codes and an isna mask — no dtype conversion needed
- Adds `ExtensionArray._groupby_first_last` which calls the indexer then uses `EA.take()` to gather results, working for all EA types universally
- Adds an early intercept in `ArrowExtensionArray._groupby_op` for Arrow types (decimal128, binary, time32/64, date32/64) that previously failed in `_to_masked()`

## Test plan
- [x] All 16 previously-failing `test_groupby_agg_extension` tests now pass (Arrow decimal128/string/binary/time/date, NumpyExtensionArray, SparseArray, DecimalArray, IntervalArray, JSONArray)
- [x] Extended `test_groupby_agg_extension` to also cover `last()` (previously only tested `first()`)
- [x] Added `test_first_last_ea_min_count` — verifies min_count with nullable EA dtypes
- [x] Added `test_first_last_ea_all_na_group` — verifies all-NA groups produce NA
- [x] Added `test_first_last_skipna_ea_types` — verifies skipna with non-numeric EAs (Categorical, IntervalArray)
- [x] All 1594 existing groupby first/last tests pass
- [x] All 846 extension groupby tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)