### PR TITLE
REF: consolidate __iter__ into TimelikeOps, standardize _validate_setitem_value

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2471,7 +2471,7 @@ class ArrowExtensionArray(
             key = key[0]
 
         key = check_array_indexer(self, key)
-        value = self._maybe_convert_setitem_value(value)
+        value = self._validate_setitem_value(value)
 
         if com.is_null_slice(key):
             # fast path (GH50248)
@@ -2717,7 +2717,7 @@ class ArrowExtensionArray(
         most_common = most_common.take(pc.array_sort_indices(most_common))
         return self._from_pyarrow_array(most_common)
 
-    def _maybe_convert_setitem_value(self, value):
+    def _validate_setitem_value(self, value):
         """Maybe convert value to be pyarrow compatible."""
         try:
             value = self._box_pa(value, self._pa_array.type)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1899,6 +1899,9 @@ class DatelikeOps(DatetimeLikeArrayMixin):
         return result.astype(object, copy=False)
 
 
+_ITER_CHUNKSIZE = 10_000
+
+
 class TimelikeOps(DatetimeLikeArrayMixin):
     """
     Common ops for TimedeltaIndex/DatetimeIndex, but not PeriodIndex.
@@ -1907,6 +1910,24 @@ class TimelikeOps(DatetimeLikeArrayMixin):
     @classmethod
     def _validate_dtype(cls, values, dtype):
         raise AbstractMethodError(cls)
+
+    def _iter_convert_chunk(self, data: np.ndarray) -> np.ndarray:
+        raise AbstractMethodError(self)
+
+    def __iter__(self) -> Iterator:
+        if self.ndim > 1:
+            for i in range(len(self)):
+                yield self[i]
+        else:
+            # convert in chunks of 10k for efficiency
+            data = self._ndarray
+            length = len(self)
+            chunksize = _ITER_CHUNKSIZE
+            chunks = (length // chunksize) + 1
+            for i in range(chunks):
+                start_i = i * chunksize
+                end_i = min((i + 1) * chunksize, length)
+                yield from self._iter_convert_chunk(data[start_i:end_i])
 
     @property
     def freq(self):

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -91,7 +91,6 @@ if TYPE_CHECKING:
     from collections.abc import (
         Callable,
         Generator,
-        Iterator,
     )
 
     import pyarrow as pa
@@ -113,9 +112,6 @@ if TYPE_CHECKING:
 
     _TimestampNoneT1 = TypeVar("_TimestampNoneT1", Timestamp, None)
     _TimestampNoneT2 = TypeVar("_TimestampNoneT2", Timestamp, None)
-
-
-_ITER_CHUNKSIZE = 10_000
 
 
 @overload
@@ -716,34 +712,10 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
         return super().__array__(dtype=dtype, copy=copy)
 
-    def __iter__(self) -> Iterator:
-        """
-        Return an iterator over the boxed values
-
-        Yields
-        ------
-        tstamp : Timestamp
-        """
-        if self.ndim > 1:
-            for i in range(len(self)):
-                yield self[i]
-        else:
-            # convert in chunks of 10k for efficiency
-            data = self.asi8
-            length = len(self)
-            chunksize = _ITER_CHUNKSIZE
-            chunks = (length // chunksize) + 1
-
-            for i in range(chunks):
-                start_i = i * chunksize
-                end_i = min((i + 1) * chunksize, length)
-                converted = ints_to_pydatetime(
-                    data[start_i:end_i],
-                    tz=self.tz,
-                    box="timestamp",
-                    reso=self._creso,
-                )
-                yield from converted
+    def _iter_convert_chunk(self, data: np.ndarray) -> np.ndarray:
+        return ints_to_pydatetime(
+            data.view("i8"), tz=self.tz, box="timestamp", reso=self._creso
+        )
 
     def astype(self, dtype, copy: bool = True):
         # We handle

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -830,10 +830,7 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
         return arr, self.dtype.na_value
 
     def _validate_setitem_value(self, value):
-        return self._maybe_convert_setitem_value(value)
-
-    def _maybe_convert_setitem_value(self, value):
-        """Maybe convert value to be StringArray compatible."""
+        """Validate / convert value to be StringArray compatible."""
         if lib.is_scalar(value):
             if isna(value):
                 value = self.dtype.na_value
@@ -864,7 +861,7 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
         if self._readonly:
             raise ValueError("Cannot modify read-only array")
 
-        value = self._maybe_convert_setitem_value(value)
+        value = self._validate_setitem_value(value)
 
         key = check_array_indexer(self, key)
         scalar_key = lib.is_scalar(key)

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -293,7 +293,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
             values = values.fill_null(na)
         return BooleanDtype().__from_arrow__(values)
 
-    def _maybe_convert_setitem_value(self, value):
+    def _validate_setitem_value(self, value):
         """Maybe convert value to be pyarrow compatible."""
         if is_scalar(value):
             if isna(value):
@@ -317,7 +317,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
                     "Invalid value for dtype 'str'. Value should be a "
                     "string or missing value (or array of those)."
                 )
-        return super()._maybe_convert_setitem_value(value)
+        return super()._validate_setitem_value(value)
 
     def isin(self, values: ArrayLike) -> npt.NDArray[np.bool_]:
         value_set = [

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -74,7 +74,7 @@ import pandas.core.common as com
 from pandas.core.ops.common import unpack_zerodim_and_defer
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable
 
     from pandas._typing import (
         AxisInt,
@@ -384,21 +384,8 @@ class TimedeltaArray(dtl.TimelikeOps):
 
         return dtl.DatetimeLikeArrayMixin.astype(self, dtype, copy=copy)
 
-    def __iter__(self) -> Iterator:
-        if self.ndim > 1:
-            for i in range(len(self)):
-                yield self[i]
-        else:
-            # convert in chunks of 10k for efficiency
-            data = self._ndarray
-            length = len(self)
-            chunksize = 10000
-            chunks = (length // chunksize) + 1
-            for i in range(chunks):
-                start_i = i * chunksize
-                end_i = min((i + 1) * chunksize, length)
-                converted = ints_to_pytimedelta(data[start_i:end_i], box=True)
-                yield from converted
+    def _iter_convert_chunk(self, data: np.ndarray) -> np.ndarray:
+        return ints_to_pytimedelta(data, box=True)
 
     # ----------------------------------------------------------------
     # Reductions

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1619,7 +1619,7 @@ def can_hold_element(arr: ArrayLike, element: Any) -> bool:
 
         if dtype == "string":
             try:
-                arr._maybe_convert_setitem_value(element)  # type: ignore[union-attr]
+                arr._validate_setitem_value(element)  # type: ignore[union-attr]
                 return True
             except (ValueError, TypeError):
                 return False

--- a/pandas/tests/indexes/datetimes/test_iter.py
+++ b/pandas/tests/indexes/datetimes/test_iter.py
@@ -7,7 +7,7 @@ from pandas import (
     date_range,
     to_datetime,
 )
-from pandas.core.arrays import datetimes
+from pandas.core.arrays import datetimelike
 
 
 class TestDatetimeIndexIteration:
@@ -69,7 +69,7 @@ class TestDatetimeIndexIteration:
         )
         num = 0
         with monkeypatch.context() as m:
-            m.setattr(datetimes, "_ITER_CHUNKSIZE", chunksize)
+            m.setattr(datetimelike, "_ITER_CHUNKSIZE", chunksize)
             for stamp in index:
                 assert index[num] == stamp
                 num += 1


### PR DESCRIPTION
## Summary
- Move the chunked `__iter__` shared by `DatetimeArray` and `TimedeltaArray` into their common base `TimelikeOps`, with each subclass providing only a `_iter_convert_chunk` hook. Also fixes `TimedeltaArray` hardcoding `10000` instead of using the `_ITER_CHUNKSIZE` constant.
- Rename `_maybe_convert_setitem_value` to `_validate_setitem_value` in `ArrowExtensionArray`, `StringArray`, and `ArrowStringArray` so all array types use the same interface name for setitem validation.

## Test plan
- [x] Existing DatetimeIndex iteration tests pass (including monkeypatch of `_ITER_CHUNKSIZE`)
- [x] Arrow, String, and StringArrow setitem tests pass
- [x] Series/DataFrame setitem and iteration tests pass
- [x] `can_hold_element` tests pass (exercises `cast.py` change)
- [x] mypy passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)