### PR TITLE
BUG: fix ArrowExtensionArray constructor raising on np.nan in string sequences

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -254,6 +254,7 @@ Conversion
 ^^^^^^^^^^
 - Bug in :class:`DataFrame` constructor where ``NaT`` in a :class:`TimedeltaIndex` row was incorrectly inferred as ``datetime64`` instead of ``timedelta64`` (:issue:`23985`)
 - Bug in :class:`DataFrame` constructor where constructing from a list of uniform-dtype arrays (e.g. pyarrow, :class:`CategoricalDtype`, nullable dtypes) lost the dtype (:issue:`49593`)
+- Bug in :func:`pd.array` raising ``ArrowTypeError`` when constructing an :class:`ArrowDtype` string array from a sequence containing ``np.nan`` (:issue:`64578`)
 - Bug in :func:`pd.array` silently converting NaN to a nonsensical integer when given float data containing NaN and a NumPy integer dtype (:issue:`41724`)
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`).
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -656,7 +656,8 @@ class ArrowExtensionArray(
             mask = None
             if is_nan_na():
                 try:
-                    arr_value = np.asarray(value)
+                    # GH#64578: dtype=object preserves np.nan as float so isna() works
+                    arr_value = np.asarray(value, dtype=object)
                     if arr_value.ndim > 1:
                         # e.g. test_fixed_size_list we have list data.  ndim > 1
                         #  means there were no scalar (NA) entries.

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3088,6 +3088,23 @@ def test_from_sequence_of_strings_boolean():
         ArrowExtensionArray._from_sequence_of_strings(strings, dtype=dtype)
 
 
+def test_arrow_array_constructor_with_nan():
+    # GH#64578
+    import pyarrow as pa
+
+    result = pd.array(["a", np.nan], dtype=ArrowDtype(pa.string()))
+    expected = pd.array(["a", None], dtype=ArrowDtype(pa.string()))
+    tm.assert_extension_array_equal(result, expected)
+
+    result2 = pd.array(["a", np.nan], dtype=ArrowDtype(pa.large_string()))
+    expected2 = pd.array(["a", None], dtype=ArrowDtype(pa.large_string()))
+    tm.assert_extension_array_equal(result2, expected2)
+
+    result3 = pd.array([1, np.nan, 3], dtype=ArrowDtype(pa.float64()))
+    expected3 = pd.array([1, None, 3], dtype=ArrowDtype(pa.float64()))
+    tm.assert_extension_array_equal(result3, expected3)
+
+
 def test_concat_empty_arrow_backed_series(dtype):
     # GH#51734
     ser = pd.Series([], dtype=dtype)


### PR DESCRIPTION
#### Problem description

When constructing an `ArrowDtype` string array via `pd.array()` with a sequence that contains `np.nan`, an `ArrowTypeError` is raised:

```python
>>> import pandas as pd
>>> import numpy as np
>>> pd.array(["a", np.nan], dtype=pd.ArrowDtype(pa.string()))
# ArrowTypeError: Expected bytes, got a 'float' object
```

#### Root cause

In `ArrowExtensionArray._box_pa_array()`, the mask is computed via:

```python
arr_value = np.asarray(value)
mask = isna(arr_value)
```

`np.asarray(["a", np.nan])` produces a `<U3` Unicode array in which `np.nan` is silently coerced to the string `'nan'`. `isna()` then returns `[False, False]`, the NA mask is empty, and pyarrow rejects the float value.

#### Fix

Pass `dtype=object` to `np.asarray()` so that scalar types are preserved and `isna()` correctly identifies `np.nan` as a missing value.

Closes #64578