### PR TITLE
TST: add test for string slice with sub-second datetime freq (#13929)

### DIFF
--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -679,3 +679,18 @@ class TestStringSlicing:
         # e.g. 2012-01-03 is rounded up to 2012-01-04 - 1ns
         result = df["2012-01-01":"2012-01-03 00:00:00.000000000"]
         tm.assert_frame_equal(result, expected)
+
+    def test_string_slice_with_subsecond_freq(self):
+        # GH#13929
+        # String-based datetime slicing should match exact boundary,
+        # not include extra sub-second rows beyond the endpoint
+        idx = date_range("2013-11-08 10:00:00", periods=72000, freq="50ms")
+        ser = Series(range(len(idx)), index=idx)
+
+        result_str = ser.loc["2013-11-08 10:15:00.000":"2013-11-08 10:17:00.000"]
+        result_dt = ser.loc[
+            "2013-11-08 10:15:00.000" : Timestamp(2013, 11, 8, 10, 17, 0, 0)
+        ]
+        expected_end = Timestamp("2013-11-08 10:17:00.000")
+        assert result_str.index[-1] <= expected_end
+        tm.assert_series_equal(result_str, result_dt)

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -684,13 +684,13 @@ class TestStringSlicing:
         # GH#13929
         # String-based datetime slicing should match exact boundary,
         # not include extra sub-second rows beyond the endpoint
-        idx = date_range("2013-11-08 10:00:00", periods=72000, freq="50ms")
+        idx = date_range("2013-11-08 10:00:00", periods=100, freq="50ms")
         ser = Series(range(len(idx)), index=idx)
 
-        result_str = ser.loc["2013-11-08 10:15:00.000":"2013-11-08 10:17:00.000"]
+        result_str = ser.loc["2013-11-08 10:00:01.000":"2013-11-08 10:00:02.000"]
         result_dt = ser.loc[
-            "2013-11-08 10:15:00.000" : Timestamp(2013, 11, 8, 10, 17, 0, 0)
+            "2013-11-08 10:00:01.000" : Timestamp(2013, 11, 8, 10, 0, 2, 0)
         ]
-        expected_end = Timestamp("2013-11-08 10:17:00.000")
-        assert result_str.index[-1] <= expected_end
+        expected_end = Timestamp("2013-11-08 10:00:02.000")
+        assert result_str.index[-1] == expected_end
         tm.assert_series_equal(result_str, result_dt)


### PR DESCRIPTION
closes #13929

Add test verifying that string-based datetime slicing on a
DatetimeIndex with sub-second frequency (50ms) matches exact
boundary endpoints, consistent with Timestamp object slicing.

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.