### PR TITLE
BUG: fix to_datetime losing sub-unit precision of origin

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -161,6 +161,7 @@ Datetimelike
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)
+- Bug in :func:`to_datetime` where sub-unit precision of ``origin`` was silently dropped when using a low-resolution ``unit`` (e.g. ``unit="D"`` with a microsecond-precision origin) (:issue:`63419`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
 
 Timedelta

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -23,7 +23,6 @@ from pandas._libs import (
 from pandas._libs.tslibs import (
     NaT,
     OutOfBoundsDatetime,
-    Timedelta,
     Timestamp,
     astype_overflowsafe,
     get_supported_dtype,
@@ -648,16 +647,10 @@ def _adjust_to_origin(arg, origin, unit):
 
         if offset.tz is not None:
             raise ValueError(f"origin offset {offset} must be tz-naive")
-        td_offset = offset - Timestamp(0)
 
-        # convert the offset to the unit of the arg
-        # this should be lossless in terms of precision
-        ioffset = td_offset // Timedelta(1, unit=unit)
+        from pandas import to_timedelta
 
-        # scalars & ndarray-like can handle the addition
-        if is_list_like(arg) and not isinstance(arg, (ABCSeries, Index, np.ndarray)):
-            arg = np.asarray(arg)
-        arg = arg + ioffset
+        arg = offset + to_timedelta(arg, unit=unit)
     return arg
 
 
@@ -1035,6 +1028,16 @@ def to_datetime(
 
     if origin != "unix":
         arg = _adjust_to_origin(arg, origin, unit)
+        if origin != "julian":
+            # GH#63419 _adjust_to_origin returned the final datetime result
+            if utc:
+                if isinstance(arg, Timestamp):
+                    arg = arg.tz_localize("utc")
+                elif isinstance(arg, ABCSeries):
+                    arg = arg.dt.tz_localize("utc")
+                elif hasattr(arg, "tz_localize"):
+                    arg = arg.tz_localize("utc")
+            return arg  # type: ignore[return-value]
 
     convert_listlike = partial(
         _convert_listlike_datetimes,

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1036,7 +1036,7 @@ def to_datetime(
                 elif isinstance(arg, ABCSeries):
                     arg = arg.dt.tz_localize("utc")
                 elif hasattr(arg, "tz_localize"):
-                    arg = arg.tz_localize("utc")
+                    arg = arg.tz_localize("utc")  # type: ignore[union-attr]
             return arg  # type: ignore[return-value]
 
     convert_listlike = partial(

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -929,7 +929,7 @@ def to_datetime(
 
     >>> pd.to_datetime([1, 2, 3], unit="D", origin=pd.Timestamp("1960-01-01"))
     DatetimeIndex(['1960-01-02', '1960-01-03', '1960-01-04'],
-                  dtype='datetime64[s]', freq=None)
+                  dtype='datetime64[us]', freq=None)
 
     **Differences with strptime behavior**
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3319,18 +3319,23 @@ class TestOrigin:
             to_datetime("2005-01-01", origin="1960-01-01", unit=unit)
 
     @pytest.mark.parametrize(
-        "epochs",
+        "epochs, origin_unit",
         [
-            Timestamp(1960, 1, 1),
-            datetime(1960, 1, 1),
-            "1960-01-01",
-            np.datetime64("1960-01-01"),
+            (Timestamp(1960, 1, 1), "us"),
+            (datetime(1960, 1, 1), "us"),
+            ("1960-01-01", "us"),
+            (np.datetime64("1960-01-01"), "s"),
         ],
     )
-    def test_epoch(self, units, epochs):
+    def test_epoch(self, units, epochs, origin_unit):
         epoch_1960 = Timestamp(1960, 1, 1)
         units_from_epochs = np.arange(5, dtype=np.int64)
-        exp_unit = "s" if units == "D" else units
+        # result resolution is max of origin resolution and unit resolution
+        unit_reso = "s" if units == "D" else units
+        reso_order = ["s", "ms", "us", "ns"]
+        exp_unit = reso_order[
+            max(reso_order.index(origin_unit), reso_order.index(unit_reso))
+        ]
         expected = Series(
             [pd.Timedelta(x, unit=units) + epoch_1960 for x in units_from_epochs],
             dtype=f"M8[{exp_unit}]",
@@ -3345,19 +3350,36 @@ class TestOrigin:
             ("random_string", ValueError),
             ("epoch", ValueError),
             ("13-24-1990", ValueError),
-            (datetime(1, 1, 1), OutOfBoundsDatetime),
         ],
     )
     def test_invalid_origins(self, origin, exc, units):
         msg = "|".join(
             [
-                f"origin {origin} is Out of Bounds",
                 f"origin {origin} cannot be converted to a Timestamp",
-                "Cannot cast .* to unit='ns' without overflow",
             ]
         )
         with pytest.raises(exc, match=msg):
             to_datetime(list(range(5)), unit=units, origin=origin)
+
+    def test_invalid_origins_oob(self):
+        # GH#63419 datetime(1,1,1) overflows only for unit='ns'
+        msg = "Cannot cast .* to unit='ns' without overflow"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            to_datetime(list(range(5)), unit="ns", origin=datetime(1, 1, 1))
+
+    def test_origin_preserves_sub_unit_precision(self):
+        # GH#63419
+        ts = Timestamp("2016-01-01 00:00:00.000001")
+        result = to_datetime([1, 2, 3], unit="D", origin=ts)
+        expected = DatetimeIndex(
+            [
+                "2016-01-02 00:00:00.000001",
+                "2016-01-03 00:00:00.000001",
+                "2016-01-04 00:00:00.000001",
+            ],
+            dtype="datetime64[us]",
+        )
+        tm.assert_index_equal(result, expected)
 
     def test_invalid_origins_tzinfo(self):
         # GH16842


### PR DESCRIPTION
Just here to demonstrate for #63915 what I have in mind.  Not for merging.