### PR TITLE
DEPR: followup warn on .at setitem when a new column expands the frame

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -819,7 +819,7 @@ You can also set using these same indexers.
 
 .. ipython:: python
 
-   df.at[dates[5], 'E'] = 7
+   df.at[dates[5], 'A'] = 7
    df.iat[3, 0] = 7
 
 ``at`` previously could enlarge the object in-place if the indexer was missing,

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -3223,33 +3223,36 @@ class _AtIndexer(_ScalarAccessIndexer):
         if self.ndim == 2:
             if not isinstance(key, tuple) or len(key) != 2:
                 return
-            check_key = key[0]
+            checks = [(key[0], self.obj.index), (key[1], self.obj.columns)]
         else:
             check_key = key
             if isinstance(key, tuple) and len(key) == 1:
                 check_key = key[0]
+            checks = [(check_key, self.obj.index)]
 
-        # Only check for scalar-like keys (including tuples for MultiIndex).
-        # Slices and list-likes are invalid for .at and will raise elsewhere.
-        if isinstance(check_key, slice) or is_list_like_indexer(check_key):
-            if not isinstance(check_key, tuple):
+        for check_key, axis in checks:
+            # Only check for scalar-like keys (including tuples for MultiIndex).
+            # Slices and list-likes are invalid for .at and will raise elsewhere.
+            if isinstance(check_key, slice) or is_list_like_indexer(check_key):
+                if not isinstance(check_key, tuple):
+                    continue
+
+            try:
+                is_expanding = check_key not in axis
+            except (TypeError, InvalidIndexError):
+                continue
+
+            if is_expanding:
+                obj_type = "DataFrame" if self.ndim == 2 else "Series"
+                warnings.warn(
+                    f"Setting a value on a {obj_type} via .at with a key "
+                    "that does not exist in the index is deprecated "
+                    "and will raise a KeyError in a future version. "
+                    "Use .loc instead.",
+                    Pandas4Warning,
+                    stacklevel=find_stack_level(),
+                )
                 return
-
-        try:
-            is_expanding = check_key not in self.obj.index
-        except (TypeError, InvalidIndexError):
-            return
-
-        if is_expanding:
-            obj_type = "DataFrame" if self.ndim == 2 else "Series"
-            warnings.warn(
-                f"Setting a value on a {obj_type} via .at with a key "
-                "that does not exist in the index is deprecated "
-                "and will raise a KeyError in a future version. "
-                "Use .loc instead.",
-                Pandas4Warning,
-                stacklevel=find_stack_level(),
-            )
 
     @property
     def _axes_are_unique(self) -> bool:

--- a/pandas/tests/indexing/test_at.py
+++ b/pandas/tests/indexing/test_at.py
@@ -195,6 +195,34 @@ class TestAtSetItemWithExpansion:
         expected = Series([1, 2, 6], index=[0, 1, 5])
         tm.assert_series_equal(ser, expected)
 
+    def test_at_setitem_expansion_deprecated_new_column(self):
+        # GH#48323 - new column (existing row) also expands
+        df = DataFrame({"a": [1, 2]})
+        msg = "Setting a value on a DataFrame via .at with a key"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            df.at[0, "b"] = 99
+        assert "b" in df.columns
+
+    def test_at_setitem_expansion_deprecated_new_column_multiindex_rows(self):
+        # GH#48323 - new column on a frame with MultiIndex rows
+        mi = MultiIndex.from_tuples([("a", 1), ("a", 2), ("b", 1)])
+        df = DataFrame({"x": [1, 2, 3]}, index=mi)
+        msg = "Setting a value on a DataFrame via .at with a key"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            df.at[("a", 1), "y"] = 99
+        assert "y" in df.columns
+
+    def test_at_setitem_expansion_deprecated_new_column_multiindex_cols(self):
+        # GH#48323 - new tuple column on a frame with MultiIndex columns
+        df = DataFrame(
+            [[1, 2], [3, 4]],
+            columns=MultiIndex.from_tuples([("a", 1), ("a", 2)]),
+        )
+        msg = "Setting a value on a DataFrame via .at with a key"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            df.at[0, ("b", 1)] = 99
+        assert ("b", 1) in df.columns
+
     def test_at_setitem_no_warning_existing_key(self):
         # GH#48323 - no warning for existing keys
         df = DataFrame({"a": [1, 2]})


### PR DESCRIPTION
## Summary

Follow-up to GH#48323 / #64753. The deprecation warning added in `_AtIndexer._warn_if_expanding` only checked the row axis, so `df.at[existing_row, new_col] = val` silently expanded the columns without firing the `Pandas4Warning`.

- `_warn_if_expanding` now checks both `key[0]` against `obj.index` and `key[1]` against `obj.columns` for ndim=2. First axis that would expand fires the warning; early return avoids double-warning when both are new.
- Added three tests in `TestAtSetItemWithExpansion` covering: new column on a plain-columns frame, new column on a frame with MultiIndex rows, and new tuple column on a frame with MultiIndex columns.

## Test plan

- [x] `pytest pandas/tests/indexing/test_at.py` — 49 passed
- [x] `pytest pandas/tests/indexing/ pandas/tests/test_multilevel.py pandas/tests/indexes/multi/test_get_set.py` — 4714 passed, 2 skipped, 22 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)