### PR TITLE
Account for privatization of matplotlib `Formatter.locs` attribute

### DIFF
--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -198,7 +198,7 @@ class TimeConverter(munits.ConversionInterface):
 # time formatter
 class TimeFormatter(mpl.ticker.Formatter):  # pyright: ignore[reportAttributeAccessIssue]
     def __init__(self, locs) -> None:
-        self.locs = locs
+        self.set_locs(locs)
 
     def __call__(self, x, pos: int | None = 0) -> str:
         """
@@ -1101,7 +1101,7 @@ class TimeSeries_DateFormatter(mpl.ticker.Formatter):  # pyright: ignore[reportA
         # don't actually use the locs. This is just needed to work with
         # matplotlib. Force to use vmin, vmax
 
-        self.locs = locs
+        super().set_locs(locs)
 
         (vmin, vmax) = tuple(self.axis.get_view_interval())
         if vmax < vmin:


### PR DESCRIPTION
With matplotlib/matplotlib#31416 (in the soon-to-be-released matplotlib 3.11), `Formatter.locs` is now private with a deprecation warning upon access.  Since the only calls within pandas are setting commands, the lines can be changed to call the still-public setting method `Formatter.set_locs()`.

Minimal example (when running at least matplotlib 3.11rc1):
```python
import warnings

import numpy as np
import matplotlib.pyplot as plt

from pandas import DataFrame

warnings.simplefilter('always', DeprecationWarning)

dates = ['2026-04-28', '2026-04-29', '2026-04-30']

data = DataFrame([0.5, 1, 2], index=np.array(dates).astype('datetime64'))
data.plot()

plt.show()
```

### Before this PR
```python
...\pandas\plotting\_matplotlib\converter.py:1104: MatplotlibDeprecationWarning: The locs attribute was deprecated in Matplotlib 3.11 and will be removed in 3.13.
  self.locs = locs
```

Failures first seen in sunpy CI using nightly matplotlib and pandas builds, also xref matplotlib/matplotlib#31589

- [N/A] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [N/A] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [N/A] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [N/A] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
