### PR TITLE
BLD: use idiomatic meson dependency pattern for fast_float + add license

### DIFF
--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -51,8 +51,7 @@ _khash_primitive_helper_dep = declare_dependency(
 )
 
 m_dep = cc.find_library('m', required: false)
-fast_float = subproject('fast_float')
-fast_float_dep = fast_float.get_variable('fast_float_dep')
+fast_float_dep = dependency('fast_float', version: '==8.2.3')
 
 subdir('tslibs')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ parentdir_prefix = "pandas-"
 
 [tool.meson-python.args]
 setup = ['--vsenv'] # For Windows
+dist = ['--include-subprojects']
 
 [tool.cibuildwheel]
 skip = ["*_i686", "*_ppc64le", "*_s390x"]

--- a/subprojects/packagefiles/fast_float/meson.build
+++ b/subprojects/packagefiles/fast_float/meson.build
@@ -8,3 +8,4 @@ project(
 fast_float_inc = include_directories('include')
 
 fast_float_dep = declare_dependency(include_directories: fast_float_inc)
+meson.override_dependency('fast_float', fast_float_dep)


### PR DESCRIPTION
## Summary
- Follow-up to #64432, addressing post-merge comments from @WillAyd and @jorisvandenbossche
- Use `meson.override_dependency('fast_float', ...)` in the subproject's `meson.build` so the dependency name is decoupled from the internal variable name
- Use `dependency('fast_float')` instead of `subproject('fast_float').get_variable('fast_float_dep')`
- Add fast_float license (MIT/Apache-2.0/Boost triple-licensed) to `LICENSES/`

## Test plan
- [x] Verified build succeeds locally (with cpp_std=c++17 fix)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)