### PR TITLE
REF: Remove TimedeltaArray._from_sequence_not_strict

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -262,37 +262,6 @@ class TimedeltaArray(dtl.TimelikeOps):
         return cls._simple_new(data, dtype=data.dtype, freq=freq)
 
     @classmethod
-    def _from_sequence_not_strict(
-        cls,
-        data,
-        *,
-        dtype=None,
-        copy: bool = False,
-        freq=lib.no_default,
-        unit=None,
-    ) -> Self:
-        """
-        _from_sequence_not_strict but without responsibility for finding the
-        result's `freq`.
-        """
-        if dtype:
-            dtype = _validate_td64_dtype(dtype)
-            if unit is None and lib.infer_dtype(data) == "integer":
-                unit = np.datetime_data(dtype)[0]
-
-        assert unit not in ["Y", "y", "M"]  # caller is responsible for checking
-
-        data, inferred_freq = sequence_to_td64ns(data, copy=copy, unit=unit)
-
-        if dtype is not None:
-            data = astype_overflowsafe(data, dtype=dtype, copy=False)
-
-        result = cls._simple_new(data, dtype=data.dtype, freq=inferred_freq)
-
-        result._maybe_pin_freq(freq, {})
-        return result
-
-    @classmethod
     def _generate_range(
         cls, start, end, periods, freq, closed=None, *, unit: TimeUnit
     ) -> Self:

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -207,9 +207,8 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
 
         # - Cases checked above all return/raise before reaching here - #
 
-        tdarr = TimedeltaArray._from_sequence_not_strict(
-            data, freq=freq, unit=None, dtype=dtype, copy=copy
-        )
+        tdarr = TimedeltaArray._from_sequence(data, dtype=dtype, copy=copy)
+        tdarr._maybe_pin_freq(freq, {})
         refs = None
         if not copy and isinstance(data, (ABCSeries, Index)):
             refs = data._references


### PR DESCRIPTION
## Summary
- Remove `TimedeltaArray._from_sequence_not_strict`, which was `_from_sequence` plus freq pinning
- Move `_maybe_pin_freq` call to `TimedeltaIndex.__new__`, keeping `_from_sequence` with the standard EA signature

## Test plan
- [x] `pandas/tests/indexes/timedeltas/` pass
- [x] `pandas/tests/arrays/timedeltas/` pass
- [x] `pandas/tests/arrays/test_timedeltas.py` passes
- [x] `pandas/tests/arrays/test_datetimelike.py` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)