### PR TITLE
BUG: fix FloatingArray.astype(str) crash with distinguish_nan_and_na=True

### DIFF
--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -770,7 +770,9 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
             # avoid costly conversion to object dtype
             na_values = scalars._mask
             result = scalars._data
-            result = lib.ensure_string_array(result, copy=copy, convert_na_value=False)
+            result = lib.ensure_string_array(
+                result, copy=copy, convert_na_value=False, skipna=False
+            )
             result[na_values] = na_value
 
         else:

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -218,7 +218,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
                     pa_arr = pc.utf8_capitalize(pa_arr)
             else:
                 result = lib.ensure_string_array(
-                    result, copy=copy, convert_na_value=False
+                    result, copy=copy, convert_na_value=False, skipna=False
                 )
                 pa_arr = pa.array(result, mask=na_values, type=pa.large_string())
         elif isinstance(scalars, ArrowExtensionArray):

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -490,6 +490,17 @@ def test_astype_from_float_dtype(float_dtype, dtype):
     tm.assert_series_equal(result, expected)
 
 
+def test_astype_from_masked_float_with_nan(dtype, using_nan_is_na):
+    # GH#61617, GH#65227 - FloatingArray.astype(str) with unmasked NaN
+    arr = pd.array([np.nan, pd.NA, 3.0], dtype="Float64")
+    result = arr.astype(dtype)
+    if using_nan_is_na:
+        expected = pd.array([pd.NA, pd.NA, "3.0"], dtype=dtype)
+    else:
+        expected = pd.array(["nan", pd.NA, "3.0"], dtype=dtype)
+    tm.assert_extension_array_equal(result, expected)
+
+
 def test_to_numpy_returns_pdna_default(dtype):
     arr = pd.array(["a", pd.NA, "b"], dtype=dtype)
     result = np.array(arr)

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -325,16 +325,6 @@ class TestFromSequenceIntBool:
         expected = pd.Series(["1", "2", None], dtype="string")
         tm.assert_series_equal(result, expected)
 
-    def test_astype_masked_float_with_nan_to_string(self, using_nan_is_na):
-        # GH#61617 - FloatingArray.astype(str) with unmasked NaN
-        arr = pd.array([np.nan, pd.NA, 3.0], dtype="Float64")
-        result = arr.astype("string")
-        if using_nan_is_na:
-            expected = ArrowStringArray._from_sequence([None, None, "3.0"])
-        else:
-            expected = ArrowStringArray._from_sequence(["nan", None, "3.0"])
-        tm.assert_extension_array_equal(result, expected)
-
 
 def test_string_dtype_error_message():
     # GH#55051

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -325,6 +325,16 @@ class TestFromSequenceIntBool:
         expected = pd.Series(["1", "2", None], dtype="string")
         tm.assert_series_equal(result, expected)
 
+    def test_astype_masked_float_with_nan_to_string(self, using_nan_is_na):
+        # GH#61617 - FloatingArray.astype(str) with unmasked NaN
+        arr = pd.array([np.nan, pd.NA, 3.0], dtype="Float64")
+        result = arr.astype("string")
+        if using_nan_is_na:
+            expected = ArrowStringArray._from_sequence([None, None, "3.0"])
+        else:
+            expected = ArrowStringArray._from_sequence(["nan", None, "3.0"])
+        tm.assert_extension_array_equal(result, expected)
+
 
 def test_string_dtype_error_message():
     # GH#55051

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -324,6 +324,17 @@ $1$,$2$
         )
         assert result == expected
 
+    def test_to_csv_float_ea_nan_distinguish(self, using_nan_is_na):
+        # GH#61617 - to_csv should not crash when FloatingArray contains
+        # unmasked NaN (with distinguish_nan_and_na=True)
+        df = DataFrame({"a": pd.array([np.nan, pd.NA, 3.0], dtype="Float64"), "b": "c"})
+        result = df.to_csv(index=False)
+        if using_nan_is_na:
+            expected = tm.convert_rows_list_to_csv_str(["a,b", ",c", ",c", "3.0,c"])
+        else:
+            expected = tm.convert_rows_list_to_csv_str(["a,b", "nan,c", ",c", "3.0,c"])
+        assert result == expected
+
     def test_to_csv_2d_float_ea(self):
         # GH#64634 - get_values_for_csv on a 2D float ExtensionArray should not fail.
         data = np.array([1.0, np.nan, 3.0, 4.0])

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -325,14 +325,25 @@ $1$,$2$
         assert result == expected
 
     def test_to_csv_float_ea_nan_distinguish(self, using_nan_is_na):
-        # GH#61617 - to_csv should not crash when FloatingArray contains
-        # unmasked NaN (with distinguish_nan_and_na=True)
+        # GH#61617, GH#65227 - to_csv should not crash when FloatingArray
+        # contains unmasked NaN (with distinguish_nan_and_na=True)
         df = DataFrame({"a": pd.array([np.nan, pd.NA, 3.0], dtype="Float64"), "b": "c"})
         result = df.to_csv(index=False)
         if using_nan_is_na:
             expected = tm.convert_rows_list_to_csv_str(["a,b", ",c", ",c", "3.0,c"])
         else:
             expected = tm.convert_rows_list_to_csv_str(["a,b", "nan,c", ",c", "3.0,c"])
+        assert result == expected
+
+    def test_to_csv_float_ea_nan_distinguish_series(self, using_nan_is_na):
+        # GH#65227 - Series.to_csv with FloatingArray containing both NaN and NA
+        ser = pd.Series((1, pd.NA, 0), index=["a", "b", "c"], dtype="Float64", name="x")
+        ser = ser / ser
+        result = ser.to_csv()
+        if using_nan_is_na:
+            expected = tm.convert_rows_list_to_csv_str([",x", "a,1.0", "b,", "c,"])
+        else:
+            expected = tm.convert_rows_list_to_csv_str([",x", "a,1.0", "b,", "c,nan"])
         assert result == expected
 
     def test_to_csv_2d_float_ea(self):


### PR DESCRIPTION
## Summary
- With `future.distinguish_nan_and_na=True`, `FloatingArray.astype(str)` (and by extension `to_csv`) crashed with `ArrowTypeError` because `ensure_string_array` left unmasked NaN values as `np.nan` float objects, which PyArrow rejects at unmasked positions.
- Pass `skipna=False` to `ensure_string_array` in `ArrowStringArray._from_sequence` so NaN values are converted to the string `"nan"` rather than left as float objects.

closes #61617
closes #65227

## Test plan
- [x] `test_astype_masked_float_with_nan_to_string` — verifies `FloatingArray.astype("string")` with both `using_nan_is_na` modes
- [x] `test_to_csv_float_ea_nan_distinguish` — verifies `to_csv` on a Float64 column containing both `np.nan` and `pd.NA`
- [x] `test_to_csv_float_ea_nan_distinguish_series` — verifies `Series.to_csv` with the GH#65227 reproducer

🤖 Generated with [Claude Code](https://claude.com/claude-code)