### PR TITLE
BUG: groupby with Grouper(freq=...) raises when all keys are NaT

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -205,6 +205,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` (and their :class:`GroupBy` counterparts) returning ``0.0`` and ``-3.0`` respectively for degenerate windows or groups; these now return ``NaN`` (:issue:`62864`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
+- Bug in :meth:`DataFrame.groupby` with a :class:`Grouper` with ``freq`` raising ``AttributeError`` when all grouping keys are ``NaT`` (:issue:`43486`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2617,6 +2617,22 @@ class TimeGrouper(Grouper):
             )
             return binner, [], labels
 
+        # GH#43486: filter NaTs up front, mirroring _get_period_bins
+        nat_count = 0
+        if ax.hasnans:
+            nat_count = ax.isna().sum()
+            ax = ax[~ax.isna()]
+
+        if len(ax) == 0:
+            # all-NaT case
+            binner = labels = DatetimeIndex(
+                data=[], freq=self.freq, name=ax.name, dtype=ax.dtype
+            )
+            bins = np.array([], dtype=np.int64)
+            binner = binner.insert(0, NaT)
+            labels = labels.insert(0, NaT)
+            return binner, np.insert(bins, 0, nat_count), labels
+
         first, last = _get_timestamp_range_edges(
             ax.min(),  # type: ignore[arg-type]
             ax.max(),  # type: ignore[arg-type]
@@ -2648,9 +2664,7 @@ class TimeGrouper(Grouper):
         binner, bin_edges = self._adjust_bin_edges(binner, ax_values)
 
         # general version, knowing nothing about relative frequencies
-        bins = lib.generate_bins_dt64(
-            ax_values, bin_edges, self.closed, hasnans=ax.hasnans
-        )
+        bins = lib.generate_bins_dt64(ax_values, bin_edges, self.closed, hasnans=False)
 
         if self.closed == "right":
             labels = binner
@@ -2659,7 +2673,10 @@ class TimeGrouper(Grouper):
         elif self.label == "right":
             labels = labels[1:]  # type: ignore[assignment]
 
-        if ax.hasnans:
+        if nat_count > 0:
+            # shift bins by the number of NaT (they sort to the front of asi8)
+            bins = bins + nat_count
+            bins = np.insert(bins, 0, nat_count)
             binner = binner.insert(0, NaT)
             labels = labels.insert(0, NaT)
 

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -959,6 +959,17 @@ class TestGroupBy:
         expected_df = gb[["Quantity"]].aggregate("mean")
         tm.assert_frame_equal(result_df, expected_df)
 
+    def test_groupby_all_nat_timegrouper(self):
+        # GH#43486
+        df = DataFrame({"date": [pd.NaT, pd.NaT], "value": [1, 2]})
+        gb = df.groupby(Grouper(freq="ME", key="date"))
+        result = gb.sum()
+        expected = DataFrame(
+            {"value": np.array([], dtype="int64")},
+            index=DatetimeIndex([], dtype="datetime64[s]", name="date"),
+        )
+        tm.assert_frame_equal(result, expected)
+
     @td.skip_if_no("pyarrow")
     def test_pyarrow_index_retention(self):
         # https://github.com/pandas-dev/pandas/issues/63518


### PR DESCRIPTION
## Summary
- Fixes #43486
- `df.groupby(pd.Grouper(freq="ME", key="date"))` raised `AttributeError: 'NaTType' object has no attribute 'normalize'` when all grouping keys were NaT
- `_get_time_bins` now filters NaTs from the axis up front (and re-inserts the NaT bin afterward), rather than deferring NaT handling to `generate_bins_dt64` — which couldn't help because the crash occurred earlier, when `ax.min()` returned NaT and was passed to `_get_timestamp_range_edges`

## Test plan
- [x] Added regression test `test_groupby_all_nat_timegrouper`
- [x] Verified identical `_get_time_bins` output for mixed-NaT cases before and after the change
- [x] All resample and timegrouper tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)