### PR TITLE
REF: remove redundant BaseMaskedArray.map override

### DIFF
--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -67,7 +67,6 @@ from pandas.core import (
 from pandas.core.algorithms import (
     factorize_array,
     isin,
-    map_array,
     mode,
     take,
 )
@@ -1800,14 +1799,6 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
 
     def count(self) -> np.int64:
         return (~self._mask).sum()
-
-    def map(self, mapper, na_action: Literal["ignore"] | None = None):
-        result = map_array(
-            self.to_numpy(dtype=object, na_value=libmissing.NA),
-            mapper,
-            na_action=na_action,
-        )
-        return self._cast_pointwise_result(result)
 
     @overload
     def any(


### PR DESCRIPTION
## Summary

- `ExtensionArray.map` now calls `_cast_pointwise_result` itself (#64801), which makes the `BaseMaskedArray.map` override equivalent to the inherited base implementation.
- Inside `map_array`, the `self.astype(object, copy=False)` step goes through `MaskedArray.astype` → `to_numpy` with `na_value=libmissing.NA` (via `to_numpy_dtype_inference`), producing exactly what the override was building explicitly.

## Test plan

- [x] `pandas/tests/extension/test_masked.py` (6429 tests)
- [x] `pandas/tests/extension/`, `pandas/tests/indexes/`, `pandas/tests/series/methods/test_map.py`, `pandas/tests/frame/methods/test_map.py`, `pandas/tests/arrays/` (~65k tests)
- [x] pre-commit, mypy (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)