### PR TITLE
PERF: use cached transition data for ZoneInfo timezones

### DIFF
--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -4,6 +4,9 @@ from datetime import (
     timezone,
 )
 import zoneinfo
+import zoneinfo._common as _zoneinfo_common
+import zoneinfo._tzpath as _zoneinfo_tzpath
+from zoneinfo._zoneinfo import _parse_tz_str as _zoneinfo_parse_tz_str
 
 from pandas.compat._optional import import_optional_dependency
 
@@ -208,6 +211,8 @@ cdef object tz_cache_key(tzinfo tz):
                              "of passing a timezone object. See "
                              "https://github.com/pandas-dev/pandas/pull/7362")
         return "dateutil" + tz._filename
+    elif is_zoneinfo(tz):
+        return "zoneinfo/" + tz.key
     else:
         return None
 
@@ -255,6 +260,71 @@ cdef object _get_utc_trans_times_from_dateutil_tz(tzinfo tz):
             last_std_offset = tti.offset
         new_trans[i] = trans - last_std_offset
     return new_trans
+
+
+cdef object _load_zoneinfo_transition_data(str key):
+    """Load raw transition data for a ZoneInfo timezone from the TZ database."""
+    file_path = _zoneinfo_tzpath.find_tzfile(key)
+    if file_path is not None:
+        file_obj = open(file_path, "rb")
+    else:
+        file_obj = _zoneinfo_common.load_tzdata(key)
+
+    with file_obj as f:
+        return _zoneinfo_common.load_data(f)
+
+
+cdef object _get_future_transitions(str tz_str, int64_t last_hist_utc):
+    """
+    Generate future DST transitions from the POSIX TZ string rules.
+
+    Parameters
+    ----------
+    tz_str : str
+        POSIX TZ string (e.g. "PST8PDT,M3.2.0,M11.1.0").
+    last_hist_utc : int64_t
+        UTC timestamp (seconds) of the last historical transition.
+
+    Returns
+    -------
+    list of (int64_t, int64_t)
+        Pairs of (utc_timestamp_seconds, utcoffset_seconds) for each
+        future transition, sorted by timestamp.
+    """
+    rule = _zoneinfo_parse_tz_str(tz_str)
+    if not hasattr(rule, "transitions"):
+        # Fixed-offset POSIX rule (no DST), no future transitions.
+        return []
+
+    cdef:
+        int std_off = int(rule.std.utcoff.total_seconds())
+        int dst_off = int(rule.dst.utcoff.total_seconds())
+        int64_t start_utc, end_utc
+        int start_year
+        list result = []
+
+    try:
+        start_year = datetime.fromtimestamp(
+            last_hist_utc, timezone.utc
+        ).year
+    except (OSError, OverflowError, ValueError):
+        start_year = 1970
+
+    for year in range(start_year, 2100):
+        try:
+            year_trans = rule.transitions(year)
+        except (ValueError, OverflowError):
+            break
+        if not year_trans:
+            break
+        start_utc, end_utc = year_trans
+        if start_utc > last_hist_utc:
+            result.append((start_utc, dst_off))
+        if end_utc > last_hist_utc:
+            result.append((end_utc, std_off))
+
+    result.sort()
+    return result
 
 
 @cython.wraparound(False)
@@ -340,6 +410,68 @@ cdef object get_dst_info(tzinfo tz):
                 # (under the just-deleted code that returned empty arrays)
                 raise AssertionError("dateutil tzinfo is not a FixedOffset "
                                      "and has an empty `_trans_list`.", tz)
+        elif is_zoneinfo(tz):
+            zi_trans_idx, zi_trans_utc, zi_utcoff, _, _, tz_str = (
+                _load_zoneinfo_transition_data(tz.key)
+            )
+            ntr = len(zi_trans_utc)
+
+            # Historical transition times and offsets
+            if ntr > 0:
+                zi_utcoff_arr = np.array(zi_utcoff, dtype=np.int64)
+                zi_trans_idx_arr = np.array(zi_trans_idx, dtype=np.intp)
+                hist_trans = (
+                    np.array(zi_trans_utc, dtype=np.int64) * 1_000_000_000
+                )
+                hist_deltas = (
+                    zi_utcoff_arr[zi_trans_idx_arr] * 1_000_000_000
+                )
+            else:
+                hist_trans = np.array([], dtype=np.int64)
+                hist_deltas = np.array([], dtype=np.int64)
+
+            # Future transitions from POSIX TZ string rules
+            if tz_str:
+                last_hist = zi_trans_utc[-1] if ntr > 0 else 0
+                future = _get_future_transitions(
+                    tz_str.decode(), last_hist
+                )
+            else:
+                future = []
+
+            if future:
+                fut_trans = np.array(
+                    [ts for ts, _ in future], dtype=np.int64
+                ) * 1_000_000_000
+                fut_deltas = np.array(
+                    [off for _, off in future], dtype=np.int64
+                ) * 1_000_000_000
+                hist_trans = np.concatenate([hist_trans, fut_trans])
+                hist_deltas = np.concatenate([hist_deltas, fut_deltas])
+
+            if len(hist_trans) == 0:
+                # Fixed-offset timezone (e.g. Etc/GMT+5, GMT)
+                trans = np.array([NPY_NAT + 1], dtype=np.int64)
+                deltas = np.array(
+                    [int(zi_utcoff[0]) * 1_000_000_000], dtype=np.int64
+                )
+                typ = "fixed"
+            else:
+                # Prepend sentinel and "before" offset.
+                # utcoff[0] matches the C implementation of ZoneInfo
+                # (see find_ttinfo in CPython's _zoneinfo.c), which
+                # returns _ttinfos[0] for timestamps before the
+                # first transition.
+                trans = np.empty(len(hist_trans) + 1, dtype=np.int64)
+                trans[0] = NPY_NAT + 1
+                trans[1:] = hist_trans
+
+                deltas = np.empty(len(hist_deltas) + 1, dtype=np.int64)
+                deltas[0] = int(zi_utcoff[0]) * 1_000_000_000
+                deltas[1:] = hist_deltas
+
+                typ = "zoneinfo"
+
         else:
             # static tzinfo, we can get here with pytz.StaticTZInfo
             #  which are not caught by treat_tz_as_pytz

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -270,8 +270,8 @@ cdef object _load_zoneinfo_transition_data(str key):
     else:
         file_obj = _zoneinfo_common.load_tzdata(key)
 
-    with file_obj as f:
-        return _zoneinfo_common.load_data(f)
+    with file_obj as fd:
+        return _zoneinfo_common.load_data(fd)
 
 
 cdef object _get_future_transitions(str tz_str, int64_t last_hist_utc):

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -317,7 +317,11 @@ cdef object _get_future_transitions(str tz_str, int64_t last_hist_utc):
             break
         if not year_trans:
             break
-        start_utc, end_utc = year_trans
+        # transitions() returns wall-clock times, not UTC.
+        # DST start is in standard time, DST end is in DST time.
+        start_wall, end_wall = year_trans
+        start_utc = start_wall - std_off
+        end_utc = end_wall - dst_off
         if start_utc > last_hist_utc:
             result.append((start_utc, dst_off))
         if end_utc > last_hist_utc:

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -83,7 +83,7 @@ cdef class Localizer:
         if is_utc(tz) or tz is None:
             self.use_utc = True
 
-        elif is_tzlocal(tz) or is_zoneinfo(tz):
+        elif is_tzlocal(tz):
             self.use_tzlocal = True
 
         else:
@@ -109,7 +109,7 @@ cdef class Localizer:
             self.ntrans = self.trans.shape[0]
             self.deltas = deltas
 
-            if typ != "pytz" and typ != "dateutil":
+            if typ not in ("pytz", "dateutil", "zoneinfo"):
                 # static/fixed; in this case we know that len(delta) == 1
                 self.use_fixed = True
                 self.delta = deltas[0]

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -6,8 +6,10 @@ from datetime import (
 import subprocess
 import sys
 import textwrap
+from zoneinfo import ZoneInfo
 
 import dateutil.tz
+import numpy as np
 import pytest
 
 from pandas._libs.tslibs import (
@@ -16,7 +18,10 @@ from pandas._libs.tslibs import (
 )
 from pandas.compat import is_platform_windows
 
-from pandas import Timestamp
+from pandas import (
+    Timestamp,
+    date_range,
+)
 
 
 @pytest.mark.single_cpu
@@ -191,3 +196,35 @@ def test_maybe_get_tz_offset_only():
 
     tz = timezones.maybe_get_tz("UTC-02:45")
     assert tz == timezone(-timedelta(hours=2, minutes=45))
+
+
+def test_zoneinfo_utc_to_local_post_2037():
+    # GH#64363 - verify that ZoneInfo DST transitions after 2037
+    # (generated from POSIX TZ string rules) produce correct local times.
+    tz = ZoneInfo("US/Pacific")
+    utc_times = date_range("2040-07-01", periods=24, freq="h", tz="UTC")
+    local = utc_times.tz_convert(tz)
+
+    expected_hours = np.array(
+        [
+            datetime(2040, 7, 1, hour, tzinfo=timezone.utc).astimezone(tz).hour
+            for hour in range(24)
+        ]
+    )
+    import pandas._testing as tm
+
+    tm.assert_numpy_array_equal(local.hour.to_numpy(), expected_hours)
+
+
+@pytest.mark.parametrize("key", ["US/Eastern", "Africa/Lusaka", "Asia/Qyzylorda"])
+def test_zoneinfo_utc_to_local_pre_first_transition(key):
+    # GH#64363 - verify that ZoneInfo offsets before the first historical
+    # transition (LMT era) match what ZoneInfo itself returns.  The "before"
+    # offset must be utcoff[0] from the TZ data (matching CPython's C
+    # implementation), NOT the first non-DST transition offset.
+    tz = ZoneInfo(key)
+    ts = Timestamp("1850-01-01", tz="UTC").tz_convert(tz)
+    result = ts.hour
+
+    expected = datetime(1850, 1, 1, tzinfo=timezone.utc).astimezone(tz).hour
+    assert result == expected

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -210,7 +210,8 @@ def test_zoneinfo_utc_to_local_post_2037():
         [
             datetime(2040, 7, 1, hour, tzinfo=timezone.utc).astimezone(tz).hour
             for hour in range(24)
-        ]
+        ],
+        dtype=np.int32,
     )
     tm.assert_numpy_array_equal(local.hour.to_numpy(), expected_hours)
 

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -224,7 +224,6 @@ def test_zoneinfo_utc_to_local_pre_first_transition(key):
     # implementation), NOT the first non-DST transition offset.
     tz = ZoneInfo(key)
     ts = Timestamp("1850-01-01", tz="UTC").tz_convert(tz)
-    result = ts.hour
 
-    expected = datetime(1850, 1, 1, tzinfo=timezone.utc).astimezone(tz).hour
-    assert result == expected
+    expected = datetime(1850, 1, 1, tzinfo=timezone.utc).astimezone(tz)
+    assert ts.minute == expected.minute

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -22,6 +22,7 @@ from pandas import (
     Timestamp,
     date_range,
 )
+import pandas._testing as tm
 
 
 @pytest.mark.single_cpu
@@ -211,8 +212,6 @@ def test_zoneinfo_utc_to_local_post_2037():
             for hour in range(24)
         ]
     )
-    import pandas._testing as tm
-
     tm.assert_numpy_array_equal(local.hour.to_numpy(), expected_hours)
 
 


### PR DESCRIPTION
Not for merging, mostly just to demonstrate a test for #64379