### PR TITLE
BUG: Compute Variance of Complex Numbers Correctly

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -32,6 +32,7 @@ Bug fixes
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Assigning :attr:`pd.NA` to a string column could trigger a PyArrow error and corrupt data (:issue:`64320`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
+- Fixed bug in :meth:`Series.var` computing the variance of complex numbers incorrectly (:issue:`62421`)
 - Fixed bug in the :meth:`~Series.sum` method with python-backed string dtype returning incorrect value for an empty Series and ignoring the ``min_count`` argument (:issue:`64683`)
 - Fixed bug where :meth:`DataFrame.div` ignored the ``axis`` argument when used with ``level`` for MultiIndex columns (:issue:`64428`)
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1002,6 +1002,13 @@ def nanvar(
         values = values.astype("f8")
         if mask is not None:
             values[mask] = np.nan
+    elif dtype.kind == "c":
+        # https://en.wikipedia.org/wiki/Complex_random_variable#Variance_and_pseudo-variance
+        # The variance is equal to the sum of
+        # the variances of the real and imaginary part of the complex random variable.
+        return nanvar(
+            values.real, axis=axis, skipna=skipna, ddof=ddof, mask=mask
+        ) + nanvar(values.imag, axis=axis, skipna=skipna, ddof=ddof, mask=mask)
 
     if values.dtype.kind == "f":
         count, d = _get_counts_nanvar(values.shape, mask, axis, ddof, values.dtype)
@@ -1021,11 +1028,8 @@ def nanvar(
     avg = _ensure_numeric(values.sum(axis=axis, dtype=np.float64)) / count
     if axis is not None:
         avg = np.expand_dims(avg, axis)
-    if values.dtype.kind == "c":
-        # Need to use absolute value for complex numbers.
-        sqr = _ensure_numeric(abs(avg - values) ** 2)
-    else:
-        sqr = _ensure_numeric((avg - values) ** 2)
+
+    sqr = _ensure_numeric((avg - values) ** 2)
     if mask is not None:
         np.putmask(sqr, mask, 0)
     result = sqr.sum(axis=axis, dtype=np.float64) / d
@@ -1079,13 +1083,17 @@ def nansem(
     nanvar(values, axis=axis, skipna=skipna, ddof=ddof, mask=mask)
 
     mask = _maybe_get_mask(values, skipna, mask)
-    if values.dtype.kind != "f":
+    # Convert to bottleneck return a float
+    if values.dtype.kind not in "fc":
         values = values.astype("f8")
 
     if not skipna and mask is not None and mask.any():
         return np.nan
 
-    count, _ = _get_counts_nanvar(values.shape, mask, axis, ddof, values.dtype)
+    dtype_count = np.dtype(np.float64)
+    if values.dtype.kind == "f":
+        dtype_count = values.dtype
+    count, _ = _get_counts_nanvar(values.shape, mask, axis, ddof, dtype_count)
     var = nanvar(values, axis=axis, skipna=skipna, ddof=ddof, mask=mask)
 
     return np.sqrt(var) / np.sqrt(count)

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -782,14 +782,15 @@ class TestSeriesReductions:
         assert result == result_numpy_dtype
         assert result == exp
 
-    @pytest.mark.filterwarnings(
-        "ignore:Casting complex values to real discards:numpy.exceptions.ComplexWarning"
+    @pytest.mark.parametrize(
+        "values,expected", [([-1j, 0j, 1j], 1.0), ([1 + 2j, 2 + 3j, 3 + 4j], 2.0)]
     )
-    def test_var_complex_array(self):
-        # GH#61645
-        ser = Series([-1j, 0j, 1j], dtype=complex)
-        assert ser.var(ddof=1) == 1.0
-        assert ser.std(ddof=1) == 1.0
+    def test_var_complex_array(self, values, expected):
+        # GH 61645, 62421
+        ser = Series(values, dtype=complex)
+        tm.assert_almost_equal(ser.var(ddof=1), expected)
+        tm.assert_almost_equal(ser.std(ddof=1), np.sqrt(expected))
+        tm.assert_almost_equal(ser.sem(ddof=1), np.sqrt(expected / len(values)))
 
     @pytest.mark.parametrize("dtype", ("m8[ns]", "M8[ns]", "M8[ns, UTC]"))
     def test_empty_timeseries_reductions_return_nat(self, dtype, skipna):

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -987,6 +987,20 @@ class TestNanvarFixedValues:
         assert np.isnan(std[3])
 
     @pytest.mark.parametrize("ddof", range(3))
+    @pytest.mark.parametrize("axis", [0, 1, None])
+    @pytest.mark.parametrize("method", ["var", "std", "sem"])
+    def test_complex_nanvar(self, ddof, axis, method):
+        arr = self.prng.standard_normal((5, 4)) + self.prng.standard_normal((5, 4)) * 1j
+        nanops_method = getattr(nanops, f"nan{method}")
+        if method in {"var", "std"}:
+            comparator_method = getattr(np, method)
+        elif method == "sem":
+            comparator_method = pytest.importorskip("scipy.stats").sem
+        result = nanops_method(arr, axis=axis, ddof=ddof)
+        expected = comparator_method(arr, axis=axis, ddof=ddof)
+        tm.assert_almost_equal(result, expected)
+
+    @pytest.mark.parametrize("ddof", range(3))
     def test_nanstd_roundoff(self, ddof):
         # Regression test for GH 10242 (test data taken from GH 10489). Ensure
         # that variance is stable.


### PR DESCRIPTION
- [x] closes #62421 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---
According to [Wikipedia](https://en.wikipedia.org/wiki/Complex_random_variable#Variance_and_pseudo-variance):

$$\text{Var} [Z]= {Var} [\Re {(Z)}]+\text{Var} [\Im {(Z)}].$$