### PR TITLE
TST: add regression test for datetime64 column index parquet roundtrip

### DIFF
--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -13,6 +13,7 @@ from pandas._config import using_string_dtype
 
 from pandas.compat import is_platform_windows
 from pandas.compat.pyarrow import (
+    pa_version_under14p0,
     pa_version_under15p0,
     pa_version_under17p0,
     pa_version_under19p0,
@@ -1262,6 +1263,9 @@ class TestParquetPyArrow(Base):
         )
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.skipif(
+        pa_version_under14p0, reason="pyarrow < 14 writes unit-less datetime64 metadata"
+    )
     def test_datetime64_column_index_roundtrip(self, pa, temp_file):
         # GH#55118
         df = pd.DataFrame([1, 2, 3])

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1262,6 +1262,12 @@ class TestParquetPyArrow(Base):
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_datetime64_column_index_roundtrip(self, pa, temp_file):
+        # GH#55118
+        df = pd.DataFrame([1, 2, 3])
+        df.columns = df.columns.astype("datetime64[us]")
+        check_round_trip(df, temp_file, pa)
+
     def test_maps_as_pydicts(self, pa, temp_file):
         pyarrow = pytest.importorskip("pyarrow", "13.0.0")
 


### PR DESCRIPTION
## Summary
- Adds a regression test for GH#55118 where `to_parquet` wrote `pandas_type: "datetime64"` (unit-less) in schema metadata for `datetime64[us]` column indexes, causing `read_parquet` to fail with `TypeError`
- The bug is already fixed on main; this adds test coverage to prevent regression

closes #55118

🤖 Generated with [Claude Code](https://claude.com/claude-code)