### PR TITLE
TST: add tests for DataFrame indexing with DateOffset columns

### DIFF
--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -45,6 +45,19 @@ class TestGetitem:
         ts = df["1/1/2000"]
         tm.assert_series_equal(ts, df.iloc[:, 0])
 
+    def test_getitem_dateoffset_columns(self):
+        # GH#20948 - indexing DataFrame with DateOffset columns
+        offsets = Series(data=[-15, -10, -5, 0, 5, 10, 15], dtype=float).map(DateOffset)
+        df = DataFrame(
+            np.arange(14).reshape(2, 7),
+            index=[0, 1],
+            columns=Index(offsets),
+        )
+
+        result = df[offsets[0]]
+        expected = Series([0, 7], index=[0, 1], name=offsets[0])
+        tm.assert_series_equal(result, expected)
+
     def test_getitem_list_of_labels_categoricalindex_cols(self):
         # GH#16115
         cats = Categorical([Timestamp("12-31-1999"), Timestamp("12-31-2000")])

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -55,7 +55,7 @@ class TestGetitem:
         )
 
         result = df[offsets[0]]
-        expected = Series([0, 7], index=[0, 1], name=offsets[0])
+        expected = df.iloc[:, 0]
         tm.assert_series_equal(result, expected)
 
     def test_getitem_list_of_labels_categoricalindex_cols(self):

--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -12,12 +12,28 @@ from pandas import (
     CategoricalDtype,
     CategoricalIndex,
     DataFrame,
+    DateOffset,
     DatetimeIndex,
+    Index,
     MultiIndex,
     Series,
     Timestamp,
 )
 import pandas._testing as tm
+
+
+def test_at_dateoffset_columns():
+    # GH#20948 - .at with DateOffset columns
+    offsets = Series(data=[-15, -10, -5, 0, 5, 10, 15], dtype=float).map(DateOffset)
+    df = DataFrame(index=[0, 1], columns=Index(offsets))
+
+    # read access
+    result = df.at[0, offsets[0]]
+    assert result is np.nan
+
+    # write access
+    df.at[0, offsets[0]] = 1
+    assert df.at[0, offsets[0]] == 1
 
 
 def test_at_timezone():

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -24,6 +24,7 @@ from pandas import (
     CategoricalDtype,
     CategoricalIndex,
     DataFrame,
+    DateOffset,
     DatetimeIndex,
     Index,
     IndexSlice,
@@ -70,6 +71,19 @@ def test_loc_dtype():
 
 
 class TestLoc:
+    def test_loc_dateoffset_columns(self):
+        # GH#20948 - .loc with DateOffset columns
+        offsets = Series(data=[-15, -10, -5, 0, 5, 10, 15], dtype=float).map(DateOffset)
+        df = DataFrame(index=[0, 1], columns=Index(offsets))
+
+        # read access
+        result = df.loc[0, offsets[0]]
+        assert result is np.nan
+
+        # write access
+        df.loc[0, offsets[0]] = 1
+        assert df.loc[0, offsets[0]] == 1
+
     def test_none_values_on_string_columns(self, using_infer_string):
         # Issue #32218
         df = DataFrame(["1", "2", None], columns=["a"], dtype=object)


### PR DESCRIPTION
## Summary
- Adds test coverage for GH#20948, which reported that indexing a DataFrame with `DateOffset` columns was broken
- The bug was fixed as a side effect of PR #21313 (v0.24.0) but no tests were added for this specific case
- Tests `__getitem__`, `.loc`, and `.at` read/write access with `DateOffset` columns

closes #20948

## Test plan
- [x] `pytest pandas/tests/frame/indexing/test_getitem.py::TestGetitem::test_getitem_dateoffset_columns`
- [x] `pytest pandas/tests/indexing/test_loc.py::TestLoc::test_loc_dateoffset_columns`
- [x] `pytest pandas/tests/indexing/test_at.py::test_at_dateoffset_columns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)