### PR TITLE
BUG: Fix formatters applied to wrong columns in truncated DataFrame.to_string (GH#35410)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -298,6 +298,7 @@ I/O
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - Bug in :meth:`DataFrame.__repr__` where horizontally truncated output could exceed the terminal width by up to 4 characters (:issue:`32461`)
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)
+- Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -767,8 +767,8 @@ class DataFrameFormatter:
             else:
                 return None
         else:
-            if is_integer(i) and i not in self.columns:
-                i = self.columns[i]
+            if is_integer(i):
+                i = self.tr_frame.columns[i]
             return self.formatters.get(i, None)
 
     def _get_formatted_column_labels(self, frame: DataFrame) -> list[list[str]]:

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -932,6 +932,20 @@ class TestDataFrameFormatting:
         result2 = repr(frame.iloc[:5])
         assert result.startswith(result2)
 
+    def test_to_string_truncate_formatters(self):
+        # GH#35410 - formatters dict applied to wrong columns after truncation
+        df = DataFrame(
+            np.arange(30).reshape(5, 6),
+            columns=[f"Col{i}" for i in range(6)],
+        )
+        formatters = {c: (lambda x, c=c: f"{c}: {x}") for c in df.columns}
+        result = df.to_string(formatters=formatters, max_cols=4)
+        # Col4 and Col5 should use their own formatters, not Col2/Col3
+        assert "Col4:" in result
+        assert "Col5:" in result
+        assert "Col2: 4" not in result
+        assert "Col3: 5" not in result
+
     def test_datetimelike_frame(self):
         # GH 12211
         df = DataFrame({"date": [Timestamp("20130101").tz_localize("UTC")] + [NaT] * 5})


### PR DESCRIPTION
- [x] closes #35410
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md

## Bug

`DataFrame.to_string()` applied `formatters` dict to wrong columns when output was horizontally truncated via `max_cols`.

**Minimal reproduction:**

```python
import pandas as pd
import numpy as np

df = pd.DataFrame(np.arange(30).reshape(5, 6), columns=[f"Col{i}" for i in range(6)])
formatters = {c: (lambda x, c=c: f"{c}: {x}") for c in df.columns}
print(df.to_string(formatters=formatters, max_cols=4))
# Before fix: Col4 shows "Col2: 4", Col5 shows "Col3: 5"
# After fix:  Col4 shows "Col4: 4", Col5 shows "Col5: 5"
```

## Root Cause

In `DataFrameFormatter._get_formatter()`, when `formatters` is a dict and `i` is an integer (positional index), the code resolved `i` against `self.columns` (the original frame). After truncation, positional index 2 in the truncated frame corresponds to e.g. Col4, but `self.columns[2]` returned Col2.

**Fix:** resolve positional indices against `self.tr_frame.columns` (the truncated frame) instead of `self.columns`. Also removed the `i not in self.columns` guard which caused incorrect behavior when column names are integers.

## AI Disclosure

This fix was developed with the assistance of GitHub Copilot (Claude Sonnet 4.6). The AI assisted with code generation and diff review. The contributor verified the fix locally and confirmed the test passes.