### PR TITLE
BUG: fix HDFStore.select scope resolution with list-of-conditions on Python 3.12+

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -231,7 +231,7 @@ I/O
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
-- Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`XXXXX`)
+- Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 
 Period
 ^^^^^^

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -231,6 +231,7 @@ I/O
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
+- Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`XXXXX`)
 
 Period
 ^^^^^^

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -41,7 +41,10 @@ from pandas._libs import (
 )
 from pandas._libs.lib import is_string_array
 from pandas._libs.tslibs import timezones
-from pandas.compat import HAS_PYARROW
+from pandas.compat import (
+    HAS_PYARROW,
+    PY312,
+)
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.pickle_compat import patch_pickle
 from pandas.errors import (
@@ -181,8 +184,14 @@ def _ensure_term(where, scope_level: int):
     # list
     level = scope_level + 1
     if isinstance(where, (list, tuple)):
+        # Pre-3.12 the list comprehension created its own stack frame,
+        # requiring an extra +1 to reach the caller's scope. PEP 709
+        # inlined comprehensions in 3.12, removing that frame.
+        comp_adjustment = 0 if PY312 else 1
         where = [
-            Term(term, scope_level=level + 1) if maybe_expression(term) else term
+            Term(term, scope_level=level + comp_adjustment)
+            if maybe_expression(term)
+            else term
             for term in where
             if term is not None
         ]

--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import Timestamp
-from pandas.compat import PY312
 
 import pandas as pd
 from pandas import (
@@ -267,7 +266,7 @@ def test_append_all_nans(temp_hdfstore, using_infer_string):
         tm.assert_frame_equal(temp_hdfstore["df2"], df, check_index_type=True)
 
 
-def test_append_frame_column_oriented(temp_hdfstore, request):
+def test_append_frame_column_oriented(temp_hdfstore):
     # column oriented
     df = DataFrame(
         np.random.default_rng(2).standard_normal((10, 4)),
@@ -285,13 +284,6 @@ def test_append_frame_column_oriented(temp_hdfstore, request):
     tm.assert_frame_equal(expected, result)
 
     # selection on the non-indexable
-    request.applymarker(
-        pytest.mark.xfail(
-            PY312,
-            reason="AST change in PY312",
-            raises=ValueError,
-        )
-    )
     result = temp_hdfstore.select("df1", ("columns=A", "index=df.index[0:4]"))
     expected = df.reindex(columns=["A"], index=df.index[0:4])
     tm.assert_frame_equal(expected, result)

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import Timestamp
-from pandas.compat import PY312
 
 import pandas as pd
 from pandas import (
@@ -268,7 +267,7 @@ def test_select_dtypes_floats_with_nan_not_first_position(temp_hdfstore):
     tm.assert_frame_equal(expected, result)
 
 
-def test_select_dtypes_comparison_with_numpy_scalar(temp_hdfstore, request):
+def test_select_dtypes_comparison_with_numpy_scalar(temp_hdfstore):
     # GH 11283
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
@@ -279,13 +278,6 @@ def test_select_dtypes_comparison_with_numpy_scalar(temp_hdfstore, request):
     expected = df[df["A"] > 0]
 
     temp_hdfstore.append("df", df, data_columns=True)
-    request.applymarker(
-        pytest.mark.xfail(
-            PY312,
-            reason="AST change in PY312",
-            raises=ValueError,
-        )
-    )
     np_zero = np.float64(0)  # noqa: F841
     result = temp_hdfstore.select("df", where=["A>np_zero"])
     tm.assert_frame_equal(expected, result)
@@ -602,7 +594,7 @@ def test_select_iterator_many_empty_frames(temp_hdfstore):
     assert len(results) == 0
 
 
-def test_frame_select(temp_hdfstore, request):
+def test_frame_select(temp_hdfstore):
     df = DataFrame(
         np.random.default_rng(2).standard_normal((10, 4)),
         columns=Index(list("ABCD")),
@@ -618,13 +610,6 @@ def test_frame_select(temp_hdfstore, request):
     crit2 = "columns=['A', 'D']"
     crit3 = "columns=A"
 
-    request.applymarker(
-        pytest.mark.xfail(
-            PY312,
-            reason="AST change in PY312",
-            raises=TypeError,
-        )
-    )
     result = temp_hdfstore.select("frame", [crit1, crit2])
     expected = df.loc[date:, ["A", "D"]]
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -625,7 +625,7 @@ def test_frame_select(temp_hdfstore):
         index=date_range("2000-01-01", periods=10, freq="B", unit="ns"),
     )
     temp_hdfstore.append("df_time", df)
-    msg = "day is out of range for month: 0"
+    msg = "day (is out of range for month|0 must be in range)"
     with pytest.raises(ValueError, match=msg):
         temp_hdfstore.select("df_time", "index>0")
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -7,8 +7,6 @@ import time
 import numpy as np
 import pytest
 
-from pandas.compat import PY312
-
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -856,20 +854,13 @@ def test_start_stop_fixed(temp_hdfstore):
     df.iloc[8:10, -2] = np.nan
 
 
-def test_select_filter_corner(temp_hdfstore, request):
+def test_select_filter_corner(temp_hdfstore):
     df = DataFrame(np.random.default_rng(2).standard_normal((50, 100)))
     df.index = [f"{c:3d}" for c in df.index]
     df.columns = [f"{c:3d}" for c in df.columns]
 
     temp_hdfstore.put("frame", df, format="table")
 
-    request.applymarker(
-        pytest.mark.xfail(
-            PY312,
-            reason="AST change in PY312",
-            raises=ValueError,
-        )
-    )
     crit = "columns=df.columns[:75]"
     result = temp_hdfstore.select("frame", [crit])
     tm.assert_frame_equal(result, df.loc[:, df.columns[:75]])


### PR DESCRIPTION
## Summary

- `_ensure_term` in `pytables.py` had `scope_level=level + 1` inside a list comprehension to account for the comprehension's extra stack frame when resolving caller-scope variables via `sys._getframe()`.
- PEP 709 (Python 3.12) inlined comprehensions, removing that frame. This caused `sys._getframe()` to overshoot by 1, grabbing the wrong frame and failing to resolve variables from the caller's scope.
- The fix conditionally applies the `+1` only on pre-3.12 Python.
- Removes the 4 corresponding `xfail(PY312, reason="AST change in PY312")` markers from tests.

## Test plan

- [x] All 4 previously-xfailed tests now pass: `test_select_dtypes_comparison_with_numpy_scalar`, `test_frame_select`, `test_select_filter_corner`, `test_append_frame_column_oriented`
- [x] Full `pandas/tests/io/pytables/` suite passes (555 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)