### PR TITLE
BUG: fix quantile precision loss for ns-resolution datetimelike data

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -172,8 +172,8 @@ Datetimelike
 - Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
-- Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
 - Bug in :meth:`Series.quantile` and :meth:`DataFrame.quantile` where nanosecond-resolution datetime or timedelta data could lose precision due to ``int64`` to ``float64`` round-trip (:issue:`49110`)
+- Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -173,6 +173,7 @@ Datetimelike
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
+- Bug in :meth:`Series.quantile` and :meth:`DataFrame.quantile` where nanosecond-resolution datetime or timedelta data could lose precision due to ``int64`` to ``float64`` round-trip (:issue:`49110`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/array_algos/quantile.py
+++ b/pandas/core/array_algos/quantile.py
@@ -186,16 +186,32 @@ def _nanquantile(
 
     if values.dtype.kind in "mM":
         # need to cast to integer to avoid rounding errors in numpy
+        i8values = values.view("i8")
+        na_value_i8 = na_value.view("i8")  # type: ignore[union-attr]
+
+        # Subtract the minimum to keep values small enough that float64
+        # can represent them without precision loss (GH#49110).
+        # Without this, ns-resolution values (large i8) lose precision
+        # during the int64 -> float64 -> int64 round-trip in np.quantile.
+        if not mask.all():
+            baseline = np.int64(i8values[~mask].min())
+        else:
+            baseline = np.int64(0)
+
         result = _nanquantile(
-            values.view("i8"),
+            i8values - baseline,
             qs=qs,
-            na_value=na_value.view("i8"),  # type: ignore[union-attr, arg-type]
+            na_value=na_value_i8,  # type: ignore[arg-type]
             mask=mask,
             interpolation=interpolation,
         )
 
-        # Note: we have to do `astype` and not view because in general we
-        #  have float result at this point, not i8
+        # Truncate to int64 before adding the baseline back, so that the
+        # addition stays in integer arithmetic and avoids a second
+        # float64 precision loss.
+        result = result.astype("i8")
+        # Avoid shifting iNaT entries that represent all-masked rows.
+        result = np.where(result == na_value_i8, result, result + baseline)
         return result.astype(values.dtype)
 
     if mask.any():

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2652,6 +2652,7 @@ class ArrowExtensionArray(
         pa_dtype = self._pa_array.type
 
         data = self._pa_array
+        baseline = None
         if pa.types.is_temporal(pa_dtype):
             # https://github.com/apache/arrow/issues/33769 in these cases
             #  we can cast to ints and back
@@ -2660,6 +2661,12 @@ class ArrowExtensionArray(
                 data = data.cast(pa.int32())
             else:
                 data = data.cast(pa.int64())
+
+            # Subtract the minimum to keep values small enough that float64
+            # can represent them without precision loss (GH#49110).
+            if nbits == 64 and pc.any(pc.is_valid(data)).as_py():
+                baseline = pc.min(data, skip_nulls=True).as_py()
+                data = pc.subtract(data, baseline)
 
         result = pc.quantile(data, q=qs, interpolation=interpolation)
 
@@ -2671,6 +2678,8 @@ class ArrowExtensionArray(
                 result = result.cast(pa.int32())
             else:
                 result = result.cast(pa.int64())
+            if baseline is not None:
+                result = pc.add(result, baseline)
             result = result.cast(pa_dtype)
 
         return self._from_pyarrow_array(result)

--- a/pandas/tests/series/methods/test_quantile.py
+++ b/pandas/tests/series/methods/test_quantile.py
@@ -252,3 +252,24 @@ def test_quantile_empty_datetimelike(typ, unit):
     ser = Series([], dtype=f"{typ}[{unit}]")
     result = ser.quantile()
     assert result is pd.NaT
+
+
+@pytest.mark.parametrize("typ", ["datetime64", "timedelta64"])
+@pytest.mark.parametrize(
+    "interpolation", ["linear", "lower", "higher", "nearest", "midpoint"]
+)
+def test_quantile_datetimelike_ns_precision(typ, interpolation):
+    # GH#49110 - quantile with ns-resolution datetimelike data should not
+    # lose precision due to int64 -> float64 -> int64 round-trip.
+    if typ == "datetime64":
+        values = pd.to_datetime(
+            ["2019-09-05 17:16:30.155681", "2019-09-05 17:16:33.155681"]
+        ).as_unit("ns")
+    else:
+        values = pd.to_timedelta(
+            ["1 days 17:16:30.155681", "1 days 17:16:33.155681"]
+        ).as_unit("ns")
+
+    ser = Series(values)
+    assert ser.quantile(0, interpolation=interpolation) == ser.min()
+    assert ser.quantile(1, interpolation=interpolation) == ser.max()


### PR DESCRIPTION
## Summary
- fixes #49110
- `Series.quantile` and `DataFrame.quantile` with nanosecond-resolution datetime or timedelta data could return imprecise results due to `int64` → `float64` → `int64` round-trip in `np.quantile`. Any ns-resolution timestamp after ~April 1970 was affected (virtually all real-world data).
- Fix subtracts a baseline (the minimum non-masked value) before calling `np.quantile`, keeping residuals small enough for float64 to represent exactly, then adds the baseline back in integer arithmetic.

## Test plan
- [x] New parametrized test `test_quantile_datetimelike_ns_precision` covering datetime64/timedelta64 × all 5 interpolation methods
- [x] All existing quantile tests pass (series, frame, groupby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)