### PR TITLE
BLD: macos x86_64 failures

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -174,7 +174,6 @@ jobs:
           CIBW_ARCHS: ${{ matrix.buildplat[1] == 'win_arm64' && 'ARM64' || 'auto' }}
           CIBW_BEFORE_BUILD_WINDOWS: 'python -m pip install delvewheel'
 
-
       - name: Set up Python for validation/upload (non-ARM64 Windows & other OS)
         # micromamba is not available for ARM64 Windows
         if: matrix.buildplat[1] != 'win_arm64'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -174,6 +174,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.buildplat[1] == 'win_arm64' && 'ARM64' || 'auto' }}
           CIBW_BEFORE_BUILD_WINDOWS: 'python -m pip install delvewheel'
 
+
       - name: Set up Python for validation/upload (non-ARM64 Windows & other OS)
         # micromamba is not available for ARM64 Windows
         if: matrix.buildplat[1] != 'win_arm64'

--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -35,6 +35,13 @@ Bug fixes
 - Fixed bug where :meth:`DataFrame.div` ignored the ``axis`` argument when used with ``level`` for MultiIndex columns (:issue:`64428`)
 
 .. ---------------------------------------------------------------------------
+.. _whatsnew_302.packaging:
+
+Packaging
+~~~~~~~~~
+- Increased the minimum macOS deployment target for x86_64 wheels to 14.0 (Sonoma) due to build environment requirements. These wheels might no longer be compatible with older macOS versions (:issue:`64730`)
+
+.. ---------------------------------------------------------------------------
 .. _whatsnew_302.contributors:
 
 Contributors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,10 @@ select = "*-macosx*"
 environment = {CFLAGS="-g0"}
 
 [[tool.cibuildwheel.overrides]]
+select = "*-macosx_x86_64"
+environment = {CFLAGS="-g0", MACOSX_DEPLOYMENT_TARGET="14.0"}
+
+[[tool.cibuildwheel.overrides]]
 select = "*pyodide*"
 test-requires = "pytest>=8.3.4 hypothesis>=6.116.0"
 # Pyodide repairs wheels on its own, using auditwheel-emscripten


### PR DESCRIPTION
- [x] closes #64730 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`. 

---

Basically trying to comply with

```
  delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 10.13:
  /private/var/folders/9n/h1d0pgxn4f5bbpg9mrrft9140000gn/T/tmpo9j_mimz/wheel/pandas/.dylibs/libunwind.1.0.dylib has a minimum target of 14.0
  Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=14.0' to update minimum supported macOS for this wheel.
```