### PR TITLE
CI: re-enable werror on Windows and MacOS Unit Tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -246,7 +246,8 @@ jobs:
           pixi run \
             --environment ${{ matrix.environment }} \
             build-pandas \
-            --editable
+            --editable \
+            -Csetup-args="--werror"
         shell: bash -euox pipefail {0}
 
       - name: Test


### PR DESCRIPTION
Noticed that `werror` was disabled for them.