### PR TITLE
BUG: preserve nullable index dtype in rename (GH#65315)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6889,7 +6889,10 @@ class Index(IndexOpsMixin, PandasObject):
             return type(self).from_arrays(values)
         else:
             items = [func(x) for x in self]
-            return Index(items, name=self.name, tupleize_cols=False)
+            try:
+                return Index(items, dtype=self.dtype, name=self.name, tupleize_cols=False)
+            except (ValueError, TypeError):
+                return Index(items, name=self.name, tupleize_cols=False)
 
     def isin(
         self, values: Axes | set, level: str_t | int | None = None


### PR DESCRIPTION
## Summary

Index._transform_index (used by `rename()`) reconstructed the index from a plain Python list via `Index(items)`, which loses extension dtypes like `Int64`, `Float64`, etc. After renaming labels, nullable integer/float indexes were silently downcast to their numpy counterparts (`Int64` → `int64`, `Float64` → `float64`).

**Fix:** Pass `dtype=self.dtype` when constructing the transformed index, with a fallback to the previous behavior if values are incompatible (e.g., when `rename` is called with a type-changing function like `str`).

## Reproducible Example (from issue)

```python
import pandas as pd\n\ndf = pd.DataFrame(\n    {"val": [1, 2, 3]},\n    index=pd.Index(pd.array([1, 2, 3], dtype="Int64"), name="id"),\n)\nprint(df.index.dtype)        # Int64\nprint(df.rename({1: 9}).index.dtype)  # was int64, now Int64 ✓
```

## Changes

- **File:** `pandas/core/indexes/base.py`, `_transform_index()` method
- **Lines changed:** +4, -1 (net +3)\- **Approach:** Try constructing with original dtype first; fall back on `ValueError`/`TypeError` for incompatible value types

Fixes #65315