### PR TITLE
[backport 3.0.x] BUG: fix "1 ," converting to 1 by `read_csv` c engine with thousands separator (#64631)

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -17,6 +17,9 @@ Fixed regressions
 - Fixed reading of Parquet files with timezone-aware timestamps or localizing of a timeseries with a ``pytz`` timezone when an older version of ``pytz`` was installed (:issue:`64978`)
 - Fixed regression in :func:`to_timedelta` ignoring the ``unit`` argument for round float values when mixed with non-round floats in a list (:issue:`65150`)
 - Fixed regression in :meth:`Series.rank` with custom extension dtypes (:issue:`64976`)
+- Fixed a regression in :func:`read_csv` with ``engine="c"`` where ``thousands=","``
+  could incorrectly parse non-numeric values like ``"1 ,"`` as integers
+  instead of strings (:issue:`64655`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.bug_fixes:

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1821,41 +1821,39 @@ int uint64_conflict(uint_state *self) {
   return self->seen_uint && (self->seen_sint || self->seen_null);
 }
 
-/* Copy a string without `char_to_remove` into `output`.
+/* Copy a numeric token without `tsep` into `output`.
  */
-static int copy_string_without_char(char output[PROCESSED_WORD_CAPACITY],
-                                    const char *str, size_t str_len,
-                                    char char_to_remove) {
-  const char *left = str;
-  const char *end_ptr = str + str_len;
+static int copy_number_without_tsep(char output[PROCESSED_WORD_CAPACITY],
+                                    const char *str, char **endptr,
+                                    size_t str_len, char tsep) {
+  const char *p = str;
+  const char *end = str + str_len;
   size_t bytes_written = 0;
 
-  while (left < end_ptr) {
-    const size_t remaining_bytes_to_read = end_ptr - left;
-    const char *right = memchr(left, char_to_remove, remaining_bytes_to_read);
+  if (p < end && (*p == '+' || *p == '-')) {
+    output[bytes_written++] = *p++;
+  }
 
-    if (!right) {
-      // If it doesn't find the char to remove, just copy until EOS.
-      right = end_ptr;
+  while (p < end && (isdigit_ascii(*p) || (tsep != '\0' && *p == tsep))) {
+    if (*p != tsep) {
+      if (bytes_written + 1 >= PROCESSED_WORD_CAPACITY) {
+        return -1;
+      }
+      output[bytes_written++] = *p;
     }
-
-    const size_t chunk_size = right - left;
-
-    if (chunk_size + bytes_written >= PROCESSED_WORD_CAPACITY) {
-      return -1;
-    }
-    memcpy(&output[bytes_written], left, chunk_size);
-    bytes_written += chunk_size;
-
-    left = right + 1;
+    p++;
   }
 
   output[bytes_written] = '\0';
+  if (endptr != NULL) {
+    *endptr = (char *)p;
+  }
   return 0;
 }
 
 int64_t str_to_int64(const char *p_item, int *error, char tsep) {
   const char *p = p_item;
+  char *number_end = NULL;
   // Skip leading spaces.
   while (isspace_ascii(*p)) {
     ++p;
@@ -1876,7 +1874,8 @@ int64_t str_to_int64(const char *p_item, int *error, char tsep) {
   char buffer[PROCESSED_WORD_CAPACITY];
   const size_t str_len = strlen(p);
   if (tsep != '\0' && memchr(p, tsep, str_len) != NULL) {
-    const int status = copy_string_without_char(buffer, p, str_len, tsep);
+    const int status =
+        copy_number_without_tsep(buffer, p, &number_end, str_len, tsep);
     if (status != 0) {
       // Word is too big, probably will cause an overflow
       *error = ERROR_OVERFLOW;
@@ -1887,6 +1886,9 @@ int64_t str_to_int64(const char *p_item, int *error, char tsep) {
 
   char *endptr;
   int64_t number = strtoll(p, &endptr, 10);
+  if (number_end != NULL) {
+    endptr = number_end;
+  }
 
   if (errno == ERANGE) {
     *error = *endptr ? ERROR_INVALID_CHARS : ERROR_OVERFLOW;
@@ -1912,6 +1914,7 @@ int64_t str_to_int64(const char *p_item, int *error, char tsep) {
 uint64_t str_to_uint64(uint_state *state, const char *p_item, int *error,
                        char tsep) {
   const char *p = p_item;
+  char *number_end = NULL;
   // Skip leading spaces.
   while (isspace_ascii(*p)) {
     ++p;
@@ -1936,7 +1939,8 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int *error,
   char buffer[PROCESSED_WORD_CAPACITY];
   const size_t str_len = strlen(p);
   if (tsep != '\0' && memchr(p, tsep, str_len) != NULL) {
-    const int status = copy_string_without_char(buffer, p, str_len, tsep);
+    const int status =
+        copy_number_without_tsep(buffer, p, &number_end, str_len, tsep);
     if (status != 0) {
       // Word is too big, probably will cause an overflow
       *error = ERROR_OVERFLOW;
@@ -1947,6 +1951,9 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int *error,
 
   char *endptr;
   uint64_t number = strtoull(p, &endptr, 10);
+  if (number_end != NULL) {
+    endptr = number_end;
+  }
 
   if (errno == ERANGE) {
     *error = *endptr ? ERROR_INVALID_CHARS : ERROR_OVERFLOW;

--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -108,6 +108,22 @@ def test_1000_sep(all_parsers, number_csv, expected_number, request):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("value", ["1 ,", ", 1", ",1"])
+def test_1000_sep_not_stripped_after_whitespace(all_parsers, value):
+    parser = all_parsers
+    data = f"a\n{value}\n"
+    expected = DataFrame({"a": [value]})
+
+    if parser.engine == "pyarrow":
+        msg = "The 'thousands' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), sep=";", thousands=",")
+        return
+
+    result = parser.read_csv(StringIO(data), sep=";", thousands=",")
+    tm.assert_frame_equal(result, expected)
+
+
 @xfail_pyarrow  # ValueError: Found non-unique column index
 def test_unnamed_columns(all_parsers):
     data = """A,B,C,,


### PR DESCRIPTION
Backport of #64631