### PR TITLE
DOC: move 3.1 whatsnew to its own section in index.rst

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -10,13 +10,20 @@ This is the list of changes to pandas between each release. For full details,
 see the `commit logs <https://github.com/pandas-dev/pandas/commits/>`_. For install and
 upgrade instructions, see :ref:`install`.
 
-Version 3.0
+Version 3.1
 -----------
 
 .. toctree::
    :maxdepth: 2
 
    v3.1.0
+
+Version 3.0
+-----------
+
+.. toctree::
+   :maxdepth: 2
+
    v3.0.3
    v3.0.2
    v3.0.1


### PR DESCRIPTION
To be consistent with how it is done for the other whatsnew entries