### PR TITLE
CI: Pass token to Codecov

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -200,7 +200,8 @@ jobs:
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
       with:
         flags: unittests
-        name: codecov-pandas-${{ matrix.name || format('{0} {1}', matrix.platform, matrix.environment) }}
+        name: codecov-pandas-${{ matrix.name || format('{0}-{1}', matrix.platform, matrix.environment) }}
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
         disable_telem: true
       # coverage report appended for single_cpu + not single_cpu steps


### PR DESCRIPTION
Follow up to https://github.com/pandas-dev/pandas/pull/64600

I suppose the reason why Codecov stopped working was because they now require a token to push coverage to protected branches (main). https://docs.codecov.com/docs/codecov-tokens