### PR TITLE
Fix doubled words and grammar errors in comments and docs

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -275,7 +275,7 @@ Flags
 ~~~~~
 
 Flags refer to attributes of the pandas object. Properties of the dataset (like
-the date is was recorded, the URL it was accessed from, etc.) should be stored
+the date it was recorded, the URL it was accessed from, etc.) should be stored
 in :attr:`DataFrame.attrs`.
 
 .. autosummary::

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -571,7 +571,7 @@ Flags
 ~~~~~
 
 Flags refer to attributes of the pandas object. Properties of the dataset (like
-the date is was recorded, the URL it was accessed from, etc.) should be stored
+the date it was recorded, the URL it was accessed from, etc.) should be stored
 in :attr:`Series.attrs`.
 
 .. autosummary::

--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -702,7 +702,7 @@ of length "1".
     df.at["h", "cats"]  # returns a string
 
 .. note::
-    The is in contrast to R's ``factor`` function, where ``factor(c(1,2,3))[1]``
+    This is in contrast to R's ``factor`` function, where ``factor(c(1,2,3))[1]``
     returns a single value ``factor``.
 
 To get a single value ``Series`` of type ``category``, you pass in a list with

--- a/doc/source/whatsnew/v0.16.0.rst
+++ b/doc/source/whatsnew/v0.16.0.rst
@@ -612,7 +612,7 @@ Bug fixes
 - Bug in groupby ``.nth()`` with a multiple column groupby (:issue:`8979`)
 - Bug in ``DataFrame.where`` and ``Series.where`` coerce numerics to string incorrectly (:issue:`9280`)
 - Bug in ``DataFrame.where`` and ``Series.where`` raise ``ValueError`` when string list-like is passed. (:issue:`9280`)
-- Accessing ``Series.str`` methods on with non-string values now raises ``TypeError`` instead of producing incorrect results (:issue:`9184`)
+- Accessing ``Series.str`` methods with non-string values now raises ``TypeError`` instead of producing incorrect results (:issue:`9184`)
 - Bug in ``DatetimeIndex.__contains__`` when index has duplicates and is not monotonic increasing (:issue:`9512`)
 - Fixed division by zero error for ``Series.kurt()`` when all values are equal (:issue:`9197`)
 - Fixed issue in the ``xlsxwriter`` engine where it added a default 'General' format to cells if no other format was applied. This prevented other row or column formatting being applied. (:issue:`9167`)

--- a/doc/source/whatsnew/v0.7.0.rst
+++ b/doc/source/whatsnew/v0.7.0.rst
@@ -260,7 +260,7 @@ If the index had been sorted, the "range selection" would have been possible:
 Changes to Series ``[]`` operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As as notational convenience, you can pass a sequence of labels or a label
+As a notational convenience, you can pass a sequence of labels or a label
 slice to a Series when getting and setting values via ``[]`` (i.e. the
 ``__getitem__`` and ``__setitem__`` methods). The behavior will be the same as
 passing similar input to ``ix`` **except in the case of integer indexing**:

--- a/doc/source/whatsnew/v2.0.0.rst
+++ b/doc/source/whatsnew/v2.0.0.rst
@@ -875,7 +875,7 @@ Removal of prior version deprecations/changes
 - Removed deprecated :meth:`Index.is_monotonic`, and :meth:`Series.is_monotonic`; use ``obj.is_monotonic_increasing`` instead (:issue:`45422`)
 - Removed deprecated :meth:`Index.is_all_dates` (:issue:`36697`)
 - Enforced deprecation disallowing passing a timezone-aware :class:`Timestamp` and ``dtype="datetime64[ns]"`` to :class:`Series` or :class:`DataFrame` constructors (:issue:`41555`)
-- Enforced deprecation disallowing passing a sequence of timezone-aware values and ``dtype="datetime64[ns]"`` to to :class:`Series` or :class:`DataFrame` constructors (:issue:`41555`)
+- Enforced deprecation disallowing passing a sequence of timezone-aware values and ``dtype="datetime64[ns]"`` to :class:`Series` or :class:`DataFrame` constructors (:issue:`41555`)
 - Enforced deprecation disallowing ``numpy.ma.mrecords.MaskedRecords`` in the :class:`DataFrame` constructor; pass ``"{name: data[name] for name in data.dtype.names}`` instead (:issue:`40363`)
 - Enforced deprecation disallowing unit-less "datetime64" dtype in :meth:`Series.astype` and :meth:`DataFrame.astype` (:issue:`47844`)
 - Enforced deprecation disallowing using ``.astype`` to convert a ``datetime64[ns]`` :class:`Series`, :class:`DataFrame`, or :class:`DatetimeIndex` to timezone-aware dtype, use ``obj.tz_localize`` or ``ser.dt.tz_localize`` instead (:issue:`39258`)

--- a/doc/source/whatsnew/v2.2.2.rst
+++ b/doc/source/whatsnew/v2.2.2.rst
@@ -28,8 +28,8 @@ As usual please report any bugs discovered to our `issue tracker <https://github
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
-- :meth:`DataFrame.__dataframe__` was producing incorrect data buffers when the a column's type was a pandas nullable on with missing values (:issue:`56702`)
-- :meth:`DataFrame.__dataframe__` was producing incorrect data buffers when the a column's type was a pyarrow nullable on with missing values (:issue:`57664`)
+- :meth:`DataFrame.__dataframe__` was producing incorrect data buffers when a column's type was a pandas nullable one with missing values (:issue:`56702`)
+- :meth:`DataFrame.__dataframe__` was producing incorrect data buffers when a column's type was a pyarrow nullable one with missing values (:issue:`57664`)
 - Avoid issuing a spurious ``DeprecationWarning`` when a custom :class:`DataFrame` or :class:`Series` subclass method is called (:issue:`57553`)
 - Fixed regression in precision of :func:`to_datetime` with string and ``unit`` input (:issue:`57051`)
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1192,7 +1192,7 @@ Datetimelike
 - Bug in :func:`tseries.api.guess_datetime_format` would fail to infer time format when "%Y" == "%H%M" (:issue:`57452`)
 - Bug in :func:`tseries.frequencies.to_offset` would fail to parse frequency strings starting with "LWOM" (:issue:`59218`)
 - Bug in :meth:`.DateOffset.rollback` (and subclass methods) with ``normalize=True`` rolling back one offset too long (:issue:`32616`)
-- Bug in :meth:`DataFrame.agg` with with missing values resulting in IndexError (:issue:`58810`)
+- Bug in :meth:`DataFrame.agg` with missing values resulting in IndexError (:issue:`58810`)
 - Bug in :meth:`DataFrame.fillna` raising an ``AssertionError`` instead of ``OutOfBoundsDatetime`` when filling a ``datetime64[ns]`` column with an out-of-bounds timestamp. Now correctly raises ``OutOfBoundsDatetime``. (:issue:`61208`)
 - Bug in :meth:`DataFrame.min` and :meth:`DataFrame.max` casting ``datetime64`` and ``timedelta64`` columns to ``float64`` and losing precision (:issue:`60850`)
 - Bug in :meth:`DatetimeIndex.asof` with a string key giving incorrect results (:issue:`50946`)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1374,7 +1374,7 @@ class FrameColumnApply(FrameApply):
                 mgr.set_values(arr)
                 object.__setattr__(ser, "_name", name)
                 if not is_view:
-                    # In apply_series_generator we store the a shallow copy of the
+                    # In apply_series_generator we store a shallow copy of the
                     # result, which potentially increases the ref count of this reused
                     # `ser` object (depending on the result of the applied function)
                     # -> if that happened and `ser` is already a copy, then we reset

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -643,7 +643,7 @@ class PyTablesExpr(expr.Expr):
 
 
 class TermValue:
-    """hold a term value the we use to construct a condition/filter"""
+    """hold a term value that we use to construct a condition/filter"""
 
     def __init__(self, value, converted, kind: str) -> None:
         assert isinstance(kind, str), kind

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1282,7 +1282,7 @@ def np_find_common_type(*dtypes: np.dtype) -> np.dtype:
     try:
         common_dtype = np.result_type(*dtypes)
         if common_dtype.kind in "mMSU":
-            # NumPy promotion currently (1.25) misbehaves for for times and strings,
+            # NumPy promotion currently (1.25) misbehaves for times and strings,
             # so fall back to object (find_common_dtype did unless there
             # was only one dtype)
             common_dtype = np.dtype("O")

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -157,7 +157,7 @@ class bottleneck_switch:
 
 
 def _bn_ok_dtype(dtype: DtypeObj, name: str) -> bool:
-    # Bottleneck chokes on datetime64, PeriodDtype (or and EA)
+    # Bottleneck chokes on datetime64, PeriodDtype (or an EA)
     if dtype != object and not needs_i8_conversion(dtype):
         # GH 42878
         # Bottleneck uses naive summation leading to O(n) loss of precision

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -365,7 +365,7 @@ def format_object_summary(
         align with the name.
     line_break_each_value : bool, default False
         If True, inserts a line break for each value of ``obj``.
-        If False, only break lines when the a line of values gets wider
+        If False, only break lines when a line of values gets wider
         than the display width.
 
     Returns

--- a/pandas/tests/groupby/methods/test_kurt.py
+++ b/pandas/tests/groupby/methods/test_kurt.py
@@ -9,7 +9,7 @@ import pandas._testing as tm
 
 def test_groupby_kurt_equivalence():
     # GH#40139
-    # Test that that groupby kurt method (which uses libgroupby.group_kurt)
+    # Test that the groupby kurt method (which uses libgroupby.group_kurt)
     #  matches the results of operating group-by-group (which uses nanops.nankurt)
     nrows = 1000
     ngroups = 3

--- a/pandas/tests/groupby/methods/test_skew.py
+++ b/pandas/tests/groupby/methods/test_skew.py
@@ -8,7 +8,7 @@ import pandas._testing as tm
 
 
 def test_groupby_skew_equivalence():
-    # Test that that groupby skew method (which uses libgroupby.group_skew)
+    # Test that the groupby skew method (which uses libgroupby.group_skew)
     #  matches the results of operating group-by-group (which uses nanops.nanskew)
     nrows = 1000
     ngroups = 3

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1016,7 +1016,7 @@ class TestLocBaseIndependent:
         # non-unique indexer with loc slice
         # https://groups.google.com/forum/?fromgroups#!topic/pydata/zTm2No0crYs
 
-        # these are going to raise because the we are non monotonic
+        # these are going to raise because we are non monotonic
         df = DataFrame(
             {"A": [1, 2, 3, 4, 5, 6], "B": [3, 4, 5, 6, 7, 8]}, index=[0, 1, 0, 1, 2, 3]
         )

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -1008,7 +1008,7 @@ class TestRolling:
         # GH 13966 (similar to #15130, closed by #15175)
 
         # superseded by 43909
-        # GH 46061: OK if the on is monotonic relative to each each group
+        # GH 46061: OK if the on is monotonic relative to each group
 
         dates = date_range(start="2016-01-01 09:30:00", periods=20, freq="s")
         df = DataFrame(


### PR DESCRIPTION
## Summary
Fix doubled words and minor grammar errors across comments, docstrings, and documentation:

- Remove doubled words: `for for`, `that that`, `to to`, `with with`, `each each`, `the a`, `As as`
- Fix wrong small words: `is was` → `it was`, `The is` → `This is`, `or and` → `or an`, `the we` → `that we`/`we`
- Fix `nullable on` → `nullable one`, remove extraneous `on`

No functional changes. All fixes are in human-readable text (comments, docstrings, and RST documentation).

17 files changed, 18 fixes.