### PR TITLE
[backport 3.0.x] REGR: restore rank() for ExtensionArrays with custom values for sorting (#64976)

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -16,6 +16,7 @@ Fixed regressions
 
 - Fixed reading of Parquet files with timezone-aware timestamps or localizing of a timeseries with a ``pytz`` timezone when an older version of ``pytz`` was installed (:issue:`64978`)
 - Fixed regression in :func:`to_timedelta` ignoring the ``unit`` argument for round float values when mixed with non-round floats in a list (:issue:`65150`)
+- Fixed regression in :meth:`Series.rank` with custom extension dtypes (:issue:`64976`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.bug_fixes:
@@ -28,6 +29,7 @@ Bug fixes
 - Fixed :class:`ArrowDtype` string arithmetic for addition between ``string`` and ``large_string`` typed arrays (:issue:`65220`)
 - Fixed a bug in adding missing values (e.g. :attr:`NA`) to a pyarrow-backed string array or Series
   raising an error instead of propagating the missing value (:issue:`64968`)
+- Fixed a bug in :meth:`Series.rank` with period dtype and missing values, always sorting missing values at the top, regardless of the ``na_option`` value (:issue:`64976`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.contributors:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1046,6 +1046,7 @@ def rank(
     na_option: str = "keep",
     ascending: bool = True,
     pct: bool = False,
+    mask: npt.NDArray[np.bool_] | None = None,
 ) -> npt.NDArray[np.float64]:
     """
     Rank the values along a given axis.
@@ -1069,6 +1070,8 @@ def rank(
     pct : bool, default False
         Whether or not to the display the returned rankings in integer form
         (e.g. 1, 2, 3) or in percentile form (e.g. 0.333..., 0.666..., 1).
+    mask : bool ndarray, optional
+        Boolean array indicating which elements to exclude from ranking.
     """
     is_datetimelike = needs_i8_conversion(values.dtype)
     values = _ensure_data(values)
@@ -1081,8 +1084,10 @@ def rank(
             ascending=ascending,
             na_option=na_option,
             pct=pct,
+            mask=mask,
         )
     elif values.ndim == 2:
+        assert mask is None
         ranks = algos.rank_2d(
             values,
             axis=axis,

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -2623,12 +2623,13 @@ class ExtensionArray:
             raise NotImplementedError
 
         return rank(
-            self,
+            self._values_for_argsort(),
             axis=axis,
             method=method,
             na_option=na_option,
             ascending=ascending,
             pct=pct,
+            mask=np.asarray(self.isna(), dtype="bool") if self._hasna else None,
         )
 
     @classmethod

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -6,7 +6,11 @@ import pytest
 
 from pandas._typing import Dtype
 
-from pandas.core.dtypes.common import is_bool_dtype
+from pandas.core.dtypes.common import (
+    is_bool_dtype,
+    is_float_dtype,
+    is_integer_dtype,
+)
 from pandas.core.dtypes.dtypes import NumpyEADtype
 from pandas.core.dtypes.missing import na_value_for_dtype
 
@@ -240,6 +244,50 @@ class BaseMethodsTests:
             {"A": [1, 1, 2], "B": data_for_sorting.take([2, 0, 1])}, index=[2, 0, 1]
         )
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("ascending", [True, False])
+    def test_rank(self, data_for_sorting, ascending):
+        ser = pd.Series(data_for_sorting)
+        result = ser.rank(ascending=ascending)
+        # result should be float, but exact dtype (numpy/nullable/pyarrow) depends
+        # so here just assert it is float and normalize to float64 for comparison
+        assert is_float_dtype(result.dtype)
+        result = result.astype("float64")
+        if is_bool_dtype(ser.dtype):
+            expected = pd.Series([2.5, 2.5, 1.0] if ascending else [1.5, 1.5, 3.0])
+        else:
+            expected = pd.Series([2.0, 3.0, 1.0] if ascending else [2.0, 1.0, 3.0])
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("method", ["average", "min"])
+    def test_rank_method(self, data_for_sorting, method):
+        ser = pd.Series(data_for_sorting.take([0, 2, 0]))
+        result = ser.rank(method=method)
+        if method == "average":
+            assert is_float_dtype(result.dtype)
+            result = result.astype("float64")
+            expected = pd.Series([2.5, 1.0, 2.5])
+        else:
+            # TODO the exact dtype here is inconsistent across EAs (should all be int?)
+            assert is_integer_dtype(result.dtype) or is_float_dtype(result.dtype)
+            expected = pd.Series([2, 1, 2], dtype=result.dtype)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("na_option", ["keep", "top", "bottom"])
+    def test_rank_missing(self, data_missing_for_sorting, na_option):
+        ser = pd.Series(data_missing_for_sorting)
+        result = ser.rank(na_option=na_option)
+        assert is_float_dtype(result.dtype)
+        result = result.astype("float64")
+        if na_option == "keep":
+            expected = pd.Series([2.0, np.nan, 1.0])
+        elif na_option == "top":
+            expected = pd.Series([3.0, 1.0, 2.0])
+        else:
+            # na_option == "bottom"
+            expected = pd.Series([2.0, 3.0, 1.0])
+
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("keep", ["first", "last", False])
     def test_duplicated(self, data, keep):


### PR DESCRIPTION
(cherry picked from commit 2b9c54e024ae088724fe892407c8b93e9f8e2c48)

Backport of #64976