### PR TITLE
BUG: fix CategoricalIndex.union/intersection with mismatched category order

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -163,6 +163,7 @@ Bug fixes
 
 Categorical
 ^^^^^^^^^^^
+- Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
 - Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
 -
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5085,6 +5085,12 @@ class Index(IndexOpsMixin, PandasObject):
         #  not zero-copy.
         # TODO: exclude RangeIndex (which allocates memory)?
         #  Doing so seems to break test_concat_datetime_timezone
+        if isinstance(self, ABCCategoricalIndex) and not self.ordered:
+            # For unordered CategoricalIndex, dtype equality does not
+            # guarantee matching category order across indexes. Since libjoin
+            # operates on codes, mismatched category order leads to incorrect
+            # results. GH#55335
+            return False
         return not isinstance(self, (ABCIntervalIndex, ABCMultiIndex))
 
     # --------------------------------------------------------------------

--- a/pandas/tests/indexes/categorical/test_setops.py
+++ b/pandas/tests/indexes/categorical/test_setops.py
@@ -8,6 +8,24 @@ from pandas import (
 import pandas._testing as tm
 
 
+@pytest.mark.parametrize("method", ["union", "intersection"])
+def test_setop_mismatched_category_order(method):
+    # GH#55335 unordered CategoricalIndex with same categories in different
+    # order should give correct results for union/intersection
+    cats1 = ["a", "b", "c", "d"]
+    cats2 = ["d", "c", "b", "a"]
+    id1 = CategoricalIndex(["a", "c"], categories=cats1)
+    id2 = CategoricalIndex(["d", "b"], categories=cats2)
+
+    result = getattr(id1, method)(id2)
+    if method == "union":
+        # values from id1 first, then values from id2 not in id1
+        expected = CategoricalIndex(["a", "c", "d", "b"], categories=cats1)
+    else:
+        expected = CategoricalIndex([], categories=cats1)
+    tm.assert_index_equal(result, expected)
+
+
 @pytest.mark.parametrize("na_value", [None, np.nan])
 def test_difference_with_na(na_value):
     # GH 57318


### PR DESCRIPTION
## Summary
- Exclude unordered `CategoricalIndex` from `_can_use_libjoin` to fix incorrect results in `union` and `intersection` when two indexes have the same categories in different orders
- The libjoin fast paths compare raw integer codes, but for unordered categoricals dtype equality does not guarantee matching category order, so identical codes can map to different values

closes #55335

## Test plan
- [x] Added `test_setop_mismatched_category_order` covering both `union` and `intersection`
- [x] Existing `test_join_with_categorical_index` (GH#47812) still passes
- [x] Full categorical index and setops test suites pass (2179 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)