### PR TITLE
TST: add regression test for Index.get_indexer_for with mixed tuples

### DIFF
--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -274,6 +274,14 @@ class TestGetIndexer:
         expected = np.array([0, 2, 3], dtype=result.dtype)
         tm.assert_numpy_array_equal(result, expected)
 
+    def test_get_indexer_for_mixed_tuples(self):
+        # GH#41882
+        idx = Index(["i", "i", "j"])
+        other = Index([("i", "i"), ("i", "j"), ("j", "i"), "j"])
+        result = idx.get_indexer_for(other)
+        expected = np.array([-1, -1, -1, 2], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
 
 class TestConvertSliceIndexer:
     def test_convert_almost_null_slice(self, index):


### PR DESCRIPTION
## Summary
- Adds a regression test for #41882 where `Index.get_indexer_for` raised `ValueError` when called on a non-unique index with a target containing mixed tuples and scalars
- The bug is already fixed; this adds test coverage to prevent regression

## Test plan
- [x] `pytest pandas/tests/indexes/test_indexing.py::TestGetIndexer::test_get_indexer_for_mixed_tuples` passes

closes #41882

🤖 Generated with [Claude Code](https://claude.com/claude-code)