### PR TITLE
BUG: DataFrame.duplicated() loses index when DataFrame has no columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -244,6 +244,7 @@ Indexing
 - Bug in :meth:`Index.get_indexer` where ``method="pad"``, ``"backfill"``, or ``"nearest"`` returned incorrect results when the target contained ``NaT`` or ``NaN`` instead of ``-1`` (:issue:`32572`)
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
 - Bug in :meth:`DataFrame.__getitem__` raising ``InvalidIndexError`` when indexing with a tuple containing a ``slice`` on a :class:`DataFrame` with :class:`MultiIndex` columns (e.g., ``df[:, "t1"]``) (:issue:`26511`)
+- Bug in :meth:`DataFrame.duplicated` returning an empty :class:`Series` without the DataFrame's index when the DataFrame had no columns (:issue:`61191`)
 - Bug in :meth:`DataFrame.iloc` setitem raising ``AttributeError`` when assigning a :class:`Series` or :class:`Index` with a nullable EA dtype (e.g. ``Int64``, ``Float64``, ``boolean``) into a column with a NumPy dtype (:issue:`47776`)
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` where incorrect values were produced when ``other`` was a :class:`Series` with :class:`ExtensionArray` values (:issue:`64635`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7969,7 +7969,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
 
         if self.empty:
-            return self._constructor_sliced(dtype=bool)
+            return self._constructor_sliced(False, dtype=bool, index=self.index)
 
         def f(vals) -> tuple[np.ndarray, int]:
             labels, shape = algorithms.factorize(vals, size_hint=len(self))

--- a/pandas/tests/frame/methods/test_duplicated.py
+++ b/pandas/tests/frame/methods/test_duplicated.py
@@ -105,6 +105,19 @@ def test_duplicated_on_empty_frame():
     tm.assert_frame_equal(result, expected)
 
 
+def test_duplicated_on_empty_frame_with_index():
+    # GH#61191
+    df = DataFrame(index=[0, 1])
+    result = df.duplicated()
+    expected = Series(False, dtype=bool, index=df.index)
+    tm.assert_series_equal(result, expected)
+
+    # Boolean indexing with the result should work
+    result = df[df.duplicated()]
+    expected = df.iloc[:0]
+    tm.assert_frame_equal(result, expected)
+
+
 def test_frame_datetime64_duplicated():
     dates = date_range("2010-07-01", end="2010-08-05")
 


### PR DESCRIPTION
## Summary
- Fix `DataFrame.duplicated()` to preserve the DataFrame's index when the DataFrame has no columns (i.e. `self.empty` is True but `self.index` is non-empty)
- Previously, `duplicated()` returned `Series(dtype=bool)` with an empty index, causing `IndexingError` when used as a boolean indexer (e.g. `df[df.duplicated()]`)

closes #61191

## Test plan
- Added `test_duplicated_on_empty_frame_with_index` covering both the `duplicated()` return value and the boolean indexing round-trip
- Existing `test_duplicated_on_empty_frame` (GH#25184) continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)