### PR TITLE
BUG: fix float-to-int64 OOB handling on ARM in to_datetime/to_timedelta

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -132,6 +132,7 @@ Categorical
 Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)
+- Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
 
 Timedelta

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1186,7 +1186,12 @@ def sequence_to_td64ns(
             #  back the requested unit (or closest-supported)
             with np.errstate(invalid="ignore"):
                 int_data = data.astype(np.int64)
-            all_round = (mask | (data == int_data)).all()
+            # On ARM, float-to-int64 overflow saturates to INT64_MAX
+            # instead of wrapping, which makes the data == int_data
+            # check pass incorrectly for OOB values like float(2**63).
+            # Exclude values outside the int64 domain from the check.
+            in_int64_range = (data >= np.float64(-(2**63))) & (data < np.float64(2**63))
+            all_round = (mask | (in_int64_range & (data == int_data))).all()
             if all_round:
                 result, _ = sequence_to_td64ns(
                     int_data, copy=False, unit=unit, errors=errors

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1190,7 +1190,10 @@ def sequence_to_td64ns(
             # instead of wrapping, which makes the data == int_data
             # check pass incorrectly for OOB values like float(2**63).
             # Exclude values outside the int64 domain from the check.
-            in_int64_range = (data >= np.float64(-(2**63))) & (data < np.float64(2**63))
+            i64 = np.iinfo(np.int64)
+            in_int64_range = (data >= np.float64(i64.min)) & (
+                data < np.float64(i64.max)
+            )
             all_round = (mask | (in_int64_range & (data == int_data))).all()
             if all_round:
                 result, _ = sequence_to_td64ns(

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -27,7 +27,6 @@ from pandas._libs.tslibs import (
     Timestamp,
     astype_overflowsafe,
     get_supported_dtype,
-    iNaT,
     is_supported_dtype,
     timezones as libtimezones,
 )
@@ -515,22 +514,14 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
 
         elif arg.dtype.kind == "f":
             mask = np.isnan(arg)
-            nat_as_float = np.float64(iNaT)
-            oob = (
-                (~mask)
-                & (arg != nat_as_float)
-                & ((arg >= np.float64(2**63)) | (arg < nat_as_float))
-            )
-            if oob.any():
-                if errors != "raise":
-                    return _to_datetime_with_unit(
-                        arg.astype(object), unit, name, utc, errors
-                    )
-                raise OutOfBoundsDatetime(f"cannot convert input with unit '{unit}'")
-
             with np.errstate(invalid="ignore"):
                 int_values = arg.astype(np.int64)
-            if (mask | (arg == int_values)).all():
+            # On ARM, float-to-int64 overflow saturates to INT64_MAX
+            # instead of wrapping, which makes the arg == int_values
+            # check pass incorrectly for OOB values like float(2**63).
+            # Exclude values outside the int64 domain from the check.
+            in_int64_range = (arg >= np.float64(-(2**63))) & (arg < np.float64(2**63))
+            if (mask | (in_int64_range & (arg == int_values))).all():
                 # With all-round-or-NaN entries, we give the requested unit
                 #  back like with integers
                 result = _to_datetime_with_unit(

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -520,7 +520,8 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
             # instead of wrapping, which makes the arg == int_values
             # check pass incorrectly for OOB values like float(2**63).
             # Exclude values outside the int64 domain from the check.
-            in_int64_range = (arg >= np.float64(-(2**63))) & (arg < np.float64(2**63))
+            i64 = np.iinfo(np.int64)
+            in_int64_range = (arg >= np.float64(i64.min)) & (arg < np.float64(i64.max))
             if (mask | (in_int64_range & (arg == int_values))).all():
                 # With all-round-or-NaN entries, we give the requested unit
                 #  back like with integers

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -389,6 +389,17 @@ class TestTimedeltas:
         with pytest.raises(OutOfBoundsTimedelta, match=msg):
             pd.Timedelta(value, unit="ns")
 
+    def test_float_to_timedelta_raise_oob_non_ns(self):
+        # On ARM, float-to-int64 overflow saturates to INT64_MAX instead
+        # of wrapping. The integer shortcut (for all-round float arrays)
+        # must exclude values outside the int64 domain to avoid silently
+        # producing incorrect results.
+        value = np.float64(2**63)
+        arr = np.array([value], dtype=np.float64)
+
+        with pytest.raises(OutOfBoundsTimedelta, match="cannot convert input"):
+            to_timedelta(arr, unit="s")
+
 
 def test_from_numeric_arrow_dtype(any_numeric_ea_dtype):
     # GH 52425


### PR DESCRIPTION
## Summary

Follow-up to #64619. On ARM, float-to-int64 overflow saturates to `INT64_MAX` instead of wrapping to `INT64_MIN` (as on x86). This caused the integer shortcut in `_to_datetime_with_unit` and `sequence_to_td64ns` to misfire for OOB float values like `float(2**63)`, because `np.float64(2**63) == np.int64(INT64_MAX)` evaluates to `True` on ARM (INT64_MAX rounds up to 2**63 in float64).

#64619 fixed the datetime case with a separate OOB pre-check in Python, but left a latent bug in the timedelta path for non-ns units. This PR replaces the pre-check with a tighter fix: an `in_int64_range` guard on the shortcut condition itself, applied consistently to both paths.

Changes:
- **`datetimes.py`**: Replace the 12-line OOB pre-check with a 4-line `in_int64_range` guard on the integer shortcut condition. OOB values now fall through to `cast_from_unit_vectorized` which already has its own OOB check, and the existing `try/except` handles the `errors` parameter. Removes the now-unused `iNaT` import.
- **`timedeltas.py`**: Add the same `in_int64_range` guard to the timedelta integer shortcut, fixing the latent ARM bug for non-ns units.
- **`test_to_timedelta.py`**: Add `test_float_to_timedelta_raise_oob_non_ns` covering the timedelta shortcut path with `unit="s"`.

## Test plan

- [x] Existing `test_float_to_datetime_raise_oob_ns` passes
- [x] Existing `test_float_to_timedelta_raise_oob_ns` passes
- [x] New `test_float_to_timedelta_raise_oob_non_ns` passes
- [x] Full `test_to_datetime.py` and `test_to_timedelta.py` suites pass (1024 passed)
- [ ] ARM CI (ubuntu-24.04-arm, macos-15) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)