### PR TITLE
TST: add tests for distinguish_nan_and_na fixing GH#61856 and GH#61617

### DIFF
--- a/pandas/tests/arrays/floating/test_construction.py
+++ b/pandas/tests/arrays/floating/test_construction.py
@@ -211,6 +211,36 @@ def test_series_from_float(data, using_nan_is_na):
     tm.assert_series_equal(result, expected)
 
 
+def test_nan_not_coerced_to_na(using_nan_is_na):
+    # GH#61617 - NaN from arithmetic should not be coerced to NA
+    arr = pd.array([0, pd.NA])
+    result = pd.Series(arr) / 0
+    if using_nan_is_na:
+        # Default: NaN is coerced to NA
+        assert result[0] is pd.NA
+    else:
+        # With distinguish_nan_and_na: NaN stays as NaN
+        assert np.isnan(result[0])
+    # The NA entry should always remain NA
+    assert result[1] is pd.NA
+
+
+def test_nan_and_na_distinct_in_construction(using_nan_is_na):
+    # GH#61617 - constructing a FloatingArray with both NaN and NA
+    # should preserve the distinction when distinguish_nan_and_na is set
+    result = pd.array([1.0, np.nan, pd.NA], dtype="Float64")
+    if using_nan_is_na:
+        # Default: NaN coerced to NA, both become NA
+        assert result[1] is pd.NA
+        assert result[2] is pd.NA
+    else:
+        # With distinguish_nan_and_na: NaN is a value, NA is missing
+        assert np.isnan(result[1])
+        assert result[2] is pd.NA
+        assert not result._mask[1]
+        assert result._mask[2]
+
+
 def test_from_arrow_nan_vs_none(using_nan_is_na):
     # GH#55668
     pyarrow = pytest.importorskip("pyarrow")

--- a/pandas/tests/frame/methods/test_values.py
+++ b/pandas/tests/frame/methods/test_values.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import pandas as pd
 from pandas import (
     DataFrame,
     NaT,
@@ -221,6 +222,23 @@ class TestDataFrameValues:
 
         values = mixed_int_frame[["C"]].values
         assert values.dtype == np.uint8
+
+    def test_values_consistent_na_nullable_float(self, using_nan_is_na):
+        # GH#61856 - .values should give consistent NA/NaN regardless of
+        # whether other columns force object dtype
+        ser = Series([1, pd.NA], dtype=pd.Float64Dtype())
+        df = DataFrame({"A": ser, "B": ["foo", "bar"]})
+
+        float_only = df[["A"]].values[1, 0]
+        mixed = df.values[1, 0]
+        if using_nan_is_na:
+            # Default: both should be NaN (but this is the known-inconsistent path)
+            assert isinstance(float_only, float) and np.isnan(float_only)
+            assert mixed is pd.NA
+        else:
+            # With distinguish_nan_and_na: both should be pd.NA
+            assert float_only is pd.NA
+            assert mixed is pd.NA
 
 
 class TestPrivateValues:


### PR DESCRIPTION
## Summary
- Adds tests confirming that `future.distinguish_nan_and_na` resolves the inconsistencies reported in #61856 and #61617
- **#61856**: `.values` on a nullable-float DataFrame gave `NaN` when all columns were float but `<NA>` when mixed with other dtypes. With the option enabled, both paths consistently return `<NA>`.
- **#61617**: NaN from arithmetic (e.g. `0/0`) was coerced to `<NA>` during FloatingArray construction. With the option enabled, NaN is preserved as a distinct value.

closes #61856
closes #61617

## Test plan
- [x] `test_values_consistent_na_nullable_float` — verifies `.values` consistency for GH#61856
- [x] `test_nan_not_coerced_to_na` — verifies NaN from arithmetic is not coerced for GH#61617
- [x] `test_nan_and_na_distinct_in_construction` — verifies NaN/NA distinction in array construction for GH#61617
- All tests parametrized over both `using_nan_is_na` settings via the existing fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)