### PR TITLE
PERF: use array indexing instead of hash lookup in recode_for_groupby

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -173,6 +173,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.equals`, :meth:`DataFrame.select_dtypes`, and other operations performing shallow column slicing on Arrow-backed columns (:issue:`58966`)
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)
+- Performance improvement in :meth:`DataFrame.groupby` and :meth:`Series.groupby` when grouping by a :class:`Categorical` with a large number of categories (:issue:`48749`)
 - Performance improvement in :meth:`DataFrame.insert` when the number of blocks is small (:issue:`57641`)
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
 - Performance improvement in :meth:`DataFrame.query` and :meth:`DataFrame.eval` when the :class:`DataFrame` contains :class:`PeriodDtype` or :class:`IntervalDtype` columns (:issue:`35247`)

--- a/pandas/core/groupby/categorical.py
+++ b/pandas/core/groupby/categorical.py
@@ -6,7 +6,6 @@ from pandas.core.algorithms import unique1d
 from pandas.core.arrays.categorical import (
     Categorical,
     CategoricalDtype,
-    recode_for_categories,
 )
 
 
@@ -51,33 +50,34 @@ def recode_for_groupby(c: Categorical, sort: bool, observed: bool) -> Categorica
         if sort:
             take_codes = np.sort(take_codes)
 
-        # we recode according to the uniques
-        categories = c.categories.take(take_codes)
-        codes = recode_for_categories(c.codes, c.categories, categories, copy=False)
-
-        # return a new categorical that maps our new codes
-        # and categories
-        dtype = CategoricalDtype(categories, ordered=c.ordered)
-        return Categorical._simple_new(codes, dtype=dtype)
-
-    # Already sorted according to c.categories; all is fine
-    if sort:
+    elif sort:
+        # Already sorted according to c.categories; all is fine
         return c
 
-    # sort=False should order groups in as-encountered order (GH-8868)
-
-    # GH:46909: Re-ordering codes faster than using (set|add|reorder)_categories
-    # GH 38140: exclude nan from indexer for categories
-    unique_notnan_codes = unique1d(c.codes[c.codes != -1])
-    if sort:
-        unique_notnan_codes = np.sort(unique_notnan_codes)
-    if (num_cat := len(c.categories)) > len(unique_notnan_codes):
-        # GH 13179: All categories need to be present, even if missing from the data
-        missing_codes = np.setdiff1d(
-            np.arange(num_cat), unique_notnan_codes, assume_unique=True
-        )
-        take_codes = np.concatenate((unique_notnan_codes, missing_codes))
     else:
-        take_codes = unique_notnan_codes
+        # sort=False should order groups in as-encountered order (GH-8868)
 
-    return Categorical(c, c.categories.take(take_codes))
+        # GH:46909: Re-ordering codes faster than using (set|add|reorder)_categories
+        # GH 38140: exclude nan from indexer for categories
+        unique_notnan_codes = unique1d(c.codes[c.codes != -1])
+        if (num_cat := len(c.categories)) > len(unique_notnan_codes):
+            # GH 13179: All categories need to be present, even if missing
+            # from the data
+            missing_codes = np.setdiff1d(
+                np.arange(num_cat), unique_notnan_codes, assume_unique=True
+            )
+            take_codes = np.concatenate((unique_notnan_codes, missing_codes))
+        else:
+            take_codes = unique_notnan_codes
+
+    # GH#48749: Remap codes using direct array indexing instead of
+    # hash-based recode_for_categories / Categorical constructor,
+    # which use get_indexer_for (hash table lookup).
+    reverse_indexer = np.empty(len(c.categories), dtype=np.intp)
+    reverse_indexer[take_codes] = np.arange(len(take_codes))
+
+    new_codes = np.where(c.codes >= 0, reverse_indexer[np.maximum(c.codes, 0)], -1)
+
+    new_cats = c.categories.take(take_codes)
+    dtype = CategoricalDtype(new_cats, ordered=c.ordered)
+    return Categorical._simple_new(new_codes, dtype=dtype)

--- a/pandas/core/groupby/categorical.py
+++ b/pandas/core/groupby/categorical.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 
-from pandas.core.algorithms import unique1d
+from pandas.core.dtypes.cast import coerce_indexer_dtype
+
+from pandas.core.algorithms import (
+    take_nd,
+    unique1d,
+)
 from pandas.core.arrays.categorical import (
     Categorical,
     CategoricalDtype,
@@ -49,6 +54,10 @@ def recode_for_groupby(c: Categorical, sort: bool, observed: bool) -> Categorica
 
         if sort:
             take_codes = np.sort(take_codes)
+            if len(take_codes) == len(c.categories):
+                # Every category is observed; sorted codes are already
+                # 0..n-1, so c is unchanged.
+                return c
 
     elif sort:
         # Already sorted according to c.categories; all is fine
@@ -70,16 +79,17 @@ def recode_for_groupby(c: Categorical, sort: bool, observed: bool) -> Categorica
         else:
             take_codes = unique_notnan_codes
 
-    # GH#48749: Remap codes using direct array indexing instead of
-    # hash-based recode_for_categories / Categorical constructor,
-    # which use get_indexer_for (hash table lookup).
+    # GH#48749: Build the old-code -> new-code mapping by scatter-assignment
+    # (cheap integer indexing) rather than recode_for_categories / the
+    # Categorical constructor, which call get_indexer_for -- a hash-table
+    # lookup over the categories that is expensive when there are many
+    # (especially string) categories. The mapping is then applied with
+    # take_nd, which maps the NaN sentinel (-1) to -1 via fill_value.
     reverse_indexer = np.empty(len(c.categories), dtype=np.intp)
     reverse_indexer[take_codes] = np.arange(len(take_codes))
+    reverse_indexer = coerce_indexer_dtype(reverse_indexer, c.categories)
 
-    mask = c.codes >= 0
-    new_codes = np.full_like(c.codes, fill_value=-1)
-    if mask.any():
-        new_codes[mask] = reverse_indexer[c.codes[mask]]
+    new_codes = take_nd(reverse_indexer, c.codes, fill_value=-1)
 
     new_cats = c.categories.take(take_codes)
     dtype = CategoricalDtype(new_cats, ordered=c.ordered)

--- a/pandas/core/groupby/categorical.py
+++ b/pandas/core/groupby/categorical.py
@@ -76,7 +76,10 @@ def recode_for_groupby(c: Categorical, sort: bool, observed: bool) -> Categorica
     reverse_indexer = np.empty(len(c.categories), dtype=np.intp)
     reverse_indexer[take_codes] = np.arange(len(take_codes))
 
-    new_codes = np.where(c.codes >= 0, reverse_indexer[np.maximum(c.codes, 0)], -1)
+    mask = c.codes >= 0
+    new_codes = np.full_like(c.codes, fill_value=-1)
+    if mask.any():
+        new_codes[mask] = reverse_indexer[c.codes[mask]]
 
     new_cats = c.categories.take(take_codes)
     dtype = CategoricalDtype(new_cats, ordered=c.ordered)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -638,6 +638,26 @@ def test_dataframe_categorical_with_nan(observed):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("categories", [["a", "b"], []])
+def test_groupby_categorical_all_nan(observed, sort, categories):
+    # GH#48749 grouping by a Categorical whose codes are all -1 (every value
+    # is NaN) must not raise, including when there are no categories at all.
+    cat = Categorical([np.nan, np.nan, np.nan], categories=categories)
+    result = Series([1, 2, 3]).groupby(cat, observed=observed, sort=sort).sum()
+
+    if observed or not categories:
+        # no observed groups -> empty result
+        expected = Series(
+            [], index=CategoricalIndex([], dtype=cat.dtype), dtype="int64"
+        )
+    else:
+        # every category is an empty group
+        expected = Series(
+            [0, 0], index=CategoricalIndex(categories, dtype=cat.dtype), dtype="int64"
+        )
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize("ordered", [True, False])
 def test_dataframe_categorical_ordered_observed_sort(ordered, observed, sort):
     # GH 25871: Fix groupby sorting on ordered Categoricals


### PR DESCRIPTION
closes #48749

Speeds up the category-recoding step (`recode_for_groupby`) used when grouping by a `Categorical`.

The previous code mapped old codes to new codes via `recode_for_categories` / the `Categorical` constructor, which call `get_indexer_for` — a hash-table lookup over the *categories*. When there are many categories (especially strings), building that hash dominates. This instead builds the old→new mapping with an integer scatter-assignment and applies it with `take_nd` (the same vectorized gather the old path already used), so the hash is avoided without adding any extra passes over the rows. An O(1) short-circuit returns the input unchanged when every category is observed and already sorted.

The speedup scales with the number of categories relative to the number of rows, and is largest for string categories. Low-cardinality and integer-keyed groupbys are unchanged.

**Benchmarks** — isolated `recode_for_groupby`, `N=2M` rows (speedup vs `main`):

| n_categories | string cats | int cats |
|---|---|---|
| ≤ 10k | ~1.0x (neutral) | ~1.0x (neutral) |
| 100k | ~1.5x | ~1.0x |
| 500k | ~2.1x | ~1.05x |

End-to-end `groupby(...).count()` on 2M rows × ~500k string categories is ~1.5x faster (201ms → 132ms).

## Test plan
- [x] New regression test `test_groupby_categorical_all_nan` covering the all-NaN / empty-categories path
- [x] `pandas/tests/groupby/test_categorical.py` and `test_grouping.py` pass (1974 passed)
- [x] Differential check vs the previous implementation across `sort` / `observed` / `ordered` / NaN / dtype — identical results
- [x] whatsnew note added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
