### PR TITLE
BUG: improve error message for slice_locs with NaN in index

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7146,11 +7146,20 @@ class Index(IndexOpsMixin, PandasObject):
             try:
                 return self._searchsorted_monotonic(label, side)
             except ValueError:
-                raise KeyError(
+                # GH#20917
+                msg = (
                     f"Cannot get {side} slice bound for non-monotonic index "
                     f"with a missing label {original_label!r}. "
-                    "Either sort the index or specify an existing label."
-                ) from None
+                )
+                if self.hasnans:
+                    msg += (
+                        "Index contains NaN values which make it non-monotonic. "
+                        "Either drop NaN values first or specify an existing "
+                        "label."
+                    )
+                else:
+                    msg += "Either sort the index or specify an existing label."
+                raise KeyError(msg) from None
 
         if isinstance(slc, np.ndarray):
             # get_loc may return a boolean array, which

--- a/pandas/tests/indexes/numeric/test_indexing.py
+++ b/pandas/tests/indexes/numeric/test_indexing.py
@@ -608,8 +608,9 @@ class TestSliceLocs:
         assert index.slice_locs(np.nan) == (1, 5)
 
     def test_slice_locs_na_raises(self):
+        # GH#20917 - error message should mention NaN when applicable
         index = Index([np.nan, 1, 2])
-        msg = "non-monotonic index with a missing label 1.5"
+        msg = "Index contains NaN values which make it non-monotonic"
         with pytest.raises(KeyError, match=msg):
             index.slice_locs(start=1.5)
 


### PR DESCRIPTION
## Summary
- closes #20917
- When `Index.slice_locs` raises `KeyError` for a missing label on a non-monotonic index, the error message now specifically identifies NaN values as the cause and suggests dropping them first

## Test plan
- [ ] Existing `test_slice_locs_na_raises` updated to check for NaN-specific error message
- [ ] Verified non-NaN non-monotonic indexes still get the original error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)