### PR TITLE
TST: add test for FloatingArray mean with skipna=True and NaN (#59965)

### DIFF
--- a/pandas/tests/arrays/floating/test_function.py
+++ b/pandas/tests/arrays/floating/test_function.py
@@ -216,3 +216,15 @@ def test_floating_array_prod(skipna, min_count, dtype):
         assert result == 2
     else:
         assert result is pd.NA
+
+
+def test_floating_array_mean_skipna_with_nan():
+    # GH#59965
+    # FloatingArray containing NaN (from 0/0 division) should still
+    # compute mean correctly when skipna=True
+    s1 = pd.Series({"a": 0.0, "b": 1, "c": 1, "d": 0})
+    s2 = pd.Series({"a": 0.0, "b": 2, "c": 2, "d": 2})
+    result = (s1.convert_dtypes() / s2.convert_dtypes()).mean(skipna=True)
+    expected = (s1 / s2).mean(skipna=True)
+    assert result == expected
+    assert result == pytest.approx(1.0 / 3)

--- a/pandas/tests/arrays/floating/test_function.py
+++ b/pandas/tests/arrays/floating/test_function.py
@@ -222,13 +222,13 @@ def test_floating_array_mean_skipna_with_nan(using_nan_is_na):
     # GH#59965
     # FloatingArray containing NaN (from 0/0 division) should
     # compute mean correctly when skipna=True
-    s1 = pd.Series({"a": 0.0, "b": 1, "c": 1, "d": 0})
-    s2 = pd.Series({"a": 0.0, "b": 2, "c": 2, "d": 2})
-    s4 = s1.convert_dtypes() / s2.convert_dtypes()
+    s1 = pd.Series({"a": 0.0, "b": 1, "c": 1, "d": 0}, dtype="Float64")
+    s2 = pd.Series({"a": 0.0, "b": 2, "c": 2, "d": 2}, dtype="Float64")
+    s4 = s1 / s2
     result = s4.mean(skipna=True)
     if using_nan_is_na:
         # NaN treated as NA → skipped, mean of [0.5, 0.5, 0.0]
-        assert result == pytest.approx(1.0 / 3)
+        tm.assert_almost_equal(result, 1.0 / 3)
     else:
         # NaN is distinct from NA → NaN propagates in mean
         assert result is pd.NA or np.isnan(result)

--- a/pandas/tests/arrays/floating/test_function.py
+++ b/pandas/tests/arrays/floating/test_function.py
@@ -218,7 +218,7 @@ def test_floating_array_prod(skipna, min_count, dtype):
         assert result is pd.NA
 
 
-def test_floating_array_mean_skipna_with_nan(using_nan_is_na):
+def test_floating_array_mean_skipna_with_nan(request, using_nan_is_na):
     # GH#59965
     # FloatingArray containing NaN (from 0/0 division) should
     # compute mean correctly when skipna=True
@@ -230,6 +230,7 @@ def test_floating_array_mean_skipna_with_nan(using_nan_is_na):
         # NaN treated as NA → skipped, mean of [0.5, 0.5, 0.0]
         tm.assert_almost_equal(result, 1.0 / 3)
     else:
-        # NaN is distinct from NA → NaN propagates in mean
-        # Currently returns pd.NA; should be NaN once nan!=NA is implemented
-        assert result is pd.NA
+        # NaN should propagate in mean, but currently returns pd.NA
+        mark = pytest.mark.xfail(reason="NaN not yet distinguished from NA")
+        request.applymarker(mark)
+        assert np.isnan(result)

--- a/pandas/tests/arrays/floating/test_function.py
+++ b/pandas/tests/arrays/floating/test_function.py
@@ -218,13 +218,17 @@ def test_floating_array_prod(skipna, min_count, dtype):
         assert result is pd.NA
 
 
-def test_floating_array_mean_skipna_with_nan():
+def test_floating_array_mean_skipna_with_nan(using_nan_is_na):
     # GH#59965
-    # FloatingArray containing NaN (from 0/0 division) should still
+    # FloatingArray containing NaN (from 0/0 division) should
     # compute mean correctly when skipna=True
     s1 = pd.Series({"a": 0.0, "b": 1, "c": 1, "d": 0})
     s2 = pd.Series({"a": 0.0, "b": 2, "c": 2, "d": 2})
-    result = (s1.convert_dtypes() / s2.convert_dtypes()).mean(skipna=True)
-    expected = (s1 / s2).mean(skipna=True)
-    assert result == expected
-    assert result == pytest.approx(1.0 / 3)
+    s4 = s1.convert_dtypes() / s2.convert_dtypes()
+    result = s4.mean(skipna=True)
+    if using_nan_is_na:
+        # NaN treated as NA → skipped, mean of [0.5, 0.5, 0.0]
+        assert result == pytest.approx(1.0 / 3)
+    else:
+        # NaN is distinct from NA → NaN propagates in mean
+        assert result is pd.NA or np.isnan(result)

--- a/pandas/tests/arrays/floating/test_function.py
+++ b/pandas/tests/arrays/floating/test_function.py
@@ -231,4 +231,4 @@ def test_floating_array_mean_skipna_with_nan(using_nan_is_na):
         tm.assert_almost_equal(result, 1.0 / 3)
     else:
         # NaN is distinct from NA → NaN propagates in mean
-        assert result is pd.NA or np.isnan(result)
+        assert np.isnan(result)

--- a/pandas/tests/arrays/floating/test_function.py
+++ b/pandas/tests/arrays/floating/test_function.py
@@ -231,4 +231,5 @@ def test_floating_array_mean_skipna_with_nan(using_nan_is_na):
         tm.assert_almost_equal(result, 1.0 / 3)
     else:
         # NaN is distinct from NA → NaN propagates in mean
-        assert np.isnan(result)
+        # Currently returns pd.NA; should be NaN once nan!=NA is implemented
+        assert result is pd.NA


### PR DESCRIPTION
closes #59965

Add test verifying that FloatingArray containing NaN values
(from division like 0/0) computes mean correctly with skipna=True,
matching the behavior of standard float64 Series.

As confirmed by @Alvaro-Kothe, the bug was fixed by e4ca40511c
(#62040). This PR adds the regression test requested by @rhshadrach.

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.