### PR TITLE
TST: assert pyarrow's quoting ValueError instead of xfailing

### DIFF
--- a/pandas/tests/io/parser/test_quoting.py
+++ b/pandas/tests/io/parser/test_quoting.py
@@ -57,12 +57,17 @@ def test_bad_quote_char(all_parsers, kwargs, msg):
         (10, 'bad "quoting" value'),  # quoting must be in the range [0, 3]
     ],
 )
-@xfail_pyarrow  # ValueError: The 'quoting' option is not supported
 def test_bad_quoting(all_parsers, quoting, msg):
     data = "1,2,3"
     parser = all_parsers
 
-    with pytest.raises(TypeError, match=msg):
+    if parser.engine == "pyarrow":
+        # pyarrow rejects ``quoting`` outright before any value validation.
+        msg = "The 'quoting' option is not supported with the 'pyarrow' engine"
+        err: type[Exception] = ValueError
+    else:
+        err = TypeError
+    with pytest.raises(err, match=msg):
         parser.read_csv(StringIO(data), quoting=quoting)
 
 


### PR DESCRIPTION
## Summary

- `test_bad_quoting` was blanket-xfailed on the pyarrow engine because passing any non-default `quoting=` raises `ValueError("The 'quoting' option is not supported with the 'pyarrow' engine")` rather than the c/python engines' `TypeError` validation message.
- Assert the pyarrow error directly so the test exercises real behavior on every engine instead of being skipped.

## Test plan

- [x] `pytest pandas/tests/io/parser/test_quoting.py::test_bad_quoting` passes on all four parser parametrizations (c_high, c_low, python, pyarrow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)