### PR TITLE
BUG: use uint64_t instead of size_t for row counts in CSV parser

### DIFF
--- a/pandas/_libs/include/pandas/parser/pd_parser.h
+++ b/pandas/_libs/include/pandas/parser/pd_parser.h
@@ -33,10 +33,10 @@ typedef struct {
   int (*parser_add_skiprow)(parser_t *, int64_t);
   void (*parser_set_skipfirstnrows)(parser_t *, int64_t);
   void (*parser_set_default_options)(parser_t *);
-  int (*parser_consume_rows)(parser_t *, size_t);
+  int (*parser_consume_rows)(parser_t *, uint64_t);
   int (*parser_trim_buffers)(parser_t *);
   int (*tokenize_all_rows)(parser_t *, const char *);
-  int (*tokenize_nrows)(parser_t *, size_t, const char *);
+  int (*tokenize_nrows)(parser_t *, uint64_t, const char *);
   int64_t (*str_to_int64)(const char *, int *, char);
   uint64_t (*str_to_uint64)(uint_state *, const char *, int *, char);
   double (*precise_xstrtod)(const char *, char **, char, char, char, int, int *,

--- a/pandas/_libs/include/pandas/parser/tokenizer.h
+++ b/pandas/_libs/include/pandas/parser/tokenizer.h
@@ -177,7 +177,7 @@ parser_t *parser_new(void);
 
 int parser_init(parser_t *self);
 
-int parser_consume_rows(parser_t *self, size_t nrows);
+int parser_consume_rows(parser_t *self, uint64_t nrows);
 
 int parser_trim_buffers(parser_t *self);
 
@@ -191,7 +191,7 @@ void parser_del(parser_t *self);
 
 void parser_set_default_options(parser_t *self);
 
-int tokenize_nrows(parser_t *self, size_t nrows, const char *encoding_errors);
+int tokenize_nrows(parser_t *self, uint64_t nrows, const char *encoding_errors);
 
 int tokenize_all_rows(parser_t *self, const char *encoding_errors);
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -925,7 +925,7 @@ cdef class TextReader:
             end = min(start + rows, self.parser.lines)
 
         num_cols = -1
-        for i in range(self.parser.lines):
+        for i in range(<int64_t>self.parser.lines):
             num_cols = (num_cols < self.parser.line_fields[i]) * \
                 self.parser.line_fields[i] + \
                 (num_cols >= self.parser.line_fields[i]) * num_cols

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -269,12 +269,14 @@ cdef extern from "pandas/parser/pd_parser.h":
 
     void parser_set_default_options(parser_t *self)
 
-    int parser_consume_rows(parser_t *self, size_t nrows)
+    int parser_consume_rows(parser_t *self, uint64_t nrows)
 
     int parser_trim_buffers(parser_t *self)
 
     int tokenize_all_rows(parser_t *self, const char *encoding_errors) nogil
-    int tokenize_nrows(parser_t *self, size_t nrows, const char *encoding_errors) nogil
+    int tokenize_nrows(
+        parser_t *self, uint64_t nrows, const char *encoding_errors
+    ) nogil
 
     int64_t str_to_int64(char *p_item,  int *error, char tsep) nogil
     uint64_t str_to_uint64(uint_state *state, char *p_item, int *error, char tsep) nogil
@@ -835,7 +837,7 @@ cdef class TextReader:
 
         return chunks
 
-    cdef _tokenize_rows(self, size_t nrows):
+    cdef _tokenize_rows(self, uint64_t nrows):
         cdef:
             int status
 
@@ -923,8 +925,7 @@ cdef class TextReader:
             end = min(start + rows, self.parser.lines)
 
         num_cols = -1
-        # Py_ssize_t cast prevents build warning
-        for i in range(<Py_ssize_t>self.parser.lines):
+        for i in range(self.parser.lines):
             num_cols = (num_cols < self.parser.line_fields[i]) * \
                 self.parser.line_fields[i] + \
                 (num_cols >= self.parser.line_fields[i]) * num_cols

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -670,7 +670,7 @@ static int skip_this_line(parser_t *self, int64_t rownum) {
   }
 }
 
-static int tokenize_bytes(parser_t *self, size_t line_limit,
+static int tokenize_bytes(parser_t *self, uint64_t line_limit,
                           uint64_t start_lines) {
   char *buf = self->data + self->datapos;
 
@@ -1187,7 +1187,7 @@ static int parser_handle_eof(parser_t *self) {
     return 0;
 }
 
-int parser_consume_rows(parser_t *self, size_t nrows) {
+int parser_consume_rows(parser_t *self, uint64_t nrows) {
   if (nrows > self->lines) {
     nrows = self->lines;
   }
@@ -1344,7 +1344,7 @@ int parser_trim_buffers(parser_t *self) {
   all : tokenize all the data vs. certain number of rows
  */
 
-static int _tokenize_helper(parser_t *self, size_t nrows, int all,
+static int _tokenize_helper(parser_t *self, uint64_t nrows, int all,
                             const char *encoding_errors) {
   int status = 0;
   const uint64_t start_lines = self->lines;
@@ -1393,12 +1393,13 @@ static int _tokenize_helper(parser_t *self, size_t nrows, int all,
   return status;
 }
 
-int tokenize_nrows(parser_t *self, size_t nrows, const char *encoding_errors) {
+int tokenize_nrows(parser_t *self, uint64_t nrows,
+                   const char *encoding_errors) {
   return _tokenize_helper(self, nrows, 0, encoding_errors);
 }
 
 int tokenize_all_rows(parser_t *self, const char *encoding_errors) {
-  return _tokenize_helper(self, -1, 1, encoding_errors);
+  return _tokenize_helper(self, 0, 1, encoding_errors);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Fixes row-count parameters in the C tokenizer that used `size_t` (32-bit on 32-bit platforms) instead of `uint64_t`, causing silent truncation when reading CSVs with more than 2^32 rows
- Updates function signatures in `tokenizer.h`, `tokenizer.c`, `pd_parser.h`, and `parsers.pyx`
- Removes a `Py_ssize_t` cast on `parser.lines` that would also truncate on 32-bit Python

closes #14131

## Test plan
- Not feasible to add a test (would require a CSV with >2^32 rows / hundreds of GB)
- All existing CSV parser tests pass (4402 passed)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)