### PR TITLE
CLN: Replace stale 0.10.1 FIXME in use_dynamic_x

### DIFF
--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -264,12 +264,17 @@ def use_dynamic_x(ax: Axes, index: Index) -> bool:
     if freq_str is None:
         return False
 
-    # FIXME: hack this for 0.10.1, creating more technical debt...sigh
+    # GH#2571: for DatetimeIndex, fall back to non-dynamic plotting if the
+    # timestamps don't align with the inferred period frequency. We only
+    # inspect the first element because the index has a (possibly inferred)
+    # freq, so the rest are evenly spaced relative to it.
     if isinstance(index, ABCDatetimeIndex):
         # error: "BaseOffset" has no attribute "_period_dtype_code"
         freq_str = OFFSET_TO_PERIOD_FREQSTR.get(freq_str, freq_str)
         base = to_offset(freq_str, is_period=True)._period_dtype_code  # type: ignore[attr-defined]
         if base <= FreqGroup.FR_DAY.value:
+            # Daily-or-coarser: any midnight timestamp is valid (e.g. month-end
+            # dates plotted monthly). Avoids tz_localize() on DST gaps.
             return index[:1].is_normalized
         period = Period(index[0], freq_str)
         assert isinstance(period, Period)


### PR DESCRIPTION
## Summary
- The FIXME at the top of the `DatetimeIndex` branch in `use_dynamic_x` dates back to GH-2571 (Jan 2013) and no longer describes what the block does.
- Replaced it with a comment explaining the alignment check and noting why daily-or-coarser uses `is_normalized` while sub-daily uses a `Period` round-trip (DST handling on `tz_localize`).
- No behavior change. The existing regression test `test_nonzero_base` (GH-2571) still covers the path.

## Test plan
- [x] `pytest pandas/tests/plotting/test_datetimelike.py` — 218 passed, 3 xfailed
- [x] pre-commit on the edited file