### PR TITLE
ENH: Add recursive parameter to StructAccessor.explode()

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -34,6 +34,7 @@ Other enhancements
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
+- :meth:`.StructAccessor.explode` now supports ``recursive=True`` to recursively flatten nested struct fields, joining field names with a configurable separator (:issue:`64915`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.notable_bug_fixes:

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -34,7 +34,7 @@ Other enhancements
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
-- :meth:`.StructAccessor.explode` now supports ``recursive=True`` to recursively flatten nested struct fields, joining field names with a configurable separator (:issue:`64915`)
+- :meth:`Series.struct.explode` now supports ``recursive=True`` to recursively flatten nested struct fields, joining field names with a configurable separator (:issue:`64915`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.notable_bug_fixes:

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -568,6 +568,9 @@ class StructAccessor(ArrowAccessor):
             for i in range(pa_type.num_fields):
                 field = pa_type.field(i)
                 field_name = field.name
+                # Handle bytes field names by converting to str
+                if isinstance(field_name, bytes):
+                    field_name = field_name.decode("utf-8")
                 full_name = f"{prefix}{separator}{field_name}" if prefix else field_name
 
                 # Extract the field data
@@ -596,9 +599,33 @@ class StructAccessor(ArrowAccessor):
 
             return results
 
+        def _get_field_names_recursive(pa_type: pa.StructType, prefix: str = "") -> list[str]:
+            """Get field names from struct type without data (for empty arrays)."""
+            names: list[str] = []
+            for i in range(pa_type.num_fields):
+                field = pa_type.field(i)
+                field_name = field.name
+                # Handle bytes field names by converting to str
+                if isinstance(field_name, bytes):
+                    field_name = field_name.decode("utf-8")
+                full_name = f"{prefix}{separator}{field_name}" if prefix else field_name
+
+                if pa.types.is_struct(field.type):
+                    names.extend(
+                        _get_field_names_recursive(field.type, full_name if prefix else field_name)
+                    )
+                else:
+                    names.append(full_name)
+            return names
+
+        # Get the flattened field names from the type (handles empty case)
+        pa_type = self._pa_array.type
+        all_field_names = _get_field_names_recursive(pa_type)
+
         fields = _get_fields_recursive(self._pa_array)
         if not fields:
-            return DataFrame(index=self._data.index)
+            # Empty series - return DataFrame with correct columns but no rows
+            return DataFrame(index=self._data.index, columns=all_field_names)
 
         _, series_list = zip(*fields)
         return concat(series_list, axis="columns")

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -546,8 +546,17 @@ class StructAccessor(ArrowAccessor):
 
         if not recursive:
             pa_type = self._pa_array.type
+            if pa_type.num_fields == 0:
+                return DataFrame(index=self._data.index)
             return concat(
                 [self.field(i) for i in range(pa_type.num_fields)], axis="columns"
+            )
+
+        # Validate separator
+        if not isinstance(separator, str):
+            raise TypeError(
+                f"'separator' must be a string when recursive=True, got "
+                f"{type(separator).__name__}"
             )
 
         # Recursive flattening
@@ -618,13 +627,11 @@ class StructAccessor(ArrowAccessor):
                     names.append(full_name)
             return names
 
-        # Get the flattened field names from the type (handles empty case)
-        pa_type = self._pa_array.type
-        all_field_names = _get_field_names_recursive(pa_type)
-
         fields = _get_fields_recursive(self._pa_array)
         if not fields:
-            # Empty series - return DataFrame with correct columns but no rows
+            # No leaf fields - compute column names from schema for empty result
+            pa_type = self._pa_array.type
+            all_field_names = _get_field_names_recursive(pa_type)
             return DataFrame(index=self._data.index, columns=all_field_names)
 
         _, series_list = zip(*fields)

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -575,14 +575,6 @@ class StructAccessor(ArrowAccessor):
 
                 # If this field is also a struct, recurse
                 if pa.types.is_struct(field_arr.type):
-                    # Create a temporary series to recurse into
-                    temp_series = Series(
-                        field_arr,
-                        dtype=ArrowDtype(field_arr.type),
-                        index=self._data.index,
-                        name=full_name,
-                    )
-                    # Get accessor for nested struct and recurse
                     results.extend(
                         _get_fields_recursive(
                             field_arr,

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -477,12 +477,18 @@ class StructAccessor(ArrowAccessor):
             name=name,
         )
 
-    def explode(self) -> DataFrame:
+    def explode(self, recursive: bool = False, separator: str = "_") -> DataFrame:
         """
         Extract all child fields of a struct as a DataFrame.
 
-        Each child field of the struct becomes a column in the resulting
-        DataFrame, with column names matching the struct field names.
+        Parameters
+        ----------
+        recursive : bool, default False
+            If True, recursively flatten nested struct fields, joining
+            field names with the specified separator.
+        separator : str, default "_"
+            The separator to use when joining nested field names.
+            Only used when ``recursive=True``.
 
         Returns
         -------
@@ -512,10 +518,95 @@ class StructAccessor(ArrowAccessor):
         0        1  pandas
         1        2  pandas
         2        1   numpy
-        """
-        from pandas import concat
 
-        pa_type = self._pa_array.type
-        return concat(
-            [self.field(i) for i in range(pa_type.num_fields)], axis="columns"
+        For nested structs, use ``recursive=True``:
+
+        >>> nested_type = pa.struct([
+        ...     ("version", pa.int64()),
+        ...     ("bar", pa.struct([("a", pa.int64()), ("b", pa.string())])),
+        ... ])
+        >>> s_nested = pd.Series(
+        ...     [
+        ...         {"version": 1, "bar": {"a": 10, "b": "x"}},
+        ...         {"version": 2, "bar": {"a": 20, "b": "y"}},
+        ...     ],
+        ...     dtype=pd.ArrowDtype(nested_type),
+        ... )
+        >>> s_nested.struct.explode(recursive=True)
+           version  bar_a bar_b
+        0        1     10     x
+        1        2     20     y
+        """
+        from pandas import (
+            ArrowDtype,
+            DataFrame,
+            Series,
+            concat,
         )
+
+        if not recursive:
+            pa_type = self._pa_array.type
+            return concat(
+                [self.field(i) for i in range(pa_type.num_fields)], axis="columns"
+            )
+
+        # Recursive flattening
+        def _get_fields_recursive(
+            pa_array: pa.ChunkedArray | pa.Array,
+            prefix: str = "",
+        ) -> list[tuple[str, Series]]:
+            """
+            Recursively get all fields from struct type.
+
+            Returns a list of (name, series) tuples where name is the
+            fully qualified field name (with prefix) and series is the
+            extracted data.
+            """
+            results: list[tuple[str, Series]] = []
+            pa_type = pa_array.type
+
+            for i in range(pa_type.num_fields):
+                field = pa_type.field(i)
+                field_name = field.name
+                full_name = f"{prefix}{separator}{field_name}" if prefix else field_name
+
+                # Extract the field data
+                field_arr = pc.struct_field(pa_array, i)
+
+                # If this field is also a struct, recurse
+                if pa.types.is_struct(field_arr.type):
+                    # Create a temporary series to recurse into
+                    temp_series = Series(
+                        field_arr,
+                        dtype=ArrowDtype(field_arr.type),
+                        index=self._data.index,
+                        name=full_name,
+                    )
+                    # Get accessor for nested struct and recurse
+                    results.extend(
+                        _get_fields_recursive(
+                            field_arr,
+                            prefix=full_name if prefix else field_name,
+                        )
+                    )
+                else:
+                    results.append(
+                        (
+                            full_name,
+                            Series(
+                                field_arr,
+                                dtype=ArrowDtype(field_arr.type),
+                                index=self._data.index,
+                                name=full_name,
+                            ),
+                        )
+                    )
+
+            return results
+
+        fields = _get_fields_recursive(self._pa_array)
+        if not fields:
+            return DataFrame(index=self._data.index)
+
+        names, series_list = zip(*fields)
+        return concat(series_list, axis="columns", keys=names)

--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -608,5 +608,5 @@ class StructAccessor(ArrowAccessor):
         if not fields:
             return DataFrame(index=self._data.index)
 
-        names, series_list = zip(*fields)
-        return concat(series_list, axis="columns", keys=names)
+        _, series_list = zip(*fields)
+        return concat(series_list, axis="columns")

--- a/pandas/tests/series/accessors/test_struct_accessor.py
+++ b/pandas/tests/series/accessors/test_struct_accessor.py
@@ -277,8 +277,13 @@ def test_struct_accessor_explode_recursive_empty():
     )
 
     actual = ser.struct.explode(recursive=True)
-    expected = DataFrame(index=Index([], dtype="object"))
-    assert list(actual.columns) == []
+    expected = DataFrame(
+        {
+            "a": Series([], dtype=ArrowDtype(pa.int64())),
+            "b_c": Series([], dtype=ArrowDtype(pa.string())),
+        },
+        index=Index([], dtype="object"),
+    )
     tm.assert_frame_equal(actual, expected)
 
 

--- a/pandas/tests/series/accessors/test_struct_accessor.py
+++ b/pandas/tests/series/accessors/test_struct_accessor.py
@@ -304,14 +304,15 @@ def test_struct_accessor_explode_recursive_bytes_field():
             ),
         ]
     )
-    ser = Series(
+    # Use pa.array to construct data with bytes keys matching the schema
+    data = pa.array(
         [
-            {"bytes_field": 1, "nested": {b"bytes_nested": "x"}},
-            {"bytes_field": 2, "nested": {b"bytes_nested": "y"}},
+            {b"bytes_field": 1, "nested": {b"bytes_nested": "x"}},
+            {b"bytes_field": 2, "nested": {b"bytes_nested": "y"}},
         ],
-        dtype=ArrowDtype(arrow_type),
-        index=index,
+        type=arrow_type,
     )
+    ser = Series(data, dtype=ArrowDtype(arrow_type), index=index)
 
     actual = ser.struct.explode(recursive=True)
     # bytes field names should be decoded to str
@@ -325,6 +326,20 @@ def test_struct_accessor_explode_recursive_bytes_field():
         },
     )
     tm.assert_frame_equal(actual, expected)
+
+
+def test_struct_accessor_explode_recursive_separator_validation():
+    # Test that separator parameter is validated
+    ser = Series(
+        [{"a": {"b": 1}}],
+        dtype=ArrowDtype(pa.struct([("a", pa.struct([("b", pa.int64())]))])),
+    )
+
+    with pytest.raises(TypeError, match="'separator' must be a string"):
+        ser.struct.explode(recursive=True, separator=None)
+
+    with pytest.raises(TypeError, match="'separator' must be a string"):
+        ser.struct.explode(recursive=True, separator=123)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/series/accessors/test_struct_accessor.py
+++ b/pandas/tests/series/accessors/test_struct_accessor.py
@@ -131,6 +131,157 @@ def test_struct_accessor_explode():
     tm.assert_frame_equal(actual, expected)
 
 
+def test_struct_accessor_explode_recursive():
+    # Test for issue #64915 - recursive flattening of nested structs
+    index = Index([0, 1, 2])
+    ser = Series(
+        [
+            {"version": 1, "project": "pandas", "bar": {"a": [1, 2, 3], "b": 10}},
+            {"version": 2, "project": "pandas", "bar": {"a": [1, 2], "b": 20}},
+            {"version": 1, "project": "numpy", "bar": {"a": [1], "b": 30}},
+        ],
+        dtype=ArrowDtype(
+            pa.struct(
+                [
+                    ("version", pa.int64()),
+                    ("project", pa.string()),
+                    (
+                        "bar",
+                        pa.struct(
+                            [
+                                ("a", pa.list_(pa.int64())),
+                                ("b", pa.int64()),
+                            ]
+                        ),
+                    ),
+                ]
+            )
+        ),
+        index=index,
+    )
+
+    # Test recursive=True flattens nested structs
+    actual = ser.struct.explode(recursive=True)
+    expected = DataFrame(
+        {
+            "version": Series([1, 2, 1], index=index, dtype=ArrowDtype(pa.int64())),
+            "project": Series(
+                ["pandas", "pandas", "numpy"], index=index, dtype=ArrowDtype(pa.string())
+            ),
+            "bar_a": Series(
+                [[1, 2, 3], [1, 2], [1]], index=index, dtype=ArrowDtype(pa.list_(pa.int64()))
+            ),
+            "bar_b": Series([10, 20, 30], index=index, dtype=ArrowDtype(pa.int64())),
+        },
+    )
+    tm.assert_frame_equal(actual, expected)
+
+
+def test_struct_accessor_explode_recursive_separator():
+    # Test custom separator
+    index = Index([0, 1])
+    ser = Series(
+        [
+            {"bar": {"a": 1, "b": "x"}},
+            {"bar": {"a": 2, "b": "y"}},
+        ],
+        dtype=ArrowDtype(
+            pa.struct(
+                [
+                    (
+                        "bar",
+                        pa.struct(
+                            [
+                                ("a", pa.int64()),
+                                ("b", pa.string()),
+                            ]
+                        ),
+                    ),
+                ]
+            )
+        ),
+        index=index,
+    )
+
+    # Default separator "_"
+    actual_default = ser.struct.explode(recursive=True)
+    assert list(actual_default.columns) == ["bar_a", "bar_b"]
+
+    # Custom separator "."
+    actual_dot = ser.struct.explode(recursive=True, separator=".")
+    assert list(actual_dot.columns) == ["bar.a", "bar.b"]
+
+    # Custom separator "/"
+    actual_slash = ser.struct.explode(recursive=True, separator="/")
+    assert list(actual_slash.columns) == ["bar/a", "bar/b"]
+
+
+def test_struct_accessor_explode_recursive_deeply_nested():
+    # Test deeply nested structs (3 levels)
+    index = Index([0, 1])
+    ser = Series(
+        [
+            {"a": {"b": {"c": 1, "d": "x"}}},
+            {"a": {"b": {"c": 2, "d": "y"}}},
+        ],
+        dtype=ArrowDtype(
+            pa.struct(
+                [
+                    (
+                        "a",
+                        pa.struct(
+                            [
+                                (
+                                    "b",
+                                    pa.struct(
+                                        [
+                                            ("c", pa.int64()),
+                                            ("d", pa.string()),
+                                        ]
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                ]
+            )
+        ),
+        index=index,
+    )
+
+    actual = ser.struct.explode(recursive=True)
+    expected = DataFrame(
+        {
+            "a_b_c": Series([1, 2], index=index, dtype=ArrowDtype(pa.int64())),
+            "a_b_d": Series(["x", "y"], index=index, dtype=ArrowDtype(pa.string())),
+        },
+    )
+    tm.assert_frame_equal(actual, expected)
+
+
+def test_struct_accessor_explode_recursive_empty():
+    # Test recursive explode on empty series
+    ser = Series(
+        [],
+        dtype=ArrowDtype(
+            pa.struct(
+                [
+                    ("a", pa.int64()),
+                    (
+                        "b",
+                        pa.struct([("c", pa.string())]),
+                    ),
+                ]
+            )
+        ),
+    )
+
+    actual = ser.struct.explode(recursive=True)
+    expected = DataFrame(index=Index([], dtype="object"))
+    assert list(actual.columns) == []
+    tm.assert_frame_equal(actual, expected)
+
+
 @pytest.mark.parametrize(
     "invalid",
     [

--- a/pandas/tests/series/accessors/test_struct_accessor.py
+++ b/pandas/tests/series/accessors/test_struct_accessor.py
@@ -287,6 +287,46 @@ def test_struct_accessor_explode_recursive_empty():
     tm.assert_frame_equal(actual, expected)
 
 
+def test_struct_accessor_explode_recursive_bytes_field():
+    # Test that bytes field names are properly handled (converted to str)
+    index = Index([0, 1])
+    # Arrow supports bytes as field names
+    arrow_type = pa.struct(
+        [
+            (b"bytes_field", pa.int64()),  # bytes field name
+            (
+                "nested",
+                pa.struct(
+                    [
+                        (b"bytes_nested", pa.string()),  # bytes in nested struct
+                    ]
+                ),
+            ),
+        ]
+    )
+    ser = Series(
+        [
+            {"bytes_field": 1, "nested": {b"bytes_nested": "x"}},
+            {"bytes_field": 2, "nested": {b"bytes_nested": "y"}},
+        ],
+        dtype=ArrowDtype(arrow_type),
+        index=index,
+    )
+
+    actual = ser.struct.explode(recursive=True)
+    # bytes field names should be decoded to str
+    assert list(actual.columns) == ["bytes_field", "nested_bytes_nested"]
+    expected = DataFrame(
+        {
+            "bytes_field": Series([1, 2], index=index, dtype=ArrowDtype(pa.int64())),
+            "nested_bytes_nested": Series(
+                ["x", "y"], index=index, dtype=ArrowDtype(pa.string())
+            ),
+        },
+    )
+    tm.assert_frame_equal(actual, expected)
+
+
 @pytest.mark.parametrize(
     "invalid",
     [


### PR DESCRIPTION
## Description

This PR adds support for recursively flattening nested struct fields in `Series.struct.explode()` by introducing a `recursive` parameter, as requested in #64915.

### Changes

- Added `recursive` parameter (default `False`) for backward compatibility
- Added `separator` parameter (default `"_"`) to customize field name joining
- Supports arbitrarily deep nesting of struct fields

### Example Usage

```python
import pyarrow as pa
import pandas as pd

# Nested struct type
nested_type = pa.struct([
    ("version", pa.int64()),
    ("project", pa.string()),
    ("bar", pa.struct([
        ("a", pa.list_(pa.int64())),
        ("b", pa.int64()),
    ])),
])

s = pd.Series([
    {"version": 1, "project": "pandas", "bar": {"a": [1, 2, 3], "b": 10}},
    {"version": 2, "project": "pandas", "bar": {"a": [1, 2], "b": 20}},
    {"version": 1, "project": "numpy", "bar": {"a": [1], "b": 30}},
], dtype=pd.ArrowDtype(nested_type))

# Without recursive (default behavior, unchanged)
s.struct.explode()
#    version project                    bar
# 0        1  pandas  {'a': [1, 2, 3], 'b': 10}
# 1        2  pandas     {'a': [1, 2], 'b': 20}
# 2        1   numpy        {'a': [1], 'b': 30}

# With recursive=True (new feature)
s.struct.explode(recursive=True)
#    version project        bar_a  bar_b
# 0        1  pandas  [1, 2, 3]     10
# 1        2  pandas     [1, 2]     20
# 2        1   numpy        [1]     30
```

### Notes

- The `separator` parameter allows customizing how nested field names are joined (default is `_`)
- Empty series are handled gracefully
- Backward compatible - default behavior unchanged

Closes #64915