### PR TITLE
DEPR: float_precision in read_csv

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -943,6 +943,10 @@ opened in text or binary mode.
 Specifying method for floating-point conversion
 '''''''''''''''''''''''''''''''''''''''''''''''
 
+.. deprecated:: 3.1.0
+   The ``float_precision`` parameter is deprecated. All float precision
+   modes now use the same converter.
+
 The parameter ``float_precision`` can be specified in order to use
 a specific floating-point converter during parsing with the C engine.
 The options are the ordinary converter, the high-precision converter, and
@@ -959,17 +963,6 @@ writing to a file). For example:
            engine="c",
            float_precision=None,
        )["c"][0] - float(val)
-   )
-   abs(
-       pd.read_csv(
-           StringIO(data),
-           engine="c",
-           float_precision="high",
-       )["c"][0] - float(val)
-   )
-   abs(
-       pd.read_csv(StringIO(data), engine="c", float_precision="round_trip")["c"][0]
-       - float(val)
    )
 
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -101,6 +101,7 @@ Deprecations
 - Deprecated automatic dtype promotion when reindexing with a ``fill_value`` that cannot be held by the original dtype. Explicitly cast to a common dtype instead (:issue:`53910`)
 - Deprecated passing unnecessary ``*args`` and ``**kwargs`` to :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.cummax`, :meth:`.SeriesGroupBy.skew`, :meth:`.DataFrameGroupBy.skew`, :meth:`.SeriesGroupBy.take`, and :meth:`.DataFrameGroupBy.take`. The ``skipna`` parameter for the cum* methods is now an explicit keyword argument (:issue:`50407`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
+- Deprecated the ``float_precision`` argument in :func:`read_csv`, :func:`read_table`, and :func:`read_fwf`. All float precision modes now use the same converter (:issue:`64395`)
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 -
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -32,6 +32,7 @@ from pandas._libs import lib
 from pandas._libs.parsers import STR_NA_VALUES
 from pandas.errors import (
     AbstractMethodError,
+    Pandas4Warning,
     ParserWarning,
 )
 from pandas.util._decorators import (
@@ -295,6 +296,14 @@ def _read(
 
     # Check for duplicates in names.
     _validate_names(kwds.get("names", None))
+
+    if kwds.get("float_precision") is not None:
+        warnings.warn(
+            "The 'float_precision' argument is deprecated. "
+            "Use the default float precision instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
 
     # Create the parser.
     parser = TextFileReader(filepath_or_buffer, **kwds)
@@ -739,6 +748,10 @@ def read_csv(
         values. The options are ``None`` or ``'high'`` for the ordinary converter,
         ``'legacy'`` for the original lower precision pandas converter, and
         ``'round_trip'`` for the round-trip converter.
+
+        .. deprecated:: 3.1.0
+            All float precision modes now use the same converter.
+            The ``float_precision`` argument will be removed in a future version.
 
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
@@ -1302,6 +1315,10 @@ def read_table(
         values. The options are ``None`` or ``'high'`` for the ordinary converter,
         ``'legacy'`` for the original lower precision pandas converter, and
         ``'round_trip'`` for the round-trip converter.
+
+        .. deprecated:: 3.1.0
+            All float precision modes now use the same converter.
+            The ``float_precision`` argument will be removed in a future version.
 
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
@@ -2071,6 +2088,10 @@ def TextParser(*args, **kwds) -> TextFileReader:
         values. The options are `None` or `high` for the ordinary converter,
         `legacy` for the original lower precision pandas converter, and
         `round_trip` for the round-trip converter.
+
+        .. deprecated:: 3.1.0
+            All float precision modes now use the same converter.
+            The ``float_precision`` argument will be removed in a future version.
     """
     kwds["engine"] = "python"
     return TextFileReader(*args, **kwds)

--- a/pandas/tests/io/parser/common/test_float.py
+++ b/pandas/tests/io/parser/common/test_float.py
@@ -8,6 +8,8 @@ from io import StringIO
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import DataFrame
 import pandas._testing as tm
 
@@ -15,6 +17,8 @@ pytestmark = pytest.mark.filterwarnings(
     "ignore:Passing a BlockManager to DataFrame:DeprecationWarning"
 )
 skip_pyarrow = pytest.mark.usefixtures("pyarrow_skip")
+
+depr_msg = "float_precision"
 
 
 @skip_pyarrow  # ParserError: CSV parse error: Empty CSV file or block
@@ -34,7 +38,9 @@ def test_scientific_no_exponent(all_parsers_all_precisions):
     data = df.to_csv(index=False)
     parser, precision = all_parsers_all_precisions
 
-    df_roundtrip = parser.read_csv(StringIO(data), float_precision=precision)
+    warn = Pandas4Warning if precision is not None else None
+    with tm.assert_produces_warning(warn, match=depr_msg, check_stacklevel=False):
+        df_roundtrip = parser.read_csv(StringIO(data), float_precision=precision)
     tm.assert_frame_equal(df_roundtrip, df)
 
 
@@ -65,7 +71,9 @@ def test_large_exponent(all_parsers_all_precisions, value, expected_value):
     parser, precision = all_parsers_all_precisions
 
     data = f"data\n{value}"
-    result = parser.read_csv(StringIO(data), float_precision=precision)
+    warn = Pandas4Warning if precision is not None else None
+    with tm.assert_produces_warning(warn, match=depr_msg, check_stacklevel=False):
+        result = parser.read_csv(StringIO(data), float_precision=precision)
     expected = DataFrame({"data": [expected_value]})
     tm.assert_frame_equal(result, expected)
 
@@ -91,7 +99,9 @@ def test_small_int_followed_by_float(
     data = f"""data
     42
     {value}"""
-    result = parser.read_csv(StringIO(data), float_precision=precision)
+    warn = Pandas4Warning if precision is not None else None
+    with tm.assert_produces_warning(warn, match=depr_msg, check_stacklevel=False):
+        result = parser.read_csv(StringIO(data), float_precision=precision)
     expected = DataFrame({"data": [42.0, expected_value]})
 
     tm.assert_frame_equal(result, expected)
@@ -123,7 +133,10 @@ def test_precise_xstrtod_large_mantissa(c_parser_only, value):
     # max_digits=17.
     parser = c_parser_only
     data = f"val\n{value}"
-    result = parser.read_csv(StringIO(data), float_precision="high")["val"][0]
+    with tm.assert_produces_warning(
+        Pandas4Warning, match=depr_msg, check_stacklevel=False
+    ):
+        result = parser.read_csv(StringIO(data), float_precision="high")["val"][0]
     assert result == float(value)
 
 
@@ -135,6 +148,8 @@ def test_invalid_float_number(all_parsers_all_precisions, value):
     parser, precision = all_parsers_all_precisions
     data = f"h1,h2,h3\ndata1,{value},data3"
 
-    result = parser.read_csv(StringIO(data), float_precision=precision)
+    warn = Pandas4Warning if precision is not None else None
+    with tm.assert_produces_warning(warn, match=depr_msg, check_stacklevel=False):
+        result = parser.read_csv(StringIO(data), float_precision=precision)
     expected = DataFrame({"h1": ["data1"], "h2": [value], "h3": "data3"})
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -9,7 +9,10 @@ from io import StringIO
 import numpy as np
 import pytest
 
-from pandas.errors import ParserWarning
+from pandas.errors import (
+    Pandas4Warning,
+    ParserWarning,
+)
 
 import pandas as pd
 from pandas import (
@@ -246,14 +249,18 @@ def decimal_number_check(request, parser, numeric_decimal, thousands, float_prec
         request.applymarker(
             pytest.mark.xfail(reason=f"thousands={thousands} and sep is in {value}")
         )
-    df = parser.read_csv(
-        StringIO(value),
-        float_precision=float_precision,
-        sep="|",
-        thousands=thousands,
-        decimal=",",
-        header=None,
-    )
+    warn = Pandas4Warning if float_precision is not None else None
+    with tm.assert_produces_warning(
+        warn, match="float_precision", check_stacklevel=False
+    ):
+        df = parser.read_csv(
+            StringIO(value),
+            float_precision=float_precision,
+            sep="|",
+            thousands=thousands,
+            decimal=",",
+            header=None,
+        )
     val = df.iloc[0, 0]
     assert val == numeric_decimal[1]
 
@@ -266,13 +273,17 @@ def test_skip_whitespace(c_parser_only, float_precision):
 2\t 1\t
 2\t 1.2 \t
 """
-    df = c_parser_only.read_csv(
-        StringIO(DATA),
-        float_precision=float_precision,
-        sep="\t",
-        header=0,
-        dtype={1: np.float64},
-    )
+    warn = Pandas4Warning if float_precision is not None else None
+    with tm.assert_produces_warning(
+        warn, match="float_precision", check_stacklevel=False
+    ):
+        df = c_parser_only.read_csv(
+            StringIO(DATA),
+            float_precision=float_precision,
+            sep="\t",
+            header=0,
+            dtype={1: np.float64},
+        )
     tm.assert_series_equal(df.iloc[:, 1], pd.Series([1.2, 2.1, 1.0, 1.2], name="num"))
 
 

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -20,6 +20,7 @@ import pytest
 
 from pandas.compat import WASM
 from pandas.errors import (
+    Pandas4Warning,
     ParserWarning,
 )
 import pandas.util._test_decorators as td
@@ -174,13 +175,25 @@ def test_precise_conversion(c_parser_only, num):
     # 25 decimal digits of precision
     text = f"a\n{num:.25}"
 
-    normal_val = float(
-        parser.read_csv(StringIO(text), float_precision="legacy")["a"][0]
-    )
-    precise_val = float(parser.read_csv(StringIO(text), float_precision="high")["a"][0])
-    roundtrip_val = float(
-        parser.read_csv(StringIO(text), float_precision="round_trip")["a"][0]
-    )
+    depr_msg = "float_precision"
+    with tm.assert_produces_warning(
+        Pandas4Warning, match=depr_msg, check_stacklevel=False
+    ):
+        normal_val = float(
+            parser.read_csv(StringIO(text), float_precision="legacy")["a"][0]
+        )
+    with tm.assert_produces_warning(
+        Pandas4Warning, match=depr_msg, check_stacklevel=False
+    ):
+        precise_val = float(
+            parser.read_csv(StringIO(text), float_precision="high")["a"][0]
+        )
+    with tm.assert_produces_warning(
+        Pandas4Warning, match=depr_msg, check_stacklevel=False
+    ):
+        roundtrip_val = float(
+            parser.read_csv(StringIO(text), float_precision="round_trip")["a"][0]
+        )
     actual_val = Decimal(text[2:])
 
     normal_errors.append(error(normal_val, actual_val))
@@ -442,7 +455,10 @@ def test_read_nrows_large(c_parser_only):
 def test_float_precision_round_trip_with_text(c_parser_only):
     # see gh-15140
     parser = c_parser_only
-    df = parser.read_csv(StringIO("a"), header=None, float_precision="round_trip")
+    with tm.assert_produces_warning(
+        Pandas4Warning, match="float_precision", check_stacklevel=False
+    ):
+        df = parser.read_csv(StringIO("a"), header=None, float_precision="round_trip")
     tm.assert_frame_equal(df, DataFrame({0: ["a"]}))
 
 
@@ -629,13 +645,17 @@ def test_1000_sep_with_decimal(
     parser = c_parser_only
     expected = DataFrame({"A": [1, 10], "B": [2334.01, 13], "C": [5, 10.0]})
 
-    result = parser.read_csv(
-        StringIO(data),
-        sep="|",
-        thousands=thousands,
-        decimal=decimal,
-        float_precision=float_precision,
-    )
+    warn = Pandas4Warning if float_precision is not None else None
+    with tm.assert_produces_warning(
+        warn, match="float_precision", check_stacklevel=False
+    ):
+        result = parser.read_csv(
+            StringIO(data),
+            sep="|",
+            thousands=thousands,
+            decimal=decimal,
+            float_precision=float_precision,
+        )
     tm.assert_frame_equal(result, expected)
 
 
@@ -644,15 +664,25 @@ def test_float_precision_options(c_parser_only):
     parser = c_parser_only
     s = "foo\n243.164\n"
     df = parser.read_csv(StringIO(s))
-    df2 = parser.read_csv(StringIO(s), float_precision="high")
+    depr_msg = "float_precision"
+    with tm.assert_produces_warning(
+        Pandas4Warning, match=depr_msg, check_stacklevel=False
+    ):
+        df2 = parser.read_csv(StringIO(s), float_precision="high")
 
     tm.assert_frame_equal(df, df2)
 
     # "legacy" now uses the same precise converter as "high"
-    df3 = parser.read_csv(StringIO(s), float_precision="legacy")
+    with tm.assert_produces_warning(
+        Pandas4Warning, match=depr_msg, check_stacklevel=False
+    ):
+        df3 = parser.read_csv(StringIO(s), float_precision="legacy")
     tm.assert_frame_equal(df, df3)
 
     msg = "Unrecognized float_precision option: junk"
 
     with pytest.raises(ValueError, match=msg):
-        parser.read_csv(StringIO(s), float_precision="junk")
+        with tm.assert_produces_warning(
+            Pandas4Warning, match=depr_msg, check_stacklevel=False
+        ):
+            parser.read_csv(StringIO(s), float_precision="junk")

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -13,7 +13,10 @@ from pathlib import Path
 
 import pytest
 
-from pandas.errors import ParserError
+from pandas.errors import (
+    Pandas4Warning,
+    ParserError,
+)
 
 import pandas._testing as tm
 
@@ -103,8 +106,12 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
             )
 
             kwargs = {default: object()}
+            warn = Pandas4Warning if default == "float_precision" else None
             with pytest.raises(ValueError, match=msg):
-                read_csv(StringIO(data), engine=python_engine, **kwargs)
+                with tm.assert_produces_warning(
+                    warn, match="float_precision", check_stacklevel=False
+                ):
+                    read_csv(StringIO(data), engine=python_engine, **kwargs)
 
     def test_python_engine_file_no_iter(self, python_engine):
         # see gh-16530
@@ -147,8 +154,12 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
             elif default == "on_bad_lines":
                 kwargs[default] = "warn"
 
+            warn = Pandas4Warning if default == "float_precision" else None
             with pytest.raises(ValueError, match=msg):
-                read_csv(StringIO(data), engine="pyarrow", **kwargs)
+                with tm.assert_produces_warning(
+                    warn, match="float_precision", check_stacklevel=False
+                ):
+                    read_csv(StringIO(data), engine="pyarrow", **kwargs)
 
     def test_on_bad_lines_callable_python_or_pyarrow(self, all_parsers):
         # GH 5686


### PR DESCRIPTION
## Summary
- Deprecate the `float_precision` argument in `read_csv`, `read_table`, and `read_fwf` with `Pandas4Warning`
- All float precision modes (`"high"`, `"legacy"`, `"round_trip"`) already use the same converter (`precise_xstrtod` backed by `fast_float`), so the parameter is no longer meaningful

- [x] Closes #64395, #64094, #39514

## Test plan
- [x] All existing `float_precision` tests updated to expect `Pandas4Warning`
- [x] Tests pass: `pytest pandas/tests/io/parser/common/test_float.py pandas/tests/io/parser/test_c_parser_only.py pandas/tests/io/parser/dtypes/test_dtypes_basic.py` (1320 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)