### PR TITLE
ENH: Add replace method to Index (closes #19495)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -31,6 +31,7 @@ Other enhancements
 - :class:`Period` now supports f-string formatting via ``__format__``, e.g. ``f"{period:%Y-%m}"`` (:issue:`48536`)
 - :meth:`.DataFrameGroupBy.agg` now allows for the provided ``func`` to return a NumPy array (:issue:`63957`)
 - Added :meth:`ExtensionArray.count` (:issue:`64450`)
+- Added :meth:`Index.replace` method to support value replacement functionality similar to :meth:`Series.replace` (:issue:`19495`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6820,6 +6820,34 @@ class Index(IndexOpsMixin, PandasObject):
             dtype = new_values.dtype
         return Index(new_values, dtype=dtype, copy=False, name=self.name)
 
+    def replace(self, to_replace=None, value=lib.no_default, regex=False):
+        """
+        Replace values in the Index.
+
+        Parameters
+        ----------
+        to_replace : scalar, list, or dict
+        value : scalar, default no_default
+        regex : bool, default False
+
+        Returns
+        -------
+        Index
+        """
+        from pandas import Series
+
+        ser = Series(self)
+
+        if self._is_multi:
+            raise NotImplementedError("replace is not implemented for MultiIndex")
+
+        if value is lib.no_default:
+            replaced = ser.replace(to_replace, regex=regex)
+        else:
+            replaced = ser.replace(to_replace, value, regex=regex)
+
+        return self._shallow_copy(replaced._values, name=self.name)
+
     # TODO: De-duplicate with map, xref GH#32349
     @final
     def _transform_index(self, func: Callable, *, level: int | None = None) -> Index:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6820,19 +6820,39 @@ class Index(IndexOpsMixin, PandasObject):
             dtype = new_values.dtype
         return Index(new_values, dtype=dtype, copy=False, name=self.name)
 
-    def replace(self, to_replace=None, value=lib.no_default, regex=False):
+    def replace(
+        self, to_replace: Any = None, value: Any = lib.no_default, regex: bool = False
+    ) -> Index:
         """
         Replace values in the Index.
+
+        Replace values given in `to_replace` with `value`. Values of the Index
+        that are not in `to_replace` are left unchanged.
 
         Parameters
         ----------
         to_replace : scalar, list, or dict
+            The value(s) to be replaced. If a dict is provided, value must be omitted.
         value : scalar, default no_default
+            The value to replace occurrences of to_replace with.
         regex : bool, default False
+            Whether to interpret to_replace as a regular expression.
 
         Returns
         -------
         Index
+            Index with replaced values.
+
+        See Also
+        --------
+        Series.replace : Replace values in a Series.
+        DataFrame.replace : Replace values in a DataFrame.
+
+        Examples
+        --------
+        >>> idx = pd.Index([1, 2, 3, 4, 5])
+        >>> idx.replace(3, 30)
+        Index([1, 2, 30, 4, 5], dtype='int64')
         """
         from pandas import Series
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6854,17 +6854,11 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx.replace(3, 30)
         Index([1, 2, 30, 4, 5], dtype='int64')
         """
-        from pandas import Series
-
-        ser = Series(self)
-
         if self._is_multi:
             raise NotImplementedError("replace is not implemented for MultiIndex")
 
-        if value is lib.no_default:
-            replaced = ser.replace(to_replace, regex=regex)
-        else:
-            replaced = ser.replace(to_replace, value, regex=regex)
+        ser = self.to_series()
+        replaced = ser.replace(to_replace, value, regex=regex)
 
         return self._shallow_copy(replaced._values, name=self.name)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6833,7 +6833,7 @@ class Index(IndexOpsMixin, PandasObject):
         ----------
         to_replace : scalar, list, or dict
             The value(s) to be replaced. If a dict is provided, value must be omitted.
-        value : scalar, default no_default
+        value : scalar, default None
             The value to replace occurrences of to_replace with.
         regex : bool, default False
             Whether to interpret to_replace as a regular expression.

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -183,6 +183,37 @@ class TestIndex:
         result = Index(data, dtype="float")
         tm.assert_index_equal(result, expected)
 
+    def test_index_replace_scalar(self):
+        idx = Index([1, 2, 3])
+
+        result = idx.replace(2, 9)
+
+        expected = Index([1, 9, 3])
+
+        tm.assert_index_equal(result, expected)
+
+    def test_index_replace_dict(self):
+        idx = Index(["a", "b", "c"])
+
+        result = idx.replace({"b": "x"})
+
+        expected = Index(["a", "x", "c"])
+
+        tm.assert_index_equal(result, expected)
+
+    def test_index_replace_preserves_name(self):
+        idx = Index([1, 2, 3], name="test")
+
+        result = idx.replace(2, 9)
+
+        assert result.name == "test"
+
+    def test_index_replace_regex(self):
+        idx = Index(["foo", "bar", "baz"])
+        result = idx.replace("^ba", "x", regex=True)
+        expected = Index(["foo", "xr", "xz"])
+        tm.assert_index_equal(result, expected)
+
     @pytest.mark.parametrize(
         "klass,dtype,na_val",
         [


### PR DESCRIPTION
This PR implements a `replace` method for `Index`, providing
functionality consistent with `Series.replace`. This addresses
GH#19495, which requested support for value replacement directly
on Index objects.

Implementation details:
- The Index is temporarily converted to a Series
- `Series.replace` is applied using the provided arguments
- The result is converted back to an Index using `_shallow_copy` to preserve metadata such as name and dtype
- Regex-based replacement is supported
- MultiIndex is currently not supported and raises `NotImplementedError`

Test coverage includes:
- scalar replacement
- dictionary-style replacement
- list-style replacement
- regex replacement
- preservation of Index metadata (name)

Closes GH #19495