### PR TITLE
PERF: reduce per-group overhead in groupby.agg with UDFs

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -151,6 +151,7 @@ Performance improvements
 - Performance improvement in :func:`read_sas` for compressed SAS7BDAT files by reusing the decompression buffer instead of allocating per row (:issue:`47339`)
 - Performance improvement in :func:`read_sas` when decoding strings (:issue:`47339`)
 - Performance improvement in :func:`util.hash_pandas_object` for PyArrow-backed string and binary types by using PyArrow's ``dictionary_encode`` instead of converting to NumPy for factorization (:issue:`48964`)
+- Performance improvement in :meth:`.DataFrameGroupBy.agg` and :meth:`.SeriesGroupBy.agg` with user-defined functions (:issue:`46505`)
 - Performance improvement in :meth:`DataFrame.corr` and :meth:`DataFrame.cov` when data contains no NaN values (:issue:`64857`)
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -34,7 +34,7 @@ class ArrowStringArrayMixin:
     def __init__(self, *args, **kwargs) -> None:
         raise NotImplementedError
 
-    def _from_pyarrow_array(self, pa_array) -> Self:
+    def _from_pyarrow_array(self, pa_array: pa.Array | pa.ChunkedArray) -> Self:
         raise NotImplementedError
 
     def _convert_bool_result(self, result, na=lib.no_default, method_name=None):

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -427,8 +427,7 @@ class ArrowExtensionArray(
         Avoids full __init__ overhead by reusing the dtype when the pyarrow
         type is unchanged.
         """
-        if not isinstance(pa_array, (pa.Array, pa.ChunkedArray)):
-            return type(self)(pa_array)
+        assert isinstance(pa_array, (pa.Array, pa.ChunkedArray))
         obj = type(self).__new__(type(self))
         if isinstance(pa_array, pa.Array):
             pa_array = pa.chunked_array([pa_array])
@@ -762,12 +761,9 @@ class ArrowExtensionArray(
                 and item.step < 0
             ):
                 item = slice(item.start, None, item.step)
-            value = self._pa_array[item]
-            if isinstance(value, pa.ChunkedArray):
-                result = self._from_pyarrow_array(value)
-                result._readonly = self._readonly
-                return result
-            return self._box_pa_scalar(value)
+            result = self._from_pyarrow_array(self._pa_array[item])
+            result._readonly = self._readonly
+            return result
 
         item = check_array_indexer(self, item)
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -422,10 +422,22 @@ class ArrowExtensionArray(
 
     def _from_pyarrow_array(self, pa_array):
         """
-        Construct from the pyarrow array result of an operation, for
-        compatibility with ArrowStringArray.
+        Construct from a pyarrow Array/ChunkedArray result of an operation.
+
+        Avoids full __init__ overhead by reusing the dtype when the pyarrow
+        type is unchanged.
         """
-        return type(self)(pa_array)
+        if not isinstance(pa_array, (pa.Array, pa.ChunkedArray)):
+            return type(self)(pa_array)
+        obj = type(self).__new__(type(self))
+        if isinstance(pa_array, pa.Array):
+            pa_array = pa.chunked_array([pa_array])
+        obj._pa_array = pa_array
+        pa_type = pa_array.type
+        obj._dtype = (
+            self._dtype if pa_type == self._dtype.pyarrow_dtype else ArrowDtype(pa_type)
+        )
+        return obj
 
     def _cast_pointwise_result(self, values) -> ArrayLike:
         if len(values) == 0:
@@ -737,6 +749,26 @@ class ArrowExtensionArray(
         For a boolean mask, return an instance of ``ExtensionArray``, filtered
         to the values where ``item`` is True.
         """
+        if isinstance(item, slice):
+            # Fast path for slices: avoid check_array_indexer (no-op for
+            # slices) and getitem_returns_view (always True for slices).
+            # Arrow bug https://github.com/apache/arrow/issues/38768
+            if item.start == item.stop:
+                pass
+            elif (
+                item.stop is not None
+                and item.stop < -len(self)
+                and item.step is not None
+                and item.step < 0
+            ):
+                item = slice(item.start, None, item.step)
+            value = self._pa_array[item]
+            if isinstance(value, pa.ChunkedArray):
+                result = self._from_pyarrow_array(value)
+                result._readonly = self._readonly
+                return result
+            return self._box_pa_scalar(value)
+
         item = check_array_indexer(self, item)
 
         if isinstance(item, np.ndarray):
@@ -778,18 +810,6 @@ class ArrowExtensionArray(
             )
         # We are not an array indexer, so maybe e.g. a slice or integer
         # indexer. We dispatch to pyarrow.
-        if isinstance(item, slice):
-            # Arrow bug https://github.com/apache/arrow/issues/38768
-            if item.start == item.stop:
-                pass
-            elif (
-                item.stop is not None
-                and item.stop < -len(self)
-                and item.step is not None
-                and item.step < 0
-            ):
-                item = slice(item.start, None, item.step)
-
         value = self._pa_array[item]
         if isinstance(value, pa.ChunkedArray):
             result = self._from_pyarrow_array(value)

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -161,10 +161,21 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
 
     def _from_pyarrow_array(self, pa_array):
         """
-        Construct from the pyarrow array result of an operation, retaining
-        self.dtype.na_value.
+        Construct from a pyarrow Array/ChunkedArray result of an operation.
+
+        Avoids full __init__ overhead (type checking, pc.cast, ArrowDtype
+        construction, etc.).
         """
-        return type(self)(pa_array, dtype=self.dtype)
+        if not isinstance(pa_array, (pa.Array, pa.ChunkedArray)):
+            return type(self)(pa_array, dtype=self.dtype)
+        if not pa.types.is_large_string(pa_array.type):
+            pa_array = pa_array.cast(pa.large_string())
+        obj = type(self).__new__(type(self))
+        if isinstance(pa_array, pa.Array):
+            pa_array = pa.chunked_array([pa_array])
+        obj._pa_array = pa_array
+        obj._dtype = self._dtype
+        return obj
 
     def _cast_pointwise_result(self, values) -> ArrayLike:
         if len(values) == 0:

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -166,8 +166,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
         Avoids full __init__ overhead (type checking, pc.cast, ArrowDtype
         construction, etc.).
         """
-        if not isinstance(pa_array, (pa.Array, pa.ChunkedArray)):
-            return type(self)(pa_array, dtype=self.dtype)
+        assert isinstance(pa_array, (pa.Array, pa.ChunkedArray))
         if not pa.types.is_large_string(pa_array.type):
             pa_array = pa_array.cast(pa.large_string())
         obj = type(self).__new__(type(self))

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1265,9 +1265,10 @@ class DataSplitter(Generic[NDFrameT]):
 
         starts, ends = lib.generate_slices(self._slabels, self.ngroups)
         sdata = self._sorted_data
-        # sdata is a fresh object owned by the splitter and its attrs/flags
-        # cannot be mutated through the yielded chunks, so the finalize gate
-        # can be evaluated once outside the loop.
+        # __finalize__ is a no-op for an exact Series/DataFrame with empty
+        # attrs and default flags; skip it in that case. Safe to compute the
+        # gate once because sdata is splitter-owned and its type/attrs/flags
+        # can't be mutated through the yielded chunks.
         needs_finalize = (
             type(sdata) is not self._sorted_cls
             or bool(sdata.attrs)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1281,8 +1281,15 @@ class SeriesSplitter(DataSplitter):
         # fastpath equivalent to `sdata.iloc[slice_obj]`
         mgr = sdata._mgr.get_slice(slice_obj)
         ser = sdata._constructor_from_mgr(mgr, axes=mgr.axes)
-        ser._name = sdata.name
-        return ser.__finalize__(sdata, method="groupby")
+        # Use object.__setattr__ to bypass NDFrame.__setattr__ overhead
+        object.__setattr__(ser, "_name", sdata.name)
+        if (
+            type(sdata) is not Series
+            or sdata.attrs
+            or not sdata._flags._allows_duplicate_labels
+        ):
+            return ser.__finalize__(sdata, method="groupby")
+        return ser
 
 
 class FrameSplitter(DataSplitter):
@@ -1291,4 +1298,10 @@ class FrameSplitter(DataSplitter):
         # return sdata.iloc[slice_obj]
         mgr = sdata._mgr.get_slice(slice_obj, axis=1)
         df = sdata._constructor_from_mgr(mgr, axes=mgr.axes)
-        return df.__finalize__(sdata, method="groupby")
+        if (
+            type(sdata) is not DataFrame
+            or sdata.attrs
+            or not sdata._flags._allows_duplicate_labels
+        ):
+            return df.__finalize__(sdata, method="groupby")
+        return df

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -1265,43 +1265,51 @@ class DataSplitter(Generic[NDFrameT]):
 
         starts, ends = lib.generate_slices(self._slabels, self.ngroups)
         sdata = self._sorted_data
+        # sdata is a fresh object owned by the splitter and its attrs/flags
+        # cannot be mutated through the yielded chunks, so the finalize gate
+        # can be evaluated once outside the loop.
+        needs_finalize = (
+            type(sdata) is not self._sorted_cls
+            or bool(sdata.attrs)
+            or not sdata._flags._allows_duplicate_labels
+        )
         for start, end in zip(starts, ends, strict=True):
-            yield self._chop(sdata, slice(start, end))
+            yield self._chop(sdata, slice(start, end), needs_finalize)
 
     @cache_readonly
     def _sorted_data(self) -> NDFrameT:
         return self.data.take(self._sort_idx, axis=0)
 
-    def _chop(self, sdata, slice_obj: slice) -> NDFrame:
+    _sorted_cls: type[NDFrame]
+
+    def _chop(self, sdata, slice_obj: slice, needs_finalize: bool) -> NDFrame:
         raise AbstractMethodError(self)
 
 
 class SeriesSplitter(DataSplitter):
-    def _chop(self, sdata: Series, slice_obj: slice) -> Series:
+    _sorted_cls = Series
+
+    def _chop(self, sdata: Series, slice_obj: slice, needs_finalize: bool) -> Series:
         # fastpath equivalent to `sdata.iloc[slice_obj]`
         mgr = sdata._mgr.get_slice(slice_obj)
         ser = sdata._constructor_from_mgr(mgr, axes=mgr.axes)
         # Use object.__setattr__ to bypass NDFrame.__setattr__ overhead
         object.__setattr__(ser, "_name", sdata.name)
-        if (
-            type(sdata) is not Series
-            or sdata.attrs
-            or not sdata._flags._allows_duplicate_labels
-        ):
+        if needs_finalize:
             return ser.__finalize__(sdata, method="groupby")
         return ser
 
 
 class FrameSplitter(DataSplitter):
-    def _chop(self, sdata: DataFrame, slice_obj: slice) -> DataFrame:
+    _sorted_cls = DataFrame
+
+    def _chop(
+        self, sdata: DataFrame, slice_obj: slice, needs_finalize: bool
+    ) -> DataFrame:
         # Fastpath equivalent to:
         # return sdata.iloc[slice_obj]
         mgr = sdata._mgr.get_slice(slice_obj, axis=1)
         df = sdata._constructor_from_mgr(mgr, axes=mgr.axes)
-        if (
-            type(sdata) is not DataFrame
-            or sdata.attrs
-            or not sdata._flags._allows_duplicate_labels
-        ):
+        if needs_finalize:
             return df.__finalize__(sdata, method="groupby")
         return df

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -585,7 +585,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
     def _constructor_from_mgr(self, mgr, axes):
         ser = Series._from_mgr(mgr, axes=axes)
-        ser._name = None  # caller is responsible for setting real name
+        # Use object.__setattr__ to bypass NDFrame.__setattr__ overhead.
+        # _name is not set by NDFrame.__init__, so we initialize it here.
+        object.__setattr__(ser, "_name", None)
 
         if type(self) is Series:
             # This would also work `if self._constructor is Series`, but

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -645,6 +645,7 @@ def test_groupby_finalize(obj, method):
     "obj", [pd.Series([0, 0]), pd.DataFrame({"A": [0, 1], "B": [1, 2]})]
 )
 def test_groupby_finalize_duplicate_labels(obj):
+    # GH#46505 ensure allows_duplicate_labels propagates through groupby splitter
     obj = obj.set_flags(allows_duplicate_labels=False)
     result = obj.groupby([0, 0]).sum()
     assert result.flags.allows_duplicate_labels is False

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -644,6 +644,15 @@ def test_groupby_finalize(obj, method):
 @pytest.mark.parametrize(
     "obj", [pd.Series([0, 0]), pd.DataFrame({"A": [0, 1], "B": [1, 2]})]
 )
+def test_groupby_finalize_duplicate_labels(obj):
+    obj = obj.set_flags(allows_duplicate_labels=False)
+    result = obj.groupby([0, 0]).sum()
+    assert result.flags.allows_duplicate_labels is False
+
+
+@pytest.mark.parametrize(
+    "obj", [pd.Series([0, 0]), pd.DataFrame({"A": [0, 1], "B": [1, 2]})]
+)
 @pytest.mark.parametrize(
     "method",
     [


### PR DESCRIPTION
## Summary

Optimizes the hot path for `groupby.agg()` with user-defined functions, where per-group iteration overhead dominates. On the benchmark from #46505 (500k rows, ~half a million groups), this gives a ~1.7x speedup (~7.4s → ~4.4s, measured against current `main`).

- **`_from_pyarrow_array`**: bypass full `__init__` validation (ArrowDtype/StringDtype construction, HAS_PYARROW checks, type validation) and reuse the dtype when the pyarrow type is unchanged
- **`ArrowExtensionArray.__getitem__`**: add a fast path for slices, avoiding `check_array_indexer` (no-op for slices) and `getitem_returns_view` (always True for slices)
- **`SeriesSplitter._chop` / `FrameSplitter._chop`**: skip `__finalize__` for non-subclass Series/DataFrame with empty attrs and default flags, where it's a no-op. The gate is evaluated once in `DataSplitter.__iter__` rather than per-group, since `sdata` is a fresh splitter-owned object whose attrs/flags can't be mutated through the yielded chunks
- **`Series._constructor_from_mgr` / `SeriesSplitter._chop`**: use `object.__setattr__` for `_name` to bypass `NDFrame.__setattr__` try/except overhead

closes #46505

## Test plan

- [x] All groupby tests pass (25k tests)
- [x] All arrow + string extension tests pass (29k tests)
- [x] Series constructor tests pass
- [x] Previously-caught regressions verified (struct dtype change, loc setitem with expansion)
- [x] Added `test_groupby_finalize_duplicate_labels` to cover the `allows_duplicate_labels` path through `_chop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)