### PR TITLE
PERF: speed up DataFrame.plot with DatetimeIndex on wide DataFrames

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -166,6 +166,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)
 - Performance improvement in :meth:`DataFrame.insert` when the number of blocks is small (:issue:`57641`)
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
+- Performance improvement in :meth:`DataFrame.plot` for line plots of wide DataFrames with a :class:`DatetimeIndex` or :class:`PeriodIndex` (:issue:`61398`)
 - Performance improvement in :meth:`DataFrame.query` and :meth:`DataFrame.eval` when the :class:`DataFrame` contains :class:`PeriodDtype` or :class:`IntervalDtype` columns (:issue:`35247`)
 - Performance improvement in :meth:`DataFrame.rank` and :meth:`Series.rank` for non-nullable numeric dtypes (:issue:`65054`)
 - Performance improvement in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` with the ``level`` parameter when the index is already sorted and not a :class:`MultiIndex` (:issue:`64883`)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1557,7 +1557,8 @@ class LinePlot(MPLPlot):
             self.data = self.data.fillna(value=0)
 
     def _make_plot(self, fig: Figure) -> None:
-        if self._is_ts_plot():
+        is_ts = self._is_ts_plot()
+        if is_ts:
             ax0 = self._get_ax(0)
             data = maybe_convert_index(ax0, self.data)
             # For BDay, maybe_convert_index produces a plain int64 index (to
@@ -1587,6 +1588,10 @@ class LinePlot(MPLPlot):
         is_errorbar = com.any_not_none(*self.errors.values())
 
         colors = self._get_colors()
+        # Collect unique ts axes so date-axis formatting + xlim run once per
+        # axis at the end, not once per column (GH#61398).
+        ts_axes: list[Axes] = []
+        seen_ax_ids: set[int] = set()
         for i, (label, y) in enumerate(it):
             ax = self._get_ax(i)
             kwds = self.kwds.copy()
@@ -1620,9 +1625,15 @@ class LinePlot(MPLPlot):
             )
             self._append_legend_handles_labels(newlines[0], label)
 
-            if self._is_ts_plot():
-                # reset of xlim should be used for ts data
-                # TODO: GH28021, should find a way to change view limit on xaxis
+            if is_ts and id(ax) not in seen_ax_ids:
+                ts_axes.append(ax)
+                seen_ax_ids.add(id(ax))
+
+        if is_ts:
+            # TODO: GH28021, should find a way to change view limit on xaxis
+            for ax in ts_axes:
+                # TODO #54485
+                format_dateaxis(ax, ax.freq, data.index)  # type: ignore[arg-type, attr-defined]
                 lines = get_all_lines(ax)
                 left, right = get_xlim(lines)
                 ax.set_xlim(left, right)
@@ -1653,15 +1664,13 @@ class LinePlot(MPLPlot):
         # accept x to be consistent with normal plot func,
         # x is not passed to tsplot as it uses data.index as x coordinate
         # column_num must be in kwds for stacking purpose
-        freq, data = prepare_ts_data(data, ax, kwds)
+        _freq, data = prepare_ts_data(data, ax, kwds)
 
         # TODO #54485
         ax._plot_data.append((data, self._kind, kwds))  # type: ignore[attr-defined]
 
         lines = self._plot(ax, data.index, np.asarray(data.values), style=style, **kwds)
-        # set date formatter, locators and rescale limits
-        # TODO #54485
-        format_dateaxis(ax, ax.freq, data.index)  # type: ignore[arg-type, attr-defined]
+        # format_dateaxis and xlim are handled once per axis in _make_plot.
         return lines
 
     @final


### PR DESCRIPTION
- closes #61398

## Summary

For line plots of time-series DataFrames, `LinePlot._make_plot` called `format_dateaxis` and reset xlim **once per column** on the shared axis. Each call re-created matplotlib locators/formatters, called `plt.draw_if_interactive`, and scanned every existing line to recompute xlim — turning the xlim reset into O(N²) in column count.

This PR collects the unique time-series axes during the column loop and runs `format_dateaxis` + xlim reset **once per axis** after the loop finishes. Output is unchanged since all columns share the same `ax.freq` and index, and the final xlim depends only on the full line set.

## Results

500-row DataFrame benchmarks (`.plot(legend=False)`):

| cols | before | after |
|------|--------|-------|
| 200  | 0.29s  | 0.14s |
| 500  | 1.10s  | 0.32s |
| 1000 | 3.58s  | 0.63s |
| 2000 | ~71s (issue repro) | 1.48s |

Scaling is now linear and roughly parallel with the `RangeIndex` path.

## Test plan

- [x] `pandas/tests/plotting/test_datetimelike.py` passes
- [x] `pandas/tests/plotting/frame/` and `test_series.py` pass
- [x] Manual correctness checks for `subplots=False`, `subplots=True`, Series, PeriodIndex, BDay freq, and RangeIndex

🤖 Generated with [Claude Code](https://claude.com/claude-code)