### PR TITLE
BUG: SparseArray.astype("Sparse[int64]") silently replaced NaT fill_value with 0

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -266,6 +266,7 @@ Reshaping
 
 Sparse
 ^^^^^^
+- Bug in :meth:`SparseArray.astype` where converting a datetime64 :class:`SparseArray` with ``NaT`` fill value to ``"Sparse[int64]"`` silently replaced the fill value with ``0`` instead of ``iNaT`` (:issue:`49631`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
 -
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1366,7 +1366,25 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             values = ensure_wrapped_if_datetimelike(values)
             return astype_array(values, dtype=future_dtype, copy=False)
 
+        # GH#49631: save whether the original arg was a string (e.g.
+        # "Sparse[int64]") vs an explicit SparseDtype object, since
+        # update_dtype will overwrite dtype below.
+        dtype_from_string = not isinstance(dtype, SparseDtype)
         dtype = self.dtype.update_dtype(dtype)
+
+        # When dtype came from a string, update_dtype returns it with the
+        # default fill_value (e.g. 0 for int64) rather than converting the
+        # source fill_value (e.g. NaT -> iNaT). Fix that here.
+        if (
+            dtype_from_string
+            and self.dtype._is_na_fill_value
+            and not dtype._is_na_fill_value
+        ):
+            fv_arr = np.atleast_1d(np.array(self.fill_value))
+            fv_arr = ensure_wrapped_if_datetimelike(fv_arr)
+            converted_fv = np.asarray(astype_array(fv_arr, dtype.subtype))
+            dtype = SparseDtype(dtype.subtype, fill_value=converted_fv[0])
+
         subtype = pandas_dtype(dtype._subtype_with_str)
         subtype = cast("np.dtype", subtype)  # ensured by update_dtype
         values = ensure_wrapped_if_datetimelike(self.sp_values)

--- a/pandas/tests/arrays/sparse/test_astype.py
+++ b/pandas/tests/arrays/sparse/test_astype.py
@@ -131,3 +131,17 @@ class TestAstype:
         arr3 = SparseArray(values, dtype=dtype)
         result3 = arr3.astype("int64")
         tm.assert_numpy_array_equal(result3, expected)
+
+    def test_astype_dt64_to_sparse_int64_fill_value(self):
+        # GH#49631 converting to "Sparse[int64]" (string) should convert
+        # the NaT fill_value to iNaT, not silently replace it with 0
+        values = np.array(["NaT", "2016-01-02", "2016-01-03"], dtype="M8[ns]")
+        arr = SparseArray(values)
+
+        result = arr.astype("Sparse[int64]")
+        iNaT = np.iinfo(np.int64).min
+        expected = SparseArray(
+            values.astype("int64"),
+            dtype=SparseDtype("int64", fill_value=iNaT),
+        )
+        tm.assert_sp_array_equal(result, expected)


### PR DESCRIPTION
## Summary
- closes #49631
- When converting a datetime64 `SparseArray` with `NaT` fill value to `"Sparse[int64]"` via string, `SparseDtype.update_dtype` returned the parsed `SparseDtype` unchanged (since it was already a `SparseDtype`), bypassing fill value conversion. The `NaT` fill value was silently replaced by the default `0` instead of being converted to `iNaT`.
- Fix detects this case in `SparseArray.astype`: when the dtype came from a string (not an explicit `SparseDtype`), the source has an NA fill value, and the result's fill value is non-NA, we explicitly convert the fill value.

## Test plan
- [x] Added `test_astype_dt64_to_sparse_int64_fill_value` verifying NaT fill value converts to iNaT
- [x] All 1424 existing sparse tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)