### PR TITLE
DEPR: Deprecate passing integers to Period, PeriodArray/PeriodIndex

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -122,6 +122,7 @@ Deprecations
   :meth:`DataFrame.var`, :meth:`DataFrame.sem`, :meth:`DataFrame.sum`,
   :meth:`DataFrame.prod` (and their :class:`Series` equivalents); this will raise in
   a future version of pandas (:issue:`53098`)
+- Deprecated passing integer-dtype data to :class:`PeriodIndex`, :func:`period_array`, and :meth:`PeriodArray._from_sequence`. In a future version, integers will be treated as period ordinals instead of year values. Use strings instead, e.g. ``PeriodIndex(["2020", "2021"], freq="Y")`` (:issue:`64227`)
 - Deprecated the inference of ``datetime64`` dtype from data containing ``datetime.date`` objects when used in comparisons or :meth:`Index.equals` with :class:`DatetimeIndex`. Use :func:`pandas.to_datetime` to explicitly convert to ``datetime64`` instead (:issue:`65056`)
 -
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -179,7 +179,7 @@ Deprecations
   :meth:`DataFrame.var`, :meth:`DataFrame.sem`, :meth:`DataFrame.sum`,
   :meth:`DataFrame.prod` (and their :class:`Series` equivalents); this will raise in
   a future version of pandas (:issue:`53098`)
-- Deprecated passing integer-dtype data to :class:`PeriodIndex`, :func:`period_array`, and :meth:`PeriodArray._from_sequence`. In a future version, integers will be treated as period ordinals instead of year values. Use strings instead, e.g. ``PeriodIndex(["2020", "2021"], freq="Y")`` (:issue:`64227`)
+- Deprecated passing integers to :class:`Period`, :class:`PeriodIndex`, :func:`period_range`, :func:`period_array`, and :meth:`PeriodArray._from_sequence`. In a future version, integers will be treated as period ordinals instead of calendar years. To keep the current behavior, pass strings, e.g. ``PeriodIndex(["2020", "2021"], freq="Y")``; to get the future behavior now, use ``Period(ordinal=...)`` or :meth:`PeriodIndex.from_ordinals` (:issue:`64227`)
 - Deprecated ``inplace`` keyword for :meth:`DataFrame.rename` and :meth:`DataFrame.drop`. This keyword will be removed in a future version (:issue:`63207`); see also `PDEP-8 <https://pandas.pydata.org/pdeps/0008-inplace-methods-in-pandas.html>`_
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -179,7 +179,7 @@ Deprecations
   :meth:`DataFrame.var`, :meth:`DataFrame.sem`, :meth:`DataFrame.sum`,
   :meth:`DataFrame.prod` (and their :class:`Series` equivalents); this will raise in
   a future version of pandas (:issue:`53098`)
-- Deprecated passing integers to :class:`Period`, :class:`PeriodIndex`, :func:`period_range`, :func:`period_array`, and :meth:`PeriodArray._from_sequence`. In a future version, integers will be treated as period ordinals instead of calendar years. To keep the current behavior, pass strings, e.g. ``PeriodIndex(["2020", "2021"], freq="Y")``; to get the future behavior now, use ``Period(ordinal=...)`` or :meth:`PeriodIndex.from_ordinals` (:issue:`64227`)
+- Deprecated passing integers to :class:`Period`, :class:`PeriodIndex`, :func:`period_range`, :func:`period_array`, and :meth:`PeriodArray._from_sequence`. In a future version, integers will be treated as period ordinals instead of calendar years. To get the future behavior now, use ``Period(ordinal=...)`` or :meth:`PeriodIndex.from_ordinals`; to keep the current behavior, construct the :class:`Period` objects explicitly (:issue:`64227`)
 - Deprecated ``inplace`` keyword for :meth:`DataFrame.rename` and :meth:`DataFrame.drop`. This keyword will be removed in a future version (:issue:`63207`); see also `PDEP-8 <https://pandas.pydata.org/pdeps/0008-inplace-methods-in-pandas.html>`_
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -177,6 +177,7 @@ Deprecations
   :meth:`DataFrame.var`, :meth:`DataFrame.sem`, :meth:`DataFrame.sum`,
   :meth:`DataFrame.prod` (and their :class:`Series` equivalents); this will raise in
   a future version of pandas (:issue:`53098`)
+- Deprecated passing integer-dtype data to :class:`PeriodIndex`, :func:`period_array`, and :meth:`PeriodArray._from_sequence`. In a future version, integers will be treated as period ordinals instead of year values. Use strings instead, e.g. ``PeriodIndex(["2020", "2021"], freq="Y")`` (:issue:`64227`)
 - Deprecated ``inplace`` keyword for :meth:`DataFrame.rename` and :meth:`DataFrame.drop`. This keyword will be removed in a future version (:issue:`63207`); see also `PDEP-8 <https://pandas.pydata.org/pdeps/0008-inplace-methods-in-pandas.html>`_
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/tslibs/period.pyi
+++ b/pandas/_libs/tslibs/period.pyi
@@ -13,6 +13,8 @@ from pandas._typing import (
 
 INVALID_FREQ_ERR_MSG: str
 DIFFERENT_FREQ: str
+INT_TO_PERIOD_DEPR_MSG: str
+INT_TO_PERIOD_SCALAR_DEPR_MSG: str
 
 class IncompatibleFrequency(TypeError): ...
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1682,6 +1682,7 @@ def extract_ordinals(ndarray values, PeriodDtypeBase dtype) -> np.ndarray:
         )
         cnp.broadcast mi = cnp.PyArray_MultiIterNew2(ordinals, values)
         object p
+        bint saw_integer = False
 
     if values.descr.type_num != cnp.NPY_OBJECT:
         # if we don't raise here, we'll segfault later!
@@ -1691,17 +1692,32 @@ def extract_ordinals(ndarray values, PeriodDtypeBase dtype) -> np.ndarray:
         # Analogous to: p = values[i]
         p = <object>(<PyObject**>cnp.PyArray_MultiIter_DATA(mi, 1))[0]
 
-        ordinal = _extract_ordinal(p, dtype)
+        ordinal = _extract_ordinal(p, dtype, &saw_integer)
 
         # Analogous to: ordinals[i] = ordinal
         (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = ordinal
 
         cnp.PyArray_MultiIter_NEXT(mi)
 
+    if saw_integer:
+        # GH#64227; warn once for the array rather than once per element
+        import warnings
+
+        from pandas.errors import Pandas4Warning
+        from pandas.util._exceptions import find_stack_level
+
+        warnings.warn(
+            INT_TO_PERIOD_DEPR_MSG,
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
+
     return ordinals
 
 
-cdef int64_t _extract_ordinal(object item, PeriodDtypeBase dtype) except? -1:
+cdef int64_t _extract_ordinal(
+    object item, PeriodDtypeBase dtype, bint* saw_integer
+) except? -1:
     """
     See extract_ordinals.
     """
@@ -1715,8 +1731,11 @@ cdef int64_t _extract_ordinal(object item, PeriodDtypeBase dtype) except? -1:
             ordinal = NPY_NAT
         else:
             # GH#64227 treat integers as calendar years, matching the
-            #  int-array path (from_calendar_ordinals) and Period(int, freq)
-            ordinal = Period(item, freq=dtype).ordinal
+            #  int-array path (from_calendar_ordinals) and Period(int, freq).
+            #  Go through str so we don't emit the scalar deprecation warning
+            #  once per element; extract_ordinals warns once for the array.
+            saw_integer[0] = True
+            ordinal = Period(str(item), freq=dtype).ordinal
     else:
         try:
             ordinal = item.ordinal
@@ -1761,6 +1780,25 @@ def extract_period_unit(ndarray[object] values) -> PeriodDtypeBase:
 
 DIFFERENT_FREQ = ("Input has different freq={other_freq} "
                   "from {cls}(freq={own_freq})")
+
+
+# GH#64227
+INT_TO_PERIOD_DEPR_MSG = (
+    "Passing integer data to PeriodArray/PeriodIndex is deprecated and will "
+    "change behavior in a future version, when integers will be treated as "
+    "period ordinals instead of calendar years. To retain the current "
+    "behavior, cast to string first, e.g. "
+    "PeriodIndex(data.astype(str), freq=...). To get the future behavior "
+    "now, use PeriodIndex.from_ordinals(data, freq=...)."
+)
+
+INT_TO_PERIOD_SCALAR_DEPR_MSG = (
+    "Passing an integer to Period is deprecated and will change behavior in "
+    "a future version, when the integer will be treated as a period ordinal "
+    "instead of a calendar year. To retain the current behavior, pass a "
+    "string, e.g. Period(str(value), freq=...). To get the future behavior "
+    "now, use Period(ordinal=value, freq=...)."
+)
 
 
 @set_module("pandas.errors")
@@ -3317,6 +3355,18 @@ class Period(_Period):
             if util.is_integer_object(value):
                 if value == NPY_NAT:
                     value = "NaT"
+                else:
+                    # GH#64227
+                    import warnings
+
+                    from pandas.errors import Pandas4Warning
+                    from pandas.util._exceptions import find_stack_level
+
+                    warnings.warn(
+                        INT_TO_PERIOD_SCALAR_DEPR_MSG,
+                        Pandas4Warning,
+                        stacklevel=find_stack_level(),
+                    )
 
                 value = str(value)
             elif type(value) is not str:

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1783,13 +1783,17 @@ DIFFERENT_FREQ = ("Input has different freq={other_freq} "
 
 
 # GH#64227
+# NB: no one-liner reproduces the current behavior for every input, because
+#  the int-array path (from_calendar_ordinals) reads an int as a calendar
+#  year while the object path parses str(value), and those disagree outside
+#  4-digit years -- e.g. 200701 gives year 200701 vs 2007-01. So we point at
+#  the unambiguous replacement and leave the rest to the user.
 INT_TO_PERIOD_DEPR_MSG = (
     "Passing integer data to PeriodArray/PeriodIndex is deprecated and will "
     "change behavior in a future version, when integers will be treated as "
-    "period ordinals instead of calendar years. To retain the current "
-    "behavior, cast to string first, e.g. "
-    "PeriodIndex(data.astype(str), freq=...). To get the future behavior "
-    "now, use PeriodIndex.from_ordinals(data, freq=...)."
+    "period ordinals instead of calendar years. To get the future behavior "
+    "now, use PeriodIndex.from_ordinals(data, freq=...). To retain the "
+    "current behavior, construct the Period objects explicitly."
 )
 
 INT_TO_PERIOD_SCALAR_DEPR_MSG = (

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1972,7 +1972,7 @@ _any_skipna_inferred_dtype = [
     #                  np.nan, np.timedelta64(2, 'D')]),
     ("timedelta", [timedelta(1), np.nan, timedelta(2)]),
     ("time", [time(1), np.nan, time(2)]),
-    ("period", [Period(2013), pd.NaT, Period(2018)]),
+    ("period", [Period("2013"), pd.NaT, Period("2018")]),
     ("interval", [Interval(0, 1), np.nan, Interval(0, 2)]),
 ]
 ids = [

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1656,7 +1656,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
                 # GH#34479
                 raise TypeError(
                     f"'{how}' with PeriodDtype is no longer supported. "
-                    f"Use (obj != pd.Period(0, freq)).{how}() instead."
+                    f"Use (obj != pd.Period(ordinal=0, freq=freq)).{how}() instead."
                 )
         # timedeltas we can add but not multiply
         elif how in ["prod", "cumprod", "skew", "kurt", "var"]:

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -302,6 +302,16 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
             return cls(ordinals, dtype=dtype)
 
         elif arrdata.dtype.kind in "iu":
+            warnings.warn(
+                "Passing integer-dtype data to PeriodArray/PeriodIndex is "
+                "deprecated. In a future version, integer data will be treated "
+                "as period ordinals instead of year values. To retain the "
+                "current behavior, use "
+                "PeriodIndex(data.astype(str), freq=...) or explicitly "
+                "construct Period objects.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
             arr = arrdata.astype(np.int64, copy=False)
             ordinals = libperiod.from_calendar_ordinals(arr, dtype)  # type: ignore[arg-type]
             return cls(ordinals, dtype=dtype)
@@ -1362,13 +1372,6 @@ def period_array(
     <PeriodArray>
     ['2017', '2018', 'NaT']
     Length: 3, dtype: period[Y-DEC]
-
-    Integers that look like years are handled
-
-    >>> period_array([2000, 2001, 2002], dtype=PeriodDtype("D"))
-    <PeriodArray>
-    ['2000-01-01', '2001-01-01', '2002-01-01']
-    Length: 3, dtype: period[D]
 
     Datetime-like strings may also be passed
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -310,6 +310,16 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
             return cls(ordinals, dtype=dtype)
 
         elif arrdata.dtype.kind in "iu":
+            warnings.warn(
+                "Passing integer-dtype data to PeriodArray/PeriodIndex is "
+                "deprecated. In a future version, integer data will be treated "
+                "as period ordinals instead of year values. To retain the "
+                "current behavior, use "
+                "PeriodIndex(data.astype(str), freq=...) or explicitly "
+                "construct Period objects.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
             arr = arrdata.astype(np.int64, copy=False)
             ordinals = libperiod.from_calendar_ordinals(arr, dtype)  # type: ignore[arg-type]
             return cls(ordinals, dtype=dtype)
@@ -1403,13 +1413,6 @@ def period_array(
     <PeriodArray>
     ['2017', '2018', 'NaT']
     Length: 3, dtype: period[Y-DEC]
-
-    Integers that look like years are handled
-
-    >>> period_array([2000, 2001, 2002], dtype=PeriodDtype("D"))
-    <PeriodArray>
-    ['2000-01-01', '2001-01-01', '2002-01-01']
-    Length: 3, dtype: period[D]
 
     Datetime-like strings may also be passed
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -47,6 +47,7 @@ from pandas._libs.tslibs.offsets import (
 )
 from pandas._libs.tslibs.period import (
     DIFFERENT_FREQ,
+    INT_TO_PERIOD_DEPR_MSG,
     IncompatibleFrequency,
     Period,
     get_period_field_arr,
@@ -311,12 +312,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
 
         elif arrdata.dtype.kind in "iu":
             warnings.warn(
-                "Passing integer-dtype data to PeriodArray/PeriodIndex is "
-                "deprecated. In a future version, integer data will be treated "
-                "as period ordinals instead of year values. To retain the "
-                "current behavior, use "
-                "PeriodIndex(data.astype(str), freq=...) or explicitly "
-                "construct Period objects.",
+                INT_TO_PERIOD_DEPR_MSG,
                 Pandas4Warning,
                 stacklevel=find_stack_level(),
             )

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -311,6 +311,10 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
             return cls(ordinals, dtype=dtype)
 
         elif arrdata.dtype.kind in "iu":
+            # GH#64227 enforcing means dropping from_calendar_ordinals here and
+            #  reading arrdata as ordinals; the object-dtype and Period-scalar
+            #  paths in tslibs.period must be enforced at the same time or the
+            #  two interpretations diverge again.
             warnings.warn(
                 INT_TO_PERIOD_DEPR_MSG,
                 Pandas4Warning,

--- a/pandas/tests/arrays/period/test_constructors.py
+++ b/pandas/tests/arrays/period/test_constructors.py
@@ -4,6 +4,7 @@ import pytest
 from pandas._libs.tslibs import iNaT
 from pandas._libs.tslibs.offsets import MonthEnd
 from pandas._libs.tslibs.period import IncompatibleFrequency
+from pandas.errors import Pandas4Warning
 
 import pandas as pd
 import pandas._testing as tm
@@ -18,7 +19,6 @@ from pandas.core.arrays import (
     [
         ([pd.Period("2017", "D")], None, [17167]),
         ([pd.Period("2017", "D")], "D", [17167]),
-        ([2017], "D", [17167]),
         (["2017"], "D", [17167]),
         ([pd.Period("2017", "D")], pd.tseries.offsets.Day(), [17167]),
         ([pd.Period("2017", "D"), None], None, [17167, iNaT]),
@@ -111,25 +111,34 @@ def test_period_array_freq_mismatch():
         PeriodArray(arr, dtype=dtype)
 
 
-def test_from_sequence_allows_i8():
-    # GH#64227 this used to be allowed for PeriodIndex and period_array
-    # but not PeriodArray._from_sequence
+def test_from_sequence_int_deprecation():
+    # GH#64227 passing integer data is deprecated; integers will be treated
+    # as period ordinals in a future version instead of year values.
     arr = period_array(["1975", "1976"], dtype="period[D]")
 
-    expected = pd.PeriodIndex([pd.Period(x, freq=arr.freq) for x in arr.asi8]).array
+    # During deprecation, integer inputs are still treated as year values
+    expected_years = pd.PeriodIndex(
+        [pd.Period(x, freq=arr.freq) for x in arr.asi8]
+    ).array
 
-    result1 = pd.PeriodIndex(arr.asi8, dtype=arr.dtype).array
-    result2 = period_array(arr.asi8, dtype=arr.dtype)
-    result3 = PeriodArray._from_sequence(arr.asi8, dtype=arr.dtype)
-    # FIXME: GH#64227 this goes through a different path and gives different behavior
-    # result4 = PeriodArray._from_sequence(arr.asi8.astype(object), dtype=arr.dtype)
-    result5 = PeriodArray._from_sequence(list(arr.asi8), dtype=arr.dtype)
+    msg = "Passing integer-dtype data to PeriodArray/PeriodIndex is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result1 = pd.PeriodIndex(arr.asi8, dtype=arr.dtype).array
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result2 = period_array(arr.asi8, dtype=arr.dtype)
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result3 = PeriodArray._from_sequence(arr.asi8, dtype=arr.dtype)
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result5 = PeriodArray._from_sequence(list(arr.asi8), dtype=arr.dtype)
 
-    tm.assert_period_array_equal(result1, expected)
-    tm.assert_period_array_equal(result2, expected)
-    tm.assert_period_array_equal(result3, expected)
-    # tm.assert_period_array_equal(result4, expected)
-    tm.assert_period_array_equal(result5, expected)
+    tm.assert_period_array_equal(result1, expected_years)
+    tm.assert_period_array_equal(result2, expected_years)
+    tm.assert_period_array_equal(result3, expected_years)
+    tm.assert_period_array_equal(result5, expected_years)
+
+    # Object array path treats integers as ordinals (target behavior, no warning)
+    result4 = PeriodArray._from_sequence(arr.asi8.astype(object), dtype=arr.dtype)
+    tm.assert_period_array_equal(result4, arr)
 
 
 def test_from_td64nat_sequence_raises():

--- a/pandas/tests/arrays/period/test_constructors.py
+++ b/pandas/tests/arrays/period/test_constructors.py
@@ -131,11 +131,13 @@ def test_from_sequence_int_deprecation():
     arr = period_array(["1975", "1976"], dtype="period[D]")
 
     # During deprecation, integer inputs are still treated as year values
-    expected_years = pd.PeriodIndex(
-        [pd.Period(x, freq=arr.freq) for x in arr.asi8]
-    ).array
+    scalar_msg = "Passing an integer to Period is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=scalar_msg):
+        expected_years = pd.PeriodIndex(
+            [pd.Period(x, freq=arr.freq) for x in arr.asi8]
+        ).array
 
-    msg = "Passing integer-dtype data to PeriodArray/PeriodIndex is deprecated"
+    msg = "Passing integer data to PeriodArray/PeriodIndex is deprecated"
     with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result1 = pd.PeriodIndex(arr.asi8, dtype=arr.dtype).array
     with tm.assert_produces_warning(Pandas4Warning, match=msg):
@@ -150,21 +152,23 @@ def test_from_sequence_int_deprecation():
     tm.assert_period_array_equal(result3, expected_years)
     tm.assert_period_array_equal(result5, expected_years)
 
-    # The object-dtype path also treats integers as year values, but is not
-    #  covered by the deprecation
-    result4 = PeriodArray._from_sequence(arr.asi8.astype(object), dtype=arr.dtype)
+    # The object-dtype path treats integers as year values too, and is
+    #  deprecated on the same timeline so the two stay in step
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result4 = PeriodArray._from_sequence(arr.asi8.astype(object), dtype=arr.dtype)
     tm.assert_period_array_equal(result4, expected_years)
 
 
 def test_from_sequence_integers_with_na_consistent():
     # GH#64227 an int is interpreted as a calendar year regardless of whether
     #  an NA is present; previously a None flipped ints to raw-ordinal values
-    msg = "Passing integer-dtype data to PeriodArray/PeriodIndex is deprecated"
+    msg = "Passing integer data to PeriodArray/PeriodIndex is deprecated"
     with tm.assert_produces_warning(Pandas4Warning, match=msg):
         expected = PeriodArray._from_sequence([2000, 2001], dtype="period[D]")
     assert expected.tolist() == [pd.Period("2000", "D"), pd.Period("2001", "D")]
 
-    result = PeriodArray._from_sequence([2000, None], dtype="period[D]")
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = PeriodArray._from_sequence([2000, None], dtype="period[D]")
     tm.assert_period_array_equal(result[:1], expected[:1])
     assert result[1] is pd.NaT
 
@@ -182,10 +186,37 @@ def test_from_sequence_masked_arrow_integers_with_na(dtype):
     if "pyarrow" in dtype:
         pytest.importorskip("pyarrow")
     values = pd.array([2000, None], dtype=dtype)
-    result = PeriodArray._from_sequence(values, dtype="period[D]")
+    msg = "Passing integer data to PeriodArray/PeriodIndex is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = PeriodArray._from_sequence(values, dtype="period[D]")
 
     expected = PeriodArray._from_sequence(
         [pd.Period("2000", "D"), None], dtype="period[D]"
+    )
+    tm.assert_period_array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        np.array([2000, 2001], dtype=np.int64),
+        np.array([2000, 2001], dtype=np.uint32),
+        np.array([2000, 2001], dtype=object),
+        [2000, 2001],
+        pd.array([2000, 2001], dtype="Int64"),
+        pd.Series([2000, 2001]),
+        pd.Index([2000, 2001]),
+    ],
+)
+def test_int_deprecation_warns_once_all_dtypes(values):
+    # GH#64227 every integer input warns exactly once, whatever container or
+    #  integer dtype it arrives in
+    msg = "Passing integer data to PeriodArray/PeriodIndex is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = PeriodArray._from_sequence(values, dtype="period[D]")
+
+    expected = PeriodArray._from_sequence(
+        [pd.Period("2000", "D"), pd.Period("2001", "D")], dtype="period[D]"
     )
     tm.assert_period_array_equal(result, expected)
 

--- a/pandas/tests/arrays/period/test_constructors.py
+++ b/pandas/tests/arrays/period/test_constructors.py
@@ -19,7 +19,6 @@ from pandas.core.arrays import (
     [
         ([pd.Period("2017", "D")], None, [17167]),
         ([pd.Period("2017", "D")], "D", [17167]),
-        ([2017], "D", [17167]),
         (["2017"], "D", [17167]),
         ([pd.Period("2017", "D")], pd.tseries.offsets.Day(), [17167]),
         ([pd.Period("2017", "D"), None], None, [17167, iNaT]),
@@ -126,30 +125,43 @@ def test_period_array_freq_mismatch():
         PeriodArray(arr, dtype=dtype)
 
 
-def test_from_sequence_allows_i8():
-    # GH#64227 this used to be allowed for PeriodIndex and period_array
-    # but not PeriodArray._from_sequence
+def test_from_sequence_int_deprecation():
+    # GH#64227 passing integer data is deprecated; integers will be treated
+    # as period ordinals in a future version instead of year values.
     arr = period_array(["1975", "1976"], dtype="period[D]")
 
-    expected = pd.PeriodIndex([pd.Period(x, freq=arr.freq) for x in arr.asi8]).array
+    # During deprecation, integer inputs are still treated as year values
+    expected_years = pd.PeriodIndex(
+        [pd.Period(x, freq=arr.freq) for x in arr.asi8]
+    ).array
 
-    result1 = pd.PeriodIndex(arr.asi8, dtype=arr.dtype).array
-    result2 = period_array(arr.asi8, dtype=arr.dtype)
-    result3 = PeriodArray._from_sequence(arr.asi8, dtype=arr.dtype)
+    msg = "Passing integer-dtype data to PeriodArray/PeriodIndex is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result1 = pd.PeriodIndex(arr.asi8, dtype=arr.dtype).array
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result2 = period_array(arr.asi8, dtype=arr.dtype)
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result3 = PeriodArray._from_sequence(arr.asi8, dtype=arr.dtype)
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result5 = PeriodArray._from_sequence(list(arr.asi8), dtype=arr.dtype)
+
+    tm.assert_period_array_equal(result1, expected_years)
+    tm.assert_period_array_equal(result2, expected_years)
+    tm.assert_period_array_equal(result3, expected_years)
+    tm.assert_period_array_equal(result5, expected_years)
+
+    # The object-dtype path also treats integers as year values, but is not
+    #  covered by the deprecation
     result4 = PeriodArray._from_sequence(arr.asi8.astype(object), dtype=arr.dtype)
-    result5 = PeriodArray._from_sequence(list(arr.asi8), dtype=arr.dtype)
-
-    tm.assert_period_array_equal(result1, expected)
-    tm.assert_period_array_equal(result2, expected)
-    tm.assert_period_array_equal(result3, expected)
-    tm.assert_period_array_equal(result4, expected)
-    tm.assert_period_array_equal(result5, expected)
+    tm.assert_period_array_equal(result4, expected_years)
 
 
 def test_from_sequence_integers_with_na_consistent():
     # GH#64227 an int is interpreted as a calendar year regardless of whether
     #  an NA is present; previously a None flipped ints to raw-ordinal values
-    expected = PeriodArray._from_sequence([2000, 2001], dtype="period[D]")
+    msg = "Passing integer-dtype data to PeriodArray/PeriodIndex is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        expected = PeriodArray._from_sequence([2000, 2001], dtype="period[D]")
     assert expected.tolist() == [pd.Period("2000", "D"), pd.Period("2001", "D")]
 
     result = PeriodArray._from_sequence([2000, None], dtype="period[D]")
@@ -157,7 +169,8 @@ def test_from_sequence_integers_with_na_consistent():
     assert result[1] is pd.NaT
 
     # the integer NaT sentinel is still respected in the object path
-    result = PeriodArray._from_sequence([iNaT, 2001], dtype="period[D]")
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = PeriodArray._from_sequence([iNaT, 2001], dtype="period[D]")
     assert result[0] is pd.NaT
     tm.assert_period_array_equal(result[1:], expected[1:])
 

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -203,7 +203,7 @@ class TestToIterable:
             "datetime64[ns, US/Central]",
         ),
         (
-            pd.PeriodIndex([2018, 2019], freq="Y"),
+            pd.PeriodIndex(["2018", "2019"], freq="Y"),
             PeriodArray,
             pd.core.dtypes.dtypes.PeriodDtype("Y-DEC"),
         ),

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -80,7 +80,8 @@ def test_values_multiindex_datetimeindex():
 def test_values_multiindex_periodindex():
     # Test to ensure we hit the boxing / nobox part of MI.values
     ints = np.arange(2007, 2012)
-    pidx = pd.PeriodIndex(ints, freq="D")
+    strs = [str(x) for x in ints]
+    pidx = pd.PeriodIndex(strs, freq="D")
 
     idx = MultiIndex.from_arrays([ints, pidx])
     result = idx.values

--- a/pandas/tests/indexes/period/methods/test_is_full.py
+++ b/pandas/tests/indexes/period/methods/test_is_full.py
@@ -4,19 +4,19 @@ from pandas import PeriodIndex
 
 
 def test_is_full():
-    index = PeriodIndex([2005, 2007, 2009], freq="Y")
+    index = PeriodIndex(["2005", "2007", "2009"], freq="Y")
     assert not index.is_full
 
-    index = PeriodIndex([2005, 2006, 2007], freq="Y")
+    index = PeriodIndex(["2005", "2006", "2007"], freq="Y")
     assert index.is_full
 
-    index = PeriodIndex([2005, 2005, 2007], freq="Y")
+    index = PeriodIndex(["2005", "2005", "2007"], freq="Y")
     assert not index.is_full
 
-    index = PeriodIndex([2005, 2005, 2006], freq="Y")
+    index = PeriodIndex(["2005", "2005", "2006"], freq="Y")
     assert index.is_full
 
-    index = PeriodIndex([2006, 2005, 2005], freq="Y")
+    index = PeriodIndex(["2006", "2005", "2005"], freq="Y")
     with pytest.raises(ValueError, match="Index is not monotonic"):
         index.is_full
 

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -247,10 +247,13 @@ class TestPeriodIndex:
         tm.assert_index_equal(PeriodIndex(list(idx.values)), idx)
 
         msg = "freq not specified and cannot be inferred"
-        with pytest.raises(ValueError, match=msg):
-            PeriodIndex(idx.asi8)
-        with pytest.raises(ValueError, match=msg):
-            PeriodIndex(list(idx.asi8))
+        depr_msg = "Passing integer-dtype data"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            with pytest.raises(ValueError, match=msg):
+                PeriodIndex(idx.asi8)
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            with pytest.raises(ValueError, match=msg):
+                PeriodIndex(list(idx.asi8))
 
         msg = "'Period' object is not iterable"
         with pytest.raises(TypeError, match=msg):
@@ -629,7 +632,7 @@ class TestPeriodIndex:
         tm.assert_index_equal(idx, org)
 
     def test_map_with_string_constructor(self):
-        raw = [2005, 2007, 2009]
+        raw = ["2005", "2007", "2009"]
         index = PeriodIndex(raw, freq="Y")
 
         expected = Index([str(num) for num in raw])

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -332,10 +332,13 @@ class TestPeriodIndex:
         tm.assert_index_equal(PeriodIndex(list(vals)), idx)
 
         msg = "freq not specified and cannot be inferred"
-        with pytest.raises(ValueError, match=msg):
-            PeriodIndex(idx.asi8)
-        with pytest.raises(ValueError, match=msg):
-            PeriodIndex(list(idx.asi8))
+        depr_msg = "Passing integer-dtype data"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            with pytest.raises(ValueError, match=msg):
+                PeriodIndex(idx.asi8)
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            with pytest.raises(ValueError, match=msg):
+                PeriodIndex(list(idx.asi8))
 
         msg = "'Period' object is not iterable"
         with pytest.raises(TypeError, match=msg):
@@ -396,18 +399,22 @@ class TestPeriodIndex:
         #  values used to silently wrap instead of raising like Period(int)
         arr = np.array([2**32 + 1985], dtype=np.int64)
         msg = "Out of bounds year: 4294969281"
-        with pytest.raises(OutOfBoundsDatetime, match=msg):
-            PeriodIndex(arr, freq="Y")
+        depr_msg = "Passing integer-dtype data"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            with pytest.raises(OutOfBoundsDatetime, match=msg):
+                PeriodIndex(arr, freq="Y")
 
         # negative out-of-range and a nanosecond-epoch-like value also raise
         for val in [-(2**32), 10**18]:
-            with pytest.raises(OutOfBoundsDatetime, match="Out of bounds year"):
-                PeriodIndex(np.array([val], dtype=np.int64), freq="Y")
+            with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+                with pytest.raises(OutOfBoundsDatetime, match="Out of bounds year"):
+                    PeriodIndex(np.array([val], dtype=np.int64), freq="Y")
 
         # int32 boundaries and >4-digit years remain valid; for freq="Y" the
         #  ordinal is year - 1970
         for val in [2**31 - 1, -(2**31), 100000]:
-            result = PeriodIndex(np.array([val], dtype=np.int64), freq="Y")
+            with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+                result = PeriodIndex(np.array([val], dtype=np.int64), freq="Y")
             assert result.asi8[0] == val - 1970
 
     @pytest.mark.parametrize("box", [None, "series", "index"])
@@ -733,7 +740,7 @@ class TestPeriodIndex:
         tm.assert_index_equal(idx, org)
 
     def test_map_with_string_constructor(self):
-        raw = [2005, 2007, 2009]
+        raw = ["2005", "2007", "2009"]
         index = PeriodIndex(raw, freq="Y")
 
         expected = Index([str(num) for num in raw])

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -332,7 +332,7 @@ class TestPeriodIndex:
         tm.assert_index_equal(PeriodIndex(list(vals)), idx)
 
         msg = "freq not specified and cannot be inferred"
-        depr_msg = "Passing integer-dtype data"
+        depr_msg = "Passing integer data"
         with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             with pytest.raises(ValueError, match=msg):
                 PeriodIndex(idx.asi8)
@@ -399,7 +399,7 @@ class TestPeriodIndex:
         #  values used to silently wrap instead of raising like Period(int)
         arr = np.array([2**32 + 1985], dtype=np.int64)
         msg = "Out of bounds year: 4294969281"
-        depr_msg = "Passing integer-dtype data"
+        depr_msg = "Passing integer data"
         with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
             with pytest.raises(OutOfBoundsDatetime, match=msg):
                 PeriodIndex(arr, freq="Y")

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -14,7 +14,7 @@ import pandas._testing as tm
 class TestPeriodIndex:
     def test_getitem_periodindex_duplicates_string_slice(self):
         # monotonic
-        idx = PeriodIndex([2000, 2007, 2007, 2009, 2009], freq="Y-JUN")
+        idx = PeriodIndex(["2000", "2007", "2007", "2009", "2009"], freq="Y-JUN")
         ts = Series(np.random.default_rng(2).standard_normal(len(idx)), index=idx)
         original = ts.copy()
 
@@ -25,7 +25,7 @@ class TestPeriodIndex:
         tm.assert_series_equal(ts, original)
 
         # not monotonic
-        idx = PeriodIndex([2000, 2007, 2007, 2009, 2007], freq="Y-JUN")
+        idx = PeriodIndex(["2000", "2007", "2007", "2009", "2007"], freq="Y-JUN")
         ts = Series(np.random.default_rng(2).standard_normal(len(idx)), index=idx)
 
         result = ts["2007"]

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -130,8 +130,8 @@ class TestPeriodIndex:
         assert not index.is_(index - 0)
 
     def test_index_unique(self):
-        idx = PeriodIndex([2000, 2007, 2007, 2009, 2009], freq="Y-JUN")
-        expected = PeriodIndex([2000, 2007, 2009], freq="Y-JUN")
+        idx = PeriodIndex(["2000", "2007", "2007", "2009", "2009"], freq="Y-JUN")
+        expected = PeriodIndex(["2000", "2007", "2009"], freq="Y-JUN")
         tm.assert_index_equal(idx.unique(), expected)
         assert idx.nunique() == 3
 
@@ -184,7 +184,7 @@ class TestPeriodIndex:
     def test_map(self):
         # test_map_dictlike generally tests
 
-        index = PeriodIndex([2005, 2007, 2009], freq="Y")
+        index = PeriodIndex(["2005", "2007", "2009"], freq="Y")
         result = index.map(lambda x: x.ordinal)
         exp = Index([x.ordinal for x in index])
         tm.assert_index_equal(result, exp)

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -136,8 +136,8 @@ class TestPeriodIndex:
         assert not index.is_(index - 0)
 
     def test_index_unique(self):
-        idx = PeriodIndex([2000, 2007, 2007, 2009, 2009], freq="Y-JUN")
-        expected = PeriodIndex([2000, 2007, 2009], freq="Y-JUN")
+        idx = PeriodIndex(["2000", "2007", "2007", "2009", "2009"], freq="Y-JUN")
+        expected = PeriodIndex(["2000", "2007", "2009"], freq="Y-JUN")
         tm.assert_index_equal(idx.unique(), expected)
         assert idx.nunique() == 3
 
@@ -190,7 +190,7 @@ class TestPeriodIndex:
     def test_map(self):
         # test_map_dictlike generally tests
 
-        index = PeriodIndex([2005, 2007, 2009], freq="Y")
+        index = PeriodIndex(["2005", "2007", "2009"], freq="Y")
         result = index.map(lambda x: x.ordinal)
         exp = Index([x.ordinal for x in index])
         tm.assert_index_equal(result, exp)

--- a/pandas/tests/indexes/period/test_tools.py
+++ b/pandas/tests/indexes/period/test_tools.py
@@ -27,7 +27,7 @@ class TestPeriodRepresentation:
             ("us", "1970-01-01"),
             ("ns", "1970-01-01"),
             ("M", "1970-01"),
-            ("Y", 1970),
+            ("Y", "1970"),
         ],
     )
     @pytest.mark.filterwarnings(r"ignore:PeriodDtype\[B\] is deprecated:FutureWarning")

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1736,7 +1736,13 @@ def test_validate_1d_input(dtype):
         *[[lambda x: Index(x, dtype=dtyp), {}] for dtyp in tm.ALL_REAL_NUMPY_DTYPES],
         [DatetimeIndex, {}],
         [TimedeltaIndex, {}],
-        [PeriodIndex, {"freq": "Y"}],
+        pytest.param(
+            PeriodIndex,
+            {"freq": "Y"},
+            marks=pytest.mark.filterwarnings(
+                "ignore:Passing integer-dtype data:pandas.errors.Pandas4Warning"
+            ),
+        ),
     ],
 )
 def test_construct_from_memoryview(klass, extra_kwargs):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1762,7 +1762,13 @@ def test_validate_1d_input(dtype):
         *[[lambda x: Index(x, dtype=dtyp), {}] for dtyp in tm.ALL_REAL_NUMPY_DTYPES],
         [DatetimeIndex, {}],
         [TimedeltaIndex, {}],
-        [PeriodIndex, {"freq": "Y"}],
+        pytest.param(
+            PeriodIndex,
+            {"freq": "Y"},
+            marks=pytest.mark.filterwarnings(
+                "ignore:Passing integer-dtype data:pandas.errors.Pandas4Warning"
+            ),
+        ),
     ],
 )
 def test_construct_from_memoryview(klass, extra_kwargs):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1766,7 +1766,7 @@ def test_validate_1d_input(dtype):
             PeriodIndex,
             {"freq": "Y"},
             marks=pytest.mark.filterwarnings(
-                "ignore:Passing integer-dtype data:pandas.errors.Pandas4Warning"
+                "ignore:Passing integer data:pandas.errors.Pandas4Warning"
             ),
         ),
     ],

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -308,19 +308,22 @@ class TestLocBaseIndependent:
     @pytest.mark.parametrize(
         "msg, key",
         [
-            (r"Period\('2019', 'Y-DEC'\), 'foo', 'bar'", (Period(2019), "foo", "bar")),
-            (r"Period\('2019', 'Y-DEC'\), 'y1', 'bar'", (Period(2019), "y1", "bar")),
-            (r"Period\('2019', 'Y-DEC'\), 'foo', 'z1'", (Period(2019), "foo", "z1")),
+            (
+                r"Period\('2019', 'Y-DEC'\), 'foo', 'bar'",
+                (Period("2019"), "foo", "bar"),
+            ),
+            (r"Period\('2019', 'Y-DEC'\), 'y1', 'bar'", (Period("2019"), "y1", "bar")),
+            (r"Period\('2019', 'Y-DEC'\), 'foo', 'z1'", (Period("2019"), "foo", "z1")),
             (
                 r"Period\('2018', 'Y-DEC'\), Period\('2016', 'Y-DEC'\), 'bar'",
-                (Period(2018), Period(2016), "bar"),
+                (Period("2018"), Period("2016"), "bar"),
             ),
-            (r"Period\('2018', 'Y-DEC'\), 'foo', 'y1'", (Period(2018), "foo", "y1")),
+            (r"Period\('2018', 'Y-DEC'\), 'foo', 'y1'", (Period("2018"), "foo", "y1")),
             (
                 r"Period\('2017', 'Y-DEC'\), 'foo', Period\('2015', 'Y-DEC'\)",
-                (Period(2017), "foo", Period(2015)),
+                (Period("2017"), "foo", Period("2015")),
             ),
-            (r"Period\('2017', 'Y-DEC'\), 'z1', 'bar'", (Period(2017), "z1", "bar")),
+            (r"Period\('2017', 'Y-DEC'\), 'z1', 'bar'", (Period("2017"), "z1", "bar")),
         ],
     )
     def test_contains_raise_error_if_period_index_is_in_multi_index(self, msg, key):
@@ -334,9 +337,9 @@ class TestLocBaseIndependent:
         """
         df = DataFrame(
             {
-                "A": [Period(2019), "x1", "x2"],
-                "B": [Period(2018), Period(2016), "y1"],
-                "C": [Period(2017), "z1", Period(2015)],
+                "A": [Period("2019"), "x1", "x2"],
+                "B": [Period("2018"), Period("2016"), "y1"],
+                "C": [Period("2017"), "z1", Period("2015")],
                 "V1": [1, 2, 3],
                 "V2": [10, 20, 30],
             }

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -171,7 +171,7 @@ class TestTSPlot:
         assert conv._get_datevalue(None, "D") is None
         assert conv._get_datevalue(1987, "Y") == 1987
         assert (
-            conv._get_datevalue(Period(1987, "Y"), "M")
+            conv._get_datevalue(Period("1987", "Y"), "M")
             == Period("1987-12", "M").ordinal
         )
         assert conv._get_datevalue("1/1/1987", "D") == Period("1987-1-1", "D").ordinal
@@ -585,7 +585,7 @@ class TestTSPlot:
 
     def test_finder_annual(self):
         xp = [1987, 1988, 1990, 1990, 1995, 2020, 2070, 2170]
-        xp = [Period(x, freq="Y").ordinal for x in xp]
+        xp = [Period(str(x), freq="Y").ordinal for x in xp]
         rs = []
         for nyears in [5, 10, 19, 49, 99, 199, 599, 1001]:
             rng = period_range("1987", periods=nyears, freq="Y")

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -466,7 +466,7 @@ class TestPeriodIndex:
         tm.assert_series_equal(result, expected)
 
     def test_resample_fill_missing(self):
-        rng = PeriodIndex([2000, 2005, 2007, 2009], freq="Y")
+        rng = PeriodIndex(["2000", "2005", "2007", "2009"], freq="Y")
 
         s = Series(np.random.default_rng(2).standard_normal(4), index=rng)
 
@@ -476,7 +476,7 @@ class TestPeriodIndex:
         tm.assert_series_equal(filled, expected)
 
     def test_cant_fill_missing_dups(self):
-        rng = PeriodIndex([2000, 2005, 2005, 2007, 2007], freq="Y")
+        rng = PeriodIndex(["2000", "2005", "2005", "2007", "2007"], freq="Y")
         s = Series(np.random.default_rng(2).standard_normal(5), index=rng)
         msg = "Reindexing only valid with uniquely valued Index objects"
         with pytest.raises(InvalidIndexError, match=msg):

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -525,7 +525,7 @@ class TestPeriodIndex:
         tm.assert_series_equal(result, expected)
 
     def test_resample_fill_missing(self):
-        rng = PeriodIndex([2000, 2005, 2007, 2009], freq="Y")
+        rng = PeriodIndex(["2000", "2005", "2007", "2009"], freq="Y")
 
         s = Series(np.random.default_rng(2).standard_normal(4), index=rng)
 
@@ -535,7 +535,7 @@ class TestPeriodIndex:
         tm.assert_series_equal(filled, expected)
 
     def test_cant_fill_missing_dups(self):
-        rng = PeriodIndex([2000, 2005, 2005, 2007, 2007], freq="Y")
+        rng = PeriodIndex(["2000", "2005", "2005", "2007", "2007"], freq="Y")
         s = Series(np.random.default_rng(2).standard_normal(5), index=rng)
         msg = "Reindexing only valid with uniquely valued Index objects"
         with pytest.raises(InvalidIndexError, match=msg):

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -254,7 +254,9 @@ class TestPeriodConstruction:
         i1 = Period("200701", freq="M")
         assert i1 == expected
 
-        i1 = Period(200701, freq="M")
+        msg = "Passing an integer to Period is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            i1 = Period(200701, freq="M")
         assert i1 == expected
 
         i1 = Period(ordinal=200701, freq="M")
@@ -310,7 +312,9 @@ class TestPeriodConstruction:
                 year=2012, month=3, day=10, freq="3B"
             )
 
-        assert Period(200701, freq=offsets.MonthEnd()) == Period(200701, freq="M")
+        msg = "Passing an integer to Period is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            assert Period(200701, freq=offsets.MonthEnd()) == Period(200701, freq="M")
 
         i1 = Period(ordinal=200701, freq=offsets.MonthEnd())
         i2 = Period(ordinal=200701, freq="M")
@@ -1316,6 +1320,27 @@ def test_period_np_str():
     result = Period(np.str_("2023-01"), freq="M")
     expected = Period("2023-01", freq="M")
     assert result == expected
+
+
+@pytest.mark.parametrize("value", [2000, np.int64(2000), np.uint16(2000)])
+def test_period_int_deprecated(value):
+    # GH#64227 an integer is currently read as a calendar year; in a future
+    #  version it will be read as an ordinal, matching PeriodArray
+    msg = "Passing an integer to Period is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = Period(value, freq="D")
+    assert result == Period("2000", freq="D")
+
+    # the two unambiguous spellings are unaffected
+    with tm.assert_produces_warning(None):
+        assert Period("2000", freq="D") == result
+        assert Period(ordinal=2000, freq="D").ordinal == 2000
+
+
+def test_period_int_nat_sentinel_not_deprecated():
+    # GH#64227 iNaT means NaT under both the old and new interpretations
+    with tm.assert_produces_warning(None):
+        assert Period(iNaT, freq="D") is NaT
 
     result = Period(np.str_("2023"), freq="Y")
     expected = Period("2023", freq="Y")

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1284,7 +1284,9 @@ class TestSeriesConstructors:
         assert result.dtype == "Period[D]"
 
     def test_construct_from_ints_including_iNaT_scalar_period_dtype(self):
-        series = Series([0, 1000, 2000, pd._libs.iNaT], dtype="period[D]")
+        msg = "Passing integer-dtype data"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            series = Series([0, 1000, 2000, pd._libs.iNaT], dtype="period[D]")
 
         val = series[3]
         assert isna(val)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1318,7 +1318,7 @@ class TestSeriesConstructors:
         assert result.dtype == "Period[D]"
 
     def test_construct_from_ints_including_iNaT_scalar_period_dtype(self):
-        msg = "Passing integer-dtype data"
+        msg = "Passing integer data"
         with tm.assert_produces_warning(Pandas4Warning, match=msg):
             series = Series([0, 1000, 2000, pd._libs.iNaT], dtype="period[D]")
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1318,7 +1318,9 @@ class TestSeriesConstructors:
         assert result.dtype == "Period[D]"
 
     def test_construct_from_ints_including_iNaT_scalar_period_dtype(self):
-        series = Series([0, 1000, 2000, pd._libs.iNaT], dtype="period[D]")
+        msg = "Passing integer-dtype data"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            series = Series([0, 1000, 2000, pd._libs.iNaT], dtype="period[D]")
 
         val = series[3]
         assert isna(val)


### PR DESCRIPTION
## Summary

Deprecate passing integers to `Period`, `PeriodIndex`, `period_range`, `period_array`, and `PeriodArray._from_sequence`. In a future version integers will be treated as period ordinals instead of calendar years, matching `PeriodArray.__init__`/`_simple_new`, which already interpret their integer input as ordinals.

During the deprecation the current behavior (ints treated as calendar years) is preserved with a `Pandas4Warning`. The message points at `Period(ordinal=...)` / `PeriodIndex.from_ordinals` to opt in to the future semantics; for keeping today's it just says to construct the `Period` objects explicitly, because no one-liner reproduces the current behavior across all inputs (see below).

All four paths that read integers as calendar years are deprecated together, so they can't diverge at enforcement:

- **int64/uint ndarrays** in `_from_sequence`.
- **object-dtype integers**, handled in `extract_ordinals`. GH-66249 deliberately aligned these *with* the int64 path; deprecating only the int64 path would have re-opened exactly the `pi1` vs `pi2` divergence that issue closed.
- **masked and arrow integer EAs**, which `_from_sequence` routes through object dtype before the integer-kind check and which therefore skipped the warning entirely.
- **the `Period` scalar**, which GH-64227 notes has to move for the array semantics to be coherent — and which the object-dtype array path is implemented in terms of.

`extract_ordinals` warns once per array rather than once per element, and converts through `str` so the scalar warning doesn't fire underneath it. Existing error messages are unchanged (out-of-bounds years, unparseable negatives), as is the `iNaT` sentinel, which means `NaT` under both the old and new interpretations.

Two knock-on changes:

- `period_range(2000, periods=3, freq="Y")` now warns, via `_get_ordinal_range` calling `Period(start, freq)`. Same ambiguity, so the same deprecation applies.
- The `any`/`all`-on-`PeriodDtype` error message suggested `pd.Period(0, freq)`, which this deprecates and which already raised `DateParseError`. Changed to `pd.Period(ordinal=0, freq=freq)`.

## Not addressed here

The int-array path and the object/scalar path do not agree today, and this PR does not make them agree — it only ensures neither can be reached without a warning. `from_calendar_ordinals` reads an int as a literal calendar year, while the other two parse `str(value)`:

| value | int64-dtype | object-dtype / scalar |
| --- | --- | --- |
| 1, 999 | `1-01-01`, `999-01-01` | `ValueError` |
| 1000–9999 | agree | agree |
| 10000 | `10000-01-01` | `DateParseError` |
| 200701 | `200701-01-01` | `2007-01-20` |

This predates the PR. Enforcement erases it: once all three sites read integers as ordinals, string parsing drops out and every entry point matches `PeriodIndex.from_ordinals` — which today already agrees with `PeriodArray.__init__`, `_simple_new`, and `Period(ordinal=)` on every one of these values, including `0`, negatives, and `iNaT`. Aligning them *before* enforcement would mean changing behavior in an already-deprecated path that is about to change again, and would contradict the scalar's documented `YYYYMM` parsing (`test_construction_month`).

Enforcing means flipping three sites together — the `_from_sequence` integer branch, `_extract_ordinal`, and `Period.__new__`. All three are tagged `GH#64227`.

closes #64227

## Test plan

- [x] `test_int_deprecation_warns_once_all_dtypes` covers all seven container/integer-dtype combinations, asserting exactly one warning each
- [x] `test_period_int_deprecated` covers the scalar; `test_period_int_nat_sentinel_not_deprecated` pins that `iNaT` stays exempt
- [x] Verified warning stacklevel lands on caller frames for both the array and scalar warnings
- [x] Full test suite green (238,495 passed; `io/test_sql.py` excluded, its failures are a missing local mysql/postgres)
- [x] Rebuilt with `-Csetup-args=--werror` for CI parity, since this touches `period.pyx`
- [x] mypy, pyright, and pre-commit clean
