### PR TITLE
BUG: Fix AttributeError in concat when result is Series

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -486,7 +486,9 @@ def concat(
         else:
             non_concat_axis = [obj.index for obj in objs]
         no_sort_result_index = union_indexes(non_concat_axis, sort=False)
-        orig = result.index if orig_axis == 1 else result.columns
+        orig = result.index if orig_axis == 1 else (
+                result.columns if hasattr(result, "columns") else result.index
+            )
         if not no_sort_result_index.equals(orig):
             msg = (
                 "Sorting by default when concatenating all DatetimeIndex is "

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -486,9 +486,11 @@ def concat(
         else:
             non_concat_axis = [obj.index for obj in objs]
         no_sort_result_index = union_indexes(non_concat_axis, sort=False)
-        orig = result.index if orig_axis == 1 else (
-                result.columns if hasattr(result, "columns") else result.index
-            )
+        orig = (
+            result.index
+            if orig_axis == 1
+            else (result.columns if hasattr(result, "columns") else result.index)
+        )
         if not no_sort_result_index.equals(orig):
             msg = (
                 "Sorting by default when concatenating all DatetimeIndex is "


### PR DESCRIPTION
## Fix pandas-dev/pandas#65333

**Bug**: `Series.combine_first` fails when `other.Series.name` is a Timestamp that sorts before `self.Series.name`.

**Error**:
```
AttributeError: 'Series' object has no attribute 'columns'
```

**Root Cause**: In `concat.py:489`, when `orig_axis == 0` and result is a Series (not DataFrame), the code tries to access `result.columns` which doesn't exist on Series objects.

**Fix**: Add `hasattr` check to fallback to `result.index` for Series objects.

```python
# Before
orig = result.index if orig_axis == 1 else result.columns

# After
orig = result.index if orig_axis == 1 else (
    result.columns if hasattr(result, "columns") else result.index
)
```

**Testing**:
```python
s1 = pd.Series([0], name=pd.to_datetime('2026'))
s3 = pd.Series([1,3], name=pd.to_datetime('2025'))
# Previously failed with AttributeError, now works
result = s1.combine_first(s3)  # ✅ Success
```

---
Closes #65333