### PR TITLE
PERF: short-circuit fragmentation check in BlockManager.insert

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -117,6 +117,7 @@ Performance improvements
 - Performance improvement in :func:`merge` and :meth:`DataFrame.join` for many-to-many joins with ``sort=False`` (:issue:`56564`)
 - Performance improvement in :func:`merge` with ``how="cross"`` (:issue:`38082`)
 - Performance improvement in :func:`merge` with ``how="left"`` (:issue:`64370`)
+- Performance improvement in :meth:`DataFrame.insert` when the number of blocks is small (:issue:`57641`)
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)
 - Performance improvement in :meth:`GroupBy.any` and :meth:`GroupBy.all` for boolean-dtype columns (:issue:`37850`)

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1572,10 +1572,11 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
 
         # len check is a cheap O(1) short-circuit to avoid the O(n) sum
         # and the get_option overhead on every insert call (GH#57641)
+        warn_threshold = 100
         if (
-            len(self.blocks) > 100
+            len(self.blocks) > warn_threshold
             and get_option("performance_warnings")
-            and sum(not block.is_extension for block in self.blocks) > 100
+            and sum(not block.is_extension for block in self.blocks) > warn_threshold
         ):
             warnings.warn(
                 "DataFrame is highly fragmented.  This is usually the result "

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1570,8 +1570,11 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         self._known_consolidated = False
         self.blocks += (block,)
 
+        # len check is a cheap O(1) short-circuit to avoid the O(n) sum
+        # and the get_option overhead on every insert call (GH#57641)
         if (
-            get_option("performance_warnings")
+            len(self.blocks) > 100
+            and get_option("performance_warnings")
             and sum(not block.is_extension for block in self.blocks) > 100
         ):
             warnings.warn(


### PR DESCRIPTION
## Summary
- Add a `len(self.blocks) > 100` guard in `BlockManager.insert` to skip the O(n) block iteration and `get_option` call when the block count is small

closes #57641

## Benchmarks

| Benchmark | Before | After | Speedup |
|---|---|---|---|
| `InsertColumns.time_insert` | 7.37 ms | 4.47 ms | **39%** |
| `InsertColumns.time_insert_middle` | 7.42 ms | 4.42 ms | **40%** |
| `InsertColumns.time_assign_with_setitem` | 5.00 ms | 2.20 ms | **56%** |

## Test plan
- [x] Existing tests pass (`test_insert.py`, `test_block_internals.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)