### PR TITLE
DOC: clarify that ExtensionArray.take does not support scalar indices

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1979,6 +1979,9 @@ class ExtensionArray:
         it's called by :meth:`Series.reindex`, or any other method
         that causes realignment, with a `fill_value`.
 
+        Scalar values for `indices` are not supported. If needed,
+        use a list-like wrapping a single element (e.g. ``[index]``).
+
         Examples
         --------
         Here's an example implementation, which relies on casting the


### PR DESCRIPTION
## Summary
- Add a note to the `ExtensionArray.take` docstring clarifying that scalar values for `indices` are not supported, and that callers should wrap a single index in a list.

closes #38762

## Test plan
- Documentation-only change, no tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)