### PR TITLE
BUG: fixed inconsistency in the behaviour of DatetimeIndex.is_year_start on the frequency "BYS" 

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2354,8 +2354,8 @@ default 'raise'
 
         >>> dates.dt.is_year_start
         0    True
-        1    False
-        2    False
+        1    True
+        2    True
         3    True
         dtype: bool
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -73,10 +73,12 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
     def _get_values(self):
         data = self._parent
         if lib.is_np_dtype(data.dtype, "M"):
-            return DatetimeIndex(data, copy=False, name=self.name)
+            freq = self._try_infer_freq(data)
+            return DatetimeIndex(data, copy=False, name=self.name, freq=freq)
 
         elif isinstance(data.dtype, DatetimeTZDtype):
-            return DatetimeIndex(data, copy=False, name=self.name)
+            freq = self._try_infer_freq(data)
+            return DatetimeIndex(data, copy=False, name=self.name, freq=freq)
 
         elif lib.is_np_dtype(data.dtype, "m"):
             return TimedeltaIndex(data, copy=False, name=self.name)
@@ -87,6 +89,17 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         raise TypeError(
             f"cannot convert an object of type {type(data)} to a datetimelike index"
         )
+
+    def _try_infer_freq(self, data):
+        from pandas import infer_freq
+
+        try:
+            inferred = infer_freq(data)
+            if inferred is not None:
+                return inferred
+        except (ValueError, TypeError):
+            pass
+        return None
 
     def _delegate_property_get(self, name: str):
         from pandas import Series

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -779,8 +779,6 @@ class TestSeriesDatetimeValues:
 
     def test_dt_is_year_start_freq_business_year_start(self):
         # GH#58920
-        # Test that Series.dt.is_year_start correctly handles
-        # business year start frequencies
         dr = date_range("2020-10-30", periods=5, freq="BYS")
 
         result = Series(dr).dt.is_year_start
@@ -789,8 +787,6 @@ class TestSeriesDatetimeValues:
 
     def test_dt_is_month_start_freq_business_month_start(self):
         # GH#58920
-        # Test that Series.dt.is_month_start correctly handles
-        # business month start frequencies
         dr = date_range("2020-01-01", periods=12, freq="BMS")
 
         result = Series(dr).dt.is_month_start
@@ -799,8 +795,6 @@ class TestSeriesDatetimeValues:
 
     def test_dt_is_quarter_start_freq_business_quarter_start(self):
         # GH#58920
-        # Test that Series.dt.is_quarter_start correctly handles
-        # business quarter start frequencies
         dr = date_range("2020-01-01", periods=8, freq="BQS")
 
         result = Series(dr).dt.is_quarter_start
@@ -809,12 +803,9 @@ class TestSeriesDatetimeValues:
 
     def test_dt_is_year_start_consistency_with_index(self):
         # GH#58920
-        # Ensure Series.dt accessor gives same result as DatetimeIndex
-        # for business frequencies
         dr = date_range("2020-10-30", periods=5, freq="BYS")
         ser = Series(dr)
 
-        # Both should give the same result
         tm.assert_series_equal(ser.dt.is_year_start, Series(dr.is_year_start))
 
 

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -777,6 +777,46 @@ class TestSeriesDatetimeValues:
         )
         tm.assert_series_equal(result, expected)
 
+    def test_dt_is_year_start_freq_business_year_start(self):
+        # GH#58920
+        # Test that Series.dt.is_year_start correctly handles
+        # business year start frequencies
+        dr = date_range("2020-10-30", periods=5, freq="BYS")
+
+        result = Series(dr).dt.is_year_start
+        expected = Series([True, True, True, True, True])
+        tm.assert_series_equal(result, expected)
+
+    def test_dt_is_month_start_freq_business_month_start(self):
+        # GH#58920
+        # Test that Series.dt.is_month_start correctly handles
+        # business month start frequencies
+        dr = date_range("2020-01-01", periods=12, freq="BMS")
+
+        result = Series(dr).dt.is_month_start
+        expected = Series([True] * 12)
+        tm.assert_series_equal(result, expected)
+
+    def test_dt_is_quarter_start_freq_business_quarter_start(self):
+        # GH#58920
+        # Test that Series.dt.is_quarter_start correctly handles
+        # business quarter start frequencies
+        dr = date_range("2020-01-01", periods=8, freq="BQS")
+
+        result = Series(dr).dt.is_quarter_start
+        expected = Series([True] * 8)
+        tm.assert_series_equal(result, expected)
+
+    def test_dt_is_year_start_consistency_with_index(self):
+        # GH#58920
+        # Ensure Series.dt accessor gives same result as DatetimeIndex
+        # for business frequencies
+        dr = date_range("2020-10-30", periods=5, freq="BYS")
+        ser = Series(dr)
+
+        # Both should give the same result
+        tm.assert_series_equal(ser.dt.is_year_start, Series(dr.is_year_start))
+
 
 class TestSeriesPeriodValuesDtAccessor:
     @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] closes #58920
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
