### PR TITLE
BUG/TST: add test for _cast_pointwise_result robustness + fix some cases

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -559,7 +559,10 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "ignore",
                 "Constructing a Categorical with a dtype and values containing",
             )
-            cat = type(self)._from_sequence(res, dtype=self.dtype)
+            try:
+                cat = type(self)._from_sequence(res, dtype=self.dtype)
+            except (TypeError, ValueError):
+                return res
         if (cat.isna() == isna(res)).all():
             # i.e. the conversion was non-lossy
             return cat

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -36,6 +36,7 @@ from pandas.util._exceptions import find_stack_level
 from pandas.core.dtypes.astype import astype_is_view
 from pandas.core.dtypes.base import ExtensionDtype
 from pandas.core.dtypes.cast import (
+    construct_1d_object_array_from_listlike,
     maybe_downcast_to_dtype,
 )
 from pandas.core.dtypes.common import (
@@ -168,7 +169,8 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
     def _cast_pointwise_result(self, values) -> ArrayLike:
         if isna(values).all():
             return type(self)._from_sequence(values, dtype=self.dtype)
-        values = np.asarray(values, dtype=object)
+        if not (isinstance(values, np.ndarray) and values.dtype == object):
+            values = construct_1d_object_array_from_listlike(values)
         result = lib.maybe_convert_objects(values, convert_to_nullable_dtype=True)
         lkind = self.dtype.kind
         rkind = result.dtype.kind

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -44,6 +44,7 @@ from pandas.util._validators import (
 
 from pandas.core.dtypes.astype import astype_array
 from pandas.core.dtypes.cast import (
+    construct_1d_object_array_from_listlike,
     find_common_type,
     maybe_box_datetimelike,
 )
@@ -624,7 +625,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         return cls(values, dtype=original.dtype)
 
     def _cast_pointwise_result(self, values):
-        values = np.asarray(values, dtype=object)
+        if not (isinstance(values, np.ndarray) and values.dtype == object):
+            values = construct_1d_object_array_from_listlike(values)
         result = lib.maybe_convert_objects(values, convert_non_numeric=True)
         if result.dtype.kind == self.dtype.kind:
             try:

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -21,6 +21,7 @@ from pandas.compat import (
 from pandas.util._decorators import set_module
 from pandas.util._validators import validate_na_arg
 
+from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import (
     is_scalar,
     pandas_dtype,
@@ -173,14 +174,14 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
         try:
             arr = pa.array(values, from_pandas=True)
         except (ValueError, TypeError):
-            values = np.asarray(values, dtype=object)
+            values = construct_1d_object_array_from_listlike(values)
             return lib.maybe_convert_objects(values, convert_non_numeric=True)
         if pa.types.is_string(arr.type) or pa.types.is_large_string(arr.type):
             return self._from_pyarrow_array(arr)
         if self.dtype.na_value is np.nan:
             # ArrowEA has different semantics, so we return numpy-based
             #  result instead
-            values = np.asarray(values, dtype=object)
+            values = construct_1d_object_array_from_listlike(values)
             return lib.maybe_convert_objects(values, convert_non_numeric=True)
         return ArrowExtensionArray(arr)
 

--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -9,6 +9,7 @@ from pandas.core.dtypes.dtypes import ExtensionDtype
 
 import pandas as pd
 import pandas._testing as tm
+from pandas.api.extensions import ExtensionArray
 
 
 class BaseInterfaceTests:
@@ -170,3 +171,34 @@ class BaseInterfaceTests:
         expected = list(data)
         assert isinstance(result, list)
         assert result == expected
+
+    def test_cast_pointwise_result_robust_any_input(self, data):
+        # the _cast_pointwise_result method should be robust to any input,
+        # and if it receives input it cannot handle for its own dtype (family),
+        # always fall back to return a generic array instead of raising an error
+        values = [
+            1,
+            "a",
+            (1, 2),
+            [1, 2],
+            {"x": 1},
+            pd.NA,
+            None,
+            np.nan,
+            pd.Timestamp("2020-01-01"),
+            pd.Timedelta("1D"),
+            True,
+        ]
+
+        result = data._cast_pointwise_result(values)
+        assert len(result) == len(values)
+        assert isinstance(result, (ExtensionArray, np.ndarray))
+
+        for val in values:
+            result = data._cast_pointwise_result([val])
+            assert len(result) == 1
+            assert isinstance(result, (ExtensionArray, np.ndarray))
+
+            result = data._cast_pointwise_result([val, val, val])
+            assert len(result) == 3
+            assert isinstance(result, (ExtensionArray, np.ndarray))

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -100,7 +100,7 @@ class JSONArray(ExtensionArray):
             # TODO replace with public function
             from pandas._libs import lib
 
-            values = np.asarray(values, dtype=object)
+            values = construct_1d_object_array_from_listlike(values)
             return lib.maybe_convert_objects(values, convert_non_numeric=True)
 
     def __getitem__(self, item):


### PR DESCRIPTION
Triggered by https://github.com/pandas-dev/pandas/pull/65316#discussion_r3116183587. Currently some implementation of `_cast_pointwise_result` fail on nested input, eg:

```python
>>> pd.array([1,2,3], dtype="Int64")._cast_pointwise_result([(1,2), (3,4), (5,6)])
...
File pandas/_libs/lib.pyx:2589, in pandas._libs.lib.maybe_convert_objects()

ValueError: Buffer has wrong number of dimensions (expected 1, got 2)
```

This essentially updates to use `construct_1d_object_array_from_listlike` instead of  `np.asarray(values, dtype=object)` to ensure 1d object input to `lib.maybe_convert_objects`, which was also already done in https://github.com/pandas-dev/pandas/pull/62523 for the base implementation and for NDArrayBackedExtensionArray (cc @jbrockmendel)


- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] ~Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.~
