### PR TITLE
DOC: move some whatsnew items from 3.1.0 to 3.0.2

### DIFF
--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -21,6 +21,7 @@ Enhancements
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed a regression in :func:`json_normalize` that caused top-level missing entries to raise a ``TypeError``. Missing entries are once again interpreted as empty records (:issue:`64188`)
+- Fixed regression in :meth:`DataFrame.convert_dtypes` resulting in corrupted result with sliced :class:`DataFrame` with mixed dtypesas input (:issue:`64702`)
 - Fixed regression in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` raising ``AssertionError`` when called with ``level=`` on a :class:`RangeIndex` (:issue:`64383`)
 - Fixed regression in :meth:`HDFStore.select` where the ``where`` clause on a datetime index silently returned empty results when the index had non-nanosecond resolution (:issue:`64310`)
 - Fixed regression in :meth:`Series.interpolate` where ``limit_direction="both"`` with ``limit`` greater than the Series length raised ``ValueError`` (:issue:`64322`)
@@ -33,7 +34,9 @@ Bug fixes
 - :func:`col` and expressions derived from it failed with power (``**``) and matrix multiplication (``@``) operators (:issue:`64267`)
 - Assigning :attr:`pd.NA` to a string column could trigger a PyArrow error and corrupt data (:issue:`64320`)
 - Bug when using :func:`col` with Python functions :func:`bool`, :func:`iter`, :func:`copy`, and :func:`deepcopy` either failed or produced incorrect results; these now all raise a ``TypeError`` (:issue:`64267`)
+- Fixed bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`)
 - Fixed bug in :meth:`Series.var` computing the variance of complex numbers incorrectly (:issue:`62421`)
+- Fixed bug in :meth:`~DataFrame.to_hdf` with string columns raising an error when using compression (:issue:`64180`)
 - Fixed bug in the :meth:`~Series.sum` method with python-backed string dtype returning incorrect value for an empty Series and ignoring the ``min_count`` argument (:issue:`64683`)
 - Fixed bug where :meth:`DataFrame.div` ignored the ``axis`` argument when used with ``level`` for MultiIndex columns (:issue:`64428`)
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -158,7 +158,6 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
-- Fix bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
 
 Categorical
@@ -198,7 +197,6 @@ Numeric
 Conversion
 ^^^^^^^^^^
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`).
-- Fixed bug in :meth:`DataFrame.convert_dtypes` where values were dropped from sliced :class:`DataFrame` objects with mixed dtypes when the internal block structure spanned multiple columns (:issue:`64702`)
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 -
 
@@ -237,7 +235,6 @@ I/O
 ^^^
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
-- Fixed bug in :meth:`HDFStore.put` where string extension dtype columns raised errors when using compression (:issue:`64180`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)


### PR DESCRIPTION
Moving the whatsnew for a few PRs that I just backported (their issues were marked for 3.0.2, but the PR was merged as for 3.1). For the 3.0.x branch, I already included the moved whatsnew items in their respective backport PRs. So this PR can just target main

https://github.com/pandas-dev/pandas/pull/64921
https://github.com/pandas-dev/pandas/pull/64922
https://github.com/pandas-dev/pandas/pull/64923
