### PR TITLE
[backport 3.0.x] BUG: fix FloatingArray.astype(str) crash with distinguish_nan_and_na=True (#65038)

### DIFF
--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -772,7 +772,9 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
             # avoid costly conversion to object dtype
             na_values = scalars._mask
             result = scalars._data
-            result = lib.ensure_string_array(result, copy=copy, convert_na_value=False)
+            result = lib.ensure_string_array(
+                result, copy=copy, convert_na_value=False, skipna=False
+            )
             result[na_values] = na_value
 
         else:

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -209,7 +209,9 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
             # numerical issues with Float32Dtype
             na_values = scalars._mask
             result = scalars._data
-            result = lib.ensure_string_array(result, copy=copy, convert_na_value=False)
+            result = lib.ensure_string_array(
+                result, copy=copy, convert_na_value=False, skipna=False
+            )
             pa_arr = pa.array(result, mask=na_values, type=pa.large_string())
         elif isinstance(scalars, ArrowExtensionArray):
             pa_type = scalars._pa_array.type

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -490,6 +490,17 @@ def test_astype_from_float_dtype(float_dtype, dtype):
     tm.assert_series_equal(result, expected)
 
 
+def test_astype_from_masked_float_with_nan(dtype, using_nan_is_na):
+    # GH#61617, GH#65227 - FloatingArray.astype(str) with unmasked NaN
+    arr = pd.array([np.nan, pd.NA, 3.0], dtype="Float64")
+    result = arr.astype(dtype)
+    if using_nan_is_na:
+        expected = pd.array([pd.NA, pd.NA, "3.0"], dtype=dtype)
+    else:
+        expected = pd.array(["nan", pd.NA, "3.0"], dtype=dtype)
+    tm.assert_extension_array_equal(result, expected)
+
+
 def test_to_numpy_returns_pdna_default(dtype):
     arr = pd.array(["a", pd.NA, "b"], dtype=dtype)
     result = np.array(arr)

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -322,6 +322,28 @@ $1$,$2$
         )
         assert result == expected
 
+    def test_to_csv_float_ea_nan_distinguish(self, using_nan_is_na):
+        # GH#61617, GH#65227 - to_csv should not crash when FloatingArray
+        # contains unmasked NaN (with distinguish_nan_and_na=True)
+        df = DataFrame({"a": pd.array([np.nan, pd.NA, 3.0], dtype="Float64"), "b": "c"})
+        result = df.to_csv(index=False)
+        if using_nan_is_na:
+            expected = tm.convert_rows_list_to_csv_str(["a,b", ",c", ",c", "3.0,c"])
+        else:
+            expected = tm.convert_rows_list_to_csv_str(["a,b", "nan,c", ",c", "3.0,c"])
+        assert result == expected
+
+    def test_to_csv_float_ea_nan_distinguish_series(self, using_nan_is_na):
+        # GH#65227 - Series.to_csv with FloatingArray containing both NaN and NA
+        ser = pd.Series((1, pd.NA, 0), index=["a", "b", "c"], dtype="Float64", name="x")
+        ser = ser / ser
+        result = ser.to_csv()
+        if using_nan_is_na:
+            expected = tm.convert_rows_list_to_csv_str([",x", "a,1.0", "b,", "c,"])
+        else:
+            expected = tm.convert_rows_list_to_csv_str([",x", "a,1.0", "b,", "c,nan"])
+        assert result == expected
+
     def test_to_csv_multi_index(self):
         # see gh-6618
         df = DataFrame([1], columns=pd.MultiIndex.from_arrays([[1], [2]]))


### PR DESCRIPTION
(cherry picked from commit 1596557e60b7fce0c4939bab1ffcd945162e9a76)
Backport of https://github.com/pandas-dev/pandas/pull/65038