### PR TITLE
BUG: preserve ExtensionArray dtype in Index._transform_index for rename

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6889,7 +6889,7 @@ class Index(IndexOpsMixin, PandasObject):
             return type(self).from_arrays(values)
         else:
             items = [func(x) for x in self]
-            return Index(items, name=self.name, tupleize_cols=False)
+            return self._constructor._with_infer(items, name=self.name)
 
     def isin(
         self, values: Axes | set, level: str_t | int | None = None


### PR DESCRIPTION
Closes #65315

**Issue:**  and  silently downcast nullable extension dtypes (Int64, Float64, etc.) on index/column labels to plain NumPy dtypes.

**Root cause:**  (called during rename) reconstructs the index from a plain Python list via , which loses the ExtensionArray dtype information.

**Fix:** Replace  with  to preserve the underlying ExtensionArray dtype through the transformation.

**Before:**


**After:** The Int64 dtype is preserved after rename.