### PR TITLE
DEPR: read_csv cache_dates keyword

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -99,6 +99,7 @@ Deprecations
 - Deprecated arithmetic operations between pandas objects (:class:`DataFrame`, :class:`Series`, :class:`Index`, and pandas-implemented :class:`ExtensionArray` subclasses) and list-likes other than ``list``, ``np.ndarray``, :class:`ExtensionArray`, :class:`Index`, :class:`Series`, :class:`DataFrame`. For e.g. ``tuple`` or ``range``, explicitly cast these to a supported object instead. In a future version, these will be treated as scalar-like for pointwise operation (:issue:`62423`)
 - Deprecated automatic dtype promotion when reindexing with a ``fill_value`` that cannot be held by the original dtype. Explicitly cast to a common dtype instead (:issue:`53910`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
+- Deprecated the ``cache_dates`` keyword in :func:`read_csv`, :func:`read_table`, and :func:`read_fwf` (:issue:`55569`)
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 -
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -32,6 +32,7 @@ from pandas._libs import lib
 from pandas._libs.parsers import STR_NA_VALUES
 from pandas.errors import (
     AbstractMethodError,
+    Pandas4Warning,
     ParserWarning,
 )
 from pandas.util._decorators import (
@@ -120,7 +121,7 @@ if TYPE_CHECKING:
         parse_dates: bool | Sequence[Hashable] | None
         date_format: str | dict[Hashable, str] | None
         dayfirst: bool
-        cache_dates: bool
+        cache_dates: bool | lib.NoDefault
         compression: CompressionOptions
         thousands: str | None
         decimal: str
@@ -296,6 +297,17 @@ def _read(
     # Check for duplicates in names.
     _validate_names(kwds.get("names", None))
 
+    # GH#55569 - deprecate cache_dates
+    if kwds.get("cache_dates", lib.no_default) is not lib.no_default:
+        warnings.warn(
+            "The 'cache_dates' keyword is deprecated and "
+            "will be removed in a future version.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+    else:
+        kwds["cache_dates"] = True
+
     # Create the parser.
     parser = TextFileReader(filepath_or_buffer, **kwds)
 
@@ -378,7 +390,7 @@ def read_csv(
     parse_dates: bool | Sequence[Hashable] | None = None,
     date_format: str | dict[Hashable, str] | None = None,
     dayfirst: bool = False,
-    cache_dates: bool = True,
+    cache_dates: bool | lib.NoDefault = lib.no_default,
     # Iteration
     iterator: bool = False,
     chunksize: int | None = None,
@@ -616,6 +628,8 @@ def read_csv(
         conversion. May produce significant speed-up when parsing duplicate
         date strings, especially ones with timezone offsets.
 
+        .. deprecated:: 3.1.0
+            The ``cache_dates`` keyword is deprecated.
     iterator : bool, default False
         Return ``TextFileReader`` object for iteration or getting chunks with
         ``get_chunk()``.
@@ -945,7 +959,7 @@ def read_table(
     parse_dates: bool | Sequence[Hashable] | None = None,
     date_format: str | dict[Hashable, str] | None = None,
     dayfirst: bool = False,
-    cache_dates: bool = True,
+    cache_dates: bool | lib.NoDefault = lib.no_default,
     # Iteration
     iterator: bool = False,
     chunksize: int | None = None,
@@ -1179,6 +1193,8 @@ def read_table(
         conversion. May produce significant speed-up when parsing duplicate
         date strings, especially ones with timezone offsets.
 
+        .. deprecated:: 3.1.0
+            The ``cache_dates`` keyword is deprecated.
     iterator : bool, default False
         Return ``TextFileReader`` object for iteration or getting chunks with
         ``get_chunk()``.

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -257,13 +257,16 @@ def test_bad_date_parse(all_parsers, cache, value):
     parser = all_parsers
     s = StringIO((f"{value},\n") * (start_caching_at + 1))
 
-    parser.read_csv(
-        s,
-        header=None,
-        names=["foo", "bar"],
-        parse_dates=["foo"],
-        cache_dates=cache,
-    )
+    with tm.assert_produces_warning(
+        Pandas4Warning, match="cache_dates", check_stacklevel=False
+    ):
+        parser.read_csv(
+            s,
+            header=None,
+            names=["foo", "bar"],
+            parse_dates=["foo"],
+            cache_dates=cache,
+        )
 
 
 def test_bad_date_parse_with_warning(all_parsers, cache):


### PR DESCRIPTION
## Summary
- Deprecate the `cache_dates` keyword in `read_csv`, `read_table`, and `read_fwf`
- `cache_dates` has no behavioral impact since date caching is always used

Note: the original scope of #55569 also included `keep_default_na` and `na_filter`, but after research both are widely used (~4k and ~6k files on GitHub respectively) with no clean alternatives, so those are left alone. See https://github.com/pandas-dev/pandas/issues/55569#issuecomment-4100209597

## Test plan
- [x] Existing parser tests updated to expect `Pandas4Warning` when `cache_dates` is passed
- [x] Full `pandas/tests/io/parser/` test suite passes
- [x] No warning when keyword is not passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)