### PR TITLE
DEPR: ExcelFile.parse

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -96,6 +96,7 @@ Other API changes
 Deprecations
 ~~~~~~~~~~~~
 - Deprecated :meth:`.DataFrameGroupBy.agg` and :meth:`.Resampler.agg` unpacking a scalar when the provided ``func`` returns a Series or array of length 1; in the future this will result in the Series or array being in the result. Users should unpack the scalar in ``func`` itself (:issue:`64014`)
+- Deprecated :meth:`ExcelFile.parse`, use :func:`read_excel` instead (:issue:`58247`)
 - Deprecated arithmetic operations between pandas objects (:class:`DataFrame`, :class:`Series`, :class:`Index`, and pandas-implemented :class:`ExtensionArray` subclasses) and list-likes other than ``list``, ``np.ndarray``, :class:`ExtensionArray`, :class:`Index`, :class:`Series`, :class:`DataFrame`. For e.g. ``tuple`` or ``range``, explicitly cast these to a supported object instead. In a future version, these will be treated as scalar-like for pointwise operation (:issue:`62423`)
 - Deprecated automatic dtype promotion when reindexing with a ``fill_value`` that cannot be held by the original dtype. Explicitly cast to a common dtype instead (:issue:`53910`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -33,7 +33,10 @@ from pandas.compat._optional import (
     get_version,
     import_optional_dependency,
 )
-from pandas.errors import EmptyDataError
+from pandas.errors import (
+    EmptyDataError,
+    Pandas4Warning,
+)
 from pandas.util._decorators import (
     set_module,
 )
@@ -493,7 +496,7 @@ def read_excel(
         )
 
     try:
-        data = io.parse(
+        data = io._reader.parse(
             sheet_name=sheet_name,
             header=header,
             names=names,
@@ -1657,6 +1660,9 @@ class ExcelFile:
         """
         Parse specified sheet(s) into a DataFrame.
 
+        .. deprecated:: 3.1.0
+            Use :func:`pd.read_excel` instead.
+
         Equivalent to read_excel(ExcelFile, ...)  See the read_excel
         docstring for more info on accepted parameters.
 
@@ -1783,6 +1789,12 @@ class ExcelFile:
         >>> file = pd.ExcelFile("myfile.xlsx")  # doctest: +SKIP
         >>> file.parse()  # doctest: +SKIP
         """
+        warnings.warn(
+            # GH#58247
+            f"{type(self).__name__}.parse is deprecated. Use pd.read_excel instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
         return self._reader.parse(
             sheet_name=sheet_name,
             header=header,

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -248,13 +248,8 @@ class TestReaders:
         monkeypatch.chdir(datapath("io", "data", "excel"))
         monkeypatch.setattr(pd, "read_excel", func)
 
-    def test_engine_used(self, read_ext, engine, monkeypatch):
+    def test_engine_used(self, read_ext, engine):
         # GH 38884
-        def parser(self, *args, **kwargs):
-            return self.engine
-
-        monkeypatch.setattr(pd.ExcelFile, "parse", parser)
-
         expected_defaults = {
             "xlsx": "openpyxl",
             "xlsm": "openpyxl",
@@ -264,7 +259,8 @@ class TestReaders:
         }
 
         with open("test1" + read_ext, "rb") as f:
-            result = pd.read_excel(f)
+            excel_file = pd.ExcelFile(f)
+            result = excel_file.engine
 
         if engine is not None:
             expected = engine
@@ -1636,9 +1632,11 @@ class TestExcelFileRead:
         tm.assert_frame_equal(df1, expected)
         tm.assert_frame_equal(df2, expected)
 
+        depr_msg = "ExcelFile.parse is deprecated"
         with pd.ExcelFile("test1" + read_ext) as excel:
-            df1 = excel.parse(0, index_col=0)
-            df2 = excel.parse(1, skiprows=[1], index_col=0)
+            with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+                df1 = excel.parse(0, index_col=0)
+                df2 = excel.parse(1, skiprows=[1], index_col=0)
         tm.assert_frame_equal(df1, expected)
         tm.assert_frame_equal(df2, expected)
 
@@ -1647,7 +1645,8 @@ class TestExcelFileRead:
         tm.assert_frame_equal(df3, df1.iloc[:-1])
 
         with pd.ExcelFile("test1" + read_ext) as excel:
-            df3 = excel.parse(0, index_col=0, skipfooter=1)
+            with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+                df3 = excel.parse(0, index_col=0, skipfooter=1)
 
         tm.assert_frame_equal(df3, df1.iloc[:-1])
 
@@ -1660,11 +1659,14 @@ class TestExcelFileRead:
         filename = "test1"
         sheet_name = "Sheet1"
 
+        depr_msg = "ExcelFile.parse is deprecated"
         with pd.ExcelFile(filename + read_ext) as excel:
-            df1_parse = excel.parse(sheet_name=sheet_name, index_col=0)  # doc
+            with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+                df1_parse = excel.parse(sheet_name=sheet_name, index_col=0)  # doc
 
         with pd.ExcelFile(filename + read_ext) as excel:
-            df2_parse = excel.parse(index_col=0, sheet_name=sheet_name)
+            with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+                df2_parse = excel.parse(index_col=0, sheet_name=sheet_name)
 
         tm.assert_frame_equal(df1_parse, expected)
         tm.assert_frame_equal(df2_parse, expected)
@@ -1676,9 +1678,11 @@ class TestExcelFileRead:
     def test_bad_sheetname_raises(self, read_ext, sheet_name):
         # GH 39250
         msg = "Worksheet index 3 is invalid|Worksheet named 'Sheet4' not found"
+        depr_msg = "ExcelFile.parse is deprecated"
         with pytest.raises(ValueError, match=msg):
             with pd.ExcelFile("blank" + read_ext) as excel:
-                excel.parse(sheet_name=sheet_name)
+                with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+                    excel.parse(sheet_name=sheet_name)
 
     def test_excel_read_buffer(self, engine, read_ext):
         pth = "test1" + read_ext

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -259,7 +259,7 @@ class TestReaders:
         }
 
         with open("test1" + read_ext, "rb") as f:
-            excel_file = pd.ExcelFile(f)
+            excel_file = pd.ExcelFile(f, engine=engine)
             result = excel_file.engine
 
         if engine is not None:

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -248,6 +248,7 @@ class TestReaders:
         monkeypatch.chdir(datapath("io", "data", "excel"))
         monkeypatch.setattr(pd, "read_excel", func)
 
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_engine_used(self, read_ext, engine):
         # GH 38884
         expected_defaults = {
@@ -259,8 +260,8 @@ class TestReaders:
         }
 
         with open("test1" + read_ext, "rb") as f:
-            excel_file = pd.ExcelFile(f, engine=engine)
-            result = excel_file.engine
+            with pd.ExcelFile(f, engine=engine) as excel_file:
+                result = excel_file.engine
 
         if engine is not None:
             expected = engine


### PR DESCRIPTION
## Summary
- Deprecates `ExcelFile.parse` in favor of `pd.read_excel` (which accepts an `ExcelFile` instance as its first argument)
- Changes `read_excel` to call `io._reader.parse()` directly so it doesn't trigger the deprecation warning
- Updates tests to assert the deprecation warning

closes #58247
closes #50953

## Test plan
- [x] Existing `test_readers.py` tests updated to expect `Pandas4Warning` on `ExcelFile.parse()` calls
- [x] `test_engine_used` updated to no longer monkeypatch `ExcelFile.parse` (since `read_excel` no longer calls it)
- [x] Full `test_readers.py` suite passes (236 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)