### PR TITLE
BUG: Add _str_getitem to ArrowStringArrayMixin

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -250,6 +250,7 @@ Conversion
 
 Strings
 ^^^^^^^
+- Bug in :attr:`Series.str` ``[]`` accessor raising ``AttributeError`` on :class:`ArrowExtensionArray` backed strings (e.g. from :meth:`DataFrame.convert_dtypes` with ``dtype_backend="pyarrow"``) (:issue:`65112`)
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 -
 

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -169,6 +169,12 @@ class ArrowStringArrayMixin:
             pa_pad(self._pa_array, width=width, padding=fillchar)
         )
 
+    def _str_getitem(self, key):
+        if isinstance(key, slice):
+            return self._str_slice(start=key.start, stop=key.stop, step=key.step)
+        else:
+            return self._str_get(key)
+
     def _str_get(self, i: int) -> Self:
         lengths = pc.utf8_length(self._pa_array)
         if i >= 0:

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -644,6 +644,25 @@ def test_string_slice_get_syntax(any_string_dtype):
     tm.assert_series_equal(result, expected)
 
 
+def test_string_slice_get_syntax_arrow_extension_array():
+    # GH#65112 - _str_getitem was missing on ArrowExtensionArray
+    pytest.importorskip("pyarrow")
+    ser = Series(["abc", "defgh", None], dtype="string[pyarrow]").convert_dtypes(
+        dtype_backend="pyarrow"
+    )
+    result = ser.str[0]
+    expected = Series(["a", "d", None], dtype=ser.dtype)
+    tm.assert_series_equal(result, expected)
+
+    result = ser.str[:3]
+    expected = Series(["abc", "def", None], dtype=ser.dtype)
+    tm.assert_series_equal(result, expected)
+
+    result = ser.str[-1]
+    expected = Series(["c", "h", None], dtype=ser.dtype)
+    tm.assert_series_equal(result, expected)
+
+
 def test_string_slice_out_of_bounds_nested():
     ser = Series([(1, 2), (1,), (3, 4, 5)])
     result = ser.str[1]


### PR DESCRIPTION
- [x] closes #65112
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] Added entry to `doc/source/whatsnew/v3.1.0.rst`

## Summary

`ArrowExtensionArray` (used by `convert_dtypes(dtype_backend="pyarrow")`) was missing the `_str_getitem` method, causing `Series.str[]` accessor to raise `AttributeError`. This was a regression from 3.0.0 when `BaseStringArrayMethods` was removed from the `ArrowExtensionArray` inheritance chain (#62155).

The fix adds `_str_getitem` to `ArrowStringArrayMixin`, which delegates to the existing `_str_slice` (for slice keys) and `_str_get` (for integer keys) methods — matching the implementation that was previously inherited from `BaseStringArrayMethods`.