### PR TITLE
TYP: accept Mapping in Styler.format formatter parameter

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import (
     Callable,
+    Mapping,
     Sequence,
 )
 from functools import partial
@@ -51,7 +52,7 @@ jinja2 = import_optional_dependency("jinja2", extra="DataFrame.style requires ji
 from markupsafe import escape as escape_html  # markupsafe is jinja2 dependency
 
 BaseFormatter: TypeAlias = str | Callable
-ExtFormatter: TypeAlias = BaseFormatter | dict[Any, BaseFormatter | None]
+ExtFormatter: TypeAlias = BaseFormatter | Mapping[Any, BaseFormatter | None]
 CSSPair: TypeAlias = tuple[str, str | float]
 CSSList: TypeAlias = list[CSSPair]
 CSSProperties: TypeAlias = str | CSSList


### PR DESCRIPTION
Widen the `ExtFormatter` type alias from `dict` to `Mapping` so callers passing a `dict[str, str]` (or any narrower mapping) are accepted. `dict` is invariant in its value type, but `Mapping` is covariant, which matches how `Styler.format`, `Styler.format_index`, and `Styler.format_index_names` actually use the argument (read-only iteration).

## Minimal repro

```py
import pandas as pd

df = pd.DataFrame({"a": [1.5], "b": [2.7]})
fmt: dict[str, str] = {"a": "{:.2f}", "b": "{:.2f}"}
df.style.format(fmt)
```

```
Argument to bound method `format` is incorrect:
  Expected `str | ((...) -> Unknown) | dict[Any, str | ((...) -> Unknown) | None] | None`
  Found    `dict[str, str]`
```

The dict literal is a perfectly valid runtime argument, but invariance of `dict` rejects it statically. No runtime change.

## Related

Same dict-invariance friction already filed for other pandas APIs: [pandas-stubs#828](https://github.com/pandas-dev/pandas-stubs/issues/828) (`DatetimeIndex`), [pandas-stubs#1161](https://github.com/pandas-dev/pandas-stubs/issues/1161) (`DataFrame.replace`).