### PR TITLE
REF: use fast_float to read custom decimal separator

### DIFF
--- a/pandas/_libs/src/parser/fast_float_strtod.cpp
+++ b/pandas/_libs/src/parser/fast_float_strtod.cpp
@@ -9,9 +9,11 @@ fast_float provides IEEE 754 round-to-even (i.e. correctly rounded) parsing.
 extern "C" {
 
 int fast_float_strtod(const char *start, const char *end, double *value,
-                      const char **endptr) {
-  auto result = fast_float::from_chars(start, end, *value);
-  if (result.ec == std::errc()) {
+                      const char **endptr, char decimal) {
+  fast_float::parse_options options{fast_float::chars_format::general, decimal};
+  auto result = fast_float::from_chars_advanced(start, end, *value, options);
+  // No error or overflow/underflow are valid
+  if (result.ec == std::errc() || result.ec == std::errc::result_out_of_range) {
     *endptr = result.ptr;
     return 0;
   }

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1415,14 +1415,14 @@ int to_boolean(const char *item, uint8_t *val) {
 // Defined in fast_float_strtod.cpp — provides IEEE 754 correctly-rounded
 // float parsing via the fast_float library.
 int fast_float_strtod(const char *start, const char *end, double *value,
-                      const char **endptr);
+                      const char **endptr, char decimal);
 
 double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
                        char tsep, int skip_trailing, int *error,
                        int *maybe_int) {
-  // Use fast_float for standard format (decimal='.', no tsep, sci='e'/'E').
+  // Use fast_float for standard format (no tsep, sci='e'/'E').
   // fast_float provides IEEE 754 correctly-rounded parsing.
-  if (decimal == '.' && tsep == '\0' && (sci == 'e' || sci == 'E')) {
+  if (tsep == '\0' && (sci == 'e' || sci == 'E')) {
     const char *p = str;
     while (isspace_ascii(*p))
       p++;
@@ -1443,7 +1443,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
 
     double value;
     const char *parsed_end;
-    if (fast_float_strtod(p, end, &value, &parsed_end) == 0) {
+    if (fast_float_strtod(p, end, &value, &parsed_end, decimal) == 0) {
       // Determine maybe_int by checking if we saw '.' or 'e'/'E'.
       if (maybe_int != NULL) {
         *maybe_int = 1;

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1427,30 +1427,23 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     while (isspace_ascii(*p))
       p++;
 
-    // Only try fast_float for numeric-looking input (digit, sign+digit,
-    // or decimal point). This avoids fast_float parsing "nan"/"inf" which
-    // the original precise_xstrtod did not handle.
-    const char *q = p;
-    if (*q == '-' || *q == '+')
-      q++;
-    if (!isdigit_ascii(*q) && !(*q == '.' && isdigit_ascii(*(q + 1))))
-      goto fallback;
-
-    // Find end of token (next whitespace or NUL).
-    const char *end = p;
-    while (*end && !isspace_ascii(*end))
-      end++;
+    // Find end of token (NUL).
+    const char *end = p + strlen(p);
 
     double value;
     const char *parsed_end;
     if (fast_float_strtod(p, end, &value, &parsed_end, decimal) == 0) {
-      // Determine maybe_int by checking if we saw '.' or 'e'/'E'.
       if (maybe_int != NULL) {
         *maybe_int = 1;
-        for (const char *c = p; c < parsed_end; c++) {
+        const char *q = *p == '+' || *p == '-' ? p + 1 : p;
+        if (*q == 'i' || *q == 'I' || *q == 'n' || *q == 'N') {
+          // parsed inf/nan
+          *maybe_int = 0;
+        }
+
+        for (const char *c = p; maybe_int && c < parsed_end; c++) {
           if (*c == '.' || *c == 'e' || *c == 'E') {
             *maybe_int = 0;
-            break;
           }
         }
       }
@@ -1463,9 +1456,6 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
   }
 
-fallback:
-    // Fallback for non-standard formats (custom decimal, tsep, or sci char).
-    ;
   const char *p = str;
   const int max_digits = 17;
 

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1444,11 +1444,11 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     double value;
     const char *parsed_end;
     if (fast_float_strtod(p, end, &value, &parsed_end, decimal) == 0) {
-      // Determine maybe_int by checking if we saw '.' or 'e'/'E'.
+      // Determine maybe_int by checking if we saw decimal or 'e'/'E'.
       if (maybe_int != NULL) {
         *maybe_int = 1;
         for (const char *c = p; c < parsed_end; c++) {
-          if (*c == '.' || *c == 'e' || *c == 'E') {
+          if (*c == decimal || *c == 'e' || *c == 'E') {
             *maybe_int = 0;
             break;
           }

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1427,23 +1427,30 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     while (isspace_ascii(*p))
       p++;
 
-    // Find end of token (NUL).
-    const char *end = p + strlen(p);
+    // Only try fast_float for numeric-looking input (digit, sign+digit,
+    // or decimal point). This avoids fast_float parsing "nan"/"inf" which
+    // the original precise_xstrtod did not handle.
+    const char *q = p;
+    if (*q == '-' || *q == '+')
+      q++;
+    if (!isdigit_ascii(*q) && !(*q == decimal && isdigit_ascii(*(q + 1))))
+      goto fallback;
+
+    // Find end of token (next whitespace or NUL).
+    const char *end = p;
+    while (*end && !isspace_ascii(*end))
+      end++;
 
     double value;
     const char *parsed_end;
     if (fast_float_strtod(p, end, &value, &parsed_end, decimal) == 0) {
+      // Determine maybe_int by checking if we saw '.' or 'e'/'E'.
       if (maybe_int != NULL) {
         *maybe_int = 1;
-        const char *q = *p == '+' || *p == '-' ? p + 1 : p;
-        if (*q == 'i' || *q == 'I' || *q == 'n' || *q == 'N') {
-          // parsed inf/nan
-          *maybe_int = 0;
-        }
-
-        for (const char *c = p; maybe_int && c < parsed_end; c++) {
+        for (const char *c = p; c < parsed_end; c++) {
           if (*c == '.' || *c == 'e' || *c == 'E') {
             *maybe_int = 0;
+            break;
           }
         }
       }
@@ -1456,6 +1463,9 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
   }
 
+fallback:
+    // Fallback for non-standard formats (custom tsep, or sci char).
+    ;
   const char *p = str;
   const int max_digits = 17;
 


### PR DESCRIPTION
- [x] xref https://github.com/pandas-dev/pandas/pull/64432#discussion_r2943005837
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.


---

| Change   | Before [497fe853] <main>   | After [08accdda] <refactor/fast_float-decimal>   |   Ratio | Benchmark (Parameter)                                                      |
|----------|----------------------------|--------------------------------------------------|---------|----------------------------------------------------------------------------|
| -        | 4.97±0.4ms                 | 4.46±0.02ms                                      |    0.9  | io.csv.ReadCSVFloatPrecision.time_read_csv_python_engine(';', '.', 'high') |
| -        | 6.39±0.4ms                 | 5.71±0.06ms                                      |    0.89 | io.csv.ParseDateComparison.time_read_csv_dayfirst(True)                    |

cc @jbrockmendel 