### PR TITLE
DOC: note optional dependencies for remote URL schemes in read_* docstrings

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -213,6 +213,10 @@ def read_excel(
         URL schemes include http, ftp, s3, and file. For file URLs, a host is
         expected. A local file could be: ``file://localhost/path/to/table.xlsx``.
 
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
+
         If you want to pass in a path object, pandas accepts any ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method,

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -103,6 +103,10 @@ def read_feather(
         object implementing a binary ``read()`` function. The string could be a URL.
         Valid URL schemes include http, ftp, s3, gs and file. For file URLs, a host is
         expected. A local file could be: ``file://localhost/path/to/table.feather``.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
     columns : sequence, default None
         If not provided, all columns are read.
     use_threads : bool, default True

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -570,6 +570,10 @@ def read_json(
         expected. A local file could be:
         ``file://localhost/path/to/table.json``.
 
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
+
         If you want to pass in a path object, pandas accepts any
         ``os.PathLike``.
 

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -62,6 +62,10 @@ def read_orc(
         Valid URL schemes include http, ftp, s3, and file. For file URLs, a host is
         expected. A local file could be:
         ``file://localhost/path/to/table.orc``.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
     columns : list, default None
         If not None, only these columns will be read from the file.
         Output always follows the ordering of the file and not the columns list.

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -554,6 +554,11 @@ def read_parquet(
         The string could be a URL. Valid URL schemes include http, ftp, s3,
         gs, and file. For file URLs, a host is expected. A local file could be:
         ``file://localhost/path/to/table.parquet``.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
+
         A file URL can also be a path to a directory that contains multiple
         partitioned parquet files. Both pyarrow and fastparquet support
         paths to directories as well as file URLs. A directory path could be:

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -428,6 +428,10 @@ def read_csv(
         URL schemes include http, ftp, s3, gs, and file. For file URLs, a host is
         expected. A local file could be: file://localhost/path/to/table.csv.
 
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
+
         If you want to pass in a path object, pandas accepts any ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method, such as
@@ -999,6 +1003,10 @@ def read_table(
         URL schemes include http, ftp, s3, gs, and file. For file URLs, a host is
         expected. A local file could be: file://localhost/path/to/table.csv.
 
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
+
         If you want to pass in a path object, pandas accepts any ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method, such as
@@ -1519,6 +1527,10 @@ def read_fwf(
         Valid URL schemes include http, ftp, s3, and file. For file URLs, a host is
         expected. A local file could be:
         ``file://localhost/path/to/table.csv``.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
     colspecs : list of tuple (int, int) or 'infer'. optional
         A list of tuples giving the extents of the fixed-width
         fields of each line as half-open intervals (i.e.,  [from, to] ).

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -48,6 +48,10 @@ def to_pickle(
         String, path object (implementing ``os.PathLike[str]``), or file-like
         object implementing a binary ``write()`` function.
         Also accepts URL. URL has to be of S3 or GCS.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
     compression : str or dict, default 'infer'
         For on-the-fly compression of the output data. If 'infer' and
         'filepath_or_buffer' is path-like, then detect compression from the
@@ -147,6 +151,10 @@ def read_pickle(
         String, path object (implementing ``os.PathLike[str]``), or file-like
         object implementing a binary ``readlines()`` function.
         Also accepts URL. URL is not limited to S3 and GCS.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
     compression : str or dict, default 'infer'
         For on-the-fly decompression of on-disk data. If 'infer' and
         'filepath_or_buffer' is path-like, then detect compression from the

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -107,6 +107,10 @@ def read_sas(
         a URL. Valid URL schemes include http, ftp, s3, and file. For file
         URLs, a host is expected. A local file could be:
         ``file://localhost/path/to/table.sas7bdat``.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
     format : str {'xport', 'sas7bdat'} or None
         If None, file format is inferred from file extension. If 'xport' or
         'sas7bdat', uses the corresponding format.

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2130,6 +2130,10 @@ def read_stata(
         URL schemes include http, ftp, s3, and file. For file URLs, a host is
         expected. A local file could be: ``file://localhost/path/to/table.dta``.
 
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
+
         If you want to pass in a path object, pandas accepts any ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method,

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -884,6 +884,10 @@ def read_xml(
         The string can further be a URL. Valid URL schemes
         include http, ftp, s3, and file.
 
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
+
     xpath : str, optional, default './\*'
         The ``XPath`` to parse required set of nodes for migration to
         :class:`~pandas.DataFrame`.``XPath`` should return a collection of elements


### PR DESCRIPTION
## Summary
- Adds a note to the `filepath_or_buffer` / `path` parameter docstrings of all `read_*` functions (and `to_pickle`) that support remote URLs, mentioning that certain URL schemes require additional packages (e.g. `s3fs` for S3)
- Cross-references `:ref:install.optional_dependencies` for the full list
- Applies to: `read_csv`, `read_fwf`, `read_json`, `read_excel`, `read_parquet`, `read_feather`, `read_orc`, `read_stata`, `read_sas`, `read_xml`, `read_pickle`, and `to_pickle`

closes #35206

🤖 Generated with [Claude Code](https://claude.com/claude-code)