### PR TITLE
BUG: Fix df.query() with 'in' operator and column references (#65357)

### DIFF
--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -725,6 +725,22 @@ class BaseExprVisitor(ast.NodeVisitor):
         # base case: we have something like a CMP b
         if len(comps) == 1:
             op = self.translate_In(ops[0])
+            # GH#65357: Unroll `in` / `not in` into row-wise comparisons (== / !=)
+            # if the RHS tuple contains variables. This prevents passing Series
+            # objects to isin(), which strictly expects scalar iterables.
+            if isinstance(ops[0], (ast.In, ast.NotIn)) and isinstance(
+                comps[0], (ast.Tuple, ast.List)
+            ):
+                elts = comps[0].elts
+                if any(isinstance(e, ast.Name) for e in elts):
+                    cmp_op = ast.Eq() if isinstance(ops[0], ast.In) else ast.NotEq()
+                    bool_op = ast.Or() if isinstance(ops[0], ast.In) else ast.And()
+                    new_values = [
+                        ast.Compare(left=node.left, ops=[cmp_op], comparators=[elt])
+                        for elt in elts
+                    ]
+                    return self.visit(ast.BoolOp(op=bool_op, values=new_values))
+
             binop = ast.BinOp(op=op, left=node.left, right=comps[0])
             return self.visit(binop)
 

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -735,7 +735,7 @@ class BaseExprVisitor(ast.NodeVisitor):
                 if any(isinstance(e, ast.Name) for e in elts):
                     cmp_op = ast.Eq() if isinstance(ops[0], ast.In) else ast.NotEq()
                     bool_op = ast.Or() if isinstance(ops[0], ast.In) else ast.And()
-                    new_values = [
+                    new_values: list[ast.expr] = [
                         ast.Compare(left=node.left, ops=[cmp_op], comparators=[elt])
                         for elt in elts
                     ]

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1626,3 +1626,82 @@ class TestDataFrameQueryBacktickQuoting:
         result = df.query("a > @now")
         expected = DataFrame({"a": []}, dtype=object)
         tm.assert_frame_equal(result, expected)
+
+
+class TestDataFrameQueryInWithColumnRefs:
+    """GH#65357 - df.query('col in (col1, col2)') with column references."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_no_pandas_parser(self, parser):
+        if parser != "pandas":
+            pytest.skip(f"cannot evaluate with parser={parser}")
+
+    def test_in_column_refs_numeric_first_row(self, engine, parser):
+        # b==a in row 0 (1==1); no match in rows 1,2
+        df = DataFrame({"a": [1, 2, 3], "b": [1, 4, 9], "c": [1, 8, 27]})
+        res = df.query("b in (a, c)", engine=engine, parser=parser)
+        expec = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
+        tm.assert_frame_equal(res, expec)
+
+    def test_in_column_refs_numeric_all_rows(self, engine, parser):
+        # every row has b == a
+        df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [10, 20, 30]})
+        res = df.query("b in (a, c)", engine=engine, parser=parser)
+        expec = df  # all rows match via b==a
+        tm.assert_frame_equal(res, expec)
+
+    def test_in_column_refs_numeric_no_match(self, engine, parser):
+        df = DataFrame({"a": [1, 2, 3], "b": [5, 6, 7], "c": [10, 20, 30]})
+        res = df.query("b in (a, c)", engine=engine, parser=parser)
+        assert res.empty
+
+    def test_in_column_refs_string(self, engine, parser):
+        # previously raised ArrowInvalid
+        df = DataFrame(
+            {"a": ["a", "a", "b"], "b": ["a", "b", "c"], "c": ["b", "b", "c"]}
+        )
+        res = df.query("b in (a, c)", engine=engine, parser=parser)
+        expec = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
+        tm.assert_frame_equal(res, expec)
+
+    def test_in_column_refs_string_pyarrow(self, engine, parser):
+        pytest.importorskip("pyarrow")
+        df = DataFrame(
+            {"a": ["a", "a", "b"], "b": ["a", "b", "c"], "c": ["b", "b", "c"]},
+            dtype="string[pyarrow]"
+        )
+
+        # Expect a RuntimeWarning when the numexpr engine falls back to python
+        warning = RuntimeWarning if engine == "numexpr" else None
+        with tm.assert_produces_warning(warning):
+            res = df.query("b in (a, c)", engine=engine, parser=parser)
+
+        expec = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
+        tm.assert_frame_equal(res, expec)
+
+    def test_not_in_column_refs_numeric(self, engine, parser):
+        df = DataFrame({"a": [1, 2, 3], "b": [1, 4, 9], "c": [1, 8, 27]})
+        res = df.query("b not in (a, c)", engine=engine, parser=parser)
+        expec = df[(df["b"] != df["a"]) & (df["b"] != df["c"])]
+        tm.assert_frame_equal(res, expec)
+
+    def test_not_in_column_refs_string(self, engine, parser):
+        df = DataFrame(
+            {"a": ["x", "y", "z"], "b": ["a", "y", "z"], "c": ["b", "b", "c"]}
+        )
+        res = df.query("b not in (a, c)", engine=engine, parser=parser)
+        expec = df[(df["b"] != df["a"]) & (df["b"] != df["c"])]
+        tm.assert_frame_equal(res, expec)
+
+    def test_in_column_ref_and_literal(self, engine, parser):
+        # `b in (a, 99)` — one Name, one Constant
+        df = DataFrame({"a": [1, 2, 3], "b": [1, 99, 5]})
+        res = df.query("b in (a, 99)", engine=engine, parser=parser)
+        expec = df[(df["b"] == df["a"]) | (df["b"] == 99)]
+        tm.assert_frame_equal(res, expec)
+
+    def test_in_pure_literals_unchanged(self, engine, parser):
+        df = DataFrame({"a": [1, 2, 3, 4]})
+        res = df.query("a in (2, 3)", engine=engine, parser=parser)
+        expec = df[df["a"].isin([2, 3])]
+        tm.assert_frame_equal(res, expec)

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1629,7 +1629,7 @@ class TestDataFrameQueryBacktickQuoting:
 
 
 class TestDataFrameQueryInWithColumnRefs:
-    """GH#65357 - df.query('col in (col1, col2)') with column references."""
+    # GH#65357 - df.query('col in (col1, col2)') with column references.
 
     @pytest.fixture(autouse=True)
     def skip_if_no_pandas_parser(self, parser):
@@ -1637,71 +1637,72 @@ class TestDataFrameQueryInWithColumnRefs:
             pytest.skip(f"cannot evaluate with parser={parser}")
 
     def test_in_column_refs_numeric_first_row(self, engine, parser):
-        # b==a in row 0 (1==1); no match in rows 1,2
         df = DataFrame({"a": [1, 2, 3], "b": [1, 4, 9], "c": [1, 8, 27]})
-        res = df.query("b in (a, c)", engine=engine, parser=parser)
-        expec = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
-        tm.assert_frame_equal(res, expec)
+        result = df.query("b in (a, c)", engine=engine, parser=parser)
+        expected = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
+        tm.assert_frame_equal(result, expected)
 
     def test_in_column_refs_numeric_all_rows(self, engine, parser):
-        # every row has b == a
         df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [10, 20, 30]})
-        res = df.query("b in (a, c)", engine=engine, parser=parser)
-        expec = df  # all rows match via b==a
-        tm.assert_frame_equal(res, expec)
+        result = df.query("b in (a, c)", engine=engine, parser=parser)
+        expected = df
+        tm.assert_frame_equal(result, expected)
 
     def test_in_column_refs_numeric_no_match(self, engine, parser):
         df = DataFrame({"a": [1, 2, 3], "b": [5, 6, 7], "c": [10, 20, 30]})
-        res = df.query("b in (a, c)", engine=engine, parser=parser)
-        assert res.empty
+        result = df.query("b in (a, c)", engine=engine, parser=parser)
+        expected = df.iloc[:0]
+        tm.assert_frame_equal(result, expected)
 
     def test_in_column_refs_string(self, engine, parser):
-        # previously raised ArrowInvalid
         df = DataFrame(
             {"a": ["a", "a", "b"], "b": ["a", "b", "c"], "c": ["b", "b", "c"]}
         )
-        res = df.query("b in (a, c)", engine=engine, parser=parser)
-        expec = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
-        tm.assert_frame_equal(res, expec)
+        result = df.query("b in (a, c)", engine=engine, parser=parser)
+        expected = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
+        tm.assert_frame_equal(result, expected)
 
+    @td.skip_if_no("pyarrow")
     def test_in_column_refs_string_pyarrow(self, engine, parser):
-        pytest.importorskip("pyarrow")
         df = DataFrame(
             {"a": ["a", "a", "b"], "b": ["a", "b", "c"], "c": ["b", "b", "c"]},
             dtype="string[pyarrow]"
         )
 
-        # Expect a RuntimeWarning when the numexpr engine falls back to python
         warning = RuntimeWarning if engine == "numexpr" else None
-        with tm.assert_produces_warning(warning):
-            res = df.query("b in (a, c)", engine=engine, parser=parser)
+        msg = (
+            "Engine has switched to 'python' because numexpr does not "
+            "support extension array dtypes. Please set your engine "
+            "to python manually."
+        )
+        with tm.assert_produces_warning(warning, match=msg):
+            result = df.query("b in (a, c)", engine=engine, parser=parser)
 
-        expec = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
-        tm.assert_frame_equal(res, expec)
+        expected = df[(df["b"] == df["a"]) | (df["b"] == df["c"])]
+        tm.assert_frame_equal(result, expected)
 
     def test_not_in_column_refs_numeric(self, engine, parser):
         df = DataFrame({"a": [1, 2, 3], "b": [1, 4, 9], "c": [1, 8, 27]})
-        res = df.query("b not in (a, c)", engine=engine, parser=parser)
-        expec = df[(df["b"] != df["a"]) & (df["b"] != df["c"])]
-        tm.assert_frame_equal(res, expec)
+        result = df.query("b not in (a, c)", engine=engine, parser=parser)
+        expected = df[(df["b"] != df["a"]) & (df["b"] != df["c"])]
+        tm.assert_frame_equal(result, expected)
 
     def test_not_in_column_refs_string(self, engine, parser):
         df = DataFrame(
             {"a": ["x", "y", "z"], "b": ["a", "y", "z"], "c": ["b", "b", "c"]}
         )
-        res = df.query("b not in (a, c)", engine=engine, parser=parser)
-        expec = df[(df["b"] != df["a"]) & (df["b"] != df["c"])]
-        tm.assert_frame_equal(res, expec)
+        result = df.query("b not in (a, c)", engine=engine, parser=parser)
+        expected = df[(df["b"] != df["a"]) & (df["b"] != df["c"])]
+        tm.assert_frame_equal(result, expected)
 
     def test_in_column_ref_and_literal(self, engine, parser):
-        # `b in (a, 99)` — one Name, one Constant
         df = DataFrame({"a": [1, 2, 3], "b": [1, 99, 5]})
-        res = df.query("b in (a, 99)", engine=engine, parser=parser)
-        expec = df[(df["b"] == df["a"]) | (df["b"] == 99)]
-        tm.assert_frame_equal(res, expec)
+        result = df.query("b in (a, 99)", engine=engine, parser=parser)
+        expected = df[(df["b"] == df["a"]) | (df["b"] == 99)]
+        tm.assert_frame_equal(result, expected)
 
-    def test_in_pure_literals_unchanged(self, engine, parser):
+    def test_in_pure_literals(self, engine, parser):
         df = DataFrame({"a": [1, 2, 3, 4]})
-        res = df.query("a in (2, 3)", engine=engine, parser=parser)
-        expec = df[df["a"].isin([2, 3])]
-        tm.assert_frame_equal(res, expec)
+        result = df.query("a in (2, 3)", engine=engine, parser=parser)
+        expected = df[df["a"].isin([2, 3])]
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #65357 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Test Plan
* Verified numeric, `object` strings, and `string[pyarrow] `
* Confirmed `in` unrolls to OR (`|`) and `not in` unrolls to AND (`&`)
* Tested full/partial/no match scenarios, and mixed tuples 
*  pure-literal tuples remain unaffected and route through `.isin()`
