### PR TITLE
BUG: Fix read_html including thead rows for nested tables

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -61,8 +61,8 @@ of multi-axis indexing.
   See more at :ref:`Selection by Label <indexing.label>`.
 
 
- Non-inclusive slicing with DatetimeIndex
----------------------------------------
+Non-inclusive slicing with DatetimeIndex
+----------------------------------------
 
 Label-based slicing using ``.loc`` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
 
@@ -74,6 +74,7 @@ If you need non-inclusive slicing (i.e., include the start but exclude the end),
 >>> ts.iloc[lo:hi]
 
 This approach provides finer control over slice boundaries.
+
 
 
 * ``.iloc`` is primarily integer position based (from ``0`` to

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -68,12 +68,12 @@ Label-based slicing using ``.loc`` includes both the start and end labels. This 
 
 If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
 
+.. code-block:: python
 
->>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
->>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
->>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
->>> ts.iloc[lo:hi]
-
+    ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
+    lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
+    hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
+    ts.iloc[lo:hi]
 
 This approach provides finer control over slice boundaries.
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -68,14 +68,13 @@ Label-based slicing using ``.loc`` includes both the start and end labels. This 
 
 If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
 
-.. code-block:: python
-
-   ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
-   lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
-   hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
-   ts.iloc[lo:hi]
+>>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
+>>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
+>>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
+>>> ts.iloc[lo:hi]
 
 This approach provides finer control over slice boundaries.
+
 
 * ``.iloc`` is primarily integer position based (from ``0`` to
   ``length-1`` of the axis), but may also be used with a boolean

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -60,6 +60,20 @@ of multi-axis indexing.
 
   See more at :ref:`Selection by Label <indexing.label>`.
 
+ Non-inclusive slicing with DatetimeIndex
+---------------------------------------
+
+Label-based slicing using `.loc` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
+
+If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods:
+
+>>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
+>>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
+>>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
+>>> ts.iloc[lo:hi]
+
+This approach provides finer control over slice boundaries.
+
 * ``.iloc`` is primarily integer position based (from ``0`` to
   ``length-1`` of the axis), but may also be used with a boolean
   array.  ``.iloc`` will raise ``IndexError`` if a requested

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -63,9 +63,9 @@ of multi-axis indexing.
  Non-inclusive slicing with DatetimeIndex
 ---------------------------------------
 
-Label-based slicing using `.loc` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
+Label-based slicing using ``.loc`` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
 
-If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods:
+If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
 
 >>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
 >>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -70,10 +70,10 @@ If you need non-inclusive slicing (i.e., include the start but exclude the end),
 
 .. code-block:: python
 
-    ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
-    lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
-    hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
-    ts.iloc[lo:hi]
+   ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
+   lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
+   hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
+   ts.iloc[lo:hi]
 
 This approach provides finer control over slice boundaries.
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -60,6 +60,7 @@ of multi-axis indexing.
 
   See more at :ref:`Selection by Label <indexing.label>`.
 
+
  Non-inclusive slicing with DatetimeIndex
 ---------------------------------------
 
@@ -67,10 +68,12 @@ Label-based slicing using ``.loc`` includes both the start and end labels. This 
 
 If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
 
+
 >>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
 >>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
 >>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
 >>> ts.iloc[lo:hi]
+
 
 This approach provides finer control over slice boundaries.
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -66,14 +66,12 @@ Non-inclusive slicing with DatetimeIndex
 
 Label-based slicing using ``.loc`` includes both the start and end labels. This differs from standard Python slicing, where the end is typically excluded.
 
-If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use lower-level index methods such as ``get_slice_bound``:
+If you need non-inclusive slicing (i.e., include the start but exclude the end), you can use boolean indexing with ``.loc``:
 
 >>> ts = pd.Series(range(10), index=pd.date_range("2000-01-01", periods=10))
->>> lo = ts.index.get_slice_bound("2000-01-04", "left", "loc")
->>> hi = ts.index.get_slice_bound("2000-01-10", "left", "loc")
->>> ts.iloc[lo:hi]
+>>> ts.loc[(ts.index >= "2000-01-04") & (ts.index < "2000-01-10")]
 
-This approach provides finer control over slice boundaries.
+This approach allows excluding the end label while filtering based on index values.
 
 
 

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -639,10 +639,13 @@ class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
         return table.select("thead tr")
 
     def _parse_tbody_tr(self, table):
-        from_tbody = table.select("tbody tr")
-        from_root = table.find_all("tr", recursive=False)
-        # HTML spec: at most one of these lists has content
-        return from_tbody + from_root
+        #HTML spec: at most one of these lists has content
+        tbody=table.find("tbody")
+        if tbody:
+            return tbody.find_all("tr",recursive=False)
+        else:
+            return table.find_all("tr",recursive=False)
+        
 
     def _parse_tfoot_tr(self, table):
         return table.select("tfoot tr")

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -639,12 +639,10 @@ class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
         return table.select("thead tr")
 
     def _parse_tbody_tr(self, table):
-        #HTML spec: at most one of these lists has content
-        tbody=table.find("tbody")
-        if tbody:
-            return tbody.find_all("tr",recursive=False)
-        else:
-            return table.find_all("tr",recursive=False)
+        tbody = table.find("tbody")
+        from_tbody = tbody.find_all("tr", recursive=False) if tbody else []
+        from_root = table.find_all("tr", recursive=False)
+        return from_tbody + from_root
         
 
     def _parse_tfoot_tr(self, table):

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1679,3 +1679,46 @@ class TestReadHtml:
         result = flavor_read_html(StringIO(data))[0]
         expected = DataFrame({"Codes": ["41651,65125,17328,02872,49459,79208,ABCDE"]})
         tm.assert_frame_equal(result, expected)
+
+    def test_read_html_nested_table_thead_not_included(self):
+        from io import StringIO
+
+        html = """
+            <table>
+                <thead>
+                    <tr>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <table id="descendant">
+                                <thead>
+                                    <tr>
+                                        <th>A</th>
+                                        <th>B</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>1</td>
+                                        <td>2</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        """
+
+        result = read_html(
+            StringIO(html),
+            flavor="bs4",
+            attrs={"id": "descendant"},
+        )[0]
+
+        expected = DataFrame({"A": [1], "B": [2]})
+
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
### Problem
When parsing nested tables using read_html with flavor="bs4", rows from <thead> of nested tables are incorrectly included as data rows in the resulting DataFrame.

### Cause
The previous implementation used table.select("tbody tr"), which also selects rows from nested tables, leading to unintended inclusion of header rows.

### Fix
Updated _parse_tbody_tr to:
- Use table.find("tbody") to target only the immediate <tbody>
- Use recursive=False to avoid selecting rows from nested tables
- Fall back to root-level rows when <tbody> is absent

### Test
Added a test to ensure that <thead> rows from nested tables are not included in the output.

Closes #64524
