### PR TITLE
TST: add test for datetime.timedelta arithmetic resolution (GH#59656)

### DIFF
--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -2329,3 +2329,15 @@ def test_add_timestamp_to_timedelta():
         ]
     )
     tm.assert_index_equal(result, expected)
+
+
+def test_timedelta_scalar_numeric_series_resolution():
+    # GH#59656 - arithmetic between datetime.timedelta scalar and numeric
+    # Series should produce timedelta64[us], consistent with
+    # pd.Timedelta(datetime.timedelta(...)).unit
+    delta = timedelta(days=1)
+    result = delta * Series([1])
+    assert result.dtype == np.dtype("timedelta64[us]")
+
+    result = Series([1]) * delta
+    assert result.dtype == np.dtype("timedelta64[us]")


### PR DESCRIPTION
## Summary
- Adds a test verifying that arithmetic between a `datetime.timedelta` scalar and a numeric `Series` produces `timedelta64[us]` resolution, consistent with `pd.Timedelta(datetime.timedelta(...)).unit`
- The underlying bug (inconsistent resolution between Series construction and scalar arithmetic) has already been fixed on main, but there was no test covering it

closes #59656

## Test plan
- [x] `pytest pandas/tests/arithmetic/test_timedelta64.py::test_timedelta_scalar_numeric_series_resolution` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)