### PR TITLE
CI: pin pyodide-build to fix venv pip wrapper crash

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -467,7 +467,14 @@ jobs:
           actions-cache-folder: emsdk-cache
 
       - name: Install pyodide-build
-        run: pip install "pyodide-build>=0.29.2"
+        # TODO: switch back to a released `pyodide-build` once a version
+        # containing the fix from pyodide/pyodide-build#341 is published.
+        # Pinned to the merge commit to keep the build reproducible. Without
+        # this fix, `pyodide venv` produces a pip wrapper that fails to import
+        # because pip>=26.1 vendors a urllib3 whose Emscripten contrib imports
+        # `js` eagerly when sys.platform is patched to "emscripten".
+        # See pyodide/pyodide-build#339.
+        run: pip install "pyodide-build @ git+https://github.com/pyodide/pyodide-build.git@471889be97c53d160909dd7e5ef8aace17e30637"
 
       - name: Build pandas for Pyodide
         run: |


### PR DESCRIPTION
## Summary

The `Pyodide build` CI job has been failing on `main` since pip 26.1 was released. `pyodide venv` generates a pip wrapper that runs on the host CPython but patches `sys.platform` to `"emscripten"` before invoking pip. pip 26.1 bumped its vendored urllib3 to a version whose `urllib3.contrib.emscripten` package imports `js` eagerly, so every pip invocation in the venv crashes with:

```
ModuleNotFoundError: No module named 'js'
  at .venv-pyodide/.../pip/_vendor/urllib3/contrib/emscripten/fetch.py:45
```

This is upstream issue [pyodide/pyodide-build#339](https://github.com/pyodide/pyodide-build/issues/339), fixed in [pyodide/pyodide-build#341](https://github.com/pyodide/pyodide-build/pull/341) by importing `pip._vendor.urllib3` before patching `sys.platform`. The fix is merged on `main` but not yet released.

Pin `pyodide-build` to the merge commit (`471889b`) until a release containing the fix ships.

## Test plan

- [ ] Pyodide build job goes green on this PR
- [ ] Drop the git pin and bump back to a released `pyodide-build` once a version containing pyodide/pyodide-build#341 is published