### PR TITLE
PERF: fast path for partial-string indexing on monotonic decreasing DTI

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -134,7 +134,7 @@ Performance improvements
 - Performance improvement in :meth:`arrays.SparseArray.isna` by avoiding a dense-then-resparsify round-trip (:issue:`41023`)
 - Performance improvement in datetime/timedelta unit conversion (e.g. ``datetime64[s]`` to ``datetime64[ns]``) (:issue:`35025`)
 - Performance improvement in indexing a :class:`DataFrame` with a :class:`CategoricalIndex` of :class:`Interval` categories (:issue:`61928`)
-- Performance improvement in partial-string indexing on a monotonic decreasing :class:`DatetimeIndex` or :class:`PeriodIndex` (:issue:`64555`)
+- Performance improvement in partial-string indexing on a monotonic decreasing :class:`DatetimeIndex` or :class:`PeriodIndex` (:issue:`64811`)
 - Performance improvement in plotting :class:`DatetimeIndex` with multiplied frequencies (e.g. ``"1000ms"``, ``"100s"``) (:issue:`50355`)
 - Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)
 - Performance improvement in repr of :class:`Series` and :class:`DataFrame` containing third-party array-like objects (e.g. xarray ``DataArray``) in object dtype columns (:issue:`61809`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -134,6 +134,7 @@ Performance improvements
 - Performance improvement in :meth:`arrays.SparseArray.isna` by avoiding a dense-then-resparsify round-trip (:issue:`41023`)
 - Performance improvement in datetime/timedelta unit conversion (e.g. ``datetime64[s]`` to ``datetime64[ns]``) (:issue:`35025`)
 - Performance improvement in indexing a :class:`DataFrame` with a :class:`CategoricalIndex` of :class:`Interval` categories (:issue:`61928`)
+- Performance improvement in partial-string indexing on a monotonic decreasing :class:`DatetimeIndex` or :class:`PeriodIndex` (:issue:`64555`)
 - Performance improvement in plotting :class:`DatetimeIndex` with multiplied frequencies (e.g. ``"1000ms"``, ``"100s"``) (:issue:`50355`)
 - Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)
 - Performance improvement in repr of :class:`Series` and :class:`DataFrame` containing third-party array-like objects (e.g. xarray ``DataArray``) in object dtype columns (:issue:`61809`)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -493,12 +493,26 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
                 # we are out of range
                 raise KeyError
 
-            # TODO: does this depend on being monotonic _increasing_?
-
-            # a monotonic (sorted) series can be sliced
+            # a monotonic increasing series can be sliced
+            #  (searchsorted requires ascending order)
             left = vals.searchsorted(unbox(t1), side="left")
             right = vals.searchsorted(unbox(t2), side="right")
             return slice(left, right)
+
+        elif self.is_monotonic_decreasing:
+            if len(self) and (
+                (t1 > self[0] and t2 > self[0]) or (t1 < self[-1] and t2 < self[-1])
+            ):
+                # we are out of range
+                raise KeyError
+
+            # searchsorted requires ascending order, so search the reversed
+            #  array and convert the indices back
+            reversed_vals = vals[::-1]
+            nvals = len(vals)
+            rev_left = reversed_vals.searchsorted(unbox(t1), side="left")
+            rev_right = reversed_vals.searchsorted(unbox(t2), side="right")
+            return slice(nvals - rev_right, nvals - rev_left)
 
         else:
             lhs_mask = vals >= unbox(t1)

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -66,6 +66,42 @@ class TestSlicing:
         expected2 = ser2.iloc[::2]
         tm.assert_series_equal(result2, expected2)
 
+    @pytest.mark.parametrize(
+        "start, freq, key",
+        [
+            ("2005-01-01", "B", "2005-05"),
+            ("2005-01-01", "h", "2005-01-10"),
+            ("2005-01-01 20:00:00", "min", "2005-01-01 22"),
+            ("2005-01-01 23:59:00", "s", "2005-01-01 23:59"),
+        ],
+    )
+    def test_partial_date_slice_decreasing_returns_slice(self, start, freq, key):
+        # monotonic decreasing should use searchsorted fast path
+        #  and return a slice, not an ndarray
+        dti = date_range(start=start, periods=500, freq=freq)
+        ser = Series(np.arange(len(dti)), index=dti)
+
+        expected = ser.loc[key].iloc[::-1]
+
+        ser_desc = ser.iloc[::-1]
+        result = ser_desc.loc[key]
+        tm.assert_series_equal(result, expected)
+
+        # check that the fast path actually returns a slice
+        parsed, reso = ser_desc.index._parse_with_reso(key)
+        indexer = ser_desc.index._partial_date_slice(reso, parsed)
+        assert isinstance(indexer, slice)
+
+    def test_partial_date_slice_decreasing_out_of_range(self):
+        dti = date_range(start="2005-01-01", periods=500, freq="D")
+        ser_desc = Series(np.arange(len(dti)), index=dti[::-1])
+
+        with pytest.raises(KeyError, match=r"^'2004-01-01'$"):
+            ser_desc["2004-01-01"]
+
+        with pytest.raises(KeyError, match=r"^'2007-01-01'$"):
+            ser_desc["2007-01-01"]
+
     def test_return_type_doesnt_depend_on_monotonicity_higher_reso(self):
         # GH#24892 we get Series back regardless of whether our DTI is monotonic
         dti = date_range(start="2015-5-13 23:59:00", freq="min", periods=3)


### PR DESCRIPTION
## Summary
- Add a `searchsorted`-based fast path in `_partial_date_slice` for monotonic decreasing `DatetimeIndex`/`PeriodIndex`, matching the existing fast path for monotonic increasing.
- Previously, monotonic decreasing fell through to the mask-based code path returning an `ndarray[intp]`; now it returns a `slice` via `searchsorted` on the reversed array.

## Test plan
- [x] Added parametrized test across 4 freq/key combos verifying correct results and that the indexer is a `slice`
- [x] Added out-of-range `KeyError` test for decreasing index
- [x] All existing partial slicing tests pass (94 tests across datetimes, period, and indexing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)