### PR TITLE
PERF: speed up strftime for common format directives

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -162,6 +162,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)
 - Performance improvement in :meth:`DataFrame.unstack` and :meth:`Series.unstack` when the :class:`MultiIndex` is already sorted and the unstacked level is the last level (:issue:`65107`)
 - Performance improvement in :meth:`DatetimeIndex.month_name` and :meth:`DatetimeIndex.day_name` when using the default string dtype by using PyArrow compute instead of going through an intermediate object array (:issue:`65104`)
+- Performance improvement in :meth:`DatetimeIndex.strftime` and :meth:`Series.dt.strftime` for formats composed of common directives (``%Y``, ``%m``, ``%d``, ``%H``, ``%M``, ``%S``, ``%f``) (:issue:`44764`)
 - Performance improvement in :meth:`GroupBy.any` and :meth:`GroupBy.all` for boolean-dtype columns (:issue:`37850`)
 - Performance improvement in :meth:`GroupBy.first` and :meth:`GroupBy.last` for Extension Array dtypes, which no longer fall back to a slow ``apply``-based implementation (:issue:`57591`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -83,7 +83,10 @@ from pandas._libs.tslibs.timestamps import Timestamp
 # Note: this is the only non-tslibs intra-pandas dependency here
 
 from pandas._libs.missing cimport checknull_with_nat_and_na
-from pandas._libs.tslibs.tzconversion cimport tz_localize_to_utc_single
+from pandas._libs.tslibs.tzconversion cimport (
+    Localizer,
+    tz_localize_to_utc_single,
+)
 
 
 def _test_parse_iso8601(ts: str):
@@ -109,6 +112,50 @@ def _test_parse_iso8601(ts: str):
         return Timestamp(obj.value, tz=obj.tzinfo)
     else:
         return Timestamp(obj.value)
+
+
+_STRFTIME_FORMAT_MAP = {
+    "%Y": "{0}",
+    "%m": "{1:02d}",
+    "%d": "{2:02d}",
+    "%H": "{3:02d}",
+    "%M": "{4:02d}",
+    "%S": "{5:02d}",
+    "%f": "{6:06d}",
+    "%%": "%",
+}
+
+
+def _convert_strftime_format(str fmt):
+    """
+    Convert a strftime format string to a str.format()-style template using
+    positional indices for npy_datetimestruct fields:
+        0=year, 1=month, 2=day, 3=hour, 4=min, 5=sec, 6=us
+
+    Returns None if the format contains unsupported directives, in which case
+    the caller should fall back to the per-element Timestamp.strftime() path.
+    """
+    result: list[str] = []
+    cdef Py_ssize_t i = 0
+    cdef Py_ssize_t n = len(fmt)
+
+    while i < n:
+        if fmt[i] == "%" and i + 1 < n:
+            directive = fmt[i:i + 2]
+            replacement = _STRFTIME_FORMAT_MAP.get(directive)
+            if replacement is None:
+                return None
+            result.append(replacement)
+            i += 2
+        elif fmt[i] in ("{", "}"):
+            # Escape braces for str.format()
+            result.append(fmt[i] * 2)
+            i += 1
+        else:
+            result.append(fmt[i])
+            i += 1
+
+    return "".join(result)
 
 
 @cython.wraparound(False)
@@ -144,6 +191,7 @@ def format_array_from_datetime(
         _Timestamp ts
         object res
         npy_datetimestruct dts
+        Py_ssize_t pos
 
         # Note that `result` (and thus `result_flat`) is C-order and
         #  `it` iterates C-order as well, so the iteration matches
@@ -152,6 +200,14 @@ def format_array_from_datetime(
         ndarray result = cnp.PyArray_EMPTY(values.ndim, values.shape, cnp.NPY_OBJECT, 0)
         object[::1] res_flat = result.ravel()     # should NOT be a copy
         cnp.flatiter it = cnp.PyArray_IterNew(values)
+
+    # Try to convert the format string to a str.format() template that uses
+    # npy_datetimestruct fields directly, avoiding per-element Timestamp
+    # creation. For tz-aware data, the UTC value is first converted to
+    # local time via a Localizer (this works because _convert_strftime_format
+    # returns None for formats containing %z/%Z).
+    fmt_template = None
+    localizer = None
 
     if tz is None:
         # if we don't have a format nor tz, then choose
@@ -176,6 +232,11 @@ def format_array_from_datetime(
         elif format == "%Y-%m-%d":
             # Default format for dates
             basic_format_day = True
+
+    if format is not None and not basic_format and not basic_format_day:
+        fmt_template = _convert_strftime_format(format)
+        if fmt_template is not None and tz is not None:
+            localizer = Localizer.__new__(Localizer, tz, reso)
 
     assert not (basic_format_day and basic_format)
 
@@ -203,6 +264,18 @@ def format_array_from_datetime(
                 res += f".{dts.us:06d}"
             elif show_ms:
                 res += f".{dts.us // 1000:03d}"
+
+        elif fmt_template is not None:
+
+            if localizer is not None:
+                val = (<Localizer>localizer).utc_val_to_local_val(
+                    val, &pos
+                )
+            pandas_datetime_to_datetimestruct(val, reso, &dts)
+            res = fmt_template.format(
+                dts.year, dts.month, dts.day,
+                dts.hour, dts.min, dts.sec, dts.us,
+            )
 
         else:
 

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -592,6 +592,13 @@ class TestSeriesDatetimeValues:
             expected = expected.astype(StringDtype(na_value=np.nan))
         tm.assert_index_equal(result, expected)
 
+    def test_strftime_literal_braces(self):
+        # Literal braces in the format string should be preserved
+        ser = Series(date_range("2024-01-01", periods=3))
+        result = ser.dt.strftime("{%Y}")
+        expected = Series(["{2024}", "{2024}", "{2024}"])
+        tm.assert_series_equal(result, expected)
+
     def test_strftime_dt64_microsecond_resolution(self):
         ser = Series([datetime(2013, 1, 1, 2, 32, 59), datetime(2013, 1, 2, 14, 32, 1)])
         result = ser.dt.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- For formats composed of common directives (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`, `%f`), parse the format string once into a `str.format()` template and format directly from `npy_datetimestruct` fields, avoiding per-element `Timestamp` creation.
- For tz-aware data, converts UTC to local time via `Localizer.utc_val_to_local_val` before extracting struct fields (works because `_convert_strftime_format` returns `None` for formats containing `%z`/`%Z`).
- Unsupported directives (`%A`, `%B`, `%z`, `%Z`, etc.) fall back to the existing per-element `Timestamp.strftime()` path.

### Benchmarks (10.5M elements, `%Y/%m/%dT%H:%M:%S`)

| Scenario | Before | After | Speedup |
|----------|--------|-------|---------|
| tz-naive | ~28s | 6.7s | **4.2x** |
| UTC | ~28s | 6.7s | **4.2x** |
| US/Eastern | ~28s | 9.9s | **2.8x** |

- closes #44764

## Test plan
- [x] All 144 existing strftime tests pass
- [x] IO format tests pass (2295 passed)
- [x] Correctness verified against per-element `Timestamp.strftime()` for multiple formats
- [x] Verified NaT handling (tz-naive and tz-aware)
- [x] Verified fallback for unsupported directives (`%A`, `%Z`)
- [x] Verified tz-aware correctness for UTC, US/Eastern (DST transitions), fixed-offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)