### PR TITLE
BUG: Fix to_typst creating empty cells for hidden items

### DIFF
--- a/pandas/io/formats/templates/typst.tpl
+++ b/pandas/io/formats/templates/typst.tpl
@@ -1,12 +1,12 @@
 #table(
-  columns: {{ head[0] | length }},
+  columns: {{ head[0] | selectattr("is_visible") | list | length }},
 {% for r in head %}
-  {% for c in r %}[{% if c["is_visible"] %}{{ c["display_value"] }}{% endif %}],{% if not loop.last %} {% endif%}{% endfor %}
+  {% for c in r %}{% if c["is_visible"] %}[{{ c["display_value"] }}],{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
 
 {% endfor %}
 
 {% for r in body %}
-  {% for c in r %}[{% if c["is_visible"] %}{{ c["display_value"] }}{% endif %}],{% if not loop.last %} {% endif%}{% endfor %}
+  {% for c in r %}{% if c["is_visible"] %}[{{ c["display_value"] }}],{% if not loop.last %} {% endif %}{% endif %}{% endfor %}
 
 {% endfor %}
 )

--- a/pandas/tests/io/formats/style/test_to_typst.py
+++ b/pandas/tests/io/formats/style/test_to_typst.py
@@ -94,3 +94,33 @@ def test_concat_chain(styler):
     )"""
     )
     assert result == expected
+
+
+def test_hidden_columns(styler):
+    result = styler.hide(axis="columns", subset=["B"]).to_typst()
+    expected = dedent(
+        """\
+    #table(
+      columns: 3,
+      [], [A], [C],
+
+      [0], [0], [ab],
+      [1], [1], [cd],
+    )"""
+    )
+    assert result == expected
+
+
+def test_hidden_index_and_columns(styler):
+    result = styler.hide(axis="index").hide(axis="columns", subset=["B"]).to_typst()
+    expected = dedent(
+        """\
+    #table(
+      columns: 2,
+      [A], [C],
+
+      [0], [ab],
+      [1], [cd],
+    )"""
+    )
+    assert result == expected


### PR DESCRIPTION
## Problem

`to_typst()` creates empty cells `[]` for hidden columns/rows and counts them in the `columns:` parameter, producing incorrect table layout.

Example:
```python
df.style.hide(axis="index").to_typst()
```
Produces `columns: 3` with empty `[],` cells for hidden rows, instead of `columns: 2` with no empty cells.

## Solution

- Count only visible cells in `columns:` parameter using `selectattr("is_visible")`
- Skip hidden cells entirely instead of rendering empty `[]`

Fixes #64663