### PR TITLE
BUG: Index.get_indexer with method and NaT/NaN target returns -1

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -217,6 +217,7 @@ Interval
 Indexing
 ^^^^^^^^
 - Bug in :meth:`DataFrame.loc` returning incorrect dtype when the column key is a ``slice`` (:issue:`63071`)
+- Bug in :meth:`Index.get_indexer` where ``method="pad"``, ``"backfill"``, or ``"nearest"`` returned incorrect results when the target contained ``NaT`` or ``NaN`` instead of ``-1`` (:issue:`32572`)
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
 - Bug in :meth:`DataFrame.iloc` setitem raising ``AttributeError`` when assigning a :class:`Series` or :class:`Index` with a nullable EA dtype (e.g. ``Int64``, ``Float64``, ``boolean``) into a column with a NumPy dtype (:issue:`47776`)
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` where incorrect values were produced when ``other`` was a :class:`Series` with :class:`ExtensionArray` values (:issue:`64635`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3890,16 +3890,17 @@ class Index(IndexOpsMixin, PandasObject):
             indexer = self._get_fill_indexer(target, method, limit, tolerance)
         elif method == "nearest":
             indexer = self._get_nearest_indexer(target, limit, tolerance)
-        elif target._is_multi and self._is_multi:
-            engine = self._engine
-            # error: Item "IndexEngine" of "Union[IndexEngine, ExtensionEngine]"
-            # has no attribute "_extract_level_codes"
-            tgt_values = engine._extract_level_codes(  # type: ignore[union-attr]
-                target
-            )
-            indexer = self._engine.get_indexer(tgt_values)  # pyright: ignore[reportArgumentType]
         else:
-            tgt_values = target._get_engine_target()
+            if target._is_multi and self._is_multi:
+                engine = self._engine
+                # error: Item "IndexEngine" of "Union[IndexEngine, ExtensionEngine]"
+                # has no attribute "_extract_level_codes"
+                tgt_values = engine._extract_level_codes(  # type: ignore[union-attr]
+                    target
+                )
+            else:
+                tgt_values = target._get_engine_target()
+
             indexer = self._engine.get_indexer(tgt_values)  # pyright: ignore[reportArgumentType]
 
         if method is not None and target._can_hold_na and not target._is_multi:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3890,18 +3890,24 @@ class Index(IndexOpsMixin, PandasObject):
             indexer = self._get_fill_indexer(target, method, limit, tolerance)
         elif method == "nearest":
             indexer = self._get_nearest_indexer(target, limit, tolerance)
-        else:
-            if target._is_multi and self._is_multi:
-                engine = self._engine
-                # error: Item "IndexEngine" of "Union[IndexEngine, ExtensionEngine]"
-                # has no attribute "_extract_level_codes"
-                tgt_values = engine._extract_level_codes(  # type: ignore[union-attr]
-                    target
-                )
-            else:
-                tgt_values = target._get_engine_target()
-
+        elif target._is_multi and self._is_multi:
+            engine = self._engine
+            # error: Item "IndexEngine" of "Union[IndexEngine, ExtensionEngine]"
+            # has no attribute "_extract_level_codes"
+            tgt_values = engine._extract_level_codes(  # type: ignore[union-attr]
+                target
+            )
             indexer = self._engine.get_indexer(tgt_values)  # pyright: ignore[reportArgumentType]
+        else:
+            tgt_values = target._get_engine_target()
+            indexer = self._engine.get_indexer(tgt_values)  # pyright: ignore[reportArgumentType]
+
+        if method is not None and target._can_hold_na and not target._is_multi:
+            # GH#32572 NaT/NaN in the target should not be matched
+            #  by pad/backfill/nearest
+            na_mask = target._isnan
+            if na_mask.any():
+                indexer[na_mask] = -1
 
         return ensure_platform_int(indexer)
 

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -623,6 +623,28 @@ class TestGetIndexer:
         expected = np.array(positions, dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
+    @pytest.mark.parametrize("tz", [None, "US/Central"])
+    @pytest.mark.parametrize("method", ["pad", "backfill", "nearest"])
+    def test_get_indexer_nat_target(self, tz, method):
+        # GH#32572 NaT in the target should not be matched
+        dti = date_range("2020-01-01", periods=5, tz=tz)
+        target = DatetimeIndex([pd.NaT], dtype=dti.dtype)
+        result = dti.get_indexer(target, method=method)
+        expected = np.array([-1], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    @pytest.mark.parametrize("tz", [None, "US/Central"])
+    @pytest.mark.parametrize("method", ["pad", "backfill", "nearest"])
+    def test_get_indexer_nat_in_target_mixed(self, tz, method):
+        # GH#32572 NaT entries should get -1, real entries should match normally
+        dti = date_range("2020-01-01", periods=5, tz=tz)
+        target = DatetimeIndex(
+            [pd.NaT, Timestamp("2020-01-03", tz=tz), pd.NaT], dtype=dti.dtype
+        )
+        result = dti.get_indexer(target, method=method)
+        expected = np.array([-1, 2, -1], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
     def test_get_indexer_pad_requires_monotonicity(self):
         rng = date_range("1/1/2000", "3/1/2000", freq="B")
 

--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -182,6 +182,15 @@ class TestGetIndexer:
         )
         tm.assert_numpy_array_equal(actual, np.array(expected, dtype=np.intp))
 
+    @pytest.mark.parametrize("method", ["pad", "backfill", "nearest"])
+    def test_get_indexer_nan_target(self, method):
+        # GH#32572 NaN in the target should not be matched
+        index = Index([1.0, 2.0, 3.0, 4.0, 5.0])
+        target = Index([np.nan])
+        result = index.get_indexer(target, method=method)
+        expected = np.array([-1], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
     def test_get_indexer_nearest_error(self):
         index = Index(np.arange(10))
         with pytest.raises(ValueError, match="limit argument"):

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -131,6 +131,15 @@ class TestGetIndexer:
         res = idx.get_indexer(target, "nearest", tolerance=Timedelta("1 hour"))
         tm.assert_numpy_array_equal(res, np.array([0, -1, 1], dtype=np.intp))
 
+    @pytest.mark.parametrize("method", ["pad", "backfill", "nearest"])
+    def test_get_indexer_nat_target(self, method):
+        # GH#32572 NaT in the target should not be matched
+        tdi = to_timedelta(["0 days", "1 days", "2 days"])
+        target = TimedeltaIndex([NaT])
+        result = tdi.get_indexer(target, method=method)
+        expected = np.array([-1], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
 
 class TestWhere:
     def test_where_doesnt_retain_freq(self):


### PR DESCRIPTION
## Summary
- `Index.get_indexer` with `method="pad"`, `"backfill"`, or `"nearest"` returned incorrect indices when the target contained `NaT` or `NaN` values. These values are not comparable and should always yield `-1`.
- The root cause was in the searchsorted path: `searchsorted` places `NaT` at the end of the array, so for pad `searchsorted(...) - 1` returned the last valid index instead of `-1`.
- The fix adds a post-processing step in `_get_indexer` that masks `NaT`/`NaN` target entries to `-1`, gated on `_can_hold_na` to avoid overhead for integer/range indexes.

closes #32572

## Test plan
- [x] Added tests for `DatetimeIndex` (tz-aware and tz-naive), `TimedeltaIndex`, and numeric `Index` with `NaN` across all three methods
- [x] Added test for mixed targets (NaT interleaved with real values)
- [x] Full `pandas/tests/indexes/` suite passes (16,612 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)