### PR TITLE
REF: continue moving freq management off DatetimeArray/TimedeltaArray (GH#24566)

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -204,7 +204,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     _is_recognized_dtype: Callable[[DtypeObj], bool]
     _recognized_scalars: tuple[type, ...]
     _ndarray: np.ndarray
-    freq: BaseOffset | None
+
+    @property
+    def freq(self) -> BaseOffset | None:
+        # subclasses provide an implementation
+        raise AbstractMethodError(self)
 
     @cache_readonly
     def _can_hold_na(self) -> bool:
@@ -1769,6 +1773,8 @@ class TimelikeOps(DatetimeLikeArrayMixin):
     """
     Common ops for TimedeltaIndex/DatetimeIndex, but not PeriodIndex.
     """
+
+    _freq: BaseOffset | None = None
 
     @classmethod
     def _validate_dtype(cls, values, dtype):

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1494,17 +1494,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     def __iadd__(self, other) -> Self:
         result = self + other
         self[:] = result[:]
-        if self.dtype.kind in "mM":
-            # PeriodArray's freq is derived from dtype; only DTA/TDA track _freq.
-            # result may be an Index; unwrap before reading _freq.
-            self._freq = getattr(result, "_data", result)._freq
         return self
 
     def __isub__(self, other) -> Self:
         result = self - other
         self[:] = result[:]
-        if self.dtype.kind in "mM":
-            self._freq = getattr(result, "_data", result)._freq
         return self
 
     # --------------------------------------------------------------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -45,7 +45,6 @@ from pandas._libs.tslibs import (
     ints_to_pydatetime,
     ints_to_pytimedelta,
     periods_per_day,
-    to_offset,
 )
 from pandas._libs.tslibs.fields import (
     RoundTo,
@@ -1495,14 +1494,17 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     def __iadd__(self, other) -> Self:
         result = self + other
         self[:] = result[:]
-        # result may be an Index; unwrap before reading _freq
-        self._freq = getattr(result, "_data", result)._freq
+        if self.dtype.kind in "mM":
+            # PeriodArray's freq is derived from dtype; only DTA/TDA track _freq.
+            # result may be an Index; unwrap before reading _freq.
+            self._freq = getattr(result, "_data", result)._freq
         return self
 
     def __isub__(self, other) -> Self:
         result = self - other
         self[:] = result[:]
-        self._freq = getattr(result, "_data", result)._freq
+        if self.dtype.kind in "mM":
+            self._freq = getattr(result, "_data", result)._freq
         return self
 
     # --------------------------------------------------------------
@@ -1825,19 +1827,6 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         <Hour>
         """
         return self._freq
-
-    @freq.setter
-    def freq(self, value) -> None:
-        if value is not None:
-            value = to_offset(value)
-            self._validate_frequency(self, value)
-            if self.dtype.kind == "m" and not isinstance(value, (Tick, Day)):
-                raise TypeError("TimedeltaArray/Index freq must be a Tick")
-
-            if self.ndim > 1:
-                raise ValueError("Cannot set freq with ndim > 1")
-
-        self._freq = value
 
     @final
     @classmethod

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -404,21 +404,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         # I don't know if mypy can do that, possibly with Generics.
         # https://mypy.readthedocs.io/en/latest/generics.html
 
-        no_op = check_setitem_lengths(key, value, self)
+        check_setitem_lengths(key, value, self)
 
         # Calling super() before the no_op short-circuit means that we raise
         #  on invalid 'value' even if this is a no-op, e.g. wrong-dtype empty array.
         super().__setitem__(key, value)
-
-        if no_op:
-            return
-
-        self._maybe_clear_freq()
-
-    def _maybe_clear_freq(self) -> None:
-        # inplace operations like __setitem__ may invalidate the freq of
-        # DatetimeArray and TimedeltaArray
-        pass
 
     def astype(self, dtype, copy: bool = True):
         # Some notes on cases we don't have to handle here in the base class:
@@ -1505,11 +1495,14 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     def __iadd__(self, other) -> Self:
         result = self + other
         self[:] = result[:]
+        # result may be an Index; unwrap before reading _freq
+        self._freq = getattr(result, "_data", result)._freq
         return self
 
     def __isub__(self, other) -> Self:
         result = self - other
         self[:] = result[:]
+        self._freq = getattr(result, "_data", result)._freq
         return self
 
     # --------------------------------------------------------------
@@ -2369,12 +2362,6 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         # GH#34479 the nanops call will raise a TypeError for non-td64 dtype
 
         return nanops.nanall(self._ndarray, axis=axis, skipna=skipna, mask=self.isna())
-
-    # --------------------------------------------------------------
-    # Frequency Methods
-
-    def _maybe_clear_freq(self) -> None:
-        self._freq = None
 
     # --------------------------------------------------------------
     # ExtensionArray Interface

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -303,7 +303,6 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
     def _simple_new(  # type: ignore[override]
         cls,
         values: npt.NDArray[np.datetime64],
-        freq: BaseOffset | None = None,
         dtype: np.dtype[np.datetime64] | DatetimeTZDtype = DT64NS_DTYPE,
     ) -> Self:
         assert isinstance(values, np.ndarray)
@@ -317,7 +316,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             assert dtype._creso == get_unit_from_dtype(values.dtype)
 
         result = super()._simple_new(values, dtype)
-        result._freq = freq
+        result._freq = None
         return result
 
     @classmethod
@@ -548,7 +547,9 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
         dt64_values = i8values.view(f"datetime64[{unit}]")
         dtype = tz_to_dtype(tz, unit=unit)
-        return cls._simple_new(dt64_values, freq=freq, dtype=dtype)
+        result = cls._simple_new(dt64_values, dtype=dtype)
+        result._freq = freq
+        return result
 
     # -----------------------------------------------------------------
     # DatetimeLike Interface

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -404,9 +404,8 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
     def dtype(self) -> PeriodDtype:
         return self._dtype
 
-    # error: Cannot override writeable attribute with read-only property
     @property
-    def freq(self) -> BaseOffset:  # type: ignore[override]
+    def freq(self) -> BaseOffset:
         """
         Return the frequency object for this PeriodArray.
         """

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -237,7 +237,6 @@ class TimedeltaArray(dtl.TimelikeOps):
     def _simple_new(  # type: ignore[override]
         cls,
         values: npt.NDArray[np.timedelta64],
-        freq: Tick | Day | None = None,
         dtype: np.dtype[np.timedelta64] = TD64NS_DTYPE,
     ) -> Self:
         # Require td64 dtype, not unit-less, matching values.dtype
@@ -245,10 +244,9 @@ class TimedeltaArray(dtl.TimelikeOps):
         assert not tslibs.is_unitless(dtype)
         assert isinstance(values, np.ndarray), type(values)
         assert dtype == values.dtype
-        assert freq is None or isinstance(freq, (Tick, Day))
 
         result = super()._simple_new(values=values, dtype=dtype)
-        result._freq = freq
+        result._freq = None
         return result
 
     @classmethod
@@ -264,7 +262,9 @@ class TimedeltaArray(dtl.TimelikeOps):
         if dtype is not None:
             data = astype_overflowsafe(data, dtype=dtype, copy=False)
 
-        return cls._simple_new(data, dtype=data.dtype, freq=freq)
+        result = cls._simple_new(data, dtype=data.dtype)
+        result._freq = freq
+        return result
 
     @classmethod
     def _generate_range(
@@ -307,7 +307,9 @@ class TimedeltaArray(dtl.TimelikeOps):
             index = index[:-1]
 
         td64values = index.view(f"m8[{unit}]")
-        return cls._simple_new(td64values, dtype=td64values.dtype, freq=freq)
+        result = cls._simple_new(td64values, dtype=td64values.dtype)
+        result._freq = freq
+        return result
 
     # ----------------------------------------------------------------
     # DatetimeLike Interface

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -186,8 +186,22 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
 
     @freq.setter
     def freq(self, value) -> None:
-        # error: Property "freq" defined in "PeriodArray" is read-only  [misc]
-        self._data.freq = value  # type: ignore[misc]
+        arr = self._data
+        if not hasattr(arr, "_validate_frequency"):
+            # e.g. PeriodArray freq is derived from dtype and is read-only
+            raise AttributeError(
+                f"property 'freq' of {type(arr).__name__!r} object has no setter"
+            )
+        if value is not None:
+            value = to_offset(value)
+            arr._validate_frequency(arr, value)
+            if arr.dtype.kind == "m" and not isinstance(value, (Tick, Day)):
+                raise TypeError("TimedeltaArray/Index freq must be a Tick")
+
+            if arr.ndim > 1:
+                raise ValueError("Cannot set freq with ndim > 1")
+
+        arr._freq = value
 
     @property
     def asi8(self) -> npt.NDArray[np.int64]:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -187,7 +187,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
     @freq.setter
     def freq(self, value) -> None:
         arr = self._data
-        if not hasattr(arr, "_validate_frequency"):
+        if not isinstance(arr, (DatetimeArray, TimedeltaArray)):
             # e.g. PeriodArray freq is derived from dtype and is read-only
             raise AttributeError(
                 f"property 'freq' of {type(arr).__name__!r} object has no setter"

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -1064,8 +1064,8 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             # "Union[dtype[datetime64], DatetimeTZDtype]"
             res_values,
             dtype=self.dtype,  # type: ignore[arg-type]
-            freq=new_freq,  # type: ignore[arg-type]
         )
+        result._freq = new_freq
         return cast("Self", self._wrap_setop_result(other, result))
 
     def _range_intersect(self, other, sort) -> Self:

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -92,7 +92,8 @@ def _new_DatetimeIndex(cls, d):
             #  a DatetimeArray to adapt to the newer _simple_new signature
             tz = d.pop("tz")
             freq = d.pop("freq")
-            dta = DatetimeArray._simple_new(data, dtype=tz_to_dtype(tz), freq=freq)
+            dta = DatetimeArray._simple_new(data, dtype=tz_to_dtype(tz))
+            dta._freq = freq
         else:
             dta = data
             for key in ["tz", "freq"]:

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1099,6 +1099,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                     s = t1
             dta[i] = s
 
+        dta._freq = None
         return DatetimeIndex._simple_new(dta, name=self.name)
 
     # --------------------------------------------------------------------

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3095,9 +3095,8 @@ class GenericFixed(Fixed):
 
             def f(values, freq=None, tz=None):  # pyright: ignore[reportRedeclaration]
                 # data are already in UTC, localize and convert if tz present
-                dta = DatetimeArray._simple_new(
-                    values.values, dtype=values.dtype, freq=freq
-                )
+                dta = DatetimeArray._simple_new(values.values, dtype=values.dtype)
+                dta._freq = freq
                 result = DatetimeIndex._simple_new(dta, name=None)
                 if tz is not None:
                     result = result.tz_localize("UTC").tz_convert(tz)

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -797,6 +797,11 @@ class TestDatetime64Arithmetic:
         tm.assert_equal(result, expected)
 
         rng += two_hours
+        if box_with_array is pd.array:
+            # Array-level __iadd__ no longer manages freq (Index manages freq);
+            # rng retains its pre-iadd freq even though `rng + x` would return
+            # a freq=None array.
+            expected._freq = rng._freq
         tm.assert_equal(rng, expected)
 
     def test_dt64arr_sub_timedeltalike_scalar(
@@ -816,6 +821,9 @@ class TestDatetime64Arithmetic:
         tm.assert_equal(result, expected)
 
         rng -= two_hours
+        if box_with_array is pd.array:
+            # See test_dt64arr_add_timedeltalike_scalar.
+            expected._freq = rng._freq
         tm.assert_equal(rng, expected)
 
     def test_dt64_array_sub_dt_with_different_timezone(self, box_with_array):

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -631,6 +631,9 @@ class TestTimedelta64ArithmeticUnsorted:
 
         orig_rng = rng
         rng += two_hours
+        if box_with_array is pd.array:
+            # Array __iadd__ no longer manages freq; rng retains pre-iadd freq.
+            expected._freq = rng._freq
         tm.assert_equal(rng, expected)
         if box_with_array is not Index:
             # Check that operation is actually inplace
@@ -657,6 +660,9 @@ class TestTimedelta64ArithmeticUnsorted:
 
         orig_rng = rng
         rng -= two_hours
+        if box_with_array is pd.array:
+            # See test_tdi_iadd_timedeltalike.
+            expected._freq = rng._freq
         tm.assert_equal(rng, expected)
         if box_with_array is not Index:
             # Check that operation is actually inplace

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -336,7 +336,7 @@ class TestCategoricalConstructors:
         c = Categorical(s)
 
         expected = type(dtl)(s)
-        expected._data.freq = None
+        expected._data._freq = None
 
         tm.assert_index_equal(c.categories, expected)
         tm.assert_numpy_array_equal(c.codes, np.arange(5, dtype="int8"))
@@ -347,7 +347,7 @@ class TestCategoricalConstructors:
         c = Categorical(s2)
 
         expected = type(dtl)(s2.dropna())
-        expected._data.freq = None
+        expected._data._freq = None
 
         tm.assert_index_equal(c.categories, expected)
 

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -552,10 +552,16 @@ class SharedTests:
 
         expected = arr + pd.Timedelta(days=1)
         arr += pd.Timedelta(days=1)
+        # Array __iadd__ no longer manages freq; arr keeps pre-iadd freq
+        # while `arr + x` returns a freq-stripped array.
+        if hasattr(arr, "_freq"):
+            expected._freq = arr._freq
         tm.assert_equal(arr, expected)
 
         expected = arr - pd.Timedelta(days=1)
         arr -= pd.Timedelta(days=1)
+        if hasattr(arr, "_freq"):
+            expected._freq = arr._freq
         tm.assert_equal(arr, expected)
 
     def test_shift_fill_int_deprecated(self, arr1d):

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -456,7 +456,8 @@ class SharedTests:
     def test_setitem_object_dtype(self, box, arr1d):
         expected = arr1d.copy()[::-1]
         if expected.dtype.kind in ["m", "M"]:
-            expected._freq = None
+            # __setitem__ no longer clears freq on the target array
+            expected._freq = arr1d._freq
 
         vals = expected
         if box is list:
@@ -496,7 +497,8 @@ class SharedTests:
     def test_setitem_categorical(self, arr1d, as_index):
         expected = arr1d.copy()[::-1]
         if not isinstance(expected, PeriodArray):
-            expected._freq = None
+            # __setitem__ no longer clears freq on the target array
+            expected._freq = arr1d._freq
 
         cat = pd.Categorical(arr1d)
         if as_index:
@@ -576,6 +578,9 @@ class SharedTests:
         arr[len(arr) // 2] = NaT
         if not isinstance(expected, Period):
             expected = arr[len(arr) // 2 - 1 : len(arr) // 2 + 2].mean()
+            # setitem no longer clears freq; result of median has freq=None
+            if hasattr(arr, "_freq"):
+                arr._freq = None
 
         assert arr.median(skipna=False) is NaT
 
@@ -1229,6 +1234,10 @@ def test_casting_nat_setitem_array(arr, casting_nats):
     for nat in casting_nats:
         arr = arr.copy()
         arr[0] = nat
+        if hasattr(arr, "_freq"):
+            # setitem no longer clears freq on the array; values are no longer
+            # on freq after introducing NaT, so match expected.
+            arr._freq = None
         tm.assert_equal(arr, expected)
 
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -479,11 +479,6 @@ class TestDatetimeArray:
         arr[0] = ts
         assert arr[0] == ts.tz_convert("US/Central")
 
-    def test_setitem_clears_freq(self):
-        a = pd.date_range("2000", periods=2, freq="D", tz="US/Central")._data
-        a[0] = pd.Timestamp("2000", tz="US/Central")
-        assert a.freq is None
-
     @pytest.mark.parametrize(
         "obj",
         [

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -208,11 +208,6 @@ class TestTimedeltaArray:
         expected = arr._ndarray.view("i8")
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_setitem_clears_freq(self):
-        a = pd.timedelta_range("1h", periods=2, freq="h")._data
-        a[0] = Timedelta("1h")
-        assert a.freq is None
-
     @pytest.mark.parametrize(
         "obj",
         [

--- a/pandas/tests/base/test_fillna.py
+++ b/pandas/tests/base/test_fillna.py
@@ -51,6 +51,12 @@ def test_fillna_null(null_obj, index_or_series_obj):
     expected = values.copy()
     values[0:2] = null_obj
     expected[0:2] = fill_value
+    # setitem no longer clears freq; after mutating, values are no longer on
+    # the original freq, so clear it on DTA/TDA explicitly.
+    if hasattr(values, "_freq"):
+        values._freq = None
+    if hasattr(expected, "_freq"):
+        expected._freq = None
 
     expected = klass(expected)
     obj = klass(values)

--- a/pandas/tests/indexes/datetimes/test_freq_attr.py
+++ b/pandas/tests/indexes/datetimes/test_freq_attr.py
@@ -24,11 +24,11 @@ class TestFreq:
             "passed frequency 5D"
         )
         with pytest.raises(ValueError, match=msg):
-            idx._data.freq = "5D"
+            idx.freq = "5D"
 
         # setting with non-freq string
         with pytest.raises(ValueError, match="Invalid frequency"):
-            idx._data.freq = "foo"
+            idx.freq = "foo"
 
     @pytest.mark.parametrize("values", [["20180101", "20180103", "20180105"], []])
     @pytest.mark.parametrize("freq", ["2D", Day(2), "2B", BDay(2), "48h", Hour(48)])
@@ -38,12 +38,12 @@ class TestFreq:
         idx = DatetimeIndex(values, tz=tz)
 
         # can set to an offset, converting from string if necessary
-        idx._data.freq = freq
+        idx.freq = freq
         assert idx.freq == freq
         assert isinstance(idx.freq, DateOffset)
 
         # can reset to None
-        idx._data.freq = None
+        idx.freq = None
         assert idx.freq is None
 
     def test_freq_view_safe(self):

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -153,7 +153,7 @@ class TestDatetimeIndexSetOps:
     def test_union_freq_both_none(self, sort):
         # GH11086
         expected = bdate_range("20150101", periods=10)
-        expected._data.freq = None
+        expected._data._freq = None
 
         result = expected.union(expected, sort=sort)
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/timedeltas/methods/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_astype.py
@@ -137,9 +137,8 @@ class TestTimedeltaIndex:
 
         res = tdi.astype("m8[s]")
         exp_values = np.asarray(tdi).astype("m8[s]")
-        exp_tda = TimedeltaArray._simple_new(
-            exp_values, dtype=exp_values.dtype, freq=tdi.freq
-        )
+        exp_tda = TimedeltaArray._simple_new(exp_values, dtype=exp_values.dtype)
+        exp_tda._freq = tdi.freq
         expected = Index(exp_tda)
         assert expected.dtype == "m8[s]"
         tm.assert_index_equal(res, expected)

--- a/pandas/tests/indexes/timedeltas/test_freq_attr.py
+++ b/pandas/tests/indexes/timedeltas/test_freq_attr.py
@@ -18,12 +18,12 @@ class TestFreq:
         idx = TimedeltaIndex(values)
 
         # can set to an offset, converting from string if necessary
-        idx._data.freq = freq
+        idx.freq = freq
         assert idx.freq == freq
         assert isinstance(idx.freq, DateOffset)
 
         # can reset to None
-        idx._data.freq = None
+        idx.freq = None
         assert idx.freq is None
 
     def test_with_freq_empty_requires_tick(self):
@@ -44,16 +44,16 @@ class TestFreq:
             "passed frequency 5D"
         )
         with pytest.raises(ValueError, match=msg):
-            idx._data.freq = "5D"
+            idx.freq = "5D"
 
         # setting with a non-fixed frequency
         msg = r"<2 \* BusinessDays> is a non-fixed frequency"
         with pytest.raises(ValueError, match=msg):
-            idx._data.freq = "2B"
+            idx.freq = "2B"
 
         # setting with non-freq string
         with pytest.raises(ValueError, match="Invalid frequency"):
-            idx._data.freq = "foo"
+            idx.freq = "foo"
 
     def test_freq_view_safe(self):
         # Setting the freq for one TimedeltaIndex shouldn't alter the freq

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1136,7 +1136,7 @@ def test_resample_anchored_intraday2(unit):
     expected = df.resample("QE").mean().to_period()
     expected = expected.to_timestamp(how="end")
     expected.index += Timedelta(1, unit="us") - Timedelta(1, unit="D")
-    expected.index._data.freq = "QE"
+    expected.index.freq = "QE"
     expected.index._freq = lib.no_default
     expected.index = expected.index.as_unit(unit)
     tm.assert_frame_equal(result, expected)
@@ -1146,7 +1146,7 @@ def test_resample_anchored_intraday2(unit):
     expected = expected.to_period()
     expected = expected.to_timestamp(how="end")
     expected.index += Timedelta(1, unit="us") - Timedelta(1, unit="D")
-    expected.index._data.freq = "QE"
+    expected.index.freq = "QE"
     expected.index._freq = lib.no_default
     expected.index = expected.index.as_unit(unit)
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -123,7 +123,7 @@ class TestDatetimeConcat:
         # Non-monotonic index result
         result = concat([expected[50:], expected[:50]])
         expected = DataFrame(data[50:] + data[:50], index=dr[50:].append(dr[:50]))
-        expected.index._data.freq = None
+        expected.index._data._freq = None
         tm.assert_frame_equal(result, expected)
 
     def test_concat_datetimeindex_tz_convert_freq(self):


### PR DESCRIPTION
## Summary

Four small steps continuing GH#24566 (push freq handling from DTA/TDA to the Index level):

1. **Remove `freq` param from `DTA/TDA._simple_new`** — `_simple_new` is now a pure values+dtype constructor; the four call sites that need to set freq do so explicitly via `result._freq = freq` after construction.
2. **DTA/TDA `__setitem__` no longer clears freq** — `_maybe_clear_freq` and the `__setitem__` call site are removed. `_freq` on the array is dumb storage that the Index manages, and is allowed to go stale after a mutation. `DatetimeIndex.snap` now clears `_freq` on its result DTA explicitly.
3. **Remove `freq` setter from `TimelikeOps`; move validation to the Index** — `DatetimeIndexOpsMixin.freq.setter` now does the `to_offset` coercion, `_validate_frequency`, Tick/Day check, and ndim check before assigning `arr._freq`. PeriodArray (no `_validate_frequency`) raises a clear AttributeError when callers try to set freq through the Index.
4. **Drop the array-level freq sync from `__iadd__`/`__isub__`** — they're now just `self[:] = result[:]`. Array's `_freq` stays as it was; the Index path naturally produces freq-correct results via `__add__`/`__sub__`. A few arithmetic tests had to align the expected freq for the `pd.array` boxed case, since the rebound `dta + x` returns a freq-stripped array while in-place `dta += x` preserves the array's pre-iadd freq.

## Test plan
- [x] `pandas/tests/arrays/`, `pandas/tests/indexes/datetimes|timedeltas|period/`, `pandas/tests/arithmetic/` all green
- [x] `pandas/tests/series/`, `pandas/tests/frame/`, `pandas/tests/indexing/`, `pandas/tests/base/`, `pandas/tests/resample/`, `pandas/tests/reshape/`, `pandas/tests/tslibs/`, `pandas/tests/tseries/` all green