### PR TITLE
BUG: Fix pyarrow-backed string dtype addition with missing values

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -20,6 +20,10 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
+- Bug in :class:`ArrowStringArray` where adding missing values (e.g. :attr:`NA`)
+  did not correctly propagate NA, sometimes raising ``TypeError`` or returning
+  incorrect values (:issue:`64968`)
+
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.contributors:
 

--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -20,9 +20,8 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
-- Bug in :class:`ArrowStringArray` where adding missing values (e.g. :attr:`NA`)
-  did not correctly propagate NA, sometimes raising ``TypeError`` or returning
-  incorrect values (:issue:`64968`)
+- Fixed a bug in adding missing values (e.g. :attr:`NA`) to a pyarrow-backed string array or Series
+  raising an error instead of propagating the missing value (:issue:`64968`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.contributors:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1001,7 +1001,7 @@ class ArrowExtensionArray(
             if op in [operator.add, roperator.radd]:
                 sep = pa.scalar("", type=pa_type)
                 if isinstance(other, pa.Scalar) and pc.is_null(other).as_py():
-                    return self._from_pyarrow_array(pa.nulls(len(self._pa_array), type=pa_type))
+                    other = other.cast(pa_type)
                 try:
                     if op is operator.add:
                         result = pc.binary_join_element_wise(self._pa_array, other, sep)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1000,6 +1000,8 @@ class ArrowExtensionArray(
         ):
             if op in [operator.add, roperator.radd]:
                 sep = pa.scalar("", type=pa_type)
+                if isinstance(other, pa.Scalar) and pc.is_null(other).as_py():
+                    return self._from_pyarrow_array(pa.nulls(len(self._pa_array), type=pa_type))
                 try:
                     if op is operator.add:
                         result = pc.binary_join_element_wise(self._pa_array, other, sep)

--- a/pandas/tests/arithmetic/test_string.py
+++ b/pandas/tests/arithmetic/test_string.py
@@ -485,6 +485,8 @@ def test_comparison_methods_list(comparison_op, any_string_dtype, box, request):
 
 def test_string_add_missing_values(any_string_dtype):
     # GH#64968 Arrow-backed str arrays should return NA when added to missing
+    if any_string_dtype == object:
+        pytest.skip("object dtype does not support NA propagation for string add")
     arr = pd.array(["y"], dtype=any_string_dtype)
     for na_val in [None, np.nan, NA]:
         # left side

--- a/pandas/tests/arithmetic/test_string.py
+++ b/pandas/tests/arithmetic/test_string.py
@@ -481,3 +481,16 @@ def test_comparison_methods_list(comparison_op, any_string_dtype, box, request):
             # if GH#62766 is addressed this check can be removed
             expected = tm.box_expected(expected, box)
         tm.assert_equal(result, expected)
+
+
+def test_string_add_missing_values(any_string_dtype):
+    # GH#64968 Arrow-backed str arrays should return NA when added to missing
+    arr = pd.array(["y"], dtype=any_string_dtype)
+    for na_val in [None, np.nan, pd.NA]:
+        # left side
+        result = arr + na_val
+        expected = pd.array([pd.NA], dtype=any_string_dtype)
+        tm.assert_extension_array_equal(result, expected)
+        # right side
+        result = na_val + arr
+        tm.assert_extension_array_equal(result, expected)

--- a/pandas/tests/arithmetic/test_string.py
+++ b/pandas/tests/arithmetic/test_string.py
@@ -486,10 +486,10 @@ def test_comparison_methods_list(comparison_op, any_string_dtype, box, request):
 def test_string_add_missing_values(any_string_dtype):
     # GH#64968 Arrow-backed str arrays should return NA when added to missing
     arr = pd.array(["y"], dtype=any_string_dtype)
-    for na_val in [None, np.nan, pd.NA]:
+    for na_val in [None, np.nan, NA]:
         # left side
         result = arr + na_val
-        expected = pd.array([pd.NA], dtype=any_string_dtype)
+        expected = pd.array([NA], dtype=any_string_dtype)
         tm.assert_extension_array_equal(result, expected)
         # right side
         result = na_val + arr

--- a/pandas/tests/arithmetic/test_string.py
+++ b/pandas/tests/arithmetic/test_string.py
@@ -244,6 +244,21 @@ def test_add_sequence(any_string_dtype, request, using_infer_string):
     tm.assert_extension_array_equal(result, expected)
 
 
+def test_string_add_missing_values(string_dtype_no_object):
+    # GH#64968 Arrow-backed str arrays should return NA when added to missing
+    arr = pd.array(["y"], dtype=string_dtype_no_object)
+    expected = pd.array([NA], dtype=string_dtype_no_object)
+
+    for na_val in [None, np.nan, NA]:
+        # left side
+        result = arr + na_val
+        tm.assert_extension_array_equal(result, expected)
+
+        # right side
+        result = na_val + arr
+        tm.assert_extension_array_equal(result, expected)
+
+
 def test_mul(any_string_dtype):
     dtype = any_string_dtype
     a = pd.array(["a", "b", None], dtype=dtype)
@@ -481,18 +496,3 @@ def test_comparison_methods_list(comparison_op, any_string_dtype, box, request):
             # if GH#62766 is addressed this check can be removed
             expected = tm.box_expected(expected, box)
         tm.assert_equal(result, expected)
-
-
-def test_string_add_missing_values(any_string_dtype):
-    # GH#64968 Arrow-backed str arrays should return NA when added to missing
-    if any_string_dtype == object:
-        pytest.skip("object dtype does not support NA propagation for string add")
-    arr = pd.array(["y"], dtype=any_string_dtype)
-    for na_val in [None, np.nan, NA]:
-        # left side
-        result = arr + na_val
-        expected = pd.array([NA], dtype=any_string_dtype)
-        tm.assert_extension_array_equal(result, expected)
-        # right side
-        result = na_val + arr
-        tm.assert_extension_array_equal(result, expected)

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -332,3 +332,11 @@ def test_string_dtype_error_message():
     msg = "Storage must be 'python' or 'pyarrow'."
     with pytest.raises(ValueError, match=msg):
         StringDtype("bla")
+
+def test_arrow_str_add_pd_na():
+    # GH#64968 Arrow-backed str arrays should return NA when added to pd.NA
+    pytest.importorskip("pyarrow")
+    arrow_col = pd.array(["y"], dtype="str")
+    result = arrow_col + pd.NA
+    expected = pd.array([pd.NA], dtype="str")
+    tm.assert_extension_array_equal(result, expected)

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -332,11 +332,3 @@ def test_string_dtype_error_message():
     msg = "Storage must be 'python' or 'pyarrow'."
     with pytest.raises(ValueError, match=msg):
         StringDtype("bla")
-
-def test_arrow_str_add_pd_na():
-    # GH#64968 Arrow-backed str arrays should return NA when added to pd.NA
-    pytest.importorskip("pyarrow")
-    arrow_col = pd.array(["y"], dtype="str")
-    result = arrow_col + pd.NA
-    expected = pd.array([pd.NA], dtype="str")
-    tm.assert_extension_array_equal(result, expected)


### PR DESCRIPTION
Closes #64968

## Problem
When adding `pd.NA` to an Arrow-backed string array, a `TypeError` was raised:
```python
arrow_col = pd.array(["y"], dtype="str")
arrow_col + pd.NA
# TypeError: operation 'add' not supported for dtype 'str' 
# with object of type <class 'pandas.api.typing.NAType'>
```

This only affected PyArrow-backed string arrays. Python-backed string arrays worked correctly.

## Root Cause
In `_evaluate_op_method` (arrow/array.py), `pd.NA` gets boxed to a null `pa.Scalar` via `self._box_pa(other)`. 

When the array is a string type and op is `add`, the code calls `pc.binary_join_element_wise()` — but PyArrow's `binary_join_element_wise` cannot handle a null scalar with no type information, so it raises `ArrowNotImplementedError` which was re-raised as `TypeError`.

## Fix
Added a null check before calling `pc.binary_join_element_wise`. When `other` is a null scalar, we return `pa.nulls(...)` directly — matching the behavior of Python-backed string arrays.
```python
if isinstance(other, pa.Scalar) and pc.is_null(other).as_py():
    return self._from_pyarrow_array(
        pa.nulls(len(self._pa_array), type=pa_type)
    )
```

## Testing
Added a test in `pandas/tests/arrays/string_/test_string_arrow.py` covering:
- `arrow_col + pd.NA`
- `pd.NA + arrow_col` (radd)