### PR TITLE
PERF: branchless calendar algorithms and batch field extractors

### DIFF
--- a/LICENSES/NERI_SCHNEIDER_LICENSE
+++ b/LICENSES/NERI_SCHNEIDER_LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 Cassio Neri <cassio.neri@gmail.com>
+Copyright (c) 2022 Lorenz Schneider <schneider@em-lyon.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pandas/_libs/include/pandas/datetime/pd_datetime.h
+++ b/pandas/_libs/include/pandas/datetime/pd_datetime.h
@@ -53,6 +53,7 @@ typedef struct {
   int (*make_iso_8601_datetime)(npy_datetimestruct *, char *, size_t, int,
                                 NPY_DATETIMEUNIT);
   int (*make_iso_8601_timedelta)(pandas_timedeltastruct *, char *, size_t *);
+  void (*set_datetimestruct_days)(npy_int64, npy_datetimestruct *);
 } PandasDateTime_CAPI;
 
 // The capsule name appears limited to module.attributename; see bpo-32414
@@ -105,6 +106,8 @@ static PandasDateTime_CAPI *PandasDateTimeAPI = NULL;
                                               (utc), (base))
 #  define make_iso_8601_timedelta(tds, outstr, outlen)                         \
     PandasDateTimeAPI->make_iso_8601_timedelta((tds), (outstr), (outlen))
+#  define set_datetimestruct_days(days, dts)                                   \
+    PandasDateTimeAPI->set_datetimestruct_days((days), (dts))
 #endif /* !defined(_PANDAS_DATETIME_IMPL) */
 
 #ifdef __cplusplus

--- a/pandas/_libs/include/pandas/vendored/numpy/datetime/np_datetime.h
+++ b/pandas/_libs/include/pandas/vendored/numpy/datetime/np_datetime.h
@@ -88,6 +88,12 @@ int is_leapyear(npy_int64 year);
 npy_int64 get_datetimestruct_days(const npy_datetimestruct *dts);
 
 /*
+ * Fills in the year, month, day in 'dts' based on the days
+ * offset from 1970. Uses Neri-Schneider branchless algorithm.
+ */
+void set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts);
+
+/*
  * Compares two npy_datetimestruct objects chronologically
  */
 int cmp_npy_datetimestruct(const npy_datetimestruct *a,

--- a/pandas/_libs/src/datetime/pd_datetime.c
+++ b/pandas/_libs/src/datetime/pd_datetime.c
@@ -289,6 +289,7 @@ static int pandas_datetime_exec(PyObject *Py_UNUSED(module)) {
   capi->get_datetime_iso_8601_strlen = get_datetime_iso_8601_strlen;
   capi->make_iso_8601_datetime = make_iso_8601_datetime;
   capi->make_iso_8601_timedelta = make_iso_8601_timedelta;
+  capi->set_datetimestruct_days = set_datetimestruct_days;
 
   PyObject *capsule = PyCapsule_New(capi, PandasDateTime_CAPSULE_NAME,
                                     pandas_datetime_destructor);

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -107,17 +107,24 @@ void add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes) {
 /*
  * Calculates the days offset from the 1970 epoch.
  *
- * Uses Hinnant's algorithm for loop-free, nearly branchless conversion.
+ * Adapted from Hinnant's days_from_civil algorithm (public domain).
+ * See: https://howardhinnant.github.io/date_algorithms.html#days_from_civil
+ *
  * The March-1 epoch trick places the leap day at the end of the year,
  * eliminating special cases for February.
- * See: https://howardhinnant.github.io/date_algorithms.html
+ *
+ * Uses overflow-checked arithmetic for the final computation because
+ * npy_int64 year values can push era far outside 32-bit range, unlike
+ * Hinnant's original which returns `era * 146097 + doe - 719468` directly.
  */
 npy_int64 get_datetimestruct_days(const npy_datetimestruct *dts) {
   npy_int64 y = dts->year - (dts->month <= 2);
   npy_int64 era = (y >= 0 ? y : y - 399) / 400;
   uint32_t yoe = (uint32_t)(y - era * 400); /* [0, 399] */
-  uint32_t mp = (uint32_t)(dts->month > 2 ? dts->month - 3 : dts->month + 9);
-  uint32_t doy = (153 * mp + 2) / 5 + (uint32_t)dts->day - 1;
+  uint32_t doy =
+      (153 * (uint32_t)(dts->month > 2 ? dts->month - 3 : dts->month + 9) + 2) /
+          5 +
+      (uint32_t)dts->day - 1;                           /* [0, 365] */
   uint32_t doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; /* [0, 146096] */
 
   npy_int64 days;
@@ -171,50 +178,48 @@ static npy_int64 days_to_yearsdays(npy_int64 *days_) {
  * Fills in the year, month, day in 'dts' based on the days
  * offset from 1970.
  *
- * Uses the Neri-Schneider algorithm for branchless, loop-free conversion
- * via Euclidean Affine Functions that replace integer divisions with
- * multiply-shift operations.
- *
- * Algorithm from: Neri C, Schneider L. "Euclidean Affine Functions and their
- * Application to Calendar Algorithms." Software: Practice and Experience.
- * 2023;53(4):937-970. doi:10.1002/spe.3172
- *
- * Ported from algorithms/neri_schneider.hpp (MIT license) in:
+ * Adapted from neri_schneider.hpp::to_date (MIT license) in:
  * https://github.com/cassioneri/eaf
  * SPDX-FileCopyrightText: 2022 Cassio Neri <cassio.neri@gmail.com>
  * SPDX-FileCopyrightText: 2022 Lorenz Schneider <schneider@em-lyon.com>
+ *
+ * Algorithm: Neri C, Schneider L. "Euclidean Affine Functions and their
+ * Application to Calendar Algorithms." Software: Practice and Experience.
+ * 2023;53(4):937-970. doi:10.1002/spe.3172
  *
  * Falls back to the classical algorithm for dates beyond ~32K years
  * before epoch or ~2.9M years after (effectively never reached in practice).
  */
 void set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts) {
   /* Neri-Schneider valid range: [-12699422, 1061042401] (~year -32800..2906945)
-   * Constants derived with shift parameter s = 82. */
+   * s = 82, K = 719468 + 146097 * s, L = 400 * s. */
   if (days >= -12699422LL && days <= 1061042401LL) {
-    const uint32_t K = 12699422u; /* 719468 + 146097 * 82 */
-    const uint32_t L = 32800u;    /* 400 * 82 */
+    const uint32_t K = 12699422u;
+    const uint32_t L = 32800u;
 
+    /* Rata die shift. */
     uint32_t N = (uint32_t)(int32_t)days + K;
 
-    /* Step 1: Century decomposition */
+    /* Century. */
     uint32_t N_1 = 4 * N + 3;
-    uint32_t C = N_1 / 146097u;
-    uint32_t N_C = N_1 % 146097u / 4;
+    uint32_t C = N_1 / 146097;
+    uint32_t N_C = N_1 % 146097 / 4;
 
-    /* Step 2: Year within century (EAF: 2939745 = ceil(2^32 / 1461)) */
+    /* Year. */
     uint32_t N_2 = 4 * N_C + 3;
-    uint64_t P_2 = (uint64_t)2939745u * N_2;
-    uint32_t Z = (uint32_t)(P_2 >> 32);
-    uint32_t N_Y = (uint32_t)P_2 / 2939745u / 4;
+    uint64_t P_2 = (uint64_t)2939745 * N_2;
+    uint32_t Z = (uint32_t)(P_2 / 4294967296);
+    uint32_t N_Y = (uint32_t)(P_2 % 4294967296) / 2939745 / 4;
 
-    /* Step 3: Month and day (EAF: 2141 = floor(2^16 * 5 / 153)) */
+    /* Month and day. */
     uint32_t N_3 = 2141 * N_Y + 197913;
-    uint32_t M = N_3 >> 16;
-    uint32_t D = (N_3 & 0xFFFF) / 2141;
+    uint32_t M = N_3 / 65536;
+    uint32_t D = N_3 % 65536 / 2141;
 
-    /* Step 4: Convert from March-based to January-based calendar */
+    /* Map from March-based to January-based calendar. */
     uint32_t J = N_Y >= 306;
-    dts->year = (npy_int64)((int32_t)(100 * C + Z - L) + (int32_t)J);
+    uint32_t Y = 100 * C + Z;
+    dts->year = (npy_int64)((int32_t)(Y - L) + (int32_t)J);
     dts->month = (npy_int32)(J ? M - 12 : M);
     dts->day = (npy_int32)(D + 1);
     return;

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -113,9 +113,7 @@ void add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes) {
  * The March-1 epoch trick places the leap day at the end of the year,
  * eliminating special cases for February.
  *
- * Uses overflow-checked arithmetic for the final computation because
- * npy_int64 year values can push era far outside 32-bit range, unlike
- * Hinnant's original which returns `era * 146097 + doe - 719468` directly.
+ * Uses overflow-checked arithmetic to detect out-of-range inputs.
  */
 npy_int64 get_datetimestruct_days(const npy_datetimestruct *dts) {
   npy_int64 y = dts->year - (dts->month <= 2);

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -106,60 +106,24 @@ void add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes) {
 
 /*
  * Calculates the days offset from the 1970 epoch.
+ *
+ * Uses Hinnant's algorithm for loop-free, nearly branchless conversion.
+ * The March-1 epoch trick places the leap day at the end of the year,
+ * eliminating special cases for February.
+ * See: https://howardhinnant.github.io/date_algorithms.html
  */
 npy_int64 get_datetimestruct_days(const npy_datetimestruct *dts) {
-  int i, month;
-  npy_int64 year, days = 0;
-  const int *month_lengths;
+  npy_int64 y = dts->year - (dts->month <= 2);
+  npy_int64 era = (y >= 0 ? y : y - 399) / 400;
+  uint32_t yoe = (uint32_t)(y - era * 400); /* [0, 399] */
+  uint32_t mp = (uint32_t)(dts->month > 2 ? dts->month - 3 : dts->month + 9);
+  uint32_t doy = (153 * mp + 2) / 5 + (uint32_t)dts->day - 1;
+  uint32_t doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; /* [0, 146096] */
 
-  PD_CHECK_OVERFLOW(checked_sub(dts->year, 1970, &year));
-  PD_CHECK_OVERFLOW(checked_mul(year, 365, &days));
-
-  /* Adjust for leap years */
-  if (days >= 0) {
-    /*
-     * 1968 is the closest leap year before 1970.
-     * Exclude the current year, so add 1.
-     */
-    PD_CHECK_OVERFLOW(checked_add(year, 1, &year));
-    /* Add one day for each 4 years */
-    PD_CHECK_OVERFLOW(checked_add(days, year / 4, &days));
-    /* 1900 is the closest previous year divisible by 100 */
-    PD_CHECK_OVERFLOW(checked_add(year, 68, &year));
-    /* Subtract one day for each 100 years */
-    PD_CHECK_OVERFLOW(checked_sub(days, year / 100, &days));
-    /* 1600 is the closest previous year divisible by 400 */
-    PD_CHECK_OVERFLOW(checked_add(year, 300, &year));
-    /* Add one day for each 400 years */
-    PD_CHECK_OVERFLOW(checked_add(days, year / 400, &days));
-  } else {
-    /*
-     * 1972 is the closest later year after 1970.
-     * Include the current year, so subtract 2.
-     */
-    PD_CHECK_OVERFLOW(checked_sub(year, 2, &year));
-    /* Subtract one day for each 4 years */
-    PD_CHECK_OVERFLOW(checked_add(days, year / 4, &days));
-    /* 2000 is the closest later year divisible by 100 */
-    PD_CHECK_OVERFLOW(checked_sub(year, 28, &year));
-    /* Add one day for each 100 years */
-    PD_CHECK_OVERFLOW(checked_sub(days, year / 100, &days));
-    /* 2000 is also the closest later year divisible by 400 */
-    /* Subtract one day for each 400 years */
-    PD_CHECK_OVERFLOW(checked_add(days, year / 400, &days));
-  }
-
-  month_lengths = days_per_month_table[is_leapyear(dts->year)];
-  month = dts->month - 1;
-
-  /* Add the months */
-  for (i = 0; i < month; ++i) {
-    PD_CHECK_OVERFLOW(checked_add(days, month_lengths[i], &days));
-  }
-
-  /* Add the days */
-  PD_CHECK_OVERFLOW(checked_add(days, dts->day - 1, &days));
-
+  npy_int64 days;
+  PD_CHECK_OVERFLOW(checked_mul(era, (npy_int64)146097, &days));
+  PD_CHECK_OVERFLOW(checked_add(days, (npy_int64)doe, &days));
+  PD_CHECK_OVERFLOW(checked_sub(days, (npy_int64)719468, &days));
   return days;
 }
 
@@ -206,8 +170,57 @@ static npy_int64 days_to_yearsdays(npy_int64 *days_) {
 /*
  * Fills in the year, month, day in 'dts' based on the days
  * offset from 1970.
+ *
+ * Uses the Neri-Schneider algorithm for branchless, loop-free conversion
+ * via Euclidean Affine Functions that replace integer divisions with
+ * multiply-shift operations.
+ *
+ * Algorithm from: Neri C, Schneider L. "Euclidean Affine Functions and their
+ * Application to Calendar Algorithms." Software: Practice and Experience.
+ * 2023;53(4):937-970. doi:10.1002/spe.3172
+ *
+ * Ported from algorithms/neri_schneider.hpp (MIT license) in:
+ * https://github.com/cassioneri/eaf
+ * SPDX-FileCopyrightText: 2022 Cassio Neri <cassio.neri@gmail.com>
+ * SPDX-FileCopyrightText: 2022 Lorenz Schneider <schneider@em-lyon.com>
+ *
+ * Falls back to the classical algorithm for dates beyond ~32K years
+ * before epoch or ~2.9M years after (effectively never reached in practice).
  */
-static void set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts) {
+void set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts) {
+  /* Neri-Schneider valid range: [-12699422, 1061042401] (~year -32800..2906945)
+   * Constants derived with shift parameter s = 82. */
+  if (days >= -12699422LL && days <= 1061042401LL) {
+    const uint32_t K = 12699422u; /* 719468 + 146097 * 82 */
+    const uint32_t L = 32800u;    /* 400 * 82 */
+
+    uint32_t N = (uint32_t)(int32_t)days + K;
+
+    /* Step 1: Century decomposition */
+    uint32_t N_1 = 4 * N + 3;
+    uint32_t C = N_1 / 146097u;
+    uint32_t N_C = N_1 % 146097u / 4;
+
+    /* Step 2: Year within century (EAF: 2939745 = ceil(2^32 / 1461)) */
+    uint32_t N_2 = 4 * N_C + 3;
+    uint64_t P_2 = (uint64_t)2939745u * N_2;
+    uint32_t Z = (uint32_t)(P_2 >> 32);
+    uint32_t N_Y = (uint32_t)P_2 / 2939745u / 4;
+
+    /* Step 3: Month and day (EAF: 2141 = floor(2^16 * 5 / 153)) */
+    uint32_t N_3 = 2141 * N_Y + 197913;
+    uint32_t M = N_3 >> 16;
+    uint32_t D = (N_3 & 0xFFFF) / 2141;
+
+    /* Step 4: Convert from March-based to January-based calendar */
+    uint32_t J = N_Y >= 306;
+    dts->year = (npy_int64)((int32_t)(100 * C + Z - L) + (int32_t)J);
+    dts->month = (npy_int32)(J ? M - 12 : M);
+    dts->day = (npy_int32)(D + 1);
+    return;
+  }
+
+  /* Fallback for extreme dates outside Neri-Schneider range */
   const int *month_lengths;
   int i;
 

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -39,17 +39,11 @@ from pandas._libs.tslibs.ccalendar cimport (
     get_week_of_year,
     iso_calendar_t,
 )
+from pandas._libs.tslibs.dtypes cimport periods_per_day
 from pandas._libs.tslibs.nattype cimport NPY_NAT
 from pandas._libs.tslibs.np_datetime cimport (
     NPY_DATETIMEUNIT,
-    NPY_FR_D,
-    NPY_FR_h,
-    NPY_FR_m,
-    NPY_FR_ms,
     NPY_FR_ns,
-    NPY_FR_ps,
-    NPY_FR_s,
-    NPY_FR_us,
     import_pandas_datetime,
     npy_datetimestruct,
     pandas_datetime_to_datetimestruct,
@@ -59,33 +53,6 @@ from pandas._libs.tslibs.np_datetime cimport (
 )
 
 import_pandas_datetime()
-
-
-cdef inline int64_t _units_per_day(NPY_DATETIMEUNIT base) noexcept nogil:
-    """Return the number of datetime units per day, or 0 for Y/M/W."""
-    if base == NPY_FR_ns:
-        return 86400000000000
-    elif base == NPY_FR_us:
-        return 86400000000
-    elif base == NPY_FR_ms:
-        return 86400000
-    elif base == NPY_FR_s:
-        return 86400
-    elif base == NPY_FR_m:
-        return 1440
-    elif base == NPY_FR_h:
-        return 24
-    elif base == NPY_FR_D:
-        return 1
-    elif base == NPY_FR_ps:
-        return 86400000000000000
-    else:
-        return 0
-
-
-cdef inline int64_t _floordiv(int64_t a, int64_t b) noexcept nogil:
-    """Floor division (rounds towards negative infinity)."""
-    return a // b
 
 
 @cython.wraparound(False)
@@ -399,7 +366,11 @@ def get_date_field(
         int64_t perday, perhour, permin, persec
 
     out = np.empty(count, dtype="i4")
-    perday = _units_per_day(reso)
+    try:
+        perday = periods_per_day(reso)
+    except ValueError:
+        # Y/M resolutions don't have a fixed number of periods per day
+        perday = 0
 
     # --- Date fields: only need calendar conversion, skip sub-day work ---
 
@@ -411,7 +382,7 @@ def get_date_field(
                     continue
                 if perday > 0:
                     set_datetimestruct_days(
-                        _floordiv(dtindex[i], perday), &dts
+                        dtindex[i] // perday, &dts
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
@@ -426,7 +397,7 @@ def get_date_field(
                     continue
                 if perday > 0:
                     set_datetimestruct_days(
-                        _floordiv(dtindex[i], perday), &dts
+                        dtindex[i] // perday, &dts
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
@@ -441,7 +412,7 @@ def get_date_field(
                     continue
                 if perday > 0:
                     set_datetimestruct_days(
-                        _floordiv(dtindex[i], perday), &dts
+                        dtindex[i] // perday, &dts
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
@@ -456,7 +427,7 @@ def get_date_field(
                     continue
                 if perday > 0:
                     set_datetimestruct_days(
-                        _floordiv(dtindex[i], perday), &dts
+                        dtindex[i] // perday, &dts
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
@@ -471,7 +442,7 @@ def get_date_field(
                     continue
                 if perday > 0:
                     set_datetimestruct_days(
-                        _floordiv(dtindex[i], perday), &dts
+                        dtindex[i] // perday, &dts
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
@@ -486,7 +457,7 @@ def get_date_field(
                     continue
                 if perday > 0:
                     set_datetimestruct_days(
-                        _floordiv(dtindex[i], perday), &dts
+                        dtindex[i] // perday, &dts
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
@@ -501,7 +472,7 @@ def get_date_field(
                     continue
                 if perday > 0:
                     set_datetimestruct_days(
-                        _floordiv(dtindex[i], perday), &dts
+                        dtindex[i] // perday, &dts
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
@@ -516,7 +487,7 @@ def get_date_field(
                     continue
                 if perday > 0:
                     set_datetimestruct_days(
-                        _floordiv(dtindex[i], perday), &dts
+                        dtindex[i] // perday, &dts
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -42,15 +42,50 @@ from pandas._libs.tslibs.ccalendar cimport (
 from pandas._libs.tslibs.nattype cimport NPY_NAT
 from pandas._libs.tslibs.np_datetime cimport (
     NPY_DATETIMEUNIT,
+    NPY_FR_D,
+    NPY_FR_h,
+    NPY_FR_m,
+    NPY_FR_ms,
     NPY_FR_ns,
+    NPY_FR_ps,
+    NPY_FR_s,
+    NPY_FR_us,
     import_pandas_datetime,
     npy_datetimestruct,
     pandas_datetime_to_datetimestruct,
     pandas_timedelta_to_timedeltastruct,
     pandas_timedeltastruct,
+    set_datetimestruct_days,
 )
 
 import_pandas_datetime()
+
+
+cdef inline int64_t _units_per_day(NPY_DATETIMEUNIT base) noexcept nogil:
+    """Return the number of datetime units per day, or 0 for Y/M/W."""
+    if base == NPY_FR_ns:
+        return 86400000000000
+    elif base == NPY_FR_us:
+        return 86400000000
+    elif base == NPY_FR_ms:
+        return 86400000
+    elif base == NPY_FR_s:
+        return 86400
+    elif base == NPY_FR_m:
+        return 1440
+    elif base == NPY_FR_h:
+        return 24
+    elif base == NPY_FR_D:
+        return 1
+    elif base == NPY_FR_ps:
+        return 86400000000000000
+    else:
+        return 0
+
+
+cdef inline int64_t _floordiv(int64_t a, int64_t b) noexcept nogil:
+    """Floor division (rounds towards negative infinity)."""
+    return a // b
 
 
 @cython.wraparound(False)
@@ -361,8 +396,12 @@ def get_date_field(
         Py_ssize_t i, count = len(dtindex)
         ndarray[int32_t] out
         npy_datetimestruct dts
+        int64_t perday, perhour, permin, persec
 
     out = np.empty(count, dtype="i4")
+    perday = _units_per_day(reso)
+
+    # --- Date fields: only need calendar conversion, skip sub-day work ---
 
     if field == "Y":
         with nogil:
@@ -370,8 +409,12 @@ def get_date_field(
                 if dtindex[i] == NPY_NAT:
                     out[i] = -1
                     continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                if perday > 0:
+                    set_datetimestruct_days(
+                        _floordiv(dtindex[i], perday), &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
                 out[i] = dts.year
         return out
 
@@ -381,8 +424,12 @@ def get_date_field(
                 if dtindex[i] == NPY_NAT:
                     out[i] = -1
                     continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                if perday > 0:
+                    set_datetimestruct_days(
+                        _floordiv(dtindex[i], perday), &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
                 out[i] = dts.month
         return out
 
@@ -392,44 +439,153 @@ def get_date_field(
                 if dtindex[i] == NPY_NAT:
                     out[i] = -1
                     continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                if perday > 0:
+                    set_datetimestruct_days(
+                        _floordiv(dtindex[i], perday), &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
                 out[i] = dts.day
         return out
 
-    elif field == "h":
+    elif field == "doy":
         with nogil:
             for i in range(count):
                 if dtindex[i] == NPY_NAT:
                     out[i] = -1
                     continue
+                if perday > 0:
+                    set_datetimestruct_days(
+                        _floordiv(dtindex[i], perday), &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                out[i] = get_day_of_year(dts.year, dts.month, dts.day)
+        return out
 
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
-                out[i] = dts.hour
-                # TODO: can we de-dup with period.pyx <accessor>s?
+    elif field == "dow":
+        with nogil:
+            for i in range(count):
+                if dtindex[i] == NPY_NAT:
+                    out[i] = -1
+                    continue
+                if perday > 0:
+                    set_datetimestruct_days(
+                        _floordiv(dtindex[i], perday), &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                out[i] = dayofweek(dts.year, dts.month, dts.day)
+        return out
+
+    elif field == "woy":
+        with nogil:
+            for i in range(count):
+                if dtindex[i] == NPY_NAT:
+                    out[i] = -1
+                    continue
+                if perday > 0:
+                    set_datetimestruct_days(
+                        _floordiv(dtindex[i], perday), &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                out[i] = get_week_of_year(dts.year, dts.month, dts.day)
+        return out
+
+    elif field == "q":
+        with nogil:
+            for i in range(count):
+                if dtindex[i] == NPY_NAT:
+                    out[i] = -1
+                    continue
+                if perday > 0:
+                    set_datetimestruct_days(
+                        _floordiv(dtindex[i], perday), &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                out[i] = ((dts.month - 1) // 3) + 1
+        return out
+
+    elif field == "dim":
+        with nogil:
+            for i in range(count):
+                if dtindex[i] == NPY_NAT:
+                    out[i] = -1
+                    continue
+                if perday > 0:
+                    set_datetimestruct_days(
+                        _floordiv(dtindex[i], perday), &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                out[i] = get_days_in_month(dts.year, dts.month)
+        return out
+
+    # --- Sub-day fields: skip calendar conversion entirely ---
+
+    elif field == "h":
+        with nogil:
+            if perday >= 24:
+                perhour = perday // 24
+                for i in range(count):
+                    if dtindex[i] == NPY_NAT:
+                        out[i] = -1
+                        continue
+                    out[i] = <int32_t>((dtindex[i] % perday) // perhour)
+            else:
+                for i in range(count):
+                    if dtindex[i] == NPY_NAT:
+                        out[i] = -1
+                        continue
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                    out[i] = dts.hour
         return out
 
     elif field == "m":
         with nogil:
-            for i in range(count):
-                if dtindex[i] == NPY_NAT:
-                    out[i] = -1
-                    continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
-                out[i] = dts.min
+            if perday >= 1440:
+                perhour = perday // 24
+                permin = perday // 1440
+                for i in range(count):
+                    if dtindex[i] == NPY_NAT:
+                        out[i] = -1
+                        continue
+                    out[i] = <int32_t>(
+                        (dtindex[i] % perhour) // permin
+                    )
+            else:
+                for i in range(count):
+                    if dtindex[i] == NPY_NAT:
+                        out[i] = -1
+                        continue
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                    out[i] = dts.min
         return out
 
     elif field == "s":
         with nogil:
-            for i in range(count):
-                if dtindex[i] == NPY_NAT:
-                    out[i] = -1
-                    continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
-                out[i] = dts.sec
+            if perday >= 86400:
+                permin = perday // 1440
+                persec = perday // 86400
+                for i in range(count):
+                    if dtindex[i] == NPY_NAT:
+                        out[i] = -1
+                        continue
+                    out[i] = <int32_t>(
+                        (dtindex[i] % permin) // persec
+                    )
+            else:
+                for i in range(count):
+                    if dtindex[i] == NPY_NAT:
+                        out[i] = -1
+                        continue
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                    out[i] = dts.sec
         return out
+
+    # --- Resolution-dependent fields: keep full struct decomposition ---
 
     elif field == "us":
         with nogil:
@@ -437,7 +593,6 @@ def get_date_field(
                 if dtindex[i] == NPY_NAT:
                     out[i] = -1
                     continue
-
                 pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
                 out[i] = dts.us
         return out
@@ -448,65 +603,10 @@ def get_date_field(
                 if dtindex[i] == NPY_NAT:
                     out[i] = -1
                     continue
-
                 pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
                 out[i] = dts.ps // 1000
         return out
-    elif field == "doy":
-        with nogil:
-            for i in range(count):
-                if dtindex[i] == NPY_NAT:
-                    out[i] = -1
-                    continue
 
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
-                out[i] = get_day_of_year(dts.year, dts.month, dts.day)
-        return out
-
-    elif field == "dow":
-        with nogil:
-            for i in range(count):
-                if dtindex[i] == NPY_NAT:
-                    out[i] = -1
-                    continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
-                out[i] = dayofweek(dts.year, dts.month, dts.day)
-        return out
-
-    elif field == "woy":
-        with nogil:
-            for i in range(count):
-                if dtindex[i] == NPY_NAT:
-                    out[i] = -1
-                    continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
-                out[i] = get_week_of_year(dts.year, dts.month, dts.day)
-        return out
-
-    elif field == "q":
-        with nogil:
-            for i in range(count):
-                if dtindex[i] == NPY_NAT:
-                    out[i] = -1
-                    continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
-                out[i] = dts.month
-                out[i] = ((out[i] - 1) // 3) + 1
-        return out
-
-    elif field == "dim":
-        with nogil:
-            for i in range(count):
-                if dtindex[i] == NPY_NAT:
-                    out[i] = -1
-                    continue
-
-                pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
-                out[i] = get_days_in_month(dts.year, dts.month)
-        return out
     elif field == "is_leap_year":
         return isleapyear_arr(get_date_field(dtindex, "Y", reso=reso))
 

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -46,6 +46,9 @@ cdef extern from "pandas/datetime/pd_datetime.h":
                                            NPY_DATETIMEUNIT fr,
                                            npy_datetimestruct *result) nogil
 
+    void set_datetimestruct_days(int64_t days,
+                                 npy_datetimestruct *result) nogil
+
     npy_datetime npy_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
                                                 npy_datetimestruct *d) except? -1 nogil
 


### PR DESCRIPTION
## Summary

- Replace `get_datetimestruct_days` (ymd→days) with Hinnant's loop-free public-domain algorithm
- Replace `set_datetimestruct_days` (days→ymd) with Neri-Schneider's branchless EAF algorithm (MIT-licensed, from `algorithms/neri_schneider.hpp` in [cassioneri/eaf](https://github.com/cassioneri/eaf))
- Optimize `get_date_field` in `fields.pyx`: date fields (Y/M/D/doy/dow/woy/q/dim) call `set_datetimestruct_days` directly skipping sub-day decomposition; sub-day fields (h/m/s) use pure modular arithmetic skipping calendar conversion entirely
- Expose `set_datetimestruct_days` through the PyCapsule C API so it's callable from Cython extension modules

```python
dti = pd.date_range("2000-01-01", periods=1_000_000, freq="min")

%timeit dti.year
3.3 ms ± 29.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   # <- PR
8.1 ms ± 42 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)     # <- main

%timeit dti.hour
1.5 ms ± 11.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- PR
8.0 ms ± 39.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   # <- main

%timeit dti.dayofweek
7.4 ms ± 58.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)   # <- PR
12.4 ms ± 78.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  # <- main
```

## Test plan

- [x] `pandas/tests/tslibs/` — 646 passed
- [x] `pandas/tests/indexes/datetimes/` — 3182 passed
- [x] `pandas/tests/series/accessors/test_dt_accessor.py` — 315 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)