### PR TITLE
BUG: .loc with (scalar, list) on MultiIndex not dropping scalar level

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -227,6 +227,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
+- Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
 -
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1836,8 +1836,10 @@ class _LocIndexer(_LocationIndexer):
                 result = self.obj.iloc[tuple(indexer)]
 
                 # GH#18631 Drop levels that were indexed with scalars,
-                # but only when the key has no slices or bool indexers
-                # (e.g., pd.IndexSlice patterns preserve all levels).
+                # but only when the key has no slices or bool indexers.
+                # Dropping scalar levels in the presence of slices would
+                # be correct in principle, but many internal operations
+                # (e.g. stack/unstack) rely on the current behavior.
                 has_slice_or_mask = any(
                     isinstance(k, slice) or com.is_bool_indexer(k) for k in key
                 )

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1842,11 +1842,26 @@ class _LocIndexer(_LocationIndexer):
                     isinstance(k, slice) or com.is_bool_indexer(k) for k in key
                 )
                 if not has_slice_or_mask:
-                    levels_to_drop = [
-                        i for i, k in enumerate(key) if not is_list_like(k)
-                    ]
+                    levels_to_drop = []
+                    for idx, k in enumerate(key):
+                        if not is_list_like(k):
+                            levels_to_drop.append(idx)
+                        elif isinstance(k, tuple):
+                            # GH#27591 A tuple might be a single label
+                            # in this level rather than a sequence of labels
+                            try:
+                                labels.levels[idx].get_loc(k)
+                                levels_to_drop.append(idx)
+                            except KeyError:
+                                pass
                     if levels_to_drop:
-                        result = result.droplevel(levels_to_drop, axis=axis)
+                        if len(levels_to_drop) >= labels.nlevels:
+                            # All levels are scalar-indexed; reduce
+                            # dimensionality instead of droplevel (which
+                            # cannot remove every level).
+                            result = result._ixs(0, axis=axis)
+                        else:
+                            result = result.droplevel(levels_to_drop, axis=axis)
 
                 return result
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1833,7 +1833,22 @@ class _LocIndexer(_LocationIndexer):
                 locs = labels.get_locs(key)
                 indexer: list[slice | npt.NDArray[np.intp]] = [slice(None)] * self.ndim
                 indexer[axis] = locs
-                return self.obj.iloc[tuple(indexer)]
+                result = self.obj.iloc[tuple(indexer)]
+
+                # GH#18631 Drop levels that were indexed with scalars,
+                # but only when the key has no slices or bool indexers
+                # (e.g., pd.IndexSlice patterns preserve all levels).
+                has_slice_or_mask = any(
+                    isinstance(k, slice) or com.is_bool_indexer(k) for k in key
+                )
+                if not has_slice_or_mask:
+                    levels_to_drop = [
+                        i for i, k in enumerate(key) if not is_list_like(k)
+                    ]
+                    if levels_to_drop:
+                        result = result.droplevel(levels_to_drop, axis=axis)
+
+                return result
 
         # fall thru to straight lookup
         self._validate_key(key, axis)

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1407,11 +1407,8 @@ class TestDataFrameIndexing:
         indexer_tuple = namedtuple("Indexer", df.index.names)
         idxr = indexer_tuple(first="A", second=["a", "b"])
         result = df.loc[idxr, :]
-        expected = DataFrame(
-            index=MultiIndex.from_tuples(
-                [("A", "a"), ("A", "b")], names=["first", "second"]
-            )
-        )
+        # GH#18631 scalar-indexed level "first" is dropped
+        expected = DataFrame(index=Index(["a", "b"], name="second"))
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("indexer", [["a"], "a"])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -3130,12 +3130,14 @@ def test_loc_getitem_multiindex_tuple_level():
     #  of labels
     result = df.loc[:, (lev1[0], lev2[0], lev3[0])]
 
-    # TODO: i think this actually should drop levels
-    expected = df.iloc[:, :1]
-    tm.assert_frame_equal(result, expected)
+    # GH#18631 scalar-indexed levels (x, z) are dropped;
+    # level y is kept because tuple label (0, 1) is list-like
+    expected_loc = df.iloc[:, :1].droplevel(["x", "z"], axis=1)
+    tm.assert_frame_equal(result, expected_loc)
 
+    expected_xs = df.iloc[:, :1]
     alt = df.xs((lev1[0], lev2[0], lev3[0]), level=[0, 1, 2], axis=1)
-    tm.assert_frame_equal(alt, expected)
+    tm.assert_frame_equal(alt, expected_xs)
 
     # same thing on a Series
     ser = df.iloc[0]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -3130,10 +3130,11 @@ def test_loc_getitem_multiindex_tuple_level():
     #  of labels
     result = df.loc[:, (lev1[0], lev2[0], lev3[0])]
 
-    # GH#18631 scalar-indexed levels (x, z) are dropped;
-    # level y is kept because tuple label (0, 1) is list-like
-    expected_loc = df.iloc[:, :1].droplevel(["x", "z"], axis=1)
-    tm.assert_frame_equal(result, expected_loc)
+    # GH#18631 all three levels are scalar-indexed so all are dropped;
+    # the tuple (0, 1) is a scalar label in level y, not a sequence of labels.
+    # df.loc[:, full_key] should match df[full_key]
+    expected_loc = df[(lev1[0], lev2[0], lev3[0])]
+    tm.assert_series_equal(result, expected_loc)
 
     expected_xs = df.iloc[:, :1]
     alt = df.xs((lev1[0], lev2[0], lev3[0]), level=[0, 1, 2], axis=1)


### PR DESCRIPTION
## Summary
- When using `.loc` with a tuple indexer containing a scalar and a list on a MultiIndex (e.g., `df.loc[(1, [3, 4]), :]`), the scalar-indexed level was not being dropped from the result
- The fix adds level-dropping logic after the `.iloc` selection in `_LocIndexer._getitem_axis`, dropping levels whose key component is a non-list-like scalar
- Tuple labels that are scalar entries in a MultiIndex level (e.g., `(0, 1)` as a label in level y) are correctly recognized as scalars via `labels.levels[idx].get_loc(k)`, rather than being misclassified as list-like sequences (GH#27591)
- When all levels are scalar-indexed, the result reduces dimensionality (e.g., DataFrame to Series) instead of raising from `droplevel`

Partially addresses GH#62926 — the scalar+list case is now fixed, but the scalar+slice case (e.g., `df.loc[(slice(None), 1), :]`) is deferred because `stack`/`unstack` and other internal operations currently rely on all levels being preserved in the presence of slices.

closes #18631

## Test plan
- [x] Verified the fix with the exact example from the issue
- [x] Tested edge cases: list+scalar, both lists, scalar+list on 2-level MI, Series
- [x] Tested that `df.loc[:, full_tuple_key]` matches `df[full_tuple_key]` for tuple-label MultiIndex levels
- [x] All indexing tests pass (frame, series, multiindex)
- [x] Updated test expectations that were testing old buggy behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)