### PR TITLE
CI: Fix numpy nightly failures from generic timedelta64 deprecation

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -389,7 +389,7 @@ class Isnull:
                 np.nan,
                 None,
                 np.datetime64("NaT"),
-                np.timedelta64("NaT"),
+                np.timedelta64("NaT", "ns"),
                 0,
                 1,
                 2.0,

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -269,7 +269,7 @@ class CountMultiDtype:
         offsets = np.random.randint(n, size=n).astype("timedelta64[ns]")
         dates = np.datetime64("now") + offsets
         dates[np.random.rand(n) > 0.5] = np.datetime64("nat")
-        offsets[np.random.rand(n) > 0.5] = np.timedelta64("nat")
+        offsets[np.random.rand(n) > 0.5] = np.timedelta64("NaT", "ns")
         value2 = np.random.randn(n)
         value2[np.random.rand(n) > 0.5] = np.nan
         obj = np.random.choice(list("ab"), size=n).astype(object)

--- a/asv_bench/benchmarks/tslibs/timedelta.py
+++ b/asv_bench/benchmarks/tslibs/timedelta.py
@@ -12,7 +12,7 @@ from pandas import Timedelta
 
 class TimedeltaConstructor:
     def setup(self):
-        self.nptimedelta64 = np.timedelta64(3600)
+        self.nptimedelta64 = np.timedelta64(3600, "s")
         self.dttimedelta = datetime.timedelta(seconds=3600)
         self.td = Timedelta(3600, unit="s")
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -292,9 +292,11 @@ cdef class _NaT(datetime):
             # GH#44460
             dtype = np.dtype(dtype)
             if dtype.kind == "M":
-                return np.datetime64("NaT").astype(dtype)
+                unit = np.datetime_data(dtype)[0]
+                return np.datetime64("NaT", unit)
             elif dtype.kind == "m":
-                return np.timedelta64("NaT").astype(dtype)
+                unit = np.datetime_data(dtype)[0]
+                return np.timedelta64("NaT", unit)
             else:
                 raise ValueError(
                     "NaT.to_numpy dtype must be a datetime64 dtype, timedelta64 "

--- a/pandas/core/arrays/_utils.py
+++ b/pandas/core/arrays/_utils.py
@@ -61,9 +61,11 @@ def to_numpy_dtype_inference(
         elif result_dtype.kind == "f":
             na_value = np.nan
         elif result_dtype.kind == "M":
-            na_value = np.datetime64("nat")
+            unit = np.datetime_data(result_dtype)[0]
+            na_value = np.datetime64("NaT", unit)
         elif result_dtype.kind == "m":
-            na_value = np.timedelta64("nat")
+            unit = np.datetime_data(result_dtype)[0]
+            na_value = np.timedelta64("NaT", unit)
         else:
             na_value = arr.dtype.na_value
 

--- a/pandas/core/arrays/_utils.py
+++ b/pandas/core/arrays/_utils.py
@@ -61,11 +61,11 @@ def to_numpy_dtype_inference(
         elif result_dtype.kind == "f":
             na_value = np.nan
         elif result_dtype.kind == "M":
-            unit = np.datetime_data(result_dtype)[0]
-            na_value = np.datetime64("NaT", unit)
+            unit = np.datetime_data(result_dtype)[0]  # type: ignore[arg-type]
+            na_value = np.datetime64("NaT", unit)  # type: ignore[call-overload]
         elif result_dtype.kind == "m":
-            unit = np.datetime_data(result_dtype)[0]
-            na_value = np.timedelta64("NaT", unit)
+            unit = np.datetime_data(result_dtype)[0]  # type: ignore[arg-type]
+            na_value = np.timedelta64("NaT", unit)  # type: ignore[call-overload]
         else:
             na_value = arr.dtype.na_value
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1042,7 +1042,8 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             # e.g. test_numeric_arr_mul_tdscalar_numexpr_path
             from pandas.core.arrays import TimedeltaArray
 
-            result[mask] = result.dtype.type("NaT")
+            unit = np.datetime_data(result.dtype)[0]
+            result[mask] = np.timedelta64("NaT", unit)  # type: ignore[call-overload]
 
             if not isinstance(result, TimedeltaArray):
                 return TimedeltaArray._simple_new(result, dtype=result.dtype)

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -684,7 +684,8 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             # In astype, we consider dtype=float to also mean na_value=np.nan
             na_value = np.nan
         elif dtype.kind == "M":
-            na_value = np.datetime64("NaT", np.datetime_data(dtype)[0])
+            unit = np.datetime_data(dtype)[0]
+            na_value = np.datetime64("NaT", unit)  # type: ignore[call-overload]
         else:
             na_value = lib.no_default
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -684,7 +684,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             # In astype, we consider dtype=float to also mean na_value=np.nan
             na_value = np.nan
         elif dtype.kind == "M":
-            na_value = np.datetime64("NaT")
+            na_value = np.datetime64("NaT", np.datetime_data(dtype)[0])
         else:
             na_value = lib.no_default
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -594,7 +594,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 if fill_value is NaT:
                     # Can't put pd.NaT in a datetime64[ns]
                     unit = np.datetime_data(self.sp_values.dtype)[0]
-                    fill_value = np.datetime64("NaT", unit)
+                    fill_value = np.datetime64("NaT", unit)  # type: ignore[call-overload]
             try:
                 dtype = np.result_type(self.sp_values.dtype, type(fill_value))
             except TypeError:

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -593,7 +593,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 # a datetime64 with pandas NaT.
                 if fill_value is NaT:
                     # Can't put pd.NaT in a datetime64[ns]
-                    fill_value = np.datetime64("NaT")
+                    unit = np.datetime_data(self.sp_values.dtype)[0]
+                    fill_value = np.datetime64("NaT", unit)
             try:
                 dtype = np.result_type(self.sp_values.dtype, type(fill_value))
             except TypeError:

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -792,7 +792,7 @@ def is_integer_dtype(arr_or_dtype) -> bool:
     False
     >>> is_integer_dtype(pd.Series([1, 2]))
     True
-    >>> is_integer_dtype(np.array([], dtype=np.timedelta64))
+    >>> is_integer_dtype(np.array([], dtype="m8[ns]"))
     False
     >>> is_integer_dtype(pd.Index([1, 2.0]))  # float
     False
@@ -859,7 +859,7 @@ def is_signed_integer_dtype(arr_or_dtype) -> bool:
     False
     >>> is_signed_integer_dtype(pd.Series([1, 2]))
     True
-    >>> is_signed_integer_dtype(np.array([], dtype=np.timedelta64))
+    >>> is_signed_integer_dtype(np.array([], dtype="m8[ns]"))
     False
     >>> is_signed_integer_dtype(pd.Index([1, 2.0]))  # float
     False
@@ -1166,7 +1166,7 @@ def is_timedelta64_ns_dtype(arr_or_dtype) -> bool:
     False
     >>> is_timedelta64_ns_dtype(np.array([1, 2], dtype="m8[ns]"))
     True
-    >>> is_timedelta64_ns_dtype(np.array([1, 2], dtype=np.timedelta64))
+    >>> is_timedelta64_ns_dtype(np.array([1, 2], dtype="m8"))
     False
     """
     return _is_dtype(arr_or_dtype, lambda dtype: dtype == TD64NS_DTYPE)
@@ -1310,7 +1310,7 @@ def is_numeric_dtype(arr_or_dtype) -> bool:
     True
     >>> is_numeric_dtype(pd.Index([1, 2.0]))
     True
-    >>> is_numeric_dtype(np.array([], dtype=np.timedelta64))
+    >>> is_numeric_dtype(np.array([], dtype="m8[ns]"))
     False
     """
     return _is_dtype_type(

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -371,7 +371,7 @@ def _wrap_results(result, dtype: np.dtype, fill_value=None):
     elif dtype.kind == "m":
         if not isinstance(result, np.ndarray):
             if result == fill_value or np.isnan(result):
-                result = np.timedelta64("NaT").astype(dtype)
+                result = np.timedelta64("NaT", np.datetime_data(dtype)[0])
 
             elif np.fabs(result) > lib.i8max:
                 # raise if we have a timedelta64[ns] which is too large

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -371,7 +371,8 @@ def _wrap_results(result, dtype: np.dtype, fill_value=None):
     elif dtype.kind == "m":
         if not isinstance(result, np.ndarray):
             if result == fill_value or np.isnan(result):
-                result = np.timedelta64("NaT", np.datetime_data(dtype)[0])
+                unit = np.datetime_data(dtype)[0]
+                result = np.timedelta64("NaT", unit)  # type: ignore[call-overload]
 
             elif np.fabs(result) > lib.i8max:
                 # raise if we have a timedelta64[ns] which is too large

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -879,7 +879,7 @@ class TestDatetime64Arithmetic:
         tz = tz_naive_fixture
 
         dti = date_range("1994-04-01", periods=9, tz=tz, freq="QS", unit="ns")
-        other = np.timedelta64("NaT")
+        other = np.timedelta64("NaT", "ns")
         expected = DatetimeIndex(["NaT"] * 9, tz=tz).as_unit("ns")
 
         obj = tm.box_expected(dti, box_with_array)
@@ -2463,11 +2463,11 @@ def test_non_nano_dt64_addsub_np_nat_scalars_unitless():
     # GH 52295
     # TODO: Can we default to the ser unit?
     ser = Series([1233242342344, 232432434324, 332434242344], dtype="datetime64[ms]")
-    result = ser - np.datetime64("nat")
+    result = ser - np.datetime64("nat", "ms")
     expected = Series([NaT] * 3, dtype="timedelta64[ms]")
     tm.assert_series_equal(result, expected)
 
-    result = ser + np.timedelta64("nat")
+    result = ser + np.timedelta64("NaT", "ms")
     expected = Series([NaT] * 3, dtype="datetime64[ms]")
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -331,7 +331,7 @@ class TestNumericArraylikeArithmeticWithDatetimeLike:
             Timedelta(hours=31).to_pytimedelta(),
             Timedelta(hours=31).to_timedelta64(),
             Timedelta(hours=31).to_timedelta64().astype("m8[h]"),
-            np.timedelta64("NaT"),
+            np.timedelta64("NaT", "ns"),
             np.timedelta64("NaT", "D"),
             pd.offsets.Minute(3),
             pd.offsets.Second(0),

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -347,6 +347,9 @@ class TestNumericArraylikeArithmeticWithDatetimeLike:
         ],
         ids=repr,
     )
+    @pytest.mark.filterwarnings(
+        "ignore:Using 'generic' unit for NumPy timedelta:DeprecationWarning"
+    )
     def test_add_sub_datetimedeltalike_invalid(
         self, numeric_idx, other, box_with_array
     ):

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -1128,7 +1128,7 @@ class TestPeriodIndexArithmetic:
     def test_parr_add_sub_td64_nat(self, box_with_array, transpose):
         # GH#23320 special handling for timedelta64("NaT")
         pi = period_range("1994-04-01", periods=9, freq="19D")
-        other = np.timedelta64("NaT")
+        other = np.timedelta64("NaT", "ns")
         expected = PeriodIndex(["NaT"] * 9, freq="19D")
 
         obj = tm.box_expected(pi, box_with_array, transpose=transpose)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -209,8 +209,8 @@ class TestTimedelta64ArrayComparisons:
                 [
                     np.timedelta64(2, "D"),
                     np.timedelta64(2, "D"),
-                    np.timedelta64("nat"),
-                    np.timedelta64("nat"),
+                    np.timedelta64("NaT", "ns"),
+                    np.timedelta64("NaT", "ns"),
                     np.timedelta64(1, "D") + np.timedelta64(2, "s"),
                     np.timedelta64(5, "D") + np.timedelta64(3, "s"),
                 ]
@@ -561,8 +561,8 @@ class TestTimedelta64ArithmeticUnsorted:
         rng = pd.date_range("2013", "2014")
         s = Series(rng)
         result1 = rng - offsets.Hour(1)
-        result2 = DatetimeIndex(s - np.timedelta64(100000000))
-        result3 = rng - np.timedelta64(100000000)
+        result2 = DatetimeIndex(s - np.timedelta64(100000000, "ns"))
+        result3 = rng - np.timedelta64(100000000, "ns")
         result4 = DatetimeIndex(s - offsets.Hour(1))
 
         assert result1.freq == rng.freq
@@ -1292,7 +1292,7 @@ class TestTimedeltaArraylikeAddSubOps:
         tm.assert_equal(result, -expected)
         assert_dtype(result, "timedelta64[ns]")
 
-    @pytest.mark.parametrize("tdnat", [np.timedelta64("NaT"), NaT])
+    @pytest.mark.parametrize("tdnat", [np.timedelta64("NaT", "us"), NaT])
     def test_td64arr_add_sub_td64_nat(self, box_with_array, tdnat):
         # GH#18808, GH#23320 special handling for timedelta64("NaT")
         box = box_with_array
@@ -1721,7 +1721,7 @@ class TestTimedeltaArraylikeMulDivOps:
         rng = timedelta_range("1 days", "10 days")
         rng = tm.box_expected(rng, box)
 
-        other = np.timedelta64("NaT")
+        other = np.timedelta64("NaT", "ns")
 
         expected = np.array([np.nan] * 10)
         expected = tm.box_expected(expected, xbox)

--- a/pandas/tests/arrays/boolean/test_logical.py
+++ b/pandas/tests/arrays/boolean/test_logical.py
@@ -47,7 +47,7 @@ class TestLogicalOps(BaseOpsUtil):
         tm.assert_extension_array_equal(a, result)
 
     @pytest.mark.parametrize(
-        "other", ["a", pd.Timestamp(2017, 1, 1, 12), np.timedelta64(4)]
+        "other", ["a", pd.Timestamp(2017, 1, 1, 12), np.timedelta64(4, "ns")]
     )
     def test_eq_mismatched_type(self, other):
         # GH-44499

--- a/pandas/tests/arrays/masked/test_indexing.py
+++ b/pandas/tests/arrays/masked/test_indexing.py
@@ -41,7 +41,7 @@ class TestSetitemValidation:
         "1.0",
         pd.NaT,
         np.datetime64("NaT"),
-        np.timedelta64("NaT"),
+        np.timedelta64("NaT", "ns"),
     ]
 
     @pytest.mark.parametrize(

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -657,7 +657,7 @@ class TestDatetimeArray:
             1,
             np.int64(1),
             1.0,
-            np.timedelta64("NaT"),
+            np.timedelta64("NaT", "ns"),
             pd.Timedelta(days=2),
             "invalid",
             np.arange(10, dtype="i8") * 24 * 3600 * 10**9,

--- a/pandas/tests/dtypes/cast/test_downcast.py
+++ b/pandas/tests/dtypes/cast/test_downcast.py
@@ -44,11 +44,17 @@ def test_downcast_conversion_empty(any_real_numpy_dtype):
     tm.assert_numpy_array_equal(result, np.array([], dtype=np.int64))
 
 
-@pytest.mark.parametrize("klass", [np.datetime64, np.timedelta64])
-def test_datetime_likes_nan(klass):
+@pytest.mark.parametrize(
+    "klass, nat",
+    [
+        (np.datetime64, np.datetime64("NaT", "ns")),
+        (np.timedelta64, np.timedelta64("NaT", "ns")),
+    ],
+)
+def test_datetime_likes_nan(klass, nat):
     dtype = np.dtype(klass.__name__ + "[ns]")
     arr = np.array([1, 2, np.nan])
 
-    exp = np.array([1, 2, klass("NaT")], dtype)
+    exp = np.array([1, 2, nat], dtype)
     res = maybe_downcast_to_dtype(arr, dtype)
     tm.assert_numpy_array_equal(res, exp)

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -529,6 +529,9 @@ def test_is_datetime64_ns_dtype():
     assert not com.is_datetime64_ns_dtype(DatetimeTZDtype("us", "US/Eastern"))
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Using 'generic' unit for NumPy timedelta:DeprecationWarning"
+)
 def test_is_timedelta64_ns_dtype():
     assert not com.is_timedelta64_ns_dtype(np.dtype("m8[ps]"))
     assert not com.is_timedelta64_ns_dtype(np.array([1, 2], dtype="m8"))

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -365,7 +365,7 @@ def test_is_integer_dtype(dtype):
         np.timedelta64,
         pd.Index([1, 2.0]),
         np.array(["a", "b"]),
-        np.array([], dtype=np.timedelta64),
+        np.array([], dtype="m8[ns]"),
     ],
 )
 def test_is_not_integer_dtype(dtype):
@@ -399,7 +399,7 @@ def test_is_signed_integer_dtype(dtype):
         np.timedelta64,
         pd.Index([1, 2.0]),
         np.array(["a", "b"]),
-        np.array([], dtype=np.timedelta64),
+        np.array([], dtype="m8[ns]"),
         *tm.UNSIGNED_INT_NUMPY_DTYPES,
         *to_numpy_dtypes(tm.UNSIGNED_INT_NUMPY_DTYPES),
         *tm.UNSIGNED_INT_EA_DTYPES,
@@ -437,7 +437,7 @@ def test_is_unsigned_integer_dtype(dtype):
         np.timedelta64,
         pd.Index([1, 2.0]),
         np.array(["a", "b"]),
-        np.array([], dtype=np.timedelta64),
+        np.array([], dtype="m8[ns]"),
         *tm.SIGNED_INT_NUMPY_DTYPES,
         *to_numpy_dtypes(tm.SIGNED_INT_NUMPY_DTYPES),
         *tm.SIGNED_INT_EA_DTYPES,
@@ -531,7 +531,7 @@ def test_is_datetime64_ns_dtype():
 
 def test_is_timedelta64_ns_dtype():
     assert not com.is_timedelta64_ns_dtype(np.dtype("m8[ps]"))
-    assert not com.is_timedelta64_ns_dtype(np.array([1, 2], dtype=np.timedelta64))
+    assert not com.is_timedelta64_ns_dtype(np.array([1, 2], dtype="m8"))
 
     assert com.is_timedelta64_ns_dtype(np.dtype("m8[ns]"))
     assert com.is_timedelta64_ns_dtype(np.array([1, 2], dtype="m8[ns]"))
@@ -566,7 +566,7 @@ def test_is_numeric_dtype():
     assert not com.is_numeric_dtype(np.datetime64)
     assert not com.is_numeric_dtype(np.timedelta64)
     assert not com.is_numeric_dtype(np.array(["a", "b"]))
-    assert not com.is_numeric_dtype(np.array([], dtype=np.timedelta64))
+    assert not com.is_numeric_dtype(np.array([], dtype="m8[ns]"))
 
     assert com.is_numeric_dtype(int)
     assert com.is_numeric_dtype(float)

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -850,7 +850,9 @@ class TestInference:
         tm.assert_numpy_array_equal(out, exp)
 
         arr = np.array([pd.NaT, np.timedelta64(1, "s")], dtype=object)
-        exp = np.array([np.timedelta64("NaT"), np.timedelta64(1, "s")], dtype="m8[s]")
+        exp = np.array(
+            [np.timedelta64("NaT", "s"), np.timedelta64(1, "s")], dtype="m8[s]"
+        )
         out = lib.maybe_convert_objects(arr, convert_non_numeric=True)
         tm.assert_numpy_array_equal(out, exp)
 
@@ -1339,10 +1341,10 @@ class TestTypeInference:
         "arr",
         [
             np.array(
-                [np.timedelta64("nat"), np.datetime64("2011-01-02")], dtype=object
+                [np.timedelta64("NaT", "ns"), np.datetime64("2011-01-02")], dtype=object
             ),
             np.array(
-                [np.datetime64("2011-01-02"), np.timedelta64("nat")], dtype=object
+                [np.datetime64("2011-01-02"), np.timedelta64("NaT", "ns")], dtype=object
             ),
             np.array([np.datetime64("2011-01-01"), Timestamp("2011-01-02")]),
             np.array([Timestamp("2011-01-02"), np.datetime64("2011-01-01")]),
@@ -1512,21 +1514,25 @@ class TestTypeInference:
             arr = np.array([pd.NaT, n, np.datetime64("nat"), n])
             assert lib.infer_dtype(arr, skipna=False) == "datetime64"
 
-        arr = np.array([np.timedelta64("nat")], dtype=object)
+        arr = np.array([np.timedelta64("NaT", "ns")], dtype=object)
         assert lib.infer_dtype(arr, skipna=False) == "timedelta"
 
         for n in [np.nan, pd.NaT, None]:
-            arr = np.array([n, np.timedelta64("nat"), n])
+            arr = np.array([n, np.timedelta64("NaT", "ns"), n])
             assert lib.infer_dtype(arr, skipna=False) == "timedelta"
 
-            arr = np.array([pd.NaT, n, np.timedelta64("nat"), n])
+            arr = np.array([pd.NaT, n, np.timedelta64("NaT", "ns"), n])
             assert lib.infer_dtype(arr, skipna=False) == "timedelta"
 
         # datetime / timedelta mixed
-        arr = np.array([pd.NaT, np.datetime64("nat"), np.timedelta64("nat"), np.nan])
+        arr = np.array(
+            [pd.NaT, np.datetime64("nat"), np.timedelta64("NaT", "ns"), np.nan]
+        )
         assert lib.infer_dtype(arr, skipna=False) == "mixed"
 
-        arr = np.array([np.timedelta64("nat"), np.datetime64("nat")], dtype=object)
+        arr = np.array(
+            [np.timedelta64("NaT", "ns"), np.datetime64("nat")], dtype=object
+        )
         assert lib.infer_dtype(arr, skipna=False) == "mixed"
 
     def test_is_datetimelike_array_all_nan_nat_like(self):
@@ -1535,12 +1541,14 @@ class TestTypeInference:
         assert lib.is_datetime64_array(arr)
         assert not lib.is_timedelta_or_timedelta64_array(arr)
 
-        arr = np.array([np.nan, pd.NaT, np.timedelta64("nat")])
+        arr = np.array([np.nan, pd.NaT, np.timedelta64("NaT", "ns")])
         assert not lib.is_datetime_array(arr)
         assert not lib.is_datetime64_array(arr)
         assert lib.is_timedelta_or_timedelta64_array(arr)
 
-        arr = np.array([np.nan, pd.NaT, np.datetime64("nat"), np.timedelta64("nat")])
+        arr = np.array(
+            [np.nan, pd.NaT, np.datetime64("nat"), np.timedelta64("NaT", "ns")]
+        )
         assert not lib.is_datetime_array(arr)
         assert not lib.is_datetime64_array(arr)
         assert not lib.is_timedelta_or_timedelta64_array(arr)

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -161,7 +161,7 @@ class TestIsNA:
             [
                 NaT,
                 np.datetime64("NaT"),
-                np.timedelta64("NaT"),
+                np.timedelta64("NaT", "ns"),
                 np.datetime64("NaT", "s"),
             ]
         )
@@ -767,7 +767,7 @@ na_vals = (
         np.complex64(np.nan),
         np.complex128(np.nan),
         np.datetime64("NaT"),
-        np.timedelta64("NaT"),
+        np.timedelta64("NaT", "ns"),
     ]
     + [np.datetime64("NaT", unit) for unit in m8_units]  # type: ignore[call-overload]
     + [np.timedelta64("NaT", unit) for unit in m8_units]  # type: ignore[call-overload]

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1132,7 +1132,7 @@ class TestDataFrameIndexing:
         df.loc[df.index[:3], "C"] = np.array([3 * one_hour] * 3, dtype="m8[ns]")
         df.loc[:, "D"] = np.array([4 * one_hour] * 4, dtype="m8[ns]")
         df.loc[df.index[:3], "E"] = np.array([5 * one_hour] * 3, dtype="m8[ns]")
-        df["F"] = np.timedelta64("NaT")
+        df["F"] = np.timedelta64("NaT", "ns")
         df.loc[df.index[:-1], "F"] = np.array([6 * one_hour] * 3, dtype="m8[ns]")
         df.loc[df.index[-3] :, "G"] = date_range("20130101", periods=3, unit="ns")
         df["H"] = np.datetime64("NaT")
@@ -1917,7 +1917,7 @@ class TestSetitemValidation:
         "1.0",
         pd.NaT,
         np.datetime64("NaT"),
-        np.timedelta64("NaT"),
+        np.timedelta64("NaT", "ns"),
     ]
     _indexers = [0, [0], slice(0, 1), [True, False, False], slice(None, None, None)]
 

--- a/pandas/tests/frame/test_repr.py
+++ b/pandas/tests/frame/test_repr.py
@@ -342,14 +342,17 @@ NaT   4"""
         df2 = DataFrame({"dt": Categorical(dt), "p": Categorical(p)})
         assert repr(df2) == exp
 
-    @pytest.mark.parametrize("arg", [np.datetime64, np.timedelta64])
+    @pytest.mark.parametrize(
+        "nat",
+        [np.datetime64("NaT", "ns"), np.timedelta64("NaT", "ns")],
+    )
     @pytest.mark.parametrize(
         "box, expected",
         [[Series, "0    NaT\ndtype: object"], [DataFrame, "     0\n0  NaT"]],
     )
-    def test_repr_np_nat_with_object(self, arg, box, expected):
+    def test_repr_np_nat_with_object(self, nat, box, expected):
         # GH 25445
-        result = repr(box([arg("NaT")], dtype=object))
+        result = repr(box([nat], dtype=object))
         assert result == expected
 
     def test_frame_datetime64_pre1900_repr(self):

--- a/pandas/tests/groupby/test_libgroupby.py
+++ b/pandas/tests/groupby/test_libgroupby.py
@@ -210,7 +210,11 @@ def test_cython_group_mean_datetimelike():
     counts = np.array([0], dtype="int64")
     data = (
         np.array(
-            [np.timedelta64(2, "ns"), np.timedelta64(4, "ns"), np.timedelta64("NaT")],
+            [
+                np.timedelta64(2, "ns"),
+                np.timedelta64(4, "ns"),
+                np.timedelta64("NaT", "ns"),
+            ],
             dtype="m8[ns]",
         )[:, None]
         .view("int64")
@@ -238,7 +242,7 @@ def test_cython_group_mean_not_datetimelike_but_has_NaT_values():
     counts = np.array([0], dtype="int64")
     data = (
         np.array(
-            [np.timedelta64("NaT"), np.timedelta64("NaT")],
+            [np.timedelta64("NaT", "ns"), np.timedelta64("NaT", "ns")],
             dtype="m8[ns]",
         )[:, None]
         .view("int64")

--- a/pandas/tests/indexes/categorical/test_indexing.py
+++ b/pandas/tests/indexes/categorical/test_indexing.py
@@ -365,7 +365,7 @@ class TestContains:
         assert None in obj
         assert pd.NaT in obj
         assert np.datetime64("NaT") in obj
-        assert np.timedelta64("NaT") not in obj
+        assert np.timedelta64("NaT", "ns") not in obj
 
         obj2 = CategoricalIndex(tdi)
         if unwrap:
@@ -375,7 +375,7 @@ class TestContains:
         assert None in obj2
         assert pd.NaT in obj2
         assert np.datetime64("NaT") not in obj2
-        assert np.timedelta64("NaT") in obj2
+        assert np.timedelta64("NaT", "ns") in obj2
 
         obj3 = CategoricalIndex(pi)
         if unwrap:
@@ -385,7 +385,7 @@ class TestContains:
         assert None in obj3
         assert pd.NaT in obj3
         assert np.datetime64("NaT") not in obj3
-        assert np.timedelta64("NaT") not in obj3
+        assert np.timedelta64("NaT", "ns") not in obj3
 
     @pytest.mark.parametrize(
         "item, expected",

--- a/pandas/tests/indexes/datetimes/methods/test_insert.py
+++ b/pandas/tests/indexes/datetimes/methods/test_insert.py
@@ -33,7 +33,7 @@ class TestInsert:
     def test_insert_invalid_na(self, tz):
         idx = DatetimeIndex(["2017-01-01"], tz=tz)
 
-        item = np.timedelta64("NaT")
+        item = np.timedelta64("NaT", "ns")
         result = idx.insert(0, item)
         expected = Index([item, *list(idx)], dtype=object)
         tm.assert_index_equal(result, expected)
@@ -236,7 +236,7 @@ class TestInsert:
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "item", [0, np.int64(0), np.float64(0), np.array(0), np.timedelta64(456)]
+        "item", [0, np.int64(0), np.float64(0), np.array(0), np.timedelta64(456, "ns")]
     )
     def test_insert_mismatched_types_raises(self, tz_aware_fixture, item):
         # GH#33703 dont cast these to dt64

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1422,7 +1422,7 @@ class TestDateRangeNonNano:
 
         exp = np.arange(
             start.astype("M8[s]").view("i8"),
-            (end + 1).astype("M8[s]").view("i8"),
+            (end + np.timedelta64(1, "D")).astype("M8[s]").view("i8"),
             24 * 3600,
         ).view("M8[s]")
 

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -479,7 +479,7 @@ class TestGetLoc:
         assert index.get_loc(np.datetime64("NaT")) == 1
 
         with pytest.raises(KeyError, match="NaT"):
-            index.get_loc(np.timedelta64("NaT"))
+            index.get_loc(np.timedelta64("NaT", "ns"))
 
     @pytest.mark.parametrize("key", [pd.Timedelta(0), pd.Timedelta(1), timedelta(0)])
     def test_get_loc_timedelta_invalid_key(self, key):

--- a/pandas/tests/indexes/period/test_searchsorted.py
+++ b/pandas/tests/indexes/period/test_searchsorted.py
@@ -68,7 +68,7 @@ class TestSearchsorted:
             pidx.searchsorted(other.astype("timedelta64[ns]"))
 
         with pytest.raises(TypeError, match=msg):
-            pidx.searchsorted(np.timedelta64(4))
+            pidx.searchsorted(np.timedelta64(4, "ns"))
 
         with pytest.raises(TypeError, match=msg):
             pidx.searchsorted(np.timedelta64("NaT", "ms"))

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -124,7 +124,7 @@ class TestIndexConstructorInference:
         "klass,dtype,ctor",
         [
             (DatetimeIndex, "datetime64[ns]", np.datetime64("nat")),
-            (TimedeltaIndex, "timedelta64[ns]", np.timedelta64("nat")),
+            (TimedeltaIndex, "timedelta64[ns]", np.timedelta64("NaT", "ns")),
         ],
     )
     def test_constructor_infer_nat_dt_like(
@@ -164,7 +164,7 @@ class TestIndexConstructorInference:
     @pytest.mark.parametrize("swap_objs", [True, False])
     def test_constructor_mixed_nat_objs_infers_object(self, swap_objs):
         # mixed np.datetime64/timedelta64 nat results in object
-        data = [np.datetime64("nat"), np.timedelta64("nat")]
+        data = [np.datetime64("nat"), np.timedelta64("NaT", "ns")]
         if swap_objs:
             data = data[::-1]
 

--- a/pandas/tests/indexes/timedeltas/methods/test_insert.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_insert.py
@@ -74,7 +74,7 @@ class TestTimedeltaIndexInsert:
             assert result.freq == expected.freq
 
     @pytest.mark.parametrize(
-        "null", [None, np.nan, np.timedelta64("NaT"), pd.NaT, pd.NA]
+        "null", [None, np.nan, np.timedelta64("NaT", "ns"), pd.NaT, pd.NA]
     )
     def test_insert_nat(self, null):
         # GH 18295 (test missing)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -725,7 +725,7 @@ class TestMerge:
     def test_join_append_timedeltas2(self):
         # timedelta64 issues with join/merge
         # GH 5695
-        td = np.timedelta64(300000000)
+        td = np.timedelta64(300000000, "ns")
         lhs = DataFrame(Series([td, td], index=["A", "B"]))
         rhs = DataFrame(Series([td], index=["A"]))
 

--- a/pandas/tests/scalar/interval/test_arithmetic.py
+++ b/pandas/tests/scalar/interval/test_arithmetic.py
@@ -150,9 +150,11 @@ class TestIntervalArithmetic:
         with pytest.raises((TypeError, ValueError), match=msg):
             delta + interval
 
-    @pytest.mark.parametrize("klass", [timedelta, np.timedelta64, Timedelta])
-    def test_timedelta_add_timestamp_interval(self, klass):
-        delta = klass(0)
+    @pytest.mark.parametrize(
+        "delta",
+        [timedelta(0), np.timedelta64(0, "ns"), Timedelta(0)],
+    )
+    def test_timedelta_add_timestamp_interval(self, delta):
         expected = Interval(Timestamp("2020-01-01"), Timestamp("2020-02-01"))
 
         result = delta + expected

--- a/pandas/tests/scalar/interval/test_arithmetic.py
+++ b/pandas/tests/scalar/interval/test_arithmetic.py
@@ -135,6 +135,9 @@ class TestIntervalArithmetic:
     @pytest.mark.parametrize(
         "delta", [Timedelta(days=7), timedelta(7), np.timedelta64(7, "D")]
     )
+    @pytest.mark.filterwarnings(
+        "ignore:Using 'generic' unit for NumPy timedelta:DeprecationWarning"
+    )
     def test_numeric_interval_add_timedelta_raises(self, interval, delta):
         # https://github.com/pandas-dev/pandas/issues/32023
         msg = "|".join(

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -439,7 +439,8 @@ def test_nat_arithmetic_scalar(op_name, value, val_type):
 
 
 @pytest.mark.parametrize(
-    "val,expected", [(np.nan, NaT), (NaT, np.nan), (np.timedelta64("NaT"), np.nan)]
+    "val,expected",
+    [(np.nan, NaT), (NaT, np.nan), (np.timedelta64("NaT", "ns"), np.nan)],
 )
 def test_nat_rfloordiv_timedelta(val, expected):
     # see gh-#18846

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -196,7 +196,7 @@ class TestTimedeltaAdditionSubtraction:
 
     def test_td_sub_td64_nat(self):
         td = Timedelta(10, unit="D")
-        td_nat = np.timedelta64("NaT")
+        td_nat = np.timedelta64("NaT", "ns")
 
         result = td - td_nat
         assert result is NaT
@@ -374,9 +374,7 @@ class TestTimedeltaMultiplicationDivision:
     # ---------------------------------------------------------------
     # Timedelta.__mul__, __rmul__
 
-    @pytest.mark.parametrize(
-        "td_nat", [NaT, np.timedelta64("NaT", "ns"), np.timedelta64("NaT")]
-    )
+    @pytest.mark.parametrize("td_nat", [NaT, np.timedelta64("NaT", "ns")])
     @pytest.mark.parametrize("op", [operator.mul, ops.rmul])
     def test_td_mul_nat(self, op, td_nat):
         # GH#19819
@@ -566,7 +564,7 @@ class TestTimedeltaMultiplicationDivision:
         result = None / td
         assert np.isnan(result)
 
-        result = np.timedelta64("NaT") / td
+        result = np.timedelta64("NaT", "ns") / td
         assert np.isnan(result)
 
         msg = r"unsupported operand type\(s\) for /: 'numpy.datetime64' and 'Timedelta'"
@@ -625,7 +623,7 @@ class TestTimedeltaMultiplicationDivision:
 
         assert td // np.nan is NaT
         assert np.isnan(td // NaT)
-        assert np.isnan(td // np.timedelta64("NaT"))
+        assert np.isnan(td // np.timedelta64("NaT", "ns"))
 
     def test_td_floordiv_offsets(self):
         # GH#19738
@@ -671,7 +669,9 @@ class TestTimedeltaMultiplicationDivision:
         expected = np.array([3], dtype=np.int64)
         tm.assert_numpy_array_equal(res, expected)
 
-        res = (10 * td) // np.array([scalar.to_timedelta64(), np.timedelta64("NaT")])
+        res = (10 * td) // np.array(
+            [scalar.to_timedelta64(), np.timedelta64("NaT", "ns")]
+        )
         expected = np.array([10, np.nan])
         tm.assert_numpy_array_equal(res, expected)
 
@@ -705,7 +705,7 @@ class TestTimedeltaMultiplicationDivision:
         td = Timedelta(hours=3, minutes=3)
 
         assert np.isnan(td.__rfloordiv__(NaT))
-        assert np.isnan(td.__rfloordiv__(np.timedelta64("NaT")))
+        assert np.isnan(td.__rfloordiv__(np.timedelta64("NaT", "ns")))
 
     def test_td_rfloordiv_offsets(self):
         # GH#19738
@@ -757,7 +757,7 @@ class TestTimedeltaMultiplicationDivision:
         expected = np.array([3], dtype=np.int64)
         tm.assert_numpy_array_equal(res, expected)
 
-        arr = np.array([(10 * scalar).to_timedelta64(), np.timedelta64("NaT")])
+        arr = np.array([(10 * scalar).to_timedelta64(), np.timedelta64("NaT", "ns")])
         res = td.__rfloordiv__(arr)
         expected = np.array([10, np.nan])
         tm.assert_numpy_array_equal(res, expected)

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -540,9 +540,10 @@ def test_construction_out_of_bounds_td64ns(val, unit):
         td.as_unit("ns")
 
     # But just back in bounds and we are OK
-    assert Timedelta(td64 - 1) == td64 - 1
+    one = np.timedelta64(1, unit)
+    assert Timedelta(td64 - one) == td64 - one
 
-    td64 *= -1
+    td64 = np.timedelta64(-val, unit)
     assert td64.astype("m8[ns]").view("i8") > 0  # i.e. naive astype will be wrong
 
     td2 = Timedelta(td64)
@@ -551,7 +552,7 @@ def test_construction_out_of_bounds_td64ns(val, unit):
         td2.as_unit("ns")
 
     # But just back in bounds and we are OK
-    assert Timedelta(td64 + 1) == td64 + 1
+    assert Timedelta(td64 + one) == td64 + one
 
 
 @pytest.mark.parametrize(
@@ -569,7 +570,8 @@ def test_construction_out_of_bounds_td64s(val, unit):
         Timedelta(td64)
 
     # But just back in bounds and we are OK
-    assert Timedelta(td64 - 10**9) == td64 - 10**9
+    offset = np.timedelta64(10**9, unit)
+    assert Timedelta(td64 - offset) == td64 - offset
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -790,7 +790,7 @@ class TestTimestampConstructors:
             Timestamp(Timestamp.min._value * 2)
 
     def test_out_of_bounds_value(self):
-        one_us = np.timedelta64(1).astype("timedelta64[us]")
+        one_us = np.timedelta64(1, "ns").astype("timedelta64[us]")
 
         # By definition we can't go out of bounds in [ns], so we
         # convert the datetime64s to [us] so we can go out of bounds

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -652,7 +652,7 @@ class TestNonNano:
 
         # subtracting 3600*24 gives a datetime64 that _can_ fit inside the
         #  nanosecond implementation bounds.
-        other = Timestamp(dt64 - 3600 * 24).as_unit("ns")
+        other = Timestamp(dt64 - np.timedelta64(3600 * 24, "s")).as_unit("ns")
         assert other < ts
         assert other.asm8 > ts.asm8  # <- numpy gets this wrong
         assert ts > other

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -482,7 +482,7 @@ class TestSetitemValidation:
         "1.0",
         NaT,
         np.datetime64("NaT"),
-        np.timedelta64("NaT"),
+        np.timedelta64("NaT", "ns"),
     ]
     _indexers = [0, [0], slice(0, 1), [True, False, False], slice(None, None, None)]
 

--- a/pandas/tests/series/methods/test_equals.py
+++ b/pandas/tests/series/methods/test_equals.py
@@ -75,8 +75,8 @@ def test_equals_matching_nas():
     assert Index(left).equals(Index(right))
     assert left.array.equals(right.array)
 
-    left = Series([np.timedelta64("NaT")], dtype=object)
-    right = Series([np.timedelta64("NaT")], dtype=object)
+    left = Series([np.timedelta64("NaT", "ns")], dtype=object)
+    right = Series([np.timedelta64("NaT", "ns")], dtype=object)
     assert left.equals(right)
     assert Index(left).equals(Index(right))
     assert left.array.equals(right.array)

--- a/pandas/tests/series/methods/test_fillna.py
+++ b/pandas/tests/series/methods/test_fillna.py
@@ -222,7 +222,7 @@ class TestSeriesFillNA:
         expected = frame_or_series(expected)
         tm.assert_equal(result, expected)
 
-        result = obj.fillna(np.timedelta64(10**9))
+        result = obj.fillna(np.timedelta64(10**9, "ns"))
         expected = Series(
             [
                 timedelta(seconds=1),

--- a/pandas/tests/series/methods/test_quantile.py
+++ b/pandas/tests/series/methods/test_quantile.py
@@ -35,7 +35,7 @@ class TestSeriesQuantile:
         assert q == pd.to_timedelta("24:00:00")
 
         # GH7661
-        result = Series([np.timedelta64("NaT")]).sum()
+        result = Series([np.timedelta64("NaT", "ns")]).sum()
         assert result == pd.Timedelta(0)
 
         msg = "percentiles should all be in the interval \\[0, 1\\]"

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1496,22 +1496,22 @@ class TestSeriesConstructors:
         td = Series([timedelta(days=1), np.nan], dtype="m8[ns]")
         assert td.dtype == "timedelta64[ns]"
 
-        td = Series([np.timedelta64(300000000), NaT], dtype="m8[ns]")
+        td = Series([np.timedelta64(300000000, "ns"), NaT], dtype="m8[ns]")
         assert td.dtype == "timedelta64[ns]"
 
         # improved inference
         # GH5689
-        td = Series([np.timedelta64(300000000), NaT])
+        td = Series([np.timedelta64(300000000, "ns"), NaT])
         assert td.dtype == "timedelta64[ns]"
 
         # because iNaT is int, not coerced to timedelta
-        td = Series([np.timedelta64(300000000), iNaT])
+        td = Series([np.timedelta64(300000000, "ns"), iNaT])
         assert td.dtype == "object"
 
-        td = Series([np.timedelta64(300000000), np.nan])
+        td = Series([np.timedelta64(300000000, "ns"), np.nan])
         assert td.dtype == "timedelta64[ns]"
 
-        td = Series([NaT, np.timedelta64(300000000)])
+        td = Series([NaT, np.timedelta64(300000000, "ns")])
         assert td.dtype == "timedelta64[ns]"
 
         td = Series([np.timedelta64(1, "s")])

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1251,7 +1251,7 @@ class TestValueCounts:
             algos.value_counts_internal(np.array(["1", 1], dtype=object), bins=1)
 
     def test_value_counts_nat(self):
-        td = Series([np.timedelta64(10000), NaT], dtype="timedelta64[ns]")
+        td = Series([np.timedelta64(10000, "ns"), NaT], dtype="timedelta64[ns]")
         dt = to_datetime(["NaT", "2014-01-01"])
 
         for ser in [td, dt]:
@@ -1264,7 +1264,7 @@ class TestValueCounts:
         result_dt = algos.value_counts_internal(dt)
         tm.assert_series_equal(result_dt, exp_dt)
 
-        exp_td = Series([1], index=[np.timedelta64(10000)], name="count")
+        exp_td = Series([1], index=[np.timedelta64(10000, "ns")], name="count")
         result_td = algos.value_counts_internal(td)
         tm.assert_series_equal(result_td, exp_td)
 

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -240,7 +240,7 @@ class TestTimedeltas:
 
     def test_to_timedelta_on_missing_values(self):
         # GH5438
-        timedelta_NaT = np.timedelta64("NaT")
+        timedelta_NaT = np.timedelta64("NaT", "ns")
 
         actual = to_timedelta(Series(["00:00:01", np.nan]))
         expected = Series(
@@ -256,12 +256,12 @@ class TestTimedeltas:
     @pytest.mark.parametrize("val", [np.nan, pd.NaT, pd.NA])
     def test_to_timedelta_on_missing_values_scalar(self, val):
         actual = to_timedelta(val)
-        assert actual._value == np.timedelta64("NaT").astype("int64")
+        assert actual._value == np.timedelta64("NaT", "ns").astype("int64")
 
     @pytest.mark.parametrize("val", [np.nan, pd.NaT, pd.NA])
     def test_to_timedelta_on_missing_values_list(self, val):
         actual = to_timedelta([val])
-        assert actual[0]._value == np.timedelta64("NaT").astype("int64")
+        assert actual[0]._value == np.timedelta64("NaT", "ns").astype("int64")
 
     def test_to_timedelta_float(self):
         # https://github.com/pandas-dev/pandas/issues/25077

--- a/pandas/tests/tslibs/test_np_datetime.py
+++ b/pandas/tests/tslibs/test_np_datetime.py
@@ -14,6 +14,7 @@ from pandas._libs.tslibs.np_datetime import (
 import pandas._testing as tm
 
 
+@pytest.mark.filterwarnings("ignore:Using 'generic' unit:DeprecationWarning")
 def test_is_unitless():
     dtype = np.dtype("M8[ns]")
     assert not is_unitless(dtype)

--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -306,7 +306,7 @@ def test_assert_almost_equal_inf(a, b):
     _assert_almost_equal_both(a, b)
 
 
-objs = [NA, np.nan, NaT, None, np.datetime64("NaT"), np.timedelta64("NaT")]
+objs = [NA, np.nan, NaT, None, np.datetime64("NaT"), np.timedelta64("NaT", "ns")]
 
 
 @pytest.mark.parametrize("left", objs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -464,8 +464,6 @@ filterwarnings = [
   "ignore:More than 20 figures have been opened:RuntimeWarning",
   "ignore:BuiltinImporter.module_repr() is deprecated and slated for removal in Python 3.12:DeprecationWarning",
   "ignore:Bitwise inversion:DeprecationWarning",
-  # Numpy nightly: generic timedelta64 deprecation triggered internally by numpy
-  "ignore:Using 'generic' unit for NumPy timedelta:DeprecationWarning",
   # Raised by coverage in PY3.14+ (coverage.exceptions.CoverageWarning)
   "ignore:Plugin file tracers",
   # Raised by coverage in freethreading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -464,6 +464,8 @@ filterwarnings = [
   "ignore:More than 20 figures have been opened:RuntimeWarning",
   "ignore:BuiltinImporter.module_repr() is deprecated and slated for removal in Python 3.12:DeprecationWarning",
   "ignore:Bitwise inversion:DeprecationWarning",
+  # Numpy nightly: generic timedelta64 deprecation triggered internally by numpy
+  "ignore:Using 'generic' unit for NumPy timedelta:DeprecationWarning",
   # Raised by coverage in PY3.14+ (coverage.exceptions.CoverageWarning)
   "ignore:Plugin file tracers",
   # Raised by coverage in freethreading


### PR DESCRIPTION
## Summary
- NumPy nightly deprecated unitless/generic `np.timedelta64` construction (e.g. `np.timedelta64("NaT")`, `np.timedelta64(300000000)`). Since CI runs with `PYTHONDEVMODE=1`, the `DeprecationWarning` becomes an error, causing ~70 test failures in the Numpy Nightly job.
- Add explicit units to all `np.timedelta64()` calls missing them, in both source code (6 files) and tests (~30 files).
- Source fixes extract the unit from the existing dtype context (via `np.datetime_data(dtype)[0]`) rather than hardcoding `"ns"`.

## Test plan
- [x] All 41,577 tests in the originally-failing test files pass with `python -W error::DeprecationWarning`
- [x] Pre-commit hooks pass (ruff, ruff-format, etc.)