### PR TITLE
Update docstring for methods where inplace keyword is deprecated

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6238,6 +6238,14 @@ class DataFrame(NDFrame, OpsMixin):
         inplace : bool, default False
             Whether to modify the DataFrame rather than creating a new one.
             If True then value of copy is ignored.
+
+            .. deprecated:: 3.0.0
+
+                This keyword can still be used but will be removed in pandas 4.0.
+                See `PDEP-8
+                <https://pandas.pydata.org/pdeps/0008-inplace-methods-in-pandas.html>`__
+                for more details.
+
         level : int or level name, default None
             In case of a MultiIndex, only rename labels in the specified
             level.


### PR DESCRIPTION
- [x] addresses second checkbox for 3.0.0 in tracker #63207 

This adds a deprecation note to the docstring of DataFrame.rename only.
Please let me know whether this (very general) wording is correct, and I will add it for the other methods mentioned in  #63207 to this PR (or a separate one, if that's preferred).

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit)
Yes, pre-commit hooks ran and passed (it skipped tests for "no files to check" which I assume is normal behavior) 

- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Yes

