### PR TITLE
REF: remove DatetimeArray._with_freq, further freq management cleanup (GH#24566)

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2386,35 +2386,6 @@ class TimelikeOps(DatetimeLikeArrayMixin):
     def _maybe_clear_freq(self) -> None:
         self._freq = None
 
-    def _with_freq(self, freq) -> Self:
-        """
-        Helper to get a view on the same data, with a new freq.
-
-        Parameters
-        ----------
-        freq : DateOffset, None, or "infer"
-
-        Returns
-        -------
-        Same type as self
-        """
-        # GH#29843
-        if freq is None:
-            # Always valid
-            pass
-        elif isinstance(freq, BaseOffset):
-            # In the TimedeltaArray case, we require a Tick offset
-            if self.dtype.kind == "m" and not isinstance(freq, (Tick, Day)):
-                raise TypeError("TimedeltaArray/Index freq must be a Tick")
-        elif freq == "infer":
-            freq = to_offset(self.inferred_freq)
-        else:
-            raise ValueError(f"Invalid frequency: {freq!r}")
-
-        arr = self.view()
-        arr._freq = freq
-        return arr
-
     # --------------------------------------------------------------
     # ExtensionArray Interface
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1105,7 +1105,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         dtype = tz_to_dtype(tz=other.tz, unit=self.unit)
         res_values = result.view(f"M8[{self.unit}]")
-        return DatetimeArray._simple_new(res_values, dtype=dtype, freq=None)
+        return DatetimeArray._simple_new(res_values, dtype=dtype)
 
     @final
     def _add_datetime_arraylike(self, other: DatetimeArray) -> DatetimeArray:
@@ -1165,7 +1165,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         res_values = add_overflowsafe(self.asi8, np.asarray(-other_i8, dtype="i8"))
         res_m8 = res_values.view(f"timedelta64[{self.unit}]")
 
-        return TimedeltaArray._simple_new(res_m8, dtype=res_m8.dtype, freq=None)
+        return TimedeltaArray._simple_new(res_m8, dtype=res_m8.dtype)
 
     @final
     def _add_period(self, other: Period) -> PeriodArray:
@@ -1227,12 +1227,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         new_values = add_overflowsafe(self.asi8, np.asarray(other_i8, dtype="i8"))
         res_values = new_values.view(self._ndarray.dtype)
 
-        # error: Unexpected keyword argument "freq" for "_simple_new" of "NDArrayBacked"
-        return type(self)._simple_new(
-            res_values,
-            dtype=self.dtype,
-            freq=None,  # type: ignore[call-arg]
-        )
+        return type(self)._simple_new(res_values, dtype=self.dtype)
 
     @final
     def _add_nat(self) -> Self:
@@ -1249,12 +1244,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         result = np.empty(self.shape, dtype=np.int64)
         result.fill(iNaT)
         result = result.view(self._ndarray.dtype)  # preserve reso
-        # error: Unexpected keyword argument "freq" for "_simple_new" of "NDArrayBacked"
-        return type(self)._simple_new(
-            result,
-            dtype=self.dtype,
-            freq=None,  # type: ignore[call-arg]
-        )
+        return type(self)._simple_new(result, dtype=self.dtype)
 
     @final
     def _sub_nat(self) -> np.ndarray:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -945,7 +945,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
         # No conversion since timestamps are all UTC to begin with
         dtype = tz_to_dtype(tz, unit=self.unit)
-        return self._simple_new(self._ndarray, dtype=dtype, freq=None)
+        return self._simple_new(self._ndarray, dtype=dtype)
 
     @dtl.ravel_compat
     def tz_localize(
@@ -1122,7 +1122,7 @@ default 'raise'
         new_dates_dt64 = new_dates.view(f"M8[{self.unit}]")
         dtype = tz_to_dtype(tz, unit=self.unit)
 
-        return self._simple_new(new_dates_dt64, dtype=dtype, freq=None)
+        return self._simple_new(new_dates_dt64, dtype=dtype)
 
     # ----------------------------------------------------------------
     # Conversion Methods - Vectorized analogues of Timestamp methods

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -992,7 +992,7 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
                 # TODO: other cases?
             return dta
         else:
-            dta = dta._with_freq("infer")
+            dta._freq = to_offset(dta.inferred_freq)
             if freq is not None:
                 freq = to_offset(freq)
                 if (

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -409,7 +409,7 @@ class TimedeltaArray(dtl.TimelikeOps):
             op = getattr(datetimelike_accumulations, name)
             result = op(self._ndarray.copy(), skipna=skipna, **kwargs)
 
-            return type(self)._simple_new(result, freq=None, dtype=self.dtype)
+            return type(self)._simple_new(result, dtype=self.dtype)
         elif name == "cumprod":
             raise TypeError("cumprod not supported for Timedelta.")
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -917,16 +917,18 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
 
     def _with_freq(self, freq):
         # GH#29843
-        if freq is None or (len(self) == 0 and isinstance(freq, BaseOffset)):
-            # None is always valid. For offsets on empty index the array's
-            # _with_freq below performs the m-dtype Tick validation.
+        if freq is None:
             pass
-        else:
-            # As an internal method, we can ensure this assertion always holds
-            assert freq == "infer"
+        elif isinstance(freq, BaseOffset):
+            if self.dtype.kind == "m" and not isinstance(freq, (Tick, Day)):
+                raise TypeError("TimedeltaArray/Index freq must be a Tick")
+        elif freq == "infer":
             freq = to_offset(self.inferred_freq)
+        else:
+            raise ValueError(f"Invalid frequency: {freq!r}")
 
-        arr = self._data._with_freq(freq)
+        arr = self._data.view()
+        arr._freq = freq
         return type(self)._simple_new(arr, name=self._name)
 
     @property

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -1220,12 +1220,13 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             return self._range_union(other, sort=sort)
 
         if self._can_fast_union(other):
-            result = self._fast_union(other, sort=sort)
             # in the case with sort=None, the _can_fast_union check ensures
             #  that result.freq == self.freq
-            return result
+            return self._fast_union(other, sort=sort)
         else:
-            return super()._union(other, sort)._with_freq("infer")  # type: ignore[union-attr]
+            # super()._union can return an ArrayLike; wrap into an Index first
+            result = self._wrap_setop_result(other, super()._union(other, sort))
+            return result._with_freq("infer")  # type: ignore[attr-defined]
 
     # --------------------------------------------------------------------
     # Join Methods

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -496,7 +496,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                        dtype='datetime64[us, Asia/Calcutta]', freq=None)
         """
         arr = self._data.normalize()
-        arr = arr._with_freq("infer")
+        arr._freq = to_offset(arr.inferred_freq)
         return type(self)._simple_new(arr, name=self.name)
 
     def tz_convert(self, tz) -> Self:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2252,7 +2252,8 @@ def maybe_coerce_values(values: ArrayLike) -> ArrayLike:
 
     if isinstance(values, (DatetimeArray, TimedeltaArray)) and values.freq is not None:
         # freq is only stored in DatetimeIndex/TimedeltaIndex, not in Series/DataFrame
-        values = values._with_freq(None)
+        values = values.view()
+        values._freq = None
 
     return values
 

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1073,7 +1073,7 @@ class TestTimedeltaArraylikeAddSubOps:
         if box_with_array is pd.array:
             # GH#24566 Array-level __neg__ and __rsub__ don't carry freq;
             # freq is managed by the Index layer.
-            expected2 = expected2._with_freq(None)
+            expected2._freq = None
 
         tm.assert_equal(ts - tdarr, expected2)
         tm.assert_equal(ts + (-tdarr), expected2)

--- a/pandas/tests/arrays/datetimes/test_constructors.py
+++ b/pandas/tests/arrays/datetimes/test_constructors.py
@@ -45,7 +45,8 @@ class TestDatetimeArrayConstructor:
     def test_from_pandas_array(self):
         arr = pd.array(np.arange(5, dtype=np.int64)) * 3600 * 10**9
 
-        result = DatetimeArray._from_sequence(arr, dtype="M8[ns]")._with_freq("infer")
+        result = DatetimeArray._from_sequence(arr, dtype="M8[ns]")
+        result._freq = pd.tseries.frequencies.to_offset(result.inferred_freq)
 
         expected = pd.date_range("1970-01-01", periods=5, freq="h", unit="ns")._data
         tm.assert_datetime_array_equal(result, expected)

--- a/pandas/tests/arrays/datetimes/test_cumulative.py
+++ b/pandas/tests/arrays/datetimes/test_cumulative.py
@@ -3,6 +3,8 @@ import pytest
 import pandas._testing as tm
 from pandas.core.arrays import DatetimeArray
 
+from pandas.tseries.frequencies import to_offset
+
 
 class TestAccumulator:
     def test_accumulators_freq(self):
@@ -14,7 +16,8 @@ class TestAccumulator:
                 "2000-01-03",
             ],
             dtype="M8[ns]",
-        )._with_freq("infer")
+        )
+        arr._freq = to_offset(arr.inferred_freq)
         result = arr._accumulate("cummin")
         expected = DatetimeArray._from_sequence(["2000-01-01"] * 3, dtype="M8[ns]")
         tm.assert_datetime_array_equal(result, expected)
@@ -39,6 +42,7 @@ class TestAccumulator:
                 "2000-01-02",
             ],
             dtype="M8[ns]",
-        )._with_freq("infer")
+        )
+        arr._freq = to_offset(arr.inferred_freq)
         with pytest.raises(TypeError, match=f"Accumulation {func}"):
             arr._accumulate(func)

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -456,7 +456,7 @@ class SharedTests:
     def test_setitem_object_dtype(self, box, arr1d):
         expected = arr1d.copy()[::-1]
         if expected.dtype.kind in ["m", "M"]:
-            expected = expected._with_freq(None)
+            expected._freq = None
 
         vals = expected
         if box is list:
@@ -496,7 +496,7 @@ class SharedTests:
     def test_setitem_categorical(self, arr1d, as_index):
         expected = arr1d.copy()[::-1]
         if not isinstance(expected, PeriodArray):
-            expected = expected._with_freq(None)
+            expected._freq = None
 
         cat = pd.Categorical(arr1d)
         if as_index:
@@ -652,7 +652,8 @@ class TestDatetimeArray(SharedTests):
 
         dta = dti._data
         result = dta.round(freq="2min")
-        expected = expected._data._with_freq(None)
+        expected = expected._data.view()
+        expected._freq = None
         tm.assert_datetime_array_equal(result, expected)
 
     def test_array_interface(self, datetime_index):

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -115,7 +115,8 @@ class TestDatetimeArray(base.ExtensionTests):
 
     def test_series_constructor(self, data):
         # Series construction drops any .freq attr
-        data = data._with_freq(None)
+        data = data.view()
+        data._freq = None
         super().test_series_constructor(data)
 
     @pytest.mark.parametrize("na_action", [None, "ignore"])

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -146,11 +146,14 @@ class TestTimedeltaIndex:
 
         # check this matches Series and TimedeltaArray
         # freq is not preserved at the array level; Index handles freq
+        exp_arr = expected._values.view()
+        exp_arr._freq = None
+
         res = tdi._data.astype("m8[s]")
-        tm.assert_equal(res, expected._values._with_freq(None))
+        tm.assert_equal(res, exp_arr)
 
         res = tdi.to_series().astype("m8[s]")
-        tm.assert_equal(res._values, expected._values._with_freq(None))
+        tm.assert_equal(res._values, exp_arr)
 
     @pytest.mark.parametrize("dtype", [float, "datetime64", "datetime64[ns]"])
     def test_astype_raises(self, dtype):

--- a/pandas/tests/indexes/timedeltas/test_freq_attr.py
+++ b/pandas/tests/indexes/timedeltas/test_freq_attr.py
@@ -33,8 +33,6 @@ class TestFreq:
         msg = "TimedeltaArray/Index freq must be a Tick"
         with pytest.raises(TypeError, match=msg):
             idx._with_freq(off)
-        with pytest.raises(TypeError, match=msg):
-            idx._data._with_freq(off)
 
     def test_freq_setter_errors(self):
         # GH#20678

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2783,7 +2783,7 @@ class TestToDatetimeMisc:
         result = to_datetime(obj, utc=True)
         if klass is not DatetimeIndex:
             # Array methods no longer set freq; freq is managed by Index
-            expected = expected._with_freq(None)
+            expected._freq = None
         tm.assert_equal(result, expected)
 
 


### PR DESCRIPTION
## Summary

Stacks on top of #65266 and continues the GH#24566 effort to move freq management out of DatetimeArray/TimedeltaArray and onto the Index layer.

- **`REF: make DatetimeTimedeltaMixin._with_freq self-contained`** — Index-level `_with_freq` stops delegating to the array's `_with_freq`. It does its own `view() + _freq =` and handles all validation (None / BaseOffset+Tick-for-m-dtype / "infer" resolution / else ValueError) directly, mirroring the `as_unit` pattern.
- **`REF: stop calling DatetimeLikeArrayMixin._with_freq from non-test core callers`** — The three non-test core callers (`blocks.maybe_coerce_values`, `PeriodArray.to_timestamp`, `DatetimeIndex.normalize`) now manage `_freq` directly via `view()` + `_freq =` or `to_offset(inferred_freq)`.
- **`REF: remove DatetimeLikeArrayMixin._with_freq`** — With no remaining non-test callers, the array method is deleted (~29 lines). ~10 test callers updated to direct `_freq =` assignment. The `_union` fallback now wraps `super()._union` via `_wrap_setop_result` before calling Index-level `_with_freq`, since the base `_union` can return an `ArrayLike` rather than an Index.
- **`CLN: drop redundant freq=None from DTA/TDA _simple_new call sites`** — 7 call sites where `freq=None` was redundant noise (it's already the default), plus several now-obsolete `# type: ignore[call-arg]` comments.
- **`TST: update test_to_datetime_dta_tz for array-level _with_freq removal`** — One missed test caller.

## Test plan

- [x] `pytest pandas/tests/arithmetic/ pandas/tests/resample/ pandas/tests/series/ pandas/tests/arrays/ pandas/tests/indexes/ pandas/tests/tseries/ pandas/tests/frame/ pandas/tests/internals/ pandas/tests/extension/ pandas/tests/tools/test_to_datetime.py` — all pass
- [x] `mypy pandas/core/arrays/datetimelike.py pandas/core/indexes/datetimelike.py pandas/core/arrays/datetimes.py pandas/core/arrays/timedeltas.py` — no new errors
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)