### PR TITLE
[backport 3.0.x] BUG: fix convert_dtypes dropping values from sliced mixed-dtype DataFrames (#64712)

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -21,6 +21,7 @@ Enhancements
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed a regression in :func:`json_normalize` that caused top-level missing entries to raise a ``TypeError``. Missing entries are once again interpreted as empty records (:issue:`64188`)
+- Fixed bug in :meth:`DataFrame.convert_dtypes` where values were dropped from sliced :class:`DataFrame` objects with mixed dtypes when the internal block structure spanned multiple columns (:issue:`64702`)
 - Fixed regression in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` raising ``AssertionError`` when called with ``level=`` on a :class:`RangeIndex` (:issue:`64383`)
 - Fixed regression in :meth:`HDFStore.select` where the ``where`` clause on a datetime index silently returned empty results when the index had non-nanosecond resolution (:issue:`64310`)
 - Fixed regression in :meth:`Series.interpolate` where ``limit_direction="both"`` with ``limit`` greater than the Series length raised ``ValueError`` (:issue:`64322`)

--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -21,7 +21,7 @@ Enhancements
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed a regression in :func:`json_normalize` that caused top-level missing entries to raise a ``TypeError``. Missing entries are once again interpreted as empty records (:issue:`64188`)
-- Fixed bug in :meth:`DataFrame.convert_dtypes` where values were dropped from sliced :class:`DataFrame` objects with mixed dtypes when the internal block structure spanned multiple columns (:issue:`64702`)
+- Fixed regression in :meth:`DataFrame.convert_dtypes` resulting in corrupted result with sliced :class:`DataFrame` with mixed dtypesas input (:issue:`64702`)
 - Fixed regression in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` raising ``AssertionError`` when called with ``level=`` on a :class:`RangeIndex` (:issue:`64383`)
 - Fixed regression in :meth:`HDFStore.select` where the ``where`` clause on a datetime index silently returned empty results when the index had non-nanosecond resolution (:issue:`64310`)
 - Fixed regression in :meth:`Series.interpolate` where ``limit_direction="both"`` with ``limit`` greater than the Series length raised ``ValueError`` (:issue:`64322`)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -544,7 +544,7 @@ class Block(PandasObject, libinternals.Block):
         for blk in blks:
             # Determine dtype column by column
             sub_blks = (
-                [blk] if blk.ndim == 1 or self.shape[0] == 1 else list(blk._split())
+                [blk] if blk.ndim == 1 or blk.shape[0] == 1 else list(blk._split())
             )
             dtypes = [
                 convert_dtypes(
@@ -558,7 +558,7 @@ class Block(PandasObject, libinternals.Block):
                 )
                 for b in sub_blks
             ]
-            if all(dtype == self.dtype for dtype in dtypes):
+            if all(dtype == blk.dtype for dtype in dtypes):
                 # Avoid block splitting if no dtype changes
                 rbs.append(blk.copy(deep=False))
                 continue

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -240,3 +240,16 @@ class TestConvertDtypes:
         )
         result = df.convert_dtypes()
         tm.assert_frame_equal(result, expected)
+
+    def test_convert_dtypes_mixed_column_after_slice(self):
+        # GH#64702
+        df = pd.DataFrame(data=[[1, "a"], [2, "b"], ["c", 3]], columns=["col1", "col2"])
+        df = df.loc[[0, 1]].copy()
+        result = df.convert_dtypes()
+        expected = pd.DataFrame(
+            {
+                "col1": pd.array([1, 2], dtype="Int64"),
+                "col2": pd.array(["a", "b"], dtype="string"),
+            }
+        )
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
(cherry picked from commit 497fe85391793659986641261ad25df0e7fa6b4b)

Backport of https://github.com/pandas-dev/pandas/pull/64712