### PR TITLE
CI: Ensure PANDAS_VERSION is set in docbuild workflow

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -57,6 +57,8 @@ jobs:
         elif [[ "$EVENT_NAME" == "push" && "$GITHUB_REF_NAME" =~ $tag_version_pat ]]; then
           PANDAS_VERSION="${GITHUB_REF_NAME:1}"
           echo "PANDAS_VERSION=$PANDAS_VERSION" >> "$GITHUB_ENV"
+        else
+          PANDAS_VERSION=""
         fi
 
         if [[ "$EVENT_NAME" == "push" && -n "$PANDAS_VERSION" ]]; then


### PR DESCRIPTION
It appears https://github.com/pandas-dev/pandas/actions/runs/24613921428/job/71972885178#step:2:41 is failing with `bash -euox` since the `Set pandas version` step has a possibility of not setting `PANDAS_VERSION` when on the main branch