### PR TITLE
BUG: Fix float16 overflow in nanmean/nansum by upcasting to float64

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -158,6 +158,7 @@ Numeric
 ^^^^^^^
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
 - Fixed bug in :meth:`Series.clip` where passing a scalar numpy array (e.g. ``np.array(0)``) would raise a ``TypeError`` (:issue:`59053`)
+- Fixed bug in :meth:`Series.mean` and :meth:`Series.sum` (and their :class:`DataFrame` counterparts) overflowing for ``float16`` dtypes instead of upcasting to ``float64`` (:issue:`43929`)
 - Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) returning ``0.0`` for degenerate distributions; these now return ``NaN`` (:issue:`62864`)
 
 Conversion

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -634,7 +634,8 @@ def nansum(
     values, mask = _get_values(values, skipna, fill_value=0, mask=mask)
     dtype_sum = _get_dtype_max(dtype)
     if dtype.kind == "f":
-        dtype_sum = dtype
+        # GH#43929 float16 sum overflows easily; upcast like numpy does
+        dtype_sum = np.dtype(np.float64) if dtype == np.float16 else dtype
     elif dtype.kind == "m":
         dtype_sum = np.dtype(np.float64)
 
@@ -708,7 +709,8 @@ def nanmean(
     elif dtype.kind in "iu":
         dtype_sum = np.dtype(np.float64)
     elif dtype.kind == "f":
-        dtype_sum = dtype
+        # GH#43929 float16 sum overflows easily; upcast like numpy does
+        dtype_sum = np.dtype(np.float64) if dtype == np.float16 else dtype
         dtype_count = dtype
 
     count = _get_counts(values.shape, mask, axis, dtype=dtype_count)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -922,7 +922,10 @@ class TestDataFrameAnalytics:
         # GH#46947
         df = DataFrame({"a": [1.0, 2.3, 4.4], "b": [2.2, 3, np.nan]}, dtype=float_type)
         result = df.sum(**kwargs)
-        expected = Series(expected_result).astype(float_type)
+        # GH#43929 float16 upcasts to float64 in nansum to avoid overflow
+        expected = Series(expected_result, dtype=float_type)
+        if float_type == "float16":
+            expected = expected.astype("float64")
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("float_type", ["float16", "float32", "float64"])

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1267,6 +1267,16 @@ def test_check_bottleneck_disallow(any_real_numpy_dtype, func):
     assert not nanops._bn_ok_dtype(np.dtype(any_real_numpy_dtype).type, func)
 
 
+def test_nanmean_float16_overflow(disable_bottleneck):
+    # GH#43929 float16 sum overflows easily; upcast to float64 like numpy does
+    ser = Series([60000.0, 60000.0], dtype=np.float16)
+    result = ser.mean()
+    assert result == 60000.0
+
+    result = ser.sum()
+    assert result == 120000.0
+
+
 @pytest.mark.parametrize("val", [2**55, -(2**55), 20150515061816532])
 def test_nanmean_overflow(disable_bottleneck, val, using_python_scalars):
     # GH 10155


### PR DESCRIPTION
## Summary
- Upcast `float16` to `float64` for the sum accumulator in `nansum` and `nanmean`, matching numpy's behavior
- Previously, `Series([60000.0, 60000.0], dtype="float16").mean()` returned `inf` due to overflow in the intermediate sum

closes #43929

## Test plan
- [x] Added `test_nanmean_float16_overflow` verifying both `mean()` and `sum()` on float16 data
- [x] Existing `test_nanops.py` tests pass (245 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)