### PR TITLE
DOC: clarify str.cat returns Series when called on Index

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -514,9 +514,15 @@ class StringMethods(NoNewAttributesMixin):
 
         Returns
         -------
-        str, Series or Index
-            If `others` is None, `str` is returned, otherwise a `Series/Index`
-            (same type as caller) of objects is returned.
+        str or Series
+            If `others` is None, `str` is returned, otherwise a Series
+            of objects is returned.
+
+            .. note::
+                When called on an Index, the result is always a Series
+                (not an Index), because the Index is internally converted
+                to a Series for alignment purposes. To obtain an Index
+                result, call ``.to_series().str.cat(...).index``.
 
         See Also
         --------
@@ -598,6 +604,16 @@ class StringMethods(NoNewAttributesMixin):
         0    aa
         4    -e
         2    -c
+        dtype: str
+
+        When calling ``.str.cat()`` on an Index with `others`, the result
+        is a Series (not an Index), because the Index is converted internally:
+
+        >>> idx = pd.Index(["a", "b", "c"])
+        >>> idx.str.cat(["x", "y", "z"], sep="-")
+        a    a-x
+        b    b-y
+        c    c-z
         dtype: str
 
         For more examples, see :ref:`here <text.concatenate>`.


### PR DESCRIPTION
Closes #35556.

## Changes

Updated the docstring for  in :

1. **Returns section**: Changed from "str, Series or Index (same type as caller)" to "str or Series", with a note explaining that Index callers always receive a Series because the Index is internally converted to a Series for alignment.

2. **Examples section**: Added an example showing  returning a Series to make the behavior explicit.

## Context

When calling  on an Index, the return type is always a Series — not an Index as the previous docstring implied with "same type as caller". This is because the code converts the Index to a Series internally (line 620 in accessor.py). The docstring now accurately reflects this behavior.