### PR TITLE
ERR: clarify error message for multi-char separators with pyarrow engine

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1739,8 +1739,7 @@ class TextFileReader(abc.Iterator):
                 # wait until regex engine integrated
                 fallback_reason = (
                     f"the '{engine}' engine does not support "
-                    "regex separators (separators > 1 char and "
-                    r"different from '\s+' are interpreted as regex)"
+                    "separators > 1 char, including regex separators"
                 )
                 engine = "python"
         elif sep is not None:

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -376,7 +376,7 @@ def test_ignore_leading_whitespace(all_parsers):
     data = " a b c\n 1 2 3\n 4 5 6\n 7 8 9"
 
     if parser.engine == "pyarrow":
-        msg = "the 'pyarrow' engine does not support regex separators"
+        msg = "the 'pyarrow' engine does not support separators > 1 char"
         with pytest.raises(ValueError, match=msg):
             parser.read_csv(StringIO(data), sep=r"\s+")
         return
@@ -546,7 +546,7 @@ A,B,C
         data = data.replace(",", "  ")
 
         if parser.engine == "pyarrow":
-            msg = "the 'pyarrow' engine does not support regex separators"
+            msg = "the 'pyarrow' engine does not support separators > 1 char"
             with pytest.raises(ValueError, match=msg):
                 parser.read_csv(
                     StringIO(data), sep=sep, skip_blank_lines=skip_blank_lines
@@ -599,7 +599,7 @@ def test_whitespace_regex_separator(all_parsers, data, expected):
     # see gh-6607
     parser = all_parsers
     if parser.engine == "pyarrow":
-        msg = "the 'pyarrow' engine does not support regex separators"
+        msg = "the 'pyarrow' engine does not support separators > 1 char"
         with pytest.raises(ValueError, match=msg):
             parser.read_csv(StringIO(data), sep=r"\s+")
         return

--- a/pandas/tests/io/parser/common/test_file_buffer_url.py
+++ b/pandas/tests/io/parser/common/test_file_buffer_url.py
@@ -250,7 +250,7 @@ def test_temporary_file(all_parsers, temp_file):
         new_file.seek(0)
 
         if parser.engine == "pyarrow":
-            msg = "the 'pyarrow' engine does not support regex separators"
+            msg = "the 'pyarrow' engine does not support separators > 1 char"
             with pytest.raises(ValueError, match=msg):
                 parser.read_csv(new_file, sep=r"\s+", header=None)
             return

--- a/pandas/tests/io/parser/common/test_ints.py
+++ b/pandas/tests/io/parser/common/test_ints.py
@@ -106,7 +106,7 @@ def test_integer_overflow_bug(all_parsers, sep):
     data = "65248E10 11\n55555E55 22\n"
     parser = all_parsers
     if parser.engine == "pyarrow" and sep != " ":
-        msg = "the 'pyarrow' engine does not support regex separators"
+        msg = "the 'pyarrow' engine does not support separators > 1 char"
         with pytest.raises(ValueError, match=msg):
             parser.read_csv(StringIO(data), header=None, sep=sep)
         return

--- a/pandas/tests/io/parser/usecols/test_usecols_basic.py
+++ b/pandas/tests/io/parser/usecols/test_usecols_basic.py
@@ -244,7 +244,7 @@ def test_usecols_regex_sep(all_parsers):
     data = "a  b  c\n4  apple  bat  5.7\n8  orange  cow  10"
 
     if parser.engine == "pyarrow":
-        msg = "the 'pyarrow' engine does not support regex separators"
+        msg = "the 'pyarrow' engine does not support separators > 1 char"
         with pytest.raises(ValueError, match=msg):
             parser.read_csv(StringIO(data), sep=r"\s+", usecols=("a", "b"))
         return


### PR DESCRIPTION
## Summary
- The error raised when using `sep="\s+"` (or any multi-char separator) with `engine="pyarrow"` previously said: *"does not support regex separators (separators > 1 char and different from '\s+' are interpreted as regex)"*. The parenthetical misleadingly implied `\s+` was exempt, when pyarrow doesn't support it either.
- Updated the message to: *"does not support separators > 1 char, including regex separators"*
- Updated test assertions to match the new message

closes #52554

🤖 Generated with [Claude Code](https://claude.com/claude-code)