### PR TITLE
CI: explicitly ignore .pixi/ for update workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 tags
 .cache/
 .vscode/
+.pixi/
 
 # Compiled source #
 ###################


### PR DESCRIPTION
The workflow to update the lockfile is still failing (https://github.com/pandas-dev/pandas/actions/runs/25011365893/job/73247681640), and a potential reason is that it is trying to create a huge commit since it is also adding (part of) the `.pixi/` directory with the actual envs.

Normally git ignores that (because the directory has a .gitinore file in it?), but for some reason that does not seem to be respected (or not generated) in CI. So I thought it can't do any harm to explicitly ignore the directory in the top-level `.gitignore` file. 

(alternative would be to let the `create-pull-request` action only look at the pixi.lock file when committing changes)