### PR TITLE
CLN: point cython3 TODOs at upstream cython#2485

### DIFF
--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -450,7 +450,7 @@ cpdef ismember(ndarray[htfunc_t] arr, ndarray[htfunc_t] values):
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def mode(ndarray[htfunc_t] values, bint dropna, const uint8_t[:] mask=None):
-    # TODO(cython3): use const htfunct_t[:]
+    # TODO(cython#2485): once possible, use const htfunc_t[:]
 
     cdef:
         ndarray[htfunc_t] keys

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1617,7 +1617,7 @@ cdef int64_t _extract_ordinal(object item, PeriodDtypeBase dtype) except? -1:
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def extract_period_unit(ndarray[object] values) -> PeriodDtypeBase:
-    # TODO: Change type to const object[:] when Cython supports that.
+    # TODO(cython#2485): once possible, use const object[:]
 
     cdef:
         Py_ssize_t i, n = len(values)


### PR DESCRIPTION
## Summary

- Two TODOs (`mode` in `hashtable_func_helper.pxi.in`, `extract_period_unit` in `period.pyx`) were ostensibly waiting on Cython 3 to enable `const ...[:]` typed memoryviews. We're now on Cython >3.1, but the real blocker is `const object[:]` memoryview support, tracked at [cython/cython#2485](https://github.com/cython/cython/issues/2485) — open since 2018, no PR, no champion. Maintainers have endorsed the change in principle (it's a small relaxation in `Nodes.py`), but it won't land on its own.
- Reword both TODOs to point at the actual upstream issue, so a future reader can see what's blocking and decide whether to upstream a fix.
- Drive-by: fix `htfunct_t` -> `htfunc_t` typo in the hashtable comment.

No behavior change.

## Test plan

- [x] pre-commit hooks pass
- N/A — comment-only change