### PR TITLE
BUG: prevent using numexpr 2.10 with newer numpy to avoid silent wrong results

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -11,6 +11,7 @@ _np_version = np.__version__
 _nlv = Version(_np_version)
 np_version_gt2 = _nlv >= Version("2.0.0")
 np_version_gt2_2 = _nlv >= Version("2.2.0")
+np_version_gt2_3 = _nlv >= Version("2.3.0")
 np_version_gt2_5 = _nlv >= Version("2.5.0")
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.26.0"

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -16,13 +16,17 @@ import numpy as np
 
 from pandas._config.config import _global_config as config
 
+from pandas.compat.numpy import np_version_gt2_3
 from pandas.util._exceptions import find_stack_level
 
 from pandas.core import roperator
 from pandas.core.computation.check import NUMEXPR_INSTALLED
+from pandas.util.version import Version
 
 if NUMEXPR_INSTALLED:
     import numexpr as ne
+
+    ne_gt_211 = Version(ne.__version__) >= Version("2.11.0")
 
 if TYPE_CHECKING:
     from pandas._typing import FuncType
@@ -47,7 +51,12 @@ def set_use_numexpr(v: bool = True) -> None:
     # set/unset to use numexpr
     global USE_NUMEXPR
     if NUMEXPR_INSTALLED:
-        USE_NUMEXPR = v
+        if np_version_gt2_3 and not ne_gt_211:
+            # incompatibility of numexpr 2.10 with newer pandas resulting in wrong data
+            # https://github.com/pandas-dev/pandas/issues/63320
+            USE_NUMEXPR = False
+        else:
+            USE_NUMEXPR = v
 
     # choose what we are going to do
     global _evaluate, _where


### PR DESCRIPTION
Closes #63320

I didn't make it into a noise warning, but just silently not using numexpr (we already don't guarantee to use numexp when it is enabled, since it also depends on the exact operator and the size of the data, so my feeling is that skipping numexpr here silently as well is fine).

This is not really tested in CI since we don't have that combo of versions (but tested this locally).

