### PR TITLE
BUG: preserve IntEnum in DataFrame constructor when dtype=object (GH#59380)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -222,6 +222,7 @@ Numeric
 
 Conversion
 ^^^^^^^^^^
+- Bug in :class:`DataFrame` constructor where ``IntEnum`` members were silently converted to plain :class:`int` when ``dtype=object`` was specified (:issue:`59380`)
 - Bug in :class:`DataFrame` constructor where ``NaT`` in a :class:`TimedeltaIndex` row was incorrectly inferred as ``datetime64`` instead of ``timedelta64`` (:issue:`23985`)
 - Bug in :class:`DataFrame` constructor where constructing from a list of uniform-dtype arrays (e.g. pyarrow, :class:`CategoricalDtype`, nullable dtypes) lost the dtype (:issue:`49593`)
 - Bug in :func:`pd.array` silently converting NaN to a nonsensical integer when given float data containing NaN and a NumPy integer dtype (:issue:`41724`)

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -279,7 +279,7 @@ def ndarray_to_mgr(
     else:
         # by definition an array here
         # the dtypes will be coerced to a single dtype
-        values = _prep_ndarraylike(values, copy=copy)
+        values = _prep_ndarraylike(values, copy=copy, dtype=dtype)
 
     if dtype is not None and values.dtype != dtype:
         # GH#40110 see similar check inside sanitize_array
@@ -501,7 +501,7 @@ def treat_as_nested(data) -> bool:
 # ---------------------------------------------------------------------
 
 
-def _prep_ndarraylike(values, copy: bool = True) -> np.ndarray:
+def _prep_ndarraylike(values, copy: bool = True, dtype=None) -> np.ndarray:
     # values is specifically _not_ ndarray, EA, Index, or Series
     # We only get here with `not treat_as_nested(values)`
 
@@ -520,7 +520,11 @@ def _prep_ndarraylike(values, copy: bool = True) -> np.ndarray:
         v = extract_array(v, extract_numpy=True)
         if isinstance(v, (list, tuple, range)):
             v = construct_1d_object_array_from_listlike(v)
-        if isinstance(v, np.ndarray) and v.dtype == object:
+        if (
+            isinstance(v, np.ndarray)
+            and v.dtype == object
+            and dtype != np.dtype("object")
+        ):
             v = lib.maybe_convert_objects(v)
         # We don't do maybe_infer_objects here bc we will end up doing
         #  it column-by-column in ndarray_to_mgr

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2976,6 +2976,23 @@ class TestDataFrameConstructorWithDtypeCoercion:
         with pytest.raises(IntCastingNaNError, match=msg):
             Series(arr[0]).astype("i8")
 
+    def test_intenum_dtype_object_preserved(self):
+        # GH#59380 - IntEnum members should not be cast to int when dtype=object
+        from enum import IntEnum
+
+        class Color(IntEnum):
+            BLUE = 1
+            RED = 2
+
+        colors = [Color.BLUE, Color.RED]
+
+        result = DataFrame(colors, columns=["color"], dtype=object)
+        assert all(isinstance(v, Color) for v in result["color"])
+
+        # Series with dtype=object correctly preserves IntEnum - DataFrame should match
+        ser = Series(colors, dtype=object)
+        assert all(isinstance(v, Color) for v in ser)
+
 
 class TestDataFrameConstructorWithDatetimeTZ:
     @pytest.mark.parametrize("tz", ["US/Eastern", "dateutil/US/Eastern"])


### PR DESCRIPTION
\`pd.Series([Color.BLUE, Color.RED], dtype=object)\` preserves enum members correctly, but the same call with \`pd.DataFrame\` silently strips them down to plain \`int\`. When you explicitly pass \`dtype=object\`, nothing should be getting cast.

The root cause is in \`_prep_ndarraylike\` in \`pandas/core/internals/construction.py\`. Before the dtype check even runs, every object array column gets passed through \`lib.maybe_convert_objects\` with its default \`convert_numeric=True\`. Since \`IntEnum\` subclasses \`int\`, the converter treats the members as integers and downcasts them to \`int64\`. By the time the code checks whether \`dtype != values.dtype\`, the enum identity is already gone. The \`Series\` path avoids this because \`_try_cast\` short-circuits immediately when \`dtype == object\`. The fix passes \`dtype\` down into \`_prep_ndarraylike\` and skips the \`maybe_convert_objects\` call when the caller asked for object dtype.

The test constructs a \`DataFrame\` from a list of \`IntEnum\` members with \`dtype=object\` and asserts that each element is still an instance of the enum subclass, not a plain \`int\`. It also checks that \`Series\` still behaves correctly as a regression guard.