### PR TITLE
TYP: add type annotations to core.array_algos.quantile

### DIFF
--- a/pandas/core/array_algos/quantile.py
+++ b/pandas/core/array_algos/quantile.py
@@ -44,7 +44,7 @@ def quantile_compat(
 def quantile_with_mask(
     values: np.ndarray,
     mask: npt.NDArray[np.bool_],
-    fill_value,
+    fill_value: Scalar,
     qs: npt.NDArray[np.float64],
     interpolation: str,
 ) -> np.ndarray:
@@ -156,10 +156,10 @@ def _nanquantile(
     values: np.ndarray,
     qs: npt.NDArray[np.float64],
     *,
-    na_value,
+    na_value: Scalar,
     mask: npt.NDArray[np.bool_],
     interpolation: str,
-):
+) -> np.ndarray:
     """
     Wrapper for np.quantile that skips missing values.
 
@@ -183,7 +183,7 @@ def _nanquantile(
         result = _nanquantile(
             values.view("i8"),
             qs=qs,
-            na_value=na_value.view("i8"),
+            na_value=na_value.view("i8"),  # type: ignore[union-attr, arg-type]
             mask=mask,
             interpolation=interpolation,
         )
@@ -195,15 +195,15 @@ def _nanquantile(
     if mask.any():
         # Caller is responsible for ensuring mask shape match
         assert mask.shape == values.shape
-        result = [
+        result_list = [
             _nanquantile_1d(val, m, qs, na_value, interpolation=interpolation)
             for (val, m) in zip(list(values), list(mask), strict=True)
         ]
         if values.dtype.kind == "f":
             # preserve itemsize
-            result = np.asarray(result, dtype=values.dtype).T
+            result = np.asarray(result_list, dtype=values.dtype).T
         else:
-            result = np.asarray(result).T
+            result = np.asarray(result_list).T
             if (
                 result.dtype != values.dtype
                 and not mask.all()

--- a/pandas/core/array_algos/quantile.py
+++ b/pandas/core/array_algos/quantile.py
@@ -36,7 +36,13 @@ def quantile_compat(
     if isinstance(values, np.ndarray):
         fill_value = na_value_for_dtype(values.dtype, compat=False)
         mask = isna(values)
-        return quantile_with_mask(values, mask, fill_value, qs, interpolation)
+        return quantile_with_mask(
+            values,
+            mask,
+            fill_value,  # pyright: ignore[reportArgumentType]
+            qs,
+            interpolation,
+        )
     else:
         return values._quantile(qs, interpolation)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -531,7 +531,6 @@ module = [
   "pandas.compat.numpy.function", # TODO
   "pandas.core._numba.executor", # TODO
   "pandas.core.array_algos.masked_reductions", # TODO
-  "pandas.core.array_algos.quantile", # TODO
   "pandas.core.array_algos.replace", # TODO
   "pandas.core.array_algos.take", # TODO
   "pandas.core.arrays.*", # TODO


### PR DESCRIPTION
## Summary
- Remove `pandas.core.array_algos.quantile` from the mypy exclusion list
- Add `Scalar` type annotation to `fill_value` in `quantile_with_mask` and `na_value` in `_nanquantile`
- Add `np.ndarray` return type to `_nanquantile`
- Rename intermediate list variable to avoid type conflict with `np.ndarray` result

## Test plan
- [x] mypy passes on `pandas/core/array_algos/quantile.py`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)