### PR TITLE
CLN: add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ doc/build/html/index.html
 # Windows specific leftover:
 doc/tmp.sv
 env/
+.venv/
 doc/source/savefig/
 
 # Interactive terminal generated files #


### PR DESCRIPTION
.venv/ is a common local virtual environment directory name in a repository root, and env/ is already ignored.

This keeps git status a bit cleaner for contributors who use that convention.