### PR TITLE
BLD: reduce meson lower bound in build-system requires as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
     "meson-python>=0.19.0,<1",
-    "meson>=1.10.1,<2",
+    "meson>=1.2.3,<2",
     "wheel",
     "Cython>3.1.0,<4.0.0a0",  # Note: sync with environment.yml and asv.conf.json
     # Force numpy higher than 2.0, so that built wheels are compatible


### PR DESCRIPTION
One more follow-up on https://github.com/pandas-dev/pandas/pull/63969#discussion_r2958581981. https://github.com/pandas-dev/pandas/pull/64861 reduced the lower pin again in the pixi env settings, but not yet in the pyproject.toml `build-system.requires`