### PR TITLE
DEPR: deprecate convert_dates and keep_default_dates in read_json

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -102,6 +102,7 @@ Deprecations
 - Deprecated automatic dtype promotion when reindexing with a ``fill_value`` that cannot be held by the original dtype. Explicitly cast to a common dtype instead (:issue:`53910`)
 - Deprecated passing unnecessary ``*args`` and ``**kwargs`` to :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.cummax`, :meth:`.SeriesGroupBy.skew`, :meth:`.DataFrameGroupBy.skew`, :meth:`.SeriesGroupBy.take`, and :meth:`.DataFrameGroupBy.take`. The ``skipna`` parameter for the cum* methods is now an explicit keyword argument (:issue:`50407`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
+- Deprecated the ``convert_dates`` and ``keep_default_dates`` parameters in :func:`read_json`. Use the ``dtype`` parameter instead to control type conversion (:issue:`59161`)
 - Deprecated the ``float_precision`` argument in :func:`read_csv`, :func:`read_table`, and :func:`read_fwf`. All float precision modes now use the same converter (:issue:`64395`)
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 - Deprecated the default value of ``exact`` in :func:`assert_index_equal`; in a future version this will default to ``True`` instead of "equiv" (:issue:`57436`)

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -32,8 +32,10 @@ from pandas.compat._optional import import_optional_dependency
 from pandas.errors import (
     AbstractMethodError,
     OutOfBoundsDatetime,
+    Pandas4Warning,
 )
 from pandas.util._decorators import set_module
+from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import check_dtype_backend
 
 from pandas.core.dtypes.common import (
@@ -443,8 +445,8 @@ def read_json(
     typ: Literal["frame"] = ...,
     dtype: DtypeArg | None = ...,
     convert_axes: bool | None = ...,
-    convert_dates: bool | list[str] = ...,
-    keep_default_dates: bool = ...,
+    convert_dates: bool | list[str] | lib.NoDefault = ...,
+    keep_default_dates: bool | lib.NoDefault = ...,
     precise_float: bool = ...,
     date_unit: str | None = ...,
     encoding: str | None = ...,
@@ -467,8 +469,8 @@ def read_json(
     typ: Literal["series"],
     dtype: DtypeArg | None = ...,
     convert_axes: bool | None = ...,
-    convert_dates: bool | list[str] = ...,
-    keep_default_dates: bool = ...,
+    convert_dates: bool | list[str] | lib.NoDefault = ...,
+    keep_default_dates: bool | lib.NoDefault = ...,
     precise_float: bool = ...,
     date_unit: str | None = ...,
     encoding: str | None = ...,
@@ -491,8 +493,8 @@ def read_json(
     typ: Literal["series"],
     dtype: DtypeArg | None = ...,
     convert_axes: bool | None = ...,
-    convert_dates: bool | list[str] = ...,
-    keep_default_dates: bool = ...,
+    convert_dates: bool | list[str] | lib.NoDefault = ...,
+    keep_default_dates: bool | lib.NoDefault = ...,
     precise_float: bool = ...,
     date_unit: str | None = ...,
     encoding: str | None = ...,
@@ -515,8 +517,8 @@ def read_json(
     typ: Literal["frame"] = ...,
     dtype: DtypeArg | None = ...,
     convert_axes: bool | None = ...,
-    convert_dates: bool | list[str] = ...,
-    keep_default_dates: bool = ...,
+    convert_dates: bool | list[str] | lib.NoDefault = ...,
+    keep_default_dates: bool | lib.NoDefault = ...,
     precise_float: bool = ...,
     date_unit: str | None = ...,
     encoding: str | None = ...,
@@ -539,8 +541,8 @@ def read_json(
     typ: Literal["frame", "series"] = "frame",
     dtype: DtypeArg | None = None,
     convert_axes: bool | None = None,
-    convert_dates: bool | list[str] = True,
-    keep_default_dates: bool = True,
+    convert_dates: bool | list[str] | lib.NoDefault = lib.no_default,
+    keep_default_dates: bool | lib.NoDefault = lib.no_default,
     precise_float: bool = False,
     date_unit: str | None = None,
     encoding: str | None = None,
@@ -633,6 +635,10 @@ def read_json(
         default datelike columns may also be converted (depending on
         keep_default_dates).
 
+        .. deprecated:: 3.1.0
+            The ``convert_dates`` parameter is deprecated. Use the ``dtype``
+            parameter instead to control type conversion.
+
     keep_default_dates : bool, default True
         If parsing dates (convert_dates is not False), then try to parse the
         default datelike columns.
@@ -647,6 +653,10 @@ def read_json(
         * it is ``'modified'``, or
 
         * it is ``'date'``.
+
+        .. deprecated:: 3.1.0
+            The ``keep_default_dates`` parameter is deprecated. Use the
+            ``dtype`` parameter instead to control type conversion.
 
     precise_float : bool, default False
         Set to enable usage of higher precision (strtod) function when
@@ -815,6 +825,28 @@ def read_json(
         raise ValueError("cannot pass both convert_axes and orient='table'")
 
     check_dtype_backend(dtype_backend)
+
+    if convert_dates is not lib.no_default:
+        warnings.warn(
+            "The 'convert_dates' keyword in read_json is deprecated and "
+            "will be removed in a future version. Use the 'dtype' parameter "
+            "instead to control type conversion.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+    else:
+        convert_dates = True
+
+    if keep_default_dates is not lib.no_default:
+        warnings.warn(
+            "The 'keep_default_dates' keyword in read_json is deprecated and "
+            "will be removed in a future version. Use the 'dtype' parameter "
+            "instead to control type conversion.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+    else:
+        keep_default_dates = True
 
     if dtype is None and orient != "table":
         # error: Incompatible types in assignment (expression has type "bool", variable

--- a/pandas/tests/io/json/test_deprecated_kwargs.py
+++ b/pandas/tests/io/json/test_deprecated_kwargs.py
@@ -4,6 +4,10 @@ Tests for the deprecated keyword arguments for `read_json`.
 
 from io import StringIO
 
+import pytest
+
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 import pandas._testing as tm
 
@@ -20,3 +24,23 @@ def test_good_kwargs():
         tm.assert_frame_equal(df, read_json(data2, orient="columns"))
         data3 = StringIO(df.to_json(orient="index"))
         tm.assert_frame_equal(df, read_json(data3, orient="index"))
+
+
+@pytest.mark.parametrize("val", [True, False, ["A"]])
+def test_deprecated_convert_dates(val):
+    # GH#59161
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    json = StringIO(df.to_json())
+    msg = "The 'convert_dates' keyword in read_json is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        read_json(json, convert_dates=val)
+
+
+@pytest.mark.parametrize("val", [True, False])
+def test_deprecated_keep_default_dates(val):
+    # GH#59161
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    json = StringIO(df.to_json())
+    msg = "The 'keep_default_dates' keyword in read_json is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        read_json(json, keep_default_dates=val)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -137,15 +137,8 @@ class TestPandasContainer:
     def test_frame_non_unique_columns(self, orient, data, request):
         df = DataFrame(data, index=[1, 2], columns=["x", "x"])
 
-        expected_warning = None
-        msg = (
-            "The default 'epoch' date format is deprecated and will be removed "
-            "in a future version, please use 'iso' date format instead."
-        )
-        if df.iloc[:, 0].dtype == "datetime64[s]":
-            expected_warning = Pandas4Warning
-
-        with tm.assert_produces_warning(expected_warning, match=msg):
+        depr_msg = "convert_dates.*deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             result = read_json(
                 StringIO(df.to_json(orient=orient)), orient=orient, convert_dates=["x"]
             )
@@ -879,7 +872,9 @@ class TestPandasContainer:
         with tm.assert_produces_warning(Pandas4Warning, match=msg):
             json = StringIO(df.to_json(date_unit="ns"))
 
-        result = read_json(json, convert_dates=False)
+        depr_msg = "convert_dates.*deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            result = read_json(json, convert_dates=False)
         expected = df.copy()
         expected["date"] = expected["date"].values.view("i8")
         expected["foo"] = expected["foo"].astype("int64")
@@ -1108,7 +1103,9 @@ class TestPandasContainer:
             df = df.convert_dtypes(dtype_backend=dtype_backend)
 
         json = df.to_json(date_format="iso", date_unit=unit)
-        result = read_json(StringIO(json), convert_dates=["date", "date_obj"])
+        depr_msg = "convert_dates.*deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            result = read_json(StringIO(json), convert_dates=["date", "date_obj"])
         tm.assert_frame_equal(result, expected)
 
     def test_weird_nested_json(self):
@@ -1166,7 +1163,9 @@ class TestPandasContainer:
     def test_url(self, httpserver):
         data = '{"created_at": ["2023-06-23T18:21:36Z"], "closed_at": ["2023-06-23T18:21:36"], "updated_at": ["2023-06-23T18:21:36Z"]}\n'  # noqa: E501
         httpserver.serve_content(content=data)
-        result = read_json(httpserver.url, convert_dates=True)
+        depr_msg = "convert_dates.*deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            result = read_json(httpserver.url, convert_dates=True)
         for field, dtype in [
             ["created_at", pd.DatetimeTZDtype("us", tz="UTC")],
             ["closed_at", "datetime64[us]"],
@@ -2377,11 +2376,13 @@ def test_read_json_lines_rangeindex():
 
 def test_large_number():
     # GH#20608
-    result = read_json(
-        StringIO('["9999999999999999"]'),
-        orient="values",
-        typ="series",
-        convert_dates=False,
-    )
+    depr_msg = "convert_dates.*deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+        result = read_json(
+            StringIO('["9999999999999999"]'),
+            orient="values",
+            typ="series",
+            convert_dates=False,
+        )
     expected = Series([9999999999999999])
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -243,6 +243,8 @@ def test_readjson_chunks_closes(chunksize, temp_file):
     )
     with reader:
         reader.read()
+    # JsonReader is not a public constructor that goes through read_json,
+    # so no deprecation warning is expected here.
     assert reader.handles.handle.closed, (
         f"didn't close stream with chunksize = {chunksize}"
     )

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from pandas.compat.pyarrow import pa_version_under17p0
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     DataFrame,
@@ -81,7 +82,8 @@ def test_to_read_gcs(gcs_buffer, format, monkeypatch, capsys, request):
         df2 = read_excel(path, parse_dates=["dt"], index_col=0)
     elif format == "json":
         df1.to_json(path, date_format="iso")
-        df2 = read_json(path, convert_dates=["dt"])
+        with tm.assert_produces_warning(Pandas4Warning, match="convert_dates"):
+            df2 = read_json(path, convert_dates=["dt"])
     elif format == "parquet":
         pytest.importorskip("pyarrow")
         pa_fs = pytest.importorskip("pyarrow.fs")


### PR DESCRIPTION
## Summary
- Deprecate the `convert_dates` and `keep_default_dates` parameters in `read_json` in favor of using the `dtype` parameter to control type conversion
- The implicit name-based date conversion heuristic (columns ending in `_at`, `_time`, starting with `timestamp`, etc.) can silently override explicit `dtype` specifications and cause unexpected data corruption (GH#39430, GH#49585)
- Closes #59161

## Test plan
- [x] Added parametrized deprecation warning tests in `test_deprecated_kwargs.py`
- [x] Updated existing tests that explicitly pass `convert_dates` or `keep_default_dates` to expect the warning
- [x] Full JSON test suite passes (1084 passed)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)