### PR TITLE
DOC: remove stale "if level specified" from reduction docstrings

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -16762,7 +16762,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         Returns
         -------
-        Series or DataFrame (if level specified)
+        Series
             Unbiased standard error of the mean over requested axis.
 
         See Also

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -8949,7 +8949,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        scalar or Series (if level specified)
+        scalar
             The minimum of the values in the Series.
 
         See Also
@@ -9020,7 +9020,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        scalar or Series (if level specified)
+        scalar
             The maximum of the values in the Series.
 
         See Also
@@ -9098,7 +9098,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        scalar or Series (if level specified)
+        scalar
             Sum of the values for the requested axis.
 
         See Also
@@ -9277,7 +9277,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        scalar or Series (if level specified)
+        scalar
             Mean of the values for the requested axis.
 
         See Also
@@ -9336,7 +9336,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        scalar or Series (if level specified)
+        scalar
             Median of the values for the requested axis.
 
         See Also
@@ -9418,7 +9418,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        scalar or Series (if level specified)
+        scalar
             Unbiased standard error of the mean over requested axis.
 
         See Also
@@ -9483,7 +9483,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Returns
         -------
-        scalar or Series (if level specified)
+        scalar
             Unbiased variance over requested axis.
 
         See Also


### PR DESCRIPTION
## Summary
- Remove outdated "(if level specified)" from the Returns sections of several Series and DataFrame reduction method docstrings
- The `level` parameter was removed long ago, but these docstrings still referenced it: `Series.min`, `Series.max`, `Series.sum`, `Series.mean`, `Series.median`, `Series.sem`, `Series.var`, and `DataFrame.sem`

closes #19892

🤖 Generated with [Claude Code](https://claude.com/claude-code)