### PR TITLE
PERF: Use SSE2 and Neon instructions to reduce moments

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -258,6 +258,47 @@ jobs:
           pytest_marker_expression: 'not slow and not db and not network and not single_cpu'
           pytest_target: 'pandas'
 
+  Ubuntu-no-SIMD:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 90
+    name: Ubuntu (no SIMD)
+    concurrency:
+      # https://github.community/t/concurrecy-not-work-for-push/183068/7
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-ubuntu-no-simd
+      cancel-in-progress: true
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        fetch-depth: 0
+
+    - name: Create virtual environment with Pixi
+      uses: ./.github/actions/setup-pixi
+      with:
+        environment: py313
+
+    - name: Build pandas
+      id: build
+      run: |
+        pixi run \
+          --environment py313 \
+          build-pandas \
+          --editable \
+          -Csetup-args="--werror" -- \
+          -Csetup-args="-Dsimd=disabled"
+      shell: bash -euox pipefail {0}
+
+    - name: Test
+      uses: ./.github/actions/run-tests
+      with:
+        environment: py313
+        numprocesses: 'auto'
+        pytest_marker_expression: 'not slow and not db and not network and not single_cpu'
+        pytest_target: 'pandas'
+
   Linux-32-bit:
     runs-on: ubuntu-24.04
     permissions:

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,5 @@
+option(
+    'simd',
+    type: 'feature',
+    description: 'Compile with SIMD instructions',
+)

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -6,6 +6,7 @@ from libc.math cimport (
 from numpy cimport (
     float64_t,
     int64_t,
+    uint8_t,
 )
 
 from pandas._libs.dtypes cimport (
@@ -48,6 +49,22 @@ cdef inline void moments_add_value(
         m3[0] += delta_n * (term1 * (n - 2.0) - 3.0 * m2[0])
     m2[0] += term1
     mean[0] += delta_n
+
+
+cdef extern from "pandas/moments.h":
+    ctypedef struct Moments:
+        int64_t n
+        float64_t mean
+        float64_t m2
+        float64_t m3
+        float64_t m4
+
+    Moments moments_reduce(
+            size_t n,
+            const double *values,
+            bint skipna,
+            const uint8_t *mask,
+            int max_moment) noexcept nogil
 
 
 @cython.cdivision(True)

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1604,9 +1604,9 @@ def diff_2d(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef void accumulate_moments_scalar(
-    const float64_t[:] values,
+    const float64_t[::1] values,
     bint skipna,
-    const uint8_t[:] mask,
+    const uint8_t[::1] mask,
     int64_t* nobs,
     float64_t* mean,
     float64_t* m2,
@@ -1615,17 +1615,20 @@ cdef void accumulate_moments_scalar(
     int max_moment,
 ) noexcept nogil:
     cdef:
-        Py_ssize_t i, n = len(values)
-        bint uses_mask = mask is not None
-        float64_t val
+        Moments moments
+        const float64_t* values_ptr = &values[0]
+        const uint8_t* mask_ptr = &mask[0] if mask is not None else NULL
+        size_t n = <size_t>values.shape[0]
 
-    for i in range(n):
-        val = values[i]
-        if uses_mask and mask[i]:
-            val = NaN
-        if skipna and isnan(val):
-            continue
-        moments_add_value(val, nobs, mean, m2, m3, m4, max_moment)
+    moments = moments_reduce(n, values_ptr, skipna, mask_ptr, max_moment)
+    if max_moment >= 4:
+        m4[0] = moments.m4
+    if max_moment >= 3:
+        m3[0] = moments.m3
+
+    m2[0] = moments.m2
+    mean[0] = moments.mean
+    nobs[0] = <int64_t>moments.n
 
 
 @cython.boundscheck(False)
@@ -1677,9 +1680,9 @@ cdef void accumulate_moments_axis(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def scalar_skew(
-    const float64_t[:] values,
+    const float64_t[::1] values,
     bint skipna,
-    const uint8_t[:] mask,
+    const uint8_t[::1] mask,
 ) -> float:
     cdef:
         int64_t nobs = 0
@@ -1694,9 +1697,9 @@ def scalar_skew(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def scalar_kurt(
-    const float64_t[:] values,
+    const float64_t[::1] values,
     bint skipna,
-    const uint8_t[:] mask,
+    const uint8_t[::1] mask,
 ) -> float:
     cdef:
         int64_t nobs = 0

--- a/pandas/_libs/include/pandas/moments.h
+++ b/pandas/_libs/include/pandas/moments.h
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2026, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  uint64_t n;
+  double mean;
+  double m2;
+  double m3;
+  double m4;
+} Moments;
+
+static inline void moments_add_valuem(Moments *moments, double val,
+                                      int max_moment) {
+  double delta = val - moments->mean;
+  moments->n++;
+  double n = (double)moments->n;
+  double delta_n = delta / n;
+  double term1 = delta * delta_n * (n - 1.0);
+
+  if (max_moment >= 4) {
+    moments->m4 +=
+        delta_n *
+        (-4.0 * moments->m3 +
+         delta_n * (6.0 * moments->m2 + term1 * (n * n - 3.0 * n + 3.0)));
+  }
+  if (max_moment >= 3) {
+    moments->m3 += delta_n * (term1 * (n - 2.0) - 3.0 * moments->m2);
+  }
+  moments->m2 += term1;
+  moments->mean += delta_n;
+}
+
+void moments_merge(Moments *acc, const Moments *src, int max_moment);
+
+/// Compute central moments until `max_moment` using `n` elements from `values`.
+Moments moments_reduce(size_t n, const double *values, bool skipna,
+                       const uint8_t *mask, int max_moment);
+#ifdef __cplusplus
+}
+#endif

--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -56,11 +56,26 @@ fast_float_dep = fast_float.get_variable('fast_float_dep')
 
 subdir('tslibs')
 
+moments_impl = 'src/moments_scalar.c'
+if get_option('simd').allowed()
+    if host_machine.cpu_family() == 'x86_64'
+        moments_impl = 'src/moments_sse2.c'
+    elif host_machine.cpu_family() == 'aarch64'
+        moments_impl = 'src/moments_neon.c'
+    endif
+endif
+
 libs_sources = {
     # Dict of extension name -> dict of {sources, include_dirs, and deps}
     # numpy include dir is implicitly included
     'algos': {
-        'sources': ['algos.pyx', _algos_common_helper, _algos_take_helper],
+        'sources': [
+            'algos.pyx',
+            'src/moments.c',
+            moments_impl,
+            _algos_common_helper,
+            _algos_take_helper,
+        ],
         'deps': [_khash_primitive_helper_dep, m_dep],
     },
     'arrays': {'sources': ['arrays.pyx']},

--- a/pandas/_libs/src/moments.c
+++ b/pandas/_libs/src/moments.c
@@ -1,0 +1,48 @@
+/*
+Copyright (c) 2026, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+#include "pandas/moments.h"
+#include <stdint.h>
+
+/// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
+void moments_merge(Moments *acc, const Moments *src, int max_moment) {
+  if (acc->n == 0) {
+    acc->n = src->n;
+    acc->mean = src->mean;
+    acc->m2 = src->m2;
+    acc->m3 = src->m3;
+    acc->m4 = src->m4;
+    return;
+  }
+  if (src->n == 0) {
+    return;
+  }
+
+  double n_a = (double)acc->n;
+  double n_b = (double)src->n;
+  acc->n += src->n;
+  double delta = src->mean - acc->mean;
+  double delta_n = delta / (double)acc->n;
+  double term1 = delta * delta_n * n_a * n_b;
+
+  if (max_moment >= 4) {
+    acc->m4 +=
+        src->m4 +
+        delta_n *
+            (4.0 * (n_a * src->m3 - n_b * acc->m3) +
+             delta_n * (6.0 * (n_a * n_a * src->m2 + n_b * n_b * acc->m2) +
+                        term1 * (n_a * n_a - n_a * n_b + n_b * n_b)));
+  }
+  if (max_moment >= 3) {
+    acc->m3 += src->m3 + delta_n * (3.0 * (n_a * src->m2 - n_b * acc->m2) +
+                                    term1 * (n_a - n_b));
+  }
+  acc->m2 += src->m2 + term1;
+  acc->mean += delta_n * n_b;
+}

--- a/pandas/_libs/src/moments_neon.c
+++ b/pandas/_libs/src/moments_neon.c
@@ -1,0 +1,119 @@
+/*
+Copyright (c) 2026, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+#include "pandas/moments.h"
+#include <arm_neon.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+Moments moments_reduce(size_t n, const double *values, bool skipna,
+                       const uint8_t *mask, int max_moment) {
+  float64x2_t mean = vdupq_n_f64(0.0);
+  float64x2_t m2 = vdupq_n_f64(0.0);
+  float64x2_t m3 = vdupq_n_f64(0.0);
+  float64x2_t m4 = vdupq_n_f64(0.0);
+  float64x2_t nobs = vdupq_n_f64(0.0);
+
+  float64x2_t one = vdupq_n_f64(1.0);
+  float64x2_t two = vdupq_n_f64(2.0);
+  float64x2_t three = vdupq_n_f64(3.0);
+  float64x2_t six = vdupq_n_f64(6.0);
+  float64x2_t minus_four = vdupq_n_f64(-4.0);
+
+  size_t vecsize = n - (n % 2);
+  for (size_t i = 0; i < vecsize; i += 2) {
+    float64x2_t val = vld1q_f64(values + i);
+
+    if (mask) {
+      double m_hi = mask[i + 1] == 0 ? 0.0 : NAN;
+      double m_lo = mask[i] == 0 ? 0.0 : NAN;
+      float64x2_t m_nan_mask = {m_lo, m_hi};
+      // NaN will propagate to val
+      val = vaddq_f64(val, m_nan_mask);
+    }
+
+    // vceqq_f64 returns all ones if val == val (not NaN)
+    uint64x2_t is_valid_mask = vceqq_f64(val, val);
+
+    if (!skipna) {
+      if (!vgetq_lane_u64(is_valid_mask, 0) ||
+          !vgetq_lane_u64(is_valid_mask, 1)) {
+        return (Moments){(uint64_t)n, NAN, NAN, NAN, NAN};
+      }
+    }
+
+    float64x2_t n_inc = vreinterpretq_f64_u64(
+        vandq_u64(is_valid_mask, vreinterpretq_u64_f64(one)));
+    nobs = vaddq_f64(nobs, n_inc);
+
+    // avoid division by zero
+    float64x2_t nobs_nonzero = vmaxq_f64(nobs, one);
+
+    float64x2_t delta = vsubq_f64(val, mean);
+    // Zero out delta for skipped elements so they don't affect moments
+    delta = vreinterpretq_f64_u64(
+        vandq_u64(is_valid_mask, vreinterpretq_u64_f64(delta)));
+
+    float64x2_t delta_n = vdivq_f64(delta, nobs_nonzero);
+    float64x2_t term1 =
+        vmulq_f64(delta, vmulq_f64(delta_n, vsubq_f64(nobs, one)));
+
+    if (max_moment >= 4) {
+      float64x2_t n2 = vmulq_f64(nobs, nobs);
+      float64x2_t n_term =
+          vaddq_f64(vsubq_f64(n2, vmulq_f64(three, nobs)), three);
+      float64x2_t m4_update = vmulq_f64(
+          delta_n,
+          vaddq_f64(vmulq_f64(minus_four, m3),
+                    vmulq_f64(delta_n, vaddq_f64(vmulq_f64(six, m2),
+                                                 vmulq_f64(term1, n_term)))));
+      m4 = vaddq_f64(m4, m4_update);
+    }
+
+    if (max_moment >= 3) {
+      float64x2_t m3_update =
+          vmulq_f64(delta_n, vsubq_f64(vmulq_f64(term1, vsubq_f64(nobs, two)),
+                                       vmulq_f64(three, m2)));
+      m3 = vaddq_f64(m3, m3_update);
+    }
+
+    m2 = vaddq_f64(m2, term1);
+    mean = vaddq_f64(mean, delta_n);
+  }
+
+  double n_arr[2], mean_arr[2], m2_arr[2], m3_arr[2], m4_arr[2];
+  vst1q_f64(n_arr, nobs);
+  vst1q_f64(mean_arr, mean);
+  vst1q_f64(m2_arr, m2);
+  vst1q_f64(m3_arr, m3);
+  vst1q_f64(m4_arr, m4);
+
+  Moments moments_arr[2];
+  for (int j = 0; j < 2; j++) {
+    moments_arr[j] = (Moments){(uint64_t)n_arr[j], mean_arr[j], m2_arr[j],
+                               m3_arr[j], m4_arr[j]};
+  }
+
+  // Handle last element
+  if (n & 1ULL) {
+    double val = values[vecsize];
+    if (mask && mask[vecsize])
+      val = NAN;
+
+    if (!isnan(val)) {
+      moments_add_valuem(&moments_arr[1], val, max_moment);
+    } else if (!skipna) {
+      return (Moments){(uint64_t)n, NAN, NAN, NAN, NAN};
+    }
+  }
+
+  moments_merge(&moments_arr[0], &moments_arr[1], max_moment);
+  return moments_arr[0];
+}

--- a/pandas/_libs/src/moments_scalar.c
+++ b/pandas/_libs/src/moments_scalar.c
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2026, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+#include "pandas/moments.h"
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+Moments moments_reduce(size_t n, const double *values, bool skipna,
+                       const uint8_t *mask, int max_moment) {
+  Moments acc = {0};
+  for (size_t i = 0; i < n; ++i) {
+    double val = values[i];
+    if (mask && mask[i])
+      val = NAN;
+
+    if (!isnan(val)) {
+      moments_add_valuem(&acc, val, max_moment);
+    } else if (!skipna) {
+      return (Moments){(uint64_t)n, NAN, NAN, NAN, NAN};
+    }
+  }
+  return acc;
+}

--- a/pandas/_libs/src/moments_sse2.c
+++ b/pandas/_libs/src/moments_sse2.c
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2026, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+#include "pandas/moments.h"
+#include <emmintrin.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+static __m128d get_nan_mask(const uint8_t *mask) {
+  double m_hi = mask[1] == 0 ? 0.0 : NAN;
+  double m_lo = mask[0] == 0 ? 0.0 : NAN;
+  return _mm_set_pd(m_hi, m_lo);
+}
+
+static void update_accumulators(int max_moment, __m128d val, __m128d skip_mask,
+                                __m128d *nobs, __m128d *mean, __m128d *m2,
+                                __m128d *m3, __m128d *m4) {
+  const __m128d one = _mm_set1_pd(1.0);
+  const __m128d two = _mm_set1_pd(2.0);
+  const __m128d three = _mm_set1_pd(3.0);
+  const __m128d six = _mm_set1_pd(6.0);
+  const __m128d minus_four = _mm_set1_pd(-4.0);
+
+  const __m128d n_inc = _mm_andnot_pd(skip_mask, one);
+  *nobs = _mm_add_pd(*nobs, n_inc);
+
+  // avoid division by zero
+  const __m128d nobs_nonzero = _mm_max_pd(*nobs, one);
+
+  __m128d delta = _mm_sub_pd(val, *mean);
+  // Zero out delta for skipped elements so they don't affect moments
+  delta = _mm_andnot_pd(skip_mask, delta);
+
+  const __m128d delta_n = _mm_div_pd(delta, nobs_nonzero);
+  const __m128d term1 =
+      _mm_mul_pd(delta, _mm_mul_pd(delta_n, _mm_sub_pd(*nobs, one)));
+
+  if (max_moment >= 4) {
+    const __m128d n2 = _mm_mul_pd(*nobs, *nobs);
+    const __m128d n_term =
+        _mm_add_pd(_mm_sub_pd(n2, _mm_mul_pd(three, *nobs)), three);
+    const __m128d m4_update = _mm_mul_pd(
+        delta_n,
+        _mm_add_pd(_mm_mul_pd(minus_four, *m3),
+                   _mm_mul_pd(delta_n, _mm_add_pd(_mm_mul_pd(six, *m2),
+                                                  _mm_mul_pd(term1, n_term)))));
+    *m4 = _mm_add_pd(*m4, m4_update);
+  }
+
+  if (max_moment >= 3) {
+    const __m128d m3_update = _mm_mul_pd(
+        delta_n, _mm_sub_pd(_mm_mul_pd(term1, _mm_sub_pd(*nobs, two)),
+                            _mm_mul_pd(three, *m2)));
+    *m3 = _mm_add_pd(*m3, m3_update);
+  }
+
+  *m2 = _mm_add_pd(*m2, term1);
+  *mean = _mm_add_pd(*mean, delta_n);
+}
+
+static void store_accumulators_in_struct(Moments dst[2], __m128d nobs,
+                                         __m128d mean, __m128d m2, __m128d m3,
+                                         __m128d m4) {
+  double n_arr[2], mean_arr[2], m2_arr[2], m3_arr[2], m4_arr[2];
+  _mm_storeu_pd(n_arr, nobs);
+  _mm_storeu_pd(mean_arr, mean);
+  _mm_storeu_pd(m2_arr, m2);
+  _mm_storeu_pd(m3_arr, m3);
+  _mm_storeu_pd(m4_arr, m4);
+
+  for (int j = 0; j < 2; j++) {
+    dst[j].n = (uint64_t)n_arr[j];
+    dst[j].mean = mean_arr[j];
+    dst[j].m2 = m2_arr[j];
+    dst[j].m3 = m3_arr[j];
+    dst[j].m4 = m4_arr[j];
+  }
+}
+
+Moments moments_reduce(size_t n, const double *values, bool skipna,
+                       const uint8_t *mask, int max_moment) {
+  __m128d nobs = _mm_setzero_pd();
+  __m128d mean = _mm_setzero_pd();
+  __m128d m2 = _mm_setzero_pd();
+  __m128d m3 = _mm_setzero_pd();
+  __m128d m4 = _mm_setzero_pd();
+
+  size_t vecsize = n - (n % 2);
+  for (size_t i = 0; i < vecsize; i += 2) {
+    __m128d val = _mm_loadu_pd(values + i);
+
+    if (mask) {
+      // NaN will propagate to val
+      const __m128d m_nan_mask = get_nan_mask(mask + i);
+      val = _mm_add_pd(val, m_nan_mask);
+    }
+
+    __m128d is_nan = _mm_cmpneq_pd(val, val);
+
+    if (!skipna) {
+      const bool contains_nan = _mm_movemask_pd(is_nan) != 0;
+      if (contains_nan) {
+        return (Moments){(uint64_t)n, NAN, NAN, NAN, NAN};
+      }
+    }
+
+    const __m128d skip_mask = is_nan;
+    update_accumulators(max_moment, val, skip_mask, &nobs, &mean, &m2, &m3,
+                        &m4);
+  }
+
+  Moments moments_arr[2];
+  store_accumulators_in_struct(moments_arr, nobs, mean, m2, m3, m4);
+
+  // Handle last element
+  if (n % 2 == 1) {
+    double val = values[vecsize];
+    if (mask && mask[vecsize])
+      val = NAN;
+
+    if (!isnan(val)) {
+      moments_add_valuem(&moments_arr[1], val, max_moment);
+    } else if (!skipna) {
+      return (Moments){(uint64_t)n, NAN, NAN, NAN, NAN};
+    }
+  }
+
+  moments_merge(&moments_arr[0], &moments_arr[1], max_moment);
+  return moments_arr[0];
+}


### PR DESCRIPTION
- [x] xref #64884 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
  - The neon instructions were created by Gemini.

---

I think this satisfies most of the ideas for the initial SIMD implementation:

- [x] Creates an option to disable SIMD
- [x] Creates a CI job with SIMD disabled.
- [x] Use only the baseline instruction set: SSE2 for x86_64 and Neon for aarch64.

---

## Benchmark Results with SSE2

<details><summary>Details</summary>
<p>

| Change | Before [01630127] <perf/reduce-moments-simd-intrinsics~1> | After [d5692a37] <perf/reduce-moments-simd-intrinsics> | Ratio | Benchmark (Parameter)                                                                  |
| ------ | --------------------------------------------------------- | ------------------------------------------------------ | ----- | -------------------------------------------------------------------------------------- |
| +      | 2.25±0.05ms                                               | 2.79±0.4ms                                             | 1.24  | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'kurt')             |
| +      | 2.01±0.04ms                                               | 2.49±0.2ms                                             | 1.24  | rolling.Methods.time_method('DataFrame', ('expanding', {}), 'int', 'skew')             |
| +      | 2.88±0.4ms                                                | 3.52±0.4ms                                             | 1.22  | rolling.Methods.time_method('DataFrame', ('rolling', {'window': 10}), 'float', 'kurt') |
| +      | 3.27±0.08ms                                               | 3.82±0.4ms                                             | 1.17  | rolling.VariableWindowMethods.time_method('DataFrame', '50s', 'int', 'skew')           |
| +      | 14.3±2ms                                                  | 16.6±4ms                                               | 1.16  | stat_ops.FrameOps.time_op('kurt', 'float', 1)                                          |
| +      | 3.07±0.1ms                                                | 3.51±0.2ms                                             | 1.14  | rolling.ForwardWindowMethods.time_rolling('Series', 1000, 'float', 'kurt')             |
| +      | 2.80±0.2ms                                                | 3.13±0.3ms                                             | 1.12  | rolling.Methods.time_method('Series', ('rolling', {'window': 10}), 'float', 'skew')    |
| -      | 3.74±0.09ms                                               | 3.39±0.2ms                                             | 0.91  | rolling.VariableWindowMethods.time_method('Series', '1d', 'float', 'kurt')             |
| -      | 29.0±0.6ms                                                | 26.2±2ms                                               | 0.91  | stat_ops.FrameOps.time_op('kurt', 'Int64', 1)                                          |
| -      | 3.89±0.2ms                                                | 3.49±0.08ms                                            | 0.9   | rolling.VariableWindowMethods.time_method('Series', '50s', 'float', 'kurt')            |
| -      | 3.62±0.2ms                                                | 3.14±0.2ms                                             | 0.87  | rolling.VariableWindowMethods.time_method('Series', '1h', 'float', 'skew')             |
| -      | 107±20μs                                                  | 92.3±5μs                                               | 0.86  | groupby.GroupByMethods.time_dtype_as_group('float', 'skew', 'direct', 1, 'cython')     |
| -      | 4.20±0.2ms                                                | 3.53±0.1ms                                             | 0.84  | rolling.VariableWindowMethods.time_method('Series', '1d', 'int', 'kurt')               |
| -      | 21.6±3μs                                                  | 17.7±3μs                                               | 0.82  | series_methods.NanOps.time_func('skew', 1000, 'int32')                                 |
| -      | 110±20μs                                                  | 87.3±10μs                                              | 0.79  | groupby.GroupByMethods.time_dtype_as_group('uint', 'skew', 'direct', 1, 'cython')      |
| -      | 4.02±0.2ms                                                | 3.17±0.06ms                                            | 0.79  | rolling.VariableWindowMethods.time_method('Series', '50s', 'int', 'skew')              |
| -      | 20.4±1μs                                                  | 16.2±2μs                                               | 0.79  | series_methods.NanOps.time_func('skew', 1000, 'int8')                                  |
| -      | 20.2±2μs                                                  | 15.4±0.8μs                                             | 0.76  | series_methods.NanOps.time_func('kurt', 1000, 'int8')                                  |
| -      | 21.9±3μs                                                  | 16.2±0.7μs                                             | 0.74  | series_methods.NanOps.time_func('skew', 1000, 'int64')                                 |
| -      | 29.8±4μs                                                  | 21.8±3μs                                               | 0.73  | series_methods.NanOps.time_func('kurt', 1000, 'Int64')                                 |
| -      | 23.3±3μs                                                  | 16.7±2μs                                               | 0.72  | series_methods.NanOps.time_func('kurt', 1000, 'int32')                                 |
| -      | 30.9±3μs                                                  | 22.0±4μs                                               | 0.71  | series_methods.NanOps.time_func('kurt', 1000, 'boolean')                               |
| -      | 7.65±0.04ms                                               | 5.33±0.6ms                                             | 0.7   | series_methods.NanOps.time_func('skew', 1000000, 'Int64')                              |
| -      | 2.89±0.4ms                                                | 2.01±0.04ms                                            | 0.7   | stat_ops.FrameOps.time_op('kurt', 'float', None)                                       |
| -      | 2.88±0.1ms                                                | 2.02±0.03ms                                            | 0.7   | stat_ops.FrameOps.time_op('skew', 'float', 0)                                          |
| -      | 24.6±3μs                                                  | 17.1±2μs                                               | 0.69  | series_methods.NanOps.time_func('kurt', 1000, 'float64')                               |
| -      | 24.9±3μs                                                  | 17.2±1μs                                               | 0.69  | series_methods.NanOps.time_func('kurt', 1000, 'int64')                                 |
| -      | 25.3±2μs                                                  | 17.6±3μs                                               | 0.69  | series_methods.NanOps.time_func('skew', 1000, 'boolean')                               |
| -      | 3.58±0.6ms                                                | 2.45±0.1ms                                             | 0.69  | stat_ops.FrameOps.time_op('skew', 'int', 0)                                            |
| -      | 4.30±0.5ms                                                | 2.91±0.04ms                                            | 0.68  | stat_ops.FrameOps.time_op('skew', 'Int64', None)                                       |
| -      | 4.51±0.1ms                                                | 3.04±0.2ms                                             | 0.67  | stat_ops.FrameOps.time_op('skew', 'int', None)                                         |
| -      | 3.42±0.4ms                                                | 2.20±0.1ms                                             | 0.64  | stat_ops.FrameOps.time_op('kurt', 'float', 0)                                          |
| -      | 4.30±0.05ms                                               | 2.74±0.1ms                                             | 0.64  | stat_ops.FrameOps.time_op('skew', 'Int64', 0)                                          |
| -      | 28.6±2μs                                                  | 18.1±3μs                                               | 0.63  | series_methods.NanOps.time_func('skew', 1000, 'Int64')                                 |
| -      | 3.78±0.4ms                                                | 2.39±0.03ms                                            | 0.63  | stat_ops.FrameOps.time_op('kurt', 'int', 0)                                            |
| -      | 3.20±0.4ms                                                | 2.01±0.1ms                                             | 0.63  | stat_ops.FrameOps.time_op('skew', 'float', None)                                       |
| -      | 779±30μs                                                  | 492±60μs                                               | 0.63  | stat_ops.SeriesOps.time_op('kurt', 'int')                                              |
| -      | 7.67±0.3ms                                                | 4.77±0.5ms                                             | 0.62  | series_methods.NanOps.time_func('skew', 1000000, 'boolean')                            |
| -      | 9.59±1ms                                                  | 5.81±0.4ms                                             | 0.61  | series_methods.NanOps.time_func('kurt', 1000000, 'Int64')                              |
| -      | 4.70±0.05ms                                               | 2.88±0.2ms                                             | 0.61  | stat_ops.FrameOps.time_op('kurt', 'Int64', None)                                       |
| -      | 4.36±0.4ms                                                | 2.66±0.4ms                                             | 0.61  | stat_ops.FrameOps.time_op('kurt', 'int', None)                                         |
| -      | 8.97±0.9ms                                                | 5.42±0.4ms                                             | 0.6   | series_methods.NanOps.time_func('kurt', 1000000, 'boolean')                            |
| -      | 24.6±2μs                                                  | 14.7±1μs                                               | 0.6   | series_methods.NanOps.time_func('skew', 1000, 'float64')                               |
| -      | 10.4±0.3ms                                                | 6.03±0.2ms                                             | 0.58  | series_methods.NanOps.time_func('kurt', 1000000, 'int64')                              |
| -      | 8.49±1ms                                                  | 4.88±0.5ms                                             | 0.58  | series_methods.NanOps.time_func('skew', 1000000, 'int32')                              |
| -      | 3.58±0.4ms                                                | 2.06±0.2ms                                             | 0.58  | stat_ops.FrameMultiIndexOps.time_op('kurt')                                            |
| -      | 10.3±0.3ms                                                | 5.70±0.3ms                                             | 0.55  | series_methods.NanOps.time_func('kurt', 1000000, 'int32')                              |
| -      | 4.42±0.07ms                                               | 2.39±0.3ms                                             | 0.54  | stat_ops.FrameOps.time_op('kurt', 'Int64', 0)                                          |
| -      | 10.1±0.2ms                                                | 5.39±0.07ms                                            | 0.53  | series_methods.NanOps.time_func('kurt', 1000000, 'int8')                               |
| -      | 9.17±0.6ms                                                | 4.74±0.5ms                                             | 0.52  | series_methods.NanOps.time_func('skew', 1000000, 'int8')                               |
| -      | 3.61±0.3ms                                                | 1.88±0.2ms                                             | 0.52  | stat_ops.FrameMultiIndexOps.time_op('skew')                                            |
| -      | 9.14±1ms                                                  | 4.64±0.2ms                                             | 0.51  | series_methods.NanOps.time_func('skew', 1000000, 'int64')                              |
| -      | 8.88±0.1ms                                                | 4.37±0.3ms                                             | 0.49  | series_methods.NanOps.time_func('kurt', 1000000, 'float64')                            |
| -      | 7.17±0.3ms                                                | 3.53±0.5ms                                             | 0.49  | series_methods.NanOps.time_func('skew', 1000000, 'float64')                            |
| -      | 960±10μs                                                  | 474±60μs                                               | 0.49  | stat_ops.SeriesOps.time_op('skew', 'int')                                              |
| -      | 925±30μs                                                  | 443±60μs                                               | 0.48  | stat_ops.SeriesOps.time_op('kurt', 'float')                                            |
| -      | 893±8μs                                                   | 427±60μs                                               | 0.48  | stat_ops.SeriesOps.time_op('skew', 'float')                                            |
| -      | 891±6μs                                                   | 414±60μs                                               | 0.46  | stat_ops.SeriesMultiIndexOps.time_op('skew')                                           |
| -      | 921±10μs                                                  | 372±4μs                                                | 0.4   | stat_ops.SeriesMultiIndexOps.time_op('kurt')                                           |


</p>
</details> 