### PR TITLE
BUG: Fix KeyError in DataFrame.to_stata with convert_dates and invalid column names

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -235,6 +235,7 @@ I/O
 - Fixed bug in :meth:`HDFStore.put` where string extension dtype columns raised errors when using compression (:issue:`64180`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
+- Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 
 Period

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2717,7 +2717,7 @@ class StataWriter(StataParser):
         # Check date conversion, and fix key if needed
         if self._convert_dates:
             for c, o in zip(columns, original_columns, strict=True):
-                if c != o:
+                if c != o and o in self._convert_dates:
                     self._convert_dates[c] = self._convert_dates[o]
                     del self._convert_dates[o]
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1847,6 +1847,24 @@ The repeated labels are:\n-+\nwolof
         with pytest.raises(ValueError, match=msg):
             original.to_stata(path, convert_dates={"wrong_name": "tc"})
 
+    def test_convert_dates_with_renamed_columns(self, temp_file):
+        # GH#60536 - convert_dates should not raise when a different column
+        # is renamed for Stata compatibility
+        df = DataFrame(
+            {
+                "1bad_name": [1, 2, 3],
+                "date_col": pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+            }
+        )
+        path = temp_file
+        msg = "Not all pandas column names were valid Stata variable names"
+        with tm.assert_produces_warning(InvalidColumnName, match=msg):
+            df.to_stata(path, convert_dates={"date_col": "td"})
+
+        result = self.read_dta(path)
+        assert "_1bad_name" in result.columns
+        assert "date_col" in result.columns
+
     @pytest.mark.parametrize("version", [114, 117, 118, 119, None])
     def test_nonfile_writing(self, version, temp_file):
         # GH 21041


### PR DESCRIPTION
## Summary
- Fix `KeyError` in `DataFrame.to_stata` when `convert_dates` is specified and a different column requires renaming for Stata compatibility
- Added guard `o in self._convert_dates` before accessing the dict during column renaming in `_check_column_names`

closes #60536

## Test plan
- [x] Added `test_convert_dates_with_renamed_columns` covering the exact scenario from the issue
- [x] All 690 existing stata tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)