### PR TITLE
[backport 3.0.x] PERF: fix slow python loop in validation for ArrowStringArray setitem value (_maybe_convert_setitem_value) (#64530)

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -528,6 +528,24 @@ class SetitemObjectDtype:
         self.df.loc[0, 1] = 1.0
 
 
+class SeriesSetitem:
+    params = ["str"]
+    param_names = ["dtype"]
+
+    def setup(self, dtype):
+        N = 500_000
+        self.s = Series(np.random.rand(N), dtype=dtype)
+        self.arr = self.s.array
+        self.arr_obj = np.asarray(self.s.array, dtype=object)
+
+    def time_setitem_slice_array(self, dtype):
+        # https://github.com/pandas-dev/pandas/pull/64530
+        self.s[:] = self.arr
+
+    def time_setitem_slice_array_infer(self, dtype):
+        self.s[:] = self.arr_obj
+
+
 class ChainIndexing:
     params = [None, "warn"]
     param_names = ["mode"]

--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -21,6 +21,7 @@ Enhancements
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed a regression in :func:`json_normalize` that caused top-level missing entries to raise a ``TypeError``. Missing entries are once again interpreted as empty records (:issue:`64188`)
+- Fixed performance regression in assigning into a string column with string data (:issue:`64530`)
 - Fixed regression in :meth:`DataFrame.convert_dtypes` resulting in corrupted result with sliced :class:`DataFrame` with mixed dtypesas input (:issue:`64702`)
 - Fixed regression in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` raising ``AssertionError`` when called with ``level=`` on a :class:`RangeIndex` (:issue:`64383`)
 - Fixed regression in :meth:`HDFStore.select` where the ``where`` clause on a datetime index silently returned empty results when the index had non-nanosecond resolution (:issue:`64310`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -610,7 +610,7 @@ class ArrowExtensionArray(
                 )
             ):
                 # See https://github.com/apache/arrow/issues/35289
-                value = value.tolist()
+                value = np.asarray(value, dtype=object)
             elif copy and is_array_like(value):
                 # pa array should not get updated when numpy array is updated
                 value = value.copy()

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -829,7 +829,7 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
         return arr, self.dtype.na_value
 
     def _maybe_convert_setitem_value(self, value):
-        """Maybe convert value to be pyarrow compatible."""
+        """Maybe convert value to be StringArray compatible."""
         if lib.is_scalar(value):
             if isna(value):
                 value = self.dtype.na_value

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -25,6 +25,7 @@ from pandas.core.dtypes.common import (
     is_scalar,
     pandas_dtype,
 )
+from pandas.core.dtypes.inference import is_array_like
 from pandas.core.dtypes.missing import isna
 
 from pandas.core.arrays._arrow_string_mixins import ArrowStringArrayMixin
@@ -285,15 +286,20 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
                     f"Invalid value '{value}' for dtype 'str'. Value should be a "
                     f"string or missing value, got '{type(value).__name__}' instead."
                 )
+        elif isinstance(value, type(self)):
+            pass
         else:
-            value = np.array(value, dtype=object, copy=True)
-            value[isna(value)] = None
-            for v in value:
-                if not (v is None or isinstance(v, str)):
-                    raise TypeError(
-                        "Invalid value for dtype 'str'. Value should be a "
-                        "string or missing value (or array of those)."
-                    )
+            if not is_array_like(value):
+                value = np.asarray(value, dtype=object)
+            else:
+                value = np.asarray(value)
+            if len(value) and not (
+                value.ndim == 1 and lib.is_string_array(value, skipna=True)
+            ):
+                raise TypeError(
+                    "Invalid value for dtype 'str'. Value should be a "
+                    "string or missing value (or array of those)."
+                )
         return super()._maybe_convert_setitem_value(value)
 
     def isin(self, values: ArrayLike) -> npt.NDArray[np.bool_]:


### PR DESCRIPTION
(cherry picked from commit 3719e7029543e52da7cdcb29f79699b4fa9fcaa3)
Backport of https://github.com/pandas-dev/pandas/pull/64530