### PR TITLE
ENH: Support axis parameter in masked array reductions for 2D arrays

### DIFF
--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -26,6 +26,24 @@ if TYPE_CHECKING:
     )
 
 
+def _get_min_value(dtype: np.dtype) -> int | float:
+    """Get the minimum value for a given numpy dtype."""
+    if dtype.kind == "f":
+        return -np.inf
+    elif dtype.kind == "u":
+        return 0
+    else:
+        return np.iinfo(dtype).min
+
+
+def _get_max_value(dtype: np.dtype) -> int | float:
+    """Get the maximum value for a given numpy dtype."""
+    if dtype.kind == "f":
+        return np.inf
+    else:
+        return np.iinfo(dtype).max
+
+
 def _reductions(
     func: Callable,
     values: np.ndarray,
@@ -62,6 +80,10 @@ def _reductions(
         kwargs["initial"] = initial
 
     if not skipna:
+        if axis is not None and values.ndim > 1:
+            # For 2D with axis, compute the reduction and let the caller
+            # handle per-row/column masking via _wrap_reduction_result.
+            return func(values, axis=axis, **kwargs)
         if mask.any() or check_below_min_count(values.shape, None, min_count):
             return libmissing.NA
         else:
@@ -132,12 +154,26 @@ def _minmax(
     axis : int, optional, default None
     """
     if not skipna:
+        if axis is not None and values.ndim > 1:
+            # For 2D with axis, compute the reduction and let the caller
+            # handle per-row/column masking via _wrap_reduction_result.
+            return func(values, axis=axis)
         if mask.any() or not values.size:
             # min/max with empty array raise in numpy, pandas returns NA
             return libmissing.NA
         else:
             return func(values, axis=axis)
     else:
+        if axis is not None and values.ndim > 1:
+            # Can't use values[~mask] which would flatten the array.
+            # Instead, replace masked values with the identity element
+            # and then reduce.
+            if func is np.min:
+                fill_value = _get_max_value(values.dtype)
+            else:
+                fill_value = _get_min_value(values.dtype)
+            filled = np.where(mask, fill_value, values)
+            return func(filled, axis=axis)
         subset = values[~mask]
         if subset.size:
             return func(subset, axis=axis)
@@ -173,9 +209,11 @@ def mean(
     skipna: bool = True,
     axis: AxisInt | None = None,
 ):
-    if not values.size or mask.all():
+    if not values.size or (mask.all() and (axis is None or values.ndim == 1)):
         return libmissing.NA
-    return _reductions(np.mean, values=values, mask=mask, skipna=skipna, axis=axis)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        return _reductions(np.mean, values=values, mask=mask, skipna=skipna, axis=axis)
 
 
 def var(
@@ -186,7 +224,7 @@ def var(
     axis: AxisInt | None = None,
     ddof: int = 1,
 ):
-    if not values.size or mask.all():
+    if not values.size or (mask.all() and (axis is None or values.ndim == 1)):
         return libmissing.NA
 
     with warnings.catch_warnings():
@@ -204,7 +242,7 @@ def std(
     axis: AxisInt | None = None,
     ddof: int = 1,
 ):
-    if not values.size or mask.all():
+    if not values.size or (mask.all() and (axis is None or values.ndim == 1)):
         return libmissing.NA
 
     with warnings.catch_warnings():

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1645,7 +1645,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
     def _wrap_min_count_reduction_result(
         self, name: str, result, *, skipna, min_count, axis
     ):
-        if min_count == 0 and isinstance(result, np.ndarray):
+        if min_count == 0 and skipna and isinstance(result, np.ndarray):
             return self._maybe_mask_result(result, np.zeros(result.shape, dtype=bool))
         return self._wrap_reduction_result(name, result, skipna=skipna, axis=axis)
 

--- a/pandas/tests/arrays/masked/test_function.py
+++ b/pandas/tests/arrays/masked/test_function.py
@@ -8,6 +8,7 @@ import pandas._testing as tm
 from pandas.core.arrays import (
     BaseMaskedArray,
     BooleanArray,
+    FloatingArray,
     IntegerArray,
 )
 
@@ -157,3 +158,176 @@ class TestAnyAll2D:
             # col0: 1,3 -> True; col1: all-NA -> True
             expected = pd.array([True, True], dtype="boolean")
         tm.assert_extension_array_equal(result, expected)
+
+
+class TestReductions2D:
+    """Tests for reductions on 2D masked arrays with axis parameter."""
+
+    @pytest.fixture
+    def int_arr2d(self):
+        # [[1,  NA],
+        #  [3,  4 ]]
+        data = np.array([[1, 2], [3, 4]], dtype=np.int64)
+        mask = np.array([[False, True], [False, False]], dtype=bool)
+        return IntegerArray._simple_new(data, mask)
+
+    @pytest.fixture
+    def float_arr2d(self):
+        # [[1.0,  NA ],
+        #  [3.0,  4.0]]
+        data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+        mask = np.array([[False, True], [False, False]], dtype=bool)
+        return FloatingArray._simple_new(data, mask)
+
+    @pytest.mark.parametrize("method", ["sum", "prod", "mean", "var", "std"])
+    def test_axis_none(self, int_arr2d, method):
+        # axis=None reduces to scalar; should match the flattened 1D result
+        result = getattr(int_arr2d, method)(axis=None)
+        expected = getattr(int_arr2d.ravel(), method)()
+        assert result == expected or (pd.isna(result) and pd.isna(expected))
+
+    @pytest.mark.parametrize("method", ["min", "max"])
+    def test_minmax_axis_none(self, int_arr2d, method):
+        result = getattr(int_arr2d, method)(axis=None)
+        expected = getattr(int_arr2d.ravel(), method)()
+        assert result == expected
+
+    # --- sum ---
+
+    def test_sum_axis0(self, int_arr2d):
+        result = int_arr2d.sum(axis=0)
+        # col0: 1+3=4, col1: 0+4=4 (NA skipped, identity=0, min_count=0)
+        expected = pd.array([4, 4], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_sum_axis1(self, int_arr2d):
+        result = int_arr2d.sum(axis=1)
+        # row0: 1+0=1 (NA skipped), row1: 3+4=7
+        expected = pd.array([1, 7], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_sum_axis0_min_count(self, int_arr2d):
+        # min_count=1: col1 has 1 valid value -> not NA
+        result = int_arr2d.sum(axis=0, min_count=1)
+        expected = pd.array([4, 4], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_sum_axis0_min_count_all_na(self):
+        # Column that is all-NA with min_count=1 -> NA
+        data = np.array([[1, 2], [3, 4]], dtype=np.int64)
+        mask = np.array([[False, True], [False, True]], dtype=bool)
+        arr = IntegerArray._simple_new(data, mask)
+        result = arr.sum(axis=0, min_count=1)
+        expected = pd.array([4, pd.NA], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    # --- prod ---
+
+    def test_prod_axis0(self, int_arr2d):
+        result = int_arr2d.prod(axis=0)
+        # col0: 1*3=3, col1: 1*4=4 (NA skipped, identity=1, min_count=0)
+        expected = pd.array([3, 4], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_prod_axis1(self, int_arr2d):
+        result = int_arr2d.prod(axis=1)
+        # row0: 1*1=1 (NA skipped), row1: 3*4=12
+        expected = pd.array([1, 12], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    # --- mean ---
+
+    def test_mean_axis0(self, int_arr2d):
+        result = int_arr2d.mean(axis=0)
+        # col0: (1+3)/2=2.0, col1: 4/1=4.0
+        expected = pd.array([2.0, 4.0], dtype="Float64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_mean_axis1(self, int_arr2d):
+        result = int_arr2d.mean(axis=1)
+        # row0: 1/1=1.0, row1: (3+4)/2=3.5
+        expected = pd.array([1.0, 3.5], dtype="Float64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_mean_axis0_all_na(self):
+        data = np.array([[1, 2], [3, 4]], dtype=np.int64)
+        mask = np.array([[False, True], [False, True]], dtype=bool)
+        arr = IntegerArray._simple_new(data, mask)
+        result = arr.mean(axis=0)
+        expected = pd.array([2.0, pd.NA], dtype="Float64")
+        tm.assert_extension_array_equal(result, expected)
+
+    # --- var / std ---
+
+    def test_var_axis0(self, float_arr2d):
+        result = float_arr2d.var(axis=0, ddof=0)
+        # col0: var([1,3])=1.0, col1: var([4])=0.0
+        expected = pd.array([1.0, 0.0], dtype="Float64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_std_axis0(self, float_arr2d):
+        result = float_arr2d.std(axis=0, ddof=0)
+        expected = pd.array([1.0, 0.0], dtype="Float64")
+        tm.assert_extension_array_equal(result, expected)
+
+    # --- min / max ---
+
+    def test_min_axis0(self, int_arr2d):
+        result = int_arr2d.min(axis=0)
+        # col0: min(1,3)=1, col1: min(4)=4 (NA skipped)
+        expected = pd.array([1, 4], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_max_axis0(self, int_arr2d):
+        result = int_arr2d.max(axis=0)
+        # col0: max(1,3)=3, col1: max(4)=4
+        expected = pd.array([3, 4], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_min_axis1(self, int_arr2d):
+        result = int_arr2d.min(axis=1)
+        # row0: min(1)=1, row1: min(3,4)=3
+        expected = pd.array([1, 3], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_max_axis1(self, int_arr2d):
+        result = int_arr2d.max(axis=1)
+        # row0: max(1)=1, row1: max(3,4)=4
+        expected = pd.array([1, 4], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_min_axis0_all_na(self):
+        data = np.array([[1, 2], [3, 4]], dtype=np.int64)
+        mask = np.array([[False, True], [False, True]], dtype=bool)
+        arr = IntegerArray._simple_new(data, mask)
+        result = arr.min(axis=0)
+        expected = pd.array([1, pd.NA], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    def test_max_axis0_all_na(self):
+        data = np.array([[1, 2], [3, 4]], dtype=np.int64)
+        mask = np.array([[False, True], [False, True]], dtype=bool)
+        arr = IntegerArray._simple_new(data, mask)
+        result = arr.max(axis=0)
+        expected = pd.array([3, pd.NA], dtype="Int64")
+        tm.assert_extension_array_equal(result, expected)
+
+    # --- skipna=False ---
+
+    @pytest.mark.parametrize("method", ["sum", "prod", "mean", "var", "std"])
+    def test_skipna_false_axis0(self, int_arr2d, method):
+        # col0: no NAs -> valid result, col1: has NA -> NA
+        kwargs = {}
+        if method in ("var", "std"):
+            kwargs["ddof"] = 0
+        result = getattr(int_arr2d, method)(axis=0, skipna=False, **kwargs)
+        assert isinstance(result, BaseMaskedArray)
+        assert not pd.isna(result[0])
+        assert pd.isna(result[1])
+
+    @pytest.mark.parametrize("method", ["min", "max"])
+    def test_minmax_skipna_false_axis0(self, int_arr2d, method):
+        result = getattr(int_arr2d, method)(axis=0, skipna=False)
+        assert isinstance(result, BaseMaskedArray)
+        assert not pd.isna(result[0])
+        assert pd.isna(result[1])


### PR DESCRIPTION
## Summary

- Support 2D arrays with `axis` parameter in `BaseMaskedArray` reductions (`sum`, `prod`, `mean`, `var`, `std`, `min`, `max`)
- Fix `_reductions` and `_minmax` in `masked_reductions.py` to not short-circuit to scalar `NA` when operating on 2D arrays with an axis parameter
- Fix `_wrap_min_count_reduction_result` to respect `skipna=False` when `min_count=0`
- Part of the long-term effort to make `IntegerArray`, `FloatingArray`, and `BooleanArray` support 2D instances

## Test plan

- [x] New `TestReductions2D` class with 31 tests covering axis=0, axis=1, axis=None, skipna=False, min_count, and all-NA column edge cases
- [x] All existing masked array tests pass (1391 passed)
- [x] All existing extension tests for masked arrays pass (6385 passed)
- [x] All DataFrame reduction tests pass (2341 passed)
- [x] 1D behavior verified unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)