### PR TITLE
FIX: silent data loss in MultiIndex __setitem__ with object-dtype level

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -261,6 +261,7 @@ MultiIndex
 ^^^^^^^^^^
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
+- Fixed silent data loss in :meth:`MultiIndex.__setitem__` when level values had object dtype containing falsy values (e.g., integer ``0`` alongside strings) (:issue:`65118`)
 -
 
 I/O

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4709,7 +4709,8 @@ class DataFrame(NDFrame, OpsMixin):
                 if (
                     not isinstance(cols_droplevel, MultiIndex)
                     and is_string_dtype(cols_droplevel.dtype)
-                    and not cols_droplevel.any()
+                    and len(cols_droplevel) > 0
+                    and (cols_droplevel == "").all()
                 ):
                     # if cols_droplevel contains only empty strings,
                     # value.reindex(cols_droplevel, axis=1) would be full of NaNs

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -298,11 +298,15 @@ class TestMultiIndexBasic:
         # with object-dtype level containing mixed types (string + int)
         # where maybe_droplevels produces an Index with a falsy integer value (0)
         cols = MultiIndex.from_tuples(
-            [("info", "M"), ("info", 0), ("earnings", 1), ("earnings", 2), ("prices", 0)]
+            [
+                ("info", "M"),
+                ("info", 0),
+                ("earnings", 1),
+                ("earnings", 2),
+                ("prices", 0),
+            ]
         )
-        df = DataFrame(
-            np.arange(20, dtype=float).reshape(4, 5), columns=cols
-        )
+        df = DataFrame(np.arange(20, dtype=float).reshape(4, 5), columns=cols)
         original = df.copy()
 
         # This used to silently drop the assignment because:
@@ -328,9 +332,7 @@ class TestMultiIndexBasic:
     def test_multiindex_setitem_object_dtype_level_falsy_values(self):
         # GH#65118 - ensure falsy but non-empty-string values in object-dtype
         # level are not mistaken for empty-string columns
-        cols = MultiIndex.from_tuples(
-            [("group", "a"), ("group", 0), ("group", "")]
-        )
+        cols = MultiIndex.from_tuples([("group", "a"), ("group", 0), ("group", "")])
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=cols)
 
         # The ("group", "") column should still be writable

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -292,3 +292,50 @@ class TestMultiIndexBasic:
         )
 
         tm.assert_frame_equal(meta, result)
+
+    def test_multiindex_setitem_object_dtype_level_no_silent_drop(self):
+        # GH#65118 - silent data loss when setting values on a MultiIndex
+        # with object-dtype level containing mixed types (string + int)
+        # where maybe_droplevels produces an Index with a falsy integer value (0)
+        cols = MultiIndex.from_tuples(
+            [("info", "M"), ("info", 0), ("earnings", 1), ("earnings", 2), ("prices", 0)]
+        )
+        df = DataFrame(
+            np.arange(20, dtype=float).reshape(4, 5), columns=cols
+        )
+        original = df.copy()
+
+        # This used to silently drop the assignment because:
+        # - is_string_dtype(object) is True
+        # - Index([0]).any() is False (0 is falsy)
+        # causing the early return intended for empty-string columns
+        df["prices"] = df["prices"] / 100
+
+        expected = original.copy()
+        expected["prices"] = expected["prices"] / 100
+        tm.assert_frame_equal(df, expected)
+
+    def test_multiindex_setitem_object_dtype_level_single_subcolumn(self):
+        # GH#65118 - variant with a single subcolumn under a top-level key
+        cols = MultiIndex.from_tuples([("A", 0), ("B", "x")])
+        df = DataFrame([[1.0, 2.0], [3.0, 4.0]], columns=cols)
+
+        df["A"] = df["A"] * 10
+
+        expected = DataFrame([[10.0, 2.0], [30.0, 4.0]], columns=cols)
+        tm.assert_frame_equal(df, expected)
+
+    def test_multiindex_setitem_object_dtype_level_falsy_values(self):
+        # GH#65118 - ensure falsy but non-empty-string values in object-dtype
+        # level are not mistaken for empty-string columns
+        cols = MultiIndex.from_tuples(
+            [("group", "a"), ("group", 0), ("group", "")]
+        )
+        df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=cols)
+
+        # The ("group", "") column should still be writable
+        result = df.copy()
+        result["group"] = result["group"] + 10
+
+        expected = DataFrame([[11, 12, 13], [14, 15, 16]], columns=cols)
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Problem

`df[key] = df[key] / x` silently drops the assignment (no error, no warning) when:
1. DataFrame has a column MultiIndex
2. Level 1 has `object` dtype due to mixed types (e.g. string + int)
3. The top-level label has exactly one sub-column

```python
cols = pd.MultiIndex.from_tuples(
    [("info", "M"), ("info", 0), ("earnings", 1), ("earnings", 2), ("prices", 0)]
)
df = pd.DataFrame(np.arange(20, dtype=float).reshape(4, 5), columns=cols)
df["prices"] = df["prices"] / 100  # silent no-op! values unchanged
```

This is a **regression from 2.3.x → 3.0.x** and causes silent data loss.

## Root Cause

In `_set_item_frame_value`, the guard added for GH#62518/GH#61841 checks:

```python
is_string_dtype(cols_droplevel.dtype) and not cols_droplevel.any()
```

When `maybe_droplevels` produces `Index([0], dtype="object")`:
- `is_string_dtype(object)` → `True`
- `Index([0]).any()` → `False` (because `0` is falsy)

This causes the early return to trigger incorrectly, silently discarding the assignment.

## Fix

Replace `not cols_droplevel.any()` with `(cols_droplevel == "").all()` to explicitly check for empty strings:

```python
and len(cols_droplevel) > 0
and (cols_droplevel == "").all()
```

This correctly identifies actual empty-string columns without being fooled by falsy integer values in object-dtype Indexes.

## Testing

Verified locally that the fix resolves the issue from the bug report:

```
# Before fix: prices values unchanged [4. 9. 14. 19.]
# After fix: prices values correctly divided [0.04 0.09 0.14 0.19]
```

Also confirmed the original GH#62518/GH#61841 cases are still protected since their columns genuinely contain only empty strings.

Fixes #65118