### PR TITLE
PERF: avoid redundant isna in NumpyExtensionArray.to_numpy

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -582,10 +582,16 @@ class NumpyExtensionArray(
         copy: bool = False,
         na_value: object = lib.no_default,
     ) -> np.ndarray:
-        mask = self.isna()
-        if na_value is not lib.no_default and mask.any():
-            result = self._ndarray.copy()
-            result[mask] = na_value
+        if na_value is not lib.no_default:
+            mask = self.isna()
+            if mask.any():
+                result = self._ndarray.copy()
+                result[mask] = na_value
+            else:
+                result = self._ndarray
+                if not copy and self._readonly:
+                    result = result.view()
+                    result.flags.writeable = False
         else:
             result = self._ndarray
             if not copy and self._readonly:

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -582,16 +582,9 @@ class NumpyExtensionArray(
         copy: bool = False,
         na_value: object = lib.no_default,
     ) -> np.ndarray:
-        if na_value is not lib.no_default:
-            mask = self.isna()
-            if mask.any():
-                result = self._ndarray.copy()
-                result[mask] = na_value
-            else:
-                result = self._ndarray
-                if not copy and self._readonly:
-                    result = result.view()
-                    result.flags.writeable = False
+        if na_value is not lib.no_default and (mask := self.isna()).any():
+            result = self._ndarray.copy()
+            result[mask] = na_value
         else:
             result = self._ndarray
             if not copy and self._readonly:


### PR DESCRIPTION
## Summary
- Defer the `isna()` call in `NumpyExtensionArray.to_numpy()` until after checking whether `na_value` was provided
- When called without `na_value` (the common path from `extract_array`), the mask was computed and immediately discarded
- This eliminates a redundant `isna` call in the object-dtype ffill/bfill path, where `extract_array(..., extract_numpy=True)` calls `to_numpy()` on the result

Profiling showed `isna` on object arrays (`_isna_string_dtype`) was called twice per ffill/bfill — once inside `pad_or_backfill_inplace` and once from `to_numpy`. The second call was wasted since no `na_value` was passed.

~2x speedup for object-dtype Series ffill/bfill (e.g. 3.3ms → 1.6ms for 100K elements).

closes #20300

## Test plan
- [x] Existing tests pass (`test_numpy.py`, `test_fillna.py`, `test_extension/test_numpy.py`)
- [x] Verified `to_numpy(na_value=...)` still works correctly
- [x] Verified ffill/bfill correctness for object and string[python] dtypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)