### PR TITLE
TST: Add regression test for read_csv memory_map with multi-char sep

### DIFF
--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -641,3 +641,19 @@ a b
     # don't skip anything
     with pytest.raises(ParserError, match="unexpected end of data"):
         parser.read_csv(StringIO(tbl), delimiter=" ", skiprows=0, engine="python")
+
+
+def test_memory_map_multichar_sep(python_parser_only, tmp_path):
+    # GH#34577 - memory_map with multi-character separator should not raise
+    # TypeError about mixing string patterns and bytes-like objects
+    parser = python_parser_only
+    path = tmp_path / "test.csv"
+    path.write_text("key1 - value1\nkey2 - value2\nkey3 - value3\n")
+
+    result = parser.read_csv(
+        path, header=None, sep=" - ", names=["key", "value"], memory_map=True
+    )
+    expected = DataFrame(
+        {"key": ["key1", "key2", "key3"], "value": ["value1", "value2", "value3"]}
+    )
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -648,7 +648,7 @@ def test_memory_map_multichar_sep(python_parser_only, tmp_path):
     # TypeError about mixing string patterns and bytes-like objects
     parser = python_parser_only
     path = tmp_path / "test.csv"
-    path.write_text("key1 - value1\nkey2 - value2\nkey3 - value3\n")
+    path.write_text("key1 - value1\nkey2 - value2\nkey3 - value3\n", encoding="utf-8")
 
     result = parser.read_csv(
         path, header=None, sep=" - ", names=["key", "value"], memory_map=True


### PR DESCRIPTION
## Summary
- Adds regression test for GH#34577: `read_table`/`read_csv` with `memory_map=True` and a multi-character separator used to raise `TypeError: cannot use a string pattern on a bytes-like object`
- The bug was fixed in #47175 but no test was added for this specific case
- closes #34577

## Test plan
- [x] `pytest pandas/tests/io/parser/test_python_parser_only.py::test_memory_map_multichar_sep` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)