### PR TITLE
DOC: Note that groupby column becomes the index in 10min tutorial

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -548,6 +548,8 @@ groups:
 
    df.groupby("A")[["C", "D"]].sum()
 
+The unique values of the grouped column now form the index of the result.
+
 Grouping by multiple columns label forms :class:`MultiIndex`.
 
 .. ipython:: python


### PR DESCRIPTION
## Summary
- Add a note in the "10 Minutes to pandas" groupby section explaining that the grouped column becomes the index of the result, which clarifies the seemingly misaligned column headers in the output.

closes #26955

## Test plan
- [ ] Verify the rst renders correctly by building the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)