### PR TITLE
TST: test improved error message for non-monotonic DatetimeIndex slicing

### DIFF
--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -418,7 +418,9 @@ class TestSlicing:
         ):
             nonmonotonic["2014-01-10":]
 
-        with pytest.raises(KeyError, match=r"Timestamp\('2014-01-10 00:00:00'\)"):
+        # GH#13090 - improved error message for non-monotonic DatetimeIndex
+        msg = "non-monotonic index with a missing label"
+        with pytest.raises(KeyError, match=msg):
             nonmonotonic[timestamp:]
 
         with pytest.raises(
@@ -426,7 +428,7 @@ class TestSlicing:
         ):
             nonmonotonic.loc["2014-01-10":]
 
-        with pytest.raises(KeyError, match=r"Timestamp\('2014-01-10 00:00:00'\)"):
+        with pytest.raises(KeyError, match=msg):
             nonmonotonic.loc[timestamp:]
 
     def test_loc_datetime_length_one(self):


### PR DESCRIPTION
## Summary
- Update `test_partial_slice_requires_monotonicity` to verify the improved error message for slicing a non-monotonic `DatetimeIndex` with a `Timestamp` key
- The test previously only matched the raw `Timestamp(...)` repr; now it asserts the descriptive `"non-monotonic index with a missing label"` message

closes #13090

## Test plan
- [x] `test_partial_slice_requires_monotonicity` passes
- [x] Full test suite (143k+ tests) confirms no other tests are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)