### PR TITLE
BUG: SeriesGroupBy.ohlc() ignores as_index=False

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3435,6 +3435,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             result = self.obj._constructor_expanddim(
                 res_values, index=self._grouper.result_index, columns=agg_names
             )
+            if not self.as_index:
+                result = self._insert_inaxis_grouper(result)
+                result.index = default_index(len(result))
             return result
 
         result = self._apply_to_column_groupbys(lambda sgb: sgb.ohlc())

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -646,6 +646,26 @@ def test_ohlc_ea_dtypes(any_numeric_ea_dtype):
     tm.assert_frame_equal(result2, expected2)
 
 
+def test_ohlc_series_groupby_as_index_false():
+    # GH#65140 - SeriesGroupBy.ohlc() should honor as_index=False
+    df = DataFrame({"key": ["A", "A", "B", "B"], "price": [1.0, 2.0, 3.0, 4.0]})
+
+    result = df.groupby("key", as_index=False)["price"].ohlc()
+    expected = DataFrame(
+        {
+            "key": ["A", "B"],
+            "open": [1.0, 3.0],
+            "high": [2.0, 4.0],
+            "low": [1.0, 3.0],
+            "close": [2.0, 4.0],
+        }
+    )
+    tm.assert_frame_equal(result, expected)
+
+    result_multi = df.groupby(["key", "key"], as_index=False)["price"].ohlc()
+    assert result_multi.index.tolist() == [0, 1]
+
+
 @pytest.mark.parametrize("dtype", [np.int64, np.uint64])
 @pytest.mark.parametrize("how", ["first", "last", "min", "max", "mean", "median"])
 def test_uint64_type_handling(dtype, how):


### PR DESCRIPTION
Closes #65140

## Problem

`df.groupby(key, as_index=False)[col].ohlc()` ignores the `as_index=False` flag. The group key is returned in the index instead of as a column, inconsistent with other aggregations (`sum`, `mean`, `min`, `max`) which all honor `as_index=False`.

```python
df = pd.DataFrame({"key": ["A", "A", "B", "B"], "price": [1.0, 2.0, 3.0, 4.0]})

# BUG: group key ends up in index, not as column
df.groupby("key", as_index=False)["price"].ohlc()
#      open  high  low  close
# key
# A     1.0   2.0  1.0    2.0   ← key in index
# B     3.0   4.0  3.0    4.0
```

## Root Cause

The `SeriesGroupBy` path in `GroupBy.ohlc` constructs the result using `result_index` and returns immediately without checking `self.as_index`. Other methods that have the same pattern (e.g. `describe`) handle this with `_insert_inaxis_grouper` + `default_index`.

## Fix

After constructing the result in the `ndim == 1` branch, apply the same `as_index=False` post-processing used by `describe`:

```python
if not self.as_index:
    result = self._insert_inaxis_grouper(result)
    result.index = default_index(len(result))
```

The `DataFrameGroupBy` path via `_apply_to_column_groupbys` already handles `as_index=False` correctly and is left unchanged.

## Tests

Added `test_ohlc_series_groupby_as_index_false` to `test_aggregate.py` covering:
- single group key
- multi-group key (`groupby(["g1","g2"], as_index=False)`)