### PR TITLE
REF: add ExtensionArray._groupby_quantile method

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2907,6 +2907,28 @@ class ArrowExtensionArray(
         arr = self.to_numpy(dtype=dtype.numpy_dtype, na_value=na_value)
         return dtype.construct_array_type()(arr, mask)
 
+    def _to_groupby_compatible(self) -> ExtensionArray:
+        """Convert to a type compatible with groupby cython ops."""
+        pa_type = self._pa_array.type
+        if pa.types.is_timestamp(pa_type):
+            return self._to_datetimearray()
+        elif pa.types.is_duration(pa_type):
+            return self._to_timedeltaarray()
+        else:
+            return self._to_masked()
+
+    def _groupby_result_to_arrow(self, result: ArrayLike) -> ArrayLike:
+        """Convert a groupby result from a delegated type back to Arrow."""
+        if isinstance(result, np.ndarray):
+            return result
+        elif isinstance(result, BaseMaskedArray):
+            pa_result = result.__arrow_array__()
+            return self._from_pyarrow_array(pa_result)
+        else:
+            # DatetimeArray, TimedeltaArray
+            pa_result = pa.array(result)
+            return self._from_pyarrow_array(pa_result)
+
     def _groupby_op(
         self,
         *,
@@ -2950,16 +2972,7 @@ class ArrowExtensionArray(
                 skipna=kwargs.get("skipna", True),
             )
 
-        # maybe convert to a compatible dtype optimized for groupby
-        values: ExtensionArray
-        pa_type = self._pa_array.type
-        if pa.types.is_timestamp(pa_type):
-            values = self._to_datetimearray()
-        elif pa.types.is_duration(pa_type):
-            values = self._to_timedeltaarray()
-        else:
-            values = self._to_masked()
-
+        values = self._to_groupby_compatible()
         result = values._groupby_op(
             how=how,
             has_dropped_na=has_dropped_na,
@@ -2968,15 +2981,35 @@ class ArrowExtensionArray(
             ids=ids,
             **kwargs,
         )
-        if isinstance(result, np.ndarray):
-            return result
-        elif isinstance(result, BaseMaskedArray):
-            pa_result = result.__arrow_array__()
-            return self._from_pyarrow_array(pa_result)
-        else:
-            # DatetimeArray, TimedeltaArray
-            pa_result = pa.array(result)
-            return self._from_pyarrow_array(pa_result)
+        return self._groupby_result_to_arrow(result)
+
+    def _groupby_quantile(
+        self,
+        *,
+        qs: npt.NDArray[np.float64],
+        interpolation: str,
+        ids: npt.NDArray[np.intp],
+        ngroups: int,
+        starts: npt.NDArray[np.int64],
+        ends: npt.NDArray[np.int64],
+    ) -> ArrayLike:
+        from pandas.core.arrays.string_ import StringDtype
+
+        if isinstance(self.dtype, StringDtype):
+            raise TypeError(
+                f"dtype '{self.dtype}' does not support operation 'quantile'"
+            )
+
+        values = self._to_groupby_compatible()
+        result = values._groupby_quantile(
+            qs=qs,
+            interpolation=interpolation,
+            ids=ids,
+            ngroups=ngroups,
+            starts=starts,
+            ends=ends,
+        )
+        return self._groupby_result_to_arrow(result)
 
     def _apply_elementwise(self, func: Callable) -> list[list[Any]]:
         """Apply a callable to each element while maintaining the chunking structure."""

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2987,7 +2987,7 @@ class ArrowExtensionArray(
         self,
         *,
         qs: npt.NDArray[np.float64],
-        interpolation: str,
+        interpolation: Literal["linear", "lower", "higher", "nearest", "midpoint"],
         ids: npt.NDArray[np.intp],
         ngroups: int,
         starts: npt.NDArray[np.int64],

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -3076,7 +3076,7 @@ class ExtensionArray:
         if inference is not None and not (
             is_integer_dtype(inference) and interpolation in {"linear", "midpoint"}
         ):
-            return out.astype(inference)
+            out = out.astype(inference)
 
         return out
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -3009,7 +3009,7 @@ class ExtensionArray:
         self,
         *,
         qs: npt.NDArray[np.float64],
-        interpolation: str,
+        interpolation: Literal["linear", "lower", "higher", "nearest", "midpoint"],
         ids: npt.NDArray[np.intp],
         ngroups: int,
         starts: npt.NDArray[np.int64],
@@ -3067,7 +3067,7 @@ class ExtensionArray:
         libgroupby.group_quantile(
             out,
             values=vals,
-            mask=mask,
+            mask=mask,  # type: ignore[arg-type]
             labels=ids,
             qs=qs,
             interpolation=interpolation,
@@ -3076,7 +3076,7 @@ class ExtensionArray:
             result_mask=None,
             is_datetimelike=False,
         )
-        out = out.ravel("K")
+        out = out.ravel("K")  # type: ignore[assignment]
 
         if inference is not None and not (
             is_integer_dtype(inference) and interpolation in {"linear", "midpoint"}

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -44,8 +44,12 @@ from pandas.util._validators import (
 from pandas.core.dtypes.astype import astype_is_view
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import (
+    is_bool_dtype,
+    is_float_dtype,
     is_integer,
+    is_integer_dtype,
     is_list_like,
+    is_object_dtype,
     is_scalar,
     pandas_dtype,
 )
@@ -3033,14 +3037,6 @@ class ExtensionArray:
         -------
         np.ndarray or ExtensionArray
         """
-        from pandas.core.dtypes.common import (
-            is_bool_dtype,
-            is_float_dtype,
-            is_integer_dtype,
-            is_object_dtype,
-        )
-        from pandas.core.dtypes.missing import isna
-
         from pandas.core.arrays.string_ import StringDtype
 
         if isinstance(self.dtype, StringDtype) or is_object_dtype(self.dtype):
@@ -3053,15 +3049,14 @@ class ExtensionArray:
         mask = np.asarray(isna(self))
         nqs = len(qs)
 
-        if is_integer_dtype(self.dtype):
+        if is_integer_dtype(self.dtype) or is_float_dtype(self.dtype):
             vals = self.to_numpy(dtype=float, na_value=np.nan)
-            inference: np.dtype | None = np.dtype(np.int64)
-        elif is_float_dtype(self.dtype):
-            vals = self.to_numpy(dtype=float, na_value=np.nan)
-            inference = np.dtype(np.float64)
         else:
             vals = np.asarray(self)
-            inference = None
+
+        inference: np.dtype | None = (
+            np.dtype(np.int64) if is_integer_dtype(self.dtype) else None
+        )
 
         out = np.empty((ngroups, nqs), dtype=np.float64)
         libgroupby.group_quantile(

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -3005,6 +3005,86 @@ class ExtensionArray:
         else:
             raise NotImplementedError
 
+    def _groupby_quantile(
+        self,
+        *,
+        qs: npt.NDArray[np.float64],
+        interpolation: str,
+        ids: npt.NDArray[np.intp],
+        ngroups: int,
+        starts: npt.NDArray[np.int64],
+        ends: npt.NDArray[np.int64],
+    ) -> ArrayLike:
+        """
+        Dispatch GroupBy quantile operation.
+
+        Parameters
+        ----------
+        qs : np.ndarray[float64]
+            Quantile(s) to compute.
+        interpolation : {'linear', 'lower', 'higher', 'nearest', 'midpoint'}
+        ids : np.ndarray[np.intp]
+            Group labels.
+        ngroups : int
+        starts : np.ndarray[int64]
+        ends : np.ndarray[int64]
+
+        Returns
+        -------
+        np.ndarray or ExtensionArray
+        """
+        from pandas.core.dtypes.common import (
+            is_bool_dtype,
+            is_float_dtype,
+            is_integer_dtype,
+            is_object_dtype,
+        )
+        from pandas.core.dtypes.missing import isna
+
+        from pandas.core.arrays.string_ import StringDtype
+
+        if isinstance(self.dtype, StringDtype) or is_object_dtype(self.dtype):
+            raise TypeError(
+                f"dtype '{self.dtype}' does not support operation 'quantile'"
+            )
+        if is_bool_dtype(self.dtype):
+            raise TypeError("Cannot use quantile with bool dtype")
+
+        mask = np.asarray(isna(self))
+        nqs = len(qs)
+
+        if is_integer_dtype(self.dtype):
+            vals = self.to_numpy(dtype=float, na_value=np.nan)
+            inference: np.dtype | None = np.dtype(np.int64)
+        elif is_float_dtype(self.dtype):
+            vals = self.to_numpy(dtype=float, na_value=np.nan)
+            inference = np.dtype(np.float64)
+        else:
+            vals = np.asarray(self)
+            inference = None
+
+        out = np.empty((ngroups, nqs), dtype=np.float64)
+        libgroupby.group_quantile(
+            out,
+            values=vals,
+            mask=mask,
+            labels=ids,
+            qs=qs,
+            interpolation=interpolation,
+            starts=starts,
+            ends=ends,
+            result_mask=None,
+            is_datetimelike=False,
+        )
+        out = out.ravel("K")
+
+        if inference is not None and not (
+            is_integer_dtype(inference) and interpolation in {"linear", "midpoint"}
+        ):
+            return out.astype(inference)
+
+        return out
+
     def _groupby_first_last(
         self,
         *,

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1794,6 +1794,57 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         res_values = res_values.view(self._ndarray.dtype)
         return self._from_backing_data(res_values)
 
+    def _groupby_quantile(
+        self,
+        *,
+        qs: npt.NDArray[np.float64],
+        interpolation: str,
+        ids: npt.NDArray[np.intp],
+        ngroups: int,
+        starts: npt.NDArray[np.int64],
+        ends: npt.NDArray[np.int64],
+    ) -> ArrayLike:
+        import pandas._libs.groupby as libgroupby
+
+        nqs = len(qs)
+        mask = self.isna()
+        i8vals = self.asi8
+
+        # Block manager may store DatetimeArray/TimedeltaArray as 2D (1, N)
+        ncols = 1
+        if self.ndim == 2:
+            ncols = self._ndarray.shape[0]
+
+        out = np.empty((ncols, ngroups, nqs), dtype=np.float64)
+        for col in range(ncols):
+            if self.ndim == 2:
+                col_mask = mask[col]
+                col_vals = i8vals[col]
+            else:
+                col_mask = mask
+                col_vals = i8vals
+
+            libgroupby.group_quantile(
+                out[col],
+                values=col_vals,
+                mask=col_mask,
+                labels=ids,
+                qs=qs,
+                interpolation=interpolation,
+                starts=starts,
+                ends=ends,
+                result_mask=None,
+                is_datetimelike=True,
+            )
+
+        if self.ndim == 1:
+            out = out.ravel("K")
+        else:
+            out = out.reshape(ncols, ngroups * nqs)
+
+        out = out.astype("i8").view(self._ndarray.dtype)
+        return self._from_backing_data(out)
+
 
 class DatelikeOps(DatetimeLikeArrayMixin):
     """

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1798,7 +1798,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         self,
         *,
         qs: npt.NDArray[np.float64],
-        interpolation: str,
+        interpolation: Literal["linear", "lower", "higher", "nearest", "midpoint"],
         ids: npt.NDArray[np.intp],
         ngroups: int,
         starts: npt.NDArray[np.int64],
@@ -1838,9 +1838,9 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             )
 
         if self.ndim == 1:
-            out = out.ravel("K")
+            out = out.ravel("K")  # type: ignore[assignment]
         else:
-            out = out.reshape(ncols, ngroups * nqs)
+            out = out.reshape(ncols, ngroups * nqs)  # type: ignore[assignment]
 
         out = out.astype("i8").view(self._ndarray.dtype)
         return self._from_backing_data(out)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -27,6 +27,7 @@ from pandas._config.config import get_option
 
 from pandas._libs import (
     algos,
+    groupby as libgroupby,
     lib,
 )
 from pandas._libs.tslibs import (
@@ -1804,8 +1805,6 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         starts: npt.NDArray[np.int64],
         ends: npt.NDArray[np.int64],
     ) -> ArrayLike:
-        import pandas._libs.groupby as libgroupby
-
         nqs = len(qs)
         mask = self.isna()
         i8vals = self.asi8

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -19,6 +19,7 @@ from pandas._config import (
 
 from pandas._libs import (
     algos as libalgos,
+    groupby as libgroupby,
     lib,
     missing as libmissing,
 )
@@ -40,6 +41,7 @@ from pandas.core.dtypes.cast import (
 )
 from pandas.core.dtypes.common import (
     is_bool,
+    is_float_dtype,
     is_integer_dtype,
     is_list_like,
     is_scalar,
@@ -2074,10 +2076,6 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         starts: npt.NDArray[np.int64],
         ends: npt.NDArray[np.int64],
     ) -> ArrayLike:
-        import pandas._libs.groupby as libgroupby
-
-        from pandas.core.dtypes.common import is_float_dtype
-
         mask = self._mask
         nqs = len(qs)
         result_mask = np.zeros((ngroups, nqs), dtype=np.bool_)

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -2064,6 +2064,51 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             #  wrap in a MaskedArray
             return self._maybe_mask_result(res_values, result_mask)
 
+    def _groupby_quantile(
+        self,
+        *,
+        qs: npt.NDArray[np.float64],
+        interpolation: str,
+        ids: npt.NDArray[np.intp],
+        ngroups: int,
+        starts: npt.NDArray[np.int64],
+        ends: npt.NDArray[np.int64],
+    ) -> ArrayLike:
+        import pandas._libs.groupby as libgroupby
+
+        from pandas.core.dtypes.common import is_float_dtype
+
+        mask = self._mask
+        nqs = len(qs)
+        result_mask = np.zeros((ngroups, nqs), dtype=np.bool_)
+
+        vals = self.to_numpy(dtype=float, na_value=np.nan)
+
+        out = np.empty((ngroups, nqs), dtype=np.float64)
+        libgroupby.group_quantile(
+            out,
+            values=vals,
+            mask=mask,
+            labels=ids,
+            qs=qs,
+            interpolation=interpolation,
+            starts=starts,
+            ends=ends,
+            result_mask=result_mask,
+            is_datetimelike=False,
+        )
+        out = out.ravel("K")
+        result_mask = result_mask.ravel("K")
+
+        if not (interpolation in {"linear", "midpoint"} and not is_float_dtype(self)):
+            # For non-interpolating methods on non-float dtypes, cast back
+            # to the original numpy dtype (e.g. float64 -> int64).
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=RuntimeWarning)
+                out = out.astype(self.dtype.numpy_dtype)
+
+        return self._maybe_mask_result(out, result_mask)
+
 
 def transpose_homogeneous_masked_arrays(
     masked_arrays: Sequence[BaseMaskedArray],

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -2068,7 +2068,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         self,
         *,
         qs: npt.NDArray[np.float64],
-        interpolation: str,
+        interpolation: Literal["linear", "lower", "higher", "nearest", "midpoint"],
         ids: npt.NDArray[np.intp],
         ngroups: int,
         starts: npt.NDArray[np.int64],
@@ -2088,7 +2088,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         libgroupby.group_quantile(
             out,
             values=vals,
-            mask=mask,
+            mask=mask,  # type: ignore[arg-type]
             labels=ids,
             qs=qs,
             interpolation=interpolation,
@@ -2097,8 +2097,8 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             result_mask=result_mask,
             is_datetimelike=False,
         )
-        out = out.ravel("K")
-        result_mask = result_mask.ravel("K")
+        out = out.ravel("K")  # type: ignore[assignment]
+        result_mask = result_mask.ravel("K")  # type: ignore[assignment]
 
         if not (interpolation in {"linear", "midpoint"} and not is_float_dtype(self)):
             # For non-interpolating methods on non-float dtypes, cast back

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4703,7 +4703,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 "linear",
                 "midpoint",
             }:
-                return out.astype(inference)
+                out = out.astype(inference)
 
             return out
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -48,7 +48,6 @@ from pandas._libs.missing import NA
 from pandas._typing import (
     AnyArrayLike,
     ArrayLike,
-    DtypeObj,
     IndexLabel,
     IntervalClosedType,
     NDFrameT,
@@ -72,7 +71,6 @@ from pandas.core.dtypes.cast import (
 from pandas.core.dtypes.common import (
     is_bool,
     is_bool_dtype,
-    is_float_dtype,
     is_hashable,
     is_integer,
     is_integer_dtype,
@@ -81,7 +79,6 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_scalar,
     is_string_dtype,
-    needs_i8_conversion,
     pandas_dtype,
 )
 from pandas.core.dtypes.missing import (
@@ -99,7 +96,6 @@ from pandas.core.arrays import (
     ArrowExtensionArray,
     BaseMaskedArray,
     ExtensionArray,
-    FloatingArray,
     IntegerArray,
 )
 from pandas.core.arrays.string_ import StringDtype
@@ -4625,94 +4621,6 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
         starts, ends = lib.generate_slices(splitter._slabels, splitter.ngroups)
 
-        def pre_processor(vals: ArrayLike) -> tuple[np.ndarray, DtypeObj | None]:
-            if isinstance(vals.dtype, StringDtype) or is_object_dtype(vals.dtype):
-                raise TypeError(
-                    f"dtype '{vals.dtype}' does not support operation 'quantile'"
-                )
-
-            inference: DtypeObj | None = None
-            if isinstance(vals, BaseMaskedArray) and is_numeric_dtype(vals.dtype):
-                out = vals.to_numpy(dtype=float, na_value=np.nan)
-                inference = vals.dtype
-            elif is_integer_dtype(vals.dtype):
-                if isinstance(vals, ExtensionArray):
-                    out = vals.to_numpy(dtype=float, na_value=np.nan)
-                else:
-                    out = vals
-                inference = np.dtype(np.int64)
-            elif is_bool_dtype(vals.dtype) and isinstance(vals, ExtensionArray):
-                out = vals.to_numpy(dtype=float, na_value=np.nan)
-            elif is_bool_dtype(vals.dtype):
-                # GH#51424 remove to match Series/DataFrame behavior
-                raise TypeError("Cannot use quantile with bool dtype")
-            elif needs_i8_conversion(vals.dtype):
-                inference = vals.dtype
-                # In this case we need to delay the casting until after the
-                #  np.lexsort below.
-                # error: Incompatible return value type (got
-                # "Tuple[Union[ExtensionArray, ndarray[Any, Any]], Union[Any,
-                # ExtensionDtype]]", expected "Tuple[ndarray[Any, Any],
-                # Optional[Union[dtype[Any], ExtensionDtype]]]")
-                return vals, inference  # type: ignore[return-value]
-            elif isinstance(vals, ExtensionArray) and is_float_dtype(vals.dtype):
-                inference = np.dtype(np.float64)
-                out = vals.to_numpy(dtype=float, na_value=np.nan)
-            else:
-                out = np.asarray(vals)
-
-            return out, inference
-
-        def post_processor(
-            vals: np.ndarray,
-            inference: DtypeObj | None,
-            result_mask: np.ndarray | None,
-            orig_vals: ArrayLike,
-        ) -> ArrayLike:
-            if inference:
-                # Check for edge case
-                if isinstance(orig_vals, BaseMaskedArray):
-                    assert result_mask is not None  # for mypy
-
-                    if interpolation in {"linear", "midpoint"} and not is_float_dtype(
-                        orig_vals
-                    ):
-                        return FloatingArray(vals, result_mask)
-                    else:
-                        # Item "ExtensionDtype" of "Union[ExtensionDtype, str,
-                        # dtype[Any], Type[object]]" has no attribute "numpy_dtype"
-                        # [union-attr]
-                        with warnings.catch_warnings():
-                            # vals.astype with nan can warn with numpy >1.24
-                            warnings.filterwarnings("ignore", category=RuntimeWarning)
-                            return type(orig_vals)(
-                                vals.astype(
-                                    inference.numpy_dtype  # type: ignore[union-attr]
-                                ),
-                                result_mask,
-                            )
-
-                elif not (
-                    is_integer_dtype(inference)
-                    and interpolation in {"linear", "midpoint"}
-                ):
-                    if needs_i8_conversion(inference):
-                        # error: Item "ExtensionArray" of "Union[ExtensionArray,
-                        # ndarray[Any, Any]]" has no attribute "_ndarray"
-                        vals = vals.astype("i8").view(
-                            orig_vals._ndarray.dtype  # type: ignore[union-attr]
-                        )
-                        # error: Item "ExtensionArray" of "Union[ExtensionArray,
-                        # ndarray[Any, Any]]" has no attribute "_from_backing_data"
-                        return orig_vals._from_backing_data(  # type: ignore[union-attr]
-                            vals
-                        )
-
-                    assert isinstance(inference, np.dtype)  # for mypy
-                    return vals.astype(inference)
-
-            return vals
-
         if is_scalar(q):
             qs = np.array([q], dtype=np.float64)
             pass_qs: None | np.ndarray = None
@@ -4737,17 +4645,30 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         )
 
         def blk_func(values: ArrayLike) -> ArrayLike:
-            orig_vals = values
-            if isinstance(values, BaseMaskedArray):
-                mask = values._mask
-                result_mask = np.zeros((ngroups, nqs), dtype=np.bool_)
-            else:
-                mask = isna(values)
-                result_mask = None
+            if isinstance(values, ExtensionArray):
+                return values._groupby_quantile(
+                    qs=qs,
+                    interpolation=interpolation,
+                    ids=ids,
+                    ngroups=ngroups,
+                    starts=starts,
+                    ends=ends,
+                )
 
-            is_datetimelike = needs_i8_conversion(values.dtype)
+            # ndarray path
+            if is_object_dtype(values.dtype):
+                raise TypeError(
+                    f"dtype '{values.dtype}' does not support operation 'quantile'"
+                )
+            if is_bool_dtype(values.dtype):
+                # GH#51424 remove to match Series/DataFrame behavior
+                raise TypeError("Cannot use quantile with bool dtype")
 
-            vals, inference = pre_processor(values)
+            mask = isna(values)
+            inference: np.dtype | None = (
+                np.dtype(np.int64) if is_integer_dtype(values.dtype) else None
+            )
+            vals = np.asarray(values)
 
             ncols = 1
             if vals.ndim == 2:
@@ -4755,17 +4676,13 @@ class GroupBy(BaseGroupBy[NDFrameT]):
 
             out = np.empty((ncols, ngroups, nqs), dtype=np.float64)
 
-            if is_datetimelike:
-                vals = vals.view("i8")
-
             if vals.ndim == 1:
-                # EA is always 1d
                 func(
                     out[0],
                     values=vals,
-                    mask=mask,  # type: ignore[arg-type]
-                    result_mask=result_mask,
-                    is_datetimelike=is_datetimelike,
+                    mask=mask,
+                    result_mask=None,
+                    is_datetimelike=False,
                 )
             else:
                 for i in range(ncols):
@@ -4774,17 +4691,21 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                         values=vals[i],
                         mask=mask[i],
                         result_mask=None,
-                        is_datetimelike=is_datetimelike,
+                        is_datetimelike=False,
                     )
 
             if vals.ndim == 1:
                 out = out.ravel("K")  # type: ignore[assignment]
-                if result_mask is not None:
-                    result_mask = result_mask.ravel("K")  # type: ignore[assignment]
             else:
                 out = out.reshape(ncols, ngroups * nqs)  # type: ignore[assignment]
 
-            return post_processor(out, inference, result_mask, orig_vals)
+            if inference is not None and interpolation not in {
+                "linear",
+                "midpoint",
+            }:
+                return out.astype(inference)
+
+            return out
 
         res_mgr = sdata._mgr.grouped_reduce(blk_func)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4689,7 +4689,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                     func(
                         out[i],
                         values=vals[i],
-                        mask=mask[i],  # type: ignore[arg-type]
+                        mask=mask[i],
                         result_mask=None,
                         is_datetimelike=False,
                     )

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4680,7 +4680,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 func(
                     out[0],
                     values=vals,
-                    mask=mask,
+                    mask=mask,  # type: ignore[arg-type]
                     result_mask=None,
                     is_datetimelike=False,
                 )
@@ -4689,7 +4689,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                     func(
                         out[i],
                         values=vals[i],
-                        mask=mask[i],
+                        mask=mask[i],  # type: ignore[arg-type]
                         result_mask=None,
                         is_datetimelike=False,
                     )


### PR DESCRIPTION
## Summary
- Moves EA-specific dtype casting out of `GroupBy.quantile`'s inline `pre_processor`/`post_processor` closures and into per-subclass `_groupby_quantile` methods, matching the `_groupby_op` pattern used by all other groupby operations.
- Adds `_groupby_quantile` to `ExtensionArray` (base), `BaseMaskedArray`, `DatetimeLikeArrayMixin`, and `ArrowExtensionArray`.
- `BaseMaskedArray` reuses the existing `_maybe_mask_result` helper for result wrapping.
- `ArrowExtensionArray` uses new `_to_groupby_compatible` / `_groupby_result_to_arrow` helpers shared with `_groupby_op`.
- Simplifies `blk_func` in `GroupBy.quantile` to a simple EA dispatch + a clean ndarray-only path.

Closes #37505

## Test plan
- [x] `pandas/tests/groupby/methods/test_quantile.py` — 321 tests pass
- [x] `pandas/tests/resample/test_base.py` and `test_timedelta.py` quantile tests pass
- [x] `pandas/tests/groupby/test_groupby.py` — 2503 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)