### PR TITLE
BUG: Categorical.map() sort categories for unordered categoricals (#58153)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -207,6 +207,7 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 - Bug in :meth:`Categorical.__repr__` where the values and categories lines could exceed ``display.width`` (:issue:`12066`)
+- Bug in :meth:`Categorical.map` where unordered categoricals preserved the positional category order from the original categories instead of sorting the mapped values, causing :meth:`DataFrame.sort_values` with ``key`` to ignore custom sort orders (:issue:`58153`)
 - Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
 - Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
 -

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1644,8 +1644,22 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             na_val = mapper(np.nan) if callable(mapper) else mapper.get(np.nan, np.nan)
 
         if new_categories.is_unique and not new_categories.hasnans and na_val is np.nan:
+            codes = self._codes.copy()
+            if not self.ordered:
+                # GH#58153
+                try:
+                    indexer = new_categories.argsort()
+                except TypeError:
+                    # mixed-type categories can't be compared; keep original order
+                    pass
+                else:
+                    new_categories = new_categories.take(indexer)
+                    reverse_indexer = np.empty(len(indexer), dtype=np.intp)
+                    reverse_indexer[indexer] = np.arange(len(indexer))
+                    mask = codes >= 0
+                    codes[mask] = reverse_indexer[codes[mask]]
             new_dtype = CategoricalDtype(new_categories, ordered=self.ordered)
-            return self.from_codes(self._codes.copy(), dtype=new_dtype, validate=False)
+            return self.from_codes(codes, dtype=new_dtype, validate=False)
 
         if has_nans:
             new_categories = new_categories.insert(len(new_categories), na_val)

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -22,8 +22,11 @@ def test_map_str(data, categories, ordered, na_action):
     # GH 31202 - override base class since we want to maintain categorical/ordered
     cat = Categorical(data, categories=categories, ordered=ordered)
     result = cat.map(str, na_action=na_action)
+    expected_categories = list(map(str, categories))
+    if not ordered:
+        expected_categories = sorted(expected_categories)  # GH#58153
     expected = Categorical(
-        map(str, data), categories=map(str, categories), ordered=ordered
+        map(str, data), categories=expected_categories, ordered=ordered
     )
     tm.assert_categorical_equal(result, expected)
 
@@ -36,7 +39,7 @@ def test_map(na_action):
 
     cat = Categorical(list("ABABC"), categories=list("BAC"), ordered=False)
     result = cat.map(lambda x: x.lower(), na_action=na_action)
-    exp = Categorical(list("ababc"), categories=list("bac"), ordered=False)
+    exp = Categorical(list("ababc"), categories=list("abc"), ordered=False)  # GH#58153
     tm.assert_categorical_equal(result, exp)
 
     # GH 12766: Return an index not an array
@@ -51,7 +54,8 @@ def test_map(na_action):
         return {"A": 10, "B": 20, "C": 30}.get(x)
 
     result = cat.map(f, na_action=na_action)
-    exp = Categorical([10, 20, 10, 20, 30], categories=[20, 10, 30], ordered=False)
+    # GH#58153
+    exp = Categorical([10, 20, 10, 20, 30], categories=[10, 20, 30], ordered=False)
     tm.assert_categorical_equal(result, exp)
 
     mapper = Series([10, 20, 30], index=["A", "B", "C"])
@@ -116,6 +120,20 @@ def test_map_with_nan_ignore(data, f, expected):  # GH 24241
         tm.assert_categorical_equal(result, expected)
     else:
         tm.assert_index_equal(result, expected)
+
+
+def test_map_unordered_sorted_categories():
+    # GH#58153: map() must sort categories for unordered categoricals so that
+    # sort_values(key=x.map(...)) respects the mapped order, not category position
+    df = pd.DataFrame({"month": pd.Categorical(["March", "Dec", "April"])})
+    custom_dict = {"March": 0, "April": 1, "Dec": 3}
+    result = df.sort_values("month", key=lambda x: x.map(custom_dict))
+    assert list(result["month"]) == ["March", "April", "Dec"]
+
+    # categories are sorted after map
+    cat = Categorical(["b", "a", "c", "a"], categories=["c", "a", "b"], ordered=False)
+    result_cat = cat.map(lambda x: x.upper())
+    assert list(result_cat.categories) == ["A", "B", "C"]
 
 
 def test_map_with_dict_or_series(na_action):

--- a/pandas/tests/indexes/categorical/test_map.py
+++ b/pandas/tests/indexes/categorical/test_map.py
@@ -22,8 +22,11 @@ def test_map_str(data, categories, ordered):
     # GH 31202 - override base class since we want to maintain categorical/ordered
     index = CategoricalIndex(data, categories=categories, ordered=ordered)
     result = index.map(str)
+    expected_categories = list(map(str, categories))
+    if not ordered:
+        expected_categories = sorted(expected_categories)  # GH#58153
     expected = CategoricalIndex(
-        map(str, data), categories=map(str, categories), ordered=ordered
+        map(str, data), categories=expected_categories, ordered=ordered
     )
     tm.assert_index_equal(result, expected)
 
@@ -38,8 +41,9 @@ def test_map():
         list("ABABC"), categories=list("BAC"), ordered=False, name="XXX"
     )
     result = ci.map(lambda x: x.lower())
+    # GH#58153
     exp = CategoricalIndex(
-        list("ababc"), categories=list("bac"), ordered=False, name="XXX"
+        list("ababc"), categories=list("abc"), ordered=False, name="XXX"
     )
     tm.assert_index_equal(result, exp)
 
@@ -55,7 +59,8 @@ def test_map():
         return {"A": 10, "B": 20, "C": 30}.get(x)
 
     result = ci.map(f)
-    exp = CategoricalIndex([10, 20, 10, 20, 30], categories=[20, 10, 30], ordered=False)
+    # GH#58153
+    exp = CategoricalIndex([10, 20, 10, 20, 30], categories=[10, 20, 30], ordered=False)
     tm.assert_index_equal(result, exp)
 
     result = ci.map(Series([10, 20, 30], index=["A", "B", "C"]))


### PR DESCRIPTION
- [x] closes #58153
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md

## Bug

`DataFrame.sort_values(key=...)` on a `Categorical` column where the key maps values to a custom order ignored the key, sorting alphabetically instead of by the mapped values.

**Minimal reproduction:**

```python
import pandas as pd

df = pd.DataFrame(
    [[1, 2, "March"], [5, 6, "Dec"], [3, 4, "April"]],
    columns=["a", "b", "month"],
)
df.month = df.month.astype("category")
custom_dict = {"March": 0, "April": 1, "Dec": 3}
print(df.sort_values(by=["month"], key=lambda x: x.map(custom_dict)))
# Before fix: sorted alphabetically (April, Dec, March) — key ignored
# After fix:  sorted by custom_dict order (March, April, Dec)
```

## Root Cause

`Categorical.map()` preserved the positional category order from the original categories. For unordered categoricals the mapped values inherited an arbitrary ordering, so `sort_values` sorted by old category position instead of the mapped values.

## Fix

In `Categorical.map()`, when the categorical is unordered, sort the mapped categories and remap codes accordingly. Data values are preserved — the implementation copies codes, sorts `new_categories`, computes a `reverse_indexer` and remaps the non-null codes before calling `from_codes`. For ordered categoricals the existing category order is preserved. Mixed-type categories that cannot be compared fall back to original order via `TypeError` catch.

## Design question for maintainers

I am aware this changes the general behaviour of `Categorical.map()` for unordered categoricals, not only the `sort_values(..., key=...)` path. Specifically, after this PR:

```python
cat = pd.Categorical(["b", "a"], categories=["b", "a"], ordered=False)
result = cat.map({"b": 2, "a": 1})
# Before: Categories [2, 1]  (mapped order preserved)
# After:  Categories [1, 2]  (sorted)
```

The current `Categorical.map()` docs say one-to-one mappings preserve category ordering. This PR intentionally deviates from that for unordered categoricals.

An alternative would be to fix only the `sort_values`/argsort path and leave `Categorical.map()` unchanged. I am happy to take either direction — mentioning this so reviewers can choose the preferred approach.

## AI Disclosure

This fix was developed with the assistance of GitHub Copilot (Claude Sonnet 4.6). The AI assisted with code generation and diff review. The contributor verified the fix locally and confirmed all 50 tests pass.