### PR TITLE
BUG: fix DatetimeIndex + DateOffset near DST transitions

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -170,7 +170,7 @@ Timedelta
 
 Timezones
 ^^^^^^^^^
--
+- Bug in :class:`DatetimeIndex` addition with a :class:`DateOffset` that has only timedelta components (e.g. ``DateOffset(hours=-2)``) raising ``ValueError`` near DST transitions, while scalar :class:`Timestamp` addition worked correctly (:issue:`28610`)
 -
 
 Numeric

--- a/pandas/_libs/tslibs/offsets.pyi
+++ b/pandas/_libs/tslibs/offsets.pyi
@@ -16,6 +16,7 @@ import numpy as np
 
 from pandas._libs.tslibs.dtypes import PeriodDtypeBase
 from pandas._libs.tslibs.nattype import NaTType
+from pandas._libs.tslibs.timedeltas import Timedelta
 from pandas._typing import (
     OffsetCalendar,
     npt,
@@ -132,7 +133,10 @@ class Micro(Tick): ...
 class Nano(Tick): ...
 
 class RelativeDeltaOffset(BaseOffset):
+    _use_relativedelta: bool
     def __init__(self, n: int = ..., normalize: bool = ..., **kwds: Any) -> None: ...
+    @property
+    def _pd_timedelta(self) -> Timedelta: ...
 
 class BusinessMixin(SingleConstructorOffset):
     def __init__(

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -47,6 +47,7 @@ from pandas._libs.tslibs import (
     tzconversion,
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
+from pandas._libs.tslibs.offsets import RelativeDeltaOffset
 from pandas.errors import PerformanceWarning
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
@@ -839,6 +840,21 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     def _add_offset(self, offset: BaseOffset) -> Self:
         assert not isinstance(offset, Tick)
 
+        # For pure-timedelta DateOffset with tz-aware data, add to UTC values
+        # directly to avoid nonexistent/ambiguous time errors from
+        # re-localizing wall-time results near DST (GH#28610).
+        if (
+            self.tz is not None
+            and isinstance(offset, RelativeDeltaOffset)
+            and not offset._use_relativedelta
+        ):
+            res_values = self._ndarray + offset._pd_timedelta
+            result = type(self)._simple_new(res_values, dtype=self.dtype)
+            if offset.normalize:
+                result = result.normalize()
+                result._freq = None
+            return result
+
         if self.tz is not None:
             values = self.tz_localize(None)
         else:
@@ -870,19 +886,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 result._freq = None
 
             if self.tz is not None:
-                # For pure-timedelta DateOffset, add to UTC values directly
-                # to avoid nonexistent/ambiguous time errors from
-                # re-localizing wall-time results near DST (GH#28610).
-                from pandas._libs.tslibs.offsets import RelativeDeltaOffset
-
-                if (
-                    isinstance(offset, RelativeDeltaOffset)
-                    and not offset._use_relativedelta
-                ):
-                    res_values = self._ndarray + offset._pd_timedelta
-                    result = type(self)._simple_new(res_values, dtype=self.dtype)
-                else:
-                    result = result.tz_localize(self.tz)
+                result = result.tz_localize(self.tz)
 
         return result
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -863,11 +863,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         try:
             res_values = offset._apply_array(values._ndarray)
             if res_values.dtype.kind == "i":
-                # error: Argument 1 to "view" of "ndarray" has
-                # incompatible type
-                # "dtype[datetime64[date | int | None]] | DatetimeTZDtype";
-                # expected "dtype[Any] | _HasDType[dtype[Any]]"  [arg-type]
-                res_values = res_values.view(values.dtype)  # type: ignore[arg-type]
+                res_values = res_values.view(values.dtype)
         except NotImplementedError:
             if get_option("performance_warnings"):
                 warnings.warn(

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -870,7 +870,19 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 result._freq = None
 
             if self.tz is not None:
-                result = result.tz_localize(self.tz)
+                # For pure-timedelta DateOffset, add to UTC values directly
+                # to avoid nonexistent/ambiguous time errors from
+                # re-localizing wall-time results near DST (GH#28610).
+                from pandas._libs.tslibs.offsets import RelativeDeltaOffset
+
+                if (
+                    isinstance(offset, RelativeDeltaOffset)
+                    and not offset._use_relativedelta
+                ):
+                    res_values = self._ndarray + offset._pd_timedelta
+                    result = type(self)._simple_new(res_values, dtype=self.dtype)
+                else:
+                    result = result.tz_localize(self.tz)
 
         return result
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1598,6 +1598,34 @@ class TestDatetime64DateOffsetArithmetic:
         )
         tm.assert_index_equal(result, expected)
 
+    def test_dt64arr_add_dateoffset_near_dst(self, unit):
+        # GH#28610 - vectorized DatetimeIndex + DateOffset should match
+        # scalar Timestamp + DateOffset near DST transitions.
+        # Europe/Berlin switched to DST on 2000-03-26 (02:00 -> 03:00).
+        dti = DatetimeIndex(
+            ["2000-03-26 04:00", "2000-03-26 01:00"],
+            tz="Europe/Berlin",
+        ).as_unit(unit)
+
+        result = dti + DateOffset(hours=-2)
+        expected = DatetimeIndex(
+            ["2000-03-26 01:00:00+01:00", "2000-03-25 23:00:00+01:00"],
+            dtype=f"datetime64[{unit}, Europe/Berlin]",
+        )
+        tm.assert_index_equal(result, expected)
+
+        # Also test the reverse direction (adding into DST)
+        dti2 = DatetimeIndex(
+            ["2000-03-26 01:00"],
+            tz="Europe/Berlin",
+        ).as_unit(unit)
+        result2 = dti2 + DateOffset(hours=2)
+        expected2 = DatetimeIndex(
+            ["2000-03-26 04:00:00+02:00"],
+            dtype=f"datetime64[{unit}, Europe/Berlin]",
+        )
+        tm.assert_index_equal(result2, expected2)
+
 
 class TestDatetime64OverflowHandling:
     # TODO: box + de-duplicate

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1607,24 +1607,30 @@ class TestDatetime64DateOffsetArithmetic:
             tz="Europe/Berlin",
         ).as_unit(unit)
 
-        result = dti + DateOffset(hours=-2)
+        offset = DateOffset(hours=-2)
+        result = dti + offset
         expected = DatetimeIndex(
             ["2000-03-26 01:00:00+01:00", "2000-03-25 23:00:00+01:00"],
             dtype=f"datetime64[{unit}, Europe/Berlin]",
         )
         tm.assert_index_equal(result, expected)
+        pointwise = DatetimeIndex([x + offset for x in dti])
+        tm.assert_index_equal(result, pointwise)
 
         # Also test the reverse direction (adding into DST)
         dti2 = DatetimeIndex(
             ["2000-03-26 01:00"],
             tz="Europe/Berlin",
         ).as_unit(unit)
-        result2 = dti2 + DateOffset(hours=2)
+        offset2 = DateOffset(hours=2)
+        result2 = dti2 + offset2
         expected2 = DatetimeIndex(
             ["2000-03-26 04:00:00+02:00"],
             dtype=f"datetime64[{unit}, Europe/Berlin]",
         )
         tm.assert_index_equal(result2, expected2)
+        pointwise2 = DatetimeIndex([x + offset2 for x in dti2])
+        tm.assert_index_equal(result2, pointwise2)
 
 
 class TestDatetime64OverflowHandling:


### PR DESCRIPTION
## Summary
- Fixes vectorized `DatetimeIndex + DateOffset` raising `ValueError` near DST transitions when the offset has only timedelta components (e.g. `DateOffset(hours=-2)`)
- The scalar `Timestamp + DateOffset` path works correctly by operating in UTC; this fix applies the same approach for the vectorized path

closes #28610
closes #43784 

## Test plan
- [x] Added regression test `test_dt64arr_add_dateoffset_near_dst` covering both directions across a DST spring-forward boundary
- [x] All existing datetime arithmetic tests pass (13,389 passed)
- [x] All offset tests pass (5,533 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)