### PR TITLE
BUG: fix convert_dtypes dropping values from sliced mixed-dtype DataFrames

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -163,6 +163,7 @@ Conversion
 ^^^^^^^^^^
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`).
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
+- Fixed bug in :meth:`DataFrame.convert_dtypes` where values were dropped from sliced :class:`DataFrame` objects with mixed dtypes when the internal block structure spanned multiple columns (:issue:`64702`)
 -
 
 Strings

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -162,8 +162,8 @@ Numeric
 Conversion
 ^^^^^^^^^^
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`).
-- Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.convert_dtypes` where values were dropped from sliced :class:`DataFrame` objects with mixed dtypes when the internal block structure spanned multiple columns (:issue:`64702`)
+- Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 -
 
 Strings

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -544,7 +544,7 @@ class Block(PandasObject, libinternals.Block):
         for blk in blks:
             # Determine dtype column by column
             sub_blks = (
-                [blk] if blk.ndim == 1 or self.shape[0] == 1 else list(blk._split())
+                [blk] if blk.ndim == 1 or blk.shape[0] == 1 else list(blk._split())
             )
             dtypes = [
                 convert_dtypes(
@@ -558,7 +558,7 @@ class Block(PandasObject, libinternals.Block):
                 )
                 for b in sub_blks
             ]
-            if all(dtype == self.dtype for dtype in dtypes):
+            if all(dtype == blk.dtype for dtype in dtypes):
                 # Avoid block splitting if no dtype changes
                 rbs.append(blk.copy(deep=False))
                 continue

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -240,3 +240,18 @@ class TestConvertDtypes:
         )
         result = df.convert_dtypes()
         tm.assert_frame_equal(result, expected)
+
+    def test_convert_dtypes_mixed_column_after_slice(self):
+        # GH#64702
+        df = pd.DataFrame(
+            data=[[1, "a"], [2, "b"], ["c", 3]], columns=["col1", "col2"]
+        )
+        df = df.loc[[0, 1]].copy()
+        result = df.convert_dtypes()
+        expected = pd.DataFrame(
+            {
+                "col1": pd.array([1, 2], dtype="Int64"),
+                "col2": pd.array(["a", "b"], dtype="string"),
+            }
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -243,9 +243,7 @@ class TestConvertDtypes:
 
     def test_convert_dtypes_mixed_column_after_slice(self):
         # GH#64702
-        df = pd.DataFrame(
-            data=[[1, "a"], [2, "b"], ["c", 3]], columns=["col1", "col2"]
-        )
+        df = pd.DataFrame(data=[[1, "a"], [2, "b"], ["c", 3]], columns=["col1", "col2"])
         df = df.loc[[0, 1]].copy()
         result = df.convert_dtypes()
         expected = pd.DataFrame(


### PR DESCRIPTION
- [x] closes #64702
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)

## Summary

After slicing a mixed-dtype DataFrame and calling `convert_dtypes()`, columns converted to ExtensionArray-backed types (e.g. Arrow strings) could silently lose values.

The root cause is in `Block.convert_dtypes`: after `self.convert()` splits the original object block into type-specific blocks, the loop still references `self.shape[0]` and `self.dtype` instead of `blk.shape[0]` and `blk.dtype`. When the original block had multiple rows (one per column in the consolidated object block), the converted single-row ExtensionBlock was unnecessarily passed through `_split()`, which sliced the 1-D backing array as if selecting a row from a 2-D array, truncating the data.

Fix: use `blk.shape[0]` and `blk.dtype` to reference the post-conversion block rather than the pre-conversion `self`.

Repro from the issue:
```python
df = pd.DataFrame(data=[[1, "a"], [2, "b"], ["c", 3]], columns=["col1", "col2"])
df = df.loc[[0, 1]].copy()
df = df.convert_dtypes()
print(df["col2"].shape)  # (1,) — should be (2,)
```