### PR TITLE
BUG: DataFrame.loc setitem expands index when no columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -264,6 +264,7 @@ Interval
 Indexing
 ^^^^^^^^
 - Bug in :meth:`DataFrame.loc` and :meth:`Series.loc` replacing the index name with the key's name when indexing with an :class:`Index` (:issue:`17110`)
+- Bug in :meth:`DataFrame.loc` raising ``ValueError`` when setting a row on a :class:`DataFrame` with no columns and the label is not in the index (:issue:`17895`)
 - Bug in :meth:`DataFrame.loc` returning incorrect dtype when the column key is a ``slice`` (:issue:`63071`)
 - Bug in :meth:`Index.get_indexer` where ``method="pad"``, ``"backfill"``, or ``"nearest"`` returned incorrect results when the target contained ``NaT`` or ``NaN`` instead of ``-1`` (:issue:`32572`)
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2869,8 +2869,12 @@ class _iLocIndexer(_LocationIndexer):
 
         elif self.ndim == 2:
             if not len(self.obj.columns):
-                # no columns and scalar
-                raise ValueError("cannot set a frame with no defined columns")
+                # GH#17895 no columns, just expand the index
+                new_index = self.obj.index.insert(len(self.obj.index), indexer)
+                self.obj._mgr = self.obj._constructor(
+                    index=new_index, columns=self.obj.columns
+                )._mgr
+                return
 
             has_dtype = hasattr(value, "dtype")
             if isinstance(value, ABCSeries):

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -82,17 +82,36 @@ class TestEmptyFrameSetitemExpansion:
         # frame
         df = DataFrame()
 
-        msg = "cannot set a frame with no defined columns"
+        # GH#17895 setting a row on a DataFrame with no columns
+        # should expand the index
+        df.loc[1] = 1
+        expected = DataFrame(index=Index([1]))
+        tm.assert_frame_equal(df, expected)
 
-        with pytest.raises(ValueError, match=msg):
-            df.loc[1] = 1
+        df2 = DataFrame()
+        df2.loc[1] = Series([1], index=["foo"])
+        tm.assert_frame_equal(df2, expected)
 
-        with pytest.raises(ValueError, match=msg):
-            df.loc[1] = Series([1], index=["foo"])
-
+        df3 = DataFrame()
         msg = "cannot set a frame with no defined index and a scalar"
         with pytest.raises(ValueError, match=msg):
-            df.loc[:, 1] = 1
+            df3.loc[:, 1] = 1
+
+    def test_partial_set_empty_frame_existing_label(self):
+        # GH#17895 setting row on DataFrame with no columns is a no-op
+        # when the label is already in the index
+        df = DataFrame(index=[1, 2, 3])
+        df.loc[1] = 3
+        expected = DataFrame(index=Index([1, 2, 3]))
+        tm.assert_frame_equal(df, expected)
+
+    def test_partial_set_empty_frame_new_label(self):
+        # GH#17895 setting row on DataFrame with no columns expands
+        # the index when the label is new
+        df = DataFrame(index=[1, 2, 3])
+        df.loc[4] = 3
+        expected = DataFrame(index=Index([1, 2, 3, 4]))
+        tm.assert_frame_equal(df, expected)
 
     def test_partial_set_empty_frame2(self):
         # these work as they don't really change


### PR DESCRIPTION
## Summary
- `df.loc[new_label] = scalar` on a DataFrame with no columns previously raised `ValueError`, while `df.loc[existing_label] = scalar` silently did nothing
- Now both cases are consistent: existing-label is a no-op, new-label expands the index

closes #17895

## Test plan
- [x] `df.loc[existing_label] = scalar` with no columns is a no-op (unchanged behavior)
- [x] `df.loc[new_label] = scalar` with no columns expands the index (was `ValueError`)
- [x] `DataFrame().loc[1] = 0` expands the index (was `ValueError`)
- [x] Normal `df.loc` setitem on DataFrames with columns still works
- [x] Full `pandas/tests/indexing/` suite passes (4632 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)