### PR TITLE
TST: use approximate comparison for pairwise rolling corr on 32-bit

### DIFF
--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import IS64
-
 from pandas import (
     DataFrame,
     Index,
@@ -308,13 +306,7 @@ class TestPairwise:
             lambda x, y: x.expanding().cov(y, pairwise=True),
             lambda x, y: x.expanding().corr(y, pairwise=True),
             lambda x, y: x.rolling(window=3).cov(y, pairwise=True),
-            # TODO: We're missing a flag somewhere in meson
-            pytest.param(
-                lambda x, y: x.rolling(window=3).corr(y, pairwise=True),
-                marks=pytest.mark.xfail(
-                    not IS64, reason="Precision issues on 32 bit", strict=False
-                ),
-            ),
+            lambda x, y: x.rolling(window=3).corr(y, pairwise=True),
             lambda x, y: x.ewm(com=3).cov(y, pairwise=True),
             lambda x, y: x.ewm(com=3).corr(y, pairwise=True),
         ],
@@ -337,7 +329,8 @@ class TestPairwise:
         result = result.dropna().values
         expected = expected.dropna().values
 
-        tm.assert_numpy_array_equal(result, expected, check_dtype=False)
+        # not exact: rolling corr rounds differently on 32-bit
+        tm.assert_almost_equal(result, expected, check_dtype=False)
 
     @pytest.mark.filterwarnings("ignore:RuntimeWarning")
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Remove flaky `xfail(not IS64, strict=False)` on `test_pairwise_with_other` for `rolling.corr`
- Use `tm.assert_almost_equal` instead of `tm.assert_numpy_array_equal` — the extra division in corr (`cov / sqrt(var_x * var_y)`) amplifies x87 80-bit intermediate rounding on 32-bit

## Test plan
- [x] `test_pairwise.py` passes (314 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)