### PR TITLE
TST: add test for comma-separated fractional seconds in Timestamp

### DIFF
--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -910,6 +910,14 @@ class TestTimestampConstructors:
         expected = Timestamp(datetime(2013, 1, 1), tz=timezone(timedelta(hours=9)))
         assert result == expected
 
+    def test_comma_separated_fractional_seconds(self):
+        # GH#59256 - comma as decimal separator should parse correctly
+        ts_comma = Timestamp("2024-06-17T18:57:43,567")
+        ts_dot = Timestamp("2024-06-17T18:57:43.567")
+        assert ts_comma == ts_dot
+        assert ts_comma.unit == ts_dot.unit
+        assert ts_comma.microsecond == 567000
+
     @pytest.mark.parametrize("box", [datetime, Timestamp])
     def test_raise_tz_and_tzinfo_in_datetime_input(self, box):
         # GH 23579


### PR DESCRIPTION
## Summary
- Add test for GH#59256: parsing a timestamp string with a comma as the decimal separator (e.g., `"2024-06-17T18:57:43,567"`) now correctly preserves fractional seconds resolution, matching the behavior of a dot separator.

closes #59256

## Test plan
- [x] `pytest pandas/tests/scalar/timestamp/test_constructors.py::TestTimestampConstructors::test_comma_separated_fractional_seconds` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)