### PR TITLE
CI: set PKG_CONFIG_PATH to fix broken system Python headers

### DIFF
--- a/.github/actions/build_pandas/action.yml
+++ b/.github/actions/build_pandas/action.yml
@@ -27,6 +27,9 @@ runs:
 
     - name: Build Pandas
       run: |
+        # Ensure meson/pkg-config finds conda's Python headers, not the
+        # system Python headers which may be broken (GH#65226).
+        export PKG_CONFIG_PATH="$CONDA_PREFIX/lib/pkgconfig"
         if [[ ${{ inputs.editable }} == "true" ]]; then
           pip install -e . --no-build-isolation -v --no-deps \
             ${{ inputs.werror == 'true' && '-Csetup-args="--werror"' || '' }}


### PR DESCRIPTION
## Summary
- The `ubuntu-24.04` runner image updated on 2026-04-14 (`ubuntu24/20260413.86`) has broken system Python 3.12 headers — the multiarch `pyconfig.h` is missing, causing the meson Cython sanity check to fail with `Compiler cython cannot compile programs`
- This breaks **Doc Build** and **Code Checks** on every PR (evidence: #65212, #65224, #65225)
- Fix: set `PKG_CONFIG_PATH` to the conda prefix so meson finds conda's Python 3.11 headers instead of the broken system ones

## Root cause
The CI conda env uses Python 3.11, but `PKG_CONFIG_PATH` was empty, so `pkg-config` fell back to system Python 3.12. The latest runner image has `/usr/include/python3.12/pyconfig.h` referencing a multiarch header (`x86_64-linux-gnu/python3.12/pyconfig.h`) that doesn't exist.

closes #65226

## Test plan
- [x] CI Doc Build and Code Checks jobs pass on this PR (they've been failing on every PR since the image update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)