### PR TITLE
BUG: DataFrame.rank() now preserves ExtensionArray dtypes (GH#52829)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -191,6 +191,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
+- Fixed bug in :meth:`DataFrame.rank` where :class:`ExtensionArray` dtypes (e.g. ``Int64``, ``int64[pyarrow]``) were silently cast to NumPy arrays, losing the nullable dtype (:issue:`52829`)
 - Fixed bug in :meth:`Series.clip` where passing a scalar numpy array (e.g. ``np.array(0)``) would raise a ``TypeError`` (:issue:`59053`)
 - Fixed bug in :meth:`Series.mean` and :meth:`Series.sum` (and their :class:`DataFrame` counterparts) overflowing for ``float16`` dtypes instead of upcasting to ``float64`` (:issue:`43929`)
 - Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) returning ``0.0`` for degenerate distributions; these now return ``NaN`` (:issue:`62864`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9591,32 +9591,58 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         def ranker(data):
             if data.ndim == 2:
-                # i.e. DataFrame, we cast to ndarray
-                values = data.values
+                # GH#52829 - use _mgr.apply to preserve ExtensionArray dtypes
+                def blk_func(blk_values):
+                    # Transpose numpy blocks from internal (n_items, n_rows)
+                    # to (n_rows, n_items) for algos.rank, mirroring _accum_func
+                    values = blk_values.T if hasattr(blk_values, "T") else blk_values
+                    if isinstance(values, ExtensionArray):
+                        result = values._rank(
+                            axis=axis_int,
+                            method=method,
+                            ascending=ascending,
+                            na_option=na_option,
+                            pct=pct,
+                        )
+                    else:
+                        result = algos.rank(
+                            values,
+                            axis=axis_int,
+                            method=method,
+                            ascending=ascending,
+                            na_option=na_option,
+                            pct=pct,
+                        )
+                    return result.T if hasattr(result, "T") else result
+
+                new_mgr = data._mgr.apply(blk_func)
+                return self._constructor_from_mgr(
+                    new_mgr, axes=new_mgr.axes
+                ).__finalize__(self, method="rank")
             else:
                 # i.e. Series, can dispatch to EA
                 values = data._values
 
-            if isinstance(values, ExtensionArray):
-                ranks = values._rank(
-                    axis=axis_int,
-                    method=method,
-                    ascending=ascending,
-                    na_option=na_option,
-                    pct=pct,
-                )
-            else:
-                ranks = algos.rank(
-                    values,
-                    axis=axis_int,
-                    method=method,
-                    ascending=ascending,
-                    na_option=na_option,
-                    pct=pct,
-                )
+                if isinstance(values, ExtensionArray):
+                    ranks = values._rank(
+                        axis=axis_int,
+                        method=method,
+                        ascending=ascending,
+                        na_option=na_option,
+                        pct=pct,
+                    )
+                else:
+                    ranks = algos.rank(
+                        values,
+                        axis=axis_int,
+                        method=method,
+                        ascending=ascending,
+                        na_option=na_option,
+                        pct=pct,
+                    )
 
-            ranks_obj = self._constructor(ranks, **data._construct_axes_dict())
-            return ranks_obj.__finalize__(self, method="rank")
+                ranks_obj = self._constructor(ranks, **data._construct_axes_dict())
+                return ranks_obj.__finalize__(self, method="rank")
 
         if numeric_only:
             if self.ndim == 1 and not is_numeric_dtype(self.dtype):

--- a/pandas/tests/frame/methods/test_rank.py
+++ b/pandas/tests/frame/methods/test_rank.py
@@ -498,3 +498,78 @@ class TestRank:
             exp_dtype = "float64"
         expected = Series([1, 2, None, 3], dtype=exp_dtype)
         tm.assert_series_equal(result, expected)
+
+
+class TestRankEADtype:
+    # GH#52829 - DataFrame.rank() should preserve ExtensionArray dtypes
+
+    def test_rank_nullable_int_average_preserves_float64_ea(self):
+        # GH#52829 - average method on Int64 should return Float64 (not float64)
+        import pandas as pd
+
+        df = DataFrame({"a": pd.array([3, 1, 2, None], dtype="Int64")})
+        result = df.rank()
+        expected = DataFrame({"a": pd.array([3.0, 1.0, 2.0, None], dtype="Float64")})
+        tm.assert_frame_equal(result, expected)
+
+    def test_rank_nullable_int_min_preserves_uint64_ea(self):
+        # GH#52829 - method='min' on Int64 should return UInt64 (not float64)
+        import pandas as pd
+
+        df = DataFrame({"a": pd.array([3, 1, 2, 1], dtype="Int64")})
+        result = df.rank(method="min")
+        expected = DataFrame({"a": pd.array([3, 1, 2, 1], dtype="UInt64")})
+        tm.assert_frame_equal(result, expected)
+
+    def test_rank_nullable_int_with_na_min_method(self):
+        # GH#52829 - NAs kept as NA in result
+        import pandas as pd
+
+        df = DataFrame({"a": pd.array([3, 1, None, 2], dtype="Int64")})
+        result = df.rank(method="min", na_option="keep")
+        expected = DataFrame({"a": pd.array([3, 1, None, 2], dtype="UInt64")})
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "method, expected_dtype",
+        [
+            ("average", "double[pyarrow]"),
+            ("min", "uint64[pyarrow]"),
+            ("max", "uint64[pyarrow]"),
+            ("first", "uint64[pyarrow]"),
+            ("dense", "uint64[pyarrow]"),
+        ],
+    )
+    def test_rank_pyarrow_int64_preserves_ea_dtype(self, method, expected_dtype):
+        # GH#52829 - pyarrow int64 columns keep EA dtype after rank
+        pytest.importorskip("pyarrow")
+        import pandas as pd
+
+        df = DataFrame({"a": pd.array([3, 1, 2, None], dtype="int64[pyarrow]")})
+        result = df.rank(method=method)
+        assert str(result["a"].dtype) == expected_dtype
+
+    def test_rank_mixed_ea_numpy_each_preserves_own_dtype(self):
+        # GH#52829 - mixed EA + numpy columns: each col preserves its own dtype
+        import pandas as pd
+
+        df = DataFrame(
+            {
+                "ea_col": pd.array([3, 1, 2], dtype="Int64"),
+                "np_col": np.array([30.0, 10.0, 20.0]),
+            }
+        )
+        result = df.rank(method="min")
+        assert result["np_col"].dtype == np.dtype("float64")
+        assert result["ea_col"].dtype != np.dtype("float64")
+        assert str(result["ea_col"].dtype) == "UInt64"
+
+    def test_rank_duplicate_column_names_shape_preserved(self):
+        # GH#52829 - duplicate column names must not be lost
+        df = DataFrame(
+            [[3, 1], [1, 2], [2, 3]],
+            columns=Index(["a", "a"]),
+        )
+        result = df.rank()
+        assert list(result.columns) == ["a", "a"]
+        assert result.shape == (3, 2)


### PR DESCRIPTION
- [x] closes #52829  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
