### PR TITLE
PERF: preserve block memory layout in Block.copy (GH#60469)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -178,6 +178,7 @@ Performance improvements
 - Performance improvement in partial-string indexing on a monotonic decreasing :class:`DatetimeIndex` or :class:`PeriodIndex` (:issue:`64811`)
 - Performance improvement in plotting :class:`DatetimeIndex` with multiplied frequencies (e.g. ``"1000ms"``, ``"100s"``) (:issue:`50355`)
 - Performance improvement in reading zip-compressed files (e.g. :func:`read_pickle`, :func:`read_csv`) on Python < 3.12 (:issue:`59279`)
+- Performance improvement in reductions along ``axis=1`` and other operations on DataFrames produced by :meth:`DataFrame.copy` (:issue:`60469`)
 - Performance improvement in repr of :class:`Series` and :class:`DataFrame` containing third-party array-like objects (e.g. xarray ``DataArray``) in object dtype columns (:issue:`61809`)
 - Performance improvement in :meth:`DataFrame.loc` and :meth:`DataFrame.iloc`
   setitem with a 2D list-of-lists value by avoiding a wasteful round-trip

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -657,7 +657,12 @@ class Block(PandasObject, libinternals.Block):
         values = self.values
         refs: BlockValuesRefs | None
         if deep:
-            values = values.copy()
+            if isinstance(values, np.ndarray):
+                # "K" preserves memory layout; default "C" flips contiguity
+                # for non-C-order blocks (GH#60469).
+                values = values.copy(order="K")
+            else:
+                values = values.copy()
             refs = None
         else:
             values = values.view()

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3563,7 +3563,13 @@ class BlockManagerFixed(GenericFixed):
             values = self.read_array(f"block{i}_values", start=_start, stop=_stop)
 
             columns = items[items.get_indexer(blk_items)]
-            df = DataFrame(values.T, columns=columns, index=axes[1], copy=False)
+            arr = values.T
+            if isinstance(arr, np.ndarray):
+                # DataFrame stores the block as arr.T, so pass a Fortran-ordered
+                # arr to get a C-contiguous block (column-major DataFrame), so
+                # per-column access is contiguous (GH#22073, GH#60469).
+                arr = np.asfortranarray(arr)
+            df = DataFrame(arr, columns=columns, index=axes[1], copy=False)
             if (
                 using_string_dtype()
                 and isinstance(values, np.ndarray)


### PR DESCRIPTION
- closes #60469
- supersedes #44871 (closed as stale 2022)

``Block.copy`` calls ``values.copy()`` without specifying ``order``. numpy's default is ``order="C"``, which flips the memory layout of non-C-contiguous blocks. Since BlockManager stores data transposed relative to the user-facing shape, a user-facing C-contiguous DataFrame has F-contiguous block storage — so after ``.copy()`` the user ends up with F-contiguous ``.values``, and e.g. ``mean(axis=1)`` walks the slow stride. Passing ``order="K"`` preserves the original layout.

Repro from #60469 on this branch:
- ``df_nan.mean(axis=1)``: 7.24 ms  →  7.24 ms
- ``df_nan_copy.mean(axis=1)``: 18.73 ms  →  7.43 ms

## ASV results

This PR was the subject of #44871, which was closed as stale in 2022 after an ASV run showed real wide-frame arithmetic regressions (``FrameWithFrameWide.time_op_different_blocks`` was 2.06× slower). A full ``asv continuous`` run on the current tree shows those regressions are no longer present — presumably resolved by internals refactoring over the last four years.

Current run: **~120 benchmarks improved (0.45×–0.91×)**, 3 apparent regressions. Re-running the 3 regressions with more repeats showed all were noise from concurrent machine activity (``BENCHMARKS NOT SIGNIFICANTLY CHANGED``).

Notable improvements (sampling):

| Ratio | Benchmark |
|---|---|
| 0.45× | ``index_cached_properties.IndexCache.time_engine('TimedeltaIndex')`` |
| 0.62× | ``strings.Methods.time_wrap('string[pyarrow]')`` |
| 0.68× | ``indexing.Setitem.time_setitem_list`` |
| 0.72× | ``arithmetic.OpWithFillValue.time_frame_op_with_fill_value_no_nas`` |
| 0.75× | ``sparse.Arithmetic.time_make_union`` |
| 0.76× | ``multiindex_object.Unique.time_unique_dups(('Int64', <NA>))`` |
| 0.78× | ``arithmetic.NumericInferOps.time_add(float64)`` |
| 0.78× | ``series_methods.ToNumpy.time_to_numpy_copy`` |

Caveat: the ASV run had some concurrent machine activity, so per-benchmark ratios are directional, not quantitative. No 2×-style regression like the 2021 one appears; the targeted re-run of the three flagged regressions cleared them.