### PR TITLE
BUG: Fix silent __setitem__ discard for MultiIndex with falsy sub-column label (GH#65118)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -198,6 +198,7 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 - Bug in :meth:`Categorical.__repr__` where the values and categories lines could exceed ``display.width`` (:issue:`12066`)
+- Bug in :meth:`Categorical.map` where unordered categoricals preserved the positional category order from the original categories instead of sorting the mapped values, causing :meth:`DataFrame.sort_values` with ``key`` to ignore custom sort orders (:issue:`58153`)
 - Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
 - Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
 -

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1641,8 +1641,26 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             na_val = mapper(np.nan) if callable(mapper) else mapper.get(np.nan, np.nan)
 
         if new_categories.is_unique and not new_categories.hasnans and na_val is np.nan:
+            codes = self._codes.copy()
+            if not self.ordered:
+                # GH#58153: For unordered categoricals, sort the mapped
+                # categories so that category order reflects the natural
+                # ordering of the new values, not the positional order
+                # inherited from the original categories.
+                try:
+                    indexer = new_categories.argsort()
+                except TypeError:
+                    # Mixed types (e.g. str and float) can't be compared;
+                    # skip sorting and keep original category order.
+                    pass
+                else:
+                    new_categories = new_categories.take(indexer)
+                    reverse_indexer = np.empty(len(indexer), dtype=np.intp)
+                    reverse_indexer[indexer] = np.arange(len(indexer))
+                    mask = codes >= 0
+                    codes[mask] = reverse_indexer[codes[mask]]
             new_dtype = CategoricalDtype(new_categories, ordered=self.ordered)
-            return self.from_codes(self._codes.copy(), dtype=new_dtype, validate=False)
+            return self.from_codes(codes, dtype=new_dtype, validate=False)
 
         if has_nans:
             new_categories = new_categories.insert(len(new_categories), na_val)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4703,11 +4703,14 @@ class DataFrame(NDFrame, OpsMixin):
                 if (
                     not isinstance(cols_droplevel, MultiIndex)
                     and is_string_dtype(cols_droplevel.dtype)
-                    and not cols_droplevel.any()
+                    and (cols_droplevel == "").all()
                 ):
                     # if cols_droplevel contains only empty strings,
                     # value.reindex(cols_droplevel, axis=1) would be full of NaNs
                     # see GH#62518 and GH#61841
+                    # Note: use (== "").all() rather than not .any() to avoid
+                    # triggering on falsy-but-non-empty values such as integer 0
+                    # (GH#65118).
                     return
                 if len(cols_droplevel) and not cols_droplevel.equals(value.columns):
                     value = value.reindex(cols_droplevel, axis=1)

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -22,8 +22,12 @@ def test_map_str(data, categories, ordered, na_action):
     # GH 31202 - override base class since we want to maintain categorical/ordered
     cat = Categorical(data, categories=categories, ordered=ordered)
     result = cat.map(str, na_action=na_action)
+    expected_categories = list(map(str, categories))
+    if not ordered:
+        # GH#58153: Unordered categoricals sort categories after map
+        expected_categories = sorted(expected_categories)
     expected = Categorical(
-        map(str, data), categories=map(str, categories), ordered=ordered
+        map(str, data), categories=expected_categories, ordered=ordered
     )
     tm.assert_categorical_equal(result, expected)
 
@@ -36,7 +40,8 @@ def test_map(na_action):
 
     cat = Categorical(list("ABABC"), categories=list("BAC"), ordered=False)
     result = cat.map(lambda x: x.lower(), na_action=na_action)
-    exp = Categorical(list("ababc"), categories=list("bac"), ordered=False)
+    # GH#58153: Unordered categoricals sort categories after map
+    exp = Categorical(list("ababc"), categories=list("abc"), ordered=False)
     tm.assert_categorical_equal(result, exp)
 
     # GH 12766: Return an index not an array
@@ -51,7 +56,8 @@ def test_map(na_action):
         return {"A": 10, "B": 20, "C": 30}.get(x)
 
     result = cat.map(f, na_action=na_action)
-    exp = Categorical([10, 20, 10, 20, 30], categories=[20, 10, 30], ordered=False)
+    # GH#58153: Unordered categoricals sort categories after map
+    exp = Categorical([10, 20, 10, 20, 30], categories=[10, 20, 30], ordered=False)
     tm.assert_categorical_equal(result, exp)
 
     mapper = Series([10, 20, 30], index=["A", "B", "C"])

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1503,3 +1503,17 @@ def test_loc_setitem_tz_aware_column_expansion():
     _time = datetime.fromtimestamp(1695887042, timezone.utc)
     df.loc[df.id >= 2, "time"] = _time
     assert df["time"].dtype == DatetimeTZDtype(tz="UTC", unit="us")
+
+
+def test_setitem_multiindex_single_subcol_falsy_label():
+    # GH#65118: df[key] = value was silently discarded when MultiIndex had
+    # object-dtype level-2 labels and the key mapped to exactly one sub-column
+    # whose label was falsy (e.g. integer 0).  The guard `not .any()` fired on
+    # Index([0]) because 0 is falsy in Python.
+    cols = MultiIndex.from_tuples(
+        [("info", "M"), ("info", 0), ("earnings", 1), ("earnings", 2), ("prices", 0)]
+    )
+    df = DataFrame(np.arange(20, dtype=float).reshape(4, 5), columns=cols)
+    df["prices"] = df["prices"] / 100
+    expected = np.array([0.04, 0.09, 0.14, 0.19])
+    tm.assert_numpy_array_equal(df[("prices", 0)].to_numpy(), expected)

--- a/pandas/tests/indexes/categorical/test_map.py
+++ b/pandas/tests/indexes/categorical/test_map.py
@@ -22,8 +22,12 @@ def test_map_str(data, categories, ordered):
     # GH 31202 - override base class since we want to maintain categorical/ordered
     index = CategoricalIndex(data, categories=categories, ordered=ordered)
     result = index.map(str)
+    expected_categories = list(map(str, categories))
+    if not ordered:
+        # GH#58153: Unordered categoricals sort categories after map
+        expected_categories = sorted(expected_categories)
     expected = CategoricalIndex(
-        map(str, data), categories=map(str, categories), ordered=ordered
+        map(str, data), categories=expected_categories, ordered=ordered
     )
     tm.assert_index_equal(result, expected)
 
@@ -38,8 +42,9 @@ def test_map():
         list("ABABC"), categories=list("BAC"), ordered=False, name="XXX"
     )
     result = ci.map(lambda x: x.lower())
+    # GH#58153: Unordered categoricals sort categories after map
     exp = CategoricalIndex(
-        list("ababc"), categories=list("bac"), ordered=False, name="XXX"
+        list("ababc"), categories=list("abc"), ordered=False, name="XXX"
     )
     tm.assert_index_equal(result, exp)
 
@@ -55,7 +60,8 @@ def test_map():
         return {"A": 10, "B": 20, "C": 30}.get(x)
 
     result = ci.map(f)
-    exp = CategoricalIndex([10, 20, 10, 20, 30], categories=[20, 10, 30], ordered=False)
+    # GH#58153: Unordered categoricals sort categories after map
+    exp = CategoricalIndex([10, 20, 10, 20, 30], categories=[10, 20, 30], ordered=False)
     tm.assert_index_equal(result, exp)
 
     result = ci.map(Series([10, 20, 30], index=["A", "B", "C"]))


### PR DESCRIPTION
#### Problem

When setting a column on a DataFrame with MultiIndex columns, the assignment was silently discarded if the target top-level key mapped to exactly one sub-column whose label was falsy (e.g. integer `0`).

```python
cols = pd.MultiIndex.from_tuples([
    ('info', 'M'), ('info', 0),
    ('earnings', 1), ('earnings', 2),
    ('prices', 0),  # <-- label 0 is falsy
])
df = pd.DataFrame(np.arange(20, dtype=float).reshape(4, 5), columns=cols)
df['prices'] = df['prices'] / 100  # silently no-ops before fix

print(df[('prices', 0)][0])  # prints 4.0 (unchanged), expected 0.04
```

#### Root cause

In `DataFrame._set_item_frame_value()`, the guard that detects all-empty-string column labels used:

```python
not cols_droplevel.any()
```

When `cols_droplevel` is `Index([0], dtype='object')`, `any()` returns `False` because `0` is falsy in Python, so `not False == True` triggers an early `return` — discarding the assignment entirely. This guard was introduced in GH#62518 / GH#61841 to handle the empty-string edge case.

#### Fix

Replace the condition with an explicit check:

```python
(cols_droplevel == "").all()
```

This correctly identifies only genuine all-empty-string index labels and does not misfire on falsy-but-valid labels like `0`.

#### Tests

Added `test_setitem_multiindex_single_subcol_falsy_label` in `pandas/tests/frame/indexing/test_setitem.py`.

Closes #65118