### PR TITLE
REF: cimport npy_datetimestruct and NPY_DATETIMEUNIT directly from numpy

### DIFF
--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -4,36 +4,31 @@ from cpython.datetime cimport (
     datetime,
 )
 from numpy cimport (
+    NPY_DATETIMEUNIT,
+    NPY_FR_B,
+    NPY_FR_D,
+    NPY_FR_GENERIC,
+    NPY_FR_M,
+    NPY_FR_W,
+    NPY_FR_Y,
+    NPY_FR_as,
+    NPY_FR_fs,
+    NPY_FR_h,
+    NPY_FR_m,
+    NPY_FR_ms,
+    NPY_FR_ns,
+    NPY_FR_ps,
+    NPY_FR_s,
+    NPY_FR_us,
     int32_t,
     int64_t,
     npy_datetime,
+    npy_datetimestruct,
     npy_timedelta,
 )
 
 
-# TODO(cython3): most of these can be cimported directly from numpy
 cdef extern from "numpy/ndarraytypes.h":
-    ctypedef struct npy_datetimestruct:
-        int64_t year
-        int32_t month, day, hour, min, sec, us, ps, as
-
-    ctypedef enum NPY_DATETIMEUNIT:
-        NPY_FR_Y
-        NPY_FR_M
-        NPY_FR_W
-        NPY_FR_D
-        NPY_FR_B
-        NPY_FR_h
-        NPY_FR_m
-        NPY_FR_s
-        NPY_FR_ms
-        NPY_FR_us
-        NPY_FR_ns
-        NPY_FR_ps
-        NPY_FR_fs
-        NPY_FR_as
-        NPY_FR_GENERIC
-
     int64_t NPY_DATETIME_NAT  # elsewhere we call this NPY_NAT
 
 


### PR DESCRIPTION
## Summary

- Drops the local `cdef extern from "numpy/ndarraytypes.h"` block in `np_datetime.pxd` that re-declared `npy_datetimestruct`, `NPY_DATETIMEUNIT`, and the 15 `NPY_FR_*` enum members. These have long been exposed by numpy's own Cython `pxd`, so re-declaring them was redundant and a latent maintenance hazard if numpy ever changed the struct layout.
- Resolves the `TODO(cython3)` tag in that file — the project's Cython floor (`>3.1.0` in `pyproject.toml`) has long since cleared the bar.
- `NPY_DATETIME_NAT` is *not* exposed by numpy's `pxd`, so a single-line extern declaration for it remains.
- Consumers (22 `.pyx`/`.pxd` files) do not need to change — they `cimport` these names from `pandas._libs.tslibs.np_datetime`, which transitively re-exports them.

I checked the rest of the codebase — `pandas/_libs/tslibs/util.pxd` is the only other file with `cdef extern from "numpy/..."` blocks, but the symbols it imports (`PyFloatingArrType_Type`, `PyComplexFloatingArrType_Type`, `PyBoolArrType_Type`, `PyArray_IsIntegerScalar`, `NPY_MIN_INT64`) are not exposed by numpy's `pxd`, so nothing else can be migrated.

## Test plan

- [x] Builds cleanly with `pbuild`
- [x] `pytest pandas/tests/tslibs/` — 646 passed
- [x] Manual smoke test: `Timestamp`, `Timedelta`, `date_range`, `timedelta_range`, `period_range`, `to_datetime`, `to_timedelta`, `astype('datetime64[ns]')`, `Timestamp.round` all work as expected
- [x] `pre-commit run --files pandas/_libs/tslibs/np_datetime.pxd` passes