### PR TITLE
TST: xfail test_no_track_times with HDF5 >= 2

### DIFF
--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -53,6 +53,10 @@ def test_context(temp_h5_path):
         assert type(tbl["a"]) == DataFrame
 
 
+@pytest.mark.xfail(
+    tuple(int(x) for x in tables.hdf5_version.split(".")) >= (2,),
+    reason="track_times=False produces non-deterministic files with HDF5 >= 2",
+)
 def test_no_track_times(temp_h5_path):
     # GH 32682
     # enables to set track_times (see `pytables` `create_table` documentation)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -26,6 +26,7 @@ import pandas._testing as tm
 from pandas.api.types import (
     CategoricalDtype,
 )
+from pandas.util.version import Version
 
 from pandas.io.pytables import (
     HDFStore,
@@ -54,7 +55,7 @@ def test_context(temp_h5_path):
 
 
 @pytest.mark.xfail(
-    tuple(int(x) for x in tables.hdf5_version.split(".")) >= (2,),
+    Version(tables.hdf5_version) >= Version("2"),
     reason="track_times=False produces non-deterministic files with HDF5 >= 2",
 )
 def test_no_track_times(temp_h5_path):


### PR DESCRIPTION
## Summary
- conda-forge updated `hdf5` from 1.14.6 to 2.1.0 on 2026-03-24, causing `test_no_track_times` to fail on all Ubuntu CI jobs
- `track_times=False` no longer produces byte-for-byte deterministic HDF5 files with HDF5 2.x
- The test creates two files with `track_times=False` one second apart and asserts identical checksums; this passes with HDF5 1.14.x but fails with 2.1.0
- xfail the test conditional on `tables.hdf5_version >= 2`

## Test plan
- [x] Test passes locally with HDF5 1.14.6 (xfail condition is False, test runs normally)
- [ ] CI with HDF5 2.1.0 should show test as xfail instead of failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)