### PR TITLE
BUG: Index.fillna with tuple fill value

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -162,7 +162,7 @@ Bug fixes
 
 Categorical
 ^^^^^^^^^^^
--
+- Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
 -
 
 Datetimelike

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2811,7 +2811,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx.fillna(0)
         Index([0.0, 0.0, 3.0], dtype='float64')
         """
-        if not is_scalar(value):
+        if is_list_like(value, allow_sets=False) and not isinstance(value, tuple):
             raise TypeError(f"'value' must be a scalar, passed: {type(value).__name__}")
 
         if self.hasnans:
@@ -5708,6 +5708,12 @@ class Index(IndexOpsMixin, PandasObject):
 
         if isinstance(values, np.ndarray):
             converted = setitem_datetimelike_compat(values, mask.sum(), converted)
+            if isinstance(converted, tuple):
+                # GH#37681 np.putmask unpacks tuples, so wrap in an
+                #  object array to ensure the tuple is treated as a scalar
+                fill_arr = np.empty(1, dtype=object)
+                fill_arr[0] = converted
+                converted = fill_arr
             np.putmask(values, mask, converted)  # pyright: ignore[reportArgumentType]
 
         else:

--- a/pandas/tests/base/test_fillna.py
+++ b/pandas/tests/base/test_fillna.py
@@ -6,6 +6,7 @@ test here to confirm these works as the same
 import numpy as np
 import pytest
 
+import pandas as pd
 from pandas import MultiIndex
 import pandas._testing as tm
 from pandas.tests.base.common import allow_na_ops
@@ -59,3 +60,11 @@ def test_fillna_null(null_obj, index_or_series_obj):
 
     # check shallow_copied
     assert obj is not result
+
+
+def test_fillna_with_tuple_on_object_index():
+    # GH#37681 np.putmask should not unpack tuple fill values
+    idx = pd.Index([(0, 1), (1, 2), None], tupleize_cols=False)
+    result = idx.fillna((9, 9))
+    expected = pd.Index([(0, 1), (1, 2), (9, 9)], tupleize_cols=False)
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/categorical/test_fillna.py
+++ b/pandas/tests/indexes/categorical/test_fillna.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import pandas as pd
 from pandas import CategoricalIndex
 import pandas._testing as tm
 
@@ -38,6 +39,18 @@ class TestFillNA:
         assert result._ndarray is not cat._ndarray
         assert result._ndarray.base is None
         assert not tm.shares_memory(result, cat)
+
+    def test_fillna_tuple_category(self):
+        # GH#37681 fillna with a tuple that is a valid category
+        ci = CategoricalIndex([(0, 1), (1, 2), pd.NA])
+        result = ci.fillna((0, 1))
+        expected = CategoricalIndex([(0, 1), (1, 2), (0, 1)])
+        tm.assert_index_equal(result, expected)
+
+        # tuple not in categories -> casts to object, same as scalar behavior
+        result = ci.fillna((9, 9))
+        expected = pd.Index([(0, 1), (1, 2), (9, 9)], tupleize_cols=False)
+        tm.assert_index_equal(result, expected)
 
     def test_fillna_validates_with_no_nas(self):
         # We validate the fill value even if fillna is a no-op


### PR DESCRIPTION
## Summary
- Fix `Index.fillna` rejecting tuple fill values with `TypeError` by relaxing the scalar check to allow tuples (which are valid elements for object-dtype and `CategoricalIndex`)
- Fix `Index.putmask` where `np.putmask` would unpack tuple values instead of treating them as scalars

closes #37681

## Test plan
- [x] `CategoricalIndex.fillna` with a tuple that is a valid category
- [x] `CategoricalIndex.fillna` with a tuple that is not a valid category (falls back to object dtype)
- [x] Object-dtype `Index.fillna` with a tuple value

🤖 Generated with [Claude Code](https://claude.com/claude-code)