### PR TITLE
CLN: remove stale cython3 conditional-nogil TODO in rank_sorted_1d

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1270,7 +1270,6 @@ cdef void rank_sorted_1d(
     # array that we sorted previously, which gives us the location of
     # that sorted value for retrieval back from the original
     # values / masked_vals arrays
-    # TODO(cython3): de-duplicate once cython supports conditional nogil
     with gil(numeric_object_t is object):
         for i in range(N):
             at_end = i == N - 1


### PR DESCRIPTION
## Summary

- Removes a stale `TODO(cython3)` comment in `rank_sorted_1d` that asked to de-duplicate "once cython supports conditional nogil." That feature is in use right below the comment (`with gil(numeric_object_t is object):`), and Cython >3.1 is now required, so the dedup is already done.

## Test plan

- [ ] Pure comment deletion — no behavior change, no tests needed.