### PR TITLE
DOC: Document Series reindexing behavior on DataFrame column assignment

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -796,6 +796,42 @@ This is like an ``append`` operation on the ``DataFrame``.
    dfi.loc[3] = 5
    dfi
 
+.. _indexing.series_alignment:
+
+Series alignment on assignment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When assigning a ``Series`` to a ``DataFrame`` column (via ``[]`` or ``.loc``),
+the ``Series`` values are aligned by **index labels**, not by position. This
+means:
+
+* Values from the ``Series`` are matched to ``DataFrame`` rows by their labels.
+* If a ``Series`` label does not exist in the ``DataFrame`` index, it is ignored.
+* If a ``DataFrame`` label does not exist in the ``Series`` index, ``NaN`` is
+  assigned.
+* The order of values in the resulting ``DataFrame`` follows the ``DataFrame``
+  index, regardless of the ``Series`` order.
+
+.. ipython:: python
+
+   df = pd.DataFrame({"A": [1, 2, 3]}, index=[0, 1, 2])
+   s = pd.Series(["two", "one", "zero"], index=[2, 1, 0])
+   df["B"] = s
+   df
+
+Note that the values in ``B`` follow the ``DataFrame`` index order, not the
+``Series`` order.
+
+When the ``Series`` has only a partial match with the ``DataFrame`` index,
+unmatched labels become ``NaN`` and extra ``Series`` labels are discarded:
+
+.. ipython:: python
+
+   df = pd.DataFrame({"A": [1, 2, 3]}, index=["x", "y", "z"])
+   s = pd.Series([10, 20], index=["y", "w"])
+   df["C"] = s
+   df
+
 .. _indexing.basics.get_value:
 
 Fast scalar value getting and setting

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -624,19 +624,33 @@ class IndexingMixin:
 
         **Assignment with Series**
 
-        When assigning a Series to .loc[row_indexer, col_indexer], pandas aligns
-        the Series by index labels, not by order or position.
+        When assigning a ``Series`` to a ``DataFrame`` column via ``.loc``,
+        values are aligned by index labels, not by position. Labels in
+        the ``Series`` that do not match the ``DataFrame`` index are ignored,
+        and ``DataFrame`` labels not present in the ``Series`` become ``NaN``.
 
-        Series assignment with .loc and index alignment:
+        Assigning a ``Series`` whose index differs in order from the
+        ``DataFrame`` index:
 
-        >>> df = pd.DataFrame({"A": [1, 2, 3]}, index=[0, 1, 2])
-        >>> s = pd.Series([10, 20], index=[1, 0])  # Note reversed order
-        >>> df.loc[:, "B"] = s  # Aligns by index, not order
+        >>> df = pd.DataFrame({"A": [1, 2, 3]}, index=["x", "y", "z"])
+        >>> s = pd.Series(["z_val", "x_val", "y_val"], index=["z", "x", "y"])
+        >>> df.loc[:, "B"] = s
         >>> df
-           A   B
-        0  1  20.0
-        1  2  10.0
-        2  3 NaN
+           A      B
+        x  1  x_val
+        y  2  y_val
+        z  3  z_val
+
+        Assigning a ``Series`` with only a partial index match.  Missing
+        labels become ``NaN`` and extra labels in the ``Series`` are ignored:
+
+        >>> s2 = pd.Series([10, 20], index=["y", "w"])
+        >>> df.loc[:, "C"] = s2
+        >>> df
+           A      B     C
+        x  1  x_val   NaN
+        y  2  y_val  10.0
+        z  3  z_val   NaN
         """
         return _LocIndexer("loc", self)
 


### PR DESCRIPTION
- [x] closes #39845
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html) if fixing a bug or adding a new feature (documentation-only change)
- [x] All [CI tests passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_environment.html)
- [x] Added entry in `doc/source/whatsnew/` for new features, deprecations, or behavior changes if applicable (not applicable for docs-only)

## Summary

Documents the reindexing behavior when assigning a `Series` to a `DataFrame` column via `.loc` or `[]`. This behavior (alignment by index labels, not position) was not clearly documented.

### Changes

- **`pandas/core/indexing.py`** (`loc` docstring): Expanded the "Assignment with Series" section with clearer explanation and two examples — one showing index reordering and one showing partial index match with `NaN` fill.
- **`doc/source/user_guide/indexing.rst`**: Added a new "Series alignment on assignment" subsection under "Setting with enlargement" explaining the four key behaviors with examples.

### Disclosure

This contribution was made with the assistance of an AI coding tool (Claude Code). The changes have been fully reviewed and verified — all doctest outputs were validated against actual pandas behavior.
