### PR TITLE
BUG: fix dt64[non_nano] + offsets with sub-unit offset parameter

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -162,6 +162,7 @@ Datetimelike
 - Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
+- Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -172,7 +172,8 @@ def apply_wraps(func):
 
         result = func(self, other)
 
-        result2 = Timestamp(result).as_unit(other.unit)
+        result = Timestamp(result)
+        result2 = result.as_unit(other.unit)
         if result == result2:
             # i.e. the conversion is non-lossy, not the case for e.g.
             #  test_milliseconds_combination

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -30,6 +30,7 @@ from pandas._libs.tslibs import (
     OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
     Resolution,
+    Timedelta,
     Timestamp,
     astype_overflowsafe,
     fields,
@@ -98,10 +99,7 @@ if TYPE_CHECKING:
         npt,
     )
 
-    from pandas import (
-        DataFrame,
-        Timedelta,
-    )
+    from pandas import DataFrame
     from pandas.core.arrays import PeriodArray
 
     _TimestampNoneT1 = TypeVar("_TimestampNoneT1", Timestamp, None)
@@ -861,7 +859,15 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                     stacklevel=find_stack_level(),
                 )
             res_values = self.astype("O") + offset
-            result = type(self)._from_sequence(res_values, dtype=self.dtype)
+            # GH#56586 use the finer resolution between self and offset.offset
+            # to avoid truncating sub-unit precision
+            res_unit = self.unit
+            if hasattr(offset, "offset") and offset.offset:
+                offset_unit = Timedelta(offset.offset).unit
+                if abbrev_to_npy_unit(offset_unit) > abbrev_to_npy_unit(res_unit):
+                    res_unit = offset_unit
+            dtype = tz_to_dtype(self.tz, unit=res_unit)
+            result = type(self)._from_sequence(res_values, dtype=dtype)
 
         else:
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -600,6 +600,29 @@ class TestCommon:
 
         tm.assert_index_equal(result, expected)
 
+    @pytest.mark.filterwarnings(
+        "ignore:Non-vectorized DateOffset being applied to Series or DatetimeIndex"
+    )
+    @pytest.mark.parametrize(
+        "offset_class",
+        [
+            CustomBusinessDay,
+            CustomBusinessMonthBegin,
+            CustomBusinessMonthEnd,
+        ],
+    )
+    @pytest.mark.parametrize("unit", ["s", "ms"])
+    def test_add_dt64_non_nano_with_offset_parameter(self, offset_class, unit):
+        # GH#56586 - sub-unit offset parameter should not be truncated
+        off = offset_class(offset=Timedelta(microseconds=500))
+        dti = date_range("2016-01-01", periods=3, freq="D", unit=unit)
+
+        result = dti + off
+
+        expected = DatetimeIndex([x + off for x in dti])
+        tm.assert_index_equal(result, expected)
+        assert result.dtype == expected.dtype
+
 
 class TestDateOffset:
     def setup_method(self):

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -619,9 +619,8 @@ class TestCommon:
 
         result = dti + off
 
-        expected = DatetimeIndex([x + off for x in dti])
+        expected = DatetimeIndex([x + off for x in dti], dtype="datetime64[us]")
         tm.assert_index_equal(result, expected)
-        assert result.dtype == expected.dtype
 
 
 class TestDateOffset:


### PR DESCRIPTION
- closes #56586

## Summary

- Fix `apply_wraps` in `offsets.pyx` to always convert the result to `Timestamp` before calling `.tz_localize()`, preventing `AttributeError` when the `as_unit` conversion is lossy
- Fix `_add_offset` in `datetimes.py` to use the finer resolution between `self.unit` and `offset.offset.unit`, preventing silent truncation of sub-unit precision
- Affects `CustomBusinessDay`, `CustomBusinessMonthBegin`, `CustomBusinessMonthEnd` with non-zero `offset` parameter on non-nano `DatetimeArray`

## Test plan

- [x] New parametrized test `test_add_dt64_non_nano_with_offset_parameter` covering all 3 affected offsets × 2 units
- [x] Existing `test_add_dt64_ndarray_non_nano` (5533 tests) all pass
- [x] Existing `test_datetime64.py` arithmetic suite (13385 tests) all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)