### PR TITLE
BUG: Timestamp with 1-3 digit BC year silently drops leading '-' (GH-55954)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -218,6 +218,7 @@ Datetimelike
 - Bug in :class:`DatetimeIndex` constructor raising ``ValueError`` when passing equivalent but not equal frequencies (e.g. ``QS-FEB`` vs ``QS-MAY``) (:issue:`61086`)
 - Bug in :class:`DatetimeIndex` raising ``AttributeError`` when comparing against Arrow date types (date32, date64) (:issue:`62051`)
 - Bug in :class:`Timestamp` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
+- Bug in :class:`Timestamp` constructor where strings with a negative year of fewer than 4 digits (e.g. ``"-111-01-01"``) silently dropped the leading ``"-"`` and were parsed as a positive year; BC dates with 1-4 digit years now parse correctly, matching :class:`numpy.datetime64` (:issue:`55954`)
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)
 - Bug in :func:`api.types.infer_dtype` returning ``"date"`` or ``"mixed"`` instead of ``"datetime"`` / ``"timedelta"`` for lists of :class:`Timestamp`/:class:`Timedelta` values mixed with ``pd.NA`` (:issue:`53023`)
 - Bug in :func:`date_range` where ``inclusive="left"`` and ``inclusive="right"`` returned a single-element result instead of empty when ``start`` equals ``end`` (:issue:`55293`)

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
@@ -179,18 +179,28 @@ int parse_iso_8601_datetime(const char *str, int len, int want_exc,
   }
 
   out->year = 0;
-  if (sublen >= 4 && isdigit(substr[0]) && isdigit(substr[1]) &&
-      isdigit(substr[2]) && isdigit(substr[3])) {
+  if (str[0] == '-') {
+    /* GH#55954: BC years may have 1-4 digits (e.g. "-111-01-01"); read
+     * digits up to a maximum of 4. The number of digits read is later
+     * used to validate that at least one digit was provided. */
+    numdigits = 0;
+    while (numdigits < 4 && sublen > 0 && isdigit(*substr)) {
+      out->year = 10 * out->year + (*substr - '0');
+      ++substr;
+      --sublen;
+      ++numdigits;
+    }
+    if (numdigits == 0) {
+      goto parse_error;
+    }
+    out->year = -out->year;
+  } else if (sublen >= 4 && isdigit(substr[0]) && isdigit(substr[1]) &&
+             isdigit(substr[2]) && isdigit(substr[3])) {
     out->year = 1000 * (substr[0] - '0') + 100 * (substr[1] - '0') +
                 10 * (substr[2] - '0') + (substr[3] - '0');
 
     substr += 4;
     sublen -= 4;
-  }
-
-  /* Negate the year if necessary */
-  if (str[0] == '-') {
-    out->year = -out->year;
   }
   /* Check whether it's a leap-year */
   year_leap = is_leapyear(out->year);

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -320,6 +320,14 @@ cdef datetime parse_datetime_string(
     except ValueError:
         pass
 
+    if date_string.lstrip().startswith("-"):
+        # GH#55954 a leading "-" indicates a BC year and is only handled by
+        # the iso8601 fast path. Falling through to dateutil would silently
+        # strip the sign and produce a positive year.
+        raise DateParseError(
+            f"Unknown datetime string format, unable to parse: {date_string}"
+        )
+
     dt = dateutil_parse(date_string, default=_DEFAULT_DATETIME,
                         dayfirst=dayfirst, yearfirst=yearfirst,
                         ignoretz=False, out_bestunit=out_bestunit, nanos=nanos)
@@ -426,6 +434,14 @@ def parse_datetime_string_with_reso(
         else:
             reso = npy_unit_to_attrname[out_bestunit]
         return parsed, reso
+
+    if date_string.lstrip().startswith("-"):
+        # GH#55954 a leading "-" indicates a BC year and is only handled by
+        # the iso8601 fast path. Falling through to dateutil would silently
+        # strip the sign and produce a positive year.
+        raise DateParseError(
+            f"Unknown datetime string format, unable to parse: {date_string}"
+        )
 
     parsed = dateutil_parse(date_string, _DEFAULT_DATETIME,
                             dayfirst=dayfirst, yearfirst=yearfirst,

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -7,6 +7,7 @@ from datetime import (
     timezone,
 )
 import locale
+import re
 import time
 import unicodedata
 import zoneinfo
@@ -948,3 +949,32 @@ def test_negative_dates():
     func = "^toordinal"
     with pytest.raises(NotImplementedError, match=func + msg):
         ts.toordinal()
+
+
+@pytest.mark.parametrize(
+    "date_string,expected_year",
+    [
+        ("-111-01-01", -111),
+        ("-12-01-01", -12),
+        ("-9-1-1", -9),
+        ("-0111-01-01", -111),
+        ("-1234-01-01", -1234),
+    ],
+)
+def test_negative_year_iso8601(date_string, expected_year):
+    # GH#55954 a leading "-" used to be silently dropped by dateutil for
+    # years with fewer than 4 digits (e.g. "-111-01-01" parsed as year 111);
+    # the iso8601 path now accepts 1-4 digit BC years like NumPy does.
+    ts = Timestamp(date_string)
+    assert ts.year == expected_year
+    assert ts.month == 1
+    assert ts.day == 1
+
+
+@pytest.mark.parametrize("date_string", ["-12:30", "--12-01-01", "- 12", "-"])
+def test_negative_prefix_non_iso_raises(date_string):
+    # GH#55954 strings starting with "-" that aren't valid iso8601 dates
+    # used to be silently mishandled by dateutil (which strips the "-").
+    msg = f"Unknown datetime string format, unable to parse: {date_string}"
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        Timestamp(date_string)


### PR DESCRIPTION
## Summary
- The iso8601 fast path required exactly 4 digits for the year, so strings like `"-111-01-01"` fell through to `dateutil`, which silently strips the leading `"-"` and parses as a positive year (so `Timestamp("-111-01-01") == Timestamp("111-01-01")` was `True`).
- Extend the iso8601 parser to accept 1-4 digit BC years, matching `numpy.datetime64` behavior.
- Raise `DateParseError` for non-iso strings starting with `"-"` (e.g. `"-12:30"`, `"--12-01-01"`) rather than letting `dateutil` silently mishandle them.

## Behavior change

| Input | Before | After |
|---|---|---|
| `Timestamp("-111-01-01")` | year 111 (silently wrong) | year **-111** ✓ |
| `Timestamp("-12-01-01")` | year 2001-12-01 | year **-12** ✓ |
| `Timestamp("-9-1-1")` | 2001-09-01 | year **-9** ✓ |
| `Timestamp("-0111-01-01")` | year -111 | year -111 (unchanged) |
| `Timestamp("-2000-01-01")` | year -2000 | year -2000 (unchanged) |
| `Timestamp("-12:30")` | 0001-01-01 12:30 (silently wrong) | `DateParseError` |

`pd.Timestamp("-111-01-01") == pd.Timestamp("111-01-01")` is now `False`, matching `np.datetime64`.

## Out of scope
`to_datetime("-0111-01-01")` still mishandles the negative sign because it goes through `_guess_datetime_format` + `array_strptime`, a different code path. That's a separate pre-existing bug.

closes #55954

## Test plan
- [x] New `test_negative_year_iso8601` parametrized over 1-4 digit BC years
- [x] New `test_negative_prefix_non_iso_raises` parametrized over malformed leading-dash strings
- [x] Existing `pandas/tests/scalar/`, `pandas/tests/tslibs/`, `pandas/tests/tools/test_to_datetime.py`, `pandas/tests/indexes/datetimes/`, `pandas/tests/indexes/period/`, `pandas/tests/arrays/datetimes/` all pass (9400 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)