### PR TITLE
DEPR: Deprecate weekday property on DatetimeIndex, PeriodIndex, Period

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -425,6 +425,10 @@ numpydoc_validation_exclude = {
     r"pandas\.Series\.dt\.dayofweek$",
     r"pandas\.Series\.dt\.dayofyear$",
     r"pandas\.Series\.dt\.daysinmonth$",
+    # Deprecated weekday property (GH#12816)
+    r"pandas\.Period\.weekday$",
+    r"pandas\.PeriodIndex\.weekday$",
+    r"pandas\.Series\.dt\.weekday$",
 }
 
 # matplotlib plot directive

--- a/doc/source/getting_started/intro_tutorials/09_timeseries.rst
+++ b/doc/source/getting_started/intro_tutorials/09_timeseries.rst
@@ -175,7 +175,7 @@ What is the average :math:`NO_2` concentration for each day of the week for each
 .. ipython:: python
 
     air_quality.groupby(
-        [air_quality["datetime"].dt.weekday, "location"])["value"].mean()
+        [air_quality["datetime"].dt.day_of_week, "location"])["value"].mean()
 
 Remember the split-apply-combine pattern provided by ``groupby`` from the
 :ref:`tutorial on statistics calculation <10min_tut_06_stats>`?

--- a/doc/source/getting_started/intro_tutorials/09_timeseries.rst
+++ b/doc/source/getting_started/intro_tutorials/09_timeseries.rst
@@ -181,7 +181,7 @@ Remember the split-apply-combine pattern provided by ``groupby`` from the
 :ref:`tutorial on statistics calculation <10min_tut_06_stats>`?
 Here, we want to calculate a given statistic (e.g. mean :math:`NO_2`)
 **for each weekday** and **for each measurement location**. To group on
-weekdays, we use the datetime property ``weekday`` (with Monday=0 and
+weekdays, we use the datetime property ``day_of_week`` (with Monday=0 and
 Sunday=6) of pandas ``Timestamp``, which is also accessible by the
 ``dt`` accessor. The grouping on both locations and weekdays can be done
 to split the calculation of the mean on each of these combinations.
@@ -247,7 +247,7 @@ index directly:
 
 .. ipython:: python
 
-    no_2.index.year, no_2.index.weekday
+    no_2.index.year, no_2.index.day_of_week
 
 Some other advantages are the convenient subsetting of time period or
 the adapted time scale on plots. Let’s apply this on our data.

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1080,7 +1080,7 @@ Let's map to the weekday names:
 
     dts = pd.date_range(dt, periods=5, freq=bday_egypt)
 
-    pd.Series(dts.weekday, dts).map(pd.Series("Mon Tue Wed Thu Fri Sat Sun".split()))
+    pd.Series(dts.day_of_week, dts).map(pd.Series("Mon Tue Wed Thu Fri Sat Sun".split()))
 
 Holiday calendars can be used to provide the list of holidays.  See the
 :ref:`holiday calendar<timeseries.holiday>` section for more information.

--- a/doc/source/whatsnew/v0.12.0.rst
+++ b/doc/source/whatsnew/v0.12.0.rst
@@ -413,7 +413,7 @@ Experimental features
       dt = datetime(2013, 4, 30)
       print(dt + 2 * bday_egypt)
       dts = pd.date_range(dt, periods=5, freq=bday_egypt)
-      print(pd.Series(dts.weekday, dts).map(pd.Series("Mon Tue Wed Thu Fri Sat Sun".split())))
+      print(pd.Series(dts.day_of_week, dts).map(pd.Series("Mon Tue Wed Thu Fri Sat Sun".split())))
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -104,6 +104,7 @@ Deprecations
 - Deprecated passing unnecessary ``*args`` and ``**kwargs`` to :meth:`.GroupBy.cumsum`, :meth:`.GroupBy.cumprod`, :meth:`.GroupBy.cummin`, :meth:`.GroupBy.cummax`, :meth:`.SeriesGroupBy.skew`, :meth:`.DataFrameGroupBy.skew`, :meth:`.SeriesGroupBy.take`, and :meth:`.DataFrameGroupBy.take`. The ``skipna`` parameter for the cum* methods is now an explicit keyword argument (:issue:`50407`)
 - Deprecated the ``.name`` property of offset objects (e.g., :class:`~pandas.tseries.offsets.Day`, :class:`~pandas.tseries.offsets.Hour`). Use ``.rule_code`` instead (:issue:`64207`)
 - Deprecated the ``float_precision`` argument in :func:`read_csv`, :func:`read_table`, and :func:`read_fwf`. All float precision modes now use the same converter (:issue:`64395`)
+- Deprecated the ``weekday`` property on :class:`DatetimeIndex`, :class:`.DatetimeArray`, :class:`PeriodIndex`, :class:`.PeriodArray`, and :class:`Period`. Use ``day_of_week`` instead. ``Timestamp.weekday()`` remains a method consistent with :meth:`datetime.datetime.weekday` (:issue:`12816`)
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 - Deprecated the default value of ``exact`` in :func:`assert_index_equal`; in a future version this will default to ``True`` instead of "equiv" (:issue:`57436`)
 -

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2560,9 +2560,18 @@ cdef class _Period(PeriodMixin):
         >>> per.end_time.day_of_week
         2
         """
-        # Docstring is a duplicate from day_of_week. Reusing docstrings with
-        # Appender doesn't work for properties in Cython files, and setting
-        # the __doc__ attribute is also not possible.
+        # GH#12816
+        import warnings
+
+        from pandas.errors import Pandas4Warning
+        from pandas.util._exceptions import find_stack_level
+
+        warnings.warn(
+            "Period.weekday is deprecated and will be removed "
+            "in a future version. Use Period.day_of_week instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
         return self.day_of_week
 
     @property

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3270,7 +3270,16 @@ class ArrowExtensionArray(
         )
         return self._dt_day_of_week
 
-    _dt_weekday = _dt_day_of_week
+    @property
+    def _dt_weekday(self) -> Self:
+        # GH#12816
+        warnings.warn(
+            "Series.dt.weekday is deprecated and will be removed "
+            "in a future version. Use Series.dt.day_of_week instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+        return self._dt_day_of_week
 
     @property
     def _dt_day_of_year(self) -> Self:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -49,10 +49,7 @@ from pandas._libs.tslibs import (
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
 from pandas._libs.tslibs.offsets import RelativeDeltaOffset
-from pandas.errors import (
-    Pandas4Warning,
-    PerformanceWarning,
-)
+from pandas.errors import PerformanceWarning
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import validate_inclusive
@@ -1969,6 +1966,7 @@ default 'raise'
     Freq: D, dtype: int32
     """
     day_of_week = _field_accessor("day_of_week", "dow", _dayofweek_doc)
+
     @property
     def weekday(self):
         # GH#12816

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1969,6 +1969,12 @@ default 'raise'
 
     @property
     def weekday(self):
+        """
+        The day of the week with Monday=0, Sunday=6.
+
+        .. deprecated:: 3.1.0
+            Use :attr:`DatetimeIndex.day_of_week` instead.
+        """
         # GH#12816
         from pandas.errors import Pandas4Warning
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -49,7 +49,10 @@ from pandas._libs.tslibs import (
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
 from pandas._libs.tslibs.offsets import RelativeDeltaOffset
-from pandas.errors import PerformanceWarning
+from pandas.errors import (
+    Pandas4Warning,
+    PerformanceWarning,
+)
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import validate_inclusive
@@ -1966,7 +1969,19 @@ default 'raise'
     Freq: D, dtype: int32
     """
     day_of_week = _field_accessor("day_of_week", "dow", _dayofweek_doc)
-    weekday = day_of_week
+    @property
+    def weekday(self):
+        # GH#12816
+        from pandas.errors import Pandas4Warning
+
+        warnings.warn(
+            f"{type(self).__name__}.weekday is deprecated and will be removed "
+            "in a future version. Use DatetimeIndex.day_of_week or "
+            "Series.dt.day_of_week instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+        return self.day_of_week
 
     @property
     def dayofweek(self):

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -650,8 +650,15 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
         Index([6, 0, 1], dtype='int64')
         """,
     )
+
     @property
     def weekday(self):
+        """
+        The day of the week with Monday=0, Sunday=6.
+
+        .. deprecated:: 3.1.0
+            Use :attr:`PeriodIndex.day_of_week` instead.
+        """
         # GH#12816
         warnings.warn(
             f"{type(self).__name__}.weekday is deprecated and will be removed "

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -646,7 +646,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
         Examples
         --------
         >>> idx = pd.PeriodIndex(["2023-01-01", "2023-01-02", "2023-01-03"], freq="D")
-        >>> idx.weekday
+        >>> idx.day_of_week
         Index([6, 0, 1], dtype='int64')
         """,
     )

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -50,10 +50,12 @@ from pandas._libs.tslibs.period import (
     get_period_field_arr,
     period_asfreq_arr,
 )
+from pandas.errors import Pandas4Warning
 from pandas.util._decorators import (
     cache_readonly,
     set_module,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     ensure_object,
@@ -648,7 +650,17 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
         Index([6, 0, 1], dtype='int64')
         """,
     )
-    weekday = day_of_week
+    @property
+    def weekday(self):
+        # GH#12816
+        warnings.warn(
+            f"{type(self).__name__}.weekday is deprecated and will be removed "
+            "in a future version. Use PeriodIndex.day_of_week or "
+            "Series.dt.day_of_week instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+        return self.day_of_week
 
     @property
     def dayofweek(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -306,7 +306,14 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     @property
     def weekday(self) -> Index:
-        return self._wrap_field("weekday")
+        # GH#12816
+        warnings.warn(
+            "DatetimeIndex.weekday is deprecated and will be removed "
+            "in a future version. Use DatetimeIndex.day_of_week instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+        return self._wrap_field("day_of_week")
 
     @property
     def dayofweek(self) -> Index:

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -12,6 +12,7 @@ from pandas._libs import (
 )
 from pandas._libs.tslibs import to_offset
 from pandas.compat.numpy import np_version_gt2
+from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.dtypes import PeriodDtype
 
@@ -817,8 +818,10 @@ class TestDatetimeArray(SharedTests):
         dti = self.index_cls(arr1d)
         arr = arr1d
 
-        result = getattr(arr, propname)
-        expected = np.array(getattr(dti, propname), dtype=result.dtype)
+        warn = Pandas4Warning if propname == "weekday" else None
+        with tm.assert_produces_warning(warn, match="weekday is deprecated"):
+            result = getattr(arr, propname)
+            expected = np.array(getattr(dti, propname), dtype=result.dtype)
 
         tm.assert_numpy_array_equal(result, expected)
 
@@ -1145,8 +1148,10 @@ class TestPeriodArray(SharedTests):
         pi = self.index_cls(arr1d)
         arr = arr1d
 
-        result = getattr(arr, propname)
-        expected = np.array(getattr(pi, propname))
+        warn = Pandas4Warning if propname == "weekday" else None
+        with tm.assert_produces_warning(warn, match="weekday is deprecated"):
+            result = getattr(arr, propname)
+            expected = np.array(getattr(pi, propname))
 
         tm.assert_numpy_array_equal(result, expected)
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -74,8 +74,10 @@ class TestNonNano:
 
         assert (dti == dta).all()
 
-        res = getattr(dta, field)
-        expected = getattr(dti._data, field)
+        warn = Pandas4Warning if field == "weekday" else None
+        with tm.assert_produces_warning(warn, match="weekday is deprecated"):
+            res = getattr(dta, field)
+            expected = getattr(dti._data, field)
         tm.assert_numpy_array_equal(res, expected)
 
     def test_normalize(self, unit):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2451,7 +2451,13 @@ def test_dt_properties(prop, expected):
         ],
         dtype=ArrowDtype(pa.timestamp("ns")),
     )
-    result = getattr(ser.dt, prop)
+    if prop == "weekday":
+        # GH#12816
+        warn = Pandas4Warning
+    else:
+        warn = None
+    with tm.assert_produces_warning(warn, match="weekday"):
+        result = getattr(ser.dt, prop)
     exp_type = None
     if isinstance(expected, date):
         exp_type = pa.date32()

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -311,7 +311,12 @@ class TestDatetimeIndexOps:
 
         # non boolean accessors -> return Index
         for accessor in DatetimeArray._field_ops:
-            res = getattr(dti, accessor)
+            if accessor == "weekday":
+                # GH#12816 weekday is deprecated
+                with tm.assert_produces_warning(Pandas4Warning, match="weekday"):
+                    res = getattr(dti, accessor)
+            else:
+                res = getattr(dti, accessor)
             assert len(res) == 365
             assert isinstance(res, Index)
             assert res.name == "name"

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -511,7 +511,7 @@ def test_calendar_roundtrip_issue(temp_hdfstore):
     mydt = dt.datetime(2013, 4, 30)
     dts = date_range(mydt, periods=5, freq=bday_egypt)
 
-    s = Series(dts.weekday, dts).map(Series("Mon Tue Wed Thu Fri Sat Sun".split()))
+    s = Series(dts.day_of_week, dts).map(Series("Mon Tue Wed Thu Fri Sat Sun".split()))
 
     temp_hdfstore.put("fixed", s)
     result = temp_hdfstore.select("fixed")

--- a/pandas/tests/scalar/period/test_asfreq.py
+++ b/pandas/tests/scalar/period/test_asfreq.py
@@ -281,17 +281,17 @@ class TestFreqConversion:
         ival_W_to_Q = Period(freq="Q", year=2007, quarter=1)
         ival_W_to_M = Period(freq="M", year=2007, month=1)
 
-        if Period(freq="D", year=2007, month=12, day=31).weekday == 6:
+        if Period(freq="D", year=2007, month=12, day=31).day_of_week == 6:
             ival_W_to_A_end_of_year = Period(freq="Y", year=2007)
         else:
             ival_W_to_A_end_of_year = Period(freq="Y", year=2008)
 
-        if Period(freq="D", year=2007, month=3, day=31).weekday == 6:
+        if Period(freq="D", year=2007, month=3, day=31).day_of_week == 6:
             ival_W_to_Q_end_of_quarter = Period(freq="Q", year=2007, quarter=1)
         else:
             ival_W_to_Q_end_of_quarter = Period(freq="Q", year=2007, quarter=2)
 
-        if Period(freq="D", year=2007, month=1, day=31).weekday == 6:
+        if Period(freq="D", year=2007, month=1, day=31).day_of_week == 6:
             ival_W_to_M_end_of_month = Period(freq="M", year=2007, month=1)
         else:
             ival_W_to_M_end_of_month = Period(freq="M", year=2007, month=2)

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -1103,7 +1103,7 @@ class TestPeriodProperties:
         assert b_date.quarter == 1
         assert b_date.month == 1
         assert b_date.day == 1
-        assert b_date.weekday == 0
+        assert b_date.day_of_week == 0
         assert b_date.day_of_year == 1
         assert b_date.days_in_month == 31
         with tm.assert_produces_warning(FutureWarning, match=bday_msg):
@@ -1115,7 +1115,7 @@ class TestPeriodProperties:
         assert d_date.quarter == 1
         assert d_date.month == 1
         assert d_date.day == 1
-        assert d_date.weekday == 0
+        assert d_date.day_of_week == 0
         assert d_date.day_of_year == 1
         assert d_date.days_in_month == 31
         assert Period(freq="D", year=2012, month=2, day=1).days_in_month == 29
@@ -1130,7 +1130,7 @@ class TestPeriodProperties:
             assert h_date.quarter == 1
             assert h_date.month == 1
             assert h_date.day == 1
-            assert h_date.weekday == 0
+            assert h_date.day_of_week == 0
             assert h_date.day_of_year == 1
             assert h_date.hour == 0
             assert h_date.days_in_month == 31
@@ -1144,7 +1144,7 @@ class TestPeriodProperties:
         assert t_date.quarter == 1
         assert t_date.month == 1
         assert t_date.day == 1
-        assert t_date.weekday == 0
+        assert t_date.day_of_week == 0
         assert t_date.day_of_year == 1
         assert t_date.hour == 0
         assert t_date.minute == 0
@@ -1163,7 +1163,7 @@ class TestPeriodProperties:
         assert s_date.quarter == 1
         assert s_date.month == 1
         assert s_date.day == 1
-        assert s_date.weekday == 0
+        assert s_date.day_of_week == 0
         assert s_date.day_of_year == 1
         assert s_date.hour == 0
         assert s_date.minute == 0

--- a/pandas/tests/series/accessors/test_cat_accessor.py
+++ b/pandas/tests/series/accessors/test_cat_accessor.py
@@ -216,7 +216,7 @@ class TestCatAccessor:
             tm.assert_equal(res, exp)
 
         # GH#46768 - exclude deprecated aliases
-        _deprecated = {"dayofweek", "dayofyear", "daysinmonth"}
+        _deprecated = {"dayofweek", "dayofyear", "daysinmonth", "weekday"}
         for attr in attr_names:
             if attr in _deprecated:
                 continue

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -43,7 +43,7 @@ ok_for_period = PeriodArray._datetimelike_ops
 ok_for_period_methods = ["strftime", "to_timestamp", "asfreq"]
 ok_for_dt = DatetimeArray._datetimelike_ops
 # GH#46768 - deprecated aliases that should be skipped in property access tests
-_deprecated_dt_attrs = {"dayofweek", "dayofyear", "daysinmonth"}
+_deprecated_dt_attrs = {"dayofweek", "dayofyear", "daysinmonth", "weekday"}
 ok_for_dt_methods = [
     "to_period",
     "to_pydatetime",

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -410,7 +410,7 @@ class _FrequencyInferer:
         )
 
     def _get_wom_rule(self) -> str | None:
-        weekdays = np.unique(self.index.weekday)
+        weekdays = np.unique(self.index.day_of_week)
         if len(weekdays) > 1:
             return None
 


### PR DESCRIPTION
## Summary
- Deprecate the `weekday` property on `DatetimeIndex`, `DatetimeArray`, `PeriodIndex`, `PeriodArray`, and `Period` with `Pandas4Warning`, directing users to `day_of_week` instead
- `Timestamp.weekday()` and `NaT.weekday()` remain as methods, consistent with `datetime.datetime.weekday()`
- This resolves the long-standing inconsistency where `weekday` was a property on Index/Array types but a method on scalar types

closes #12816

## Test plan
- [x] Verified deprecation warnings fire on `DatetimeIndex.weekday`, `PeriodIndex.weekday`, `Period.weekday`, `Series.dt.weekday` (both numpy and Arrow-backed)
- [x] Verified `Timestamp.weekday()` and `NaT.weekday()` are unaffected (remain methods, no warning)
- [x] Updated tests using `.weekday` as a property to use `.day_of_week`
- [x] Updated internal usage in `pandas/tseries/frequencies.py`
- [x] All pre-commit hooks pass
- [x] All related test suites pass (4425 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)