### PR TITLE
BUG: Fix __getitem__ KeyError for np.True_/np.False_ column keys

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -197,6 +197,7 @@ Indexing
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)
 - Bug in :meth:`MultiIndex.loc` returning incorrect results when indexing with :class:`numpy.datetime64` on a level containing :class:`datetime.date` objects (:issue:`55969`)
+- Bug in :meth:`DataFrame.__getitem__` raising ``KeyError`` when a column was created with a ``numpy`` bool scalar (e.g. ``np.True_``) and accessed with a Python ``bool`` (e.g. ``True``) (:issue:`64749`)
 -
 
 Missing

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -211,8 +211,13 @@ static inline int pyobject_cmp(PyObject *a, PyObject *b) {
       return tupleobject_cmp((PyTupleObject *)a, (PyTupleObject *)b);
     }
     // frozenset isn't yet supported
-  } else if (PyBool_Check(a) != PyBool_Check(b)) {
+  } else if (PyBool_Check(a) != PyBool_Check(b) &&
+             (PyLong_CheckExact(a) || PyLong_CheckExact(b))) {
     // GH#62888: distinguish bool from int, e.g. 0 vs False, 1 vs True
+    // GH#64749: only skip equality when the non-bool side is a Python int;
+    // numpy bool scalars (np.True_/np.False_) are not PyBool but do compare
+    // equal to True/False via PyObject_RichCompareBool, so let them fall
+    // through to the RichCompareBool path below.
     return 0;
   }
 

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -468,3 +468,37 @@ class TestGetitemDeprecatedIndexers:
         )
         with pytest.raises(TypeError, match="as an indexer is not supported"):
             df[key]
+
+
+class TestGetitemNumpyBool:
+    def test_getitem_nptrue_column_with_true(self):
+        # GH#64749 - np.True_ column key should be accessible via Python True
+        df = DataFrame({True: [4, 5]})
+        result = df[True]
+        expected = Series([4, 5], name=True)
+        tm.assert_series_equal(result, expected)
+
+    def test_getitem_nptrue_column_after_concat(self):
+        # GH#64749 - np.True_ column key accessible with True after concat
+        df = DataFrame({True: [4, 5]})
+        s = Series([7, 8], name="_tmp")
+        df2 = concat([df[True], s], axis=1)
+        result = df2[True]
+        expected = Series([4, 5], name=True)
+        tm.assert_series_equal(result, expected)
+
+    def test_getitem_npfalse_column_with_false(self):
+        # GH#64749 - np.False_ column key should be accessible via Python False
+        df = DataFrame({False: [4, 5]})
+        result = df[False]
+        expected = Series([4, 5], name=False)
+        tm.assert_series_equal(result, expected)
+
+    def test_getitem_bool_int_still_distinct(self):
+        # GH#62888 - Python bool and Python int should remain distinct
+        df = DataFrame({True: [1, 2], 1: [3, 4]})
+        result_bool = df[True]
+        result_int = df[1]
+        # True and 1 must index different columns
+        tm.assert_series_equal(result_bool, Series([1, 2], name=True))
+        tm.assert_series_equal(result_int, Series([3, 4], name=1))


### PR DESCRIPTION
## Summary

Fixes #64749.

The fix in #64639 added `PyBool_Check(a) != PyBool_Check(b)` to the `pyobject_cmp` function in `khash_python.h` to distinguish Python `bool` from Python `int`. However, `np.True_` and `np.False_` are numpy bool scalars — `PyBool_Check(np.True_)` returns 0 — so they were incorrectly treated as unequal to Python `True`/`False`, breaking hash-table lookups for columns created with numpy bool keys.

**Root cause:** `PyBool_Check(True) = 1` but `PyBool_Check(np.True_) = 0`, so `PyBool_Check(a) != PyBool_Check(b)` fires and returns 0 (not equal) even though `np.True_ == True` should hold.

**Fix:** Narrow the guard by also requiring `PyLong_CheckExact(a) || PyLong_CheckExact(b)`. This ensures the short-circuit only applies when the non-bool side is a Python `int`. Numpy bool scalars are neither `PyBool` nor `PyLong`, so they fall through to `PyObject_RichCompareBool`, which correctly handles `np.True_ == True`.

## Changes

- `pandas/_libs/include/pandas/vendored/klib/khash_python.h`: add `PyLong_CheckExact` guard to the `PyBool_Check` condition
- `pandas/tests/frame/indexing/test_getitem.py`: add `TestGetitemNumpyBool` with 4 tests
- `doc/source/whatsnew/v3.1.0.rst`: add entry under Indexing bugs

## Test plan

- [ ] `test_getitem_nptrue_column_with_true` — `df[True]` on a `{True: ...}` DataFrame works
- [ ] `test_getitem_nptrue_column_after_concat` — exact repro from the issue (concat then index)
- [ ] `test_getitem_npfalse_column_with_false` — same for `np.False_`/`False`
- [ ] `test_getitem_bool_int_still_distinct` — GH#62888 regression guard: Python `True` and `1` remain distinct column keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)