### PR TITLE
DOC: note that DataFrame.values is not writeable

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -18767,6 +18767,15 @@ class DataFrame(NDFrame, OpsMixin):
 
         Notes
         -----
+        The returned array is not intended to be written to. When the
+        DataFrame is backed by a single NumPy array (single dtype, single
+        block), the result is a read-only view; when the DataFrame has
+        multiple internal blocks (e.g. after adding a new column), the
+        result is a copy and modifications to it will not be reflected in
+        the original DataFrame. Use :meth:`DataFrame.to_numpy` for more
+        explicit control over copy behavior, or use :attr:`DataFrame.iloc`
+        to modify values in-place.
+
         The dtype will be a lower-common-denominator dtype (implicit
         upcasting); that is to say if the dtypes (even of numeric types)
         are mixed, the one that accommodates all will be chosen. Use this


### PR DESCRIPTION
## Summary
- Adds a note to the `DataFrame.values` docstring clarifying that the returned array should not be written to: it is either a read-only view (single block) or a detached copy (multiple blocks).
- Points users to `DataFrame.to_numpy()` for explicit copy control and `DataFrame.iloc` for in-place modification.

closes #52712

## Test plan
- [ ] Verify docstring renders correctly in built docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)