### PR TITLE
Refactor source file inspection logic in conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -962,28 +962,41 @@ def linkcode_resolve(domain, info) -> str | None:
                 obj = getattr(obj, part)
         except AttributeError:
             return None
-
     try:
-        fn = inspect.getsourcefile(inspect.unwrap(obj))
+        unwrapped = inspect.unwrap(obj)
+        fn = inspect.getsourcefile(unwrapped)
+        if fn is None:
+            try:
+                fn = inspect.getfile(unwrapped)
+            except TypeError:
+                fn = None
     except TypeError:
         try:  # property
-            fn = inspect.getsourcefile(inspect.unwrap(obj.fget))
+            unwrapped = inspect.unwrap(obj.fget)
+            fn = inspect.getsourcefile(unwrapped)
+            if fn is None:
+                try:
+                    fn = inspect.getfile(unwrapped)
+                except TypeError:
+                    fn = None
         except (AttributeError, TypeError):
             fn = None
-    if not fn:
+
+    if fn is None:
         return None
 
     try:
-        source, lineno = inspect.getsourcelines(obj)
+        source, lineno = inspect.getsourcelines(unwrapped)
     except TypeError:
-        try:  # property
-            source, lineno = inspect.getsourcelines(obj.fget)
+        try:
+            source, lineno = inspect.getsourcelines(unwrapped.fget)
         except (AttributeError, TypeError):
+            source = None
             lineno = None
     except OSError:
+        source=None
         lineno = None
-
-    if lineno:
+    if lineno and source:
         linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
     else:
         linespec = ""


### PR DESCRIPTION
Fix incorrect source link for pandas.DataFrame caused by __module__ override.

- Updated linkcode_resolve to use inspect.getfile() as a fallback when inspect.getsourcefile() returns None
- Ensures correct resolution of source file paths instead of incorrectly pointing to pandas/__init__.py
- Uses inspect.unwrap() to resolve the actual underlying object
- Added safe handling for edge cases where source file or line numbers are unavailable to prevent doc build failures

This previously caused the [source] link in the documentation to point to the wrong file.

Closes #64224
