### PR TITLE
TST: remove dead-code xfails in test_append_common

### DIFF
--- a/pandas/tests/reshape/concat/test_append_common.py
+++ b/pandas/tests/reshape/concat/test_append_common.py
@@ -187,17 +187,7 @@ class TestConcatAppendCommon:
             pytest.skip("categorical type tested elsewhere")
 
         # specify expected dtype
-        if typ1 == "bool" and typ2 in ("int64", "float64"):
-            # series coerces to numeric based on numpy rule
-            # index doesn't because bool is object dtype
-            exp_series_dtype = typ2
-            mark = pytest.mark.xfail(reason="GH#39187 casting to object")
-            request.applymarker(mark)
-        elif typ2 == "bool" and typ1 in ("int64", "float64"):
-            exp_series_dtype = typ1
-            mark = pytest.mark.xfail(reason="GH#39187 casting to object")
-            request.applymarker(mark)
-        elif typ1 in {"datetime64[ns, US/Eastern]", "timedelta64[ns]"} or typ2 in {
+        if typ1 in {"datetime64[ns, US/Eastern]", "timedelta64[ns]"} or typ2 in {
             "datetime64[ns, US/Eastern]",
             "timedelta64[ns]",
         }:


### PR DESCRIPTION
## Summary

- Remove unreachable xfail branches for GH#39187 in `test_concatlike_dtypes_coercion`
- The `item2` fixture returns `item`, so `typ1 == typ2` is always `True` and the test skips on line 184 before reaching the bool + int64/float64 xfail logic on lines 190-199

## Test plan

- [x] `test_append_common.py` passes (82 passed, 9 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)