### PR TITLE
TST: add regression test for #26558

### DIFF
--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -2152,6 +2152,28 @@ def test_arithmetic_multiindex_column_align_with_fillvalue():
     tm.assert_frame_equal(result, expected)
 
 
+def test_arithmetic_multiindex_add_with_mixed_string_datetime_index():
+    # GH#26558
+    df1 = DataFrame(
+        data=[10],
+        index=MultiIndex.from_tuples([("Z", "2019-05-31")]),
+        columns=["A"],
+    )
+    df2 = DataFrame(
+        data=[20],
+        index=MultiIndex.from_tuples([("Z", datetime(2019, 5, 31))]),
+        columns=["A"],
+    )
+
+    with tm.assert_produces_warning(RuntimeWarning, match="are unorderable"):
+        result = df1.add(df2, fill_value=0)
+
+    assert len(result) == 2
+    assert result.loc[("Z", "2019-05-31"), "A"] == 10
+    assert result.loc[("Z", datetime(2019, 5, 31)), "A"] == 20
+
+
+
 def test_bool_frame_mult_float():
     # GH 18549
     df = DataFrame(True, list("ab"), list("cd"))

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -2173,7 +2173,6 @@ def test_arithmetic_multiindex_add_with_mixed_string_datetime_index():
     assert result.loc[("Z", datetime(2019, 5, 31)), "A"] == 20
 
 
-
 def test_bool_frame_mult_float():
     # GH 18549
     df = DataFrame(True, list("ab"), list("cd"))

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -2165,12 +2165,18 @@ def test_arithmetic_multiindex_add_with_mixed_string_datetime_index():
         columns=["A"],
     )
 
+    expected = DataFrame(
+        data=[20.0, 10.0],
+        index=MultiIndex.from_tuples(
+            [("Z", datetime(2019, 5, 31)), ("Z", "2019-05-31")]
+        ),
+        columns=["A"],
+    )
+
     with tm.assert_produces_warning(RuntimeWarning, match="are unorderable"):
         result = df1.add(df2, fill_value=0)
 
-    assert len(result) == 2
-    assert result.loc[("Z", "2019-05-31"), "A"] == 10
-    assert result.loc[("Z", datetime(2019, 5, 31)), "A"] == 20
+    tm.assert_frame_equal(result, expected)
 
 
 def test_bool_frame_mult_float():


### PR DESCRIPTION
## Summary

Adds a regression test for `DataFrame.add(fill_value=0)` when the index is a `MultiIndex` containing a mix of string and `datetime` labels.

References: #26558 

## Why

I couldn’t reproduce the incorrect result from GH#26558 on current `main`, but I also couldn’t find a test covering this exact case. This adds coverage for the behavior so we don’t regress it later.

## Testing

- Added a targeted test in `pandas/tests/frame/test_arithmetic.py`
- Ran:
  ```bash
  python -m pytest pandas/tests/frame/test_arithmetic.py -k mixed_string_datetime_index -n 0
  ```
- Result: passed