### PR TITLE
BUG: pd.array raises IntCastingNaNError for float-with-NaN to integer dtype

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -199,6 +199,7 @@ Conversion
 ^^^^^^^^^^
 - Bug in :class:`DataFrame` constructor where ``NaT`` in a :class:`TimedeltaIndex` row was incorrectly inferred as ``datetime64`` instead of ``timedelta64`` (:issue:`23985`)
 - Bug in :class:`DataFrame` constructor where constructing from a list of uniform-dtype arrays (e.g. pyarrow, :class:`CategoricalDtype`, nullable dtypes) lost the dtype (:issue:`49593`)
+- Bug in :func:`pd.array` silently converting NaN to a nonsensical integer when given float data containing NaN and a NumPy integer dtype (:issue:`41724`)
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`).
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -144,8 +144,8 @@ class NumpyExtensionArray(
             if np.issubdtype(result.dtype, np.floating):
                 result = astype_float_to_int_nansafe(
                     result,
-                    np.dtype(dtype),
-                    copy=copy,  # type: ignore[arg-type]
+                    np.dtype(dtype),  # type: ignore[arg-type]
+                    copy=copy,
                 )
             else:
                 result = np.asarray(scalars, dtype=dtype)  # type: ignore[arg-type]

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -17,6 +17,7 @@ from pandas.util._decorators import set_module
 
 from pandas.core.dtypes.astype import (
     astype_array,
+    astype_float_to_int_nansafe,
     astype_is_view,
 )
 from pandas.core.dtypes.cast import (
@@ -137,12 +138,22 @@ class NumpyExtensionArray(
         if isinstance(dtype, NumpyEADtype):
             dtype = dtype._dtype
 
-        # error: Argument "dtype" to "asarray" has incompatible type
-        # "Union[ExtensionDtype, str, dtype[Any], dtype[floating[_64Bit]], Type[object],
-        # None]"; expected "Union[dtype[Any], None, type, _SupportsDType, str,
-        # Union[Tuple[Any, int], Tuple[Any, Union[int, Sequence[int]]], List[Any],
-        # _DTypeDict, Tuple[Any, Any]]]"
-        result = np.asarray(scalars, dtype=dtype)  # type: ignore[arg-type]
+        result = np.asarray(scalars)
+        if (
+            dtype is not None
+            and np.issubdtype(result.dtype, np.floating)
+            and np.dtype(dtype).kind in "iu"
+        ):
+            # GH#41724 - validate NaN before casting float -> int
+            result = astype_float_to_int_nansafe(result, np.dtype(dtype), copy=copy)
+        else:
+            # error: Argument "dtype" to "asarray" has incompatible type
+            # "Union[ExtensionDtype, str, dtype[Any], dtype[floating[_64Bit]],
+            # Type[object], None]"; expected "Union[dtype[Any], None, type,
+            # _SupportsDType, str, Union[Tuple[Any, int], Tuple[Any,
+            # Union[int, Sequence[int]]], List[Any], _DTypeDict,
+            # Tuple[Any, Any]]]"
+            result = np.asarray(scalars, dtype=dtype)  # type: ignore[arg-type]
         if (
             result.ndim > 1
             and not hasattr(scalars, "dtype")

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -138,14 +138,17 @@ class NumpyExtensionArray(
         if isinstance(dtype, NumpyEADtype):
             dtype = dtype._dtype
 
-        result = np.asarray(scalars)
-        if (
-            dtype is not None
-            and np.issubdtype(result.dtype, np.floating)
-            and np.dtype(dtype).kind in "iu"
-        ):
+        if dtype is not None and np.dtype(dtype).kind in "iu":  # type: ignore[arg-type]
             # GH#41724 - validate NaN before casting float -> int
-            result = astype_float_to_int_nansafe(result, np.dtype(dtype), copy=copy)
+            result = np.asarray(scalars)
+            if np.issubdtype(result.dtype, np.floating):
+                result = astype_float_to_int_nansafe(
+                    result,
+                    np.dtype(dtype),
+                    copy=copy,  # type: ignore[arg-type]
+                )
+            else:
+                result = np.asarray(scalars, dtype=dtype)  # type: ignore[arg-type]
         else:
             # error: Argument "dtype" to "asarray" has incompatible type
             # "Union[ExtensionDtype, str, dtype[Any], dtype[floating[_64Bit]],

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -137,26 +137,18 @@ class NumpyExtensionArray(
     ) -> NumpyExtensionArray:
         if isinstance(dtype, NumpyEADtype):
             dtype = dtype._dtype
+        if dtype is not None:
+            dtype = np.dtype(dtype)  # type: ignore[arg-type]
 
-        if dtype is not None and np.dtype(dtype).kind in "iu":  # type: ignore[arg-type]
+        if dtype is not None and dtype.kind in "iu":
             # GH#41724 - validate NaN before casting float -> int
             result = np.asarray(scalars)
             if np.issubdtype(result.dtype, np.floating):
-                result = astype_float_to_int_nansafe(
-                    result,
-                    np.dtype(dtype),  # type: ignore[arg-type]
-                    copy=copy,
-                )
+                result = astype_float_to_int_nansafe(result, dtype, copy=copy)
             else:
-                result = np.asarray(scalars, dtype=dtype)  # type: ignore[arg-type]
+                result = np.asarray(scalars, dtype=dtype)
         else:
-            # error: Argument "dtype" to "asarray" has incompatible type
-            # "Union[ExtensionDtype, str, dtype[Any], dtype[floating[_64Bit]],
-            # Type[object], None]"; expected "Union[dtype[Any], None, type,
-            # _SupportsDType, str, Union[Tuple[Any, int], Tuple[Any,
-            # Union[int, Sequence[int]]], List[Any], _DTypeDict,
-            # Tuple[Any, Any]]]"
-            result = np.asarray(scalars, dtype=dtype)  # type: ignore[arg-type]
+            result = np.asarray(scalars, dtype=dtype)
         if (
             result.ndim > 1
             and not hasattr(scalars, "dtype")

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -100,7 +100,7 @@ def _astype_nansafe(
         ).reshape(shape)
 
     elif np.issubdtype(arr.dtype, np.floating) and dtype.kind in "iu":
-        return _astype_float_to_int_nansafe(arr, dtype, copy)
+        return astype_float_to_int_nansafe(arr, dtype, copy)
 
     elif arr.dtype == object:
         # if we have a datetime/timedelta array of objects
@@ -137,7 +137,7 @@ def _astype_nansafe(
     return arr.astype(dtype, copy=copy)
 
 
-def _astype_float_to_int_nansafe(
+def astype_float_to_int_nansafe(
     values: np.ndarray, dtype: np.dtype, copy: bool
 ) -> np.ndarray:
     """

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -499,6 +499,15 @@ def test_scalar_raises():
         pd.array(1)
 
 
+@pytest.mark.parametrize("dtype", ["i8", "int64", "u8", "uint64"])
+def test_pd_array_float_with_nan_to_integer_raises(dtype):
+    # GH#41724
+    arr = np.array([np.nan, 1.0])
+    msg = "Cannot convert non-finite values"
+    with pytest.raises(pd.errors.IntCastingNaNError, match=msg):
+        pd.array(arr, dtype=dtype)
+
+
 def test_dataframe_raises():
     # GH#51167 don't accidentally cast to StringArray by doing inference on columns
     df = pd.DataFrame([[1, 2], [3, 4]], columns=["A", "B"])


### PR DESCRIPTION
## Summary
- closes #41724
- `pd.array(float_data_with_nan, dtype=np.int64)` now raises `IntCastingNaNError` instead of silently producing nonsensical integer values, matching the behavior of `Series` and `Index` constructors.
- Renames `_astype_float_to_int_nansafe` to `astype_float_to_int_nansafe` so it can be imported in `NumpyExtensionArray._from_sequence`.

## Test plan
- [x] Added parametrized test for `i8`, `int64`, `u8`, `uint64` dtypes
- [x] Existing tests pass (`test_array.py`, `test_numpy.py`, `test_astype.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)