### PR TITLE
DOC: Document pyarrow vs python string storage differences (#63105)

### DIFF
--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -908,10 +908,10 @@ Example:
    s_pyarrow = pd.Series(['ß'], dtype=pd.StringDtype(storage='pyarrow'))
    s_python.str.upper()
    # 0    SS
-   # dtype: string
+   # dtype: string[python]
    s_pyarrow.str.upper()
    # 0    ẞ
-   # dtype: string
+   # dtype: string[pyarrow]
 
 See `Apache Arrow #34599 <https://github.com/apache/arrow/issues/34599>`_
 for discussion on Unicode standard compliance.

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -907,7 +907,11 @@ Example:
    s_python = pd.Series(['ß'], dtype=pd.StringDtype(storage='python'))
    s_pyarrow = pd.Series(['ß'], dtype=pd.StringDtype(storage='pyarrow'))
    s_python.str.upper()
+   # 0    SS
+   # dtype: string
    s_pyarrow.str.upper()
+   # 0    ẞ
+   # dtype: string
 
 See `Apache Arrow #34599 <https://github.com/apache/arrow/issues/34599>`_
 for discussion on Unicode standard compliance.

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -836,6 +836,119 @@ represented and behave as ``pd.NA``.
 Notice that the last three values are all inferred by pandas as being NA
 values, and hence stored as ``pd.NA``.
 
+Performance considerations and known differences
+=================================================
+
+.. _text.performance_considerations:
+
+Performance Trade-offs
+----------------------
+
+The choice of storage backend (PyArrow vs Python) involves important
+performance trade-offs:
+
+**PyArrow storage** (``storage='pyarrow'``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Advantages**: Compact memory footprint, fast vectorized operations
+- **Disadvantages**: Immutable strings - any modification creates a new PyArrow ChunkedArray
+- **Recommendation**: Use for best performance when PyArrow is available
+
+When using PyArrow-backed strings, operations benefit from vectorization and
+Arrow's efficient memory layout. This often results in significantly better
+performance and lower memory usage compared to Python storage, especially for
+large datasets.
+
+**Python storage** (``storage='python'``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Advantages**: Mutable strings, compatible without external dependencies
+- **Disadvantages**: Highest memory overhead (each string is a separate Python object), no vectorization
+- **Recommendation**: Use when mutations are necessary or PyArrow is not available
+
+Python-backed strings store actual Python string objects, allowing in-place
+modifications. However, this comes at the cost of greater memory consumption
+and slower operations due to lack of vectorization.
+
+.. _text.known_differences:
+
+Known Behavior Differences
+---------------------------
+
+While pandas aims to provide consistent behavior regardless of storage backend,
+there are some edge cases where PyArrow and Python storage behave differently:
+
+**Regex Operations**
+~~~~~~~~~~~~~~~~~~~~
+
+The underlying regex engines differ between backends:
+
+- **Python storage**: Uses Python's ``re`` module (full Perl-compatible regex support)
+- **PyArrow storage**: Uses Google's RE2 engine (some regex features not supported)
+
+This can lead to different results for complex regex patterns. For example,
+lookahead/lookbehind assertions work in Python's ``re`` but not in RE2.
+
+See :issue:`63683` for more details on regex engine differences.
+
+**Unicode Case Operations**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The German character "ß" is handled differently during case conversion:
+
+- **Python storage**: ``'ß'.upper()`` returns ``'SS'`` (standard Python behavior)
+- **PyArrow storage**: Returns ``'ẞ'`` (capital sharp S, following Unicode standard)
+
+Example:
+
+.. ipython:: python
+
+   import pandas as pd
+   s_python = pd.Series(['ß'], dtype=pd.StringDtype(storage='python'))
+   s_pyarrow = pd.Series(['ß'], dtype=pd.StringDtype(storage='pyarrow'))
+   s_python.str.upper()
+   s_pyarrow.str.upper()
+
+See `Apache Arrow #34599 <https://github.com/apache/arrow/issues/34599>`_
+for discussion on Unicode standard compliance.
+
+**Unicode Digit Detection**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unicode characters representing fractions behave differently in the ``isdigit()`` method:
+
+- **Python storage**: ``'⅕'.isdigit()`` returns ``False``
+- **PyArrow storage**: ``'⅕'.isdigit()`` returns ``True``
+
+This stems from different interpretations of the Unicode standard. PyArrow
+treats Unicode fraction characters as digits, while Python's standard
+library does not.
+
+See :issue:`61466` for more details.
+
+**Other Unicode Edge Cases**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Various other Unicode operations may differ due to:
+
+- Different Unicode normalization implementations
+- Different character property classifications
+- Different interpretations of the Unicode standard
+
+If you encounter unexpected differences in string operations between storage
+backends, it's often related to these Unicode edge cases. When consistency
+is critical, test your operations with both backends.
+
+**Recommendation**
+~~~~~~~~~~~~~~~~~~
+
+When deploying code that must behave identically across environments:
+
+1. Always explicitly specify the ``storage`` parameter if consistency is critical
+2. Test string operations with both backends if using Unicode-sensitive operations
+3. Consider using ``storage='pyarrow'`` for performance but validate regex behavior
+4. Use ``storage='python'`` if exact Python regex semantics are required
+
 Method summary
 ==============
 

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -848,7 +848,7 @@ The choice of storage backend (PyArrow vs Python) involves important
 performance trade-offs:
 
 **PyArrow storage** (``storage='pyarrow'``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Advantages**: Compact memory footprint, fast vectorized operations
 - **Disadvantages**: Immutable strings - any modification creates a new PyArrow ChunkedArray
@@ -860,7 +860,7 @@ performance and lower memory usage compared to Python storage, especially for
 large datasets.
 
 **Python storage** (``storage='python'``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Advantages**: Mutable strings, compatible without external dependencies
 - **Disadvantages**: Highest memory overhead (each string is a separate Python object), no vectorization
@@ -873,7 +873,7 @@ and slower operations due to lack of vectorization.
 .. _text.known_differences:
 
 Known Behavior Differences
----------------------------
+--------------------------
 
 While pandas aims to provide consistent behavior regardless of storage backend,
 there are some edge cases where PyArrow and Python storage behave differently:

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -111,6 +111,13 @@ class StringDtype(StorageExtensionDtype):
     ----------
     storage : {"python", "pyarrow"}, optional
         If not given, the value of ``pd.options.mode.string_storage``.
+        This determines the storage backend for string data:
+
+        - "pyarrow": Uses PyArrow for efficient vectorized operations
+          but immutable strings
+        - "python": Uses Python objects for mutable strings but with
+          higher memory overhead
+
     na_value : {np.nan, pd.NA}, default pd.NA
         Whether the dtype follows NaN or NA missing value semantics.
 
@@ -123,6 +130,19 @@ class StringDtype(StorageExtensionDtype):
     -------
     None
 
+    Notes
+    -----
+    When choosing between storage backends, consider the following:
+
+    - PyArrow storage offers superior performance and memory efficiency
+      but immutability (modifications create new arrays)
+    - Python storage allows string mutations but with higher memory overhead
+      and slower operations
+
+    There are also some known behavioral differences between storage backends
+    for edge cases involving Unicode operations and regex handling. See the
+    :ref:`text.known_differences` section in the user guide for details.
+
     See Also
     --------
     BooleanDtype : Extension dtype for boolean data.
@@ -134,6 +154,9 @@ class StringDtype(StorageExtensionDtype):
 
     >>> pd.StringDtype(storage="python")
     <StringDtype(storage='python', na_value=<NA>)>
+
+    For more information on storage variants and their trade-offs,
+    see :ref:`text.performance_considerations` in the user guide.
     """
 
     @property
@@ -176,9 +199,22 @@ class StringDtype(StorageExtensionDtype):
 
         Can be either "pyarrow" or "python".
 
+        The storage backend determines how string data is stored internally:
+
+        - "pyarrow": Uses Apache Arrow for efficient vectorized operations.
+          Offers better performance and memory efficiency but with immutable strings.
+        - "python": Uses NumPy object arrays containing Python string objects.
+          Allows string mutations but with higher memory overhead.
+
         See Also
         --------
         StringDtype.na_value : The missing value for this dtype.
+
+        Notes
+        -----
+        For detailed information on performance trade-offs and known differences
+        between storage backends, see :ref:`text.performance_considerations`
+        and :ref:`text.known_differences` in the user guide.
 
         Examples
         --------

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -130,6 +130,10 @@ class StringDtype(StorageExtensionDtype):
     -------
     None
 
+    See Also
+    --------
+    BooleanDtype : Extension dtype for boolean data.
+
     Notes
     -----
     When choosing between storage backends, consider the following:
@@ -142,10 +146,6 @@ class StringDtype(StorageExtensionDtype):
     There are also some known behavioral differences between storage backends
     for edge cases involving Unicode operations and regex handling. See the
     :ref:`text.known_differences` section in the user guide for details.
-
-    See Also
-    --------
-    BooleanDtype : Extension dtype for boolean data.
 
     Examples
     --------


### PR DESCRIPTION
## Description
Documents the known differences and performance trade-offs between `string[pyarrow]` and `string[python]` storage variants as requested in #63105.

## Changes
- Added comprehensive "Performance considerations and known differences" section to user guide
- Documents PyArrow vs Python storage trade-offs (performance, memory, mutability)
- Details known behavior differences:
  - Regex operations (Python `re` vs Arrow's RE2)
  - Unicode case operations (ß character handling)
  - Unicode digit detection (fractions like ⅕)
- Enhanced StringDtype docstring with storage backend explanations
- Added cross-references to documentation from API docstrings

## Closes
#63105

## Type
Documentation

## Testing
Documentation rendered correctly with appropriate cross-links and examples.
