### PR TITLE
REF: relocate _freq storage from DTA/TDA arrays to Index (GH#24566)

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -547,9 +547,7 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
         dt64_values = i8values.view(f"datetime64[{unit}]")
         dtype = tz_to_dtype(tz, unit=unit)
-        result = cls._simple_new(dt64_values, dtype=dtype)
-        result._freq = freq
-        return result
+        return cls._simple_new(dt64_values, dtype=dtype)
 
     # -----------------------------------------------------------------
     # DatetimeLike Interface

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -977,6 +977,23 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
         new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
         dta = DatetimeArray._from_sequence(new_data, dtype=new_data.dtype)
         assert dta.unit == unit
+        return dta
+
+    def _to_timestamp_freq(
+        self, dta: DatetimeArray, target_freq, how: str
+    ) -> BaseOffset | None:
+        """
+        Determine the freq to stamp on the DatetimeArray returned by
+        ``self.to_timestamp(target_freq, how)``.
+
+        Called by ``PeriodIndex.to_timestamp`` so the array-level
+        ``to_timestamp`` can return a bare DatetimeArray.
+        """
+        how = libperiod.validate_end_alias(how)
+        if how == "E":
+            # For the "end" case, to_timestamp routes through arithmetic that
+            # does not preserve freq; match that behavior here.
+            return None
 
         if self.freq.rule_code == "B":
             # See if we can retain BDay instead of Day in cases where
@@ -985,22 +1002,23 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
             if len(diffs) == 1:
                 diff = diffs[0]
                 if diff == self.dtype._n:
-                    dta._freq = self.freq
+                    return self.freq
                 elif diff == 1:
-                    dta._freq = self.freq.base
+                    return self.freq.base
                 # TODO: other cases?
-            return dta
-        else:
-            dta._freq = to_offset(dta.inferred_freq)
-            if freq is not None:
-                freq = to_offset(freq)
-                if (
-                    isinstance(dta.freq, Day)
-                    and not isinstance(freq, Day)
-                    and Timedelta(freq) == Timedelta(days=dta.freq.n)
-                ):
-                    dta._freq = freq
-            return dta
+            return None
+
+        result_freq = to_offset(dta.inferred_freq)
+        if target_freq is not None:
+            # match the normalization applied in to_timestamp
+            target_freq = Period._maybe_convert_freq(target_freq)
+            if (
+                isinstance(result_freq, Day)
+                and not isinstance(target_freq, Day)
+                and Timedelta(target_freq) == Timedelta(days=result_freq.n)
+            ):
+                result_freq = target_freq
+        return result_freq
 
     # --------------------------------------------------------------------
 

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -307,9 +307,7 @@ class TimedeltaArray(dtl.TimelikeOps):
             index = index[:-1]
 
         td64values = index.view(f"m8[{unit}]")
-        result = cls._simple_new(td64values, dtype=td64values.dtype)
-        result._freq = freq
-        return result
+        return cls._simple_new(td64values, dtype=td64values.dtype)
 
     # ----------------------------------------------------------------
     # DatetimeLike Interface

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -681,7 +681,9 @@ class Grouping:
         elif isinstance(self.grouping_vector, ops.BaseGrouper):
             # we have a list of groupers
             codes = self.grouping_vector.codes_info
-            uniques = self.grouping_vector.result_index._values
+            # Pass the full Index (not ._values) so DatetimeIndex/TimedeltaIndex
+            # freq survives the trip through _with_infer.
+            uniques = self.grouping_vector.result_index  # type: ignore[assignment]
         elif self._uniques is not None:
             # GH#50486 Code grouping_vector using _uniques; allows
             # including uniques that are not present in grouping_vector.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -581,7 +581,14 @@ class Index(IndexOpsMixin, PandasObject):
         klass = cls._dtype_to_subclass(arr.dtype)
 
         arr = klass._ensure_array(arr, arr.dtype, copy=False)
-        return klass._simple_new(arr, name, refs=refs)  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
+        out = klass._simple_new(arr, name, refs=refs)
+        # Preserve freq when wrapping a DatetimeIndex/TimedeltaIndex input,
+        # since _simple_new doesn't copy Index-level attributes like _freq.
+        if isinstance(data, (ABCDatetimeIndex, ABCTimedeltaIndex)) and isinstance(
+            out, (ABCDatetimeIndex, ABCTimedeltaIndex)
+        ):
+            out._freq = data._freq
+        return out  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
 
     @classmethod
     def _ensure_array(cls, data: ArrayLike, dtype: DtypeObj, copy: bool) -> ArrayLike:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -998,10 +998,11 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         # Note: in the DatetimeTZ case, _generate_range will infer the
         #  appropriate timezone from `start` and `end`, so tz does not need
         #  to be passed explicitly.
-        result = self._data._generate_range(
+        arr = self._data._generate_range(
             start=start, end=end, periods=None, freq=self.freq, unit=self.unit
         )
-        return type(self)._simple_new(result, name=self.name)
+        arr._freq = self.freq
+        return type(self)._simple_new(arr, name=self.name)
 
     @cache_readonly
     def inferred_freq(self) -> str | None:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -673,6 +673,32 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
 
     @property
     def freq(self) -> BaseOffset | None:
+        """
+        Return the frequency object if it is set, otherwise None.
+
+        To learn more about the frequency strings, please see
+        :ref:`this link<timeseries.offset_aliases>`.
+
+        See Also
+        --------
+        DatetimeIndex.freq : Return the frequency object if it is set, otherwise None.
+        PeriodIndex.freq : Return the frequency object if it is set, otherwise None.
+
+        Examples
+        --------
+        >>> datetimeindex = pd.date_range(
+        ...     "2022-02-22 02:22:22", periods=10, tz="America/Chicago", freq="h"
+        ... )
+        >>> datetimeindex
+        DatetimeIndex(['2022-02-22 02:22:22-06:00', '2022-02-22 03:22:22-06:00',
+                       '2022-02-22 04:22:22-06:00', '2022-02-22 05:22:22-06:00',
+                       '2022-02-22 06:22:22-06:00', '2022-02-22 07:22:22-06:00',
+                       '2022-02-22 08:22:22-06:00', '2022-02-22 09:22:22-06:00',
+                       '2022-02-22 10:22:22-06:00', '2022-02-22 11:22:22-06:00'],
+                      dtype='datetime64[us, America/Chicago]', freq='h')
+        >>> datetimeindex.freq
+        <Hour>
+        """
         return self._freq
 
     @freq.setter

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -182,26 +182,9 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         >>> datetimeindex.freq
         <Hour>
         """
+        # PeriodIndex reads from the array (derived from dtype);
+        # DatetimeTimedeltaMixin overrides to read from self._freq.
         return self._data.freq
-
-    @freq.setter
-    def freq(self, value) -> None:
-        arr = self._data
-        if not isinstance(arr, (DatetimeArray, TimedeltaArray)):
-            # e.g. PeriodArray freq is derived from dtype and is read-only
-            raise AttributeError(
-                f"property 'freq' of {type(arr).__name__!r} object has no setter"
-            )
-        if value is not None:
-            value = to_offset(value)
-            arr._validate_frequency(arr, value)
-            if arr.dtype.kind == "m" and not isinstance(value, (Tick, Day)):
-                raise TypeError("TimedeltaArray/Index freq must be a Tick")
-
-            if arr.ndim > 1:
-                raise ValueError("Cannot set freq with ndim > 1")
-
-        arr._freq = value
 
     @property
     def asi8(self) -> npt.NDArray[np.int64]:
@@ -282,15 +265,12 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         >>> idx.freqstr
         'M'
         """
-        from pandas import PeriodIndex
-
-        if self._data.freqstr is not None and isinstance(
-            self._data, (PeriodArray, PeriodIndex)
-        ):
-            freq = PeriodDtype(self._data.freq)._freqstr
-            return freq
-        else:
-            return self._data.freqstr  # type: ignore[return-value]
+        freq = self.freq
+        if freq is None:
+            return freq  # type: ignore[return-value]
+        if isinstance(self._data, PeriodArray):
+            return PeriodDtype(freq)._freqstr
+        return freq.freqstr
 
     @cache_readonly
     def _resolution_obj(self) -> Resolution:
@@ -684,58 +664,89 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
     _data: DatetimeArray | TimedeltaArray
     _comparables = ["name", "freq"]
     _attributes = ["name", "freq"]
+    _freq: BaseOffset | None = None
 
     # Compat for frequency inference, see GH#23789
     _is_monotonic_increasing = Index.is_monotonic_increasing
     _is_monotonic_decreasing = Index.is_monotonic_decreasing
     _is_unique = Index.is_unique
 
+    @property
+    def freq(self) -> BaseOffset | None:
+        return self._freq
+
+    @freq.setter
+    def freq(self, value) -> None:
+        arr = self._data
+        if value is not None:
+            value = to_offset(value)
+            arr._validate_frequency(arr, value)
+            if arr.dtype.kind == "m" and not isinstance(value, (Tick, Day)):
+                raise TypeError("TimedeltaArray/Index freq must be a Tick")
+
+            if arr.ndim > 1:
+                raise ValueError("Cannot set freq with ndim > 1")
+
+        self._freq = value
+
     def astype(self, dtype, copy: bool = True):
         result = super().astype(dtype, copy=copy)
         if isinstance(result, type(self)):
             # Preserve freq for unit conversions (e.g. datetime64[ns] -> [us])
-            result._data._freq = self.freq
+            result._freq = self._freq
         return result
 
     def putmask(self, mask, value) -> Index:
         # GH#24555 putmask may modify values out-of-sequence; drop freq
         result = super().putmask(mask, value)
         if isinstance(result, type(self)):
-            result._data._freq = None
+            result._freq = None
+        return result
+
+    def _view(self) -> Self:
+        result = super()._view()
+        result._freq = self._freq
+        return result
+
+    def copy(self, name: Hashable | None = None, deep: bool = False) -> Self:
+        result = super().copy(name=name, deep=deep)
+        result._freq = self._freq
         return result
 
     def _pin_freq(self, freq, validate_kwds: dict) -> None:
         """
-        Constructor helper to pin the appropriate ``freq`` attribute on
-        ``self._data``.  Assumes ``self._data._freq`` is currently set to any
-        freq inferred from input data.
+        Constructor helper to pin the appropriate ``freq`` attribute on self.
+        Assumes ``self._data._freq`` holds any freq inferred from input data
+        (stashed there by ``_from_sequence_not_strict`` before wrapping).
         """
         arr = self._data
+        inferred = arr._freq
         if freq is None:
             # user explicitly passed None -> override any inferred_freq
-            arr._freq = None
+            self._freq = None
         elif freq == "infer":
-            # if arr._freq is *not* None then we already inferred a freq
-            #  and there is nothing left to do
-            if arr._freq is None:
+            if inferred is not None:
+                # already inferred during construction
+                self._freq = inferred
+            else:
                 # Set _freq directly to bypass duplicative _validate_frequency
                 # check.
-                arr._freq = to_offset(self.inferred_freq)
+                self._freq = to_offset(self.inferred_freq)
         elif freq is lib.no_default:
             # user did not specify anything, keep inferred freq if the original
-            #  data had one, otherwise do nothing
-            pass
-        elif arr._freq is None:
+            #  data had one, otherwise leave as None (class default)
+            self._freq = inferred
+        elif inferred is None:
             # We cannot inherit a freq from the data, so we need to validate
             #  the user-passed freq
             freq = to_offset(freq)
             type(arr)._validate_frequency(self, freq, **validate_kwds)
-            arr._freq = freq
+            self._freq = freq
         else:
             # Otherwise we just need to check that the user-passed freq
             #  doesn't conflict with the one we already have.
             freq = to_offset(freq)
-            if freq != arr._freq:
+            if freq != inferred:
                 # GH#61086 freq may be equivalent but not equal (e.g.
                 # QS-FEB vs QS-MAY), so validate against the actual data.
                 if len(self) == 0:
@@ -743,7 +754,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
                 elif len(self) == 1:
                     if not freq.is_on_offset(self[0]):
                         raise ValueError(
-                            f"Inferred frequency {arr._freq} from passed "
+                            f"Inferred frequency {inferred} from passed "
                             "values does not conform to passed frequency "
                             f"{freq.freqstr}"
                         )
@@ -757,11 +768,13 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
                         type(arr)._validate_frequency(self, freq, **validate_kwds)
                 else:
                     raise ValueError(
-                        f"Inferred frequency {arr._freq} from passed "
+                        f"Inferred frequency {inferred} from passed "
                         "values does not conform to passed frequency "
                         f"{freq.freqstr}"
                     )
-            arr._freq = freq
+            self._freq = freq
+        # Reset the transitional stash on the array so _freq isn't duplicated.
+        arr._freq = None
 
     def _get_arithmetic_result_freq(self, other) -> BaseOffset | None:
         """
@@ -818,7 +831,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             if new_freq is not None and isinstance(result, DatetimeTimedeltaMixin):
                 if op is roperator.rsub:
                     new_freq = -new_freq
-                result._data._freq = new_freq
+                result._freq = new_freq
         return result
 
     def factorize(
@@ -926,7 +939,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         """
         arr = self._data.as_unit(unit)
         result = type(self)._simple_new(arr, name=self.name)
-        result._data._freq = self.freq
+        result._freq = self.freq
         return result
 
     def _with_freq(self, freq):
@@ -942,8 +955,9 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             raise ValueError(f"Invalid frequency: {freq!r}")
 
         arr = self._data.view()
-        arr._freq = freq
-        return type(self)._simple_new(arr, name=self._name)
+        result = type(self)._simple_new(arr, name=self._name)
+        result._freq = freq
+        return result
 
     @property
     def values(self) -> np.ndarray:
@@ -1001,8 +1015,9 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         arr = self._data._generate_range(
             start=start, end=end, periods=None, freq=self.freq, unit=self.unit
         )
-        arr._freq = self.freq
-        return type(self)._simple_new(arr, name=self.name)
+        result = type(self)._simple_new(arr, name=self.name)
+        result._freq = self.freq
+        return result
 
     @cache_readonly
     def inferred_freq(self) -> str | None:
@@ -1073,15 +1088,16 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         # This raising is incorrect, as 'on_freq' is incorrect. This will
         # be fixed by GH#41493
         res_values = res_i8.values.view(self._data._ndarray.dtype)
-        result = type(self._data)._simple_new(
+        arr = type(self._data)._simple_new(
             # error: Argument "dtype" to "_simple_new" of "DatetimeArray" has
             # incompatible type "Union[dtype[Any], ExtensionDtype]"; expected
             # "Union[dtype[datetime64], DatetimeTZDtype]"
             res_values,
             dtype=self.dtype,  # type: ignore[arg-type]
         )
+        result = cast("Self", self._wrap_setop_result(other, arr))
         result._freq = new_freq
-        return cast("Self", self._wrap_setop_result(other, result))
+        return result
 
     def _range_intersect(self, other, sort) -> Self:
         # Dispatch to RangeIndex intersection logic.
@@ -1133,12 +1149,12 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         start = right[0]
 
         if end < start:
-            result = self[:0]
-        else:
-            lslice = slice(*left.slice_locs(start, end))
-            result = left._values[lslice]
-            result._freq = self.freq  # type: ignore[union-attr]
+            return self[:0]
 
+        lslice = slice(*left.slice_locs(start, end))
+        arr = left._values[lslice]
+        result = type(self)._simple_new(arr, name=self.name)
+        result._freq = self.freq
         return result
 
     def _can_fast_intersect(self, other: Self) -> bool:
@@ -1204,7 +1220,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             right_chunk = right._values[:loc]
             dates = concat_compat((left._values, right_chunk))
             result = type(self)._simple_new(dates, name=self.name)
-            result._data._freq = self.freq
+            result._freq = self.freq
             return result
         else:
             left, right = other, self
@@ -1220,8 +1236,8 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             # The can_fast_union check ensures that the result.freq
             #  should match self.freq
             assert isinstance(dates, type(self._data))
-            dates._freq = self.freq  # type: ignore[union-attr]
             result = type(self)._simple_new(dates)
+            result._freq = self.freq
             return result
         else:
             return left
@@ -1267,7 +1283,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         join_index, lidx, ridx = super()._wrap_join_result(
             joined, other, lidx, ridx, how
         )
-        join_index._data._freq = self._get_join_freq(other)
+        join_index._freq = self._get_join_freq(other)
         return join_index, lidx, ridx
 
     def _get_engine_target(self) -> np.ndarray:
@@ -1300,13 +1316,13 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
 
     def _getitem_slice(self, slobj: slice) -> Self:
         result = super()._getitem_slice(slobj)
-        result._data._freq = self._get_getitem_freq(slobj)
+        result._freq = self._get_getitem_freq(slobj)
         return result
 
     def __getitem__(self, key):
         result = super().__getitem__(key)
         if isinstance(result, type(self)):
-            result._data._freq = self._get_getitem_freq(key)
+            result._freq = self._get_getitem_freq(key)
         return result
 
     def _get_getitem_freq(self, key) -> BaseOffset | None:
@@ -1347,7 +1363,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         ):
             pairs = pairwise(to_concat_nonempty)
             if all(pair[0][-1] + obj.freq == pair[1][0] for pair in pairs):
-                result._data._freq = obj.freq
+                result._freq = obj.freq
 
         return result
 
@@ -1428,7 +1444,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         Index(['b'], dtype='str')
         """
         result = super().delete(loc)
-        result._data._freq = self._get_delete_freq(loc)
+        result._freq = self._get_delete_freq(loc)
         return result
 
     def insert(self, loc: int, item):
@@ -1462,7 +1478,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         result = super().insert(loc, item)
         if isinstance(result, type(self)):
             # i.e. parent class method did not cast
-            result._data._freq = self._get_insert_freq(loc, item)
+            result._freq = self._get_insert_freq(loc, item)
         return result
 
     # --------------------------------------------------------------------
@@ -1527,5 +1543,5 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         maybe_slice = lib.maybe_indices_to_slice(indices, len(self))
         if isinstance(maybe_slice, slice):
             freq = self._get_getitem_freq(maybe_slice)
-            result._data._freq = freq
+            result._freq = freq
         return result

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1763,6 +1763,7 @@ def date_range(
         unit=unit,
         **kwargs,
     )
+    dtarr._freq = freq
     return DatetimeIndex._simple_new(dtarr, name=name)
 
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -93,16 +93,16 @@ def _new_DatetimeIndex(cls, d):
             tz = d.pop("tz")
             freq = d.pop("freq")
             dta = DatetimeArray._simple_new(data, dtype=tz_to_dtype(tz))
-            dta._freq = freq
         else:
             dta = data
-            for key in ["tz", "freq"]:
-                # These are already stored in our DatetimeArray; if they are
-                #  also in the pickle and don't match, we have a problem.
-                if key in d:
-                    assert d[key] == getattr(dta, key)
-                    d.pop(key)
+            if "tz" in d:
+                assert d.pop("tz") == dta.tz
+            # Legacy pickles stored freq on the DatetimeArray; current pickles
+            # include it in ``d``. Migrate either up onto the Index.
+            freq = d.pop("freq", dta._freq)
+            dta._freq = None
         result = cls._simple_new(dta, **d)
+        result._freq = freq
     else:
         with warnings.catch_warnings():
             # TODO: If we knew what was going in to **d, we might be able to
@@ -497,8 +497,9 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                        dtype='datetime64[us, Asia/Calcutta]', freq=None)
         """
         arr = self._data.normalize()
-        arr._freq = to_offset(arr.inferred_freq)
-        return type(self)._simple_new(arr, name=self.name)
+        result = type(self)._simple_new(arr, name=self.name)
+        result._freq = to_offset(arr.inferred_freq)
+        return result
 
     def tz_convert(self, tz) -> Self:
         """
@@ -572,10 +573,10 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                         dtype='datetime64[us]', freq='h')
         """  # noqa: E501
         arr = self._data.tz_convert(tz)
-        freq = self._data.freq
-        if isinstance(freq, Tick):
-            arr._freq = freq
-        return type(self)._simple_new(arr, name=self.name, refs=self._references)
+        result = type(self)._simple_new(arr, name=self.name, refs=self._references)
+        if isinstance(self.freq, Tick):
+            result._freq = self.freq
+        return result
 
     def tz_localize(
         self,
@@ -722,16 +723,17 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         1   2015-03-29 03:30:00+02:00
         dtype: datetime64[ns, Europe/Warsaw]
         """  # noqa: E501
-        freq = self._data.freq
+        freq = self._freq
         arr = self._data.tz_localize(tz, ambiguous, nonexistent)
+        result = type(self)._simple_new(arr, name=self.name)
         if timezones.is_utc(arr.tz) or (len(arr) == 1 and arr[0] is not NaT):
             # we can preserve freq
             # TODO: Also for fixed-offsets
-            arr._freq = freq
+            result._freq = freq
         elif arr.tz is None and self._data.tz is None:
             # no-op
-            arr._freq = freq
-        return type(self)._simple_new(arr, name=self.name)
+            result._freq = freq
+        return result
 
     def to_period(self, freq=None) -> PeriodIndex:
         """
@@ -900,16 +902,16 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             # Note in this particular case we retain non-nano.
             if copy:
                 data = data.copy()
-            return cls._simple_new(data, name=name)
+            result = cls._simple_new(data, name=name)
+            result._freq = data._freq
+            return result
 
         # Extract freq from incoming data before array conversion strips it
         inferred_freq = None
         if isinstance(data, DatetimeArray):
             inferred_freq = data.freq
-        elif isinstance(data, (Index, ABCSeries)):
-            values = data._values
-            if isinstance(values, DatetimeArray):
-                inferred_freq = values.freq
+        elif isinstance(data, DatetimeIndex):
+            inferred_freq = data.freq
 
         dtarr = DatetimeArray._from_sequence_not_strict(
             data,
@@ -921,6 +923,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             ambiguous=ambiguous,
         )
 
+        # Stash inferred freq on the DTA so _pin_freq can read it below.
         if inferred_freq is not None:
             dtarr._freq = inferred_freq
 
@@ -952,7 +955,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         return self._values._is_dates_only
 
     def __reduce__(self):
-        d = {"data": self._data, "name": self.name}
+        d = {"data": self._data, "name": self.name, "freq": self._freq}
         return _new_DatetimeIndex, (type(self), d), None
 
     def _is_comparable_dtype(self, dtype: DtypeObj) -> bool:
@@ -1099,7 +1102,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                     s = t1
             dta[i] = s
 
-        dta._freq = None
         return DatetimeIndex._simple_new(dta, name=self.name)
 
     # --------------------------------------------------------------------
@@ -1763,8 +1765,9 @@ def date_range(
         unit=unit,
         **kwargs,
     )
-    dtarr._freq = freq
-    return DatetimeIndex._simple_new(dtarr, name=name)
+    result = DatetimeIndex._simple_new(dtarr, name=name)
+    result._freq = freq
+    return result
 
 
 @set_module("pandas")

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -284,7 +284,9 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         DatetimeIndex(['2023-01-01', '2023-02-01', '2023-02-01', '2023-03-01'],
         dtype='datetime64[us]', freq=None)
         """
-        arr = self._data.to_timestamp(freq, how)
+        parr = self._data
+        arr = parr.to_timestamp(freq, how)
+        arr._freq = parr._to_timestamp_freq(arr, target_freq=freq, how=how)
         return DatetimeIndex._simple_new(arr, name=self.name)
 
     @property

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -286,8 +286,9 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         """
         parr = self._data
         arr = parr.to_timestamp(freq, how)
-        arr._freq = parr._to_timestamp_freq(arr, target_freq=freq, how=how)
-        return DatetimeIndex._simple_new(arr, name=self.name)
+        result = DatetimeIndex._simple_new(arr, name=self.name)
+        result._freq = parr._to_timestamp_freq(arr, target_freq=freq, how=how)
+        return result
 
     @property
     def hour(self) -> Index:

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     cast,
 )
+import warnings
 
 from pandas._libs import (
     index as libindex,
@@ -53,6 +54,30 @@ if TYPE_CHECKING:
         DtypeObj,
         TimeUnit,
     )
+
+
+def _new_TimedeltaIndex(cls, d):
+    """
+    This is called upon unpickling, rather than the default which doesn't
+    have arguments and breaks __new__
+    """
+    if "data" in d and not isinstance(d["data"], TimedeltaIndex):
+        data = d.pop("data")
+        if isinstance(data, TimedeltaArray):
+            tdarr = data
+        else:
+            tdarr = TimedeltaArray._simple_new(data, dtype=data.dtype)
+        # Legacy pickles stored freq on the TimedeltaArray; current pickles
+        # include it in ``d``. Migrate either up onto the Index.
+        freq = d.pop("freq", tdarr._freq)
+        tdarr._freq = None
+        result = cls._simple_new(tdarr, **d)
+        result._freq = freq
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = cls.__new__(cls, **d)
+    return result
 
 
 @inherit_names(
@@ -192,7 +217,9 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         ):
             if copy:
                 data = data.copy()
-            return cls._simple_new(data, name=name)
+            result = cls._simple_new(data, name=name)
+            result._freq = data._freq
+            return result
 
         if (
             isinstance(data, TimedeltaIndex)
@@ -208,6 +235,9 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         # - Cases checked above all return/raise before reaching here - #
 
         tdarr = TimedeltaArray._from_sequence(data, dtype=dtype, copy=copy)
+        # Stash any incoming freq on the DTA so _pin_freq can read it below.
+        if isinstance(data, TimedeltaIndex):
+            tdarr._freq = data.freq  # type: ignore[assignment]
         refs = None
         if not copy and isinstance(data, (ABCSeries, Index)):
             refs = data._references
@@ -215,6 +245,10 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         result = cls._simple_new(tdarr, name=name, refs=refs)
         result._pin_freq(freq, {})
         return result
+
+    def __reduce__(self):
+        d = {"data": self._data, "name": self.name, "freq": self._freq}
+        return _new_TimedeltaIndex, (type(self), d), None
 
     # -------------------------------------------------------------------
 
@@ -233,14 +267,14 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
         result = self._data.__neg__()
         idx = type(self)._simple_new(result, name=self.name)
         if self.freq is not None:
-            idx._data._freq = -self.freq  # type: ignore[assignment]
+            idx._freq = -self.freq
         return idx
 
     def __pos__(self) -> TimedeltaIndex:
         result = self._data.__pos__()
         idx = type(self)._simple_new(result, name=self.name)
         if self.freq is not None:
-            idx._data._freq = self.freq  # type: ignore[assignment]
+            idx._freq = self.freq
         return idx
 
     def _arith_method(self, other: object, op: Callable) -> Index:
@@ -260,7 +294,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
             new_freq = self._get_rsub_datetime_result_freq(other)
 
         if new_freq is not None:
-            result._data._freq = new_freq
+            result._freq = new_freq
         return result
 
     def _get_arith_result_freq(self, other: object, op: Callable) -> Day | Tick | None:
@@ -518,5 +552,6 @@ def timedelta_range(
     tdarr = TimedeltaArray._generate_range(
         start, end, periods, freq, closed=closed, unit=unit
     )
-    tdarr._freq = freq
-    return TimedeltaIndex._simple_new(tdarr, name=name)
+    result = TimedeltaIndex._simple_new(tdarr, name=name)
+    result._freq = freq
+    return result

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -518,4 +518,5 @@ def timedelta_range(
     tdarr = TimedeltaArray._generate_range(
         start, end, periods, freq, closed=closed, unit=unit
     )
+    tdarr._freq = freq
     return TimedeltaIndex._simple_new(tdarr, name=name)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3096,8 +3096,8 @@ class GenericFixed(Fixed):
             def f(values, freq=None, tz=None):  # pyright: ignore[reportRedeclaration]
                 # data are already in UTC, localize and convert if tz present
                 dta = DatetimeArray._simple_new(values.values, dtype=values.dtype)
-                dta._freq = freq
                 result = DatetimeIndex._simple_new(dta, name=None)
+                result._freq = freq
                 if tz is not None:
                     result = result.tz_localize("UTC").tz_convert(tz)
                 return result

--- a/pandas/tests/arrays/datetimes/test_constructors.py
+++ b/pandas/tests/arrays/datetimes/test_constructors.py
@@ -46,9 +46,9 @@ class TestDatetimeArrayConstructor:
         arr = pd.array(np.arange(5, dtype=np.int64)) * 3600 * 10**9
 
         result = DatetimeArray._from_sequence(arr, dtype="M8[ns]")
-        result._freq = pd.tseries.frequencies.to_offset(result.inferred_freq)
 
         expected = pd.date_range("1970-01-01", periods=5, freq="h", unit="ns")._data
+        # freq is now Index-level state, so neither array carries one
         tm.assert_datetime_array_equal(result, expected)
 
     def test_bool_dtype_raises(self):

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -1112,7 +1112,10 @@ class TestPeriodArray(SharedTests):
         pi = self.index_cls(arr1d)
         arr = arr1d
 
-        expected = DatetimeIndex(pi.to_timestamp(how=how))._data
+        # Array-level to_timestamp returns a freq-less DTA; freq computation
+        # lives on the wrapping PeriodIndex.
+        expected = pi.to_timestamp(how=how)._data
+        expected._freq = None
         result = arr.to_timestamp(how=how)
         assert isinstance(result, DatetimeArray)
 
@@ -1120,22 +1123,21 @@ class TestPeriodArray(SharedTests):
 
     def test_to_timestamp_roundtrip_bday(self):
         # Case where infer_freq inside would choose "D" instead of "B"
-        dta = pd.date_range("2021-10-18", periods=3, freq="B", unit="ns")._data
-        parr = dta.to_period("B")
-        result = parr.to_timestamp()
+        dti = pd.date_range("2021-10-18", periods=3, freq="B", unit="ns")
+        pi = dti.to_period("B")
+        result = pi.to_timestamp()
         assert result.freq == "B"
-        tm.assert_extension_array_equal(result, dta.as_unit("us"))
+        tm.assert_index_equal(result, dti.as_unit("us"))
 
-        dta2 = dta[::2]
-        parr2 = dta2.to_period("2B")
-        result2 = parr2.to_timestamp()
+        pi2 = dti[::2].to_period("2B")
+        result2 = pi2.to_timestamp()
         assert result2.freq == "2B"
-        tm.assert_extension_array_equal(result2, dta2.as_unit("us"))
+        tm.assert_index_equal(result2, dti[::2].as_unit("us"))
 
-        parr3 = dta.to_period("2B")
-        result3 = parr3.to_timestamp()
+        pi3 = dti.to_period("2B")
+        result3 = pi3.to_timestamp()
         assert result3.freq == "B"
-        tm.assert_extension_array_equal(result3, dta.as_unit("us"))
+        tm.assert_index_equal(result3, dti.as_unit("us"))
 
     def test_to_timestamp_out_of_bounds(self):
         # GH#19643 previously overflowed silently

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -299,7 +299,8 @@ class TestDatetimeArrayComparisons:
 
         dti = pd.date_range("2016-01-1", freq="MS", periods=9, tz=None)
         arr = dti._data
-        assert arr.freq == dti.freq
+        # freq is now Index-level state; the underlying array never carries one
+        assert arr.freq is None
         assert arr.tz == dti.tz
 
         right = dti

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1154,7 +1154,7 @@ class TestBusinessDateRange:
         # GH #456
         rng1 = bdate_range("12/5/2011", "12/5/2011")
         rng2 = bdate_range("12/2/2011", "12/5/2011")
-        assert rng2._data.freq == BDay()
+        assert rng2.freq == BDay()
 
         result = rng1.union(rng2)
         assert isinstance(result, DatetimeIndex)
@@ -1212,7 +1212,7 @@ class TestCustomDateRange:
         # GH #456
         rng1 = bdate_range("12/5/2011", "12/5/2011", freq="C")
         rng2 = bdate_range("12/2/2011", "12/5/2011", freq="C")
-        assert rng2._data.freq == CDay()
+        assert rng2.freq == CDay()
 
         result = rng1.union(rng2)
         assert isinstance(result, DatetimeIndex)

--- a/pandas/tests/indexes/datetimes/test_freq_attr.py
+++ b/pandas/tests/indexes/datetimes/test_freq_attr.py
@@ -56,6 +56,7 @@ class TestFreq:
         dti2 = DatetimeIndex(dta)._with_freq(None)
         assert dti2.freq is None
 
-        # Original was not altered
+        # Original was not altered. freq is now Index-level state, so the
+        # underlying DatetimeArray never carries a freq.
         assert dti.freq == "D"
-        assert dta.freq == "D"
+        assert dta.freq is None

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -153,7 +153,7 @@ class TestDatetimeIndexSetOps:
     def test_union_freq_both_none(self, sort):
         # GH11086
         expected = bdate_range("20150101", periods=10)
-        expected._data._freq = None
+        expected._freq = None
 
         result = expected.union(expected, sort=sort)
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/period/test_freq_attr.py
+++ b/pandas/tests/indexes/period/test_freq_attr.py
@@ -16,7 +16,7 @@ class TestFreq:
         with tm.assert_produces_warning(None):
             idx.freq
 
-        # warning for setter
-        msg = "property 'freq' of 'PeriodArray' object has no setter"
+        # PeriodIndex freq is derived from dtype and read-only
+        msg = "property 'freq' of 'PeriodIndex' object has no setter"
         with pytest.raises(AttributeError, match=msg):
             idx.freq = offsets.Day()

--- a/pandas/tests/indexes/timedeltas/test_freq_attr.py
+++ b/pandas/tests/indexes/timedeltas/test_freq_attr.py
@@ -65,6 +65,7 @@ class TestFreq:
         tdi2 = TimedeltaIndex(tda)._with_freq(None)
         assert tdi2.freq is None
 
-        # Original was not altered
+        # Original was not altered. freq is now Index-level state, so the
+        # underlying TimedeltaArray never carries a freq.
         assert tdi.freq == "2D"
-        assert tda.freq == "2D"
+        assert tda.freq is None

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -5,7 +5,6 @@ import zoneinfo
 import numpy as np
 import pytest
 
-from pandas._libs import lib
 from pandas._libs.tslibs import Day
 from pandas._typing import DatetimeNaTType
 from pandas.compat import is_platform_windows
@@ -1137,7 +1136,6 @@ def test_resample_anchored_intraday2(unit):
     expected = expected.to_timestamp(how="end")
     expected.index += Timedelta(1, unit="us") - Timedelta(1, unit="D")
     expected.index.freq = "QE"
-    expected.index._freq = lib.no_default
     expected.index = expected.index.as_unit(unit)
     tm.assert_frame_equal(result, expected)
 
@@ -1147,7 +1145,6 @@ def test_resample_anchored_intraday2(unit):
     expected = expected.to_timestamp(how="end")
     expected.index += Timedelta(1, unit="us") - Timedelta(1, unit="D")
     expected.index.freq = "QE"
-    expected.index._freq = lib.no_default
     expected.index = expected.index.as_unit(unit)
     tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
## Summary
- **Split `PeriodArray.to_timestamp` freq inference** into `PeriodArray._to_timestamp_freq(dta, target_freq, how)`. Array-level `to_timestamp` now returns a bare DTA; `PeriodIndex.to_timestamp` calls the helper and stamps the result.
- **Move freq-stamping out of `_generate_range`.** `DatetimeArray._generate_range` and `TimedeltaArray._generate_range` now return bare arrays; the three callers (`date_range`, `timedelta_range`, `DatetimeIndexOpsMixin.shift`) own the freq stamp.
- **Relocate `_freq` storage from DTA/TDA to `DatetimeTimedeltaMixin`.** Getter, validating setter, and class attribute all live on the Index now. Every former \`self._data._freq = X\` / \`arr._freq = X\` write site in \`pandas/core/indexes/\` is rewritten to stamp \`self._freq\` on the wrapping Index. \`copy()\`, \`_view()\`, \`Index.__new__\` (wrap-DTI/TDI case), and \`as_unit()\` explicitly carry \`_freq\` forward; \`pytables\`, \`DatetimeIndex.__new__\` fastpath, and \`_pin_freq\` were updated to match.
- **Pickle compat.** \`DatetimeIndex/TimedeltaIndex.__reduce__\` now include freq in the dict; \`_new_DatetimeIndex\` / new \`_new_TimedeltaIndex\` migrate legacy array-side \`_freq\` payloads up onto the Index on unpickle.
- **Bycatch:** \`Grouper._codes_and_uniques\` was returning \`grouping_vector.result_index._values\` (a DTA) for BaseGrouper uniques, which lost freq on the trip through \`Index._with_infer\`. Returning the full \`result_index\` (combined with the new Index-preserving branch in \`Index.__new__\`) fixes pivot_table silently dropping freq.

Part of GH#24566. Follows up on #65266 / #65276 / #65285.

## Test plan
- [x] \`pandas/tests/indexes\`, \`arrays\`, \`arithmetic\`, \`resample\`, \`reshape\`, \`tseries\`, \`tools\`, \`groupby\`, \`frame\`, \`series\` — 124K+ tests pass
- [x] \`pandas/tests/io\` (ex-SQL/GBQ), \`pandas/tests/plotting\` — 15K+ tests pass
- [x] pickle round-trip preserves freq for DatetimeIndex and TimedeltaIndex
- [x] pre-commit clean; mypy clean on touched files (pre-existing \`frame.py:17388\` unused-ignore remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)