### PR TITLE
BUG: C engine read_csv silently casts "1 ," to int when thousands=","

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1670,6 +1670,41 @@ static int copy_string_without_char(char output[PROCESSED_WORD_CAPACITY],
   return 0;
 }
 
+/* Copy a string into `output`, removing only occurrences of `tsep` that
+ * appear between two digit characters (valid thousands separators).
+ * A `tsep` that is not flanked by a digit on both sides (e.g. a trailing
+ * comma in "1 ,") is left in place, causing the caller's end-pointer check
+ * to reject the value as non-numeric.
+ * Returns 0 on success, -1 if the output buffer would overflow.
+ */
+static int copy_string_without_tsep(char output[PROCESSED_WORD_CAPACITY],
+                                    const char *str, size_t str_len,
+                                    char tsep) {
+  const char *end_ptr = str + str_len;
+  size_t bytes_written = 0;
+
+  for (const char *p = str; p < end_ptr; p++) {
+    if (*p == tsep) {
+      // Only treat as thousands separator when the previous output char is a
+      // digit and the next input char is also a digit.
+      const bool prev_is_digit =
+          bytes_written > 0 && isdigit_ascii(output[bytes_written - 1]);
+      const bool next_is_digit = (p + 1 < end_ptr) && isdigit_ascii(*(p + 1));
+      if (prev_is_digit && next_is_digit) {
+        // Skip this tsep character (don't copy it).
+        continue;
+      }
+    }
+    if (bytes_written + 1 >= PROCESSED_WORD_CAPACITY) {
+      return -1;
+    }
+    output[bytes_written++] = *p;
+  }
+
+  output[bytes_written] = '\0';
+  return 0;
+}
+
 int64_t str_to_int64(const char *p_item, int *error, char tsep) {
   const char *p = p_item;
   // Skip leading spaces.
@@ -1692,7 +1727,7 @@ int64_t str_to_int64(const char *p_item, int *error, char tsep) {
   char buffer[PROCESSED_WORD_CAPACITY];
   const size_t str_len = strlen(p);
   if (tsep != '\0' && memchr(p, tsep, str_len) != NULL) {
-    const int status = copy_string_without_char(buffer, p, str_len, tsep);
+    const int status = copy_string_without_tsep(buffer, p, str_len, tsep);
     if (status != 0) {
       // Word is too big, probably will cause an overflow
       *error = ERROR_OVERFLOW;
@@ -1752,7 +1787,7 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int *error,
   char buffer[PROCESSED_WORD_CAPACITY];
   const size_t str_len = strlen(p);
   if (tsep != '\0' && memchr(p, tsep, str_len) != NULL) {
-    const int status = copy_string_without_char(buffer, p, str_len, tsep);
+    const int status = copy_string_without_tsep(buffer, p, str_len, tsep);
     if (status != 0) {
       // Word is too big, probably will cause an overflow
       *error = ERROR_OVERFLOW;

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -655,6 +655,18 @@ def test_1000_sep_with_decimal(
     tm.assert_frame_equal(result, expected)
 
 
+def test_trailing_thousands_sep_not_converted_to_int(c_parser_only):
+    # GH#64655 - C engine must not strip a trailing thousands separator and
+    # silently cast the value to an integer.  "1 ," has a comma that is NOT
+    # a thousands separator (it comes after a space, not between digits), so
+    # the whole value should be kept as a string, matching the Python engine.
+    parser = c_parser_only
+    txt = "a\n1 ,\n"
+    result = parser.read_csv(StringIO(txt), sep=";", thousands=",", engine="c")
+    expected = DataFrame({"a": ["1 ,"]})
+    tm.assert_frame_equal(result, expected)
+
+
 def test_float_precision_options(c_parser_only):
     # GH 17154, 36228
     parser = c_parser_only


### PR DESCRIPTION
## Summary

Fixes #64655.

The C CSV parser's `str_to_int64` / `str_to_uint64` called
`copy_string_without_char` to strip **all** occurrences of the thousands
separator before handing the string to `strtoll` / `strtoull`. This caused a
value like `"1 ,"` to have its trailing comma removed, leaving `"1 "` whose
trailing space was then consumed by the whitespace-skip loop, so the value
was silently returned as integer `1` instead of being kept as the string
`"1 ,"`.

The Python engine correctly returns `"1 ,"` as a string.

## Root cause

```c
// Before fix – strips ALL commas, including non-separator ones
copy_string_without_char(buffer, p, str_len, tsep);
```

## Fix

Added `copy_string_without_tsep`, which only removes a `tsep` character when
it appears **between two digit characters** (the only positions where it is a
genuine thousands separator, e.g. the comma in `"1,000"`). A `tsep` that is
not digit-flanked on both sides is kept in the buffer; the `endptr` check in
`strtoll` / `strtoull` then detects leftover characters and raises
`ERROR_INVALID_CHARS`, causing the value to fall through to string dtype.

This matches the behaviour of `precise_xstrtod`, which already skips `tsep`
only immediately after a digit character.

## Test plan

- [ ] Added `test_trailing_thousands_sep_not_converted_to_int` in
      `pandas/tests/io/parser/test_c_parser_only.py` covering the exact
      reproducer from the issue (`"1 ,"` with `sep=";"`, `thousands=","`)
- [ ] Existing `test_1000_sep_with_decimal` (both engines) continues to pass —
      legitimate thousands separators such as `"2,334.01"` still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)