### PR TITLE
DOC: move misplaced whatsnew note for GH-64836

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -15,6 +15,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed reading of Parquet files with timezone-aware timestamps or localizing of a timeseries with a ``pytz`` timezone when an older version of ``pytz`` was installed (:issue:`64978`)
+- Fixed regression in :meth:`Timedelta.round`, :meth:`Timedelta.floor`, and :meth:`Timedelta.ceil` raising ``ZeroDivisionError`` for sub-second ``freq`` (:issue:`64828`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.bug_fixes:

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -222,7 +222,6 @@ Timedelta
 - Bug in :attr:`TimedeltaIndex.resolution` raising when the index has no frequency (:issue:`65186`)
 - Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
 - Bug in :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
-- Fixed regression in :meth:`Timedelta.round`, :meth:`Timedelta.floor`, and :meth:`Timedelta.ceil` raising ``ZeroDivisionError`` for sub-second ``freq`` (:issue:`64828`)
 
 Timezones
 ^^^^^^^^^


### PR DESCRIPTION
Moving whatsnew of https://github.com/pandas-dev/pandas/pull/64836, for 3.0.x this was already included in https://github.com/pandas-dev/pandas/pull/65201