### PR TITLE
BUG: .dt.seconds Discrepancy Between NumPy and PyArrow Timedelta Dtypes

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -20,6 +20,8 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
+- Fixed :attr:`Series.dt.seconds` for PyArrow-backed durations to return seconds modulo one day, matching NumPy-backed timedeltas (:issue:`63283`).
+
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.contributors:
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3185,7 +3185,7 @@ class ArrowExtensionArray(
     def _dt_seconds(self) -> Self:
         return self._from_pyarrow_array(
             pa.array(
-                self._to_timedeltaarray().components.seconds,
+                self._to_timedeltaarray().seconds,
                 from_pandas=True,
                 type=pa.int32(),
             )

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -12,6 +12,7 @@ from typing import (
 import warnings
 
 import numpy as np
+import pyarrow as pa
 
 from pandas._libs import lib
 from pandas.errors import Pandas4Warning
@@ -248,18 +249,20 @@ class ArrowTemporalProperties(PandasDelegate, PandasObject, NoNewAttributesMixin
     def components(self) -> DataFrame:
         from pandas import DataFrame
 
+        arr = cast("ArrowExtensionArray", self._parent.array)
+        seconds = arr._to_timedeltaarray().components.seconds
+
         components_df = DataFrame(
             {
-                col: getattr(self._parent.array, f"_dt_{col}")
-                for col in [
-                    "days",
-                    "hours",
-                    "minutes",
-                    "seconds",
-                    "milliseconds",
-                    "microseconds",
-                    "nanoseconds",
-                ]
+                "days": arr._dt_days,
+                "hours": arr._dt_hours,
+                "minutes": arr._dt_minutes,
+                "seconds": arr._from_pyarrow_array(
+                    pa.array(seconds, from_pandas=True, type=pa.int32())
+                ),
+                "milliseconds": arr._dt_milliseconds,
+                "microseconds": arr._dt_microseconds,
+                "nanoseconds": arr._dt_nanoseconds,
             }
         )
         return components_df

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -12,7 +12,6 @@ from typing import (
 import warnings
 
 import numpy as np
-import pyarrow as pa
 
 from pandas._libs import lib
 from pandas.errors import Pandas4Warning
@@ -250,16 +249,16 @@ class ArrowTemporalProperties(PandasDelegate, PandasObject, NoNewAttributesMixin
         from pandas import DataFrame
 
         arr = cast("ArrowExtensionArray", self._parent.array)
+
         seconds = arr._to_timedeltaarray().components.seconds
+        seconds_array = type(arr)._from_sequence(seconds, dtype=arr._dt_days.dtype)
 
         components_df = DataFrame(
             {
                 "days": arr._dt_days,
                 "hours": arr._dt_hours,
                 "minutes": arr._dt_minutes,
-                "seconds": arr._from_pyarrow_array(
-                    pa.array(seconds, from_pandas=True, type=pa.int32())
-                ),
+                "seconds": seconds_array,
                 "milliseconds": arr._dt_milliseconds,
                 "microseconds": arr._dt_microseconds,
                 "nanoseconds": arr._dt_nanoseconds,

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2978,6 +2978,30 @@ def test_dt_to_pytimedelta():
     tm.assert_numpy_array_equal(result, expected)
 
 
+def test_dt_seconds_duration():
+    ser = pd.Series(
+        [
+            pd.Timedelta(days=1, hours=2),
+            pd.Timedelta(hours=5, minutes=30),
+            pd.Timedelta(minutes=45, seconds=15),
+        ],
+        dtype=ArrowDtype(pa.duration("us")),
+    )
+
+    result = ser.dt.seconds
+    expected = pd.Series(
+        ArrowExtensionArray(pa.array([7200, 19800, 2715], type=pa.int32()))
+    )
+    tm.assert_series_equal(result, expected)
+
+    components_seconds = ser.dt.components["seconds"]
+    expected_components = pd.Series(
+        ArrowExtensionArray(pa.array([0, 0, 15], type=pa.int32())),
+        name="seconds",
+    )
+    tm.assert_series_equal(components_seconds, expected_components)
+
+
 def test_dt_components():
     # GH 52284
     ser = pd.Series(


### PR DESCRIPTION
- [x] closes #63283  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
