### PR TITLE
PERF: restore libjoin fastpath for CategoricalIndex intersection/union

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5143,12 +5143,6 @@ class Index(IndexOpsMixin, PandasObject):
         #  which negates the performance benefit of libjoin.
         # Also exclude RangeIndex which allocates memory in _get_join_target,
         #  negating the performance benefit of the fastpath.
-        if isinstance(self, ABCCategoricalIndex) and not self.ordered:
-            # For unordered CategoricalIndex, dtype equality does not
-            # guarantee matching category order across indexes. Since libjoin
-            # operates on codes, mismatched category order leads to incorrect
-            # results. GH#55335
-            return False
         return not isinstance(self, (ABCIntervalIndex, ABCMultiIndex, ABCRangeIndex))
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -487,7 +487,8 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
             and isinstance(other, CategoricalIndex)
             and not self.categories.equals(other.categories)
         ):
-            other = other.reorder_categories(self.categories)
+            reordered = other._data.reorder_categories(self.categories)
+            other = other._shallow_copy(reordered)
         return super()._intersection(other, sort=sort)
 
     def _union(self, other: Index, sort):
@@ -497,7 +498,8 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
             and isinstance(other, CategoricalIndex)
             and not self.categories.equals(other.categories)
         ):
-            other = other.reorder_categories(self.categories)
+            reordered = other._data.reorder_categories(self.categories)
+            other = other._shallow_copy(reordered)
         return super()._union(other, sort)
 
     def map(self, mapper, na_action: Literal["ignore"] | None = None):

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -477,6 +477,29 @@ class CategoricalIndex(NDArrayBackedExtensionIndex):
     def _is_comparable_dtype(self, dtype: DtypeObj) -> bool:
         return self.categories._is_comparable_dtype(dtype)
 
+    def _intersection(self, other: Index, sort: bool = False):
+        # For unordered CategoricalIndex, libjoin operates on integer codes.
+        # When two indexes have the same categories in different order, matching
+        # codes map to different values, giving incorrect results (GH#55335).
+        # Reorder other's categories to match self so the codes align.
+        if (
+            not self.ordered
+            and isinstance(other, CategoricalIndex)
+            and not self.categories.equals(other.categories)
+        ):
+            other = other.reorder_categories(self.categories)
+        return super()._intersection(other, sort=sort)
+
+    def _union(self, other: Index, sort):
+        # See _intersection for explanation of GH#55335.
+        if (
+            not self.ordered
+            and isinstance(other, CategoricalIndex)
+            and not self.categories.equals(other.categories)
+        ):
+            other = other.reorder_categories(self.categories)
+        return super()._union(other, sort)
+
     def map(self, mapper, na_action: Literal["ignore"] | None = None):
         """
         Map values using input an input mapping or function.

--- a/pandas/tests/indexes/categorical/test_setops.py
+++ b/pandas/tests/indexes/categorical/test_setops.py
@@ -26,6 +26,22 @@ def test_setop_mismatched_category_order(method):
     tm.assert_index_equal(result, expected)
 
 
+@pytest.mark.parametrize("method", ["union", "intersection"])
+def test_setop_matching_category_order(method):
+    # GH#55335 - when categories match, the libjoin fastpath should be used
+    # and produce correct results. Monotonic + unique indexes hit the fastpath.
+    cats = ["a", "b", "c", "d"]
+    idx1 = CategoricalIndex(["a", "b", "c"], categories=cats)
+    idx2 = CategoricalIndex(["b", "c", "d"], categories=cats)
+
+    result = getattr(idx1, method)(idx2)
+    if method == "union":
+        expected = CategoricalIndex(["a", "b", "c", "d"], categories=cats)
+    else:
+        expected = CategoricalIndex(["b", "c"], categories=cats)
+    tm.assert_index_equal(result, expected)
+
+
 @pytest.mark.parametrize("na_value", [None, np.nan])
 def test_difference_with_na(na_value):
     # GH 57318


### PR DESCRIPTION
## Summary
- GH#64951 fixed incorrect results for `CategoricalIndex.union`/`intersection` with mismatched category order (GH#55335) by blanket-disabling `_can_use_libjoin` for unordered `CategoricalIndex`. This caused a ~10x regression in the `categoricals.Indexing.time_intersection` ASV benchmark.
- Instead of disabling libjoin entirely, override `_intersection` and `_union` in `CategoricalIndex` to `reorder_categories` when category order doesn't match, then delegate to the base class libjoin fastpath. This is the same approach `Index.join` already uses.
- When categories already match (the common case), `super()` is called directly with no overhead.

## Test plan
- [x] Added `test_setop_matching_category_order` covering both `union` and `intersection` through the libjoin fastpath (monotonic + unique + matching categories)
- [x] Existing `test_setop_mismatched_category_order` (GH#55335) still passes
- [x] Full categorical index test suite passes (157 tests)
- [x] Full setops test suite passes (2026 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)