### PR TITLE
TST: add tests for mixed-resolution datetime64 in object Index

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -10,6 +10,7 @@ from pandas.util.version import Version
 _np_version = np.__version__
 _nlv = Version(_np_version)
 np_version_gt2 = _nlv >= Version("2.0.0")
+np_version_gt2_2 = _nlv >= Version("2.2.0")
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.26.0"
 

--- a/pandas/tests/indexes/object/test_indexing.py
+++ b/pandas/tests/indexes/object/test_indexing.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.missing import is_matching_na
+from pandas.compat import WASM
 from pandas.compat.numpy import np_version_gt2
 
 from pandas import Index
@@ -160,13 +161,14 @@ class TestGetIndexerNonUnique:
             tm.assert_numpy_array_equal(missing, expected_missing)
 
 
-@pytest.mark.xfail(
-    not np_version_gt2,
-    reason="numpy < 2 violates hash invariant for mixed-resolution datetime64",
-)
 class TestMixedResolutionDatetime64:
     # GH#50690 - object-dtype Index with mixed-resolution datetime64 values
     # should respect the invariant x == y => hash(x) == hash(y)
+
+    _xfail_np_hash = pytest.mark.xfail(
+        not np_version_gt2 or WASM,
+        reason="numpy < 2 violates hash invariant for mixed-resolution datetime64",
+    )
 
     @pytest.fixture
     def dt_ms(self):
@@ -176,6 +178,7 @@ class TestMixedResolutionDatetime64:
     def dt_us(self):
         return np.datetime64(1000, "us")
 
+    @_xfail_np_hash
     def test_contains(self, dt_ms, dt_us):
         # GH#50690
         left = Index([dt_ms], dtype=object)
@@ -184,6 +187,7 @@ class TestMixedResolutionDatetime64:
         assert dt_us in left
         assert dt_ms in right
 
+    @_xfail_np_hash
     def test_get_loc(self, dt_ms, dt_us):
         # GH#50690
         left = Index([dt_ms], dtype=object)
@@ -201,6 +205,7 @@ class TestMixedResolutionDatetime64:
         expected = np.array([0], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
+    @_xfail_np_hash
     def test_get_indexer_non_monotonic(self, dt_ms, dt_us):
         # GH#50690 - non-monotonic case uses hashtable; this is where
         # the hash invariant violation caused incorrect results
@@ -212,6 +217,7 @@ class TestMixedResolutionDatetime64:
         expected = np.array([0], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
+    @_xfail_np_hash
     def test_get_indexer_non_unique(self, dt_ms, dt_us):
         # GH#50690
         idx = Index([dt_ms, "foo", dt_ms], dtype=object)

--- a/pandas/tests/indexes/object/test_indexing.py
+++ b/pandas/tests/indexes/object/test_indexing.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.missing import is_matching_na
+from pandas.compat.numpy import np_version_gt2
 
 from pandas import Index
 import pandas._testing as tm
@@ -157,3 +158,67 @@ class TestGetIndexerNonUnique:
             expected_indexer = np.array([1, 3], dtype=np.intp)
             tm.assert_numpy_array_equal(indexer, expected_indexer)
             tm.assert_numpy_array_equal(missing, expected_missing)
+
+
+@pytest.mark.xfail(
+    not np_version_gt2,
+    reason="numpy < 2 violates hash invariant for mixed-resolution datetime64",
+)
+class TestMixedResolutionDatetime64:
+    # GH#50690 - object-dtype Index with mixed-resolution datetime64 values
+    # should respect the invariant x == y => hash(x) == hash(y)
+
+    @pytest.fixture
+    def dt_ms(self):
+        return np.datetime64(1, "ms")
+
+    @pytest.fixture
+    def dt_us(self):
+        return np.datetime64(1000, "us")
+
+    def test_contains(self, dt_ms, dt_us):
+        # GH#50690
+        left = Index([dt_ms], dtype=object)
+        right = Index([dt_us], dtype=object)
+
+        assert dt_us in left
+        assert dt_ms in right
+
+    def test_get_loc(self, dt_ms, dt_us):
+        # GH#50690
+        left = Index([dt_ms], dtype=object)
+        right = Index([dt_us], dtype=object)
+
+        assert left.get_loc(dt_us) == 0
+        assert right.get_loc(dt_ms) == 0
+
+    def test_get_indexer_monotonic(self, dt_ms, dt_us):
+        # GH#50690 - monotonic case uses binary search, not hashtable
+        left = Index([dt_ms], dtype=object)
+        right = Index([dt_us], dtype=object)
+
+        result = left.get_indexer(right)
+        expected = np.array([0], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_get_indexer_non_monotonic(self, dt_ms, dt_us):
+        # GH#50690 - non-monotonic case uses hashtable; this is where
+        # the hash invariant violation caused incorrect results
+        sec = np.datetime64("9999-01-01", "s")
+        day = np.datetime64("2016-01-01", "D")
+        idx = Index([dt_ms, sec, day], dtype=object)
+
+        result = idx.get_indexer(Index([dt_us], dtype=object))
+        expected = np.array([0], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_get_indexer_non_unique(self, dt_ms, dt_us):
+        # GH#50690
+        idx = Index([dt_ms, "foo", dt_ms], dtype=object)
+
+        indexer, missing = idx.get_indexer_non_unique(Index([dt_us], dtype=object))
+
+        expected_indexer = np.array([0, 2], dtype=np.intp)
+        expected_missing = np.array([], dtype=np.intp)
+        tm.assert_numpy_array_equal(indexer, expected_indexer)
+        tm.assert_numpy_array_equal(missing, expected_missing)

--- a/pandas/tests/indexes/object/test_indexing.py
+++ b/pandas/tests/indexes/object/test_indexing.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.missing import is_matching_na
-from pandas.compat import WASM
 from pandas.compat.numpy import np_version_gt2_2
 
 from pandas import Index
@@ -166,7 +165,7 @@ class TestMixedResolutionDatetime64:
     # should respect the invariant x == y => hash(x) == hash(y)
 
     _xfail_np_hash = pytest.mark.xfail(
-        not np_version_gt2_2 or WASM,
+        not np_version_gt2_2,
         reason="numpy < 2.2 violates hash invariant for mixed-resolution datetime64",
     )
 

--- a/pandas/tests/indexes/object/test_indexing.py
+++ b/pandas/tests/indexes/object/test_indexing.py
@@ -5,7 +5,7 @@ import pytest
 
 from pandas._libs.missing import is_matching_na
 from pandas.compat import WASM
-from pandas.compat.numpy import np_version_gt2
+from pandas.compat.numpy import np_version_gt2_2
 
 from pandas import Index
 import pandas._testing as tm
@@ -166,8 +166,8 @@ class TestMixedResolutionDatetime64:
     # should respect the invariant x == y => hash(x) == hash(y)
 
     _xfail_np_hash = pytest.mark.xfail(
-        not np_version_gt2 or WASM,
-        reason="numpy < 2 violates hash invariant for mixed-resolution datetime64",
+        not np_version_gt2_2 or WASM,
+        reason="numpy < 2.2 violates hash invariant for mixed-resolution datetime64",
     )
 
     @pytest.fixture


### PR DESCRIPTION
## Summary
- Add tests for GH#50690: `Index.__contains__`, `get_loc`, `get_indexer`, and `get_indexer_non_unique` with mixed-resolution `datetime64` values in object-dtype Index.
- The bug was caused by numpy < 2 violating the hash invariant (`x == y => hash(x) == hash(y)`) for `datetime64` objects with different resolutions. numpy 2.0+ fixed this upstream.
- Tests are xfailed on numpy < 2 since the fix is in numpy, not pandas.

closes #50690

## Test plan
- [x] All 5 new tests pass with numpy 2.3
- [x] Full `test_indexing.py` suite passes (700 tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)