### PR TITLE
CLN: only try to normalize pytz in index when pytz is installed

### DIFF
--- a/pandas/io/_util.py
+++ b/pandas/io/_util.py
@@ -282,7 +282,7 @@ def _normalize_timezone_dtypes(df: pd.DataFrame) -> pd.DataFrame:
                 if normalized_tz is not col.dtype.tz:
                     df.isetitem(i, col.dt.tz_convert(normalized_tz))
 
-    df.index = _normalize_timezone_index(df.index)
-    df.columns = _normalize_timezone_index(df.columns)
+        df.index = _normalize_timezone_index(df.index)
+        df.columns = _normalize_timezone_index(df.columns)
 
     return df


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/65134, I noticed that I was always checking the timezones of index/columns labels, while this should only be needed when pytz is available, as is done for the columns itself. Not a bug per se, but just a small optimization, avoiding unnecessary post-processing
