### PR TITLE
BLD: remove deprecated option cpython-freethreading

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -97,7 +97,7 @@ jobs:
           - [macos-15, macosx_arm64]
           - [windows-2025, win_amd64]
           - [windows-11-arm, win_arm64]
-        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "3.14"], ["cp314t", "3.14"]]
+        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp314", "3.14"], ["cp314t", "3.14"]]
         include:
           - buildplat: [ubuntu-24.04, pyodide_wasm32]
             python: ["cp312", "3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,6 @@ test-command = """
   pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db", "--numprocesses=2", "--dist=worksteal", "--no-strict-data-files"]); \
   pd.test(extra_args=["-m not clipboard and single_cpu and not slow and not network and not db", "--no-strict-data-files"]);' \
   """
-enable = ["cpython-freethreading"]
 
 [tool.cibuildwheel.windows]
 environment = {}


### PR DESCRIPTION
The option `cpython-freethreading` for `cibuildwheel` is [deprecated in version 3.4.1](https://cibuildwheel.pypa.io/en/stable/changelog/#v341) and, by extension, building wheels for CPython 3.13 with free-threading.