### PR TITLE
BUG: MultiIndex.loc raises KeyError for string keys on numeric levels

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -263,6 +263,7 @@ Indexing
 - Bug in :meth:`DataFrame.__getitem__` raising ``InvalidIndexError`` when indexing with a tuple containing a ``slice`` on a :class:`DataFrame` with :class:`MultiIndex` columns (e.g., ``df[:, "t1"]``) (:issue:`26511`)
 - Bug in :meth:`DataFrame.duplicated` returning an empty :class:`Series` without the DataFrame's index when the DataFrame had no columns (:issue:`61191`)
 - Bug in :meth:`DataFrame.iloc` setitem raising ``AttributeError`` when assigning a :class:`Series` or :class:`Index` with a nullable EA dtype (e.g. ``Int64``, ``Float64``, ``boolean``) into a column with a NumPy dtype (:issue:`47776`)
+- Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` returning wrong results instead of raising ``KeyError`` when passing string keys for numeric index levels (:issue:`60104`)
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` where incorrect values were produced when ``other`` was a :class:`Series` with :class:`ExtensionArray` values (:issue:`64635`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
 - Bug in :meth:`DataFrame.xs` where ``drop_level=False`` was ignored for fully specified :class:`MultiIndex` keys when ``level`` was not explicitly provided (:issue:`6507`)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -53,6 +53,7 @@ from pandas.core.dtypes.common import (
     is_integer,
     is_iterator,
     is_list_like,
+    is_numeric_dtype,
     is_object_dtype,
     is_scalar,
     is_string_dtype,
@@ -3516,6 +3517,10 @@ class MultiIndex(Index):
             loc: npt.NDArray[np.intp] | np.intp | int
             if lab not in lev and not isna(lab):
                 # short circuit
+                if isinstance(lab, str) and is_numeric_dtype(lev.dtype):
+                    # GH#60104 - numpy searchsorted gives wrong results for
+                    # string vs numeric comparisons; raise early
+                    raise TypeError(f"Level type mismatch: {lab}")
                 try:
                     loc = algos.searchsorted(lev, lab, side=side)
                 except TypeError as err:

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -777,6 +777,25 @@ class TestGetLoc:
         with pytest.raises(KeyError, match=re.escape(str(key))):
             mi.get_loc(key)
 
+    def test_get_loc_string_key_on_numeric_level(self):
+        # GH#60104 - string key on integer level should raise KeyError,
+        # not return wrong results due to numpy searchsorted cross-dtype bug
+        mi = MultiIndex.from_product([[2000, 2001], ["a", "b"], ["x", "y"]])
+        df = DataFrame({"value": range(8)}, index=mi)
+
+        with pytest.raises(KeyError, match="2000"):
+            df.loc[("2000",)]
+        with pytest.raises(KeyError, match="a"):
+            df.loc[("2000", "a")]
+        with pytest.raises(KeyError, match="GIBBERISH"):
+            df.loc[("2000", "GIBBERISH")]
+
+        # Valid lookups should still work
+        result = df.loc[(2000, "a")]
+        assert len(result) == 2
+        result = df.loc[(2000,)]
+        assert len(result) == 4
+
 
 class TestWhere:
     def test_where(self):


### PR DESCRIPTION
## Summary
- Fixes `.loc` on a MultiIndex silently returning wrong results when string keys are passed for numeric (int/float/bool) index levels
- Root cause: `numpy.searchsorted` gives wrong results for cross-dtype comparisons (numpy/numpy#24032); added an early type check in `MultiIndex._partial_tup_index` before the `searchsorted` call

closes #60104

## Test plan
- [x] Added test `test_get_loc_string_key_on_numeric_level` verifying `KeyError` is raised for string keys on int levels
- [x] Verified valid lookups with correct types still work
- [x] Verified datetime partial string indexing is unaffected
- [x] All existing MultiIndex indexing tests pass (147 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)