### PR TITLE
PERF: fix slow repr for Series/DataFrame with third-party array-like objects

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -116,6 +116,7 @@ Performance improvements
 - Performance improvement in datetime/timedelta unit conversion (e.g. ``datetime64[s]`` to ``datetime64[ns]``) (:issue:`35025`)
 - Performance improvement in indexing a :class:`DataFrame` with a :class:`CategoricalIndex` of :class:`Interval` categories (:issue:`61928`)
 - Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)
+- Performance improvement in repr of :class:`Series` and :class:`DataFrame` containing third-party array-like objects (e.g. xarray ``DataArray``) in object dtype columns (:issue:`61809`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -23,10 +23,14 @@ import numpy as np
 
 from pandas._config import get_option
 
+from pandas.core.dtypes.generic import (
+    ABCExtensionArray,
+    ABCIndex,
+    ABCNDFrame,
+)
 from pandas.core.dtypes.inference import (
     is_float,
     is_scalar,
-    is_sequence,
 )
 from pandas.core.dtypes.missing import notna
 
@@ -229,7 +233,27 @@ def pprint_thing(
         result = _pprint_dict(
             thing, _nest_lvl, quote_strings=True, max_seq_items=max_seq_items
         )
-    elif is_sequence(thing) and _nest_lvl < get_option("display.pprint_nest_depth"):
+    elif (
+        # GH#61809 Only iterate over types where element-by-element formatting
+        # is appropriate. Third-party array-like objects (e.g. xarray DataArray)
+        # can be extremely expensive to iterate and should use their own repr.
+        isinstance(
+            thing,
+            (
+                np.ndarray,
+                np.void,
+                list,
+                tuple,
+                set,
+                frozenset,
+                range,
+                ABCExtensionArray,
+                ABCIndex,
+                ABCNDFrame,
+            ),
+        )
+        and _nest_lvl < get_option("display.pprint_nest_depth")
+    ):
         result = _pprint_seq(
             # error: Argument 1 to "_pprint_seq" has incompatible type "object";
             # expected "ExtensionArray | ndarray[Any, Any] | Index | Series |


### PR DESCRIPTION
## Summary
- Replaces the duck-type `is_sequence()` check in `pprint_thing()` with an explicit `isinstance` allowlist of types that `_pprint_seq` was designed to handle.
- Previously, any object with `__iter__` and `__len__` (e.g. xarray `DataArray`) would be recursively iterated element-by-element, causing ~20,000 expensive repr calls for a single large DataArray stored in an object-dtype column.
- Now only built-in Python sequences, numpy arrays, and pandas types are iterated; everything else falls through to `str()`, using the object's own repr.
- **~1500x speedup** for the reproducer in #61809 (3s → 0.002s).

Closes #61809

## Test plan
- [x] Existing tests in `test_printing.py`, `test_format.py`, `test_formats.py`, `test_repr.py`, `test_groupby.py`, `test_sorting.py`, `test_to_string.py` all pass
- [x] Verified basic sequence types (list, tuple, set, range, ndarray, np.record, Index, DataFrame) preserve existing formatting behavior
- [x] Verified xarray DataArray repr is fast and produces clean truncated output

🤖 Generated with [Claude Code](https://claude.com/claude-code)