### PR TITLE
DOC: Remove old tutorials

### DIFF
--- a/doc/source/getting_started/tutorials.rst
+++ b/doc/source/getting_started/tutorials.rst
@@ -40,19 +40,6 @@ entails.
 For the table of contents, see the `pandas-cookbook GitHub
 repository <https://github.com/jvns/pandas-cookbook>`_.
 
-pandas workshop by Stefanie Molin
----------------------------------
-
-An introductory workshop by `Stefanie Molin <https://github.com/stefmolin>`_
-designed to quickly get you up to speed with pandas using real-world datasets.
-It covers getting started with pandas, data wrangling, and data visualization
-(with some exposure to matplotlib and seaborn). The
-`pandas-workshop GitHub repository <https://github.com/stefmolin/pandas-workshop>`_
-features detailed environment setup instructions (including a Binder environment),
-slides and notebooks for following along, and exercises to practice the concepts.
-There is also a lab with new exercises on a dataset not covered in the workshop for
-additional practice.
-
 Learn pandas by Hernan Rojas
 ----------------------------
 
@@ -92,11 +79,6 @@ The source may be found in the GitHub repository
 * `Visualization <https://tomaugspurger.github.io/modern-6-visualization.html>`_
 * `Timeseries <https://tomaugspurger.github.io/modern-7-timeseries.html>`_
 
-Excel charts with pandas, vincent and xlsxwriter
-------------------------------------------------
-
-*  `Using Pandas and XlsxWriter to create Excel charts <https://pandas-xlsxwriter-charts.readthedocs.io/>`_
-
 Joyful pandas
 -------------
 
@@ -110,12 +92,6 @@ All the datasets and related materials can be found in the GitHub repository
 Video tutorials
 ---------------
 
-* `Pandas From The Ground Up <https://www.youtube.com/watch?v=5JnMutdy6Fw>`_
-  (2015) (2:24)
-  `GitHub repo <https://github.com/brandon-rhodes/pycon-pandas-tutorial>`__
-* `Introduction Into Pandas <https://www.youtube.com/watch?v=-NR-ynQg0YM>`_
-  (2016) (1:28)
-  `GitHub repo <https://github.com/chendaniely/2016-pydata-carolinas-pandas>`__
 * `Pandas: .head() to .tail() <https://www.youtube.com/watch?v=7vuO9QXDN50>`_
   (2016) (1:26)
   `GitHub repo <https://github.com/TomAugspurger/pydata-chi-h2t>`__
@@ -133,10 +109,6 @@ Various tutorials
 -----------------
 
 * `Wes McKinney's (pandas BDFL) blog <https://wesmckinney.com/archives.html>`_
-* `Statistical analysis made easy in Python with SciPy and pandas DataFrames, by Randal Olson <http://www.randalolson.com/2012/08/06/statistical-analysis-made-easy-in-python/>`_
-* `Statistical Data Analysis in Python, tutorial by Christopher Fonnesbeck from SciPy 2013 <https://github.com/fonnesbeck/statistical-analysis-python-tutorial>`_
-* `Financial analysis in Python, by Thomas Wiecki <https://nbviewer.org/github/twiecki/financial-analysis-python-tutorial/blob/master/1.%20Pandas%20Basics.ipynb>`_
-* `Intro to pandas data structures, by Greg Reda <http://www.gregreda.com/2013/10/26/intro-to-pandas-data-structures/>`_
 * `Pandas DataFrames Tutorial, by Karlijn Willems <https://www.datacamp.com/community/tutorials/pandas-tutorial-dataframe-python>`_
 * `A concise tutorial with real life examples <https://tutswiki.com/pandas-cookbook/chapter1/>`_
 * `430+ Searchable Pandas recipes by Isshin Inada <https://skytowner.com/explore/pandas_recipes_reference>`_


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/pandas/pull/65374#issuecomment-4331891511

Wasn't sure if we should remove `Modern pandas` by @TomAugspurger and the 2016-2018 PyCon videos.