### PR TITLE
DOC: clarify NDFrame.get returns default when any list key is missing

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4447,6 +4447,17 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         >>> ser.get("2014-02-10", "[unknown]")
         '[unknown]'
+
+        When passing a list of keys, all keys must be present. If any key
+        is missing, the ``default`` value is returned instead of a partial result.
+
+        >>> ser = pd.Series(["a", "b", "c"], index=[1, 2, 3])
+        >>> ser.get([1, 2])
+        1    a
+        2    b
+        dtype: str
+        >>> ser.get([1, 2, -1]) is None
+        True
         """
         try:
             return self[key]


### PR DESCRIPTION
closes #36248

Adds a note and examples to the `NDFrame.get` docstring clarifying that when passing a list of keys, all keys must be present or the `default` value is returned. This was a common source of confusion (users expected partial results for partially-matching key lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)