### PR TITLE
BUG: fix float64 precision loss in Series.interpolate for datetime/timedelta indexes

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -229,6 +229,7 @@ Indexing
 Missing
 ^^^^^^^
 - Bug in :meth:`DataFrame.fillna` with a dict value raising ``RecursionError`` when columns are a :class:`MultiIndex` with duplicate entries (:issue:`53498`)
+- Bug in :meth:`Series.interpolate` with ``method="index"`` or ``method="values"`` giving incorrect results for :class:`DatetimeIndex` or :class:`TimedeltaIndex` with nanosecond resolution due to float64 precision loss of large i8 values (:issue:`34601`)
 -
 
 MultiIndex

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -444,6 +444,19 @@ def _index_to_interp_indices(index: Index, method: str) -> np.ndarray:
             if inds.dtype == np.object_:
                 inds = lib.maybe_convert_objects(inds)
 
+    if needs_i8_conversion(index.dtype) and len(inds) > 0:
+        # GH#34601 large i8 values (nanosecond timestamps) lose precision
+        # when np.interp converts to float64. Subtract the minimum to work
+        # with smaller relative offsets that fit precisely in float64.
+        offset = inds.min()
+        if offset < 0 and inds.max() > np.iinfo(np.int64).max + offset:
+            # Data range exceeds int64, so int64 subtraction would overflow.
+            # This only happens for datetime ranges spanning more than ~292
+            # years (ns resolution), where float64 precision is acceptable.
+            inds = inds.astype(np.float64) - np.float64(offset)
+        else:
+            inds = inds - offset
+
     return inds
 
 

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -647,6 +647,53 @@ class TestSeriesInterpolateData:
         with pytest.raises(ValueError, match=msg):
             ser.interpolate(method="pad")
 
+    @pytest.mark.parametrize("method", ["index", "values"])
+    @pytest.mark.parametrize("year", ["2000", "2001"])
+    def test_interp_datetime_index_float64_precision(self, method, year):
+        # GH#34601 large i8 values (nanosecond timestamps) lose precision
+        # when np.interp converts to float64; result should not depend on year
+        dti = pd.DatetimeIndex(
+            [
+                f"{year}-01-01 00:00:00.000000",
+                f"{year}-01-01 00:00:00.000001",
+                f"{year}-01-01 00:00:00.000003",
+            ]
+        ).as_unit("ns")
+        ser = Series([0, None, 1], index=dti)
+        result = ser.interpolate(method=method)
+        expected = Series([0.0, 1.0 / 3.0, 1.0], index=dti)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("method", ["index", "values"])
+    def test_interp_timedelta_index_float64_precision(self, method):
+        # GH#34601 same precision issue applies to large TimedeltaIndex values
+        tdi = pd.to_timedelta(
+            [
+                1_000_000_000_000_000_000,
+                1_000_000_000_000_001_000,
+                1_000_000_000_000_003_000,
+            ],
+            unit="ns",
+        )
+        ser = Series([0, None, 1], index=tdi)
+        result = ser.interpolate(method=method)
+        expected = Series([0.0, 1.0 / 3.0, 1.0], index=tdi)
+        tm.assert_series_equal(result, expected)
+
+    def test_interp_datetime_index_pre_epoch_float64_precision(self):
+        # GH#34601 pre-epoch timestamps have large negative i8 values
+        dti = pd.DatetimeIndex(
+            [
+                "1950-01-01 00:00:00.000000",
+                "1950-01-01 00:00:00.000001",
+                "1950-01-01 00:00:00.000003",
+            ]
+        ).as_unit("ns")
+        ser = Series([0, None, 1], index=dti)
+        result = ser.interpolate(method="index")
+        expected = Series([0.0, 1.0 / 3.0, 1.0], index=dti)
+        tm.assert_series_equal(result, expected)
+
     def test_interp_limit_no_nans(self):
         # GH 7173
         s = Series([1.0, 2.0, 3.0])


### PR DESCRIPTION
## Summary
- When using `Series.interpolate(method="index")` or `method="values"` with a `DatetimeIndex` or `TimedeltaIndex`, the i8 (nanoseconds-since-epoch) values were passed directly to `np.interp`, which converts to float64. Values exceeding 2^53 lose precision, giving incorrect interpolation results.
- Fix by subtracting the minimum i8 value in `_index_to_interp_indices` so that `np.interp` works with small relative offsets. Includes an overflow guard that falls back to float64 subtraction for datetime ranges wider than ~292 years (ns resolution).

## Test plan
- [x] Added regression tests for DatetimeIndex (ns resolution, years 2000/2001, pre-epoch 1950)
- [x] Added regression test for TimedeltaIndex with large values
- [x] All 7 new tests fail on main, pass with the fix
- [x] All existing interpolation tests pass (series + frame)

closes #34601

🤖 Generated with [Claude Code](https://claude.com/claude-code)