### PR TITLE
[backport 3.0.x] DOC: start 3.0.3 whatsnew notes (#64942)

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -16,6 +16,7 @@ Version 3.0
 .. toctree::
    :maxdepth: 2
 
+   v3.0.3
    v3.0.2
    v3.0.1
    v3.0.0

--- a/doc/source/whatsnew/v3.0.1.rst
+++ b/doc/source/whatsnew/v3.0.1.rst
@@ -29,7 +29,7 @@ Fixed regressions
 .. _whatsnew_301.bugs:
 
 Bug fixes
-^^^^^^^^^
+~~~~~~~~~
 - Fixed a bug in the :class:`DataFrame` constructor when passed a :class:`Series` or
   :class:`Index` correctly handling Copy-on-Write (:issue:`63899`)
 - Added additional typing aliases in :py:mod:`pandas.api.typing.aliases` (:issue:`64098`)

--- a/doc/source/whatsnew/v3.0.2.rst
+++ b/doc/source/whatsnew/v3.0.2.rst
@@ -33,7 +33,7 @@ Fixed regressions
 .. _whatsnew_302.bug_fixes:
 
 Bug fixes
-^^^^^^^^^
+~~~~~~~~~
 - Fixed a bug in :func:`to_datetime` that could give an unnecessary ``RuntimeWarning`` when converting DataFrame containing missing values (:issue:`64141`)
 - Fixed a bug in :meth:`Series.var` computing the variance of complex numbers incorrectly (:issue:`62421`)
 - Fixed a bug in :meth:`~DataFrame.to_hdf` with string columns raising an error when using compression (:issue:`64180`)
@@ -49,4 +49,4 @@ Bug fixes
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v3.0.1..v3.0.2|HEAD
+.. contributors:: v3.0.1..v3.0.2

--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -1,0 +1,29 @@
+.. _whatsnew_303:
+
+What's new in 3.0.3 (April XX, 2026)
+---------------------------------------
+
+These are the changes in pandas 3.0.3. See :ref:`release` for a full changelog
+including other versions of pandas.
+
+{{ header }}
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_303.regressions:
+
+Fixed regressions
+~~~~~~~~~~~~~~~~~
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_303.bug_fixes:
+
+Bug fixes
+~~~~~~~~~
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_303.contributors:
+
+Contributors
+~~~~~~~~~~~~
+
+.. contributors:: v3.0.2..v3.0.3|HEAD


### PR DESCRIPTION
(cherry picked from commit b3331038ea3a8844e069b539d7cca98af80ba704)
Backport of https://github.com/pandas-dev/pandas/pull/64942