### PR TITLE
CLN: inline and remove maybe_convert_platform

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1896,10 +1896,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 def _maybe_convert_platform_interval(values) -> ArrayLike:
     """
     Try to do platform conversion, with special casing for IntervalArray.
-    Wrapper around maybe_convert_platform that alters the default return
-    dtype in certain cases to be compatible with IntervalArray.  For example,
-    empty lists return with integer dtype instead of object dtype, which is
-    prohibited for IntervalArray.
+    For example, empty lists return with integer dtype instead of object dtype,
+    which is prohibited for IntervalArray.
 
     Parameters
     ----------

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -32,7 +32,6 @@ from pandas.core.dtypes.cast import (
     ensure_dtype_can_hold_na,
     maybe_cast_to_datetime,
     maybe_cast_to_integer_array,
-    maybe_convert_platform,
     maybe_promote,
 )
 from pandas.core.dtypes.common import (
@@ -690,18 +689,12 @@ def sanitize_array(
             subarr = _try_cast(data, dtype, copy)
 
         else:
-            subarr = maybe_convert_platform(data)
-            if subarr.dtype == object:
-                subarr = cast("np.ndarray", subarr)
-                subarr = lib.maybe_convert_objects(
-                    subarr,
-                    # Here we do not convert numeric dtypes, as if we wanted that,
-                    #  numpy would have done it for us.
-                    convert_numeric=False,
-                    convert_non_numeric=True,
-                    convert_to_nullable_dtype=False,
-                    dtype_if_all_nat=np.dtype("M8[s]"),
-                )
+            subarr = construct_1d_object_array_from_listlike(data)
+            subarr = lib.maybe_convert_objects(
+                subarr,
+                convert_non_numeric=True,
+                dtype_if_all_nat=np.dtype("M8[s]"),
+            )
 
     subarr = _sanitize_ndim(subarr, data, dtype, index, allow_2d=allow_2d)
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -124,26 +124,6 @@ _dtype_obj = np.dtype(object)
 NumpyArrayT = TypeVar("NumpyArrayT", bound=np.ndarray)
 
 
-def maybe_convert_platform(
-    values: list | tuple | range | np.ndarray | ExtensionArray,
-) -> ArrayLike:
-    """try to do platform conversion, allow ndarray or list here"""
-    arr: ArrayLike
-
-    if isinstance(values, (list, tuple, range)):
-        arr = construct_1d_object_array_from_listlike(values)
-    else:
-        # The caller is responsible for ensuring that we have np.ndarray
-        #  or ExtensionArray here.
-        arr = values
-
-    if arr.dtype == _dtype_obj:
-        arr = cast("np.ndarray", arr)
-        arr = lib.maybe_convert_objects(arr)
-
-    return arr
-
-
 def is_nested_object(obj: object) -> bool:
     """
     return a boolean if we have a nested object, e.g. a Series with 1 or

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -21,9 +21,9 @@ from pandas._libs import lib
 from pandas.core.dtypes.astype import astype_is_view
 from pandas.core.dtypes.cast import (
     construct_1d_arraylike_from_scalar,
+    construct_1d_object_array_from_listlike,
     dict_compat,
     maybe_cast_to_datetime,
-    maybe_convert_platform,
 )
 from pandas.core.dtypes.common import (
     is_1d_only_ea_dtype,
@@ -518,10 +518,13 @@ def _prep_ndarraylike(values, copy: bool = True) -> np.ndarray:
             return v
 
         v = extract_array(v, extract_numpy=True)
-        res = maybe_convert_platform(v)
+        if isinstance(v, (list, tuple, range)):
+            v = construct_1d_object_array_from_listlike(v)
+        if isinstance(v, np.ndarray) and v.dtype == object:
+            v = lib.maybe_convert_objects(v)
         # We don't do maybe_infer_objects here bc we will end up doing
         #  it column-by-column in ndarray_to_mgr
-        return res
+        return v
 
     # we could have a 1-dim or 2-dim list here
     # this is equiv of np.asarray, but does object conversion


### PR DESCRIPTION
## Summary
- `maybe_convert_platform` was only called in two places, and in both cases parts of it were redundant with surrounding code
- In `core/construction.py`: the two-pass `maybe_convert_objects` (first with defaults, then with `convert_non_numeric=True`) is replaced by a single call with `convert_non_numeric=True`
- In `core/internals/construction.py`: the list/tuple/range → object array conversion and object-dtype `maybe_convert_objects` call are inlined directly
- Removes stale docstring reference in `_maybe_convert_platform_interval` (which despite its name never called `maybe_convert_platform`)

## Test plan
- [x] Existing constructor tests pass (`test_constructors.py` for both Series and DataFrame)
- [x] Interval index tests pass
- [x] Broader index, internals, and dtypes/cast test suites pass (21k+ tests)
- [x] mypy clean, pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)