### PR TITLE
BUG: honor drop_level=False in DataFrame.xs for fully specified MultiIndex keys

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -201,6 +201,7 @@ Indexing
 ^^^^^^^^
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
+- Bug in :meth:`DataFrame.xs` where ``drop_level=False`` was ignored for fully specified :class:`MultiIndex` keys when ``level`` was not explicitly provided (:issue:`6507`)
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)
 - Bug in :meth:`Index.insert` silently casting booleans to numeric when used with nullable numeric dtypes like ``Float64`` or ``Int64`` (:issue:`61709`)
 - Bug in :meth:`MultiIndex.loc` returning incorrect results when indexing with :class:`numpy.datetime64` on a level containing :class:`datetime.date` objects (:issue:`55969`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4282,6 +4282,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 # so just return them (GH 6394)
                 return self._values[loc]
 
+            if not drop_level and isinstance(index, MultiIndex):
+                # GH#6507 - honor drop_level=False for fully specified keys
+                result = self.iloc[loc : loc + 1]
+                result.index = new_index
+                return result
+
             new_mgr = self._mgr.fast_xs(loc)
 
             result = self._constructor_sliced_from_mgr(new_mgr, axes=new_mgr.axes)

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -379,6 +379,18 @@ class TestXSWithMultiIndex:
         expected = DataFrame({"a": [1]})
         tm.assert_frame_equal(result, expected)
 
+    def test_xs_full_key_droplevel_false(self):
+        # GH#6507 - drop_level=False should be honored for fully specified keys
+        df = DataFrame(
+            {"value": [1, 2, 3]},
+            index=MultiIndex.from_tuples(
+                [(1, 2, 3), (4, 5, 6), (7, 8, 9)], names=["a", "b", "c"]
+            ),
+        )
+        result = df.xs((1, 2, 3), drop_level=False)
+        expected = df.iloc[:1]
+        tm.assert_frame_equal(result, expected)
+
     def test_xs_list_indexer_droplevel_false(self):
         # GH#41760
         mi = MultiIndex.from_tuples([("x", "m", "a"), ("x", "n", "b"), ("y", "o", "c")])


### PR DESCRIPTION
## Summary
- Fixes `DataFrame.xs()` ignoring `drop_level=False` when called with a fully specified `MultiIndex` key and no explicit `level=` parameter. Previously returned a Series with levels dropped; now correctly returns a DataFrame with the original index preserved.

closes #6507

## Test plan
- [x] Added `test_xs_full_key_droplevel_false` covering the fix
- [x] All existing xs tests pass
- [x] Full test suite passes (226k+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)