### PR TITLE
BUG: MultiIndex.get_loc returns scalar for unique key in non-unique index

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -280,8 +280,8 @@ Indexing
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)
 - Bug in :meth:`Index.get_loc` raising ``KeyError`` when looking up a tuple in an object-dtype :class:`Index` with duplicates (:issue:`37800`)
 - Bug in :meth:`Index.insert` silently casting booleans to numeric when used with nullable numeric dtypes like ``Float64`` or ``Int64`` (:issue:`61709`)
-- Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
 - Bug in :meth:`MultiIndex.get_loc` returning a slice instead of an integer for a unique key when the :class:`MultiIndex` contained duplicates elsewhere, causing ``.loc`` to return a :class:`Series` instead of a scalar (:issue:`42102`)
+- Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
 - Fixed segfault in :meth:`DataFrame.loc` when repeatedly adding new rows to an object-dtype-indexed :class:`DataFrame` (:issue:`21968`)
 -
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -281,6 +281,7 @@ Indexing
 - Bug in :meth:`Index.get_loc` raising ``KeyError`` when looking up a tuple in an object-dtype :class:`Index` with duplicates (:issue:`37800`)
 - Bug in :meth:`Index.insert` silently casting booleans to numeric when used with nullable numeric dtypes like ``Float64`` or ``Int64`` (:issue:`61709`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
+- Bug in :meth:`MultiIndex.get_loc` returning a slice instead of an integer for a unique key when the :class:`MultiIndex` contained duplicates elsewhere, causing ``.loc`` to return a :class:`Series` instead of a scalar (:issue:`42102`)
 - Fixed segfault in :meth:`DataFrame.loc` when repeatedly adding new rows to an object-dtype-indexed :class:`DataFrame` (:issue:`21968`)
 -
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3653,7 +3653,7 @@ class MultiIndex(Index):
                 f"Key length ({keylen}) exceeds index depth ({self.nlevels})"
             )
 
-        if keylen == self.nlevels and self.is_unique:
+        if keylen == self.nlevels:
             # TODO: what if we have an IntervalIndex level?
             #  i.e. do we need _index_as_unique on that level?
             try:
@@ -3667,7 +3667,7 @@ class MultiIndex(Index):
                 loc, _ = self.get_loc_level(key, range(self.nlevels))
                 return loc
 
-        # -- partial selection or non-unique index
+        # -- partial selection
         # break the key into 2 parts based on the lexsort_depth of the index;
         # the first part returns a continuous slice of the index; the 2nd part
         # needs linear search within the slice
@@ -3841,10 +3841,10 @@ class MultiIndex(Index):
                 pass
 
             if not any(isinstance(k, slice) for k in key):
-                if len(key) == self.nlevels and self.is_unique:
-                    # Complete key in unique index -> standard get_loc
+                if len(key) == self.nlevels:
+                    # Complete key -> standard get_loc
                     try:
-                        return (self._engine.get_loc(key), None)
+                        loc = self._engine.get_loc(key)
                     except KeyError as err:
                         raise KeyError(key) from err
                     except (TypeError, ValueError):
@@ -3853,7 +3853,10 @@ class MultiIndex(Index):
                         # ValueError: e.g. IntervalIndex level where the
                         #  engine can't convert scalar to interval code
                         #  (GH#27456)
-                        pass
+                        loc = None
+
+                    if is_integer(loc):
+                        return loc, None
 
                 # partial selection
                 indexer = self.get_loc(key)

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -132,7 +132,7 @@ def test_unsortedindex():
         df.loc(axis=0)["q", :]
 
 
-def test_unsortedindex_doc_examples(performance_warning):
+def test_unsortedindex_doc_examples():
     # https://pandas.pydata.org/pandas-docs/stable/advanced.html#sorting-a-multiindex
     dfm = DataFrame(
         {
@@ -143,8 +143,8 @@ def test_unsortedindex_doc_examples(performance_warning):
     )
 
     dfm = dfm.set_index(["jim", "joe"])
-    with tm.assert_produces_warning(performance_warning):
-        dfm.loc[(1, "z")]
+    # Full-length key uses the engine directly; no PerformanceWarning
+    dfm.loc[(1, "z")]
 
     msg = r"Key length \(2\) was greater than MultiIndex lexsort depth \(1\)"
     with pytest.raises(UnsortedIndexError, match=msg):

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -352,14 +352,12 @@ def dataframe_with_duplicate_index():
     "indexer", [lambda df: df[("A", "A1")], lambda df: df.loc[:, ("A", "A1")]]
 )
 def test_frame_mi_access(dataframe_with_duplicate_index, indexer):
-    # GH 4145
+    # GH#4145, GH#42102
     df = dataframe_with_duplicate_index
-    index = Index(["h1", "h3", "h5"])
-    columns = MultiIndex.from_tuples([("A", "A1")], names=["main", "sub"])
-    expected = DataFrame([["a", 1, 1]], index=columns, columns=index).T
+    expected = Series(["a", 1, 1], index=Index(["h1", "h3", "h5"]), name=("A", "A1"))
 
     result = indexer(df)
-    tm.assert_frame_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_frame_mi_access_returns_series(dataframe_with_duplicate_index):

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -40,7 +40,7 @@ class TestMultiIndexLoc:
         df.loc[("bar", "two"), 1] = 7
         assert df.loc[("bar", "two"), 1] == 7
 
-    def test_loc_getitem_general(self, performance_warning, any_real_numpy_dtype):
+    def test_loc_getitem_general(self, any_real_numpy_dtype):
         # GH#2817
         dtype = any_real_numpy_dtype
         data = {
@@ -53,8 +53,7 @@ class TestMultiIndexLoc:
         df = df.set_index(keys=["col", "num"])
         key = 4.0, 12
 
-        with tm.assert_produces_warning(performance_warning):
-            tm.assert_frame_equal(df.loc[key], df.iloc[2:])
+        tm.assert_frame_equal(df.loc[key], df.iloc[2:])
 
         # this is ok
         return_value = df.sort_index(inplace=True)
@@ -518,6 +517,27 @@ def test_loc_getitem_duplicates_multiindex_non_scalar_type_object():
     result = df.loc["function", ("functs", "mean")]
     expected = np.mean
     assert result == expected
+
+
+def test_loc_getitem_unique_key_in_nonunique_multiindex():
+    # GH#42102 - unique key in a non-unique MultiIndex should return scalar
+    mi = MultiIndex.from_tuples([(0, 0), (1, 0), (1, 0)])
+    ser = Series(range(3), index=mi)
+
+    # (0, 0) is unique even though the overall index is non-unique
+    result = ser.loc[(0, 0)]
+    assert result == 0
+    assert not isinstance(result, Series)
+
+    # (1, 0) is duplicated, should still return a Series
+    result = ser.loc[(1, 0)]
+    assert isinstance(result, Series)
+
+    # DataFrame column case: unique key in non-unique column MultiIndex
+    columns = MultiIndex.from_tuples([("A", "x"), ("B", "y"), ("B", "y")])
+    df = DataFrame([[1, 2, 3]], columns=columns)
+    result = df[("A", "x")]
+    assert isinstance(result, Series)
 
 
 def test_loc_getitem_tuple_plus_slice():

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -25,9 +25,10 @@ class TestMultiIndexBasic:
             }
         ).set_index(["jim", "joe"])
 
-        with tm.assert_produces_warning(performance_warning):
-            df.loc[(1, "z")]
+        # Full-length key uses the engine directly; no PerformanceWarning
+        df.loc[(1, "z")]
 
+        # Partial key still goes through lexsort path
         df = df.iloc[[2, 1, 3, 0]]
         with tm.assert_produces_warning(performance_warning):
             df.loc[(0,)]

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -325,27 +325,20 @@ class TestMultiIndexConcat:
         )
         tm.assert_frame_equal(result_df, expected_df)
 
-    def test_concat_with_key_not_unique(self, performance_warning):
+    def test_concat_with_key_not_unique(self):
         # GitHub #46519
         df1 = DataFrame({"name": [1]})
         df2 = DataFrame({"name": [2]})
         df3 = DataFrame({"name": [3]})
         df_a = concat([df1, df2, df3], keys=["x", "y", "x"])
-        # the warning is caused by indexing unsorted multi-index
-        with tm.assert_produces_warning(
-            performance_warning, match="indexing past lexsort depth"
-        ):
-            out_a = df_a.loc[("x", 0), :]
+        out_a = df_a.loc[("x", 0), :]
         df_b = DataFrame(
             {"name": [1, 2, 3]},
             index=MultiIndex(
                 levels=[["x", "y"], range(1)], codes=[[0, 1, 0], [0, 0, 0]]
             ),
         )
-        with tm.assert_produces_warning(
-            performance_warning, match="indexing past lexsort depth"
-        ):
-            out_b = df_b.loc[("x", 0)]
+        out_b = df_b.loc[("x", 0)]
 
         tm.assert_frame_equal(out_a, out_b)
 
@@ -353,10 +346,7 @@ class TestMultiIndexConcat:
         df2 = DataFrame({"name": ["a", "b"]})
         df3 = DataFrame({"name": ["c", "d"]})
         df_a = concat([df1, df2, df3], keys=["x", "y", "x"])
-        with tm.assert_produces_warning(
-            performance_warning, match="indexing past lexsort depth"
-        ):
-            out_a = df_a.loc[("x", 0), :]
+        out_a = df_a.loc[("x", 0), :]
 
         df_b = DataFrame(
             {
@@ -366,10 +356,7 @@ class TestMultiIndexConcat:
             }
         ).set_index(["a", "b"])
         df_b.index.names = [None, None]
-        with tm.assert_produces_warning(
-            performance_warning, match="indexing past lexsort depth"
-        ):
-            out_b = df_b.loc[("x", 0), :]
+        out_b = df_b.loc[("x", 0), :]
 
         tm.assert_frame_equal(out_a, out_b)
 


### PR DESCRIPTION
## Summary

- Fixed `MultiIndex.get_loc` and `MultiIndex._get_loc_level` to use the engine directly for full-length keys regardless of index uniqueness, so that a unique key in a non-unique `MultiIndex` correctly returns a scalar instead of a Series/DataFrame.

closes #42102

## Test plan

- [x] Added `test_loc_getitem_unique_key_in_nonunique_multiindex` covering Series row access and DataFrame column access
- [x] Updated existing tests that were codifying the buggy behavior
- [x] All indexing tests pass (4619 passed)
- [x] All multi-index tests pass (912 passed)
- [x] All frame/series indexing tests pass (3976 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)