### PR TITLE
PERF: speed up lexsort_indexer for numeric dtypes

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -135,6 +135,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.insert` when the number of blocks is small (:issue:`57641`)
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
 - Performance improvement in :meth:`DataFrame.query` and :meth:`DataFrame.eval` when the :class:`DataFrame` contains :class:`PeriodDtype` or :class:`IntervalDtype` columns (:issue:`35247`)
+- Performance improvement in :meth:`DataFrame.sort_values` with multiple numeric columns by avoiding unnecessary :class:`Categorical` conversion (:issue:`15389`)
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)
 - Performance improvement in :meth:`GroupBy.any` and :meth:`GroupBy.all` for boolean-dtype columns (:issue:`37850`)
 - Performance improvement in :meth:`GroupBy.first` and :meth:`GroupBy.last` for Extension Array dtypes, which no longer fall back to a slow ``apply``-based implementation (:issue:`57591`)

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -350,17 +350,6 @@ def lexsort_indexer(
         if codes_given:
             codes = cast("np.ndarray", k)
             n = codes.max() + 1 if len(codes) else 0
-
-            mask = codes == -1
-
-            if na_position == "last" and mask.any():
-                codes = np.where(mask, n, codes)
-
-            # not order means descending
-            if not order:
-                codes = np.where(mask, codes, n - codes - 1)
-
-            labels.append(codes)
         else:
             # Fast path for numeric numpy arrays: skip Categorical
             # conversion and pass values directly to np.lexsort.
@@ -384,21 +373,22 @@ def lexsort_indexer(
                     # for descending to avoid overflow with negation.
                     arr = ~arr
                 labels.append(arr)
-            else:
-                cat = Categorical(k, ordered=True)
-                codes = cat.codes
-                n = len(cat.categories)
+                continue
 
-                mask = codes == -1
+            cat = Categorical(k, ordered=True)
+            codes = cat.codes
+            n = len(cat.categories)
 
-                if na_position == "last" and mask.any():
-                    codes = np.where(mask, n, codes)
+        mask = codes == -1
 
-                # not order means descending
-                if not order:
-                    codes = np.where(mask, codes, n - codes - 1)
+        if na_position == "last" and mask.any():
+            codes = np.where(mask, n, codes)
 
-                labels.append(codes)
+        # not order means descending
+        if not order:
+            codes = np.where(mask, codes, n - codes - 1)
+
+        labels.append(codes)
 
     return np.lexsort(labels)
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -350,21 +350,55 @@ def lexsort_indexer(
         if codes_given:
             codes = cast("np.ndarray", k)
             n = codes.max() + 1 if len(codes) else 0
+
+            mask = codes == -1
+
+            if na_position == "last" and mask.any():
+                codes = np.where(mask, n, codes)
+
+            # not order means descending
+            if not order:
+                codes = np.where(mask, codes, n - codes - 1)
+
+            labels.append(codes)
         else:
-            cat = Categorical(k, ordered=True)
-            codes = cat.codes
-            n = len(cat.categories)
+            # Fast path for numeric numpy arrays: skip Categorical
+            # conversion and pass values directly to np.lexsort.
+            arr = extract_array(k, extract_numpy=True)
+            if isinstance(arr, np.ndarray) and arr.dtype.kind in "fiub":
+                if arr.dtype.kind == "f":
+                    # For float dtypes, np.lexsort sorts NaN to the end.
+                    mask = np.isnan(arr)
+                    has_na = mask.any()
+                    if not order:
+                        # Descending: negate values. NaN stays NaN
+                        # and still sorts last.
+                        arr = -arr
+                        if na_position == "first" and has_na:
+                            arr[mask] = -np.inf
+                    elif na_position == "first" and has_na:
+                        arr = arr.copy()
+                        arr[mask] = -np.inf
+                elif not order:
+                    # int/uint/bool: no NaN possible, use bitwise NOT
+                    # for descending to avoid overflow with negation.
+                    arr = ~arr
+                labels.append(arr)
+            else:
+                cat = Categorical(k, ordered=True)
+                codes = cat.codes
+                n = len(cat.categories)
 
-        mask = codes == -1
+                mask = codes == -1
 
-        if na_position == "last" and mask.any():
-            codes = np.where(mask, n, codes)
+                if na_position == "last" and mask.any():
+                    codes = np.where(mask, n, codes)
 
-        # not order means descending
-        if not order:
-            codes = np.where(mask, codes, n - codes - 1)
+                # not order means descending
+                if not order:
+                    codes = np.where(mask, codes, n - codes - 1)
 
-        labels.append(codes)
+                labels.append(codes)
 
     return np.lexsort(labels)
 

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -7,6 +7,7 @@ import pytest
 
 from pandas import (
     NA,
+    Categorical,
     DataFrame,
     MultiIndex,
     Series,
@@ -164,7 +165,6 @@ class TestSorting:
     )
     def test_lexsort_indexer_numeric_dtypes(self, dtype, order, na_position):
         # GH#15389 - fast path for numeric dtypes should match Categorical path
-        from pandas.core.arrays import Categorical
 
         if dtype == np.bool_:
             key1 = np.array([True, False, True, False, True])
@@ -195,7 +195,6 @@ class TestSorting:
     @pytest.mark.parametrize("na_position", ["last", "first"])
     def test_lexsort_indexer_float_with_nan(self, order, na_position):
         # GH#15389 - float fast path must handle NaN placement correctly
-        from pandas.core.arrays import Categorical
 
         key1 = np.array([3.0, np.nan, 1.0, np.nan, 2.0])
         key2 = np.arange(len(key1), dtype=np.float64)

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -150,6 +150,85 @@ class TestSorting:
         result = lexsort_indexer(keys, orders=order, na_position=na_position)
         tm.assert_numpy_array_equal(result, np.array(exp, dtype=np.intp))
 
+    @pytest.mark.parametrize("order", [True, False])
+    @pytest.mark.parametrize("na_position", ["last", "first"])
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            np.float64,
+            np.float32,
+            np.int64,
+            np.uint64,
+            np.bool_,
+        ],
+    )
+    def test_lexsort_indexer_numeric_dtypes(self, dtype, order, na_position):
+        # GH#15389 - fast path for numeric dtypes should match Categorical path
+        from pandas.core.arrays import Categorical
+
+        if dtype == np.bool_:
+            key1 = np.array([True, False, True, False, True])
+        else:
+            key1 = np.array([3, 1, 5, 2, 4], dtype=dtype)
+        key2 = np.arange(len(key1), dtype=np.int64)
+        keys = [key1, key2]
+
+        result = lexsort_indexer(keys, orders=order, na_position=na_position)
+
+        # Compare with Categorical-based reference implementation
+        labels = []
+        for key, ord_ in zip(reversed(keys), [order, order], strict=True):
+            cat = Categorical(key, ordered=True)
+            codes = cat.codes
+            num_categories = len(cat.categories)
+            mask = codes == -1
+            if na_position == "last" and mask.any():
+                codes = np.where(mask, num_categories, codes)
+            if not ord_:
+                codes = np.where(mask, codes, num_categories - codes - 1)
+            labels.append(codes)
+        expected = np.lexsort(labels)
+
+        tm.assert_numpy_array_equal(result, expected)
+
+    @pytest.mark.parametrize("order", [True, False])
+    @pytest.mark.parametrize("na_position", ["last", "first"])
+    def test_lexsort_indexer_float_with_nan(self, order, na_position):
+        # GH#15389 - float fast path must handle NaN placement correctly
+        from pandas.core.arrays import Categorical
+
+        key1 = np.array([3.0, np.nan, 1.0, np.nan, 2.0])
+        key2 = np.arange(len(key1), dtype=np.float64)
+        keys = [key1, key2]
+
+        result = lexsort_indexer(keys, orders=order, na_position=na_position)
+
+        labels = []
+        for key, ord_ in zip(reversed(keys), [order, order], strict=True):
+            cat = Categorical(key, ordered=True)
+            codes = cat.codes
+            num_categories = len(cat.categories)
+            mask = codes == -1
+            if na_position == "last" and mask.any():
+                codes = np.where(mask, num_categories, codes)
+            if not ord_:
+                codes = np.where(mask, codes, num_categories - codes - 1)
+            labels.append(codes)
+        expected = np.lexsort(labels)
+
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_lexsort_indexer_int_descending_overflow(self):
+        # GH#15389 - int64 min value must not overflow during descending sort
+        key1 = np.array([2, np.iinfo(np.int64).min, 1, 0], dtype=np.int64)
+        key2 = np.arange(len(key1), dtype=np.int64)
+
+        result = lexsort_indexer([key1, key2], orders=False, na_position="last")
+
+        # Descending: 2, 1, 0, int64_min
+        expected = np.array([0, 2, 3, 1], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
     @pytest.mark.parametrize(
         "ascending, na_position, exp",
         [


### PR DESCRIPTION
## Summary

- Skip `Categorical` conversion for numeric numpy arrays (float, int, uint, bool) in `lexsort_indexer` and pass values directly to `np.lexsort`
- Uses negation for descending float and bitwise NOT for descending int/uint/bool to avoid int64 overflow
- ~3x speedup for multi-column `DataFrame.sort_values` on numeric DataFrames (e.g. 3.0s → 1.1s for 1M rows × 10 float64 columns)

The bottleneck was `Categorical()` construction (~190ms per column), which is necessary for non-numeric types but unnecessary for numeric types that `np.lexsort` handles natively.

closes #15389

## Test plan

- [x] All existing sort tests pass (359 passed)
- [x] Added `test_lexsort_indexer_numeric_dtypes`: 20 cases (5 dtypes × 2 order × 2 na_position), each compared against original Categorical-based implementation
- [x] Added `test_lexsort_indexer_float_with_nan`: 4 cases for float NaN placement correctness
- [x] Added `test_lexsort_indexer_int_descending_overflow`: verifies `int64.min` doesn't overflow during descending sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)