### PR TITLE
DEPR: Deprecate as_index argument in groupby

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -294,7 +294,7 @@ Method 2 : sort then take first of each
 
 .. ipython:: python
 
-   df.sort_values(by="BBB").groupby("AAA", as_index=False).first()
+   df.sort_values(by="BBB").groupby("AAA").first().reset_index()
 
 Notice the same results, with the exception of the index.
 

--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -489,11 +489,11 @@ column in a group of values.
    animals.groupby("kind").sum()
 
 In the result, the keys of the groups appear in the index by default. They can be
-instead included in the columns by passing ``as_index=False``.
+instead included in the columns by using :meth:`~DataFrame.reset_index`.
 
 .. ipython:: python
 
-   animals.groupby("kind", as_index=False).sum()
+   animals.groupby("kind").sum().reset_index()
 
 .. _groupby.aggregate.builtin:
 
@@ -599,18 +599,13 @@ Any reduction method that pandas implements can be passed as a string to
 The result of the aggregation will have the group names as the
 new index. In the case of multiple keys, the result is a
 :ref:`MultiIndex <advanced.hierarchical>` by default. As mentioned above, this can be
-changed by using the ``as_index`` option:
+changed by using :meth:`~DataFrame.reset_index`:
 
 .. ipython:: python
 
-   grouped = df.groupby(["A", "B"], as_index=False)
-   grouped.agg("sum")
+   df.groupby(["A", "B"]).agg("sum").reset_index()
 
-   df.groupby("A", as_index=False)[["C", "D"]].agg("sum")
-
-Note that you could use the :meth:`DataFrame.reset_index` DataFrame function to achieve
-the same result as the column names are stored in the resulting ``MultiIndex``, although
-this will make an extra copy.
+   df.groupby("A")[["C", "D"]].agg("sum").reset_index()
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.14.0.rst
+++ b/doc/source/whatsnew/v0.14.0.rst
@@ -379,6 +379,7 @@ More consistent behavior for some groupby methods:
   Filtering
 
   .. ipython:: python
+     :okwarning:
 
      gf = df.groupby('A', as_index=False)
      gf.nth(0)
@@ -397,6 +398,7 @@ More consistent behavior for some groupby methods:
 - passing ``as_index`` will leave the grouped column in-place (this is not change in 0.14.0)
 
   .. ipython:: python
+     :okwarning:
 
      df = pd.DataFrame([[1, np.nan], [1, 4], [5, 6], [5, 8]], columns=['A', 'B'])
      g = df.groupby('A', as_index=False)

--- a/doc/source/whatsnew/v0.18.1.rst
+++ b/doc/source/whatsnew/v0.18.1.rst
@@ -466,6 +466,7 @@ Previous behavior:
 New behavior:
 
 .. ipython:: python
+   :okwarning:
 
     df.groupby("A", as_index=True)["B"].nth(0)
     df.groupby("A", as_index=False)["B"].nth(0)

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -626,6 +626,7 @@ Using :meth:`DataFrame.groupby` with ``as_index=False`` and the function ``idxma
 *New behavior*:
 
 .. ipython:: python
+   :okwarning:
 
    df.groupby("a", as_index=False).nunique()
 
@@ -645,6 +646,7 @@ The method :meth:`.DataFrameGroupBy.size` would previously ignore ``as_index=Fal
 *New behavior*:
 
 .. ipython:: python
+   :okwarning:
 
    df.groupby("a", as_index=False).size()
 
@@ -679,6 +681,7 @@ the previous index (:issue:`32240`).
 *New behavior*:
 
 .. ipython:: python
+   :okwarning:
 
    grouped = df.groupby("key", as_index=False)
    result = grouped.agg(min_val=pd.NamedAgg(column="val", aggfunc="min"))

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -608,6 +608,7 @@ Using :meth:`DataFrame.groupby` with ``as_index=True`` and the aggregation ``nun
 *New behavior*:
 
 .. ipython:: python
+   :okwarning:
 
    df.groupby("a", as_index=True).nunique()
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -102,6 +102,7 @@ Deprecations
 - Deprecated automatic dtype promotion when reindexing with a ``fill_value`` that cannot be held by the original dtype. Explicitly cast to a common dtype instead (:issue:`53910`)
 - Deprecated passing unnecessary ``*args`` and ``**kwargs`` to :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.cummax`, :meth:`.SeriesGroupBy.skew`, :meth:`.DataFrameGroupBy.skew`, :meth:`.SeriesGroupBy.take`, and :meth:`.DataFrameGroupBy.take`. The ``skipna`` parameter for the cum* methods is now an explicit keyword argument (:issue:`50407`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
+- Deprecated the ``as_index`` argument in :meth:`DataFrame.groupby`. Use ``groupby(...).reset_index()`` instead of ``groupby(..., as_index=False)`` (:issue:`35860`)
 - Deprecated the ``float_precision`` argument in :func:`read_csv`, :func:`read_table`, and :func:`read_fwf`. All float precision modes now use the same converter (:issue:`64395`)
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 - Deprecated the default value of ``exact`` in :func:`assert_index_equal`; in a future version this will default to ``True`` instead of "equiv" (:issue:`57436`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -665,7 +665,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Return the dataframe interchange object implementing the interchange protocol.
 
-        .. deprecated:: 3.1.0
+        .. deprecated:: 3.0.0
 
             The Dataframe Interchange Protocol is deprecated.
             For dataframe-agnostic code, you may want to look into:
@@ -3953,7 +3953,7 @@ class DataFrame(NDFrame, OpsMixin):
             Note that a copy is always required for mixed dtype DataFrames,
             or for DataFrames with any extension types.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5668,7 +5668,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5758,7 +5758,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -6238,7 +6238,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -6706,7 +6706,7 @@ class DataFrame(NDFrame, OpsMixin):
             necessary. Setting to False will improve the performance of this
             method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
         Returns
         -------
@@ -14823,7 +14823,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -18323,7 +18323,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -18409,7 +18409,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12433,7 +12433,7 @@ class DataFrame(NDFrame, OpsMixin):
         self,
         by=None,
         level: IndexLabel | None = None,
-        as_index: bool = True,
+        as_index: bool | lib.NoDefault = lib.no_default,
         sort: bool = True,
         group_keys: bool = True,
         observed: bool = True,
@@ -12655,7 +12655,7 @@ class DataFrame(NDFrame, OpsMixin):
         if level is None and by is None:
             raise TypeError("You have to supply one of 'by' and 'level'")
 
-        if not as_index:
+        if as_index is not lib.no_default:
             warnings.warn(
                 "The 'as_index' argument in groupby is deprecated and "
                 "will be removed in a future version. "
@@ -12663,6 +12663,8 @@ class DataFrame(NDFrame, OpsMixin):
                 Pandas4Warning,
                 stacklevel=find_stack_level(),
             )
+        else:
+            as_index = True
 
         return DataFrameGroupBy(
             obj=self,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -665,7 +665,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Return the dataframe interchange object implementing the interchange protocol.
 
-        .. deprecated:: 3.0.0
+        .. deprecated:: 3.1.0
 
             The Dataframe Interchange Protocol is deprecated.
             For dataframe-agnostic code, you may want to look into:
@@ -3953,7 +3953,7 @@ class DataFrame(NDFrame, OpsMixin):
             Note that a copy is always required for mixed dtype DataFrames,
             or for DataFrames with any extension types.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5668,7 +5668,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5758,7 +5758,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -6238,7 +6238,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -6706,7 +6706,7 @@ class DataFrame(NDFrame, OpsMixin):
             necessary. Setting to False will improve the performance of this
             method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
         Returns
         -------
@@ -12472,6 +12472,10 @@ class DataFrame(NDFrame, OpsMixin):
             such as ``head()``, ``tail()``, ``nth()`` and in transformations
             (see the `transformations in the user guide
             <https://pandas.pydata.org/docs/dev/user_guide/groupby.html#transformation>`_).
+
+            .. deprecated:: 3.1.0
+                The ``as_index`` argument is deprecated and will be removed in
+                a future version. Use ``groupby(...).reset_index()`` instead.
         sort : bool, default True
             Sort group keys. Get better performance by turning this off.
             Note this does not influence the order of observations within each
@@ -12650,6 +12654,15 @@ class DataFrame(NDFrame, OpsMixin):
 
         if level is None and by is None:
             raise TypeError("You have to supply one of 'by' and 'level'")
+
+        if not as_index:
+            warnings.warn(
+                "The 'as_index' argument in groupby is deprecated and "
+                "will be removed in a future version. "
+                "Use groupby(...).reset_index() instead.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
 
         return DataFrameGroupBy(
             obj=self,
@@ -14810,7 +14823,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -18310,7 +18323,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -18396,7 +18409,7 @@ class DataFrame(NDFrame, OpsMixin):
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -3271,7 +3271,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 medium     FR         0.25
         Name: proportion, dtype: float64
 
-        >>> df.groupby("gender", as_index=False).value_counts()
+        >>> df.groupby("gender").value_counts().reset_index()
            gender education country  count
         0  female      high      US      1
         1  female      high      FR      1
@@ -3279,7 +3279,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         3    male       low      US      1
         4    male    medium      FR      1
 
-        >>> df.groupby("gender", as_index=False).value_counts(normalize=True)
+        >>> df.groupby("gender").value_counts(normalize=True).reset_index()
            gender education country  proportion
         0  female      high      US        0.50
         1  female      high      FR        0.50

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4563,7 +4563,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 values = np.where(nulls, NA, grouper)  # type: ignore[call-overload]
                 grouper = Index(values, dtype="Int64", copy=False)
 
-        grb = dropped.groupby(grouper, as_index=self.as_index, sort=self.sort)
+        grb = dropped.groupby(grouper, sort=self.sort)
         return grb.nth(n)
 
     @final

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1998,7 +1998,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         self,
         by=None,
         level: IndexLabel | None = None,
-        as_index: bool = True,
+        as_index: bool | lib.NoDefault = lib.no_default,
         sort: bool = True,
         group_keys: bool = True,
         observed: bool = True,
@@ -2221,8 +2221,18 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         if level is None and by is None:
             raise TypeError("You have to supply one of 'by' and 'level'")
-        if not as_index:
-            raise TypeError("as_index=False only valid with DataFrame")
+        if as_index is not lib.no_default:
+            if not as_index:
+                raise TypeError("as_index=False only valid with DataFrame")
+            warnings.warn(
+                "The 'as_index' argument in groupby is deprecated and "
+                "will be removed in a future version. "
+                "Use groupby(...).reset_index() instead.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
+        else:
+            as_index = True
 
         return SeriesGroupBy(
             obj=self,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2037,6 +2037,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             such as ``head()``, ``tail()``, ``nth()`` and in transformations
             (see the `transformations in the user guide
             <https://pandas.pydata.org/docs/dev/user_guide/groupby.html#transformation>`_).
+
+            .. deprecated:: 3.1.0
+                The ``as_index`` argument is deprecated and will be removed in
+                a future version. Use ``groupby(...).reset_index()`` instead.
         sort : bool, default True
             Sort group keys. Get better performance by turning this off.
             Note this does not influence the order of observations within each
@@ -4434,7 +4438,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5341,7 +5345,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5423,7 +5427,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         """
         Assign desired index to given axis.
 
-        .. deprecated:: 3.0.0
+        .. deprecated:: 3.1.0
             This keyword is ignored and will be removed in pandas 4.0. Since
             pandas 3.0, this method always returns a new object using a lazy
             copy mechanism that defers copies until necessary
@@ -5513,7 +5517,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5766,7 +5770,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -6791,7 +6795,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -6868,7 +6872,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.0.0
+            .. deprecated:: 3.1.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4438,7 +4438,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5345,7 +5345,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5427,7 +5427,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         """
         Assign desired index to given axis.
 
-        .. deprecated:: 3.1.0
+        .. deprecated:: 3.0.0
             This keyword is ignored and will be removed in pandas 4.0. Since
             pandas 3.0, this method always returns a new object using a lazy
             copy mechanism that defers copies until necessary
@@ -5517,7 +5517,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -5770,7 +5770,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -6795,7 +6795,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy
@@ -6872,7 +6872,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             This keyword is now ignored; changing its value will have no
             impact on the method.
 
-            .. deprecated:: 3.1.0
+            .. deprecated:: 3.0.0
 
                 This keyword is ignored and will be removed in pandas 4.0. Since
                 pandas 3.0, this method always returns a new object using a lazy

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -43,8 +43,7 @@ class BaseGroupbyTests:
             #  (see data_for_grouping docstring)
             df = df.iloc[:-1]
 
-        warn = Pandas4Warning if not as_index else None
-        with tm.assert_produces_warning(warn, match="as_index"):
+        with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
             gb = df.groupby("B", as_index=as_index)
         result = gb.A.mean()
         _, uniques = pd.factorize(data_for_grouping, sort=True)

--- a/pandas/tests/extension/base/groupby.py
+++ b/pandas/tests/extension/base/groupby.py
@@ -2,6 +2,8 @@ import re
 
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_numeric_dtype,
@@ -41,7 +43,10 @@ class BaseGroupbyTests:
             #  (see data_for_grouping docstring)
             df = df.iloc[:-1]
 
-        result = df.groupby("B", as_index=as_index).A.mean()
+        warn = Pandas4Warning if not as_index else None
+        with tm.assert_produces_warning(warn, match="as_index"):
+            gb = df.groupby("B", as_index=as_index)
+        result = gb.A.mean()
         _, uniques = pd.factorize(data_for_grouping, sort=True)
 
         exp_vals = [3.0, 1.0, 4.0]

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -2,7 +2,6 @@
 test .agg behavior / note that .apply is tested generally in test_groupby.py
 """
 
-from contextlib import nullcontext
 import datetime
 import functools
 from functools import partial
@@ -1065,8 +1064,7 @@ def test_groupby_aggregate_empty_key_empty_return():
 def test_groupby_aggregate_empty_with_multiindex_frame_single(as_index):
     # GH 39178, 51445
     df = DataFrame(columns=["a", "b", "c"])
-    warn = Pandas4Warning if not as_index else None
-    with tm.assert_produces_warning(warn, match="as_index"):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(["a", "b"], group_keys=False, as_index=as_index)
     result = gb.agg(lambda x: x.sum())
     expected = DataFrame(
@@ -1080,11 +1078,7 @@ def test_groupby_aggregate_empty_with_multiindex_frame_single(as_index):
 def test_groupby_aggregate_empty_with_multiindex_frame_multi(as_index):
     # GH 39178
     df = DataFrame(columns=["a", "b", "c"])
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         result = df.groupby(["a", "b"], group_keys=False, as_index=as_index).agg(
             d=("c", list)
         )
@@ -1149,7 +1143,8 @@ def test_groupby_as_index_agg(df):
     expected2["D"] = grouped.sum()["D"]
     tm.assert_frame_equal(result2, expected2)
 
-    grouped = df.groupby("A", as_index=True)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("A", as_index=True)
 
     msg = r"nested renamer is not supported"
     with pytest.raises(SpecificationError, match=msg):
@@ -1190,7 +1185,8 @@ def test_groupby_as_index_agg(df):
             gr = df.groupby(ts, as_index=False)
         left = getattr(gr, attr)()
 
-        gr = df.groupby(ts.values, as_index=True)
+        with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+            gr = df.groupby(ts.values, as_index=True)
         right = getattr(gr, attr)().reset_index(drop=True)
 
         tm.assert_frame_equal(left, right)
@@ -1432,8 +1428,7 @@ class TestLambdaMangling:
 def test_pass_args_kwargs_duplicate_columns(tsframe, as_index):
     # go through _aggregate_frame with self.axis == 0 and duplicate columns
     tsframe.columns = ["A", "B", "A", "C"]
-    warn = Pandas4Warning if not as_index else None
-    with tm.assert_produces_warning(warn, match="as_index"):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = tsframe.groupby(lambda x: x.month, as_index=as_index)
 
     res = gb.agg(np.percentile, 80, axis=0)

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -2,6 +2,7 @@
 test .agg behavior / note that .apply is tested generally in test_groupby.py
 """
 
+from contextlib import nullcontext
 import datetime
 import functools
 from functools import partial
@@ -640,7 +641,8 @@ def test_ohlc_ea_dtypes(any_numeric_ea_dtype):
     )
     tm.assert_frame_equal(result, expected)
 
-    gb2 = df.groupby("a", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb2 = df.groupby("a", as_index=False)
     result2 = gb2.ohlc()
     expected2 = expected.reset_index()
     tm.assert_frame_equal(result2, expected2)
@@ -1063,7 +1065,9 @@ def test_groupby_aggregate_empty_key_empty_return():
 def test_groupby_aggregate_empty_with_multiindex_frame_single(as_index):
     # GH 39178, 51445
     df = DataFrame(columns=["a", "b", "c"])
-    gb = df.groupby(["a", "b"], group_keys=False, as_index=as_index)
+    warn = Pandas4Warning if not as_index else None
+    with tm.assert_produces_warning(warn, match="as_index"):
+        gb = df.groupby(["a", "b"], group_keys=False, as_index=as_index)
     result = gb.agg(lambda x: x.sum())
     expected = DataFrame(
         columns=["c"], index=MultiIndex([[], []], [[], []], names=["a", "b"])
@@ -1076,9 +1080,14 @@ def test_groupby_aggregate_empty_with_multiindex_frame_single(as_index):
 def test_groupby_aggregate_empty_with_multiindex_frame_multi(as_index):
     # GH 39178
     df = DataFrame(columns=["a", "b", "c"])
-    result = df.groupby(["a", "b"], group_keys=False, as_index=as_index).agg(
-        d=("c", list)
-    )
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        result = df.groupby(["a", "b"], group_keys=False, as_index=as_index).agg(
+            d=("c", list)
+        )
     expected = DataFrame(
         columns=["d"], index=MultiIndex([[], []], [[], []], names=["a", "b"])
     )
@@ -1096,7 +1105,8 @@ def test_groupby_agg_loses_results_with_as_index_false_relabel():
         {"key": ["x", "y", "z", "x", "y", "z"], "val": [1.0, 0.8, 2.0, 3.0, 3.6, 0.75]}
     )
 
-    grouped = df.groupby("key", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("key", as_index=False)
     result = grouped.agg(min_val=pd.NamedAgg(column="val", aggfunc="min"))
     expected = DataFrame({"key": ["x", "y", "z"], "min_val": [1.0, 0.8, 0.75]})
     tm.assert_frame_equal(result, expected)
@@ -1115,7 +1125,8 @@ def test_groupby_agg_loses_results_with_as_index_false_relabel_multiindex():
         }
     )
 
-    grouped = df.groupby(["key", "key1"], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby(["key", "key1"], as_index=False)
     result = grouped.agg(min_val=pd.NamedAgg(column="val", aggfunc="min"))
     expected = DataFrame(
         {"key": ["x", "x", "y"], "key1": ["a", "c", "b"], "min_val": [1.0, 0.75, 0.8]}
@@ -1124,7 +1135,8 @@ def test_groupby_agg_loses_results_with_as_index_false_relabel_multiindex():
 
 
 def test_groupby_as_index_agg(df):
-    grouped = df.groupby("A", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("A", as_index=False)
 
     # single-key
 
@@ -1145,7 +1157,8 @@ def test_groupby_as_index_agg(df):
 
     # multi-key
 
-    grouped = df.groupby(["A", "B"], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby(["A", "B"], as_index=False)
 
     result = grouped.agg("mean")
     expected = grouped.mean()
@@ -1173,7 +1186,8 @@ def test_groupby_as_index_agg(df):
     gr.nth(0)  # invokes set_selection_from_grouper internally
 
     for attr in ["mean", "max", "count", "idxmax", "cumsum", "all"]:
-        gr = df.groupby(ts, as_index=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+            gr = df.groupby(ts, as_index=False)
         left = getattr(gr, attr)()
 
         gr = df.groupby(ts.values, as_index=True)
@@ -1418,7 +1432,9 @@ class TestLambdaMangling:
 def test_pass_args_kwargs_duplicate_columns(tsframe, as_index):
     # go through _aggregate_frame with self.axis == 0 and duplicate columns
     tsframe.columns = ["A", "B", "A", "C"]
-    gb = tsframe.groupby(lambda x: x.month, as_index=as_index)
+    warn = Pandas4Warning if not as_index else None
+    with tm.assert_produces_warning(warn, match="as_index"):
+        gb = tsframe.groupby(lambda x: x.month, as_index=as_index)
 
     res = gb.agg(np.percentile, 80, axis=0)
 
@@ -1778,7 +1794,8 @@ def test_agg_groupings_selection():
 def test_agg_multiple_with_as_index_false_subset_to_a_single_column():
     # GH#50724
     df = DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]})
-    gb = df.groupby("a", as_index=False)["b"]
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby("a", as_index=False)["b"]
     result = gb.agg(["sum", "mean"])
     expected = DataFrame({"a": [1, 2], "sum": [7, 5], "mean": [3.5, 5.0]})
     tm.assert_frame_equal(result, expected)
@@ -1787,7 +1804,8 @@ def test_agg_multiple_with_as_index_false_subset_to_a_single_column():
 def test_agg_with_as_index_false_with_list():
     # GH#52849
     df = DataFrame({"a1": [0, 0, 1], "a2": [2, 3, 3], "b": [4, 5, 6]})
-    gb = df.groupby(by=["a1", "a2"], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby(by=["a1", "a2"], as_index=False)
     result = gb.agg(["sum"])
 
     expected = DataFrame(
@@ -2045,7 +2063,8 @@ def test_agg_lambda_pyarrow_struct_to_object_dtype_conversion():
 
 def test_groupby_aggregate_empty_builtin_sum():
     df = DataFrame(columns=["Group", "Data"])
-    result = df.groupby(["Group"], as_index=False)["Data"].agg("sum")
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(["Group"], as_index=False)["Data"].agg("sum")
     expected = DataFrame(columns=["Group", "Data"])
     tm.assert_frame_equal(result, expected)
 
@@ -2055,7 +2074,8 @@ def test_groupby_aggregate_empty_udf():
         return sum(x)
 
     df = DataFrame(columns=["Group", "Data"])
-    result = df.groupby(["Group"], as_index=False)["Data"].agg(func)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(["Group"], as_index=False)["Data"].agg(func)
     expected = DataFrame(columns=["Group", "Data"])
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -1,8 +1,13 @@
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
 
 from pandas.compat import is_platform_arm
-from pandas.errors import NumbaUtilError
+from pandas.errors import (
+    NumbaUtilError,
+    Pandas4Warning,
+)
 
 from pandas import (
     DataFrame,
@@ -106,7 +111,12 @@ def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, as_index):
         "nogil": nogil,
         "parallel": parallel,
     }
-    grouped = data.groupby(0, as_index=as_index)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        grouped = data.groupby(0, as_index=as_index)
     if frame_or_series is Series:
         grouped = grouped[1]
 

--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -111,11 +109,7 @@ def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, as_index):
         "nogil": nogil,
         "parallel": parallel,
     }
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         grouped = data.groupby(0, as_index=as_index)
     if frame_or_series is Series:
         grouped = grouped[1]

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -600,7 +600,8 @@ def test_agg_category_nansum(observed):
 def test_agg_list_like_func():
     # GH 18473
     df = DataFrame({"A": [str(x) for x in range(3)], "B": [str(x) for x in range(3)]})
-    grouped = df.groupby("A", as_index=False, sort=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("A", as_index=False, sort=False)
     result = grouped.agg({"B": lambda x: list(x)})
     expected = DataFrame(
         {"A": [str(x) for x in range(3)], "B": [[str(x)] for x in range(3)]}

--- a/pandas/tests/groupby/conftest.py
+++ b/pandas/tests/groupby/conftest.py
@@ -1,12 +1,15 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     DataFrame,
     Index,
     Series,
     date_range,
 )
+import pandas._testing as tm
 from pandas.core.groupby.base import (
     reduction_kernels,
     transformation_kernels,
@@ -110,7 +113,8 @@ def slice_test_df():
 
 @pytest.fixture
 def slice_test_grouped(slice_test_df):
-    return slice_test_df.groupby("Group", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        return slice_test_df.groupby("Group", as_index=False)
 
 
 @pytest.fixture(params=sorted(reduction_kernels))

--- a/pandas/tests/groupby/methods/test_describe.py
+++ b/pandas/tests/groupby/methods/test_describe.py
@@ -1,5 +1,9 @@
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
+
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 from pandas import (
@@ -49,7 +53,12 @@ def test_series_describe_as_index(as_index, keys):
             "foo2": [1, 2, 4, 4, 6],
         }
     )
-    gb = df.groupby(keys, as_index=as_index)["foo2"]
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(keys, as_index=as_index)["foo2"]
     result = gb.describe()
     expected = DataFrame(
         {
@@ -190,7 +199,12 @@ def test_describe_with_duplicate_output_column_names(as_index, keys):
     if not as_index:
         expected = expected.reset_index()
 
-    result = df.groupby(keys, as_index=as_index).describe()
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        result = df.groupby(keys, as_index=as_index).describe()
 
     tm.assert_frame_equal(result, expected)
 
@@ -240,7 +254,8 @@ def test_describe_non_cython_paths():
     result = gb.describe()
     tm.assert_frame_equal(result, expected)
 
-    gni = df.groupby("A", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gni = df.groupby("A", as_index=False)
     expected = expected.reset_index()
     result = gni.describe()
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/methods/test_describe.py
+++ b/pandas/tests/groupby/methods/test_describe.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -53,11 +51,7 @@ def test_series_describe_as_index(as_index, keys):
             "foo2": [1, 2, 4, 4, 6],
         }
     )
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(keys, as_index=as_index)["foo2"]
     result = gb.describe()
     expected = DataFrame(
@@ -199,11 +193,7 @@ def test_describe_with_duplicate_output_column_names(as_index, keys):
     if not as_index:
         expected = expected.reset_index()
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         result = df.groupby(keys, as_index=as_index).describe()
 
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/methods/test_nth.py
+++ b/pandas/tests/groupby/methods/test_nth.py
@@ -1,5 +1,9 @@
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
+
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 from pandas import (
@@ -96,7 +100,8 @@ def test_first_last_with_None(method):
     # https://github.com/pandas-dev/pandas/issues/32800
     # None should be preserved as object dtype
     df = DataFrame.from_dict({"id": ["a"], "value": [None]})
-    groups = df.groupby("id", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        groups = df.groupby("id", as_index=False)
     result = getattr(groups, method)()
 
     tm.assert_frame_equal(result, df)
@@ -241,11 +246,13 @@ def test_nth2():
         }
     ).set_index(["color", "food"])
 
-    result = df.groupby(level=0, as_index=False).nth(2)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(level=0, as_index=False).nth(2)
     expected = df.iloc[[-1]]
     tm.assert_frame_equal(result, expected)
 
-    result = df.groupby(level=0, as_index=False).nth(3)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(level=0, as_index=False).nth(3)
     expected = df.loc[[]]
     tm.assert_frame_equal(result, expected)
 
@@ -302,7 +309,8 @@ def test_nth_bdays(unit):
     df = DataFrame(1, index=business_dates, columns=["a", "b"])
     # get the first, fourth and last two business days for each month
     key = [df.index.year, df.index.month]
-    result = df.groupby(key, as_index=False).nth([0, 3, -2, -1])
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(key, as_index=False).nth([0, 3, -2, -1])
     expected_dates = pd.to_datetime(
         [
             "2014/4/1",
@@ -388,20 +396,24 @@ def test_first_last_tz(data, expected_first, expected_last):
 
     df = DataFrame(data)
 
-    result = df.groupby("id", as_index=False).first()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby("id", as_index=False).first()
     expected = DataFrame(expected_first)
     cols = ["id", "time", "foo"]
     tm.assert_frame_equal(result[cols], expected[cols])
 
-    result = df.groupby("id", as_index=False)["time"].first()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby("id", as_index=False)["time"].first()
     tm.assert_frame_equal(result, expected[["id", "time"]])
 
-    result = df.groupby("id", as_index=False).last()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby("id", as_index=False).last()
     expected = DataFrame(expected_last)
     cols = ["id", "time", "foo"]
     tm.assert_frame_equal(result[cols], expected[cols])
 
-    result = df.groupby("id", as_index=False)["time"].last()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby("id", as_index=False)["time"].last()
     tm.assert_frame_equal(result, expected[["id", "time"]])
 
 
@@ -531,7 +543,12 @@ def test_nth_multi_index_as_expected():
 @pytest.mark.parametrize("columns", [None, [], ["A"], ["B"], ["A", "B"]])
 def test_groupby_head_tail(op, n, expected_rows, columns, as_index):
     df = DataFrame([[1, 2], [1, 4], [5, 6]], columns=["A", "B"])
-    g = df.groupby("A", as_index=as_index)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        g = df.groupby("A", as_index=as_index)
     expected = df.iloc[expected_rows]
     if columns is not None:
         g = g[columns]

--- a/pandas/tests/groupby/methods/test_nth.py
+++ b/pandas/tests/groupby/methods/test_nth.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -543,11 +541,7 @@ def test_nth_multi_index_as_expected():
 @pytest.mark.parametrize("columns", [None, [], ["A"], ["B"], ["A", "B"]])
 def test_groupby_head_tail(op, n, expected_rows, columns, as_index):
     df = DataFrame([[1, 2], [1, 4], [5, 6]], columns=["A", "B"])
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         g = df.groupby("A", as_index=as_index)
     expected = df.iloc[expected_rows]
     if columns is not None:

--- a/pandas/tests/groupby/methods/test_size.py
+++ b/pandas/tests/groupby/methods/test_size.py
@@ -1,5 +1,9 @@
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
+
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     DataFrame,
@@ -53,7 +57,12 @@ def test_size_period_index():
 def test_size_on_categorical(as_index):
     df = DataFrame([[1, 1], [2, 2]], columns=["A", "B"])
     df["A"] = df["A"].astype("category")
-    result = df.groupby(["A", "B"], as_index=as_index, observed=False).size()
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        result = df.groupby(["A", "B"], as_index=as_index, observed=False).size()
 
     expected = DataFrame(
         [[1, 1, 1], [1, 2, 0], [2, 1, 0], [2, 2, 1]], columns=["A", "B", "size"]

--- a/pandas/tests/groupby/methods/test_size.py
+++ b/pandas/tests/groupby/methods/test_size.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -57,11 +55,7 @@ def test_size_period_index():
 def test_size_on_categorical(as_index):
     df = DataFrame([[1, 1], [2, 2]], columns=["A", "B"])
     df["A"] = df["A"].astype("category")
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         result = df.groupby(["A", "B"], as_index=as_index, observed=False).size()
 
     expected = DataFrame(

--- a/pandas/tests/groupby/methods/test_value_counts.py
+++ b/pandas/tests/groupby/methods/test_value_counts.py
@@ -4,8 +4,12 @@ with different size combinations. This is to ensure stability of the sorting
 and proper parameter handling
 """
 
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
+
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     Categorical,
@@ -296,7 +300,12 @@ def test_against_frame_and_seriesgroupby(
         "function": lambda x: education_df["country"][x] == "US",
     }[groupby]
 
-    gp = education_df.groupby(by=by, as_index=as_index)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gp = education_df.groupby(by=by, as_index=as_index)
     result = gp[["gender", "education"]].value_counts(
         normalize=normalize, sort=sort, ascending=ascending
     )
@@ -374,7 +383,8 @@ def test_compound(
     education_df = education_df.astype(dtype)
     education_df.columns = education_df.columns.astype(dtype)
     # Multiple groupby keys and as_index=False
-    gp = education_df.groupby(["country", "gender"], as_index=False, sort=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gp = education_df.groupby(["country", "gender"], as_index=False, sort=False)
     result = gp["education"].value_counts(
         normalize=normalize, sort=sort, ascending=ascending
     )
@@ -560,9 +570,14 @@ def test_categorical_single_grouper_with_only_observed_categories(
     # Test single categorical grouper with only observed grouping categories
     # when non-groupers are also categorical
 
-    gp = education_df.astype("category").groupby(
-        "country", as_index=as_index, observed=observed
-    )
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gp = education_df.astype("category").groupby(
+            "country", as_index=as_index, observed=observed
+        )
     result = gp.value_counts(normalize=normalize)
 
     expected_index = MultiIndex.from_tuples(
@@ -611,7 +626,12 @@ def assert_categorical_single_grouper(
     # Add non-observed grouping categories
     education_df["country"] = education_df["country"].cat.add_categories(["ASIA"])
 
-    gp = education_df.groupby("country", as_index=as_index, observed=observed)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gp = education_df.groupby("country", as_index=as_index, observed=observed)
     result = gp.value_counts(normalize=normalize)
 
     expected_series = Series(
@@ -816,9 +836,14 @@ def test_categorical_multiple_groupers(
     education_df["country"] = education_df["country"].astype("category")
     education_df["education"] = education_df["education"].astype("category")
 
-    gp = education_df.groupby(
-        ["country", "education"], as_index=as_index, observed=observed
-    )
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gp = education_df.groupby(
+            ["country", "education"], as_index=as_index, observed=observed
+        )
     result = gp.value_counts(normalize=normalize)
 
     expected_series = Series(
@@ -870,7 +895,12 @@ def test_categorical_non_groupers(
     education_df["gender"] = education_df["gender"].astype("category")
     education_df["education"] = education_df["education"].astype("category")
 
-    gp = education_df.groupby("country", as_index=as_index, observed=observed)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gp = education_df.groupby("country", as_index=as_index, observed=observed)
     result = gp.value_counts(normalize=normalize)
 
     expected_index = [
@@ -919,7 +949,8 @@ def test_categorical_non_groupers(
 def test_mixed_groupings(normalize, expected_label, expected_values):
     # Test multiple groupings
     df = DataFrame({"A": [1, 2, 1], "B": [1, 2, 3]})
-    gp = df.groupby([[4, 5, 4], "A", lambda i: 7 if i == 1 else 8], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gp = df.groupby([[4, 5, 4], "A", lambda i: 7 if i == 1 else 8], as_index=False)
     result = gp.value_counts(sort=True, normalize=normalize)
     expected = DataFrame(
         {
@@ -946,7 +977,12 @@ def test_column_label_duplicates(test, columns, expected_names, as_index):
     df = DataFrame([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]], columns=columns)
     expected_data = [(1, 0, 7, 3, 5, 9), (2, 1, 8, 4, 6, 10)]
     keys = ["a", np.array([0, 1], dtype=np.int64), "d"]
-    result = df.groupby(keys, as_index=as_index).value_counts()
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        result = df.groupby(keys, as_index=as_index).value_counts()
     if as_index:
         expected = Series(
             data=(1, 1),
@@ -975,9 +1011,10 @@ def test_column_label_duplicates(test, columns, expected_names, as_index):
 )
 def test_result_label_duplicates(normalize, expected_label):
     # Test for result column label duplicating an input column label
-    gb = DataFrame([[1, 2, 3]], columns=["a", "b", expected_label]).groupby(
-        "a", as_index=False
-    )
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = DataFrame([[1, 2, 3]], columns=["a", "b", expected_label]).groupby(
+            "a", as_index=False
+        )
     msg = f"Column label '{expected_label}' is duplicate of result column"
     with pytest.raises(ValueError, match=msg):
         gb.value_counts(normalize=normalize)
@@ -1077,7 +1114,8 @@ def test_value_counts_time_grouper(utc, unit):
 def test_value_counts_integer_columns():
     # GH#55627
     df = DataFrame({1: ["a", "a", "a"], 2: ["a", "a", "d"], 3: ["a", "b", "c"]})
-    gp = df.groupby([1, 2], as_index=False, sort=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gp = df.groupby([1, 2], as_index=False, sort=False)
     result = gp[3].value_counts()
     expected = DataFrame(
         {1: ["a", "a", "a"], 2: ["a", "a", "d"], 3: ["a", "b", "c"], "count": 1}

--- a/pandas/tests/groupby/methods/test_value_counts.py
+++ b/pandas/tests/groupby/methods/test_value_counts.py
@@ -4,8 +4,6 @@ with different size combinations. This is to ensure stability of the sorting
 and proper parameter handling
 """
 
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -300,11 +298,7 @@ def test_against_frame_and_seriesgroupby(
         "function": lambda x: education_df["country"][x] == "US",
     }[groupby]
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gp = education_df.groupby(by=by, as_index=as_index)
     result = gp[["gender", "education"]].value_counts(
         normalize=normalize, sort=sort, ascending=ascending
@@ -570,11 +564,7 @@ def test_categorical_single_grouper_with_only_observed_categories(
     # Test single categorical grouper with only observed grouping categories
     # when non-groupers are also categorical
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gp = education_df.astype("category").groupby(
             "country", as_index=as_index, observed=observed
         )
@@ -626,11 +616,7 @@ def assert_categorical_single_grouper(
     # Add non-observed grouping categories
     education_df["country"] = education_df["country"].cat.add_categories(["ASIA"])
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gp = education_df.groupby("country", as_index=as_index, observed=observed)
     result = gp.value_counts(normalize=normalize)
 
@@ -836,11 +822,7 @@ def test_categorical_multiple_groupers(
     education_df["country"] = education_df["country"].astype("category")
     education_df["education"] = education_df["education"].astype("category")
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gp = education_df.groupby(
             ["country", "education"], as_index=as_index, observed=observed
         )
@@ -895,11 +877,7 @@ def test_categorical_non_groupers(
     education_df["gender"] = education_df["gender"].astype("category")
     education_df["education"] = education_df["education"].astype("category")
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gp = education_df.groupby("country", as_index=as_index, observed=observed)
     result = gp.value_counts(normalize=normalize)
 
@@ -977,11 +955,7 @@ def test_column_label_duplicates(test, columns, expected_names, as_index):
     df = DataFrame([[1, 3, 5, 7, 9], [2, 4, 6, 8, 10]], columns=columns)
     expected_data = [(1, 0, 7, 3, 5, 9), (2, 1, 8, 4, 6, 10)]
     keys = ["a", np.array([0, 1], dtype=np.int64), "d"]
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         result = df.groupby(keys, as_index=as_index).value_counts()
     if as_index:
         expected = Series(

--- a/pandas/tests/groupby/test_all_methods.py
+++ b/pandas/tests/groupby/test_all_methods.py
@@ -11,6 +11,8 @@ such as:
  - test_raises
 """
 
+from contextlib import nullcontext
+
 import pytest
 
 from pandas.errors import Pandas4Warning
@@ -46,12 +48,22 @@ def test_duplicate_columns(request, groupby_func, as_index):
         request.applymarker(pytest.mark.xfail(reason=msg))
     df = DataFrame([[1, 3, 6], [1, 4, 7], [2, 5, 8]], columns=list("abb"))
     args = get_groupby_method_args(groupby_func, df)
-    gb = df.groupby("a", as_index=as_index)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby("a", as_index=as_index)
     result = getattr(gb, groupby_func)(*args)
 
     expected_df = df.set_axis(["a", "b", "c"], axis=1)
     expected_args = get_groupby_method_args(groupby_func, expected_df)
-    expected_gb = expected_df.groupby("a", as_index=as_index)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        expected_gb = expected_df.groupby("a", as_index=as_index)
     expected = getattr(expected_gb, groupby_func)(*expected_args)
     if groupby_func not in ("size", "ngroup", "cumcount"):
         expected = expected.rename(columns={"c": "b"})

--- a/pandas/tests/groupby/test_all_methods.py
+++ b/pandas/tests/groupby/test_all_methods.py
@@ -11,8 +11,6 @@ such as:
  - test_raises
 """
 
-from contextlib import nullcontext
-
 import pytest
 
 from pandas.errors import Pandas4Warning
@@ -48,21 +46,13 @@ def test_duplicate_columns(request, groupby_func, as_index):
         request.applymarker(pytest.mark.xfail(reason=msg))
     df = DataFrame([[1, 3, 6], [1, 4, 7], [2, 5, 8]], columns=list("abb"))
     args = get_groupby_method_args(groupby_func, df)
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby("a", as_index=as_index)
     result = getattr(gb, groupby_func)(*args)
 
     expected_df = df.set_axis(["a", "b", "c"], axis=1)
     expected_args = get_groupby_method_args(groupby_func, expected_df)
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         expected_gb = expected_df.groupby("a", as_index=as_index)
     expected = getattr(expected_gb, groupby_func)(*expected_args)
     if groupby_func not in ("size", "ngroup", "cumcount"):

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from datetime import (
     date,
     datetime,
@@ -281,7 +282,8 @@ def test_apply_with_mixed_dtype():
     df = DataFrame({"c1": [1, 2, 6, 6, 8]})
     df["c2"] = df.c1 / 2.0
     result1 = df.groupby("c2").mean().reset_index()
-    result2 = df.groupby("c2", as_index=False).mean()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result2 = df.groupby("c2", as_index=False).mean()
     tm.assert_frame_equal(result1, result2)
 
 
@@ -294,7 +296,12 @@ def test_groupby_as_index_apply(as_index):
             "time": range(6),
         }
     )
-    gb = df.groupby("user_id", as_index=as_index)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby("user_id", as_index=as_index)
 
     expected = DataFrame(
         {
@@ -328,7 +335,8 @@ def test_groupby_as_index_apply(as_index):
 def test_groupby_as_index_apply_str():
     ind = Index(list("abcde"))
     df = DataFrame([[1, 2], [2, 3], [1, 4], [1, 5], [2, 6]], index=ind)
-    res = df.groupby(0, as_index=False, group_keys=False).apply(lambda x: x).index
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        res = df.groupby(0, as_index=False, group_keys=False).apply(lambda x: x).index
     tm.assert_index_equal(res, ind)
 
 
@@ -412,7 +420,8 @@ def test_apply_frame_to_series(df):
 
 def test_apply_frame_not_as_index_column_name(df):
     # GH 35964 - path within _wrap_applied_output not hit by a test
-    grouped = df.groupby(["A", "B"], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby(["A", "B"], as_index=False)
     result = grouped.apply(len)
     expected = grouped.count().rename(columns={"C": np.nan}).drop(columns="D")
     # TODO(GH#34306): Use assert_frame_equal when column name is not np.nan
@@ -1032,7 +1041,8 @@ def test_apply_function_with_indexing_return_column():
             "foo2": [1, 2, 4, 4, 5, 6],
         }
     )
-    result = df.groupby("foo1", as_index=False).apply(lambda x: x.mean())
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby("foo1", as_index=False).apply(lambda x: x.mean())
     expected = DataFrame(
         {
             "foo1": ["one", "three", "two"],
@@ -1187,7 +1197,12 @@ def test_apply_dropna_with_indexed_same(dropna):
 def test_apply_as_index_constant_lambda(as_index, expected):
     # GH 13217
     df = DataFrame({"a": [1, 1, 2, 2], "b": [1, 1, 2, 2], "c": [1, 1, 1, 1]})
-    result = df.groupby(["a", "b"], as_index=as_index).apply(lambda x: 1)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        result = df.groupby(["a", "b"], as_index=as_index).apply(lambda x: 1)
     tm.assert_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext
 from datetime import (
     date,
     datetime,
@@ -296,11 +295,7 @@ def test_groupby_as_index_apply(as_index):
             "time": range(6),
         }
     )
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby("user_id", as_index=as_index)
 
     expected = DataFrame(
@@ -1197,11 +1192,7 @@ def test_apply_dropna_with_indexed_same(dropna):
 def test_apply_as_index_constant_lambda(as_index, expected):
     # GH 13217
     df = DataFrame({"a": [1, 1, 2, 2], "b": [1, 1, 2, 2], "c": [1, 1, 1, 1]})
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         result = df.groupby(["a", "b"], as_index=as_index).apply(lambda x: 1)
     tm.assert_equal(result, expected)
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from datetime import datetime
 
 import numpy as np
@@ -445,8 +446,9 @@ def test_observed_with_as_index(observed):
     df = DataFrame(d)
     cat = pd.cut(df["foo"], np.linspace(0, 10, 3))
     df["range"] = cat
-    groups = df.groupby(["range", "baz"], as_index=False, observed=observed)
-    result = groups.agg("mean")
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        groups = df.groupby(["range", "baz"], as_index=False, observed=observed)
+        result = groups.agg("mean")
 
     groups2 = df.groupby(["range", "baz"], as_index=True, observed=observed)
     expected = groups2.agg("mean").reset_index()
@@ -809,7 +811,8 @@ def test_as_index():
             "B": [101, 102, 103],
         }
     )
-    result = df.groupby(["cat", "A"], as_index=False, observed=True).sum()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(["cat", "A"], as_index=False, observed=True).sum()
     expected = DataFrame(
         {
             "cat": Categorical([1, 2], categories=df.cat.cat.categories),
@@ -822,7 +825,8 @@ def test_as_index():
 
     # function grouper
     f = lambda r: df.loc[r, "A"]
-    result = df.groupby(["cat", f], as_index=False, observed=True).sum()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(["cat", f], as_index=False, observed=True).sum()
     expected = DataFrame(
         {
             "cat": Categorical([1, 2], categories=df.cat.cat.categories),
@@ -835,7 +839,8 @@ def test_as_index():
 
     # another not in-axis grouper (conflicting names in index)
     s = Series(["a", "b", "b"], name="cat")
-    result = df.groupby(["cat", s], as_index=False, observed=True).sum()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(["cat", s], as_index=False, observed=True).sum()
     expected = DataFrame(
         {
             "cat": ["a", "b"],
@@ -858,7 +863,8 @@ def test_as_index():
 
     for name in [None, "X", "B"]:
         df.index = Index(list("abc"), name=name)
-        result = df.groupby(group_columns, as_index=False, observed=True).sum()
+        with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+            result = df.groupby(group_columns, as_index=False, observed=True).sum()
 
         tm.assert_frame_equal(result, expected)
 
@@ -916,7 +922,10 @@ def test_preserve_categorical_dtype(col):
             "C2": Categorical(list("bac"), categories=list("bac"), ordered=True),
         }
     )
-    result1 = df.groupby(by=col, as_index=False, observed=False).mean(numeric_only=True)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result1 = df.groupby(by=col, as_index=False, observed=False).mean(
+            numeric_only=True
+        )
     result2 = (
         df.groupby(by=col, as_index=True, observed=False)
         .mean(numeric_only=True)
@@ -1224,7 +1233,12 @@ def test_groupby_agg_observed_true_single_column(as_index, expected):
         {"a": Series([1, 1, 2], dtype="category"), "b": [1, 2, 2], "x": [1, 2, 3]}
     )
 
-    result = df.groupby(["a", "b"], as_index=as_index, observed=True)["x"].sum()
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        result = df.groupby(["a", "b"], as_index=as_index, observed=True)["x"].sum()
 
     tm.assert_equal(result, expected)
 
@@ -1932,7 +1946,12 @@ def test_category_order_reducer(
         df["a2"] = df["a"]
         df = df.set_index(keys)
     args = get_groupby_method_args(reduction_func, df)
-    gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
 
     if not observed and reduction_func in ["idxmin", "idxmax"]:
         # idxmin and idxmax are designed to fail on empty inputs
@@ -1981,7 +2000,12 @@ def test_category_order_transformer(
         df["a2"] = df["a"]
         df = df.set_index(keys)
     args = get_groupby_method_args(transformation_func, df)
-    gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
     op_result = getattr(gb, transformation_func)(*args)
     result = op_result.index.get_level_values("a").categories
     expected = Index([1, 4, 3, 2])
@@ -2014,7 +2038,12 @@ def test_category_order_head_tail(
         keys = ["a", "a2"]
         df["a2"] = df["a"]
         df = df.set_index(keys)
-    gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
     op_result = getattr(gb, method)()
     if index_kind == "range":
         result = op_result["a"].cat.categories
@@ -2052,7 +2081,12 @@ def test_category_order_apply(as_index, sort, observed, method, index_kind, orde
         keys = ["a", "a2"]
         df["a2"] = df["a"]
         df = df.set_index(keys)
-    gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
     op_result = getattr(gb, method)(lambda x: x.sum(numeric_only=True))
     if (method == "transform" or not as_index) and index_kind == "range":
         result = op_result["a"].cat.categories
@@ -2083,7 +2117,12 @@ def test_many_categories(as_index, sort, index_kind, ordered):
         keys = ["a", "a2"]
         df["a2"] = df["a"]
         df = df.set_index(keys)
-    gb = df.groupby(keys, as_index=as_index, sort=sort, observed=True)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(keys, as_index=as_index, sort=sort, observed=True)
     result = gb.sum()
 
     # Test is setup so that data and index are the same values
@@ -2121,7 +2160,12 @@ def test_agg_list(request, as_index, observed, reduction_func, test_series, keys
     df = df.astype({"a1": "category", "a2": "category"})
     if "a2" not in keys:
         df = df.drop(columns="a2")
-    gb = df.groupby(by=keys, as_index=as_index, observed=observed)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(by=keys, as_index=as_index, observed=observed)
     if test_series:
         gb = gb["b"]
     args = get_groupby_method_args(reduction_func, df)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext
 from datetime import datetime
 
 import numpy as np
@@ -450,7 +449,8 @@ def test_observed_with_as_index(observed):
         groups = df.groupby(["range", "baz"], as_index=False, observed=observed)
         result = groups.agg("mean")
 
-    groups2 = df.groupby(["range", "baz"], as_index=True, observed=observed)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        groups2 = df.groupby(["range", "baz"], as_index=True, observed=observed)
     expected = groups2.agg("mean").reset_index()
     tm.assert_frame_equal(result, expected)
 
@@ -926,11 +926,9 @@ def test_preserve_categorical_dtype(col):
         result1 = df.groupby(by=col, as_index=False, observed=False).mean(
             numeric_only=True
         )
-    result2 = (
-        df.groupby(by=col, as_index=True, observed=False)
-        .mean(numeric_only=True)
-        .reset_index()
-    )
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby(by=col, as_index=True, observed=False)
+    result2 = gb.mean(numeric_only=True).reset_index()
     expected = exp_full.reindex(columns=result1.columns)
     tm.assert_frame_equal(result1, expected)
     tm.assert_frame_equal(result2, expected)
@@ -1233,11 +1231,7 @@ def test_groupby_agg_observed_true_single_column(as_index, expected):
         {"a": Series([1, 1, 2], dtype="category"), "b": [1, 2, 2], "x": [1, 2, 3]}
     )
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         result = df.groupby(["a", "b"], as_index=as_index, observed=True)["x"].sum()
 
     tm.assert_equal(result, expected)
@@ -1579,7 +1573,8 @@ def test_series_groupby_categorical_aggregation_getitem():
     df = DataFrame(d)
     cat = pd.cut(df["foo"], np.linspace(0, 20, 5))
     df["range"] = cat
-    groups = df.groupby(["range", "baz"], as_index=True, sort=True, observed=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        groups = df.groupby(["range", "baz"], as_index=True, sort=True, observed=False)
     result = groups["foo"].agg("mean")
     expected = groups.agg("mean")["foo"]
     tm.assert_series_equal(result, expected)
@@ -1946,11 +1941,7 @@ def test_category_order_reducer(
         df["a2"] = df["a"]
         df = df.set_index(keys)
     args = get_groupby_method_args(reduction_func, df)
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
 
     if not observed and reduction_func in ["idxmin", "idxmax"]:
@@ -2000,11 +1991,7 @@ def test_category_order_transformer(
         df["a2"] = df["a"]
         df = df.set_index(keys)
     args = get_groupby_method_args(transformation_func, df)
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
     op_result = getattr(gb, transformation_func)(*args)
     result = op_result.index.get_level_values("a").categories
@@ -2038,11 +2025,7 @@ def test_category_order_head_tail(
         keys = ["a", "a2"]
         df["a2"] = df["a"]
         df = df.set_index(keys)
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
     op_result = getattr(gb, method)()
     if index_kind == "range":
@@ -2081,11 +2064,7 @@ def test_category_order_apply(as_index, sort, observed, method, index_kind, orde
         keys = ["a", "a2"]
         df["a2"] = df["a"]
         df = df.set_index(keys)
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(keys, as_index=as_index, sort=sort, observed=observed)
     op_result = getattr(gb, method)(lambda x: x.sum(numeric_only=True))
     if (method == "transform" or not as_index) and index_kind == "range":
@@ -2117,11 +2096,7 @@ def test_many_categories(as_index, sort, index_kind, ordered):
         keys = ["a", "a2"]
         df["a2"] = df["a"]
         df = df.set_index(keys)
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(keys, as_index=as_index, sort=sort, observed=True)
     result = gb.sum()
 
@@ -2160,11 +2135,7 @@ def test_agg_list(request, as_index, observed, reduction_func, test_series, keys
     df = df.astype({"a1": "category", "a2": "category"})
     if "a2" not in keys:
         df = df.drop(columns="a2")
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(by=keys, as_index=as_index, observed=observed)
     if test_series:
         gb = gb["b"]

--- a/pandas/tests/groupby/test_counting.py
+++ b/pandas/tests/groupby/test_counting.py
@@ -4,6 +4,8 @@ from string import ascii_lowercase
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     DataFrame,
     Index,
@@ -302,7 +304,8 @@ def test_count_non_nulls():
     )
 
     count_as = df.groupby("A").count()
-    count_not_as = df.groupby("A", as_index=False).count()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        count_not_as = df.groupby("A", as_index=False).count()
 
     expected = DataFrame([[1, 2], [0, 0]], columns=["B", "C"], index=[1, 3])
     expected.index.name = "A"

--- a/pandas/tests/groupby/test_cumulative.py
+++ b/pandas/tests/groupby/test_cumulative.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -364,10 +362,6 @@ def test_cython_api2(as_index):
     # GH 5755 - cumsum is a transformer and should ignore as_index
     df = DataFrame([[1, 2, np.nan], [1, np.nan, 9], [3, 4, 9]], columns=["A", "B", "C"])
     expected = DataFrame([[2, np.nan], [np.nan, 9], [4, 9]], columns=["B", "C"])
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         result = df.groupby("A", as_index=as_index).cumsum()
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_cumulative.py
+++ b/pandas/tests/groupby/test_cumulative.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
 
@@ -362,5 +364,10 @@ def test_cython_api2(as_index):
     # GH 5755 - cumsum is a transformer and should ignore as_index
     df = DataFrame([[1, 2, np.nan], [1, np.nan, 9], [3, 4, 9]], columns=["A", "B", "C"])
     expected = DataFrame([[2, np.nan], [np.nan, 9], [4, 9]], columns=["B", "C"])
-    result = df.groupby("A", as_index=as_index).cumsum()
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        result = df.groupby("A", as_index=as_index).cumsum()
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -104,7 +104,9 @@ def test_pass_args_kwargs_dataframe(tsframe, as_index):
     def f(x, q=None, axis=0):
         return np.percentile(x, q, axis=axis)
 
-    df_grouped = tsframe.groupby(lambda x: x.month, as_index=as_index)
+    warn = Pandas4Warning if not as_index else None
+    with tm.assert_produces_warning(warn, match="as_index"):
+        df_grouped = tsframe.groupby(lambda x: x.month, as_index=as_index)
     agg_result = df_grouped.agg(np.percentile, 80, axis=0)
     apply_result = df_grouped.apply(DataFrame.quantile, 0.8)
     expected = df_grouped.quantile(0.8)
@@ -316,7 +318,9 @@ def test_frame_set_name_single(df):
     result = grouped.mean(numeric_only=True)
     assert result.index.name == "A"
 
-    result = df.groupby("A", as_index=False).mean(numeric_only=True)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby("A", as_index=False)
+    result = gb.mean(numeric_only=True)
     assert result.index.name != "A"
 
     result = grouped[["C", "D"]].agg("mean")
@@ -514,13 +518,15 @@ def test_groupby_multiple_columns(df, op):
 def test_as_index_select_column():
     # GH 5764
     df = DataFrame([[1, 2], [1, 4], [5, 6]], columns=["A", "B"])
-    result = df.groupby("A", as_index=False)["B"].get_group(1)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby("A", as_index=False)
+    result = gb["B"].get_group(1)
     expected = Series([2, 4], name="B")
     tm.assert_series_equal(result, expected)
 
-    result = df.groupby("A", as_index=False, group_keys=True)["B"].apply(
-        lambda x: x.cumsum()
-    )
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby("A", as_index=False, group_keys=True)
+    result = gb["B"].apply(lambda x: x.cumsum())
     expected = Series([2, 6, 6], name="B", index=range(3))
     tm.assert_series_equal(result, expected)
 
@@ -528,7 +534,9 @@ def test_as_index_select_column():
 def test_groupby_as_index_select_column_sum_empty_df():
     # GH 35246
     df = DataFrame(columns=Index(["A", "B", "C"], name="alpha"))
-    left = df.groupby(by="A", as_index=False)["B"].sum(numeric_only=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby(by="A", as_index=False)
+    left = gb["B"].sum(numeric_only=False)
 
     expected = DataFrame(columns=df.columns[:2], index=range(0))
     # GH#50744 - Columns after selection shouldn't retain names
@@ -555,7 +563,8 @@ def test_ops_not_as_index(reduction_func):
         # 32 bit compat -> groupby preserves dtype whereas reset_index casts to int64
         expected["a"] = expected["a"].astype(df["a"].dtype)
 
-    g = df.groupby("a", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        g = df.groupby("a", as_index=False)
 
     result = getattr(g, reduction_func)()
     tm.assert_frame_equal(result, expected)
@@ -571,8 +580,10 @@ def test_ops_not_as_index(reduction_func):
 
 
 def test_as_index_series_return_frame(df):
-    grouped = df.groupby("A", as_index=False)
-    grouped2 = df.groupby(["A", "B"], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("A", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped2 = df.groupby(["A", "B"], as_index=False)
 
     result = grouped["C"].agg("sum")
     expected = grouped.agg("sum").loc[:, ["A", "C"]]
@@ -597,7 +608,8 @@ def test_as_index_series_return_frame(df):
 
 def test_as_index_series_column_slice_raises(df):
     # GH15072
-    grouped = df.groupby("A", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("A", as_index=False)
     msg = r"Column\(s\) C already selected"
 
     with pytest.raises(IndexError, match=msg):
@@ -608,7 +620,8 @@ def test_groupby_as_index_cython(df):
     data = df
 
     # single-key
-    grouped = data.groupby("A", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = data.groupby("A", as_index=False)
     result = grouped.mean(numeric_only=True)
     expected = data.groupby(["A"]).mean(numeric_only=True)
     expected.insert(0, "A", expected.index)
@@ -616,7 +629,8 @@ def test_groupby_as_index_cython(df):
     tm.assert_frame_equal(result, expected)
 
     # multi-key
-    grouped = data.groupby(["A", "B"], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = data.groupby(["A", "B"], as_index=False)
     result = grouped.mean()
     expected = data.groupby(["A", "B"]).mean()
 
@@ -628,7 +642,8 @@ def test_groupby_as_index_cython(df):
 
 
 def test_groupby_as_index_series_scalar(df):
-    grouped = df.groupby(["A", "B"], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby(["A", "B"], as_index=False)
 
     # GH #421
 
@@ -1005,12 +1020,16 @@ def test_groupby_wrong_multi_labels():
 
 def test_groupby_series_with_name(df):
     result = df.groupby(df["A"]).mean(numeric_only=True)
-    result2 = df.groupby(df["A"], as_index=False).mean(numeric_only=True)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb2 = df.groupby(df["A"], as_index=False)
+    result2 = gb2.mean(numeric_only=True)
     assert result.index.name == "A"
     assert "A" in result2
 
     result = df.groupby([df["A"], df["B"]]).mean()
-    result2 = df.groupby([df["A"], df["B"]], as_index=False).mean()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb2 = df.groupby([df["A"], df["B"]], as_index=False)
+    result2 = gb2.mean()
     assert result.index.names == ("A", "B")
     assert "A" in result2
     assert "B" in result2
@@ -2196,7 +2215,9 @@ def test_subsetting_columns_keeps_attrs(klass, attr, value):
     if attr != "axis":
         df = df.set_index("a")
 
-    expected = df.groupby("a", **{attr: value})
+    warn = Pandas4Warning if attr == "as_index" else None
+    with tm.assert_produces_warning(warn, match="as_index"):
+        expected = df.groupby("a", **{attr: value})
     result = expected[["b"]] if klass is DataFrame else expected["b"]
     assert getattr(result, attr) == getattr(expected, attr)
 
@@ -2321,7 +2342,9 @@ def test_groupby_all_nan_groups_drop():
 def test_groupby_empty_multi_column(as_index, numeric_only):
     # GH 15106 & GH 41998
     df = DataFrame(data=[], columns=["A", "B", "C"])
-    gb = df.groupby(["A", "B"], as_index=as_index)
+    warn = Pandas4Warning if not as_index else None
+    with tm.assert_produces_warning(warn, match="as_index"):
+        gb = df.groupby(["A", "B"], as_index=as_index)
     result = gb.sum(numeric_only=numeric_only)
     if as_index:
         index = MultiIndex([[], []], [[], []], names=["A", "B"])
@@ -2524,7 +2547,8 @@ def test_groupby_string_dtype():
         }
     )
     expected["str_col"] = expected["str_col"].astype("string")
-    grouped = df.groupby("str_col", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("str_col", as_index=False)
     result = grouped.mean()
     tm.assert_frame_equal(result, expected)
 
@@ -2715,7 +2739,8 @@ def test_groupby_numeric_only_std_no_result(numeric_only):
     # GH 51080
     dicts_non_numeric = [{"a": "foo", "b": "bar"}, {"a": "car", "b": "dar"}]
     df = DataFrame(dicts_non_numeric, dtype=object)
-    dfgb = df.groupby("a", as_index=False, sort=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        dfgb = df.groupby("a", as_index=False, sort=False)
 
     if numeric_only:
         result = dfgb.std(numeric_only=True)
@@ -2972,7 +2997,9 @@ def test_groupby_agg_namedagg_with_duplicate_columns():
         }
     )
 
-    result = df.groupby(by=["col1", "col1", "col2"], as_index=False).agg(
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby(by=["col1", "col1", "col2"], as_index=False)
+    result = gb.agg(
         new_col=pd.NamedAgg(column="col1", aggfunc="min"),
         new_col1=pd.NamedAgg(column="col1", aggfunc="max"),
         new_col2=pd.NamedAgg(column="col2", aggfunc="count"),

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -104,8 +104,7 @@ def test_pass_args_kwargs_dataframe(tsframe, as_index):
     def f(x, q=None, axis=0):
         return np.percentile(x, q, axis=axis)
 
-    warn = Pandas4Warning if not as_index else None
-    with tm.assert_produces_warning(warn, match="as_index"):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         df_grouped = tsframe.groupby(lambda x: x.month, as_index=as_index)
     agg_result = df_grouped.agg(np.percentile, 80, axis=0)
     apply_result = df_grouped.apply(DataFrame.quantile, 0.8)
@@ -2342,8 +2341,7 @@ def test_groupby_all_nan_groups_drop():
 def test_groupby_empty_multi_column(as_index, numeric_only):
     # GH 15106 & GH 41998
     df = DataFrame(data=[], columns=["A", "B", "C"])
-    warn = Pandas4Warning if not as_index else None
-    with tm.assert_produces_warning(warn, match="as_index"):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(["A", "B"], as_index=as_index)
     result = gb.sum(numeric_only=numeric_only)
     if as_index:

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
 
@@ -452,7 +454,14 @@ def test_no_sort_keep_na(sequence, dtype, test_series, as_index):
             "a": [0, 1, 2, 3],
         }
     )
-    gb = df.groupby("key", dropna=False, sort=False, as_index=as_index, observed=False)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(
+            "key", dropna=False, sort=False, as_index=as_index, observed=False
+        )
     if test_series:
         gb = gb["a"]
     result = gb.sum()
@@ -535,9 +544,14 @@ def test_categorical_reducers(reduction_func, observed, sort, as_index, index_ki
         args = (args[0].drop(columns=keys),)
         args_filled = (args_filled[0].drop(columns=keys),)
 
-    gb_keepna = df.groupby(
-        keys, dropna=False, observed=observed, sort=sort, as_index=as_index
-    )
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb_keepna = df.groupby(
+            keys, dropna=False, observed=observed, sort=sort, as_index=as_index
+        )
 
     if not observed and reduction_func in ["idxmin", "idxmax"]:
         with pytest.raises(
@@ -617,9 +631,14 @@ def test_categorical_transformers(transformation_func, observed, sort, as_index)
         null_group_data = getattr(null_group_values, transformation_func)(*args)
     null_group_result = pd.DataFrame({"y": null_group_data})
 
-    gb_keepna = df.groupby(
-        "x", dropna=False, observed=observed, sort=sort, as_index=as_index
-    )
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb_keepna = df.groupby(
+            "x", dropna=False, observed=observed, sort=sort, as_index=as_index
+        )
     gb_dropna = df.groupby("x", dropna=True, observed=observed, sort=sort)
 
     result = getattr(gb_keepna, transformation_func)(*args)
@@ -649,7 +668,14 @@ def test_categorical_head_tail(method, observed, sort, as_index):
     df = pd.DataFrame(
         {"x": pd.Categorical(values, categories=[1, 2, 3]), "y": range(len(values))}
     )
-    gb = df.groupby("x", dropna=False, observed=observed, sort=sort, as_index=as_index)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gb = df.groupby(
+            "x", dropna=False, observed=observed, sort=sort, as_index=as_index
+        )
     result = getattr(gb, method)()
 
     if method == "tail":

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -454,11 +452,7 @@ def test_no_sort_keep_na(sequence, dtype, test_series, as_index):
             "a": [0, 1, 2, 3],
         }
     )
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(
             "key", dropna=False, sort=False, as_index=as_index, observed=False
         )
@@ -544,11 +538,7 @@ def test_categorical_reducers(reduction_func, observed, sort, as_index, index_ki
         args = (args[0].drop(columns=keys),)
         args_filled = (args_filled[0].drop(columns=keys),)
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb_keepna = df.groupby(
             keys, dropna=False, observed=observed, sort=sort, as_index=as_index
         )
@@ -560,7 +550,8 @@ def test_categorical_reducers(reduction_func, observed, sort, as_index, index_ki
             getattr(gb_keepna, reduction_func)(*args)
         return
 
-    gb_filled = df_filled.groupby(keys, observed=observed, sort=sort, as_index=True)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb_filled = df_filled.groupby(keys, observed=observed, sort=sort, as_index=True)
     if reduction_func == "corrwith":
         warn = Pandas4Warning
         msg = "DataFrameGroupBy.corrwith is deprecated"
@@ -631,11 +622,7 @@ def test_categorical_transformers(transformation_func, observed, sort, as_index)
         null_group_data = getattr(null_group_values, transformation_func)(*args)
     null_group_result = pd.DataFrame({"y": null_group_data})
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb_keepna = df.groupby(
             "x", dropna=False, observed=observed, sort=sort, as_index=as_index
         )
@@ -668,11 +655,7 @@ def test_categorical_head_tail(method, observed, sort, as_index):
     df = pd.DataFrame(
         {"x": pd.Categorical(values, categories=[1, 2, 3]), "y": range(len(values))}
     )
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb = df.groupby(
             "x", dropna=False, observed=observed, sort=sort, as_index=as_index
         )

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -535,8 +535,10 @@ class TestGrouping:
     def test_agg_with_dict_raises(self, df):
         df.columns = np.arange(len(df.columns))
         msg = "nested renamer is not supported"
+        with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+            gb = df.groupby(1, as_index=False)
         with pytest.raises(SpecificationError, match=msg):
-            df.groupby(1, as_index=False)[2].agg({"Q": np.mean})
+            gb[2].agg({"Q": np.mean})
 
     def test_multiindex_columns_empty_level(self):
         lst = [["count", "values"], ["to filter", ""]]
@@ -1195,7 +1197,8 @@ class TestIteration:
 def test_grouping_by_key_is_in_axis():
     # GH#50413 - Groupers specified by key are in-axis
     df = DataFrame({"a": [1, 1, 2], "b": [1, 1, 2], "c": [3, 4, 5]}).set_index("a")
-    gb = df.groupby([Grouper(level="a"), Grouper(key="b")], as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb = df.groupby([Grouper(level="a"), Grouper(key="b")], as_index=False)
     assert not gb._grouper.groupings[0].in_axis
     assert gb._grouper.groupings[1].in_axis
 

--- a/pandas/tests/groupby/test_indexing.py
+++ b/pandas/tests/groupby/test_indexing.py
@@ -3,6 +3,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 import pandas._testing as tm
 
@@ -103,7 +105,8 @@ def test_doc_examples():
         [["a", 1], ["a", 2], ["a", 3], ["b", 4], ["b", 5]], columns=["A", "B"]
     )
 
-    grouped = df.groupby("A", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("A", as_index=False)
 
     result = grouped._positional_selector[1:2]
     expected = pd.DataFrame([["a", 2], ["b", 5]], columns=["A", "B"], index=[1, 4])
@@ -148,7 +151,8 @@ def test_multiindex():
         multiindex_data[date] = levels
 
     df = _make_df_from_data(multiindex_data)
-    result = df.groupby("Date", as_index=False).nth(slice(3, -3))
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby("Date", as_index=False).nth(slice(3, -3))
 
     sliced = {date: values[3:-3] for date, values in multiindex_data.items()}
     expected = _make_df_from_data(sliced)
@@ -175,7 +179,8 @@ def test_against_head_and_tail(arg, method, simulated):
         ],
     }
     df = pd.DataFrame(data)
-    grouped = df.groupby("group", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("group", as_index=False)
     size = arg if arg >= 0 else n_rows_per_group + arg
 
     if method == "head":
@@ -223,7 +228,8 @@ def test_against_df_iloc(start, stop, step):
         "value": list(range(n_rows)),
     }
     df = pd.DataFrame(data)
-    grouped = df.groupby("group", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("group", as_index=False)
 
     result = grouped._positional_selector[start:stop:step]
     expected = df.iloc[start:stop:step]
@@ -249,7 +255,8 @@ def test_step(step):
     data += [["z", f"z{i}"] for i in range(3)]
     df = pd.DataFrame(data, columns=["A", "B"])
 
-    grouped = df.groupby("A", as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        grouped = df.groupby("A", as_index=False)
 
     result = grouped._positional_selector[::step]
 

--- a/pandas/tests/groupby/test_numba.py
+++ b/pandas/tests/groupby/test_numba.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pandas.compat import is_platform_arm
+from pandas.errors import Pandas4Warning
 
 from pandas import (
     DataFrame,
@@ -66,7 +67,8 @@ class TestEngine:
     def test_as_index_false_unsupported(self, numba_supported_reductions):
         func, kwargs = numba_supported_reductions
         df = DataFrame({"a": [3, 2, 3, 2], "b": range(4), "c": range(1, 5)})
-        gb = df.groupby("a", as_index=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+            gb = df.groupby("a", as_index=False)
         with pytest.raises(NotImplementedError, match="as_index=False"):
             getattr(gb, func)(engine="numba", **kwargs)
 

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -1,5 +1,4 @@
 import builtins
-from contextlib import nullcontext
 import datetime as dt
 from string import ascii_lowercase
 
@@ -1193,19 +1192,11 @@ def test_series_groupby_nunique(sort, dropna, as_index, with_nan, keys):
         df.loc[8::19, "julie"] = None
         df.loc[9::19, "julie"] = None
     original_df = df.copy()
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gr = df.groupby(keys, as_index=as_index, sort=sort)
     left = gr["julie"].nunique(dropna=dropna)
 
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gr = df.groupby(keys, as_index=as_index, sort=sort)
     right = gr["julie"].apply(Series.nunique, dropna=dropna)
     if not as_index:

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -1,4 +1,5 @@
 import builtins
+from contextlib import nullcontext
 import datetime as dt
 from string import ascii_lowercase
 
@@ -6,6 +7,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import iNaT
+from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.common import pandas_dtype
 from pandas.core.dtypes.missing import na_value_for_dtype
@@ -837,7 +839,8 @@ def test_min_date_with_nans():
     ).dt.date
     df = DataFrame({"a": [np.nan, "1", np.nan], "b": [0, 1, 1], "c": dates})
 
-    result = df.groupby("b", as_index=False)["c"].min()["c"]
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby("b", as_index=False)["c"].min()["c"]
     expected = pd.to_datetime(
         Series(["2019-05-09", "2019-05-09"], name="c"), format="%Y-%m-%d"
     ).dt.date
@@ -1190,10 +1193,20 @@ def test_series_groupby_nunique(sort, dropna, as_index, with_nan, keys):
         df.loc[8::19, "julie"] = None
         df.loc[9::19, "julie"] = None
     original_df = df.copy()
-    gr = df.groupby(keys, as_index=as_index, sort=sort)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gr = df.groupby(keys, as_index=as_index, sort=sort)
     left = gr["julie"].nunique(dropna=dropna)
 
-    gr = df.groupby(keys, as_index=as_index, sort=sort)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        gr = df.groupby(keys, as_index=as_index, sort=sort)
     right = gr["julie"].apply(Series.nunique, dropna=dropna)
     if not as_index:
         right = right.reset_index(drop=True)
@@ -1209,7 +1222,8 @@ def test_nunique():
     df = DataFrame({"A": list("abbacc"), "B": list("abxacc"), "C": list("abbacx")})
 
     expected = DataFrame({"A": list("abc"), "B": [1, 2, 1], "C": [1, 1, 2]})
-    result = df.groupby("A", as_index=False).nunique()
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby("A", as_index=False).nunique()
     tm.assert_frame_equal(result, expected)
 
     # as_index

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -106,11 +104,7 @@ def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, as_index):
         {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
     engine_kwargs = {"nogil": nogil, "parallel": parallel}
-    with (
-        tm.assert_produces_warning(Pandas4Warning, match="as_index")
-        if not as_index
-        else nullcontext()
-    ):
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         grouped = data.groupby(0, as_index=as_index)
     if frame_or_series is Series:
         grouped = grouped[1]

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -1,8 +1,13 @@
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
 
 from pandas.compat import is_platform_arm
-from pandas.errors import NumbaUtilError
+from pandas.errors import (
+    NumbaUtilError,
+    Pandas4Warning,
+)
 
 from pandas import (
     DataFrame,
@@ -101,7 +106,12 @@ def test_numba_vs_cython(jit, frame_or_series, nogil, parallel, as_index):
         {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
     engine_kwargs = {"nogil": nogil, "parallel": parallel}
-    grouped = data.groupby(0, as_index=as_index)
+    with (
+        tm.assert_produces_warning(Pandas4Warning, match="as_index")
+        if not as_index
+        else nullcontext()
+    ):
+        grouped = data.groupby(0, as_index=as_index)
     if frame_or_series is Series:
         grouped = grouped[1]
 

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1475,7 +1475,8 @@ def test_as_index_no_change(keys, df, groupby_func):
         # Column B is string dtype; will fail on some ops
         df = df.drop(columns="B")
     args = get_groupby_method_args(groupby_func, df)
-    gb_as_index_true = df.groupby(keys, as_index=True)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb_as_index_true = df.groupby(keys, as_index=True)
     with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
         gb_as_index_false = df.groupby(keys, as_index=False)
     if groupby_func == "corrwith":

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1476,7 +1476,8 @@ def test_as_index_no_change(keys, df, groupby_func):
         df = df.drop(columns="B")
     args = get_groupby_method_args(groupby_func, df)
     gb_as_index_true = df.groupby(keys, as_index=True)
-    gb_as_index_false = df.groupby(keys, as_index=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        gb_as_index_false = df.groupby(keys, as_index=False)
     if groupby_func == "corrwith":
         warn = Pandas4Warning
         msg = "DataFrameGroupBy.corrwith is deprecated"
@@ -1509,7 +1510,8 @@ def test_idxmin_idxmax_transform_args(how, skipna, numeric_only):
 def test_transform_sum_one_column_no_matching_labels():
     df = DataFrame({"X": [1.0]})
     series = Series(["Y"])
-    result = df.groupby(series, as_index=False).transform("sum")
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(series, as_index=False).transform("sum")
     expected = DataFrame({"X": [1.0]})
     tm.assert_frame_equal(result, expected)
 
@@ -1518,7 +1520,8 @@ def test_transform_sum_no_matching_labels():
     df = DataFrame({"X": [1.0, -93204, 4935]})
     series = Series(["A", "B", "C"])
 
-    result = df.groupby(series, as_index=False).transform("sum")
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(series, as_index=False).transform("sum")
     expected = DataFrame({"X": [1.0, -93204, 4935]})
     tm.assert_frame_equal(result, expected)
 
@@ -1527,7 +1530,8 @@ def test_transform_sum_one_column_with_matching_labels():
     df = DataFrame({"X": [1.0, -93204, 4935]})
     series = Series(["A", "B", "A"])
 
-    result = df.groupby(series, as_index=False).transform("sum")
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(series, as_index=False).transform("sum")
     expected = DataFrame({"X": [4936.0, -93204, 4936.0]})
     tm.assert_frame_equal(result, expected)
 
@@ -1536,7 +1540,8 @@ def test_transform_sum_one_column_with_missing_labels():
     df = DataFrame({"X": [1.0, -93204, 4935]})
     series = Series(["A", "C"])
 
-    result = df.groupby(series, as_index=False).transform("sum")
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(series, as_index=False).transform("sum")
     expected = DataFrame({"X": [1.0, -93204, np.nan]})
     tm.assert_frame_equal(result, expected)
 
@@ -1545,7 +1550,8 @@ def test_transform_sum_one_column_with_matching_labels_and_missing_labels():
     df = DataFrame({"X": [1.0, -93204, 4935]})
     series = Series(["A", "A"])
 
-    result = df.groupby(series, as_index=False).transform("sum")
+    with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+        result = df.groupby(series, as_index=False).transform("sum")
     expected = DataFrame({"X": [-93203.0, -93203.0, np.nan]})
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -154,6 +154,7 @@ def test_scikit_learn():
     clf.predict(digits.data[-1:])
 
 
+@pytest.mark.filterwarnings("ignore:The 'as_index' argument:DeprecationWarning")
 def test_seaborn(mpl_cleanup):
     seaborn = pytest.importorskip("seaborn")
     tips = DataFrame(

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -916,9 +916,9 @@ class TestRolling:
         df = df.set_index(["date"])
 
         gp_by = [getattr(df, attr) for attr in by]
-        result = (
-            df.groupby(gp_by, as_index=False).rolling(window=2, min_periods=1).mean()
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="as_index"):
+            gb = df.groupby(gp_by, as_index=False)
+        result = gb.rolling(window=2, min_periods=1).mean()
 
         expected = {"id": ["A", "A", "B", "B"]}
         expected.update(expected_data)


### PR DESCRIPTION
I'm not pushing for this, just putting it up to make it easy if @rhshadrach (the author of the issue) wants to.

## Summary
- Deprecates the `as_index` parameter in `DataFrame.groupby()`, directing users to use `.reset_index()` instead
- Adds `Pandas4Warning` when `as_index=False` is passed
- Updates all groupby and window tests to expect the deprecation warning

closes #35860

## Test plan
- [x] All 25052 groupby + window/groupby tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)