### PR TITLE
TST: add test for CategoricalIndex of Intervals scalar indexing (#27437)

### DIFF
--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -232,3 +232,19 @@ class TestIntervalIndexInsideMultiIndex:
         result = df.loc[("b", 16)]
         expected = Series([7, 8], name=("b", pd.Interval(13, 17, closed="right")))
         tm.assert_series_equal(result, expected)
+
+
+def test_categorical_interval_index_getitem_scalar():
+    # GH#27437
+    # Scalar indexing on Series with CategoricalIndex of Intervals
+    # should use interval membership (point-in-interval lookup)
+    ser = Series(
+        ["a", "b", "c", "d", "e"],
+        index=pd.CategoricalIndex(IntervalIndex.from_breaks(range(6))),
+    )
+    # 0.5 is in (0, 1], 1.5 is in (1, 2], etc.
+    assert ser[0.5] == "a"
+    assert ser[1.5] == "b"
+    # Points on boundaries: 1 is in (0, 1] (right-closed)
+    assert ser[1] == "a"
+    assert ser[2] == "b"


### PR DESCRIPTION
closes #27437

Add test verifying that scalar indexing on a Series with a
CategoricalIndex wrapping IntervalIndex uses point-in-interval
membership lookup (the designed behavior). This documents the
expected behavior where `ser[0.5]` returns the value for the
interval containing 0.5.

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.