### PR TITLE
DOC/BLD: temporary disable upload of docs to get artifact

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -125,15 +125,15 @@ jobs:
 
     - name: Upload web
       run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: false # github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload dev docs
       run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: false # github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload prod docs
       run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
-      if: ${{ env.PUBLISH_PROD == 'true' }}
+      if: false # ${{ env.PUBLISH_PROD == 'true' }}
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs


### PR DESCRIPTION
Quickly disabling the server upload steps, as those are currently failing, and therefore preventing we run the artifact upload step (which we can for now use to get the built docs to update manually)