### PR TITLE
TST: add regression test for groupby agg with multiple partial functions

### DIFF
--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -2087,3 +2087,22 @@ def test_agg_relabel_with_name_match_and_namedagg():
 
     expected = DataFrame({"B": [3, 7]}, index=Index([0, 1], name="A"))
     tm.assert_frame_equal(result, expected)
+
+
+def test_multiple_partial_functions_same_name():
+    # GH#28570
+    quant50 = partial(np.percentile, q=50)
+    quant70 = partial(np.percentile, q=70)
+
+    df = DataFrame({"col1": ["a", "a", "b", "b", "b"], "col2": [1, 2, 3, 4, 5]})
+    expected = DataFrame(
+        [[1.5, 1.7], [4.0, 4.4]],
+        index=Index(["a", "b"], name="col1"),
+        columns=MultiIndex(
+            levels=[["col2"], ["percentile"]],
+            codes=[[0, 0], [0, 0]],
+        ),
+    )
+    gb = df.groupby("col1")
+    result = gb.agg({"col2": [quant50, quant70]})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #28570
- [x] tests added / passed
- [x] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) for how to run them

## Summary

Adds a regression test for #28570, where `groupby().agg()` with a dict of multiple `functools.partial` functions sharing the same base function name on the same column silently produced incorrect results.

The bug is already fixed on `main`. This PR adds a test to prevent regression.

### Test added

`test_multiple_partial_functions_same_name` in `pandas/tests/groupby/aggregate/test_aggregate.py` verifies that:

```python
quant50 = partial(np.percentile, q=50)
quant70 = partial(np.percentile, q=70)

df.groupby("col1").agg({"col2": [quant50, quant70]})
```

produces correct, distinct values for each partial function even though both share the underlying function name `percentile`.