### PR TITLE
BUG: disable numexpr for incompatible numpy>=2.3 + numexpr<2.11 combos

### DIFF
--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -193,6 +193,22 @@ def _where_numexpr(cond, left_op, right_op):
 
 
 # turn myself on
+# Disable numexpr for known incompatible numpy/numexpr combinations
+# that produce incorrect results (see GH#63320)
+if NUMEXPR_INSTALLED:
+    _np_version = tuple(int(x) for x in np.__version__.split(".")[:2])
+    _ne_version = tuple(int(x) for x in ne.__version__.split(".")[:2])
+    if _np_version >= (2, 3) and _ne_version < (2, 11):
+        import warnings
+        warnings.warn(
+            "Disabling numexpr due to known incorrect results with "
+            f"numpy {_np_version} and numexpr {_ne_version}. "
+            "Set use_numexpr=False to suppress this warning.",
+            UserWarning,
+            stacklevel=find_stack_level(),
+        )
+        config["compute"]["use_numexpr"] = False
+
 set_use_numexpr(config["compute"]["use_numexpr"])
 
 


### PR DESCRIPTION
When using numpy >= 2.3 with numexpr < 2.11, numexpr can produce
incorrect results (e.g., zeros in division output for large DataFrames).
Automatically disable numexpr for this known broken combination and
warn the user.

Fixes #63320

The issue reports that with numpy 2.3.x and numexpr 2.10.x, division
operations on DataFrames with >4096 columns can produce incorrect results
(zeros where non-zero values are expected). Downgrading numexpr to >=2.11
or numpy to <2.3 resolves the issue, confirming this is a numexpr
compatibility problem.

This change adds a version check at module load time that detects the
incompatible combination and automatically disables numexpr with a warning,
similar to how pandas handles other known-incompatible dependency combos.