### PR TITLE
ENH: Raise ValueError when numeric_only=None in reduction operations …

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11779,6 +11779,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> Series | float:
         nv.validate_stat_ddof_func((), kwargs, fname=name)
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        validate_bool_kwarg(numeric_only, "numeric_only", none_allowed=False)
 
         return self._reduce(
             func, name, axis=axis, numeric_only=numeric_only, skipna=skipna, ddof=ddof
@@ -11837,6 +11838,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         nv.validate_func(name, (), kwargs)
 
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        validate_bool_kwarg(numeric_only, "numeric_only", none_allowed=False)
 
         return self._reduce(
             func, name=name, axis=axis, skipna=skipna, numeric_only=numeric_only
@@ -11941,6 +11943,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         nv.validate_func(name, (), kwargs)
 
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
+        validate_bool_kwarg(numeric_only, "numeric_only", none_allowed=False)
 
         return self._reduce(
             func,

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -539,6 +539,19 @@ class TestDataFrameAnalytics:
             assert not (result < 0).any()
 
     @pytest.mark.parametrize("meth", ["sem", "var", "std"])
+
+    @pytest.mark.parametrize("meth", ["sum", "prod", "mean", "median", "var", "std", "sem", "skew", "kurt", "min", "max"])
+    def test_numeric_only_bool_validation(self, meth):
+        # GH 53098
+        df = DataFrame({"a": [1, 2], "b": [3, 4]})
+        msg = 'For argument "numeric_only" expected type bool, received type NoneType.'
+        with pytest.raises(ValueError, match=msg):
+            getattr(df, meth)(numeric_only=None)
+
+        msg2 = 'For argument "numeric_only" expected type bool, received type int.'
+        with pytest.raises(ValueError, match=msg2):
+            getattr(df, meth)(numeric_only=1)
+
     def test_numeric_only_flag(self, meth):
         # GH 9201
         df1 = DataFrame(


### PR DESCRIPTION
…(#53098)

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
