### PR TITLE
PERF: parallelize nancorr (POC for cython.prange)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -284,7 +284,7 @@ jobs:
         run: |
           /opt/python/cp313-cp313/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
+          python -m pip install --no-cache-dir -U pip wheel meson[ninja]==1.5.0 meson-python==0.18.0
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
           python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
@@ -324,7 +324,7 @@ jobs:
         run: |
           /opt/python/cp313-cp313/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
-          python -m pip install --no-cache-dir -U pip wheel meson-python==0.18.0 meson[ninja]==1.2.3
+          python -m pip install --no-cache-dir -U pip wheel meson-python==0.18.0 meson[ninja]==1.5.0
           python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
@@ -395,7 +395,7 @@ jobs:
       - name: Build Environment
         run: |
           python --version
-          python -m pip install --upgrade pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
+          python -m pip install --upgrade pip wheel meson[ninja]==1.5.0 meson-python==0.18.0
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.116.0 pytest>=8.3.4 pytest-xdist>=3.6.1 pytest-cov
           python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"

--- a/ci/deps/actions-311-minimum_versions.yaml
+++ b/ci/deps/actions-311-minimum_versions.yaml
@@ -9,7 +9,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython<4.0.0a0
-  - meson=1.2.3
+  - meson=1.5.0
   - meson-python=0.18.0
 
   # test dependencies

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -151,6 +151,7 @@ Performance improvements
 - Performance improvement in :func:`read_sas` for compressed SAS7BDAT files by reusing the decompression buffer instead of allocating per row (:issue:`47339`)
 - Performance improvement in :func:`read_sas` when decoding strings (:issue:`47339`)
 - Performance improvement in :func:`util.hash_pandas_object` for PyArrow-backed string and binary types by using PyArrow's ``dictionary_encode`` instead of converting to NumPy for factorization (:issue:`48964`)
+- Performance improvement in :meth:`DataFrame.corr` and :meth:`DataFrame.cov` on multi-core systems when OpenMP is available, especially for wide DataFrames (:issue:`40956`)
 - Performance improvement in :meth:`DataFrame.corr` and :meth:`DataFrame.cov` when data contains no NaN values (:issue:`64857`)
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   # build dependencies
   - versioneer
   - cython>=3.1.0,<4.0.0a0
-  - meson>=1.2.3,<2
+  - meson>=1.5.0,<2
   - meson-python>=0.18.0,<1
 
   # test dependencies

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
     'cython',
     version: run_command(['generate_version.py', '--print'], check: true).stdout().strip(),
     license: 'BSD-3',
-    meson_version: '>=1.2.3',
+    meson_version: '>=1.5.0',
     default_options: [
         'buildtype=release',
         'c_std=c17',
@@ -49,6 +49,12 @@ if cc.get_id() == 'msvc'
         language: ['c', 'cpp'],
     )
 endif
+
+# OpenMP is required for cython.prange parallel loops.
+# On macOS with Apple Clang: brew install libomp
+# Meson >= 1.5.0 auto-detects Homebrew's libomp.
+# If unavailable, prange falls back to sequential range.
+openmp_dep = dependency('OpenMP', language: 'c', required: false)
 
 if fs.exists('_version_meson.py')
     py.install_sources('_version_meson.py', subdir: 'pandas')

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1,5 +1,6 @@
 cimport cython
 from cython cimport Py_ssize_t
+from cython.parallel cimport prange
 from libc.math cimport (
     isnan,
     sqrt,
@@ -351,15 +352,78 @@ def kth_smallest(numeric_t[::1] arr, Py_ssize_t k) -> numeric_t:
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
+cdef inline void _nancorr_pair(
+    Py_ssize_t xi,
+    Py_ssize_t yi,
+    Py_ssize_t N,
+    const float64_t[:, :] mat,
+    const uint8_t[:, :] mask,
+    float64_t[:, ::1] result,
+    bint no_nans,
+    bint cov,
+    int64_t minpv,
+) noexcept nogil:
+    cdef:
+        Py_ssize_t i
+        int64_t nobs = 0
+        float64_t vx, vy, dx, dy, meanx, meany, divisor, ssqdmx, ssqdmy, covxy, val
+
+    # Welford's method for the variance-calculation
+    # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+    ssqdmx = ssqdmy = covxy = meanx = meany = 0
+
+    if no_nans:
+        nobs = N
+        for i in range(N):
+            vx = mat[i, xi]
+            vy = mat[i, yi]
+            dx = vx - meanx
+            dy = vy - meany
+            meanx += 1. / (i + 1) * dx
+            meany += 1. / (i + 1) * dy
+            ssqdmx += (vx - meanx) * dx
+            ssqdmy += (vy - meany) * dy
+            covxy += (vx - meanx) * dy
+    else:
+        for i in range(N):
+            if mask[i, xi] and mask[i, yi]:
+                vx = mat[i, xi]
+                vy = mat[i, yi]
+                nobs += 1
+                dx = vx - meanx
+                dy = vy - meany
+                meanx += 1. / nobs * dx
+                meany += 1. / nobs * dy
+                ssqdmx += (vx - meanx) * dx
+                ssqdmy += (vy - meany) * dy
+                covxy += (vx - meanx) * dy
+
+    if nobs < minpv:
+        result[xi, yi] = result[yi, xi] = NaN
+    else:
+        divisor = (nobs - 1.0) if cov else sqrt(ssqdmx * ssqdmy)
+
+        # clip `covxy / divisor` to ensure coeff is within bounds
+        if divisor != 0:
+            val = covxy / divisor
+            if not cov:
+                if val > 1.0:
+                    val = 1.0
+                elif val < -1.0:
+                    val = -1.0
+            result[xi, yi] = result[yi, xi] = val
+        else:
+            result[xi, yi] = result[yi, xi] = NaN
+
+
 def nancorr(const float64_t[:, :] mat, bint cov=False, minp=None):
     cdef:
-        Py_ssize_t i, xi, yi, N, K
+        Py_ssize_t xi, yi, N, K
         int64_t minpv
         float64_t[:, ::1] result
         uint8_t[:, :] mask
-        int64_t nobs = 0
-        float64_t vx, vy, dx, dy, meanx, meany, divisor, ssqdmx, ssqdmy, covxy, val
         bint no_nans
+        int num_threads
 
     N, K = (<object>mat).shape
     if minp is None:
@@ -371,55 +435,23 @@ def nancorr(const float64_t[:, :] mat, bint cov=False, minp=None):
     mask = np.isfinite(mat).view(np.uint8)
     no_nans = np.asarray(mask).all()
 
+    # OpenMP fork/join costs ~100us, so parallelism is only a win once the
+    # per-call work exceeds that by a comfortable margin. The inner work is
+    # ~K*(K+1)/2 pairs * N rows; empirically the breakeven is around
+    # K*K*N ~ 1e5 and every shape above 2e5 shows >=1.2x speedup.
+    if <int64_t>K * K * N < 200_000:
+        num_threads = 1
+    else:
+        num_threads = 0  # let OpenMP choose
+
     with nogil:
-        for xi in range(K):
+        # schedule="dynamic" because inner loop length grows with xi, so
+        # static scheduling would leave threads with small xi idle.
+        for xi in prange(K, schedule="dynamic", num_threads=num_threads):
             for yi in range(xi + 1):
-                # Welford's method for the variance-calculation
-                # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
-                nobs = ssqdmx = ssqdmy = covxy = meanx = meany = 0
-
-                if no_nans:
-                    nobs = N
-                    for i in range(N):
-                        vx = mat[i, xi]
-                        vy = mat[i, yi]
-                        dx = vx - meanx
-                        dy = vy - meany
-                        meanx += 1. / (i + 1) * dx
-                        meany += 1. / (i + 1) * dy
-                        ssqdmx += (vx - meanx) * dx
-                        ssqdmy += (vy - meany) * dy
-                        covxy += (vx - meanx) * dy
-                else:
-                    for i in range(N):
-                        if mask[i, xi] and mask[i, yi]:
-                            vx = mat[i, xi]
-                            vy = mat[i, yi]
-                            nobs += 1
-                            dx = vx - meanx
-                            dy = vy - meany
-                            meanx += 1. / nobs * dx
-                            meany += 1. / nobs * dy
-                            ssqdmx += (vx - meanx) * dx
-                            ssqdmy += (vy - meany) * dy
-                            covxy += (vx - meanx) * dy
-
-                if nobs < minpv:
-                    result[xi, yi] = result[yi, xi] = NaN
-                else:
-                    divisor = (nobs - 1.0) if cov else sqrt(ssqdmx * ssqdmy)
-
-                    # clip `covxy / divisor` to ensure coeff is within bounds
-                    if divisor != 0:
-                        val = covxy / divisor
-                        if not cov:
-                            if val > 1.0:
-                                val = 1.0
-                            elif val < -1.0:
-                                val = -1.0
-                        result[xi, yi] = result[yi, xi] = val
-                    else:
-                        result[xi, yi] = result[yi, xi] = NaN
+                _nancorr_pair(
+                    xi, yi, N, mat, mask, result, no_nans, cov, minpv
+                )
 
     return result.base
 

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -105,7 +105,7 @@ cdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna, const uint8
     cdef:
         int64_t[::1] result_counts = np.empty(table.size + na_add, dtype=np.int64)
 
-    for i in range(table.size):
+    for i in range(<Py_ssize_t>table.size):
         {{if dtype == 'object'}}
         k = kh_get_{{ttype}}(table, result_keys.data[i])
         {{else}}
@@ -114,7 +114,7 @@ cdef value_count_{{dtype}}(const {{dtype}}_t[:] values, bint dropna, const uint8
         result_counts[i] = table.vals[k]
 
     if na_counter > 0:
-        result_counts[table.size] = na_counter
+        result_counts[<Py_ssize_t>table.size] = na_counter
         result_keys.append(val)
 
     kh_destroy_{{ttype}}(table)

--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -61,7 +61,7 @@ libs_sources = {
     # numpy include dir is implicitly included
     'algos': {
         'sources': ['algos.pyx', _algos_common_helper, _algos_take_helper],
-        'deps': [_khash_primitive_helper_dep, m_dep],
+        'deps': [_khash_primitive_helper_dep, m_dep, openmp_dep],
     },
     'arrays': {'sources': ['arrays.pyx']},
     'groupby': {'sources': ['groupby.pyx'], 'deps': [m_dep]},

--- a/pixi.lock
+++ b/pixi.lock
@@ -3138,7 +3138,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.3-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.3-py311h2b939e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mmh3-4.1.0-py311hb755f60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mmhash3-3.0.1-py313h94de1ce_3.conda
@@ -3501,7 +3501,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.9.3-py311hfecb2dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.9.3-py311h0385ec1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mmh3-4.1.0-py311h8715677_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mmhash3-3.0.1-py313h94de1ce_3.conda
@@ -3842,7 +3842,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.3-py311h6eed73b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.3-py311h19a4563_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mmh3-4.1.0-py311hdd0406b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mmhash3-3.0.1-py313h94de1ce_3.conda
@@ -4145,7 +4145,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.9.3-py311ha1ab1f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.3-py311h031da69_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mmh3-4.1.0-py311h92babd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mmhash3-3.0.1-py313h94de1ce_3.conda
@@ -4428,7 +4428,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.3-py311h1ea47a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.3-py311h8f1b1e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mmh3-4.1.0-py311h12c1d0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mmhash3-3.0.1-py313h94de1ce_3.conda
@@ -36488,17 +36488,17 @@ packages:
   - pkg:pypi/meson?source=hash-mapping
   size: 762880
   timestamp: 1773600816980
-- conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.2.3-pyhd8ed1ab_0.conda
-  sha256: 8781b90ae65e1e982a7a28850567630d3f5b6b9c4a88cd9aa3f8a7a4971991e2
-  md5: 884e718cb42b3dbdf07f0ebea32ccacd
+- conda: https://conda.anaconda.org/conda-forge/noarch/meson-1.5.0-pyhd8ed1ab_0.conda
+  sha256: 9ca86c9ecedfcc727a9bb1f66787e26e230f57f0b49e24b673fa34e3a8376f34
+  md5: 9d971c5bf99aed063664d6650e7e7ed8
   depends:
   - ninja >=1.8.2
-  - python >=3.5.2
+  - python >=3.7
   - setuptools
   license: Apache-2.0
   license_family: APACHE
-  size: 618539
-  timestamp: 1697868378316
+  size: 648522
+  timestamp: 1720651658395
 - conda: https://conda.anaconda.org/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
   sha256: f608b7ee5ef089c31a80ea3b5dd42765f6792438a5c23efaad8419ad4e47b96d
   md5: 369afcc2d4965e7a6a075ab82e2a26b8

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ name = "pandas"
 # Build dependencies
 versioneer = ">=0.29"
 cython = ">3.1.0,<4.0.0a0"
-meson = ">=1.2.3,<2"
+meson = ">=1.5.0,<2"
 meson-python = ">=0.19.0,<1"
 c-compiler = "*"
 cxx-compiler = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # See https://github.com/scipy/scipy/pull/12940 for the AIX issue.
 requires = [
     "meson-python>=0.19.0,<1",
-    "meson>=1.2.3,<2",
+    "meson>=1.5.0,<2",
     "wheel",
     "Cython>3.1.0,<4.0.0a0",  # Note: sync with environment.yml and asv.conf.json
     # Force numpy higher than 2.0, so that built wheels are compatible

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 pip
 versioneer[toml]
 cython>=3.1.0,<4.0.0a0
-meson[ninja]>=1.2.3,<2
+meson[ninja]>=1.5.0,<2
 meson-python>=0.18.0,<1
 pytest>=8.3.4
 pytest-cov


### PR DESCRIPTION
Stacks on top of #64541 — proof of concept requested by @mroeschke showing measurable perf gains from `cython.prange` on an existing extension before merging the build infrastructure.

Once #64541 merges this PR's diff will shrink to just the nancorr changes.

## Summary
- Convert the outer `xi` loop in `nancorr` to `prange(..., schedule="dynamic")` so the K·(K+1)/2 pairwise correlations run in parallel across K.
- Extract each (xi, yi) Welford reduction into a `noexcept nogil` helper `_nancorr_pair` so Cython's reduction inference (triggered by `+=` on running accumulators) stays local.
- Add `openmp_dep` to the `algos` extension in `pandas/_libs/meson.build`.
- Small-input guard: `num_threads=1` when `K*K*N < 200_000` (~2x the empirical breakeven) to avoid paying OpenMP fork/join overhead on tiny inputs.

## Benchmark (12-core M-series, OpenMP default threads)

Crossover sweep across 50 shapes showed breakeven at `K*K*N ≈ 1e5` (no-NaN) / `1.25e5` (NaN); threshold of `2e5` gives a safety margin. With the guard active:

| shape | serial (ms) | parallel (ms) | speedup |
|---|---|---|---|
| (100, 5)  — below threshold | 0.008 | 0.008 | 1.00x |
| (1000, 10) — below threshold | 0.12 | 0.12 | 1.00x |
| (500, 20)  — smallest parallel case | 0.21 | 0.18 | 1.23x |
| (5000, 50) | 13.1 | 2.3 | 5.6x |
| (1000, 100) | 10.2 | 1.66 | 6.2x |
| (1000, 500) — motivating case from #40956 | 252 | 34 | **7.5x** |
| (5000, 500) | 1574 | 248 | 6.3x |
| (1000, 1000) | 1013 | 140 | **7.2x** |

NaN-path shapes show a similar profile (min 1.20x above threshold, up to 6.96x). No shape in the tuning sweep regresses.

closes #40956

## Test plan
- [x] `pytest pandas/tests/frame/methods/test_cov_corr.py` — all 78 pass
- [x] Rebuild confirms libomp is linked into `algos.cpython-*.so`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)