### PR TITLE
DOC: fix run-on sentence in invalid plot kind error message

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1342,7 +1342,8 @@ class PlotAccessor(PandasObject):
 
         if kind not in self._all_kinds:
             raise ValueError(
-                f"{kind} is not a valid plot kind Valid plot kinds: {self._all_kinds}"
+                f"{kind} is not a valid plot kind. "
+                f"Valid plot kinds: {self._all_kinds}"
             )
 
         data = self._parent


### PR DESCRIPTION

**Repo:** pandas-dev/pandas (⭐ 43000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-1

## What
The `ValueError` raised in `pandas/plotting/_core.py` when a user passes an unsupported `kind` to `DataFrame.plot()` / `Series.plot()` previously concatenated two sentences without punctuation: `"foo is not a valid plot kind Valid plot kinds: [...]"`. This change inserts a period and splits the message across two f-string lines so the error reads as two clear sentences.

## Why
The error message is user-facing and is a common encounter for newcomers experimenting with `.plot(kind=...)`. The missing period made the message look like a typo and harder to scan. Existing tests in `pandas/tests/plotting/test_series.py:638` and `pandas/tests/plotting/frame/test_frame.py:1546` use `pytest.raises(... match="invalid_kind is not a valid plot kind")`, which still matches the new message (the `match=` regex stops before the period), so no test changes are required.

## Testing
- `git diff` confirms a 1-file, 2/-1 line change.
- The two existing test assertions match the substring before the inserted period and continue to pass logically.
- No behavioral change beyond the punctuation/formatting of the error string.

## Risk
Low — pure error-message wording change; existing match-based tests still satisfied.
