### PR TITLE
DOC: add missing list orient example to DataFrame.to_dict

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1980,6 +1980,9 @@ class DataFrame(NDFrame, OpsMixin):
 
         You can specify the return orientation.
 
+        >>> df.to_dict("list")
+        {'col1': [1, 2], 'col2': [0.5, 0.75]}
+
         >>> df.to_dict("series")
         {'col1': row1    1
                  row2    2


### PR DESCRIPTION
## Summary

The docstring for `DataFrame.to_dict` demonstrates six of the seven `orient` options but omits the `"list"` orient. This PR adds the missing example.

### Before
Examples shown: `dict` (default), `series`, `split`, `records`, `index`, `tight`

### After
Examples shown: `dict` (default), **`list`**, `series`, `split`, `records`, `index`, `tight`

## Changes

- `pandas/core/frame.py`: Added `>>> df.to_dict("list")` example with expected output

## Test Plan

- [x] Documentation-only change
- [x] Example output verified manually