### PR TITLE
PERF: use PyArrow compute for month_name/day_name with string dtype

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -148,6 +148,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.rank` and :meth:`Series.rank` by skipping unnecessary ``putmask`` for non-nullable dtypes (:issue:`64857`)
 - Performance improvement in :meth:`DataFrame.sort_values` with multiple numeric columns by avoiding unnecessary :class:`Categorical` conversion (:issue:`15389`)
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)
+- Performance improvement in :meth:`DatetimeIndex.month_name` and :meth:`DatetimeIndex.day_name` when using the default string dtype by using PyArrow compute instead of going through an intermediate object array (:issue:`65104`)
 - Performance improvement in :meth:`GroupBy.any` and :meth:`GroupBy.all` for boolean-dtype columns (:issue:`37850`)
 - Performance improvement in :meth:`GroupBy.first` and :meth:`GroupBy.last` for Extension Array dtypes, which no longer fall back to a slow ``apply``-based implementation (:issue:`57591`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
@@ -163,7 +164,6 @@ Performance improvements
 - Performance improvement in plotting :class:`DatetimeIndex` with multiplied frequencies (e.g. ``"1000ms"``, ``"100s"``) (:issue:`50355`)
 - Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)
 - Performance improvement in repr of :class:`Series` and :class:`DataFrame` containing third-party array-like objects (e.g. xarray ``DataArray``) in object dtype columns (:issue:`61809`)
-- Performance improvement in :meth:`DatetimeIndex.month_name` and :meth:`DatetimeIndex.day_name` when using the default string dtype by using PyArrow compute instead of going through an intermediate object array (:issue:`XXXXX`)
 - Performance improvement in :meth:`DataFrame.loc` and :meth:`DataFrame.iloc`
   setitem with a 2D list-of-lists value by avoiding a wasteful round-trip
   through an intermediate object array (:issue:`64229`).

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -163,6 +163,7 @@ Performance improvements
 - Performance improvement in plotting :class:`DatetimeIndex` with multiplied frequencies (e.g. ``"1000ms"``, ``"100s"``) (:issue:`50355`)
 - Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)
 - Performance improvement in repr of :class:`Series` and :class:`DataFrame` containing third-party array-like objects (e.g. xarray ``DataArray``) in object dtype columns (:issue:`61809`)
+- Performance improvement in :meth:`DatetimeIndex.month_name` and :meth:`DatetimeIndex.day_name` when using the default string dtype by using PyArrow compute instead of going through an intermediate object array (:issue:`XXXXX`)
 - Performance improvement in :meth:`DataFrame.loc` and :meth:`DataFrame.iloc`
   setitem with a 2D list-of-lists value by avoiding a wasteful round-trip
   through an intermediate object array (:issue:`64229`).

--- a/pandas/_libs/tslibs/ccalendar.pyi
+++ b/pandas/_libs/tslibs/ccalendar.pyi
@@ -1,7 +1,9 @@
 DAYS: list[str]
+DAYS_FULL: list[str]
 MONTH_ALIASES: dict[int, str]
 MONTH_NUMBERS: dict[str, int]
 MONTHS: list[str]
+MONTHS_FULL: list[str]
 int_to_weekday: dict[int, str]
 
 def get_firstbday(year: int, month: int) -> int: ...

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -94,6 +94,8 @@ if TYPE_CHECKING:
         Iterator,
     )
 
+    import pyarrow as pa
+
     from pandas._typing import (
         ArrayLike,
         DateTimeErrorChoices,
@@ -107,6 +109,7 @@ if TYPE_CHECKING:
 
     from pandas import DataFrame
     from pandas.core.arrays import PeriodArray
+    from pandas.core.arrays.string_arrow import ArrowStringArray
 
     _TimestampNoneT1 = TypeVar("_TimestampNoneT1", Timestamp, None)
     _TimestampNoneT2 = TypeVar("_TimestampNoneT2", Timestamp, None)
@@ -1416,7 +1419,7 @@ default 'raise'
         Index(['Janeiro', 'Fevereiro', 'Março'], dtype='str')
         """
         if locale is None and HAS_PYARROW and using_string_dtype():
-            return self._month_name_arrow()
+            return self._month_name_arrow()  # type: ignore[return-value]
 
         values = self._local_timestamps()
 
@@ -1433,7 +1436,7 @@ default 'raise'
             return pd_array(result, dtype=StringDtype(na_value=np.nan))  # type: ignore[return-value]
         return result
 
-    def _month_name_arrow(self):
+    def _month_name_arrow(self) -> ArrowStringArray:
         import pyarrow as pa
         import pyarrow.compute as pc
 
@@ -1500,7 +1503,7 @@ default 'raise'
         Index(['Segunda', 'Terça', 'Quarta'], dtype='str')
         """
         if locale is None and HAS_PYARROW and using_string_dtype():
-            return self._day_name_arrow()
+            return self._day_name_arrow()  # type: ignore[return-value]
 
         values = self._local_timestamps()
 
@@ -1517,7 +1520,7 @@ default 'raise'
             return pd_array(result, dtype=StringDtype(na_value=np.nan))  # type: ignore[return-value]
         return result
 
-    def _day_name_arrow(self):
+    def _day_name_arrow(self) -> ArrowStringArray:
         import pyarrow as pa
         import pyarrow.compute as pc
 
@@ -1526,7 +1529,7 @@ default 'raise'
         result = pc.take(pa_days, pc.day_of_week(pa_ts))
         return self._wrap_pa_str_result(result)
 
-    def _to_local_pa_timestamp(self):
+    def _to_local_pa_timestamp(self) -> pa.Array:
         """Convert to a pyarrow TimestampArray with local timestamps."""
         import pyarrow as pa
 
@@ -1535,13 +1538,13 @@ default 'raise'
         return pa.array(values, mask=mask, type=pa.timestamp(self.unit))
 
     @staticmethod
-    def _wrap_pa_str_result(pa_arr):
+    def _wrap_pa_str_result(pa_arr: pa.Array) -> ArrowStringArray:
         """Wrap a pyarrow StringArray in an ArrowStringArray with StringDtype."""
         from pandas.core.arrays.string_ import StringDtype
 
         dtype = StringDtype(na_value=np.nan)
         cls = dtype.construct_array_type()
-        return cls(pa_arr, dtype=dtype)  # type: ignore[call-arg]
+        return cls(pa_arr, dtype=dtype)  # type: ignore[call-arg, return-value]
 
     @property
     def time(self) -> npt.NDArray[np.object_]:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1541,7 +1541,7 @@ default 'raise'
 
         dtype = StringDtype(na_value=np.nan)
         cls = dtype.construct_array_type()
-        return cls(pa_arr, dtype=dtype)
+        return cls(pa_arr, dtype=dtype)  # type: ignore[call-arg]
 
     @property
     def time(self) -> npt.NDArray[np.object_]:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -47,6 +47,10 @@ from pandas._libs.tslibs import (
     tz_convert_from_utc,
     tzconversion,
 )
+from pandas._libs.tslibs.ccalendar import (
+    DAYS_FULL,
+    MONTHS_FULL,
+)
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
 from pandas._libs.tslibs.offsets import RelativeDeltaOffset
 from pandas.compat.pyarrow import HAS_PYARROW
@@ -1411,7 +1415,7 @@ default 'raise'
         >>> idx.month_name(locale="pt_BR.utf8")  # doctest: +SKIP
         Index(['Janeiro', 'Fevereiro', 'Março'], dtype='str')
         """
-        if using_string_dtype() and locale is None and HAS_PYARROW:
+        if locale is None and HAS_PYARROW and using_string_dtype():
             return self._month_name_arrow()
 
         values = self._local_timestamps()
@@ -1433,12 +1437,10 @@ default 'raise'
         import pyarrow as pa
         import pyarrow.compute as pc
 
-        from pandas._libs.tslibs.ccalendar import MONTHS_FULL
-
         pa_months = pa.array(MONTHS_FULL, type=pa.large_string())
         pa_ts = self._to_local_pa_timestamp()
         result = pc.take(pa_months, pc.month(pa_ts))
-        return self._from_pyarrow_string_array(result)
+        return self._wrap_pa_str_result(result)
 
     def day_name(self, locale=None) -> npt.NDArray[np.object_]:
         """
@@ -1497,7 +1499,7 @@ default 'raise'
         >>> idx.day_name(locale="pt_BR.utf8")  # doctest: +SKIP
         Index(['Segunda', 'Terça', 'Quarta'], dtype='str')
         """
-        if using_string_dtype() and locale is None and HAS_PYARROW:
+        if locale is None and HAS_PYARROW and using_string_dtype():
             return self._day_name_arrow()
 
         values = self._local_timestamps()
@@ -1519,12 +1521,10 @@ default 'raise'
         import pyarrow as pa
         import pyarrow.compute as pc
 
-        from pandas._libs.tslibs.ccalendar import DAYS_FULL
-
         pa_days = pa.array(DAYS_FULL, type=pa.large_string())
         pa_ts = self._to_local_pa_timestamp()
         result = pc.take(pa_days, pc.day_of_week(pa_ts))
-        return self._from_pyarrow_string_array(result)
+        return self._wrap_pa_str_result(result)
 
     def _to_local_pa_timestamp(self):
         """Convert to a pyarrow TimestampArray with local timestamps."""
@@ -1535,9 +1535,9 @@ default 'raise'
         return pa.array(values, mask=mask, type=pa.timestamp(self.unit))
 
     @staticmethod
-    def _from_pyarrow_string_array(pa_arr):
+    def _wrap_pa_str_result(pa_arr):
         """Wrap a pyarrow StringArray in an ArrowStringArray with StringDtype."""
-        from pandas import StringDtype
+        from pandas.core.arrays.string_ import StringDtype
         from pandas.core.arrays.string_arrow import ArrowStringArray
 
         return ArrowStringArray(pa_arr, dtype=StringDtype(na_value=np.nan))

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -49,6 +49,7 @@ from pandas._libs.tslibs import (
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
 from pandas._libs.tslibs.offsets import RelativeDeltaOffset
+from pandas.compat.pyarrow import HAS_PYARROW
 from pandas.errors import PerformanceWarning
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
@@ -1410,8 +1411,8 @@ default 'raise'
         >>> idx.month_name(locale="pt_BR.utf8")  # doctest: +SKIP
         Index(['Janeiro', 'Fevereiro', 'Março'], dtype='str')
         """
-        if using_string_dtype() and locale is None:
-            return self._month_name_arrow()  # type: ignore[return-value]
+        if using_string_dtype() and locale is None and HAS_PYARROW:
+            return self._month_name_arrow()
 
         values = self._local_timestamps()
 
@@ -1496,8 +1497,8 @@ default 'raise'
         >>> idx.day_name(locale="pt_BR.utf8")  # doctest: +SKIP
         Index(['Segunda', 'Terça', 'Quarta'], dtype='str')
         """
-        if using_string_dtype() and locale is None:
-            return self._day_name_arrow()  # type: ignore[return-value]
+        if using_string_dtype() and locale is None and HAS_PYARROW:
+            return self._day_name_arrow()
 
         values = self._local_timestamps()
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1410,6 +1410,9 @@ default 'raise'
         >>> idx.month_name(locale="pt_BR.utf8")  # doctest: +SKIP
         Index(['Janeiro', 'Fevereiro', 'Março'], dtype='str')
         """
+        if using_string_dtype() and locale is None:
+            return self._month_name_arrow()  # type: ignore[return-value]
+
         values = self._local_timestamps()
 
         result = fields.get_date_name_field(
@@ -1424,6 +1427,17 @@ default 'raise'
 
             return pd_array(result, dtype=StringDtype(na_value=np.nan))  # type: ignore[return-value]
         return result
+
+    def _month_name_arrow(self):
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        from pandas._libs.tslibs.ccalendar import MONTHS_FULL
+
+        pa_months = pa.array(MONTHS_FULL, type=pa.large_string())
+        pa_ts = self._to_local_pa_timestamp()
+        result = pc.take(pa_months, pc.month(pa_ts))
+        return self._from_pyarrow_string_array(result)
 
     def day_name(self, locale=None) -> npt.NDArray[np.object_]:
         """
@@ -1482,6 +1496,9 @@ default 'raise'
         >>> idx.day_name(locale="pt_BR.utf8")  # doctest: +SKIP
         Index(['Segunda', 'Terça', 'Quarta'], dtype='str')
         """
+        if using_string_dtype() and locale is None:
+            return self._day_name_arrow()  # type: ignore[return-value]
+
         values = self._local_timestamps()
 
         result = fields.get_date_name_field(
@@ -1489,7 +1506,6 @@ default 'raise'
         )
         result = self._maybe_mask_results(result, fill_value=None)
         if using_string_dtype():
-            # TODO: no tests that check for dtype of result as of 2024-08-15
             from pandas import (
                 StringDtype,
                 array as pd_array,
@@ -1497,6 +1513,33 @@ default 'raise'
 
             return pd_array(result, dtype=StringDtype(na_value=np.nan))  # type: ignore[return-value]
         return result
+
+    def _day_name_arrow(self):
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        from pandas._libs.tslibs.ccalendar import DAYS_FULL
+
+        pa_days = pa.array(DAYS_FULL, type=pa.large_string())
+        pa_ts = self._to_local_pa_timestamp()
+        result = pc.take(pa_days, pc.day_of_week(pa_ts))
+        return self._from_pyarrow_string_array(result)
+
+    def _to_local_pa_timestamp(self):
+        """Convert to a pyarrow TimestampArray with local timestamps."""
+        import pyarrow as pa
+
+        values = self._local_timestamps()
+        mask = self._isnan
+        return pa.array(values, mask=mask, type=pa.timestamp(self.unit))
+
+    @staticmethod
+    def _from_pyarrow_string_array(pa_arr):
+        """Wrap a pyarrow StringArray in an ArrowStringArray with StringDtype."""
+        from pandas import StringDtype
+        from pandas.core.arrays.string_arrow import ArrowStringArray
+
+        return ArrowStringArray(pa_arr, dtype=StringDtype(na_value=np.nan))
 
     @property
     def time(self) -> npt.NDArray[np.object_]:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1538,9 +1538,10 @@ default 'raise'
     def _wrap_pa_str_result(pa_arr):
         """Wrap a pyarrow StringArray in an ArrowStringArray with StringDtype."""
         from pandas.core.arrays.string_ import StringDtype
-        from pandas.core.arrays.string_arrow import ArrowStringArray
 
-        return ArrowStringArray(pa_arr, dtype=StringDtype(na_value=np.nan))
+        dtype = StringDtype(na_value=np.nan)
+        cls = dtype.construct_array_type()
+        return cls(pa_arr, dtype=dtype)
 
     @property
     def time(self) -> npt.NDArray[np.object_]:


### PR DESCRIPTION
## Summary
- When using the default string dtype (pyarrow-backed), `month_name()` and `day_name()` now use `pc.month`/`pc.day_of_week` + `pc.take` to build Arrow string arrays directly, avoiding the intermediate `ndarray[object]`.
- Falls back to the existing Cython path when `locale` is specified.

## Benchmarks (N=1,000,000)
| Method | Before | After | Speedup |
|---|---|---|---|
| `month_name()` | 34ms | 13ms | **2.6x** |
| `day_name()` | 38ms | 11ms | **3.5x** |

## Test plan
- [x] Existing tests pass (`test_scalar_compat.py`, `test_dt_accessor.py`, `test_arrow.py`, `test_fields.py` — 25737 passed)
- [x] Verified correctness with NaT, timezone-aware data, and basic cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)