### PR TITLE
BUG: fix loc setitem with list of tuples on object-dtype column

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -266,6 +266,7 @@ Indexing
 - Bug in :meth:`DataFrame.at` raising ``TypeError`` when accessing a :class:`MultiIndex` with a partial date string on a :class:`DatetimeIndex` level (:issue:`43395`)
 - Bug in :meth:`DataFrame.duplicated` returning an empty :class:`Series` without the DataFrame's index when the DataFrame had no columns (:issue:`61191`)
 - Bug in :meth:`DataFrame.iloc` setitem raising ``AttributeError`` when assigning a :class:`Series` or :class:`Index` with a nullable EA dtype (e.g. ``Int64``, ``Float64``, ``boolean``) into a column with a NumPy dtype (:issue:`47776`)
+- Bug in :meth:`DataFrame.loc` raising ``ValueError`` when assigning a list of tuples to an object-dtype column with a boolean mask on a mixed-dtype DataFrame (:issue:`37629`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` returning wrong results instead of raising ``KeyError`` when passing string keys for numeric index levels (:issue:`60104`)
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` where incorrect values were produced when ``other`` was a :class:`Series` with :class:`ExtensionArray` values (:issue:`64635`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
@@ -275,7 +276,6 @@ Indexing
 - Bug in :meth:`Index.insert` silently casting booleans to numeric when used with nullable numeric dtypes like ``Float64`` or ``Int64`` (:issue:`61709`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
 -
-
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2581,7 +2581,11 @@ class _iLocIndexer(_LocationIndexer):
             if isinstance(value, ABCDataFrame):
                 self._setitem_with_indexer_frame_value(indexer, value, name)
 
-            elif _is_2d_value(value):
+            elif _is_2d_value(value) and not (
+                isinstance(value, list)
+                and isinstance(value[0], tuple)
+                and len(value[0]) != len(ilocs)
+            ):
                 self._setitem_with_indexer_2d_value(indexer, value)
 
             elif len(ilocs) == 1 and lplane_indexer == len(value) and not is_scalar(pi):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -41,6 +41,7 @@ from pandas.core.dtypes.astype import (
 from pandas.core.dtypes.cast import (
     LossySetitemError,
     can_hold_element,
+    construct_1d_object_array_from_listlike,
     convert_dtypes,
     find_result_type,
     np_can_hold_element,
@@ -1138,12 +1139,9 @@ class Block(PandasObject, libinternals.Block):
                     and len(casted) > 0
                     and isinstance(casted[0], (tuple, list, np.ndarray))
                 ):
-                    # Wrap in a 1D object array to prevent numpy from
-                    # unpacking nested containers (e.g. tuples) during
-                    # boolean-indexed assignment. GH#37629
-                    obj_arr = np.empty(len(casted), dtype=object)
-                    obj_arr[:] = casted
-                    casted = obj_arr
+                    # Prevent numpy from unpacking nested containers
+                    # (e.g. tuples) during boolean-indexed assignment. GH#37629
+                    casted = construct_1d_object_array_from_listlike(casted)
 
             self = self._maybe_copy(inplace=True)
             values = cast("np.ndarray", self.values.T)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1133,6 +1133,18 @@ class Block(PandasObject, libinternals.Block):
                     num_set = len(values[indexer])
                 casted = setitem_datetimelike_compat(values, num_set, casted)
 
+                if (
+                    isinstance(casted, list)
+                    and len(casted) > 0
+                    and isinstance(casted[0], (tuple, list, np.ndarray))
+                ):
+                    # Wrap in a 1D object array to prevent numpy from
+                    # unpacking nested containers (e.g. tuples) during
+                    # boolean-indexed assignment. GH#37629
+                    obj_arr = np.empty(len(casted), dtype=object)
+                    obj_arr[:] = casted
+                    casted = obj_arr
+
             self = self._maybe_copy(inplace=True)
             values = cast("np.ndarray", self.values.T)
             if isinstance(casted, np.ndarray) and casted.ndim == 1 and len(casted) == 1:

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1142,6 +1142,27 @@ def test_scalar_setitem_series_with_nested_value_length1(value, indexer_sli):
         assert ser.loc[0] == value
 
 
+def test_loc_setitem_list_of_tuples_on_object_column():
+    # GH#37629 - assigning list of tuples to object-dtype column
+    # with a boolean mask on a mixed-dtype DataFrame
+    df = DataFrame({"a": [1, 1, 2, 1], "b": [(1, 1, 0)] * 4})
+
+    # list of tuples matching selected row count
+    df.loc[df["a"] == 1, "b"] = [(0, 0, 1), (0, 0, 1), (0, 0, 1)]
+    expected = DataFrame(
+        {"a": [1, 1, 2, 1], "b": [(0, 0, 1), (0, 0, 1), (1, 1, 0), (0, 0, 1)]}
+    )
+    tm.assert_frame_equal(df, expected)
+    # verify tuples are preserved as tuples
+    assert isinstance(df["b"].iloc[0], tuple)
+
+    # doubly-nested list: [[(tuple)]] treated as 2D with 1 row x 1 col,
+    # tuple value broadcast to all matching rows
+    df2 = DataFrame({"a": [1, 1, 2, 1], "b": [(1, 1, 0)] * 4})
+    df2.loc[df2["a"] == 1, "b"] = [[(0, 0, 1)]]
+    tm.assert_frame_equal(df2, expected)
+
+
 def test_object_dtype_series_set_series_element():
     # GH 48933
     s1 = Series(dtype="O", index=["a", "b"])


### PR DESCRIPTION
## Summary
- Fix `DataFrame.loc` raising `ValueError` when assigning a list of tuples to an object-dtype column with a boolean mask on a mixed-dtype DataFrame
- Two root causes: `_is_2d_value` misrouting list-of-tuples to the 2D assignment path, and numpy's boolean-indexed assignment unpacking nested containers

closes #37629

## Test plan
- [x] Added test `test_loc_setitem_list_of_tuples_on_object_column` covering list-of-tuples and doubly-nested-list cases
- [x] All 4630 indexing tests pass
- [x] All 1639 frame indexing + internals tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)