### PR TITLE
TST: add test for tz-aware datetime column expansion via loc (#55423)

### DIFF
--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1,4 +1,7 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 import numpy as np
 import pytest
@@ -1498,3 +1501,13 @@ def test_setitem_partial_row_multiple_columns():
         }
     )
     tm.assert_frame_equal(df, expected)
+
+
+def test_loc_setitem_tz_aware_column_expansion():
+    # GH#55423
+    # Enlarging a DataFrame with a tz-aware datetime via loc
+    # should preserve datetime64[us, tz] dtype, not fall back to object
+    df = DataFrame([{"id": 1}, {"id": 2}, {"id": 3}])
+    _time = datetime.fromtimestamp(1695887042, timezone.utc)
+    df.loc[df.id >= 2, "time"] = _time
+    assert df["time"].dtype == DatetimeTZDtype(tz="UTC", unit="us")


### PR DESCRIPTION
closes #55423

Add test verifying that enlarging a DataFrame by assigning a
tz-aware datetime to a subset of rows via loc preserves
datetime64[us, tz] dtype instead of falling back to object.

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.