### PR TITLE
TST: make test assertions stricter

### DIFF
--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -52,8 +52,8 @@ class TestDataFrameIndexingWhere:
             rs = df.where(cond, other1)
             rs2 = df.where(cond.values, other1)
             for k, v in rs.items():
-                exp = Series(np.where(cond[k], df[k], other1[k]), index=v.index)
-                tm.assert_series_equal(v, exp, check_names=False)
+                exp = Series(np.where(cond[k], df[k], other1[k]), index=v.index, name=k)
+                tm.assert_series_equal(v, exp)
             tm.assert_frame_equal(rs, rs2)
 
             # dtypes

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -841,7 +841,7 @@ class TestDataFrameConstructors:
 
         result = DataFrame(data)
         expected = DataFrame({k: list(v) for k, v in data.items()})
-        tm.assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_dict_of_ranges(self):
         # GH 26356
@@ -1404,18 +1404,18 @@ class TestDataFrameConstructors:
         columns = ["num", "str"]
         result = DataFrame(lst_containers, columns=columns)
         expected = DataFrame([[1, "a"], [2, "b"]], columns=columns)
-        tm.assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_stdlib_array(self):
         # GH 4297
         # support Array
         result = DataFrame({"A": array.array("i", range(10))})
         expected = DataFrame({"A": list(range(10))})
-        tm.assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected)
 
         expected = DataFrame([list(range(10)), list(range(10))])
         result = DataFrame([array.array("i", range(10)), array.array("i", range(10))])
-        tm.assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_range(self):
         # GH26342
@@ -1462,7 +1462,7 @@ class TestDataFrameConstructors:
         gen = ([i, "a"] for i in range(10))
         result = DataFrame(gen)
         expected = DataFrame({0: range(10), 1: "a"})
-        tm.assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_list_of_dicts(self):
         result = DataFrame([{}])
@@ -1555,7 +1555,7 @@ class TestDataFrameConstructors:
         idx = Index(range(3))
         df = DataFrame({"a": 0}, index=idx)
         expected = DataFrame({"a": [0, 0, 0]}, index=idx)
-        tm.assert_frame_equal(df, expected, check_dtype=False)
+        tm.assert_frame_equal(df, expected)
 
     def test_constructor_Series_copy_bug(self, float_frame):
         df = DataFrame(float_frame["A"], index=float_frame.index, columns=["A"])

--- a/pandas/tests/groupby/methods/test_nth.py
+++ b/pandas/tests/groupby/methods/test_nth.py
@@ -258,7 +258,7 @@ def test_nth3():
     gb = df[0]
     expected = ser.groupby(gb).first()
     expected2 = ser.groupby(gb).apply(lambda x: x.iloc[0])
-    tm.assert_series_equal(expected2, expected, check_names=False)
+    tm.assert_series_equal(expected2, expected)
     assert expected.name == 1
     assert expected2.name == 1
 

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -438,7 +438,7 @@ def test_apply_frame_concat_series():
 
     result = df.groupby("A").apply(trans)
     exp = df.groupby("A")["C"].apply(trans2)
-    tm.assert_series_equal(result, exp, check_names=False)
+    tm.assert_series_equal(result, exp)
     assert result.name == "C"
 
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -169,8 +169,8 @@ def test_basic_monotonic():
     result3 = gbc.transform(max)
     result4 = gbc.transform(np.maximum.reduce)
     result5 = gbc.transform(lambda xs: np.maximum.reduce(xs))
-    tm.assert_frame_equal(result2, df[["a"]], check_dtype=False)
-    tm.assert_frame_equal(result3, df[["a"]], check_dtype=False)
+    tm.assert_frame_equal(result2, df[["a"]])
+    tm.assert_frame_equal(result3, df[["a"]])
     tm.assert_frame_equal(result4, df[["a"]])
     tm.assert_frame_equal(result5, df[["a"]])
 

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -361,7 +361,7 @@ class TestBase:
 
         result = index.argsort()
         expected = np.array(index).argsort()
-        tm.assert_numpy_array_equal(result, expected, check_dtype=False)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_numpy_argsort(self, index):
         result = np.argsort(index)


### PR DESCRIPTION
## Summary
- Remove unnecessary `check_dtype=False` flags in 7 test assertions where dtypes now match
- Remove unnecessary `check_names=False` flags in 2 test assertions where names match
- Fix 1 test to construct the expected Series with the correct `name` instead of suppressing the name check

## Files changed
- `tests/indexes/test_old_base.py` — `argsort()` returns consistent int64 dtype
- `tests/groupby/test_categorical.py` — `transform(lambda)` and `transform(max)` preserve int64
- `tests/frame/test_constructors.py` — tuple, stdlib array, generator, and scalar constructors produce matching dtypes
- `tests/groupby/methods/test_nth.py` — `first()` and `apply(iloc[0])` produce matching names
- `tests/groupby/test_apply.py` — both sides of comparison have `name="C"`
- `tests/frame/indexing/test_where.py` — add `name=k` to expected Series instead of using `check_names=False`

## Test plan
- [x] All modified tests pass locally
- [ ] CI (including 32-bit builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)