### PR TITLE
DOC: Improve to_numeric return type documentation clarity

### DIFF
--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -101,8 +101,8 @@ def to_numeric(
         performed on the data.
 
     dtype_backend : {'numpy_nullable', 'pyarrow'}
-        Back-end data type applied to the resultant :class:`DataFrame`
-        (still experimental). If not specified, the default behavior
+        Back-end data type applied to the result (still experimental).
+        If not specified, the default behavior
         is to not use nullable data types. If specified, the behavior
         is as follows:
 
@@ -114,8 +114,13 @@ def to_numeric(
     Returns
     -------
     ret
-        Numeric if parsing succeeded.
-        Return type depends on input.  Series if Series, otherwise ndarray.
+        Numeric result of parsing.
+        Return type depends on input:
+
+        * For scalar inputs, the result is a numeric scalar (int or float).
+        * For 1-dimensional inputs, the result is a Series if the input is a Series,
+          an Index if the input is an Index, otherwise an array-like structure
+          depending on ``dtype_backend``.
 
     Raises
     ------


### PR DESCRIPTION
Clarify the description of the `dtype_backend` parameter and the return type of `to_numeric`.

- [x] closes #65369
- [ ] Tests added and passed
- [ ] All code checks passed
- [ ] Added type annotations
- [ ] Added whatsnew entry
- [x] I have reviewed and followed the contribution guidelines
- [ ] If I used AI, I followed AGENTS.md