### PR TITLE
PERF: avoid expensive DataFrame snapshot in loc.__setitem__

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -949,8 +949,10 @@ class _LocationIndexer(NDFrameIndexerBase):
         # slice and copy every block.
         if self.obj.ndim == 1:
             orig_dtype_info = self.obj.dtype
+            orig_columns = None
         else:
             orig_dtype_info = self.obj._mgr.get_dtypes().copy()
+            orig_columns = self.obj.columns
 
         iloc: _iLocIndexer = (
             cast("_iLocIndexer", self) if self.name == "iloc" else self.obj.iloc
@@ -958,9 +960,9 @@ class _LocationIndexer(NDFrameIndexerBase):
         iloc._setitem_with_indexer(indexer, value, self.name)
 
         if self.obj.shape[0] != orig_nrows:
-            self._post_expansion_casting(orig_dtype_info)
+            self._post_expansion_casting(orig_dtype_info, orig_columns)
 
-    def _post_expansion_casting(self, orig_dtype_info) -> None:
+    def _post_expansion_casting(self, orig_dtype_info, orig_columns) -> None:
         # setitem-with-expansion added new rows.  Try to retain
         #  original dtypes
         if self.obj.ndim == 1:
@@ -985,17 +987,17 @@ class _LocationIndexer(NDFrameIndexerBase):
                     )
                     self.obj.isetitem(idx, new_arr)
 
-            elif self.obj.columns.is_unique:
-                # Added rows and columns
-                for col_idx in range(len(orig_dtypes)):
-                    new_dtype = new_dtypes[col_idx]
-                    orig_dtype = orig_dtypes[col_idx]
+            elif orig_columns.is_unique and self.obj.columns.is_unique:
+                # Added rows and columns; iterate by label since positional
+                # correspondence between orig and new is not guaranteed.
+                for col, orig_dtype in zip(orig_columns, orig_dtypes, strict=True):
+                    new_dtype = self.obj[col].dtype
                     if new_dtype != orig_dtype:
                         orig_arr = pd_array([], dtype=orig_dtype)
                         new_arr = infer_and_maybe_downcast(
-                            orig_arr, self.obj.iloc[:, col_idx]._values
+                            orig_arr, self.obj[col]._values
                         )
-                        self.obj.isetitem(col_idx, new_arr)
+                        self.obj[col] = new_arr
             else:
                 # In these cases there isn't a one-to-one correspondence between
                 #  old columns and new columns, which makes casting hairy.

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
         ArrayLike,
         Axis,
         AxisInt,
+        DtypeObj,
         T,
         npt,
     )
@@ -951,7 +952,7 @@ class _LocationIndexer(NDFrameIndexerBase):
             orig_dtype_info = self.obj.dtype
             orig_columns = None
         else:
-            orig_dtype_info = self.obj._mgr.get_dtypes().copy()
+            orig_dtype_info = self.obj._mgr.get_dtypes()
             orig_columns = self.obj.columns
 
         iloc: _iLocIndexer = (
@@ -962,19 +963,25 @@ class _LocationIndexer(NDFrameIndexerBase):
         if self.obj.shape[0] != orig_nrows:
             self._post_expansion_casting(orig_dtype_info, orig_columns)
 
-    def _post_expansion_casting(self, orig_dtype_info, orig_columns) -> None:
+    def _post_expansion_casting(
+        self,
+        orig_dtype_info: DtypeObj | npt.NDArray[np.object_],
+        orig_columns: Index | None,
+    ) -> None:
         # setitem-with-expansion added new rows.  Try to retain
         #  original dtypes
         if self.obj.ndim == 1:
-            orig_dtype = orig_dtype_info
-            if orig_dtype != self.obj.dtype:
-                orig_arr = pd_array([], dtype=orig_dtype)
+            assert not isinstance(orig_dtype_info, np.ndarray)
+            if orig_dtype_info != self.obj.dtype:
+                orig_arr = pd_array([], dtype=orig_dtype_info)
                 new_arr = infer_and_maybe_downcast(orig_arr, self.obj._values)
                 new_ser = self.obj._constructor(
                     new_arr, index=self.obj.index, name=self.obj.name
                 )
                 self.obj._mgr = new_ser._mgr
         else:
+            assert isinstance(orig_dtype_info, np.ndarray)
+            assert orig_columns is not None
             orig_dtypes = orig_dtype_info
             new_dtypes = self.obj._mgr.get_dtypes()
             if len(orig_dtypes) == len(new_dtypes):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -987,15 +987,15 @@ class _LocationIndexer(NDFrameIndexerBase):
 
             elif self.obj.columns.is_unique:
                 # Added rows and columns
-                for idx in range(len(orig_dtypes)):
-                    new_dtype = new_dtypes[idx]
-                    orig_dtype = orig_dtypes[idx]
+                for col_idx in range(len(orig_dtypes)):
+                    new_dtype = new_dtypes[col_idx]
+                    orig_dtype = orig_dtypes[col_idx]
                     if new_dtype != orig_dtype:
                         orig_arr = pd_array([], dtype=orig_dtype)
                         new_arr = infer_and_maybe_downcast(
-                            orig_arr, self.obj.iloc[:, idx]._values
+                            orig_arr, self.obj.iloc[:, col_idx]._values
                         )
-                        self.obj.isetitem(idx, new_arr)
+                        self.obj.isetitem(col_idx, new_arr)
             else:
                 # In these cases there isn't a one-to-one correspondence between
                 #  old columns and new columns, which makes casting hairy.

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -937,48 +937,65 @@ class _LocationIndexer(NDFrameIndexerBase):
         else:
             maybe_callable = com.apply_if_callable(key, self.obj)
             key = self._raise_callable_usage(key, maybe_callable)
-        orig_obj = self.obj[:].iloc[:0].copy()  # copy to avoid extra refs
+        # Capture the row count before _get_setitem_indexer which may add
+        # columns (but not rows).
+        orig_nrows = self.obj.shape[0]
         indexer = self._get_setitem_indexer(key)  # may alter self.obj
         self._has_valid_setitem_indexer(key)
+
+        # Capture dtype info cheaply between potential column expansion
+        # (above) and potential row expansion (below).  This replaces the
+        # much more expensive ``self.obj[:].iloc[:0].copy()`` that had to
+        # slice and copy every block.
+        if self.obj.ndim == 1:
+            orig_dtype_info = self.obj.dtype
+        else:
+            orig_dtype_info = self.obj._mgr.get_dtypes().copy()
 
         iloc: _iLocIndexer = (
             cast("_iLocIndexer", self) if self.name == "iloc" else self.obj.iloc
         )
         iloc._setitem_with_indexer(indexer, value, self.name)
 
-        self._post_expansion_casting(orig_obj)
+        if self.obj.shape[0] != orig_nrows:
+            self._post_expansion_casting(orig_dtype_info)
 
-    def _post_expansion_casting(self, orig_obj) -> None:
-        if orig_obj.shape[0] != self.obj.shape[0]:
-            # setitem-with-expansion added new rows.  Try to retain
-            #  original dtypes
-            if orig_obj.ndim == 1:
-                if orig_obj.dtype != self.obj.dtype:
-                    new_arr = infer_and_maybe_downcast(orig_obj.array, self.obj._values)
-                    new_ser = self.obj._constructor(
-                        new_arr, index=self.obj.index, name=self.obj.name
-                    )
-                    self.obj._mgr = new_ser._mgr
-            elif orig_obj.shape[1] == self.obj.shape[1]:
-                # We added rows but not columns
-                changed_dtypes = (
-                    self.obj._mgr.get_dtypes() != orig_obj._mgr.get_dtypes()
+    def _post_expansion_casting(self, orig_dtype_info) -> None:
+        # setitem-with-expansion added new rows.  Try to retain
+        #  original dtypes
+        if self.obj.ndim == 1:
+            orig_dtype = orig_dtype_info
+            if orig_dtype != self.obj.dtype:
+                orig_arr = pd_array([], dtype=orig_dtype)
+                new_arr = infer_and_maybe_downcast(orig_arr, self.obj._values)
+                new_ser = self.obj._constructor(
+                    new_arr, index=self.obj.index, name=self.obj.name
                 )
-                for i in np.flatnonzero(changed_dtypes):
+                self.obj._mgr = new_ser._mgr
+        else:
+            orig_dtypes = orig_dtype_info
+            new_dtypes = self.obj._mgr.get_dtypes()
+            if len(orig_dtypes) == len(new_dtypes):
+                # We added rows but not columns
+                changed_dtypes = new_dtypes != orig_dtypes
+                for idx in np.flatnonzero(changed_dtypes):
+                    orig_arr = pd_array([], dtype=orig_dtypes[idx])
                     new_arr = infer_and_maybe_downcast(
-                        orig_obj.iloc[:, i].array, self.obj.iloc[:, i]._values
+                        orig_arr, self.obj.iloc[:, idx]._values
                     )
-                    self.obj.isetitem(i, new_arr)
+                    self.obj.isetitem(idx, new_arr)
 
-            elif orig_obj.columns.is_unique and self.obj.columns.is_unique:
-                for col in orig_obj.columns:
-                    new_dtype = self.obj[col].dtype
-                    orig_dtype = orig_obj[col].dtype
+            elif self.obj.columns.is_unique:
+                # Added rows and columns
+                for idx in range(len(orig_dtypes)):
+                    new_dtype = new_dtypes[idx]
+                    orig_dtype = orig_dtypes[idx]
                     if new_dtype != orig_dtype:
+                        orig_arr = pd_array([], dtype=orig_dtype)
                         new_arr = infer_and_maybe_downcast(
-                            orig_obj[col].array, self.obj[col]._values
+                            orig_arr, self.obj.iloc[:, idx]._values
                         )
-                        self.obj[col] = new_arr
+                        self.obj.isetitem(idx, new_arr)
             else:
                 # In these cases there isn't a one-to-one correspondence between
                 #  old columns and new columns, which makes casting hairy.


### PR DESCRIPTION
## Summary
- Replace `self.obj[:].iloc[:0].copy()` in `_LocationIndexer.__setitem__` with cheap metadata capture (row count + dtypes array).
- Skip `_post_expansion_casting` entirely when no row expansion occurred (the common case).
- For the rare expansion case, reconstruct empty arrays from saved dtypes via `pd_array([], dtype=...)` instead of slicing/copying every block.

The old approach created a 0-row copy of the entire DataFrame on every `loc.__setitem__`, which required slicing and copying every block. For a 100-column EA DataFrame this meant ~300 block operations per call. In `DataFrame.fillna(value=dict, inplace=True)`, `.loc[:, k] = res_k` is called once per column, creating O(n_columns²) total block operations—all wasted since no expansion ever happens.

Benchmark (`frame_methods.Fillna.time_fillna`, 10K rows × 100 cols, `inplace=True`):

| dtype | Before | After | Speedup |
|-------|--------|-------|---------|
| Int64 | 67.5 ms | 8.5 ms | **8×** |
| Float64 | 68.7 ms | 8.6 ms | **8×** |
| float64 | 101 ms | 8.8 ms | **12×** |
| datetime64[ns, tz] | 79 ms | 12.8 ms | **6×** |

## Test plan
- [x] `pytest pandas/tests/indexing/test_loc.py` — 1178 passed
- [x] `pytest pandas/tests/indexing/test_iloc.py` — 247 passed
- [x] `pytest pandas/tests/indexing/ -k expansion` — 149 passed
- [x] `pytest pandas/tests/frame/methods/test_fillna.py` — 68 passed
- [x] `pytest pandas/tests/series/methods/test_fillna.py` — 146 passed
- [x] `pytest pandas/tests/series/indexing/` — 2595 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)