### PR TITLE
BUG: infer_dtype treats pd.NA as a generic null in TemporalValidator

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -212,6 +212,7 @@ Datetimelike
 - Bug in :class:`DatetimeIndex` raising ``AttributeError`` when comparing against Arrow date types (date32, date64) (:issue:`62051`)
 - Bug in :class:`Timestamp` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)
+- Bug in :func:`api.types.infer_dtype` returning ``"date"`` or ``"mixed"`` instead of ``"datetime"`` / ``"timedelta"`` for lists of :class:`Timestamp`/:class:`Timedelta` values mixed with ``pd.NA`` (:issue:`53023`)
 - Bug in :func:`date_range` where ``inclusive="left"`` and ``inclusive="right"`` returned a single-element result instead of empty when ``start`` equals ``end`` (:issue:`55293`)
 - Bug in :func:`date_range` where ``inclusive`` parameter failed to filter endpoints when only ``start`` and ``periods`` or ``end`` and ``periods`` were specified (:issue:`46331`)
 - Bug in :func:`date_range` where ``periods=1`` with offsets that disallow ``n=0`` (e.g. :class:`offsets.LastWeekOfMonth`, :class:`offsets.FY5253`) raised ``ValueError`` (:issue:`41563`)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2087,7 +2087,9 @@ cdef class TemporalValidator(Validator):
     cdef bint is_valid_skipna(self, object value) except -1:
         cdef:
             bint is_typed_null = self.is_valid_null(value)
-            bint is_generic_null = value is None or util.is_nan(value)
+            bint is_generic_null = (
+                value is None or value is C_NA or util.is_nan(value)
+            )
         if not is_generic_null:
             self.all_generic_na = False
         return self.is_value_typed(value) or is_typed_null or is_generic_null

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1367,12 +1367,12 @@ class TestTypeInference:
     def test_infer_dtype_datetime(self, arr):
         assert lib.infer_dtype(np.array(arr), skipna=True) == "datetime"
 
-    @pytest.mark.parametrize("na_value", [pd.NaT, np.nan])
+    @pytest.mark.parametrize("na_value", [pd.NaT, np.nan, pd.NA])
     @pytest.mark.parametrize(
         "time_stamp", [Timestamp("2011-01-01"), datetime(2011, 1, 1)]
     )
     def test_infer_dtype_datetime_with_na(self, na_value, time_stamp):
-        # starts with nan
+        # GH#53023: pd.NA should be treated as a generic null
         arr = np.array([na_value, time_stamp])
         assert lib.infer_dtype(arr, skipna=True) == "datetime"
 
@@ -1390,12 +1390,12 @@ class TestTypeInference:
     def test_infer_dtype_timedelta(self, arr):
         assert lib.infer_dtype(arr, skipna=True) == "timedelta"
 
-    @pytest.mark.parametrize("na_value", [pd.NaT, np.nan])
+    @pytest.mark.parametrize("na_value", [pd.NaT, np.nan, pd.NA])
     @pytest.mark.parametrize(
         "delta", [Timedelta("1 days"), np.timedelta64(1, "D"), timedelta(1)]
     )
     def test_infer_dtype_timedelta_with_na(self, na_value, delta):
-        # starts with nan
+        # GH#53023: pd.NA should be treated as a generic null
         arr = np.array([na_value, delta])
         assert lib.infer_dtype(arr, skipna=True) == "timedelta"
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3233,10 +3233,12 @@ def test_infer_dtype_pyarrow_dtype(data, request):
     res = lib.infer_dtype(data)
     assert res != "unknown-array"
 
-    if data._hasna and res in ["datetime64", "timedelta64"]:
+    if res in ["datetime64", "timedelta64"]:
+        # infer_dtype on the pyarrow-backed array returns datetime64/timedelta64
+        # via _TYPE_MAP, but infer_dtype on list(data) returns datetime/timedelta
+        # because the elements are pd.Timestamp/pd.Timedelta (PyDateTime/PyDelta).
         mark = pytest.mark.xfail(
-            reason="in infer_dtype pd.NA is not ignored in these cases "
-            "even with skipna=True in the list(data) check below"
+            reason="infer_dtype(arrow_array) vs infer_dtype(list) naming mismatch"
         )
         request.applymarker(mark)
 

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -259,8 +259,8 @@ Attribute "inferred_type" are different
 \\[left\\]:  mixed
 \\[right\\]: datetime"""
 
-    idx1 = Index([NA, np.datetime64("nat", "ns")])
-    idx2 = Index([NA, NaT])
+    idx1 = Index([NA, np.datetime64("nat", "ns")], dtype=object)
+    idx2 = Index([NA, NaT], dtype=object)
     with pytest.raises(AssertionError, match=msg):
         tm.assert_index_equal(idx1, idx2)
 


### PR DESCRIPTION
## Summary

- `TemporalValidator.is_valid_skipna` only recognized `None` and `NaN` as generic nulls, so `infer_dtype` on a list of `Timestamp` / `Timedelta` values mixed with `pd.NA` returned `"date"` (since `Timestamp` is a `date` subclass) or `"mixed"` instead of `"datetime"` / `"timedelta"`. Add `value is C_NA` to the generic-null check.
- Extend the parametrized `test_infer_dtype_datetime_with_na` and `test_infer_dtype_timedelta_with_na` to cover `pd.NA` alongside `pd.NaT` and `np.nan`.
- The `pyarrow` `test_infer_dtype_pyarrow_dtype` xfail had a misleading reason that pointed at this `pd.NA` handling. The test still fails for an unrelated reason (`infer_dtype(arrow_array)` returns `"datetime64"` via `_TYPE_MAP` while `infer_dtype(list)` returns `"datetime"` from the value-based path), so the xfail is kept but with a more accurate reason.
- `test_assert_index_equal_different_inferred_types` previously relied on `Index([NA, np.datetime64(\"nat\", \"ns\")])` falling through to object dtype with `inferred_type == \"mixed\"`. With `pd.NA` now recognized as a generic null, that constructs a `DatetimeIndex`. Force `dtype=object` on both indexes so the test continues to exercise the `inferred_type are different` assertion path.

## Test plan

- [x] `pytest pandas/tests/dtypes/test_inference.py::TestTypeInference::test_infer_dtype_datetime_with_na pandas/tests/dtypes/test_inference.py::TestTypeInference::test_infer_dtype_timedelta_with_na`
- [x] `pytest pandas/tests/util/test_assert_index_equal.py::test_assert_index_equal_different_inferred_types`
- [x] `pytest pandas/tests/extension/test_arrow.py::test_infer_dtype_pyarrow_dtype`
- [x] `pytest pandas/tests/util/ pandas/tests/dtypes/ pandas/tests/extension/test_arrow.py pandas/tests/indexes/` — 48,712 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)