### PR TITLE
REF: move resolution, resolution_obj from arrays to indexes

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -36,7 +36,6 @@ from pandas._libs.tslibs import (
     NaT,
     NaTType,
     Period,
-    Resolution,
     Tick,
     Timedelta,
     Timestamp,
@@ -993,18 +992,6 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             return frequencies.infer_freq(self)
         except ValueError:
             return None
-
-    @property  # NB: override with cache_readonly in immutable subclasses
-    def _resolution_obj(self) -> Resolution | None:
-        raise NotImplementedError
-
-    @property  # NB: override with cache_readonly in immutable subclasses
-    def resolution(self) -> str:
-        """
-        Returns day, hour, minute, second, millisecond or microsecond
-        """
-        # error: Item "None" of "Optional[Any]" has no attribute "attrname"
-        return self._resolution_obj.attrname  # type: ignore[union-attr]
 
     # monotonicity/uniqueness properties are called via frequencies.infer_freq,
     #  see GH#23789

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -29,12 +29,10 @@ from pandas._libs.tslibs import (
     NaTType,
     OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
-    Resolution,
     Timedelta,
     Timestamp,
     astype_overflowsafe,
     fields,
-    get_resolution,
     get_supported_dtype,
     get_unit_from_dtype,
     ints_to_pydatetime,
@@ -697,10 +695,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         Returns True if all of the dates are at midnight ("no time")
         """
         return is_date_array_normalized(self.asi8, self.tz, reso=self._creso)
-
-    @property  # NB: override with cache_readonly in immutable subclasses
-    def _resolution_obj(self) -> Resolution:
-        return get_resolution(self.asi8, self.tz, reso=self._creso)
 
     # ----------------------------------------------------------------
     # Array-Like / EA-Interface Methods

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -273,19 +273,13 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
             return self._data.freqstr  # type: ignore[return-value]
 
     @cache_readonly
-    def _resolution_obj(self) -> Resolution | None:
+    def _resolution_obj(self) -> Resolution:
         if isinstance(self.dtype, PeriodDtype):
             return self.dtype._resolution_obj
         elif self.dtype.kind == "M":
             return get_resolution(self.asi8, self.tz, reso=self._data._creso)
         else:
-            freqstr = self.freqstr
-            if freqstr is None:
-                return None
-            try:
-                return Resolution.get_reso_from_freqstr(freqstr)
-            except KeyError:
-                return None
+            return get_resolution(self.asi8, tz=None, reso=self._data._creso)
 
     @cache_readonly
     def resolution(self) -> str:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -277,9 +277,9 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         if isinstance(self.dtype, PeriodDtype):
             return self.dtype._resolution_obj
         elif self.dtype.kind == "M":
-            return get_resolution(self.asi8, self.tz, reso=self._data._creso)
+            return get_resolution(self.asi8, self.tz, reso=self._data._creso)  # type: ignore[attr-defined,union-attr]
         else:
-            return get_resolution(self.asi8, tz=None, reso=self._data._creso)
+            return get_resolution(self.asi8, tz=None, reso=self._data._creso)  # type: ignore[attr-defined,union-attr]
 
     @cache_readonly
     def resolution(self) -> str:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from abc import (
     ABC,
-    abstractmethod,
 )
 import operator
 from typing import (
@@ -32,6 +31,7 @@ from pandas._libs.tslibs import (
     Tick,
     Timedelta,
     Timestamp,
+    get_resolution,
     parsing,
     timezones,
     to_offset,
@@ -273,15 +273,26 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
             return self._data.freqstr  # type: ignore[return-value]
 
     @cache_readonly
-    @abstractmethod
-    def _resolution_obj(self) -> Resolution: ...
+    def _resolution_obj(self) -> Resolution | None:
+        if isinstance(self.dtype, PeriodDtype):
+            return self.dtype._resolution_obj
+        elif self.dtype.kind == "M":
+            return get_resolution(self.asi8, self.tz, reso=self._data._creso)
+        else:
+            freqstr = self.freqstr
+            if freqstr is None:
+                return None
+            try:
+                return Resolution.get_reso_from_freqstr(freqstr)
+            except KeyError:
+                return None
 
     @cache_readonly
     def resolution(self) -> str:
         """
         Returns day, hour, minute, second, millisecond or microsecond
         """
-        return self._data.resolution
+        return self._resolution_obj.attrname
 
     # ------------------------------------------------------------------------
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -279,7 +279,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         elif self.dtype.kind == "M":
             return get_resolution(self.asi8, self.tz, reso=self._data._creso)  # type: ignore[attr-defined,union-attr]
         else:
-            return get_resolution(self.asi8, tz=None, reso=self._data._creso)  # type: ignore[attr-defined,union-attr]
+            return get_resolution(self.asi8, tz=None, reso=self._data._creso)  # type: ignore[union-attr]
 
     @cache_readonly
     def resolution(self) -> str:

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -785,10 +785,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         df = self._data.isocalendar()
         return df.set_index(self)
 
-    @cache_readonly
-    def _resolution_obj(self) -> Resolution:
-        return self._data._resolution_obj
-
     # --------------------------------------------------------------------
     # Constructors
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -23,7 +23,6 @@ from pandas._libs.tslibs import (
 )
 from pandas._libs.tslibs.dtypes import OFFSET_TO_PERIOD_FREQSTR
 from pandas.util._decorators import (
-    cache_readonly,
     set_module,
 )
 
@@ -178,11 +177,6 @@ class PeriodIndex(DatetimeIndexOpsMixin):
     @property
     def _engine_type(self) -> type[libindex.PeriodEngine]:
         return libindex.PeriodEngine
-
-    @cache_readonly
-    def _resolution_obj(self) -> Resolution:
-        # for compat with DatetimeIndex
-        return self.dtype._resolution_obj
 
     # --------------------------------------------------------------------
     # methods that dispatch to array and wrap result in Index

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -163,10 +163,6 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
     # Use base class method instead of DatetimeTimedeltaMixin._get_string_slice
     _get_string_slice = Index._get_string_slice
 
-    @property
-    def _resolution_obj(self) -> Resolution:
-        return self._data._resolution_obj
-
     # -------------------------------------------------------------------
     # Constructors
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -259,7 +259,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
             new_freq = self._get_rsub_datetime_result_freq(other)
 
         if new_freq is not None:
-            result._data._freq = new_freq  # type: ignore[union-attr]
+            result._data._freq = new_freq
         return result
 
     def _get_arith_result_freq(self, other: object, op: Callable) -> Day | Tick | None:


### PR DESCRIPTION
Part of #24566, gradually moving freq-needing things off the arrays so we can move the freq itself off the array.  Besides better hygiene, this will make it easier to support pyarrow-backed DatetimeIndex.