### PR TITLE
DEPR: deprecate SparseArray sparse_index parameter, add from_indices

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -30,6 +30,7 @@ Other enhancements
 ^^^^^^^^^^^^^^^^^^
 - :meth:`.DataFrameGroupBy.agg` now allows for the provided ``func`` to return a NumPy array (:issue:`63957`)
 - Added :meth:`ExtensionArray.count` (:issue:`64450`)
+- Added :meth:`arrays.SparseArray.from_indices` to construct a :class:`arrays.SparseArray` from sparse values and their indices without materializing a dense array (:issue:`43628`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
@@ -103,6 +104,7 @@ Deprecations
 - Deprecated passing unnecessary ``*args`` and ``**kwargs`` to :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.cummax`, :meth:`.SeriesGroupBy.skew`, :meth:`.DataFrameGroupBy.skew`, :meth:`.SeriesGroupBy.take`, and :meth:`.DataFrameGroupBy.take`. The ``skipna`` parameter for the cum* methods is now an explicit keyword argument (:issue:`50407`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
 - Deprecated the ``float_precision`` argument in :func:`read_csv`, :func:`read_table`, and :func:`read_fwf`. All float precision modes now use the same converter (:issue:`64395`)
+- Deprecated the ``sparse_index`` parameter of :class:`arrays.SparseArray`. Use :meth:`arrays.SparseArray.from_indices` instead (:issue:`43628`)
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 - Deprecated the default value of ``exact`` in :func:`assert_index_equal`; in a future version this will default to ``True`` instead of "equiv" (:issue:`57436`)
 -

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -287,7 +287,7 @@ def _wrap_result(
         # fill_value may be np.bool_
         fill_value = bool(fill_value)
     if dtype is not None:
-        data = np.asarray(data, dtype=dtype)
+        data = np.asarray(data, dtype=dtype)  # type: ignore[arg-type]
     else:
         data = np.asarray(data)
     sparse_dtype = SparseDtype(data.dtype, fill_value)
@@ -634,7 +634,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         This avoids materializing a dense array of length 7.
         """
-        sparse_values = np.asarray(data, dtype=dtype)
+        sparse_values = np.asarray(data, dtype=dtype)  # type: ignore[arg-type]
         indices = np.asarray(indices, dtype=np.int32)
 
         if len(sparse_values) != len(indices):
@@ -1516,7 +1516,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 raise ValueError(msg)
             return new_sp_val
 
-        sp_values = sanitize_array([func(x) for x in self.sp_values], index=None)
+        sp_values = np.asarray(
+            sanitize_array([func(x) for x in self.sp_values], index=None)
+        )
 
         sparse_dtype = SparseDtype(sp_values.dtype, fill_val)
         return type(self)._simple_new(sp_values, self.sp_index, sparse_dtype)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -286,9 +286,12 @@ def _wrap_result(
     if is_bool_dtype(dtype):
         # fill_value may be np.bool_
         fill_value = bool(fill_value)
-    return SparseArray(
-        data, sparse_index=sparse_index, fill_value=fill_value, dtype=dtype
-    )
+    if dtype is not None:
+        data = np.asarray(data, dtype=dtype)
+    else:
+        data = np.asarray(data)
+    sparse_dtype = SparseDtype(data.dtype, fill_value)
+    return SparseArray._simple_new(data, sparse_index, sparse_dtype)
 
 
 _BOOL_SPARSE_DTYPE_FALSE_FILL = SparseDtype(bool, False)
@@ -312,6 +315,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         `fill_value`.
     sparse_index : SparseIndex, optional
         Index indicating the locations of sparse elements.
+
+        .. deprecated:: 3.1.0
+            Use :meth:`SparseArray.from_indices` instead.
     fill_value : scalar, optional
         Elements in data that are ``fill_value`` are not stored in the
         SparseArray. For memory savings, this should be the most common value
@@ -385,12 +391,23 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
     def __init__(
         self,
         data,
-        sparse_index=None,
+        sparse_index=lib.no_default,
         fill_value=None,
         kind: SparseIndexKind = "integer",
         dtype: Dtype | None = None,
         copy: bool = False,
     ) -> None:
+        if sparse_index is not lib.no_default and sparse_index is not None:
+            warnings.warn(
+                "The 'sparse_index' parameter of SparseArray.__init__ is "
+                "deprecated and will be removed in a future version. "
+                "Use SparseArray.from_indices instead.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
+        elif sparse_index is lib.no_default:
+            sparse_index = None
+
         if fill_value is None and isinstance(dtype, SparseDtype):
             fill_value = dtype.fill_value
 
@@ -562,6 +579,77 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         index = IntIndex(length, idx)
 
         return cls._simple_new(arr, index, dtype)
+
+    @classmethod
+    def from_indices(
+        cls,
+        data,
+        indices,
+        length: int,
+        fill_value=None,
+        kind: SparseIndexKind = "integer",
+        dtype: Dtype | None = None,
+    ) -> Self:
+        """
+        Create a SparseArray from an array of sparse values and their indices.
+
+        This allows constructing a SparseArray without materializing a dense
+        array, which is useful for large arrays where most values are the
+        fill value.
+
+        Parameters
+        ----------
+        data : array-like
+            The sparse (non-fill) values.
+        indices : array-like of int
+            The indices in the dense array where the sparse values are located.
+            Must be strictly increasing and within ``[0, length)``.
+        length : int
+            The total length of the resulting SparseArray.
+        fill_value : scalar, optional
+            The fill value to use for positions not in ``indices``.
+            By default, uses ``np.nan`` for float dtypes and the appropriate
+            NA value for other dtypes.
+        kind : {{'integer', 'block'}}, default 'integer'
+            The type of sparse index to use.
+        dtype : np.dtype or ExtensionDtype, optional
+            The dtype for the sparse values.
+
+        Returns
+        -------
+        SparseArray
+
+        See Also
+        --------
+        SparseArray.from_spmatrix : Create a SparseArray from a scipy.sparse matrix.
+
+        Examples
+        --------
+        >>> SparseArray.from_indices(
+        ...     [1, 2, 3], indices=[1, 3, 5], length=7, fill_value=0
+        ... )
+        <SparseArray>
+        [0, 1, 0, 2, 0, 3, 0]
+        Length: 7, dtype: Sparse[int64, 0]
+
+        This avoids materializing a dense array of length 7.
+        """
+        sparse_values = np.asarray(data, dtype=dtype)
+        indices = np.asarray(indices, dtype=np.int32)
+
+        if len(sparse_values) != len(indices):
+            raise ValueError(
+                f"Length of data ({len(sparse_values)}) must match "
+                f"length of indices ({len(indices)})."
+            )
+
+        sparse_index = make_sparse_index(length, indices, kind)
+
+        if fill_value is None:
+            fill_value = na_value_for_dtype(sparse_values.dtype)
+
+        sparse_dtype = SparseDtype(sparse_values.dtype, fill_value)
+        return cls._simple_new(sparse_values, sparse_index, sparse_dtype)
 
     def __array__(
         self, dtype: NpDtype | None = None, copy: bool | None = None
@@ -1300,7 +1388,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
             sp_index = BlockIndex(length, blocs_arr, blengths_arr)
 
-        return cls(data, sparse_index=sp_index, fill_value=fill_value)
+        sparse_dtype = SparseDtype(data.dtype, fill_value)
+        return cls._simple_new(data, sp_index, sparse_dtype)
 
     def astype(self, dtype: AstypeArg | None = None, copy: bool = True):
         """
@@ -1427,9 +1516,10 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 raise ValueError(msg)
             return new_sp_val
 
-        sp_values = [func(x) for x in self.sp_values]
+        sp_values = sanitize_array([func(x) for x in self.sp_values], index=None)
 
-        return type(self)(sp_values, sparse_index=self.sp_index, fill_value=fill_val)
+        sparse_dtype = SparseDtype(sp_values.dtype, fill_val)
+        return type(self)._simple_new(sp_values, self.sp_index, sparse_dtype)
 
     def _groupby_op(
         self,
@@ -1648,11 +1738,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if not self._null_fill_value:
             return SparseArray(self.to_dense(), fill_value=np.nan).cumsum()
 
-        return SparseArray(
-            self.sp_values.cumsum(),
-            sparse_index=self.sp_index,
-            fill_value=self.fill_value,
-        )
+        cumsum_values = self.sp_values.cumsum()
+        sparse_dtype = SparseDtype(cumsum_values.dtype, self.fill_value)
+        return type(self)._simple_new(cumsum_values, self.sp_index, sparse_dtype)
 
     def mean(self, axis: Axis = 0, *args, **kwargs):
         """

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -397,7 +397,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         dtype: Dtype | None = None,
         copy: bool = False,
     ) -> None:
-        if sparse_index is not lib.no_default and sparse_index is not None:
+        if sparse_index is not lib.no_default:
             warnings.warn(
                 "The 'sparse_index' parameter of SparseArray.__init__ is "
                 "deprecated and will be removed in a future version. "
@@ -405,7 +405,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 Pandas4Warning,
                 stacklevel=find_stack_level(),
             )
-        elif sparse_index is lib.no_default:
+        else:
             sparse_index = None
 
         if fill_value is None and isinstance(dtype, SparseDtype):

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -635,7 +635,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         This avoids materializing a dense array of length 7.
         """
         sparse_values = np.asarray(
-            sanitize_array(data, index=None),
+            sanitize_array(data, index=None),  # type: ignore[arg-type]
             dtype=dtype,  # type: ignore[arg-type]
         )
         indices = np.asarray(indices, dtype=np.int32)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -634,7 +634,10 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         This avoids materializing a dense array of length 7.
         """
-        sparse_values = np.asarray(data, dtype=dtype)  # type: ignore[arg-type]
+        sparse_values = np.asarray(
+            sanitize_array(data, index=None),
+            dtype=dtype,  # type: ignore[arg-type]
+        )
         indices = np.asarray(indices, dtype=np.int32)
 
         if len(sparse_values) != len(indices):

--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -339,7 +339,7 @@ def _get_dummies_1d(
         for col, ixs in zip(dummy_cols, sp_indices, strict=True):
             sp_values = np.ones(len(ixs), dtype=dtype)
             sp_index = IntIndex(N, ixs)
-            sparse_dtype = SparseDtype(dtype, fill_value)
+            sparse_dtype = SparseDtype(sp_values.dtype, fill_value)
             sarr = SparseArray._simple_new(sp_values, sp_index, sparse_dtype)
             sparse_series.append(Series(data=sarr, index=index, name=col, copy=False))
 

--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -23,6 +23,7 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import (
     ArrowDtype,
     CategoricalDtype,
+    SparseDtype,
 )
 
 from pandas.core.arrays import SparseArray
@@ -336,12 +337,10 @@ def _get_dummies_1d(
             sp_indices = sp_indices[1:]
             dummy_cols = dummy_cols[1:]
         for col, ixs in zip(dummy_cols, sp_indices, strict=True):
-            sarr = SparseArray(
-                np.ones(len(ixs), dtype=dtype),
-                sparse_index=IntIndex(N, ixs),
-                fill_value=fill_value,
-                dtype=dtype,
-            )
+            sp_values = np.ones(len(ixs), dtype=dtype)
+            sp_index = IntIndex(N, ixs)
+            sparse_dtype = SparseDtype(dtype, fill_value)
+            sarr = SparseArray._simple_new(sp_values, sp_index, sparse_dtype)
             sparse_series.append(Series(data=sarr, index=index, name=col, copy=False))
 
         return concat(sparse_series, axis=1)

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -388,7 +388,11 @@ class TestSparseArrayArithmetics:
         t = SparseArray([True, False, True, False])
         result = s ^ t
         sp_index = pd.core.arrays.sparse.IntIndex(4, np.array([0, 1, 2], dtype="int32"))
-        expected = SparseArray([False, True, True], sparse_index=sp_index)
+        expected = SparseArray._simple_new(
+            np.array([False, True, True]),
+            sp_index,
+            SparseDtype(bool, False),
+        )
         tm.assert_sp_array_equal(result, expected)
 
 

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -280,7 +280,7 @@ class TestSparseArrayAnalytics:
 
         sparse = SparseArray([1, -1, 2, -2], fill_value=1)
         result = SparseArray._simple_new(
-            np.array([1, 2, 2]),
+            np.array([1, 2, 2], dtype=np.int64),
             sparse.sp_index,
             SparseDtype(np.int64, 1),
         )

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -279,7 +279,11 @@ class TestSparseArrayAnalytics:
         tm.assert_sp_array_equal(np.abs(sparse), result)
 
         sparse = SparseArray([1, -1, 2, -2], fill_value=1)
-        result = SparseArray([1, 2, 2], sparse_index=sparse.sp_index, fill_value=1)
+        result = SparseArray._simple_new(
+            np.array([1, 2, 2]),
+            sparse.sp_index,
+            SparseDtype(np.int64, 1),
+        )
         tm.assert_sp_array_equal(abs(sparse), result)
         tm.assert_sp_array_equal(np.abs(sparse), result)
 

--- a/pandas/tests/arrays/sparse/test_constructors.py
+++ b/pandas/tests/arrays/sparse/test_constructors.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.sparse import IntIndex
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 from pandas import (
@@ -105,7 +106,9 @@ class TestConstructors:
         tm.assert_sp_array_equal(result, expected)
 
     def test_constructor_spindex_dtype(self):
-        arr = SparseArray(data=[1, 2], sparse_index=IntIndex(4, [1, 2]))
+        depr_msg = "The 'sparse_index' parameter of SparseArray.__init__ is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            arr = SparseArray(data=[1, 2], sparse_index=IntIndex(4, [1, 2]))
         # TODO: actionable?
         # XXX: Behavior change: specifying SparseIndex no longer changes the
         # fill_value
@@ -114,50 +117,63 @@ class TestConstructors:
         assert arr.dtype == SparseDtype(np.int64)
         assert arr.fill_value == 0
 
-        arr = SparseArray(
-            data=[1, 2, 3],
-            sparse_index=IntIndex(4, [1, 2, 3]),
-            dtype=np.int64,
-            fill_value=0,
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            arr = SparseArray(
+                data=[1, 2, 3],
+                sparse_index=IntIndex(4, [1, 2, 3]),
+                dtype=np.int64,
+                fill_value=0,
+            )
         exp = SparseArray([0, 1, 2, 3], dtype=np.int64, fill_value=0)
         tm.assert_sp_array_equal(arr, exp)
         assert arr.dtype == SparseDtype(np.int64)
         assert arr.fill_value == 0
 
-        arr = SparseArray(
-            data=[1, 2], sparse_index=IntIndex(4, [1, 2]), fill_value=0, dtype=np.int64
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            arr = SparseArray(
+                data=[1, 2],
+                sparse_index=IntIndex(4, [1, 2]),
+                fill_value=0,
+                dtype=np.int64,
+            )
         exp = SparseArray([0, 1, 2, 0], fill_value=0, dtype=np.int64)
         tm.assert_sp_array_equal(arr, exp)
         assert arr.dtype == SparseDtype(np.int64)
         assert arr.fill_value == 0
 
-        arr = SparseArray(
-            data=[1, 2, 3],
-            sparse_index=IntIndex(4, [1, 2, 3]),
-            dtype=None,
-            fill_value=0,
-        )
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            arr = SparseArray(
+                data=[1, 2, 3],
+                sparse_index=IntIndex(4, [1, 2, 3]),
+                dtype=None,
+                fill_value=0,
+            )
         exp = SparseArray([0, 1, 2, 3], dtype=None)
         tm.assert_sp_array_equal(arr, exp)
         assert arr.dtype == SparseDtype(np.int64)
         assert arr.fill_value == 0
 
-    @pytest.mark.parametrize("sparse_index", [None, IntIndex(1, [0])])
-    def test_constructor_spindex_dtype_scalar(self, sparse_index):
+    def test_constructor_spindex_dtype_scalar(self):
         # scalar input
+        depr_msg = "The 'sparse_index' parameter of SparseArray.__init__ is deprecated"
         msg = "Cannot construct SparseArray from scalar data. Pass a sequence instead"
-        with pytest.raises(TypeError, match=msg):
-            SparseArray(data=1, sparse_index=sparse_index, dtype=None)
 
         with pytest.raises(TypeError, match=msg):
-            SparseArray(data=1, sparse_index=IntIndex(1, [0]), dtype=None)
+            SparseArray(data=1, sparse_index=None, dtype=None)
+
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            with pytest.raises(TypeError, match=msg):
+                SparseArray(data=1, sparse_index=IntIndex(1, [0]), dtype=None)
 
     def test_constructor_spindex_dtype_scalar_broadcasts(self):
-        arr = SparseArray(
-            data=[1, 2], sparse_index=IntIndex(4, [1, 2]), fill_value=0, dtype=None
-        )
+        depr_msg = "The 'sparse_index' parameter of SparseArray.__init__ is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            arr = SparseArray(
+                data=[1, 2],
+                sparse_index=IntIndex(4, [1, 2]),
+                fill_value=0,
+                dtype=None,
+            )
         exp = SparseArray([0, 1, 2, 0], fill_value=0, dtype=None)
         tm.assert_sp_array_equal(arr, exp)
         assert arr.dtype == SparseDtype(np.int64)
@@ -278,3 +294,61 @@ class TestConstructors:
         dense = arr.to_dense()
         assert dense.dtype == np.float32
         tm.assert_numpy_array_equal(dense, data)
+
+
+class TestFromIndices:
+    def test_basic_integer(self):
+        result = SparseArray.from_indices(
+            [1, 2, 3], indices=[1, 3, 5], length=7, fill_value=0
+        )
+        expected = SparseArray([0, 1, 0, 2, 0, 3, 0], fill_value=0)
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_float_default_fill_value(self):
+        result = SparseArray.from_indices([1.0, 2.0], indices=[0, 2], length=4)
+        expected = SparseArray([1.0, np.nan, 2.0, np.nan])
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_bool_dtype(self):
+        result = SparseArray.from_indices(
+            [True, True], indices=[0, 2], length=4, fill_value=False
+        )
+        expected = SparseArray([True, False, True, False], fill_value=False)
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_block_kind(self):
+        result = SparseArray.from_indices(
+            [1, 2], indices=[1, 2], length=5, fill_value=0, kind="block"
+        )
+        assert result.kind == "block"
+        expected = SparseArray([0, 1, 2, 0, 0], fill_value=0, kind="block")
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_empty(self):
+        result = SparseArray.from_indices(
+            [], indices=[], length=5, fill_value=0, dtype=np.int64
+        )
+        expected = SparseArray([0, 0, 0, 0, 0], fill_value=0)
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_explicit_dtype(self):
+        result = SparseArray.from_indices(
+            [1, 2], indices=[0, 1], length=3, fill_value=0, dtype=np.float64
+        )
+        assert result.dtype.subtype == np.float64
+
+    def test_length_mismatch_raises(self):
+        msg = "Length of data .* must match length of indices"
+        with pytest.raises(ValueError, match=msg):
+            SparseArray.from_indices([1, 2, 3], indices=[0, 1], length=5)
+
+    def test_invalid_indices_raises(self):
+        with pytest.raises(
+            ValueError, match="All indices must be less than the length"
+        ):
+            SparseArray.from_indices([1], indices=[10], length=5)
+
+    def test_deprecation_sparse_index_parameter(self):
+        msg = "The 'sparse_index' parameter of SparseArray.__init__ is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            SparseArray(data=[1, 2], sparse_index=IntIndex(4, [1, 2]))

--- a/pandas/tests/arrays/sparse/test_constructors.py
+++ b/pandas/tests/arrays/sparse/test_constructors.py
@@ -158,8 +158,9 @@ class TestConstructors:
         depr_msg = "The 'sparse_index' parameter of SparseArray.__init__ is deprecated"
         msg = "Cannot construct SparseArray from scalar data. Pass a sequence instead"
 
-        with pytest.raises(TypeError, match=msg):
-            SparseArray(data=1, sparse_index=None, dtype=None)
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            with pytest.raises(TypeError, match=msg):
+                SparseArray(data=1, sparse_index=None, dtype=None)
 
         with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
## Summary
- Deprecate the `sparse_index` parameter of `SparseArray.__init__` with a `Pandas4Warning`
- Add `SparseArray.from_indices` classmethod for constructing a SparseArray from sparse values + indices without materializing a dense array
- Migrate all internal callers of `sparse_index=` to `_simple_new()` to avoid triggering the deprecation

closes #43628

## Test plan
- [x] Added `TestFromIndices` class with tests for basic integer, float, bool, block kind, empty, explicit dtype, length mismatch, invalid indices, and deprecation warning
- [x] Existing tests that passed `sparse_index=` either moved to `from_indices`/`_simple_new` or, where the keyword itself is under test, wrap with `assert_produces_warning(Pandas4Warning)`
- [x] Full sparse test suite passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
