### PR TITLE
BUG: fix sum of empty series for python-backed str dtype and account for min_count

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -31,6 +31,7 @@ Bug fixes
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Assigning :attr:`pd.NA` to a string column could trigger a PyArrow error and corrupt data (:issue:`64320`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
+- Fixed bug in the :meth:`~Series.sum` method with python-backed string dtype returning incorrect value for an empty Series and ignoring the ``min_count`` argument (:issue:`64683`)
 - Fixed bug where :meth:`DataFrame.div` ignored the ``axis`` argument when used with ``level`` for MultiIndex columns (:issue:`64428`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -54,6 +54,9 @@ def _reductions(
         The required number of valid values to perform the operation. If fewer than
         ``min_count`` non-NA values are present the result will be NA.
     axis : int, optional, default None
+    initial : scalar, optional
+        Starting value for the reduction. NumPy has a default value for most
+        data types, but for object-dtype arrays we need to specify it explicitly
     """
     if initial is not lib.no_default:
         kwargs["initial"] = initial

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -10,7 +10,10 @@ import warnings
 
 import numpy as np
 
-from pandas._libs import missing as libmissing
+from pandas._libs import (
+    lib,
+    missing as libmissing,
+)
 
 from pandas.core.nanops import check_below_min_count
 
@@ -31,6 +34,7 @@ def _reductions(
     skipna: bool = True,
     min_count: int = 0,
     axis: AxisInt | None = None,
+    initial: object | lib.NoDefault = lib.no_default,
     **kwargs,
 ):
     """
@@ -51,6 +55,9 @@ def _reductions(
         ``min_count`` non-NA values are present the result will be NA.
     axis : int, optional, default None
     """
+    if initial is not lib.no_default:
+        kwargs["initial"] = initial
+
     if not skipna:
         if mask.any() or check_below_min_count(values.shape, None, min_count):
             return libmissing.NA
@@ -62,10 +69,6 @@ def _reductions(
         ):
             return libmissing.NA
 
-        if values.dtype == np.dtype(object):
-            # object dtype does not support `where` without passing an initial
-            values = values[~mask]
-            return func(values, axis=axis, **kwargs)
         return func(values, where=~mask, axis=axis, **kwargs)
 
 
@@ -76,9 +79,16 @@ def sum(
     skipna: bool = True,
     min_count: int = 0,
     axis: AxisInt | None = None,
+    initial: object | lib.NoDefault = lib.no_default,
 ):
     return _reductions(
-        np.sum, values=values, mask=mask, skipna=skipna, min_count=min_count, axis=axis
+        np.sum,
+        values=values,
+        mask=mask,
+        skipna=skipna,
+        min_count=min_count,
+        axis=axis,
+        initial=initial,
     )
 
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -1079,7 +1079,11 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
     ) -> Scalar:
         nv.validate_sum((), kwargs)
         result = masked_reductions.sum(
-            values=self._ndarray, mask=self.isna(), skipna=skipna
+            values=self._ndarray,
+            mask=self.isna(),
+            skipna=skipna,
+            min_count=min_count,
+            initial="",
         )
         return self._wrap_reduction_result(axis, result)
 

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -276,6 +276,24 @@ def test_reduce_missing(skipna, dtype):
         assert pd.isna(result)
 
 
+@pytest.mark.parametrize("min_count", [0, 1])
+def test_reduce_empty(skipna, dtype, min_count):
+    arr = pd.Series([], dtype=dtype)
+    result = arr.sum(skipna=skipna, min_count=min_count)
+    if min_count == 0:
+        assert result == ""
+    else:
+        assert pd.isna(result)
+
+    # all-missing
+    arr = pd.Series([None, None], dtype=dtype)
+    result = arr.sum(skipna=skipna, min_count=min_count)
+    if skipna and min_count == 0:
+        assert result == ""
+    else:
+        assert pd.isna(result)
+
+
 @pytest.mark.parametrize("method", ["min", "max"])
 def test_min_max(method, skipna, dtype):
     arr = pd.Series(["a", "b", "c", None], dtype=dtype)


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/pull/64664#discussion_r2952141511 for context

- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.