### PR TITLE
BUG: fix colorbar side effect changing scatter colors when all c values identical (GH#64980)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -773,6 +773,7 @@ Plotting
 ^^^^^^^^
 - Bug in :meth:`DataFrame.plot.bar` and :meth:`DataFrame.plot.barh` raising ``AttributeError`` for a regularly-spaced :class:`DatetimeIndex` whose ``freq`` attribute is unset (:issue:`66771`)
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
+- Bug in :meth:`DataFrame.plot.scatter` where ``colorbar=True`` changed the color of the points when every value in ``c`` was the same (:issue:`64980`)
 - Bug in :meth:`DataFrame.plot` and :meth:`Series.plot` with ``secondary_y`` hiding the primary y-axis when the data already on the axes was drawn as a collection rather than as lines, e.g. by :meth:`DataFrame.plot.scatter` (:issue:`66789`)
 - Bug in :meth:`Series.plot`, :meth:`DataFrame.plot`, :meth:`DataFrame.plot.scatter`, :meth:`Series.hist`, :meth:`DataFrame.hist`, :func:`plotting.lag_plot` and :func:`plotting.parallel_coordinates` with timezone-aware data labelling the axis in UTC instead of in the data's own timezone (:issue:`64613`)
 -

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1479,6 +1479,7 @@ class ScatterPlot(PlanePlot):
         else:
             cmap = None
 
+        norm: mpl.colors.Normalize | None
         if color_by_categorical and cmap is not None:
             n_cats = len(self.data[c].cat.categories)
             cmap = mpl.colors.ListedColormap([cmap(i) for i in range(cmap.N)])

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1497,12 +1497,13 @@ class ScatterPlot(PlanePlot):
                 # Explicitly setting vmin/vmax prevents this side effect.
                 try:
                     c_arr = np.asarray(c_values, dtype=float)
-                    vmin = float(np.nanmin(c_arr))
-                    vmax = float(np.nanmax(c_arr))
-                    if np.isfinite(vmin) and np.isfinite(vmax):
-                        if vmin == vmax:
-                            vmax = vmin + 1
-                        norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
+                    if c_arr.ndim == 1:
+                        vmin = float(np.nanmin(c_arr))
+                        vmax = float(np.nanmax(c_arr))
+                        if np.isfinite(vmin) and np.isfinite(vmax):
+                            if vmin == vmax:
+                                vmax = vmin + 1
+                            norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
                 except (TypeError, ValueError):
                     pass
         return norm, cmap

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1488,6 +1488,22 @@ class ScatterPlot(PlanePlot):
             #  Doesn't happen in any tests 2023-11-09
         else:
             norm = self.norm
+            if norm is None:
+                # GH#64980: matplotlib's colorbar._process_values() calls
+                # nonsingular() on the norm, which modifies the shared norm
+                # object in-place. When all c values are identical (vmin==vmax),
+                # nonsingular expands the range, changing scatter colors.
+                # Explicitly setting vmin/vmax prevents this side effect.
+                try:
+                    c_arr = np.asarray(c_values, dtype=float)
+                    vmin = float(np.nanmin(c_arr))
+                    vmax = float(np.nanmax(c_arr))
+                    if np.isfinite(vmin) and np.isfinite(vmax):
+                        if vmin == vmax:
+                            vmax = vmin + 1
+                        norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
+                except (TypeError, ValueError):
+                    pass
         return norm, cmap
 
     def _get_colorbar(self, c_values, c_is_column: bool) -> bool:

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1493,6 +1493,7 @@ class ScatterPlot(PlanePlot):
         else:
             cmap = None
 
+        norm: mpl.colors.Normalize | None
         if color_by_categorical and cmap is not None:
             n_cats = len(self.data[c].cat.categories)
             cmap = mpl.colors.ListedColormap([cmap(i) for i in range(cmap.N)])
@@ -1502,7 +1503,26 @@ class ScatterPlot(PlanePlot):
             #  Doesn't happen in any tests 2023-11-09
         else:
             norm = self.norm
+            if norm is None:
+                norm = self._get_scatter_norm(c_values)
         return norm, cmap
+
+    def _get_scatter_norm(self, c_values) -> mpl.colors.Normalize | None:
+        # GH#64980: the colorbar widens the norm it shares with the scatter,
+        #  which recolors the points. Set the limits here so it has nothing
+        #  left to widen.
+        try:
+            values = np.asarray(c_values, dtype=float)
+        except (TypeError, ValueError):
+            return None  # color names
+        if values.ndim != 1 or not np.isfinite(values).any():
+            return None  # RGB(A) values, or nothing to scale to
+        vmin = np.nanmin(values)
+        vmax = np.nanmax(values)
+        if vmin == vmax:
+            # +1 is not enough at large magnitudes, e.g. 1e16 + 1 == 1e16
+            vmax = vmin + max(abs(vmin), 1.0)
+        return mpl.colors.Normalize(vmin=vmin, vmax=vmax)
 
     def _get_colorbar(self, c_values, c_is_column: bool) -> bool:
         # plot colorbar if

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -312,6 +312,34 @@ class TestDataFrameColor:
         assert ax.collections[0].cmap.name == "cividis"
         assert ax.collections[1].cmap.name == "magma"
 
+    def test_scatter_colorbar_no_side_effect_on_colors(self):
+        # GH#64980: colorbar=True should not change scatter point colors.
+        # When all c values are identical, matplotlib's colorbar._process_values
+        # called nonsingular() on the shared norm in-place, expanding vmin/vmax
+        # from (0, 0) to (-0.1, 0.1), which shifted norm(0) from 0.0 to 0.5
+        # and mapped to a different colormap color.
+        from matplotlib.colors import ListedColormap
+
+        df = DataFrame({"x": [1, 2, 3], "c": [0, 0, 0]})
+        cmap = ListedColormap(["blue", "red"])
+
+        _, ax_no_cb = plt.subplots()
+        df.plot("x", "x", kind="scatter", c=df["c"], colormap=cmap, colorbar=False,
+                ax=ax_no_cb)
+        ax_no_cb.get_figure().canvas.draw()
+        colors_no_cb = ax_no_cb.collections[-1].get_facecolor()
+
+        _, ax_with_cb = plt.subplots()
+        df.plot("x", "x", kind="scatter", c=df["c"], colormap=cmap, colorbar=True,
+                ax=ax_with_cb)
+        ax_with_cb.get_figure().canvas.draw()
+        colors_with_cb = ax_with_cb.collections[-1].get_facecolor()
+
+        tm.assert_numpy_array_equal(colors_no_cb, colors_with_cb)
+        # All points should map to the first colormap color (blue = [0, 0, 1, 1])
+        expected_color = np.array([[0.0, 0.0, 1.0, 1.0]] * 3)
+        tm.assert_numpy_array_equal(colors_no_cb, expected_color)
+
     def test_line_colors(self):
         custom_colors = "rgcby"
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -324,14 +324,28 @@ class TestDataFrameColor:
         cmap = ListedColormap(["blue", "red"])
 
         _, ax_no_cb = plt.subplots()
-        df.plot("x", "x", kind="scatter", c=df["c"], colormap=cmap, colorbar=False,
-                ax=ax_no_cb)
+        df.plot(
+            "x",
+            "x",
+            kind="scatter",
+            c=df["c"],
+            colormap=cmap,
+            colorbar=False,
+            ax=ax_no_cb,
+        )
         ax_no_cb.get_figure().canvas.draw()
         colors_no_cb = ax_no_cb.collections[-1].get_facecolor()
 
         _, ax_with_cb = plt.subplots()
-        df.plot("x", "x", kind="scatter", c=df["c"], colormap=cmap, colorbar=True,
-                ax=ax_with_cb)
+        df.plot(
+            "x",
+            "x",
+            kind="scatter",
+            c=df["c"],
+            colormap=cmap,
+            colorbar=True,
+            ax=ax_with_cb,
+        )
         ax_with_cb.get_figure().canvas.draw()
         colors_with_cb = ax_with_cb.collections[-1].get_facecolor()
 

--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -330,6 +330,36 @@ class TestDataFrameColor:
         assert ax.collections[0].cmap.name == "cividis"
         assert ax.collections[1].cmap.name == "magma"
 
+    @pytest.mark.parametrize("value", [0, -5, 1e16])
+    def test_scatter_colorbar_no_side_effect_on_colors(self, value):
+        # GH#64980: colorbar=True used to recolor the points when every c
+        #  value was the same
+        df = DataFrame({"x": [1, 2, 3], "c": [value] * 3})
+        cmap = mpl.colors.ListedColormap(["blue", "red"])
+
+        colors = []
+        for colorbar in [False, True]:
+            _, ax = plt.subplots()
+            df.plot(
+                "x", "x", kind="scatter", c="c", colormap=cmap, colorbar=colorbar, ax=ax
+            )
+            ax.get_figure().canvas.draw()
+            colors.append(ax.collections[-1].get_facecolor())
+
+        tm.assert_numpy_array_equal(colors[0], colors[1])
+        # every point maps to the bottom of the colormap, blue
+        expected = np.array([[0.0, 0.0, 1.0, 1.0]] * 3)
+        tm.assert_numpy_array_equal(colors[0], expected)
+
+    def test_scatter_all_nan_c_no_warning(self):
+        # GH#64980: an all-NaN c should not leak numpy's "All-NaN slice
+        #  encountered" RuntimeWarning
+        df = DataFrame({"x": [1, 2, 3], "c": [np.nan, np.nan, np.nan]})
+        _, ax = plt.subplots()
+        with tm.assert_produces_warning(None):
+            df.plot("x", "x", kind="scatter", c=df["c"], ax=ax)
+        ax.get_figure().canvas.draw()
+
     def test_line_colors(self):
         custom_colors = "rgcby"
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))


### PR DESCRIPTION
When all `c` values in a scatter plot are identical, `colorbar=True` and `colorbar=False` produced different point colors. This happened because matplotlib's `Colorbar._process_values()` calls `nonsingular()` on the shared norm object in-place, expanding a degenerate range (vmin=vmax=0) to (-0.1, 0.1) and shifting the normalized value from 0.0 to 0.5, which maps to a different colormap color.

The fix explicitly sets `vmin`/`vmax` on the norm from the actual data in `_get_norm_and_cmap()`. When all values are identical (vmin == vmax), `vmax` is set to `vmin + 1` so `nonsingular` won't change the range. Fix for the issue #64980