### PR TITLE
[backport 3.0.x] BUG: Suppress unnecessary RuntimeWarning in to_datetime with missing componentsFix runtime warning (#64292)

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -33,6 +33,7 @@ Bug fixes
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Assigning :attr:`pd.NA` to a string column could trigger a PyArrow error and corrupt data (:issue:`64320`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
+- Fixed bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`)
 - Fixed bug in :meth:`Series.var` computing the variance of complex numbers incorrectly (:issue:`62421`)
 - Fixed bug in the :meth:`~Series.sum` method with python-backed string dtype returning incorrect value for an empty Series and ignoring the ``min_count`` argument (:issue:`64683`)
 - Fixed bug where :meth:`DataFrame.div` ignored the ``axis`` argument when used with ``level`` for MultiIndex columns (:issue:`64428`)

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1160,7 +1160,8 @@ def sequence_to_td64ns(
         if unit is not None and unit != "ns":
             # if all non-NaN entries are round, treat these like ints and give
             #  back the requested unit (or closest-supported)
-            int_data = data.astype(np.int64)
+            with np.errstate(invalid="ignore"):
+                int_data = data.astype(np.int64)
             all_round = (mask | (data == int_data)).all()
             if all_round:
                 result, _ = sequence_to_td64ns(

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3827,3 +3827,19 @@ def test_to_datetime_lxml_elementunicoderesult_with_format(cache):
 
     out = to_datetime(Series([val]), format="%Y-%m-%d %H:%M:%S", cache=cache)
     assert out.iloc[0] == Timestamp(s)
+
+
+def test_to_datetime_missing_component_no_runtime_warning():
+    df = DataFrame(
+        {
+            "year": [2023, 2023],
+            "month": [12, 2],
+            "day": [1, 2],
+            "hour": [2, np.nan],
+        }
+    )
+
+    with tm.assert_produces_warning(None):
+        result = to_datetime(df)
+
+    assert result.iloc[1] is NaT


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/64292