### PR TITLE
fix: BUG: constructing string ArrowExtensionArray with NaNs fails

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -682,6 +682,10 @@ class ArrowExtensionArray(
                 pa_array = pa.array(value, type=pa_type, mask=mask)
             except (pa.ArrowInvalid, pa.ArrowTypeError):
                 # GH50430: let pyarrow infer type, then cast
+                if mask is not None and mask.any():
+                    value = [
+                        None if m else v for v, m in zip(value, mask, strict=False)
+                    ]
                 pa_array = pa.array(value, mask=mask)
 
             if pa_type is None and pa.types.is_duration(pa_array.type):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1542,6 +1542,13 @@ def test_astype_float_from_non_pyarrow_str():
     tm.assert_series_equal(result, expected)
 
 
+def test_construct_string_arrow_with_nan():
+    # GH#64578
+    result = pd.array(["a", np.nan], dtype=pd.ArrowDtype(pa.string()))
+    expected = pd.array(["a", None], dtype="string[pyarrow]")
+    tm.assert_extension_array_equal(result, expected)
+
+
 def test_astype_errors_ignore():
     # GH 55399
     expected = pd.DataFrame({"col": [17000000]}, dtype="int32[pyarrow]")


### PR DESCRIPTION
Fixes #64578

When constructing an `ArrowExtensionArray` with mixed string and NaN values, pyarrow raised `ArrowInvalid` because NaN is not a valid string. The fallback path in `ArrowExtensionArray.__init__` (in `pandas/core/arrays/arrow/array.py`) passed the raw `value` and `mask` to `pa.array()` without substituting masked positions, causing pyarrow to reject the NaN values even in the inferred-type path. The fix pre-processes `value` in the exception handler to replace masked entries with `None` before calling `pa.array()`, ensuring pyarrow sees valid null values. A regression test covering `pd.array(["a", np.nan], dtype=pd.ArrowDtype(pa.string()))` is added in `pandas/tests/extension/test_arrow.py`.