### PR TITLE
TYP: enable mypy for core.flags

### DIFF
--- a/pandas/core/flags.py
+++ b/pandas/core/flags.py
@@ -109,13 +109,13 @@ class Flags:
 
         self._allows_duplicate_labels = value
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key: str) -> bool:
         if key not in self._keys:
             raise KeyError(key)
 
         return getattr(self, key)
 
-    def __setitem__(self, key: str, value) -> None:
+    def __setitem__(self, key: str, value: bool) -> None:
         if key not in self._keys:
             raise ValueError(f"Unknown flag {key}. Must be one of {self._keys}")
         setattr(self, key, value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -581,7 +581,6 @@ module = [
   "pandas.core.arraylike", # TODO
   "pandas.core.base", # TODO
   "pandas.core.construction", # TODO
-  "pandas.core.flags", # TODO
   "pandas.core.frame", # TODO
   "pandas.core.generic", # TODO
   "pandas.core.indexing", # TODO


### PR DESCRIPTION
## Summary
- Add return type annotation (`-> bool`) to `Flags.__getitem__`
- Add parameter type annotation (`value: bool`) to `Flags.__setitem__`
- Remove `pandas.core.flags` from the mypy ignore list

## Test plan
- [x] mypy passes cleanly on `pandas/core/flags.py`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)