### PR TITLE
[backport 3.0.x] Parquet IO: also use zoneinfo timezones by default even when pyarrow uses pytz (#65134)

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -9,6 +9,20 @@ including other versions of pandas.
 {{ header }}
 
 .. ---------------------------------------------------------------------------
+.. _whatsnew_303.enhancements:
+
+Enhancements
+~~~~~~~~~~~~
+- Starting with pandas 3.0.0, time zones are represented by default using the
+  standard library's :mod:`zoneinfo` module (or ``datetime.timezone`` for fixed
+  offsets) instead of using ``pytz`` (:ref:`release note  <whatsnew_300.api_breaking.pytz>`).
+
+  The IO methods using ``pyarrow`` under the hood such as :func:`read_parquet`,
+  :func:`read_feather` and :func:`read_orc` (or :func:`read_csv` when specifying
+  the engine) were still returning timezone using ``pytz``. Those have now been
+  updated to consistently use default ``zoneinfo`` time zones as well (:issue:`65134`).
+
+.. ---------------------------------------------------------------------------
 .. _whatsnew_303.regressions:
 
 Fixed regressions

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -36,6 +36,8 @@ from pandas.compat.pyarrow import (
     pa_version_under19p0,
     pa_version_under20p0,
     pa_version_under21p0,
+    pa_version_under22p0,
+    pa_version_under23p0,
 )
 
 if TYPE_CHECKING:
@@ -170,4 +172,6 @@ __all__ = [
     "pa_version_under19p0",
     "pa_version_under20p0",
     "pa_version_under21p0",
+    "pa_version_under22p0",
+    "pa_version_under23p0",
 ]

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -22,6 +22,7 @@ try:
     pa_version_under20p0 = _palv < Version("20.0.0")
     pa_version_under21p0 = _palv < Version("21.0.0")
     pa_version_under22p0 = _palv < Version("22.0.0")
+    pa_version_under23p0 = _palv < Version("23.0.0")
     HAS_PYARROW = _palv >= Version(PYARROW_MIN_VERSION)
 except ImportError:
     pa_version_under14p0 = True
@@ -34,6 +35,7 @@ except ImportError:
     pa_version_under20p0 = True
     pa_version_under21p0 = True
     pa_version_under22p0 = True
+    pa_version_under23p0 = True
     HAS_PYARROW = False
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5528,7 +5528,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             return True
 
-        blk_dtypes = [blk.dtype for blk in self._mgr.blocks]
+        blk_dtypes = self._mgr.get_unique_dtypes()
         if (
             np.object_ in include
             and str not in include
@@ -5554,6 +5554,18 @@ class DataFrame(NDFrame, OpsMixin):
 
         mgr = self._mgr._get_data_subset(predicate).copy(deep=False)
         return self._constructor_from_mgr(mgr, axes=mgr.axes).__finalize__(self)
+
+    def _select_dtypes_indices(self, dtype_class) -> np.ndarray:
+        """
+        Return the indices of the columns of a given dtype.
+
+        Currently only works given a class, so mostly useful for ExtensionDtypes.
+        """
+
+        def predicate(arr: ArrayLike) -> bool:
+            return isinstance(arr.dtype, dtype_class)
+
+        return self._mgr._get_data_subset_indices(predicate)
 
     def insert(
         self,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7090,7 +7090,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             if axis == 1:
                 # Check that all columns in result have the same dtype
                 # otherwise don't bother with fillna and losing accurate dtypes
-                unique_dtypes = algos.unique(self._mgr.get_dtypes())
+                unique_dtypes = self._mgr.get_unique_dtypes()
                 if len(unique_dtypes) > 1:
                     raise ValueError(
                         "All columns must have the same dtype, but got dtypes: "

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -336,6 +336,9 @@ class BaseBlockManager(PandasObject):
         blk = self.blocks[blkno]
         return any(blk is ref() for ref in mgr.blocks[blkno].refs.referenced_blocks)
 
+    def get_unique_dtypes(self) -> npt.NDArray[np.object_]:
+        return algos.unique(np.array([blk.dtype for blk in self.blocks], dtype=object))
+
     def get_dtypes(self) -> npt.NDArray[np.object_]:
         dtypes = np.array([blk.dtype for blk in self.blocks], dtype=object)
         return dtypes.take(self.blknos)
@@ -655,6 +658,11 @@ class BaseBlockManager(PandasObject):
     def _get_data_subset(self, predicate: Callable) -> Self:
         blocks = [blk for blk in self.blocks if predicate(blk.values)]
         return self._combine(blocks)
+
+    def _get_data_subset_indices(self, predicate: Callable) -> np.ndarray:
+        blocks = [blk for blk in self.blocks if predicate(blk.values)]
+        indexer = np.sort(np.concatenate([b.mgr_locs.as_array for b in blocks]))
+        return indexer
 
     def get_bool_data(self) -> Self:
         """

--- a/pandas/io/_util.py
+++ b/pandas/io/_util.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import datetime as dt
 from typing import (
     TYPE_CHECKING,
     Literal,
 )
+import zoneinfo
 
 import numpy as np
 
 from pandas._config import using_string_dtype
 
 from pandas._libs import lib
+from pandas._libs.tslibs import timezones
 from pandas.compat import (
     pa_version_under18p0,
     pa_version_under19p0,
@@ -33,6 +36,9 @@ if TYPE_CHECKING:
         DtypeArg,
         DtypeBackend,
     )
+
+
+pytz = import_optional_dependency("pytz", errors="ignore")
 
 
 def _arrow_dtype_mapping() -> dict:
@@ -120,7 +126,9 @@ def arrow_table_to_pandas(
         raise NotImplementedError
 
     df = table.to_pandas(types_mapper=types_mapper, **to_pandas_kwargs)
-    return _post_convert_dtypes(df, dtype_backend, dtype, names)
+    df = _post_convert_dtypes(df, dtype_backend, dtype, names)
+    df = _normalize_timezone_dtypes(df)
+    return df
 
 
 def _post_convert_dtypes(
@@ -187,5 +195,80 @@ def _post_convert_dtypes(
                         ordered=dtype.ordered,
                     )
                     df[col] = df[col].astype(cat_dtype)
+
+    return df
+
+
+def _normalize_pytz_timezone(tz: dt.tzinfo) -> dt.tzinfo:
+    """
+    If the input tz is a pytz timezone, attempt to convert it to "default"
+    tzinfo object (zoneinfo or datetime.timezone).
+    """
+    if not type(tz).__module__.startswith("pytz"):
+        # isinstance(col.dtype.tz, pytz.BaseTzInfo) does not included
+        # fixed offsets
+        return tz
+
+    if timezones.is_utc(tz):
+        return dt.timezone.utc
+
+    if tz.zone is not None:  # type: ignore[attr-defined]
+        try:
+            return zoneinfo.ZoneInfo(tz.zone)  # type: ignore[attr-defined]
+        except Exception:
+            # some pytz timezones might not be available for zoneinfo
+            pass
+
+    if timezones.is_fixed_offset(tz):
+        # Convert pytz fixed offset to datetime.timezone
+        try:
+            offset = tz.utcoffset(None)
+            if offset is not None:
+                return dt.timezone(offset)
+        except Exception:
+            pass
+
+    return tz
+
+
+def _normalize_timezone_index(index: pd.Index) -> pd.Index:
+    if isinstance(index, pd.MultiIndex):
+        if any(isinstance(level.dtype, pd.DatetimeTZDtype) for level in index.levels):
+            levels = [_normalize_timezone_index(level) for level in index.levels]
+            return index.set_levels(levels)
+
+        return index
+
+    if isinstance(index.dtype, pd.DatetimeTZDtype):
+        normalized_tz = _normalize_pytz_timezone(index.dtype.tz)
+        if normalized_tz is not index.dtype.tz:
+            return index.tz_convert(normalized_tz)  # type: ignore[attr-defined]
+
+    return index
+
+
+def _normalize_timezone_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    PyArrow uses pytz by default for timezones, but pandas uses
+    zoneinfo / datetime.timezone since pandas 3.0.
+
+    TODO: Starting with pyarrow 25, it will use zoneinfo by default, and then
+    this normalization can be skipped (https://github.com/apache/arrow/pull/49694).
+    """
+    if pytz is not None:
+        # Convert any pytz timezones to zoneinfo / fixed offset timezones
+        if any(
+            isinstance(dtype, pd.DatetimeTZDtype)
+            for dtype in df._mgr.get_unique_dtypes()
+        ):
+            col_indices = df._select_dtypes_indices(pd.DatetimeTZDtype)
+            for i in col_indices:
+                col = df.iloc[:, i]
+                normalized_tz = _normalize_pytz_timezone(col.dtype.tz)
+                if normalized_tz is not col.dtype.tz:
+                    df.isetitem(i, col.dt.tz_convert(normalized_tz))
+
+    df.index = _normalize_timezone_index(df.index)
+    df.columns = _normalize_timezone_index(df.columns)
 
     return df

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -218,13 +218,9 @@ def test_parse_tz_aware(all_parsers):
         {"x": [0.5]}, index=Index([Timestamp("2012-06-13 01:39:00+00:00")], name="Date")
     )
     if parser.engine == "pyarrow":
-        pytz = pytest.importorskip("pytz")
-        expected_tz = pytz.utc
         expected.index = expected.index.as_unit("s")
-    else:
-        expected_tz = timezone.utc
     tm.assert_frame_equal(result, expected)
-    assert result.index.tz is expected_tz
+    assert result.index.tz is timezone.utc
 
 
 @pytest.mark.parametrize("kwargs", [{}, {"index_col": "C"}])

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1010,31 +1010,7 @@ class TestParquetPyArrow(Base):
     def test_timezone_aware_index(self, pa, timezone_aware_date_list, temp_file):
         idx = 5 * [timezone_aware_date_list]
         df = pd.DataFrame(index=idx, data={"index_as_col": idx})
-
-        # see gh-36004
-        # compare time(zone) values only, skip their class:
-        # pyarrow always creates fixed offset timezones using pytz.FixedOffset()
-        # even if it was datetime.timezone() originally
-        #
-        # technically they are the same:
-        # they both implement datetime.tzinfo
-        # they both wrap datetime.timedelta()
-        # this use-case sets the resolution to 1 minute
-
-        expected = df[:]
-        if timezone_aware_date_list.tzinfo != datetime.UTC:
-            # pyarrow returns pytz.FixedOffset while pandas constructs datetime.timezone
-            # https://github.com/pandas-dev/pandas/issues/37286
-            try:
-                import pytz
-            except ImportError:
-                pass
-            else:
-                offset = df.index.tz.utcoffset(timezone_aware_date_list)
-                tz = pytz.FixedOffset(offset.total_seconds() / 60)
-                expected.index = expected.index.tz_convert(tz)
-                expected["index_as_col"] = expected["index_as_col"].dt.tz_convert(tz)
-        check_round_trip(df, temp_file, pa, check_dtype=False, expected=expected)
+        check_round_trip(df, temp_file, pa, check_dtype=False)
 
     def test_filter_row_groups(self, pa, temp_file):
         # https://github.com/pandas-dev/pandas/issues/26551

--- a/pandas/tests/io/test_util.py
+++ b/pandas/tests/io/test_util.py
@@ -1,0 +1,69 @@
+import zoneinfo
+
+import pytest
+
+from pandas.compat import (
+    pa_version_under18p0,
+    pa_version_under23p0,
+)
+
+import pandas as pd
+import pandas._testing as tm
+
+from pandas.io._util import arrow_table_to_pandas
+
+pa = pytest.importorskip("pyarrow")
+pytz = pytest.importorskip("pytz")
+
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Passing a BlockManager to DataFrame:DeprecationWarning"
+)
+
+
+def test_arrow_table_to_pandas_normalize_timezones():
+    df = pd.DataFrame(
+        {"ts": pd.date_range("2024-03-01", periods=2, tz="America/New_York")},
+        index=pd.date_range("2024-01-01", periods=2, tz="US/Eastern"),
+    )
+    expected = df.copy()
+    expected.index = expected.index._with_freq(None)
+
+    table = pa.Table.from_pandas(df)
+    result = arrow_table_to_pandas(table)
+
+    tm.assert_frame_equal(result, expected)
+    assert isinstance(result["ts"].dtype.tz, zoneinfo.ZoneInfo)
+    assert isinstance(result.index.tz, zoneinfo.ZoneInfo)
+
+
+def test_arrow_table_to_pandas_normalize_timezones_columns():
+    df = pd.DataFrame(
+        [[1, 2], [3, 4]],
+        columns=pd.date_range("2024-02-01", periods=2, tz="Europe/Berlin"),
+    )
+    expected = df.copy()
+
+    table = pa.Table.from_pandas(df)
+    result = arrow_table_to_pandas(table)
+
+    if pa_version_under23p0 and not pa_version_under18p0:
+        expected.columns = expected.columns.as_unit("ns")
+
+    tm.assert_frame_equal(result, expected)
+    assert isinstance(result.columns.tz, zoneinfo.ZoneInfo)
+
+
+def test_arrow_table_to_pandas_normalize_timezones_multiindex():
+    df = pd.DataFrame(
+        {"ts": pd.date_range("2024-03-01", periods=2, tz="America/New_York")},
+        index=pd.Index([1, 2], name="index"),
+    ).set_index("ts", append=True, drop=False)
+    expected = df.copy()
+
+    table = pa.Table.from_pandas(df)
+    result = arrow_table_to_pandas(table)
+
+    tm.assert_frame_equal(result, expected)
+    assert isinstance(result["ts"].dtype.tz, zoneinfo.ZoneInfo)
+    assert isinstance(result.index.get_level_values("ts").tz, zoneinfo.ZoneInfo)

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -6,6 +6,7 @@ from datetime import (
 import subprocess
 import sys
 import textwrap
+import zoneinfo
 
 import dateutil.tz
 import pytest
@@ -191,3 +192,18 @@ def test_maybe_get_tz_offset_only():
 
     tz = timezones.maybe_get_tz("UTC-02:45")
     assert tz == timezone(-timedelta(hours=2, minutes=45))
+
+
+def test_normalize_pytz_timezone():
+    pytz = pytest.importorskip("pytz")
+
+    from pandas.io._util import _normalize_pytz_timezone
+
+    for tz, expected in [
+        (pytz.UTC, timezone.utc),
+        (pytz.FixedOffset(90), timezone(timedelta(minutes=90))),
+        (pytz.timezone("America/New_York"), zoneinfo.ZoneInfo("America/New_York")),
+        (pytz.timezone("Etc/GMT+1"), zoneinfo.ZoneInfo("Etc/GMT+1")),
+    ]:
+        result = _normalize_pytz_timezone(tz)
+        assert result == expected


### PR DESCRIPTION
(cherry picked from commit 9eb6685e0537d1de6e6556fb8215e2024345c70f)

Backport of https://github.com/pandas-dev/pandas/pull/65134