### PR TITLE
BUG: date_range with inclusive="left"/"right" inconsistent when start==end

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -170,6 +170,7 @@ Datetimelike
 ^^^^^^^^^^^^
 - Bug in :class:`Timestamp` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)
+- Bug in :func:`date_range` where ``inclusive="left"`` and ``inclusive="right"`` kept the single generated point when ``start`` equals ``end``, inconsistent with the behavior when ``start`` differs from ``end`` (:issue:`61483`)
 - Bug in :func:`date_range` where ``inclusive`` parameter failed to filter endpoints when only ``start`` and ``periods`` or ``end`` and ``periods`` were specified (:issue:`46331`)
 - Bug in :func:`date_range` where calendar-based offsets (e.g. ``MS``, ``ME``, ``QS``, ``YS``) could exclude the last offset boundary when ``end``'s time-of-day was earlier than ``start``'s (:issue:`35342`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -547,7 +547,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 i8values = i8values.astype("i8")
 
         if start == end:
-            if not left_inclusive and not right_inclusive:
+            if not left_inclusive or not right_inclusive:
                 i8values = i8values[1:-1]
         else:
             start_i8 = (

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -728,7 +728,7 @@ class TestDateRanges:
         tm.assert_index_equal(result, expected)
 
     def test_range_where_start_equal_end(self, inclusive_endpoints_fixture):
-        # GH 43394
+        # GH#43394, GH#55293
         start = "2021-09-02"
         end = "2021-09-02"
         result = date_range(
@@ -736,11 +736,30 @@ class TestDateRanges:
         )
 
         both_range = date_range(start=start, end=end, freq="D", inclusive="both")
-        if inclusive_endpoints_fixture == "neither":
-            expected = both_range[1:-1]
-        elif inclusive_endpoints_fixture in ("left", "right", "both"):
+        if inclusive_endpoints_fixture == "both":
             expected = both_range[:]
+        else:
+            # (a, a], [a, a), and (a, a) are all empty
+            expected = both_range[1:-1]
 
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "inclusive, expected_values",
+        [
+            ("both", ["2021-09-02"]),
+            ("left", []),
+            ("right", []),
+            ("neither", []),
+        ],
+    )
+    def test_start_equal_end_inclusive(self, inclusive, expected_values):
+        # GH#55293 - when start == end, only inclusive="both" should
+        # return the singleton; left, right, and neither should all be empty
+        result = date_range(
+            start="2021-09-02", end="2021-09-02", freq="D", inclusive=inclusive
+        )
+        expected = DatetimeIndex(expected_values, dtype="datetime64[us]", freq="D")
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- When `start == end` in `date_range`, `inclusive="left"` and `inclusive="right"` incorrectly kept the single generated point, while for `start != end` (with delta < freq) the point was correctly removed
- One-character fix: change `and` to `or` in the `start == end` filtering condition in `DatetimeArray._generate_range`
- Updated existing test to expect the corrected behavior

closes #61483

## Test plan
- [x] Existing `test_range_where_start_equal_end` updated and passes
- [x] All 3198 datetime index tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)