### PR TITLE
ENH: Suggest alternative package managers in optional dependency error

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -34,7 +34,6 @@ Other enhancements
 - Added :meth:`ExtensionArray.count` (:issue:`64450`)
 - Added :meth:`Index.replace` method to support value replacement functionality similar to :meth:`Series.replace` (:issue:`19495`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
-- Improved the error message shown when an optional dependency is missing to suggest alternative package managers (e.g. ``uv``, ``poetry``) in addition to ``pip`` and ``conda`` (:issue:`62796`)
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -34,6 +34,7 @@ Other enhancements
 - Added :meth:`ExtensionArray.count` (:issue:`64450`)
 - Added :meth:`Index.replace` method to support value replacement functionality similar to :meth:`Series.replace` (:issue:`19495`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
+- Improved the error message shown when an optional dependency is missing to suggest alternative package managers (e.g. ``uv``, ``poetry``) in addition to ``pip`` and ``conda`` (:issue:`62796`)
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -152,7 +152,8 @@ def import_optional_dependency(
 
     msg = (
         f"`Import {install_name}` failed. {extra} "
-        f"Use pip or conda to install the {install_name} package."
+        f"Use pip, conda, or your preferred package management tool "
+        f"to install the {install_name} package."
     )
     try:
         module = importlib.import_module(name)

--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -280,7 +280,10 @@ def test_s3_parquet(s3_bucket_public, s3so, df1):
 
 @td.skip_if_installed("fsspec")
 def test_not_present_exception():
-    msg = "`Import fsspec` failed.  Use pip or conda to install the fsspec package."
+    msg = (
+        "`Import fsspec` failed.  Use pip, conda, or your preferred package "
+        "management tool to install the fsspec package."
+    )
     with pytest.raises(ImportError, match=msg):
         read_csv("memory://test/test.csv")
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -361,7 +361,10 @@ def test_get_engine_auto_error_message():
             with pytest.raises(ImportError, match=match):
                 get_engine("auto")
         else:
-            match = "Use pip or conda to install the fastparquet package"
+            match = (
+                "Use pip, conda, or your preferred package management tool "
+                "to install the fastparquet package"
+            )
             with pytest.raises(ImportError, match=match):
                 get_engine("auto")
 

--- a/pandas/tests/test_optional_dependency.py
+++ b/pandas/tests/test_optional_dependency.py
@@ -12,7 +12,7 @@ import pandas._testing as tm
 
 
 def test_import_optional():
-    match = "Import .*notapackage.* pip .* conda .* notapackage"
+    match = "Import .*notapackage.*pip.*conda.*notapackage"
     with pytest.raises(ImportError, match=match) as exc_info:
         import_optional_dependency("notapackage")
     # The original exception should be there as context:


### PR DESCRIPTION
- [x] closes #62796
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (N/A - no type signatures changed)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Updates the error raised by `import_optional_dependency` when an optional dependency is missing. The message previously suggested only `pip` or `conda`; it now acknowledges other common package managers (`uv`, `poetry`, etc.) so users who have moved away from `conda` receive relevant guidance.

Existing tests that asserted on the literal message (`test_parquet.py`, `test_fsspec.py`) are updated. The regex in `test_optional_dependency.py::test_import_optional` is relaxed to match the new comma-separated phrasing.
