### PR TITLE
REF: move freq computation from TimedeltaArray arithmetic to TimedeltaIndex

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -25,7 +25,6 @@ from pandas._libs.tslibs import (
     iNaT,
     is_supported_dtype,
     periods_per_second,
-    to_offset,
 )
 from pandas._libs.tslibs.conversion import cast_from_unit_vectorized
 from pandas._libs.tslibs.fields import (
@@ -455,13 +454,7 @@ class TimedeltaArray(dtl.TimelikeOps):
                 # numpy >= 2.1 may not raise a TypeError
                 # and seems to dispatch to others.__rmul__?
                 raise TypeError(f"Cannot multiply with {type(other).__name__}")
-            freq = None
-            if self.freq is not None and not isna(other):
-                freq = self.freq * other
-                if freq.n == 0:
-                    # GH#51575 Better to have no freq than an incorrect one
-                    freq = None
-            return type(self)._simple_new(result, dtype=result.dtype, freq=freq)
+            return type(self)._simple_new(result, dtype=result.dtype)
 
         if not hasattr(other, "dtype"):
             # list, tuple
@@ -529,24 +522,7 @@ class TimedeltaArray(dtl.TimelikeOps):
                 )
 
             result = op(self._ndarray, other)
-            freq = None
-
-            if self.freq is not None:
-                # Note: freq gets division, not floor-division, even if op
-                #  is floordiv.
-                if isinstance(self.freq, Day):
-                    if self.freq.n % other == 0:
-                        freq = Day(self.freq.n // other)
-                    else:
-                        freq = to_offset(Timedelta(days=self.freq.n)) / other
-                else:
-                    freq = self.freq / other
-                if freq.nanos == 0 and self.freq.nanos != 0:
-                    # e.g. if self.freq is Nano(1) then dividing by 2
-                    #  rounds down to zero
-                    freq = None
-
-            return type(self)._simple_new(result, dtype=result.dtype, freq=freq)
+            return type(self)._simple_new(result, dtype=result.dtype)
 
     def _cast_divlike_op(self, other):
         if not hasattr(other, "dtype"):
@@ -715,15 +691,10 @@ class TimedeltaArray(dtl.TimelikeOps):
         return res1, res2
 
     def __neg__(self) -> TimedeltaArray:
-        freq = None
-        if self.freq is not None:
-            freq = -self.freq
-        return type(self)._simple_new(-self._ndarray, dtype=self.dtype, freq=freq)
+        return type(self)._simple_new(-self._ndarray, dtype=self.dtype)
 
     def __pos__(self) -> TimedeltaArray:
-        return type(self)._simple_new(
-            self._ndarray.copy(), dtype=self.dtype, freq=self.freq
-        )
+        return type(self)._simple_new(self._ndarray.copy(), dtype=self.dtype)
 
     def __abs__(self) -> TimedeltaArray:
         # Note: freq is not preserved

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -278,7 +278,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         freq = self.freq
         assert freq is not None  # caller ensures this
         if op in (operator.mul, rmul):
-            if isna(other):
+            if bool(isna(other)):
                 return None
             # error: No overload variant of "__mul__" of "BaseOffset"
             # matches argument type "object"

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import operator
 from typing import (
     TYPE_CHECKING,
     cast,
@@ -12,8 +13,12 @@ from pandas._libs import (
     lib,
 )
 from pandas._libs.tslibs import (
+    Day,
     Resolution,
+    Tick,
     Timedelta,
+    Timestamp,
+    timezones,
     to_offset,
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
@@ -25,6 +30,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.dtypes import ArrowDtype
 from pandas.core.dtypes.generic import ABCSeries
+from pandas.core.dtypes.missing import isna
 
 from pandas.core.arrays.timedeltas import TimedeltaArray
 import pandas.core.common as com
@@ -34,13 +40,15 @@ from pandas.core.indexes.base import (
 )
 from pandas.core.indexes.datetimelike import DatetimeTimedeltaMixin
 from pandas.core.indexes.extension import inherit_names
+from pandas.core.roperator import (
+    rmul,
+    rsub,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pandas._libs import NaTType
-    from pandas._libs.tslibs import (
-        Day,
-        Tick,
-    )
     from pandas._typing import (
         DtypeObj,
         TimeUnit,
@@ -49,8 +57,6 @@ if TYPE_CHECKING:
 
 @inherit_names(
     [
-        "__neg__",
-        "__pos__",
         "__abs__",
         "total_seconds",
         "round",
@@ -224,6 +230,107 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         if isinstance(dtype, ArrowDtype):
             return dtype.kind == "m"
         return lib.is_np_dtype(dtype, "m")  # aka self._data._is_recognized_dtype
+
+    # -------------------------------------------------------------------
+    # Arithmetic Methods
+
+    def __neg__(self) -> TimedeltaIndex:
+        result = self._data.__neg__()
+        idx = type(self)._simple_new(result, name=self.name)
+        if self.freq is not None:
+            idx._data._freq = -self.freq  # type: ignore[assignment]
+        return idx
+
+    def __pos__(self) -> TimedeltaIndex:
+        result = self._data.__pos__()
+        idx = type(self)._simple_new(result, name=self.name)
+        if self.freq is not None:
+            idx._data._freq = self.freq  # type: ignore[assignment]
+        return idx
+
+    def _arith_method(self, other: object, op: Callable) -> Index:
+        result = super()._arith_method(other, op)
+        if self.freq is None or not is_scalar(other):
+            return result
+
+        new_freq = None
+        if isinstance(result, type(self)):
+            new_freq = self._get_arith_result_freq(other, op)
+        elif (
+            getattr(getattr(result, "dtype", None), "kind", None) == "M" and op is rsub
+        ):
+            # Timestamp/datetime - TDI produces a DatetimeIndex.
+            # The array __rsub__ does (-self) + other, losing freq in
+            # negation. Compute the freq at the Index level.
+            new_freq = self._get_rsub_datetime_result_freq(other)
+
+        if new_freq is not None:
+            result._data._freq = new_freq  # type: ignore[union-attr]
+        return result
+
+    def _get_arith_result_freq(self, other: object, op: Callable) -> Day | Tick | None:
+        """
+        Compute the result freq for arithmetic operations whose result
+        is also a TimedeltaIndex.
+
+        Caller is responsible for checking self.freq is not None.
+        """
+        freq = self.freq
+        assert freq is not None  # caller ensures this
+        if op in (operator.mul, rmul):
+            if isna(other):
+                return None
+            # error: No overload variant of "__mul__" of "BaseOffset"
+            # matches argument type "object"
+            new_freq = freq * other  # type: ignore[operator]
+            if new_freq.n == 0:
+                # GH#51575 Better to have no freq than an incorrect one
+                return None
+            return new_freq
+
+        if op in (operator.truediv, operator.floordiv):
+            # Note: freq gets division, not floor-division, even if op
+            #  is floordiv.
+            if isinstance(freq, Day):
+                if freq.n % other == 0:  # type: ignore[operator]
+                    new_freq = Day(freq.n // other)  # type: ignore[operator]
+                else:
+                    new_freq = to_offset(Timedelta(days=freq.n)) / other  # type: ignore[operator]
+            else:
+                new_freq = freq / other  # type: ignore[operator]
+            if new_freq.nanos == 0 and freq.nanos != 0:
+                # e.g. if self.freq is Nano(1) then dividing by 2
+                #  rounds down to zero
+                return None
+            return new_freq
+
+        if op is rsub:
+            # scalar_timedelta - TDI: the array uses (-self) + other,
+            # losing freq in negation. Result freq is -self.freq.
+            return -freq  # type: ignore[return-value]
+
+        return None
+
+    def _get_rsub_datetime_result_freq(self, other: object) -> Day | Tick | None:
+        """
+        Compute the result freq for Timestamp/datetime - TimedeltaIndex.
+
+        Mirrors the logic of _get_arithmetic_result_freq for the negated
+        array case.
+        """
+        freq = self.freq
+        assert freq is not None  # caller ensures this
+        if isinstance(freq, Tick):
+            return -freq
+
+        # freq is a Day; only preserve with tz-naive or UTC
+        if isinstance(other, Timestamp):
+            tz = other.tz
+        else:
+            tz = Timestamp(other).tz  # type: ignore[arg-type]
+        if tz is None or timezones.is_utc(tz):
+            return -freq  # type: ignore[return-value]
+        return None
 
     # -------------------------------------------------------------------
     # Indexing Methods

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1062,6 +1062,10 @@ class TestTimedeltaArraylikeAddSubOps:
             #  it represents Calendar-Day instead of 24h
             expected2 = expected2._with_freq(None)
         expected2 = tm.box_expected(expected2, box_with_array)
+        if box_with_array is pd.array:
+            # GH#24566 Array-level __neg__ and __rsub__ don't carry freq;
+            # freq is managed by the Index layer.
+            expected2 = expected2._with_freq(None)
 
         tm.assert_equal(ts - tdarr, expected2)
         tm.assert_equal(ts + (-tdarr), expected2)


### PR DESCRIPTION
## Summary

- Stop `TimedeltaArray.__mul__`, `_scalar_divlike_op`, `__neg__`, and `__pos__` from reading `self.freq` for computation. These array methods now return results with `freq=None`.
- Add `__neg__`, `__pos__`, and `_arith_method` overrides on `TimedeltaIndex` to compute and set the appropriate freq on arithmetic results.
- Also handles the `rsub` case (`scalar - TimedeltaIndex`) where the array-level `__rsub__` uses `(-self) + other` internally, which loses freq after the `__neg__` change.

Part of #24566 (moving freq management from DTA/TDA arrays to the Index layer).

## Test plan

- [x] `pytest pandas/tests/arithmetic/test_timedelta64.py` (2102 passed)
- [x] `pytest pandas/tests/indexes/timedeltas/` (all passed)
- [x] `pytest pandas/tests/arrays/timedeltas/` (all passed)
- [x] `pytest pandas/tests/arithmetic/` (20741 passed)
- [x] `pytest pandas/tests/resample/` (4103 passed)
- [x] `pytest pandas/tests/tseries/` (7247 passed)
- [x] mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)