### PR TITLE
BUG: DataFrame.rank() loses ExtensionArray dtype (GH#52829)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -310,7 +310,7 @@ Sparse
 ExtensionArray
 ^^^^^^^^^^^^^^
 - Fixed bug in :meth:`Series.apply` and :meth:`Series.map` where nullable integer dtypes were converted to float, causing precision loss for large integers; now the nullable dtype will be preserved (:issue:`63903`).
--
+- Fixed bug in :meth:`DataFrame.rank` where :class:`ExtensionArray` dtypes (e.g. ``ArrowDtype``, nullable ``Int64``) were silently converted to ``float64`` instead of being preserved, unlike the consistent behavior of :meth:`Series.rank` (:issue:`52829`).
 -
 
 Styler

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9599,8 +9599,47 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         def ranker(data):
             if data.ndim == 2:
-                # i.e. DataFrame, we cast to ndarray
-                values = data.values
+                if axis_int == 0:
+                    # GH#52829 - when ranking along axis=0 (the default,
+                    # ranking each column independently), use _mgr.apply so
+                    # that ExtensionArray dtypes are preserved instead of being
+                    # cast to numpy float64 via data.values.
+                    #
+                    # Blocks are stored in transposed (ncols, nrows) layout, so
+                    # for numpy blocks and 2-D EAs (e.g. DatetimeArray) we
+                    # transpose, rank along axis=0 (rows), then transpose back.
+                    # 1-D EAs (e.g. ArrowExtensionArray, IntegerArray) are
+                    # stored flat so their _rank(axis=0) is correct as-is.
+                    def _rank_block(blk_values):
+                        if isinstance(blk_values, ExtensionArray) and blk_values.ndim == 1:
+                            # 1-D EAs can rank in-place preserving dtype.
+                            return blk_values._rank(
+                                axis=0,
+                                method=method,
+                                ascending=ascending,
+                                na_option=na_option,
+                                pct=pct,
+                            )
+                        # numpy blocks and 2-D EAs are (ncols, nrows);
+                        # transpose so axis=0 corresponds to within each column.
+                        transposed = blk_values.T
+                        ranked = algos.rank(
+                            transposed,
+                            axis=0,
+                            method=method,
+                            ascending=ascending,
+                            na_option=na_option,
+                            pct=pct,
+                        )
+                        return ranked.T
+
+                    new_mgr = data._mgr.apply(_rank_block)
+                    ranks_obj = data._constructor_from_mgr(new_mgr, axes=new_mgr.axes)
+                    return ranks_obj.__finalize__(self, method="rank")
+                else:
+                    # axis=1: must consolidate to 2D ndarray since ranking
+                    # across columns cannot be done column-by-column.
+                    values = data.values
             else:
                 # i.e. Series, can dispatch to EA
                 values = data._values

--- a/pandas/tests/frame/methods/test_rank.py
+++ b/pandas/tests/frame/methods/test_rank.py
@@ -498,3 +498,35 @@ class TestRank:
             exp_dtype = "float64"
         expected = Series([1, 2, None, 3], dtype=exp_dtype)
         tm.assert_series_equal(result, expected)
+
+    def test_rank_preserves_ea_dtype(self):
+        # GH#52829 - DataFrame.rank() should preserve ExtensionArray dtypes
+        # the same way Series.rank() does.
+        pa = pytest.importorskip("pyarrow")
+        from pandas import ArrowDtype
+
+        s = Series([1, 2, 3], dtype=ArrowDtype(pa.int32()))
+        df = s.to_frame(name="a")
+
+        # Series.rank() preserves the ArrowDtype
+        s_result = s.rank(method="min")
+        # DataFrame.rank() should also preserve the ArrowDtype (GH#52829)
+        df_result = df.rank(method="min")
+
+        assert s_result.dtype == df_result["a"].dtype, (
+            f"Series.rank() dtype {s_result.dtype} != "
+            f"DataFrame.rank() column dtype {df_result['a'].dtype}"
+        )
+
+    def test_rank_preserves_nullable_int_dtype(self):
+        # GH#52829 - DataFrame.rank() should preserve nullable integer dtypes
+        s = Series([1, 2, 3], dtype="Int64")
+        df = s.to_frame(name="a")
+
+        s_result = s.rank(method="min")
+        df_result = df.rank(method="min")
+
+        assert s_result.dtype == df_result["a"].dtype, (
+            f"Series.rank() dtype {s_result.dtype} != "
+            f"DataFrame.rank() column dtype {df_result['a'].dtype}"
+        )


### PR DESCRIPTION
## Problem

`DataFrame.rank()` silently converts ExtensionArray-backed columns (e.g. `ArrowDtype`, nullable `Int64`) to `float64`, while `Series.rank()` correctly preserves the original dtype.

```python
import pandas as pd
import pyarrow as pa

s = pd.Series([1, 2], dtype=pd.ArrowDtype(pa.int32()))
df = s.to_frame(name="a")

s.rank(method="min").dtype        # uint64[pyarrow]  checkmark
df.rank(method="min")["a"].dtype  # float64  before fix
                                  # uint64[pyarrow]  after fix
```

## Root cause

In `NDFrame.ranker()`, the DataFrame branch used `data.values` which consolidates all blocks into a single numpy array, stripping EA type info.

## Fix

For `axis=0` (default), use `_mgr.apply()` to process each block independently:
- **1-D EAs** (ArrowExtensionArray, IntegerArray, etc.) call their own `_rank()`, preserving dtype.
- **numpy blocks and 2-D EAs** (DatetimeArray) are transposed, ranked with `algos.rank(axis=0)`, and transposed back.
- **`axis=1`** keeps the old `data.values` path (cross-column ranking must see all columns at once).

Closes #52829