### PR TITLE
DEPR: deprecate pd.lreshape

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -96,6 +96,7 @@ Other API changes
 Deprecations
 ~~~~~~~~~~~~
 - Deprecated :attr:`Timestamp.dayofweek`, :attr:`Timestamp.dayofyear`, :attr:`Timestamp.daysinmonth` in favor of :attr:`Timestamp.day_of_week`, :attr:`Timestamp.day_of_year`, :attr:`Timestamp.days_in_month`, respectively. The same deprecation applies to the corresponding attributes on :class:`Period`, :class:`DatetimeIndex`, :class:`PeriodIndex`, and :attr:`Series.dt` (:issue:`46768`)
+- Deprecated :func:`lreshape`. Use :func:`melt` instead (:issue:`34313`)
 - Deprecated :meth:`.DataFrameGroupBy.agg` and :meth:`.Resampler.agg` unpacking a scalar when the provided ``func`` returns a Series or array of length 1; in the future this will result in the Series or array being in the result. Users should unpack the scalar in ``func`` itself (:issue:`64014`)
 - Deprecated :meth:`ExcelFile.parse`, use :func:`read_excel` instead (:issue:`58247`)
 - Deprecated ``engine="fastparquet"`` and ``engine="auto"`` in :func:`read_parquet` and :meth:`DataFrame.to_parquet`. The ``fastparquet`` library has been retired; use ``engine="pyarrow"`` or do not pass ``engine`` to use the default. (:issue:`64597`)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -198,6 +198,7 @@ def pytest_collection_modifyitems(items, config) -> None:
         ("read_parquet", "Passing a BlockManager to DataFrame is deprecated"),
         ("Timestamp.utcfromtimestamp", "Timestamp.utcfromtimestamp is deprecated"),
         ("BaseOffset.name.__get__", "The 'name' property is deprecated"),
+        ("lreshape", "lreshape is deprecated"),
     ]
 
     if is_doctest:

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import re
 from typing import TYPE_CHECKING
+import warnings
 
 import numpy as np
 
+from pandas.errors import Pandas4Warning
 from pandas.util._decorators import set_module
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_iterator,
@@ -283,6 +286,10 @@ def lreshape(data: DataFrame, groups: dict, dropna: bool = True) -> DataFrame:
     """
     Reshape wide-format data to long. Generalized inverse of DataFrame.pivot.
 
+    .. deprecated:: 3.1.0
+        lreshape is deprecated and will be removed in a future version of
+        pandas. Use :func:`pandas.melt` instead.
+
     Accepts a dictionary, ``groups``, in which each key is a new column name
     and each value is a list of old column names that will be "melted" under
     the new column name as part of the reshape.
@@ -338,6 +345,12 @@ def lreshape(data: DataFrame, groups: dict, dropna: bool = True) -> DataFrame:
     2  Red Sox  2008  545
     3  Yankees  2008  526
     """
+    warnings.warn(
+        "lreshape is deprecated and will be removed in a future version of "
+        "pandas. Use pandas.melt instead.",
+        Pandas4Warning,
+        stacklevel=find_stack_level(),
+    )
     mdata = {}
     pivot_cols = []
     all_cols: set[Hashable] = set()

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -3,6 +3,8 @@ import re
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -593,11 +595,13 @@ class TestLreshape:
 
         df = DataFrame(data)
 
+        msg = "lreshape is deprecated"
         spec = {
             "visitdt": [f"visitdt{i:d}" for i in range(1, 4)],
             "wt": [f"wt{i:d}" for i in range(1, 4)],
         }
-        result = lreshape(df, spec)
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            result = lreshape(df, spec)
 
         exp_data = {
             "birthdt": [
@@ -675,7 +679,8 @@ class TestLreshape:
         exp = DataFrame(exp_data, columns=result.columns)
         tm.assert_frame_equal(result, exp)
 
-        result = lreshape(df, spec, dropna=False)
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            result = lreshape(df, spec, dropna=False)
         exp_data = {
             "birthdt": [
                 "08jan2009",
@@ -787,9 +792,9 @@ class TestLreshape:
             "visitdt": [f"visitdt{i:d}" for i in range(1, 3)],
             "wt": [f"wt{i:d}" for i in range(1, 4)],
         }
-        msg = "All column lists must be same length"
-        with pytest.raises(ValueError, match=msg):
-            lreshape(df, spec)
+        with pytest.raises(ValueError, match="All column lists must be same length"):
+            with tm.assert_produces_warning(Pandas4Warning, match=msg):
+                lreshape(df, spec)
 
 
 class TestWideToLong:


### PR DESCRIPTION
## Summary
- Deprecate `pd.lreshape` with `Pandas4Warning`, directing users to `pd.melt` instead
- GitHub code search shows virtually no real-world usage (~3-5 genuine callers outside pandas)

closes #34313

## Test plan
- [x] Existing `TestLreshape` tests updated to assert the deprecation warning
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)