### PR TITLE
BUG: Fix DatetimeIndex.round raising AmbiguousTimeError near DST transitions

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -210,6 +210,7 @@ Timedelta
 Timezones
 ^^^^^^^^^
 - Bug in :class:`DatetimeIndex` addition with a :class:`DateOffset` that has only timedelta components (e.g. ``DateOffset(hours=-2)``) raising ``ValueError`` near DST transitions, while scalar :class:`Timestamp` addition worked correctly (:issue:`28610`)
+- Bug in :meth:`DatetimeIndex.round`, :meth:`DatetimeIndex.floor`, and :meth:`DatetimeIndex.ceil` raising ``AmbiguousTimeError`` for tz-aware indexes spanning a DST fall-back transition, even though the timestamps were unambiguous (:issue:`55864`)
 -
 
 Numeric

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2170,6 +2170,20 @@ class TimelikeOps(DatetimeLikeArrayMixin):
             self = cast("DatetimeArray", self)
             naive = self.tz_localize(None)
             result = naive._round(freq, mode, ambiguous, nonexistent)
+
+            # GH#55864: When rounding tz-aware timestamps near a DST
+            # fall-back, the rounded local times may be ambiguous. Use the
+            # original UTC offsets to resolve: DST has the larger offset.
+            if isinstance(ambiguous, str) and ambiguous == "raise":
+                offsets = naive.asi8 - self.asi8
+                notna_mask = self.asi8 != iNaT
+                valid_offsets = offsets[notna_mask]
+                if (
+                    len(valid_offsets) > 0
+                    and valid_offsets.min() != valid_offsets.max()
+                ):
+                    ambiguous = offsets > valid_offsets.min()
+
             return result.tz_localize(
                 self.tz, ambiguous=ambiguous, nonexistent=nonexistent
             )

--- a/pandas/tests/indexes/datetimes/methods/test_round.py
+++ b/pandas/tests/indexes/datetimes/methods/test_round.py
@@ -12,6 +12,14 @@ import pandas._testing as tm
 
 
 class TestDatetimeIndexRound:
+    @pytest.mark.parametrize("method", ["round", "floor", "ceil"])
+    def test_round_dst_ambiguous(self, method):
+        # GH#55864
+        index = date_range("2023-10-28", "2023-10-30", freq="30min", tz="Europe/Vienna")
+        result = getattr(index, method)("1min")
+        expected = index
+        tm.assert_index_equal(result, expected)
+
     def test_round_daily(self):
         dti = date_range("20130101 09:10:11", periods=5)
         result = dti.round("D")

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -355,9 +355,11 @@ class TestSeriesDatetimeValues:
         expected.iloc[0:2] = pd.NaT
         tm.assert_series_equal(result, expected)
 
-        # raise
-        with tm.external_error_raised(ValueError):
-            getattr(df1.date.dt, method)("h", ambiguous="raise")
+        # GH#55864: ambiguous="raise" (the default) now resolves using the
+        # original UTC offsets instead of raising
+        result = getattr(df1.date.dt, method)("h", ambiguous="raise")
+        expected = df1["date"]
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "method, ts_str, freq",


### PR DESCRIPTION
## Summary
- Fixes `DatetimeIndex.round`/`floor`/`ceil` raising `AmbiguousTimeError` for tz-aware indexes spanning a DST fall-back transition, even though the timestamps are unambiguous (stored as UTC internally)
- When `ambiguous="raise"` (the default) and the data spans a DST transition, the original UTC offsets are used to resolve the fold instead of erroring
- closes #55864

## Test plan
- [x] Added `test_round_dst_ambiguous` reproducing the exact issue (parametrized over round/floor/ceil)
- [x] Updated `test_dt_round_tz_ambiguous` which previously expected `ambiguous="raise"` to error
- [x] Verified non-DST timezones, NaT handling, and non-hour-aligned offsets (e.g. Asia/Kolkata) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)