### PR TITLE
TST: add test for .at with incompatible Decimal type

### DIFF
--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -2,6 +2,7 @@ from datetime import (
     datetime,
     timezone,
 )
+from decimal import Decimal
 
 import numpy as np
 import pytest
@@ -72,6 +73,13 @@ def test_at_multiindex_partial_date_string():
         name="col",
     )
     tm.assert_series_equal(result, expected)
+
+
+def test_at_incompatible_type_decimal():
+    # GH#22740 - .at should not silently discard incompatible type
+    df = DataFrame({"A": [1, 2, 3]})
+    with pytest.raises(TypeError, match="Invalid value"):
+        df.at[0, "A"] = Decimal("1")
 
 
 def test_at_timezone():


### PR DESCRIPTION
## Summary
- Adds a test for GH#22740, where `.at` silently discarded incompatible types (e.g. `Decimal` into an int64 column)
- This was fixed as a side effect of PR #49772 (`.at` now falls back to `.loc`) and PR #59007 (PDEP-6 enforcement raises `TypeError` on upcast)
- The test verifies that `df.at[0, "A"] = Decimal("1")` raises `TypeError` on an int64 column

closes #22740

🤖 Generated with [Claude Code](https://claude.com/claude-code)