### PR TITLE
DOC: clarify resolution-dependence of Timestamp/Timedelta min/max/resolution

### DIFF
--- a/doc/source/user_guide/timedeltas.rst
+++ b/doc/source/user_guide/timedeltas.rst
@@ -106,14 +106,29 @@ is numeric:
 Timedelta limitations
 ~~~~~~~~~~~~~~~~~~~~~
 
-pandas represents ``Timedeltas`` in nanosecond resolution using
-64 bit integers. As such, the 64 bit integer limits determine
-the ``Timedelta`` limits.
+:class:`Timedelta` uses a 64-bit integer to represent time, so the representable
+range depends on the chosen resolution (``unit``). The class-level attributes
+:attr:`Timedelta.min`, :attr:`Timedelta.max`, and :attr:`Timedelta.resolution`
+default to nanosecond limits:
 
 .. ipython:: python
 
    pd.Timedelta.min
    pd.Timedelta.max
+   pd.Timedelta.resolution
+
+On a :class:`Timedelta` *instance*, the same attributes reflect the bounds and
+step size of that instance's resolution:
+
+.. ipython:: python
+
+   td = pd.Timedelta(1, unit="s")
+   td.min
+   td.max
+   td.resolution
+
+Different resolutions can be converted to each other through
+:meth:`Timedelta.as_unit`.
 
 .. _timedeltas.operations:
 

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -526,17 +526,43 @@ used if a custom frequency string is passed.
 Timestamp limitations
 ---------------------
 
-The limits of timestamp representation depend on the chosen resolution. For
-nanosecond resolution, the time span that
-can be represented using a 64-bit integer is limited to approximately 584 years:
+:class:`Timestamp` uses a 64-bit integer to represent time, so the representable
+range depends on the chosen resolution (``unit``). For the default nanosecond
+resolution the span is limited to approximately 584 years; coarser resolutions
+such as second extend the range to roughly ``+/- 2.9e11`` years.
+
+The class-level attributes :attr:`Timestamp.min`, :attr:`Timestamp.max`, and
+:attr:`Timestamp.resolution` default to nanosecond limits:
 
 .. ipython:: python
 
    pd.Timestamp.min
    pd.Timestamp.max
+   pd.Timestamp.resolution
 
-When choosing second-resolution, the available range grows to  ``+/- 2.9e11 years``.
-Different resolutions can be converted to each other through ``as_unit``.
+On a :class:`Timestamp` *instance*, the same attributes reflect the bounds and
+step size of that instance's resolution:
+
+.. ipython:: python
+
+   ts = pd.Timestamp("2262-04-12").as_unit("s")
+   ts.min
+   ts.max
+   ts.resolution
+
+Because :class:`Timestamp` construction automatically picks a resolution wide
+enough to represent the input, a value outside the nanosecond range (such as
+``"3000-06-10"``) is parsed using a coarser unit rather than raising
+:class:`OutOfBoundsDatetime`:
+
+.. ipython:: python
+
+   far_future = pd.Timestamp("3000-06-10")
+   far_future
+   far_future.unit
+
+Different resolutions can be converted to each other through
+:meth:`Timestamp.as_unit`.
 
 .. seealso::
 

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1157,8 +1157,9 @@ cdef class _Timedelta(timedelta):
     _docstring_min = """
     Returns the minimum bound possible for Timedelta.
 
-    This property provides access to the smallest possible value that
-    can be represented by a Timedelta object.
+    Accessed on the class (``pd.Timedelta.min``), this returns the minimum
+    bound for nanosecond resolution. Accessed on an instance, it returns the
+    minimum bound for that instance's resolution (see :attr:`Timedelta.unit`).
 
     Returns
     -------
@@ -1174,13 +1175,17 @@ cdef class _Timedelta(timedelta):
     --------
     >>> pd.Timedelta.min
     -106752 days +00:12:43.145224193
+
+    >>> pd.Timedelta(1, unit="s").min
+    -106751991167301 days +08:29:53
     """
 
     _docstring_max = """
     Returns the maximum bound possible for Timedelta.
 
-    This property provides access to the largest possible value that
-    can be represented by a Timedelta object.
+    Accessed on the class (``pd.Timedelta.max``), this returns the maximum
+    bound for nanosecond resolution. Accessed on an instance, it returns the
+    maximum bound for that instance's resolution (see :attr:`Timedelta.unit`).
 
     Returns
     -------
@@ -1196,13 +1201,18 @@ cdef class _Timedelta(timedelta):
     --------
     >>> pd.Timedelta.max
     106751 days 23:47:16.854775807
+
+    >>> pd.Timedelta(1, unit="s").max
+    106751991167300 days 15:30:07
     """
 
     _docstring_reso = """
     Returns the smallest possible difference between non-equal Timedelta objects.
 
-    The resolution value is determined by the underlying representation of time
-    units and is equivalent to Timedelta(nanoseconds=1).
+    Accessed on the class (``pd.Timedelta.resolution``), this returns the
+    resolution for nanosecond-unit Timedeltas (one nanosecond). Accessed on an
+    instance, it returns the step size of that instance's resolution (see
+    :attr:`Timedelta.unit`).
 
     Returns
     -------
@@ -1217,6 +1227,9 @@ cdef class _Timedelta(timedelta):
     --------
     >>> pd.Timedelta.resolution
     0 days 00:00:00.000000001
+
+    >>> pd.Timedelta(1, unit="s").resolution
+    0 days 00:00:01
     """
 
     min = MinMaxReso("min", _docstring_min)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -278,8 +278,9 @@ cdef class _Timestamp(ABCTimestamp):
     _docstring_min = """
     Returns the minimum bound possible for Timestamp.
 
-    This property provides access to the smallest possible value that
-    can be represented by a Timestamp object.
+    Accessed on the class (``pd.Timestamp.min``), this returns the minimum
+    bound for nanosecond resolution. Accessed on an instance, it returns the
+    minimum bound for that instance's resolution (see :attr:`Timestamp.unit`).
 
     Returns
     -------
@@ -295,13 +296,17 @@ cdef class _Timestamp(ABCTimestamp):
     --------
     >>> pd.Timestamp.min
     Timestamp('1677-09-21 00:12:43.145224193')
+
+    >>> pd.Timestamp("2000-01-01").as_unit("s").min
+    Timestamp('-292277022657-01-27 08:29:53')
     """
 
     _docstring_max = """
     Returns the maximum bound possible for Timestamp.
 
-    This property provides access to the largest possible value that
-    can be represented by a Timestamp object.
+    Accessed on the class (``pd.Timestamp.max``), this returns the maximum
+    bound for nanosecond resolution. Accessed on an instance, it returns the
+    maximum bound for that instance's resolution (see :attr:`Timestamp.unit`).
 
     Returns
     -------
@@ -317,13 +322,18 @@ cdef class _Timestamp(ABCTimestamp):
     --------
     >>> pd.Timestamp.max
     Timestamp('2262-04-11 23:47:16.854775807')
+
+    >>> pd.Timestamp("2000-01-01").as_unit("s").max
+    Timestamp('292277026596-12-04 15:30:07')
     """
 
     _docstring_reso = """
     Returns the smallest possible difference between non-equal Timestamp objects.
 
-    The resolution value is determined by the underlying representation of time
-    units and is equivalent to Timedelta(nanoseconds=1).
+    Accessed on the class (``pd.Timestamp.resolution``), this returns the
+    resolution for nanosecond-unit Timestamps (one nanosecond). Accessed on an
+    instance, it returns the step size of that instance's resolution (see
+    :attr:`Timestamp.unit`).
 
     Returns
     -------
@@ -338,6 +348,9 @@ cdef class _Timestamp(ABCTimestamp):
     --------
     >>> pd.Timestamp.resolution
     Timedelta('0 days 00:00:00.000000001')
+
+    >>> pd.Timestamp("2000-01-01").as_unit("s").resolution
+    Timedelta('0 days 00:00:01')
     """
 
     min = MinMaxReso("min", _docstring_min)


### PR DESCRIPTION
## Summary

- closes #52164
- Updates the ``Timestamp`` and ``Timedelta`` "limitations" sections of the user guide to spell out that ``min`` / ``max`` / ``resolution`` default to the nanosecond limits when accessed on the class, but adapt to the instance's ``unit`` when accessed on an instance. Adds a second-resolution example to each.
- Updates the ``Timestamp.min/max/resolution`` and ``Timedelta.min/max/resolution`` docstrings with the same class-vs-instance framing and an instance-resolution example.
- Notes in the timeseries user guide that ``Timestamp`` construction from a value outside the nanosecond range now picks a coarser unit automatically rather than raising ``OutOfBoundsDatetime`` (the exact surprise reported in #52164).

No behavior change.

## Test plan

- [x] ``pytest --doctest-cython pandas/_libs/tslibs/timestamps.pyx pandas/_libs/tslibs/timedeltas.pyx`` — all new/changed doctests pass (one pre-existing unrelated ``to_julian_date`` failure).
- [ ] docbuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)