### PR TITLE
BUG: Fix DataFrame.var/std/sem(axis=1) returning object dtype with mixed numeric types

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -244,6 +244,7 @@ Timezones
 
 Numeric
 ^^^^^^^
+- Bug in :meth:`DataFrame.var`, :meth:`DataFrame.std`, and :meth:`DataFrame.sem` where calling with ``axis=1`` on a :class:`DataFrame` with mixed numeric dtypes returned a Series with ``object`` dtype instead of ``float64`` (:issue:`55194`)
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
 - Fixed bug in :meth:`Series.clip` where passing a scalar numpy array (e.g. ``np.array(0)``) would raise a ``TypeError`` (:issue:`59053`)
 - Fixed bug in :meth:`Series.mean` and :meth:`Series.sum` (and their :class:`DataFrame` counterparts) overflowing for ``float16`` dtypes instead of upcasting to ``float64`` (:issue:`43929`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -15706,7 +15706,19 @@ class DataFrame(NDFrame, OpsMixin):
                 # GH#51474: block-wise axis=1 reduction avoiding expensive
                 # transpose for numpy-backed and 2D EA blocks.
                 if (
-                    name in ("sum", "prod", "min", "max", "any", "all", "mean")
+                    name
+                    in (
+                        "sum",
+                        "prod",
+                        "min",
+                        "max",
+                        "any",
+                        "all",
+                        "mean",
+                        "var",
+                        "std",
+                        "sem",
+                    )
                     and len(df._mgr.blocks) > 1
                     and all(
                         (isinstance(bv, np.ndarray) and bv.dtype.kind != "O")
@@ -15724,6 +15736,7 @@ class DataFrame(NDFrame, OpsMixin):
                         op,
                         skipna=skipna,
                         min_count=kwds.get("min_count", 0),
+                        ddof=kwds.get("ddof", 1),
                     )
                 dtype = find_common_type(
                     [block.values.dtype for block in df._mgr.blocks]
@@ -15766,7 +15779,7 @@ class DataFrame(NDFrame, OpsMixin):
         return out
 
     def _reduce_axis1(
-        self, name: str, func, skipna: bool, min_count: int = 0
+        self, name: str, func, skipna: bool, min_count: int = 0, ddof: int = 1
     ) -> Series:
         """
         Special case for _reduce to try to avoid a potentially-expensive transpose.
@@ -15797,6 +15810,59 @@ class DataFrame(NDFrame, OpsMixin):
         elif name == "max":
             result = None
             ufunc = np.fmax if skipna else np.maximum  # type: ignore[assignment]
+        elif name in ("var", "std", "sem"):
+            # GH#55194: two-pass block-wise variance computation
+            total_sum = np.zeros(len(self), dtype="float64")
+            non_null_count = np.zeros(len(self), dtype=np.intp)
+            for block in self._mgr.blocks:
+                vals = block.values
+                block_sum = nanops.nansum(  # type: ignore[arg-type]
+                    vals, axis=0, skipna=skipna, min_count=0
+                )
+                total_sum += np.asarray(block_sum, dtype="float64")
+                if vals.dtype.kind in "biu":
+                    non_null_count += vals.shape[0]
+                else:
+                    non_null_count += vals.shape[0] - np.isnan(
+                        np.asarray(vals, dtype="float64")
+                    ).sum(axis=0)
+
+            row_mean = np.divide(
+                total_sum,
+                non_null_count,
+                out=np.full(len(self), np.nan),
+                where=non_null_count > 0,
+            )
+
+            sum_sq = np.zeros(len(self), dtype="float64")
+            for block in self._mgr.blocks:
+                vals = block.values
+                float_vals = np.asarray(vals, dtype="float64")
+                dev = float_vals - row_mean
+                sq = dev**2
+                if skipna and vals.dtype.kind not in "biu":
+                    nan_mask = np.isnan(float_vals)
+                    sq[nan_mask] = 0.0
+                sum_sq += sq.sum(axis=0)
+
+            denom = (non_null_count - ddof).astype("float64")
+            var_result = np.divide(
+                sum_sq,
+                denom,
+                out=np.full(len(self), np.nan),
+                where=denom > 0,
+            )
+
+            if name == "std":
+                var_result = np.sqrt(var_result)
+            elif name == "sem":
+                with np.errstate(invalid="ignore"):
+                    var_result = np.sqrt(var_result) / np.sqrt(
+                        non_null_count.astype("float64")
+                    )
+                var_result[non_null_count == 0] = np.nan
+
+            return self._constructor_sliced(var_result, index=self.index, copy=False)
         else:
             raise NotImplementedError(name)
 

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -792,6 +792,162 @@ class TestSeriesReductions:
         tm.assert_almost_equal(ser.std(ddof=1), np.sqrt(expected))
         tm.assert_almost_equal(ser.sem(ddof=1), np.sqrt(expected / len(values)))
 
+    @pytest.mark.parametrize("func", ["var", "std", "sem"])
+    def test_var_std_sem_axis1_mixed_dtype(self, func):
+        # GH#55194
+        df = DataFrame(
+            {
+                "A": [1, -2, 3],
+                "B": [1.0, -2, 3],
+                "C": [True, False, True],
+            }
+        )
+        result = getattr(df, func)(axis=1)
+        assert result.dtype == np.float64
+
+        for i in range(len(df)):
+            row = df.iloc[i].values.astype(float)
+            if func == "var":
+                expected = np.var(row, ddof=1)
+            elif func == "std":
+                expected = np.std(row, ddof=1)
+            else:  # sem
+                expected = np.std(row, ddof=1) / np.sqrt(len(row))
+            tm.assert_almost_equal(result.iloc[i], expected)
+
+    @pytest.mark.parametrize("func", ["var", "std", "sem"])
+    def test_var_std_sem_axis1_with_nan(self, func):
+        # GH#55194
+        df = DataFrame(
+            {
+                "A": [1.0, np.nan, 3.0],
+                "B": [4.0, 5.0, np.nan],
+                "C": [np.nan, np.nan, np.nan],
+            }
+        )
+        result_skipna = getattr(df, func)(axis=1, skipna=True)
+        assert result_skipna.dtype == np.float64
+        assert np.isnan(result_skipna.iloc[1])
+        assert np.isnan(result_skipna.iloc[2])
+        row0 = np.array([1.0, 4.0])
+        if func == "var":
+            tm.assert_almost_equal(result_skipna.iloc[0], np.var(row0, ddof=1))
+        elif func == "std":
+            tm.assert_almost_equal(result_skipna.iloc[0], np.std(row0, ddof=1))
+        else:
+            tm.assert_almost_equal(
+                result_skipna.iloc[0], np.std(row0, ddof=1) / np.sqrt(len(row0))
+            )
+
+        result_no_skipna = getattr(df, func)(axis=1, skipna=False)
+        assert result_no_skipna.dtype == np.float64
+        assert np.isnan(result_no_skipna.iloc[0])
+        assert np.isnan(result_no_skipna.iloc[1])
+        assert np.isnan(result_no_skipna.iloc[2])
+
+    @pytest.mark.parametrize("func", ["var", "std", "sem"])
+    def test_var_std_sem_axis1_ddof0(self, func):
+        # GH#55194
+        df = DataFrame(
+            {
+                "A": [1, -2, 3],
+                "B": [1.0, -2, 3],
+                "C": [True, False, True],
+            }
+        )
+        result = getattr(df, func)(axis=1, ddof=0)
+        assert result.dtype == np.float64
+        for i in range(len(df)):
+            row = df.iloc[i].values.astype(float)
+            if func == "var":
+                tm.assert_almost_equal(result.iloc[i], np.var(row, ddof=0))
+            elif func == "std":
+                tm.assert_almost_equal(result.iloc[i], np.std(row, ddof=0))
+            else:  # sem: std(ddof=0) / sqrt(n)
+                tm.assert_almost_equal(
+                    result.iloc[i], np.std(row, ddof=0) / np.sqrt(len(row))
+                )
+
+    @pytest.mark.parametrize("func", ["var", "std", "sem"])
+    def test_var_std_sem_axis1_ddof_exceeds_count(self, func):
+        # GH#55194
+        df = DataFrame({"A": [1.0, 2.0], "B": [3.0, 4.0]})
+        result = getattr(df, func)(axis=1, ddof=2)
+        assert result.dtype == np.float64
+        assert np.isnan(result.iloc[0])
+        assert np.isnan(result.iloc[1])
+
+    @pytest.mark.parametrize("func", ["var", "std", "sem"])
+    def test_var_std_sem_axis1_all_nan_row(self, func):
+        # GH#55194
+        df = DataFrame(
+            {
+                "A": [1.0, np.nan],
+                "B": [2.0, np.nan],
+            }
+        )
+        result = getattr(df, func)(axis=1, skipna=True)
+        assert result.dtype == np.float64
+        assert np.isnan(result.iloc[1])
+
+    @pytest.mark.parametrize("func", ["var", "std", "sem"])
+    def test_var_std_sem_axis1_nan_in_multiblock(self, func):
+        # GH#55194
+        df = DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": [4.0, 5.0, np.nan],
+                "C": [np.nan, np.nan, np.nan],
+            }
+        )
+        assert len(df._mgr.blocks) > 1, "test requires multiple blocks"
+
+        result_skipna = getattr(df, func)(axis=1, skipna=True)
+        assert result_skipna.dtype == np.float64
+        assert not np.isnan(result_skipna.iloc[0])
+        assert not np.isnan(result_skipna.iloc[1])
+        assert np.isnan(result_skipna.iloc[2])
+        row0 = np.array([1.0, 4.0])
+        row1 = np.array([2.0, 5.0])
+        if func == "var":
+            tm.assert_almost_equal(result_skipna.iloc[0], np.var(row0, ddof=1))
+            tm.assert_almost_equal(result_skipna.iloc[1], np.var(row1, ddof=1))
+        elif func == "std":
+            tm.assert_almost_equal(result_skipna.iloc[0], np.std(row0, ddof=1))
+            tm.assert_almost_equal(result_skipna.iloc[1], np.std(row1, ddof=1))
+        else:
+            tm.assert_almost_equal(
+                result_skipna.iloc[0], np.std(row0, ddof=1) / np.sqrt(len(row0))
+            )
+            tm.assert_almost_equal(
+                result_skipna.iloc[1], np.std(row1, ddof=1) / np.sqrt(len(row1))
+            )
+
+        result_no_skipna = getattr(df, func)(axis=1, skipna=False)
+        assert result_no_skipna.dtype == np.float64
+        assert np.isnan(result_no_skipna.iloc[0])
+        assert np.isnan(result_no_skipna.iloc[1])
+        assert np.isnan(result_no_skipna.iloc[2])
+
+    @pytest.mark.parametrize("func", ["var", "std", "sem"])
+    def test_var_std_sem_axis1_all_nan_row_multiblock(self, func):
+        # GH#55194
+        df = DataFrame({"A": [1, 2], "B": [2.0, np.nan]})
+        assert len(df._mgr.blocks) > 1, "test requires multiple blocks"
+        result = getattr(df, func)(axis=1, skipna=True)
+        assert result.dtype == np.float64
+        assert np.isnan(result.iloc[1])
+
+    @pytest.mark.parametrize("func", ["var", "std", "sem"])
+    def test_var_std_sem_axis1_ddof_exceeds_count_multiblock(self, func):
+        # GH#55194
+        df = DataFrame({"A": [1, 2], "B": [3.0, 4.0]})
+        assert len(df._mgr.blocks) > 1, "test requires multiple blocks"
+        result = getattr(df, func)(axis=1, ddof=2)
+        assert result.dtype == np.float64
+        assert np.isnan(result.iloc[0])
+        assert np.isnan(result.iloc[1])
+
     @pytest.mark.parametrize("dtype", ("m8[ns]", "M8[ns]", "M8[ns, UTC]"))
     def test_empty_timeseries_reductions_return_nat(self, dtype, skipna):
         # covers GH#11245


### PR DESCRIPTION
- [x] closes #55194
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added type annotations to new arguments/methods/functions
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md

## Bug

`DataFrame.var()`, `.std()`, and `.sem()` with `axis=1` returned a Series with `object` dtype instead of `float64` when the DataFrame had mixed numeric dtypes (int, float, bool).

**Minimal reproduction:**

```python
import pandas as pd

df = pd.DataFrame({"A": [1, 2], "B": [1.0, 2.0], "C": [True, False]})
print(df.var(axis=1).dtype)  # Before fix: object  After fix: float64
```

## Root Cause

The `_reduce()` method in `frame.py` has an optimized `_reduce_axis1()` path for block-wise axis=1 reductions. This path was only enabled for `sum`, `prod`, `min`, `max`, `any`, `all`, and `mean`. When `var`/`std`/`sem` were called with `axis=1`, they fell through to a transpose-based path (`df = df.T`) that coerced mixed numeric dtypes into a single `object` dtype.

## Fix

- Added `var`, `std`, `sem` to the `_reduce_axis1` optimization condition
- Implemented a two-pass block-wise algorithm:
  - Pass 1: Compute row-wise sum and non-null count across blocks to derive the mean
  - Pass 2: Sum of squared deviations from the mean across blocks
  - Then: `var = sum_sq / (count - ddof)`, `std = sqrt(var)`, `sem = std / sqrt(count)`
- Proper handling of `ddof`, `skipna`, and NaN values

## Tests

8 test methods (24 parametrized cases) covering:
- Basic correctness with mixed int/float/bool dtypes (multi-block path)
- NaN handling with `skipna=True` and `skipna=False`
- `ddof=0` and `ddof >= non-null count` (→ NaN)
- All-NaN rows
- The above NaN and ddof edge cases explicitly in the **multi-block path** (`len(df._mgr.blocks) > 1`), each guarded with an assertion to ensure the new code path is exercised

## AI Disclosure

This fix was developed with the assistance of GitHub Copilot (Claude Sonnet 4.6). The AI assisted with code generation, algorithm design, and diff review. The contributor verified the fix locally against edge cases (skipna=False, ddof!=1, NaN rows) and confirmed the tests pass.