### PR TITLE
BUG: raise `TypeError` on comparisons involving `None`

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -94,6 +94,7 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_iterator,
     is_list_like,
+    is_object_dtype,
     is_scalar,
     is_sequence,
     is_string_dtype,
@@ -8987,6 +8988,7 @@ class DataFrame(NDFrame, OpsMixin):
         axis: Literal[1] = 1  # only relevant for Series other case
 
         self, other = self._align_for_op(other, axis, flex=False, level=None)
+        self._maybe_raise_on_cmp_with_none(other, op, axis=axis)
 
         # See GH#4537 for discussion of scalar op behavior
         new_data = self._dispatch_frame_op(other, op, axis=axis)
@@ -9075,6 +9077,41 @@ class DataFrame(NDFrame, OpsMixin):
         return type(self)._from_arrays(
             arrays, self.columns, self.index, verify_integrity=False
         )
+
+    def _maybe_raise_on_cmp_with_none(
+        self, other, op: Callable, axis: AxisInt | None
+    ) -> None:
+        op_name = op.__name__.strip("_").lstrip("r")
+        if op_name not in {"gt", "ge", "lt", "le"}:
+            return
+
+        if not any(is_object_dtype(left.dtype) for left in self._iter_column_arrays()):
+            return
+
+        for i, left in enumerate(self._iter_column_arrays()):
+            if not is_object_dtype(left.dtype):
+                continue
+
+            for j, val in enumerate(left):
+                if val is not None:
+                    continue
+
+                if isinstance(other, DataFrame):
+                    right = other.iat[j, i]
+                    if isinstance(right, np.generic):
+                        right = right.item()
+                    op(val, right)
+                elif isinstance(other, Series):
+                    right = other.iat[i] if axis == 1 else other.iat[j]
+                    if isinstance(right, np.generic):
+                        right = right.item()
+                    op(val, right)
+                else:
+                    if isna(other):
+                        return
+                    op(val, other)
+
+                return
 
     def _combine_frame(self, other: DataFrame, func, fill_value=None):
         # at this point we have `self._indexed_same(other)`
@@ -9434,6 +9471,7 @@ class DataFrame(NDFrame, OpsMixin):
         axis = self._get_axis_number(axis) if axis is not None else 1
 
         self, other = self._align_for_op(other, axis, flex=True, level=level)
+        self._maybe_raise_on_cmp_with_none(other, op, axis=axis)
 
         new_data = self._dispatch_frame_op(other, op, axis=axis)
         return self._construct_result(new_data, other=other)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6981,10 +6981,24 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     # Template-Based Arithmetic/Comparison Methods
 
     def _cmp_method(self, other, op) -> Series:
-        res_name = ops.get_op_result_name(self, other)
-
         if isinstance(other, Series) and not self._indexed_same(other):
             raise ValueError("Can only compare identically-labeled Series objects")
+
+        if isinstance(other, Series):
+            return self._binop(other, op)
+
+        if (
+            is_object_dtype(self.dtype)
+            and op not in {operator.eq, operator.ne}
+            and is_scalar(other)
+            and not isna(other)
+            and any(val is None for val in self._values)
+        ):
+            return self._binop(
+                self._constructor(other, index=self.index, copy=False), op
+            )
+
+        res_name = ops.get_op_result_name(self, other)
 
         lvalues = self._values
         rvalues = extract_array(other, extract_numpy=True, extract_range=True)

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -30,9 +30,14 @@ class TestObjectComparisons:
 
         func = comparison_op
 
-        result = func(ser, shifted)
-        expected = func(ser.astype(float), shifted.astype(float))
-        tm.assert_series_equal(result, expected)
+        if func in {operator.eq, operator.ne}:
+            result = func(ser, shifted)
+            expected = func(ser.astype(float), shifted.astype(float))
+            tm.assert_series_equal(result, expected)
+        else:
+            msg = "not supported between instances of"
+            with pytest.raises(TypeError, match=msg):
+                func(ser, shifted)
 
     @pytest.mark.parametrize(
         "infer_string", [False, pytest.param(True, marks=td.skip_if_no("pyarrow"))]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -441,6 +441,28 @@ class TestFrameFlexComparisons:
         exp = DataFrame({"col": [False, True, False]})
         tm.assert_frame_equal(result, exp)
 
+    def test_bool_flex_frame_none_raises(self):
+        x = Series([None], dtype=object)
+        y = Series([0])
+        X = x.to_frame()
+        Y = y.to_frame()
+
+        msg = r"'>' not supported between instances of 'NoneType' and 'int'"
+        with pytest.raises(TypeError, match=msg):
+            X > Y
+        with pytest.raises(TypeError, match=msg):
+            X.gt(Y)
+        with pytest.raises(TypeError, match=msg):
+            X.gt(y)
+        with pytest.raises(TypeError, match=msg):
+            X.gt(0)
+        with pytest.raises(TypeError, match=msg):
+            X > y
+        with pytest.raises(TypeError, match=msg):
+            X > 0
+        with pytest.raises(TypeError, match=msg):
+            y < X
+
     def test_flex_comparison_nat(self):
         # GH 15697, GH 22163 df.eq(pd.NaT) should behave like df == pd.NaT,
         # and _definitely_ not be NaN

--- a/pandas/tests/series/methods/test_clip.py
+++ b/pandas/tests/series/methods/test_clip.py
@@ -36,6 +36,14 @@ class TestSeriesClip:
 
         for s in sers:
             thresh = s[2]
+            if s.dtype == object and isinstance(thresh, str):
+                msg = "not supported between instances of 'NoneType' and 'str'"
+                with pytest.raises(TypeError, match=msg):
+                    s.clip(lower=thresh)
+                with pytest.raises(TypeError, match=msg):
+                    s.clip(upper=thresh)
+                continue
+
             lower = s.clip(lower=thresh)
             upper = s.clip(upper=thresh)
             assert lower[notna(lower)].min() == thresh

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -779,6 +779,18 @@ class TestSeriesComparison:
 
         tm.assert_series_equal(result, expected)
 
+    def test_comparison_operators_none_raises(self):
+        left = Series([None], dtype=object)
+        right = Series([0])
+
+        msg = r"'>' not supported between instances of 'NoneType' and 'int'"
+        with pytest.raises(TypeError, match=msg):
+            left.gt(0)
+        with pytest.raises(TypeError, match=msg):
+            left > 0
+        with pytest.raises(TypeError, match=msg):
+            left > right
+
     def test_ne(self):
         ts = Series([3, 4, 5, 6, 7], [3, 4, 5, 6, 7], dtype=float)
         expected = np.array([True, True, False, True, True])


### PR DESCRIPTION
- [x] closes #59418 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
