### PR TITLE
BUG: Fix DataFrame.sum() crash on empty DataFrame with mixed string+numeric columns

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -31,6 +31,7 @@ Bug fixes
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Assigning :attr:`pd.NA` to a string column could trigger a PyArrow error and corrupt data (:issue:`64320`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
+- Fixed :meth:`DataFrame.sum` raising ``ValueError`` on empty DataFrames with mixed string and numeric dtypes (:issue:`64657`)
 - Fixed bug in the :meth:`~Series.sum` method with python-backed string dtype returning incorrect value for an empty Series and ignoring the ``min_count`` argument (:issue:`64683`)
 - Fixed bug where :meth:`DataFrame.div` ignored the ``axis`` argument when used with ``level`` for MultiIndex columns (:issue:`64428`)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -15684,8 +15684,12 @@ class DataFrame(NDFrame, OpsMixin):
             out = out.astype(object)
         elif len(self) == 0 and out.dtype == object and name in ("sum", "prod"):
             # Even if we are object dtype, follow numpy and return
-            #  float64, see test_apply_funcs_over_empty
-            out = out.astype(np.float64)
+            # float64, see test_apply_funcs_over_empty.
+            # However, skip the cast when the result contains non-numeric values
+            # (e.g. empty-string results from Arrow-backed string columns), as
+            # attempting astype(float64) would raise ValueError. GH#64657
+            if out.apply(lambda x: isinstance(x, (int, float, complex))).all():
+                out = out.astype(np.float64)
 
         return out
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -2231,3 +2231,16 @@ def test_mean_nullable_int_axis_1():
     result = df.mean(axis=1, skipna=False)
     expected = Series([1.0, 2.0, 3.5, pd.NA], dtype="Float64")
     tm.assert_series_equal(result, expected)
+
+
+def test_sum_empty_df_mixed_string_numeric():
+    # GH#64657 - DataFrame.sum() should not crash on an empty DataFrame that
+    # has both string and numeric columns (e.g. Arrow-backed string dtype).
+    df = DataFrame({"col1": ["x", "y", "z"], "col2": [1, 2, 3]})
+    empty_df = df[df["col2"] > 5]
+
+    # Must not raise ValueError: could not convert string to float: ''
+    result = empty_df.sum()
+
+    assert result["col2"] == 0
+    assert result["col1"] == "" or result["col1"] == 0


### PR DESCRIPTION
## Summary

- Fixes `DataFrame.sum()` raising `ValueError: could not convert string to float: ''` on an empty DataFrame that contains both Arrow-backed string columns and numeric columns (#64657)
- Root cause: `DataFrame._reduce()` unconditionally cast the result `out` to `np.float64` for empty DataFrames returning an object-dtype Series from `sum`/`prod`. With `infer_string=True` (the default since pandas 3.0), Arrow-backed string columns produce `""` as their empty sum, which cannot be cast to float.
- Fix: guard the float64 cast so it only fires when **all** values in `out` are already numeric Python scalars. Non-numeric values (e.g. `""` from string columns) are left untouched.
- Backward compatible: pure-numeric empty DataFrames still get their result cast to float64 (preserving `test_apply_funcs_over_empty` semantics).

## Checklist

- [x] closes #64657
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] Added an entry in `doc/source/whatsnew/v3.0.2.rst`

## Test plan

- New test `test_sum_empty_df_mixed_string_numeric` in `pandas/tests/frame/test_reductions.py` reproduces the exact scenario from the issue report and verifies it no longer raises.
- Existing `test_apply_funcs_over_empty` continues to work because all-numeric empty DataFrames still get their result cast to `float64`.

Closes #64657

🤖 Generated with [Claude Code](https://claude.com/claude-code)