### PR TITLE
BUG: Fix DataFrame.agg with list of functions and numeric_only=True

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -326,6 +326,7 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
+- Bug in :meth:`DataFrame.agg` with a list of functions and ``numeric_only=True`` returning ``NaN`` for non-numeric columns instead of excluding them (:issue:`65218`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)
 -

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -865,7 +865,14 @@ class NDFrameApply(Apply):
             return None
 
         obj = self.obj
+        if self.kwargs.get("numeric_only", False):
+            obj = obj._get_numeric_data()
         func_names = cast("list[str]", func)
+
+        if obj.columns.empty:
+            from pandas import DataFrame
+
+            return DataFrame(index=func_names, columns=obj.columns)
 
         # Cannot reindex with duplicate column names
         if not obj.columns.is_unique:

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -1334,6 +1334,23 @@ def test_agg_multiple_mixed_raises():
         mdf[["D", "C", "B", "A"]].agg(["sum", "min"])
 
 
+def test_agg_list_numeric_only():
+    # GH#65218 - numeric_only should exclude non-numeric columns, not fill NaN
+    df = DataFrame(
+        {
+            "A": [1, 2, 3],
+            "B": [1.0, 2.0, 3.0],
+            "C": ["foo", "bar", "baz"],
+        }
+    )
+    result = df.agg(["sum", "mean"], numeric_only=True)
+    expected = DataFrame(
+        {"A": [6.0, 2.0], "B": [6.0, 2.0]},
+        index=["sum", "mean"],
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_agg_reduce(axis, float_frame):
     other_axis = 1 if axis in {0, "index"} else 0
     name1, name2 = float_frame.axes[other_axis].unique()[:2].sort_values()


### PR DESCRIPTION
## Problem

`DataFrame.agg()` with a list of functions and `numeric_only=True` incorrectly includes non-numeric columns filled with `NaN` in the result, instead of excluding them.

```python
import pandas as pd

df = pd.DataFrame({
    'A': [1, 2, 3],
    'B': [1.0, 2.0, 3.0],
    'C': ['foo', 'bar', 'baz'],
})

# Before fix: includes C column with NaN
df.agg(['sum', 'mean'], numeric_only=True)
#         A    B   C
# sum   6.0  6.0 NaN
# mean  2.0  2.0 NaN

# After fix: correctly excludes C
df.agg(['sum', 'mean'], numeric_only=True)
#         A    B
# sum   6.0  6.0
# mean  2.0  2.0
```

## Root Cause

In `_agg_list_like_frame_reductions()` (the fast path for `DataFrame.agg` with a list of string function names), the `numeric_only` kwarg was passed through to individual reductions but the DataFrame itself was never filtered. Non-numeric dtype groups produced empty Series from reductions (e.g., `sub.sum(numeric_only=True)`), but `result.reindex(columns=obj.columns)` added them back as `NaN`.

## Fix

Filter `obj` to numeric columns via `obj._get_numeric_data()` when `numeric_only=True` before the dtype-group processing. Also handles the edge case where all columns are non-numeric (returns an empty DataFrame).

Closes #65218