### PR TITLE
TST: add test for display.precision with float in object index

### DIFF
--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1923,15 +1923,14 @@ class TestGenericArrayFormatter:
         assert res[1] == " [[False, True], [True, False]]"
 
 
-class TestDisplayPrecisionObjectIndex:
-    def test_precision_float_in_object_index(self):
-        # GH#25919 - display.precision not honored for float values in object index
-        float_val = 0.55555555
-        df = DataFrame([float_val, "foo"], index=[float_val, "foo"])
-        with option_context("display.precision", 3):
-            result = repr(df)
-        assert "0.556" in result
-        assert "0.55555555" not in result
+def test_precision_float_in_object_index():
+    # GH#25919 - display.precision not honored for float values in object index
+    float_val = 0.55555555
+    df = DataFrame([float_val, "foo"], index=[float_val, "foo"])
+    with option_context("display.precision", 3):
+        result = repr(df)
+    assert "0.556" in result
+    assert "0.55555555" not in result
 
 
 def _three_digit_exp():

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1923,6 +1923,17 @@ class TestGenericArrayFormatter:
         assert res[1] == " [[False, True], [True, False]]"
 
 
+class TestDisplayPrecisionObjectIndex:
+    def test_precision_float_in_object_index(self):
+        # GH#25919 - display.precision not honored for float values in object index
+        float_val = 0.55555555
+        df = DataFrame([float_val, "foo"], index=[float_val, "foo"])
+        with option_context("display.precision", 3):
+            result = repr(df)
+        assert "0.556" in result
+        assert "0.55555555" not in result
+
+
 def _three_digit_exp():
     return f"{1.7e8:.4g}" == "1.7e+008"
 


### PR DESCRIPTION
## Summary
- Add regression test for GH#25919 (`display.precision` not honored for float values in an object-dtype index), which has already been fixed
- Closes #25919

## Test plan
- [x] `pytest pandas/tests/io/formats/test_format.py::TestDisplayPrecisionObjectIndex` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)