### PR TITLE
TST: Add regression test for read_csv escapechar round-trip

### DIFF
--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -3,6 +3,7 @@ Tests that work on both the Python and C engines but do not have a
 specific classification into the other test modules.
 """
 
+import csv
 from datetime import datetime
 from inspect import signature
 from io import StringIO
@@ -368,6 +369,40 @@ def test_escapechar(all_parsers):
     assert result["SEARCH_TERM"][2] == 'SLAGBORD, "Bergslagen", IKEA:s 1700-tals series'
 
     tm.assert_index_equal(result.columns, Index(["SEARCH_TERM", "ACTUAL_URL"]))
+
+
+@skip_pyarrow
+def test_escapechar_quoting_round_trip(all_parsers):
+    # GH#25501 - round-trip with escapechar before quotechar
+    parser = all_parsers
+    escape = "\\"
+    quote = '"'
+    sep = "|"
+
+    sample_data = [i * escape + quote for i in range(1, 11)]
+    initial_df = DataFrame(sample_data, columns=["column"])
+
+    csv_text = initial_df.to_csv(
+        sep=sep,
+        columns=None,
+        header=None,
+        index=False,
+        doublequote=False,
+        quoting=csv.QUOTE_ALL,
+        quotechar=quote,
+        escapechar=escape,
+    )
+
+    result = parser.read_csv(
+        StringIO(csv_text),
+        sep=sep,
+        escapechar=escape,
+        quoting=csv.QUOTE_ALL,
+        header=None,
+        doublequote=False,
+    )
+    expected = DataFrame(sample_data)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_ignore_leading_whitespace(all_parsers):


### PR DESCRIPTION
## Summary
- Adds regression test for GH#25501 — `read_csv` wasn't reading escape characters properly when round-tripping through `to_csv`/`read_csv` with `escapechar`, `quoting=QUOTE_ALL`, and `doublequote=False`
- The bug is already fixed on main, this adds test coverage to prevent regression

closes #25501

## Test plan
- [x] `pytest pandas/tests/io/parser/common/test_common_basic.py::test_escapechar_quoting_round_trip` passes for c and python engines, skips pyarrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)