### PR TITLE
CLN: remove unnecessary usage of option_context with future.infer_string in tests

### DIFF
--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -6,20 +6,13 @@ from typing import (
     TYPE_CHECKING,
     Any,
 )
-import warnings
-
-import numpy as np
-
-from pandas._config import using_string_dtype
 
 from pandas._libs import lib
 from pandas.compat._optional import import_optional_dependency
-from pandas.errors import Pandas4Warning
 from pandas.util._decorators import set_module
 from pandas.util._validators import check_dtype_backend
 
 from pandas.core.api import DataFrame
-from pandas.core.arrays.string_ import StringDtype
 
 from pandas.io._util import arrow_table_to_pandas
 from pandas.io.common import get_handle
@@ -157,24 +150,6 @@ def read_feather(
     with get_handle(
         path, "rb", storage_options=storage_options, is_text=False
     ) as handles:
-        if dtype_backend is lib.no_default and not using_string_dtype():
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    "make_block is deprecated",
-                    Pandas4Warning,
-                )
-
-                df = feather.read_feather(
-                    handles.handle, columns=columns, use_threads=bool(use_threads)
-                )
-                # Convert any StringDtype columns to object dtype (pyarrow always
-                # uses string dtype even when the infer_string option is False)
-                for col, dtype in zip(df.columns, df.dtypes, strict=True):
-                    if isinstance(dtype, StringDtype) and dtype.na_value is np.nan:
-                        df[col] = df[col].astype("object")
-                return df
-
         pa_table = feather.read_table(
             handles.handle, columns=columns, use_threads=bool(use_threads)
         )

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1854,31 +1854,29 @@ def test_adding_new_conditional_column() -> None:
     tm.assert_frame_equal(df, expected)
 
 
-@pytest.mark.parametrize(
-    ("dtype", "infer_string"),
-    [
-        (object, False),
-        (pd.StringDtype(na_value=np.nan), True),
-    ],
-)
-def test_adding_new_conditional_column_with_string(dtype, infer_string) -> None:
+def test_adding_new_conditional_column_with_string(using_infer_string) -> None:
     # https://github.com/pandas-dev/pandas/issues/56204
     df = DataFrame({"a": [1, 2], "b": [3, 4]})
-    with pd.option_context("future.infer_string", infer_string):
-        df.loc[df["a"] == 1, "c"] = "1"
-    expected = DataFrame({"a": [1, 2], "b": [3, 4], "c": ["1", float("nan")]}).astype(
-        {"a": "int64", "b": "int64", "c": dtype}
+    df.loc[df["a"] == 1, "c"] = "1"
+    expected = DataFrame({"a": [1, 2], "b": [3, 4], "c": ["1", float("nan")]})
+    expected["c"] = expected["c"].astype(
+        pd.StringDtype(na_value=np.nan) if using_infer_string else object
     )
     tm.assert_frame_equal(df, expected)
 
 
-def test_add_new_column_infer_string():
+def test_add_new_column_infer_string(using_infer_string):
     # GH#55366
     df = DataFrame({"x": [1]})
-    with pd.option_context("future.infer_string", True):
-        df.loc[df["x"] == 1, "y"] = "1"
+    df.loc[df["x"] == 1, "y"] = "1"
     expected = DataFrame(
-        {"x": [1], "y": Series(["1"], dtype=pd.StringDtype(na_value=np.nan))},
+        {
+            "x": [1],
+            "y": Series(
+                ["1"],
+                dtype=pd.StringDtype(na_value=np.nan) if using_infer_string else object,
+            ),
+        },
         columns=Index(["x", "y"], dtype="str"),
     )
     tm.assert_frame_equal(df, expected)

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -777,10 +777,8 @@ class TestDataFrameSetItem:
 
     def test_setitem_string_option_object_index(self):
         # GH#55638
-        pytest.importorskip("pyarrow")
         df = DataFrame({"a": [1, 2]})
-        with pd.option_context("future.infer_string", True):
-            df["b"] = Index(["a", "b"], dtype=object)
+        df["b"] = Index(["a", "b"], dtype=object)
         expected = DataFrame({"a": [1, 2], "b": Series(["a", "b"], dtype=object)})
         tm.assert_frame_equal(df, expected)
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -10,7 +10,6 @@ from pandas.errors import (
     Pandas4Warning,
     SpecificationError,
 )
-import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
@@ -2211,23 +2210,13 @@ def test_groupby_column_index_name_lost(func):
     tm.assert_index_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "infer_string",
-    [
-        False,
-        pytest.param(True, marks=td.skip_if_no("pyarrow")),
-    ],
-)
-def test_groupby_duplicate_columns(infer_string):
+def test_groupby_duplicate_columns():
     # GH: 31735
-    if infer_string:
-        pytest.importorskip("pyarrow")
     df = DataFrame(
         {"A": ["f", "e", "g", "h"], "B": ["a", "b", "c", "d"], "C": [1, 2, 3, 4]}
     ).astype(object)
     df.columns = ["A", "B", "B"]
-    with pd.option_context("future.infer_string", infer_string):
-        result = df.groupby([0, 0, 0, 0]).min()
+    result = df.groupby([0, 0, 0, 0]).min()
     expected = DataFrame(
         [["e", "a", 1]], index=np.array([0]), columns=["A", "B", "B"], dtype=object
     )

--- a/pandas/tests/indexes/base_class/test_constructors.py
+++ b/pandas/tests/indexes/base_class/test_constructors.py
@@ -53,8 +53,7 @@ class TestIndexConstructor:
         tm.assert_index_equal(ser, expected)
 
         expected = Index(["a", 1], dtype="object")
-        with pd.option_context("future.infer_string", True):
-            ser = Index(["a", 1])
+        ser = Index(["a", 1])
         tm.assert_index_equal(ser, expected)
 
     @pytest.mark.parametrize("klass", [Series, Index])

--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -90,34 +90,25 @@ def test_read_unsupported_compression_type(temp_file):
         pd.read_json(temp_file, compression="unsupported")
 
 
-@pytest.mark.parametrize(
-    "infer_string", [False, pytest.param(True, marks=td.skip_if_no("pyarrow"))]
-)
 @pytest.mark.parametrize("to_infer", [True, False])
 @pytest.mark.parametrize("read_infer", [True, False])
 def test_to_json_compression(
-    compression_only,
-    read_infer,
-    to_infer,
-    compression_to_extension,
-    infer_string,
-    tmp_path,
+    compression_only, read_infer, to_infer, compression_to_extension, tmp_path
 ):
-    with pd.option_context("future.infer_string", infer_string):
-        # see gh-15008
-        compression = compression_only
+    # see gh-15008
+    compression = compression_only
 
-        # We'll complete file extension subsequently.
-        filename = tmp_path / f"test.{compression_to_extension[compression]}"
+    # We'll complete file extension subsequently.
+    filename = tmp_path / f"test.{compression_to_extension[compression]}"
 
-        df = pd.DataFrame({"A": [1]})
+    df = pd.DataFrame({"A": [1]})
 
-        to_compression = "infer" if to_infer else compression
-        read_compression = "infer" if read_infer else compression
+    to_compression = "infer" if to_infer else compression
+    read_compression = "infer" if read_infer else compression
 
-        df.to_json(filename, compression=to_compression)
-        result = pd.read_json(filename, compression=read_compression)
-        tm.assert_frame_equal(result, df)
+    df.to_json(filename, compression=to_compression)
+    result = pd.read_json(filename, compression=read_compression)
+    tm.assert_frame_equal(result, df)
 
 
 def test_to_json_compression_mode(compression):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2335,16 +2335,9 @@ def test_json_roundtrip_string_inference(orient):
     df = DataFrame(
         [["a", "b"], ["c", "d"]], index=["row 1", "row 2"], columns=["col 1", "col 2"]
     )
+    expected = df.copy()
     out = df.to_json()
-    with pd.option_context("future.infer_string", True):
-        result = read_json(StringIO(out))
-    dtype = pd.StringDtype(na_value=np.nan)
-    expected = DataFrame(
-        [["a", "b"], ["c", "d"]],
-        dtype=dtype,
-        index=Index(["row 1", "row 2"], dtype=dtype),
-        columns=Index(["col 1", "col 2"], dtype=dtype),
-    )
+    result = read_json(StringIO(out))
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -562,7 +562,12 @@ y,2
     result = parser.read_csv(StringIO(data))
 
     expected = DataFrame(
-        {"a": pd.Series(["x", "y", None], dtype=dtype), "b": [1, 2, 3]},
+        {
+            "a": pd.Series(
+                ["x", "y", None if parser.engine == "pyarrow" else np.nan], dtype=dtype
+            ),
+            "b": [1, 2, 3],
+        },
         columns=pd.Index(["a", "b"], dtype=dtype),
     )
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -550,17 +550,16 @@ def test_ea_int_avoid_overflow(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-def test_string_inference(all_parsers):
+def test_string_inference(all_parsers, using_infer_string):
     # GH#54430
-    dtype = pd.StringDtype(na_value=np.nan)
+    dtype = pd.StringDtype(na_value=np.nan) if using_infer_string else object
 
     data = """a,b
 x,1
 y,2
 ,3"""
     parser = all_parsers
-    with pd.option_context("future.infer_string", True):
-        result = parser.read_csv(StringIO(data))
+    result = parser.read_csv(StringIO(data))
 
     expected = DataFrame(
         {"a": pd.Series(["x", "y", None], dtype=dtype), "b": [1, 2, 3]},
@@ -577,28 +576,30 @@ x,a
 y,a
 z,a"""
     parser = all_parsers
-    with pd.option_context("future.infer_string", True):
-        result = parser.read_csv(StringIO(data), dtype=dtype)
+    result = parser.read_csv(StringIO(data), dtype=dtype)
 
-    expected_dtype = pd.StringDtype(na_value=np.nan) if dtype is str else object
+    expected_dtype = (
+        pd.StringDtype(na_value=np.nan)
+        if dtype is str and using_infer_string
+        else object
+    )
     expected = DataFrame(
         {
             "a": pd.Series(["x", "y", "z"], dtype=expected_dtype),
             "b": pd.Series(["a", "a", "a"], dtype=expected_dtype),
         },
-        columns=pd.Index(["a", "b"], dtype=pd.StringDtype(na_value=np.nan)),
+        columns=pd.Index(["a", "b"]),
     )
     tm.assert_frame_equal(result, expected)
 
-    with pd.option_context("future.infer_string", True):
-        result = parser.read_csv(StringIO(data), dtype={"a": dtype})
+    result = parser.read_csv(StringIO(data), dtype={"a": dtype})
 
     expected = DataFrame(
         {
             "a": pd.Series(["x", "y", "z"], dtype=expected_dtype),
-            "b": pd.Series(["a", "a", "a"], dtype=pd.StringDtype(na_value=np.nan)),
+            "b": pd.Series(["a", "a", "a"]),
         },
-        columns=pd.Index(["a", "b"], dtype=pd.StringDtype(na_value=np.nan)),
+        columns=pd.Index(["a", "b"]),
     )
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/pytables/test_read.py
+++ b/pandas/tests/io/pytables/test_read.py
@@ -6,7 +6,6 @@ import pytest
 
 from pandas.compat import is_platform_windows
 
-import pandas as pd
 from pandas import (
     DataFrame,
     HDFStore,
@@ -287,14 +286,8 @@ def test_read_infer_string(temp_h5_path):
     # GH#54431
     df = DataFrame({"a": ["a", "b", None]})
     df.to_hdf(temp_h5_path, key="data", format="table")
-    with pd.option_context("future.infer_string", True):
-        result = read_hdf(temp_h5_path, key="data", mode="r")
-    expected = DataFrame(
-        {"a": ["a", "b", None]},
-        dtype=pd.StringDtype(na_value=np.nan),
-        columns=Index(["a"], dtype=pd.StringDtype(na_value=np.nan)),
-    )
-    tm.assert_frame_equal(result, expected)
+    result = read_hdf(temp_h5_path, key="data", mode="r")
+    tm.assert_frame_equal(result, df)
 
 
 def test_hdfstore_read_datetime64_unit_s(temp_hdfstore):

--- a/pandas/tests/io/pytables/test_read.py
+++ b/pandas/tests/io/pytables/test_read.py
@@ -284,7 +284,7 @@ def test_read_hdf_series_mode_r(temp_h5_path, format):
 
 def test_read_infer_string(temp_h5_path):
     # GH#54431
-    df = DataFrame({"a": ["a", "b", None]})
+    df = DataFrame({"a": ["a", "b", np.nan]})
     df.to_hdf(temp_h5_path, key="data", format="table")
     result = read_hdf(temp_h5_path, key="data", mode="r")
     tm.assert_frame_equal(result, df)

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -7,7 +7,6 @@ import pytest
 from pandas._libs.tslibs import Timestamp
 from pandas.compat import is_platform_windows
 
-import pandas as pd
 from pandas import (
     DataFrame,
     DatetimeIndex,
@@ -557,14 +556,9 @@ def test_round_trip_equals(temp_h5_path):
 
 
 def test_infer_string_columns(temp_h5_path):
-    # GH#
-    pytest.importorskip("pyarrow")
-    with pd.option_context("future.infer_string", True):
-        df = DataFrame(1, columns=list("ABCD"), index=list(range(10))).set_index(
-            ["A", "B"]
-        )
-        expected = df.copy()
-        df.to_hdf(temp_h5_path, key="df", format="table")
+    df = DataFrame(1, columns=list("ABCD"), index=list(range(10))).set_index(["A", "B"])
+    expected = df.copy()
+    df.to_hdf(temp_h5_path, key="df", format="table")
 
-        result = read_hdf(temp_h5_path, "df")
-        tm.assert_frame_equal(result, expected)
+    result = read_hdf(temp_h5_path, "df")
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -8,7 +8,6 @@ import pytest
 
 from pandas.compat.pyarrow import (
     pa_version_under18p0,
-    pa_version_under19p0,
 )
 
 import pandas as pd
@@ -239,26 +238,12 @@ class TestFeather:
         with pytest.raises(ValueError, match=msg):
             read_feather(temp_file, dtype_backend="numpy")
 
-    def test_string_inference(self, temp_file, using_infer_string):
+    def test_string_inference(self, temp_file):
         # GH#54431
         df = pd.DataFrame(data={"a": ["x", "y"]})
         df.to_feather(temp_file)
-        with pd.option_context("future.infer_string", True):
-            result = read_feather(temp_file)
-        dtype = pd.StringDtype(na_value=np.nan)
-        expected = pd.DataFrame(
-            data={"a": ["x", "y"]}, dtype=pd.StringDtype(na_value=np.nan)
-        )
-        expected = pd.DataFrame(
-            data={"a": ["x", "y"]},
-            dtype=dtype,
-            columns=pd.Index(
-                ["a"],
-                dtype=object
-                if pa_version_under19p0 and not using_infer_string
-                else dtype,
-            ),
-        )
+        result = read_feather(temp_file)
+        expected = df
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.skipif(pa_version_under18p0, reason="not supported before 18.0")
@@ -270,12 +255,9 @@ class TestFeather:
         table = pa.table({"a": pa.array([None, "b", "c"], pa.string_view())})
         feather.write_feather(table, temp_file)
 
-        with pd.option_context("future.infer_string", True):
-            result = read_feather(temp_file)
+        result = read_feather(temp_file)
 
-            expected = pd.DataFrame(
-                data={"a": [None, "b", "c"]}, dtype=pd.StringDtype(na_value=np.nan)
-            )
+        expected = pd.DataFrame({"a": [None, "b", "c"]})
         tm.assert_frame_equal(result, expected)
 
     def test_out_of_bounds_datetime_to_feather(self, temp_file):

--- a/pandas/tests/io/test_orc.py
+++ b/pandas/tests/io/test_orc.py
@@ -421,12 +421,7 @@ def test_invalid_dtype_backend(temp_file):
 def test_string_inference(temp_file):
     # GH#54431
     df = pd.DataFrame(data={"a": ["x", "y"]})
+    expected = df.copy()
     df.to_orc(temp_file)
-    with pd.option_context("future.infer_string", True):
-        result = read_orc(temp_file)
-    expected = pd.DataFrame(
-        data={"a": ["x", "y"]},
-        dtype=pd.StringDtype(na_value=np.nan),
-        columns=pd.Index(["a"], dtype=pd.StringDtype(na_value=np.nan)),
-    )
+    result = read_orc(temp_file)
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1189,20 +1189,10 @@ class TestParquetPyArrow(Base):
         # GH#54431
         df = pd.DataFrame(data={"a": ["x", "y"]}, index=["a", "b"])
         df.to_parquet(temp_file, engine=pa)
-        with pd.option_context("future.infer_string", True):
-            result = read_parquet(temp_file, engine=pa)
-        dtype = pd.StringDtype(na_value=np.nan)
-        expected = pd.DataFrame(
-            data={"a": ["x", "y"]},
-            dtype=dtype,
-            index=pd.Index(["a", "b"], dtype=dtype),
-            columns=pd.Index(
-                ["a"],
-                dtype=(
-                    object if pa_version_under19p0 and not using_infer_string else dtype
-                ),
-            ),
-        )
+        result = read_parquet(temp_file, engine=pa)
+        expected = df.copy()
+        if pa_version_under19p0 and not using_infer_string:
+            expected.columns = expected.columns.astype(object)
         tm.assert_frame_equal(result, expected)
 
     def test_roundtrip_decimal(self, temp_file, pa):
@@ -1225,13 +1215,10 @@ class TestParquetPyArrow(Base):
 
         table = pa.table({"a": pa.array([None, "b", "c"], pa.large_string())})
         pq.write_table(table, temp_file)
-
-        with pd.option_context("future.infer_string", True):
-            result = read_parquet(temp_file)
+        result = read_parquet(temp_file)
         expected = pd.DataFrame(
             data={"a": [None, "b", "c"]},
             dtype=pd.StringDtype(na_value=np.nan),
-            columns=pd.Index(["a"], dtype=pd.StringDtype(na_value=np.nan)),
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1216,10 +1216,7 @@ class TestParquetPyArrow(Base):
         table = pa.table({"a": pa.array([None, "b", "c"], pa.large_string())})
         pq.write_table(table, temp_file)
         result = read_parquet(temp_file)
-        expected = pd.DataFrame(
-            data={"a": [None, "b", "c"]},
-            dtype=pd.StringDtype(na_value=np.nan),
-        )
+        expected = pd.DataFrame(data={"a": [None, "b", "c"]})
         tm.assert_frame_equal(result, expected)
 
     # NOTE: this test is not run by default, because it requires a lot of memory (>5GB)

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -3853,16 +3853,10 @@ def test_read_sql_string_inference(sqlite_engine):
     # GH#54430
     table = "test"
     df = DataFrame({"a": ["x", "y"]})
+    expected = df.copy()
+
     df.to_sql(table, con=conn, index=False, if_exists="replace")
-
-    with pd.option_context("future.infer_string", True):
-        result = read_sql_table(table, conn)
-
-    dtype = pd.StringDtype(na_value=np.nan)
-    expected = DataFrame(
-        {"a": ["x", "y"]}, dtype=dtype, columns=Index(["a"], dtype=dtype)
-    )
-
+    result = read_sql_table(table, conn)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -2068,8 +2068,7 @@ class TestSeriesConstructors:
         tm.assert_series_equal(ser, expected)
 
         expected = Series(["a", 1], dtype="object")
-        with pd.option_context("future.infer_string", True):
-            ser = Series(["a", 1])
+        ser = Series(["a", 1])
         tm.assert_series_equal(ser, expected)
 
     @pytest.mark.parametrize("na_value", [None, np.nan, pd.NA])

--- a/pandas/tests/series/test_reductions.py
+++ b/pandas/tests/series/test_reductions.py
@@ -74,13 +74,11 @@ def test_mode_nullable_dtype_edge_case(any_numeric_ea_dtype):
     tm.assert_series_equal(result, expected)
 
 
-def test_mode_infer_string():
+def test_mode_string(any_string_dtype):
     # GH#56183
-    pytest.importorskip("pyarrow")
-    ser = Series(["a", "b"], dtype=object)
-    with pd.option_context("future.infer_string", True):
-        result = ser.mode()
-    expected = Series(["a", "b"], dtype=object)
+    ser = Series(["a", "b"], dtype=any_string_dtype)
+    result = ser.mode()
+    expected = Series(["a", "b"], dtype=any_string_dtype)
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
Noticed this in one of the tests: this is mostly a leftover from the time when the option was not enabled by default, and we wanted to test some of those things consistently (not only in the one build that enabled it). 
Now that is no longer needed (and we also still have one build that disables it). The remaining use cases of `pd.option_context("future.infer_string", ..)` are in the (dtype) constructor tests that explicitly test the resulting dtype, and where it would be more verbose to update those tests to depend on `using_infer_string` fixture to have it pass everywhere.