### PR TITLE
DOC: document silent integer overflow in gotchas page

### DIFF
--- a/doc/source/user_guide/gotchas.rst
+++ b/doc/source/user_guide/gotchas.rst
@@ -338,8 +338,6 @@ overflow without raising an error:
 
 .. ipython:: python
 
-   import numpy as np
-
    series = pd.Series([406, 372, 496, 41, 63, 118, 311, 271, 431, 95, 57, 52])
    series.dtype
 

--- a/doc/source/user_guide/gotchas.rst
+++ b/doc/source/user_guide/gotchas.rst
@@ -360,8 +360,8 @@ correct result:
 
 This behavior comes from NumPy and affects all integer arithmetic operations
 (addition, subtraction, multiplication, etc.), not just :meth:`~Series.prod`. See the
-`NumPy documentation on integer overflow <https://numpy.org/doc/stable/reference/generated/numpy.iinfo.html>`__
-for more details on the ranges of each integer type.
+`NumPy documentation on overflow errors <https://numpy.org/doc/stable/user/basics.types.html#overflow-errors>`__
+for more details.
 
 If your computation may exceed ``int64`` range, you can convert to ``float64`` first
 (at the cost of precision for very large values) or use Python's built-in integers

--- a/doc/source/user_guide/gotchas.rst
+++ b/doc/source/user_guide/gotchas.rst
@@ -329,6 +329,51 @@ However, R ``NA`` semantics are now available by using masked NumPy types such a
 or PyArrow types (:class:`ArrowDtype`).
 
 
+Integer overflow
+----------------
+
+pandas uses NumPy's fixed-width integer types (``int64`` by default) rather than
+Python's arbitrary-precision integers. This means integer arithmetic can silently
+overflow without raising an error:
+
+.. ipython:: python
+
+   import numpy as np
+
+   series = pd.Series([406, 372, 496, 41, 63, 118, 311, 271, 431, 95, 57, 52])
+   series.dtype
+
+The product of these integers exceeds the range of ``int64``, so the result wraps
+around silently:
+
+.. ipython:: python
+
+   series.prod()
+
+Compare this to pure Python, which uses arbitrary-precision integers and gives the
+correct result:
+
+.. ipython:: python
+
+   python_product = 1
+   for val in [406, 372, 496, 41, 63, 118, 311, 271, 431, 95, 57, 52]:
+       python_product *= val
+   python_product
+
+This behavior comes from NumPy and affects all integer arithmetic operations
+(addition, subtraction, multiplication, etc.), not just :meth:`~Series.prod`. See the
+`NumPy documentation on integer overflow <https://numpy.org/doc/stable/reference/generated/numpy.iinfo.html>`__
+for more details on the ranges of each integer type.
+
+If your computation may exceed ``int64`` range, you can convert to ``float64`` first
+(at the cost of precision for very large values) or use Python's built-in integers
+via ``object`` dtype:
+
+.. ipython:: python
+
+   series.astype("float64").prod()
+   series.astype("object").prod()
+
 Differences with NumPy
 ----------------------
 For :class:`Series` and :class:`DataFrame` objects, :meth:`~DataFrame.var` normalizes by


### PR DESCRIPTION
## Summary
- Adds an "Integer overflow" section to the FAQ/gotchas documentation page explaining that pandas uses NumPy's fixed-width int64 (not Python's arbitrary-precision integers), so integer arithmetic can silently overflow
- Shows the issue with a concrete example using `Series.prod()`
- Documents workarounds: casting to `float64` or `object` dtype

closes #15557

## Test plan
- [ ] Verify the new `.. ipython::` blocks render correctly in the built docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)