### PR TITLE
BUG: fix iloc setitem with nullable EA dtype Series/Index (#47776)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -200,6 +200,7 @@ Interval
 Indexing
 ^^^^^^^^
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
+- Bug in :meth:`DataFrame.iloc` setitem raising ``AttributeError`` when assigning a :class:`Series` or :class:`Index` with a nullable EA dtype (e.g. ``Int64``, ``Float64``, ``boolean``) into a column with a NumPy dtype (:issue:`47776`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)
 - Bug in :meth:`Index.insert` silently casting booleans to numeric when used with nullable numeric dtypes like ``Float64`` or ``Int64`` (:issue:`61709`)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1744,7 +1744,11 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
             if not isinstance(tipo, np.dtype):
                 # i.e. nullable IntegerDtype; we can put this into an ndarray
                 #  losslessly iff it has no NAs
-                arr = element._values if isinstance(element, ABCSeries) else element
+                arr = (
+                    element._values
+                    if isinstance(element, (ABCIndex, ABCSeries))
+                    else element
+                )
                 if arr._hasna:
                     raise LossySetitemError
                 return element
@@ -1780,7 +1784,12 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
             if not isinstance(tipo, np.dtype):
                 # i.e. nullable IntegerDtype or FloatingDtype;
                 #  we can put this into an ndarray losslessly iff it has no NAs
-                if element._hasna:
+                arr = (
+                    element._values
+                    if isinstance(element, (ABCIndex, ABCSeries))
+                    else element
+                )
+                if arr._hasna:
                     raise LossySetitemError
                 return element
             elif tipo.itemsize > dtype.itemsize or tipo.kind != dtype.kind:
@@ -1820,7 +1829,12 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
             if tipo.kind == "b":
                 if not isinstance(tipo, np.dtype):
                     # i.e. we have a BooleanArray
-                    if element._hasna:
+                    arr = (
+                        element._values
+                        if isinstance(element, (ABCIndex, ABCSeries))
+                        else element
+                    )
+                    if arr._hasna:
                         # i.e. there are pd.NA elements
                         raise LossySetitemError
                 return element

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1749,7 +1749,7 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
                     if isinstance(element, (ABCIndex, ABCSeries))
                     else element
                 )
-                if arr._hasna:
+                if arr._hasna:  # type: ignore[union-attr]
                     raise LossySetitemError
                 return element
 
@@ -1789,7 +1789,7 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
                     if isinstance(element, (ABCIndex, ABCSeries))
                     else element
                 )
-                if arr._hasna:
+                if arr._hasna:  # type: ignore[union-attr]
                     raise LossySetitemError
                 return element
             elif tipo.itemsize > dtype.itemsize or tipo.kind != dtype.kind:
@@ -1834,7 +1834,7 @@ def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
                         if isinstance(element, (ABCIndex, ABCSeries))
                         else element
                     )
-                    if arr._hasna:
+                    if arr._hasna:  # type: ignore[union-attr]
                         # i.e. there are pd.NA elements
                         raise LossySetitemError
                 return element

--- a/pandas/tests/dtypes/cast/test_can_hold_element.py
+++ b/pandas/tests/dtypes/cast/test_can_hold_element.py
@@ -1,8 +1,13 @@
 import numpy as np
+import pytest
 
 from pandas.core.dtypes.cast import can_hold_element
 
-from pandas import Categorical
+import pandas as pd
+from pandas import (
+    Categorical,
+    Series,
+)
 
 
 def test_can_hold_element_range(any_int_numpy_dtype):
@@ -106,3 +111,44 @@ def test_can_hold_element_categorical():
     cat = Categorical([1, 2, None])
 
     assert can_hold_element(arr, cat)
+
+
+@pytest.mark.parametrize(
+    "dtype, ea_dtype",
+    [
+        (np.dtype("int64"), "Int64"),
+        (np.dtype("uint64"), "UInt64"),
+        (np.dtype("float64"), "Float64"),
+        (np.dtype("float64"), "Int64"),
+        (np.dtype("bool"), "boolean"),
+    ],
+)
+def test_can_hold_element_ea_series_no_na(dtype, ea_dtype):
+    # GH#47776
+    arr = np.array([], dtype=dtype)
+    if dtype.kind == "b":
+        ser = Series([True, False], dtype=ea_dtype)
+    else:
+        ser = Series([1, 2], dtype=ea_dtype)
+
+    assert can_hold_element(arr, ser)
+
+
+@pytest.mark.parametrize(
+    "dtype, ea_dtype",
+    [
+        (np.dtype("int64"), "Int64"),
+        (np.dtype("uint64"), "UInt64"),
+        (np.dtype("float64"), "Float64"),
+        (np.dtype("bool"), "boolean"),
+    ],
+)
+def test_can_hold_element_ea_series_with_na(dtype, ea_dtype):
+    # GH#47776 - Series with NA cannot be held losslessly
+    arr = np.array([], dtype=dtype)
+    if dtype.kind == "b":
+        ser = Series([True, pd.NA], dtype=ea_dtype)
+    else:
+        ser = Series([1, pd.NA], dtype=ea_dtype)
+
+    assert not can_hold_element(arr, ser)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -578,6 +578,28 @@ class TestFancy:
         df.loc[:, "A"] = df["A"].astype(np.int64)
         tm.assert_frame_equal(df, expected)
 
+    @pytest.mark.parametrize(
+        "dtype, ea_dtype",
+        [
+            ("float64", "Int64"),
+            ("float64", "Float64"),
+            ("bool", "boolean"),
+        ],
+    )
+    @pytest.mark.parametrize("box", [Series, Index])
+    def test_iloc_setitem_ea_dtype_series(self, dtype, ea_dtype, box):
+        # GH#47776
+        if dtype == "bool":
+            df = DataFrame({"A": [True, False, True]})
+            val = box([False, True, False], dtype=ea_dtype)
+        else:
+            df = DataFrame({"A": [1.0, 2.0, 3.0]})
+            val = box([4, 5, 6], dtype=ea_dtype)
+
+        df.iloc[:, 0] = val
+        expected = DataFrame({"A": val.to_numpy(dtype=dtype)})
+        tm.assert_frame_equal(df, expected)
+
     @pytest.mark.parametrize("indexer", [tm.getitem, tm.loc])
     def test_index_type_coercion(self, indexer):
         # GH 11836


### PR DESCRIPTION
## Summary
- Fixed `np_can_hold_element` raising `AttributeError` when a `Series` or `Index` with a nullable EA dtype (e.g. `Int64`, `Float64`, `boolean`) is passed as the element, because `_hasna` is an attribute of `ExtensionArray`, not `Series`/`Index`.
- The float and boolean branches were missing the `element._values` unwrapping that the integer branch already had; additionally, all three branches now also handle `Index`.
- User-facing repro: `df.iloc[:, 0] = Series([4, 5, 6], dtype="Int64")` into a `float64` column raises `AttributeError: 'Series' object has no attribute '_hasna'`.

closes #47776

## Test plan
- [x] Added unit tests for `can_hold_element` with EA-dtype Series (with and without NA)
- [x] Added user-facing test for `df.iloc` setitem with EA-dtype Series and Index
- [x] Existing tests pass (`test_can_hold_element`, `test_setitem`, `test_indexing`, `test_shift`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)