### PR TITLE
BUG: rename() silently downcasts nullable ExtensionArray index dtypes to NumPy

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -336,6 +336,7 @@ Reshaping
 ^^^^^^^^^
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
+- Bug in :meth:`DataFrame.rename` and :meth:`Series.rename` silently downcasting nullable extension dtypes (e.g. ``Int64``, ``Float64``) to the corresponding NumPy dtype on index and column labels (:issue:`65315`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)
 -
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6889,6 +6889,16 @@ class Index(IndexOpsMixin, PandasObject):
             return type(self).from_arrays(values)
         else:
             items = [func(x) for x in self]
+            if isinstance(self.dtype, ExtensionDtype):
+                # Reconstruct through the original ExtensionArray type so that
+                # nullable dtypes (e.g. Int64, Float64) are not silently downcast
+                # to the corresponding NumPy dtype when building from a Python list.
+                # GH#65315
+                try:
+                    arr = self._data._from_sequence(items, dtype=self.dtype)
+                    return Index(arr, name=self.name)
+                except (TypeError, ValueError):
+                    pass
             return Index(items, name=self.name, tupleize_cols=False)
 
     def isin(

--- a/pandas/tests/frame/methods/test_rename.py
+++ b/pandas/tests/frame/methods/test_rename.py
@@ -4,11 +4,13 @@ import inspect
 import numpy as np
 import pytest
 
+import pandas as pd
 from pandas import (
     DataFrame,
     Index,
     MultiIndex,
     Series,
+    array,
     merge,
 )
 import pandas._testing as tm
@@ -440,3 +442,33 @@ class TestRename:
 
         # check we didn't corrupt the original
         tm.assert_series_equal(ser, orig.iloc[0])
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    ["Int64", "Float64", "boolean", "UInt8"],
+)
+def test_rename_preserves_nullable_index_dtype(dtype):
+    # GH#65315: rename() must not silently downcast nullable ExtensionArray index
+    # dtypes to the corresponding NumPy dtype.
+    idx = Index(array([1, 2, 3], dtype=dtype))
+    df = DataFrame({"val": [10, 20, 30]}, index=idx)
+
+    renamed = df.rename({1: 9})
+    assert renamed.index.dtype == idx.dtype, (
+        f"rename() downcast nullable dtype {dtype!r} to {renamed.index.dtype!r}"
+    )
+    assert renamed.index[0] == 9
+
+
+@pytest.mark.parametrize("dtype", ["Int64", "Float64"])
+def test_rename_preserves_nullable_series_index_dtype(dtype):
+    # GH#65315: Series.rename() must preserve nullable ExtensionArray index dtype.
+    idx = Index(array([10, 20, 30], dtype=dtype))
+    ser = Series([1, 2, 3], index=idx)
+
+    renamed = ser.rename({10: 99})
+    assert renamed.index.dtype == idx.dtype, (
+        f"Series.rename() downcast nullable dtype {dtype!r} to {renamed.index.dtype!r}"
+    )
+    assert renamed.index[0] == 99


### PR DESCRIPTION
## Problem

`DataFrame.rename()` and `Series.rename()` silently downcast nullable extension dtypes (e.g. `Int64`, `Float64`) on index/column labels to their NumPy equivalents (`int64`, `float64`):

```python
import pandas as pd

df = pd.DataFrame(
    {"val": [1, 2, 3]},
    index=pd.Index(pd.array([1, 2, 3], dtype="Int64"), name="id"),
)
print(df.index.dtype)              # Int64 (nullable)
print(df.rename({1: 9}).index.dtype)  # int64 (NumPy — wrong!)
```

## Root cause

`Index._transform_index()` transforms labels via `[func(x) for x in self]` and then calls `Index(items, ...)`, which infers dtype from the Python list. For nullable integer/float dtypes this loses the `ExtensionDtype` and falls back to a NumPy dtype.

## Fix

In `_transform_index`, when the original `Index` has an `ExtensionDtype`, rebuild via `self._data._from_sequence(items, dtype=self.dtype)` to preserve the nullable dtype. Falls back to the previous list-based path if `_from_sequence` raises `TypeError` or `ValueError`.

## Tests added

- `test_rename_preserves_nullable_index_dtype` — parametrized over `Int64`, `Float64`, `boolean`, `UInt8`; verifies the index dtype is unchanged after rename.
- `test_rename_preserves_nullable_series_index_dtype` — same for `Series.rename()`.

## Whatsnew

Entry added to `v3.1.0.rst` Reshaping section.

Closes #65315

@jorisvandenbossche @rhshadrach