### PR TITLE
BUG: Fix to_sql passing incorrect index column name

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -270,6 +270,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` raising ``ValueError`` when assigning a list of tuples to an object-dtype column with a boolean mask on a mixed-dtype DataFrame (:issue:`37629`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` returning wrong results instead of raising ``KeyError`` when passing string keys for numeric index levels (:issue:`60104`)
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` where incorrect values were produced when ``other`` was a :class:`Series` with :class:`ExtensionArray` values (:issue:`64635`)
+- Bug in :meth:`DataFrame.to_sql` where the ``keys`` passed to a callable ``method`` contained tuple-stringified index names instead of the actual SQL column names when the :class:`DataFrame` had :class:`MultiIndex` columns (:issue:`59112`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
 - Bug in :meth:`DataFrame.xs` where ``drop_level=False`` was ignored for fully specified :class:`MultiIndex` keys when ``level`` was not explicitly provided (:issue:`6507`)
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1042,7 +1042,12 @@ class SQLTable(PandasObject):
         else:
             temp = self.frame
 
-        column_names = list(map(str, temp.columns))
+        if self.index is not None:
+            column_names = [str(name) for name in self.index] + [
+                str(c) for c in self.frame.columns
+            ]
+        else:
+            column_names = list(map(str, temp.columns))
         ncols = len(column_names)
         # this just pre-allocates the list: None's will be replaced with ndarrays
         # error: List item 0 has incompatible type "None"; expected "ndarray"

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1224,6 +1224,30 @@ def test_to_sql_callable(conn, test_frame1, request):
     assert count_rows(conn, "test_frame") == len(test_frame1)
 
 
+@pytest.mark.parametrize("conn", sqlalchemy_connectable)
+def test_to_sql_callable_multiindex_columns(conn, request):
+    # GH#59112
+    conn = request.getfixturevalue(conn)
+
+    keys_received = []
+
+    def capture_keys(pd_table, conn, keys, data_iter):
+        keys_received.extend(keys)
+        data = [dict(zip(keys, row, strict=True)) for row in data_iter]
+        conn.execute(pd_table.table.insert(), data)
+
+    columns = MultiIndex.from_tuples([("A", "X"), ("A", "Y")])
+    df = DataFrame([[1.0, 2.0], [3.0, 4.0]], columns=columns)
+
+    with pandasSQL_builder(conn, need_transaction=True) as pandasSQL:
+        pandasSQL.to_sql(df, "test_multiindex_cols", method=capture_keys)
+
+    table_col_names = [
+        c.name for c in pandasSQL.get_table("test_multiindex_cols").columns
+    ]
+    assert keys_received == table_col_names
+
+
 @pytest.mark.parametrize("conn", all_connectable_types)
 def test_default_type_conversion(conn, request):
     conn_name = conn


### PR DESCRIPTION
- [x] closes #59112 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

When `DataFrame.to_sql` is called with `index=True` and a callable `method` on a DataFrame with `MultiIndex` columns, the `keys` list passed to the callable contained tuple-stringified index names (e.g., `"('index', '')"`) instead of the actual SQL column name (`"index"`). 

This is because `insert_data()` called `reset_index()` on the temporary frame, which pads scalar index names to tuples to match the `MultiIndex` column levels. Then `list(map(str, temp.columns))` converted those tuples to strings, meaning there is a mismatch with the SQL column names. 

I fixed this by explicitly constructing the `column_names` list directly from `self.index ` and the original `self.frame.columns`. This bypasses the tuple padding from `reset_index`, which was causing the bug. 