### PR TITLE
BUG: str.replace hangs indefinitely on empty pattern with PyArrow backend

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -255,7 +255,7 @@ Conversion
 Strings
 ^^^^^^^
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
--
+- Bug in :meth:`Series.str.replace` and :meth:`Index.str.replace` hanging indefinitely when ``pat`` is an empty string and the backend is PyArrow (:issue:`64941`)
 
 Interval
 ^^^^^^^^

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -239,6 +239,29 @@ class ArrowStringArrayMixin:
                 "named group references (\\g<...>)"
             )
 
+        # GH#64941: pyarrow's replace_substring{_regex} hangs indefinitely
+        # when the pattern is an empty string (apache/arrow#39149).
+        # Fall back to element-wise Python which handles it correctly,
+        # e.g. "ab".replace("", "X") -> "XaXbX".
+        if pat == "":
+            if regex:
+                compiled = re.compile("")
+                count = 0 if n < 0 else n  # re.sub: 0 means replace all
+                result_list = [
+                    compiled.sub(repl, val, count=count) if val is not None else None
+                    for val in self._pa_array.to_pylist()
+                ]
+            else:
+                result_list = [
+                    (val.replace("", repl) if n < 0 else val.replace("", repl, n))
+                    if val is not None
+                    else None
+                    for val in self._pa_array.to_pylist()
+                ]
+            return self._from_pyarrow_array(
+                pa.array(result_list, type=self._pa_array.type)
+            )
+
         func = pc.replace_substring_regex if regex else pc.replace_substring
         # https://github.com/apache/arrow/issues/39149
         # GH 56404, unexpected behavior with negative max_replacements with pyarrow.

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -791,6 +791,25 @@ def test_pyarrow_backend_group_replacement(pattern, repl, expected_list):
     tm.assert_series_equal(result, expected)
 
 
+@td.skip_if_no("pyarrow")
+@pytest.mark.parametrize("regex", [False, True])
+@pytest.mark.parametrize(
+    "repl, expected",
+    [
+        # empty replacement: no-op (matches Python's str.replace("", "") behaviour)
+        ("", ["abcd", "ef", None]),
+        # non-empty replacement: insert at every position incl. start and end
+        ("X", ["XaXbXcXdX", "XeXfX", None]),
+    ],
+)
+def test_replace_empty_pattern_pyarrow(repl, expected, regex):
+    # GH#64941 - pyarrow's replace_substring hangs on empty pattern
+    ser = Series(["abcd", "ef", None]).convert_dtypes(dtype_backend="pyarrow")
+    result = ser.str.replace("", repl, regex=regex)
+    expected_ser = Series(expected).convert_dtypes(dtype_backend="pyarrow")
+    tm.assert_series_equal(result, expected_ser)
+
+
 def test_replace_callable_named_groups(any_string_dtype):
     # test regex named groups
     ser = Series(["Foo Bar Baz", np.nan], dtype=any_string_dtype)


### PR DESCRIPTION
- [x] closes #64941
- [x] Tests added and passed if fixing a bug or adding a new feature
- [ ] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Problem

`Series.str.replace("", ...)` with a PyArrow-backed Series hangs indefinitely, catching kill signals, making the process unresponsive. The hang also reproduces in CI (e.g. skrub-data/skrub#1772).

Root cause: PyArrow's `replace_substring` / `replace_substring_regex` enters an infinite loop when given an empty pattern (apache/arrow#39149). After substituting at position 0, the loop advances by `len("") = 0` and never moves forward.

A previous fix (GH#56404, GH#56406) guarded against negative `max_replacements`, but empty patterns were not addressed.

## Fix

In `_arrow_string_mixins._str_replace`, detect `pat == ""` before calling into PyArrow and fall back to element-wise Python processing, which replicates Python's own semantics:

```python
"abcd".replace("", "")   # -> "abcd"        (no-op)
"abcd".replace("", "X")  # -> "XaXbXcXdX"  (insert at every position)
```

Both `regex=True` (via `re.sub`) and `regex=False` (via `str.replace`) paths are handled. `None` / `NA` values are preserved.

## AI disclosure

I used Claude Code (claude-sonnet-4-6) to locate the hang site and draft the fix. I reviewed the logic — checking that `re.sub("", ...)` and `str.replace("", ...)` produce identical output for the empty-pattern case, and that the `n` / `count` semantics map correctly — before committing.