### PR TITLE
TST: regression test for to_timedelta with sub-int64 NumPy scalars (GH-56996)

### DIFF
--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -486,6 +486,16 @@ def test_to_timedelta_np_str():
     tm.assert_index_equal(result, expected)
 
 
+@pytest.mark.parametrize("dtype", [np.int16, np.int32, np.uint32, np.int64])
+def test_to_timedelta_subint64_with_unit(dtype):
+    # GH#56996 NumPy 2 / NEP 50 made `np.int32(x) - py_int` return np.int32,
+    # which then overflowed when multiplied by a unit factor that exceeds
+    # the dtype's range (e.g. 86_400_000_000_000 ns/day for int32).
+    assert to_timedelta(dtype(0), unit="D") == pd.Timedelta(0, unit="D")
+    assert to_timedelta(dtype(1), unit="D") == pd.Timedelta(1, unit="D")
+    assert pd.Timedelta(dtype(1), unit="D") == pd.Timedelta(1, unit="D")
+
+
 @pytest.mark.parametrize("unit", ["ns", "ms"])
 def test_from_timedelta_arrow_dtype(unit):
     # GH 54298


### PR DESCRIPTION
## Summary

- Adds a regression test for GH-56996 covering `to_timedelta(np.int32(0), unit="D")` and similar sub-int64 NumPy integer scalars.
- The original `OutOfBoundsTimedelta` was incidentally fixed by GH-63302 (`Timedelta.__new__` integer branch now short-circuits through `np.timedelta64(value, unit)` for non-`ns` units, avoiding the NEP 50 path in `cast_from_unit`).
- No code change needed beyond the test — closes #56996.

## Background

Under NumPy 2 / NEP 50, `np.int32(x) - py_int` returns `np.int32` rather than a Python int. `cast_from_unit` then computed `frac * m` where `m` could exceed int32 range (e.g. `86_400_000_000_000` ns/day), raising `OutOfBoundsTimedelta`. The integer fast-path added in GH-63302 means that path is no longer reachable from `to_timedelta`/`Timedelta` for integer scalars with a non-`ns` unit, but a regression test ensures it stays that way.

## Test plan

- [x] `pytest pandas/tests/tools/test_to_timedelta.py` — 101 passed (including 4 new parametrized cases for `int16`, `int32`, `uint32`, `int64`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)