### PR TITLE
BUG: Index.insert silently casts bool to numeric for masked dtypes

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -196,6 +196,7 @@ Indexing
 ^^^^^^^^
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)
+- Bug in :meth:`Index.insert` silently casting booleans to numeric when used with nullable numeric dtypes like ``Float64`` or ``Int64`` (:issue:`61709`)
 - Bug in :meth:`MultiIndex.loc` returning incorrect results when indexing with :class:`numpy.datetime64` on a level containing :class:`datetime.date` objects (:issue:`55969`)
 -
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -367,6 +367,11 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         #  py38 builds.
         raise TypeError(f"Invalid value '{value!s}' for dtype '{self.dtype}'")
 
+    def insert(self, loc: int, item) -> Self:
+        if not is_valid_na_for_dtype(item, self.dtype):
+            self._validate_setitem_value(item)
+        return super().insert(loc, item)
+
     def __setitem__(self, key, value) -> None:
         if self._readonly:
             raise ValueError("Cannot modify read-only array")

--- a/pandas/tests/indexes/base_class/test_reshape.py
+++ b/pandas/tests/indexes/base_class/test_reshape.py
@@ -36,6 +36,27 @@ class TestReshape:
         null_index = Index([])
         tm.assert_index_equal(Index(["a"]), null_index.insert(0, "a"))
 
+    @pytest.mark.parametrize("val", [True, False])
+    def test_insert_bool_into_numeric_ea(self, val):
+        # GH#61709 - bool should not be silently cast to numeric
+        float_idx = Index([1.0, 2.0, 3.0], dtype="Float64")
+        result = float_idx.insert(1, val)
+        expected = Index([1.0, val, 2.0, 3.0], dtype=object)
+        tm.assert_index_equal(result, expected)
+
+        int_idx = Index([1, 2, 3], dtype="Int64")
+        result = int_idx.insert(1, val)
+        expected = Index([1, val, 2, 3], dtype=object)
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize("val", [0, 1])
+    def test_insert_int_into_boolean_ea(self, val):
+        # GH#61709 - int should not be silently cast to bool
+        bool_idx = Index([True, False, True], dtype="boolean")
+        result = bool_idx.insert(1, val)
+        expected = Index([True, val, False, True], dtype=object)
+        tm.assert_index_equal(result, expected)
+
     def test_insert_missing(self, nulls_fixture, using_infer_string):
         # GH#22295
         # test there is no mangling of NA values


### PR DESCRIPTION
## Summary
- Override `BaseMaskedArray.insert` to call `_validate_setitem_value` for non-NA items, so incompatible types (e.g. `bool` into `Float64`) raise `TypeError`
- `Index.insert` already catches `TypeError` and falls back to object dtype, matching the numpy-backed behavior

closes #61709

## Test plan
- [x] `test_insert_bool_into_numeric_ea` — `True`/`False` into `Float64` and `Int64` indexes produce object dtype
- [x] `test_insert_int_into_boolean_ea` — `0`/`1` into `boolean` index produces object dtype
- [x] Existing masked extension insert tests pass (6418 passed)
- [x] Existing index insert tests pass (391 passed)
- [x] Existing coercion tests pass (403 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)