### PR TITLE
PERF: avoid redundant category re-validation in Categorical._simple_new

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -381,7 +381,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     ) -> Self:
         # NB: This is not _quite_ as simple as the "usual" _simple_new
         codes = coerce_indexer_dtype(codes, dtype.categories)
-        dtype = CategoricalDtype(ordered=False).update_dtype(dtype)
+        if dtype.ordered is None:
+            dtype = CategoricalDtype._from_fastpath(dtype.categories, ordered=False)
         return super()._simple_new(codes, dtype)
 
     def __init__(
@@ -509,7 +510,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             full_codes[~null_mask] = codes
             codes = full_codes
 
-        dtype = CategoricalDtype(ordered=False).update_dtype(dtype)
+        if dtype.ordered is None:
+            dtype = CategoricalDtype._from_fastpath(dtype.categories, ordered=False)
         arr = coerce_indexer_dtype(codes, dtype.categories)
         super().__init__(arr, dtype)
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -628,7 +628,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         )
         new_ordered = dtype.ordered if dtype.ordered is not None else self.ordered
 
-        return CategoricalDtype(new_categories, new_ordered)
+        return CategoricalDtype._from_fastpath(new_categories, new_ordered)
 
     @property
     def categories(self) -> Index:


### PR DESCRIPTION
## Summary
- Replace `CategoricalDtype(ordered=False).update_dtype(dtype)` with a direct `ordered is None` check in `_simple_new` and `__init__`, using `_from_fastpath` to skip redundant `is_unique`/`hasnans` checks on already-validated categories.
- Use `_from_fastpath` in `CategoricalDtype.update_dtype` for the same reason — categories passed through `update_dtype` originate from existing `CategoricalDtype` instances and are already validated.

For users who need to skip the *first* `is_unique` check (the expensive one), the workaround is to construct the dtype and Categorical directly:
```python
dtype = pd.CategoricalDtype._from_fastpath(cats, ordered=False)
cat = pd.Categorical._simple_new(codes, dtype)
```

closes #60981

## Test plan
- [x] `pandas/tests/arrays/categorical/` — 634 passed
- [x] `pandas/tests/dtypes/test_dtypes.py` — 285 passed
- [x] Broader categorical-adjacent tests (astype, concat, groupby, indexes) — 2698 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)