### PR TITLE
DOC: add User Guide link to DataFrame.fillna

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6976,6 +6976,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     ) -> Self:
         """
         Fill NA/NaN values with `value`.
+        See the :ref:`User Guide <missing_data>` for more on which values are
+        considered missing, and how to work with missing data.
 
         This method replaces missing values with a specified value.
 


### PR DESCRIPTION
Adds a cross-reference to the Missing Data user guide on the 
DataFrame.fillna API page.

Closes #62357