### PR TITLE
CLN: drop stale FIXME for closed pyperclip#55 in clipboard module

### DIFF
--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -536,8 +536,9 @@ def determine_clipboard():
         "cygwin" in platform.system().lower()
     ):  # Cygwin has a variety of values returned by platform.system(),
         # such as 'CYGWIN_NT-6.1'
-        # FIXME(pyperclip#55): pyperclip currently does not support Cygwin,
-        # see https://github.com/asweigart/pyperclip/issues/55
+        # Cygwin uses /dev/clipboard; upstream pyperclip#55 was closed in 2017
+        # as "mostly works" -- known imperfections are warned about per-call
+        # in copy_dev_clipboard.
         if os.path.exists("/dev/clipboard"):
             warnings.warn(
                 "Pyperclip's support for Cygwin is not perfect, "


### PR DESCRIPTION
## Summary

- The FIXME in `pandas/io/clipboard/__init__.py` claimed *"pyperclip currently does not support Cygwin"* and pointed at [asweigart/pyperclip#55](https://github.com/asweigart/pyperclip/issues/55), but that issue was closed in 2017 when `/dev/clipboard` support was added — which the code immediately below the FIXME already uses.
- Replace the FIXME with a brief comment summarizing the upstream status.
- Keep the user-facing warning (upstream closed #55 as "mostly works"; specific imperfections like blank-string and `\r` handling are still warned about per-call inside `copy_dev_clipboard`).

## Test plan

- [ ] Pre-commit hooks pass locally
- [ ] No behavior change on non-Cygwin platforms; warning text and warning trigger condition unchanged on Cygwin