### PR TITLE
BUG: Fix regex inference in ArrowExtensionArray._str_split (GH#58321)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -396,6 +396,7 @@ Strings
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
+- Bug in :meth:`Series.str.split` with :class:`ArrowDtype` ``string`` not inferring regex for multi-character patterns when ``regex=None``, causing the pattern to be treated as a literal instead of a regular expression (:issue:`58321`)
 - Bug in :meth:`Series.unique`, :meth:`Index.unique` and :func:`factorize` on object dtype returning incorrect results when the values were not UTF-8 encodable, e.g. lone surrogates (:issue:`34550`)
 
 Interval

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3549,10 +3549,15 @@ class ArrowExtensionArray(
             n = None
         if pat is None:
             split_func = pc.utf8_split_whitespace
-        elif regex:
+        elif regex is True:
             split_func = functools.partial(pc.split_pattern_regex, pattern=pat)
-        else:
+        elif regex is False:
             split_func = functools.partial(pc.split_pattern, pattern=pat)
+        # GH#58321: regex is None — infer: single-char literal, multi-char regex
+        elif len(pat) == 1:
+            split_func = functools.partial(pc.split_pattern, pattern=pat)
+        else:
+            split_func = functools.partial(pc.split_pattern_regex, pattern=pat)
         return self._from_pyarrow_array(split_func(self._pa_array, max_splits=n))
 
     def _str_rsplit(self, pat: str | None = None, n: int | None = -1) -> Self:

--- a/pandas/tests/strings/test_split_partition.py
+++ b/pandas/tests/strings/test_split_partition.py
@@ -6,9 +6,11 @@ import pytest
 
 import pandas as pd
 from pandas import (
+    ArrowDtype,
     DataFrame,
     Index,
     MultiIndex,
+    RangeIndex,
     Series,
     _testing as tm,
 )
@@ -776,3 +778,59 @@ def test_get_strings(any_string_dtype):
     result = ser.str.get(2)
     expected = Series([np.nan, np.nan, np.nan, "c"], dtype=any_string_dtype)
     tm.assert_series_equal(result, expected)
+
+
+def test_split_arrow_dtype_regex_inference():
+    # GH#58321 - ArrowDtype string should infer regex for multi-char patterns
+    pa = pytest.importorskip("pyarrow")
+
+    ser = Series(["230/270/270", "240-290-290"], dtype=ArrowDtype(pa.string()))
+    result = ser.str.split(r"/|-", expand=True)
+    expected = DataFrame(
+        {"0": ["230", "240"], "1": ["270", "290"], "2": ["270", "290"]},
+        dtype=ArrowDtype(pa.string()),
+    )
+    expected.columns = RangeIndex(3)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_split_arrow_dtype_regex_true():
+    # GH#58321 - explicit regex=True should use regex splitting
+    pa = pytest.importorskip("pyarrow")
+
+    ser = Series(["230/270/270", "240-290-290"], dtype=ArrowDtype(pa.string()))
+    result = ser.str.split(r"/|-", expand=True, regex=True)
+    expected = DataFrame(
+        {"0": ["230", "240"], "1": ["270", "290"], "2": ["270", "290"]},
+        dtype=ArrowDtype(pa.string()),
+    )
+    expected.columns = RangeIndex(3)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_split_arrow_dtype_single_char_literal():
+    # GH#58321 - single-char pattern with regex=None should be literal
+    pa = pytest.importorskip("pyarrow")
+
+    ser = Series(["a.b.c"], dtype=ArrowDtype(pa.string()))
+    result = ser.str.split(".", expand=True)
+    expected = DataFrame(
+        {"0": ["a"], "1": ["b"], "2": ["c"]},
+        dtype=ArrowDtype(pa.string()),
+    )
+    expected.columns = RangeIndex(3)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_split_arrow_dtype_regex_false_multichar():
+    # GH#58321 - regex=False with multi-char pattern: "|" is literal, not alternation
+    pa = pytest.importorskip("pyarrow")
+
+    ser = Series(["a|b|c", "d/e/f"], dtype=ArrowDtype(pa.string()))
+    result = ser.str.split("|", regex=False, expand=True)
+    expected = DataFrame(
+        {"0": ["a", "d/e/f"], "1": ["b", None], "2": ["c", None]},
+        dtype=ArrowDtype(pa.string()),
+    )
+    expected.columns = RangeIndex(3)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #58321
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md

## Bug

`Series.str.split()` with `ArrowDtype(pa.string())` treated multi-character patterns as literal strings instead of regex when `regex=None`, unlike the `object` dtype which correctly infers regex for multi-character patterns.

**Minimal reproduction:**

```python
import pandas as pd
import pyarrow as pa

ser = pd.Series(["230/270/270", "240-290-290"], dtype=pd.ArrowDtype(pa.string()))
print(ser.str.split(r"/|-", expand=True))
# Before fix: original strings unsplit (pattern treated as literal "/|-")
# After fix:  correctly splits into 3 columns
```

## Root Cause

In `ArrowExtensionArray._str_split()`, the condition `elif regex:` treated `None` as falsy, always falling through to the literal split path. The `object_array.py` implementation uses explicit `is True` / `is False` checks and infers regex for multi-character patterns when `regex=None`.

**Fix:** match the inference logic from `object_array.py` — `regex is True` → regex, `regex is False` → literal, `regex is None` → infer from pattern length.

## AI Disclosure

This fix was developed with the assistance of GitHub Copilot (Claude Sonnet 4.6). The AI assisted with code generation and diff review. The contributor verified the fix locally and confirmed all three tests pass.