### PR TITLE
TST: add test for DataFrame.update with mixed index types and partial…

### DIFF
--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -259,3 +259,22 @@ class TestDataFrameUpdate:
         expected = DataFrame({"date": [pd.Timestamp("2026-02-05")]}, dtype=object)
 
         tm.assert_frame_equal(other, expected)
+    
+    ############################# me
+    def test_update_mixed_index_partial_overlap(self):
+        df1 = DataFrame(
+        {"col": ["a", "b", "c"]},
+        index=[1, 2, 3]
+        )
+
+        df2 = DataFrame(
+        {"col": ["x", "y", "z"]},
+        index=["1", 2, "3"]
+        )
+
+        # Only index 2 should match
+        df1.update(df2)
+
+        assert df1.loc[1, "col"] == "a"
+        assert df1.loc[2, "col"] == "y"
+        assert df1.loc[3, "col"] == "c"

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -260,7 +260,6 @@ class TestDataFrameUpdate:
 
         tm.assert_frame_equal(other, expected)
     
-    ############################# me
     def test_update_mixed_index_partial_overlap(self):
         df1 = DataFrame(
         {"col": ["a", "b", "c"]},


### PR DESCRIPTION
## What does this PR do?

Adds a regression test for `DataFrame.update` when indices have mixed types with partial overlap.

## Why is this needed?

Existing tests cover cases where there is no intersection between indices, but they do not cover cases where some indices match and others differ because of index dtype mismatches (for example, `2` vs `"2"`).

This test ensures that only truly matching indices are updated.

- [x] closes #19905
- [x] Tests added and passed
- [x] All code checks passed
- [ ] Added an entry in whatsnew (not needed; test-only change)
- [x] I have reviewed and followed the contribution guidelines