### PR TITLE
DEPR: deprecate inference of datetime.date objects as datetime64

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -113,6 +113,7 @@ Deprecations
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 - Deprecated the default value of ``exact`` in :func:`assert_index_equal`; in a future version this will default to ``True`` instead of "equiv" (:issue:`57436`)
 - Deprecated the default value of ``track_times`` in :meth:`HDFStore.put`. In a future version, the default will change from ``True`` to ``False`` so that HDF5 files are deterministic by default (:issue:`51456`)
+- Deprecated the inference of ``datetime64`` dtype from data containing ``datetime.date`` objects when used in comparisons or :meth:`Index.equals` with :class:`DatetimeIndex`. Use :func:`pandas.to_datetime` to explicitly convert to ``datetime64`` instead (:issue:`XXXXX`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -113,7 +113,7 @@ Deprecations
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 - Deprecated the default value of ``exact`` in :func:`assert_index_equal`; in a future version this will default to ``True`` instead of "equiv" (:issue:`57436`)
 - Deprecated the default value of ``track_times`` in :meth:`HDFStore.put`. In a future version, the default will change from ``True`` to ``False`` so that HDF5 files are deterministic by default (:issue:`51456`)
-- Deprecated the inference of ``datetime64`` dtype from data containing ``datetime.date`` objects when used in comparisons or :meth:`Index.equals` with :class:`DatetimeIndex`. Use :func:`pandas.to_datetime` to explicitly convert to ``datetime64`` instead (:issue:`XXXXX`)
+- Deprecated the inference of ``datetime64`` dtype from data containing ``datetime.date`` objects when used in comparisons or :meth:`Index.equals` with :class:`DatetimeIndex`. Use :func:`pandas.to_datetime` to explicitly convert to ``datetime64`` instead (:issue:`65056`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -689,15 +689,17 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             )
             converted = ensure_wrapped_if_datetimelike(converted)
             if isinstance(converted, type(self)):
-                try:
-                    value = type(self)._from_sequence(value)
-                except (ValueError, TypeError) as err:
-                    if allow_object:
-                        return value
-                    msg = self._validation_error_message(value, True)
-                    raise TypeError(msg) from err
-            elif lib.infer_dtype(value) == "date":
-                # GH#XXXXX
+                if (
+                    self.dtype.kind in "mM"
+                    and not allow_object
+                    and self.unit != converted.unit
+                ):  # type: ignore[attr-defined]
+                    converted = converted.as_unit(self.unit, round_ok=False)  # type: ignore[attr-defined]
+                if arr.ndim != 1:
+                    converted = converted.reshape(arr.shape)
+                return converted
+            elif self.dtype.kind == "M" and lib.infer_dtype(value) == "date":
+                # GH#65056
                 warnings.warn(
                     "Inferring datetime64 from data containing datetime.date "
                     "objects is deprecated. In a future version, these will "

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -210,8 +210,6 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         freq
     """
 
-    # _infer_matches -> which infer_dtype strings are close enough to our own
-    _infer_matches: tuple[str, ...]
     _is_recognized_dtype: Callable[[DtypeObj], bool]
     _recognized_scalars: tuple[type, ...]
     _ndarray: np.ndarray
@@ -684,7 +682,31 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         if hasattr(value, "dtype") and value.dtype == object:
             # `array` below won't do inference if value is an Index or Series.
             #  so do so here.  in the Index case, inferred_type may be cached.
-            if lib.infer_dtype(value) in self._infer_matches:
+            arr = np.asarray(value)
+            flat = arr.ravel() if arr.ndim != 1 else arr
+            converted = lib.maybe_convert_objects(
+                flat, convert_non_numeric=True, dtype_if_all_nat=self.dtype
+            )
+            converted = ensure_wrapped_if_datetimelike(converted)
+            if isinstance(converted, type(self)):
+                try:
+                    value = type(self)._from_sequence(value)
+                except (ValueError, TypeError) as err:
+                    if allow_object:
+                        return value
+                    msg = self._validation_error_message(value, True)
+                    raise TypeError(msg) from err
+            elif lib.infer_dtype(value) == "date":
+                # GH#XXXXX
+                warnings.warn(
+                    "Inferring datetime64 from data containing datetime.date "
+                    "objects is deprecated. In a future version, these will "
+                    "be left as object dtype. Use "
+                    "pd.to_datetime to explicitly convert "
+                    "to datetime64.",
+                    Pandas4Warning,
+                    stacklevel=find_stack_level(),
+                )
                 try:
                     value = type(self)._from_sequence(value)
                 except (ValueError, TypeError) as err:

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -692,8 +692,8 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                 if (
                     self.dtype.kind in "mM"
                     and not allow_object
-                    and self.unit != converted.unit
-                ):  # type: ignore[attr-defined]
+                    and self.unit != converted.unit  # type: ignore[attr-defined]
+                ):
                     converted = converted.as_unit(self.unit, round_ok=False)  # type: ignore[attr-defined]
                 if arr.ndim != 1:
                     converted = converted.reshape(arr.shape)
@@ -709,13 +709,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                     Pandas4Warning,
                     stacklevel=find_stack_level(),
                 )
-                try:
-                    value = type(self)._from_sequence(value)
-                except (ValueError, TypeError) as err:
-                    if allow_object:
-                        return value
-                    msg = self._validation_error_message(value, True)
-                    raise TypeError(msg) from err
+                value = type(self)._from_sequence(value)
 
         if isinstance(value, list):
             value = construct_1d_object_array_from_listlike(value)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -235,7 +235,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     _is_recognized_dtype: Callable[[DtypeObj], bool] = lambda x: (
         lib.is_np_dtype(x, "M") or isinstance(x, DatetimeTZDtype)
     )
-    _infer_matches = ("datetime", "datetime64", "date")
 
     @property
     def _internal_fill_value(self) -> np.datetime64:

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -183,7 +183,6 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
     _is_recognized_dtype: Callable[[DtypeObj], bool] = lambda x: isinstance(
         x, PeriodDtype
     )  # check_compatible_with checks freq match
-    _infer_matches = ("period",)
 
     @property
     def _scalar_type(self) -> type[Period]:

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -161,7 +161,6 @@ class TimedeltaArray(dtl.TimelikeOps):
     _typ = "timedeltaarray"
     _recognized_scalars = (timedelta, np.timedelta64, Tick)
     _is_recognized_dtype: Callable[[DtypeObj], bool] = lambda x: lib.is_np_dtype(x, "m")
-    _infer_matches = ("timedelta", "timedelta64")
 
     @property
     def _internal_fill_value(self) -> np.timedelta64:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9903,7 +9903,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         for warning_msg in caught:
             if "datetime.date" in str(warning_msg.message):
-                # GH#XXXXX - re-issue with a message appropriate for
+                # GH#65056 - re-issue with a message appropriate for
                 #  alignment operations
                 warnings.warn(
                     "Alignment of a DataFrame/Series with a DatetimeIndex "

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -50,7 +50,10 @@ from pandas.errors import (
 )
 from pandas.errors.cow import _chained_assignment_method_msg
 from pandas.util._decorators import deprecate_kwarg
-from pandas.util._exceptions import find_stack_level
+from pandas.util._exceptions import (
+    find_stack_level,
+    rewrite_warning,
+)
 from pandas.util._validators import (
     check_dtype_backend,
     validate_ascending,
@@ -9878,9 +9881,19 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if axis is not None:
             axis = self._get_axis_number(axis)
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always", category=Pandas4Warning)
-
+        # GH#65056 - rewrite the date-inference deprecation with a message
+        #  appropriate for alignment operations
+        with rewrite_warning(
+            target_message="datetime.date",
+            target_category=Pandas4Warning,
+            new_message=(
+                "Alignment of a DataFrame/Series with a DatetimeIndex "
+                "and a DataFrame/Series with an object-dtype Index of "
+                "datetime.date objects is deprecated. Convert the "
+                "datetime.date Index to DatetimeIndex using "
+                "pd.to_datetime before performing this operation."
+            ),
+        ):
             if isinstance(other, ABCDataFrame):
                 left, _right, join_index = self._align_frame(
                     other,
@@ -9900,27 +9913,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 )
             else:  # pragma: no cover
                 raise TypeError(f"unsupported type: {type(other)}")
-
-        for warning_msg in caught:
-            if "datetime.date" in str(warning_msg.message):
-                # GH#65056 - re-issue with a message appropriate for
-                #  alignment operations
-                warnings.warn(
-                    "Alignment of a DataFrame/Series with a DatetimeIndex "
-                    "and a DataFrame/Series with an object-dtype Index of "
-                    "datetime.date objects is deprecated. Convert the "
-                    "datetime.date Index to DatetimeIndex using "
-                    "pd.to_datetime before performing this operation.",
-                    Pandas4Warning,
-                    stacklevel=find_stack_level(),
-                )
-            else:
-                warnings.warn_explicit(
-                    warning_msg.message,
-                    warning_msg.category,
-                    warning_msg.filename,
-                    warning_msg.lineno,
-                )
 
         right = cast("NDFrameT", _right)
         if self.ndim == 1 or axis == 0:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9877,25 +9877,50 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         _right: DataFrame | Series
         if axis is not None:
             axis = self._get_axis_number(axis)
-        if isinstance(other, ABCDataFrame):
-            left, _right, join_index = self._align_frame(
-                other,
-                join=join,
-                axis=axis,
-                level=level,
-                fill_value=fill_value,
-            )
 
-        elif isinstance(other, ABCSeries):
-            left, _right, join_index = self._align_series(
-                other,
-                join=join,
-                axis=axis,
-                level=level,
-                fill_value=fill_value,
-            )
-        else:  # pragma: no cover
-            raise TypeError(f"unsupported type: {type(other)}")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", category=Pandas4Warning)
+
+            if isinstance(other, ABCDataFrame):
+                left, _right, join_index = self._align_frame(
+                    other,
+                    join=join,
+                    axis=axis,
+                    level=level,
+                    fill_value=fill_value,
+                )
+
+            elif isinstance(other, ABCSeries):
+                left, _right, join_index = self._align_series(
+                    other,
+                    join=join,
+                    axis=axis,
+                    level=level,
+                    fill_value=fill_value,
+                )
+            else:  # pragma: no cover
+                raise TypeError(f"unsupported type: {type(other)}")
+
+        for warning_msg in caught:
+            if "datetime.date" in str(warning_msg.message):
+                # GH#XXXXX - re-issue with a message appropriate for
+                #  alignment operations
+                warnings.warn(
+                    "Alignment of a DataFrame/Series with a DatetimeIndex "
+                    "and a DataFrame/Series with an object-dtype Index of "
+                    "datetime.date objects is deprecated. Convert the "
+                    "datetime.date Index to DatetimeIndex using "
+                    "pd.to_datetime before performing this operation.",
+                    Pandas4Warning,
+                    stacklevel=find_stack_level(),
+                )
+            else:
+                warnings.warn_explicit(
+                    warning_msg.message,
+                    warning_msg.category,
+                    warning_msg.filename,
+                    warning_msg.lineno,
+                )
 
         right = cast("NDFrameT", _right)
         if self.ndim == 1 or axis == 0:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -16,6 +16,7 @@ from typing import (
     cast,
     final,
 )
+import warnings
 
 import numpy as np
 
@@ -39,10 +40,12 @@ from pandas.errors import (
     NullFrequencyError,
     OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
+    Pandas4Warning,
 )
 from pandas.util._decorators import (
     cache_readonly,
 )
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import (
     is_integer,
@@ -61,6 +64,7 @@ from pandas.core.arrays import (
     TimedeltaArray,
 )
 import pandas.core.common as com
+from pandas.core.construction import ensure_wrapped_if_datetimelike
 from pandas.core.indexes.base import (
     Index,
 )
@@ -294,12 +298,51 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
             return False
         elif not isinstance(other, type(self)):
             should_try = False
-            inferable = self._data._infer_matches
             if other.dtype == object:
-                should_try = other.inferred_type in inferable
+                converted = lib.maybe_convert_objects(
+                    np.asarray(other), convert_non_numeric=True
+                )
+                converted = ensure_wrapped_if_datetimelike(converted)
+                if isinstance(converted, type(self._data)):
+                    should_try = True
+                elif lib.infer_dtype(other) == "date":
+                    # GH#XXXXX
+                    warnings.warn(
+                        "Inferring datetime64 from data containing "
+                        "datetime.date objects is deprecated. In a future "
+                        "version, these will be left as object dtype. Use "
+                        "pd.to_datetime to explicitly convert to datetime64.",
+                        Pandas4Warning,
+                        stacklevel=find_stack_level(),
+                    )
+                    should_try = True
             elif isinstance(other.dtype, CategoricalDtype):
                 other = cast("CategoricalIndex", other)
-                should_try = other.categories.inferred_type in inferable
+                cat_vals = np.asarray(other.categories)
+                if cat_vals.dtype == object:
+                    converted = lib.maybe_convert_objects(
+                        cat_vals, convert_non_numeric=True
+                    )
+                    converted = ensure_wrapped_if_datetimelike(converted)
+                else:
+                    converted = ensure_wrapped_if_datetimelike(cat_vals)
+                if isinstance(converted, type(self._data)):
+                    should_try = True
+                elif (
+                    cat_vals.dtype == object
+                    and lib.infer_dtype(other.categories) == "date"
+                ):
+                    # GH#XXXXX
+                    warnings.warn(
+                        "Inferring datetime64 from data containing "
+                        "datetime.date objects is deprecated. In a "
+                        "future version, these will be left as object "
+                        "dtype. Use pd.to_datetime to explicitly "
+                        "convert to datetime64.",
+                        Pandas4Warning,
+                        stacklevel=find_stack_level(),
+                    )
+                    should_try = True
 
             if should_try:
                 try:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -297,16 +297,15 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         elif other.dtype.kind in "iufc":
             return False
         elif not isinstance(other, type(self)):
-            should_try = False
             if other.dtype == object:
                 converted = lib.maybe_convert_objects(
                     np.asarray(other), convert_non_numeric=True
                 )
                 converted = ensure_wrapped_if_datetimelike(converted)
                 if isinstance(converted, type(self._data)):
-                    should_try = True
-                elif lib.infer_dtype(other) == "date":
-                    # GH#XXXXX
+                    other = type(self)._simple_new(converted)
+                elif self.dtype.kind == "M" and lib.infer_dtype(other) == "date":
+                    # GH#65056
                     warnings.warn(
                         "Inferring datetime64 from data containing "
                         "datetime.date objects is deprecated. In a future "
@@ -315,7 +314,10 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
                         Pandas4Warning,
                         stacklevel=find_stack_level(),
                     )
-                    should_try = True
+                    try:
+                        other = type(self)(other)
+                    except (ValueError, TypeError, OverflowError):
+                        return False
             elif isinstance(other.dtype, CategoricalDtype):
                 other = cast("CategoricalIndex", other)
                 cat_vals = np.asarray(other.categories)
@@ -327,12 +329,16 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
                 else:
                     converted = ensure_wrapped_if_datetimelike(cat_vals)
                 if isinstance(converted, type(self._data)):
-                    should_try = True
+                    try:
+                        other = type(self)(other)
+                    except (ValueError, TypeError, OverflowError):
+                        return False
                 elif (
-                    cat_vals.dtype == object
+                    self.dtype.kind == "M"
+                    and cat_vals.dtype == object
                     and lib.infer_dtype(other.categories) == "date"
                 ):
-                    # GH#XXXXX
+                    # GH#65056
                     warnings.warn(
                         "Inferring datetime64 from data containing "
                         "datetime.date objects is deprecated. In a "
@@ -342,17 +348,10 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
                         Pandas4Warning,
                         stacklevel=find_stack_level(),
                     )
-                    should_try = True
-
-            if should_try:
-                try:
-                    other = type(self)(other)
-                except (ValueError, TypeError, OverflowError):
-                    # e.g.
-                    #  ValueError -> cannot parse str entry, or OutOfBoundsDatetime
-                    #  TypeError  -> trying to convert IntervalIndex to DatetimeIndex
-                    #  OverflowError -> Index([very_large_timedeltas])
-                    return False
+                    try:
+                        other = type(self)(other)
+                    except (ValueError, TypeError, OverflowError):
+                        return False
 
         if type(self) != type(other):
             return False

--- a/pandas/io/_util.py
+++ b/pandas/io/_util.py
@@ -157,6 +157,20 @@ def _post_convert_dtypes(
                 key: pandas_dtype(dtype[key]) for key in dtype if key in df.columns
             }
 
+            # GH#65056 pyarrow returns datetime.date objects which trigger
+            #  a deprecation warning when compared against DatetimeIndex
+            #  categories. Convert to datetime64 first since the user can't
+            #  control pyarrow's behavior.
+            for col, col_dtype in dtype.items():
+                if (
+                    isinstance(col_dtype, pd.CategoricalDtype)
+                    and col_dtype.categories is not None
+                    and isinstance(col_dtype.categories, pd.DatetimeIndex)
+                    and df[col].dtype == np.dtype("object")
+                    and lib.infer_dtype(df[col]) == "date"
+                ):
+                    df[col] = pd.to_datetime(df[col])
+
         else:
             dtype = pandas_dtype(dtype)
 

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -549,7 +549,9 @@ class TestGetIndexer:
     def test_get_indexer_date_objs(self):
         rng = date_range("1/1/2000", periods=20)
 
-        result = rng.get_indexer(rng.map(lambda x: x.date()))
+        msg = "Inferring datetime64 from data containing datetime.date objects"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            result = rng.get_indexer(rng.map(lambda x: x.date()))
         expected = rng.get_indexer(rng)
         tm.assert_numpy_array_equal(result, expected)
 

--- a/pandas/tests/io/parser/dtypes/test_categorical.py
+++ b/pandas/tests/io/parser/dtypes/test_categorical.py
@@ -279,11 +279,7 @@ def test_categorical_coerces_datetime(all_parsers):
     data = "b\n2017-01-01\n2018-01-01\n2019-01-01"
     expected = DataFrame({"b": Categorical(dtype["b"].categories)})
 
-    # pyarrow parser returns datetime.date objects, triggering the deprecation
-    warn = Pandas4Warning if parser.engine == "pyarrow" else None
-    msg = "Inferring datetime64 from data containing datetime.date objects"
-    with tm.assert_produces_warning(warn, match=msg, check_stacklevel=False):
-        result = parser.read_csv(StringIO(data), dtype=dtype)
+    result = parser.read_csv(StringIO(data), dtype=dtype)
     tm.assert_frame_equal(result, expected)
 
 
@@ -294,11 +290,7 @@ def test_categorical_coerces_timestamp(all_parsers):
     data = "b\n2014-01-01\n2014-01-01"
     expected = DataFrame({"b": Categorical([Timestamp("2014")] * 2)})
 
-    # pyarrow parser returns datetime.date objects, triggering the deprecation
-    warn = Pandas4Warning if parser.engine == "pyarrow" else None
-    msg = "Inferring datetime64 from data containing datetime.date objects"
-    with tm.assert_produces_warning(warn, match=msg, check_stacklevel=False):
-        result = parser.read_csv(StringIO(data), dtype=dtype)
+    result = parser.read_csv(StringIO(data), dtype=dtype)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/parser/dtypes/test_categorical.py
+++ b/pandas/tests/io/parser/dtypes/test_categorical.py
@@ -279,7 +279,11 @@ def test_categorical_coerces_datetime(all_parsers):
     data = "b\n2017-01-01\n2018-01-01\n2019-01-01"
     expected = DataFrame({"b": Categorical(dtype["b"].categories)})
 
-    result = parser.read_csv(StringIO(data), dtype=dtype)
+    # pyarrow parser returns datetime.date objects, triggering the deprecation
+    warn = Pandas4Warning if parser.engine == "pyarrow" else None
+    msg = "Inferring datetime64 from data containing datetime.date objects"
+    with tm.assert_produces_warning(warn, match=msg, check_stacklevel=False):
+        result = parser.read_csv(StringIO(data), dtype=dtype)
     tm.assert_frame_equal(result, expected)
 
 
@@ -290,7 +294,11 @@ def test_categorical_coerces_timestamp(all_parsers):
     data = "b\n2014-01-01\n2014-01-01"
     expected = DataFrame({"b": Categorical([Timestamp("2014")] * 2)})
 
-    result = parser.read_csv(StringIO(data), dtype=dtype)
+    # pyarrow parser returns datetime.date objects, triggering the deprecation
+    warn = Pandas4Warning if parser.engine == "pyarrow" else None
+    msg = "Inferring datetime64 from data containing datetime.date objects"
+    with tm.assert_produces_warning(warn, match=msg, check_stacklevel=False):
+        result = parser.read_csv(StringIO(data), dtype=dtype)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -895,8 +895,10 @@ class TestTimeSeriesArithmetic:
         ts2 = ts_slice.copy()
         ts2.index = [x.date() for x in ts2.index]
 
-        result = ts + ts2
-        result2 = ts2 + ts
+        msg = "object-dtype Index of datetime.date objects is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            result = ts + ts2
+            result2 = ts2 + ts
         expected = ts + ts[5:]
         expected.index = expected.index._with_freq(None)
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
xref #62158

## Summary
- Replace the `_infer_matches` pattern in datetimelike arrays/indexes with `lib.maybe_convert_objects` + `ensure_wrapped_if_datetimelike`
- The only behavioral change is for `datetime.date` objects, which `maybe_convert_objects` does not handle — these now emit a `Pandas4Warning`
- In `NDFrame.align`, the low-level warning is caught and re-issued with a message appropriate for alignment/arithmetic operations

## Test plan
- [x] Existing tests for `equals`, `get_indexer`, comparisons, and alignment all pass
- [x] Tests updated to expect `Pandas4Warning` where `datetime.date` inference occurs
- [x] Full test suite passes (168k+ tests)
- [x] mypy clean
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)