### PR TITLE
TST: add regression tests for Needs Tests issues

### DIFF
--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1866,3 +1866,17 @@ def test_agg_dist_like_and_nonunique_columns():
 def test_wrong_engine(engine_name):
     with pytest.raises(ValueError, match="Unknown engine "):
         DataFrame().apply(lambda x: x, engine=engine_name)
+
+
+def test_apply_timedelta_preserves_resolution():
+    # GH#52411 - UDFs via apply should preserve datetime resolution
+    # rather than always returning nanoseconds
+    df = DataFrame(
+        {
+            "a": Series(["2023-01-01", "2023-01-02"], dtype="datetime64[s]"),
+            "b": Series(["2023-01-02", "2023-01-03"], dtype="datetime64[s]"),
+        }
+    )
+    direct = df["a"] - df["b"]
+    applied = df.apply(lambda row: row["a"] - row["b"], axis=1)
+    assert applied.dtype == direct.dtype

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -14,6 +14,7 @@ from pandas import (
     Timestamp,
     date_range,
     to_datetime,
+    to_numeric,
 )
 import pandas._testing as tm
 from pandas.tests.frame.common import _check_mixed_float
@@ -21,6 +22,7 @@ from pandas.tests.frame.common import _check_mixed_float
 
 class TestFillNA:
     def test_fillna_dict_inplace_nonunique_columns(self):
+        # GH#38966
         df = DataFrame(
             {"A": [np.nan] * 3, "B": [NaT, Timestamp(1), NaT], "C": [np.nan, "foo", 2]}
         )
@@ -854,3 +856,16 @@ def test_fillna_out_of_bounds_datetime():
     msg = "Cannot cast 0001-01-01 00:00:00 to unit='ns' without overflow"
     with pytest.raises(OutOfBoundsDatetime, match=msg):
         df.fillna(Timestamp("0001-01-01"))
+
+
+def test_fillna_dtype_preservation_after_apply():
+    # GH#14407 - fillna after apply should preserve dtypes correctly
+    # (block splitting should occur for mixed-dtype results)
+    df = DataFrame(
+        {"c1": list("ABC"), "c2": list("123"), "c3": [1.5, 2.5, 3.5], "c4": [0, 1, 2]}
+    )
+    result = df.apply(lambda x: to_numeric(x, errors="coerce")).fillna(df)
+    assert result["c1"].dtype == object
+    assert result["c2"].dtype == np.int64
+    assert result["c3"].dtype == np.float64
+    assert result["c4"].dtype == np.int64

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -489,3 +489,15 @@ class TestSlicing:
         )
         result = df.loc["2000", "A"]
         tm.assert_series_equal(result, expected)
+
+
+def test_string_slice_vs_datetime_slice_consistency():
+    # GH#13929 - slicing with string endpoints at sub-second frequency
+    # should produce the same result as slicing with datetime endpoints
+    index = date_range("2013-01-01 00:00:00", periods=80, freq="50ms")
+    data = DataFrame({"val": range(len(index))}, index=index)
+
+    str_slice = data.loc["2013-01-01 00:00:01.000":"2013-01-01 00:00:02.000"]
+    dt_slice = data.loc["2013-01-01 00:00:01.000" : datetime(2013, 1, 1, 0, 0, 2)]
+
+    tm.assert_frame_equal(str_slice, dt_slice)

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -261,3 +261,20 @@ def test_numpy_type_funcs(idx, func):
     )
     with pytest.raises(TypeError, match=msg):
         func(idx)
+
+
+def test_categorical_multiindex_preserved_after_arithmetic():
+    # GH#42785 - CategoricalIndex levels should be preserved after
+    # division when the divisor has fewer levels (alignment/broadcasting).
+    # The bug specifically lost CategoricalIndex on leftmost levels.
+    v0 = pd.CategoricalIndex([10, 20, 30], name="V0")
+    v1 = pd.CategoricalIndex(["B", "A"], name="V1")
+    v2 = pd.CategoricalIndex(["X", "Y"], name="V2")
+    mi = MultiIndex.from_product([v0, v1, v2])
+
+    ser = pd.Series(range(12), index=mi)
+    norm = ser.groupby(level=["V1", "V2"]).sum()
+    result = ser.div(norm)
+
+    for level_idx in range(result.index.nlevels):
+        assert isinstance(result.index.levels[level_idx], pd.CategoricalIndex)

--- a/pandas/tests/indexing/test_datetime.py
+++ b/pandas/tests/indexing/test_datetime.py
@@ -1,5 +1,6 @@
 import re
 
+import numpy as np
 import pytest
 
 import pandas as pd
@@ -189,3 +190,18 @@ class TestDatetimeIndex:
             ),
         )
         tm.assert_equal(result, expected)
+
+
+def test_loc_setitem_integer_on_datetimeindex_no_error():
+    # GH#22040 - loc with integer key on DatetimeIndex should not
+    # raise TypeError (it enlarges the DataFrame with the new key)
+    index = date_range("2018-01-01", periods=2)
+    df = DataFrame({"col1": [1.0, 2.0], "col2": [3.0, 4.0]}, index=index)
+    # This previously raised TypeError: cannot insert DatetimeIndex
+    # with incompatible label
+    df.loc[0, "col1"] = 0
+    expected = DataFrame(
+        {"col1": [1.0, 2.0, 0.0], "col2": [3.0, 4.0, np.nan]},
+        index=Index([Timestamp("2018-01-01"), Timestamp("2018-01-02"), 0]),
+    )
+    tm.assert_frame_equal(df, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -3598,3 +3598,15 @@ class TestLocSeries:
         result = s[["a", "b"]]
         expected = Series([np.nan, np.nan], index=["a", "b"])
         tm.assert_series_equal(result, expected)
+
+
+def test_loc_setitem_extension_array_into_object_series():
+    # GH#42437 - assigning an ExtensionArray with array-like elements
+    # to an object-dtype Series via .loc should not raise
+    pa = pytest.importorskip("pyarrow")
+
+    arr = pd.array([[1, 2], [3, 4], [5, 6]], dtype=pd.ArrowDtype(pa.list_(pa.int64())))
+    ser = Series([None, None, None], dtype=object)
+    ser.loc[:] = arr
+    expected = Series(list(arr), dtype=object)
+    tm.assert_series_equal(ser, expected)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -2188,3 +2188,17 @@ def test_resample_A_raises(freq):
     s = Series(range(10), index=date_range("20130101", freq="D", periods=10))
     with pytest.raises(ValueError, match=msg):
         s.resample(freq).mean()
+
+
+def test_resample_sum_with_inat_value():
+    # GH#16674 - int64 min value (same as iNaT sentinel) should not
+    # cause incorrect dtype casting during resample aggregation
+    max_int = np.iinfo(np.int64).max
+    min_int = np.iinfo(np.int64).min
+    df = DataFrame(
+        [max_int, min_int],
+        index=[datetime(2013, 1, 1), datetime(2013, 1, 1)],
+    )
+    result = df.resample("MS").apply(np.sum)
+    expected = DataFrame([-1], index=date_range("2013-01-01", periods=1, freq="MS"))
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -628,3 +628,24 @@ def test_concat_datetime64_different_resolutions():
 
     # The result should be a datetime64 dtype, not object
     assert combined.dates.dtype.kind == "M"
+
+
+def test_concat_non_ns_datetime_axis1(unit):
+    # GH#58471 - concat with non-ns datetime unit on axis=1 should
+    # preserve all data, matching the behavior of ns-resolution
+    dti1 = date_range("2024-01-01 00:00", periods=3, freq="5min", unit=unit)
+    dti2 = date_range("2024-01-01 00:15", periods=3, freq="5min", unit=unit)
+    ser1 = Series([1.0, 2.0, 3.0], index=dti1, name="a")
+    ser2 = Series([4.0, 5.0, 6.0], index=dti2, name="b")
+
+    result = concat([ser1, ser2], axis=1)
+
+    expected_index = date_range("2024-01-01 00:00", periods=6, freq="5min", unit=unit)
+    expected = DataFrame(
+        {
+            "a": [1.0, 2.0, 3.0, np.nan, np.nan, np.nan],
+            "b": [np.nan, np.nan, np.nan, 4.0, 5.0, 6.0],
+        },
+        index=expected_index,
+    )
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -778,3 +778,12 @@ def test_parsed_unit():
     # 7 digits after the decimal
     td = Timedelta("1 Day 2:03:04.0123450")
     assert td.unit == "ns"
+
+
+def test_timedelta_resolution_consistent_arg_styles():
+    # GH#33992 - Timedelta resolution should be the same regardless
+    # of whether the value is passed positionally or as a keyword
+    td_positional = Timedelta(1 / 128, "seconds")
+    td_keyword = Timedelta(seconds=1 / 128)
+    assert td_positional == td_keyword
+    assert td_positional.unit == td_keyword.unit


### PR DESCRIPTION
## Summary

Add regression tests for issues labeled "Needs Tests":

- [x] closes #58471: `concat` with non-ns datetime unit on axis=1
- [x] closes #52411: `apply` preserves timedelta resolution
- [x] closes #42785: `CategoricalIndex` preserved after MultiIndex arithmetic with broadcasting
- [x] closes #42437: ExtensionArray with array-like elements assigned to object Series via `.loc`
- [x] closes #33992: `Timedelta` resolution consistent between positional and keyword args
- [x] closes #38966: add GH ref to existing `test_fillna_dict_inplace_nonunique_columns`
- [x] closes #14407: `fillna` dtype preservation after `apply`
- [x] closes #13929: string vs datetime slice consistency at sub-second frequency
- [x] closes #16674: `resample` sum with iNaT sentinel value not cast to float
- [x] closes #22040: `loc` setitem with integer key on DatetimeIndex no longer raises

## Test plan
- [x] All 12 new test cases pass locally
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)