### PR TITLE
BUG: Fix numpy.bool_ hashing regression in object-dtype hash table

### DIFF
--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -192,6 +192,20 @@ static inline int tupleobject_cmp(PyTupleObject *a, PyTupleObject *b) {
   return 1;
 }
 
+static inline int is_bool_like(PyObject *obj) {
+  if (PyBool_Check(obj)) {
+    return 1;
+  }
+  const char *tp_name = Py_TYPE(obj)->tp_name;
+  if (tp_name != NULL) {
+    if ((tp_name[0] == 'n' && strcmp(tp_name, "numpy.bool_") == 0) ||
+        (tp_name[0] == 'b' && strcmp(tp_name, "bool_") == 0)) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
 static inline int pyobject_cmp(PyObject *a, PyObject *b) {
   if (a == b) {
     return 1;
@@ -211,8 +225,9 @@ static inline int pyobject_cmp(PyObject *a, PyObject *b) {
       return tupleobject_cmp((PyTupleObject *)a, (PyTupleObject *)b);
     }
     // frozenset isn't yet supported
-  } else if (PyBool_Check(a) != PyBool_Check(b)) {
+  } else if (is_bool_like(a) != is_bool_like(b)) {
     // GH#62888: distinguish bool from int, e.g. 0 vs False, 1 vs True
+    // GH#64749: np.True_ and True should both be considered bools
     return 0;
   }
 

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -80,7 +80,7 @@ class TestGetitem:
         # GH 64749
         list_of_dicts = [{np.True_: 1, np.False_: 0}]
         df = DataFrame(list_of_dicts)
-        
+
         result = df[True]
         expected = Series([1], name=np.True_)
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -76,6 +76,22 @@ class TestGetitem:
         expected = df["A"]
         tm.assert_series_equal(result, expected)
 
+    def test_getitem_numpy_bool_scalar(self):
+        # GH 64749
+        list_of_dicts = [{np.True_: 1, np.False_: 0}]
+        df = DataFrame(list_of_dicts)
+        
+        result = df[True]
+        expected = Series([1], name=np.True_)
+        tm.assert_series_equal(result, expected)
+
+        result_false = df[False]
+        expected_false = Series([0], name=np.False_)
+        tm.assert_series_equal(result_false, expected_false)
+
+        with pytest.raises(KeyError, match="1"):
+            df[1]
+
 
 class TestGetitemListLike:
     def test_getitem_list_missing_key(self):

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -45,6 +45,18 @@ class TestSeriesGetitemScalars:
         assert ser["a"] == 1
         assert ser[1.0] == 1
 
+    def test_getitem_numpy_bool_scalar(self):
+        # GH#64749
+        ser = Series([1, 0], index=[np.True_, np.False_])
+        assert ser[True] == 1
+        assert ser[np.True_] == 1
+        assert ser[False] == 0
+        assert ser[np.False_] == 0
+
+        with pytest.raises(KeyError, match="1"):
+            ser[1]
+
+
     def test_getitem_float_keys_tuple_values(self):
         # see GH#13509
 

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -56,7 +56,6 @@ class TestSeriesGetitemScalars:
         with pytest.raises(KeyError, match="1"):
             ser[1]
 
-
     def test_getitem_float_keys_tuple_values(self):
         # see GH#13509
 


### PR DESCRIPTION
- [x] closes #64749
- [x] Tests added and passed 
- [x] All code checks passed
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.

### Description

This PR fixes issue #64749 where `np.True_` and `True` are no longer treated as equivalent in object-dtype hash tables (a regression from #64639). Due to `PyBool_Check(a)` returning `0` for numpy's `numpy.bool_` scalar, the hash table treated Python booleans and Numpy booleans as fundamentally distinct keys. This resulted in `df[True]` throwing a KeyError when indexing an array keyed with `np.True_`, and even grouped `np.True_` with `1` during hashing.

This PR introduces an `is_bool_like()` hook in `khash_python.h` which checks `Py_TYPE(obj)->tp_name` to appropriately group `numpy.bool_` and `bool_` together with built-in Python booleans. 

Test cases tracking `__getitem__` equivalency with dictionary-instantiated arrays on indexing have been added to DataFrame and Series `test_getitem.py`.
