### PR TITLE
DEPR: deprecate DataFrame.iterrows

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -1503,6 +1503,7 @@ To iterate over the rows of a DataFrame, you can use the following methods:
   For example, in the following case setting the value has no effect:
 
   .. ipython:: python
+     :okwarning:
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
 
@@ -1538,6 +1539,7 @@ DataFrame as Series objects. It returns an iterator yielding each
 index value along with a Series containing the data in each row:
 
 .. ipython:: python
+   :okwarning:
 
    for row_index, row in df.iterrows():
        print(row_index, row, sep="\n")
@@ -1549,6 +1551,7 @@ index value along with a Series containing the data in each row:
    preserved across columns for DataFrames). For example,
 
    .. ipython:: python
+      :okwarning:
 
       df_orig = pd.DataFrame([[1, 1.5]], columns=["int", "float"])
       df_orig.dtypes
@@ -1570,6 +1573,7 @@ index value along with a Series containing the data in each row:
 For instance, a contrived way to transpose the DataFrame would be:
 
 .. ipython:: python
+   :okwarning:
 
    df2 = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
    print(df2)

--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -1524,6 +1524,7 @@ through key-value pairs:
 For example:
 
 .. ipython:: python
+   :okwarning:
 
    for label, ser in df.items():
        print(label)

--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -1465,15 +1465,8 @@ Thus, for example, iterating over a DataFrame gives you the column names:
 pandas objects also have the dict-like :meth:`~DataFrame.items` method to
 iterate over the (key, value) pairs.
 
-To iterate over the rows of a DataFrame, you can use the following methods:
-
-* :meth:`~DataFrame.iterrows`: Iterate over the rows of a DataFrame as (index, Series) pairs.
-  This converts the rows to Series objects, which can change the dtypes and has some
-  performance implications.
-* :meth:`~DataFrame.itertuples`: Iterate over the rows of a DataFrame
-  as namedtuples of the values.  This is a lot faster than
-  :meth:`~DataFrame.iterrows`, and is in most cases preferable to use
-  to iterate over the values of a DataFrame.
+To iterate over the rows of a DataFrame, you can use :meth:`~DataFrame.itertuples`,
+which iterates over the rows as namedtuples of the values.
 
 .. warning::
 
@@ -1500,18 +1493,6 @@ To iterate over the rows of a DataFrame, you can use the following methods:
   data types, the iterator returns a copy and not a view, and writing
   to it will have no effect!
 
-  For example, in the following case setting the value has no effect:
-
-  .. ipython:: python
-     :okwarning:
-
-    df = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
-
-    for index, row in df.iterrows():
-        row["a"] = 10
-
-    df
-
 items
 ~~~~~
 
@@ -1524,64 +1505,14 @@ through key-value pairs:
 For example:
 
 .. ipython:: python
-   :okwarning:
+
+   df = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
 
    for label, ser in df.items():
        print(label)
        print(ser)
 
 .. _basics.iterrows:
-
-iterrows
-~~~~~~~~
-
-:meth:`~DataFrame.iterrows` allows you to iterate through the rows of a
-DataFrame as Series objects. It returns an iterator yielding each
-index value along with a Series containing the data in each row:
-
-.. ipython:: python
-   :okwarning:
-
-   for row_index, row in df.iterrows():
-       print(row_index, row, sep="\n")
-
-.. note::
-
-   Because :meth:`~DataFrame.iterrows` returns a Series for each row,
-   it does **not** preserve dtypes across the rows (dtypes are
-   preserved across columns for DataFrames). For example,
-
-   .. ipython:: python
-      :okwarning:
-
-      df_orig = pd.DataFrame([[1, 1.5]], columns=["int", "float"])
-      df_orig.dtypes
-      row = next(df_orig.iterrows())[1]
-      row
-
-   All values in ``row``, returned as a Series, are now upcasted
-   to floats, also the original integer value in column ``x``:
-
-   .. ipython:: python
-
-      row["int"].dtype
-      df_orig["int"].dtype
-
-   To preserve dtypes while iterating over the rows, it is better
-   to use :meth:`~DataFrame.itertuples` which returns namedtuples of the values
-   and which is generally much faster than :meth:`~DataFrame.iterrows`.
-
-For instance, a contrived way to transpose the DataFrame would be:
-
-.. ipython:: python
-   :okwarning:
-
-   df2 = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
-   print(df2)
-   print(df2.T)
-
-   df2_t = pd.DataFrame({idx: values for idx, values in df2.iterrows()})
-   print(df2_t)
 
 itertuples
 ~~~~~~~~~~
@@ -1600,8 +1531,7 @@ For instance:
 
 This method does not convert the row to a Series object; it merely
 returns the values inside a namedtuple. Therefore,
-:meth:`~DataFrame.itertuples` preserves the data type of the values
-and is generally faster than :meth:`~DataFrame.iterrows`.
+:meth:`~DataFrame.itertuples` preserves the data type of the values.
 
 .. note::
 

--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -802,7 +802,6 @@ Apply
 <https://stackoverflow.com/questions/17349981/converting-pandas-dataframe-with-categorical-values-into-binary-values>`__
 
 .. ipython:: python
-   :okwarning:
 
    df = pd.DataFrame(
        data={
@@ -815,9 +814,7 @@ Apply
    def SeriesFromSubList(aList):
        return pd.Series(aList)
 
-   df_orgz = pd.concat(
-       {ind: row.apply(SeriesFromSubList) for ind, row in df.iterrows()}
-   )
+   df_orgz = df.stack().apply(SeriesFromSubList)
    df_orgz
 
 `Rolling apply with a DataFrame returning a Series

--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -802,6 +802,7 @@ Apply
 <https://stackoverflow.com/questions/17349981/converting-pandas-dataframe-with-categorical-values-into-binary-values>`__
 
 .. ipython:: python
+   :okwarning:
 
    df = pd.DataFrame(
        data={

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -96,6 +96,7 @@ Other API changes
 Deprecations
 ~~~~~~~~~~~~
 - Deprecated :meth:`.DataFrameGroupBy.agg` and :meth:`.Resampler.agg` unpacking a scalar when the provided ``func`` returns a Series or array of length 1; in the future this will result in the Series or array being in the result. Users should unpack the scalar in ``func`` itself (:issue:`64014`)
+- Deprecated :meth:`DataFrame.iterrows`. Use :meth:`DataFrame.itertuples` instead (:issue:`43874`)
 - Deprecated :meth:`ExcelFile.parse`, use :func:`read_excel` instead (:issue:`58247`)
 - Deprecated arithmetic operations between pandas objects (:class:`DataFrame`, :class:`Series`, :class:`Index`, and pandas-implemented :class:`ExtensionArray` subclasses) and list-likes other than ``list``, ``np.ndarray``, :class:`ExtensionArray`, :class:`Index`, :class:`Series`, :class:`DataFrame`. For e.g. ``tuple`` or ``range``, explicitly cast these to a supported object instead. In a future version, these will be treated as scalar-like for pointwise operation (:issue:`62423`)
 - Deprecated automatic dtype promotion when reindexing with a ``fill_value`` that cannot be held by the original dtype. Explicitly cast to a common dtype instead (:issue:`53910`)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -198,6 +198,7 @@ def pytest_collection_modifyitems(items, config) -> None:
         ("read_parquet", "Passing a BlockManager to DataFrame is deprecated"),
         ("Timestamp.utcfromtimestamp", "Timestamp.utcfromtimestamp is deprecated"),
         ("BaseOffset.name.__get__", "The 'name' property is deprecated"),
+        ("DataFrame.iterrows", "DataFrame.iterrows is deprecated"),
     ]
 
     if is_doctest:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1299,6 +1299,9 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Iterate over DataFrame rows as (index, Series) pairs.
 
+        .. deprecated:: 3.1.0
+            Use :meth:`itertuples` instead.
+
         Each row is yielded as a (index, Series) tuple; the Series has
         the same index as the DataFrame columns. Note that dtypes may
         not be preserved across rows. Prefer :meth:`itertuples` for
@@ -1345,6 +1348,12 @@ class DataFrame(NDFrame, OpsMixin):
         >>> print(df["int"].dtype)
         int64
         """
+        warnings.warn(
+            f"{type(self).__name__}.iterrows is deprecated and "
+            "will be removed in a future version. Use .itertuples instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
         columns = self.columns
         klass = self._constructor_sliced
         for k, v in zip(self.index, self.values, strict=True):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1338,14 +1338,14 @@ class DataFrame(NDFrame, OpsMixin):
         --------
 
         >>> df = pd.DataFrame([[1, 1.5]], columns=["int", "float"])
-        >>> row = next(df.iterrows())[1]
-        >>> row
+        >>> row = next(df.iterrows())[1]  # doctest: +SKIP
+        >>> row  # doctest: +SKIP
         int      1.0
         float    1.5
         Name: 0, dtype: float64
-        >>> print(row["int"].dtype)
+        >>> print(row["int"].dtype)  # doctest: +SKIP
         float64
-        >>> print(df["int"].dtype)
+        >>> print(df["int"].dtype)  # doctest: +SKIP
         int64
         """
         warnings.warn(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1338,14 +1338,14 @@ class DataFrame(NDFrame, OpsMixin):
         --------
 
         >>> df = pd.DataFrame([[1, 1.5]], columns=["int", "float"])
-        >>> row = next(df.iterrows())[1]  # doctest: +SKIP
-        >>> row  # doctest: +SKIP
+        >>> row = next(df.iterrows())[1]
+        >>> row
         int      1.0
         float    1.5
         Name: 0, dtype: float64
-        >>> print(row["int"].dtype)  # doctest: +SKIP
+        >>> print(row["int"].dtype)
         float64
-        >>> print(df["int"].dtype)  # doctest: +SKIP
+        >>> print(df["int"].dtype)
         int64
         """
         warnings.warn(

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -3299,10 +3299,9 @@ class StataStrLWriter:
         selected = gso_df[self.columns]
         col_index = [(col, columns.index(col)) for col in self.columns]
         keys = np.empty(selected.shape, dtype=np.uint64)
-        selected_values = selected.to_numpy(dtype=object, na_value=None)
         for o in range(len(selected)):
             for j, (col, v) in enumerate(col_index):
-                val = selected_values[o, j]
+                val = selected.iloc[o, j]
                 # Allow columns with mixed str and None or pd.NA (GH 23633)
                 val = "" if isna(val) else val
                 key = gso_table.get(val, None)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -3299,9 +3299,10 @@ class StataStrLWriter:
         selected = gso_df[self.columns]
         col_index = [(col, columns.index(col)) for col in self.columns]
         keys = np.empty(selected.shape, dtype=np.uint64)
-        for o, (idx, row) in enumerate(selected.iterrows()):
+        selected_values = selected.to_numpy(dtype=object, na_value=None)
+        for o in range(len(selected)):
             for j, (col, v) in enumerate(col_index):
-                val = row[col]
+                val = selected_values[o, j]
                 # Allow columns with mixed str and None or pd.NA (GH 23633)
                 val = "" if isna(val) else val
                 key = gso_table.get(val, None)

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import HAS_PYARROW
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 from pandas import (
@@ -1261,8 +1262,9 @@ def test_iterrows():
     df = DataFrame({"a": 0, "b": 1}, index=[1, 2, 3])
     df_orig = df.copy()
 
-    for _, sub in df.iterrows():
-        sub.iloc[0] = 100
+    with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+        for _, sub in df.iterrows():
+            sub.iloc[0] = 100
     tm.assert_frame_equal(df, df_orig)
 
 

--- a/pandas/tests/frame/methods/test_iterrows.py
+++ b/pandas/tests/frame/methods/test_iterrows.py
@@ -1,16 +1,27 @@
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     DataFrame,
     Timedelta,
 )
+import pandas._testing as tm
+
+
+def test_iterrows_deprecated():
+    # GH#43874
+    df = DataFrame({"a": [1, 2]})
+    with tm.assert_produces_warning(Pandas4Warning, match="iterrows is deprecated"):
+        next(df.iterrows())
 
 
 def test_no_overflow_of_freq_and_time_in_dataframe():
-    # GH 35665
+    # GH#35665
     df = DataFrame(
         {
             "some_string": ["2222Y3"],
             "time": [Timedelta("0 days 00:00:00.990000")],
         }
     )
-    for _, row in df.iterrows():
-        assert row.dtype == "object"
+    with tm.assert_produces_warning(Pandas4Warning, match="iterrows is deprecated"):
+        for _, row in df.iterrows():
+            assert row.dtype == "object"

--- a/pandas/tests/frame/test_iteration.py
+++ b/pandas/tests/frame/test_iteration.py
@@ -174,9 +174,5 @@ class TestIteration:
         for t in df.itertuples(index=False):
             str(t)
 
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for row, s in df.iterrows():
-                str(s)
-
         for c, col in df.items():
             str(col)

--- a/pandas/tests/frame/test_iteration.py
+++ b/pandas/tests/frame/test_iteration.py
@@ -7,6 +7,7 @@ from pandas.compat import (
     IS64,
     is_platform_windows,
 )
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     Categorical,
@@ -43,13 +44,15 @@ class TestIteration:
         assert list(float_frame) == list(float_frame.columns)
 
     def test_iterrows(self, float_frame, float_string_frame):
-        for k, v in float_frame.iterrows():
-            exp = float_frame.loc[k]
-            tm.assert_series_equal(v, exp)
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for k, v in float_frame.iterrows():
+                exp = float_frame.loc[k]
+                tm.assert_series_equal(v, exp)
 
-        for k, v in float_string_frame.iterrows():
-            exp = float_string_frame.loc[k]
-            tm.assert_series_equal(v, exp)
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for k, v in float_string_frame.iterrows():
+                exp = float_string_frame.loc[k]
+                tm.assert_series_equal(v, exp)
 
     def test_iterrows_iso8601(self):
         # GH#19671
@@ -59,9 +62,10 @@ class TestIteration:
                 "iso8601": date_range("2000-01-01", periods=4, freq="ME"),
             }
         )
-        for k, v in s.iterrows():
-            exp = s.loc[k]
-            tm.assert_series_equal(v, exp)
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for k, v in s.iterrows():
+                exp = s.loc[k]
+                tm.assert_series_equal(v, exp)
 
     def test_iterrows_no_datetime_coercion(self):
         # GH#26427 - string that looks like a year should not be coerced
@@ -73,10 +77,11 @@ class TestIteration:
             }
         )
         df["a"] = df["a"].astype(object)
-        for idx, row in df.iterrows():
-            assert isinstance(row["a"], str), (
-                f"row {idx}: 'a' was coerced to {type(row['a'])}"
-            )
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for idx, row in df.iterrows():
+                assert isinstance(row["a"], str), (
+                    f"row {idx}: 'a' was coerced to {type(row['a'])}"
+                )
 
     def test_iterrows_corner(self):
         # GH#12222
@@ -97,7 +102,8 @@ class TestIteration:
             name=0,
             dtype="object",
         )
-        _, result = next(df.iterrows())
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            _, result = next(df.iterrows())
         tm.assert_series_equal(result, expected)
 
     def test_itertuples(self, float_frame):
@@ -168,8 +174,9 @@ class TestIteration:
         for t in df.itertuples(index=False):
             str(t)
 
-        for row, s in df.iterrows():
-            str(s)
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for row, s in df.iterrows():
+                str(s)
 
         for c, col in df.items():
             str(col)

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1067,10 +1067,10 @@ class TestDataFrameReshape:
         assert left.notna().values.sum() == 2 * len(df)
 
         for col in ["jim", "joe"]:
-            with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-                for _, r in df.iterrows():
-                    key = r["1st"], (col, r["2nd"], r["3rd"])
-                    assert r[col] == left.loc[key]
+            for idx in range(len(df)):
+                row = df.iloc[idx]
+                key = row["1st"], (col, row["2nd"], row["3rd"])
+                assert row[col] == left.loc[key]
 
     def test_stack_datetime_column_multiIndex(self, future_stack):
         # GH 8039

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1067,9 +1067,10 @@ class TestDataFrameReshape:
         assert left.notna().values.sum() == 2 * len(df)
 
         for col in ["jim", "joe"]:
-            for _, r in df.iterrows():
-                key = r["1st"], (col, r["2nd"], r["3rd"])
-                assert r[col] == left.loc[key]
+            with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+                for _, r in df.iterrows():
+                    key = r["1st"], (col, r["2nd"], r["3rd"])
+                    assert r[col] == left.loc[key]
 
     def test_stack_datetime_column_multiIndex(self, future_stack):
         # GH 8039

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -207,9 +209,10 @@ class TestDataFrameSubclassing:
     def test_subclass_iterrows(self):
         # GH 13977
         df = tm.SubclassedDataFrame({"a": [1]})
-        for i, row in df.iterrows():
-            assert isinstance(row, tm.SubclassedSeries)
-            tm.assert_series_equal(row, df.loc[i])
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for i, row in df.iterrows():
+                assert isinstance(row, tm.SubclassedSeries)
+                tm.assert_series_equal(row, df.loc[i])
 
     def test_subclass_stack(self):
         # GH 15564

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -3,8 +3,6 @@ from string import ascii_letters
 import numpy as np
 import pytest
 
-from pandas.errors import Pandas4Warning
-
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -47,9 +45,8 @@ class TestCaching:
         # loop through df to update out
         six = Timestamp("5/7/2014")
         eix = Timestamp("5/9/2014")
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for ix, row in df.iterrows():
-                out.loc[six:eix, row["C"]] = out.loc[six:eix, row["C"]] + row["D"]
+        for row in df.itertuples():
+            out.loc[six:eix, row.C] = out.loc[six:eix, row.C] + row.D
 
         tm.assert_frame_equal(out, expected)
         tm.assert_series_equal(out["A"], expected["A"])
@@ -58,19 +55,17 @@ class TestCaching:
         # this actually works
         out = DataFrame({"A": [0, 0, 0]}, index=date_range("5/7/2014", "5/9/2014"))
         out_original = out.copy()
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for ix, row in df.iterrows():
-                v = out[row["C"]][six:eix] + row["D"]
-                with tm.raises_chained_assignment_error():
-                    out[row["C"]][six:eix] = v
+        for row in df.itertuples():
+            v = out[row.C][six:eix] + row.D
+            with tm.raises_chained_assignment_error():
+                out[row.C][six:eix] = v
 
         tm.assert_frame_equal(out, out_original)
         tm.assert_series_equal(out["A"], out_original["A"])
 
         out = DataFrame({"A": [0, 0, 0]}, index=date_range("5/7/2014", "5/9/2014"))
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for ix, row in df.iterrows():
-                out.loc[six:eix, row["C"]] += row["D"]
+        for row in df.itertuples():
+            out.loc[six:eix, row.C] += row.D
 
         tm.assert_frame_equal(out, expected)
         tm.assert_series_equal(out["A"], expected["A"])

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -3,6 +3,8 @@ from string import ascii_letters
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -45,8 +47,9 @@ class TestCaching:
         # loop through df to update out
         six = Timestamp("5/7/2014")
         eix = Timestamp("5/9/2014")
-        for ix, row in df.iterrows():
-            out.loc[six:eix, row["C"]] = out.loc[six:eix, row["C"]] + row["D"]
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for ix, row in df.iterrows():
+                out.loc[six:eix, row["C"]] = out.loc[six:eix, row["C"]] + row["D"]
 
         tm.assert_frame_equal(out, expected)
         tm.assert_series_equal(out["A"], expected["A"])
@@ -55,17 +58,19 @@ class TestCaching:
         # this actually works
         out = DataFrame({"A": [0, 0, 0]}, index=date_range("5/7/2014", "5/9/2014"))
         out_original = out.copy()
-        for ix, row in df.iterrows():
-            v = out[row["C"]][six:eix] + row["D"]
-            with tm.raises_chained_assignment_error():
-                out[row["C"]][six:eix] = v
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for ix, row in df.iterrows():
+                v = out[row["C"]][six:eix] + row["D"]
+                with tm.raises_chained_assignment_error():
+                    out[row["C"]][six:eix] = v
 
         tm.assert_frame_equal(out, out_original)
         tm.assert_series_equal(out["A"], out_original["A"])
 
         out = DataFrame({"A": [0, 0, 0]}, index=date_range("5/7/2014", "5/9/2014"))
-        for ix, row in df.iterrows():
-            out.loc[six:eix, row["C"]] += row["D"]
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for ix, row in df.iterrows():
+                out.loc[six:eix, row["C"]] += row["D"]
 
         tm.assert_frame_equal(out, expected)
         tm.assert_series_equal(out["A"], expected["A"])

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -9,6 +9,8 @@ import itertools
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     DataFrame,
     Index,
@@ -206,9 +208,10 @@ class TestAtAndiAT:
         df = DataFrame(
             [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]], columns=["a", "b", "c", 1, 2]
         )
-        for rowIdx, row in df.iterrows():
-            for el, item in row.items():
-                assert df.at[rowIdx, el] == df.loc[rowIdx, el] == item
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for rowIdx, row in df.iterrows():
+                for el, item in row.items():
+                    assert df.at[rowIdx, el] == df.loc[rowIdx, el] == item
 
         for row in range(2):
             for i in range(5):

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -9,8 +9,6 @@ import itertools
 import numpy as np
 import pytest
 
-from pandas.errors import Pandas4Warning
-
 from pandas import (
     DataFrame,
     Index,
@@ -208,10 +206,9 @@ class TestAtAndiAT:
         df = DataFrame(
             [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]], columns=["a", "b", "c", 1, 2]
         )
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for rowIdx, row in df.iterrows():
-                for el, item in row.items():
-                    assert df.at[rowIdx, el] == df.loc[rowIdx, el] == item
+        for rowIdx in range(len(df)):
+            for col in df.columns:
+                assert df.at[rowIdx, col] == df.loc[rowIdx, col] == df.iloc[rowIdx][col]
 
         for row in range(2):
             for i in range(5):

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -205,14 +205,15 @@ class TestReaders:
 
         tm.assert_frame_equal(df1, df2)
 
-        for idx, row in df2.iterrows():
-            for col in df2.columns:
-                val = row[col]
-                exp_val = df1.iloc[idx][col]
-                # Check if values match
-                assert val == exp_val, (
-                    f"Mismatch at Row {idx} Column {col}: {val} != {exp_val}"
-                )
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for idx, row in df2.iterrows():
+                for col in df2.columns:
+                    val = row[col]
+                    exp_val = df1.iloc[idx][col]
+                    # Check if values match
+                    assert val == exp_val, (
+                        f"Mismatch at Row {idx} Column {col}: {val} != {exp_val}"
+                    )
                 # Check if types match
                 assert type(val) == type(exp_val), (
                     f"Type mismatch at Row {idx} Column {col}: "

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -205,15 +205,14 @@ class TestReaders:
 
         tm.assert_frame_equal(df1, df2)
 
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for idx, row in df2.iterrows():
-                for col in df2.columns:
-                    val = row[col]
-                    exp_val = df1.iloc[idx][col]
-                    # Check if values match
-                    assert val == exp_val, (
-                        f"Mismatch at Row {idx} Column {col}: {val} != {exp_val}"
-                    )
+        for idx in range(len(df2)):
+            for col in df2.columns:
+                val = df2.iloc[idx][col]
+                exp_val = df1.iloc[idx][col]
+                # Check if values match
+                assert val == exp_val, (
+                    f"Mismatch at Row {idx} Column {col}: {val} != {exp_val}"
+                )
                 # Check if types match
                 assert type(val) == type(exp_val), (
                     f"Type mismatch at Row {idx} Column {col}: "

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -23,7 +23,6 @@ from pandas._config import using_string_dtype
 from pandas._libs import lib
 from pandas.compat import pa_version_under14p1
 from pandas.compat._optional import import_optional_dependency
-from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -4201,10 +4200,9 @@ def test_xsqlite_write_row_by_row(sqlite_buildin):
     cur.execute(create_sql)
 
     ins = "INSERT INTO test VALUES (%s, %s, %s, %s)"
-    with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-        for _, row in frame.iterrows():
-            fmt_sql = format_query(ins, *row)
-            tquery(fmt_sql, con=sqlite_buildin)
+    for row in frame.itertuples(index=False):
+        fmt_sql = format_query(ins, *row)
+        tquery(fmt_sql, con=sqlite_buildin)
 
     sqlite_buildin.commit()
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -23,6 +23,7 @@ from pandas._config import using_string_dtype
 from pandas._libs import lib
 from pandas.compat import pa_version_under14p1
 from pandas.compat._optional import import_optional_dependency
+from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -4200,9 +4201,10 @@ def test_xsqlite_write_row_by_row(sqlite_buildin):
     cur.execute(create_sql)
 
     ins = "INSERT INTO test VALUES (%s, %s, %s, %s)"
-    for _, row in frame.iterrows():
-        fmt_sql = format_query(ins, *row)
-        tquery(fmt_sql, con=sqlite_buildin)
+    with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+        for _, row in frame.iterrows():
+            fmt_sql = format_query(ins, *row)
+            tquery(fmt_sql, con=sqlite_buildin)
 
     sqlite_buildin.commit()
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -11,6 +11,8 @@ import pytest
 
 from pandas._config import using_string_dtype
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     ArrowDtype,
@@ -541,8 +543,9 @@ class TestPivotTable:
             pv = pd.pivot(df, index="a", columns="b", values="c")
         assert pv.notna().values.sum() == len(df)
 
-        for _, row in df.iterrows():
-            assert pv.loc[row["a"], row["b"]] == row["c"]
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for _, row in df.iterrows():
+                assert pv.loc[row["a"], row["b"]] == row["c"]
 
         if method:
             result = df.pivot(index="b", columns="a", values="c")

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -11,8 +11,6 @@ import pytest
 
 from pandas._config import using_string_dtype
 
-from pandas.errors import Pandas4Warning
-
 import pandas as pd
 from pandas import (
     ArrowDtype,
@@ -543,9 +541,8 @@ class TestPivotTable:
             pv = pd.pivot(df, index="a", columns="b", values="c")
         assert pv.notna().values.sum() == len(df)
 
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for _, row in df.iterrows():
-                assert pv.loc[row["a"], row["b"]] == row["c"]
+        for row in df.itertuples():
+            assert pv.loc[row.a, row.b] == row.c
 
         if method:
             result = df.pivot(index="b", columns="a", values="c")

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -5,8 +5,6 @@ from itertools import product
 import numpy as np
 import pytest
 
-from pandas.errors import Pandas4Warning
-
 from pandas import (
     NA,
     DataFrame,
@@ -279,13 +277,11 @@ class TestMerge:
         # manually compute outer merge
         ldict, rdict = defaultdict(list), defaultdict(list)
 
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for idx, row in left.set_index(list("ABCDEFG")).iterrows():
-                ldict[idx].append(row["left"])
+        for row in left.set_index(list("ABCDEFG")).itertuples():
+            ldict[row.Index].append(row.left)
 
-        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
-            for idx, row in right.set_index(list("ABCDEFG")).iterrows():
-                rdict[idx].append(row["right"])
+        for row in right.set_index(list("ABCDEFG")).itertuples():
+            rdict[row.Index].append(row.right)
 
         vals = []
         for k, lval in ldict.items():

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -5,6 +5,8 @@ from itertools import product
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     NA,
     DataFrame,
@@ -277,11 +279,13 @@ class TestMerge:
         # manually compute outer merge
         ldict, rdict = defaultdict(list), defaultdict(list)
 
-        for idx, row in left.set_index(list("ABCDEFG")).iterrows():
-            ldict[idx].append(row["left"])
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for idx, row in left.set_index(list("ABCDEFG")).iterrows():
+                ldict[idx].append(row["left"])
 
-        for idx, row in right.set_index(list("ABCDEFG")).iterrows():
-            rdict[idx].append(row["right"])
+        with tm.assert_produces_warning(Pandas4Warning, match="iterrows"):
+            for idx, row in right.set_index(list("ABCDEFG")).iterrows():
+                rdict[idx].append(row["right"])
 
         vals = []
         for k, lval in ldict.items():


### PR DESCRIPTION
## Summary
- Deprecates `DataFrame.iterrows` with a `Pandas4Warning`, directing users to use `itertuples` instead
- Replaces the internal usage in `StataStrLWriter.generate_table()` with direct numpy array indexing
- Updates all affected tests to expect the deprecation warning

closes #43874