### PR TITLE
BUG: DataFrame repr raising TypeError for structured-dtype column (GH-55011)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -315,6 +315,7 @@ I/O
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
+- Bug in :meth:`DataFrame.__repr__` raising ``TypeError`` for a column with a NumPy structured dtype (e.g. produced by :meth:`DataFrame.from_records` from a structured ``ndarray``) (:issue:`55011`)
 - Bug in :meth:`DataFrame.__repr__` where horizontally truncated output could exceed the terminal width by up to 4 characters (:issue:`32461`)
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)
 - Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -243,8 +243,8 @@ def _isna_array(values: ArrayLike) -> npt.NDArray[np.bool_] | NDFrame:
         # "Union[ndarray[Any, Any], ExtensionArrayNaResult]", variable has
         # type "ndarray[Any, dtype[bool_]]")
         result = values.isna()  # type: ignore[assignment]
-    elif isinstance(values, np.rec.recarray):
-        # GH 48526
+    elif dtype.names is not None:
+        # GH#48526 (np.rec.recarray), GH#55011 (structured np.ndarray)
         result = _isna_recarray_dtype(values)
     elif is_string_or_object_np_dtype(values.dtype):
         result = _isna_string_dtype(values)
@@ -273,7 +273,7 @@ def _isna_string_dtype(values: np.ndarray) -> npt.NDArray[np.bool_]:
     return result
 
 
-def _isna_recarray_dtype(values: np.rec.recarray) -> npt.NDArray[np.bool_]:
+def _isna_recarray_dtype(values: np.ndarray) -> npt.NDArray[np.bool_]:
     result = np.zeros(values.shape, dtype=bool)
     for i, record in enumerate(values):
         record_as_array = np.array(record.tolist())

--- a/pandas/tests/frame/test_repr.py
+++ b/pandas/tests/frame/test_repr.py
@@ -436,6 +436,17 @@ NaT   4"""
         result = repr(df)
         assert result == expected
 
+    def test_from_records_with_nested_structured_dtype_repr(self):
+        # GH#55011 structured ndarray (not np.rec.recarray) with a nested
+        # field-of-fields dtype
+        ar = np.array(
+            [((255, 0),), ((255, 1),), ((255, 2),)],
+            dtype=[("x", [("null", "u1"), ("val", "<i8")])],
+        )
+        df = DataFrame.from_records(ar)
+        expected = "          x\n0  (255, 0)\n1  (255, 1)\n2  (255, 2)"
+        assert repr(df) == expected
+
     def test_masked_ea_with_formatter(self):
         # GH#39336
         df = DataFrame(


### PR DESCRIPTION
- closes #55011

## Summary

`DataFrame.__repr__` raises `TypeError` when a column holds a NumPy *structured* `ndarray` (as produced by `DataFrame.from_records` on a structured array, including nested field-of-fields dtypes). The previous fix for the related GH-48526 only routed `np.rec.recarray` to the structured-aware `_isna_recarray_dtype`; plain structured `ndarray` fell through to `np.isnan`, which does not support structured dtypes.

This PR broadens the dispatch in `_isna_array` from `isinstance(values, np.rec.recarray)` to `dtype.names is not None`, which matches both `np.rec.recarray` and structured `np.ndarray`. The body of `_isna_recarray_dtype` already handles both since it goes through `record.tolist()`.

## Test plan

- [x] Added `test_from_records_with_nested_structured_dtype_repr` covering the issue's reproducer
- [x] `pandas/tests/frame/test_repr.py` — 65 passed (includes the four existing GH-48526 recarray repr tests)
- [x] `pandas/tests/dtypes/test_missing.py` + `pandas/tests/io/formats/test_format.py` + `pandas/tests/io/formats/test_to_string.py` — 588 passed, 5 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)