### PR TITLE
DOC: Add explanation for non-inclusive slicing on DatetimeIndex

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -61,8 +61,8 @@ of multi-axis indexing.
   See more at :ref:`Selection by Label <indexing.label>`.
 
 
- Non-inclusive slicing with DatetimeIndex
----------------------------------------
+Non-inclusive slicing with DatetimeIndex
+----------------------------------------
 
 Label-based slicing using ``.loc`` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
 
@@ -74,6 +74,7 @@ If you need non-inclusive slicing (i.e., include the start but exclude the end),
 >>> ts.iloc[lo:hi]
 
 This approach provides finer control over slice boundaries.
+
 
 
 * ``.iloc`` is primarily integer position based (from ``0`` to

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -68,12 +68,12 @@ Label-based slicing using ``.loc`` includes both the start and end labels. This 
 
 If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
 
+.. code-block:: python
 
->>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
->>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
->>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
->>> ts.iloc[lo:hi]
-
+    ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
+    lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
+    hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
+    ts.iloc[lo:hi]
 
 This approach provides finer control over slice boundaries.
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -68,14 +68,13 @@ Label-based slicing using ``.loc`` includes both the start and end labels. This 
 
 If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
 
-.. code-block:: python
-
-   ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
-   lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
-   hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
-   ts.iloc[lo:hi]
+>>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
+>>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
+>>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
+>>> ts.iloc[lo:hi]
 
 This approach provides finer control over slice boundaries.
+
 
 * ``.iloc`` is primarily integer position based (from ``0`` to
   ``length-1`` of the axis), but may also be used with a boolean

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -60,6 +60,20 @@ of multi-axis indexing.
 
   See more at :ref:`Selection by Label <indexing.label>`.
 
+ Non-inclusive slicing with DatetimeIndex
+---------------------------------------
+
+Label-based slicing using `.loc` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
+
+If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods:
+
+>>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
+>>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
+>>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
+>>> ts.iloc[lo:hi]
+
+This approach provides finer control over slice boundaries.
+
 * ``.iloc`` is primarily integer position based (from ``0`` to
   ``length-1`` of the axis), but may also be used with a boolean
   array.  ``.iloc`` will raise ``IndexError`` if a requested

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -63,9 +63,9 @@ of multi-axis indexing.
  Non-inclusive slicing with DatetimeIndex
 ---------------------------------------
 
-Label-based slicing using `.loc` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
+Label-based slicing using ``.loc`` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
 
-If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods:
+If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
 
 >>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
 >>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -70,10 +70,10 @@ If you need non-inclusive slicing (i.e., include the start but exclude the end),
 
 .. code-block:: python
 
-    ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
-    lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
-    hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
-    ts.iloc[lo:hi]
+   ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
+   lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
+   hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
+   ts.iloc[lo:hi]
 
 This approach provides finer control over slice boundaries.
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -60,6 +60,7 @@ of multi-axis indexing.
 
   See more at :ref:`Selection by Label <indexing.label>`.
 
+
  Non-inclusive slicing with DatetimeIndex
 ---------------------------------------
 
@@ -67,10 +68,12 @@ Label-based slicing using ``.loc`` includes both the start and end labels. This 
 
 If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
 
+
 >>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
 >>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
 >>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
 >>> ts.iloc[lo:hi]
+
 
 This approach provides finer control over slice boundaries.
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -66,14 +66,12 @@ Non-inclusive slicing with DatetimeIndex
 
 Label-based slicing using ``.loc`` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
 
-If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
+If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use boolean indexing with ``.loc``:
 
 >>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
->>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
->>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
->>> ts.iloc[lo:hi]
+>>> ts.loc[(ts.index >= "2000-01-04") & (ts.index < "2000-01-10")]
 
-This approach provides finer control over slice boundaries.
+This approach allows excluding the end label while filtering based on index values.
 
 
 


### PR DESCRIPTION
- Added documentation explaining how to achieve non-inclusive slicing with DatetimeIndex using `get_slice_bound`.

- Included example demonstrating how to exclude the end label while slicing.

Closes #16571