### PR TITLE
CLN: Make _CustomBusinessMonth.cbday_roll and month_roll private

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -352,9 +352,6 @@ numpydoc_validation_exclude = {
     r"pandas\.tseries\.offsets\.Nano\.rollforward$",
     # Easter.method
     r"pandas\.tseries\.offsets\.Easter\.method$",
-    # CustomBusinessMonth helper methods
-    r"pandas\.tseries\.offsets\.CustomBusinessMonthEnd\.month_roll$",
-    r"pandas\.tseries\.offsets\.CustomBusinessMonthBegin\.month_roll$",
     # ExtensionDtype base class stubs
     r"pandas\.api\.extensions\.ExtensionDtype\.construct_array_type$",
     r"pandas\.api\.extensions\.ExtensionDtype\.construct_from_string$",

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -6869,9 +6869,18 @@ cdef class _CustomBusinessMonth(BusinessMixin):
         return moff
 
     @cache_readonly
-    def month_roll(self):
+    def _month_roll(self):
         """
         Define default roll function to be called in apply method.
+
+        Returns ``MonthEnd.rollforward`` for month-end offsets and
+        ``MonthBegin.rollback`` for month-begin offsets.
+
+        Returns
+        -------
+        callable
+            The bound ``rollforward`` or ``rollback`` method of the
+            underlying ``m_offset`` instance.
         """
         if self._prefix.endswith("S"):
             # MonthBegin
@@ -6884,7 +6893,7 @@ cdef class _CustomBusinessMonth(BusinessMixin):
     @apply_wraps
     def _apply(self, other: datetime) -> datetime:
         # First move to month offset
-        cur_month_offset_date = self.month_roll(other)
+        cur_month_offset_date = self._month_roll(other)
 
         # Find this custom month offset
         compare_date = self._cbday_roll(cur_month_offset_date)


### PR DESCRIPTION
Renamed `month_roll` to `_month_roll` on `_CustomBusinessMonth`, as it is an internal helper 
only used within `_apply` and not part of the public API.

Also added an extended summary and `Returns` section to the docstring, and removed the 
corresponding numpydoc validation exclusions from `doc/source/conf.py`.

This is a follow-up to #64734 which did the same for `cbday_roll`.