### PR TITLE
REF: remove _Datetime64TZFormatter in favor of _Datetime64Formatter

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1123,11 +1123,8 @@ def format_array(
     List[str]
     """
     fmt_klass: type[_GenericArrayFormatter]
-    if lib.is_np_dtype(values.dtype, "M"):
+    if lib.is_np_dtype(values.dtype, "M") or isinstance(values.dtype, DatetimeTZDtype):
         fmt_klass = _Datetime64Formatter
-        values = cast("DatetimeArray", values)
-    elif isinstance(values.dtype, DatetimeTZDtype):
-        fmt_klass = _Datetime64TZFormatter
         values = cast("DatetimeArray", values)
     elif lib.is_np_dtype(values.dtype, "m"):
         fmt_klass = _Timedelta64Formatter
@@ -1502,7 +1499,6 @@ class _Datetime64Formatter(_GenericArrayFormatter):
         self.date_format = date_format
 
     def _format_strings(self) -> list[str]:
-        """we by definition have DO NOT have a TZ"""
         values = self.values
 
         if self.formatter is not None:
@@ -1659,21 +1655,6 @@ def get_format_datetime64(
         )
     else:
         return lambda x: _format_datetime64(x, nat_rep=nat_rep)
-
-
-class _Datetime64TZFormatter(_Datetime64Formatter):
-    values: DatetimeArray
-
-    def _format_strings(self) -> list[str]:
-        """we by definition have a TZ"""
-        ido = self.values._is_dates_only
-        values = self.values.astype(object)
-        formatter = self.formatter or get_format_datetime64(
-            ido, date_format=self.date_format
-        )
-        fmt_values = [formatter(x) for x in values]
-
-        return fmt_values
 
 
 class _Timedelta64Formatter(_GenericArrayFormatter):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -2218,7 +2218,7 @@ class TestDatetime64Formatter:
             .dt.tz_localize("US/Pacific")
             ._values
         )
-        result = fmt._Datetime64TZFormatter(x).get_result()
+        result = fmt._Datetime64Formatter(x).get_result()
         assert result[0].strip() == "2999-01-01 00:00:00-08:00"
         assert result[1].strip() == "2999-01-02 00:00:00-08:00"
 


### PR DESCRIPTION
## Summary
- Remove `_Datetime64TZFormatter` subclass — `_Datetime64Formatter._format_strings` already calls `_format_native_types()` which handles TZ-aware arrays correctly via the Cython `format_array_from_datetime` (accepts a `tz` parameter)
- Merge the two `DatetimeArray` dispatch branches in `format_array()` into a single condition
- Remove stale comment from `_Datetime64Formatter._format_strings`

## Test plan
- [x] `pytest pandas/tests/io/formats/test_format.py` — 4156 tests pass
- [x] `pytest pandas/tests/io/formats/test_to_string.py` — pass
- [x] `pytest pandas/tests/indexes/datetimes/` — pass
- [x] `pytest pandas/tests/io/formats/test_to_csv.py` — pass
- [x] `pytest pandas/tests/frame/methods/test_to_csv.py` — pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)