### PR TITLE
CLN: make _CustomBusinessMonth.cbday_roll private

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -356,9 +356,7 @@ numpydoc_validation_exclude = {
     # Easter.method
     r"pandas\.tseries\.offsets\.Easter\.method$",
     # CustomBusinessMonth helper methods
-    r"pandas\.tseries\.offsets\.CustomBusinessMonthEnd\.cbday_roll$",
     r"pandas\.tseries\.offsets\.CustomBusinessMonthEnd\.month_roll$",
-    r"pandas\.tseries\.offsets\.CustomBusinessMonthBegin\.cbday_roll$",
     r"pandas\.tseries\.offsets\.CustomBusinessMonthBegin\.month_roll$",
     # ExtensionDtype base class stubs
     r"pandas\.api\.extensions\.ExtensionDtype\.construct_array_type$",

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -6802,9 +6802,18 @@ cdef class _CustomBusinessMonth(BusinessMixin):
         self._init_custom(weekmask, holidays, calendar)
 
     @cache_readonly
-    def cbday_roll(self):
+    def _cbday_roll(self):
         """
         Define default roll function to be called in apply method.
+
+        Returns ``CustomBusinessDay.rollback`` for month-end offsets and
+        ``CustomBusinessDay.rollforward`` for month-begin offsets.
+
+        Returns
+        -------
+        callable
+            The bound ``rollback`` or ``rollforward`` method of a
+            ``CustomBusinessDay`` instance.
         """
         cbday_kwds = self.kwds.copy()
         cbday_kwds["offset"] = timedelta(0)
@@ -6867,11 +6876,11 @@ cdef class _CustomBusinessMonth(BusinessMixin):
         cur_month_offset_date = self.month_roll(other)
 
         # Find this custom month offset
-        compare_date = self.cbday_roll(cur_month_offset_date)
+        compare_date = self._cbday_roll(cur_month_offset_date)
         n = roll_convention(other.day, self._n, compare_date.day)
 
         new = cur_month_offset_date + n * self.m_offset
-        result = self.cbday_roll(new)
+        result = self._cbday_roll(new)
 
         if self._offset:
             result = result + self._offset


### PR DESCRIPTION
Renamed `cbday_roll` to `_cbday_roll` on `_CustomBusinessMonth`, as it is an internal helper only used within `_apply` and not part of the public API.

Also added an extended summary and `Returns` section to the docstring, and removed the corresponding numpydoc validation exclusions from `doc/source/conf.py`.