### PR TITLE
BUG: Fix DataFrame.at/iat raising ValueError when storing list-like in a single cell

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -281,6 +281,7 @@ Indexing
 - Bug in :meth:`Index.get_indexer` where ``method="pad"``, ``"backfill"``, or ``"nearest"`` returned incorrect results when the target contained ``NaT`` or ``NaN`` instead of ``-1`` (:issue:`32572`)
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
 - Bug in :meth:`DataFrame.__getitem__` raising ``InvalidIndexError`` when indexing with a tuple containing a ``slice`` on a :class:`DataFrame` with :class:`MultiIndex` columns (e.g., ``df[:, "t1"]``) (:issue:`26511`)
+- Bug in :meth:`DataFrame.at` and :meth:`DataFrame.iat` raising ``ValueError`` when storing a list-like value in a single cell of an object-dtype column (:issue:`61223`)
 - Bug in :meth:`DataFrame.at` raising ``TypeError`` when accessing a :class:`MultiIndex` with a partial date string on a :class:`DatetimeIndex` level (:issue:`43395`)
 - Bug in :meth:`DataFrame.duplicated` returning an empty :class:`Series` without the DataFrame's index when the DataFrame had no columns (:issue:`61191`)
 - Bug in :meth:`DataFrame.iloc` setitem raising ``AttributeError`` when assigning a :class:`Series` or :class:`Index` with a nullable EA dtype (e.g. ``Int64``, ``Float64``, ``boolean``) into a column with a NumPy dtype (:issue:`47776`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4823,7 +4823,17 @@ class DataFrame(NDFrame, OpsMixin):
             else:
                 icol = self.columns.get_loc(col)
                 iindex = self.index.get_loc(index)  # type: ignore[assignment]
-            self._mgr.column_setitem(icol, iindex, value, inplace_only=True)
+            if (
+                not takeable
+                and not isinstance(icol, int)
+                and is_list_like(value)
+                and not isinstance(value, dict)
+            ):
+                # GH#61223: non-unique columns; force except branch to raise
+                raise KeyError(col)
+            self._mgr.column_setitem(
+                cast("int", icol), iindex, value, inplace_only=True
+            )
 
         except (KeyError, TypeError, ValueError, LossySetitemError):
             # get_loc might raise a KeyError for missing labels (falling back
@@ -4831,7 +4841,48 @@ class DataFrame(NDFrame, OpsMixin):
             # column_setitem will do validation that may raise TypeError,
             #  ValueError, or LossySetitemError
             # set using a non-recursive method & reset the cache
-            if takeable:
+            if is_list_like(value) and not isinstance(value, dict):
+                # GH#61223: store list-like as single cell, bypassing .loc/.iloc
+                if takeable:
+                    col_label = self.columns[col]
+                    iindex = cast("int", index)
+                else:
+                    col_label = col
+                    try:
+                        _iindex = self.index.get_loc(index)
+                    except KeyError:
+                        # GH#48323 missing row: fall back to .loc (deprecated)
+                        self.loc[index, col] = value
+                        return
+                    if not isinstance(_iindex, int):
+                        # GH#61223: partial MultiIndex key; .at requires unique row
+                        raise KeyError(index) from None
+                    iindex = _iindex
+                    if col not in self.columns:
+                        warnings.warn(
+                            f"Setting a value on a {type(self).__name__} via "
+                            f".at with a column key '{col}' that does not "
+                            "exist is deprecated and will raise a KeyError "
+                            "in a future version. Use .loc instead.",
+                            Pandas4Warning,
+                            stacklevel=find_stack_level(),
+                        )
+                        self[col] = Series(dtype=object, index=self.index)
+                icol = self.columns.get_loc(col_label)
+                if not isinstance(icol, int):
+                    # GH#61223: non-unique column label
+                    raise KeyError(col) from None
+                if self.dtypes.iloc[icol] != np.dtype("object"):
+                    # GH#61223 list-like requires object dtype (PDEP6)
+                    raise ValueError(
+                        f"Cannot store a list-like value in column "
+                        f"'{col_label}' with dtype "
+                        f"'{self.dtypes.iloc[icol]}'. Cast the column to "
+                        "object dtype explicitly: "
+                        f"df['{col_label}'] = df['{col_label}'].astype(object)"
+                    ) from None
+                self._mgr.column_setitem(icol, iindex, value, inplace_only=True)
+            elif takeable:
                 self.iloc[index, col] = value
             else:
                 self.loc[index, col] = value

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -3303,6 +3303,10 @@ class _AtIndexer(_ScalarAccessIndexer):
             if not isinstance(key, tuple) or not all(is_scalar(x) for x in key):
                 raise ValueError("Invalid call for scalar access (setting)!")
 
+            if is_list_like(value) and not isinstance(value, dict):
+                # GH#61223: non-unique axes; .loc would distribute list-like
+                raise KeyError(key[-1])
+
             self.obj.loc[key] = value
             return
 

--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -162,6 +162,15 @@ class TestAtSetItem:
         df.at[row, 0] = 0.5
         tm.assert_frame_equal(df, expected)
 
+    def test_at_setitem_list_like_object_dtype_no_warning(self):
+        # GH#61223 - list-like in object-dtype column succeeds without warning
+        df = DataFrame({"A": Series([[1, 2], [3, 4], [5, 6]])})
+        assert df["A"].dtype == np.dtype("object")
+        with tm.assert_produces_warning(None):
+            df.at[0, "A"] = [10, 20, 30]
+        assert df.at[0, "A"] == [10, 20, 30]
+        assert df["A"].dtype == np.dtype("object")
+
 
 class TestAtSetItemWithExpansion:
     def test_at_setitem_expansion_series_dt64tz_value(self, tz_naive_fixture):
@@ -235,6 +244,52 @@ class TestAtSetItemWithExpansion:
             ser.at[0] = 99
         assert ser.at[0] == 99
 
+    def test_at_setitem_list_like_missing_row_object_dtype(self):
+        # GH#61223 - missing row falls back to .loc with Pandas4Warning
+        df = DataFrame({"A": Series([[1], [2]], dtype=object)}, index=["a", "b"])
+        msg = "Setting a value on a DataFrame via .at with a key"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            df.at["c", "A"] = [3, 4]
+        assert df.at["c", "A"] == [3, 4]
+        assert df["A"].dtype == np.dtype("object")
+
+    def test_at_setitem_list_like_new_column(self):
+        # GH#61223 - list-like stored as single cell in new object-dtype column
+        df = DataFrame({"A": [1, 2, 3]}, index=["a", "b", "c"])
+        with tm.assert_produces_warning(
+            Pandas4Warning, match="column key 'B' that does not exist"
+        ):
+            df.at["a", "B"] = [10, 20, 30]
+        assert df.at["a", "B"] == [10, 20, 30]
+        assert df["B"].dtype == np.dtype("object")
+        assert df.at["b", "B"] is np.nan
+
+    def test_at_setitem_ndarray_new_column(self):
+        # GH#61223 - np.ndarray stored as single cell in new object-dtype column
+        df = DataFrame({"A": [1, 2, 3]}, index=["a", "b", "c"])
+        arr = np.array([10, 20, 30])
+        with tm.assert_produces_warning(
+            Pandas4Warning, match="column key 'B' that does not exist"
+        ):
+            df.at["a", "B"] = arr
+        stored = df.at["a", "B"]
+        assert isinstance(stored, np.ndarray)
+        tm.assert_numpy_array_equal(stored, arr)
+        assert df["B"].dtype == np.dtype("object")
+        assert df.at["b", "B"] is np.nan
+
+    def test_at_setitem_series_value_new_column(self):
+        # GH#61223 - Series stored as single cell in new object-dtype column
+        df = DataFrame({"A": [1, 2, 3]}, index=["a", "b", "c"])
+        val = Series([10, 20], index=["x", "y"])
+        with tm.assert_produces_warning(
+            Pandas4Warning, match="column key 'B' that does not exist"
+        ):
+            df.at["a", "B"] = val
+        result = df.at["a", "B"]
+        tm.assert_series_equal(result, val)
+        assert df["B"].dtype == np.dtype("object")
+
 
 class TestAtWithDuplicates:
     def test_at_with_duplicate_axes_requires_scalar_lookup(self):
@@ -258,6 +313,18 @@ class TestAtWithDuplicates:
             df.at[1, ["A"]] = 1
         with pytest.raises(ValueError, match=msg):
             df.at[:, "A"] = 1
+
+    def test_at_setitem_list_like_nonunique_columns_raises(self):
+        # GH#61223 - non-unique column key with list-like raises KeyError
+        df = DataFrame([[1, 2]], columns=["A", "A"])
+        with pytest.raises(KeyError, match="A"):
+            df.at[0, "A"] = [10, 20]
+
+    def test_at_setitem_list_like_nonunique_columns_object_dtype_raises(self):
+        # GH#61223 - non-unique column with object dtype also raises KeyError
+        df = DataFrame([[[1], [2]]], columns=["A", "A"])
+        with pytest.raises(KeyError, match="A"):
+            df.at[0, "A"] = [10, 20]
 
 
 class TestAtErrors:
@@ -348,3 +415,102 @@ class TestAtErrors:
             match=f"You can only assign a scalar value not a \\{type(new_row)}",
         ):
             df.at["a"] = new_row
+
+    def test_at_setitem_list_like_wrong_dtype(self):
+        # GH#61223 - list-like in non-object dtype column raises ValueError
+        df = DataFrame({"A": [1, 2, 3]}, index=["a", "b", "c"])
+        with pytest.raises(ValueError, match="Cannot store a list-like value"):
+            df.at["b", "A"] = [100, 200]
+
+    def test_iat_setitem_list_like(self):
+        # GH#61223 - .iat raises ValueError for non-object dtype
+        df = DataFrame({"A": [1, 2, 3]})
+        with pytest.raises(ValueError, match="Cannot store a list-like value"):
+            df.iat[0, 0] = [99, 88, 77]
+
+    def test_at_setitem_tuple_value(self):
+        # GH#61223 - tuple raises ValueError for non-object dtype
+        df = DataFrame({"A": [1, 2, 3]}, index=["a", "b", "c"])
+        with pytest.raises(ValueError, match="Cannot store a list-like value"):
+            df.at["a", "A"] = (10, 20, 30)
+
+    def test_at_setitem_list_like_multiindex_row(self):
+        # GH#61223 - .at with MultiIndex row raises ValueError for non-object dtype
+        idx = MultiIndex.from_tuples([("r1", 0), ("r2", 1)])
+        df = DataFrame({"A": [1, 2]}, index=idx)
+        with pytest.raises(ValueError, match="Cannot store a list-like value"):
+            df.at[("r1", 0), "A"] = [10, 20]
+
+    def test_at_setitem_list_like_multiindex_partial_key(self):
+        # GH#61223 - partial MultiIndex key raises KeyError (.at requires unique row)
+        idx = MultiIndex.from_tuples([("a", 1), ("a", 2), ("b", 3)])
+        df = DataFrame({"A": [[1], [2], [3]]}, index=idx)
+        with pytest.raises(KeyError, match="a"):
+            df.at["a", "A"] = [10, 20, 30]
+
+    def test_at_setitem_list_like_partial_multiindex_key_matching_len(self):
+        # GH#61223 - partial MultiIndex key; new column fires Pandas4Warning
+        idx = MultiIndex.from_tuples([("r1", 0), ("r1", 1), ("r2", 0)])
+        df = DataFrame({"A": [1, 2, 3]}, index=idx)
+        msg_warn = "Setting a value on a DataFrame via .at with a key"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg_warn):
+            with pytest.raises(KeyError, match="r1"):
+                df.at["r1", "B"] = [10, 20]
+
+    def test_at_setitem_ndarray_existing_column(self):
+        # GH#61223 - np.ndarray in non-object dtype column raises ValueError
+        df = DataFrame({"A": [1, 2, 3]}, index=["a", "b", "c"])
+        with pytest.raises(ValueError, match="Cannot store a list-like value"):
+            df.at["b", "A"] = np.array([100, 200])
+
+    def test_at_setitem_dict_value_not_affected(self):
+        # GH#61223 - dict is not list-like; .at raises ValueError as before
+        df = DataFrame({"A": [1, 2, 3]}, index=["a", "b", "c"])
+        with pytest.raises(ValueError, match="Incompatible indexer"):
+            df.at["a", "A"] = {"key": "val"}
+
+    def test_at_setitem_series_value_single_cell(self):
+        # GH#61223 - Series raises ValueError for non-object dtype
+        df = DataFrame({"A": [1, 2, 3]}, index=["a", "b", "c"])
+        val = Series([10, 20], index=["x", "y"])
+        with pytest.raises(ValueError, match="Cannot store a list-like value"):
+            df.at["a", "A"] = val
+
+    def test_at_setitem_list_like_float_column(self):
+        # GH#61223 - float64 column raises ValueError like int64
+        df = DataFrame({"A": [1.0, 2.0, 3.0]}, index=["a", "b", "c"])
+        with pytest.raises(ValueError, match="Cannot store a list-like value"):
+            df.at["b", "A"] = [10.5, 20.5]
+
+    def test_at_setitem_list_like_multiindex_row_object_dtype(self):
+        # GH#61223 - full tuple key on unique MultiIndex stores list-like as single cell
+        idx = MultiIndex.from_tuples([("r1", 0), ("r2", 1)])
+        df = DataFrame({"A": Series([[1, 2], [3, 4]], index=idx)})
+        assert df["A"].dtype == np.dtype("object")
+        df.at[("r1", 0), "A"] = [10, 20, 30]
+        assert df.at[("r1", 0), "A"] == [10, 20, 30]
+        assert df["A"].dtype == np.dtype("object")
+
+    def test_iat_setitem_list_like_object_dtype(self):
+        # GH#61223 - .iat on object-dtype column stores list-like as single cell
+        df = DataFrame({"A": Series([[1, 2], [3, 4], [5, 6]])})
+        assert df["A"].dtype == np.dtype("object")
+        df.iat[0, 0] = [10, 20, 30]
+        assert df.iat[0, 0] == [10, 20, 30]
+        assert df["A"].dtype == np.dtype("object")
+
+    def test_at_setitem_tuple_value_object_dtype(self):
+        # GH#61223 - tuple value in object-dtype column stores as single cell
+        df = DataFrame({"A": Series([(1, 2), (3, 4)])})
+        assert df["A"].dtype == np.dtype("object")
+        df.at[0, "A"] = (10, 20, 30)
+        assert df.at[0, "A"] == (10, 20, 30)
+
+    def test_at_setitem_series_value_object_dtype_column(self):
+        # GH#61223 - Series value in object-dtype column stores as single cell
+        df = DataFrame({"A": Series([[1, 2], [3, 4]])})
+        assert df["A"].dtype == np.dtype("object")
+        val = Series([10, 20], index=["x", "y"])
+        df.at[0, "A"] = val
+        result = df.at[0, "A"]
+        tm.assert_series_equal(result, val)


### PR DESCRIPTION
closes #61223

- [x] Tests added and passed
- [x] All code checks passed
- [x] Added type annotations to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Problem

`DataFrame.at` and `DataFrame.iat` raise a confusing `ValueError` when storing
a list-like value (list, tuple, `np.ndarray`, Series, etc.) into a single cell
even when the column already has object dtype.

```python
>>> df = pd.DataFrame({"A": [[1, 2], [3, 4]]})  # object dtype
>>> df.at[0, "A"] = [10, 20, 30]               # ValueError (should work)
```

## Root cause

`_set_value` in `frame.py` falls into the `except` branch on fast-path failure
and calls `.loc[index, col] = value`. `.loc` interprets a list-like value as a
multi-row assignment, which raises `ValueError: Must have equal len keys and value`.

## Fix

Intercept list-like values (excluding `dict`) inside the `except` block of
`_set_value`, after the fast path has already failed. This keeps the scalar fast
path free of any `is_list_like` overhead.

When a list-like is detected in the `except` handler:

1. **Object dtype column** (already compatible): stored directly via
   `_mgr.column_setitem` — no warning, no copy.
2. **Non-object dtype column** (e.g. `int64`): raises `ValueError` with a clear
   message pointing to the explicit workaround (`df[col] = df[col].astype(object)`).
   Consistent with PDEP6 (no silent upcasting).
3. **Missing row key**: falls through to `.loc` for row-expansion behaviour
   (deprecated via `Pandas4Warning`, GH#48323).
4. **Partial key on MultiIndex**: raises `KeyError` — consistent with how `.at`
   handles partial keys for scalar values.
5. **Column expansion** (`col not in self.columns`): a new object-dtype column is
   created after emitting `Pandas4Warning` (expansion via `.at` is deprecated,
   GH#48323). Row existence is validated *first* so a partial MultiIndex key
   raises `KeyError` before any column is created.
6. **Non-unique columns**: raises `KeyError` consistently — the previous behaviour
   was to silently distribute the list-like across *all* matching columns. Fixed in
   both the `_AtIndexer.__setitem__` path in `indexing.py` (which bypasses
   `_set_value` entirely for non-unique axes) and the `frame.py` try-block guard.

## AI Disclosure

I used GitHub Copilot (Claude Sonnet 4.6) to develop this pull request
end-to-end: root cause analysis, fix implementation, tests, and whatsnew entry.
I prompted it to follow `AGENTS.md`. I reviewed all generated code and understand the changes made.
