### PR TITLE
TYP: fix mypy errors in get_values_for_csv

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -140,6 +140,7 @@ from pandas.core.arrays import (
     Categorical,
     DatetimeArray,
     ExtensionArray,
+    PeriodArray,
     TimedeltaArray,
 )
 from pandas.core.arrays.floating import FloatingDtype
@@ -216,10 +217,7 @@ if TYPE_CHECKING:
         MultiIndex,
         Series,
     )
-    from pandas.core.arrays import (
-        IntervalArray,
-        PeriodArray,
-    )
+    from pandas.core.arrays import IntervalArray
 
 __all__ = ["Index"]
 
@@ -8388,9 +8386,7 @@ def get_values_for_csv(
 
     values = ensure_wrapped_if_datetimelike(values)  # type: ignore[no-untyped-call]
 
-    if isinstance(values, (DatetimeArray, TimedeltaArray)) or isinstance(
-        values.dtype, PeriodDtype
-    ):
+    if isinstance(values, (DatetimeArray, TimedeltaArray, PeriodArray)):
         if values.ndim == 1:
             result = values._format_native_types(na_rep=na_rep, date_format=date_format)
             result = result.astype(object, copy=False)


### PR DESCRIPTION
## Summary
- Fix mypy errors introduced in #65198 by importing `PeriodArray` at runtime and using `isinstance(values, (DatetimeArray, TimedeltaArray, PeriodArray))` instead of checking `values.dtype`, allowing mypy to narrow the type properly.

## Test plan
- [x] `mypy pandas` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)