### PR TITLE
DOC: Remove references to 'good first issue'

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,6 @@ All contributions, bug reports, bug fixes, documentation improvements, enhanceme
 
 A detailed overview on how to contribute can be found in the **[contributing guide](https://pandas.pydata.org/docs/dev/development/contributing.html)**.
 
-If you are simply looking to start working with the pandas codebase, navigate to the [GitHub "issues" tab](https://github.com/pandas-dev/pandas/issues) and start looking through interesting issues. There are a number of issues listed under [Docs](https://github.com/pandas-dev/pandas/issues?q=is%3Aissue%20state%3Aopen%20label%3ADocs%20sort%3Aupdated-desc) and [good first issue](https://github.com/pandas-dev/pandas/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22%20sort%3Aupdated-desc) where you could start out.
-
 You can also triage issues which may include reproducing bug reports, or asking for vital information such as version numbers or reproduction instructions. If you would like to start triaging issues, one easy way to get started is to [subscribe to pandas on CodeTriage](https://www.codetriage.com/pandas-dev/pandas).
 
 Or maybe through using pandas you have an idea of your own or are looking for something in the documentation and thinking ‘this can be improved’... you can do something about it!

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -55,13 +55,6 @@ to find issues that interest you and are available to work on. Issues available 
 * Issues that have not been started by another contributor. Please check that another contributor has not commented their intent
   to work on the issue or already submitted an open pull request to address the issue before proceeding.
 
-.. tip::
-    We recommend issues labeled `Docs
-    <https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3ADocs+no%3Aassignee>`_
-    and `good first issue
-    <https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22+no%3Aassignee>`_
-    for newer contributors.
-
 Once you've found an interesting, available issue, leave a comment with your intention
 to start working on it. If somebody else has
 already commented on the issue but they have shown a lack of activity in the issue

--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -122,16 +122,16 @@ Here's a typical workflow for triaging a newly opened issue.
 
 7. **What labels and milestones should I add?**
 
-   Apply the relevant labels. This is a bit of an art, and comes with experience.
-   Look at similar issues to get a feel for how things are labeled.
+   Apply the relevant `labels <https://github.com/pandas-dev/pandas/labels>`_ that would help
+   other users and maintainers find this issue. Generally labels fall into:
 
-   If the issue is clearly defined and the fix seems relatively straightforward,
-   label the issue as "Good first issue".
+   * Project topics (e.g. "CI", "Web", "Community")
+   * Specific topic or API in the pandas library (e.g. "Sorting", "Index")
 
    If the issue is a regression report, add the "Regression" label and the next patch
    release milestone.
 
-   Once you have completed the above, make sure to remove the "Needs Triage" label.
+   Once you have triaged and validated the issue, make sure to remove the "Needs Triage" label.
 
 .. _maintaining.regressions:
 
@@ -250,7 +250,7 @@ and that's best done by ensuring that the quality of our open issues is high.
 
 Occasionally, bugs are fixed but the issue isn't linked to in the Pull Request.
 In these cases, comment that "This has been fixed, but could use a test." and
-label the issue as "Good First Issue" and "Needs Test".
+label the issue as "Needs Test".
 
 If an older issue doesn't follow our issue template, edit the original post to
 include a minimal example, the actual output, and the expected output. Uniformity
@@ -274,8 +274,7 @@ so passes with no response, thank them for their work and then either:
   across the line, or for fixing a small merge conflict.
 
 If closing the pull request, then please comment on the original issue that
-"There's a stalled PR at #1234 that may be helpful.", and perhaps label the issue
-as "Good first issue" if the PR was relatively close to being accepted.
+"There's a stalled PR at #1234 that may be helpful."
 
 Becoming a pandas maintainer
 ----------------------------


### PR DESCRIPTION
Discussed on the dev call yesterday, the maintainers are not getting much value from having a `good first issue` issue label in Github so removing it from our docs.