### PR TITLE
BUG: date_range with periods=1 raises for offsets that disallow n=0

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -171,6 +171,7 @@ Datetimelike
 - Bug in :class:`Timestamp` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)
 - Bug in :func:`date_range` where ``inclusive`` parameter failed to filter endpoints when only ``start`` and ``periods`` or ``end`` and ``periods`` were specified (:issue:`46331`)
+- Bug in :func:`date_range` where ``periods=1`` with offsets that disallow ``n=0`` (e.g. :class:`offsets.LastWeekOfMonth`, :class:`offsets.FY5253`) raised ``ValueError`` (:issue:`41563`)
 - Bug in :func:`date_range` where calendar-based offsets (e.g. ``MS``, ``ME``, ``QS``, ``YS``) could exclude the last offset boundary when ``end``'s time-of-day was earlier than ``start``'s (:issue:`35342`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -3223,21 +3223,21 @@ def _generate_range(
         periods = 0
 
     if end is None:
-        # error: No overload variant of "__radd__" of "BaseOffset" matches
-        # argument type "None"
         # GH#41563 avoid 0 * offset for offsets where n=0 is not allowed
         if periods == 1:
             end = start
         else:
+            # error: No overload variant of "__radd__" of "BaseOffset" matches
+            # argument type "None"
             end = start + (periods - 1) * offset  # type: ignore[operator]
 
     if start is None:
-        # error: No overload variant of "__radd__" of "BaseOffset" matches
-        # argument type "None"
         # GH#41563 avoid 0 * offset for offsets where n=0 is not allowed
         if periods == 1:
             start = end
         else:
+            # error: No overload variant of "__radd__" of "BaseOffset" matches
+            # argument type "None"
             start = end - (periods - 1) * offset  # type: ignore[operator]
 
     start = cast("Timestamp", start)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -3225,12 +3225,20 @@ def _generate_range(
     if end is None:
         # error: No overload variant of "__radd__" of "BaseOffset" matches
         # argument type "None"
-        end = start + (periods - 1) * offset  # type: ignore[operator]
+        # GH#41563 avoid 0 * offset for offsets where n=0 is not allowed
+        if periods == 1:
+            end = start
+        else:
+            end = start + (periods - 1) * offset  # type: ignore[operator]
 
     if start is None:
         # error: No overload variant of "__radd__" of "BaseOffset" matches
         # argument type "None"
-        start = end - (periods - 1) * offset  # type: ignore[operator]
+        # GH#41563 avoid 0 * offset for offsets where n=0 is not allowed
+        if periods == 1:
+            start = end
+        else:
+            start = end - (periods - 1) * offset  # type: ignore[operator]
 
     start = cast("Timestamp", start)
     end = cast("Timestamp", end)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1055,6 +1055,19 @@ class TestGenRangeGeneration:
         tm.assert_index_equal(result1, expected1)
         tm.assert_index_equal(result2, expected2)
 
+    @pytest.mark.parametrize(
+        "freq",
+        [
+            offsets.LastWeekOfMonth(1),
+            offsets.FY5253(1),
+        ],
+    )
+    def test_generate_range_periods1_no_n0_error(self, freq):
+        # GH#41563 - offsets that disallow n=0 should not raise
+        # when periods=1 (which computes 0 * offset internally)
+        result = date_range("2018-04-01", periods=1, freq=freq)
+        assert len(result) == 1
+
     dt1, dt2 = "2017-01-01", "2017-01-01"
     tz1, tz2 = "US/Eastern", "Europe/London"
 


### PR DESCRIPTION
closes #41563

## Summary
- `pd.date_range('2018-04-01', periods=1, freq=LastWeekOfMonth(1))` raised `ValueError: N cannot be 0` because `_generate_range` computed `0 * offset`, which constructs the offset with `n=0`
- Short-circuit the `end`/`start` computation in `_generate_range` when `periods == 1` to avoid the problematic multiplication
- Also affects `FY5253`, the only other offset that disallows `n=0`

## Test plan
- [x] Added parametrized test for `LastWeekOfMonth` and `FY5253` with `periods=1`
- [x] Existing `TestGenRangeGeneration` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)