### PR TITLE
CI: allow running update-pixi-lock workflow on demand

### DIFF
--- a/.github/workflows/update-pixi-lock.yml
+++ b/.github/workflows/update-pixi-lock.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # 4:10 UTC every Sunday
     - cron: "10 4 * * 0"
+  workflow_dispatch:
 
 permissions: {}
 defaults:


### PR DESCRIPTION
@mroeschke might make it easier to test things after merging a change (don't have to wait a week)