### PR TITLE
BUG: DataFrame.at raises TypeError with partial date string on MultiIndex

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -261,6 +261,7 @@ Indexing
 - Bug in :meth:`Index.get_indexer` where ``method="pad"``, ``"backfill"``, or ``"nearest"`` returned incorrect results when the target contained ``NaT`` or ``NaN`` instead of ``-1`` (:issue:`32572`)
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
 - Bug in :meth:`DataFrame.__getitem__` raising ``InvalidIndexError`` when indexing with a tuple containing a ``slice`` on a :class:`DataFrame` with :class:`MultiIndex` columns (e.g., ``df[:, "t1"]``) (:issue:`26511`)
+- Bug in :meth:`DataFrame.at` raising ``TypeError`` when accessing a :class:`MultiIndex` with a partial date string on a :class:`DatetimeIndex` level (:issue:`43395`)
 - Bug in :meth:`DataFrame.duplicated` returning an empty :class:`Series` without the DataFrame's index when the DataFrame had no columns (:issue:`61191`)
 - Bug in :meth:`DataFrame.iloc` setitem raising ``AttributeError`` when assigning a :class:`Series` or :class:`Index` with a nullable EA dtype (e.g. ``Int64``, ``Float64``, ``boolean``) into a column with a NumPy dtype (:issue:`47776`)
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` where incorrect values were produced when ``other`` was a :class:`Series` with :class:`ExtensionArray` values (:issue:`64635`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4402,7 +4402,12 @@ class DataFrame(NDFrame, OpsMixin):
 
         # For MultiIndex going through engine effectively restricts us to
         #  same-length tuples; see test_get_set_value_no_partial_indexing
-        loc = self.index._engine.get_loc(index)
+        try:
+            loc = self.index._engine.get_loc(index)
+        except TypeError:
+            # e.g. partial string slicing on DatetimeIndex level;
+            #  see GH#43395
+            loc = self.index.get_loc(index)
         return series._values[loc]
 
     def isetitem(self, loc, value) -> None:

--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -39,6 +39,41 @@ def test_at_dateoffset_columns():
     assert df.at[0, offsets[0]] == 1
 
 
+def test_at_multiindex_partial_date_string():
+    # GH#43395 - .at with partial date string on MultiIndex with DatetimeIndex level
+    timestamps = DatetimeIndex(
+        ["2021-08-01", "2021-08-01 12:00", "2021-08-02", "2021-08-02 12:00"]
+    )
+    index = MultiIndex.from_product(
+        [["A", "B"], timestamps], names=["ticker", "timestamp"]
+    )
+    df = DataFrame({"col": range(len(index))}, index=index)
+
+    # DataFrame.at with partial date string should not raise TypeError
+    result = df.at[("A", "2021-08-02"), "col"]
+    expected = np.array([2, 3], dtype=np.int64)
+    tm.assert_numpy_array_equal(result, expected)
+
+    # Series.at with partial date string
+    ser = df["col"]
+    result = ser.at[("A", "2021-08-02")]
+    expected = Series(
+        [2, 3],
+        index=MultiIndex.from_arrays(
+            [
+                ["A", "A"],
+                DatetimeIndex(
+                    ["2021-08-02", "2021-08-02 12:00"],
+                    dtype="datetime64[us]",
+                ),
+            ],
+            names=["ticker", "timestamp"],
+        ),
+        name="col",
+    )
+    tm.assert_series_equal(result, expected)
+
+
 def test_at_timezone():
     # https://github.com/pandas-dev/pandas/issues/33544
     result = DataFrame({"foo": [datetime(2000, 1, 1)]})


### PR DESCRIPTION
## Summary
- Fixed `DataFrame.at` raising `TypeError: unsupported operand type(s) for +: 'slice' and 'int'` when accessing a `MultiIndex` with a partial date string on a `DatetimeIndex` level (e.g. `df.at[("AMZN", "2021-08-02"), "col"]`)
- The engine fastpath in `DataFrame._get_value` assumed `level.get_loc()` always returns an integer, but `DatetimeIndex.get_loc` returns a `slice` for partial date strings. Added a `TypeError` fallback to `MultiIndex.get_loc`, consistent with how `MultiIndex.get_loc` itself handles this case.

closes #43395

## Test plan
- [x] Added test for `DataFrame.at` with partial date string on MultiIndex
- [x] Added test for `Series.at` with partial date string on MultiIndex
- [x] Existing `.at` and MultiIndex indexing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)