### PR TITLE
PERF: Use _global_config directly when accessing configs

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -16,7 +16,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     NaT,
@@ -2286,8 +2286,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         """
         max_categories = (
             10
-            if get_option("display.max_categories") == 0
-            else get_option("display.max_categories")
+            if _global_config["display"]["max_categories"] == 0
+            else _global_config["display"]["max_categories"]
         )
         from pandas.io.formats import format as fmt
 
@@ -2322,7 +2322,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         dtype = str(self.categories.dtype)
         levheader = f"Categories ({len(self.categories)}, {dtype}): "
         width, _ = get_terminal_size()
-        max_width = get_option("display.width") or width
+        max_width = _global_config["display"]["width"] or width
         if console.in_ipython_frontend():
             # 0 = no breaks
             max_width = 0

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -23,7 +23,7 @@ import warnings
 import numpy as np
 
 from pandas._config import using_string_dtype
-from pandas._config.config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     algos,
@@ -1386,7 +1386,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             # If both 1D then broadcasting is unambiguous
             return op(self, other[0])
 
-        if get_option("performance_warnings"):
+        if _global_config["mode"]["performance_warnings"]:
             warnings.warn(
                 "Adding/subtracting object-dtype array to "
                 f"{type(self).__name__} not vectorized.",

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 
 from pandas._config import using_string_dtype
-from pandas._config.config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     lib,
@@ -853,7 +853,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 # expected "dtype[Any] | _HasDType[dtype[Any]]"  [arg-type]
                 res_values = res_values.view(values.dtype)  # type: ignore[arg-type]
         except NotImplementedError:
-            if get_option("performance_warnings"):
+            if _global_config["mode"]["performance_warnings"]:
                 warnings.warn(
                     "Non-vectorized DateOffset being applied to Series or "
                     "DatetimeIndex.",

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -19,7 +19,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config.config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import lib
 import pandas._libs.sparse as splib
@@ -1239,7 +1239,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         side: Literal["left", "right"] = "left",
         sorter: NumpySorter | None = None,
     ) -> npt.NDArray[np.intp] | np.intp:
-        if get_option("performance_warnings"):
+        if _global_config["mode"]["performance_warnings"]:
             msg = "searchsorted requires high memory usage."
             warnings.warn(msg, PerformanceWarning, stacklevel=find_stack_level())
         v = np.asarray(v)

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -14,10 +14,8 @@ import warnings
 
 import numpy as np
 
-from pandas._config import (
-    get_option,
-    using_string_dtype,
-)
+from pandas._config import using_string_dtype
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     lib,
@@ -201,7 +199,7 @@ class StringDtype(StorageExtensionDtype):
     ) -> None:
         # infer defaults
         if storage is None:
-            storage = get_option("mode.string_storage")
+            storage = _global_config["mode"]["string_storage"]
             if storage == "auto":
                 if HAS_PYARROW:
                     storage = "pyarrow"

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -13,7 +13,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config.config import get_option
+from pandas._config.config import _global_config
 
 from pandas.errors import PerformanceWarning
 from pandas.util._exceptions import find_stack_level
@@ -128,7 +128,7 @@ def _align_core(terms):
 
                 ordm = np.log10(max(1, abs(reindexer_size - term_axis_size)))
                 if (
-                    get_option("performance_warnings")
+                    _global_config["mode"]["performance_warnings"]
                     and ordm >= 1
                     and reindexer_size >= 10000
                 ):

--- a/pandas/core/computation/common.py
+++ b/pandas/core/computation/common.py
@@ -4,7 +4,7 @@ from functools import reduce
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 
 def ensure_decoded(s) -> str:
@@ -12,7 +12,7 @@ def ensure_decoded(s) -> str:
     If we have bytes, decode them to unicode.
     """
     if isinstance(s, (np.bytes_, bytes)):
-        s = s.decode(get_option("display.encoding"))
+        s = s.decode(_global_config["display"]["encoding"])
     return s
 
 

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -14,7 +14,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas.util._exceptions import find_stack_level
 
@@ -193,7 +193,7 @@ def _where_numexpr(cond, left_op, right_op):
 
 
 # turn myself on
-set_use_numexpr(get_option("compute.use_numexpr"))
+set_use_numexpr(_global_config["compute"]["use_numexpr"])
 
 
 def _has_bool_dtype(x):

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -43,7 +43,7 @@ use_bottleneck_doc = """
 def use_bottleneck_cb(key: str) -> None:
     from pandas.core import nanops
 
-    nanops.set_use_bottleneck(cf.get_option(key))
+    nanops.set_use_bottleneck(cf._global_config["compute"]["use_bottleneck"])
 
 
 use_numexpr_doc = """
@@ -57,7 +57,7 @@ use_numexpr_doc = """
 def use_numexpr_cb(key: str) -> None:
     from pandas.core.computation import expressions
 
-    expressions.set_use_numexpr(cf.get_option(key))
+    expressions.set_use_numexpr(cf._global_config["compute"]["use_numexpr"])
 
 
 use_numba_doc = """
@@ -71,7 +71,7 @@ use_numba_doc = """
 def use_numba_cb(key: str) -> None:
     from pandas.core.util import numba_
 
-    numba_.set_use_numba(cf.get_option(key))
+    numba_.set_use_numba(cf._global_config["compute"]["use_numba"])
 
 
 with cf.config_prefix("compute"):
@@ -290,7 +290,7 @@ pc_memory_usage_doc = """
 def table_schema_cb(key: str) -> None:
     from pandas.io.formats.printing import enable_data_resource_formatter
 
-    enable_data_resource_formatter(cf.get_option(key))
+    enable_data_resource_formatter(cf._global_config["display"]["html"]["table_schema"])
 
 
 def is_terminal() -> bool:
@@ -651,7 +651,7 @@ def register_converter_cb(key: str) -> None:
         register_matplotlib_converters,
     )
 
-    if cf.get_option(key):
+    if cf._global_config["plotting"]["matplotlib"]["register_converters"]:
         register_matplotlib_converters()
     else:
         deregister_matplotlib_converters()

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -23,7 +23,7 @@ import zoneinfo
 
 import numpy as np
 
-from pandas._config.config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     lib,
@@ -2149,7 +2149,7 @@ class SparseDtype(ExtensionDtype):
 
         # np.nan isn't a singleton, so we may end up with multiple
         # NaNs here, so we ignore the all NA case too.
-        if get_option("performance_warnings") and (
+        if _global_config["mode"]["performance_warnings"] and (
             not (len(set(fill_values)) == 1 or isna(fill_values).all())
         ):
             warnings.warn(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -31,7 +31,7 @@ import warnings
 import numpy as np
 from numpy import ma
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     algos as libalgos,
@@ -883,7 +883,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Check length against max_rows.
         """
-        max_rows = get_option("display.max_rows")
+        max_rows = _global_config["display"]["max_rows"]
         return len(self) <= max_rows
 
     def _repr_fits_horizontal_(self) -> bool:
@@ -892,7 +892,7 @@ class DataFrame(NDFrame, OpsMixin):
         options width and max_columns.
         """
         width, height = console.get_console_size()
-        max_columns = get_option("display.max_columns")
+        max_columns = _global_config["display"]["max_columns"]
         nb_columns = len(self.columns)
 
         # exceed max columns
@@ -906,11 +906,14 @@ class DataFrame(NDFrame, OpsMixin):
         if width is None or not console.in_interactive_session():
             return True
 
-        if get_option("display.width") is not None or console.in_ipython_frontend():
+        if (
+            _global_config["display"]["width"] is not None
+            or console.in_ipython_frontend()
+        ):
             # check at least the column row for excessive width
             max_rows = 1
         else:
-            max_rows = get_option("display.max_rows")
+            max_rows = _global_config["display"]["max_rows"]
 
         # when auto-detecting, so width=None and not in ipython front end
         # check whether repr fits horizontal by actually checking
@@ -937,7 +940,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         True if the repr should show the info view.
         """
-        info_repr_option = get_option("display.large_repr") == "info"
+        info_repr_option = _global_config["display"]["large_repr"] == "info"
         return info_repr_option and not (
             self._repr_fits_horizontal_() and self._repr_fits_vertical_()
         )
@@ -968,12 +971,12 @@ class DataFrame(NDFrame, OpsMixin):
             val = val.replace(">", r"&gt;", 1)
             return f"<pre>{val}</pre>"
 
-        if get_option("display.notebook_repr_html"):
-            max_rows = get_option("display.max_rows")
-            min_rows = get_option("display.min_rows")
-            max_cols = get_option("display.max_columns")
-            show_dimensions = get_option("display.show_dimensions")
-            show_floats = get_option("display.float_format")
+        if _global_config["display"]["notebook_repr_html"]:
+            max_rows = _global_config["display"]["max_rows"]
+            min_rows = _global_config["display"]["min_rows"]
+            max_cols = _global_config["display"]["max_columns"]
+            show_dimensions = _global_config["display"]["show_dimensions"]
+            show_floats = _global_config["display"]["float_format"]
 
             formatter = fmt.DataFrameFormatter(
                 self,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -27,6 +27,7 @@ import warnings
 import numpy as np
 
 from pandas._config import config
+from pandas._config.config import _global_config
 
 from pandas._libs import lib
 from pandas._libs.lib import is_range_indexer
@@ -2125,7 +2126,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Returns a LaTeX representation for a particular object.
         Mainly for use with nbconvert (jupyter notebook conversion to pdf).
         """
-        if config.get_option("styler.render.repr") == "latex":
+        if _global_config["styler"]["render"]["repr"] == "latex":
             return self.to_latex()
         else:
             return None
@@ -2136,8 +2137,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Not a real Jupyter special repr method, but we use the same
         naming convention.
         """
-        if config.get_option("display.html.table_schema"):
-            data = self.head(config.get_option("display.max_rows"))
+        if _global_config["display"]["html"]["table_schema"]:
+            data = self.head(_global_config["display"]["max_rows"])
 
             as_json = data.to_json(orient="table")
             as_json = cast("str", as_json)
@@ -3559,15 +3560,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if self.ndim == 1:
             self = self.to_frame()
         if longtable is None:
-            longtable = config.get_option("styler.latex.environment") == "longtable"
+            longtable = _global_config["styler"]["latex"]["environment"] == "longtable"
         if escape is None:
-            escape = config.get_option("styler.format.escape") == "latex"
+            escape = _global_config["styler"]["format"]["escape"] == "latex"
         if multicolumn is None:
-            multicolumn = config.get_option("styler.sparse.columns")
+            multicolumn = _global_config["styler"]["sparse"]["columns"]
         if multicolumn_format is None:
-            multicolumn_format = config.get_option("styler.latex.multicol_align")
+            multicolumn_format = _global_config["styler"]["latex"]["multicol_align"]
         if multirow is None:
-            multirow = config.get_option("styler.sparse.index")
+            multirow = _global_config["styler"]["sparse"]["index"]
 
         if column_format is not None and not isinstance(column_format, str):
             raise ValueError("`column_format` must be str or unicode")

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -22,10 +22,10 @@ import warnings
 import numpy as np
 
 from pandas._config import (
-    get_option,
     is_nan_na,
     using_string_dtype,
 )
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     NaT,
@@ -900,7 +900,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         return {
             c
-            for c in self.unique(level=0)[: get_option("display.max_dir_items")]
+            for c in self.unique(level=0)[: _global_config["display"]["max_dir_items"]]
             if isinstance(c, str) and c.isidentifier()
         }
 
@@ -1459,7 +1459,7 @@ class Index(IndexOpsMixin, PandasObject):
         elif self._is_multi and any(x is not None for x in self.names):
             attrs.append(("names", default_pprint(self.names)))
 
-        max_seq_items = get_option("display.max_seq_items") or len(self)
+        max_seq_items = _global_config["display"]["max_seq_items"] or len(self)
         if len(self) > max_seq_items:
             attrs.append(("length", len(self)))
         return attrs

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -22,7 +22,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     algos as libalgos,
@@ -1671,7 +1671,7 @@ class MultiIndex(Index):
             result_levels.append(level)
 
         if sparsify is None:
-            sparsify = get_option("display.multi_sparse")
+            sparsify = _global_config["display"]["multi_sparse"]
 
         if sparsify:
             sentinel: Literal[""] | bool | lib.NoDefault = ""
@@ -2888,7 +2888,10 @@ class MultiIndex(Index):
                     step = loc.step if loc.step is not None else 1
                     inds.extend(range(loc.start, loc.stop, step))
                 elif com.is_bool_indexer(loc):
-                    if get_option("performance_warnings") and self._lexsort_depth == 0:
+                    if (
+                        _global_config["mode"]["performance_warnings"]
+                        and self._lexsort_depth == 0
+                    ):
                         warnings.warn(
                             "dropping on a non-lexsorted multi-index "
                             "without a level parameter may impact performance.",
@@ -3630,7 +3633,7 @@ class MultiIndex(Index):
         if not follow_key:
             return slice(start, stop)
 
-        if get_option("performance_warnings"):
+        if _global_config["mode"]["performance_warnings"]:
             warnings.warn(
                 "indexing past lexsort depth may impact performance.",
                 PerformanceWarning,

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -14,7 +14,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config.config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     algos as libalgos,
@@ -1575,7 +1575,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         warn_threshold = 100
         if (
             len(self.blocks) > warn_threshold
-            and get_option("performance_warnings")
+            and _global_config["mode"]["performance_warnings"]
             and sum(not block.is_extension for block in self.blocks) > warn_threshold
         ):
             warnings.warn(

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -11,7 +11,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     NaT,
@@ -66,7 +66,7 @@ def set_use_bottleneck(v: bool = True) -> None:
         _USE_BOTTLENECK = v
 
 
-set_use_bottleneck(get_option("compute.use_bottleneck"))
+set_use_bottleneck(_global_config["compute"]["use_bottleneck"])
 
 
 class disallow:

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -10,7 +10,7 @@ import warnings
 
 import numpy as np
 
-from pandas._config.config import get_option
+from pandas._config.config import _global_config
 
 import pandas._libs.reshape as libreshape
 from pandas.errors import (
@@ -158,7 +158,7 @@ class _Unstacker:
             self.removed_level = self.removed_level.take(unique_codes)
             self.removed_level_full = self.removed_level_full.take(unique_codes)
 
-        if get_option("performance_warnings"):
+        if _global_config["mode"]["performance_warnings"]:
             # Bug fix GH 20601
             # If the data frame is too big, the number of unique index combination
             # will cause int32 overflow on windows environments.

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -6,6 +6,8 @@ from io import StringIO
 from typing import TYPE_CHECKING
 import warnings
 
+from pandas._config.config import _global_config
+
 from pandas._libs import lib
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
@@ -13,10 +15,7 @@ from pandas.util._validators import check_dtype_backend
 
 from pandas.core.dtypes.generic import ABCDataFrame
 
-from pandas import (
-    get_option,
-    option_context,
-)
+from pandas import option_context
 
 if TYPE_CHECKING:
     from pandas._typing import DtypeBackend
@@ -91,7 +90,9 @@ def read_clipboard(
 
     # Try to decode (if needed, as "text" might already be a string here).
     try:
-        text = text.decode(kwargs.get("encoding") or get_option("display.encoding"))
+        text = text.decode(
+            kwargs.get("encoding") or _global_config["display"]["encoding"]
+        )
     except AttributeError:
         pass
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -26,7 +26,7 @@ from typing import (
 import warnings
 import zipfile
 
-from pandas._config import config
+from pandas._config.config import _global_config
 
 from pandas._libs import lib
 from pandas.compat._optional import (
@@ -1175,7 +1175,7 @@ class ExcelWriter(Generic[_WorkbookT]):
                     ext = "xlsx"
 
                 try:
-                    engine = config.get_option(f"io.excel.{ext}.writer")
+                    engine = _global_config["io"]["excel"][ext]["writer"]
                     if engine == "auto":
                         engine = get_default_engine(ext, mode="writer")
                 except KeyError as err:
@@ -1619,7 +1619,7 @@ class ExcelFile:
                     )
 
             if engine is None:
-                engine = config.get_option(f"io.excel.{ext}.reader")
+                engine = _global_config["io"]["excel"][ext]["reader"]
                 if engine == "auto":
                     engine = get_default_engine(ext, mode="reader")
 

--- a/pandas/io/formats/console.py
+++ b/pandas/io/formats/console.py
@@ -13,10 +13,10 @@ def get_console_size() -> tuple[int | None, int | None]:
 
     Returns (None,None) in non-interactive session.
     """
-    from pandas import get_option
+    from pandas._config.config import _global_config
 
-    display_width = get_option("display.width")
-    display_height = get_option("display.max_rows")
+    display_width = _global_config["display"]["width"]
+    display_height = _global_config["display"]["max_rows"]
 
     # Consider
     # interactive shell terminal, can detect term size
@@ -61,14 +61,16 @@ def in_interactive_session() -> bool:
     bool
         True if running under python/ipython interactive shell.
     """
-    from pandas import get_option
+    from pandas._config.config import _global_config
 
     def check_main() -> bool:
         try:
             import __main__ as main
         except ModuleNotFoundError:
-            return get_option("mode.sim_interactive")
-        return not hasattr(main, "__file__") or get_option("mode.sim_interactive")
+            return _global_config["mode"]["sim_interactive"]
+        return (
+            not hasattr(main, "__file__") or _global_config["mode"]["sim_interactive"]
+        )
 
     try:
         # error: Name '__IPYTHON__' is not defined

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -29,7 +29,7 @@ from typing import (
 import numpy as np
 
 from pandas._config.config import (
-    get_option,
+    _global_config,
     set_option,
 )
 
@@ -152,7 +152,7 @@ class SeriesFormatter:
         self.min_rows = min_rows
 
         if float_format is None:
-            float_format = get_option("display.float_format")
+            float_format = _global_config["display"]["float_format"]
         self.float_format = float_format
         self.dtype = dtype
         self.adj = printing.get_adjustment()
@@ -304,16 +304,16 @@ def get_dataframe_repr_params() -> dict[str, Any]:
     """
     from pandas.io.formats import console
 
-    if get_option("display.expand_frame_repr"):
+    if _global_config["display"]["expand_frame_repr"]:
         line_width, _ = console.get_console_size()
     else:
         line_width = None
     return {
-        "max_rows": get_option("display.max_rows"),
-        "min_rows": get_option("display.min_rows"),
-        "max_cols": get_option("display.max_columns"),
-        "max_colwidth": get_option("display.max_colwidth"),
-        "show_dimensions": get_option("display.show_dimensions"),
+        "max_rows": _global_config["display"]["max_rows"],
+        "min_rows": _global_config["display"]["min_rows"],
+        "max_cols": _global_config["display"]["max_columns"],
+        "max_colwidth": _global_config["display"]["max_colwidth"],
+        "show_dimensions": _global_config["display"]["show_dimensions"],
         "line_width": line_width,
     }
 
@@ -334,16 +334,16 @@ def get_series_repr_params() -> dict[str, Any]:
     True
     """
     width, height = get_terminal_size()
-    max_rows_opt = get_option("display.max_rows")
+    max_rows_opt = _global_config["display"]["max_rows"]
     max_rows = height if max_rows_opt == 0 else max_rows_opt
-    min_rows = height if max_rows_opt == 0 else get_option("display.min_rows")
+    min_rows = height if max_rows_opt == 0 else _global_config["display"]["min_rows"]
 
     return {
         "name": True,
         "dtype": True,
         "min_rows": min_rows,
         "max_rows": max_rows,
-        "length": get_option("display.show_dimensions"),
+        "length": _global_config["display"]["show_dimensions"],
     }
 
 
@@ -521,7 +521,7 @@ class DataFrameFormatter:
 
     def _initialize_sparsify(self, sparsify: bool | None) -> bool:
         if sparsify is None:
-            return get_option("display.multi_sparse")
+            return _global_config["display"]["multi_sparse"]
         return sparsify
 
     def _initialize_formatters(
@@ -539,7 +539,7 @@ class DataFrameFormatter:
 
     def _initialize_justify(self, justify: str | None) -> str:
         if justify is None:
-            return get_option("display.colheader_justify")
+            return _global_config["display"]["colheader_justify"]
         else:
             return justify
 
@@ -1145,10 +1145,10 @@ def format_array(
         space = 12
 
     if float_format is None:
-        float_format = get_option("display.float_format")
+        float_format = _global_config["display"]["float_format"]
 
     if digits is None:
-        digits = get_option("display.precision")
+        digits = _global_config["display"]["precision"]
 
     fmt_obj = fmt_klass(
         values,
@@ -1203,9 +1203,9 @@ class _GenericArrayFormatter:
 
     def _format_strings(self) -> list[str]:
         if self.float_format is None:
-            float_format = get_option("display.float_format")
+            float_format = _global_config["display"]["float_format"]
             if float_format is None:
-                precision = get_option("display.precision")
+                precision = _global_config["display"]["precision"]
                 float_format = lambda x: _trim_zeros_single_float(
                     f"{x: .{precision:d}f}"
                 )
@@ -1393,7 +1393,7 @@ class FloatArrayFormatter(_GenericArrayFormatter):
             return format_with_na_rep(self.values, self.formatter, self.na_rep)
 
         if self.fixed_width:
-            threshold = get_option("display.chop_threshold")
+            threshold = _global_config["display"]["chop_threshold"]
         else:
             threshold = None
 
@@ -1750,7 +1750,7 @@ def _make_fixed_width(
     if minimum is not None:
         max_len = max(minimum, max_len)
 
-    conf_max = get_option("display.max_colwidth")
+    conf_max = _global_config["display"]["max_colwidth"]
     if conf_max is not None and max_len > conf_max:
         max_len = conf_max
 

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -12,7 +12,7 @@ from typing import (
     cast,
 )
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import lib
 
@@ -66,7 +66,7 @@ class HTMLFormatter:
         self.escape = self.fmt.escape
         self.show_dimensions = self.fmt.show_dimensions
         if border is None or border is True:
-            border = cast("int", get_option("display.html.border"))
+            border = cast("int", _global_config["display"]["html"]["border"])
         elif not border:
             border = None
 
@@ -238,7 +238,7 @@ class HTMLFormatter:
 
     def _write_table(self, indent: int = 0) -> None:
         _classes = ["dataframe"]  # Default class.
-        use_mathjax = get_option("display.html.use_mathjax")
+        use_mathjax = _global_config["display"]["html"]["use_mathjax"]
         if not use_mathjax:
             _classes.append("tex2jax_ignore")
             _classes.append("mathjax_ignore")

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -7,7 +7,7 @@ from abc import (
 import sys
 from typing import TYPE_CHECKING
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas.io.formats import format as fmt
 from pandas.io.formats.printing import pprint_thing
@@ -94,7 +94,7 @@ def _initialize_memory_usage(
 ) -> bool | str:
     """Get memory usage based on inputs and display options."""
     if memory_usage is None:
-        memory_usage = get_option("display.memory_usage")
+        memory_usage = _global_config["display"]["memory_usage"]
     return memory_usage
 
 
@@ -364,7 +364,7 @@ class _DataFrameInfoPrinter(_InfoPrinterAbstract):
     @property
     def max_rows(self) -> int:
         """Maximum info rows to be displayed."""
-        return get_option("display.max_info_rows")
+        return _global_config["display"]["max_info_rows"]
 
     @property
     def exceeds_info_cols(self) -> bool:
@@ -383,7 +383,7 @@ class _DataFrameInfoPrinter(_InfoPrinterAbstract):
 
     def _initialize_max_cols(self, max_cols: int | None) -> int:
         if max_cols is None:
-            return get_option("display.max_info_columns")
+            return _global_config["display"]["max_info_columns"]
         return max_cols
 
     def _initialize_show_counts(self, show_counts: bool | None) -> bool:

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -21,7 +21,7 @@ from unicodedata import east_asian_width
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas.core.dtypes.generic import (
     ABCExtensionArray,
@@ -130,7 +130,9 @@ def _pprint_seq(
     if max_seq_items is False:
         max_items = None
     else:
-        max_items = max_seq_items or get_option("max_seq_items") or len(seq)
+        max_items = (
+            max_seq_items or _global_config["display"]["max_seq_items"] or len(seq)
+        )
 
     s = iter(seq)
     # handle sets, no slicing
@@ -144,7 +146,7 @@ def _pprint_seq(
             # GH#60503
             from pandas.io.formats.format import _trim_zeros_single_float
 
-            precision = get_option("display.precision")
+            precision = _global_config["display"]["precision"]
             item = _trim_zeros_single_float(f"{item:.{precision}f}")
         r.append(pprint_thing(item, _nest_lvl + 1, max_seq_items=max_seq_items, **kwds))
     body = ", ".join(r)
@@ -172,7 +174,7 @@ def _pprint_dict(
     if max_seq_items is False:
         nitems = len(seq)
     else:
-        nitems = max_seq_items or get_option("max_seq_items") or len(seq)
+        nitems = max_seq_items or _global_config["display"]["max_seq_items"] or len(seq)
 
     for k, v in list(seq.items())[:nitems]:
         pairs.append(
@@ -227,8 +229,9 @@ def pprint_thing(
             result = f"'{result}'"
     elif hasattr(thing, "__next__"):
         return str(thing)
-    elif isinstance(thing, Mapping) and _nest_lvl < get_option(
-        "display.pprint_nest_depth"
+    elif (
+        isinstance(thing, Mapping)
+        and _nest_lvl < _global_config["display"]["pprint_nest_depth"]
     ):
         result = _pprint_dict(
             thing, _nest_lvl, quote_strings=True, max_seq_items=max_seq_items
@@ -252,7 +255,7 @@ def pprint_thing(
                 ABCNDFrame,
             ),
         )
-        and _nest_lvl < get_option("display.pprint_nest_depth")
+        and _nest_lvl < _global_config["display"]["pprint_nest_depth"]
     ):
         result = _pprint_seq(
             # error: Argument 1 to "_pprint_seq" has incompatible type "object";
@@ -374,7 +377,7 @@ def format_object_summary(
     """
     display_width, _ = get_console_size()
     if display_width is None:
-        display_width = get_option("display.width") or 80
+        display_width = _global_config["display"]["width"] or 80
     if name is None:
         name = type(obj).__name__
 
@@ -393,7 +396,7 @@ def format_object_summary(
         sep = ",\n " + " " * len(name)
     else:
         sep = ","
-    max_seq_items = get_option("display.max_seq_items") or n
+    max_seq_items = _global_config["display"]["max_seq_items"] or n
 
     # are we a truncated display
     is_truncated = n > max_seq_items
@@ -562,7 +565,7 @@ class PrettyDict(dict[_KT, _VT]):
 
 class _TextAdjustment:
     def __init__(self) -> None:
-        self.encoding = get_option("display.encoding")
+        self.encoding = _global_config["display"]["encoding"]
 
     def len(self, text: str) -> int:
         return len(text)
@@ -585,7 +588,7 @@ class _TextAdjustment:
 class _EastAsianTextAdjustment(_TextAdjustment):
     def __init__(self) -> None:
         super().__init__()
-        if get_option("display.unicode.ambiguous_as_wide"):
+        if _global_config["display"]["unicode"]["ambiguous_as_wide"]:
             self.ambiguous_width = 2
         else:
             self.ambiguous_width = 1
@@ -622,7 +625,7 @@ class _EastAsianTextAdjustment(_TextAdjustment):
 
 
 def get_adjustment() -> _TextAdjustment:
-    use_east_asian_width = get_option("display.unicode.east_asian_width")
+    use_east_asian_width = _global_config["display"]["unicode"]["east_asian_width"]
     if use_east_asian_width:
         return _EastAsianTextAdjustment()
     else:

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -16,7 +16,7 @@ from typing import (
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas.compat._optional import import_optional_dependency
 
@@ -239,11 +239,11 @@ class Styler(StylerRenderer):
         )
 
         # validate ordered args
-        thousands = thousands or get_option("styler.format.thousands")
-        decimal = decimal or get_option("styler.format.decimal")
-        na_rep = na_rep or get_option("styler.format.na_rep")
-        escape = escape or get_option("styler.format.escape")
-        formatter = formatter or get_option("styler.format.formatter")
+        thousands = thousands or _global_config["styler"]["format"]["thousands"]
+        decimal = decimal or _global_config["styler"]["format"]["decimal"]
+        na_rep = na_rep or _global_config["styler"]["format"]["na_rep"]
+        escape = escape or _global_config["styler"]["format"]["escape"]
+        formatter = formatter or _global_config["styler"]["format"]["formatter"]
         # precision is handled by superclass as default for performance
 
         self.format(
@@ -376,12 +376,12 @@ class Styler(StylerRenderer):
         Hooks into Jupyter notebook rich display system, which calls _repr_html_ by
         default if an object is returned at the end of a cell.
         """
-        if get_option("styler.render.repr") == "html":
+        if _global_config["styler"]["render"]["repr"] == "html":
             return self.to_html()
         return None
 
     def _repr_latex_(self) -> str | None:
-        if get_option("styler.render.repr") == "latex":
+        if _global_config["styler"]["render"]["repr"] == "latex":
             return self.to_latex()
         return None
 
@@ -1248,7 +1248,9 @@ class Styler(StylerRenderer):
                 overwrite=False,
             )
 
-        hrules = get_option("styler.latex.hrules") if hrules is None else hrules
+        hrules = (
+            _global_config["styler"]["latex"]["hrules"] if hrules is None else hrules
+        )
         if hrules:
             obj.set_table_styles(
                 [
@@ -1269,12 +1271,16 @@ class Styler(StylerRenderer):
             obj.set_caption(caption)
 
         if sparse_index is None:
-            sparse_index = get_option("styler.sparse.index")
+            sparse_index = _global_config["styler"]["sparse"]["index"]
         if sparse_columns is None:
-            sparse_columns = get_option("styler.sparse.columns")
-        environment = environment or get_option("styler.latex.environment")
-        multicol_align = multicol_align or get_option("styler.latex.multicol_align")
-        multirow_align = multirow_align or get_option("styler.latex.multirow_align")
+            sparse_columns = _global_config["styler"]["sparse"]["columns"]
+        environment = environment or _global_config["styler"]["latex"]["environment"]
+        multicol_align = (
+            multicol_align or _global_config["styler"]["latex"]["multicol_align"]
+        )
+        multirow_align = (
+            multirow_align or _global_config["styler"]["latex"]["multirow_align"]
+        )
         latex = obj._render_latex(
             sparse_index=sparse_index,
             sparse_columns=sparse_columns,
@@ -1287,7 +1293,7 @@ class Styler(StylerRenderer):
         )
 
         encoding = (
-            (encoding or get_option("styler.render.encoding"))
+            (encoding or _global_config["styler"]["render"]["encoding"])
             if isinstance(buf, str)  # i.e. a filepath
             else encoding
         )
@@ -1388,9 +1394,9 @@ class Styler(StylerRenderer):
         obj = self._copy(deepcopy=True)
 
         if sparse_index is None:
-            sparse_index = get_option("styler.sparse.index")
+            sparse_index = _global_config["styler"]["sparse"]["index"]
         if sparse_columns is None:
-            sparse_columns = get_option("styler.sparse.columns")
+            sparse_columns = _global_config["styler"]["sparse"]["columns"]
 
         text = obj._render_typst(
             sparse_columns=sparse_columns,
@@ -1552,9 +1558,9 @@ class Styler(StylerRenderer):
             obj.set_table_attributes(table_attributes)
 
         if sparse_index is None:
-            sparse_index = get_option("styler.sparse.index")
+            sparse_index = _global_config["styler"]["sparse"]["index"]
         if sparse_columns is None:
-            sparse_columns = get_option("styler.sparse.columns")
+            sparse_columns = _global_config["styler"]["sparse"]["columns"]
 
         if bold_headers:
             obj.set_table_styles(
@@ -1571,7 +1577,7 @@ class Styler(StylerRenderer):
             max_rows=max_rows,
             max_cols=max_columns,
             exclude_styles=exclude_styles,
-            encoding=encoding or get_option("styler.render.encoding"),
+            encoding=encoding or _global_config["styler"]["render"]["encoding"],
             doctype_html=doctype_html,
             **kwargs,
         )
@@ -1672,9 +1678,9 @@ class Styler(StylerRenderer):
         obj = self._copy(deepcopy=True)
 
         if sparse_index is None:
-            sparse_index = get_option("styler.sparse.index")
+            sparse_index = _global_config["styler"]["sparse"]["index"]
         if sparse_columns is None:
-            sparse_columns = get_option("styler.sparse.columns")
+            sparse_columns = _global_config["styler"]["sparse"]["columns"]
 
         text = obj._render_string(
             sparse_columns=sparse_columns,

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 
 import numpy as np
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
@@ -137,7 +137,9 @@ class StylerRenderer:
         self._todo: list[tuple[Callable, tuple, dict]] = []
         self.tooltips: Tooltips | None = None
         precision = (
-            get_option("styler.format.precision") if precision is None else precision
+            _global_config["styler"]["format"]["precision"]
+            if precision is None
+            else precision
         )
         self._display_funcs: DefaultDict[  # maps (row, col) -> format func
             tuple[int, int], Callable[[Any], str]
@@ -329,9 +331,13 @@ class StylerRenderer:
             "caption": self.caption,
         }
 
-        max_elements = get_option("styler.render.max_elements")
-        max_rows = max_rows if max_rows else get_option("styler.render.max_rows")
-        max_cols = max_cols if max_cols else get_option("styler.render.max_columns")
+        max_elements = _global_config["styler"]["render"]["max_elements"]
+        max_rows = (
+            max_rows if max_rows else _global_config["styler"]["render"]["max_rows"]
+        )
+        max_cols = (
+            max_cols if max_cols else _global_config["styler"]["render"]["max_columns"]
+        )
         max_rows, max_cols = _get_trimming_maximums(
             len(self.data.index),
             len(self.data.columns),
@@ -381,7 +387,7 @@ class StylerRenderer:
             )
 
         table_attr = self.table_attributes
-        if not get_option("styler.html.mathjax"):
+        if not _global_config["styler"]["html"]["mathjax"]:
             table_attr = table_attr or ""
             if 'class="' in table_attr:
                 table_attr = table_attr.replace(
@@ -2006,7 +2012,9 @@ def _maybe_wrap_formatter(
         func_0 = formatter
     elif formatter is None:
         precision = (
-            get_option("styler.format.precision") if precision is None else precision
+            _global_config["styler"]["format"]["precision"]
+            if precision is None
+            else precision
         )
         func_0 = partial(
             _default_formatter, precision=precision, thousands=(thousands is not None)

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -15,6 +15,8 @@ from warnings import (
     filterwarnings,
 )
 
+from pandas._config.config import _global_config
+
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
 from pandas.errors import (
@@ -24,10 +26,7 @@ from pandas.errors import (
 from pandas.util._decorators import set_module
 from pandas.util._validators import check_dtype_backend
 
-from pandas import (
-    DataFrame,
-    get_option,
-)
+from pandas import DataFrame
 
 from pandas.io._util import arrow_table_to_pandas
 from pandas.io.common import (
@@ -52,7 +51,7 @@ if TYPE_CHECKING:
 def get_engine(engine: str) -> BaseImpl:
     """return our implementation"""
     if engine == "auto":
-        engine = get_option("io.parquet.engine")
+        engine = _global_config["io"]["parquet"]["engine"]
 
     if engine == "auto":
         # try engines in this order

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -31,9 +31,9 @@ import numpy as np
 
 from pandas._config import (
     config,
-    get_option,
     using_string_dtype,
 )
+from pandas._config.config import _global_config
 
 from pandas._libs import (
     lib,
@@ -1220,7 +1220,7 @@ class HDFStore:
         >>> store.put("data", df)  # doctest: +SKIP
         """
         if format is None:
-            format = get_option("io.hdf.default_format") or "fixed"
+            format = _global_config["io"]["hdf"]["default_format"] or "fixed"
         format = self._validate_format(format)
         self._write_to_group(
             key,
@@ -1399,9 +1399,9 @@ class HDFStore:
             )
 
         if dropna is None:
-            dropna = get_option("io.hdf.dropna_table")
+            dropna = _global_config["io"]["hdf"]["dropna_table"]
         if format is None:
-            format = get_option("io.hdf.default_format") or "table"
+            format = _global_config["io"]["hdf"]["default_format"] or "table"
         format = self._validate_format(format)
         self._write_to_group(
             key,
@@ -3323,7 +3323,7 @@ class GenericFixed(Fixed):
                 pass
             elif inferred_type == "string":
                 pass
-            elif get_option("performance_warnings"):
+            elif _global_config["mode"]["performance_warnings"]:
                 ws = performance_doc % (inferred_type, key, items)
                 warnings.warn(ws, PerformanceWarning, stacklevel=find_stack_level())
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -33,6 +33,7 @@ import warnings
 import numpy as np
 
 from pandas._config import using_string_dtype
+from pandas._config.config import _global_config
 
 from pandas._libs import lib
 from pandas.compat._optional import (
@@ -56,7 +57,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from pandas.core.dtypes.missing import isna
 
-from pandas import get_option
 from pandas.core.api import (
     DataFrame,
     Series,
@@ -1584,7 +1584,7 @@ class SQLAlchemyEngine(BaseEngine):
 def get_engine(engine: str) -> BaseEngine:
     """return our implementation"""
     if engine == "auto":
-        engine = get_option("io.sql.engine")
+        engine = _global_config["io"]["sql"]["engine"]
 
     if engine == "auto":
         # try engines in this order

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -6,7 +6,7 @@ from typing import (
     Literal,
 )
 
-from pandas._config import get_option
+from pandas._config.config import _global_config
 
 from pandas.util._decorators import set_module
 
@@ -2469,7 +2469,7 @@ def _get_plot_backend(backend: str | None = None):
     -----
     Modifies `_backends` with imported backend as a side effect.
     """
-    backend_str: str = backend or get_option("plotting.backend")
+    backend_str: str = backend or _global_config["plotting"]["backend"]
 
     if backend_str in _backends:
         return _backends[backend_str]

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -18,6 +18,8 @@ import matplotlib.dates as mdates
 import matplotlib.units as munits
 import numpy as np
 
+from pandas._config.config import _global_config
+
 from pandas._libs import lib
 from pandas._libs.tslibs import (
     Timestamp,
@@ -39,7 +41,6 @@ from pandas.core.dtypes.common import (
 from pandas import (
     Index,
     Series,
-    get_option,
 )
 import pandas.core.common as com
 from pandas.core.indexes.datetimes import (
@@ -103,7 +104,7 @@ def pandas_converters() -> Generator[None]:
     --------
     register_pandas_matplotlib_converters : Decorator that applies this.
     """
-    value = get_option("plotting.matplotlib.register_converters")
+    value = _global_config["plotting"]["matplotlib"]["register_converters"]
 
     if value:
         # register for True or "auto"


### PR DESCRIPTION
Closes #57641

A micro-optimization, but can make a different when hit in a tight loop. Direct access is ~20x faster than `get_option`.

```python
from pandas import get_option
from pandas._config.config import _global_config

%timeit get_option("mode.performance_warnings")
# 707 ns ± 6.74 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
%timeit _global_config["mode"]["performance_warnings"]
# 30.2 ns ± 3.59 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

If we want to import `_global_config` under a different alias, happy to entertain bikeshedding here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)