### PR TITLE
TST: remove np.sum xfails from rolling/expanding consistency tests

### DIFF
--- a/pandas/tests/window/moments/test_moments_consistency_expanding.py
+++ b/pandas/tests/window/moments/test_moments_consistency_expanding.py
@@ -5,29 +5,8 @@ from pandas import Series
 import pandas._testing as tm
 
 
-def no_nans(x):
-    if isinstance(x, Series):
-        return x.notna().all()
-    else:
-        return x.notna().all().all()
-
-
-def all_na(x):
-    if isinstance(x, Series):
-        return x.isnull().all()
-    else:
-        return x.isnull().all().all()
-
-
-@pytest.mark.parametrize("f", [lambda v: Series(v).sum(), np.nansum, np.sum])
-def test_expanding_apply_consistency_sum_nans(request, all_data, min_periods, f):
-    if f is np.sum:
-        if not no_nans(all_data) and not (
-            all_na(all_data) and not all_data.empty and min_periods > 0
-        ):
-            request.applymarker(
-                pytest.mark.xfail(reason="np.sum has different behavior with NaNs")
-            )
+@pytest.mark.parametrize("f", [lambda v: Series(v).sum(), np.nansum])
+def test_expanding_apply_consistency_sum_nans(all_data, min_periods, f):
     expanding_f_result = all_data.expanding(min_periods=min_periods).sum()
     expanding_apply_f_result = all_data.expanding(min_periods=min_periods).apply(
         func=f, raw=True

--- a/pandas/tests/window/moments/test_moments_consistency_rolling.py
+++ b/pandas/tests/window/moments/test_moments_consistency_rolling.py
@@ -5,33 +5,16 @@ from pandas import Series
 import pandas._testing as tm
 
 
-def no_nans(x):
-    return x.notna().all(axis=None)
-
-
-def all_na(x):
-    return x.isnull().all(axis=None)
-
-
 @pytest.fixture(params=[(1, 0), (5, 1)])
 def rolling_consistency_cases(request):
     """window, min_periods"""
     return request.param
 
 
-@pytest.mark.parametrize("f", [lambda v: Series(v).sum(), np.nansum, np.sum])
-def test_rolling_apply_consistency_sum(
-    request, all_data, rolling_consistency_cases, center, f
-):
+@pytest.mark.parametrize("f", [lambda v: Series(v).sum(), np.nansum])
+def test_rolling_apply_consistency_sum(all_data, rolling_consistency_cases, center, f):
     window, min_periods = rolling_consistency_cases
 
-    if f is np.sum:
-        if not no_nans(all_data) and not (
-            all_na(all_data) and not all_data.empty and min_periods > 0
-        ):
-            request.applymarker(
-                pytest.mark.xfail(reason="np.sum has different behavior with NaNs")
-            )
     rolling_f_result = all_data.rolling(
         window=window, min_periods=min_periods, center=center
     ).sum()


### PR DESCRIPTION
## Summary
- Remove `np.sum` from the parametrize list in rolling/expanding consistency sum tests
- `np.sum` propagates NaN while pandas `.sum()` skips NaN, so they were never expected to match — the xfail was documenting a known behavioral difference, not a bug
- `np.nansum` already covers the NaN-skipping comparison
- Remove now-unused `no_nans`/`all_na` helper functions

## Test plan
- [x] `test_moments_consistency_expanding.py` — 344 passed, 0 xfailed
- [x] `test_moments_consistency_rolling.py` — 688 passed, 0 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)