### PR TITLE
DOC: Remove dateutil and scipy intersphinx mappings

### DIFF
--- a/doc/source/user_guide/sparse.rst
+++ b/doc/source/user_guide/sparse.rst
@@ -192,7 +192,7 @@ Use :meth:`DataFrame.sparse.from_spmatrix` to create a :class:`DataFrame` with s
    sdf.head()
    sdf.dtypes
 
-All sparse formats are supported, but matrices that are not in :mod:`COOrdinate <scipy.sparse>` format will be converted, copying data as needed.
+All sparse formats are supported, but matrices that are not in ``COOrdinate`` format will be converted, copying data as needed.
 To convert back to sparse SciPy matrix in COO format, you can use the :meth:`DataFrame.sparse.to_coo` method:
 
 .. ipython:: python

--- a/doc/source/whatsnew/v0.20.0.rst
+++ b/doc/source/whatsnew/v0.20.0.rst
@@ -352,7 +352,7 @@ SciPy sparse matrix from/to SparseDataFrame
 pandas now supports creating sparse dataframes directly from ``scipy.sparse.spmatrix`` instances.
 See the :ref:`documentation <sparse.scipysparse>` for more information. (:issue:`4343`)
 
-All sparse formats are supported, but matrices that are not in :mod:`COOrdinate <scipy.sparse>` format will be converted, copying data as needed.
+All sparse formats are supported, but matrices that are not in ``COOrdinate`` format will be converted, copying data as needed.
 
 .. code-block:: python
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -314,7 +314,7 @@ Other enhancements
 - :meth:`Series.update` now accepts objects that can be coerced to a :class:`Series`,
   such as ``dict`` and ``list``, mirroring the behavior of :meth:`DataFrame.update` (:issue:`33215`)
 - :meth:`.DataFrameGroupBy.transform` and :meth:`.DataFrameGroupBy.aggregate` have gained ``engine`` and ``engine_kwargs`` arguments that support executing functions with ``Numba`` (:issue:`32854`, :issue:`33388`)
-- :meth:`.Resampler.interpolate` now supports SciPy interpolation method :class:`scipy.interpolate.CubicSpline` as method ``cubicspline`` (:issue:`33670`)
+- :meth:`.Resampler.interpolate` now supports SciPy interpolation method ``scipy.interpolate.CubicSpline`` as method ``cubicspline`` (:issue:`33670`)
 - :class:`.DataFrameGroupBy` and :class:`.SeriesGroupBy` now implement the ``sample`` method for doing random sampling within groups (:issue:`31775`)
 - :meth:`DataFrame.to_numpy` now supports the ``na_value`` keyword to control the NA sentinel in the output array (:issue:`33820`)
 - Added :class:`api.extension.ExtensionArray.equals` to the extension array interface, similar to :meth:`Series.equals` (:issue:`27081`)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -751,7 +751,7 @@ def to_datetime(
         - If :const:`True` parses dates with the year first, e.g.
           :const:`"10/11/12"` is parsed as :const:`2010-11-12`.
         - If both `dayfirst` and `yearfirst` are :const:`True`, `yearfirst` is
-          preceded (same as :mod:`dateutil`).
+          preceded (same as ``dateutil``).
 
         .. warning::
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1941,7 +1941,7 @@ class PlotAccessor(PandasObject):
             The method used to calculate the estimator bandwidth. This can be
             'scott', 'silverman', a scalar constant or a callable.
             If None (default), 'scott' is used.
-            See :class:`scipy.stats.gaussian_kde` for more information.
+            See ``scipy.stats.gaussian_kde`` for more information.
         ind : NumPy array or int, optional
             Evaluation points for the estimated PDF. If None (default),
             1000 equally spaced points are used. If `ind` is a NumPy array, the


### PR DESCRIPTION
Historically and recently, fetching the Scipy intersphinx mapping has been unreliable (https://github.com/scipy/docs.scipy.org/issues/102) e.g.

https://github.com/pandas-dev/pandas/actions/runs/23811386462/job/69399063862#step:9:23

```python
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.scipy.org/doc/scipy/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectTimeout'>:
```

We very sparsely reference Scipy objects in the pandas documentation (including very old whatsnew files) anyways, so just modifying the references to Scipy objects to remove the Sphinx mapping.

Also removes fetching the intersphinx mapping for dateutil as well since it was only used once (incorrectly) to avoid another network call when building the docs.