### PR TITLE
TYP: enable mypy checks for core.dtypes.concat

### DIFF
--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
         DtypeObj,
     )
 
+    from pandas import (
+        CategoricalIndex,
+        Series,
+    )
     from pandas.core.arrays import (
         Categorical,
         ExtensionArray,
@@ -175,7 +179,9 @@ def _get_result_dtype(
 
 @set_module("pandas.api.types")
 def union_categoricals(
-    to_union, sort_categories: bool = False, ignore_order: bool = False
+    to_union: Sequence[CategoricalIndex | Series | Categorical],
+    sort_categories: bool = False,
+    ignore_order: bool = False,
 ) -> Categorical:
     """
     Combine list-like of Categorical-like, unioning categories.
@@ -283,7 +289,9 @@ def union_categoricals(
     if len(to_union) == 0:
         raise ValueError("No Categoricals to union")
 
-    def _maybe_unwrap(x):
+    def _maybe_unwrap(
+        x: CategoricalIndex | Series | Categorical,
+    ) -> Categorical:
         if isinstance(x, (ABCCategoricalIndex, ABCSeries)):
             return x._values
         elif isinstance(x, Categorical):
@@ -291,13 +299,13 @@ def union_categoricals(
         else:
             raise TypeError("all components to combine must be Categorical")
 
-    to_union = [_maybe_unwrap(x) for x in to_union]
+    to_union = cast("list[Categorical]", [_maybe_unwrap(x) for x in to_union])
     first = to_union[0]
 
     if not lib.dtypes_all_equal([obj.categories.dtype for obj in to_union]):
         raise TypeError("dtype of categories must be the same")
 
-    ordered = False
+    ordered: bool | None = False
     if all(first._categories_match_up_to_permutation(other) for other in to_union[1:]):
         # identical categories - fastpath
         categories = first.categories

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -354,7 +354,7 @@ def _concatenate_chunks(
 
         dtype = dtypes.pop()
         if isinstance(dtype, CategoricalDtype):
-            result[name] = union_categoricals(arrs, sort_categories=False)
+            result[name] = union_categoricals(arrs, sort_categories=False)  # type: ignore[arg-type]
         else:
             result[name] = concat_compat(arrs)
             if len(non_cat_dtypes) > 1 and result[name].dtype == np.dtype(object):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -539,7 +539,6 @@ module = [
   "pandas.core.computation.*", # TODO
   "pandas.core.dtypes.astype", # TODO
   "pandas.core.dtypes.common", # TODO
-  "pandas.core.dtypes.concat", # TODO
   "pandas.core.dtypes.dtypes", # TODO
   "pandas.core.dtypes.generic", # TODO
   "pandas.core.dtypes.missing", # TODO


### PR DESCRIPTION
## Summary
- Remove `pandas.core.dtypes.concat` from the mypy ignore list in `pyproject.toml`
- Add type annotations to `union_categoricals` and its nested `_maybe_unwrap` helper
- Add `type: ignore[arg-type]` in `c_parser_wrapper.py` where the internal caller passes `list[ExtensionArray | ndarray]`

## Test plan
- [x] `mypy pandas/core/dtypes/concat.py` passes (only unrelated pre-existing error in `frame.py`)
- [x] `pytest pandas/tests/dtypes/test_concat.py` passes
- [x] `pytest pandas/tests/reshape/concat/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)