### PR TITLE
DEPR: dropna in pivot_table and crosstab

### DIFF
--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -577,11 +577,13 @@ If :func:`~pandas.crosstab` receives only two :class:`Series`, it will provide a
     pd.crosstab(foo, bar)
 
 For :class:`Categorical` data, to include **all** of data categories even if the actual data does
-not contain any instances of a particular category, use ``dropna=False``.
+not contain any instances of a particular category, reindex the result:
 
 .. ipython:: python
 
-    pd.crosstab(foo, bar, dropna=False)
+    result = pd.crosstab(foo, bar)
+    result = result.reindex(index=foo.categories, columns=bar.categories, fill_value=0)
+    result
 
 Normalization
 ~~~~~~~~~~~~~

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -31,6 +31,7 @@ Other enhancements
 - :class:`Period` now supports f-string formatting via ``__format__``, e.g. ``f"{period:%Y-%m}"`` (:issue:`48536`)
 - :meth:`.DataFrameGroupBy.agg` now allows for the provided ``func`` to return a NumPy array (:issue:`63957`)
 - Added :meth:`ExtensionArray.count` (:issue:`64450`)
+- Added ``observed`` parameter to :func:`crosstab` (:issue:`53521`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
@@ -108,6 +109,7 @@ Deprecations
 - Deprecated passing unnecessary ``*args`` and ``**kwargs`` to :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.cummax`, :meth:`.SeriesGroupBy.skew`, :meth:`.DataFrameGroupBy.skew`, :meth:`.SeriesGroupBy.take`, and :meth:`.DataFrameGroupBy.take`. The ``skipna`` parameter for the cum* methods is now an explicit keyword argument (:issue:`50407`)
 - Deprecated setting values with :meth:`DataFrame.at` and :meth:`Series.at` when the key does not exist in the index, which previously expanded the object. Use ``.loc`` instead (:issue:`48323`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
+- Deprecated the ``dropna`` keyword in :func:`pivot_table` and :func:`crosstab`. Manually handle NA values before and after calling these functions instead (:issue:`53521`)
 - Deprecated the ``dropna`` keyword in :meth:`DataFrame.to_hdf`, :meth:`HDFStore.put`, :meth:`HDFStore.append`, and :meth:`HDFStore.append_to_multiple`, and the ``io.hdf.dropna_table`` option. Use :meth:`DataFrame.dropna` before writing instead (:issue:`32038`)
 - Deprecated the ``float_precision`` argument in :func:`read_csv`, :func:`read_table`, and :func:`read_fwf`. All float precision modes now use the same converter (:issue:`64395`)
 - Deprecated the ``weekday`` property on :class:`DatetimeIndex`, :class:`.DatetimeArray`, :class:`PeriodIndex`, :class:`.PeriodArray`, and :class:`Period`. Use ``day_of_week`` instead. ``Timestamp.weekday()`` remains a method consistent with :meth:`datetime.datetime.weekday` (:issue:`12816`)
@@ -296,8 +298,10 @@ Groupby/resample/rolling
 
 Reshaping
 ^^^^^^^^^
+- Bug in :func:`crosstab` where the ``observed`` keyword was not available and was instead incorrectly coupled to the ``dropna`` keyword (:issue:`53521`)
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
+- Bug in :func:`pivot_table` where the ``observed`` parameter was ignored during margins computation (:issue:`53521`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)
 -
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12879,7 +12879,7 @@ class DataFrame(NDFrame, OpsMixin):
         aggfunc: AggFuncType = "mean",
         fill_value=None,
         margins: bool = False,
-        dropna: bool = True,
+        dropna: bool | lib.NoDefault = lib.no_default,
         margins_name: Level = "All",
         observed: bool = True,
         sort: bool = True,
@@ -12926,6 +12926,10 @@ class DataFrame(NDFrame, OpsMixin):
               margins,
             * index/column keys containing NA values will be dropped (see ``dropna``
               parameter in :meth:`DataFrame.groupby`).
+
+            .. deprecated:: 3.1.0
+                The dropna keyword is deprecated. Manually handle NA values
+                before and after calling pivot_table.
 
         margins_name : str, default 'All'
             Name of the row / column that will contain the totals

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -1112,8 +1112,8 @@ def crosstab(
     foo    2     2    1     2
 
     Here 'c' and 'f' are not represented in the data and will not be
-    shown in the output because dropna is True by default. Set
-    dropna=False to preserve categories with no data.
+    shown in the output because dropna is True by default. To preserve
+    categories with no data, manually reindex the result.
 
     >>> foo = pd.Categorical(["a", "b"], categories=["a", "b", "c"])
     >>> bar = pd.Categorical(["d", "e"], categories=["d", "e", "f"])
@@ -1122,7 +1122,10 @@ def crosstab(
     row_0
     a      1  0
     b      0  1
-    >>> pd.crosstab(foo, bar, dropna=False)
+    >>> result = pd.crosstab(foo, bar)
+    >>> idx = pd.CategoricalIndex(foo.categories, name=result.index.name)
+    >>> cols = pd.CategoricalIndex(bar.categories, name=result.columns.name)
+    >>> result.reindex(index=idx, columns=cols, fill_value=0)
     col_0  d  e  f
     row_0
     a      1  0  0

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -6,11 +6,14 @@ from typing import (
     Literal,
     cast,
 )
+import warnings
 
 import numpy as np
 
 from pandas._libs import lib
+from pandas.errors import Pandas4Warning
 from pandas.util._decorators import set_module
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.cast import maybe_downcast_to_dtype
 from pandas.core.dtypes.common import (
@@ -64,7 +67,7 @@ def pivot_table(
     aggfunc: AggFuncType = "mean",
     fill_value=None,
     margins: bool = False,
-    dropna: bool = True,
+    dropna: bool | lib.NoDefault = lib.no_default,
     margins_name: Hashable = "All",
     observed: bool = True,
     sort: bool = True,
@@ -112,6 +115,10 @@ def pivot_table(
         * rows with an NA value in any column will be omitted before computing margins,
         * index/column keys containing NA values will be dropped (see ``dropna``
           parameter in :meth:``DataFrame.groupby``).
+
+        .. deprecated:: 3.1.0
+            The dropna keyword is deprecated. Manually handle NA values
+            before and after calling pivot_table.
 
     margins_name : str, default 'All'
         Name of the row / column that will contain the totals
@@ -246,6 +253,17 @@ def pivot_table(
     foo large  2.000000   5  4.500000    4
         small  2.333333   6  4.333333    2
     """
+    if dropna is not lib.no_default:
+        warnings.warn(
+            "The dropna keyword in pivot_table is deprecated and will be "
+            "removed in a future version. Manually handle NA values before "
+            "and after calling pivot_table.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+    else:
+        dropna = True
+
     index = _convert_by(index)
     columns = _convert_by(columns)
 
@@ -407,7 +425,7 @@ def __internal_pivot_table(
             cols=columns,
             aggfunc=aggfunc,
             kwargs=kwargs,
-            observed=dropna,
+            observed=observed,
             margins_name=margins_name,
             fill_value=fill_value,
             dropna=dropna,
@@ -960,8 +978,9 @@ def crosstab(
     aggfunc=None,
     margins: bool = False,
     margins_name: Hashable = "All",
-    dropna: bool = True,
+    dropna: bool | lib.NoDefault = lib.no_default,
     normalize: bool | Literal[0, 1, "all", "index", "columns"] = False,
+    observed: bool = True,
 ) -> DataFrame:
     """
     Compute a simple cross tabulation of two (or more) factors.
@@ -991,6 +1010,11 @@ def crosstab(
         when margins is True.
     dropna : bool, default True
         Do not include columns whose entries are all NaN.
+
+        .. deprecated:: 3.1.0
+            The dropna keyword is deprecated. Manually handle NA values
+            before and after calling crosstab.
+
     normalize : bool, {'all', 'index', 'columns'}, or {0,1}, default False
         Normalize by dividing all values by the sum of values.
 
@@ -998,6 +1022,13 @@ def crosstab(
         - If passed 'index' will normalize over each row.
         - If passed 'columns' will normalize over each column.
         - If margins is `True`, will also normalize margin values.
+
+    observed : bool, default True
+        This only applies if any of the groupers are Categoricals.
+        If True: only show observed values for categorical groupers.
+        If False: show all values for categorical groupers.
+
+        .. versionadded:: 3.1.0
 
     Returns
     -------
@@ -1098,6 +1129,15 @@ def crosstab(
     b      0  1  0
     c      0  0  0
     """
+    if dropna is not lib.no_default:
+        warnings.warn(
+            "The dropna keyword in crosstab is deprecated and will be "
+            "removed in a future version. Manually handle NA values before "
+            "and after calling crosstab.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+
     if values is None and aggfunc is not None:
         raise ValueError("aggfunc cannot be used without values.")
 
@@ -1149,7 +1189,7 @@ def crosstab(
         margins=margins,
         margins_name=margins_name,
         dropna=dropna,
-        observed=dropna,
+        observed=observed,
         **kwargs,  # type: ignore[arg-type]
     )
 

--- a/pandas/tests/reshape/test_crosstab.py
+++ b/pandas/tests/reshape/test_crosstab.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     CategoricalDtype,
@@ -229,7 +231,8 @@ class TestCrosstab:
         c = np.array(
             ["dull", "dull", "dull", "dull", "dull", "shiny", "shiny"], dtype=object
         )
-        res = crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"], dropna=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            res = crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"], dropna=False)
         m = MultiIndex.from_tuples(
             [("one", "dull"), ("one", "shiny"), ("two", "dull"), ("two", "shiny")],
             names=["b", "c"],
@@ -256,7 +259,8 @@ class TestCrosstab:
         # when margins=true and dropna=true
 
         df = DataFrame({"a": [1, 2, 2, 2, 2, np.nan], "b": [3, 3, 4, 4, 4, 4]})
-        actual = crosstab(df.a, df.b, margins=True, dropna=True)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            actual = crosstab(df.a, df.b, margins=True, dropna=True)
         expected = DataFrame([[1, 0, 1], [1, 3, 4], [2, 3, 5]])
         expected.index = Index([1.0, 2.0, "All"], name="a")
         expected.columns = Index([3, 4, "All"], name="b")
@@ -266,7 +270,8 @@ class TestCrosstab:
         df = DataFrame(
             {"a": [1, np.nan, np.nan, np.nan, 2, np.nan], "b": [3, np.nan, 4, 4, 4, 4]}
         )
-        actual = crosstab(df.a, df.b, margins=True, dropna=True)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            actual = crosstab(df.a, df.b, margins=True, dropna=True)
         expected = DataFrame([[1, 0, 1], [0, 1, 1], [1, 1, 2]])
         expected.index = Index([1.0, 2.0, "All"], name="a")
         expected.columns = Index([3.0, 4.0, "All"], name="b")
@@ -276,7 +281,8 @@ class TestCrosstab:
         df = DataFrame(
             {"a": [1, np.nan, np.nan, np.nan, np.nan, 2], "b": [3, 3, 4, 4, 4, 4]}
         )
-        actual = crosstab(df.a, df.b, margins=True, dropna=True)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            actual = crosstab(df.a, df.b, margins=True, dropna=True)
         expected = DataFrame([[1, 0, 1], [0, 1, 1], [1, 1, 2]])
         expected.index = Index([1.0, 2.0, "All"], name="a")
         expected.columns = Index([3, 4, "All"], name="b")
@@ -288,7 +294,8 @@ class TestCrosstab:
         # when margins=True and dropna=False
         # GH: 10772: Keep np.nan in result with dropna=False
         df = DataFrame({"a": [1, 2, 2, 2, 2, np.nan], "b": [3, 3, 4, 4, 4, 4]})
-        actual = crosstab(df.a, df.b, margins=True, dropna=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            actual = crosstab(df.a, df.b, margins=True, dropna=False)
         expected = DataFrame([[1, 0, 1], [1, 3, 4], [0, 1, 1], [2, 4, 6]])
         expected.index = Index([1.0, 2.0, np.nan, "All"], name="a")
         expected.columns = Index([3, 4, "All"], name="b")
@@ -299,7 +306,8 @@ class TestCrosstab:
         df = DataFrame(
             {"a": [1, np.nan, np.nan, np.nan, 2, np.nan], "b": [3, np.nan, 4, 4, 4, 4]}
         )
-        actual = crosstab(df.a, df.b, margins=True, dropna=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            actual = crosstab(df.a, df.b, margins=True, dropna=False)
         expected = DataFrame(
             [[1, 0, 0, 1.0], [0, 1, 0, 1.0], [0, 3, 1, 4.0], [1, 4, 1, 6.0]]
         )
@@ -315,9 +323,15 @@ class TestCrosstab:
             ["dull", "dull", "dull", "dull", "dull", "shiny", "shiny"], dtype=object
         )
 
-        actual = crosstab(
-            a, [b, c], rownames=["a"], colnames=["b", "c"], margins=True, dropna=False
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            actual = crosstab(
+                a,
+                [b, c],
+                rownames=["a"],
+                colnames=["b", "c"],
+                margins=True,
+                dropna=False,
+            )
         m = MultiIndex.from_arrays(
             [
                 ["one", "one", "two", "two", np.nan, np.nan, "All"],
@@ -332,9 +346,15 @@ class TestCrosstab:
         expected.index = Index(["bar", "foo", "All"], name="a")
         tm.assert_frame_equal(actual, expected)
 
-        actual = crosstab(
-            [a, b], c, rownames=["a", "b"], colnames=["c"], margins=True, dropna=False
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            actual = crosstab(
+                [a, b],
+                c,
+                rownames=["a", "b"],
+                colnames=["c"],
+                margins=True,
+                dropna=False,
+            )
         m = MultiIndex.from_arrays(
             [
                 ["bar", "bar", "bar", "foo", "foo", "foo", "All"],
@@ -357,9 +377,15 @@ class TestCrosstab:
         expected.columns = Index(["dull", "shiny", "All"], name="c")
         tm.assert_frame_equal(actual, expected)
 
-        actual = crosstab(
-            [a, b], c, rownames=["a", "b"], colnames=["c"], margins=True, dropna=True
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            actual = crosstab(
+                [a, b],
+                c,
+                rownames=["a", "b"],
+                colnames=["c"],
+                margins=True,
+                dropna=True,
+            )
         m = MultiIndex.from_arrays(
             [["bar", "bar", "foo", "foo", "All"], ["one", "two", "one", "two", ""]],
             names=["a", "b"],
@@ -859,7 +885,8 @@ def test_categoricals(a_dtype, b_dtype):
     g = np.random.default_rng(2)
     a = Series(g.integers(0, 3, size=100)).astype(a_dtype)
     b = Series(g.integers(0, 2, size=100)).astype(b_dtype)
-    result = crosstab(a, b, margins=True, dropna=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+        result = crosstab(a, b, margins=True, dropna=False, observed=False)
     columns = Index([0, 1, "All"], dtype="object", name="col_0")
     index = Index([0, 1, 2, "All"], dtype="object", name="row_0")
     values = [[10, 18, 28], [23, 16, 39], [17, 16, 33], [50, 50, 100]]
@@ -870,7 +897,8 @@ def test_categoricals(a_dtype, b_dtype):
     a.loc[a == 1] = 2
     a_is_cat = isinstance(a.dtype, CategoricalDtype)
     assert not a_is_cat or a.value_counts().loc[1] == 0
-    result = crosstab(a, b, margins=True, dropna=False)
+    with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+        result = crosstab(a, b, margins=True, dropna=False, observed=False)
     values = [[10, 18, 28], [0, 0, 0], [40, 32, 72], [50, 50, 100]]
     expected = DataFrame(values, index, columns)
     if not a_is_cat:

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -11,6 +11,8 @@ import pytest
 
 from pandas._config import using_string_dtype
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import (
     ArrowDtype,
@@ -156,12 +158,14 @@ class TestPivotTable:
                 "quantity": {0: 2000000, 1: 500000, 2: 1000000, 3: 1000000},
             }
         )
-        pv_col = df.pivot_table(
-            "quantity", "month", ["customer", "product"], dropna=False
-        )
-        pv_ind = df.pivot_table(
-            "quantity", ["customer", "product"], "month", dropna=False
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            pv_col = df.pivot_table(
+                "quantity", "month", ["customer", "product"], dropna=False
+            )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            pv_ind = df.pivot_table(
+                "quantity", ["customer", "product"], "month", dropna=False
+            )
 
         m = MultiIndex.from_tuples(
             [
@@ -191,9 +195,10 @@ class TestPivotTable:
             ["c", "d", "c", "d"], categories=["c", "d", "y"], ordered=True
         )
         df = DataFrame({"A": cat1, "B": cat2, "values": [1, 2, 3, 4]})
-        result = pivot_table(
-            df, values="values", index=["A", "B"], dropna=True, observed=False
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = pivot_table(
+                df, values="values", index=["A", "B"], dropna=True, observed=False
+            )
 
         exp_index = MultiIndex.from_arrays([cat1, cat2], names=["A", "B"])
         expected = DataFrame({"values": [1.0, 2.0, 3.0, 4.0]}, index=exp_index)
@@ -212,9 +217,10 @@ class TestPivotTable:
         )
 
         df["A"] = df["A"].astype(CategoricalDtype(categories, ordered=False))
-        result = df.pivot_table(
-            index="B", columns="A", values="C", dropna=dropna, observed=False
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(
+                index="B", columns="A", values="C", dropna=dropna, observed=False
+            )
         expected_columns = Series(["a", "b", "c"], name="A")
         expected_columns = expected_columns.astype(
             CategoricalDtype(categories, ordered=False)
@@ -244,7 +250,10 @@ class TestPivotTable:
             }
         )
 
-        result = df.pivot_table(index="A", values="B", dropna=dropna, observed=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(
+                index="A", values="B", dropna=dropna, observed=False
+            )
         if dropna:
             values = [2.0, 3.0]
             codes = [0, 1]
@@ -275,7 +284,10 @@ class TestPivotTable:
             }
         )
 
-        result = df.pivot_table(index="A", values="B", dropna=dropna, observed=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(
+                index="A", values="B", dropna=dropna, observed=False
+            )
         expected = DataFrame(
             {"B": [2.0, 3.0, 0.0]},
             index=Index(
@@ -299,7 +311,10 @@ class TestPivotTable:
         interval_values = Categorical(pd.IntervalIndex.from_arrays(left, right, closed))
         df = DataFrame({"A": interval_values, "B": 1})
 
-        result = df.pivot_table(index="A", values="B", dropna=dropna, observed=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(
+                index="A", values="B", dropna=dropna, observed=False
+            )
         expected = DataFrame(
             {"B": 1.0}, index=Index(interval_values.unique(), name="A")
         )
@@ -1094,7 +1109,8 @@ class TestPivotTable:
                 "C": dti,
             }
         )
-        result = df.pivot_table(index=["B", "C"], dropna=False)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(index=["B", "C"], dropna=False)
 
         # check tz retention
         assert result.index.levels[1].equals(dti)
@@ -1931,7 +1947,8 @@ class TestPivotTable:
         expected.index = Index([0, 1, "All"], name="y")
         expected.columns = Index([0, 1, "All"], name="z")
 
-        table = df.pivot_table("x", "y", "z", dropna=observed, margins=True)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            table = df.pivot_table("x", "y", "z", dropna=observed, margins=True)
         tm.assert_frame_equal(table, expected)
 
     def test_categorical_margins_category(self, observed):
@@ -1945,9 +1962,10 @@ class TestPivotTable:
 
         df.y = df.y.astype("category")
         df.z = df.z.astype("category")
-        table = df.pivot_table(
-            "x", "y", "z", dropna=observed, margins=True, observed=False
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            table = df.pivot_table(
+                "x", "y", "z", dropna=observed, margins=True, observed=False
+            )
         tm.assert_frame_equal(table, expected)
 
     def test_margins_casted_to_float(self):
@@ -2009,14 +2027,15 @@ class TestPivotTable:
             {"C1": ["A", "B", "C", "C"], "C2": ["a", "a", "b", "b"], "V": [1, 2, 3, 4]}
         )
         df["C1"] = df["C1"].astype("category")
-        result = df.pivot_table(
-            "V",
-            index="C1",
-            columns="C2",
-            dropna=observed,
-            aggfunc="count",
-            observed=False,
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(
+                "V",
+                index="C1",
+                columns="C2",
+                dropna=observed,
+                aggfunc="count",
+                observed=False,
+            )
 
         expected_index = pd.CategoricalIndex(
             ["A", "B", "C"], categories=["A", "B", "C"], ordered=False, name="C1"
@@ -2293,9 +2312,13 @@ class TestPivotTable:
         def ret_none(x):
             return np.nan
 
-        result = pivot_table(
-            df, columns="fruit", aggfunc=[ret_sum, ret_none, ret_one], dropna=dropna
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = pivot_table(
+                df,
+                columns="fruit",
+                aggfunc=[ret_sum, ret_none, ret_one],
+                dropna=dropna,
+            )
 
         data = [[3, 1, np.nan, np.nan, 1, 1], [13, 6, np.nan, np.nan, 1, 1]]
         col = MultiIndex.from_product(
@@ -2315,7 +2338,8 @@ class TestPivotTable:
             {"A": ["one", "two", "one"], "x": [3, np.nan, 2], "y": [1, np.nan, np.nan]}
         )
 
-        result = pivot_table(df, columns="A", aggfunc="mean", dropna=dropna)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = pivot_table(df, columns="A", aggfunc="mean", dropna=dropna)
 
         data = [[2.5, np.nan], [1, np.nan]]
         col = Index(["one", "two"], name="A")
@@ -2490,9 +2514,10 @@ class TestPivotTable:
         # GH#47477
         # GH#47971
         df = DataFrame({"x": "a", "y": "b", "age": Series([20, 40], dtype=dtype)})
-        result = df.pivot_table(
-            index="x", columns="y", values="age", aggfunc="mean", dropna=dropna
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(
+                index="x", columns="y", values="age", aggfunc="mean", dropna=dropna
+            )
         expected = DataFrame(
             [[30]],
             index=Index(["a"], name="x"),
@@ -2640,7 +2665,10 @@ class TestPivotTable:
         # GH#61113
         data = {"row": [None, *range(4)], "col": [*range(4), None], "val": range(5)}
         df = DataFrame(data)
-        result = df.pivot_table(values="val", index="row", columns="col", dropna=dropna)
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(
+                values="val", index="row", columns="col", dropna=dropna
+            )
         e_axis = [*range(4), None]
         nan = np.nan
         e_data = [
@@ -2710,14 +2738,15 @@ class TestPivotTable:
             }
         )
 
-        result = df.pivot_table(
-            index="g1",
-            columns="g2",
-            values="i",
-            aggfunc="count",
-            dropna=False,
-            margins=True,
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match="dropna"):
+            result = df.pivot_table(
+                index="g1",
+                columns="g2",
+                values="i",
+                aggfunc="count",
+                dropna=False,
+                margins=True,
+            )
 
         expected = DataFrame(
             {


### PR DESCRIPTION
I'm not pushing for this, just putting it up to make it easy in case @rhshadrach (the OP of the motivating issue) wants to.

## Summary

- Deprecate the `dropna` parameter in `pivot_table` and `crosstab` with `Pandas4Warning` (GH#53521)
- Fix bug where `observed=dropna` was incorrectly passed to `_add_margins` in `pivot_table`, ignoring the user's `observed` setting
- Fix same `observed=dropna` coupling in `crosstab`
- Add `observed` parameter to `crosstab` (previously unavailable)

closes #53521

## Test plan

- [x] All existing pivot_table and crosstab tests pass (246 passed, 3 xfailed)
- [x] Tests that explicitly pass `dropna=` are wrapped with `tm.assert_produces_warning(Pandas4Warning)`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)