### PR TITLE
PERF: speed up read_sas for full-precision numeric columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -150,6 +150,7 @@ Performance improvements
 - Performance improvement in :func:`read_html` and the Python CSV parser when ``thousands`` is set, fixing catastrophic regex backtracking on cells with many comma-separated digit groups followed by non-numeric text (:issue:`52619`)
 - Performance improvement in :func:`read_sas` by reading page header fields directly in Cython instead of falling back to Python (:issue:`47339`)
 - Performance improvement in :func:`read_sas` for SAS7BDAT files by pre-computing date/datetime column classification once during metadata parsing instead of per chunk (:issue:`47339`)
+- Performance improvement in :func:`read_sas` for SAS7BDAT files with full-precision (8-byte) numeric columns, with up to ~2x speedup on bulk reads (:issue:`47339`)
 - Performance improvement in :func:`read_sas` for compressed SAS7BDAT files by reusing the decompression buffer instead of allocating per row (:issue:`47339`)
 - Performance improvement in :func:`read_sas` when decoding strings (:issue:`47339`)
 - Performance improvement in :func:`util.hash_pandas_object` for PyArrow-backed string and binary types by using PyArrow's ``dictionary_encode`` instead of converting to NumPy for factorization (:issue:`48964`)

--- a/pandas/_libs/sas.pyx
+++ b/pandas/_libs/sas.pyx
@@ -581,13 +581,21 @@ cdef class Parser:
             start = offsets[j]
             ct = column_types[j]
             if ct == column_type_decimal:
-                # decimal
+                # decimal — copy lngt (3..8) bytes from source to byte_chunk.
+                # Fast path for the common case of full-precision SAS doubles
+                # (lngt == 8): a single 8-byte load/store, ~2x faster than
+                # the per-byte fallback.
                 if self.is_little_endian:
                     m = s + 8 - lngt
                 else:
                     m = s
-                for k in range(lngt):
-                    byte_chunk[jb, m + k] = buf_get(source, start + k)
+                if lngt == 8:
+                    (<uint64_t *>&byte_chunk[jb, m])[0] = (
+                        (<uint64_t *>&source.data[start])[0]
+                    )
+                else:
+                    for k in range(lngt):
+                        byte_chunk[jb, m + k] = buf_get(source, start + k)
                 jb += 1
             elif column_types[j] == column_type_string:
                 # string


### PR DESCRIPTION
## Summary

The SAS7BDAT cython parser's inner loop copies bytes from the page buffer into ``byte_chunk`` one byte at a time via ``buf_get`` (a memoryview-indexed read with an assert). The vast majority of SAS numeric columns are stored as full-precision 8-byte doubles, where this loop can be replaced by a single 8-byte load/store. Shorter widths (3–7 bytes) keep the existing per-byte path.

xref #47339

## Benchmarks

156 real-world SAS7BDAT files, best of 5–25 iterations per file, on macOS / Apple Silicon:

| Bucket               | n   | min   | median | max   |
|----------------------|----:|------:|-------:|------:|
| Large (>1 MB)        |   7 | 1.01× | 1.62×  | 1.82× |
| Medium (100KB–1MB)   |  12 | 0.93× | 0.99×  | 1.72× |
| Small (<100KB)       | 137 | 0.82× | 0.98×  | 1.07× |

Top files by absolute time:

```
file                          size_kb     rows  cols  str   before    after  speedup
dr1iff_c.sas7bdat               87457   131164    82    0   70.6ms   39.6ms   1.78x
drxiff_b.sas7bdat               84769   143004    74    0   68.7ms   39.7ms   1.73x
dr1tot_c.sas7bdat               12881     9643   160    0   15.9ms    8.8ms   1.82x
demoadv.sas7bdat                 5809    10122    72    0    6.8ms    4.2ms   1.62x
ct_19931231.sas7bdat            12856   325689     9    3   23.8ms   23.5ms   1.01x  (mixed/narrow floats)
demo_c.sas7bdat                  2513    10122    31    0    3.0ms    1.9ms   1.60x
demo_b.sas7bdat                  2097    11039    24    0    2.5ms    1.6ms   1.60x
calcmilk.sas7bdat                 809    10122    10    0    1.4ms    0.8ms   1.72x
```

The win scales with ``nrows × n_full_precision_float_cols``. Files with mostly short-width float columns see no change. Small (<100 KB) files show occasional 5–20 µs regressions on sub-millisecond reads — likely the cost of the extra ``if lngt == 8`` branch when the fast path never triggers. These are at the noise floor of files dominated by I/O and DataFrame construction, not the inner loop.

## Test plan

- [x] All existing 117 SAS tests pass (covers RLE/RDC compression, mix/meta/data pages, datetime conversion, encoding, iterator paths)
- [ ] CI green