### PR TITLE
 BUG: `GroupBy.any()`/`all()` returns `NaN` for unobserved categorical groups on bool dtype

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -286,6 +286,7 @@ Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)
+- Bug in :meth:`.GroupBy.any` and :meth:`.GroupBy.all` returning ``NaN`` with ``float64`` dtype for unobserved categorical groups on NumPy ``bool`` data instead of the boolean identity value with ``bool`` dtype (:issue:`65100`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` (and their :class:`GroupBy` counterparts) returning ``0.0`` and ``-3.0`` respectively for degenerate windows or groups; these now return ``NaN`` (:issue:`62864`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
 - Bug in :meth:`DataFrame.groupby` with a :class:`Grouper` with ``freq`` raising ``AttributeError`` when all grouping keys are ``NaT`` (:issue:`43486`)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1526,7 +1526,10 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             # GH#37850 For numpy boolean data, any==max and all==min.
             # The min/max Cython path is faster (fused types, no mask overhead).
             # Excludes nullable BooleanDtype which needs Kleene logic.
-            if how in ["any", "all"] and values.dtype == np.dtype("bool"):
+            use_bool_fastpath = how in ["any", "all"] and values.dtype == np.dtype(
+                "bool"
+            )
+            if use_bool_fastpath:
                 _how = "max" if how == "any" else "min"
             else:
                 _how = how
@@ -1547,6 +1550,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
                 if alt is None or how in ["any", "all", "std", "sem"]:
                     raise  # TODO: re-raise as TypeError?  should not be reached
             else:
+                if use_bool_fastpath and result.dtype.kind == "f":
+                    fill = 0.0 if how == "any" else 1.0
+                    result = np.where(
+                        np.isnan(result), fill, np.asarray(result)
+                    ).astype(bool)
                 return result
 
             assert alt is not None

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -251,6 +251,22 @@ def test_empty(frame_or_series, all_boolean_reductions):
     tm.assert_equal(result, expected)
 
 
+@pytest.mark.parametrize("method,fill_value", [("any", False), ("all", True)])
+def test_numpy_bool_unobserved_categorical_group_returns_identity(method, fill_value):
+    # GH#65100
+    key = pd.Categorical(["A", "B"], categories=["A", "B", "C"])
+    ser = Series(np.array([True, False], dtype=bool))
+
+    result = getattr(ser.groupby(key, observed=False), method)()
+
+    expected = Series(
+        [True, False, fill_value],
+        index=pd.CategoricalIndex(["A", "B", "C"], categories=["A", "B", "C"]),
+        dtype=bool,
+    )
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize("how", ["idxmin", "idxmax"])
 def test_idxmin_idxmax_extremes(how, any_real_numpy_dtype):
     # GH#57040


### PR DESCRIPTION
- [X] closes #65100 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

TL;DR is that the optimization treated `any/all` as interchangeable with `max/min` for NumPy `bool` data. That is correct for non-empty groups, but not for empty ones `group_any_all` seeds the output with the identity (`False` for `any`, `True` for `all`), while the `max/min` path does not preserve that behavior and empty groups surface as `NaN`.

So I fixed this by detecting when the `bool` `max`/`min` fast path returns a floating result, filling `NaN` entries with the boolean identity (`False` for `any`, `True` for `all`), and casting the result back to `bool`. Did run some benchmarks, and results are almost the same. 

| n         | before #64677 any | before #64677 all | after #64677 any | after #64677 all | after fix any | after fix all |
|-----------|-------------------:|------------------:|-----------------:|-----------------:|--------------:|--------------:|
| 100,000   | 0.86ms             | 0.86ms            | 0.37ms           | 0.38ms           | 0.40ms        | 0.42ms        |
| 250,000   | 2.11ms             | 2.20ms            | 1.06ms           | 1.07ms           | 1.01ms        | 1.06ms        |
| 500,000   | 4.12ms             | 4.13ms            | 1.96ms           | 1.99ms           | 2.02ms        | 1.95ms        |
| 1,000,000 | 8.52ms             | 8.58ms            | 3.88ms           | 3.71ms           | 3.79ms        | 3.85ms        |
| 2,000,000 | 17.35ms            | 16.86ms           | 7.69ms           | 7.61ms           | 7.61ms        | 7.60ms        |
| 5,000,000 | 41.68ms            | 41.96ms           | 19.07ms          | 19.18ms          | 18.95ms       | 18.94ms       |