### PR TITLE
TST: remove/fix stale xfails

### DIFF
--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -203,12 +203,6 @@ class TestJSONArray(base.ExtensionTests):
     def test_combine_le(self, data_repeated):
         super().test_combine_le(data_repeated)
 
-    @pytest.mark.xfail(
-        reason="combine for JSONArray not supported - "
-        "may pass depending on random data",
-        strict=False,
-        raises=AssertionError,
-    )
     def test_combine_first(self, data):
         super().test_combine_first(data)
 

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1312,13 +1312,7 @@ class TestDataFrameSetitemCopyViewSemantics:
         [
             "a",
             ["a"],
-            pytest.param(
-                [True, False],
-                marks=pytest.mark.xfail(
-                    reason="Boolean indexer incorrectly setting inplace",
-                    strict=False,  # passing on some builds, no obvious pattern
-                ),
-            ),
+            [True, False],
         ],
     )
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -1030,29 +1030,19 @@ class TestDatetimeIndex:
         result2 = DatetimeIndex(np.array(vals, dtype=object), dtype=dtype)
         tm.assert_index_equal(result2, expected)
 
-    def test_dti_constructor_with_non_nano_now_today(self, request):
-        # GH#55756
+    def test_dti_constructor_with_non_nano_now_today(self):
+        # GH#55756, GH#57535
         now = Timestamp.now()
         today = Timestamp.today()
         result = DatetimeIndex(["now", "today"], dtype="M8[s]")
+        now_after = Timestamp.now()
         assert result.dtype == "M8[s]"
 
-        diff0 = result[0] - now.as_unit("s")
-        diff1 = result[1] - today.as_unit("s")
-        assert diff1 >= pd.Timedelta(0), f"The difference is {diff0}"
-        assert diff0 >= pd.Timedelta(0), f"The difference is {diff0}"
-
-        # result may not exactly match [now, today] so we'll test it up to a tolerance.
-        #  (it *may* match exactly due to rounding)
-        # GH 57535
-        request.applymarker(
-            pytest.mark.xfail(
-                reason="result may not exactly match [now, today]", strict=False
-            )
-        )
-        tolerance = pd.Timedelta(seconds=1)
-        assert diff0 < tolerance, f"The difference is {diff0}"
-        assert diff1 < tolerance, f"The difference is {diff0}"
+        # result should be between the before/after timestamps
+        assert result[0] >= now.as_unit("s")
+        assert result[0] <= now_after.as_unit("s")
+        assert result[1] >= today.as_unit("s")
+        assert result[1] <= now_after.as_unit("s")
 
     def test_dti_constructor_object_float_matches_float_dtype(self):
         # GH#55780

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -23,7 +23,6 @@ from pandas.core.dtypes.common import (
 
 import pandas as pd
 from pandas import (
-    CategoricalIndex,
     MultiIndex,
     PeriodIndex,
     RangeIndex,
@@ -444,16 +443,9 @@ def test_sort_values_invalid_na_position(index_with_missing, na_position):
 
 @pytest.mark.filterwarnings(r"ignore:PeriodDtype\[B\] is deprecated:FutureWarning")
 @pytest.mark.parametrize("na_position", ["first", "last"])
-def test_sort_values_with_missing(index_with_missing, na_position, request):
+def test_sort_values_with_missing(index_with_missing, na_position):
     # GH 35584. Test that sort_values works with missing values,
     # sort non-missing and place missing according to na_position
-
-    if isinstance(index_with_missing, CategoricalIndex):
-        request.applymarker(
-            pytest.mark.xfail(
-                reason="missing value sorting order not well-defined", strict=False
-            )
-        )
 
     missing_count = np.sum(index_with_missing.isna())
     not_na_vals = index_with_missing[index_with_missing.notna()].values


### PR DESCRIPTION
## Summary

Remove four stale xfails where the underlying issues have been fixed:

- `test_sort_values_with_missing[categorical-*]`: CategoricalIndex sorting with NAs works
- `test_setitem_not_operating_inplace` (boolean indexer): fixed by CoW
- `test_combine_first` (JSONArray): data is deterministic (seeded RNG), xfail reason was wrong
- `test_dti_constructor_with_non_nano_now_today`: replace fragile 1-second tolerance with before/after timestamp bracketing

## Test plan

- [x] All modified test files pass locally
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)