### PR TITLE
BUG: add out of bounds time checks for float inputs exceeding int64 limits

### DIFF
--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -126,6 +126,19 @@ def cast_from_unit_vectorized(
     m, p = precision_from_unit(in_reso, out_reso)
 
     nan_mask = np.isnan(values)
+    nat_as_float = np.float64(NPY_NAT)
+
+    # Preserve float(iNaT) -> NaT, but reject other values that are already
+    # outside the int64 domain before the integer cast can alias them to NPY_NAT.
+    oob = (~nan_mask) & (values != nat_as_float) & (
+        (values >= np.float64(2**63)) | (values < nat_as_float)
+    )
+    if oob.any():
+        bad_idx = int(np.where(oob)[0][0])
+        raise OutOfBoundsDatetime(
+            f"cannot convert input {values[bad_idx]} with the unit '{unit}'"
+        )
+
     # Replace NaN with 0.0 for safe int casting; NaN positions set to NPY_NAT below
     safe = np.where(nan_mask, 0.0, values)
 
@@ -134,10 +147,9 @@ def cast_from_unit_vectorized(
     base = safe.astype("i8")
     frac = safe - base.astype("f8")
 
-    # float(iNaT) == float(INT64_MIN) == -2**63, which truncates to INT64_MIN.
-    # The original loop treated base == NPY_NAT as NaT; replicate that here.
-    nan_mask = nan_mask | (base == NPY_NAT)
-    base[nan_mask] = 0
+    # float(iNaT) == float(INT64_MIN) == -2**63, which should round-trip to NaT.
+    nat_mask = nan_mask | (safe == nat_as_float)
+    base[nat_mask] = 0
 
     if p:
         frac = np.round(frac, p)
@@ -149,7 +161,7 @@ def cast_from_unit_vectorized(
     if m != 1:
         result_f = base.astype("f8") * m + frac * m
         oob = (result_f >= 2**63) | (result_f < -(2**63))
-        non_nat = ~nan_mask
+        non_nat = ~nat_mask
         if (oob & non_nat).any():
             bad_idx = int(np.where(oob & non_nat)[0][0])
             raise OutOfBoundsDatetime(
@@ -157,7 +169,7 @@ def cast_from_unit_vectorized(
             )
 
     out = base * np.int64(m) + (frac * m).astype("i8")
-    out[nan_mask] = NPY_NAT
+    out[nat_mask] = NPY_NAT
     return out
 
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -27,6 +27,7 @@ from pandas._libs.tslibs import (
     Timestamp,
     astype_overflowsafe,
     get_supported_dtype,
+    iNaT,
     is_supported_dtype,
     timezones as libtimezones,
 )
@@ -513,9 +514,22 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
             tz_parsed = None
 
         elif arg.dtype.kind == "f":
+            mask = np.isnan(arg)
+            nat_as_float = np.float64(iNaT)
+            oob = (
+                (~mask)
+                & (arg != nat_as_float)
+                & ((arg >= np.float64(2**63)) | (arg < nat_as_float))
+            )
+            if oob.any():
+                if errors != "raise":
+                    return _to_datetime_with_unit(
+                        arg.astype(object), unit, name, utc, errors
+                    )
+                raise OutOfBoundsDatetime(f"cannot convert input with unit '{unit}'")
+
             with np.errstate(invalid="ignore"):
                 int_values = arg.astype(np.int64)
-            mask = np.isnan(arg)
             if (mask | (arg == int_values)).all():
                 # With all-round-or-NaN entries, we give the requested unit
                 #  back like with integers

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2060,6 +2060,20 @@ class TestToDatetimeUnit:
         with pytest.raises(OutOfBoundsDatetime, match=msg3):
             Timestamp(should_fail2[1], unit="D")
 
+    def test_float_to_datetime_raise_oob_ns(self):
+        value = np.float64(2**63)
+        arr = np.array([value], dtype=np.float64)
+
+        msg = "cannot convert input with unit 'ns'"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            to_datetime(arr, unit="ns", errors="raise")
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            to_datetime(value, unit="ns", errors="raise")
+
+        msg = "Out of bounds nanosecond timestamp"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            Timestamp(value, unit="ns")
+
 
 class TestToDatetimeDataFrame:
     @pytest.fixture

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -378,6 +378,17 @@ class TestTimedeltas:
         with pytest.raises(OutOfBoundsTimedelta, match=scalar_msg2):
             pd.Timedelta(should_fail2[1], unit="D")
 
+    def test_float_to_timedelta_raise_oob_ns(self):
+        value = np.float64(2**63)
+        arr = np.array([value], dtype=np.float64)
+
+        with pytest.raises(OutOfBoundsTimedelta, match="cannot convert input"):
+            to_timedelta(arr, unit="ns")
+
+        msg = r"Cannot cast .* from ns to 'ns' without overflow"
+        with pytest.raises(OutOfBoundsTimedelta, match=msg):
+            pd.Timedelta(value, unit="ns")
+
 
 def test_from_numeric_arrow_dtype(any_numeric_ea_dtype):
     # GH 52425


### PR DESCRIPTION
Fixes the following bug introduced in #64438.
```python
import numpy as np
import pandas as pd

x = np.array([np.float64(2**63)], dtype="float64")

print(pd.to_timedelta(x, unit="ns"))
# RuntimeWarning: invalid value encountered in cast
#  data = cast_from_unit_vectorized(data, unit or "ns")
# TimedeltaIndex([NaT], dtype='timedelta64[ns]', freq=None)
print(pd.to_datetime(x, unit="ns")) # same

pd.Timedelta(np.float64(2**63), unit="ns")   # raises OutOfBoundsTimedelta
pd.Timestamp(np.float64(2**63), unit="ns")   # raises OutOfBoundsDatetime
```
After this PR, the behavior is consistent again without damaging the performance improvement of #64438.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
