### PR TITLE
BUG: DataFrame.at/iat fail to store list-like values in a single cell

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -257,6 +257,7 @@ Interval
 
 Indexing
 ^^^^^^^^
+- Bug in :meth:`DataFrame.at` and :meth:`DataFrame.iat` failing to store list-like values in a single cell when the column didn't exist or had an incompatible dtype (:issue:`61223`)
 - Bug in :meth:`DataFrame.loc` returning incorrect dtype when the column key is a ``slice`` (:issue:`63071`)
 - Bug in :meth:`Index.get_indexer` where ``method="pad"``, ``"backfill"``, or ``"nearest"`` returned incorrect results when the target contained ``NaT`` or ``NaN`` instead of ``-1`` (:issue:`32572`)
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4844,7 +4844,9 @@ class DataFrame(NDFrame, OpsMixin):
                 if self.dtypes.iloc[icol] != np.dtype("object"):
                     self[col_label] = self[col_label].astype(object)
                     icol = self.columns.get_loc(col_label)
-                self._mgr.column_setitem(icol, iindex, value, inplace_only=True)
+                self._mgr.column_setitem(
+                    cast("int", icol), iindex, value, inplace_only=True
+                )
             elif takeable:
                 self.iloc[index, col] = value
             else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4828,7 +4828,24 @@ class DataFrame(NDFrame, OpsMixin):
             # column_setitem will do validation that may raise TypeError,
             #  ValueError, or LossySetitemError
             # set using a non-recursive method & reset the cache
-            if takeable:
+            if is_list_like(value) and not isinstance(value, dict):
+                # GH#61223 .loc/.iloc misinterpret list-like values as
+                # multi-element setitem. Ensure object dtype column first.
+                if takeable:
+                    col_label = self.columns[col]
+                    iindex = cast("int", index)
+                else:
+                    col_label = col
+                    if col not in self.columns:
+                        self[col] = Series(dtype=object, index=self.index)
+                    iindex = self.index.get_loc(index)  # type: ignore[assignment]
+
+                icol = self.columns.get_loc(col_label)
+                if self.dtypes.iloc[icol] != np.dtype("object"):
+                    self[col_label] = self[col_label].astype(object)
+                    icol = self.columns.get_loc(col_label)
+                self._mgr.column_setitem(icol, iindex, value, inplace_only=True)
+            elif takeable:
                 self.iloc[index, col] = value
             else:
                 self.loc[index, col] = value

--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -277,3 +277,27 @@ class TestAtErrors:
             match=f"You can only assign a scalar value not a \\{type(new_row)}",
         ):
             df.at["a"] = new_row
+
+    @pytest.mark.parametrize("value", [[1, 2, 3], (1, 2, 3), np.array([1, 2, 3])])
+    def test_at_setitem_list_like_into_new_column(self, value):
+        # GH#61223 .at should store list-like as single cell in new column
+        df = DataFrame({"A": [1, 2]}, index=["a", "b"])
+        df.at["a", "B"] = value
+        assert df["B"].dtype == object
+        result = df.at["a", "B"]
+        if isinstance(value, np.ndarray):
+            tm.assert_numpy_array_equal(result, value)
+        else:
+            assert result == value
+
+    @pytest.mark.parametrize("value", [[1, 2, 3], (1, 2, 3), np.array([1, 2, 3])])
+    def test_at_setitem_list_like_into_incompatible_dtype(self, value):
+        # GH#61223 .at should cast column to object when storing list-like
+        df = DataFrame({"A": [1, 2]}, index=["a", "b"])
+        df.at["a", "A"] = value
+        assert df["A"].dtype == object
+        result = df.at["a", "A"]
+        if isinstance(value, np.ndarray):
+            tm.assert_numpy_array_equal(result, value)
+        else:
+            assert result == value


### PR DESCRIPTION
## Summary
- Fixes `.at` and `.iat` raising `ValueError` when setting a list-like value (list, tuple, numpy array) into a cell where the column doesn't exist or has an incompatible dtype
- When the fast path (`column_setitem(inplace_only=True)`) fails and the value is list-like, the fallback to `.loc`/`.iloc` misinterprets the value as multi-element setitem. The fix ensures the target column is object dtype first, then sets the value directly via `column_setitem`.

closes #61223

## Test plan
- [x] Added parameterized tests for lists, tuples, and numpy arrays into new columns and incompatible-dtype columns
- [x] All existing indexing tests pass (4630+ tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)