### PR TITLE
BUG: nansem with mask + skipna=False + axis returns scalar nan instead of array

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -195,6 +195,7 @@ Numeric
 - Fixed bug in :meth:`Series.mean` and :meth:`Series.sum` (and their :class:`DataFrame` counterparts) overflowing for ``float16`` dtypes instead of upcasting to ``float64`` (:issue:`43929`)
 - Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) returning ``0.0`` for degenerate distributions; these now return ``NaN`` (:issue:`62864`)
 - Fixed bug where :class:`DataFrame` arithmetic operations with :class:`Series` did not support the fill_value parameter(:issue:`61581`)
+- Fixed bug in :func:`~pandas.core.nanops.nansem` where passing ``mask`` with ``skipna=False`` and an ``axis`` argument incorrectly returned a scalar ``np.nan`` instead of an array of ``np.nan`` (:issue:`65373`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1000,6 +1000,8 @@ class ArrowExtensionArray(
         ):
             if op in [operator.add, roperator.radd]:
                 sep = pa.scalar("", type=pa_type)
+                if isinstance(other, pa.Scalar) and pc.is_null(other).as_py():
+                    return self._from_pyarrow_array(pa.nulls(len(self._pa_array), type=pa_type))
                 try:
                     if op is operator.add:
                         result = pc.binary_join_element_wise(self._pa_array, other, sep)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1001,7 +1001,9 @@ class ArrowExtensionArray(
             if op in [operator.add, roperator.radd]:
                 sep = pa.scalar("", type=pa_type)
                 if isinstance(other, pa.Scalar) and pc.is_null(other).as_py():
-                    return self._from_pyarrow_array(pa.nulls(len(self._pa_array), type=pa_type))
+                    return self._from_pyarrow_array(
+                        pa.nulls(len(self._pa_array), type=pa_type)
+                    )
                 try:
                     if op is operator.add:
                         result = pc.binary_join_element_wise(self._pa_array, other, sep)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1087,7 +1087,7 @@ def nansem(
     if values.dtype.kind not in "fc":
         values = values.astype("f8")
 
-    if not skipna and mask is not None and mask.any():
+    if not skipna and mask is not None and axis is None and mask.any():
         return np.nan
 
     dtype_count = np.dtype(np.float64)

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -332,3 +332,11 @@ def test_string_dtype_error_message():
     msg = "Storage must be 'python' or 'pyarrow'."
     with pytest.raises(ValueError, match=msg):
         StringDtype("bla")
+
+def test_arrow_str_add_pd_na():
+    # GH#64968 Arrow-backed str arrays should return NA when added to pd.NA
+    pytest.importorskip("pyarrow")
+    arrow_col = pd.array(["y"], dtype="str")
+    result = arrow_col + pd.NA
+    expected = pd.array([pd.NA], dtype="str")
+    tm.assert_extension_array_equal(result, expected)

--- a/pandas/tests/arrays/string_/test_string_arrow.py
+++ b/pandas/tests/arrays/string_/test_string_arrow.py
@@ -333,6 +333,7 @@ def test_string_dtype_error_message():
     with pytest.raises(ValueError, match=msg):
         StringDtype("bla")
 
+
 def test_arrow_str_add_pd_na():
     # GH#64968 Arrow-backed str arrays should return NA when added to pd.NA
     pytest.importorskip("pyarrow")

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1245,6 +1245,45 @@ def test_nanops_independent_of_mask_param(operation):
     median_result = operation(ser._values, mask=mask._values)
     assert median_expected == median_result
 
+def test_nansem_mask_skipna_false_axis_returns_array():
+    # GH#65373 - nansem with mask + skipna=False + axis={0,1} was returning
+    # a scalar np.nan instead of an array of np.nan
+    rng = np.random.default_rng(2)
+    n = 5
+    values = rng.standard_normal((n, n))
+
+    # Place np.nan on the main diagonal so every slice along both axes
+    # contains an actual NaN value
+    np.fill_diagonal(values, np.nan)
+
+    # Shifted diagonal mask: one True per row and per column,
+    # so every slice has both a NaN value and a masked entry
+    mask = np.zeros((n, n), dtype=bool)
+    for i in range(n):
+        mask[i, (i + 1) % n] = True
+
+    expected = np.full(n, np.nan)
+
+    result = nanops.nansem(values, mask=mask, skipna=False, axis=0)
+    tm.assert_numpy_array_equal(result, expected)
+
+    result = nanops.nansem(values, mask=mask, skipna=False, axis=1)
+    tm.assert_numpy_array_equal(result, expected)
+
+    # axis=None: scalar nan expected (this behavior is correct and unchanged)
+    result = nanops.nansem(values, mask=mask, skipna=False, axis=None)
+    assert np.isnan(result)
+
+    # partial mask: only [0, 0] masked -> only col 0 (axis=0) becomes nan,
+    # all other columns remain valid floats
+    values_partial = rng.standard_normal((n, n))
+    values_partial[0, 0] = np.nan
+    mask_partial = np.zeros((n, n), dtype=bool)
+    mask_partial[0, 0] = True
+
+    result = nanops.nansem(values_partial, mask=mask_partial, skipna=False, axis=0)
+    assert np.isnan(result[0])
+    assert not np.any(np.isnan(result[1:]))
 
 @pytest.mark.parametrize("min_count", [-1, 0])
 def test_check_below_min_count_negative_or_zero_min_count(min_count):


### PR DESCRIPTION
closes #65373

Problem: nansem with mask + skipna=False + axis={0,1} returned a scalar
np.nan instead of an array due to an early return that ignored the axis
argument entirely.

Fix: Narrowed the early return guard to axis=None only. For axis=0/1,
nanvar already propagates nan correctly per-slice, so the early return
was unnecessary and wrong.