### PR TITLE
BUG: Fix bar plot xticks treating index values as axis positions (#55508)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -329,6 +329,7 @@ Period
 
 Plotting
 ^^^^^^^^
+- Bug in :meth:`DataFrame.plot.bar` and :meth:`Series.plot.bar` where passing ``xticks`` (or ``yticks`` for :meth:`DataFrame.plot.barh`) used the values as raw axis positions instead of mapping them to the corresponding bar positions (:issue:`55508`)
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
 -
 

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1887,6 +1887,12 @@ class BarPlot(MPLPlot):
 
         MPLPlot.__init__(self, data, **kwargs)
 
+        # GH#55508: save xticks/yticks before _adorn_subplots sets raw positions
+        self._bar_xticks = self.xticks
+        self.xticks = None
+        self._bar_yticks = self.yticks
+        self.yticks = None
+
         if self._is_ts_plot():
             self.tick_pos = np.array(
                 PeriodConverter.convert_from_freq(
@@ -2076,8 +2082,18 @@ class BarPlot(MPLPlot):
     ) -> None:
         ax.set_xlim((start_edge, end_edge))
 
-        if self.xticks is not None:
-            ax.set_xticks(np.array(self.xticks))
+        if self._bar_xticks is not None:
+            # GH#55508: map xtick values to internal bar positions
+            xtick_arr = np.array(self._bar_xticks)
+            index = self.data.index
+            mask = index.isin(xtick_arr)
+            if mask.any():
+                ticks = self.tick_pos[mask]
+                labels = [ticklabels[i] for i, m in enumerate(mask) if m]
+                ax.set_xticks(ticks)
+                ax.set_xticklabels(labels)
+            else:
+                ax.set_xticks(xtick_arr)
         else:
             ax.set_xticks(self.tick_pos)
             ax.set_xticklabels(ticklabels)
@@ -2128,8 +2144,23 @@ class BarhPlot(BarPlot):
     ) -> None:
         # horizontal bars
         ax.set_ylim((start_edge, end_edge))
-        ax.set_yticks(self.tick_pos)
-        ax.set_yticklabels(ticklabels)
+
+        if self._bar_yticks is not None:
+            # GH#55508: same as BarPlot._decorate_ticks above, for yticks
+            ytick_arr = np.array(self._bar_yticks)
+            index = self.data.index
+            mask = index.isin(ytick_arr)
+            if mask.any():
+                ticks = self.tick_pos[mask]
+                labels = [ticklabels[i] for i, m in enumerate(mask) if m]
+                ax.set_yticks(ticks)
+                ax.set_yticklabels(labels)
+            else:
+                ax.set_yticks(ytick_arr)
+        else:
+            ax.set_yticks(self.tick_pos)
+            ax.set_yticklabels(ticklabels)
+
         if name is not None and self.use_index:
             ax.set_ylabel(name)
         # error: Argument 1 to "set_xlabel" of "_AxesBase" has incompatible type

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -831,6 +831,49 @@ class TestSeriesPlots:
         exp = np.array(list(range(0, 11, 2)))
         tm.assert_numpy_array_equal(exp, ax.get_xticks())
 
+    def test_bar_xticks_index_values(self):
+        # GH#55508
+        s = Series([1, 3, 2], index=[2010, 2015, 2020])
+        ax = s.plot.bar(xticks=[2010, 2020])
+        result_ticks = ax.get_xticks()
+        expected_ticks = np.array([0, 2])
+        tm.assert_numpy_array_equal(result_ticks, expected_ticks)
+        result_labels = [t.get_text() for t in ax.get_xticklabels()]
+        assert result_labels == ["2010", "2020"]
+        assert ax.get_xlim()[1] < 10
+
+    def test_barh_yticks_index_values(self):
+        # GH#55508
+        s = Series([1, 3, 2], index=[2010, 2015, 2020])
+        ax = s.plot.barh(yticks=[2010, 2020])
+        result_ticks = ax.get_yticks()
+        expected_ticks = np.array([0, 2])
+        tm.assert_numpy_array_equal(result_ticks, expected_ticks)
+        result_labels = [t.get_text() for t in ax.get_yticklabels()]
+        assert result_labels == ["2010", "2020"]
+        assert ax.get_ylim()[1] < 10
+
+    def test_bar_xticks_partial_index_match(self):
+        # GH#55508 - xtick values not in the index are silently dropped
+        s = Series([1, 3, 2], index=[2010, 2015, 2020])
+        ax = s.plot.bar(xticks=[2010, 9999])
+        result_ticks = ax.get_xticks()
+        expected_ticks = np.array([0])
+        tm.assert_numpy_array_equal(result_ticks, expected_ticks)
+        result_labels = [t.get_text() for t in ax.get_xticklabels()]
+        assert result_labels == ["2010"]
+
+    def test_bar_xticks_dataframe(self):
+        # GH#55508
+        df = DataFrame({"A": [1, 3, 2], "B": [4, 2, 5]}, index=[2010, 2015, 2020])
+        ax = df.plot.bar(xticks=[2010, 2020])
+        result_ticks = ax.get_xticks()
+        expected_ticks = np.array([0, 2])
+        tm.assert_numpy_array_equal(result_ticks, expected_ticks)
+        result_labels = [t.get_text() for t in ax.get_xticklabels()]
+        assert result_labels == ["2010", "2020"]
+        assert ax.get_xlim()[1] < 10
+
     def test_custom_business_day_freq(self):
         # GH7222
         s = Series(


### PR DESCRIPTION
Fixes #55508.

When passing `xticks` to a bar plot, the values were used as raw matplotlib axis positions. Since pandas bar plots use internal integer positions (0, 1, 2, ...) rather than actual index values, the axis would stretch far beyond the bars — e.g. `xticks=[2010, 2020]` on a 3-bar chart pushed the xlim to 2020.

**Before / After:**

Before — ticks placed at raw axis positions 2010/2020, far from the bars:
![before](https://github.com/user-attachments/assets/2c408518-b8e5-4b02-91e5-8cd5764ae056)

After — ticks correctly mapped to the bar positions for index values 2010/2020:
![after](https://github.com/user-attachments/assets/c62d5baa-4d45-4480-b05f-c57fa913d490)

**Fix:** in `_decorate_ticks()`, user-provided tick values are matched against the index via `index.isin()` and resolved to the corresponding bar positions. The same fix is applied to `BarhPlot` for `yticks`, which was previously ignored entirely. If a tick value is not in the index it is silently dropped; if none match, a fallback to raw positions preserves backward compatibility.

**Tests:**
- Existing `test_xtick_barPlot` (GH#28172) still passes
- `test_bar_xticks_index_values`: basic fix for Series bar plot
- `test_barh_yticks_index_values`: same fix for horizontal bar
- `test_bar_xticks_partial_index_match`: xtick values not in the index are silently dropped
- `test_bar_xticks_dataframe`: fix applies to `DataFrame.plot.bar()` too

---
- [x] closes #55508
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added an entry in `doc/source/whatsnew/v3.1.0.rst`
