### PR TITLE
DOC: note that bool and int are not distinguished in object-dtype factorize/unique

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -355,6 +355,12 @@ def unique(values):
     Index.unique : Return unique values from an Index.
     Series.unique : Return unique values of Series object.
 
+    Notes 
+    --------
+    For object-dtype inputs, boolean and integer values are not
+    distinguished. For example, ``True`` and ``1`` are treated as
+    equivalent values.
+
     Examples
     --------
     >>> pd.unique(pd.Series([2, 1, 3, 3]))
@@ -700,6 +706,9 @@ def factorize(
     Notes
     -----
     Reference :ref:`the user guide <reshaping.factorize>` for more examples.
+    For object-dtype inputs, boolean and integer values are not
+    distinguished. For example, ``True`` and ``1`` are treated as
+    equivalent values.
 
     Examples
     --------

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -355,7 +355,7 @@ def unique(values):
     Index.unique : Return unique values from an Index.
     Series.unique : Return unique values of Series object.
 
-    Notes 
+    Notes
     --------
     For object-dtype inputs, boolean and integer values are not
     distinguished. For example, ``True`` and ``1`` are treated as

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -356,10 +356,10 @@ def unique(values):
     Series.unique : Return unique values of Series object.
 
     Notes
-    --------
-    For object-dtype inputs, boolean and integer values are not
-    distinguished. For example, ``True`` and ``1`` are treated as
-    equivalent values.
+    -----
+    For object-dtype inputs, pandas follows Python's object hash/equality
+    semantics, so boolean and integer values are not distinguished.
+    For example, ``True`` and ``1`` are treated as equivalent values.
 
     Examples
     --------


### PR DESCRIPTION
What does this PR do?
Adds a note in the docstrings of `factorize` and `unique` in `pandas/core/algorithms.py` clarifying that for object-dtype inputs, boolean and integer values are not distinguished (e.g. `True` and `1` are treated as equivalent values).