### PR TITLE
BUG: DataFrame.loc with list of partial tuple keys on MultiIndex

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -291,6 +291,7 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
+- Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where indexing with a list of partial tuple keys (e.g., ``df.loc[[(1, "a")]]`` on a 3-level index) raised ``AssertionError`` instead of selecting matching rows (:issue:`16083`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.get_loc` where looking up a tuple key containing a scalar inside an :class:`IntervalIndex` level with overlapping intervals raised ``KeyError`` or returned incorrect results (:issue:`27456`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3370,8 +3370,8 @@ class MultiIndex(Index):
                 if isinstance(loc, slice):
                     indexers.extend(range(*loc.indices(len(self))))
                 elif isinstance(loc, np.ndarray) and loc.dtype == bool:
-                    indexers.extend(np.where(loc)[0])
-                elif isinstance(loc, (int, np.integer)):
+                    indexers.extend(loc.nonzero()[0])
+                elif lib.is_integer(loc):
                     indexers.append(int(loc))
                 else:
                     indexers.extend(loc)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3359,6 +3359,25 @@ class MultiIndex(Index):
             self._raise_if_missing(key, indexer, axis_name)
             return self[indexer], indexer
 
+        if len(keyarr) and any(
+            isinstance(tup, tuple) and len(tup) < self.nlevels for tup in keyarr
+        ):
+            # GH#16083 - handle partial tuple keys (fewer elements than nlevels)
+            # by using get_loc for each key, which already supports partial keys
+            indexers: list[int] = []
+            for tup in keyarr:
+                loc = self.get_loc(tup)
+                if isinstance(loc, slice):
+                    indexers.extend(range(*loc.indices(len(self))))
+                elif isinstance(loc, np.ndarray) and loc.dtype == bool:
+                    indexers.extend(np.where(loc)[0])
+                elif isinstance(loc, (int, np.integer)):
+                    indexers.append(int(loc))
+                else:
+                    indexers.extend(loc)
+            indexer = np.array(indexers, dtype=np.intp)
+            return self[indexer], indexer
+
         return super()._get_indexer_strict(key, axis_name)
 
     def _raise_if_missing(self, key, indexer, axis_name: str) -> None:

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -1064,3 +1064,31 @@ def test_loc_multiindex_with_overlapping_interval_multiple_matches():
     result = ser.loc[("A", 1.5)]
     expected = np.array([10, 20], dtype=result.values.dtype)
     tm.assert_numpy_array_equal(result.values, expected)
+
+
+def test_loc_partial_tuple_keys_in_list():
+    # GH#16083
+    mi = MultiIndex.from_product([[1, 2], ["a", "b"], ["i", "ii"]])
+    df = DataFrame({"A": -1, "B": -1}, index=mi)
+
+    # list of 2-element tuples on a 3-level MultiIndex
+    result = df.loc[[(1, "a")]]
+    expected = df.loc[(1, "a", slice(None)), :]
+    tm.assert_frame_equal(result, expected)
+
+    # list of 1-element tuples
+    result = df.loc[[(1,)]]
+    expected = df.loc[[1]]
+    tm.assert_frame_equal(result, expected)
+
+    # multiple partial keys
+    result = df.loc[[(1, "a"), (2, "b")]]
+    idx = MultiIndex.from_tuples(
+        [(1, "a", "i"), (1, "a", "ii"), (2, "b", "i"), (2, "b", "ii")]
+    )
+    expected = DataFrame({"A": -1, "B": -1}, index=idx)
+    tm.assert_frame_equal(result, expected)
+
+    # missing partial key raises
+    with pytest.raises(KeyError, match=r"\(3, 'a'\)"):
+        df.loc[[(3, "a")]]


### PR DESCRIPTION
## Summary
- fixes `.loc` with a list of partial tuple keys on a MultiIndex (e.g. `df.loc[[(1, "a")]]` on a 3-level index), which previously raised `AssertionError`
- Partial tuple keys now correctly select all matching rows, consistent with scalar partial key behavior

closes #16083

## Test plan
- [x] Added `test_loc_partial_tuple_keys_in_list` covering 2-element and 1-element partial tuples, multiple partial keys, and missing key error
- [x] All 356 existing `pandas/tests/indexing/multiindex/` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)