### PR TITLE
TYP: enable mypy for pandas.util._test_decorators

### DIFF
--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -125,7 +125,7 @@ skip_if_thread_unsafe_warnings = pytest.mark.skipif(
 )
 
 
-def parametrize_fixture_doc(*args) -> Callable[[F], F]:
+def parametrize_fixture_doc(*args: str) -> Callable[[F], F]:
     """
     Intended for use as a decorator for parametrized fixture,
     this function will wrap the decorated function with a pytest
@@ -145,8 +145,9 @@ def parametrize_fixture_doc(*args) -> Callable[[F], F]:
         ``parametrize_fixture_doc`` mark
     """
 
-    def documented_fixture(fixture):
-        fixture.__doc__ = fixture.__doc__.format(*args)
+    def documented_fixture(fixture: F) -> F:
+        if fixture.__doc__:
+            fixture.__doc__ = fixture.__doc__.format(*args)
         return fixture
 
     return documented_fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -620,7 +620,6 @@ module = [
   "pandas.tseries.holiday", # TODO
   "pandas.util._decorators", # TODO
   "pandas.util._doctools", # TODO
-  "pandas.util._test_decorators", # TODO
   "pandas.util._validators", # TODO
   "pandas.util", # TODO
   "pandas.conftest",


### PR DESCRIPTION
## Summary
- Remove `pandas.util._test_decorators` from the untyped mypy overrides in `pyproject.toml`
- Add type annotations to `parametrize_fixture_doc` (`*args: str`) and its inner `documented_fixture` closure (`fixture: F -> F`)
- Guard against `__doc__` being `None` before calling `.format()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)