### PR TITLE
CI: Use coverage instead of pytest-cov

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -286,7 +286,7 @@ jobs:
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel meson[ninja]==1.2.1 meson-python==0.13.1
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
-          python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
+          python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
           python -m pytest -m 'not slow and not network and not clipboard and not single_cpu' pandas
@@ -325,7 +325,7 @@ jobs:
           /opt/python/cp313-cp313/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel meson-python==0.13.1 meson[ninja]==1.2.1
-          python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
+          python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
 
@@ -397,7 +397,7 @@ jobs:
           python --version
           python -m pip install --upgrade pip wheel meson[ninja]==1.2.1 meson-python==0.13.1
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-          python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.116.0 pytest>=8.3.4 pytest-xdist>=3.6.1 pytest-cov
+          python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.116.0 pytest>=8.3.4 pytest-xdist>=3.6.1
           python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
           python -m pip list
 
@@ -462,7 +462,7 @@ jobs:
       - name: Test pandas for Pyodide
         run: |
           source .venv-pyodide/bin/activate
-          pip install pytest hypothesis pytest-cov
+          pip install pytest hypothesis
           # do not import pandas from the checked out repo
           cd ..
           python -c 'import pandas as pd; pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db"])'

--- a/ci/deps/actions-311-minimum_versions.yaml
+++ b/ci/deps/actions-311-minimum_versions.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - pytest-localserver>=0.9.0
   - pytest-qt>=4.4.0

--- a/ci/deps/actions-311.yaml
+++ b/ci/deps/actions-311.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - pytest-localserver>=0.9.0
   - pytest-qt>=4.4.0

--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - pytest-localserver>=0.9.0
   - pytest-qt>=4.4.0

--- a/ci/deps/actions-313-downstream_compat.yaml
+++ b/ci/deps/actions-313-downstream_compat.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - pytest-localserver>=0.9.0
   - pytest-qt>=4.4.0

--- a/ci/deps/actions-313-freethreading.yaml
+++ b/ci/deps/actions-313-freethreading.yaml
@@ -23,6 +23,6 @@ dependencies:
 
   - pip:
     # No free-threaded coveragepy (with the C-extension) on conda-forge yet
-    - pytest-cov
+    - coverage
     - tzdata>=2023.3
     - "--extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"

--- a/ci/deps/actions-313-numpydev.yaml
+++ b/ci/deps/actions-313-numpydev.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - hypothesis>=6.116.0
 

--- a/ci/deps/actions-313-pyarrownightly.yaml
+++ b/ci/deps/actions-313-pyarrownightly.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - hypothesis>=6.116.0
 

--- a/ci/deps/actions-313.yaml
+++ b/ci/deps/actions-313.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - pytest-localserver>=0.9.0
   - pytest-qt>=4.4.0

--- a/ci/deps/actions-314.yaml
+++ b/ci/deps/actions-314.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - pytest-localserver>=0.9.0
   - pytest-qt>=4.4.0

--- a/ci/meta.yaml
+++ b/ci/meta.yaml
@@ -63,7 +63,6 @@ test:
     - pip
     - pytest >=8.3.4
     - pytest-xdist >=3.6.1
-    - pytest-cov
     - hypothesis >=6.116.0
 
 about:

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -6,9 +6,7 @@
 PYTHONHASHSEED=$(python -c 'import random; print(random.randint(1, 4294967295))')
 export PYTHONHASHSEED
 
-COVERAGE="-s --cov=pandas --cov-report=xml --cov-append --cov-config=pyproject.toml"
-
-PYTEST_CMD="MESONPY_EDITABLE_VERBOSE=1 PYTHONDEVMODE=1 PYTHONWARNDEFAULTENCODING=1 pytest -r fE -n $PYTEST_WORKERS --dist=worksteal $COVERAGE $PYTEST_TARGET"
+PYTEST_CMD="MESONPY_EDITABLE_VERBOSE=1 PYTHONDEVMODE=1 PYTHONWARNDEFAULTENCODING=1 pytest -r fE -n $PYTEST_WORKERS --dist=worksteal $PYTEST_TARGET"
 
 if [[ "$PATTERN" ]]; then
   PYTEST_CMD="$PYTEST_CMD -m \"$PATTERN\""

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,7 @@ coverage:
     project:
       default:
         target: '82'
+        informational: true
     patch:
       default:
         target: '50'

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 
   # test dependencies
   - pytest>=8.3.4
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.6.1
   - pytest-qt>=4.4.0
   - pytest-localserver

--- a/pixi.toml
+++ b/pixi.toml
@@ -147,8 +147,6 @@ cmd = [
   "run",
   "--append",
   "-m",
-  "python",
-  "-m",
   "pytest",
   "-r",
   "fE",

--- a/pixi.toml
+++ b/pixi.toml
@@ -155,4 +155,7 @@ cmd = [
   "--dist=worksteal",
   "--capture=no",
   "{{ pytest_target }}",
+  "&&",
+  "coverage",
+  "xml",
 ]

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,13 +46,7 @@ python-freethreading = "3.13.*"
 pytest = ">=8.3.4"
 pytest-xdist = ">=3.6.1"
 hypothesis = ">=6.116.0"
-
-[feature.pytest-cov-conda.dependencies]
-pytest-cov = ">=7.0.0"
-
-[feature.pytest-cov-pypi.pypi-dependencies]
-# No free-threaded coveragepy (with the C-extension) on conda-forge yet
-pytest-cov = ">=7.0.0"
+coverage = ">=7.13.5"
 
 [feature.test-network.dependencies]
 pytest-localserver = ">=0.9.0"
@@ -118,16 +112,16 @@ pyyaml = "*"
 xarray = ">=2024.10.0"
 
 [environments]
-py311 = { features = ["py311", "numpy", "test-base", "pytest-cov-conda", "test-clipboard", "test-network", "pyarrow", "optional-dependencies"] }
-py312 = { features = ["py312", "numpy", "test-base", "pytest-cov-conda", "test-clipboard", "test-network", "pyarrow", "optional-dependencies"] }
-py313 = { features = ["py313", "numpy", "test-base", "pytest-cov-conda", "test-clipboard", "test-network", "pyarrow", "optional-dependencies"] }
-py314 = { features = ["py314", "numpy", "test-base", "pytest-cov-conda", "test-clipboard", "test-network", "pyarrow", "optional-dependencies"] }
-no-pyarrow = { features = ["py313", "numpy", "test-base", "pytest-cov-conda", "test-clipboard", "test-network", "optional-dependencies"] }
-minimum-versions = { features = ["py311", "numpy", "test-base", "pytest-cov-conda", "test-clipboard", "test-network", "pyarrow", "optional-dependencies", "minimum-versions"] }
-py313-freethreading = { features = ["py313-freethreading", "numpy", "test-base", "pytest-cov-pypi"] }
-numpy-nightly = { features = ["py313", "numpy-nightly", "test-base", "pytest-cov-conda"] }
-pyarrow-nightly = { features = ["py313", "numpy", "test-base", "pytest-cov-conda", "pyarrow-nightly"] }
-downstream = { features = ["py313", "numpy", "test-base", "pytest-cov-conda", "downstream"] }
+py311 = { features = ["py311", "numpy", "test-base", "test-clipboard", "test-network", "pyarrow", "optional-dependencies"] }
+py312 = { features = ["py312", "numpy", "test-base", "test-clipboard", "test-network", "pyarrow", "optional-dependencies"] }
+py313 = { features = ["py313", "numpy", "test-base", "test-clipboard", "test-network", "pyarrow", "optional-dependencies"] }
+py314 = { features = ["py314", "numpy", "test-base", "test-clipboard", "test-network", "pyarrow", "optional-dependencies"] }
+no-pyarrow = { features = ["py313", "numpy", "test-base", "test-clipboard", "test-network", "optional-dependencies"] }
+minimum-versions = { features = ["py311", "numpy", "test-base", "test-clipboard", "test-network", "pyarrow", "optional-dependencies", "minimum-versions"] }
+py313-freethreading = { features = ["py313-freethreading", "numpy", "test-base"] }
+numpy-nightly = { features = ["py313", "numpy-nightly", "test-base"] }
+pyarrow-nightly = { features = ["py313", "numpy", "test-base", "pyarrow-nightly"] }
+downstream = { features = ["py313", "numpy", "test-base", "downstream"] }
 
 
 [tasks]
@@ -149,6 +143,10 @@ args = [
   { "arg" = "pytest_target", "default" = "pandas" },
 ]
 cmd = [
+  "coverage",
+  "run",
+  "--append",
+  "-m",
   "python",
   "-m",
   "pytest",
@@ -158,8 +156,5 @@ cmd = [
   "--numprocesses={{ numprocesses }}",
   "--dist=worksteal",
   "--capture=no",
-  "--cov=pandas",
-  "--cov-report=xml",
-  "--cov-append",
   "{{ pytest_target }}",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -681,6 +681,20 @@ branch = true
 omit = ["pandas/_typing.py"]
 source = ["pandas"]
 
+[tool.coverage.report]
+ignore_errors = false
+show_missing = true
+exclude_lines = [
+  # Have to re-enable the standard pragma
+  "pragma: no cover",
+  # Don't complain if tests don't hit defensive assertion code:
+  "raise AssertionError",
+  "AbstractMethodError",
+  # Don't complain if non-runnable code isn't run:
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]
+
 [tool.codespell]
 ignore-words-list = "blocs, coo, hist, nd, sav, ser, recuse, nin, timere, expec, expecs, indext, SME, NotIn, tructures, tru, indx, abd, ABD"
 ignore-regex = 'https://([\w/\.])+'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -679,8 +679,6 @@ reportReturnType = false
 [tool.coverage.run]
 branch = true
 omit = ["pandas/_typing.py"]
-# TODO: This isn't actually installed in CI
-plugins = ["Cython.Coverage"]
 source = ["pandas"]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -679,30 +679,9 @@ reportReturnType = false
 [tool.coverage.run]
 branch = true
 omit = ["pandas/_typing.py"]
+# TODO: This isn't actually installed in CI
 plugins = ["Cython.Coverage"]
 source = ["pandas"]
-
-[tool.coverage.report]
-ignore_errors = false
-show_missing = true
-exclude_lines = [
-  # Have to re-enable the standard pragma
-  "pragma: no cover",
-  # Don't complain about missing debug-only code:s
-  "def __repr__",
-  "if self.debug",
-  # Don't complain if tests don't hit defensive assertion code:
-  "raise AssertionError",
-  "raise NotImplementedError",
-  "AbstractMethodError",
-  # Don't complain if non-runnable code isn't run:
-  "if 0:",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
-
-[tool.coverage.html]
-directory = "coverage_html_report"
 
 [tool.codespell]
 ignore-words-list = "blocs, coo, hist, nd, sav, ser, recuse, nin, timere, expec, expecs, indext, SME, NotIn, tructures, tru, indx, abd, ABD"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ cython>=3.1.0,<4.0.0a0
 meson[ninja]>=1.2.1,<2
 meson-python>=0.17.1,<1
 pytest>=8.3.4
-pytest-cov
+coverage
 pytest-xdist>=3.6.1
 pytest-qt>=4.4.0
 pytest-localserver

--- a/scripts/tests/data/deps_expected_random.yaml
+++ b/scripts/tests/data/deps_expected_random.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   # test dependencies
   - pytest>=7.3.2
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.4.0
   - psutil
   - boto3

--- a/scripts/tests/data/deps_unmodified_random.yaml
+++ b/scripts/tests/data/deps_unmodified_random.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   # test dependencies
   - pytest>=7.3.2
-  - pytest-cov
+  - coverage
   - pytest-xdist>=3.4.0
   - psutil
   - boto3


### PR DESCRIPTION
Follow up to https://github.com/pandas-dev/pandas/pull/64600

In Codecov, I believe we're seeing decreased coverage due to https://github.com/pytest-dev/pytest-cov/issues/455. Appears the suggestion is to use `coverage` directly (as I don't think we're using the extra benefits of `pytest-cov`)