### PR TITLE
REF: remove GeoDataFrame shim in _constructor_from_mgr

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -425,11 +425,6 @@ class DataFrame(NDFrame, OpsMixin):
             #  this check is slightly faster, benefiting the most-common case.
             return df
 
-        elif type(self).__name__ == "GeoDataFrame":
-            # Shim until geopandas can override their _constructor_from_mgr
-            #  bc they have different behavior for Managers than for DataFrames
-            return self._constructor(mgr)
-
         # We assume that the subclass __init__ knows how to handle a
         #  pd.DataFrame object.
         return self._constructor(df)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -606,20 +606,6 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         return DataFrame
 
-    def _constructor_expanddim_from_mgr(self, mgr, axes):
-        from pandas.core.frame import DataFrame
-
-        df = DataFrame._from_mgr(mgr, axes=mgr.axes)
-
-        if type(self) is Series:
-            # This would also work `if self._constructor_expanddim is DataFrame`,
-            #  but this check is slightly faster, benefiting the most-common case.
-            return df
-
-        # We assume that the subclass __init__ knows how to handle a
-        #  pd.DataFrame object.
-        return self._constructor_expanddim(df)
-
     # types
     @property
     def _can_hold_na(self) -> bool:
@@ -1910,8 +1896,12 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         else:
             columns = Index([name])
 
+        from pandas.core.frame import DataFrame
+
         mgr = self._mgr.to_2d_mgr(columns)
-        df = self._constructor_expanddim_from_mgr(mgr, axes=mgr.axes)
+        df = DataFrame._from_mgr(mgr, axes=mgr.axes)
+        if type(self) is not Series:
+            df = self._constructor_expanddim(df)
         return df.__finalize__(self, method="to_frame")
 
     @classmethod

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -606,6 +606,20 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         return DataFrame
 
+    def _constructor_expanddim_from_mgr(self, mgr, axes):
+        from pandas.core.frame import DataFrame
+
+        df = DataFrame._from_mgr(mgr, axes=mgr.axes)
+
+        if type(self) is Series:
+            # This would also work `if self._constructor_expanddim is DataFrame`,
+            #  but this check is slightly faster, benefiting the most-common case.
+            return df
+
+        # We assume that the subclass __init__ knows how to handle a
+        #  pd.DataFrame object.
+        return self._constructor_expanddim(df)
+
     # types
     @property
     def _can_hold_na(self) -> bool:
@@ -1896,12 +1910,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         else:
             columns = Index([name])
 
-        from pandas.core.frame import DataFrame
-
         mgr = self._mgr.to_2d_mgr(columns)
-        df = DataFrame._from_mgr(mgr, axes=mgr.axes)
-        if type(self) is not Series:
-            df = self._constructor_expanddim(df)
+        df = self._constructor_expanddim_from_mgr(mgr, axes=mgr.axes)
         return df.__finalize__(self, method="to_frame")
 
     @classmethod


### PR DESCRIPTION
## Summary
- Remove dead `GeoDataFrame` name-check shim in `DataFrame._constructor_from_mgr` — geopandas has overridden `_constructor_from_mgr` directly since v0.14.3 (Jan 2024)
- ~Remove `_constructor_expanddim_from_mgr` and inline its logic into `Series.to_frame()`, its only call site~

Part of #56681.

## Test plan
- [x] `pandas/tests/series/methods/test_to_frame.py` — passes
- [x] `pandas/tests/frame/test_subclass.py` — passes
- [x] `pandas/tests/series/test_subclass.py` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)