### PR TITLE
Backport PR #64836 on branch 3.0.x (BUG: Timedelta.round() raises ZeroDivisionError when internal unit is 's' and target frequency is sub-second)

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -20,6 +20,7 @@ Fixed regressions
 Bug fixes
 ^^^^^^^^^
 - Fixed regression in :func:`pandas.bdate_range` where specifying ``end`` on a weekend with ``periods`` returned fewer dates than expected (:issue:`64834`)
+- Fixed regression in :meth:`Timedelta.round`, :meth:`Timedelta.floor`, and :meth:`Timedelta.ceil` raising ``ZeroDivisionError`` for sub-second ``freq`` (:issue:`64828`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.contributors:

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -17,6 +17,8 @@ from cpython.object cimport (
     PyObject_RichCompare,
 )
 
+from pandas._libs.tslibs.offsets cimport to_offset
+
 import numpy as np
 
 cimport numpy as cnp
@@ -2321,17 +2323,24 @@ class Timedelta(_Timedelta):
     @cython.cdivision(True)
     def _round(self, freq, mode):
         cdef:
-            int64_t result, unit
+            int64_t result, nanos
             ndarray[int64_t] arr
+        freq_arg = freq
+        freq = to_offset(freq, is_period=False)
+        nanos = get_unit_for_round(freq, self._creso)
+        if nanos == 0:
+            if freq.nanos == 0:
+                raise ValueError("Division by zero in rounding")
 
-        unit = get_unit_for_round(freq, self._creso)
+            # e.g. self.unit == "s" and sub-second freq
+            return self
 
         arr = np.array([self._value], dtype="i8")
         try:
-            result = round_nsint64(arr, mode, unit)[0]
+            result = round_nsint64(arr, mode, nanos)[0]
         except OverflowError as err:
             raise OutOfBoundsTimedelta(
-                f"Cannot round {self} to freq={freq} without overflow"
+                f"Cannot round {self} to freq={freq_arg} without overflow"
             ) from err
         return Timedelta._from_value_and_reso(result, self._creso)
 

--- a/pandas/tests/scalar/timedelta/methods/test_round.py
+++ b/pandas/tests/scalar/timedelta/methods/test_round.py
@@ -185,3 +185,11 @@ class TestTimedeltaRound:
         res = td.ceil("min")
         assert res == Timedelta("1 days 02:35:00")
         assert res._creso == td._creso
+
+    def test_round_freq_finer_than_resolution(self):
+        # GH#64828
+        td = Timedelta(1.0, unit="days").as_unit("s")
+        assert td.unit == "s"
+        assert td.round("100ms") == Timedelta("1 days 00:00:00")
+        assert td.floor("100ms") == Timedelta("1 days 00:00:00")
+        assert td.ceil("100ms") == Timedelta("1 days 00:00:00")


### PR DESCRIPTION
Backport PR #64836 on branch 3.0.x (BUG: Timedelta.round() raises ZeroDivisionError when internal unit is 's' and target frequency is sub-second)

Manual backport due to change in the location of WhatsNew.