### PR TITLE
DOC: Clarify BusinessDay offset parameter docstring

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2511,7 +2511,7 @@ cdef class BusinessDay(BusinessMixin):
     normalize : bool, default False
         Normalize start/end dates to midnight.
     offset : timedelta, default timedelta(0)
-        Time offset to apply.
+        Additional time offset applied after the business day calculation.
 
     See Also
     --------


### PR DESCRIPTION
## Summary
- Clarify that the `offset` parameter on `BusinessDay` is applied *after* the business day calculation, not instead of it.

closes #35020

🤖 Generated with [Claude Code](https://claude.com/claude-code)