### PR TITLE
BUG: Index repr attributes now wrap to respect display.width

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -158,6 +158,7 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
+- Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
 
 Categorical

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -175,6 +175,7 @@ from pandas.io.formats.printing import (
     PrettyDict,
     default_pprint,
     format_object_summary,
+    get_adjustment,
     pprint_thing,
 )
 
@@ -1408,9 +1409,51 @@ class Index(IndexOpsMixin, PandasObject):
         klass_name = type(self).__name__
         data = self._format_data()
         attrs = self._format_attrs()
-        attrs_str = [f"{k}={v}" for k, v in attrs]
-        prepr = ", ".join(attrs_str)
 
+        display_width = _global_config["display"]["width"] or 80
+        indent = len(klass_name) + 1  # length of "ClassName("
+        indent_str = " " * indent
+
+        # Determine the length of the line where attrs start
+        if "\n" in data:
+            last_line = data.rsplit("\n", 1)[-1]
+            line_len = len(last_line)
+        else:
+            line_len = indent + len(data)
+
+        adj = get_adjustment()
+
+        # Build the attrs portion with width-aware wrapping.
+        # Reserve 1 char for trailing comma when not the last attr.
+        parts: list[str_t] = []
+        num_attrs = len(attrs)
+        for attr_idx, (key, val) in enumerate(attrs):
+            attr = f"{key}={val}"
+            attr_len = adj.len(attr)
+            comma = 1 if attr_idx < num_attrs - 1 else 0
+            if not parts:
+                # First attr: wrap onto new line if it won't fit on the
+                # current line (which already contains data)
+                if line_len + attr_len + comma > display_width:
+                    parts.append("\n" + indent_str + attr)
+                    line_len = indent + attr_len
+                else:
+                    parts.append(attr)
+                    line_len += attr_len
+            else:
+                sep = ", "
+                if line_len + len(sep) + attr_len + comma > display_width:
+                    parts.append(",\n" + indent_str + attr)
+                    line_len = indent + attr_len
+                else:
+                    parts.append(sep + attr)
+                    line_len += len(sep) + attr_len
+
+        prepr = "".join(parts)
+        if prepr.startswith("\n"):
+            # First attr wrapped to a new line; strip trailing whitespace
+            # from the data portion (e.g. trailing ", " separator)
+            data = data.rstrip()
         return f"{klass_name}({data}{prepr})"
 
     def _formatter_func(self, val: object) -> str_t:

--- a/pandas/tests/arrays/categorical/test_repr.py
+++ b/pandas/tests/arrays/categorical/test_repr.py
@@ -395,67 +395,115 @@ Categories (20, timedelta64[us]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
 
     def test_categorical_index_repr(self):
         idx = CategoricalIndex(Categorical([1, 2, 3]))
-        exp = """CategoricalIndex([1, 2, 3], categories=[1, 2, 3], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex([1, 2, 3], categories=[1, 2, 3], ordered=False,\n"
+            "                 dtype='category')"
+        )
         assert repr(idx) == exp
 
         i = CategoricalIndex(Categorical(np.arange(10, dtype=np.int64)))
-        exp = """CategoricalIndex([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], categories=[0, 1, 2, 3, ..., 6, 7, 8, 9], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],\n"
+            "                 categories=[0, 1, 2, 3, ..., 6, 7, 8, 9],"
+            " ordered=False,\n"
+            "                 dtype='category')"
+        )
         assert repr(i) == exp
 
     def test_categorical_index_repr_ordered(self):
         i = CategoricalIndex(Categorical([1, 2, 3], ordered=True))
-        exp = """CategoricalIndex([1, 2, 3], categories=[1, 2, 3], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex([1, 2, 3], categories=[1, 2, 3], "
+            "ordered=True, dtype='category')"
+        )
         assert repr(i) == exp
 
         i = CategoricalIndex(Categorical(np.arange(10, dtype=np.int64), ordered=True))
-        exp = """CategoricalIndex([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], categories=[0, 1, 2, 3, ..., 6, 7, 8, 9], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex([0, 1, 2, 3, 4, 5, 6, 7, 8, 9],\n"
+            "                 categories=[0, 1, 2, 3, ..., 6, 7, 8, 9],"
+            " ordered=True,\n"
+            "                 dtype='category')"
+        )
         assert repr(i) == exp
 
     def test_categorical_index_repr_datetime(self):
         idx = date_range("2011-01-01 09:00", freq="h", periods=5)
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['2011-01-01 09:00:00', '2011-01-01 10:00:00',
-                  '2011-01-01 11:00:00', '2011-01-01 12:00:00',
-                  '2011-01-01 13:00:00'],
-                 categories=[2011-01-01 09:00:00, 2011-01-01 10:00:00, 2011-01-01 11:00:00, 2011-01-01 12:00:00, 2011-01-01 13:00:00], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00:00', '2011-01-01 10:00:00',\n"
+            "                  '2011-01-01 11:00:00', '2011-01-01 12:00:00',\n"
+            "                  '2011-01-01 13:00:00'],\n"
+            "                 categories=[2011-01-01 09:00:00, 2011-01-01 10:00:00, "
+            "2011-01-01 11:00:00, 2011-01-01 12:00:00, 2011-01-01 13:00:00],\n"
+            "                 ordered=False, dtype='category')"
+        )
 
         assert repr(i) == exp
 
         idx = date_range("2011-01-01 09:00", freq="h", periods=5, tz="US/Eastern")
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['2011-01-01 09:00:00-05:00', '2011-01-01 10:00:00-05:00',
-                  '2011-01-01 11:00:00-05:00', '2011-01-01 12:00:00-05:00',
-                  '2011-01-01 13:00:00-05:00'],
-                 categories=[2011-01-01 09:00:00-05:00, 2011-01-01 10:00:00-05:00, 2011-01-01 11:00:00-05:00, 2011-01-01 12:00:00-05:00, 2011-01-01 13:00:00-05:00], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00:00-05:00', "
+            "'2011-01-01 10:00:00-05:00',\n"
+            "                  '2011-01-01 11:00:00-05:00', "
+            "'2011-01-01 12:00:00-05:00',\n"
+            "                  '2011-01-01 13:00:00-05:00'],\n"
+            "                 categories=[2011-01-01 09:00:00-05:00, "
+            "2011-01-01 10:00:00-05:00, 2011-01-01 11:00:00-05:00, "
+            "2011-01-01 12:00:00-05:00, 2011-01-01 13:00:00-05:00],\n"
+            "                 ordered=False, dtype='category')"
+        )
 
         assert repr(i) == exp
 
     def test_categorical_index_repr_datetime_ordered(self):
         idx = date_range("2011-01-01 09:00", freq="h", periods=5)
         i = CategoricalIndex(Categorical(idx, ordered=True))
-        exp = """CategoricalIndex(['2011-01-01 09:00:00', '2011-01-01 10:00:00',
-                  '2011-01-01 11:00:00', '2011-01-01 12:00:00',
-                  '2011-01-01 13:00:00'],
-                 categories=[2011-01-01 09:00:00, 2011-01-01 10:00:00, 2011-01-01 11:00:00, 2011-01-01 12:00:00, 2011-01-01 13:00:00], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00:00', '2011-01-01 10:00:00',\n"
+            "                  '2011-01-01 11:00:00', '2011-01-01 12:00:00',\n"
+            "                  '2011-01-01 13:00:00'],\n"
+            "                 categories=[2011-01-01 09:00:00, 2011-01-01 10:00:00, "
+            "2011-01-01 11:00:00, 2011-01-01 12:00:00, 2011-01-01 13:00:00],\n"
+            "                 ordered=True, dtype='category')"
+        )
 
         assert repr(i) == exp
 
         idx = date_range("2011-01-01 09:00", freq="h", periods=5, tz="US/Eastern")
         i = CategoricalIndex(Categorical(idx, ordered=True))
-        exp = """CategoricalIndex(['2011-01-01 09:00:00-05:00', '2011-01-01 10:00:00-05:00',
-                  '2011-01-01 11:00:00-05:00', '2011-01-01 12:00:00-05:00',
-                  '2011-01-01 13:00:00-05:00'],
-                 categories=[2011-01-01 09:00:00-05:00, 2011-01-01 10:00:00-05:00, 2011-01-01 11:00:00-05:00, 2011-01-01 12:00:00-05:00, 2011-01-01 13:00:00-05:00], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00:00-05:00', "
+            "'2011-01-01 10:00:00-05:00',\n"
+            "                  '2011-01-01 11:00:00-05:00', "
+            "'2011-01-01 12:00:00-05:00',\n"
+            "                  '2011-01-01 13:00:00-05:00'],\n"
+            "                 categories=[2011-01-01 09:00:00-05:00, "
+            "2011-01-01 10:00:00-05:00, 2011-01-01 11:00:00-05:00, "
+            "2011-01-01 12:00:00-05:00, 2011-01-01 13:00:00-05:00],\n"
+            "                 ordered=True, dtype='category')"
+        )
 
         assert repr(i) == exp
 
         i = CategoricalIndex(Categorical(idx.append(idx), ordered=True))
-        exp = """CategoricalIndex(['2011-01-01 09:00:00-05:00', '2011-01-01 10:00:00-05:00',
-                  '2011-01-01 11:00:00-05:00', '2011-01-01 12:00:00-05:00',
-                  '2011-01-01 13:00:00-05:00', '2011-01-01 09:00:00-05:00',
-                  '2011-01-01 10:00:00-05:00', '2011-01-01 11:00:00-05:00',
-                  '2011-01-01 12:00:00-05:00', '2011-01-01 13:00:00-05:00'],
-                 categories=[2011-01-01 09:00:00-05:00, 2011-01-01 10:00:00-05:00, 2011-01-01 11:00:00-05:00, 2011-01-01 12:00:00-05:00, 2011-01-01 13:00:00-05:00], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00:00-05:00', "
+            "'2011-01-01 10:00:00-05:00',\n"
+            "                  '2011-01-01 11:00:00-05:00', "
+            "'2011-01-01 12:00:00-05:00',\n"
+            "                  '2011-01-01 13:00:00-05:00', "
+            "'2011-01-01 09:00:00-05:00',\n"
+            "                  '2011-01-01 10:00:00-05:00', "
+            "'2011-01-01 11:00:00-05:00',\n"
+            "                  '2011-01-01 12:00:00-05:00', "
+            "'2011-01-01 13:00:00-05:00'],\n"
+            "                 categories=[2011-01-01 09:00:00-05:00, "
+            "2011-01-01 10:00:00-05:00, 2011-01-01 11:00:00-05:00, "
+            "2011-01-01 12:00:00-05:00, 2011-01-01 13:00:00-05:00],\n"
+            "                 ordered=True, dtype='category')"
+        )
 
         assert repr(i) == exp
 
@@ -463,84 +511,156 @@ Categories (20, timedelta64[us]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         # test all length
         idx = period_range("2011-01-01 09:00", freq="h", periods=1)
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['2011-01-01 09:00'], categories=[2011-01-01 09:00], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00'], "
+            "categories=[2011-01-01 09:00],\n"
+            "                 ordered=False, dtype='category')"
+        )
         assert repr(i) == exp
 
         idx = period_range("2011-01-01 09:00", freq="h", periods=2)
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00'], categories=[2011-01-01 09:00, 2011-01-01 10:00], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00'],\n"
+            "                 categories=[2011-01-01 09:00, "
+            "2011-01-01 10:00], ordered=False,\n"
+            "                 dtype='category')"
+        )
         assert repr(i) == exp
 
         idx = period_range("2011-01-01 09:00", freq="h", periods=3)
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00', '2011-01-01 11:00'], categories=[2011-01-01 09:00, 2011-01-01 10:00, 2011-01-01 11:00], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00', "
+            "'2011-01-01 11:00'],\n"
+            "                 categories=[2011-01-01 09:00, "
+            "2011-01-01 10:00, 2011-01-01 11:00],\n"
+            "                 ordered=False, dtype='category')"
+        )
         assert repr(i) == exp
 
         idx = period_range("2011-01-01 09:00", freq="h", periods=5)
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00', '2011-01-01 11:00',
-                  '2011-01-01 12:00', '2011-01-01 13:00'],
-                 categories=[2011-01-01 09:00, 2011-01-01 10:00, 2011-01-01 11:00, 2011-01-01 12:00, 2011-01-01 13:00], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00', "
+            "'2011-01-01 11:00',\n"
+            "                  '2011-01-01 12:00', '2011-01-01 13:00'],\n"
+            "                 categories=[2011-01-01 09:00, 2011-01-01 10:00, "
+            "2011-01-01 11:00, 2011-01-01 12:00, 2011-01-01 13:00],\n"
+            "                 ordered=False, dtype='category')"
+        )
 
         assert repr(i) == exp
 
         i = CategoricalIndex(Categorical(idx.append(idx)))
-        exp = """CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00', '2011-01-01 11:00',
-                  '2011-01-01 12:00', '2011-01-01 13:00', '2011-01-01 09:00',
-                  '2011-01-01 10:00', '2011-01-01 11:00', '2011-01-01 12:00',
-                  '2011-01-01 13:00'],
-                 categories=[2011-01-01 09:00, 2011-01-01 10:00, 2011-01-01 11:00, 2011-01-01 12:00, 2011-01-01 13:00], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00', "
+            "'2011-01-01 11:00',\n"
+            "                  '2011-01-01 12:00', '2011-01-01 13:00', "
+            "'2011-01-01 09:00',\n"
+            "                  '2011-01-01 10:00', '2011-01-01 11:00', "
+            "'2011-01-01 12:00',\n"
+            "                  '2011-01-01 13:00'],\n"
+            "                 categories=[2011-01-01 09:00, 2011-01-01 10:00, "
+            "2011-01-01 11:00, 2011-01-01 12:00, 2011-01-01 13:00],\n"
+            "                 ordered=False, dtype='category')"
+        )
 
         assert repr(i) == exp
 
         idx = period_range("2011-01", freq="M", periods=5)
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['2011-01', '2011-02', '2011-03', '2011-04', '2011-05'], categories=[2011-01, 2011-02, 2011-03, 2011-04, 2011-05], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01', '2011-02', '2011-03', '2011-04', "
+            "'2011-05'],\n"
+            "                 categories=[2011-01, 2011-02, 2011-03, "
+            "2011-04, 2011-05],\n"
+            "                 ordered=False, dtype='category')"
+        )
         assert repr(i) == exp
 
     def test_categorical_index_repr_period_ordered(self):
         idx = period_range("2011-01-01 09:00", freq="h", periods=5)
         i = CategoricalIndex(Categorical(idx, ordered=True))
-        exp = """CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00', '2011-01-01 11:00',
-                  '2011-01-01 12:00', '2011-01-01 13:00'],
-                 categories=[2011-01-01 09:00, 2011-01-01 10:00, 2011-01-01 11:00, 2011-01-01 12:00, 2011-01-01 13:00], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01-01 09:00', '2011-01-01 10:00', "
+            "'2011-01-01 11:00',\n"
+            "                  '2011-01-01 12:00', '2011-01-01 13:00'],\n"
+            "                 categories=[2011-01-01 09:00, 2011-01-01 10:00, "
+            "2011-01-01 11:00, 2011-01-01 12:00, 2011-01-01 13:00],\n"
+            "                 ordered=True, dtype='category')"
+        )
 
         assert repr(i) == exp
 
         idx = period_range("2011-01", freq="M", periods=5)
         i = CategoricalIndex(Categorical(idx, ordered=True))
-        exp = """CategoricalIndex(['2011-01', '2011-02', '2011-03', '2011-04', '2011-05'], categories=[2011-01, 2011-02, 2011-03, 2011-04, 2011-05], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['2011-01', '2011-02', '2011-03', '2011-04', "
+            "'2011-05'],\n"
+            "                 categories=[2011-01, 2011-02, 2011-03, "
+            "2011-04, 2011-05],\n"
+            "                 ordered=True, dtype='category')"
+        )
         assert repr(i) == exp
 
     def test_categorical_index_repr_timedelta(self):
         idx = timedelta_range("1 days", periods=5)
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['1 days', '2 days', '3 days', '4 days', '5 days'], categories=[1 days, 2 days, 3 days, 4 days, 5 days], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['1 days', '2 days', '3 days', '4 days', "
+            "'5 days'],\n"
+            "                 categories=[1 days, 2 days, 3 days, 4 days, "
+            "5 days],\n"
+            "                 ordered=False, dtype='category')"
+        )
         assert repr(i) == exp
 
         idx = timedelta_range("1 hours", periods=10)
         i = CategoricalIndex(Categorical(idx))
-        exp = """CategoricalIndex(['0 days 01:00:00', '1 days 01:00:00', '2 days 01:00:00',
-                  '3 days 01:00:00', '4 days 01:00:00', '5 days 01:00:00',
-                  '6 days 01:00:00', '7 days 01:00:00', '8 days 01:00:00',
-                  '9 days 01:00:00'],
-                 categories=[0 days 01:00:00, 1 days 01:00:00, 2 days 01:00:00, 3 days 01:00:00, ..., 6 days 01:00:00, 7 days 01:00:00, 8 days 01:00:00, 9 days 01:00:00], ordered=False, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['0 days 01:00:00', '1 days 01:00:00', "
+            "'2 days 01:00:00',\n"
+            "                  '3 days 01:00:00', '4 days 01:00:00', "
+            "'5 days 01:00:00',\n"
+            "                  '6 days 01:00:00', '7 days 01:00:00', "
+            "'8 days 01:00:00',\n"
+            "                  '9 days 01:00:00'],\n"
+            "                 categories=[0 days 01:00:00, 1 days 01:00:00, "
+            "2 days 01:00:00, 3 days 01:00:00, ..., 6 days 01:00:00, "
+            "7 days 01:00:00, 8 days 01:00:00, 9 days 01:00:00],\n"
+            "                 ordered=False, dtype='category')"
+        )
 
         assert repr(i) == exp
 
     def test_categorical_index_repr_timedelta_ordered(self):
         idx = timedelta_range("1 days", periods=5)
         i = CategoricalIndex(Categorical(idx, ordered=True))
-        exp = """CategoricalIndex(['1 days', '2 days', '3 days', '4 days', '5 days'], categories=[1 days, 2 days, 3 days, 4 days, 5 days], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['1 days', '2 days', '3 days', '4 days', "
+            "'5 days'],\n"
+            "                 categories=[1 days, 2 days, 3 days, 4 days, "
+            "5 days],\n"
+            "                 ordered=True, dtype='category')"
+        )
         assert repr(i) == exp
 
         idx = timedelta_range("1 hours", periods=10)
         i = CategoricalIndex(Categorical(idx, ordered=True))
-        exp = """CategoricalIndex(['0 days 01:00:00', '1 days 01:00:00', '2 days 01:00:00',
-                  '3 days 01:00:00', '4 days 01:00:00', '5 days 01:00:00',
-                  '6 days 01:00:00', '7 days 01:00:00', '8 days 01:00:00',
-                  '9 days 01:00:00'],
-                 categories=[0 days 01:00:00, 1 days 01:00:00, 2 days 01:00:00, 3 days 01:00:00, ..., 6 days 01:00:00, 7 days 01:00:00, 8 days 01:00:00, 9 days 01:00:00], ordered=True, dtype='category')"""  # noqa: E501
+        exp = (
+            "CategoricalIndex(['0 days 01:00:00', '1 days 01:00:00', "
+            "'2 days 01:00:00',\n"
+            "                  '3 days 01:00:00', '4 days 01:00:00', "
+            "'5 days 01:00:00',\n"
+            "                  '6 days 01:00:00', '7 days 01:00:00', "
+            "'8 days 01:00:00',\n"
+            "                  '9 days 01:00:00'],\n"
+            "                 categories=[0 days 01:00:00, 1 days 01:00:00, "
+            "2 days 01:00:00, 3 days 01:00:00, ..., 6 days 01:00:00, "
+            "7 days 01:00:00, 8 days 01:00:00, 9 days 01:00:00],\n"
+            "                 ordered=True, dtype='category')"
+        )
 
         assert repr(i) == exp
 

--- a/pandas/tests/indexes/categorical/test_formats.py
+++ b/pandas/tests/indexes/categorical/test_formats.py
@@ -11,83 +11,137 @@ class TestCategoricalIndexReprStringCategories:
     def test_string_categorical_index_repr(self):
         # short
         idx = CategoricalIndex(["a", "bb", "ccc"])
-        expected = """CategoricalIndex(['a', 'bb', 'ccc'], categories=['a', 'bb', 'ccc'], ordered=False, dtype='category')"""  # noqa: E501
+        expected = (
+            "CategoricalIndex(['a', 'bb', 'ccc'], "
+            "categories=['a', 'bb', 'ccc'],\n"
+            "                 ordered=False, dtype='category')"
+        )
         assert repr(idx) == expected
 
     def test_categorical_index_repr_multiline(self):
         # multiple lines
         idx = CategoricalIndex(["a", "bb", "ccc"] * 10)
-        expected = """CategoricalIndex(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
-                  'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb',
-                  'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc'],
-                 categories=['a', 'bb', 'ccc'], ordered=False, dtype='category')"""  # noqa: E501
+        expected = (
+            "CategoricalIndex(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', "
+            "'bb', 'ccc', 'a',\n"
+            "                  'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', "
+            "'ccc', 'a', 'bb',\n"
+            "                  'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', "
+            "'a', 'bb', 'ccc'],\n"
+            "                 categories=['a', 'bb', 'ccc'], "
+            "ordered=False, dtype='category')"
+        )
         assert repr(idx) == expected
 
     def test_categorical_index_repr_truncated(self):
         # truncated
         idx = CategoricalIndex(["a", "bb", "ccc"] * 100)
-        expected = """CategoricalIndex(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
-                  ...
-                  'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc'],
-                 categories=['a', 'bb', 'ccc'], ordered=False, dtype='category', length=300)"""  # noqa: E501
+        expected = (
+            "CategoricalIndex(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', "
+            "'bb', 'ccc', 'a',\n"
+            "                  ...\n"
+            "                  'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', "
+            "'a', 'bb', 'ccc'],\n"
+            "                 categories=['a', 'bb', 'ccc'], "
+            "ordered=False, dtype='category',\n"
+            "                 length=300)"
+        )
         assert repr(idx) == expected
 
     def test_categorical_index_repr_many_categories(self):
         # larger categories
         idx = CategoricalIndex(list("abcdefghijklmmo"))
-        expected = """CategoricalIndex(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
-                  'm', 'm', 'o'],
-                 categories=['a', 'b', 'c', 'd', ..., 'k', 'l', 'm', 'o'], ordered=False, dtype='category')"""  # noqa: E501
+        expected = (
+            "CategoricalIndex(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', "
+            "'i', 'j', 'k', 'l',\n"
+            "                  'm', 'm', 'o'],\n"
+            "                 categories=['a', 'b', 'c', 'd', ..., "
+            "'k', 'l', 'm', 'o'],\n"
+            "                 ordered=False, dtype='category')"
+        )
         assert repr(idx) == expected
 
     def test_categorical_index_repr_unicode(self):
         # short
         idx = CategoricalIndex(["あ", "いい", "ううう"])
-        expected = """CategoricalIndex(['あ', 'いい', 'ううう'], categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""  # noqa: E501
+        expected = (
+            "CategoricalIndex(['あ', 'いい', 'ううう'], "
+            "categories=['あ', 'いい', 'ううう'],\n"
+            "                 ordered=False, dtype='category')"
+        )
         assert repr(idx) == expected
 
     def test_categorical_index_repr_unicode_multiline(self):
         # multiple lines
         idx = CategoricalIndex(["あ", "いい", "ううう"] * 10)
-        expected = """CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ',
-                  'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
-                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
-                 categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""  # noqa: E501
+        expected = (
+            "CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', "
+            "'あ', 'いい', 'ううう', 'あ',\n"
+            "                  'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', "
+            "'いい', 'ううう', 'あ', 'いい',\n"
+            "                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', "
+            "'ううう', 'あ', 'いい', 'ううう'],\n"
+            "                 categories=['あ', 'いい', 'ううう'], "
+            "ordered=False, dtype='category')"
+        )
         assert repr(idx) == expected
 
     def test_categorical_index_repr_unicode_truncated(self):
         # truncated
         idx = CategoricalIndex(["あ", "いい", "ううう"] * 100)
-        expected = """CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ',
-                  ...
-                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
-                 categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category', length=300)"""  # noqa: E501
+        expected = (
+            "CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', "
+            "'あ', 'いい', 'ううう', 'あ',\n"
+            "                  ...\n"
+            "                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', "
+            "'ううう', 'あ', 'いい', 'ううう'],\n"
+            "                 categories=['あ', 'いい', 'ううう'], "
+            "ordered=False, dtype='category',\n"
+            "                 length=300)"
+        )
         assert repr(idx) == expected
 
     def test_categorical_index_repr_unicode_many_categories(self):
         # larger categories
         idx = CategoricalIndex(list("あいうえおかきくけこさしすせそ"))
-        expected = """CategoricalIndex(['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ', 'さ', 'し',
-                  'す', 'せ', 'そ'],
-                 categories=['あ', 'い', 'う', 'え', ..., 'し', 'す', 'せ', 'そ'], ordered=False, dtype='category')"""  # noqa: E501
+        expected = (
+            "CategoricalIndex(['あ', 'い', 'う', 'え', 'お', 'か', 'き', "
+            "'く', 'け', 'こ', 'さ', 'し',\n"
+            "                  'す', 'せ', 'そ'],\n"
+            "                 categories=['あ', 'い', 'う', 'え', ..., "
+            "'し', 'す', 'せ', 'そ'],\n"
+            "                 ordered=False, dtype='category')"
+        )
         assert repr(idx) == expected
 
     def test_categorical_index_repr_east_asian_width(self):
         with cf.option_context("display.unicode.east_asian_width", True):
             # short
             idx = CategoricalIndex(["あ", "いい", "ううう"])
-            expected = """CategoricalIndex(['あ', 'いい', 'ううう'], categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""  # noqa: E501
+            expected = (
+                "CategoricalIndex(['あ', 'いい', 'ううう'], "
+                "categories=['あ', 'いい', 'ううう'],\n"
+                "                 ordered=False, dtype='category')"
+            )
             assert repr(idx) == expected
 
     def test_categorical_index_repr_east_asian_width_multiline(self):
         with cf.option_context("display.unicode.east_asian_width", True):
             # multiple lines
             idx = CategoricalIndex(["あ", "いい", "ううう"] * 10)
-            expected = """CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
-                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
-                  'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
-                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
-                 categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""  # noqa: E501
+            expected = (
+                "CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', "
+                "'ううう', 'あ', 'いい',\n"
+                "                  'ううう', 'あ', 'いい', 'ううう', 'あ', "
+                "'いい', 'ううう',\n"
+                "                  'あ', 'いい', 'ううう', 'あ', 'いい', "
+                "'ううう', 'あ', 'いい',\n"
+                "                  'ううう', 'あ', 'いい', 'ううう', 'あ', "
+                "'いい', 'ううう'],\n"
+                "                 categories=['あ', 'いい', 'ううう'], "
+                "ordered=False,\n"
+                "                 dtype='category')"
+            )
 
             assert repr(idx) == expected
 
@@ -95,20 +149,31 @@ class TestCategoricalIndexReprStringCategories:
         with cf.option_context("display.unicode.east_asian_width", True):
             # truncated
             idx = CategoricalIndex(["あ", "いい", "ううう"] * 100)
-            expected = """CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
-                  'ううう', 'あ',
-                  ...
-                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
-                  'あ', 'いい', 'ううう'],
-                 categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category', length=300)"""  # noqa: E501
+            expected = (
+                "CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', "
+                "'ううう', 'あ', 'いい',\n"
+                "                  'ううう', 'あ',\n"
+                "                  ...\n"
+                "                  'ううう', 'あ', 'いい', 'ううう', 'あ', "
+                "'いい', 'ううう',\n"
+                "                  'あ', 'いい', 'ううう'],\n"
+                "                 categories=['あ', 'いい', 'ううう'], "
+                "ordered=False,\n"
+                "                 dtype='category', length=300)"
+            )
 
             assert repr(idx) == expected
 
     def test_categorical_index_repr_east_asian_width_many_categories(self):
         with cf.option_context("display.unicode.east_asian_width", True):
             idx = CategoricalIndex(list("あいうえおかきくけこさしすせそ"))
-            expected = """CategoricalIndex(['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ',
-                  'さ', 'し', 'す', 'せ', 'そ'],
-                 categories=['あ', 'い', 'う', 'え', ..., 'し', 'す', 'せ', 'そ'], ordered=False, dtype='category')"""  # noqa: E501
+            expected = (
+                "CategoricalIndex(['あ', 'い', 'う', 'え', 'お', 'か', 'き', "
+                "'く', 'け', 'こ',\n"
+                "                  'さ', 'し', 'す', 'せ', 'そ'],\n"
+                "                 categories=['あ', 'い', 'う', 'え', ..., "
+                "'し', 'す', 'せ', 'そ'],\n"
+                "                 ordered=False, dtype='category')"
+            )
 
             assert repr(idx) == expected

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -108,8 +108,9 @@ class TestDatetimeIndexRendering:
             (
                 ["2012-01-01 00:00:00", "2012-01-01 01:00:00"],
                 "60min",
-                "DatetimeIndex(['2012-01-01 00:00:00', '2012-01-01 01:00:00'], "
-                "dtype='datetime64[ns]', freq='60min')",
+                "DatetimeIndex(['2012-01-01 00:00:00', "
+                "'2012-01-01 01:00:00'],\n"
+                "              dtype='datetime64[ns]', freq='60min')",
             ),
             (
                 ["2012-01-01"],
@@ -123,6 +124,16 @@ class TestDatetimeIndexRendering:
         dti = DatetimeIndex(dates, freq).as_unit(unit)
         actual_repr = repr(dti)
         assert actual_repr == expected_repr.replace("[ns]", f"[{unit}]")
+
+    def test_dti_repr_wraps_at_display_width(self):
+        # GH#11552
+        dti = pd.date_range("2011-01-01", periods=3, freq="D", name="dates")
+        result = repr(dti)
+        expected = (
+            "DatetimeIndex(['2011-01-01', '2011-01-02', '2011-01-03'],\n"
+            "              dtype='datetime64[us]', name='dates', freq='D')"
+        )
+        assert result == expected
 
     def test_dti_representation(self, unit):
         idxs = []

--- a/pandas/tests/indexes/interval/test_formats.py
+++ b/pandas/tests/indexes/interval/test_formats.py
@@ -109,7 +109,9 @@ class TestIntervalIndexRendering:
         index = IntervalIndex.from_arrays(left, right)
         result = repr(index)
         expected = (
-            "IntervalIndex([(2020-01-01 00:00:00+00:00, 2020-01-02 00:00:00+00:00]], "
+            "IntervalIndex([(2020-01-01 00:00:00+00:00, "
+            "2020-01-02 00:00:00+00:00]],\n"
+            "              "
             f"dtype='interval[datetime64[{unit}, UTC], right]')"
         )
         assert result == expected

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -72,6 +72,18 @@ class TestRangeIndex:
         result = eval(result)
         tm.assert_index_equal(result, i, exact=True)
 
+    def test_repr_wraps_at_display_width(self):
+        # GH#11552
+        idx = RangeIndex(100, name="my_long_index_name")
+
+        with pd.option_context("display.width", 40):
+            result = repr(idx)
+        expected = (
+            "RangeIndex(start=0, stop=100, step=1,\n"
+            "           name='my_long_index_name')"
+        )
+        assert result == expected
+
     def test_insert(self):
         idx = RangeIndex(5, name="Foo")
         result = idx[1:4]


### PR DESCRIPTION
NB: I manually checked the output on main vs this branch on width=80 terminals and it is a big improvement.

## Summary
- Index `__repr__` now wraps attribute key-value pairs (dtype, name, freq, categories, etc.) to respect `display.width`, matching the existing width-aware wrapping of data values.
- Previously, the attributes footer was joined with a simple `", ".join()` and could produce arbitrarily long lines regardless of the width setting.

closes #11552

## Test plan
- [x] Updated expected strings in `pandas/tests/indexes/categorical/test_formats.py` (12 tests)
- [x] Updated expected strings in `pandas/tests/indexes/datetimes/test_formats.py` (1 test)
- [x] Updated expected strings in `pandas/tests/arrays/categorical/test_repr.py` (8 tests)
- [x] Verified no performance regression via benchmarking
- [x] Full index test suite passes (16633 tests)
- [x] All repr/format tests pass (1167 + 3230 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)