### PR TITLE
DOC: Add MSVC v143 fallback for cl.exe not found error

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -32,6 +32,8 @@ You will need `Build Tools for Visual Studio 2026
    If you encounter an error indicating ``cl.exe``,
    reopen the installer and also select the optional component
    **MSVC v142 - VS 2019 C++ x64/x86 build tools** in the right pane for installation.
+   If that does not resolve the error, also add the optional component
+   **MSVC v143 - VS 2022 C++ x64/x86 build tools**.
 
 Alternatively, you can install the necessary components on the commandline using
 `vs_BuildTools.exe <https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?source=recommendations&view=vs-2022>`_


### PR DESCRIPTION
## Description

When the MSVC v142 optional component doesn't resolve the `cl.exe` build error on Windows, users should also try adding the MSVC v143 - VS 2022 C++ x64/x86 build tools component.

This was reported by a contributor who found that MSVC v143 resolved their issue when v142 did not.

## Changes
- Added a fallback note in the contributing environment docs under the Windows C compiler installation section.

Closes #64650