### PR TITLE
[backport 3.0.x] BUG: prevent using numexpr 2.10 with newer numpy to avoid silent wrong results (#65400)

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -10,6 +10,7 @@ from pandas.util.version import Version
 _np_version = np.__version__
 _nlv = Version(_np_version)
 np_version_gt2 = _nlv >= Version("2.0.0")
+np_version_gt2_3 = _nlv >= Version("2.3.0")
 np_version_gt2_5 = _nlv >= Version("2.5.0")
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.26.0"

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -16,13 +16,17 @@ import numpy as np
 
 from pandas._config import get_option
 
+from pandas.compat.numpy import np_version_gt2_3
 from pandas.util._exceptions import find_stack_level
 
 from pandas.core import roperator
 from pandas.core.computation.check import NUMEXPR_INSTALLED
+from pandas.util.version import Version
 
 if NUMEXPR_INSTALLED:
     import numexpr as ne
+
+    ne_gt_211 = Version(ne.__version__) >= Version("2.11.0")
 
 if TYPE_CHECKING:
     from pandas._typing import FuncType
@@ -47,7 +51,12 @@ def set_use_numexpr(v: bool = True) -> None:
     # set/unset to use numexpr
     global USE_NUMEXPR
     if NUMEXPR_INSTALLED:
-        USE_NUMEXPR = v
+        if np_version_gt2_3 and not ne_gt_211:
+            # incompatibility of numexpr 2.10 with newer pandas resulting in wrong data
+            # https://github.com/pandas-dev/pandas/issues/63320
+            USE_NUMEXPR = False
+        else:
+            USE_NUMEXPR = v
 
     # choose what we are going to do
     global _evaluate, _where


### PR DESCRIPTION

(cherry picked from commit 6401071f926a321e30c74e4ff7d699f0063fa931)

Backport of https://github.com/pandas-dev/pandas/pull/65400