### PR TITLE
BUG: Fix _replace_regex mutating StringArray in-place for non-inplace replace

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -171,7 +171,7 @@ Conversion
 
 Strings
 ^^^^^^^
--
+- Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 -
 
 Interval

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -777,7 +777,12 @@ class Block(PandasObject, libinternals.Block):
         if not (
             self._can_hold_element(value) or (self.dtype == "string" and is_re(value))
         ):
+            # GH#57733 - astype to object may return a block sharing memory
+            # with self (e.g. StringArray backed by object ndarray). Since
+            # replace_regex mutates values in-place, we must ensure the
+            # block's data is independent.
             block = self.astype(np.dtype(object))
+            block = block._maybe_copy(inplace=True)
         else:
             block = self._maybe_copy(inplace)
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -782,7 +782,8 @@ class Block(PandasObject, libinternals.Block):
             # replace_regex mutates values in-place, we must ensure the
             # block's data is independent.
             block = self.astype(np.dtype(object))
-            block = block._maybe_copy(inplace=True)
+            if astype_is_view(self.dtype, np.dtype(object)):
+                block = block._maybe_copy(inplace=True)
         else:
             block = self._maybe_copy(inplace)
 

--- a/pandas/tests/copy_view/test_replace.py
+++ b/pandas/tests/copy_view/test_replace.py
@@ -69,6 +69,20 @@ def test_replace_regex_inplace():
     assert not tm.shares_memory(get_array(df2, "a"), get_array(df, "a"))
 
 
+def test_replace_regex_non_inplace_does_not_mutate_original():
+    # GH#57733 - replace_regex with non-string value triggers astype to object,
+    # which for StringArray (backed by object ndarray) returned a view, causing
+    # in-place mutation of the original
+    df = DataFrame({"b": list("ab..")})
+    df_orig = df.copy()
+    result = df.replace([r"\s*\.\s*", "b"], 0, regex=True)
+
+    expected = DataFrame({"b": ["a", 0, 0, 0]}, dtype=object)
+    tm.assert_frame_equal(result, expected)
+    # Original must be unchanged
+    tm.assert_frame_equal(df, df_orig)
+
+
 def test_replace_regex_inplace_no_op():
     df = DataFrame({"a": [1, 2]})
     arr = get_array(df, "a")

--- a/pandas/tests/copy_view/test_replace.py
+++ b/pandas/tests/copy_view/test_replace.py
@@ -69,11 +69,12 @@ def test_replace_regex_inplace():
     assert not tm.shares_memory(get_array(df2, "a"), get_array(df, "a"))
 
 
-def test_replace_regex_non_inplace_does_not_mutate_original():
+@pytest.mark.parametrize("dtype", ["object", "string[python]"])
+def test_replace_regex_non_inplace_does_not_mutate_original(dtype):
     # GH#57733 - replace_regex with non-string value triggers astype to object,
     # which for StringArray (backed by object ndarray) returned a view, causing
     # in-place mutation of the original
-    df = DataFrame({"b": list("ab..")})
+    df = DataFrame({"b": list("ab..")}, dtype=dtype)
     df_orig = df.copy()
     result = df.replace([r"\s*\.\s*", "b"], 0, regex=True)
 


### PR DESCRIPTION
This unblocks #57733

`Block._replace_regex` calls `self.astype(np.dtype(object))` when the replacement value can't be held in the current dtype. For `StringArray` (backed by an object ndarray), this astype chain returns a block whose values share memory with the original `StringArray._ndarray` — because the underlying conversion is object→object with `copy=False`, which is a no-op. `replace_regex` then mutates this shared array in-place, corrupting the original.

Fix: call `_maybe_copy(inplace=True)` on the astype result before mutation, which copies only when the block shares refs with the original (i.e., when astype returned a view).

Reproducer:
```python
df = pd.DataFrame({"b": list("ab..")})
df_orig = df.copy()
result = df.replace([r"\s*\.\s*", "b"], 0, regex=True)
# Before fix: df["b"]._ndarray contains ints, df != df_orig
# After fix: df is unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)