### PR TITLE
REF: IntervalArray _validate_setitem_value delegates to _validate_scalar

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -692,8 +692,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         if self._readonly:
             raise ValueError("Cannot modify read-only array")
 
-        value_left, value_right = self._validate_setitem_value(value)
         key = check_array_indexer(self, key)
+        value_left, value_right = self._validate_setitem_value(value)
 
         self._left[key] = value_left
         self._right[key] = value_right
@@ -900,7 +900,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         if limit is not None:
             raise ValueError("limit must be None")
 
-        value_left, value_right = self._validate_scalar(value)
+        value_left, value_right = self._validate_setitem_value(value)
 
         left = self.left.fillna(value=value_left)
         right = self.right.fillna(value=value_right)
@@ -1169,7 +1169,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         if isinstance(value, Interval):
             self._check_closed_matches(value, name="value")
             left, right = value.left, value.right
-            # TODO: check subdtype match like _validate_setitem_value?
+            self.left._validate_fill_value(left)
+            self.left._validate_fill_value(right)
         elif is_valid_na_for_dtype(value, self.left.dtype):
             # GH#18295
             left = right = self.left._na_value
@@ -1180,27 +1181,19 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         return left, right
 
     def _validate_setitem_value(self, value):
+        if is_list_like(value):
+            return self._validate_listlike(value)
+
+        left, right = self._validate_scalar(value)
+
         if is_valid_na_for_dtype(value, self.left.dtype):
-            # na value: need special casing to set directly on numpy arrays
-            value = self.left._na_value
             if is_integer_dtype(self.dtype.subtype):
                 # can't set NaN on a numpy integer array
                 # GH#45484 TypeError, not ValueError, matches what we get with
                 #  non-NA un-holdable value.
                 raise TypeError("Cannot set float NaN to integer-backed IntervalArray")
-            value_left, value_right = value, value
 
-        elif isinstance(value, Interval):
-            # scalar interval
-            self._check_closed_matches(value, name="value")
-            value_left, value_right = value.left, value.right
-            self.left._validate_fill_value(value_left)
-            self.left._validate_fill_value(value_right)
-
-        else:
-            return self._validate_listlike(value)
-
-        return value_left, value_right
+        return left, right
 
     # ---------------------------------------------------------------------
     # Rendering Methods

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -157,7 +157,7 @@ class TestSetitem:
         result = IntervalArray.from_arrays(left, right, copy=True)
 
         if result.dtype.subtype.kind not in ["m", "M"]:
-            msg = "'value' should be an interval type, got <.*NaTType'> instead."
+            msg = "can only insert Interval objects and NA into an IntervalArray"
             with pytest.raises(TypeError, match=msg):
                 result[0] = pd.NaT
         if result.dtype.subtype.kind in ["i", "u"]:
@@ -266,6 +266,6 @@ class TestReductions:
 
 def test_fillna_non_scalar_raises():
     arr = IntervalArray.from_tuples([None, (0, 1)])
-    msg = "can only insert Interval objects and NA into an IntervalArray"
+    msg = "'value' should be an interval type, got <class 'list'> instead."
     with pytest.raises(TypeError, match=msg):
         arr.fillna([1, 1])


### PR DESCRIPTION
## Summary

- Consolidate duplicated validation logic between `_validate_scalar` and `_validate_setitem_value` to match the pattern used by `DatetimeLikeArrayMixin` and `Categorical`
- `_validate_scalar` now includes subdtype compatibility checks (resolving the TODO at the old line 1172), so both methods share a single code path for scalar validation
- `_validate_setitem_value` delegates to `_validate_scalar` for scalars and `_validate_listlike` for list-like values
- `fillna` calls `_validate_setitem_value` instead of `_validate_scalar`, matching the standard pattern in `NDArrayBackedExtensionArray`
- `__setitem__` reordered to match the standard `check_array_indexer` then `_validate_setitem_value` pattern

## Test plan

- [x] `pandas/tests/arrays/interval/` (210 passed)
- [x] `pandas/tests/indexes/interval/` (1657 passed)
- [x] `pandas/tests/extension/test_interval.py` (525 passed)
- [x] mypy clean on `pandas/core/arrays/interval.py`
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)