### PR TITLE
BUG: IntervalArray/IntervalIndex constructors upcast sub-64-bit dtypes

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -250,7 +250,7 @@ Strings
 
 Interval
 ^^^^^^^^
--
+- Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors unnecessarily upcasting sub-64-bit numeric dtypes (e.g. ``float32``, ``int32``) to 64-bit (:issue:`45412`)
 -
 
 Indexing

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -45,10 +45,7 @@ from pandas.errors import (
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
 
-from pandas.core.dtypes.cast import (
-    LossySetitemError,
-    maybe_upcast_numeric_to_64bit,
-)
+from pandas.core.dtypes.cast import LossySetitemError
 from pandas.core.dtypes.common import (
     is_float_dtype,
     is_integer_dtype,
@@ -283,10 +280,8 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         from pandas.core.indexes.base import ensure_index
 
         left = ensure_index(left, copy=copy)
-        left = maybe_upcast_numeric_to_64bit(left)
 
         right = ensure_index(right, copy=copy)
-        right = maybe_upcast_numeric_to_64bit(right)
 
         if closed is None and isinstance(dtype, IntervalDtype):
             closed = dtype.closed

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -269,3 +269,15 @@ def test_fillna_non_scalar_raises():
     msg = "can only insert Interval objects and NA into an IntervalArray"
     with pytest.raises(TypeError, match=msg):
         arr.fillna([1, 1])
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int32, np.uint32])
+@pytest.mark.parametrize("constructor", [IntervalArray, IntervalIndex])
+def test_sub64bit_dtype_preserved(constructor, dtype):
+    # GH#45412
+    left = np.array([0, 1, 2], dtype=dtype)
+    right = np.array([1, 2, 3], dtype=dtype)
+    result = constructor.from_arrays(left, right)
+    assert result.dtype.subtype == dtype
+    assert result.left.dtype == dtype
+    assert result.right.dtype == dtype

--- a/pandas/tests/indexes/interval/test_interval_range.py
+++ b/pandas/tests/indexes/interval/test_interval_range.py
@@ -30,6 +30,10 @@ class TestIntervalRange:
     def test_constructor_numeric(self, closed, name, freq, periods):
         start, end = 0, 100
         breaks = np.arange(101, step=freq)
+        if breaks.dtype.kind == "f":
+            breaks = breaks.astype(np.float64)
+        else:
+            breaks = breaks.astype(np.int64)
         expected = IntervalIndex.from_breaks(breaks, name=name, closed=closed)
 
         # defined from start/end/freq

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1221,7 +1221,8 @@ class TestSeriesConstructors:
         # construction from interval & array of intervals
         intervals = interval_constructor.from_breaks(np.arange(3), closed="right")
         result = Series(intervals)
-        assert result.dtype == "interval[int64, right]"
+        expected_subtype = np.dtype(np.intp)
+        assert result.dtype == f"interval[{expected_subtype}, right]"
         tm.assert_index_equal(Index(result.values), Index(intervals))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- IntervalArray/IntervalIndex constructors (`from_arrays`, `from_breaks`, `__new__`) unnecessarily upcasted sub-64-bit numeric dtypes (e.g. `float32`, `int32`, `uint32`) to 64-bit
- The upcast was a compensating hack added in #49560 when `ensure_index` stopped auto-upcasting — it preserved prior behavior but was not needed for correctness
- The IntervalTree (Cython) requires 64-bit types, but that upcast is already handled in `IntervalIndex._engine` where the tree is built — IntervalArray itself never uses IntervalTree

closes #45412

## Test plan
- [x] Added parametrized test for `float32`/`int32`/`uint32` x `IntervalArray`/`IntervalIndex`
- [x] All 1873 existing interval tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)