### PR TITLE
PERF: optimize DataFrame.__repr__ formatting

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -136,6 +136,7 @@ Performance improvements
   single column by label on a :class:`DataFrame` with duplicate column names.
   (:issue:`64126`).
 - Performance improvement in :attr:`Series.is_monotonic_increasing` and :attr:`Series.is_monotonic_decreasing` for :class:`ArrowDtype` and masked dtypes by dispatching to the :class:`ExtensionArray` (:issue:`56619`)
+- Performance improvement in :class:`DataFrame` repr by avoiding redundant formatting when columns exceed terminal width (:issue:`64863`)
 - Performance improvement in :class:`GroupBy` reductions and transformations for :class:`SparseDtype` columns (:issue:`36123`)
 - Performance improvement in :func:`bdate_range` and :func:`date_range` with ``freq="B"`` or ``freq="C"`` (business day frequencies) (:issue:`16463`)
 - Performance improvement in :func:`infer_freq` (:issue:`64463`)
@@ -185,7 +186,6 @@ Performance improvements
 - Performance improvement in :meth:`Series.iloc` and :meth:`DataFrame.iloc`
   when setting datetimelike values into object-dtype data with list-like
   indexers (:issue:`64250`).
-- Performance improvement in :class:`DataFrame` repr by avoiding redundant formatting when columns exceed terminal width (:issue:`XXXXX`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -185,6 +185,7 @@ Performance improvements
 - Performance improvement in :meth:`Series.iloc` and :meth:`DataFrame.iloc`
   when setting datetimelike values into object-dtype data with list-like
   indexers (:issue:`64250`).
+- Performance improvement in :class:`DataFrame` repr by avoiding redundant formatting when columns exceed terminal width (:issue:`XXXXX`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.bug_fixes:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -747,7 +747,7 @@ class DataFrameFormatter:
         frame = self.tr_frame
         formatter = self._get_formatter(i)
         return format_array(
-            frame.iloc[:, i]._values,
+            frame._get_column_array(i),
             formatter,
             float_format=self.float_format,
             na_rep=self.na_rep,

--- a/pandas/io/formats/string.py
+++ b/pandas/io/formats/string.py
@@ -66,9 +66,6 @@ class StringFormatter:
         return bool(self.fmt.max_cols is None or self.fmt.max_cols > 0)
 
     def _insert_dot_separators(self, strcols: list[list[str]]) -> list[list[str]]:
-        # All columns (including the index if present) have the same number of
-        # rows, so we can use any column's length instead of re-formatting the
-        # index just to get the row count.
         index_length = len(strcols[0])
 
         if self.fmt.is_truncated_horizontally:
@@ -196,7 +193,8 @@ class StringFormatter:
         col_num = max_cols_fitted // 2
         has_index = self.fmt.index
         if has_index:
-            kept = strcols[:1] + strcols[1 : col_num + 1] + strcols[-col_num:]
+            # strcols[0] is the index
+            kept = strcols[: col_num + 1] + strcols[-col_num:]
             insert_pos = col_num + 1
         else:
             kept = strcols[:col_num] + strcols[-col_num:]

--- a/pandas/io/formats/string.py
+++ b/pandas/io/formats/string.py
@@ -66,8 +66,10 @@ class StringFormatter:
         return bool(self.fmt.max_cols is None or self.fmt.max_cols > 0)
 
     def _insert_dot_separators(self, strcols: list[list[str]]) -> list[list[str]]:
-        str_index = self.fmt._get_formatted_index(self.fmt.tr_frame)
-        index_length = len(str_index)
+        # All columns (including the index if present) have the same number of
+        # rows, so we can use any column's length instead of re-formatting the
+        # index just to get the row count.
+        index_length = len(strcols[0])
 
         if self.fmt.is_truncated_horizontally:
             strcols = self._insert_dot_separator_horizontal(strcols, index_length)
@@ -184,11 +186,27 @@ class StringFormatter:
         max_cols_fitted = max(max_cols_fitted, 2)
         self.fmt.max_cols_fitted = max_cols_fitted
 
-        # Call again _truncate to cut frame appropriately
-        # and then generate string representation
-        self.fmt.truncate()
-        strcols = self._get_strcols()
-        return self.adj.adjoin(1, *strcols)
+        # Reuse already-formatted columns instead of re-truncating and
+        # re-formatting the entire DataFrame.
+        num_data_cols = len(strcols) - self.fmt.index
+        if max_cols_fitted >= num_data_cols:
+            # All data columns fit (can happen due to the max(..., 2) above)
+            return self.adj.adjoin(1, *strcols)
+
+        col_num = max_cols_fitted // 2
+        has_index = self.fmt.index
+        if has_index:
+            kept = strcols[:1] + strcols[1 : col_num + 1] + strcols[-col_num:]
+            insert_pos = col_num + 1
+        else:
+            kept = strcols[:col_num] + strcols[-col_num:]
+            insert_pos = col_num
+
+        # Insert horizontal "..." separator column
+        row_count = len(kept[0]) if kept else 0
+        kept.insert(insert_pos, [" ..."] * row_count)
+
+        return self.adj.adjoin(1, *kept)
 
 
 def _binify(cols: list[int], line_width: int) -> list[int]:


### PR DESCRIPTION
## Summary
- Avoid double rendering in `_fit_strcols_to_terminal_width` by reusing already-formatted column strings instead of re-truncating and re-formatting the entire DataFrame
- Remove redundant `_get_formatted_index` call in `_insert_dot_separators`; use `len(strcols[0])` to get row count instead
- Use `_get_column_array` in `format_col` instead of `iloc[:, i]._values` to avoid the full indexing/Series-creation overhead

### Before / After (10 000-row float DataFrame, 80-col terminal)

| Columns | Before | After | Speedup |
|---------|--------|-------|---------|
| 8       | 1.61 ms | 0.56 ms | **2.9×** |
| 10      | 1.85 ms | 0.65 ms | **2.8×** |
| 15      | 2.25 ms | 0.94 ms | **2.4×** |
| 20      | 4.43 ms | 1.10 ms | **4.0×** |
| 30      | 3.69 ms | 1.58 ms | **2.3×** |
| 50      | 5.45 ms | 2.96 ms | **1.8×** |

The bottleneck was `_fit_strcols_to_terminal_width`: it formatted *all* columns, discovered the output exceeded terminal width, then re-truncated the DataFrame and formatted *again*. The fix selects the first/last N columns directly from the already-formatted strings.

## Test plan
- [x] `pytest pandas/tests/io/formats/ pandas/tests/frame/test_repr.py` — 2 367 passed, 1 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)