### PR TITLE
BUG: fix extra trailing bin in resample("D", closed="right")

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -282,6 +282,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
 - Bug in :meth:`DataFrame.groupby` with a :class:`Grouper` with ``freq`` raising ``AttributeError`` when all grouping keys are ``NaT`` (:issue:`43486`)
 - Bug in :meth:`Series.resample` and :meth:`DataFrame.resample` where same-frequency resampling with monthly, quarterly, or annual frequencies bypassed aggregation, returning the original values instead of the aggregation result (:issue:`18553`)
+- Bug in :meth:`Series.resample` and :meth:`DataFrame.resample` with ``"D"`` frequency and ``closed="right"`` producing an extra trailing empty bin when the last value falls on a Day boundary (:issue:`62200`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2964,14 +2964,20 @@ def _get_timestamp_range_edges(
         )
     else:
         first = first.normalize()
-        last = last.normalize()
+        last_normalized = last.normalize()
 
         if closed == "left":
             first = Timestamp(freq.rollback(first))
         else:
             first = Timestamp(first - freq)
 
-        last = Timestamp(last + freq)
+        if closed == "right" and isinstance(freq, Day) and last == last_normalized:
+            # GH#62200: when closed="right" and last is already on a
+            # Day boundary (midnight), it belongs to the previous bin's
+            # right edge, so we don't need to extend to the next bin.
+            last = last_normalized
+        else:
+            last = Timestamp(last_normalized + freq)
 
     return first, last
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -2202,3 +2202,47 @@ def test_resample_sum_with_inat_value():
     result = df.resample("MS").apply(np.sum)
     expected = DataFrame([-1], index=date_range("2013-01-01", periods=1, freq="MS"))
     tm.assert_frame_equal(result, expected)
+
+
+def test_resample_D_closed_right_no_extra_bin():
+    # GH#62200: resample("D", closed="right") should not produce an extra
+    # trailing empty bin when last value falls exactly on a Day boundary.
+    index = date_range("2000-05-13", "2000-05-15", freq="h")
+    ser = Series(range(len(index)), index=index)
+
+    result_d = ser.resample("D", closed="right").count()
+    result_24h = ser.resample("24h", closed="right").count()
+
+    expected = Series(
+        [1, 24, 24],
+        index=date_range("2000-05-12", periods=3, freq="D"),
+    )
+    tm.assert_series_equal(result_d, expected)
+    tm.assert_series_equal(result_24h, expected, check_freq=False)
+
+
+def test_resample_D_closed_right_label_right_no_extra_bin():
+    # GH#62200: original reproducer with label="right" and closed="right"
+    index = date_range("1-1-2000", "2-15-2000", freq="h").union(
+        date_range("4-15-2000", "5-15-2000", freq="h")
+    )
+    ser = Series(range(len(index)), index=index)
+    result_d = ser.resample("D", label="right", closed="right").count()
+    result_24h = ser.resample("24h", label="right", closed="right").count()
+
+    assert len(result_d) == len(result_24h)
+    tm.assert_series_equal(result_d, result_24h, check_freq=False)
+
+
+def test_resample_D_closed_right_not_on_boundary():
+    # GH#62200: when last value is NOT on a Day boundary, the trailing
+    # bin should still be present.
+    index = date_range("2000-05-13", "2000-05-15 12:00", freq="h")
+    ser = Series(range(len(index)), index=index)
+
+    result = ser.resample("D", closed="right").count()
+    expected = Series(
+        [1, 24, 24, 12],
+        index=date_range("2000-05-12", periods=4, freq="D"),
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- Fixes the regression where `resample("D", closed="right")` produced an extra trailing empty bin compared to `resample("24h", closed="right")` when the last value falls on a Day boundary (midnight).
- When `Day` was changed from a `Tick` subclass, the non-Tick path in `_get_timestamp_range_edges` unconditionally extended `last` by one freq. Now it skips the extension when `closed="right"`, freq is `Day`, and `last` is already at midnight.

closes #62200

## Test plan
- [x] Added `test_resample_D_closed_right_no_extra_bin` — verifies `D` and `24h` produce the same result with `closed="right"`
- [x] Added `test_resample_D_closed_right_label_right_no_extra_bin` — original reproducer from the issue
- [x] Added `test_resample_D_closed_right_not_on_boundary` — ensures trailing bin is still present when last value is not at midnight
- [x] Full resample test suite passes (4102 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)