### PR TITLE
BUG: Fix Behavior Change from #64366 Regarding NaN Handling With Mask

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1621,7 +1621,10 @@ cdef void accumulate_moments_scalar(
 
     for i in range(n):
         val = values[i]
-        is_na_entry = (uses_mask and mask[i]) or (not uses_mask and isnan(val))
+        if uses_mask:
+            is_na_entry = mask[i]
+        else:
+            is_na_entry = isnan(val)
 
         if skipna and is_na_entry:
             continue

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1616,15 +1616,24 @@ cdef void accumulate_moments_scalar(
 ) noexcept nogil:
     cdef:
         Py_ssize_t i, n = len(values)
-        bint uses_mask = mask is not None
+        bint is_na_entry, uses_mask = mask is not None
         float64_t val
 
     for i in range(n):
         val = values[i]
-        if uses_mask and mask[i]:
-            val = NaN
-        if skipna and isnan(val):
+        is_na_entry = (uses_mask and mask[i]) or (not uses_mask and isnan(val))
+
+        if skipna and is_na_entry:
             continue
+        elif is_na_entry:
+            if max_moment >= 4:
+                m4[0] = NaN
+            if max_moment >= 3:
+                m3[0] = NaN
+            m2[0] = NaN
+            mean[0] = NaN
+            nobs[0] = n
+            return
         moments_add_value(val, nobs, mean, m2, m3, m4, max_moment)
 
 
@@ -1645,7 +1654,7 @@ cdef void accumulate_moments_axis(
     cdef:
         Py_ssize_t i, j, nrows = values.shape[0], ncols = values.shape[1]
         Py_ssize_t nouter, ninner
-        bint uses_mask = mask is not None
+        bint is_na_entry, uses_mask = mask is not None
         float64_t val
         float64_t* m3_ptr = NULL
         float64_t* m4_ptr = NULL
@@ -1666,10 +1675,22 @@ cdef void accumulate_moments_axis(
             m4_ptr = &m4[i]
         for j in range(ninner):
             val = values[j, i] if axis == 0 else values[i, j]
-            if uses_mask and (mask[j, i] if axis == 0 else mask[i, j]):
-                val = NaN
-            if skipna and isnan(val):
+            if uses_mask:
+                is_na_entry = mask[j, i] if axis == 0 else mask[i, j]
+            else:
+                is_na_entry = isnan(val)
+
+            if skipna and is_na_entry:
                 continue
+            elif is_na_entry:
+                if max_moment >= 4:
+                    m4[i] = NaN
+                if max_moment >= 3:
+                    m3[i] = NaN
+                m2[i] = NaN
+                mean[i] = NaN
+                nobs[i] = ninner
+                break
             moments_add_value(val, &nobs[i], &mean[i], &m2[i], m3_ptr, m4_ptr,
                               max_moment)
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -6,6 +6,7 @@ from cython cimport (
 from libc.math cimport (
     NAN,
     isfinite,
+    isnan,
     sqrt,
 )
 from libc.stdlib cimport (
@@ -1068,12 +1069,9 @@ def group_skew(
 
         for i in range(ngroups):
             for j in range(K):
-                if nobs[i, j] < 3:
-                    if result_mask is not None:
-                        result_mask[i, j] = 1
-                    out[i, j] = NaN
-                else:
-                    out[i, j] = calc_skew(nobs[i, j], M2[i, j], M3[i, j])
+                out[i, j] = calc_skew(nobs[i, j], M2[i, j], M3[i, j])
+                if result_mask is not None and isnan(out[i, j]):
+                    result_mask[i, j] = 1
 
 
 @cython.wraparound(False)
@@ -1138,12 +1136,9 @@ def group_kurt(
 
         for i in range(ngroups):
             for j in range(K):
-                if nobs[i, j] < 4:
-                    if result_mask is not None:
-                        result_mask[i, j] = 1
-                    out[i, j] = NaN
-                else:
-                    out[i, j] = calc_kurt(nobs[i, j], M2[i, j], M4[i, j])
+                out[i, j] = calc_kurt(nobs[i, j], M2[i, j], M4[i, j])
+                if result_mask is not None and isnan(out[i, j]):
+                    result_mask[i, j] = 1
 
 
 @cython.wraparound(False)

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -6,7 +6,6 @@ from cython cimport (
 from libc.math cimport (
     NAN,
     isfinite,
-    isnan,
     sqrt,
 )
 from libc.stdlib cimport (
@@ -1059,10 +1058,14 @@ def group_skew(
                 else:
                     isna_entry = _treat_as_na(val, False)
 
-                if skipna and isna_entry:
+                if isna_entry:
+                    if not skipna:
+                        if result_mask is not None:
+                            result_mask[lab, j] = 1
+                        mean[lab, j] = NaN
+                        M2[lab, j] = NaN
+                        M3[lab, j] = NaN
                     continue
-                elif isna_entry:
-                    val = NaN
 
                 moments_add_value(val, &nobs[lab, j], &mean[lab, j], &M2[lab, j],
                                   &M3[lab, j], NULL, 3)
@@ -1070,7 +1073,7 @@ def group_skew(
         for i in range(ngroups):
             for j in range(K):
                 out[i, j] = calc_skew(nobs[i, j], M2[i, j], M3[i, j])
-                if result_mask is not None and isnan(out[i, j]):
+                if result_mask is not None and nobs[i, j] < 3:
                     result_mask[i, j] = 1
 
 
@@ -1126,10 +1129,15 @@ def group_kurt(
                 else:
                     isna_entry = _treat_as_na(val, False)
 
-                if skipna and isna_entry:
+                if isna_entry:
+                    if not skipna:
+                        if result_mask is not None:
+                            result_mask[lab, j] = 1
+                        mean[lab, j] = NaN
+                        M2[lab, j] = NaN
+                        M3[lab, j] = NaN
+                        M4[lab, j] = NaN
                     continue
-                elif isna_entry:
-                    val = NaN
 
                 moments_add_value(val, &nobs[lab, j], &mean[lab, j], &M2[lab, j],
                                   &M3[lab, j], &M4[lab, j], 4)
@@ -1137,7 +1145,7 @@ def group_kurt(
         for i in range(ngroups):
             for j in range(K):
                 out[i, j] = calc_kurt(nobs[i, j], M2[i, j], M4[i, j])
-                if result_mask is not None and isnan(out[i, j]):
+                if result_mask is not None and nobs[i, j] < 4:
                     result_mask[i, j] = 1
 
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -6,7 +6,6 @@ from cython cimport (
 from libc.math cimport (
     NAN,
     isfinite,
-    isnan,
     sqrt,
 )
 from libc.stdlib cimport (
@@ -1025,7 +1024,7 @@ def group_skew(
         Py_ssize_t i, j, N, K, lab, ngroups = len(counts)
         int64_t[:, ::1] nobs
         Py_ssize_t len_values = len(values), len_labels = len(labels)
-        bint uses_mask = mask is not None
+        bint isna_entry, uses_mask = mask is not None
         float64_t[:, ::1] mean, M2, M3
         float64_t val
 
@@ -1054,20 +1053,27 @@ def group_skew(
             for j in range(K):
                 val = values[i, j]
 
-                if uses_mask and mask[i, j]:
-                    val = NaN
+                if uses_mask:
+                    isna_entry = mask[i, j]
+                else:
+                    isna_entry = _treat_as_na(val, False)
 
-                if skipna and (isnan(val) or _treat_as_na(val, False)):
+                if skipna and isna_entry:
                     continue
+                elif isna_entry:
+                    val = NaN
 
                 moments_add_value(val, &nobs[lab, j], &mean[lab, j], &M2[lab, j],
                                   &M3[lab, j], NULL, 3)
 
         for i in range(ngroups):
             for j in range(K):
-                out[i, j] = calc_skew(nobs[i, j], M2[i, j], M3[i, j])
-                if result_mask is not None and isnan(out[i, j]):
-                    result_mask[i, j] = 1
+                if nobs[i, j] < 3:
+                    if result_mask is not None:
+                        result_mask[i, j] = 1
+                    out[i, j] = NaN
+                else:
+                    out[i, j] = calc_skew(nobs[i, j], M2[i, j], M3[i, j])
 
 
 @cython.wraparound(False)
@@ -1087,7 +1093,7 @@ def group_kurt(
         Py_ssize_t i, j, N, K, lab, ngroups = len(counts)
         int64_t[:, ::1] nobs
         Py_ssize_t len_values = len(values), len_labels = len(labels)
-        bint uses_mask = mask is not None
+        bint isna_entry, uses_mask = mask is not None
         float64_t[:, ::1] mean, M2, M3, M4
         float64_t val
 
@@ -1117,20 +1123,27 @@ def group_kurt(
             for j in range(K):
                 val = values[i, j]
 
-                if uses_mask and mask[i, j]:
-                    val = NaN
+                if uses_mask:
+                    isna_entry = mask[i, j]
+                else:
+                    isna_entry = _treat_as_na(val, False)
 
-                if skipna and (isnan(val) or _treat_as_na(val, False)):
+                if skipna and isna_entry:
                     continue
+                elif isna_entry:
+                    val = NaN
 
                 moments_add_value(val, &nobs[lab, j], &mean[lab, j], &M2[lab, j],
                                   &M3[lab, j], &M4[lab, j], 4)
 
         for i in range(ngroups):
             for j in range(K):
-                out[i, j] = calc_kurt(nobs[i, j], M2[i, j], M4[i, j])
-                if result_mask is not None and isnan(out[i, j]):
-                    result_mask[i, j] = 1
+                if nobs[i, j] < 4:
+                    if result_mask is not None:
+                        result_mask[i, j] = 1
+                    out[i, j] = NaN
+                else:
+                    out[i, j] = calc_kurt(nobs[i, j], M2[i, j], M4[i, j])
 
 
 @cython.wraparound(False)

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -1650,3 +1650,45 @@ def test_mean_numeric_only_validates_bool():
 
     with pytest.raises(ValueError, match=msg):
         df.groupby(["A"]).mean(numeric_only=1)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "sum",
+        "mean",
+        "median",
+        "std",
+        "var",
+        "sem",
+        "max",
+        "min",
+        "skew",
+        "kurt",
+        "prod",
+    ],
+)
+def test_groupby_reductions_dont_skip_nan_with_mask(
+    method, skipna, using_nan_is_na, request
+):
+    if method in ("median", "max", "min"):
+        request.applymarker(pytest.mark.xfail(reason=f"{method} skips NaN"))
+
+    values = np.array([1.0, 2.0, 3.0, 4.0, np.nan], dtype="float64")
+    mask = np.array([False, False, False, False, False], dtype="bool")
+
+    ser = Series(pd.arrays.FloatingArray(values, mask))
+    df = DataFrame({"A": [1] * 5, "B": ser})
+
+    gb = df.groupby("A")["B"]
+    result = getattr(gb, method)(skipna=skipna)
+
+    if using_nan_is_na:
+        expected = Series(
+            [pd.NA], index=pd.Index([1], name="A"), name="B", dtype="Float64"
+        )
+    else:
+        expected = Series(
+            [np.nan], index=pd.Index([1], name="A"), name="B", dtype="Float64"
+        )
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -1657,12 +1657,9 @@ def test_mean_numeric_only_validates_bool():
     [
         "sum",
         "mean",
-        "median",
         "std",
         "var",
         "sem",
-        "max",
-        "min",
         "skew",
         "kurt",
         "prod",
@@ -1671,9 +1668,6 @@ def test_mean_numeric_only_validates_bool():
 def test_groupby_reductions_dont_skip_nan_with_mask(
     method, skipna, using_nan_is_na, request
 ):
-    if method in ("median", "max", "min"):
-        request.applymarker(pytest.mark.xfail(reason=f"{method} skips NaN"))
-
     values = np.array([1.0, 2.0, 3.0, 4.0, np.nan], dtype="float64")
     mask = np.array([False, False, False, False, False], dtype="bool")
 

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -1665,9 +1665,7 @@ def test_mean_numeric_only_validates_bool():
         "prod",
     ],
 )
-def test_groupby_reductions_dont_skip_nan_with_mask(
-    method, skipna, using_nan_is_na, request
-):
+def test_groupby_reductions_dont_skip_nan_with_mask(method, skipna, using_nan_is_na):
     values = np.array([1.0, 2.0, 3.0, 4.0, np.nan], dtype="float64")
     mask = np.array([False, False, False, False, False], dtype="bool")
 

--- a/pandas/tests/groupby/test_reductions.py
+++ b/pandas/tests/groupby/test_reductions.py
@@ -1684,3 +1684,30 @@ def test_groupby_reductions_dont_skip_nan_with_mask(method, skipna, using_nan_is
             [np.nan], index=pd.Index([1], name="A"), name="B", dtype="Float64"
         )
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "sum",
+        "mean",
+        "std",
+        "var",
+        "sem",
+        "skew",
+        "kurt",
+        "prod",
+    ],
+)
+def test_groupby_skipna_false_propagates_na_when_distinguish_nan_and_na(method):
+    # GH-65372: under future.distinguish_nan_and_na, a genuine NA with
+    # skipna=False must propagate to NA.
+    with pd.option_context("future.distinguish_nan_and_na", True):
+        ser = Series([1.0, 2.0, 3.0, 4.0, pd.NA], dtype="Float64")
+        df = DataFrame({"A": [1] * 5, "B": ser})
+        gb = df.groupby("A")["B"]
+        expected = Series(
+            [pd.NA], index=pd.Index([1], name="A"), name="B", dtype="Float64"
+        )
+        result = getattr(gb, method)(skipna=False)
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1246,6 +1246,59 @@ def test_nanops_independent_of_mask_param(operation):
     assert median_expected == median_result
 
 
+@pytest.mark.parametrize(
+    "nanops_operation",
+    [
+        "nansum",
+        "nanmean",
+        "nanmedian",
+        "nanstd",
+        "nanvar",
+        "nansem",
+        "nanmax",
+        "nanmin",
+        "nanskew",
+        "nankurt",
+        "nanprod",
+    ],
+)
+@pytest.mark.parametrize("axis", [None, 0, 1])
+def test_nanops_reductions_dont_skip_nan_with_mask(
+    nanops_operation, skipna, axis, request
+):
+    if skipna and nanops_operation == "nanmedian":
+        mark = pytest.mark.xfail(reason="nanmedian skips NaN")
+        request.applymarker(mark)
+    elif not skipna and axis in {0, 1} and nanops_operation == "nansem":
+        mark = pytest.mark.xfail(reason="nansem returns a scalar nan")
+        request.applymarker(mark)
+    if axis is None:
+        expected = np.nan
+    else:
+        expected = np.array([np.nan, np.nan, np.nan, np.nan, np.nan])
+    values = np.array(
+        [
+            [np.nan, 1.0, 2.0, 3.0, 4.0],
+            [0.0, np.nan, 2.0, 3.0, 4.0],
+            [0.0, 1.0, np.nan, 3.0, 4.0],
+            [0.0, 1.0, 2.0, np.nan, 4.0],
+            [0.0, 1.0, 2.0, 3.0, np.nan],
+        ]
+    )
+    mask = np.array(
+        [
+            [False, True, False, False, False],
+            [False, False, True, False, False],
+            [False, False, False, True, False],
+            [False, False, False, False, True],
+            [True, False, False, False, False],
+        ]
+    )
+    operation = getattr(nanops, nanops_operation)
+    result = operation(values, mask=mask, skipna=skipna, axis=axis)
+    tm.assert_equal(result, expected)
+
+
 @pytest.mark.parametrize("min_count", [-1, 0])
 def test_check_below_min_count_negative_or_zero_min_count(min_count):
     # GH35227

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1251,7 +1251,6 @@ def test_nanops_independent_of_mask_param(operation):
     [
         "nansum",
         "nanmean",
-        "nanmedian",
         "nanstd",
         "nanvar",
         "nansem",
@@ -1266,10 +1265,7 @@ def test_nanops_independent_of_mask_param(operation):
 def test_nanops_reductions_dont_skip_nan_with_mask(
     nanops_operation, skipna, axis, request
 ):
-    if skipna and nanops_operation == "nanmedian":
-        mark = pytest.mark.xfail(reason="nanmedian skips NaN")
-        request.applymarker(mark)
-    elif not skipna and axis in {0, 1} and nanops_operation == "nansem":
+    if not skipna and axis in {0, 1} and nanops_operation == "nansem":
         mark = pytest.mark.xfail(reason="nansem returns a scalar nan")
         request.applymarker(mark)
     if axis is None:


### PR DESCRIPTION
Pointed out by @jbrockmendel in https://github.com/pandas-dev/pandas/pull/64848#discussion_r3141221209.

Previously `NaN` was checked only without a mask. After #64366 it's being checked unconditionally. Restore original behavior and adds tests for `groupby` and `nanops`.

Went back in history to check that the tests fails on b935209dd0 and doesn't fail on 027ea1edde4ee1de97c89cca4f782a00d1955375, with the exception that `nanskew` and `nankurt` have shown the same wrong behavior as `nansem` regarding returning a scalar `np.nan` when using `axis` not `None`.
