### PR TITLE
REF: make Index._formatter_func a method instead of property

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1412,12 +1412,11 @@ class Index(IndexOpsMixin, PandasObject):
 
         return f"{klass_name}({data}{prepr})"
 
-    @property
-    def _formatter_func(self) -> Callable:
+    def _formatter_func(self, val: object) -> str_t:
         """
-        Return the formatter function.
+        Return the formatted value.
         """
-        return default_pprint
+        return default_pprint(val)
 
     @final
     def _format_data(self, name: str_t | None = None) -> str_t:

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -345,9 +345,8 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
     # --------------------------------------------------------------------
     # Rendering Methods
 
-    @property
-    def _formatter_func(self):
-        return self.categories._formatter_func
+    def _formatter_func(self, val) -> str:
+        return self.categories._formatter_func(val)
 
     def _format_attrs(self):
         """

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -384,9 +384,8 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
             self._get_values_for_csv(na_rep=na_rep, date_format=date_format)
         )
 
-    @property
-    def _formatter_func(self):
-        return self._data._formatter()
+    def _formatter_func(self, val) -> str:
+        return self._data._formatter()(val)
 
     def _format_attrs(self):
         """

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -767,14 +767,16 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     # --------------------------------------------------------------------
     # Rendering Methods
 
-    @cache_readonly
-    def _formatter_func(self):
+    def _formatter_func(self, val) -> str:
         # Note this is equivalent to the DatetimeIndexOpsMixin method but
         #  uses the maybe-cached self._is_dates_only instead of re-computing it.
+        return f"'{self._date_formatter(val)}'"
+
+    @cache_readonly
+    def _date_formatter(self):
         from pandas.io.formats.format import get_format_datetime64
 
-        formatter = get_format_datetime64(is_dates_only=self._is_dates_only)
-        return lambda x: f"'{formatter(x)}'"
+        return get_format_datetime64(is_dates_only=self._is_dates_only)
 
     # --------------------------------------------------------------------
     # Set Operation Methods

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1575,12 +1575,14 @@ class MultiIndex(Index):
     # --------------------------------------------------------------------
     # Rendering Methods
 
-    def _formatter_func(self, tup):
+    def _formatter_func(self, tup) -> tuple[str, ...]:  # type: ignore[override]
         """
         Formats each item in tup according to its level's formatter function.
         """
-        formatter_funcs = (level._formatter_func for level in self.levels)
-        return tuple(func(val) for func, val in zip(formatter_funcs, tup, strict=True))
+        return tuple(
+            level._formatter_func(val)
+            for level, val in zip(self.levels, tup, strict=True)
+        )
 
     def _get_values_for_csv(
         self, *, na_rep: str = "nan", **kwargs


### PR DESCRIPTION
## Summary
- `_formatter_func` was a `@property` returning a callable in `Index`/`CategoricalIndex`/`DatetimeIndexOpsMixin`/`DatetimeIndex`, but a plain method in `MultiIndex`. Standardize on the method pattern across all subclasses.
- Add return type annotations (`str` for most subclasses, `tuple[str, ...]` for `MultiIndex`).
- Extract `DatetimeIndex`'s cached formatter setup into a separate `@cache_readonly` `_date_formatter` property.

## Test plan
- [x] `pandas/tests/indexes/` (16,587 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)