### PR TITLE
DOC: fix grammar in the .dt accessor section

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -1628,7 +1628,7 @@ This enables nice expressions like this:
 
    s[s.dt.day == 2]
 
-You can easily produces tz aware transformations:
+You can easily produce tz aware transformations:
 
 .. ipython:: python
 


### PR DESCRIPTION
Fixes typo ("produces" -> "produce") in the .dt accessor doc