### PR TITLE
BUG: Fix str.replace() hanging on empty pattern for Arrow-backed strings

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -251,6 +251,7 @@ Conversion
 Strings
 ^^^^^^^
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
+- Bug in :meth:`Series.str.replace` hanging indefinitely when using Arrow-backed string dtypes (e.g. ``string[pyarrow]``) and an empty pattern (``pat=""``), due to an upstream pyarrow issue (:issue:`64941`)
 -
 
 Interval

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -239,6 +239,28 @@ class ArrowStringArrayMixin:
                 "named group references (\\g<...>)"
             )
 
+        # GH#64941: pyarrow hangs indefinitely on empty patterns
+        # (upstream: https://github.com/apache/arrow/issues/39149).
+        # Fall back to element-wise Python behavior which handles this correctly.
+        if isinstance(pat, str) and not pat:
+            if regex:
+                # re.sub count=0 means "replace all"; pandas n=-1 also means all
+                re_count = 0 if n < 0 else n
+                result_list = [
+                    re.sub("", repl, val, count=re_count) if val is not None else None
+                    for val in self._pa_array.to_pylist()
+                ]
+            else:
+                result_list = [
+                    (val.replace("", repl) if n < 0 else val.replace("", repl, n))
+                    if val is not None
+                    else None
+                    for val in self._pa_array.to_pylist()
+                ]
+            return self._from_pyarrow_array(
+                pa.array(result_list, type=self._pa_array.type)
+            )
+
         func = pc.replace_substring_regex if regex else pc.replace_substring
         # https://github.com/apache/arrow/issues/39149
         # GH 56404, unexpected behavior with negative max_replacements with pyarrow.

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1695,3 +1695,26 @@ def test_flags_kwarg(any_string_dtype):
     with tm.assert_produces_warning(UserWarning, match=msg):
         result = data.str.contains(pat, flags=re.IGNORECASE)
     assert result.iloc[0]
+
+
+@pytest.mark.parametrize("dtype", ["string[pyarrow]", "large_string[pyarrow]"])
+@pytest.mark.parametrize("regex", [True, False])
+def test_replace_empty_pattern_arrow(dtype, regex):
+    # GH#64941: pyarrow hangs indefinitely on empty pattern
+    # Expected behavior matches Python's str.replace("", repl)
+    pytest.importorskip("pyarrow")
+    ser = Series(["abcd", "xy", pd.NA], dtype=dtype)
+
+    # replace with non-empty repl: inserts repl at every position
+    result = ser.str.replace("", "X", regex=regex)
+    expected = Series(["XaXbXcXdX", "XxXyX", pd.NA], dtype=dtype)
+    tm.assert_series_equal(result, expected)
+
+    # replace with empty repl: no-op
+    result_noop = ser.str.replace("", "", regex=regex)
+    tm.assert_series_equal(result_noop, ser)
+
+    # limited replacements
+    result_n = ser.str.replace("", "X", n=2, regex=regex)
+    expected_n = Series(["XaXbcd", "XxXy", pd.NA], dtype=dtype)
+    tm.assert_series_equal(result_n, expected_n)


### PR DESCRIPTION
- [ ] closes #64941
- [x] Tests added and passed
- [ ] All code checks passed (CI pending)
- [x] Added type annotations — no new arguments/methods added
- [x] Added an entry in `doc/source/whatsnew/v3.1.0.rst`
- [x] I have reviewed and followed all the contribution guidelines
- [x] AI used: prompted to follow `AGENTS.md`

## Summary

`pd.Series(["abcd"], dtype="string[pyarrow]").str.replace("", "X")` hangs indefinitely due to a [bug in pyarrow](https://github.com/apache/arrow/issues/39149) where `pc.replace_substring` and `pc.replace_substring_regex` enter an infinite loop when the pattern is an empty string.

## Fix

Added an early-exit guard in `ArrowStringArrayMixin._str_replace()` that detects an empty string pattern and falls back to element-wise Python `str.replace()`, which handles this case correctly. This covers `string[pyarrow]` (`ArrowStringArray`) and other Arrow-backed string dtypes like `large_string[pyarrow]` (`ArrowExtensionArray`), both `regex=True`/`False`, and the `n` parameter.

## Note on related PR

There is an earlier PR #65135 addressing the same issue. That PR adds the guard in `string_arrow.py` (covers `string[pyarrow]` only), while this PR adds it in `_arrow_string_mixins.py` (covers all Arrow-backed string types). Happy to close this one if maintainers prefer #65135.

## AI Disclosure

This fix was generated with GitHub Copilot (Claude Sonnet 4.6). I reviewed the generated code, verified the root cause, confirmed the fix logic is correct, and ran the tests myself.