### PR TITLE
TST: narrow xfail in test_categorical_dtype_single for pyarrow

### DIFF
--- a/pandas/tests/io/parser/dtypes/test_categorical.py
+++ b/pandas/tests/io/parser/dtypes/test_categorical.py
@@ -67,10 +67,9 @@ def test_categorical_dtype_single(all_parsers, dtype, request):
     expected = DataFrame(
         {"a": [1, 1, 2], "b": Categorical(["a", "a", "b"]), "c": [3.4, 3.4, 4.5]}
     )
-    if parser.engine == "pyarrow":
+    if parser.engine == "pyarrow" and any(isinstance(key, int) for key in dtype):
         mark = pytest.mark.xfail(
-            strict=False,
-            reason="Flaky test sometimes gives object dtype instead of Categorical",
+            reason="pyarrow doesn't support specifying dtype by column index",
         )
         request.applymarker(mark)
 


### PR DESCRIPTION
## Summary
- Narrow the `xfail(strict=False)` in `test_categorical_dtype_single` from all pyarrow parametrizations to only `dtype1` (`{1: "category"}`), which consistently fails because pyarrow doesn't support specifying dtype by integer column index.
- `dtype0` (`{"b": "category"}`) now consistently passes with pyarrow (verified across 10 consecutive runs), so it no longer needs the xfail.
- Make the xfail `strict=True` (default) since the failure is consistent, not flaky.

## Test plan
- [x] `test_categorical_dtype_single[pyarrow-dtype0]`: now PASSED (was XPASS)
- [x] `test_categorical_dtype_single[pyarrow-dtype1]`: now XFAIL (was XPASS/XFAIL depending on flakiness)
- [x] Full parser test suite: 4402 passed, 173 skipped, 230 xfailed, **0 xpassed** (was 1 xpassed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)