### PR TITLE
Fix #64825 by using .get_indexer_for() instead of .get_indexer()

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -149,6 +149,7 @@ Bug fixes
 ~~~~~~~~~
 - Bug in object-dtype hash table operations (``factorize``, ``unique``, ``duplicated``, ``isin``, ``value_counts``, ``groupby``, ``Index.get_loc``) not distinguishing between ``int`` and ``bool`` values, e.g. treating ``0`` and ``False`` as equal (:issue:`62888`)
 - Fix bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`)
+- Fix bug when concatenating Series with overlapping intervals as names (:issue:`64825`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -972,7 +972,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
 
     for hlevel, level in zip(zipped, levels, strict=True):
         hlevel_index = ensure_index(hlevel)
-        mapped = level.get_indexer(hlevel_index)
+        mapped = level.get_indexer_for(hlevel_index)
 
         mask = mapped == -1
         if mask.any():

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -19,6 +19,8 @@ import pandas as pd
 from pandas import (
     DataFrame,
     Index,
+    Interval,
+    IntervalIndex,
     MultiIndex,
     PeriodIndex,
     RangeIndex,
@@ -1008,3 +1010,22 @@ def test_concat_of_series_and_frame(inputs, ignore_index, axis, expected):
     # GH #60723 and #56257
     result = concat(inputs, ignore_index=ignore_index, axis=axis)
     tm.assert_frame_equal(result, expected)
+
+
+# GH #64825
+def test_concat_overlapping_interval_series():
+    value_index = IntervalIndex.from_tuples([(0.0, 1.0), (1.0, 2.0)], name="foo")
+    level_index = IntervalIndex.from_tuples([(0.0, 10.0), (0.0, 20.0)], name="bar")
+
+    values = [
+        Series([1.0, 3.0], name=Interval(0.0, 10.0), index=value_index),
+        Series([5.0, 7.0], name=Interval(0.0, 20.0), index=value_index),
+    ]
+
+    result = concat(values, keys=level_index, levels=[level_index], names=["bar"])
+
+    expected = Series(
+        [1.0, 3.0, 5.0, 7.0], index=MultiIndex.from_product([level_index, value_index])
+    )
+
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [X] closes #64825
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] (not relevant) Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [X] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
