### PR TITLE
BUG: fix Index.drop failing to match NA values for Arrow-backed indexes

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -173,6 +173,7 @@ Interval
 Indexing
 ^^^^^^^^
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
+- Bug in :meth:`DataFrame.drop` where dropping rows with NA values failed for Arrow-backed indexes (:issue:`63304`)
 -
 
 Missing

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7354,6 +7354,18 @@ class Index(IndexOpsMixin, PandasObject):
             labels = com.index_labels_to_array(labels, dtype=arr_dtype)
 
         indexer = self.get_indexer_for(labels)
+
+        # GH#63304 - handle NA values in labels that get_indexer_for may not
+        # match for Arrow-backed or other ExtensionArray-backed indexes.
+        # When labels contain NA-like values, get_indexer may return -1 even
+        # though the index contains NA entries, because the NA representation
+        # in the labels array (e.g. pd.NA as object) differs from the index's
+        # native NA representation.
+        unmatched_na = isna(labels) & (indexer == -1)
+        if unmatched_na.any() and self.hasnans:
+            nan_indexer = self.isna().nonzero()[0]
+            indexer[unmatched_na] = nan_indexer[0]
+
         mask = indexer == -1
         if mask.any():
             if errors != "ignore":


### PR DESCRIPTION
- [ ] closes #63304
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## What

After the `mode.nan_is_na` change (commit e4ca405 from #62040), calling `drop(index=[pd.NA])` on a DataFrame with an Arrow-backed index raises `KeyError: [<NA>] not found in axis`, even when the index contains NA entries.

The root cause is that `Index.drop` delegates to `get_indexer_for`, which converts the labels to a numpy object array containing `pd.NA`. When comparing against the Arrow-backed index, this `pd.NA` object doesn't match the native null entries, so it returns -1 (not found).

## Fix

Added a fallback in `Index.drop` that checks for unmatched NA values in the labels and resolves them against the index's own NA entries using `self.isna()`. This is similar to the existing NA-handling logic in `get_indexer` for CategoricalIndex (lines ~3798-3826).

## Reproducer (from the issue)

```python
import pyarrow as pa
import pandas as pd

df = pd.DataFrame(
    index=pd.Index(
        [None, b'\xe3', b'\xe3'],
        dtype='binary[pyarrow]',
        name='bytes_col'
    )
)
df.drop(index=[pd.NA])  # was: KeyError, now works correctly
```

**Disclosure**: I used an AI coding assistant to help analyze the code paths involved in this regression. I fully reviewed and tested the fix.