### PR TITLE
CLN: remove using_cow parameter from _iLocIndexer._align_series

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2649,12 +2649,17 @@ class _iLocIndexer(_LocationIndexer):
                 item = self.obj.columns[loc]
                 if item in value:
                     sub_indexer[1] = item
+                    ser = value[item]
                     val = self._align_series(
                         tuple(sub_indexer),
-                        value[item],
+                        ser,
                         multiindex_indexer,
-                        using_cow=True,
                     )
+                    # If _align_series did not need to reindex, pass the
+                    # original Series so that _setitem_single_column can
+                    # preserve CoW ref tracking through isetitem.
+                    if val is ser._values:
+                        val = ser
                 else:
                     val = np.nan
 
@@ -2870,8 +2875,7 @@ class _iLocIndexer(_LocationIndexer):
         indexer,
         ser: Series,
         multiindex_indexer: bool = False,
-        using_cow: bool = False,
-    ):
+    ) -> ArrayLike | Series:
         """
         Parameters
         ----------
@@ -2949,9 +2953,7 @@ class _iLocIndexer(_LocationIndexer):
                     else:
                         new_ix = Index(new_ix)
                     if not len(new_ix) or ser.index.equals(new_ix):
-                        if using_cow:
-                            return ser
-                        return ser._values.copy()
+                        return ser._values
 
                     return ser.reindex(new_ix)._values
 
@@ -2965,6 +2967,7 @@ class _iLocIndexer(_LocationIndexer):
 
         elif is_integer(indexer) and self.ndim == 1:
             if is_object_dtype(self.obj.dtype):
+                # Store the Series as a scalar element in object-dtype Series
                 return ser
             ax = self.obj._get_axis(0)
 


### PR DESCRIPTION
## Summary
- Remove the `using_cow` parameter from `_iLocIndexer._align_series` since CoW is always-on
- The method now consistently returns `ser._values` (no copy) instead of conditionally returning `ser` or `ser._values.copy()` based on the `using_cow` flag
- Add `-> ArrayLike | Series` return type annotation
- Preserve CoW ref tracking at the call site in `_setitem_with_indexer_frame_value` by passing the original Series to `_setitem_single_column` when no reindex was needed

## Test plan
- [x] `pandas/tests/copy_view/test_indexing.py::test_loc_enlarging_with_dataframe` — CoW memory sharing preserved
- [x] `pandas/tests/extension/json/test_json.py::TestJSONArray::test_setitem_with_expansion_dataframe_column` — extension array setitem works
- [x] `pandas/tests/series/indexing/test_setitem.py::TestSetitemScalarIndexer::test_setitem_series_object_dtype` — object-dtype scalar setitem works
- [x] `pandas/tests/indexing/test_loc.py` — 1178 passed
- [x] `pandas/tests/indexing/test_iloc.py` — 247 passed
- [x] `pandas/tests/copy_view/test_indexing.py` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)