### PR TITLE
CI: Fix numpy nightly build

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -11,6 +11,7 @@ _np_version = np.__version__
 _nlv = Version(_np_version)
 np_version_gt2 = _nlv >= Version("2.0.0")
 np_version_gt2_2 = _nlv >= Version("2.2.0")
+np_version_gt2_5 = _nlv >= Version("2.5.0")
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.26.0"
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -263,7 +263,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
             new_freq = self._get_rsub_datetime_result_freq(other)
 
         if new_freq is not None:
-            result._data._freq = new_freq  # type: ignore[union-attr]
+            result._data._freq = new_freq
         return result
 
     def _get_arith_result_freq(self, other: object, op: Callable) -> Day | Tick | None:

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -348,7 +348,7 @@ class TestNumericArraylikeArithmeticWithDatetimeLike:
         ids=repr,
     )
     @pytest.mark.filterwarnings(
-        "ignore:Using 'generic' unit for NumPy timedelta:DeprecationWarning"
+        "ignore:.*'generic' unit for NumPy timedelta:DeprecationWarning"
     )
     def test_add_sub_datetimedeltalike_invalid(
         self, numeric_idx, other, box_with_array

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -11,7 +11,10 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import tz_compare
-from pandas.compat.numpy import np_version_gt2_5
+from pandas.compat.numpy import (
+    is_numpy_dev,
+    np_version_gt2_5,
+)
 from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
@@ -209,7 +212,7 @@ class TestNonNano:
         tm.assert_numpy_array_equal(result, expected)
 
         if op not in [operator.eq, operator.ne]:
-            if not np_version_gt2_5:
+            if not np_version_gt2_5 and not is_numpy_dev:
                 # This was fixed by numpy in
                 # https://github.com/numpy/numpy/pull/31085
                 np_res = op(left._ndarray, right._ndarray)

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import tz_compare
+from pandas.compat.numpy import np_version_gt2_5
 from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
@@ -208,10 +209,11 @@ class TestNonNano:
         tm.assert_numpy_array_equal(result, expected)
 
         if op not in [operator.eq, operator.ne]:
-            # check that numpy still gets this wrong; if it is fixed we may be
-            #  able to remove compare_mismatched_resolutions
-            np_res = op(left._ndarray, right._ndarray)
-            tm.assert_numpy_array_equal(np_res[1:], ~expected[1:])
+            if not np_version_gt2_5:
+                # This was fixed by numpy in
+                # https://github.com/numpy/numpy/pull/31085
+                np_res = op(left._ndarray, right._ndarray)
+                tm.assert_numpy_array_equal(np_res[1:], ~expected[1:])
 
     def test_add_mismatched_reso_doesnt_downcast(self):
         # https://github.com/pandas-dev/pandas/pull/48748#issuecomment-1260181008

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -212,9 +212,14 @@ class TestNonNano:
         tm.assert_numpy_array_equal(result, expected)
 
         if op not in [operator.eq, operator.ne]:
-            if not np_version_gt2_5 and not is_numpy_dev:
-                # This was fixed by numpy in
+            if is_numpy_dev or np_version_gt2_5:
+                # numpy now raises instead of silently overflowing
                 # https://github.com/numpy/numpy/pull/31085
+                with pytest.raises(OverflowError, match="Overflow"):
+                    op(left._ndarray, right._ndarray)
+            else:
+                # check that numpy still gets this wrong; if it is fixed we may
+                #  be able to remove compare_mismatched_resolutions
                 np_res = op(left._ndarray, right._ndarray)
                 tm.assert_numpy_array_equal(np_res[1:], ~expected[1:])
 

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -530,7 +530,7 @@ def test_is_datetime64_ns_dtype():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:Using 'generic' unit for NumPy timedelta:DeprecationWarning"
+    "ignore:.*'generic' unit for NumPy timedelta:DeprecationWarning"
 )
 def test_is_timedelta64_ns_dtype():
     assert not com.is_timedelta64_ns_dtype(np.dtype("m8[ps]"))

--- a/pandas/tests/scalar/interval/test_arithmetic.py
+++ b/pandas/tests/scalar/interval/test_arithmetic.py
@@ -136,7 +136,7 @@ class TestIntervalArithmetic:
         "delta", [Timedelta(days=7), timedelta(7), np.timedelta64(7, "D")]
     )
     @pytest.mark.filterwarnings(
-        "ignore:Using 'generic' unit for NumPy timedelta:DeprecationWarning"
+        "ignore:.*'generic' unit for NumPy timedelta:DeprecationWarning"
     )
     def test_numeric_interval_add_timedelta_raises(self, interval, delta):
         # https://github.com/pandas-dev/pandas/issues/32023

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -6,6 +6,10 @@ import pytest
 
 from pandas._libs.tslibs import OutOfBoundsTimedelta
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
+from pandas.compat.numpy import (
+    is_numpy_dev,
+    np_version_gt2_5,
+)
 from pandas.errors import Pandas4Warning
 
 from pandas import (
@@ -527,7 +531,12 @@ def test_construction_out_of_bounds_td64ns(val, unit):
 
     # Timedelta.max is just under 106752 days
     td64 = np.timedelta64(val, unit)
-    assert td64.astype("m8[ns]").view("i8") < 0  # i.e. naive astype will be wrong
+    if is_numpy_dev or np_version_gt2_5:
+        # numpy now raises instead of silently overflowing
+        with pytest.raises(OverflowError, match="Overflow"):
+            td64.astype("m8[ns]")
+    else:
+        assert td64.astype("m8[ns]").view("i8") < 0  # i.e. naive astype will be wrong
 
     td = Timedelta(td64)
     if unit != "M":
@@ -544,7 +553,11 @@ def test_construction_out_of_bounds_td64ns(val, unit):
     assert Timedelta(td64 - one) == td64 - one
 
     td64 = np.timedelta64(-val, unit)
-    assert td64.astype("m8[ns]").view("i8") > 0  # i.e. naive astype will be wrong
+    if is_numpy_dev or np_version_gt2_5:
+        with pytest.raises(OverflowError, match="Overflow"):
+            td64.astype("m8[ns]")
+    else:
+        assert td64.astype("m8[ns]").view("i8") > 0  # i.e. naive astype will be wrong
 
     td2 = Timedelta(td64)
     msg = r"Cannot cast -1067\d\d days .* to unit='ns' without overflow"

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -30,6 +30,10 @@ from pandas._libs.tslibs.timezones import (
     tz_compare,
 )
 from pandas.compat import IS64
+from pandas.compat.numpy import (
+    is_numpy_dev,
+    np_version_gt2_5,
+)
 from pandas.errors import Pandas4Warning
 
 from pandas import (
@@ -654,9 +658,11 @@ class TestNonNano:
         #  nanosecond implementation bounds.
         other = Timestamp(dt64 - np.timedelta64(3600 * 24, "s")).as_unit("ns")
         assert other < ts
-        assert other.asm8 > ts.asm8  # <- numpy gets this wrong
+        if not is_numpy_dev and not np_version_gt2_5:
+            assert other.asm8 > ts.asm8  # <- numpy gets this wrong
         assert ts > other
-        assert ts.asm8 < other.asm8  # <- numpy gets this wrong
+        if not is_numpy_dev and not np_version_gt2_5:
+            assert ts.asm8 < other.asm8  # <- numpy gets this wrong
         assert not other == ts
         assert ts != other
 

--- a/pandas/tests/tslibs/test_np_datetime.py
+++ b/pandas/tests/tslibs/test_np_datetime.py
@@ -10,11 +10,15 @@ from pandas._libs.tslibs.np_datetime import (
     py_get_unit_from_dtype,
     py_td64_to_tdstruct,
 )
+from pandas.compat.numpy import (
+    is_numpy_dev,
+    np_version_gt2_5,
+)
 
 import pandas._testing as tm
 
 
-@pytest.mark.filterwarnings("ignore:Using 'generic' unit:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:.*'generic' unit:DeprecationWarning")
 def test_is_unitless():
     dtype = np.dtype("M8[ns]")
     assert not is_unitless(dtype)
@@ -173,10 +177,15 @@ class TestAstypeOverflowSafe:
         dt = np.datetime64("2262-04-05", "D")
         arr = dt + np.arange(10, dtype="m8[D]")
 
-        # arr.astype silently overflows, so this
-        wrong = arr.astype(dtype)
-        roundtrip = wrong.astype(arr.dtype)
-        assert not (wrong == roundtrip).all()
+        if is_numpy_dev or np_version_gt2_5:
+            # numpy now raises instead of silently overflowing
+            with pytest.raises(OverflowError, match="Overflow"):
+                arr.astype(dtype)
+        else:
+            # arr.astype silently overflows, so this
+            wrong = arr.astype(dtype)
+            roundtrip = wrong.astype(arr.dtype)
+            assert not (wrong == roundtrip).all()
 
         msg = "Out of bounds nanosecond timestamp"
         with pytest.raises(OutOfBoundsDatetime, match=msg):
@@ -195,10 +204,15 @@ class TestAstypeOverflowSafe:
         arr = dt + np.arange(10, dtype="m8[D]")
         arr = arr.view("m8[D]")
 
-        # arr.astype silently overflows, so this
-        wrong = arr.astype(dtype)
-        roundtrip = wrong.astype(arr.dtype)
-        assert not (wrong == roundtrip).all()
+        if is_numpy_dev or np_version_gt2_5:
+            # numpy now raises instead of silently overflowing
+            with pytest.raises(OverflowError, match="Overflow"):
+                arr.astype(dtype)
+        else:
+            # arr.astype silently overflows, so this
+            wrong = arr.astype(dtype)
+            roundtrip = wrong.astype(arr.dtype)
+            assert not (wrong == roundtrip).all()
 
         msg = r"Cannot convert 106752 days to timedelta64\[ns\] without overflow"
         with pytest.raises(OutOfBoundsTimedelta, match=msg):


### PR DESCRIPTION
They implemented correct overflow detection for astype, which then fails on our "check that they fail".