### PR TITLE
BUG: fix TimedeltaIndex.resolution raising when freq is not set

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -218,7 +218,7 @@ Datetimelike
 
 Timedelta
 ^^^^^^^^^
-- Bug in :attr:`TimedeltaIndex.resolution` raising when the index has no frequency (:issue:`XXXXX`)
+- Bug in :attr:`TimedeltaIndex.resolution` raising when the index has no frequency (:issue:`65186`)
 - Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
 - Bug in :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Fixed regression in :meth:`Timedelta.round`, :meth:`Timedelta.floor`, and :meth:`Timedelta.ceil` raising ``ZeroDivisionError`` for sub-second ``freq`` (:issue:`64828`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -218,6 +218,7 @@ Datetimelike
 
 Timedelta
 ^^^^^^^^^
+- Bug in :attr:`TimedeltaIndex.resolution` raising when the index has no frequency (:issue:`XXXXX`)
 - Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
 - Bug in :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Fixed regression in :meth:`Timedelta.round`, :meth:`Timedelta.floor`, and :meth:`Timedelta.ceil` raising ``ZeroDivisionError`` for sub-second ``freq`` (:issue:`64828`)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -997,13 +997,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
     @property  # NB: override with cache_readonly in immutable subclasses
     def _resolution_obj(self) -> Resolution | None:
-        freqstr = self.freqstr
-        if freqstr is None:
-            return None
-        try:
-            return Resolution.get_reso_from_freqstr(freqstr)
-        except KeyError:
-            return None
+        raise NotImplementedError
 
     @property  # NB: override with cache_readonly in immutable subclasses
     def resolution(self) -> str:

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -24,6 +24,7 @@ from pandas._libs.tslibs import (
     Day,
     NaT,
     NaTType,
+    Resolution,
     Timedelta,
     add_overflowsafe,
     astype_overflowsafe,
@@ -414,6 +415,14 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
     @property
     def freqstr(self) -> str:
         return PeriodDtype(self.freq)._freqstr
+
+    @property  # NB: override with cache_readonly in immutable subclasses
+    def _resolution_obj(self) -> Resolution:
+        freqstr = self.freqstr
+        try:
+            return Resolution.get_reso_from_freqstr(freqstr)
+        except KeyError:
+            return None  # type: ignore[return-value]
 
     def __array__(
         self, dtype: NpDtype | None = None, copy: bool | None = None

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -18,9 +18,11 @@ from pandas._libs.tslibs import (
     Day,
     NaT,
     NaTType,
+    Resolution,
     Tick,
     Timedelta,
     astype_overflowsafe,
+    get_resolution,
     get_supported_dtype,
     iNaT,
     is_supported_dtype,
@@ -212,6 +214,10 @@ class TimedeltaArray(dtl.TimelikeOps):
         numpy.dtype
         """
         return self._ndarray.dtype
+
+    @property  # NB: override with cache_readonly in immutable subclasses
+    def _resolution_obj(self) -> Resolution:
+        return get_resolution(self.asi8, tz=None, reso=self._creso)
 
     # ----------------------------------------------------------------
     # Constructors

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -157,10 +157,8 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
     # Use base class method instead of DatetimeTimedeltaMixin._get_string_slice
     _get_string_slice = Index._get_string_slice
 
-    # error: Signature of "_resolution_obj" incompatible with supertype
-    # "DatetimeIndexOpsMixin"
     @property
-    def _resolution_obj(self) -> Resolution | None:  # type: ignore[override]
+    def _resolution_obj(self) -> Resolution:
         return self._data._resolution_obj
 
     # -------------------------------------------------------------------

--- a/pandas/tests/indexes/timedeltas/methods/test_resolution.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_resolution.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pandas import TimedeltaIndex
+
+
+@pytest.mark.parametrize(
+    "timedelta_val,expected",
+    [
+        ("1 day", "day"),
+        ("1 hour", "hour"),
+        ("1 minute", "minute"),
+        ("1 second", "second"),
+        ("1 millisecond", "millisecond"),
+        ("1 microsecond", "microsecond"),
+    ],
+)
+def test_tdi_resolution(timedelta_val, expected):
+    # GH#?????
+    tdi = TimedeltaIndex([timedelta_val])
+    assert tdi.resolution == expected
+
+
+def test_tdi_resolution_no_freq():
+    # GH#????? resolution should work even without a freq
+    tdi = TimedeltaIndex(["1 day", "2 days", "4 days"])
+    assert tdi.resolution == "day"
+
+    tdi = TimedeltaIndex(["1 day 2 hours", "3 days"])
+    assert tdi.resolution == "hour"


### PR DESCRIPTION
## Summary

- Fixed `TimedeltaIndex.resolution` raising `AttributeError` when the index has no frequency (e.g. `TimedeltaIndex(["1 day", "2 days", "4 days"])`)
- Override `_resolution_obj` in `TimedeltaArray` to compute resolution from actual data values via `get_resolution`, matching the `DatetimeArray` approach
- Override `_resolution_obj` in `PeriodArray` from `freqstr`, and replace the now-dead base class implementation with `raise NotImplementedError`

## Test plan

- [x] New test file `pandas/tests/indexes/timedeltas/methods/test_resolution.py` covering all resolution levels and the no-freq case
- [x] All existing datetime, timedelta, and period index tests pass (3178 tests)
- [x] mypy clean
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)