### PR TITLE
BUG: MultiIndex indexing silently drops labels present in level but missing in context

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -284,6 +284,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
+- Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` silently dropping missing labels instead of raising ``KeyError`` when a label exists in the level vocabulary but not under the positions restricted by prior levels (:issue:`39424`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
 -

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4153,6 +4153,17 @@ class MultiIndex(Index):
                     if na_count:
                         lvl_indexer = lvl_indexer | (level_codes == -1)
 
+                    # GH#39424: A label may exist in the level's vocabulary
+                    # but not in the positions allowed by prior levels.
+                    # e.g. ("z", ["a", "b", "c"]) where "c" exists in level 1
+                    # (from ("y", "c")) but not under "z".
+                    if indexer is not None:
+                        active_codes = level_codes[indexer]
+                        if not np.isin(k_codes, active_codes).all():
+                            raise KeyError(k) from None
+                        if na_count and not (active_codes == -1).any():
+                            raise KeyError(k) from None
+
                 if lvl_indexer is None:
                     # no matches we are done
                     # test_loc_getitem_duplicates_multiindex_empty_indexer

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -1051,6 +1051,20 @@ def test_get_locs_list_like_nan_not_in_level():
         idx.get_locs((["a"], [np.nan]))
 
 
+def test_get_locs_list_like_missing_in_level_context():
+    # GH#39424 - label exists in the level vocabulary but not under
+    # the positions restricted by prior levels
+    idx = MultiIndex.from_tuples([("z", "a"), ("z", "b"), ("y", "b"), ("y", "c")])
+    # "c" is in level 1 (from ("y", "c")) but not under "z"
+    with pytest.raises(KeyError, match="a.*b.*c"):
+        idx.get_locs(("z", ["a", "b", "c"]))
+
+    # all labels exist somewhere under the prior-level constraint -> no error
+    result = idx.get_locs((["z", "y"], ["a", "b"]))
+    expected = np.array([0, 1, 2], dtype=np.intp)
+    tm.assert_numpy_array_equal(result, expected)
+
+
 def test_get_indexer_for_multiindex_with_nans(nulls_fixture):
     # GH37222
     idx1 = MultiIndex.from_product([["A"], [1.0, 2.0]], names=["id1", "id2"])

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -793,6 +793,26 @@ class TestKeyErrorsWithMultiIndex:
         with pytest.raises(KeyError, match=r"\('b', '1'\)"):
             df.loc[("b", "1"), :]
 
+    def test_loc_multiindex_missing_label_in_level_context(self):
+        # GH#39424 - label exists in the level vocabulary but not under
+        # the positions restricted by prior levels
+        df = DataFrame(
+            {
+                ("z", "a"): [1, 2],
+                ("z", "b"): [4, 5],
+                ("y", "b"): [6, 7],
+                ("y", "c"): [6, 7],
+            }
+        )
+        # "c" is in level 1 (from ("y", "c")) but not under "z"
+        with pytest.raises(KeyError, match="a.*b.*c"):
+            df.loc[:, ("z", ["a", "b", "c"])]
+
+        # When all labels exist somewhere under the prior-level constraint, no error
+        result = df.loc[:, (["z", "y"], ["a", "b"])]
+        expected = df.loc[:, [("z", "a"), ("z", "b"), ("y", "b")]]
+        tm.assert_frame_equal(result, expected)
+
 
 def test_getitem_loc_commutability(multiindex_year_month_day_dataframe_random_data):
     df = multiindex_year_month_day_dataframe_random_data


### PR DESCRIPTION
## Summary
- closes #39424
- When indexing a MultiIndex with a tuple containing a list at one level (e.g. `df.loc[:, ("z", ["a", "b", "c"])]`), labels that exist in the level's vocabulary but don't exist in combination with the prior-level constraints were silently dropped instead of raising `KeyError`.
- The fix validates requested label codes against `level_codes[indexer]` (restricted by prior levels) rather than only checking the full level vocabulary.

## Test plan
- [x] Added `test_get_locs_list_like_missing_in_level_context` in `pandas/tests/indexes/multi/test_indexing.py`
- [x] Added `test_loc_multiindex_missing_label_in_level_context` in `pandas/tests/indexing/multiindex/test_loc.py`
- [x] All existing MultiIndex indexing tests pass (504 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)