### PR TITLE
DOC: add docstring with examples to NDFrame.__invert__ (~ operator)

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -114,6 +114,13 @@ Binary operator functions
    DataFrame.combine
    DataFrame.combine_first
 
+Unary operator functions
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: api/
+
+   DataFrame.__invert__
+
 Function application, GroupBy & window
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -109,6 +109,7 @@ Binary operator functions
    Series.ge
    Series.ne
    Series.eq
+   Series.__invert__
    Series.product
    Series.dot
 

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -109,9 +109,15 @@ Binary operator functions
    Series.ge
    Series.ne
    Series.eq
-   Series.__invert__
    Series.product
    Series.dot
+
+Unary operator functions
+-------------------------
+.. autosummary::
+   :toctree: api/
+
+   Series.__invert__
 
 Function application, GroupBy & window
 --------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1490,6 +1490,52 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
     @final
     def __invert__(self) -> Self:
+        """
+        Return the bitwise inverse of the Series/DataFrame, element-wise.
+
+        Equivalent to applying the ``~`` (tilde) operator element-wise. For
+        boolean data this returns the logical NOT; for integer data it returns
+        the bitwise NOT (ones complement).
+
+        Returns
+        -------
+        Series or DataFrame
+            A new object of the same type and shape with every element
+            bitwise inverted.
+
+        See Also
+        --------
+        numpy.invert : Compute bitwise inversion element-wise.
+        Series.apply : Apply a function along an axis of the Series.
+
+        Examples
+        --------
+        **Boolean Series:**
+
+        >>> s = pd.Series([True, False, True])
+        >>> ~s
+        0    False
+        1     True
+        2    False
+        dtype: bool
+
+        **Integer Series:**
+
+        >>> s = pd.Series([1, 0, 3], dtype="int8")
+        >>> ~s
+        0   -2
+        1   -1
+        2   -4
+        dtype: int8
+
+        **Boolean DataFrame:**
+
+        >>> df = pd.DataFrame({"a": [True, False], "b": [False, True]})
+        >>> ~df
+               a      b
+        0  False   True
+        1   True  False
+        """
         if not self.size:
             # inv fails with 0 len
             return self.copy(deep=False)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1506,7 +1506,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         See Also
         --------
         numpy.invert : Compute bitwise inversion element-wise.
-        Series.apply : Apply a function along an axis of the Series.
 
         Examples
         --------


### PR DESCRIPTION
#### Problem description

The `__invert__` dunder method (the `~` tilde operator) has no docstring in `NDFrame`, so `Series.__invert__` and `DataFrame.__invert__` show only the signature in the generated API docs with no explanation or examples.

Issue: #62516

A maintainer confirmed in that issue that documenting dunder methods broadly is a positive direction.

#### Changes

- Added a numpydoc-style docstring to `NDFrame.__invert__` in `pandas/core/generic.py` with:
  - A description of the behavior for boolean (logical NOT) and integer (bitwise NOT) data
  - `Returns`, `See Also`, and `Examples` sections
  - Three working doctests covering boolean Series, integer Series, and boolean DataFrame
- Registered `Series.__invert__` in `doc/source/reference/series.rst` under Binary operator functions

#### Checklist

- [x] Tests added and passed
- [x] Whatsnew entry not needed (documentation-only addition)