### PR TITLE
BUG: fix concat with overlapping IntervalIndex levels (#64825)

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -49,6 +49,7 @@ from pandas.core.indexes.api import (
     union_indexes,
 )
 from pandas.core.indexes.datetimes import DatetimeIndex
+from pandas.core.indexes.interval import IntervalIndex
 from pandas.core.internals import concatenate_managers
 
 if TYPE_CHECKING:
@@ -972,7 +973,10 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
 
     for hlevel, level in zip(zipped, levels, strict=True):
         hlevel_index = ensure_index(hlevel)
-        mapped = level.get_indexer(hlevel_index)
+        if isinstance(level, IntervalIndex):
+            mapped, _ = level.get_indexer_non_unique(hlevel_index)
+        else:
+            mapped = level.get_indexer(hlevel_index)
 
         mask = mapped == -1
         if mask.any():

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -19,6 +19,8 @@ import pandas as pd
 from pandas import (
     DataFrame,
     Index,
+    Interval,
+    IntervalIndex,
     MultiIndex,
     PeriodIndex,
     RangeIndex,
@@ -553,6 +555,35 @@ class TestConcatenate:
         msg = "Reindexing only valid with uniquely valued Index objects"
         with pytest.raises(InvalidIndexError, match=msg):
             concat([df1, df2], axis=1)
+
+    def test_concat_series_with_overlapping_intervalindex_levels(self):
+        # GH #64825
+        value_index = IntervalIndex.from_tuples([(0.0, 1.0), (1.0, 2.0)], name="foo")
+        level_index = IntervalIndex.from_tuples([(0.0, 10.0), (0.0, 20.0)], name="bar")
+        values = [
+            Series(
+                [1.0, 3.0],
+                name=Interval(0.0, 10.0),
+                index=value_index,
+            ),
+            Series(
+                [5.0, 7.0],
+                name=Interval(0.0, 20.0),
+                index=value_index,
+            ),
+        ]
+        result = concat(
+            values,
+            keys=level_index,
+            levels=[level_index],
+            names=["bar"],
+        )
+        expected_index = MultiIndex.from_product([level_index, value_index])
+        expected = Series(
+            [1.0, 3.0, 5.0, 7.0],
+            index=expected_index,
+        )
+        tm.assert_series_equal(result, expected)
 
 
 def test_concat_no_unnecessary_upcast(float_numpy_dtype, frame_or_series):


### PR DESCRIPTION
- [x] closes #64825 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Note: AI used just to know the code and files.