### PR TITLE
Fix #65140: groupby(as_index=False)[col].ohlc() returns keys in index

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3423,6 +3423,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             result = self.obj._constructor_expanddim(
                 res_values, index=self._grouper.result_index, columns=agg_names
             )
+            if not self.as_index:
+                result = self._insert_inaxis_grouper(result)
+                result.index = default_index(len(result))
             return result
 
         result = self._apply_to_column_groupbys(lambda sgb: sgb.ohlc())


### PR DESCRIPTION
## Summary
- Fixes group keys appearing in index when as_index=False with ohlc()
Generated by [OwlMind](https://owlmind.dev)