### PR TITLE
CLN: remove _offset_map cache in offsets.pyx

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyi
+++ b/pandas/_libs/tslibs/offsets.pyi
@@ -339,5 +339,3 @@ def shift_months(
     day_opt: str | None = ...,
     reso: int = ...,
 ) -> npt.NDArray[np.int64]: ...
-
-_offset_map: dict[str, BaseOffset]

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -7143,10 +7143,6 @@ _dont_uppercase = {"min", "h", "bh", "cbh", "s", "ms", "us", "ns"}
 
 INVALID_FREQ_ERR_MSG = "Invalid frequency: {0}"
 
-# TODO: still needed?
-# cache of previously seen offsets
-_offset_map = {}
-
 
 deprec_to_valid_alias = {
     "H": "h",
@@ -7265,23 +7261,18 @@ def _get_offset(name: str) -> BaseOffset:
     --------
     _get_offset('EOM') --> BMonthEnd(1)
     """
-    if name not in _offset_map:
-        try:
-            split = name.split("-")
-            klass = prefix_mapping[split[0]]
-            # handles case where there's no suffix (and will TypeError if too
-            # many '-')
-            offset = klass._from_name(*split[1:])
-        except (ValueError, TypeError, KeyError) as err:
-            # bad prefix or suffix
-            raise_invalid_freq(
-                freq=name,
-                extra_message=f"Failed to parse with error message: {repr(err)}."
-            )
-        # cache
-        _offset_map[name] = offset
-
-    return _offset_map[name]
+    try:
+        split = name.split("-")
+        klass = prefix_mapping[split[0]]
+        # handles case where there's no suffix (and will TypeError if too
+        # many '-')
+        return klass._from_name(*split[1:])
+    except (ValueError, TypeError, KeyError) as err:
+        # bad prefix or suffix
+        raise_invalid_freq(
+            freq=name,
+            extra_message=f"Failed to parse with error message: {repr(err)}."
+        )
 
 
 cpdef to_offset(freq, bint is_period=False):

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -23,7 +23,6 @@ from pandas._libs.tslibs import (
 import pandas._libs.tslibs.offsets as liboffsets
 from pandas._libs.tslibs.offsets import (
     _get_offset,
-    _offset_map,
     to_offset,
 )
 from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
@@ -625,9 +624,6 @@ class TestCommon:
 
 
 class TestDateOffset:
-    def setup_method(self):
-        _offset_map.clear()
-
     def test_repr(self):
         repr(DateOffset())
         repr(DateOffset(2))
@@ -837,21 +833,10 @@ def test_get_offset_legacy():
 
 
 class TestOffsetAliases:
-    def setup_method(self):
-        _offset_map.clear()
-
-    def test_alias_equality(self):
-        for k, v in _offset_map.items():
-            if v is None:
-                continue
-            assert k == v.copy()
-
     def test_rule_code(self):
         lst = ["ME", "MS", "BME", "BMS", "D", "B", "h", "min", "s", "ms", "us"]
         for k in lst:
             assert k == _get_offset(k).rule_code
-            # should be cached - this is kind of an internals test...
-            assert k in _offset_map
             assert k == (_get_offset(k) * 3).rule_code
 
         suffix_lst = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
@@ -942,7 +927,6 @@ class TestReprNames:
         days = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
         names += ["W-" + day for day in days]
         names += ["WOM-" + week + day for week in ("1", "2", "3", "4") for day in days]
-        _offset_map.clear()
         for name in names:
             offset = _get_offset(name)
             assert offset.freqstr == name


### PR DESCRIPTION
## Summary

Removes the `_offset_map` dict cache inside `_get_offset` (offsets.pyx). It was added in 2012 (commit `0cc1a3d`) when offset construction was slow enough that caching alias→offset lookups was worth it.

Today the cache buys very little:
- Construction itself is ~0.3 µs; the cache saves ~0.3 µs at the bare-`_get_offset` level and ~0.5 µs at the realistic `to_offset(non-tick)` level (~5–25%).
- Tick aliases (`D`, `h`, `min`, `s`, `ms`, `us`, `ns`) bypass `_get_offset` entirely, so the cache never serves them.
- `to_offset` itself never returned cached identity even with the cache, because the trailing `offset * int(np.fabs(stride) * stride_sign)` step always produces a fresh instance. So `to_offset(name) is to_offset(name)` was already `False` for every name, and equality is preserved.

After the change, `_get_offset` is just `prefix_mapping[split[0]]._from_name(*split[1:])` with the existing error wrapping.

## Test plan

- [x] `pytest pandas/tests/tseries/offsets/test_offsets.py` — 3818 passed
- [x] `pytest pandas/tests/tseries/frequencies/ pandas/tests/tslibs/test_to_offset.py` — 1405 passed
- [x] `pre-commit run` on changed files — clean