### PR TITLE
PERF: short-circuit sort_index(level=...) on monotonic non-MultiIndex

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -159,6 +159,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
 - Performance improvement in :meth:`DataFrame.query` and :meth:`DataFrame.eval` when the :class:`DataFrame` contains :class:`PeriodDtype` or :class:`IntervalDtype` columns (:issue:`35247`)
 - Performance improvement in :meth:`DataFrame.rank` and :meth:`Series.rank` for non-nullable numeric dtypes (:issue:`65054`)
+- Performance improvement in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` with the ``level`` parameter when the index is already sorted and not a :class:`MultiIndex` (:issue:`64883`)
 - Performance improvement in :meth:`DataFrame.sort_values` with multiple numeric columns by avoiding unnecessary :class:`Categorical` conversion (:issue:`15389`)
 - Performance improvement in :meth:`DataFrame.sum`, :meth:`DataFrame.prod`, :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`DataFrame.mean`, :meth:`DataFrame.any`, and :meth:`DataFrame.all` with ``axis=1`` for multi-block DataFrames by avoiding a transpose (:issue:`51474`)
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -90,6 +90,14 @@ def get_indexer_indexer(
     target = ensure_key_mapped(target, key, levels=level)  # type: ignore[assignment]
     target = target._sort_levels_monotonic()
 
+    if (np.all(ascending) and target.is_monotonic_increasing) or (
+        not np.any(ascending) and target.is_monotonic_decreasing
+    ):
+        # GH#11080, GH#64883: on a non-MultiIndex, `level` is a no-op,
+        # so short-circuit even when level is specified.
+        if level is None or not isinstance(target, ABCMultiIndex):
+            return None
+
     if level is not None:
         _, indexer = target.sortlevel(
             level,  # type: ignore[arg-type]
@@ -97,11 +105,6 @@ def get_indexer_indexer(
             sort_remaining=sort_remaining,
             na_position=na_position,
         )
-    elif (np.all(ascending) and target.is_monotonic_increasing) or (
-        not np.any(ascending) and target.is_monotonic_decreasing
-    ):
-        # Check monotonic-ness before sort an index (GH 11080)
-        return None
     elif isinstance(target, ABCMultiIndex):
         codes = [lev.codes for lev in target._get_codes_for_sorting()]
         indexer = lexsort_indexer(

--- a/pandas/tests/frame/methods/test_sort_index.py
+++ b/pandas/tests/frame/methods/test_sort_index.py
@@ -6,6 +6,7 @@ from pandas import (
     CategoricalDtype,
     CategoricalIndex,
     DataFrame,
+    Index,
     IntervalIndex,
     MultiIndex,
     RangeIndex,
@@ -821,6 +822,24 @@ class TestDataFrameSortIndex:
         df.index.names = ["foo"]
         result = df.sort_index(level="foo")
         tm.assert_frame_equal(result, df)
+
+    def test_sort_index_level_monotonic_no_copy(self):
+        # GH#64883: sort_index(level=...) on a monotonic non-MultiIndex
+        # should short-circuit and not copy data blocks
+        df = DataFrame({"a": np.arange(5, dtype=np.float64)}, index=Index(range(5)))
+        df.index.name = "foo"
+        result = df.sort_index(level="foo")
+        tm.assert_frame_equal(result, df)
+        assert np.shares_memory(result["a"].values, df["a"].values)
+
+        # descending on a decreasing index also short-circuits
+        df2 = DataFrame(
+            {"a": np.arange(5, dtype=np.float64)},
+            index=Index([5, 4, 3, 2, 1], name="foo"),
+        )
+        result2 = df2.sort_index(level="foo", ascending=False)
+        tm.assert_frame_equal(result2, df2)
+        assert np.shares_memory(result2["a"].values, df2["a"].values)
 
 
 class TestDataFrameSortIndexKey:


### PR DESCRIPTION
## Summary

- On a non-MultiIndex, the `level` parameter to `sort_index` is effectively a no-op — it can only refer to the single level, so sorting is identical to `level=None`.
- Before this change, `sort_index(level=...)` on an already-sorted non-MultiIndex skipped the existing monotonic short-circuit in `get_indexer_indexer` and fell through to `sortlevel`/`sort_values`, which returned an identity indexer — causing `_mgr.take()` to copy every data block for no reason.
- Reordered the checks in `get_indexer_indexer` so the monotonic short-circuit also fires when `level is not None` and the target is not a `MultiIndex`.

Closes #64883

## Test plan

- [x] New regression test `test_sort_index_level_monotonic_no_copy` verifies via `np.shares_memory` that the ascending and descending monotonic cases don't copy the underlying data.
- [x] All 67 existing `pandas/tests/frame/methods/test_sort_index.py` tests pass.
- [x] 258 adjacent sort tests (`test_sort_values` for DataFrame/Series, `test_sort_index` for Series, `pandas/tests/test_sorting.py`) pass.
- [x] The reproducer from the issue now runs `sort_index(level="idx")` at parity with `sort_index()` (~0.01 ms on 1M rows vs. the previous full-block copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)