### PR TITLE
BUG: warn when DataFrame.update finds no matches due to index dtype mismatch

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12413,6 +12413,18 @@ class DataFrame(NDFrame, OpsMixin):
 
         index_intersection = other.index.intersection(self.index)
         if index_intersection.empty:
+            if (
+                len(self.index) > 0
+                and len(other.index) > 0
+                and self.index.dtype != other.index.dtype
+                and not self.index.map(str).intersection(other.index.map(str)).empty
+            ):
+                warnings.warn(
+                    "DataFrame.update found no matching indices because the index "
+                    "dtypes do not match.",
+                    UserWarning,
+                    stacklevel=find_stack_level(),
+                )
             return
         other = other.reindex(index_intersection)
         this_data = self.loc[index_intersection]

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -220,8 +220,24 @@ class TestDataFrameUpdate:
         orig = DataFrame({"a": [1]}, index=[1])
         df = orig.copy()
         other = DataFrame({"a": [2]}, index=[2])
-        df.update(other)
+        with tm.assert_produces_warning(None):
+            df.update(other)
         tm.assert_frame_equal(df, orig)
+
+    def test_update_warns_on_index_dtype_mismatch_with_apparent_overlap(self):
+        # GH#19905
+        df = DataFrame({"col": ["foo", "bar", np.nan]}, index=[1, 2, 3])
+        other = DataFrame({"col": [np.nan, np.nan, "baz"]}, index=["1", "2", "3"])
+
+        msg = (
+            "DataFrame.update found no matching indices because the index dtypes "
+            "do not match."
+        )
+        with tm.assert_produces_warning(UserWarning, match=msg):
+            df.update(other)
+
+        expected = DataFrame({"col": ["foo", "bar", np.nan]}, index=[1, 2, 3])
+        tm.assert_frame_equal(df, expected)
 
     def test_update_on_duplicate_frame_unique_argument_index(self):
         # GH#55509


### PR DESCRIPTION
- closes #19905
## Summary

This adds a warning in `DataFrame.update` when the operation finds no matching
indices because the two indexes have different dtypes, but their labels still
appear to overlap once stringified.

That preserves the existing no-op behavior for genuinely non-overlapping indexes,
while surfacing the misleading case described in GH#19905.

## Changes

- warn from `DataFrame.update` when:
  - the index intersection is empty
  - both indexes are non-empty
  - the index dtypes differ
  - the labels appear to overlap after string conversion
- add a regression test for the dtype-mismatch case
- assert that the existing no-intersection case remains warning-free

## Testing

- `python -m pytest pandas/tests/frame/methods/test_update.py -k "index_dtype_mismatch_with_apparent_overlap or without_intersection" -q`
- `python -m pytest pandas/tests/frame/methods/test_update.py -q`