### PR TITLE
CI: make wheel builds compilation more verbose

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ dist = ['--include-subprojects']
 skip = ["*_i686", "*_ppc64le", "*_s390x"]
 build-verbosity = 3
 build-frontend = "pip"
+config-settings = { compile-args = ["-v"] }
 environment = {LDFLAGS="-Wl,--strip-all"}
 test-extras = "test"
 test-command = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ dist = ['--include-subprojects']
 
 [tool.cibuildwheel]
 skip = ["*_i686", "*_ppc64le", "*_s390x"]
-build-verbosity = 3
+build-verbosity = 2
 build-frontend = "pip"
 config-settings = { compile-args = ["-v"] }
 environment = {LDFLAGS="-Wl,--strip-all"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ dist = ['--include-subprojects']
 
 [tool.cibuildwheel]
 skip = ["*_i686", "*_ppc64le", "*_s390x"]
-build-verbosity = 2
+build-verbosity = 1
 build-frontend = "pip"
 config-settings = { compile-args = ["-v"] }
 environment = {LDFLAGS="-Wl,--strip-all"}


### PR DESCRIPTION
Including the meson compile verbosity ensures we see the commands used to build the extensions (e.g. useful to inspect which compiler flags are being passed)

Reducing the build (pip) verbosity avoids that it prints out all the PyPI interaction (which is like 9000 lines long of listing wheel files being skipped), while still giving most details we care about, as far as I can see.