### PR TITLE
WARN: add FutureWarning when DataFrame.update() is called with mismatched index dtypes (GH#19905)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12430,6 +12430,16 @@ class DataFrame(NDFrame, OpsMixin):
 
         index_intersection = other.index.intersection(self.index)
         if index_intersection.empty:
+            if self.index.dtype != other.index.dtype:
+                warnings.warn(
+                    "The index of the calling DataFrame and the index of `other` "
+                    "have different dtypes. No update was performed. "
+                    f"Caller index dtype: {self.index.dtype}, "
+                    f"other index dtype: {other.index.dtype}. "
+                    "Cast the index to the same dtype before calling update().",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
             return
         other = other.reindex(index_intersection)
         this_data = self.loc[index_intersection]

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12431,14 +12431,14 @@ class DataFrame(NDFrame, OpsMixin):
         index_intersection = other.index.intersection(self.index)
         if index_intersection.empty:
             if self.index.dtype != other.index.dtype:
-                from pandas.errors import PandasFutureWarning
+                from pandas.errors import UserWarning
                 warnings.warn(
                     "The index of the calling DataFrame and the index of `other` "
                     "have different dtypes. No update was performed. "
                     f"Caller index dtype: {self.index.dtype}, "
                     f"other index dtype: {other.index.dtype}. "
                     "Cast the index to the same dtype before calling update().",
-                    PandasFutureWarning,
+                    UserWarning,
                     stacklevel=find_stack_level(),
                 )
         other = other.reindex(index_intersection)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12431,16 +12431,16 @@ class DataFrame(NDFrame, OpsMixin):
         index_intersection = other.index.intersection(self.index)
         if index_intersection.empty:
             if self.index.dtype != other.index.dtype:
+                from pandas.errors import PandasFutureWarning
                 warnings.warn(
                     "The index of the calling DataFrame and the index of `other` "
                     "have different dtypes. No update was performed. "
                     f"Caller index dtype: {self.index.dtype}, "
                     f"other index dtype: {other.index.dtype}. "
                     "Cast the index to the same dtype before calling update().",
-                    FutureWarning,
+                    PandasFutureWarning,
                     stacklevel=find_stack_level(),
                 )
-            return
         other = other.reindex(index_intersection)
         this_data = self.loc[index_intersection]
 

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -260,6 +260,7 @@ class TestDataFrameUpdate:
 
         tm.assert_frame_equal(other, expected)
 
+    from pandas.errors import PandasFutureWarning
     def test_update_mismatched_index_dtype(self):
         # GH#19905 - update silently does nothing when index dtypes differ
         df_int = DataFrame(
@@ -270,7 +271,7 @@ class TestDataFrameUpdate:
             {"col": [np.nan, np.nan, "baz"]},
             index=["1", "2", "3"]
         )
-        with tm.assert_produces_warning(FutureWarning, match="Index dtype mismatch"):
+        with tm.assert_produces_warning(PandasFutureWarning, match="Index dtype mismatch"):
             df_int.update(df_obj)
         # no rows match due to dtype mismatch, so df_int should be unchanged
         expected = DataFrame(

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -260,7 +260,6 @@ class TestDataFrameUpdate:
 
         tm.assert_frame_equal(other, expected)
 
-    from pandas.errors import PandasFutureWarning
     def test_update_mismatched_index_dtype(self):
         # GH#19905 - update silently does nothing when index dtypes differ
         df_int = DataFrame(
@@ -271,7 +270,9 @@ class TestDataFrameUpdate:
             {"col": [np.nan, np.nan, "baz"]},
             index=["1", "2", "3"]
         )
-        with tm.assert_produces_warning(PandasFutureWarning, match="Index dtype mismatch"):
+        with tm.assert_produces_warning(
+            UserWarning, match="Index dtype mismatch"
+        ):
             df_int.update(df_obj)
         # no rows match due to dtype mismatch, so df_int should be unchanged
         expected = DataFrame(

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -259,3 +259,22 @@ class TestDataFrameUpdate:
         expected = DataFrame({"date": [pd.Timestamp("2026-02-05")]}, dtype=object)
 
         tm.assert_frame_equal(other, expected)
+
+    def test_update_mismatched_index_dtype(self):
+        # GH#19905 - update silently does nothing when index dtypes differ
+        df_int = DataFrame(
+            {"col": ["foo", "bar", np.nan]},
+            index=[1, 2, 3]
+        )
+        df_obj = DataFrame(
+            {"col": [np.nan, np.nan, "baz"]},
+            index=["1", "2", "3"]
+        )
+        with tm.assert_produces_warning(FutureWarning, match="Index dtype mismatch"):
+            df_int.update(df_obj)
+        # no rows match due to dtype mismatch, so df_int should be unchanged
+        expected = DataFrame(
+            {"col": ["foo", "bar", np.nan]},
+            index=[1, 2, 3]
+        )
+        tm.assert_frame_equal(df_int, expected)


### PR DESCRIPTION
Closes #19905

When DataFrame.update() is called with another DataFrame whose index 
has a different dtype (e.g. int vs str), the index intersection is 
empty and the update silently does nothing. This is a common source 
of confusion as the indices may appear identical to the user.

This PR adds a FutureWarning when this situation is detected, telling 
the user exactly what the dtype mismatch is and that no update was 
performed.

Changes:
- Added FutureWarning in DataFrame.update() when index dtypes differ 
  and intersection is empty
- Added regression test test_update_mismatched_index_dtype to 
  pandas/tests/frame/methods/test_update.py