### PR TITLE
DOC: note that replace() uses equality, not identity

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7537,6 +7537,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         * When dict is used as the `to_replace` value, it is like
           key(s) in the dict are the to_replace part and
           value(s) in the dict are the value parameter.
+        * Replacement is based on equality, not identity. Since Python treats
+          ``True == 1`` and ``False == 0``, replacing one will also affect
+          the other when they share a dtype (e.g. ``object``).
 
         Examples
         --------


### PR DESCRIPTION
## Summary
- Adds a note to `replace()` docstring clarifying that replacement is based on equality, not identity, so `True`/`1` and `False`/`0` will match each other when they share a dtype

closes #31633

## Test plan
- [ ] Docstring renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)