### PR TITLE
PERF: Speed up Timedelta.total_seconds

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -176,6 +176,7 @@ Performance improvements
 - Performance improvement in :meth:`Index.join` and :meth:`Index.union` for :class:`RangeIndex` by avoiding unnecessary memory allocation in the libjoin fastpath (:issue:`54646`)
 - Performance improvement in :meth:`IntervalIndex.get_indexer` for monotonic non-overlapping indexes, which now uses binary search instead of the interval tree (:issue:`47614`)
 - Performance improvement in :meth:`NDFrame.__finalize__`, :meth:`Series.to_numpy`, :attr:`DataFrame.dtypes`, and :meth:`DataFrame.__getitem__` (:issue:`57431`)
+- Performance improvement in :meth:`Timedelta.total_seconds` (:issue:`65388`)
 - Performance improvement in :meth:`arrays.SparseArray.isna` by avoiding a dense-then-resparsify round-trip (:issue:`41023`)
 - Performance improvement in datetime/timedelta unit conversion (e.g. ``datetime64[s]`` to ``datetime64[ns]``) (:issue:`35025`)
 - Performance improvement in indexing a :class:`DataFrame` with a :class:`CategoricalIndex` of :class:`Interval` categories (:issue:`61928`)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1261,7 +1261,7 @@ cdef class _Timedelta(timedelta):
         return npy_unit_to_abbrev(self._creso)
 
     @property
-    def days(self) -> int:  # TODO(cython3): make cdef property
+    def days(self) -> int:
         """
         Returns the days of the timedelta.
 
@@ -1297,7 +1297,7 @@ cdef class _Timedelta(timedelta):
         return self._d
 
     @property
-    def seconds(self) -> int:  # TODO(cython3): make cdef property
+    def seconds(self) -> int:
         """
         Return the total hours, minutes, and seconds of the timedelta as seconds.
 
@@ -1335,7 +1335,7 @@ cdef class _Timedelta(timedelta):
         return self._h * 3600 + self._m * 60 + self._s
 
     @property
-    def microseconds(self) -> int:  # TODO(cython3): make cdef property
+    def microseconds(self) -> int:
         # NB: using the python C-API PyDateTime_DELTA_GET_MICROSECONDS will fail
         #  (or be incorrect)
         """
@@ -1396,7 +1396,12 @@ cdef class _Timedelta(timedelta):
         """
         # We need to override bc we overrode days/seconds/microseconds
         # TODO: add nanos/1e9?
-        return self.days * 24 * 3600 + self.seconds + self.microseconds / 1_000_000
+        self._ensure_components()
+        return (
+            self._d * 86400
+            + self._h * 3600 + self._m * 60 + self._s
+            + (self._ms * 1000 + self._us) / 1_000_000
+        )
 
     @property
     def unit(self) -> str:


### PR DESCRIPTION
## Summary

- `_Timedelta.total_seconds()` reads `_d/_h/_m/_s/_ms/_us` directly instead of going through the `days`, `seconds`, and `microseconds` `@property` descriptors. ~3.3x faster on a microbenchmark (~118 ns → ~36 ns/call).
- Drops the stale `TODO(cython3): make cdef property` comments on `days`/`seconds`/`microseconds`. Cython 3's `cdef property` syntax (`@property cdef inline ... noexcept`) only applies to `extern` cdef classes (e.g. the entries in `cpython/datetime.pxd`); it errors out on regular `cdef class _Timedelta(timedelta)` with "Cdef functions cannot take arbitrary decorators." So the TODO is not actionable, and this PR achieves the underlying intent (skip the Python descriptor on internal cdef calls) by reading the typed fields directly.

## Test plan

- [x] `pytest pandas/tests/scalar/timedelta/` (569 passed, 1 xfailed)
- [x] `pre-commit run --files ...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)