### PR TITLE
BUG: Fix str.replace with empty pattern hanging on pyarrow backend

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -493,6 +493,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
                 isinstance(repl, str) and r"\g<" in repl
             )
             or (regex and self._has_unsupported_regex(pat))
+            or (isinstance(pat, str) and pat == "")
         ):
             return super()._str_replace(pat, repl, n, case, flags, regex)
 

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -968,7 +968,7 @@ def test_replace_regex(any_string_dtype):
     "repl, expected_data",
     [
         ("", ["abcd", np.nan, ""]),
-        ("X", ["XaXbXcXdX", np.nan, ""]),
+        ("X", ["XaXbXcXdX", np.nan, "X"]),
     ],
 )
 def test_replace_empty_pattern(any_string_dtype, regex, repl, expected_data):

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -964,6 +964,23 @@ def test_replace_regex(any_string_dtype):
 
 
 @pytest.mark.parametrize("regex", [True, False])
+@pytest.mark.parametrize(
+    "repl, expected_data",
+    [
+        ("", ["abcd", np.nan, ""]),
+        ("X", ["XaXbXcXdX", np.nan, ""]),
+    ],
+)
+def test_replace_empty_pattern(any_string_dtype, regex, repl, expected_data):
+    # GH#64941 - str.replace with empty pattern should not hang
+    # and should match Python's str.replace / re.sub behavior
+    ser = Series(["abcd", np.nan, ""], dtype=any_string_dtype)
+    result = ser.str.replace("", repl, regex=regex)
+    expected = Series(expected_data, dtype=any_string_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("regex", [True, False])
 def test_replace_regex_single_character(regex, any_string_dtype):
     # https://github.com/pandas-dev/pandas/pull/24809, enforced in 2.0
     # GH 24804


### PR DESCRIPTION
## Summary

Fixes #64941 - `Series.str.replace("", repl)` would hang indefinitely when using pyarrow-backed string dtypes, caused by an upstream pyarrow issue with `replace_substring` and empty patterns (apache/arrow#39149).

The fix adds a guard in `ArrowStringArray._str_replace` to fall back to the object-based implementation when the pattern is an empty string. This correctly handles the replacement using Python's native `str.replace`/`re.sub` behavior.

**What changed:**
- Added an early return condition `or (isinstance(pat, str) and pat == "")` in `ArrowStringArray._str_replace` (`pandas/core/arrays/string_arrow.py`) so that empty patterns bypass the pyarrow compute functions and fall back to the base class implementation.
- Added test `test_replace_empty_pattern` covering both `regex=True` and `regex=False` with empty and non-empty replacements.

**Behavior after fix:**
```python
>>> s = pd.Series(["abcd"], dtype="string[pyarrow]")
>>> s.str.replace("", "")
0    abcd
dtype: str
>>> s.str.replace("", "X")
0    XaXbXcXdX
dtype: str
```

This matches Python's `str.replace` and `re.sub` behavior for empty patterns.

## Tests

- Added `test_replace_empty_pattern` in `pandas/tests/strings/test_find_replace.py` with parametrization for `regex` (True/False) and `repl` (empty/non-empty), using the `any_string_dtype` fixture to cover all string dtype variants.
- Manually verified no regressions in existing replace functionality (normal patterns, regex patterns, max replacements).
- Fix was tested locally with pyarrow backend, python backend, and default string dtype.

Bahtya