### PR TITLE
TST: add _honors_copy_keyword to extension test base class

### DIFF
--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -6,6 +6,14 @@ import pandas._testing as tm
 
 
 class BaseMissingTests:
+    def _honors_copy_keyword(self, data) -> bool:
+        """Whether the EA honors the copy keyword in methods like fillna.
+
+        EAs that always return new data regardless of copy=False should
+        override this to return False.
+        """
+        return True
+
     def test_isna(self, data_missing):
         expected = np.array([True, False])
 
@@ -137,10 +145,11 @@ class BaseMissingTests:
         assert result[0] == data_missing[1]
         tm.assert_extension_array_equal(data, data_missing)
 
-        # but with copy=False, this raises for EAs that respect the copy keyword
-        with pytest.raises(ValueError, match="Cannot modify read-only array"):
-            data.fillna(data_missing[1], copy=False)
-        tm.assert_extension_array_equal(data, data_missing)
+        if self._honors_copy_keyword(data_missing):
+            # with copy=False, this raises for EAs that respect the copy keyword
+            with pytest.raises(ValueError, match="Cannot modify read-only array"):
+                data.fillna(data_missing[1], copy=False)
+            tm.assert_extension_array_equal(data, data_missing)
 
     def test_fillna_series(self, data_missing):
         fill_value = data_missing[1]

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -67,6 +67,9 @@ def data_for_grouping():
 
 
 class TestDecimalArray(base.ExtensionTests):
+    def _honors_copy_keyword(self, data) -> bool:
+        return False
+
     def _get_expected_exception(
         self, op_name: str, obj, other
     ) -> type[Exception] | tuple[type[Exception], ...] | None:
@@ -166,10 +169,6 @@ class TestDecimalArray(base.ExtensionTests):
             DeprecationWarning, match=msg, check_stacklevel=False
         ):
             super().test_fillna_limit_series(data_missing)
-
-    @pytest.mark.xfail(reason="copy keyword is missing")
-    def test_fillna_readonly(self, data_missing):
-        super().test_fillna_readonly(data_missing)
 
     def test_series_repr(self, data):
         # Overriding this base test to explicitly test that

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -271,6 +271,9 @@ def data_for_twos(data):
 
 
 class TestArrowArray(base.ExtensionTests):
+    def _honors_copy_keyword(self, data) -> bool:
+        return False
+
     def _construct_for_combine_add(self, left, right):
         dtype = left.dtype
 
@@ -665,21 +668,6 @@ class TestArrowArray(base.ExtensionTests):
         result = data.fillna(valid)
         assert result is not data
         tm.assert_extension_array_equal(result, data)
-
-    def test_fillna_readonly(self, data_missing):
-        data = data_missing.copy()
-        data._readonly = True
-
-        # by default fillna(copy=True), then this works fine
-        result = data.fillna(data_missing[1])
-        assert result[0] == data_missing[1]
-        tm.assert_extension_array_equal(data, data_missing)
-
-        # fillna(copy=False) is generally not honored by Arrow-backed array,
-        # but always returns new data -> same result as above
-        result = data.fillna(data_missing[1])
-        assert result[0] == data_missing[1]
-        tm.assert_extension_array_equal(data, data_missing)
 
     @pytest.mark.xfail(
         reason="GH 45419: pyarrow.ChunkedArray does not support views", run=False

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -83,6 +83,9 @@ def data_for_grouping():
 class TestIntervalArray(base.ExtensionTests):
     divmod_exc = TypeError
 
+    def _honors_copy_keyword(self, data) -> bool:
+        return False
+
     def _supports_reduction(self, ser: pd.Series, op_name: str) -> bool:
         return op_name in ["min", "max", "count"]
 
@@ -102,10 +105,6 @@ class TestIntervalArray(base.ExtensionTests):
     )
     def test_fillna_length_mismatch(self, data_missing):
         super().test_fillna_length_mismatch(data_missing)
-
-    @pytest.mark.xfail(reason="copy=False is not Implemented")
-    def test_fillna_readonly(self, data_missing):
-        super().test_fillna_readonly(data_missing)
 
     @pytest.mark.filterwarnings(
         "ignore:invalid value encountered in cast:RuntimeWarning"

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -97,6 +97,9 @@ def data_for_compare(request):
 
 
 class TestSparseArray(base.ExtensionTests):
+    def _honors_copy_keyword(self, data) -> bool:
+        return False
+
     def _supports_reduction(self, obj, op_name: str) -> bool:
         return True
 
@@ -236,21 +239,6 @@ class TestSparseArray(base.ExtensionTests):
 
     def test_fillna_no_op_returns_copy(self, data, request):
         super().test_fillna_no_op_returns_copy(data)
-
-    def test_fillna_readonly(self, data_missing):
-        # copy keyword is ignored by SparseArray.fillna
-        # -> copy=True vs False doesn't make a difference
-        data = data_missing.copy()
-        data._readonly = True
-
-        result = data.fillna(data_missing[1])
-        assert result[0] == data_missing[1]
-        tm.assert_extension_array_equal(data, data_missing)
-
-        # fillna(copy=False) is ignored -> so same result as above
-        result = data.fillna(data_missing[1], copy=False)
-        assert result[0] == data_missing[1]
-        tm.assert_extension_array_equal(data, data_missing)
 
     @pytest.mark.xfail(reason="Unsupported")
     def test_fillna_series(self, data_missing):

--- a/pandas/tests/extension/test_string.py
+++ b/pandas/tests/extension/test_string.py
@@ -101,6 +101,9 @@ def data_for_grouping(dtype, chunked):
 
 
 class TestStringArray(base.ExtensionTests):
+    def _honors_copy_keyword(self, data) -> bool:
+        return data.dtype.storage != "pyarrow"
+
     @pytest.mark.parametrize("na_action", [None, "ignore"])
     def test_map(self, data_missing, na_action, request, using_infer_string):
         if data_missing.dtype.storage == "python" and not using_infer_string:
@@ -179,25 +182,6 @@ class TestStringArray(base.ExtensionTests):
         result = data.fillna(valid)
         assert result is not data
         tm.assert_extension_array_equal(result, data)
-
-    def test_fillna_readonly(self, data_missing):
-        data = data_missing.copy()
-        data._readonly = True
-
-        # by default fillna(copy=True), then this works fine
-        result = data.fillna(data_missing[1])
-        assert result[0] == data_missing[1]
-        tm.assert_extension_array_equal(data, data_missing)
-
-        # fillna(copy=False) is generally not honored by Arrow-backed array,
-        # but always returns new data -> same result as above
-        if data.dtype.storage == "pyarrow":
-            result = data.fillna(data_missing[1])
-            assert result[0] == data_missing[1]
-        else:
-            with pytest.raises(ValueError, match="Cannot modify read-only array"):
-                data.fillna(data_missing[1], copy=False)
-        tm.assert_extension_array_equal(data, data_missing)
 
     def _get_expected_exception(
         self, op_name: str, obj, other


### PR DESCRIPTION
## Summary
- Add a `_honors_copy_keyword` method to `BaseMissingTests` so `test_fillna_readonly` skips the `copy=False` assertion for EAs that always return new data regardless. Removes full test overrides in sparse, arrow, string, interval, and decimal test classes.

closes #63040

## Test plan
- [x] All extension test suites pass (sparse, arrow, string, interval, decimal, masked, numpy, datetime, period, json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)