### PR TITLE
TYP: enable mypy checks for core.internals.ops

### DIFF
--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -74,7 +74,7 @@ def operate_blockwise(
             and hasattr(res_values, "reshape")
             and not is_1d_only_ea_dtype(res_values.dtype)
         ):
-            res_values = res_values.reshape(1, -1)
+            res_values = res_values.reshape(1, -1)  # pyright: ignore[reportGeneralTypeIssues]
         nbs = rblk._split_op_result(res_values)
 
         # Assertions are disabled for performance, but should hold:

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -8,7 +8,10 @@ from typing import (
 from pandas.core.dtypes.common import is_1d_only_ea_dtype
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import (
+        Callable,
+        Iterator,
+    )
 
     from pandas._libs.internals import BlockPlacement
     from pandas._typing import ArrayLike
@@ -55,7 +58,9 @@ def _iter_block_pairs(
 
 
 def operate_blockwise(
-    left: BlockManager, right: BlockManager, array_op
+    left: BlockManager,
+    right: BlockManager,
+    array_op: Callable[[ArrayLike, ArrayLike], ArrayLike],
 ) -> BlockManager:
     # At this point we have already checked the parent DataFrames for
     #  assert rframe._indexed_same(lframe)
@@ -94,7 +99,7 @@ def operate_blockwise(
     return new_mgr
 
 
-def _reset_block_mgr_locs(nbs: list[Block], locs) -> None:
+def _reset_block_mgr_locs(nbs: list[Block], locs: BlockPlacement) -> None:
     """
     Reset mgr_locs to correspond to our original DataFrame.
     """
@@ -144,7 +149,11 @@ def _get_same_shape_values(
     return lvals, rvals
 
 
-def blockwise_all(left: BlockManager, right: BlockManager, op) -> bool:
+def blockwise_all(
+    left: BlockManager,
+    right: BlockManager,
+    op: Callable[[ArrayLike, ArrayLike], bool],
+) -> bool:
     """
     Blockwise `all` reduction.
     """

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -74,7 +74,7 @@ def operate_blockwise(
             and hasattr(res_values, "reshape")
             and not is_1d_only_ea_dtype(res_values.dtype)
         ):
-            res_values = res_values.reshape(1, -1)  # pyright: ignore[reportGeneralTypeIssues]
+            res_values = res_values.reshape(1, -1)  # pyright: ignore[reportAttributeAccessIssue]
         nbs = rblk._split_op_result(res_values)
 
         # Assertions are disabled for performance, but should hold:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -558,7 +558,12 @@ module = [
   "pandas.core.interchange.column", # TODO
   "pandas.core.interchange.dataframe_protocol", # TODO
   "pandas.core.interchange.from_dataframe", # TODO
-  "pandas.core.internals.*", # TODO
+  "pandas.core.internals", # TODO
+  "pandas.core.internals.api", # TODO
+  "pandas.core.internals.blocks", # TODO
+  "pandas.core.internals.concat", # TODO
+  "pandas.core.internals.construction", # TODO
+  "pandas.core.internals.managers", # TODO
   "pandas.core.ops.array_ops", # TODO
   "pandas.core.ops.common", # TODO
   "pandas.core.ops.missing", # TODO


### PR DESCRIPTION
## Summary
- Remove `pandas.core.internals.ops` from the mypy ignore list by expanding the `pandas.core.internals.*` wildcard into explicit entries for the remaining submodules
- Add type annotations to the three previously untyped parameters: `array_op` in `operate_blockwise`, `locs` in `_reset_block_mgr_locs`, and `op` in `blockwise_all`

## Test plan
- [x] `mypy pandas/core/internals/ops.py` passes cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)