### PR TITLE
REF: stop array from propagating freq in core operations

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -5,7 +5,6 @@ from datetime import (
     timedelta,
 )
 from functools import wraps
-from itertools import pairwise
 import operator
 from typing import (
     TYPE_CHECKING,
@@ -70,7 +69,6 @@ from pandas._typing import (
     PositionalIndexerTuple,
     ScalarIndexer,
     SequenceIndexer,
-    TakeIndexer,
     TimeAmbiguous,
     TimeNonexistent,
     npt,
@@ -132,16 +130,12 @@ from pandas.core.arrays._mixins import (
 from pandas.core.arrays.arrow.array import ArrowExtensionArray
 from pandas.core.arrays.base import ExtensionArray
 from pandas.core.arrays.integer import IntegerArray
-import pandas.core.common as com
 from pandas.core.construction import (
     array as pd_array,
     ensure_wrapped_if_datetimelike,
     extract_array,
 )
-from pandas.core.indexers import (
-    check_array_indexer,
-    check_setitem_lengths,
-)
+from pandas.core.indexers import check_setitem_lengths
 from pandas.core.ops.common import unpack_zerodim_and_defer
 from pandas.core.ops.invalid import (
     invalid_comparison,
@@ -396,37 +390,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         else:
             # At this point we know the result is an array.
             result = cast("Self", result)
-        # error: Incompatible types in assignment (expression has type
-        # "BaseOffset | None", variable has type "None")
-        result._freq = self._get_getitem_freq(key)  # type: ignore[assignment]
         return result
-
-    def _get_getitem_freq(self, key) -> BaseOffset | None:
-        """
-        Find the `freq` attribute to assign to the result of a __getitem__ lookup.
-        """
-        is_period = isinstance(self.dtype, PeriodDtype)
-        if is_period:
-            freq = self.freq
-        elif self.ndim != 1:
-            freq = None
-        else:
-            key = check_array_indexer(self, key)  # maybe ndarray[bool] -> slice
-            freq = None
-            if isinstance(key, slice):
-                if self.freq is not None and key.step is not None:
-                    freq = key.step * self.freq
-                else:
-                    freq = self.freq
-            elif key is Ellipsis:
-                # GH#21282 indexing with Ellipsis is similar to a full slice,
-                #  should preserve `freq` attribute
-                freq = self.freq
-            elif com.is_bool_indexer(key):
-                new_key = lib.maybe_booleans_to_slice(key.view(np.uint8))
-                if isinstance(new_key, slice):
-                    return self._get_getitem_freq(new_key)
-        return freq
 
     # error: Argument 1 of "__setitem__" is incompatible with supertype
     # "ExtensionArray"; supertype defines the argument type as "Union[int,
@@ -2580,24 +2544,11 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         axis: AxisInt = 0,
     ) -> Self:
         new_obj = super()._concat_same_type(to_concat, axis)
-
-        obj = to_concat[0]
-
-        if axis == 0:
-            # GH 3232: If the concat result is evenly spaced, we can retain the
-            # original frequency
-            to_concat = [x for x in to_concat if len(x)]
-
-            if obj.freq is not None and all(x.freq == obj.freq for x in to_concat):
-                pairs = pairwise(to_concat)
-                if all(pair[0][-1] + obj.freq == pair[1][0] for pair in pairs):
-                    new_freq = obj.freq
-                    new_obj._freq = new_freq
         return new_obj
 
     def copy(self, order: str = "C") -> Self:
         new_obj = super().copy(order=order)
-        new_obj._freq = self.freq
+        new_obj._freq = self._freq
         return new_obj
 
     def interpolate(
@@ -2637,27 +2588,6 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         if not copy:
             return self
         return type(self)._simple_new(out_data, dtype=self.dtype)
-
-    def take(
-        self,
-        indices: TakeIndexer,
-        *,
-        allow_fill: bool = False,
-        fill_value: Any = None,
-        axis: AxisInt = 0,
-    ) -> Self:
-        result = super().take(
-            indices=indices, allow_fill=allow_fill, fill_value=fill_value, axis=axis
-        )
-
-        indices = np.asarray(indices, dtype=np.intp)
-        maybe_slice = lib.maybe_indices_to_slice(indices, len(self))  # type: ignore[arg-type]
-
-        if isinstance(maybe_slice, slice):
-            freq = self._get_getitem_freq(maybe_slice)
-            result._freq = freq  # type: ignore[assignment]
-
-        return result
 
     # --------------------------------------------------------------
     # Unsorted

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -1180,10 +1180,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
     def __getitem__(self, key):
         result = super().__getitem__(key)
         if isinstance(result, type(self)):
-            # Slices are already handled by _getitem_slice; for non-slice keys
-            # (Ellipsis, bool arrays) we need to compute freq here.
-            if not isinstance(key, slice):
-                result._data._freq = self._get_getitem_freq(key)
+            result._data._freq = self._get_getitem_freq(key)
         return result
 
     def _get_getitem_freq(self, key) -> BaseOffset | None:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -8,8 +8,8 @@ from abc import (
     ABC,
     abstractmethod,
 )
-import operator
-from typing import (
+from itertools import pairwise
+import operatorfrom typing import (
     TYPE_CHECKING,
     Any,
     Literal,
@@ -69,6 +69,7 @@ from pandas.core.arrays import (
 )
 import pandas.core.common as com
 from pandas.core.construction import ensure_wrapped_if_datetimelike
+from pandas.core.indexers import check_array_indexer
 from pandas.core.indexes.base import (
     Index,
 )
@@ -77,7 +78,10 @@ from pandas.core.indexes.range import RangeIndex
 from pandas.core.tools.timedeltas import to_timedelta
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import (
+        Hashable,
+        Sequence,
+    )
     from datetime import datetime
 
     from pandas._typing import (
@@ -1006,7 +1010,8 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             result = self[:0]
         else:
             lslice = slice(*left.slice_locs(start, end))
-            result = left._values[lslice]  # type: ignore[assignment]
+            result = left._values[lslice]
+            result._freq = self.freq  # type: ignore[union-attr]
 
         return result
 
@@ -1073,6 +1078,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             right_chunk = right._values[:loc]
             dates = concat_compat((left._values, right_chunk))
             result = type(self)._simple_new(dates, name=self.name)
+            result._data._freq = self.freq
             return result
         else:
             left, right = other, self
@@ -1088,9 +1094,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             # The can_fast_union check ensures that the result.freq
             #  should match self.freq
             assert isinstance(dates, type(self._data))
-            # error: Item "ExtensionArray" of "ExtensionArray |
-            # ndarray[Any, Any]" has no attribute "_freq"
-            assert dates._freq == self.freq  # type: ignore[union-attr]
+            dates._freq = self.freq  # type: ignore[union-attr]
             result = type(self)._simple_new(dates)
             return result
         else:
@@ -1166,6 +1170,65 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
 
     # --------------------------------------------------------------------
     # List-like Methods
+
+    def _getitem_slice(self, slobj: slice) -> Self:
+        result = super()._getitem_slice(slobj)
+        result._data._freq = self._get_getitem_freq(slobj)
+        return result
+
+    def __getitem__(self, key):
+        result = super().__getitem__(key)
+        if isinstance(result, type(self)):
+            # Slices are already handled by _getitem_slice; for non-slice keys
+            # (Ellipsis, bool arrays) we need to compute freq here.
+            if not isinstance(key, slice):
+                result._data._freq = self._get_getitem_freq(key)
+        return result
+
+    def _get_getitem_freq(self, key) -> BaseOffset | None:
+        """
+        Find the `freq` attribute to assign to the result of a __getitem__ lookup.
+        """
+        if self.ndim != 1:
+            return None
+
+        key = check_array_indexer(self._data, key)  # maybe ndarray[bool] -> slice
+        freq = None
+        if isinstance(key, slice):
+            if self.freq is not None and key.step is not None:
+                freq = key.step * self.freq
+            else:
+                freq = self.freq
+        elif key is Ellipsis:
+            # GH#21282 indexing with Ellipsis is similar to a full slice,
+            #  should preserve `freq` attribute
+            freq = self.freq
+        elif com.is_bool_indexer(key):
+            new_key = lib.maybe_booleans_to_slice(key.view(np.uint8))
+            if isinstance(new_key, slice):
+                return self._get_getitem_freq(new_key)
+        return freq
+
+    def _concat(self, to_concat: list[Index], name: Hashable) -> Index:
+        result = super()._concat(to_concat, name)
+
+        # GH#3232: If the concat result is evenly spaced, we can retain the
+        # original frequency
+        obj = cast("DatetimeTimedeltaMixin", to_concat[0])
+        to_concat_nonempty = cast(
+            "list[DatetimeTimedeltaMixin]",
+            [idx for idx in to_concat if len(idx)],
+        )
+        if (
+            isinstance(result, type(self))
+            and obj.freq is not None
+            and all(idx.freq == obj.freq for idx in to_concat_nonempty)
+        ):
+            pairs = pairwise(to_concat_nonempty)
+            if all(pair[0][-1] + obj.freq == pair[1][0] for pair in pairs):
+                result._data._freq = obj.freq
+
+        return result
 
     def _get_delete_freq(self, loc: int | slice | Sequence[int]):
         """
@@ -1342,6 +1405,6 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
 
         maybe_slice = lib.maybe_indices_to_slice(indices, len(self))
         if isinstance(maybe_slice, slice):
-            freq = self._data._get_getitem_freq(maybe_slice)
+            freq = self._get_getitem_freq(maybe_slice)
             result._data._freq = freq
         return result

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -9,7 +9,8 @@ from abc import (
     abstractmethod,
 )
 from itertools import pairwise
-import operatorfrom typing import (
+import operator
+from typing import (
     TYPE_CHECKING,
     Any,
     Literal,

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2044,7 +2044,17 @@ class MultiIndex(Index):
         if unique:
             level_codes = algos.unique(level_codes)
         filled = algos.take_nd(lev._values, level_codes, fill_value=lev._na_value)
-        return lev._shallow_copy(filled, name=name)
+        result = lev._shallow_copy(filled, name=name)
+        # Restore freq that may have been lost during the array-level take,
+        # since take_nd goes through _from_backing_data which doesn't copy _freq.
+        freq = getattr(lev, "freq", None)
+        if freq is not None and hasattr(filled, "_freq"):
+            indices = np.asarray(level_codes, dtype=np.intp)
+            maybe_slice = lib.maybe_indices_to_slice(indices, len(lev))
+            if isinstance(maybe_slice, slice):
+                if maybe_slice.step is None or maybe_slice.step == 1:
+                    result._data._freq = freq
+        return result
 
     def get_level_values(self, level) -> Index:
         """

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2043,17 +2043,12 @@ class MultiIndex(Index):
         name = self._names[level]
         if unique:
             level_codes = algos.unique(level_codes)
-        filled = algos.take_nd(lev._values, level_codes, fill_value=lev._na_value)
-        result = lev._shallow_copy(filled, name=name)
-        # Restore freq that may have been lost during the array-level take,
-        # since take_nd goes through _from_backing_data which doesn't copy _freq.
-        freq = getattr(lev, "freq", None)
-        if freq is not None and hasattr(filled, "_freq"):
-            indices = np.asarray(level_codes, dtype=np.intp)
-            maybe_slice = lib.maybe_indices_to_slice(indices, len(lev))
-            if isinstance(maybe_slice, slice):
-                if maybe_slice.step is None or maybe_slice.step == 1:
-                    result._data._freq = freq
+        if lev._can_hold_na:
+            result = lev.take(level_codes, fill_value=lev._na_value).rename(name)
+        else:
+            # Index.take raises for integer dtypes with -1 (NA) codes
+            filled = algos.take_nd(lev._values, level_codes, fill_value=lev._na_value)
+            result = lev._shallow_copy(filled, name=name)
         return result
 
     def get_level_values(self, level) -> Index:

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -263,7 +263,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
             new_freq = self._get_rsub_datetime_result_freq(other)
 
         if new_freq is not None:
-            result._data._freq = new_freq  # type: ignore[union-attr]
+            result._data._freq = new_freq
         return result
 
     def _get_arith_result_freq(self, other: object, op: Callable) -> Day | Tick | None:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2669,9 +2669,9 @@ class TimeGrouper(Grouper):
         if self.closed == "right":
             labels = binner
             if self.label == "right":
-                labels = labels[1:]  # type: ignore[assignment]
+                labels = labels[1:]
         elif self.label == "right":
-            labels = labels[1:]  # type: ignore[assignment]
+            labels = labels[1:]
 
         if nat_count > 0:
             # shift bins by the number of NaT (they sort to the front of asi8)
@@ -2684,7 +2684,7 @@ class TimeGrouper(Grouper):
         # adjust the labels
         # GH4076
         if len(bins) < len(labels):
-            labels = labels[: len(bins)]  # type: ignore[assignment]
+            labels = labels[: len(bins)]
 
         return binner, bins, labels
 
@@ -2721,7 +2721,7 @@ class TimeGrouper(Grouper):
             # intraday values on last day
             if bin_edges[-2] > ax_values.max():
                 bin_edges = bin_edges[:-1]
-                binner = binner[:-1]  # type: ignore[assignment]
+                binner = binner[:-1]
         else:
             bin_edges = binner.asi8
         return binner, bin_edges

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -270,7 +270,7 @@ def use_dynamic_x(ax: Axes, index: Index) -> bool:
         freq_str = OFFSET_TO_PERIOD_FREQSTR.get(freq_str, freq_str)
         base = to_offset(freq_str, is_period=True)._period_dtype_code  # type: ignore[attr-defined]
         if base <= FreqGroup.FR_DAY.value:
-            return index[:1].is_normalized  # type: ignore[attr-defined]
+            return index[:1].is_normalized
         period = Period(index[0], freq_str)
         assert isinstance(period, Period)
         return period.to_timestamp().tz_localize(index.tz) == index[0]

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -1115,7 +1115,7 @@ class TestPeriodArray(SharedTests):
         tm.assert_extension_array_equal(result, dta.as_unit("us"))
 
         dta2 = dta[::2]
-        parr2 = dta2.to_period()
+        parr2 = dta2.to_period("2B")
         result2 = parr2.to_timestamp()
         assert result2.freq == "2B"
         tm.assert_extension_array_equal(result2, dta2.as_unit("us"))

--- a/pandas/tests/groupby/methods/test_quantile.py
+++ b/pandas/tests/groupby/methods/test_quantile.py
@@ -31,7 +31,7 @@ import pandas._testing as tm
         ),
         (
             pd.date_range("1/1/18", freq="D", periods=5).as_unit("s"),
-            pd.date_range("1/1/18", freq="D", periods=5)[::-1].as_unit("s"),  # type: ignore[attr-defined]
+            pd.date_range("1/1/18", freq="D", periods=5)[::-1].as_unit("s"),
         ),
         # All NA
         ([np.nan] * 5, [np.nan] * 5),

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -29,8 +29,8 @@ rng = pd.Index(range(3))
 @pytest.fixture(
     params=[
         dti,
-        dti.tz_localize("UTC"),  # type: ignore[attr-defined]
-        dti.to_period("W"),  # type: ignore[attr-defined]
+        dti.tz_localize("UTC"),
+        dti.to_period("W"),
         dti - dti[0],
         rng,
         pd.Index([1, 2, 3]),


### PR DESCRIPTION
## Summary

- Move freq management from `DatetimeLikeArrayMixin`/`TimelikeOps` to `DatetimeTimedeltaMixin` (the Index level) as part of GH#24566
- Array methods (`__getitem__`, `take`, `_concat_same_type`) stop computing freq; the Index manages it via new overrides (`_getitem_slice`, `__getitem__`, `_get_getitem_freq`, `_concat`)
- `copy()` preserves `_freq` as dumb storage on the array
- Fix `_fast_union`/`_fast_intersect` to explicitly set freq instead of relying on array-level propagation
- Fix `MultiIndex._get_level_values` to restore freq after array-level `take_nd`

## Test plan

- [ ] CI green on datetime/timedelta index tests
- [ ] CI green on period index tests (no changes expected)
- [ ] CI green on MultiIndex get_level_values tests
- [ ] CI green on extension/datetime tests
- [ ] CI green on resample tests
- [ ] CI green on concat tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)