### PR TITLE
CLN: Remove TRACE macro in tokenizer

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -62,6 +62,3 @@ prune pandas/tests/io/parser/data
 # Selectively re-add *.cxx files that were excluded above
 graft pandas/_libs/src
 graft pandas/_libs/include
-
-# Include cibw script in sdist since it's needed for building wheels
-include scripts/cibw_before_build.sh

--- a/pandas/_libs/include/pandas/parser/tokenizer.h
+++ b/pandas/_libs/include/pandas/parser/tokenizer.h
@@ -36,13 +36,6 @@ See LICENSE for the license
  *  functions.
  */
 
-// #define VERBOSE
-#if defined(VERBOSE)
-#  define TRACE(X) printf X;
-#else
-#  define TRACE(X)
-#endif // VERBOSE
-
 #define PARSER_OUT_OF_MEMORY -1
 
 /*

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -41,7 +41,6 @@ void coliter_setup(coliter_t *self, parser_t *parser, int64_t i,
 }
 
 static void free_if_not_null(void **ptr) {
-  TRACE(("free_if_not_null %p\n", *ptr))
   if (*ptr != NULL) {
     free(*ptr);
     *ptr = NULL;
@@ -224,13 +223,8 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
 
   int status;
   char *orig_ptr = (void *)self->stream;
-  TRACE(("\n\nmake_stream_space: nbytes = %zu.  grow_buffer(self->stream...)\n",
-         nbytes))
   self->stream = (char *)grow_buffer((void *)self->stream, self->stream_len,
                                      &self->stream_cap, nbytes * 2, 1, &status);
-  TRACE(("make_stream_space: self->stream=%p, self->stream_len = %zu, "
-         "self->stream_cap=%zu, status=%zu\n",
-         self->stream, self->stream_len, self->stream_cap, status))
 
   if (status != 0) {
     return PARSER_OUT_OF_MEMORY;
@@ -266,18 +260,13 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
   self->words =
       (char **)grow_buffer((void *)self->words, length, &self->words_cap,
                            nbytes, sizeof(char *), &status);
-  TRACE(("make_stream_space: grow_buffer(self->self->words, %zu, %zu, %zu, "
-         "%d)\n",
-         self->words_len, self->words_cap, nbytes, status))
+
   if (status != 0) {
     return PARSER_OUT_OF_MEMORY;
   }
 
   // realloc took place
   if (words_cap != self->words_cap) {
-    TRACE(("make_stream_space: cap != self->words_cap, nbytes = %d, "
-           "self->words_cap=%d\n",
-           nbytes, self->words_cap))
     int64_t *newptr = (int64_t *)realloc(self->word_starts,
                                          sizeof(int64_t) * self->words_cap);
     if (newptr == NULL) {
@@ -294,16 +283,12 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
   self->line_start = (int64_t *)grow_buffer((void *)self->line_start,
                                             self->lines + 1, &self->lines_cap,
                                             nbytes, sizeof(int64_t), &status);
-  TRACE(
-      ("make_stream_space: grow_buffer(self->line_start, %zu, %zu, %zu, %d)\n",
-       self->lines + 1, self->lines_cap, nbytes, status))
   if (status != 0) {
     return PARSER_OUT_OF_MEMORY;
   }
 
   // realloc took place
   if (lines_cap != self->lines_cap) {
-    TRACE(("make_stream_space: cap != self->lines_cap, nbytes = %d\n", nbytes))
     int64_t *newptr = (int64_t *)realloc(self->line_fields,
                                          sizeof(int64_t) * self->lines_cap);
     if (newptr == NULL) {
@@ -317,12 +302,7 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
 }
 
 static int push_char(parser_t *self, char c) {
-  TRACE(("push_char: self->stream[%zu] = %x, stream_cap=%zu\n",
-         self->stream_len + 1, c, self->stream_cap))
   if (self->stream_len >= self->stream_cap) {
-    TRACE(("push_char: ERROR!!! self->stream_len(%d) >= "
-           "self->stream_cap(%d)\n",
-           self->stream_len, self->stream_cap))
     const size_t bufsize = 100;
     self->error_msg = malloc(bufsize);
     snprintf(self->error_msg, bufsize,
@@ -336,9 +316,6 @@ static int push_char(parser_t *self, char c) {
 static inline int end_field(parser_t *self) {
   // XXX cruft
   if (self->words_len >= self->words_cap) {
-    TRACE(("end_field: ERROR!!! self->words_len(%zu) >= "
-           "self->words_cap(%zu)\n",
-           self->words_len, self->words_cap))
     const size_t bufsize = 100;
     self->error_msg = malloc(bufsize);
     snprintf(self->error_msg, bufsize,
@@ -351,12 +328,6 @@ static inline int end_field(parser_t *self) {
 
   // set pointer and metadata
   self->words[self->words_len] = self->pword_start;
-
-  TRACE(("end_field: Char diff: %d\n", self->pword_start - self->words[0]));
-
-  TRACE(("end_field: Saw word %s at: %d. Total: %d\n", self->pword_start,
-         self->word_start, self->words_len + 1))
-
   self->word_starts[self->words_len] = self->word_start;
   self->words_len++;
 
@@ -390,9 +361,6 @@ static int end_line(parser_t *self) {
   int64_t ex_fields = self->expected_fields;
   int64_t fields = self->line_fields[self->lines];
 
-  TRACE(("end_line: Line end, nfields: %d\n", fields));
-
-  TRACE(("end_line: lines: %d\n", self->lines));
   if (self->lines > 0) {
     if (self->expected_fields >= 0) {
       ex_fields = self->expected_fields;
@@ -400,13 +368,11 @@ static int end_line(parser_t *self) {
       ex_fields = self->line_fields[self->lines - 1];
     }
   }
-  TRACE(("end_line: ex_fields: %d\n", ex_fields));
 
   if (self->state == START_FIELD_IN_SKIP_LINE ||
       self->state == IN_FIELD_IN_SKIP_LINE ||
       self->state == IN_QUOTED_FIELD_IN_SKIP_LINE ||
       self->state == QUOTE_IN_QUOTED_FIELD_IN_SKIP_LINE) {
-    TRACE(("end_line: Skipping row %d\n", self->file_lines));
     // increment file line count
     self->file_lines++;
 
@@ -437,9 +403,6 @@ static int end_line(parser_t *self) {
                "Expected %" PRId64 " fields in line %" PRIu64 ", saw %" PRId64
                "\n",
                ex_fields, self->file_lines, fields);
-
-      TRACE(("Error at line %d, %d fields\n", self->file_lines, fields));
-
       return -1;
     } else {
       // simply skip bad lines
@@ -478,8 +441,6 @@ static int end_line(parser_t *self) {
 
     // good line, set new start point
     if (self->lines >= self->lines_cap) {
-      TRACE(("end_line: ERROR!!! self->lines(%zu) >= self->lines_cap(%zu)\n",
-             self->lines, self->lines_cap))
       const size_t bufsize = 100;
       self->error_msg = malloc(bufsize);
       snprintf(self->error_msg, bufsize,
@@ -490,14 +451,9 @@ static int end_line(parser_t *self) {
     self->line_start[self->lines] =
         (self->line_start[self->lines - 1] + fields);
 
-    TRACE(("end_line: new line start: %d\n", self->line_start[self->lines]));
-
     // new line start with 0 fields
     self->line_fields[self->lines] = 0;
   }
-
-  TRACE(("end_line: Finished line, at %d\n", self->lines));
-
   return 0;
 }
 
@@ -534,9 +490,6 @@ static int parser_buffer_bytes(parser_t *self, size_t nbytes,
   self->datapos = 0;
   self->data =
       self->cb_io(self->source, nbytes, &bytes_read, &status, encoding_errors);
-  TRACE(
-      ("parser_buffer_bytes self->cb_io: nbytes=%zu, datalen: %d, status=%d\n",
-       nbytes, bytes_read, status));
   self->datalen = bytes_read;
 
   if (status != REACHED_EOF && self->data == NULL) {
@@ -552,9 +505,6 @@ static int parser_buffer_bytes(parser_t *self, size_t nbytes,
     }
     return -1;
   }
-
-  TRACE(("datalen: %d\n", self->datalen));
-
   return status;
 }
 
@@ -565,11 +515,7 @@ static int parser_buffer_bytes(parser_t *self, size_t nbytes,
 */
 
 #define PUSH_CHAR(c)                                                           \
-  TRACE(("PUSH_CHAR: Pushing %c, slen= %d, stream_cap=%zu, stream_len=%zu\n",  \
-         c, slen, self->stream_cap, self->stream_len))                         \
   if (slen >= self->stream_cap) {                                              \
-    TRACE(("PUSH_CHAR: ERROR!!! slen(%d) >= stream_cap(%d)\n", slen,           \
-           self->stream_cap))                                                  \
     const size_t bufsize = 100;                                                \
     self->error_msg = malloc(bufsize);                                         \
     snprintf(self->error_msg, bufsize,                                         \
@@ -638,9 +584,7 @@ static int parser_buffer_bytes(parser_t *self, size_t nbytes,
 
 #define _TOKEN_CLEANUP()                                                       \
   self->stream_len = slen;                                                     \
-  self->datapos = i;                                                           \
-  TRACE(("_TOKEN_CLEANUP: datapos: %d, datalen: %d\n", self->datapos,          \
-         self->datalen));
+  self->datapos = i;
 
 #define CHECK_FOR_BOM()                                                        \
   if (self->datalen - self->datapos >= 3 && *buf == '\xef' &&                  \
@@ -736,8 +680,6 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
     breaks_field_scan[index] |= 0x2;
   }
 
-  TRACE(("%s\n", buf));
-
   if (self->file_lines == 0) {
     CHECK_FOR_BOM();
   }
@@ -747,11 +689,6 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
   for (i = self->datapos; i < self->datalen; ++i) {
     // next character in file
     c = *buf++;
-
-    TRACE(("tokenize_bytes - Iter: %d Char: 0x%x Line %d field_count %d, "
-           "state %d\n",
-           i, c, self->file_lines + 1, self->line_fields[self->lines],
-           self->state));
 
     switch (self->state) {
     case START_FIELD_IN_SKIP_LINE:
@@ -1126,8 +1063,6 @@ static int tokenize_bytes(parser_t *self, size_t line_limit,
 
   _TOKEN_CLEANUP();
 
-  TRACE(("Finished tokenizing input\n"))
-
   return 0;
 
 parsingerror:
@@ -1145,8 +1080,6 @@ linelimit:
 
 static int parser_handle_eof(parser_t *self) {
   const size_t bufsize = 100;
-
-  TRACE(("handling eof, datalen: %d, pstate: %d\n", self->datalen, self->state))
 
   if (self->datalen != 0)
     return -1;
@@ -1206,9 +1139,6 @@ int parser_consume_rows(parser_t *self, size_t nrows) {
       word_deletions >= 1 ? (self->word_starts[word_deletions - 1] +
                              strlen(self->words[word_deletions - 1]) + 1)
                           : 0;
-
-  TRACE(("parser_consume_rows: Deleting %d words, %d chars\n", word_deletions,
-         char_count));
 
   /* move stream, only if something to move */
   if (char_count < self->stream_len) {
@@ -1275,7 +1205,6 @@ int parser_trim_buffers(parser_t *self) {
   /* trim words, word_starts */
   size_t new_cap = _next_pow2(self->words_len) + 1;
   if (new_cap < self->words_cap) {
-    TRACE(("parser_trim_buffers: new_cap < self->words_cap\n"));
     self->words = realloc(self->words, new_cap * sizeof(char *));
     if (self->words == NULL) {
       return PARSER_OUT_OF_MEMORY;
@@ -1289,12 +1218,7 @@ int parser_trim_buffers(parser_t *self) {
 
   /* trim stream */
   new_cap = _next_pow2(self->stream_len) + 1;
-  TRACE(("parser_trim_buffers: new_cap = %zu, stream_cap = %zu, lines_cap = "
-         "%zu\n",
-         new_cap, self->stream_cap, self->lines_cap));
   if (new_cap < self->stream_cap) {
-    TRACE(("parser_trim_buffers: new_cap < self->stream_cap, calling "
-           "realloc\n"));
     void *newptr = realloc(self->stream, new_cap);
     if (newptr == NULL) {
       return PARSER_OUT_OF_MEMORY;
@@ -1320,7 +1244,6 @@ int parser_trim_buffers(parser_t *self) {
   /* trim line_start, line_fields */
   new_cap = _next_pow2(self->lines) + 1;
   if (new_cap < self->lines_cap) {
-    TRACE(("parser_trim_buffers: new_cap < self->lines_cap\n"));
     void *newptr = realloc(self->line_start, new_cap * sizeof(int64_t));
     if (newptr == NULL) {
       return PARSER_OUT_OF_MEMORY;
@@ -1353,10 +1276,6 @@ static int _tokenize_helper(parser_t *self, size_t nrows, int all,
     return 0;
   }
 
-  TRACE(
-      ("_tokenize_helper: Asked to tokenize %d rows, datapos=%d, datalen=%d\n",
-       nrows, self->datapos, self->datalen));
-
   while (1) {
     if (!all && self->lines - start_lines >= nrows)
       break;
@@ -1374,22 +1293,14 @@ static int _tokenize_helper(parser_t *self, size_t nrows, int all,
       }
     }
 
-    TRACE(("_tokenize_helper: Trying to process %d bytes, datalen=%d, "
-           "datapos= %d\n",
-           self->datalen - self->datapos, self->datalen, self->datapos));
-
     status = tokenize_bytes(self, nrows, start_lines);
 
     if (status < 0) {
       // XXX
-      TRACE(("_tokenize_helper: Status %d returned from tokenize_bytes, "
-             "breaking\n",
-             status));
       status = -1;
       break;
     }
   }
-  TRACE(("leaving tokenize_helper\n"));
   return status;
 }
 


### PR DESCRIPTION
I think this is largely not needed anymore since `verbose` was removed from `read_csv`

We also no longer have a `scripts/cibw_before_build.sh` so can remove that from `MANIFEST.in`