### PR TITLE
REF: merge PeriodArray branch in get_values_for_csv

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -8388,7 +8388,9 @@ def get_values_for_csv(
 
     values = ensure_wrapped_if_datetimelike(values)  # type: ignore[no-untyped-call]
 
-    if isinstance(values, (DatetimeArray, TimedeltaArray)):
+    if isinstance(values, (DatetimeArray, TimedeltaArray)) or isinstance(
+        values.dtype, PeriodDtype
+    ):
         if values.ndim == 1:
             result = values._format_native_types(na_rep=na_rep, date_format=date_format)
             result = result.astype(object, copy=False)
@@ -8403,14 +8405,7 @@ def get_values_for_csv(
             results_converted.append(result.astype(object, copy=False))
         return np.vstack(results_converted)
 
-    elif isinstance(values.dtype, PeriodDtype):
-        # TODO: tests that get here in column path
-        values = cast("PeriodArray", values)
-        res = values._format_native_types(na_rep=na_rep, date_format=date_format)
-        return res
-
     elif isinstance(values.dtype, IntervalDtype):
-        # TODO: tests that get here in column path
         values = cast("IntervalArray", values)
         mask = values.isna()
         if not quoting:

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -297,6 +297,38 @@ $1$,$2$
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
         assert df.to_csv(index=False) == expected
 
+    def test_to_csv_period_columns(self):
+        # GH#55426 - exercise the column path for PeriodArray
+        df = DataFrame(
+            {
+                "a": pd.period_range("2020-01-01", periods=2, freq="D"),
+                "b": pd.period_range("2020-03-01", periods=2, freq="D"),
+            }
+        )
+        expected_rows = [
+            "a,b",
+            "2020-01-01,2020-03-01",
+            "2020-01-02,2020-03-02",
+        ]
+        expected = tm.convert_rows_list_to_csv_str(expected_rows)
+        assert df.to_csv(index=False) == expected
+
+    def test_to_csv_interval_columns(self):
+        # GH#55426 - exercise the column path for IntervalArray
+        df = DataFrame(
+            {
+                "a": pd.arrays.IntervalArray.from_breaks([0, 1, 2]),
+                "b": pd.arrays.IntervalArray.from_breaks([3, 4, 5]),
+            }
+        )
+        expected_rows = [
+            "a,b",
+            '"(0, 1]","(3, 4]"',
+            '"(1, 2]","(4, 5]"',
+        ]
+        expected = tm.convert_rows_list_to_csv_str(expected_rows)
+        assert df.to_csv(index=False) == expected
+
     def test_to_csv_date_format_in_categorical(self):
         # GH#40754
         ser = pd.Series(pd.to_datetime(["2021-03-27", pd.NaT], format="%Y-%m-%d"))


### PR DESCRIPTION
## Summary
- Merge the separate `PeriodArray` branch into the existing `DatetimeArray`/`TimedeltaArray` branch in `get_values_for_csv`, since both just call `_format_native_types(na_rep=na_rep, date_format=date_format)` (GH#55426 item C-ii)
- Add column-path tests for `PeriodArray` and `IntervalArray` via `DataFrame.to_csv`, addressing the TODO comments

## Test plan
- [x] `pytest pandas/tests/io/formats/test_to_csv.py` — 119 passed
- [x] `pytest pandas/tests/frame/methods/test_to_csv.py` — 434 passed
- [x] `pytest pandas/tests/series/methods/test_to_csv.py` — 112 passed
- [x] `pytest pandas/tests/indexes/period/test_formats.py` — 12 passed
- [x] `pytest pandas/tests/indexes/interval/test_formats.py` — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)