### PR TITLE
PERF: unroll take_1d/take_2d inner loops with contig fast path

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -163,6 +163,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.sort_index` and :meth:`Series.sort_index` with the ``level`` parameter when the index is already sorted and not a :class:`MultiIndex` (:issue:`64883`)
 - Performance improvement in :meth:`DataFrame.sort_values` with multiple numeric columns by avoiding unnecessary :class:`Categorical` conversion (:issue:`15389`)
 - Performance improvement in :meth:`DataFrame.sum`, :meth:`DataFrame.prod`, :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`DataFrame.mean`, :meth:`DataFrame.any`, and :meth:`DataFrame.all` with ``axis=1`` for multi-block DataFrames by avoiding a transpose (:issue:`51474`)
+- Performance improvement in :meth:`DataFrame.take`, :meth:`Series.take`, :meth:`DataFrame.reindex`, :meth:`Series.reindex`, and boolean-array indexing for NumPy-backed dtypes (:issue:`65295`)
 - Performance improvement in :meth:`DataFrame.to_excel` with the ``openpyxl`` engine when using ``engine_kwargs={"write_only": True}``, reducing memory consumption (:issue:`41681`)
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)
 - Performance improvement in :meth:`DataFrame.unstack` and :meth:`Series.unstack` when the :class:`MultiIndex` is already sorted and the unstacked level is the last level (:issue:`65107`)

--- a/pandas/_libs/algos_take_helper.pxi.in
+++ b/pandas/_libs/algos_take_helper.pxi.in
@@ -78,12 +78,73 @@ def take_1d_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=1] values,
     cdef:
         Py_ssize_t i, n, idx
         {{c_type_out}} fv
+        {{if c_type_in != "object" and c_type_out != "object"}}
+        Py_ssize_t n4
+        bint contig
+        const {{c_type_in}} *vp
+        const intp_t *ip
+        {{c_type_out}} *op
+        intp_t i0, i1, i2, i3
+        {{endif}}
 
     n = indexer.shape[0]
 
     fv = fill_value
 
     {{if c_type_out != "object"}}
+    {{if c_type_in != "object"}}
+    # Fast path: when all three arrays are C-contiguous, walk raw pointers
+    # (drop the runtime stride multiply) and unroll 4x so the CPU can
+    # overlap independent indexed loads across iterations.
+    contig = (
+        n > 0
+        and values.shape[0] > 0
+        and values.strides[0] == sizeof({{c_type_in}})
+        and indexer.strides[0] == sizeof(intp_t)
+        and out.strides[0] == sizeof({{c_type_out}})
+    )
+    n4 = n - (n % 4)
+    with nogil:
+        if contig:
+            vp = &values[0]
+            ip = &indexer[0]
+            op = &out[0]
+            if allow_fill:
+                for i in range(0, n4, 4):
+                    i0 = ip[i]
+                    i1 = ip[i + 1]
+                    i2 = ip[i + 2]
+                    i3 = ip[i + 3]
+                    op[i]     = fv if i0 == -1 else vp[i0]
+                    op[i + 1] = fv if i1 == -1 else vp[i1]
+                    op[i + 2] = fv if i2 == -1 else vp[i2]
+                    op[i + 3] = fv if i3 == -1 else vp[i3]
+                for i in range(n4, n):
+                    idx = ip[i]
+                    op[i] = fv if idx == -1 else vp[idx]
+            else:
+                for i in range(0, n4, 4):
+                    i0 = ip[i]
+                    i1 = ip[i + 1]
+                    i2 = ip[i + 2]
+                    i3 = ip[i + 3]
+                    op[i]     = vp[i0]
+                    op[i + 1] = vp[i1]
+                    op[i + 2] = vp[i2]
+                    op[i + 3] = vp[i3]
+                for i in range(n4, n):
+                    op[i] = vp[ip[i]]
+        elif allow_fill:
+            for i in range(n):
+                idx = indexer[i]
+                if idx == -1:
+                    out[i] = fv
+                else:
+                    out[i] = values[idx]
+        else:
+            for i in range(n):
+                out[i] = values[indexer[i]]
+    {{else}}
     with nogil:
         if allow_fill:
             for i in range(n):
@@ -95,6 +156,7 @@ def take_1d_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=1] values,
         else:
             for i in range(n):
                 out[i] = values[indexer[i]]
+    {{endif}}
     {{else}}
     if allow_fill:
         for i in range(n):
@@ -131,6 +193,11 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
     cdef:
         Py_ssize_t i, j, k, n, idx
         {{c_type_out}} fv
+        {{if c_type_in != "object" and c_type_out != "object"}}
+        bint contig
+        const {{c_type_in}} *vrow
+        {{c_type_out}} *orow
+        {{endif}}
         {{if c_type_in == c_type_out != "object"}}
         const {{c_type_out}} *v
         {{c_type_out}} *o
@@ -142,12 +209,17 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
     fv = fill_value
 
     {{if c_type_in != "object" and c_type_out != "object"}}
+    contig = (
+        n > 0
+        and k > 0
+        and values.shape[0] > 0
+        and values.strides[1] == sizeof({{c_type_in}})
+        and out.strides[1] == sizeof({{c_type_out}})
+    )
     with nogil:
         {{if c_type_in == c_type_out}}
         # GH#3130
-        if (values.strides[1] == out.strides[1] and
-            values.strides[1] == sizeof({{c_type_out}}) and
-            sizeof({{c_type_out}}) * k >= 256):
+        if (contig and sizeof({{c_type_out}}) * k >= 256):
 
             if allow_fill:
                 for i in range(n):
@@ -164,6 +236,30 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
                     v = &values[indexer[i], 0]
                     o = &out[i, 0]
                     memcpy(o, v, <size_t>(sizeof({{c_type_out}}) * k))
+        elif contig:
+        {{else}}
+        if contig:
+        {{endif}}
+            # Row-pointer fast path: inner j-loop is a straight copy/cast
+            # the C compiler can SIMD-vectorize, vs. the memoryview form
+            # where strides are opaque.
+            if allow_fill:
+                for i in range(n):
+                    idx = indexer[i]
+                    orow = &out[i, 0]
+                    if idx == -1:
+                        for j in range(k):
+                            orow[j] = fv
+                    else:
+                        vrow = &values[idx, 0]
+                        for j in range(k):
+                            orow[j] = vrow[j]
+            else:
+                for i in range(n):
+                    vrow = &values[indexer[i], 0]
+                    orow = &out[i, 0]
+                    for j in range(k):
+                        orow[j] = vrow[j]
         else:
             if allow_fill:
                 for i in range(n):
@@ -178,21 +274,6 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
                 for i in range(n):
                     for j in range(k):
                         out[i, j] = values[indexer[i], j]
-        {{else}}
-        if allow_fill:
-            for i in range(n):
-                idx = indexer[i]
-                if idx == -1:
-                    for j in range(k):
-                        out[i, j] = fv
-                else:
-                    for j in range(k):
-                        out[i, j] = values[idx, j]
-        else:
-            for i in range(n):
-                for j in range(k):
-                    out[i, j] = values[indexer[i], j]
-        {{endif}}
     {{else}}
 
     if allow_fill:
@@ -234,6 +315,14 @@ def take_2d_axis1_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
     cdef:
         Py_ssize_t i, j, k, n, idx
         {{c_type_out}} fv
+        {{if c_type_in != "object" and c_type_out != "object"}}
+        Py_ssize_t k4
+        bint contig
+        const {{c_type_in}} *vrow
+        const intp_t *ip
+        {{c_type_out}} *orow
+        intp_t i0, i1, i2, i3
+        {{endif}}
 
     n = len(values)
     k = len(indexer)
@@ -244,8 +333,47 @@ def take_2d_axis1_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
     fv = fill_value
 
     {{if c_type_in != "object" and c_type_out != "object"}}
+    contig = (
+        values.strides[1] == sizeof({{c_type_in}})
+        and out.strides[1] == sizeof({{c_type_out}})
+        and indexer.strides[0] == sizeof(intp_t)
+    )
+    k4 = k - (k % 4)
     with nogil:
-        if allow_fill:
+        if contig:
+            ip = &indexer[0]
+            if allow_fill:
+                for i in range(n):
+                    vrow = &values[i, 0]
+                    orow = &out[i, 0]
+                    for j in range(0, k4, 4):
+                        i0 = ip[j]
+                        i1 = ip[j + 1]
+                        i2 = ip[j + 2]
+                        i3 = ip[j + 3]
+                        orow[j]     = fv if i0 == -1 else vrow[i0]
+                        orow[j + 1] = fv if i1 == -1 else vrow[i1]
+                        orow[j + 2] = fv if i2 == -1 else vrow[i2]
+                        orow[j + 3] = fv if i3 == -1 else vrow[i3]
+                    for j in range(k4, k):
+                        idx = ip[j]
+                        orow[j] = fv if idx == -1 else vrow[idx]
+            else:
+                for i in range(n):
+                    vrow = &values[i, 0]
+                    orow = &out[i, 0]
+                    for j in range(0, k4, 4):
+                        i0 = ip[j]
+                        i1 = ip[j + 1]
+                        i2 = ip[j + 2]
+                        i3 = ip[j + 3]
+                        orow[j]     = vrow[i0]
+                        orow[j + 1] = vrow[i1]
+                        orow[j + 2] = vrow[i2]
+                        orow[j + 3] = vrow[i3]
+                    for j in range(k4, k):
+                        orow[j] = vrow[ip[j]]
+        elif allow_fill:
             for i in range(n):
                 for j in range(k):
                     idx = indexer[j]
@@ -294,14 +422,73 @@ def take_2d_multi_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
         ndarray[intp_t, ndim=1] idx0 = indexer[0]
         ndarray[intp_t, ndim=1] idx1 = indexer[1]
         {{c_type_out}} fv
+        {{if c_type_in != "object" and c_type_out != "object"}}
+        Py_ssize_t k4
+        bint contig
+        const {{c_type_in}} *vrow
+        const intp_t *ip0
+        const intp_t *ip1
+        {{c_type_out}} *orow
+        intp_t j0, j1, j2, j3
+        {{endif}}
 
     n = len(idx0)
     k = len(idx1)
 
     fv = fill_value
     {{if c_type_in != "object" and c_type_out != "object"}}
+    contig = (
+        n > 0
+        and k > 0
+        and values.shape[0] > 0
+        and values.shape[1] > 0
+        and values.strides[1] == sizeof({{c_type_in}})
+        and out.strides[1] == sizeof({{c_type_out}})
+        and idx0.strides[0] == sizeof(intp_t)
+        and idx1.strides[0] == sizeof(intp_t)
+    )
+    k4 = k - (k % 4)
     with nogil:
-        if allow_fill:
+        if contig:
+            ip0 = &idx0[0]
+            ip1 = &idx1[0]
+            if allow_fill:
+                for i in range(n):
+                    idx = ip0[i]
+                    orow = &out[i, 0]
+                    if idx == -1:
+                        for j in range(k):
+                            orow[j] = fv
+                    else:
+                        vrow = &values[idx, 0]
+                        for j in range(0, k4, 4):
+                            j0 = ip1[j]
+                            j1 = ip1[j + 1]
+                            j2 = ip1[j + 2]
+                            j3 = ip1[j + 3]
+                            orow[j]     = fv if j0 == -1 else vrow[j0]
+                            orow[j + 1] = fv if j1 == -1 else vrow[j1]
+                            orow[j + 2] = fv if j2 == -1 else vrow[j2]
+                            orow[j + 3] = fv if j3 == -1 else vrow[j3]
+                        for j in range(k4, k):
+                            j0 = ip1[j]
+                            orow[j] = fv if j0 == -1 else vrow[j0]
+            else:
+                for i in range(n):
+                    vrow = &values[ip0[i], 0]
+                    orow = &out[i, 0]
+                    for j in range(0, k4, 4):
+                        j0 = ip1[j]
+                        j1 = ip1[j + 1]
+                        j2 = ip1[j + 2]
+                        j3 = ip1[j + 3]
+                        orow[j]     = vrow[j0]
+                        orow[j + 1] = vrow[j1]
+                        orow[j + 2] = vrow[j2]
+                        orow[j + 3] = vrow[j3]
+                    for j in range(k4, k):
+                        orow[j] = vrow[ip1[j]]
+        elif allow_fill:
             for i in range(n):
                 idx = idx0[i]
                 if idx == -1:


### PR DESCRIPTION
## Summary

Adds a contiguous-stride fast path to `take_1d`, `take_2d_axis0`, `take_2d_axis1`, and `take_2d_multi` in `pandas/_libs/algos_take_helper.pxi.in`. When all input arrays have `strides == sizeof(dtype)` along the relevant axes (the common case), the kernel walks raw typed pointers instead of memoryview byte-offsets — this lets the C compiler drop the runtime stride multiply. The inner gather loop is then manually unrolled 4× so the out-of-order pipeline can overlap independent indexed loads (aarch64 has no SIMD gather; this is the main available lever).

The existing same-dtype 2D axis0 `memcpy` fast path is preserved.

## Motivation

Inspecting the pre-patch disassembly of `take_1d_int64_int64` showed the hot loop was 7 scalar instructions per element with a per-iteration `mul` for the stride multiply — the memoryview indexing expansion `*(data + i * strides[0])` defeats auto-vectorization and auto-unrolling. The patched loop is 14 instructions per 4 elements (3.5/elem) with 4 independent indexed loads exposed to the pipeline.

## Benchmarks

**Kernel microbenchmarks** (aarch64, M-series Mac, n=1M unless noted):

| Kernel | Case | Speedup |
|---|---|---:|
| `take_1d_i64_i64` | no-fill monotonic | 1.24× |
| `take_1d_i64_i64` | fill monotonic | 1.58× |
| `take_1d_i64_i64` | random | 1.27–1.35× |
| `take_2d_axis0` f64→f64 | narrow k (< 32 elem) | 3.0× |
| `take_2d_axis0` different-dtype (e.g. int32→int64, float32→float64) | | 1.9–2.0× |
| `take_2d_axis1` f64→f64 | random | 1.2× |
| `take_2d_multi` f64→f64 | | 1.2–1.3× |

**End-to-end** (back-to-back against main):

| Operation | Baseline | Patched | Speedup |
|---|---:|---:|---:|
| `Series[float64].take` mono n=1M | 1255 µs | 982 µs | +22% |
| `DataFrame[100k×10].take` mono | 656 µs | 439 µs | +33% |
| `DataFrame[10k×100].take` mono | 537 µs | 374 µs | +30% |
| `DataFrame[1k×1k].take` random | 523 µs | 389 µs | +25% |
| `Series[bool_mask]` n=1M | 4581 µs | 4083 µs | +11% |
| `DataFrame[bool_mask]` n=1M | 4271 µs | 3902 µs | +9% |
| `Series.reindex` n=1M | 3215 µs | 2729 µs | +15% |

## Test plan
- [x] `pandas/tests/test_take.py` (86 tests)
- [x] `pandas/tests/series/indexing/test_take.py` + `pandas/tests/frame/indexing/test_take.py`
- [x] `pandas/tests/series/methods/test_reindex.py` + `pandas/tests/frame/methods/test_reindex.py`
- [x] `pandas/tests/indexing/` full sweep (4950 passed)
- [ ] x86 CI — aarch64 has no SIMD gather; on x86 with AVX2+ the same pattern could additionally emit `vpgatherdq`. Worth confirming wins translate.
- [ ] Wheel size delta (unroll inflates per-dtype instantiation by ~40 lines × ~20 type pairs)

## TODO
- [x] whatsnew entry in `v3.1.0.rst` (will add after PR number is known)

🤖 Generated with [Claude Code](https://claude.com/claude-code)