### PR TITLE
BUG: DataFrame.loc setitem with MultiIndex columns and partial key introduces NaN

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -284,6 +284,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
+- Bug in :meth:`DataFrame.loc` setitem with :class:`MultiIndex` columns where assigning a :class:`DataFrame` obtained via partial key selection (e.g., ``df.loc[:, key] = df.loc[:, key]``) introduced ``NaN`` values (:issue:`40186`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
 -

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2704,9 +2704,22 @@ class _iLocIndexer(_LocationIndexer):
         else:
             for loc in ilocs:
                 item = self.obj.columns[loc]
-                if item in value:
+
+                # GH#40186: When assigning from a DataFrame obtained via
+                # partial MultiIndex key (e.g., df.loc[:, key] = df.loc[:, key]),
+                # value.columns corresponds to the remaining sub-levels,
+                # not the full MultiIndex tuples. Extract the sub-key for
+                # lookup in value.
+                lookup_item = item
+                if item not in value and multiindex_indexer and isinstance(item, tuple):
+                    nlevels_value = value.columns.nlevels
+                    lookup_item = (
+                        item[-nlevels_value:] if nlevels_value > 1 else item[-1]
+                    )
+
+                if lookup_item in value:
                     sub_indexer[1] = item
-                    ser = value[item]
+                    ser = value[lookup_item]
                     val = self._align_series(
                         tuple(sub_indexer),
                         ser,

--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -550,3 +550,58 @@ def test_frame_setitem_partial_multiindex():
     expected = df.copy()
     expected["d"] = 8
     tm.assert_frame_equal(result, expected)
+
+
+def test_loc_setitem_partial_multiindex_columns_identity():
+    # GH#40186
+    cols = MultiIndex.from_product([[1], ["a", "b"]])
+    df = DataFrame(np.ones((2, 2)), columns=cols)
+    df.loc[:, 1] = df.loc[:, 1]
+    expected = DataFrame(np.ones((2, 2)), columns=cols)
+    tm.assert_frame_equal(df, expected)
+
+
+def test_loc_setitem_partial_multiindex_columns_modified_values():
+    # GH#40186
+    cols = MultiIndex.from_product([[1], ["a", "b"]])
+    df = DataFrame(np.ones((2, 2)), columns=cols)
+    df.loc[:, 1] = df.loc[:, 1] * 3
+    expected = DataFrame(np.full((2, 2), 3.0), columns=cols)
+    tm.assert_frame_equal(df, expected)
+
+
+def test_loc_setitem_partial_multiindex_columns_multiple_level0():
+    # GH#40186 - only selected level-0 group should change
+    cols = MultiIndex.from_product([[1, 2], ["a", "b"]])
+    df = DataFrame(np.ones((2, 4)), columns=cols)
+    df.loc[:, 1] = df.loc[:, 1] * 5
+    expected = DataFrame([[5.0, 5.0, 1.0, 1.0], [5.0, 5.0, 1.0, 1.0]], columns=cols)
+    tm.assert_frame_equal(df, expected)
+
+
+def test_loc_setitem_partial_multiindex_columns_3_levels():
+    # GH#40186 - 3-level MultiIndex columns
+    cols = MultiIndex.from_product([[1], ["a", "b"], ["x", "y"]])
+    df = DataFrame(np.ones((2, 4)), columns=cols)
+    df.loc[:, 1] = df.loc[:, 1]
+    expected = DataFrame(np.ones((2, 4)), columns=cols)
+    tm.assert_frame_equal(df, expected)
+
+
+def test_loc_setitem_partial_multiindex_columns_alignment():
+    # GH#40186 - assignment aligns by column name, not position
+    cols = MultiIndex.from_product([[1], ["a", "b"]])
+    df = DataFrame([[1.0, 2.0], [3.0, 4.0]], columns=cols)
+    rhs = df.loc[:, 1][["b", "a"]]
+    df.loc[:, 1] = rhs
+    expected = DataFrame([[1.0, 2.0], [3.0, 4.0]], columns=cols)
+    tm.assert_frame_equal(df, expected)
+
+
+def test_loc_setitem_partial_multiindex_columns_augmented_assignment():
+    # GH#40186
+    cols = MultiIndex.from_product([[1], ["a", "b"]])
+    df = DataFrame(np.ones((2, 2)), columns=cols)
+    df.loc[:, 1] *= 3
+    expected = DataFrame(np.full((2, 2), 3.0), columns=cols)
+    tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
## Summary
- Fixed `df.loc[:, key] = df.loc[:, key]` introducing `NaN` when `df` has `MultiIndex` columns
- The column lookup in `_setitem_with_indexer_frame_value` compared full MultiIndex tuples (e.g. `(1, 'a')`) against the value's sub-level columns (e.g. `'a'`), always failing and filling with `NaN`
- When the direct lookup fails and columns are a `MultiIndex`, extract the sub-key matching the value's column levels

## Test plan
- [x] Added 6 tests covering identity assignment, modified values, multiple level-0 groups, 3-level MultiIndex, column alignment with reordered columns, and augmented assignment (`*=`)
- [x] Existing MultiIndex indexing tests pass (loc, setitem)
- [x] Full `test_loc.py` suite passes

closes #40186

🤖 Generated with [Claude Code](https://claude.com/claude-code)