### PR TITLE
BUG: MultiIndex slicing with datetime.date raises TypeError

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -261,6 +261,7 @@ MultiIndex
 ^^^^^^^^^^
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
+- Bug in slicing a :class:`MultiIndex` with a :class:`DatetimeIndex` level using a ``datetime.date`` object raising ``TypeError`` (:issue:`15906`)
 -
 
 I/O

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -261,7 +261,7 @@ MultiIndex
 ^^^^^^^^^^
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
-- Bug in slicing a :class:`MultiIndex` with a :class:`DatetimeIndex` level using a ``datetime.date`` object raising ``TypeError`` (:issue:`15906`)
+- Bug in slicing a :class:`MultiIndex` with a :class:`DatetimeIndex` level using a ``datetime.date`` object raising ``TypeError``. This usage is now deprecated, use :class:`Timestamp` instead (:issue:`15906`)
 -
 
 I/O

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -8,6 +8,7 @@ from collections.abc import (
     Iterable,
     Sequence,
 )
+import datetime as dt
 from functools import wraps
 from itertools import zip_longest
 from sys import getsizeof
@@ -30,9 +31,11 @@ from pandas._libs import (
     lib,
 )
 from pandas._libs.hashtable import duplicated
+from pandas._libs.tslibs import Timestamp
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
     InvalidIndexError,
+    Pandas4Warning,
     PerformanceWarning,
     UnsortedIndexError,
 )
@@ -3447,6 +3450,17 @@ class MultiIndex(Index):
         zipped = zip(tup, self.levels, self.codes, strict=True)
         for k, (lab, lev, level_codes) in enumerate(zipped):
             section = level_codes[start:end]
+
+            if isinstance(lab, dt.date) and not isinstance(lab, dt.datetime):
+                # GH#15906 coerce datetime.date to Timestamp for
+                # DatetimeIndex levels, matching DatetimeIndex behavior
+                lab = Timestamp(lab)
+                warnings.warn(
+                    "Indexing a MultiIndex with a datetime.date object is "
+                    "deprecated. Explicitly cast to Timestamp instead.",
+                    Pandas4Warning,
+                    stacklevel=find_stack_level(),
+                )
 
             loc: npt.NDArray[np.intp] | np.intp | int
             if lab not in lev and not isna(lab):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3456,8 +3456,9 @@ class MultiIndex(Index):
                 # DatetimeIndex levels, matching DatetimeIndex behavior
                 lab = Timestamp(lab)
                 warnings.warn(
-                    "Indexing a MultiIndex with a datetime.date object is "
-                    "deprecated. Explicitly cast to Timestamp instead.",
+                    "Slicing a MultiIndex containing a DatetimeIndex level "
+                    "with a datetime.date object is deprecated. "
+                    "Explicitly cast to Timestamp instead.",
                     Pandas4Warning,
                     stacklevel=find_stack_level(),
                 )

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -91,7 +91,7 @@ class TestSliceLocs:
         dti = date_range("2016-10-01", periods=4, freq="D")
         mi = MultiIndex.from_arrays([dti, [1, 2, 3, 4]])
 
-        msg = "Indexing a MultiIndex with a datetime.date object is deprecated"
+        msg = "Slicing a MultiIndex containing a DatetimeIndex level"
         with tm.assert_produces_warning(pd.errors.Pandas4Warning, match=msg):
             result = mi.slice_locs(dt.date(2016, 10, 2))
         expected = mi.slice_locs(pd.Timestamp("2016-10-02"))

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import datetime as dt
 from datetime import timedelta
 import re
 
@@ -83,6 +84,23 @@ class TestSliceLocs:
         # TODO: Try creating a UnicodeDecodeError in exception message
         with pytest.raises(TypeError, match="^Level type mismatch"):
             idx.slice_locs(df.index[1], (16, "a"))
+
+    def test_slice_locs_with_datetime_date(self):
+        # GH#15906 slicing MultiIndex with datetime.date should work
+        # (with deprecation warning), matching DatetimeIndex behavior
+        dti = date_range("2016-10-01", periods=4, freq="D")
+        mi = MultiIndex.from_arrays([dti, [1, 2, 3, 4]])
+
+        msg = "Indexing a MultiIndex with a datetime.date object is deprecated"
+        with tm.assert_produces_warning(pd.errors.Pandas4Warning, match=msg):
+            result = mi.slice_locs(dt.date(2016, 10, 2))
+        expected = mi.slice_locs(pd.Timestamp("2016-10-02"))
+        assert result == expected
+
+        with tm.assert_produces_warning(pd.errors.Pandas4Warning, match=msg):
+            result = mi.slice_locs(dt.date(2016, 10, 2), dt.date(2016, 10, 3))
+        expected = mi.slice_locs(pd.Timestamp("2016-10-02"), pd.Timestamp("2016-10-03"))
+        assert result == expected
 
     def test_slice_locs_not_sorted(self):
         index = MultiIndex(


### PR DESCRIPTION
## Summary
- Slicing a MultiIndex with a DatetimeIndex level using a `datetime.date` object raised `TypeError: Level type mismatch`, even though this works on a regular DatetimeIndex (with a deprecation warning)
- Coerce `datetime.date` to `Timestamp` in `MultiIndex._partial_tup_index`, with a `Pandas4Warning` matching the existing DatetimeIndex deprecation

closes #15906

## Test plan
- [x] Added test `test_slice_locs_with_datetime_date` covering single and double-bound slicing
- [x] Existing MultiIndex tests pass (1269 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)