### PR TITLE
REF: Move _get_arithmetic_result_freq from array to Index

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -47,7 +47,6 @@ from pandas._libs.tslibs import (
     ints_to_pydatetime,
     ints_to_pytimedelta,
     periods_per_day,
-    timezones,
     to_offset,
 )
 from pandas._libs.tslibs.fields import (
@@ -1136,48 +1135,6 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         return i8values, mask
 
     @final
-    def _get_arithmetic_result_freq(self, other) -> BaseOffset | None:
-        """
-        Check if we can preserve self.freq in addition or subtraction.
-        """
-        # Adding or subtracting a Timedelta/Timestamp scalar is freq-preserving
-        #  whenever self.freq is a Tick
-        if isinstance(self.dtype, PeriodDtype):
-            return self.freq
-        elif not lib.is_scalar(other):
-            return None
-        elif isinstance(self.freq, Tick):
-            # In these cases
-            return self.freq
-        elif self.dtype.kind == "m" and isinstance(other, Timedelta):
-            return self.freq
-        elif (
-            self.dtype.kind == "m"
-            and isinstance(other, Timestamp)
-            and (other.tz is None or timezones.is_utc(other.tz))
-        ):
-            # e.g. test_td64arr_add_sub_datetimelike_scalar tdarr + timestamp
-            #  gives a DatetimeArray. As long as the timestamp has no timezone
-            #  or UTC, the result can retain a Day freq.
-            return self.freq
-        elif (
-            lib.is_np_dtype(self.dtype, "M")
-            and isinstance(self.freq, Day)
-            and isinstance(other, Timedelta)
-        ):
-            # e.g. TestTimedelta64ArithmeticUnsorted::test_timedelta
-            # Day is unambiguously 24h
-            return self.freq
-        elif (
-            lib.is_np_dtype(self.dtype, "M")
-            and isinstance(other, Timestamp)
-            and isinstance(self.freq, Day)
-        ):
-            return self.freq
-
-        return None
-
-    @final
     def _add_datetimelike_scalar(self, other) -> DatetimeArray:
         if not lib.is_np_dtype(self.dtype, "m"):
             raise TypeError(
@@ -1208,8 +1165,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         dtype = tz_to_dtype(tz=other.tz, unit=self.unit)
         res_values = result.view(f"M8[{self.unit}]")
-        new_freq = self._get_arithmetic_result_freq(other)
-        return DatetimeArray._simple_new(res_values, dtype=dtype, freq=new_freq)
+        return DatetimeArray._simple_new(res_values, dtype=dtype, freq=None)
 
     @final
     def _add_datetime_arraylike(self, other: DatetimeArray) -> DatetimeArray:
@@ -1269,9 +1225,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         res_values = add_overflowsafe(self.asi8, np.asarray(-other_i8, dtype="i8"))
         res_m8 = res_values.view(f"timedelta64[{self.unit}]")
 
-        new_freq = self._get_arithmetic_result_freq(other)
-        new_freq = cast("Tick | None", new_freq)
-        return TimedeltaArray._simple_new(res_m8, dtype=res_m8.dtype, freq=new_freq)
+        return TimedeltaArray._simple_new(res_m8, dtype=res_m8.dtype, freq=None)
 
     @final
     def _add_period(self, other: Period) -> PeriodArray:
@@ -1333,13 +1287,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         new_values = add_overflowsafe(self.asi8, np.asarray(other_i8, dtype="i8"))
         res_values = new_values.view(self._ndarray.dtype)
 
-        new_freq = self._get_arithmetic_result_freq(other)
-
         # error: Unexpected keyword argument "freq" for "_simple_new" of "NDArrayBacked"
         return type(self)._simple_new(
             res_values,
             dtype=self.dtype,
-            freq=new_freq,  # type: ignore[call-arg]
+            freq=None,  # type: ignore[call-arg]
         )
 
     @final

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -8,6 +8,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
+import operator
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -26,11 +27,13 @@ from pandas._libs import (
 )
 from pandas._libs.tslibs import (
     BaseOffset,
+    Day,
     Resolution,
     Tick,
     Timedelta,
     Timestamp,
     parsing,
+    timezones,
     to_offset,
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
@@ -57,6 +60,7 @@ from pandas.core.dtypes.dtypes import (
     PeriodDtype,
 )
 
+from pandas.core import roperator
 from pandas.core.arrays import (
     DatetimeArray,
     ExtensionArray,
@@ -660,6 +664,64 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
     _is_monotonic_increasing = Index.is_monotonic_increasing
     _is_monotonic_decreasing = Index.is_monotonic_decreasing
     _is_unique = Index.is_unique
+
+    def _get_arithmetic_result_freq(self, other) -> BaseOffset | None:
+        """
+        Check if we can preserve self.freq in addition or subtraction.
+        """
+        if not lib.is_scalar(other):
+            return None
+
+        # Normalize scalar types to their pandas equivalents.
+        # Array arithmetic methods internally convert Tick/timedelta/
+        # np.timedelta64 → Timedelta and datetime/np.datetime64 → Timestamp.
+        # Since we receive the original user argument, normalize here.
+        if isinstance(other, Tick):
+            other = Timedelta(other)
+        elif isinstance(other, np.timedelta64):
+            other = Timedelta(other)
+        elif isinstance(other, np.datetime64):
+            other = Timestamp(other)
+        elif not isinstance(other, (Timedelta, Timestamp)):
+            # Handles datetime.timedelta, datetime.datetime
+            try:
+                other = Timedelta(other)
+            except (ValueError, TypeError, OverflowError):
+                try:
+                    other = Timestamp(other)
+                except (ValueError, TypeError, OverflowError):
+                    return None
+
+        if isinstance(self.freq, Tick):
+            return self.freq
+        elif self.dtype.kind == "m" and isinstance(other, Timedelta):
+            return self.freq
+        elif (
+            self.dtype.kind == "m"
+            and isinstance(other, Timestamp)
+            and (other.tz is None or timezones.is_utc(other.tz))
+        ):
+            return self.freq
+        elif (
+            lib.is_np_dtype(self.dtype, "M")
+            and isinstance(self.freq, Day)
+            and isinstance(other, (Timedelta, Timestamp))
+        ):
+            return self.freq
+
+        return None
+
+    def _arith_method(self, other, op):
+        result = super()._arith_method(other, op)
+        if result is NotImplemented:
+            return result
+        if op in (operator.add, roperator.radd, operator.sub, roperator.rsub):
+            new_freq = self._get_arithmetic_result_freq(other)
+            if new_freq is not None and isinstance(result, DatetimeTimedeltaMixin):
+                if op is roperator.rsub:
+                    new_freq = -new_freq
+                result._data._freq = new_freq
+        return result
 
     @property
     def unit(self) -> TimeUnit:

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -784,7 +784,7 @@ class TestDatetime64Arithmetic:
 
         rng = date_range("2000-01-01", "2000-02-01", tz=tz, unit="ns")
         expected = date_range("2000-01-01 02:00", "2000-02-01 02:00", tz=tz, unit="ns")
-        if tz is not None:
+        if tz is not None or box_with_array is pd.array:
             expected = expected._with_freq(None)
 
         rng = tm.box_expected(rng, box_with_array)
@@ -806,7 +806,7 @@ class TestDatetime64Arithmetic:
 
         rng = date_range("2000-01-01", "2000-02-01", tz=tz, unit="ns")
         expected = date_range("1999-12-31 22:00", "2000-01-31 22:00", tz=tz, unit="ns")
-        if tz is not None:
+        if tz is not None or box_with_array is pd.array:
             expected = expected._with_freq(None)
 
         rng = tm.box_expected(rng, box_with_array)
@@ -1272,6 +1272,9 @@ class TestDatetime64DateOffsetArithmetic:
             freq="h",
             tz=tz,
         ).as_unit("ns")
+        if box_with_array is pd.array:
+            expected = expected._with_freq(None)
+            dates = dates._with_freq(None)
 
         dates = tm.box_expected(dates, box_with_array)
         expected = tm.box_expected(expected, box_with_array)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -623,6 +623,8 @@ class TestTimedelta64ArithmeticUnsorted:
             #  new dtype.  For the others, the op can assign a new array
             #  and get the dtype that normally results from `rng + two_hours`
             expected = expected.as_unit("ns")
+        if box_with_array is pd.array:
+            expected = expected._with_freq(None)
 
         rng = tm.box_expected(rng, box_with_array)
         expected = tm.box_expected(expected, box_with_array)
@@ -647,6 +649,8 @@ class TestTimedelta64ArithmeticUnsorted:
             #  new dtype.  For the others, the op can assign a new array
             #  and get the dtype that normally results from `rng - two_hours`
             expected = expected.as_unit("ns")
+        if box_with_array is pd.array:
+            expected = expected._with_freq(None)
 
         rng = tm.box_expected(rng, box_with_array)
         expected = tm.box_expected(expected, box_with_array)
@@ -1045,7 +1049,10 @@ class TestTimedeltaArraylikeAddSubOps:
 
         tdi = timedelta_range("1 day", periods=3)
         expected = pd.date_range("2012-01-02", periods=3, tz=tz)
-        if tz is not None and not timezones.is_utc(expected.tz):
+        if box_with_array is pd.array or (
+            tz is not None and not timezones.is_utc(expected.tz)
+        ):
+            # Array arithmetic does not compute freq (GH#24566).
             # Day is no longer preserved by timedelta add/sub in pandas3 because
             #  it represents Calendar-Day instead of 24h
             expected = expected._with_freq(None)
@@ -1057,9 +1064,10 @@ class TestTimedeltaArraylikeAddSubOps:
         tm.assert_equal(tdarr + ts, expected)
 
         expected2 = pd.date_range("2011-12-31", periods=3, freq="-1D", tz=tz)
-        if tz is not None and not timezones.is_utc(expected2.tz):
-            # Day is no longer preserved by timedelta add/sub in pandas3 because
-            #  it represents Calendar-Day instead of 24h
+        if box_with_array is pd.array or (
+            tz is not None and not timezones.is_utc(expected2.tz)
+        ):
+            # Array arithmetic does not compute freq (GH#24566).
             expected2 = expected2._with_freq(None)
         expected2 = tm.box_expected(expected2, box_with_array)
 
@@ -1317,6 +1325,8 @@ class TestTimedeltaArraylikeAddSubOps:
         expected = timedelta_range("1 days 02:00:00", "10 days 02:00:00", freq="D")
         if isinstance(two_hours, Timedelta) and two_hours.unit == "ns":
             expected = expected.as_unit("ns")
+        if box is pd.array:
+            expected = expected._with_freq(None)
 
         rng = tm.box_expected(rng, box)
         expected = tm.box_expected(expected, box)
@@ -1335,6 +1345,8 @@ class TestTimedeltaArraylikeAddSubOps:
         expected = timedelta_range("0 days 22:00:00", "9 days 22:00:00")
         if isinstance(two_hours, Timedelta) and two_hours.unit == "ns":
             expected = expected.as_unit("ns")
+        if box is pd.array:
+            expected = expected._with_freq(None)
 
         rng = tm.box_expected(rng, box)
         expected = tm.box_expected(expected, box)


### PR DESCRIPTION
## Summary

- Move `_get_arithmetic_result_freq` from `DatetimeLikeArrayMixin` to `DatetimeTimedeltaMixin` (Index level)
- Array arithmetic methods (`_add_datetimelike_scalar`, `_sub_datetimelike`, `_add_timedeltalike`) now pass `freq=None` to `_simple_new`
- `DatetimeTimedeltaMixin._arith_method` override computes and sets freq on the result after the array operation returns

Part of #24566 — arrays stop reading `self._freq` for arithmetic computation; freq management moves to the Index.

## Test plan
- [x] `pytest pandas/tests/arithmetic/ -q` — 20741 passed
- [x] `pytest pandas/tests/indexes/datetimes/ pandas/tests/indexes/timedeltas/ pandas/tests/indexes/period/` — 3941 passed
- [x] `pytest pandas/tests/tseries/` — 8750 passed
- [x] `pytest pandas/tests/resample/` — 4103 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)