### PR TITLE
PERF: speed up to_csv for sparse DataFrames by optimizing SparseArray.isna

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -121,6 +121,7 @@ Performance improvements
 - Performance improvement in :meth:`GroupBy.first` and :meth:`GroupBy.last` for Extension Array dtypes, which no longer fall back to a slow ``apply``-based implementation (:issue:`57591`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
 - Performance improvement in :meth:`Index.get_indexer` for large monotonic indexes, which now uses binary search instead of building a hash table when the number of targets is small (:issue:`14273`)
+- Performance improvement in :meth:`arrays.SparseArray.isna` by avoiding a dense-then-resparsify round-trip (:issue:`41023`)
 - Performance improvement in datetime/timedelta unit conversion (e.g. ``datetime64[s]`` to ``datetime64[ns]``) (:issue:`35025`)
 - Performance improvement in indexing a :class:`DataFrame` with a :class:`CategoricalIndex` of :class:`Interval` categories (:issue:`61928`)
 - Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -291,6 +291,10 @@ def _wrap_result(
     )
 
 
+_BOOL_SPARSE_DTYPE_FALSE_FILL = SparseDtype(bool, False)
+_BOOL_SPARSE_DTYPE_TRUE_FILL = SparseDtype(bool, True)
+
+
 @set_module("pandas.arrays")
 class SparseArray(OpsMixin, PandasObject, ExtensionArray):
     """
@@ -786,12 +790,23 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
     def isna(self) -> Self:  # type: ignore[override]
         # If null fill value, we want SparseDtype[bool, true]
         # to preserve the same memory usage.
-        dtype = SparseDtype(bool, self._null_fill_value)
         if self._null_fill_value:
-            return type(self)._simple_new(isna(self.sp_values), self.sp_index, dtype)
-        mask = np.full(len(self), False, dtype=np.bool_)
-        mask[self.sp_index.indices] = isna(self.sp_values)
-        return type(self)(mask, fill_value=False, dtype=dtype)
+            return type(self)._simple_new(
+                isna(self.sp_values),
+                self.sp_index,
+                _BOOL_SPARSE_DTYPE_TRUE_FILL,
+            )
+        # GH#41023 - avoid densify-then-resparsify round-trip.
+        # The NA positions are exactly the subset of sp_index where sp_values
+        # are NA; we can construct the sparse index directly.
+        sp_mask = isna(self.sp_values)
+        na_indices = self.sp_index.indices[sp_mask]
+        new_sp_index = make_sparse_index(len(self), na_indices, self.kind)
+        return type(self)._simple_new(
+            np.ones(len(na_indices), dtype=bool),
+            new_sp_index,
+            _BOOL_SPARSE_DTYPE_FALSE_FILL,
+        )
 
     def fillna(
         self,

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -349,6 +349,50 @@ class TestSparseArrayAnalytics:
         assert arr.npoints == 1
 
 
+class TestIsna:
+    # GH#41023
+    @pytest.mark.parametrize("kind", ["integer", "block"])
+    def test_isna_non_null_fill_no_nas(self, kind):
+        # Common case: non-null fill value, no NAs in sp_values
+        arr = SparseArray([0, 1, 0, 2, 0], fill_value=0, kind=kind)
+        result = arr.isna()
+        assert result.dtype == SparseDtype(bool, False)
+        expected_dense = np.array([False, False, False, False, False])
+        tm.assert_numpy_array_equal(np.asarray(result), expected_dense)
+        assert result.sp_values.size == 0
+
+    @pytest.mark.parametrize("kind", ["integer", "block"])
+    def test_isna_non_null_fill_with_nas(self, kind):
+        # Non-null fill value, some NAs among sp_values
+        arr = SparseArray([0, np.nan, 0, 2, np.nan], fill_value=0, kind=kind)
+        result = arr.isna()
+        expected_dense = np.array([False, True, False, False, True])
+        tm.assert_numpy_array_equal(np.asarray(result), expected_dense)
+
+    @pytest.mark.parametrize("kind", ["integer", "block"])
+    def test_isna_non_null_fill_all_sp_values_na(self, kind):
+        # Non-null fill value, all sp_values are NA
+        arr = SparseArray([0, np.nan, 0, np.nan], fill_value=0, kind=kind)
+        result = arr.isna()
+        expected_dense = np.array([False, True, False, True])
+        tm.assert_numpy_array_equal(np.asarray(result), expected_dense)
+
+    @pytest.mark.parametrize("kind", ["integer", "block"])
+    def test_isna_null_fill_value(self, kind):
+        # Null fill value
+        arr = SparseArray([np.nan, 1, np.nan, 2], kind=kind)
+        result = arr.isna()
+        expected_dense = np.array([True, False, True, False])
+        tm.assert_numpy_array_equal(np.asarray(result), expected_dense)
+
+    def test_isna_empty_sparse(self):
+        # All fill values, no sp_values at all
+        arr = SparseArray([0, 0, 0], fill_value=0)
+        result = arr.isna()
+        expected_dense = np.array([False, False, False])
+        tm.assert_numpy_array_equal(np.asarray(result), expected_dense)
+
+
 def test_setting_fill_value_fillna_still_works():
     # This is why letting users update fill_value / dtype is bad
     # astype has the same problem.


### PR DESCRIPTION
## Summary

Sparse DataFrame `to_csv` was ~5x slower than converting to dense first — the CSV writer's generic ExtensionArray path calls `isna()` on every column in every chunk, and `SparseArray.isna()` was the dominant cost.

The non-null fill value branch of `SparseArray.isna()` was creating a dense bool array then passing it through `__init__`, which called `_make_sparse` to rediscover the sparse structure we already know. Instead, compute the sparse index directly from the subset of `sp_index` where `sp_values` are NA, and use `_simple_new`. Also cache the `SparseDtype(bool, False/True)` objects as module-level constants to avoid repeated construction.

Benchmarking the reproducer from the issue (1000×1000 sparse DataFrame):
- Before: sparse `to_csv` ~4.7x slower than dense
- After: ~3.5x slower (the remaining gap is inherent densification cost in the CSV writer's generic EA path)

xref #41023 (makes an improvement, not sure if there is more room to improve)

## Test plan

- [x] Existing sparse tests pass (1415 in `tests/arrays/sparse/`, 832 in `tests/extension/test_sparse.py`)
- [x] Added `TestIsna` class with 5 new tests (9 cases with parametrization) covering both fill value types, presence/absence of NAs, empty arrays, and both sparse index kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)