### PR TITLE
REF: Move freq-based factorize short-circuit from array to Index

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -58,13 +58,11 @@ from pandas.core.dtypes.dtypes import (
     NumpyEADtype,
 )
 from pandas.core.dtypes.generic import (
-    ABCDatetimeArray,
     ABCExtensionArray,
     ABCIndex,
     ABCMultiIndex,
     ABCNumpyExtensionArray,
     ABCSeries,
-    ABCTimedeltaArray,
 )
 from pandas.core.dtypes.missing import (
     isna,
@@ -789,16 +787,7 @@ def factorize(
     values = _ensure_arraylike(values, func_name="factorize")
     original = values
 
-    if (
-        isinstance(values, (ABCDatetimeArray, ABCTimedeltaArray))
-        and values.freq is not None
-    ):
-        # The presence of 'freq' means we can fast-path sorting and know there
-        #  aren't NAs
-        codes, uniques = values.factorize(sort=sort)
-        return codes, uniques
-
-    elif not isinstance(values, np.ndarray):
+    if not isinstance(values, np.ndarray):
         # i.e. ExtensionArray
         codes, uniques = values.factorize(use_na_sentinel=use_na_sentinel)
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2553,16 +2553,6 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         use_na_sentinel: bool = True,
         sort: bool = False,
     ):
-        if self.freq is not None:
-            # We must be unique, so can short-circuit (and retain freq)
-            if sort and self.freq.n < 0:
-                codes = np.arange(len(self) - 1, -1, -1, dtype=np.intp)
-                uniques = self[::-1]
-            else:
-                codes = np.arange(len(self), dtype=np.intp)
-                uniques = self.copy()  # TODO: copy or view?
-            return codes, uniques
-
         if sort:
             # algorithms.factorize only passes sort=True here when freq is
             #  not None, so this should not be reached.

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -723,6 +723,22 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
                 result._data._freq = new_freq
         return result
 
+    def factorize(
+        self,
+        sort: bool = False,
+        use_na_sentinel: bool = True,
+    ):
+        if self.freq is not None:
+            # We must be unique, so can short-circuit (and retain freq)
+            if sort and self.freq.n < 0:
+                codes = np.arange(len(self) - 1, -1, -1, dtype=np.intp)
+                uniques = self[::-1]
+            else:
+                codes = np.arange(len(self), dtype=np.intp)
+                uniques = self.copy()
+            return codes, uniques
+        return super().factorize(sort=sort, use_na_sentinel=use_na_sentinel)
+
     @property
     def unit(self) -> TimeUnit:
         """

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -736,6 +736,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             else:
                 codes = np.arange(len(self), dtype=np.intp)
                 uniques = self.copy()
+            uniques._name = None
             return codes, uniques
         return super().factorize(sort=sort, use_na_sentinel=use_na_sentinel)
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -263,7 +263,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
             new_freq = self._get_rsub_datetime_result_freq(other)
 
         if new_freq is not None:
-            result._data._freq = new_freq  # type: ignore[union-attr]
+            result._data._freq = new_freq
         return result
 
     def _get_arith_result_freq(self, other: object, op: Callable) -> Day | Tick | None:


### PR DESCRIPTION
## Summary
- Move the freq-based `factorize` short-circuit from `TimelikeOps` (array level) and `algorithms.factorize` to `DatetimeTimedeltaMixin` (Index level)
- Part of GH#24566 (moving freq management from DTA/TDA arrays to Index)

## Design
Arrays stop reading `self.freq` in `factorize`. The Index checks `self.freq`, does the short-circuit if applicable, otherwise delegates to `super().factorize()`.

The override goes on `DatetimeTimedeltaMixin` (not `DatetimeIndexOpsMixin`) since the array-level method was on `TimelikeOps` which excludes `PeriodArray` — `PeriodArray.freq` is always set (part of the dtype), so applying the "must be unique" short-circuit there would be incorrect for `PeriodIndex` with duplicate values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)