### PR TITLE
TST: Add regression test for to_csv with utf-16 encoding

### DIFF
--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -53,6 +53,14 @@ class TestToCSV:
         df.to_csv(temp_file)
         tm.assert_frame_equal(pd.read_csv(temp_file, index_col=0), df)
 
+    @pytest.mark.parametrize("encoding", ["utf-16", "utf-16-le", "utf-16-be"])
+    def test_to_csv_utf16_encoding(self, encoding, temp_file):
+        # GH#10755
+        df = DataFrame({"col": ["abc", "déf", "日本語"]})
+        df.to_csv(temp_file, encoding=encoding)
+        result = pd.read_csv(temp_file, index_col=0, encoding=encoding)
+        tm.assert_frame_equal(result, df)
+
     def test_to_csv_quotechar(self, temp_file):
         df = DataFrame({"col": [1, 2]})
         expected = """\


### PR DESCRIPTION
## Summary
- Add regression test for GH#10755 (`to_csv` writes wrong utf-16)
- The underlying bug has been fixed; this adds a parametrized test covering `utf-16`, `utf-16-le`, and `utf-16-be` round-trips to prevent regression

closes #10755

## Test plan
- [x] `pytest pandas/tests/io/formats/test_to_csv.py::TestToCSV::test_to_csv_utf16_encoding` passes (3 parametrized cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)