### PR TITLE
TST: add tests for assert_frame_equal/assert_series_equal near int64 bounds

### DIFF
--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -416,6 +416,17 @@ def test_datetimelike_compat_deprecated():
         tm.assert_series_equal(df["a"], df["a"], check_datetimelike_compat=False)
 
 
+def test_assert_frame_equal_int_near_bounds():
+    # GH#40719 - integer comparisons near int64 bounds should be exact by default
+    min_val = np.iinfo(np.int64).min
+    df1 = DataFrame({"B": [min_val]}, dtype=np.int64)
+    df2 = DataFrame({"B": [min_val + 1]}, dtype=np.int64)
+
+    msg = r'DataFrame.iloc\[:, 0\] \(column name="B"\) values are different'
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_frame_equal(df1, df2)
+
+
 @pytest.mark.parametrize("na_value", [pd.NA, np.nan, None])
 def test_assert_frame_equal_nested_df_na(na_value):
     # GH#43022

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -507,3 +507,14 @@ def test_assert_series_equal_check_exact_index_default(left_idx, right_idx):
     ser2 = Series(np.zeros(6, dtype=int), right_idx)
     tm.assert_series_equal(ser1, ser2)
     tm.assert_frame_equal(ser1.to_frame(), ser2.to_frame())
+
+
+def test_assert_series_equal_int_near_bounds():
+    # GH#40719 - integer comparisons near int64 bounds should be exact by default
+    min_val = np.iinfo(np.int64).min
+    ser1 = Series([min_val], dtype=np.int64)
+    ser2 = Series([min_val + 1], dtype=np.int64)
+
+    msg = "Series are different"
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_series_equal(ser1, ser2)


### PR DESCRIPTION
## Summary
- Adds regression tests for GH#40719: `assert_frame_equal` and `assert_series_equal` now correctly raise when comparing integer values that differ by 1 near `int64` bounds (e.g. `iinfo(int64).min` vs `iinfo(int64).min + 1`).
- The underlying fix (auto-setting `check_exact=True` for integer dtypes) is already in place, but there were no tests exercising the near-bounds case.

closes #40719

## Test plan
- [x] `pytest pandas/tests/util/test_assert_frame_equal.py::test_assert_frame_equal_int_near_bounds` passes
- [x] `pytest pandas/tests/util/test_assert_series_equal.py::test_assert_series_equal_int_near_bounds` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)