### PR TITLE
PERF: avoid dtype.name in DataFrame block grouping

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -2383,37 +2383,26 @@ def raise_construction_error(
 # -----------------------------------------------------------------------
 
 
-def _grouping_key(tup: tuple[int, ArrayLike]) -> Hashable:
-    dtype = tup[1].dtype
-
-    if isinstance(dtype, np.dtype):
-        # Only numpy dtypes get stacked into 2D blocks in _form_blocks,
-        # so only they need real grouping by dtype.
-        return dtype.name
-    else:
-        # Extension dtypes each get their own block regardless, so grouping
-        # doesn't matter. Use id() to avoid potentially expensive __hash__
-        # (e.g. CategoricalDtype hashes all categories).
-        return id(dtype)
-
-
 def _form_blocks(arrays: list[ArrayLike], consolidate: bool, refs: list) -> list[Block]:
-    tuples = enumerate(arrays)
-
     if not consolidate:
-        return _tuples_to_blocks_no_consolidate(tuples, refs)
+        return _tuples_to_blocks_no_consolidate(enumerate(arrays), refs)
 
     # when consolidating, we can ignore refs (either stacking always copies,
     # or the EA is already copied in the calling dict_to_mgr)
 
-    # group by dtype using a dict faster than old itertools.groupby
+    # Group by dtype using a dict (faster than the old itertools.groupby).
+    # np.dtype has cheap hash/eq so it is used directly as the key. Extension
+    # dtypes each get their own block regardless, so id() is used to avoid
+    # a potentially expensive __hash__ (e.g. CategoricalDtype hashes all
+    # categories).
     groups: dict[Hashable, list[tuple[int, ArrayLike]]] = {}
-    for tup in tuples:
-        key = _grouping_key(tup)
+    for i, arr in enumerate(arrays):
+        dtype = arr.dtype
+        key = dtype if isinstance(dtype, np.dtype) else id(dtype)
         try:
-            groups[key].append(tup)
+            groups[key].append((i, arr))
         except KeyError:
-            groups[key] = [tup]
+            groups[key] = [(i, arr)]
 
     nbs: list[Block] = []
     for tup_block in groups.values():

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -2384,20 +2384,20 @@ def raise_construction_error(
 
 
 def _form_blocks(arrays: list[ArrayLike], consolidate: bool, refs: list) -> list[Block]:
+    tuples = enumerate(arrays)
+
     if not consolidate:
-        return _tuples_to_blocks_no_consolidate(enumerate(arrays), refs)
+        return _tuples_to_blocks_no_consolidate(tuples, refs)
 
     # when consolidating, we can ignore refs (either stacking always copies,
     # or the EA is already copied in the calling dict_to_mgr)
 
-    # Group by dtype using a dict (faster than the old itertools.groupby).
-    # np.dtype has cheap hash/eq so it is used directly as the key. Extension
-    # dtypes each get their own block regardless, so id() is used to avoid
-    # a potentially expensive __hash__ (e.g. CategoricalDtype hashes all
-    # categories).
     groups: dict[Hashable, list[tuple[int, ArrayLike]]] = {}
-    for i, arr in enumerate(arrays):
+    for i, arr in tuples:
         dtype = arr.dtype
+        # Extension dtypes each get their own block regardless, so use id()
+        # to avoid a potentially expensive __hash__ (e.g. CategoricalDtype
+        # hashes all categories).
         key = dtype if isinstance(dtype, np.dtype) else id(dtype)
         try:
             groups[key].append((i, arr))


### PR DESCRIPTION
## Summary

- The `_grouping_key` helper added in #64574 keys the per-dtype grouping dict on `dtype.name` for numpy dtypes. Reading `np.dtype.name` walks through `_name_get` → `_name_includes_bit_suffix` → `issubdtype` at ~225ns per call — about 22× the cost of using the `np.dtype` object itself as the key (which already has cheap hash/eq).
- Switch to using the dtype directly as the key for numpy dtypes, keep `id(dtype)` for ExtensionDtypes (whose `__hash__` can be expensive, e.g. `CategoricalDtype`).
- Inline the (now trivial) helper into `_form_blocks` to remove the per-array Python function call overhead.

## Benchmark

`frame_ctor.FromArrays.time_frame_from_arrays_float` (1000×1000 float arrays), best of 15 × 200-iter repeats:

|                            | min        | mean       |
|----------------------------|------------|------------|
| HEAD (pre-fix)             | ~1.90 ms   | ~2.00 ms   |
| pandas 3.0.1               | 0.978 ms   | 1.196 ms   |
| **HEAD + fix**             | **0.914 ms** | **0.970 ms** |

Profile confirms the remaining runtime is dominated by `_stack_arrays`, which is itself ~37% faster on HEAD than on 3.0.1 thanks to the `np.concatenate`-vs-`np.vstack` change in #64574.

## Test plan

- [x] `pandas/tests/frame/test_constructors.py` — 1258 passed
- [x] `pandas/tests/internals/` — passed
- [x] `pandas/tests/frame/methods/` — 5870 passed
- [x] Verified structured-dtype grouping still produces a single block (dtype-as-key works under numpy's non-singleton instances for structured dtypes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)