### PR TITLE
PERF: read zip-compressed files into memory instead of streaming

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -115,6 +115,7 @@ Performance improvements
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
 - Performance improvement in datetime/timedelta unit conversion (e.g. ``datetime64[s]`` to ``datetime64[ns]``) (:issue:`35025`)
 - Performance improvement in indexing a :class:`DataFrame` with a :class:`CategoricalIndex` of :class:`Interval` categories (:issue:`61928`)
+- Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -846,7 +846,14 @@ def get_handle(
                 handles.append(handle)
                 zip_names = handle.buffer.namelist()
                 if len(zip_names) == 1:
-                    handle = handle.buffer.open(zip_names.pop())
+                    # Read the entire zip entry into memory rather than
+                    # returning a streaming ZipExtFile via .open(). On
+                    # Python <3.12, ZipExtFile has poor buffering that
+                    # causes O(n²) performance with pickle.load() and
+                    # other consumers that issue many small reads
+                    # (GH#59279). Can be reverted to .open() once the
+                    # minimum Python version is 3.12.
+                    handle = BytesIO(handle.buffer.read(zip_names.pop()))
                 elif not zip_names:
                     raise ValueError(f"Zero files found in ZIP file {path_or_buf}")
                 else:


### PR DESCRIPTION
- [x] closes #59279

## Summary
- Fixes a performance regression when reading zip-compressed files (e.g. `read_pickle("file.pickle.zip")`) on Python <3.12
- On Python <3.12, `zipfile.ZipExtFile` has poor buffering that causes O(n²) performance when consumers like `pickle.load()` issue many small reads from the streaming handle
- Changes `get_handle()` to fully decompress the zip entry into a `BytesIO` buffer instead of returning a streaming `ZipExtFile`

## Test plan
- [x] Existing pickle, compression, and common IO tests all pass (975 tests)
- [x] Verified roundtrip correctness for `read_pickle`, `read_csv`, and `read_json` with zip compression

🤖 Generated with [Claude Code](https://claude.com/claude-code)