### PR TITLE
BUG: NumpyExtensionArray._validate_setitem_value fails to raise for incompatible values

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
         FillnaOptions,
         InterpolateOptions,
         NpDtype,
+        NumpySorter,
+        NumpyValueArrayLike,
         Scalar,
         TakeIndexer,
         npt,
@@ -58,6 +60,7 @@ if TYPE_CHECKING:
 
     from pandas import Index
     from pandas.arrays import StringArray
+    from pandas.core.arrays.base import ExtensionArray
 
 
 @set_module("pandas.arrays")
@@ -184,14 +187,14 @@ class NumpyExtensionArray(
 
     def searchsorted(
         self,
-        value: NpDtype | npt.NDArray[np.generic],
+        value: NumpyValueArrayLike | ExtensionArray,
         side: Literal["left", "right"] = "left",
-        sorter: npt.NDArray[np.intp] | None = None,
+        sorter: NumpySorter | None = None,
     ) -> npt.NDArray[np.intp] | np.intp:
         # Override to skip _validate_setitem_value; numpy's searchsorted
         # handles type coercion correctly and we don't want to reject
         # e.g. float values when searching an integer array.
-        return self._ndarray.searchsorted(value, side=side, sorter=sorter)
+        return self._ndarray.searchsorted(value, side=side, sorter=sorter)  # type: ignore[arg-type]
 
     def _cast_pointwise_result(self, values) -> ArrayLike:
         result = super()._cast_pointwise_result(values)

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -13,6 +13,7 @@ import numpy as np
 from pandas._libs import lib
 from pandas._libs.tslibs import is_supported_dtype
 from pandas.compat.numpy import function as nv
+from pandas.errors import LossySetitemError
 from pandas.util._decorators import set_module
 
 from pandas.core.dtypes.astype import (
@@ -23,6 +24,7 @@ from pandas.core.dtypes.astype import (
 from pandas.core.dtypes.cast import (
     construct_1d_object_array_from_listlike,
     maybe_downcast_to_dtype,
+    np_can_hold_element,
 )
 from pandas.core.dtypes.common import pandas_dtype
 from pandas.core.dtypes.dtypes import NumpyEADtype
@@ -160,6 +162,36 @@ class NumpyExtensionArray(
         if copy and result is scalars:
             result = result.copy()
         return cls(result)
+
+    def _validate_setitem_value(self, value):
+        dtype = self._ndarray.dtype
+        if lib.is_scalar(value) and isna(value):
+            # Allow NA values (None, np.nan, etc.) for dtypes that support
+            # them (e.g. float); numpy will handle the conversion.
+            return value
+
+        if isinstance(value, type(self)):
+            value = value._ndarray
+
+        try:
+            return np_can_hold_element(dtype, value)
+        except LossySetitemError as err:
+            raise TypeError(f"Invalid value '{value!s}' for dtype '{dtype}'") from err
+        except NotImplementedError:
+            # np_can_hold_element doesn't handle all dtypes (e.g. "U"),
+            # fall back to no validation for those.
+            return value
+
+    def searchsorted(
+        self,
+        value: NpDtype | npt.NDArray[np.generic],
+        side: Literal["left", "right"] = "left",
+        sorter: npt.NDArray[np.intp] | None = None,
+    ) -> npt.NDArray[np.intp] | np.intp:
+        # Override to skip _validate_setitem_value; numpy's searchsorted
+        # handles type coercion correctly and we don't want to reject
+        # e.g. float values when searching an integer array.
+        return self._ndarray.searchsorted(value, side=side, sorter=sorter)
 
     def _cast_pointwise_result(self, values) -> ArrayLike:
         result = super()._cast_pointwise_result(values)

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -28,7 +28,10 @@ from pandas.core.dtypes.cast import (
 )
 from pandas.core.dtypes.common import pandas_dtype
 from pandas.core.dtypes.dtypes import NumpyEADtype
-from pandas.core.dtypes.missing import isna
+from pandas.core.dtypes.missing import (
+    is_valid_na_for_dtype,
+    isna,
+)
 
 from pandas.core import (
     arraylike,
@@ -167,19 +170,21 @@ class NumpyExtensionArray(
         return cls(result)
 
     def _validate_setitem_value(self, value):
-        dtype = self._ndarray.dtype
-        if lib.is_scalar(value) and isna(value):
-            # Allow NA values (None, np.nan, etc.) for dtypes that support
-            # them (e.g. float); numpy will handle the conversion.
-            return value
-
         if isinstance(value, type(self)):
             value = value._ndarray
 
+        # Match Block._standardize_fill_value behavior
+        if self._ndarray.dtype.kind != "O" and is_valid_na_for_dtype(
+            value, self._ndarray.dtype
+        ):
+            value = self.dtype.na_value
+
         try:
-            return np_can_hold_element(dtype, value)
+            return np_can_hold_element(self._ndarray.dtype, value)
         except LossySetitemError as err:
-            raise TypeError(f"Invalid value '{value!s}' for dtype '{dtype}'") from err
+            raise TypeError(
+                f"Invalid value '{value!s}' for dtype '{self.dtype}'"
+            ) from err
         except NotImplementedError:
             # np_can_hold_element doesn't handle all dtypes (e.g. "U"),
             # fall back to no validation for those.
@@ -191,9 +196,9 @@ class NumpyExtensionArray(
         side: Literal["left", "right"] = "left",
         sorter: NumpySorter | None = None,
     ) -> npt.NDArray[np.intp] | np.intp:
-        # Override to skip _validate_setitem_value; numpy's searchsorted
-        # handles type coercion correctly and we don't want to reject
-        # e.g. float values when searching an integer array.
+        # Parent's searchsorted calls _validate_setitem_value, which is
+        # too strict for search (e.g. rejects float into int). Delegate
+        # directly to numpy which handles cross-dtype searches correctly.
         return self._ndarray.searchsorted(value, side=side, sorter=sorter)  # type: ignore[arg-type]
 
     def _cast_pointwise_result(self, values) -> ArrayLike:

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -826,6 +826,9 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
 
         return arr, self.dtype.na_value
 
+    def _validate_setitem_value(self, value):
+        return self._maybe_convert_setitem_value(value)
+
     def _maybe_convert_setitem_value(self, value):
         """Maybe convert value to be StringArray compatible."""
         if lib.is_scalar(value):

--- a/pandas/tests/arrays/numpy_/test_numpy.py
+++ b/pandas/tests/arrays/numpy_/test_numpy.py
@@ -298,14 +298,13 @@ def test_setitem_object_typecode(dtype):
 
 def test_setitem_no_coercion():
     # https://github.com/pandas-dev/pandas/issues/28150
+    # GH#51044
     arr = NumpyExtensionArray(np.array([1, 2, 3]))
-    with pytest.raises(ValueError, match="int"):
+    with pytest.raises(TypeError, match="int"):
         arr[0] = "a"
 
-    # With a value that we do coerce, check that we coerce the value
-    #  and not the underlying array.
-    arr[0] = 2.5
-    assert isinstance(arr[0], (int, np.integer)), type(arr[0])
+    with pytest.raises(TypeError, match="int"):
+        arr[0] = 2.5
 
 
 def test_setitem_preserves_views():
@@ -320,7 +319,7 @@ def test_setitem_preserves_views():
     assert view2[0] == 9
     assert view3[0] == 9
 
-    arr[-1] = 2.5
+    arr[-1] = 5
     view1[-1] = 5
     assert arr[-1] == 5
 


### PR DESCRIPTION
## Summary
- closes #51044
- Adds `_validate_setitem_value` override to `NumpyExtensionArray` that uses `np_can_hold_element` to validate values are compatible with the underlying numpy dtype, raising `TypeError` for incompatible values
- Overrides `searchsorted` to delegate directly to numpy without setitem validation, since searching doesn't modify the array
- Updates existing tests that relied on the old no-op validation behavior

## Test plan
- [x] Existing `pandas/tests/arrays/numpy_/` tests pass (141 passed)
- [x] Existing `pandas/tests/extension/test_numpy.py` tests pass (1134 passed)
- [x] `pandas/tests/indexing/` tests pass (4627 passed)
- [x] `pandas/tests/series/indexing/` tests pass (2595 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)