### PR TITLE
[backport 3.0.x] CI: fix numpy nightly DeprecationWarning for generic-unit datetime64/timedelta64 (#65340)

### DIFF
--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -409,7 +409,7 @@ def _dtype_to_na_value(dtype: DtypeObj, has_none_blocks: bool):
     if isinstance(dtype, ExtensionDtype):
         return dtype.na_value
     elif dtype.kind in "mM":
-        return dtype.type("NaT")
+        return dtype.type("NaT", np.datetime_data(dtype)[0])
     elif dtype.kind in "fc":
         return dtype.type("NaN")
     elif dtype.kind == "b":

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -502,8 +502,8 @@ class TestDatetimeIndexComparisons:
             [
                 np.datetime64("2014-02-01 00:00"),
                 np.datetime64("2014-03-01 00:00"),
-                np.datetime64("nat"),
-                np.datetime64("nat"),
+                np.datetime64("nat", "ns"),
+                np.datetime64("nat", "ns"),
                 np.datetime64("2014-06-01 00:00"),
                 np.datetime64("2014-07-01 00:00"),
             ]

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1072,8 +1072,13 @@ class TestTimedeltaArraylikeAddSubOps:
         with pytest.raises(TypeError, match=msg):
             tdarr - ts
 
+    @pytest.mark.filterwarnings("ignore:.*generic.*unit.*:DeprecationWarning")
     def test_td64arr_add_datetime64_nat(self, box_with_array):
         # GH#23215
+        # The bare np.datetime64("NaT") is load-bearing here: the expected
+        # M8[us] dtype comes from numpy's default unit promotion from the
+        # generic-unit scalar. NumPy nightly emits a DeprecationWarning for
+        # the bare form, which the filterwarnings marker ignores.
         other = np.datetime64("NaT")
 
         tdi = timedelta_range("1 day", periods=3)

--- a/pandas/tests/arrays/masked/test_indexing.py
+++ b/pandas/tests/arrays/masked/test_indexing.py
@@ -40,7 +40,7 @@ class TestSetitemValidation:
         "1",
         "1.0",
         pd.NaT,
-        np.datetime64("NaT"),
+        np.datetime64("NaT", "ns"),
         np.timedelta64("NaT", "ns"),
     ]
 

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -235,7 +235,7 @@ class TestTimedeltaArray:
             1,
             np.int64(1),
             1.0,
-            np.datetime64("NaT"),
+            np.datetime64("NaT", "ns"),
             pd.Timestamp("2021-01-01"),
             "invalid",
             np.arange(10, dtype="i8") * 24 * 3600 * 10**9,

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1350,8 +1350,12 @@ class TestTypeInference:
             np.array([Timestamp("2011-01-02"), np.datetime64("2011-01-01")]),
             np.array([np.nan, Timestamp("2011-01-02"), 1.1]),
             np.array([np.nan, "2011-01-01", Timestamp("2011-01-02")], dtype=object),
-            np.array([np.datetime64("nat"), np.timedelta64(1, "D")], dtype=object),
-            np.array([np.timedelta64(1, "D"), np.datetime64("nat")], dtype=object),
+            np.array(
+                [np.datetime64("nat", "ns"), np.timedelta64(1, "D")], dtype=object
+            ),
+            np.array(
+                [np.timedelta64(1, "D"), np.datetime64("nat", "ns")], dtype=object
+            ),
         ],
     )
     def test_infer_datetimelike_dtype_mixed(self, arr):
@@ -1443,12 +1447,12 @@ class TestTypeInference:
 
     def test_infer_dtype_period_mixed(self):
         arr = np.array(
-            [Period("2011-01", freq="M"), np.datetime64("nat")], dtype=object
+            [Period("2011-01", freq="M"), np.datetime64("nat", "ns")], dtype=object
         )
         assert lib.infer_dtype(arr, skipna=False) == "mixed"
 
         arr = np.array(
-            [np.datetime64("nat"), Period("2011-01", freq="M")], dtype=object
+            [np.datetime64("nat", "ns"), Period("2011-01", freq="M")], dtype=object
         )
         assert lib.infer_dtype(arr, skipna=False) == "mixed"
 
@@ -1504,14 +1508,14 @@ class TestTypeInference:
         assert lib.infer_dtype(arr, skipna=False) == "datetime"
 
         # np.datetime64(nat)
-        arr = np.array([np.datetime64("nat")])
+        arr = np.array([np.datetime64("nat", "ns")])
         assert lib.infer_dtype(arr, skipna=False) == "datetime64"
 
         for n in [np.nan, pd.NaT, None]:
-            arr = np.array([n, np.datetime64("nat"), n])
+            arr = np.array([n, np.datetime64("nat", "ns"), n])
             assert lib.infer_dtype(arr, skipna=False) == "datetime64"
 
-            arr = np.array([pd.NaT, n, np.datetime64("nat"), n])
+            arr = np.array([pd.NaT, n, np.datetime64("nat", "ns"), n])
             assert lib.infer_dtype(arr, skipna=False) == "datetime64"
 
         arr = np.array([np.timedelta64("NaT", "ns")], dtype=object)
@@ -1526,17 +1530,17 @@ class TestTypeInference:
 
         # datetime / timedelta mixed
         arr = np.array(
-            [pd.NaT, np.datetime64("nat"), np.timedelta64("NaT", "ns"), np.nan]
+            [pd.NaT, np.datetime64("nat", "ns"), np.timedelta64("NaT", "ns"), np.nan]
         )
         assert lib.infer_dtype(arr, skipna=False) == "mixed"
 
         arr = np.array(
-            [np.timedelta64("NaT", "ns"), np.datetime64("nat")], dtype=object
+            [np.timedelta64("NaT", "ns"), np.datetime64("nat", "ns")], dtype=object
         )
         assert lib.infer_dtype(arr, skipna=False) == "mixed"
 
     def test_is_datetimelike_array_all_nan_nat_like(self):
-        arr = np.array([np.nan, pd.NaT, np.datetime64("nat")])
+        arr = np.array([np.nan, pd.NaT, np.datetime64("nat", "ns")])
         assert lib.is_datetime_array(arr)
         assert lib.is_datetime64_array(arr)
         assert not lib.is_timedelta_or_timedelta64_array(arr)
@@ -1547,7 +1551,7 @@ class TestTypeInference:
         assert lib.is_timedelta_or_timedelta64_array(arr)
 
         arr = np.array(
-            [np.nan, pd.NaT, np.datetime64("nat"), np.timedelta64("NaT", "ns")]
+            [np.nan, pd.NaT, np.datetime64("nat", "ns"), np.timedelta64("NaT", "ns")]
         )
         assert not lib.is_datetime_array(arr)
         assert not lib.is_datetime64_array(arr)
@@ -1661,7 +1665,8 @@ class TestTypeInference:
             np.array(["foo", "bar", pd.NaT], dtype=object), skipna=True
         )
         assert not lib.is_string_array(
-            np.array(["foo", "bar", np.datetime64("NaT")], dtype=object), skipna=True
+            np.array(["foo", "bar", np.datetime64("NaT", "ns")], dtype=object),
+            skipna=True,
         )
         assert not lib.is_string_array(
             np.array(["foo", "bar", Decimal("NaN")], dtype=object), skipna=True
@@ -2026,7 +2031,7 @@ class TestIsScalar:
             "foobar",
             np.datetime64("2014-01-01"),
             np.timedelta64(1, "h"),
-            np.datetime64("NaT"),
+            np.datetime64("NaT", "ns"),
         ],
     )
     def test_is_scalar_numpy_zerodim_arrays(self, zerodim):

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -160,7 +160,7 @@ class TestIsNA:
         arr = np.array(
             [
                 NaT,
-                np.datetime64("NaT"),
+                np.datetime64("NaT", "ns"),
                 np.timedelta64("NaT", "ns"),
                 np.datetime64("NaT", "s"),
             ]
@@ -766,7 +766,7 @@ na_vals = (
         np.float32("NaN"),
         np.complex64(np.nan),
         np.complex128(np.nan),
-        np.datetime64("NaT"),
+        np.datetime64("NaT", "ns"),
         np.timedelta64("NaT", "ns"),
     ]
     + [np.datetime64("NaT", unit) for unit in m8_units]  # type: ignore[call-overload]

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1135,7 +1135,7 @@ class TestDataFrameIndexing:
         df["F"] = np.timedelta64("NaT", "ns")
         df.loc[df.index[:-1], "F"] = np.array([6 * one_hour] * 3, dtype="m8[ns]")
         df.loc[df.index[-3] :, "G"] = date_range("20130101", periods=3, unit="ns")
-        df["H"] = np.datetime64("NaT")
+        df["H"] = np.datetime64("NaT", "ns")
         result = df.dtypes
         expected = Series(
             [np.dtype("timedelta64[ns]")] * 6 + [np.dtype("datetime64[ns]")] * 2,
@@ -1917,7 +1917,7 @@ class TestSetitemValidation:
         "1",
         "1.0",
         pd.NaT,
-        np.datetime64("NaT"),
+        np.datetime64("NaT", "ns"),
         np.timedelta64("NaT", "ns"),
     ]
     _indexers = [0, [0], slice(0, 1), [True, False, False], slice(None, None, None)]

--- a/pandas/tests/frame/methods/test_rank.py
+++ b/pandas/tests/frame/methods/test_rank.py
@@ -388,7 +388,7 @@ class TestRank:
             "float64": np.nan,
             "float32": np.nan,
             "object": None,
-            "datetime64": np.datetime64("nat"),
+            "datetime64": np.datetime64("nat", "ns"),
         }
         # Insert nans at random positions if underlying dtype has missing
         # value. Then adjust the expected order by adding nans accordingly

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2032,11 +2032,11 @@ class TestDataFrameConstructors:
         [
             np.array([None, None, None, None, datetime.now(), None]),
             np.array([None, None, datetime.now(), None]),
-            [[np.datetime64("NaT")], [None]],
-            [[np.datetime64("NaT")], [pd.NaT]],
-            [[None], [np.datetime64("NaT")]],
+            [[np.datetime64("NaT", "ns")], [None]],
+            [[np.datetime64("NaT", "ns")], [pd.NaT]],
+            [[None], [np.datetime64("NaT", "ns")]],
             [[None], [pd.NaT]],
-            [[pd.NaT], [np.datetime64("NaT")]],
+            [[pd.NaT], [np.datetime64("NaT", "ns")]],
             [[pd.NaT], [None]],
         ],
     )

--- a/pandas/tests/groupby/methods/test_nth.py
+++ b/pandas/tests/groupby/methods/test_nth.py
@@ -634,14 +634,14 @@ def test_first_categorical_and_datetime_data_nat():
     df = DataFrame(
         {
             "group": ["first", "first", "second", "third", "third"],
-            "time": 5 * [np.datetime64("NaT")],
+            "time": 5 * [np.datetime64("NaT", "ns")],
             "categories": Series(["a", "b", "c", "a", "b"], dtype="category"),
         }
     )
     result = df.groupby("group").first()
     expected = DataFrame(
         {
-            "time": 3 * [np.datetime64("NaT")],
+            "time": 3 * [np.datetime64("NaT", "ns")],
             "categories": Series(["a", "c", "a"]).astype(
                 pd.CategoricalDtype(["a", "b", "c"])
             ),

--- a/pandas/tests/indexes/categorical/test_indexing.py
+++ b/pandas/tests/indexes/categorical/test_indexing.py
@@ -364,7 +364,7 @@ class TestContains:
         assert np.nan in obj
         assert None in obj
         assert pd.NaT in obj
-        assert np.datetime64("NaT") in obj
+        assert np.datetime64("NaT", "ns") in obj
         assert np.timedelta64("NaT", "ns") not in obj
 
         obj2 = CategoricalIndex(tdi)
@@ -374,7 +374,7 @@ class TestContains:
         assert np.nan in obj2
         assert None in obj2
         assert pd.NaT in obj2
-        assert np.datetime64("NaT") not in obj2
+        assert np.datetime64("NaT", "ns") not in obj2
         assert np.timedelta64("NaT", "ns") in obj2
 
         obj3 = CategoricalIndex(pi)
@@ -384,7 +384,7 @@ class TestContains:
         assert np.nan in obj3
         assert None in obj3
         assert pd.NaT in obj3
-        assert np.datetime64("NaT") not in obj3
+        assert np.datetime64("NaT", "ns") not in obj3
         assert np.timedelta64("NaT", "ns") not in obj3
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/datetimes/methods/test_insert.py
+++ b/pandas/tests/indexes/datetimes/methods/test_insert.py
@@ -16,7 +16,9 @@ import pandas._testing as tm
 
 
 class TestInsert:
-    @pytest.mark.parametrize("null", [None, np.nan, np.datetime64("NaT"), NaT, NA])
+    @pytest.mark.parametrize(
+        "null", [None, np.nan, np.datetime64("NaT", "ns"), NaT, NA]
+    )
     @pytest.mark.parametrize("tz", [None, "UTC", "US/Eastern"])
     def test_insert_nat(self, tz, null):
         # GH#16537, GH#18295 (test missing)

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -476,7 +476,7 @@ class TestGetLoc:
 
         assert index.get_loc(pd.NA) == 1
 
-        assert index.get_loc(np.datetime64("NaT")) == 1
+        assert index.get_loc(np.datetime64("NaT", "ns")) == 1
 
         with pytest.raises(KeyError, match="NaT"):
             index.get_loc(np.timedelta64("NaT", "ns"))

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -123,7 +123,7 @@ class TestIndexConstructorInference:
     @pytest.mark.parametrize(
         "klass,dtype,ctor",
         [
-            (DatetimeIndex, "datetime64[ns]", np.datetime64("nat")),
+            (DatetimeIndex, "datetime64[ns]", np.datetime64("nat", "ns")),
             (TimedeltaIndex, "timedelta64[ns]", np.timedelta64("NaT", "ns")),
         ],
     )
@@ -164,7 +164,7 @@ class TestIndexConstructorInference:
     @pytest.mark.parametrize("swap_objs", [True, False])
     def test_constructor_mixed_nat_objs_infers_object(self, swap_objs):
         # mixed np.datetime64/timedelta64 nat results in object
-        data = [np.datetime64("nat"), np.timedelta64("NaT", "ns")]
+        data = [np.datetime64("nat", "ns"), np.timedelta64("NaT", "ns")]
         if swap_objs:
             data = data[::-1]
 

--- a/pandas/tests/indexes/timedeltas/methods/test_insert.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_insert.py
@@ -86,14 +86,14 @@ class TestTimedeltaIndexInsert:
     def test_insert_invalid_na(self):
         idx = TimedeltaIndex(["4day", "1day", "2day"], name="idx")
 
-        item = np.datetime64("NaT")
+        item = np.datetime64("NaT", "ns")
         result = idx.insert(0, item)
 
         expected = Index([item, *list(idx)], dtype=object, name="idx")
         tm.assert_index_equal(result, expected)
 
         # Also works if we pass a different dt64nat object
-        item2 = np.datetime64("NaT")
+        item2 = np.datetime64("NaT", "ns")
         result = idx.insert(0, item2)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -65,7 +65,7 @@ class TestGetItem:
             datetime(1970, 1, 1),
             Timestamp("1970-01-03").to_datetime64(),
             # non-matching NA values
-            np.datetime64("NaT"),
+            np.datetime64("NaT", "ns"),
         ],
     )
     def test_timestamp_invalid_key(self, key):

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -347,7 +347,7 @@ class TestUltraJSONTests:
         assert expected == output
 
     @pytest.mark.parametrize(
-        "decoded_input", [NaT, np.datetime64("NaT"), np.nan, np.inf, -np.inf]
+        "decoded_input", [NaT, np.datetime64("NaT", "ns"), np.nan, np.inf, -np.inf]
     )
     def test_encode_as_null(self, decoded_input):
         assert ujson.ujson_dumps(decoded_input) == "null", "Expected null"

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -355,14 +355,14 @@ def test_null_date(datapath):
             "datecol": np.array(
                 [
                     datetime(9999, 12, 29),
-                    np.datetime64("NaT"),
+                    np.datetime64("NaT", "ns"),
                 ],
                 dtype="M8[s]",
             ),
             "datetimecol": np.array(
                 [
                     datetime(9999, 12, 29, 23, 59, 59, 999000),
-                    np.datetime64("NaT"),
+                    np.datetime64("NaT", "ns"),
                 ],
                 dtype="M8[ms]",
             ),

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -256,7 +256,7 @@ class TestTimedeltaAdditionSubtraction:
         result = NaT - td
         assert result is NaT
 
-        result = np.datetime64("NaT") - td
+        result = np.datetime64("NaT", "ns") - td
         assert result is NaT
 
     def test_td_rsub_offset(self):
@@ -569,7 +569,7 @@ class TestTimedeltaMultiplicationDivision:
 
         msg = r"unsupported operand type\(s\) for /: 'numpy.datetime64' and 'Timedelta'"
         with pytest.raises(TypeError, match=msg):
-            np.datetime64("NaT") / td
+            np.datetime64("NaT", "ns") / td
 
         msg = r"unsupported operand type\(s\) for /: 'float' and 'Timedelta'"
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -1097,7 +1097,9 @@ def test_non_nano_value():
     assert result == -52_700_112_000 * 10**6
 
 
-@pytest.mark.parametrize("na_value", [None, np.nan, np.datetime64("NaT"), NaT, NA])
+@pytest.mark.parametrize(
+    "na_value", [None, np.nan, np.datetime64("NaT", "ns"), NaT, NA]
+)
 def test_timestamp_constructor_na_value(na_value):
     # GH45481
     result = Timestamp(na_value)

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -481,7 +481,7 @@ class TestSetitemValidation:
         "1",
         "1.0",
         NaT,
-        np.datetime64("NaT"),
+        np.datetime64("NaT", "ns"),
         np.timedelta64("NaT", "ns"),
     ]
     _indexers = [0, [0], slice(0, 1), [True, False, False], slice(None, None, None)]

--- a/pandas/tests/series/methods/test_equals.py
+++ b/pandas/tests/series/methods/test_equals.py
@@ -69,8 +69,8 @@ def test_equals_false_negative():
 
 def test_equals_matching_nas():
     # matching but not identical NAs
-    left = Series([np.datetime64("NaT")], dtype=object)
-    right = Series([np.datetime64("NaT")], dtype=object)
+    left = Series([np.datetime64("NaT", "ns")], dtype=object)
+    right = Series([np.datetime64("NaT", "ns")], dtype=object)
     assert left.equals(right)
     assert Index(left).equals(Index(right))
     assert left.array.equals(right.array)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1593,7 +1593,7 @@ class TestDuplicated:
             np.array([Timestamp(d) for d in dt]),
             np.array([Timestamp(d, tz="US/Eastern") for d in dt]),
             np.array([Period(d, freq="D") for d in dt]),
-            np.array([np.datetime64(d) for d in dt]),
+            np.array([np.datetime64(d, "ns") for d in dt]),
             np.array([Timedelta(d) for d in td]),
         ]
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3421,9 +3421,9 @@ def test_nullable_integer_to_datetime():
         [
             np.datetime64("1970-01-01 00:00:00.000000001"),
             np.datetime64("1970-01-01 00:00:00.000000002"),
-            np.datetime64("NaT"),
+            np.datetime64("NaT", "ns"),
             np.datetime64("2043-01-25 23:56:49.213693952"),
-            np.datetime64("NaT"),
+            np.datetime64("NaT", "ns"),
         ]
     )
     tm.assert_series_equal(res, expected)

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -45,7 +45,7 @@ class TestArrayToDatetimeResolutionInference:
         arr = np.array([None, dt2, dt2, dt2], dtype=object)
         result, tz = tslib.array_to_datetime(arr, creso=creso_infer)
         assert tz is None
-        expected = np.array([np.datetime64("NaT"), dt2, dt2, dt2], dtype="M8[s]")
+        expected = np.array([np.datetime64("NaT", "ns"), dt2, dt2, dt2], dtype="M8[s]")
         tm.assert_numpy_array_equal(result, expected)
 
     def test_infer_homogeoneous_dt64(self):
@@ -54,7 +54,9 @@ class TestArrayToDatetimeResolutionInference:
         arr = np.array([None, dt64, dt64, dt64], dtype=object)
         result, tz = tslib.array_to_datetime(arr, creso=creso_infer)
         assert tz is None
-        expected = np.array([np.datetime64("NaT"), dt64, dt64, dt64], dtype="M8[ms]")
+        expected = np.array(
+            [np.datetime64("NaT", "ns"), dt64, dt64, dt64], dtype="M8[ms]"
+        )
         tm.assert_numpy_array_equal(result, expected)
 
     def test_infer_homogeoneous_timestamps(self):
@@ -63,7 +65,9 @@ class TestArrayToDatetimeResolutionInference:
         arr = np.array([None, ts, ts, ts], dtype=object)
         result, tz = tslib.array_to_datetime(arr, creso=creso_infer)
         assert tz is None
-        expected = np.array([np.datetime64("NaT")] + [ts.asm8] * 3, dtype="M8[ns]")
+        expected = np.array(
+            [np.datetime64("NaT", "ns")] + [ts.asm8] * 3, dtype="M8[ns]"
+        )
         tm.assert_numpy_array_equal(result, expected)
 
     def test_infer_homogeoneous_datetimes_strings(self):
@@ -71,7 +75,9 @@ class TestArrayToDatetimeResolutionInference:
         arr = np.array([None, item, item, item], dtype=object)
         result, tz = tslib.array_to_datetime(arr, creso=creso_infer)
         assert tz is None
-        expected = np.array([np.datetime64("NaT"), item, item, item], dtype="M8[us]")
+        expected = np.array(
+            [np.datetime64("NaT", "ns"), item, item, item], dtype="M8[us]"
+        )
         tm.assert_numpy_array_equal(result, expected)
 
     def test_infer_heterogeneous(self):
@@ -98,7 +104,7 @@ class TestArrayToDatetimeResolutionInference:
         arr = np.array([dt, item], dtype=object)
         result, tz = tslib.array_to_datetime(arr, creso=creso_infer)
         assert tz is None
-        expected = np.array([dt, np.datetime64("NaT")], dtype="M8[us]")
+        expected = np.array([dt, np.datetime64("NaT", "ns")], dtype="M8[us]")
         tm.assert_numpy_array_equal(result, expected)
 
         result2, tz2 = tslib.array_to_datetime(arr[::-1], creso=creso_infer)

--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -306,7 +306,7 @@ def test_assert_almost_equal_inf(a, b):
     _assert_almost_equal_both(a, b)
 
 
-objs = [NA, np.nan, NaT, None, np.datetime64("NaT"), np.timedelta64("NaT", "ns")]
+objs = [NA, np.nan, NaT, None, np.datetime64("NaT", "ns"), np.timedelta64("NaT", "ns")]
 
 
 @pytest.mark.parametrize("left", objs)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -259,7 +259,7 @@ Attribute "inferred_type" are different
 \\[left\\]:  mixed
 \\[right\\]: datetime"""
 
-    idx1 = Index([NA, np.datetime64("nat")])
+    idx1 = Index([NA, np.datetime64("nat", "ns")])
     idx2 = Index([NA, NaT])
     with pytest.raises(AssertionError, match=msg):
         tm.assert_index_equal(idx1, idx2)


### PR DESCRIPTION
(cherry picked from commit 8985f92c1a17ec831b4815715b69de8ea0a8f624)

Backport of #65340