### PR TITLE
PERF: speed up Index._engine construction

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -871,12 +871,12 @@ class Index(IndexOpsMixin, PandasObject):
 
         # to avoid a reference cycle, bind `target_values` to a local variable, so
         # `self` is not passed into the lambda.
-        if target_values.dtype == bool:  # type: ignore[union-attr]
-            return libindex.BoolEngine(target_values)
-        elif target_values.dtype == np.complex64:  # type: ignore[union-attr]
-            return libindex.Complex64Engine(target_values)
-        elif target_values.dtype == np.complex128:  # type: ignore[union-attr]
-            return libindex.Complex128Engine(target_values)
+        if target_values.dtype == bool:
+            return libindex.BoolEngine(target_values)  # type: ignore[arg-type]
+        elif target_values.dtype == np.complex64:
+            return libindex.Complex64Engine(target_values)  # type: ignore[arg-type]
+        elif target_values.dtype == np.complex128:
+            return libindex.Complex128Engine(target_values)  # type: ignore[arg-type]
         elif needs_i8_conversion(dtype):
             # We need to keep M8/m8 dtype when initializing the Engine,
             #  but don't want to change _get_engine_target bc it is used

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -872,11 +872,11 @@ class Index(IndexOpsMixin, PandasObject):
         # to avoid a reference cycle, bind `target_values` to a local variable, so
         # `self` is not passed into the lambda.
         if target_values.dtype == bool:  # type: ignore[union-attr]
-            return libindex.BoolEngine(target_values)  # type: ignore[arg-type]
+            return libindex.BoolEngine(target_values)
         elif target_values.dtype == np.complex64:  # type: ignore[union-attr]
-            return libindex.Complex64Engine(target_values)  # type: ignore[arg-type]
+            return libindex.Complex64Engine(target_values)
         elif target_values.dtype == np.complex128:  # type: ignore[union-attr]
-            return libindex.Complex128Engine(target_values)  # type: ignore[arg-type]
+            return libindex.Complex128Engine(target_values)
         elif needs_i8_conversion(dtype):
             # We need to keep M8/m8 dtype when initializing the Engine,
             #  but don't want to change _get_engine_target bc it is used
@@ -885,7 +885,7 @@ class Index(IndexOpsMixin, PandasObject):
             # ndarray[Any, Any]]" has no attribute "_ndarray"  [union-attr]
             target_values = self._data._ndarray  # type: ignore[union-attr]
         elif isinstance(dtype, StringDtype):
-            return libindex.StringObjectEngine(target_values, dtype.na_value)  # type: ignore[arg-type]
+            return libindex.StringObjectEngine(target_values, dtype.na_value)
 
         # error: Argument 1 to "ExtensionEngine" has incompatible type
         # "ndarray[Any, Any]"; expected "ExtensionArray"

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -844,17 +844,19 @@ class Index(IndexOpsMixin, PandasObject):
         self,
     ) -> libindex.IndexEngine | libindex.ExtensionEngine | libindex.MaskedIndexEngine:
         # For base class (object dtype) we get ObjectEngine
+        dtype = self.dtype
         target_values = self._get_engine_target()
 
-        if isinstance(self._values, ArrowExtensionArray) and self.dtype.kind in "Mm":
+        if isinstance(dtype, ArrowDtype) and dtype.kind in "Mm":
             import pyarrow as pa
 
-            pa_type = self._values._pa_array.type
+            values = self._values
+            pa_type = values._pa_array.type  # type: ignore[union-attr]
             if pa.types.is_timestamp(pa_type):
-                target_values = self._values._to_datetimearray()
+                target_values = values._to_datetimearray()  # type: ignore[union-attr]
                 return libindex.DatetimeEngine(target_values._ndarray)
             elif pa.types.is_duration(pa_type):
-                target_values = self._values._to_timedeltaarray()
+                target_values = values._to_timedeltaarray()  # type: ignore[union-attr]
                 return libindex.TimedeltaEngine(target_values._ndarray)
 
         if isinstance(target_values, ExtensionArray):
@@ -867,24 +869,23 @@ class Index(IndexOpsMixin, PandasObject):
             elif self._engine_type is libindex.ObjectEngine:
                 return libindex.ExtensionEngine(target_values)
 
-        target_values = cast("np.ndarray", target_values)
         # to avoid a reference cycle, bind `target_values` to a local variable, so
         # `self` is not passed into the lambda.
-        if target_values.dtype == bool:
-            return libindex.BoolEngine(target_values)
-        elif target_values.dtype == np.complex64:
-            return libindex.Complex64Engine(target_values)
-        elif target_values.dtype == np.complex128:
-            return libindex.Complex128Engine(target_values)
-        elif needs_i8_conversion(self.dtype):
+        if target_values.dtype == bool:  # type: ignore[union-attr]
+            return libindex.BoolEngine(target_values)  # type: ignore[arg-type]
+        elif target_values.dtype == np.complex64:  # type: ignore[union-attr]
+            return libindex.Complex64Engine(target_values)  # type: ignore[arg-type]
+        elif target_values.dtype == np.complex128:  # type: ignore[union-attr]
+            return libindex.Complex128Engine(target_values)  # type: ignore[arg-type]
+        elif needs_i8_conversion(dtype):
             # We need to keep M8/m8 dtype when initializing the Engine,
             #  but don't want to change _get_engine_target bc it is used
             #  elsewhere
             # error: Item "ExtensionArray" of "Union[ExtensionArray,
             # ndarray[Any, Any]]" has no attribute "_ndarray"  [union-attr]
             target_values = self._data._ndarray  # type: ignore[union-attr]
-        elif is_string_dtype(self.dtype) and not is_object_dtype(self.dtype):
-            return libindex.StringObjectEngine(target_values, self.dtype.na_value)  # type: ignore[union-attr]
+        elif isinstance(dtype, StringDtype):
+            return libindex.StringObjectEngine(target_values, dtype.na_value)  # type: ignore[arg-type]
 
         # error: Argument 1 to "ExtensionEngine" has incompatible type
         # "ndarray[Any, Any]"; expected "ExtensionArray"
@@ -5263,17 +5264,17 @@ class Index(IndexOpsMixin, PandasObject):
                 return vals._ndarray.view("i8")
         if (
             type(self) is Index
-            and isinstance(self._values, ExtensionArray)
-            and not isinstance(self._values, BaseMaskedArray)
+            and isinstance(vals, ExtensionArray)
+            and not isinstance(vals, BaseMaskedArray)
             and not (
-                isinstance(self._values, ArrowExtensionArray)
+                isinstance(vals, ArrowExtensionArray)
                 and is_numeric_dtype(self.dtype)
                 # Exclude decimal
                 and self.dtype.kind != "O"
             )
         ):
             # TODO(ExtensionIndex): remove special-case, just use self._values
-            return self._values.astype(object)
+            return vals.astype(object)
         return vals
 
     @final


### PR DESCRIPTION
NB: motivated by a regression vs 3.0

## Summary

- Cache `self.dtype` in a local variable to avoid repeated property dispatch
- Check dtype instead of `self._values` for Arrow detection (avoids redundant property access)
- Remove no-op `cast()` call
- Replace `is_string_dtype()`/`is_object_dtype()` with `isinstance(dtype, StringDtype)`
- Reuse local `vals` variable in `_get_engine_target` instead of re-accessing `self._values`

Benchmarked with `index_cached_properties.IndexCache.time_engine`:

| Index type | v3.0.0 | HEAD before | HEAD after |
|---|---|---|---|
| Float64Index | 1.5 us | 1.7 us | 0.9 us |
| UInt64Index | 1.5 us | 1.6 us | 0.9 us |
| CategoricalIndex | 2.1 us | 2.3 us | 1.5 us |
| DatetimeIndex | 1.2 us | 1.4 us | 1.2 us |
| TimedeltaIndex | 1.2 us | 1.3 us | 1.2 us |
| PeriodIndex | 0.8 us | 0.9 us | 0.8 us |
| RangeIndex | 11.3 us | 11.8 us | 11.1 us |

## Test plan

- [x] All existing index tests pass (`test_engines`, `test_any_index`, `test_old_base`, ranges, datetimes, timedeltas, period, categorical, interval, indexing, setops)
- [x] Verified correct engine types for all index types including Arrow, Masked, Bool, String, Object