### PR TITLE
TST: add mutation-catching test for reindex column fill_value (#58517)

### DIFF
--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -833,11 +833,23 @@ class TestDataFrameSelectReindex:
         tm.assert_frame_equal(result, expected)
 
     def test_reindex_new_columns_fill_value(self):
-        # GH#58517 (mutation testing: col_idx == -1 in take.py)
-        # Ensure fill_value is correctly applied to new columns
-        df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-        result = df.reindex(columns=["a", "b", "c"], fill_value=99)
-        expected = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [99, 99, 99]})
+        # GH#58517 (mutation testing: col_mask = col_idx == -1 in take_2d_multi)
+        # To exercise take_2d_multi we need a homogeneous DataFrame reindexed
+        # on both axes (row permutation keeps row_idx free of -1 so the
+        # col_mask mutation is not rescued by row_needs in the depromote
+        # branch). A promoting fill_value makes dtype != arr.dtype so the
+        # guarded block is entered.
+        df = DataFrame(np.arange(6).reshape(2, 3), columns=list("abc"))
+        result = df.reindex(index=[1, 0], columns=list("abcd"), fill_value=np.nan)
+        expected = DataFrame(
+            {
+                "a": [3.0, 0.0],
+                "b": [4.0, 1.0],
+                "c": [5.0, 2.0],
+                "d": [np.nan, np.nan],
+            },
+            index=[1, 0],
+        )
         tm.assert_frame_equal(result, expected)
 
     def test_reindex_dups(self):

--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -832,6 +832,15 @@ class TestDataFrameSelectReindex:
         expected = DataFrame({"a": [0], "b": ["missing"], "c": ["missing"]})
         tm.assert_frame_equal(result, expected)
 
+    def test_reindex_new_columns_fill_value_with_dtype_promotion(self):
+        # GH#58517 (mutation testing: col_idx == -1 in take.py)
+        # Ensure fill_value is correctly applied to new columns even when
+        # dtype promotion is triggered (int -> float for NaN fill)
+        df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        result = df.reindex(columns=["a", "b", "c"], fill_value=99)
+        expected = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [99, 99, 99]})
+        tm.assert_frame_equal(result, expected)
+
     def test_reindex_dups(self):
         # GH4746, reindex on duplicate index error messages
         arr = np.random.default_rng(2).standard_normal(10)

--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -832,10 +832,9 @@ class TestDataFrameSelectReindex:
         expected = DataFrame({"a": [0], "b": ["missing"], "c": ["missing"]})
         tm.assert_frame_equal(result, expected)
 
-    def test_reindex_new_columns_fill_value_with_dtype_promotion(self):
+    def test_reindex_new_columns_fill_value(self):
         # GH#58517 (mutation testing: col_idx == -1 in take.py)
-        # Ensure fill_value is correctly applied to new columns even when
-        # dtype promotion is triggered (int -> float for NaN fill)
+        # Ensure fill_value is correctly applied to new columns
         df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         result = df.reindex(columns=["a", "b", "c"], fill_value=99)
         expected = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [99, 99, 99]})


### PR DESCRIPTION
Partial fix for #58517 (mutation testing results)

Addresses the **take.py:254** mutant where `col_idx == -1` is changed
to `col_idx < -1`. The mutation causes fill_value to not be applied
to new columns during reindex. This test catches that mutation by
verifying fill_value is correctly applied when reindexing with new
columns that trigger dtype promotion.

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.