### PR TITLE
Test: Add regression test for DataFrame.sum() with negative values and NaN

### DIFF
--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1282,6 +1282,33 @@ class TestSeriesReductions:
             assert isinstance(result, int)
         else:
             assert isinstance(result, np.uint64)
+            
+    def test_sum_mixed_negative_nan(self):
+        """
+        Test DataFrame.sum() with negative values and NaN.
+        
+        Regression test to ensure sum() correctly handles:
+        - Negative numbers
+        - NaN values (should be ignored)
+        - Mixed positive and negative
+        """
+        
+        # ARRANGE
+        df = DataFrame({
+            "losses": [-100, np.nan, -50, -25],
+            "gains": [50, 100, np.nan, 75]
+        })
+        
+        # ACT
+        result = df.sum()
+        
+        # ASSERT
+        expected = Series({
+            "losses": -175.0,
+            "gains": 225.0
+        })
+        
+        tm.assert_series_equal(result, expected)
 
 
 class TestDatetime64SeriesReductions:


### PR DESCRIPTION
## What does this test?
Adds a regression test to ensure `DataFrame.sum()` correctly handles:
- Negative numbers
- NaN values (ignored by default)  
- Mixed positive/negative columns

## Why is this needed?
Currently there is no explicit test for the combination of:
1. Negative values
2. NaN values in the same DataFrame
3. Multiple columns with different signs

This is common when working with:
- Financial data (profits/losses)
- Temperature changes
- Performance metrics (gains/losses)

## Test Verification
The test verifies that:
- NaN values are ignored (not included in sum)
- Negative values are summed correctly
- Works with multiple columns having different signs

Example:
```python
df = DataFrame({
    "losses": [-100, np.nan, -50, -25],  # Sum: -175
    "gains": [50, 100, np.nan, 75]       # Sum: 225
})
df.sum()  # Returns {"losses": -175.0, "gains": 225.0}
