### PR TITLE
BUG: hexbin plot now respects rcParams["image.cmap"]

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -248,7 +248,7 @@ Period
 
 Plotting
 ^^^^^^^^
--
+- Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
 -
 
 Groupby/resample/rolling

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1524,8 +1524,7 @@ class HexBinPlot(PlanePlot):
         x, y, data, C = self.x, self.y, self.data, self.C
         ax = self.axes[0]
         # pandas uses colormap, matplotlib uses cmap.
-        cmap = self.colormap or None
-        cmap = mpl.colormaps.get_cmap(cmap)
+        cmap = mpl.colormaps.get_cmap(self.colormap) if self.colormap else None
         cb = self.colorbar
 
         if C is None:

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1524,7 +1524,7 @@ class HexBinPlot(PlanePlot):
         x, y, data, C = self.x, self.y, self.data, self.C
         ax = self.axes[0]
         # pandas uses colormap, matplotlib uses cmap.
-        cmap = self.colormap or "BuGn"
+        cmap = self.colormap or None
         cmap = mpl.colormaps.get_cmap(cmap)
         cb = self.colorbar
 

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -1642,7 +1642,6 @@ class TestDataFramePlots:
     @pytest.mark.parametrize(
         "kwargs, expected",
         [
-            ({}, "BuGn"),  # default cmap
             ({"colormap": "cubehelix"}, "cubehelix"),
             ({"cmap": "YlGn"}, "YlGn"),
         ],
@@ -1657,6 +1656,19 @@ class TestDataFramePlots:
         )
         ax = df.plot.hexbin(x="A", y="B", **kwargs)
         assert ax.collections[0].cmap.name == expected
+
+    def test_hexbin_cmap_default_follows_rcparams(self):
+        # GH#31871 hexbin should respect rcParams["image.cmap"] when no
+        # colormap is specified by the user
+        df = DataFrame(
+            {
+                "A": np.random.default_rng(2).uniform(size=20),
+                "B": np.random.default_rng(2).uniform(size=20),
+            }
+        )
+        with mpl.rc_context({"image.cmap": "plasma"}):
+            ax = df.plot.hexbin(x="A", y="B")
+        assert ax.collections[0].cmap.name == "plasma"
 
     def test_pie_df_err(self):
         df = DataFrame(


### PR DESCRIPTION
NB: manually confirmed that the actual image produced in the new test is plasma-y.

## Summary
- Fix `DataFrame.plot.hexbin` to respect `rcParams["image.cmap"]` instead of always defaulting to `"BuGn"` when no colormap is specified
- Change fallback from `"BuGn"` to `None` so `mpl.colormaps.get_cmap(None)` returns the current default colormap

closes #31871

## Test plan
- [x] Added test that sets `rcParams["image.cmap"]` to `"plasma"` and verifies hexbin uses it
- [x] Existing colormap override tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)