### PR TITLE
BUG: regression in bdate_range for end on weekend

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -15,6 +15,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed reading of Parquet files with timezone-aware timestamps or localizing of a timeseries with a ``pytz`` timezone when an older version of ``pytz`` was installed (:issue:`64978`)
+- Fixed regression in :func:`pandas.bdate_range` where specifying ``end`` on a weekend with ``periods`` returned fewer dates than expected (:issue:`64834`)
 - Fixed regression in :func:`to_timedelta` ignoring the ``unit`` argument for round float values when mixed with non-round floats in a list (:issue:`65150`)
 - Fixed regression in :meth:`Series.rank` with custom extension dtypes (:issue:`64976`)
 - Fixed regression in :meth:`Timedelta.round`, :meth:`Timedelta.floor`, and :meth:`Timedelta.ceil` raising ``ZeroDivisionError`` for sub-second ``freq`` (:issue:`64828`)
@@ -23,9 +24,7 @@ Fixed regressions
 .. _whatsnew_303.bug_fixes:
 
 Bug fixes
-^^^^^^^^^
-- Fixed regression in :func:`pandas.bdate_range` where specifying ``end`` on a weekend with ``periods`` returned fewer dates than expected (:issue:`64834`)
-
+~~~~~~~~~
 - Fixed :class:`ArrowDtype` string arithmetic for addition between ``string`` and ``large_string`` typed arrays (:issue:`65220`)
 - Fixed a bug in adding missing values (e.g. :attr:`NA`) to a pyarrow-backed string array or Series
   raising an error instead of propagating the missing value (:issue:`64968`)

--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -23,7 +23,8 @@ Fixed regressions
 .. _whatsnew_303.bug_fixes:
 
 Bug fixes
-~~~~~~~~~
+^^^^^^^^^
+- Fixed regression in :func:`pandas.bdate_range` where specifying ``end`` on a weekend with ``periods`` returned fewer dates than expected (:issue:`64834`)
 
 - Fixed :class:`ArrowDtype` string arithmetic for addition between ``string`` and ``large_string`` typed arrays (:issue:`65220`)
 - Fixed a bug in adding missing values (e.g. :attr:`NA`) to a pyarrow-backed string array or Series

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -3189,13 +3189,6 @@ def _generate_range(
     else:
         end = None
 
-    # GH #64834 FIX for bdate_range regression
-    if end is not None and periods is not None and not offset.is_on_offset(end):
-        if offset.n >= 0:
-            end = offset.rollback(end)  # type: ignore[assignment]
-        else:
-            end = offset.rollforward(end)  # type: ignore[assignment]
-
     if start and not offset.is_on_offset(start):
         # Incompatible types in assignment (expression has type "datetime",
         # variable has type "Optional[Timestamp]")

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -3189,6 +3189,13 @@ def _generate_range(
     else:
         end = None
 
+    # GH #64834 FIX for bdate_range regression
+    if end is not None and periods is not None and not offset.is_on_offset(end):
+        if offset.n >= 0:
+            end = offset.rollback(end)  # type: ignore[assignment]
+        else:
+            end = offset.rollforward(end)  # type: ignore[assignment]
+
     if start and not offset.is_on_offset(start):
         # Incompatible types in assignment (expression has type "datetime",
         # variable has type "Optional[Timestamp]")

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1185,6 +1185,18 @@ class TestBusinessDateRange:
         with pytest.raises(OutOfBoundsDatetime, match=msg):
             date_range(start, periods=2, freq="B", unit="ns")
 
+    def test_bdate_range_end_weekend_periods(self):
+        # GH#64834
+        result = bdate_range(end="2026-03-21", periods=3)
+        expected = DatetimeIndex(["2026-03-18", "2026-03-19", "2026-03-20"])
+        tm.assert_index_equal(result, expected)
+
+    def test_bdate_range_end_sunday_periods(self):
+        # GH#64834
+        result = bdate_range(end="2026-03-22", periods=3)
+        expected = DatetimeIndex(["2026-03-18", "2026-03-19", "2026-03-20"])
+        tm.assert_index_equal(result, expected)
+
 
 class TestCustomDateRange:
     def test_constructor(self):

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1191,10 +1191,7 @@ class TestBusinessDateRange:
         expected = DatetimeIndex(["2026-03-18", "2026-03-19", "2026-03-20"])
         tm.assert_index_equal(result, expected)
 
-    def test_bdate_range_end_sunday_periods(self):
-        # GH#64834
         result = bdate_range(end="2026-03-22", periods=3)
-        expected = DatetimeIndex(["2026-03-18", "2026-03-19", "2026-03-20"])
         tm.assert_index_equal(result, expected)
 
 


### PR DESCRIPTION
Redo of #64880 targeting main, just keeping the tests and whatsnew since the actual fix doesn't seem required anymore (bacause of https://github.com/pandas-dev/pandas/pull/64648)