### PR TITLE
BUG: fix DataFrame repr exceeding terminal width after horizontal truncation

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -237,6 +237,7 @@ I/O
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
+- Bug in :meth:`DataFrame.__repr__` where horizontally truncated output could exceed the terminal width by up to 4 characters because the ``" ..."`` separator column was not accounted for in the width budget (:issue:`32461`)
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)

--- a/pandas/io/formats/string.py
+++ b/pandas/io/formats/string.py
@@ -168,6 +168,10 @@ class StringFormatter:
             # is_truncated_horizontally remains False.
             return self.adj.adjoin(1, *strcols)
 
+        # Account for the " ..." separator column that will be inserted
+        # after horizontal truncation (GH#32461)
+        adj_dif += 4 + 1  # 4 chars for " ..." + 1 adjoin spacing
+
         while adj_dif > 0 and n_cols > 1:
             mid = round(n_cols / 2)
             # adjoin adds one

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -285,6 +285,31 @@ class TestDataFrameFormatting:
         )
         assert "..." not in str(df)
 
+    def test_repr_truncation_accounts_for_dot_separator(self, monkeypatch):
+        # GH#32461 - repr should not exceed terminal width after inserting
+        # the " ..." separator column during horizontal truncation.
+        # Width 82 hits the boundary where the unfixed code overflows by 4
+        # because the " ..." separator column (4 chars + 1 adjoin spacing)
+        # was not budgeted.
+        terminal_width = 82
+        monkeypatch.setattr(
+            "pandas.io.formats.string.get_terminal_size",
+            lambda: (terminal_width, 24),
+        )
+
+        ncols = 20
+        df = DataFrame(
+            {
+                f"col_{idx:02d}": np.random.default_rng(2).standard_normal(3)
+                for idx in range(ncols)
+            }
+        )
+
+        with option_context("display.width", terminal_width, "display.max_columns", 0):
+            result = repr(df)
+            for line in result.split("\n"):
+                assert len(line) <= terminal_width
+
     def test_repr_truncation_column_size(self):
         # dataframe with last column very wide -> check it is not used to
         # determine size of truncation (...) column


### PR DESCRIPTION
NB: I manually checked that the test example spills outside the terminal width on main, truncates correctly on this branch.

## Summary
- closes #32461
- `_fit_strcols_to_terminal_width` calculates how many columns to remove so the repr fits the terminal, then calls `truncate()` + `_get_strcols()` which inserts a `" ..."` separator column. This separator (4 chars + 1 adjoin spacing) was not budgeted for, causing the repr to overflow by up to 4 characters.
- Fix: add `adj_dif += 4 + 1` before the column-removal loop to account for the separator.

## Test plan
- [x] Added `test_repr_truncation_accounts_for_dot_separator` that monkeypatches terminal size and asserts every line of the repr fits within the width
- [x] Existing `test_format.py` tests pass (188/188)

🤖 Generated with [Claude Code](https://claude.com/claude-code)