### PR TITLE
DOC: add MSVC v143 fallback for cl.exe not found error

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -32,6 +32,10 @@ You will need `Build Tools for Visual Studio 2026
    If you encounter an error indicating ``cl.exe``,
    reopen the installer and also select the optional component
    **MSVC v142 - VS 2019 C++ x64/x86 build tools** in the right pane for installation.
+   If that does not resolve the issue, try installing
+   **MSVC v143 - VS 2022 C++ x64/x86 build tools** instead.
+   Note that Build Tools for Visual Studio 2022 may also be
+   distributed as Visual Studio Build Tools 2026.
 
 Alternatively, you can install the necessary components on the commandline using
 `vs_BuildTools.exe <https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?source=recommendations&view=vs-2022>`_


### PR DESCRIPTION
Closes #64650

Updated the Windows C compiler installation instructions to mention
MSVC v143 (VS 2022) as a fallback if MSVC v142 does not resolve
the cl.exe not found error during Meson build. Also clarified that
Visual Studio Build Tools 2026 is an alias for the 2022 version.

- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)