### PR TITLE
CI: fix pixi.lock update workflow to handle PyPI deps

### DIFF
--- a/.github/workflows/update-pixi-lock.yml
+++ b/.github/workflows/update-pixi-lock.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Generate lock files
       id: check-lock-file
-      run: pixi update --no-install
+      run: pixi update
 
     # There should be an update since pixi.toml references nightly packages
     # or use https://github.com/prefix-dev/pixi/issues/5813


### PR DESCRIPTION
The last run (https://github.com/pandas-dev/pandas/actions/runs/24621591485/job/71993221998) was failing with

```
Error:   × failed to solve the pypi requirements of environment 'docs-and-web' for platform 'linux-aarch64'
  ╰─▶ build dispatch initialization failed: installation of conda environment is required to solve PyPI source dependencies but `--no-install` flag has been set
```