### PR TITLE
PERF: restore hash table pre-allocation in value_count

### DIFF
--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -73,7 +73,7 @@ cdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna, const uint8
             else:
                 table.vals[k] += 1
     {{else}}
-    kh_resize_{{ttype}}(table, n // 10)
+    kh_resize_{{ttype}}(table, n)
 
     for i in range(n):
         val = {{to_c_type}}(values[i])


### PR DESCRIPTION
NB: motivated by an asv regression vs 3.0

## Summary
- Restore `kh_resize(table, n)` for non-object dtypes in `value_count`, reverting the inadvertent change to `n // 10` from #64543
- The `n // 10` pre-allocation causes expensive hash table resizes during insertion for float64 (whose hash function uses murmur2 + NaN handling), resulting in ~2x regression in `Series.mode()` for float dtype
- Object dtype keeps `n // 10` as it was in v3.0

## Benchmark (float, N=100000)
| | median (ms) |
|---|---|
| `n // 10` (regressed) | 19.97 |
| `n` (this PR) | 10.66 |

## Test plan
- [x] `pytest pandas/tests/test_algos.py` — 494 passed
- [x] `pytest pandas/tests/base/test_value_counts.py pandas/tests/frame/methods/test_value_counts.py pandas/tests/series/methods/test_value_counts.py pandas/tests/frame/methods/test_duplicated.py pandas/tests/series/methods/test_duplicated.py` — 301 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)