### PR TITLE
REF: stop DatetimeArray/TimedeltaArray methods from reading self.freq

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1865,8 +1865,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
     def _maybe_pin_freq(self, freq, validate_kwds: dict) -> None:
         """
         Constructor helper to pin the appropriate `freq` attribute.  Assumes
-        that self._freq is currently set to any freq inferred in
-        _from_sequence_not_strict.
+        that self._freq is currently set to any freq inferred from input data.
         """
         if freq is None:
             # user explicitly passed None -> override any inferred_freq
@@ -2466,14 +2465,14 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         if freq is None:
             # Always valid
             pass
-        elif len(self) == 0 and isinstance(freq, BaseOffset):
-            # Always valid.  In the TimedeltaArray case, we require a Tick offset
+        elif isinstance(freq, BaseOffset):
+            # In the TimedeltaArray case, we require a Tick offset
             if self.dtype.kind == "m" and not isinstance(freq, (Tick, Day)):
                 raise TypeError("TimedeltaArray/Index freq must be a Tick")
-        else:
-            # As an internal method, we can ensure this assertion always holds
-            assert freq == "infer"
+        elif freq == "infer":
             freq = to_offset(self.inferred_freq)
+        else:
+            raise ValueError(f"Invalid frequency: {freq!r}")
 
         arr = self.view()
         arr._freq = freq

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1520,19 +1520,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     def __iadd__(self, other) -> Self:
         result = self + other
         self[:] = result[:]
-
-        if not isinstance(self.dtype, PeriodDtype):
-            # restore freq, which is invalidated by setitem
-            self._freq = result.freq
         return self
 
     def __isub__(self, other) -> Self:
         result = self - other
         self[:] = result[:]
-
-        if not isinstance(self.dtype, PeriodDtype):
-            # restore freq, which is invalidated by setitem
-            self._freq = result.freq
         return self
 
     # --------------------------------------------------------------
@@ -2067,12 +2059,9 @@ class TimelikeOps(DatetimeLikeArrayMixin):
             tz = cast("DatetimeArray", self).tz
             new_dtype = DatetimeTZDtype(tz=tz, unit=unit)
 
-        # error: Unexpected keyword argument "freq" for "_simple_new" of
-        # "NDArrayBacked"  [call-arg]
         return type(self)._simple_new(
             new_values,
             dtype=new_dtype,
-            freq=self.freq,  # type: ignore[call-arg]
         )
 
     # TODO: annotate other as DatetimeArray | TimedeltaArray | Timestamp | Timedelta

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -332,7 +332,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         dtype=None,
         copy: bool = False,
         tz=lib.no_default,
-        freq: str | BaseOffset | lib.NoDefault | None = lib.no_default,
         dayfirst: bool = False,
         yearfirst: bool = False,
         ambiguous: TimeAmbiguous = "raise",
@@ -360,9 +359,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         data, copy = dtl.ensure_arraylike_for_datetimelike(
             data, copy, cls_name="DatetimeArray"
         )
-        inferred_freq = None
-        if isinstance(data, DatetimeArray):
-            inferred_freq = data.freq
 
         subarr, tz = _sequence_to_dt64(
             data,
@@ -384,7 +380,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         data_unit = np.datetime_data(subarr.dtype)[0]
         data_unit = cast("TimeUnit", data_unit)
         data_dtype = tz_to_dtype(tz, data_unit)
-        result = cls._simple_new(subarr, freq=inferred_freq, dtype=data_dtype)
+        result = cls._simple_new(subarr, dtype=data_dtype)
         if unit is not None and unit != result.unit:
             # If unit was specified in user-passed dtype, cast to it here
             # error: Argument 1 to "as_unit" of "TimelikeOps" has
@@ -392,8 +388,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             # [arg-type]
             result = result.as_unit(unit)  # type: ignore[arg-type]
 
-        validate_kwds = {"ambiguous": ambiguous}
-        result._maybe_pin_freq(freq, validate_kwds)
         return result
 
     @classmethod

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -721,7 +721,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
                 # tzaware unit conversion e.g. datetime64[s, UTC]
                 np_dtype = np.dtype(dtype.str)
                 res_values = astype_overflowsafe(self._ndarray, np_dtype, copy=copy)
-                return type(self)._simple_new(res_values, dtype=dtype, freq=self.freq)
+                return type(self)._simple_new(res_values, dtype=dtype)
 
         elif (
             self.tz is None
@@ -815,7 +815,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             result = type(self)._simple_new(res_values, dtype=self.dtype)
             if offset.normalize:
                 result = result.normalize()
-                result._freq = None
             return result
 
         if self.tz is not None:
@@ -850,7 +849,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             result = type(self)._simple_new(res_values, dtype=res_values.dtype)
             if offset.normalize:
                 result = result.normalize()
-                result._freq = None
 
             if self.tz is not None:
                 result = result.tz_localize(self.tz)
@@ -1273,10 +1271,6 @@ default 'raise'
 
         if freq is None:
             freq = self.freqstr or self.inferred_freq
-            if isinstance(self.freq, BaseOffset) and hasattr(
-                self.freq, "_period_dtype_code"
-            ):
-                freq = PeriodDtype(self.freq)._freqstr
 
             if freq is None:
                 raise ValueError(

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -347,9 +347,7 @@ class TimedeltaArray(dtl.TimelikeOps):
             if is_supported_dtype(dtype):
                 # unit conversion e.g. timedelta64[s]
                 res_values = astype_overflowsafe(self._ndarray, dtype, copy=False)
-                return type(self)._simple_new(
-                    res_values, dtype=res_values.dtype, freq=self.freq
-                )
+                return type(self)._simple_new(res_values, dtype=res_values.dtype)
             else:
                 raise ValueError(
                     f"Cannot convert from {self.dtype} to {dtype}. "

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -849,6 +849,19 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         return result
 
     def _with_freq(self, freq):
+        # GH#29843
+        if freq is None:
+            # Always valid
+            pass
+        elif len(self) == 0 and isinstance(freq, BaseOffset):
+            # Always valid.  In the TimedeltaArray case, we require a Tick offset
+            if self.dtype.kind == "m" and not isinstance(freq, (Tick, Day)):
+                raise TypeError("TimedeltaArray/Index freq must be a Tick")
+        else:
+            # As an internal method, we can ensure this assertion always holds
+            assert freq == "infer"
+            freq = to_offset(self.inferred_freq)
+
         arr = self._data._with_freq(freq)
         return type(self)._simple_new(arr, name=self._name)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -675,6 +675,13 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
     _is_monotonic_decreasing = Index.is_monotonic_decreasing
     _is_unique = Index.is_unique
 
+    def astype(self, dtype, copy: bool = True):
+        result = super().astype(dtype, copy=copy)
+        if isinstance(result, type(self)):
+            # Preserve freq for unit conversions (e.g. datetime64[ns] -> [us])
+            result._data._freq = self.freq
+        return result
+
     def _get_arithmetic_result_freq(self, other) -> BaseOffset | None:
         """
         Check if we can preserve self.freq in addition or subtraction.
@@ -837,7 +844,9 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         TimedeltaIndex(['1 days 00:03:00'], dtype='timedelta64[s]', freq=None)
         """
         arr = self._data.as_unit(unit)
-        return type(self)._simple_new(arr, name=self.name)
+        result = type(self)._simple_new(arr, name=self.name)
+        result._data._freq = self.freq
+        return result
 
     def _with_freq(self, freq):
         arr = self._data._with_freq(freq)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -901,16 +901,29 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 data = data.copy()
             return cls._simple_new(data, name=name)
 
+        # Extract freq from incoming data before array conversion strips it
+        inferred_freq = None
+        if isinstance(data, DatetimeArray):
+            inferred_freq = data.freq
+        elif isinstance(data, (Index, ABCSeries)):
+            values = data._values
+            if isinstance(values, DatetimeArray):
+                inferred_freq = values.freq
+
         dtarr = DatetimeArray._from_sequence_not_strict(
             data,
             dtype=dtype,
             copy=copy,
             tz=tz,
-            freq=freq,
             dayfirst=dayfirst,
             yearfirst=yearfirst,
             ambiguous=ambiguous,
         )
+
+        if inferred_freq is not None:
+            dtarr._freq = inferred_freq
+        dtarr._maybe_pin_freq(freq, {"ambiguous": ambiguous})
+
         refs = None
         if not copy and isinstance(data, (Index, ABCSeries)):
             refs = data._references

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -117,7 +117,14 @@ def _new_DatetimeIndex(cls, d):
         method
         for method in DatetimeArray._datetimelike_methods
         if method
-        not in ("tz_localize", "tz_convert", "normalize", "to_period", "strftime")
+        not in (
+            "tz_localize",
+            "tz_convert",
+            "normalize",
+            "to_period",
+            "strftime",
+            "as_unit",
+        )
     ],
     DatetimeArray,
     wrap=True,
@@ -783,10 +790,13 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         from pandas.tseries.frequencies import get_period_alias
 
         if freq is None:
-            dt_freq = self._data.freq
+            dt_freq = self.freq
             freq = self.freqstr
             if dt_freq is not None and hasattr(dt_freq, "_period_dtype_code"):
                 freq = PeriodDtype(dt_freq)._freqstr
+
+            if freq is None:
+                freq = self.inferred_freq
 
             if freq is not None:
                 res = get_period_alias(freq)

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -145,8 +145,9 @@ class TestTimedeltaIndex:
         tm.assert_index_equal(res, expected)
 
         # check this matches Series and TimedeltaArray
+        # freq is not preserved at the array level; Index handles freq
         res = tdi._data.astype("m8[s]")
-        tm.assert_equal(res, expected._values)
+        tm.assert_equal(res, expected._values._with_freq(None))
 
         res = tdi.to_series().astype("m8[s]")
         tm.assert_equal(res._values, expected._values._with_freq(None))


### PR DESCRIPTION
## Summary
- Stop `DTA/TDA.astype` and `as_unit` from passing `freq=self.freq`; preserve freq at the Index level instead
- Move BaseOffset-specific freq resolution from `DTA.to_period` to `DTI.to_period`
- Remove no-op `result._freq = None` writes from `DTA._add_offset`
- Remove `__iadd__`/`__isub__` freq restoration (already no-op after #65184)
- Remove `freq` parameter from `DTA._from_sequence_not_strict`; `DTI.__new__` now extracts freq from incoming data and calls `_maybe_pin_freq` externally (following #65162 pattern for TDA)
- Move `_with_freq` freq-resolution logic to `DatetimeTimedeltaMixin._with_freq`

Part of #24566.

## Test plan
- [x] `pandas/tests/indexes/datetimes/` (3243 passed)
- [x] `pandas/tests/indexes/timedeltas/` (239 passed)
- [x] `pandas/tests/indexes/period/` (466 passed)
- [x] `pandas/tests/arrays/test_datetimelike.py` (9970 passed)
- [x] `pandas/tests/resample/` (4103 passed)
- [x] `pandas/tests/arithmetic/test_datetime64.py` + `test_timedelta64.py` (15259 passed)
- [x] mypy, pyright, doctests clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)