### PR TITLE
CLN: fill in placeholder GH refs in test comments

### DIFF
--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -758,7 +758,7 @@ class TestCategoricalConstructors:
         tm.assert_index_equal(cat.categories, idx)
 
     def test_categorical_extension_array_nullable(self, nulls_fixture):
-        # GH:
+        # GH#37611
         arr = pd.array([nulls_fixture] * 2, dtype=pd.StringDtype())
         result = Categorical(arr)
         assert arr.dtype == result.categories.dtype

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3796,7 +3796,7 @@ def test_date_vs_timestamp_scalar_comparison():
 # TODO: reuse assert_invalid_comparison?
 def test_date_vs_timestamp_array_comparison():
     # GH#62157 match non-pyarrow behavior
-    # GH#
+    # GH#60937
     ser = pd.Series(["2016-01-01"], dtype="date32[pyarrow]")
     ser2 = ser.astype("timestamp[ns][pyarrow]")
     ser3 = ser.astype("datetime64[ns]")

--- a/pandas/tests/frame/methods/test_align.py
+++ b/pandas/tests/frame/methods/test_align.py
@@ -309,7 +309,7 @@ class TestDataFrameAlign:
             df.align(series)
 
     def test_align_series_check_copy(self):
-        # GH#
+        # GH#49473
         df = DataFrame({0: [1, 2]})
         ser = Series([1], name=0)
         expected = ser.copy()

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -360,7 +360,7 @@ class TestDataFrameInterpolate:
         tm.assert_frame_equal(result, expected)
 
     def test_interp_ignore_all_good(self):
-        # GH
+        # GH#6290
         df = DataFrame(
             {
                 "A": [1, 2, np.nan, 4],

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -2009,7 +2009,7 @@ class TestFrameArithmeticUnsorted:
             getattr(df, all_arithmetic_operators)(b)
 
     def test_dunder_methods_binary(self, all_arithmetic_operators):
-        # GH#??? frame.__foo__ should only accept one argument
+        # GH#36796 frame.__foo__ should only accept one argument
         df = DataFrame({"A": [0.0, 0.0], "B": [0.0, None]})
         b = df["B"]
         with pytest.raises(TypeError, match="takes 2 positional arguments"):

--- a/pandas/tests/groupby/test_filters.py
+++ b/pandas/tests/groupby/test_filters.py
@@ -543,7 +543,7 @@ def test_filter_and_transform_with_non_unique_string_index():
 def test_filter_has_access_to_grouped_cols():
     df = DataFrame([[1, 2], [1, 3], [5, 6]], columns=["A", "B"])
     g = df.groupby("A")
-    # previously didn't have access to col A #????
+    # previously didn't have access to col A GH#6512
     filt = g.filter(lambda x: x["A"].sum() == 2)
     tm.assert_frame_equal(filt, df.iloc[[0, 1]])
 

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -390,7 +390,7 @@ class TestGroupBy:
         expected = (
             df.groupby("user_id")["whole_cost"]
             .resample(freq)
-            .sum(min_count=1)  # XXX
+            .sum(min_count=1)  # TODO: can we drop min_count=1 + dropna() below?
             .dropna()
             .reorder_levels(["date", "user_id"])
             .sort_index()

--- a/pandas/tests/indexes/base_class/test_setops.py
+++ b/pandas/tests/indexes/base_class/test_setops.py
@@ -30,7 +30,7 @@ class TestIndexSetOps:
         with pytest.raises(ValueError, match="The 'sort' keyword only takes"):
             getattr(idx1, method)(idx2, sort=2)
 
-        # sort=True is supported as of GH#??
+        # sort=True is supported as of GH#25151
         getattr(idx1, method)(idx2, sort=True)
 
     def test_setops_preserve_object_dtype(self):

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -197,7 +197,7 @@ class TestDateRanges:
         tm.assert_index_equal(idx, exp)
 
     def test_date_range_near_implementation_bound(self):
-        # GH#???
+        # GH#24124
         freq = Timedelta(1)
 
         with pytest.raises(OutOfBoundsDatetime, match="Cannot generate range with"):

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -440,7 +440,7 @@ def test_setops_sort_validation(method):
     with pytest.raises(ValueError, match="The 'sort' keyword only takes"):
         getattr(idx1, method)(idx2, sort=2)
 
-    # sort=True is supported as of GH#?
+    # sort=True is supported as of GH#25151
     getattr(idx1, method)(idx2, sort=True)
 
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1315,7 +1315,7 @@ class TestLocBaseIndependent:
             tm.assert_frame_equal(result, expected)
 
         # assigning the entire column using __setitem__ swaps in the new array
-        # GH#???
+        # GH#38896
         result["A"] = [float(x) for x in col_data]
         expected = DataFrame(col_data, columns=["A"], dtype=float)
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/common/test_float.py
+++ b/pandas/tests/io/parser/common/test_float.py
@@ -117,7 +117,7 @@ def test_small_int_followed_by_float(
     ],
 )
 def test_precise_xstrtod_large_mantissa(c_parser_only, value):
-    # GH#XXXXX
+    # GH#64357
     # When a 17-digit mantissa's 16-digit prefix crosses 2^53
     # (= 9007199254740992), the old per-digit FP accumulation
     #   number = number * 10. + digit

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -147,7 +147,7 @@ class TestTake:
 
     @pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.uint64])
     def test_1d_unsigned_int_uses_cython_path(self, dtype):
-        # GH#????? - _take_1d_dict had wrong keys for uint16/uint32/uint64,
+        # GH#64437 - _take_1d_dict had wrong keys for uint16/uint32/uint64,
         # causing fallback to the slow object path instead of the fast
         # Cython path. Verify the optimized function is found.
         from pandas.core.array_algos.take import _get_take_nd_function_cached


### PR DESCRIPTION
## Summary

- Replaces placeholder GH refs (`GH#XXXXX`, `GH#???`, `GH#?`, `# GH`, `# GH:`, bare `#????`) with the issue/PR number found via `git blame` + the PR's closing-issue link.
- One leftover `# XXX` annotation in `tests/groupby/test_timegrouper.py` (from PR GH-18921's `min_count=1` workaround) is reworded to a clearer `# TODO