### PR TITLE
TST: add tests for .loc setitem with non-unique string index

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -377,6 +377,32 @@ class TestLocBaseIndependent:
         result = df.loc[1]
         tm.assert_series_equal(result, expected)
 
+    def test_loc_setitem_nonunique_string_index(self):
+        # GH#22500 - .loc setitem with non-unique string index should behave
+        # consistently with non-unique numeric index
+        df = DataFrame({"val": 1.0}, index=Index(["a", "b", "a"], name="idx"))
+        df_10 = df.copy()
+        df_10["val"] = 10.0
+
+        expected = df.copy()
+        expected.loc["a", "val"] = 10.0
+
+        # scalar string key
+        result = df.copy()
+        result.loc["a", "val"] = df_10.loc["a", "val"]
+        tm.assert_frame_equal(result, expected)
+
+        # single-element tuple
+        result = df.copy()
+        result.loc[("a",), "val"] = df_10.loc[("a",), "val"]
+        tm.assert_frame_equal(result, expected)
+
+        # boolean mask cross-assignment
+        result = df.copy()
+        mask = result.index == "a"
+        result.loc[mask, "val"] = df_10.loc[mask, "val"]
+        tm.assert_frame_equal(result, expected)
+
     def test_loc_setitem_dups(self):
         # GH 6541
         df_orig = DataFrame(
@@ -1849,6 +1875,23 @@ class TestLocWithMultiIndex:
         expected = Series([1, 1, 100, 100, 100, 100, 1, 1], index=index)
 
         tm.assert_series_equal(result, expected)
+
+    def test_loc_setitem_multiindex_boolean_mask(self):
+        # GH#22500 - boolean mask assignment with MultiIndex
+        midx = MultiIndex.from_tuples(
+            [(1, "a"), (1, "b"), (2, "a"), (2, "b")], names=["num", "let"]
+        )
+        df = DataFrame({"val": 1.0}, index=midx)
+        df_10 = df.copy()
+        df_10["val"] = 10.0
+
+        expected = df.copy()
+        expected.loc[(1, "a"), "val"] = 10.0
+
+        result = df.copy()
+        mask = result.index == (1, "a")
+        result.loc[mask, "val"] = df_10.loc[mask, "val"]
+        tm.assert_frame_equal(result, expected)
 
     def test_loc_getitem_slice_datetime_objs_with_datetimeindex(self):
         times = date_range("2000-01-01", freq="10min", periods=100000)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -380,12 +380,10 @@ class TestLocBaseIndependent:
     def test_loc_setitem_nonunique_string_index(self):
         # GH#22500 - .loc setitem with non-unique string index should behave
         # consistently with non-unique numeric index
-        df = DataFrame({"val": 1.0}, index=Index(["a", "b", "a"], name="idx"))
-        df_10 = df.copy()
-        df_10["val"] = 10.0
-
-        expected = df.copy()
-        expected.loc["a", "val"] = 10.0
+        idx = Index(["a", "b", "a"], name="idx")
+        df = DataFrame({"val": 1.0}, index=idx)
+        df_10 = DataFrame({"val": 10.0}, index=idx)
+        expected = DataFrame({"val": [10.0, 1.0, 10.0]}, index=idx)
 
         # scalar string key
         result = df.copy()
@@ -1882,11 +1880,8 @@ class TestLocWithMultiIndex:
             [(1, "a"), (1, "b"), (2, "a"), (2, "b")], names=["num", "let"]
         )
         df = DataFrame({"val": 1.0}, index=midx)
-        df_10 = df.copy()
-        df_10["val"] = 10.0
-
-        expected = df.copy()
-        expected.loc[(1, "a"), "val"] = 10.0
+        df_10 = DataFrame({"val": 10.0}, index=midx)
+        expected = DataFrame({"val": [10.0, 1.0, 1.0, 1.0]}, index=midx)
 
         result = df.copy()
         mask = result.index == (1, "a")


### PR DESCRIPTION
## Summary
- Add tests for GH#22500 which reported inconsistent `.loc` setitem behavior with non-unique string indexes vs numeric indexes
- The bugs are already fixed; this adds regression tests covering:
  - Scalar string key, single-element tuple, and boolean mask assignment on a non-unique string `Index`
  - Boolean mask assignment on a `MultiIndex`

closes #22500

## Test plan
- [x] `pytest pandas/tests/indexing/test_loc.py::TestLocBaseIndependent::test_loc_setitem_nonunique_string_index` passes
- [x] `pytest pandas/tests/indexing/test_loc.py::TestLocWithMultiIndex::test_loc_setitem_multiindex_boolean_mask` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)