### PR TITLE
PERF: pass fill_value to align in NDFrame._where

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10019,6 +10019,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         # align the cond to same shape as myself
         cond = common.apply_if_callable(cond, self)
+        fill_value = bool(inplace)
         if isinstance(cond, NDFrame):
             # CoW: Make sure reference is not kept alive
             if cond.ndim == 1 and self.ndim == 2:
@@ -10027,7 +10028,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     copy=False,
                 )
                 cond.columns = self.columns
-            cond = cond.align(self, join="right")[0]
+            # GH#51547 pass fill_value to avoid extra fillna work later
+            cond = cond.align(self, join="right", fill_value=fill_value)[0]
         else:
             if not hasattr(cond, "shape"):
                 cond = np.asanyarray(cond)
@@ -10036,7 +10038,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             cond = self._constructor(cond, **self._construct_axes_dict(), copy=False)
 
         # make sure we are boolean
-        fill_value = bool(inplace)
         cond = cond.fillna(fill_value)
         cond = cond.infer_objects()
 


### PR DESCRIPTION
## Summary
- Pass `fill_value` to `cond.align()` in `NDFrame._where` so that positions introduced by index mismatch are filled directly rather than left as NaN for the subsequent `fillna()` call to handle.
- Also separates alignment fill behavior from pre-existing-NA fill behavior, which is relevant for GH#60729.

Closes #51547.

## Test plan
- [x] Existing where/mask/setitem tests pass (2120 tests)
- [x] Full indexing test suite passes (4609 tests)
- [x] Extension array where/mask/setitem tests pass (12019 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)