### PR TITLE
BUG: fix segfault in Rolling method='table' sum/mean/median/min/max

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -317,6 +317,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.GroupBy.any` and :meth:`.GroupBy.all` returning ``NaN`` with ``float64`` dtype for unobserved categorical groups on NumPy ``bool`` data instead of the boolean identity value with ``bool`` dtype (:issue:`65100`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` (and their :class:`GroupBy` counterparts) returning ``0.0`` and ``-3.0`` respectively for degenerate windows or groups; these now return ``NaN`` (:issue:`62864`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
+- Bug in :meth:`.Rolling.sum`, :meth:`.Rolling.mean`, :meth:`.Rolling.median`, :meth:`.Rolling.min`, and :meth:`.Rolling.max` with ``method="table"``, ``engine="numba"``, and ``engine_kwargs={"parallel": True}`` could cause a segfault (:issue:`40454`)
 - Bug in :meth:`.SeriesGroupBy.ohlc` ignoring ``as_index=False`` (:issue:`65140`)
 - Bug in :meth:`DataFrame.groupby` with a :class:`Grouper` with ``freq`` raising ``AttributeError`` when all grouping keys are ``NaT`` (:issue:`43486`)
 - Bug in :meth:`Series.resample` and :meth:`DataFrame.resample` where same-frequency resampling with monthly, quarterly, or annual frequencies bypassed aggregation, returning the original values instead of the aggregation result (:issue:`18553`)

--- a/pandas/core/window/numba_.py
+++ b/pandas/core/window/numba_.py
@@ -242,7 +242,10 @@ def generate_manual_numpy_nan_agg_with_axis(nan_func):
     else:
         numba = import_optional_dependency("numba")
 
-    @numba.jit(nogil=True, parallel=True)
+    # parallel=False is load-bearing: this is invoked inside an outer
+    # parallel=True jit, and nested parallel launches crash numba's
+    # non-threadsafe workqueue threading layer (GH#40454)
+    @numba.jit(nogil=True, parallel=False)
     def nan_agg_with_axis(table):
         result = np.empty(table.shape[1])
         for i in numba.prange(table.shape[1]):

--- a/pandas/core/window/numba_.py
+++ b/pandas/core/window/numba_.py
@@ -242,10 +242,11 @@ def generate_manual_numpy_nan_agg_with_axis(nan_func):
     else:
         numba = import_optional_dependency("numba")
 
-    # parallel=False is load-bearing: this is invoked inside an outer
-    # parallel=True jit, and nested parallel launches crash numba's
-    # non-threadsafe workqueue threading layer (GH#40454)
-    @numba.jit(nogil=True, parallel=False)
+    # Not jitted directly: this is passed through jit_user_function in
+    # generate_numba_table_func, which wraps it with register_jitable so it
+    # inlines into roll_table's outer jit. A standalone @jit(parallel=True)
+    # here nests parallel regions and crashes the workqueue threading layer
+    # on platforms without tbb/openmp (GH#40454).
     def nan_agg_with_axis(table):
         result = np.empty(table.shape[1])
         for i in numba.prange(table.shape[1]):


### PR DESCRIPTION
## Summary
- Closes the long-standing segfault in ``Rolling.{sum,mean,median,min,max}`` with ``method='table'``, ``engine='numba'``, and ``engine_kwargs={'parallel': True}`` on platforms where numba falls back to the non-threadsafe ``workqueue`` threading layer (notably macOS without ``tbb`` / ``intel-openmp``, including all arm64 Macs since those packages have no arm64 wheels on PyPI).
- The inner ``nan_agg_with_axis`` was pre-jitted with ``parallel=True``, nesting inside the outer ``parallel=True`` ``roll_table`` kernel. On ``workqueue`` the nested launch trips "Concurrent access has been detected" and aborts.
- Fix: drop ``parallel=True`` from the inner function. The inner prange iterates over DataFrame columns; the outer iterates over windows (typically thousands+), which already saturates cores — nested prange on threadsafe layers was close to a no-op.
- Reproducer (portable, no macOS required): ``NUMBA_THREADING_LAYER=workqueue pytest pandas/tests/window/test_numba.py::TestTableMethod::test_table_method_rolling_methods``.

closes #40454

## Test plan
- [x] ``pytest pandas/tests/window/test_numba.py`` passes locally (752/752, incl. the 90 parametrizations of ``test_table_method_rolling_methods`` that previously segfaulted).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)