### PR TITLE
DOC: clarify that read_hdf only reads pandas-written HDF5 files

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3978,6 +3978,14 @@ the high performance HDF5 format using the excellent `PyTables
 <https://www.pytables.org/>`__ library. See the :ref:`cookbook <cookbook.hdf>`
 for some advanced strategies
 
+.. note::
+
+   pandas reads and writes HDF5 files using a pandas-specific layout built on
+   top of PyTables. :func:`read_hdf` and :class:`HDFStore` are intended for
+   round-tripping pandas objects and **do not read arbitrary HDF5 files**, such
+   as those produced directly by ``h5py`` or plain PyTables. To work with
+   general HDF5 files, use ``h5py`` or ``PyTables`` directly.
+
 .. warning::
 
    pandas uses PyTables for reading and writing HDF5 files, which allows

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2683,6 +2683,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         In order to add another DataFrame or Series to an existing HDF file
         please use append mode and a different a key.
 
+        .. note::
+
+           Files produced by this method use a pandas-specific layout on top
+           of PyTables and are intended to be read back with :func:`read_hdf`
+           or :class:`HDFStore`. They are valid HDF5 files but are not a
+           general-purpose interchange format for arbitrary HDF5 consumers.
+
         .. warning::
 
            One can store a subclass of ``DataFrame`` or ``Series`` to HDF5,

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -355,6 +355,14 @@ def read_hdf(
     criteria. This function requires the
     `PyTables <https://www.pytables.org/>`_ library.
 
+    .. note::
+
+       This function only reads HDF5 files written by pandas (via
+       :meth:`DataFrame.to_hdf`, :meth:`Series.to_hdf`, or :class:`HDFStore`),
+       which use a pandas-specific layout built on PyTables. Arbitrary HDF5
+       files produced by other tools such as ``h5py`` or plain PyTables are
+       not supported; use those libraries directly to read such files.
+
     .. warning::
 
        Pandas uses PyTables for reading and writing HDF5 files, which allows
@@ -518,6 +526,13 @@ class HDFStore:
     Dict-like IO interface for storing pandas objects in PyTables.
 
     Either Fixed or Table format.
+
+    .. note::
+
+       ``HDFStore`` uses a pandas-specific layout on top of PyTables and is
+       intended for round-tripping pandas objects. It cannot read arbitrary
+       HDF5 files produced by other tools such as ``h5py`` or plain PyTables;
+       use those libraries directly for general HDF5 interoperability.
 
     .. warning::
 


### PR DESCRIPTION
## Summary

- Add a note to the HDF5 user guide section explaining that pandas uses a pandas-specific PyTables layout and does not read arbitrary HDF5 files (e.g. those produced by ``h5py`` or plain PyTables).
- Add equivalent notes to the ``read_hdf``, ``HDFStore``, and ``DataFrame.to_hdf`` docstrings.

closes #56560

## Test plan

- [ ] Sphinx builds the user guide and rendered docstrings without warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)