### PR TITLE
TST: add test for Series constructor dtype enforcement from Series input (#59060)

### DIFF
--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -2268,3 +2268,12 @@ def test_dict_keys_rangeindex():
     result = Series({0: 1, 1: 2})
     expected = Series([1, 2], index=RangeIndex(2))
     tm.assert_series_equal(result, expected, check_index_type=True)
+
+
+def test_constructor_from_series_with_incompatible_dtype_raises():
+    # GH#59060
+    # Series(series_with_mixed_types, dtype=int) should raise consistently
+    # whether creating directly or from an existing Series
+    ser = Series([1, 2, "x", 4, 5])
+    with pytest.raises(ValueError, match="invalid literal"):
+        Series(ser, dtype=int)


### PR DESCRIPTION
closes #59060

Add test verifying that constructing a Series from another Series
with an incompatible dtype (e.g. mixed types to int) raises ValueError,
consistent with direct construction from a list.

As noted by @jbrockmendel and @rhshadrach, the 2nd example from the OP
now correctly raises on main. This PR adds the regression test.

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.