### PR TITLE
CI: Reduce meson lower boundin pixi to 1.2.3

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ name = "pandas"
 # Build dependencies
 versioneer = ">=0.29"
 cython = ">3.1.0,<4.0.0a0"
-meson = ">=1.10.1,<2"
+meson = ">=1.2.3,<2"
 meson-python = ">=0.19.0,<1"
 c-compiler = "*"
 cxx-compiler = "*"


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/63969#discussion_r2958581981

investigate why I bumped meson for the minimum version test job