### PR TITLE
check dtype kind before monotonic/unique in _maybe_promote_to_rangeindex

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2030,7 +2030,7 @@ class _MergeOperation:
 
 
 def _maybe_promote_to_rangeindex(idx: Index) -> Index:
-    if idx.is_monotonic_increasing and idx.is_unique and idx.dtype.kind in "iu":
+    if idx.dtype.kind in "iu" and idx.is_monotonic_increasing and idx.is_unique:
         values = idx._values
         if isinstance(values, np.ndarray):
             result = maybe_sequence_to_range(values)


### PR DESCRIPTION
- [X] closes #64146 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Follow-up from #64148. Reorder condition checks in `_maybe_promote_to_rangeindex` to evaluate the dtype check before `is_monotonic_increasing` and `is_unique` checks.

cc @mroeschke