### PR TITLE
TST: add regression test for enlarging a DataFrame by adding an extra column with a tz-aware datetime results in object dtype

### DIFF
--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -412,3 +412,29 @@ def test_loc_empty_multiindex():
     result = df
     expected = DataFrame([1, 2, 3, 4], index=index, columns=["value"])
     tm.assert_frame_equal(result, expected)
+
+def test_multiindex_datetime_date_slicing_with_numpy_datetime64():
+    import numpy as np
+    import datetime as dt
+    from pandas import DataFrame, MultiIndex
+    import pandas._testing as tm
+
+    # Regression test for GH#55969
+    dates = [dt.datetime(2023, 11, 1).date(), 
+             dt.datetime(2023, 11, 1).date(), 
+             dt.datetime(2023, 11, 2).date()]
+    t1 = ["A", "B", "C"]
+    t2 = ["C", "D", "E"]
+    vals = [0.1, 0.2, 0.3]
+
+    df = DataFrame(
+        {"vals": vals}, 
+        index=MultiIndex.from_arrays([dates, t1, t2], names=["dates", "t1", "t2"])
+    )
+
+    date_query = np.datetime64("2023-11-01")
+
+    # The bug: it erroneously returned two rows for 'A'
+    result = df.loc[(date_query, "A")]
+    expected = df.iloc[[0]].droplevel(["dates", "t1"])
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/test_gh55423.py
+++ b/pandas/tests/test_gh55423.py
@@ -1,0 +1,9 @@
+import pandas as pd
+import datetime as dt
+
+def test_loc_setitem_expansion_preserves_tz_aware_dtype():
+    # GH#55423: Test for tz-aware datetime expansion
+    df = pd.DataFrame([{'id': 1}, {'id': 2}, {'id': 3}])
+    _time = dt.datetime.fromtimestamp(1695887042, tz=dt.timezone.utc)
+    df.loc[df.id >= 2, 'time'] = _time
+    assert str(df['time'].dtype).startswith('datetime64[ns, UTC]')


### PR DESCRIPTION
- [x] closes #55423 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
