### PR TITLE
Contrib documentation fixes 032025

### DIFF
--- a/doc/source/development/contributing_docstring.rst
+++ b/doc/source/development/contributing_docstring.rst
@@ -3,7 +3,7 @@
 {{ header }}
 
 ======================
-Pandas Docstring Guide
+Pandas docstring guide
 ======================
 
 About docstrings and standards

--- a/doc/source/development/contributing_docstring.rst
+++ b/doc/source/development/contributing_docstring.rst
@@ -3,7 +3,7 @@
 {{ header }}
 
 ======================
-pandas docstring guide
+Pandas Docstring Guide
 ======================
 
 About docstrings and standards

--- a/doc/source/development/contributing_documentation.rst
+++ b/doc/source/development/contributing_documentation.rst
@@ -46,7 +46,7 @@ Some other important things to know about the docs:
   instructions on how to write a correct docstring.
 
   .. toctree::
-     :maxdepth: 2
+     :maxdepth: 1
 
      contributing_docstring.rst
 

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -12,9 +12,6 @@ changes, you can skip to :ref:`contributing to the documentation <contributing_d
 creating the development environment you won't be able to build the documentation
 locally before pushing your changes. It's recommended to also install the :ref:`pre-commit hooks <contributing.pre-commit>`.
 
-.. toctree::
-    :maxdepth: 2
-    :hidden:
 
 
 Step 1: install a C compiler

--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -1,7 +1,7 @@
 .. _maintaining:
 
 ******************
-Pandas Maintenance
+Pandas maintenance
 ******************
 
 This guide is for pandas' maintainers. It may also be interesting to contributors

--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -1,7 +1,7 @@
 .. _maintaining:
 
 ******************
-pandas maintenance
+Pandas Maintenance
 ******************
 
 This guide is for pandas' maintainers. It may also be interesting to contributors


### PR DESCRIPTION
- didnt bother with a github issue
- only documentation commits, so removed all the codebase stuff.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.


Corrected capitalization on docstring guide and maintenance pages in the development documentation. Also removed an unnecessary level of depth from a toctree. Finally, removed an unneeded toctree that caused a dropdown arrow on the contributing environment page, despite it having no sub-pages. 