### PR TITLE
CI: lowercase types-pymysql/types-pyyaml to fix mamba 2.6.0 shard lookup

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -97,9 +97,9 @@ dependencies:
   # static typing
   - scipy-stubs
   - types-python-dateutil
-  - types-PyMySQL
+  - types-pymysql
   - types-pytz
-  - types-PyYAML
+  - types-pyyaml
 
   # documentation (jupyter notebooks)
   - nbconvert>=7.11.0

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -864,7 +864,8 @@ class NDFrameApply(Apply):
         if not all(isinstance(f, str) for f in func):
             return None
 
-        obj = self.obj
+        # Caller restricts this path to ndim == 2 (DataFrame); narrow for mypy.
+        obj = cast("DataFrame", self.obj)
         func_names = cast("list[str]", func)
 
         # Cannot reindex with duplicate column names
@@ -884,7 +885,7 @@ class NDFrameApply(Apply):
             return obj._constructor(index=func_names, columns=obj.columns)
 
         # Compute reductions per dtype group to preserve per-column dtypes.
-        groups = obj.columns.groupby(obj.dtypes)  # type: ignore[arg-type]
+        groups = obj.columns.groupby(obj.dtypes)
         pieces = []
         for dtype in groups:
             cols = groups[dtype]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -67,9 +67,9 @@ sphinx-design
 sphinx-copybutton
 scipy-stubs
 types-python-dateutil
-types-PyMySQL
+types-pymysql
 types-pytz
-types-PyYAML
+types-pyyaml
 nbconvert>=7.11.0
 nbsphinx
 pandoc


### PR DESCRIPTION
## Summary

- Lowercase ``types-PyMySQL`` → ``types-pymysql`` and ``types-PyYAML`` → ``types-pyyaml`` in ``environment.yml`` and ``requirements-dev.txt``.
- Fixes the Code Checks job that has been failing on every PR since 2026-04-29 ~21:00 UTC with:

  ```
  error    libmamba Could not solve for environment specs
      The following package could not be installed
      └─ types-pymysql =* * does not exist (perhaps a typo or a missing channel).
  ```

## Root cause

[mamba 2.6.0](https://github.com/mamba-org/mamba/releases/tag/2.6.0) was released on 2026-04-29 14:04 UTC and made **sharded repodata the default**. Shard keys on conda-forge are normalized to lowercase (the feedstock recipe sets ``package.name: {{ name|lower }}``), and the new shard lookup is case-sensitive. Mixed-case entries in ``environment.yml`` therefore stop resolving — even though the packages still exist on the channel.

The Unit Tests workflow is unaffected because it switched to pixi; only Code Checks (and the doc build) still go through ``setup-micromamba`` + ``environment.yml``.

The mamba-org/setup-micromamba action is already pinned by SHA in our workflow, but it downloads the latest micromamba binary on each run, which is why a pure upstream change broke us without any workflow edit.

## Test plan

- [ ] Code Checks job passes on this PR