### PR TITLE
PERF: fix O(n) linear scan in _bin_search for ObjectEngine.get_loc

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -548,28 +548,16 @@ cdef Py_ssize_t _bin_search(ndarray values, object val) except -1:
     # This is equivalent to the stdlib's bisect.bisect_left
 
     cdef:
-        Py_ssize_t mid = 0, lo = 0, hi = len(values) - 1
-        object pval
-
-    if hi == 0 or (hi > 0 and val > PySequence_GetItem(values, hi)):
-        return len(values)
+        Py_ssize_t mid, lo = 0, hi = len(values)
 
     while lo < hi:
         mid = (lo + hi) // 2
-        pval = PySequence_GetItem(values, mid)
-        if val < pval:
-            hi = mid
-        elif val > pval:
+        if PySequence_GetItem(values, mid) < val:
             lo = mid + 1
         else:
-            while mid > 0 and val == PySequence_GetItem(values, mid - 1):
-                mid -= 1
-            return mid
+            hi = mid
 
-    if val <= PySequence_GetItem(values, mid):
-        return mid
-    else:
-        return mid + 1
+    return lo
 
 
 cdef Py_ssize_t _bin_search_right(ndarray values, object val) except -1:


### PR DESCRIPTION
NB: motivated by a pretty by a 245x asv regression vs 3.0

## Summary
- Fixes perf regression in `ObjectEngineIndexing.time_get_loc('monotonic_incr')` vs 3.0
- The `_bin_search` function had a linear backward scan (`while mid > 0 and val == values[mid-1]: mid -= 1`) when landing on a matching element during binary search, degrading from O(log n) to O(n) for indexes with many duplicates
- This was always present in `_bin_search`, but only became a problem after #64817 added `ObjectEngine._get_loc_duplicates` which calls `_bin_search` on non-unique indexes
- Replace with a proper `bisect_left` implementation, matching the structure already used by `_bin_search_right`

## Performance
`ObjectEngineIndexing.time_get_loc('monotonic_incr')` with 300k elements (100k duplicates each of "a", "b", "c"):
- Before: O(n) — linear scan through ~50k elements
- After: O(log n) — pure binary search (~17 comparisons)

## Test plan
- [x] All 16,642 `pandas/tests/indexes/` tests pass
- [x] Correctness verified for monotonic_incr, monotonic_decr, non_monotonic, unique, and missing-key cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)