### PR TITLE
BUG: Fix groupby pct_change with freq, clean up GH#23918 xfail

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -139,6 +139,7 @@ Performance improvements
 - Performance improvement in :func:`read_sas` for compressed SAS7BDAT files by reusing the decompression buffer instead of allocating per row (:issue:`47339`)
 - Performance improvement in :func:`read_sas` when decoding strings (:issue:`47339`)
 - Performance improvement in :func:`util.hash_pandas_object` for PyArrow-backed string and binary types by using PyArrow's ``dictionary_encode`` instead of converting to NumPy for factorization (:issue:`48964`)
+- Performance improvement in :meth:`.DataFrameGroupBy.pct_change` and :meth:`.SeriesGroupBy.pct_change` when ``freq`` is provided (:issue:`23918`)
 - Performance improvement in :meth:`DataFrame.corr` and :meth:`DataFrame.cov` when data contains no NaN values (:issue:`64857`)
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)
@@ -284,6 +285,7 @@ Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)
+- Bug in :meth:`.DataFrameGroupBy.pct_change` and :meth:`.SeriesGroupBy.pct_change` with ``freq`` dropping the rows corresponding to null group keys (:issue:`23918`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` (and their :class:`GroupBy` counterparts) returning ``0.0`` and ``-3.0`` respectively for degenerate windows or groups; these now return ``NaN`` (:issue:`62864`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
 - Bug in :meth:`DataFrame.groupby` with a :class:`Grouper` with ``freq`` raising ``AttributeError`` when all grouping keys are ``NaT`` (:issue:`43486`)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -45,6 +45,7 @@ from pandas._libs import (
 from pandas._libs.algos import rank_1d
 import pandas._libs.groupby as libgroupby
 from pandas._libs.missing import NA
+from pandas._libs.tslibs import OutOfBoundsDatetime
 from pandas._typing import (
     AnyArrayLike,
     ArrayLike,
@@ -5716,13 +5717,29 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             # GH#23918: shift(freq=...) moves the index, not the values.
             #  When groups are recombined, shifted indices from one group can
             #  align with another group during division. Use a MultiIndex
-            #  keyed by (group_code, index_value) to make lookups group-aware.
-            codes = self._grouper.codes_info
-            target_index = filled.index.shift(-periods, freq)
-            mi = MultiIndex.from_arrays([codes, filled.index])
-            target_mi = MultiIndex.from_arrays([codes, target_index])
-            denominator = filled.copy()
-            denominator.index = mi
+            #  keyed by (group_id, index_value) to make lookups group-aware.
+            ids = self._grouper.ids
+            mi = MultiIndex.from_arrays([ids, filled.index])
+            target_index = None
+            # freq="infer" must be inferred per-group, and duplicate index
+            #  values within a group make the reindex below ambiguous; in
+            #  those cases fall back to per-group pct_change.
+            if mi.is_unique and not (isinstance(freq, str) and freq == "infer"):
+                try:
+                    # use NDFrame.shift for index-type handling (PeriodIndex)
+                    target_index = filled.shift(-periods, freq=freq).index
+                except (OverflowError, OutOfBoundsDatetime):
+                    # target labels not representable; the per-group shift
+                    #  moves the index the other direction and may still work
+                    pass
+            if target_index is None:
+                return self._python_apply_general(
+                    lambda group: group.pct_change(periods=periods, freq=freq),
+                    self._selected_obj,
+                    is_transform=True,
+                )
+            target_mi = MultiIndex.from_arrays([ids, target_index])
+            denominator = filled.set_axis(mi)
             denominator = denominator.reindex(target_mi)
             denominator.index = filled.index
             return (filled / denominator) - 1

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -5706,8 +5706,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         if fill_method is not None:
             raise ValueError(f"fill_method must be None; got {fill_method=}.")
 
-        # TODO(GH#23918): Remove this conditional for SeriesGroupBy when
-        #  GH#23918 is fixed
+        # GH#23918: the vectorized path below shifts the combined result's
+        #  index, so values from different groups can bleed into each other
+        #  during alignment. Use the per-group slow path instead.
         if freq is not None:
             f = lambda x: x.pct_change(
                 periods=periods,

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -5706,24 +5706,29 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         if fill_method is not None:
             raise ValueError(f"fill_method must be None; got {fill_method=}.")
 
-        # GH#23918: the vectorized path below shifts the combined result's
-        #  index, so values from different groups can bleed into each other
-        #  during alignment. Use the per-group slow path instead.
-        if freq is not None:
-            f = lambda x: x.pct_change(
-                periods=periods,
-                freq=freq,
-                axis=0,
-            )
-            return self._python_apply_general(f, self._selected_obj, is_transform=True)
-
         if fill_method is None:  # GH30463
             op = "ffill"
         else:
             op = fill_method
         filled = getattr(self, op)(limit=0)
+
+        if freq is not None:
+            # GH#23918: shift(freq=...) moves the index, not the values.
+            #  When groups are recombined, shifted indices from one group can
+            #  align with another group during division. Use a MultiIndex
+            #  keyed by (group_code, index_value) to make lookups group-aware.
+            codes = self._grouper.codes_info
+            target_index = filled.index.shift(-periods, freq)
+            mi = MultiIndex.from_arrays([codes, filled.index])
+            target_mi = MultiIndex.from_arrays([codes, target_index])
+            denominator = filled.copy()
+            denominator.index = mi
+            denominator = denominator.reindex(target_mi)
+            denominator.index = filled.index
+            return (filled / denominator) - 1
+
         fill_grp = filled.groupby(self._grouper.codes, group_keys=self.group_keys)
-        shifted = fill_grp.shift(periods=periods, freq=freq)
+        shifted = fill_grp.shift(periods=periods)
         return (filled / shifted) - 1
 
     @final

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -943,6 +943,154 @@ def test_pct_change_with_freq(frame_or_series, periods):
     tm.assert_equal(result, expected)
 
 
+def test_pct_change_with_freq_duplicate_index(frame_or_series):
+    # GH#23918: duplicate index values within a group; resolved the same
+    #  way Series.pct_change does (first occurrence wins)
+    idx = pd.to_datetime(
+        ["2020-01-01", "2020-01-02", "2020-01-02", "2020-01-01", "2020-01-02"]
+    )
+    vals = [1.0, 3.0, 4.0, 5.0, 10.0]
+    groups = list("aaabb")
+
+    if frame_or_series is Series:
+        obj = Series(vals, index=idx)
+    else:
+        obj = DataFrame({"vals": vals}, index=idx)
+    gb = obj.groupby(groups)
+
+    result = gb.pct_change(freq="D")
+
+    exp_vals = [np.nan, 2.0, 2.0, np.nan, 1.0]
+    if frame_or_series is Series:
+        expected = Series(exp_vals, index=idx)
+    else:
+        expected = DataFrame({"vals": exp_vals}, index=idx)
+
+    tm.assert_equal(result, expected)
+
+
+def test_pct_change_with_freq_dates_shared_across_groups(frame_or_series):
+    # GH#23918: the same dates appear in multiple groups; denominator
+    #  lookups must not cross groups
+    idx = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"] * 2)
+    vals = [1.0, 2.0, 4.0, 3.0, 9.0, 27.0]
+    groups = list("aaabbb")
+
+    if frame_or_series is Series:
+        obj = Series(vals, index=idx)
+    else:
+        obj = DataFrame({"vals": vals}, index=idx)
+
+    result = obj.groupby(groups).pct_change(freq="D")
+
+    exp_vals = [np.nan, 1.0, 1.0, np.nan, 2.0, 2.0]
+    if frame_or_series is Series:
+        expected = Series(exp_vals, index=idx)
+    else:
+        expected = DataFrame({"vals": exp_vals}, index=idx)
+
+    tm.assert_equal(result, expected)
+
+
+def test_pct_change_with_freq_period_index(frame_or_series):
+    # GH#23918
+    idx = pd.period_range("2020-01", periods=6, freq="M")
+    vals = [2.0, 4.0, 1.0, 3.0, 6.0, 12.0]
+    groups = list("aaabbb")
+
+    if frame_or_series is Series:
+        obj = Series(vals, index=idx)
+    else:
+        obj = DataFrame({"vals": vals}, index=idx)
+
+    result = obj.groupby(groups).pct_change(freq="M")
+
+    exp_vals = [np.nan, 1.0, -0.75, np.nan, 1.0, 1.0]
+    if frame_or_series is Series:
+        expected = Series(exp_vals, index=idx)
+    else:
+        expected = DataFrame({"vals": exp_vals}, index=idx)
+
+    tm.assert_equal(result, expected)
+
+
+def test_pct_change_with_freq_infer(frame_or_series):
+    # GH#23918: freq="infer" is inferred per group
+    # group a is every 2 days, group b is daily
+    idx = pd.to_datetime(
+        [
+            "2020-01-01",
+            "2020-01-03",
+            "2020-01-05",
+            "2020-01-02",
+            "2020-01-03",
+            "2020-01-04",
+        ]
+    )
+    vals = [1.0, 2.0, 4.0, 1.0, 3.0, 9.0]
+    groups = list("aaabbb")
+
+    if frame_or_series is Series:
+        obj = Series(vals, index=idx)
+    else:
+        obj = DataFrame({"vals": vals}, index=idx)
+
+    result = obj.groupby(groups).pct_change(freq="infer")
+
+    exp_vals = [np.nan, 1.0, 1.0, np.nan, 2.0, 2.0]
+    if frame_or_series is Series:
+        expected = Series(exp_vals, index=idx)
+    else:
+        expected = DataFrame({"vals": exp_vals}, index=idx)
+
+    tm.assert_equal(result, expected)
+
+
+def test_pct_change_with_freq_grouper_unsorted(frame_or_series):
+    # GH#23918: Grouper(freq=...) sorts the index internally; the group
+    #  ids must stay aligned with the filled values
+    idx = pd.to_datetime(["2020-01-08", "2020-01-01", "2020-01-09", "2020-01-02"])
+    vals = [1.0, 2.0, 4.0, 8.0]
+
+    if frame_or_series is Series:
+        obj = Series(vals, index=idx)
+    else:
+        obj = DataFrame({"vals": vals}, index=idx)
+
+    result = obj.groupby(pd.Grouper(freq="W")).pct_change(freq="D")
+
+    exp_vals = [np.nan, 3.0, np.nan, 3.0]
+    if frame_or_series is Series:
+        expected = Series(exp_vals, index=idx.sort_values())
+    else:
+        expected = DataFrame({"vals": exp_vals}, index=idx.sort_values())
+
+    tm.assert_equal(result, expected)
+
+
+def test_pct_change_with_freq_null_group_key(frame_or_series):
+    # GH#23918: rows with null group keys are kept as NaN, consistent
+    #  with freq=None
+    idx = date_range("2020-01-01", periods=4, freq="D")
+    vals = [1.0, 2.0, 4.0, 8.0]
+    groups = ["a", "a", np.nan, np.nan]
+
+    if frame_or_series is Series:
+        obj = Series(vals, index=idx)
+    else:
+        obj = DataFrame({"vals": vals}, index=idx)
+
+    result = obj.groupby(groups).pct_change(freq="D")
+
+    exp_vals = [np.nan, 1.0, np.nan, np.nan]
+    if frame_or_series is Series:
+        expected = Series(exp_vals, index=idx)
+    else:
+        expected = DataFrame({"vals": exp_vals}, index=idx)
+
+    tm.assert_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "func, expected_status",
     [

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -889,13 +889,15 @@ def test_pad_stable_sorting(fill_method):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("freq", [None, "D"])
 @pytest.mark.parametrize("periods", [1, -1])
-def test_pct_change(frame_or_series, periods):
-    # GH 21200, 21621, 30463
+def test_pct_change(frame_or_series, freq, periods):
+    # GH 21200, 21621, 30463, 23918
     vals = [3, np.nan, np.nan, np.nan, 1, 2, 4, 10, np.nan, 4]
     keys = ["a", "b"]
     key_v = np.repeat(keys, len(vals))
-    df = DataFrame({"key": key_v, "vals": vals * 2})
+    idx = date_range("2020-01-01", periods=len(key_v), freq="D")
+    df = DataFrame({"key": key_v, "vals": vals * 2}, index=idx)
 
     df_g = df
     grp = df_g.groupby(df.key)
@@ -909,7 +911,7 @@ def test_pct_change(frame_or_series, periods):
     else:
         expected = expected.to_frame("vals")
 
-    result = gb.pct_change(periods=periods)
+    result = gb.pct_change(periods=periods, freq=freq)
     tm.assert_equal(result, expected)
 
 

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -889,20 +889,8 @@ def test_pad_stable_sorting(fill_method):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "freq",
-    [
-        None,
-        pytest.param(
-            "D",
-            marks=pytest.mark.xfail(
-                reason="GH#23918 before method uses freq in vectorized approach"
-            ),
-        ),
-    ],
-)
 @pytest.mark.parametrize("periods", [1, -1])
-def test_pct_change(frame_or_series, freq, periods):
+def test_pct_change(frame_or_series, periods):
     # GH 21200, 21621, 30463
     vals = [3, np.nan, np.nan, np.nan, 1, 2, 4, 10, np.nan, 4]
     keys = ["a", "b"]
@@ -921,7 +909,35 @@ def test_pct_change(frame_or_series, freq, periods):
     else:
         expected = expected.to_frame("vals")
 
-    result = gb.pct_change(periods=periods, freq=freq)
+    result = gb.pct_change(periods=periods)
+    tm.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize("periods", [1, -1])
+def test_pct_change_with_freq(frame_or_series, periods):
+    # GH#23918
+    idx = date_range("2020-01-01", periods=6, freq="D")
+    vals = [2.0, 4.0, 1.0, 3.0, 6.0, 12.0]
+    groups = list("aaabbb")
+
+    if frame_or_series is Series:
+        obj = Series(vals, index=idx)
+    else:
+        obj = DataFrame({"vals": vals}, index=idx)
+    gb = obj.groupby(groups)
+
+    result = gb.pct_change(periods=periods, freq="D")
+
+    if periods == 1:
+        exp_vals = [np.nan, 1.0, -0.75, np.nan, 1.0, 1.0]
+    else:
+        exp_vals = [-0.5, 3.0, np.nan, -0.5, -0.5, np.nan]
+
+    if frame_or_series is Series:
+        expected = Series(exp_vals, index=idx)
+    else:
+        expected = DataFrame({"vals": exp_vals}, index=idx)
+
     tm.assert_equal(result, expected)
 
 


### PR DESCRIPTION
closes #23918

Vectorizes `GroupBy.pct_change` with `freq`, replacing the per-group apply path. `shift(freq=...)` moves the index rather than the values, so the shifted denominator is looked up via a `(group_id, index_value)` MultiIndex reindex, keeping lookups group-aware (no cross-group bleed when groups share or abut dates).

The per-group apply path is kept as a fallback where the vectorized lookup would be ambiguous or unsupported:
- duplicate index values within a group (non-unique MultiIndex; duplicates resolve the same way `Series.pct_change` does)
- `freq="infer"` (groups can have different inferable freqs)
- target-index shift overflow near `Timestamp.min`/`max`

The target index is computed with `NDFrame.shift` so `PeriodIndex` works, and group ids come from `grouper.ids` so `Grouper(freq=...)` with an unsorted index stays aligned with the transform output.

Two user-visible fixes along the way (whatsnew added):
- rows with null group keys are now kept as NaN, consistent with `freq=None` (previously dropped)
- the old test xfail is removed; `test_pct_change` now exercises `freq="D"` on a `DatetimeIndex`, plus new tests for shared dates across groups, in-group duplicate dates, `PeriodIndex`, `freq="infer"`, unsorted `Grouper(freq=...)`, and null group keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)