### PR TITLE
BUG: fix RecursionError in fillna with dict and duplicate MultiIndex columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -201,7 +201,7 @@ Indexing
 
 Missing
 ^^^^^^^
--
+- Bug in :meth:`DataFrame.fillna` with a dict value raising ``RecursionError`` when columns are a :class:`MultiIndex` with duplicate entries (:issue:`53498`)
 -
 
 MultiIndex

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4659,9 +4659,15 @@ class DataFrame(NDFrame, OpsMixin):
                 if len(cols_droplevel) and not cols_droplevel.equals(value.columns):
                     value = value.reindex(cols_droplevel, axis=1)
 
-                for col, col_droplevel in zip(cols, cols_droplevel, strict=True):
-                    self[col] = value[col_droplevel]
-                return
+                if not cols_droplevel.equals(cols):
+                    # Levels were actually dropped, so we can safely use
+                    # key-based indexing without re-entering this method.
+                    for col, col_droplevel in zip(cols, cols_droplevel, strict=True):
+                        self[col] = value[col_droplevel]
+                    return
+                # If cols_droplevel == cols (key matched all levels),
+                # fall through to positional isetitem to avoid
+                # infinite recursion (GH#53498).
 
             if is_scalar(cols):
                 self[cols] = value[value.columns[0]]

--- a/pandas/tests/frame/methods/test_fillna.py
+++ b/pandas/tests/frame/methods/test_fillna.py
@@ -7,6 +7,7 @@ from pandas import (
     Categorical,
     DataFrame,
     DatetimeIndex,
+    MultiIndex,
     NaT,
     PeriodIndex,
     Series,
@@ -726,6 +727,20 @@ class TestFillNA:
             }
         )
         tm.assert_frame_equal(pdf.fillna({("x", "b"): -2, "x": -1}), expected)
+
+    def test_fillna_multiindex_with_duplicate_columns(self):
+        # GH#53498
+        data = [[np.nan, 2, 3], [4, np.nan, 6], [7, 8, np.nan]]
+        df = DataFrame(
+            data,
+            columns=MultiIndex.from_tuples([("x", "a"), ("x", "a"), ("y", "b")]),
+        )
+        result = df.fillna({("x", "a"): 0})
+        expected = DataFrame(
+            [[0.0, 2.0, 3.0], [4.0, 0.0, 6.0], [7.0, 8.0, np.nan]],
+            columns=MultiIndex.from_tuples([("x", "a"), ("x", "a"), ("y", "b")]),
+        )
+        tm.assert_frame_equal(result, expected)
 
 
 def test_fillna_nonconsolidated_frame():


### PR DESCRIPTION
## Summary
- Fixes `RecursionError` when calling `DataFrame.fillna` with a dict value on a DataFrame whose columns are a `MultiIndex` with duplicate entries.
- The recursion occurred in `_set_item_frame_value`: when `maybe_droplevels` couldn't reduce levels (key matched all MultiIndex levels), `self[col] = value[col_droplevel]` re-entered the same method with the same duplicate key infinitely.
- Fix: when no levels were actually dropped, fall through to positional `isetitem` instead of the recursive key-based loop.

closes #53498

## Test plan
- [x] Added `test_fillna_multiindex_with_duplicate_columns` covering the exact reproducer from the issue
- [x] All existing `test_fillna.py` tests pass (68 tests)
- [x] All existing `test_setitem.py` tests pass (248 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)