### PR TITLE
REGR: fix plotting DataFrame with descending DatetimeIndex

### DIFF
--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -219,6 +219,10 @@ def _get_period_alias(freq: timedelta | BaseOffset | str) -> str | None:
     # and the special-case BDay handling doesn't support multiplied freq.
     if alias == "B":
         return alias
+    # Use abs(n) because the sign only indicates traversal direction
+    # (e.g. descending DatetimeIndex infers freq "-1D"), not period span.
+    # GH#64819
+    n = abs(n)
     if n != 1:
         return f"{n}{alias}"
     return alias

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -296,6 +296,12 @@ class TestTSPlot:
         ser = ser.iloc[[0, 3, 5, 6]]
         _check_plot_works(ser.plot)
 
+    def test_line_plot_descending_datetime_index(self):
+        # GH#64819 - descending DatetimeIndex (negative inferred freq) should plot
+        idx = date_range("2020-01-03", periods=3, freq="-1D")
+        df = DataFrame([0.5, 1, 2], index=idx)
+        _check_plot_works(df.plot)
+
     def test_fake_inferred_business(self):
         _, ax = mpl.pyplot.subplots()
         rng = date_range("2001-1-1", "2001-1-10")


### PR DESCRIPTION
closes #64819

`_get_period_alias` (changed in #64376) now preserves the frequency multiplier `n`, but didn't account for negative `n` from descending DatetimeIndex (e.g. inferred freq `"-1D"`). The negative multiplier propagated into `to_period(freq="-1D")` which raised `ValueError: Frequency must be positive`.

Fix: use `abs(n)` since the sign indicates traversal direction, not period span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)