### PR TITLE
DOC: clarify missing-value handling in pandas and NumPy reductions

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -320,6 +320,19 @@ The descriptive statistics and computational methods discussed in the
 <api.series.stats>` and :ref:`here <api.dataframe.stats>`) all
 account for missing data.
 
+The default behavior differs from many NumPy reduction functions. For example,
+pandas reductions such as :meth:`Series.std` and :meth:`DataFrame.std`
+skip missing values by default, while :func:`numpy.std` returns ``nan``
+when the input contains ``nan`` values. To include missing values in
+pandas reductions, pass ``skipna=False``.
+
+.. ipython:: python
+
+   ser = pd.Series([1.0, np.nan, 3.0])
+   ser.std()
+   ser.std(skipna=False)
+   np.std(ser.to_numpy(), ddof=1)
+
 When summing data, NA values or empty data will be treated as zero.
 
 .. ipython:: python

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -17110,8 +17110,8 @@ class DataFrame(NDFrame, OpsMixin):
 
         Notes
         -----
-        To have the same behaviour as `numpy.std`, use `ddof=0` (instead of the
-        default `ddof=1`)
+        To have the same behaviour as ``numpy.std``, use ``ddof=0`` (instead of
+        the default ``ddof=1``) and ``skipna=False``.
 
         Examples
         --------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2213,6 +2213,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Series.std : Apply function std to a Series.
         DataFrame.std : Apply function std to each row or column of a DataFrame.
 
+        Notes
+        -----
+        To have the same behaviour as ``numpy.std``, use ``ddof=0`` (instead of
+        the default ``ddof=1``) and ``skipna=False``.
+
         Examples
         --------
         For SeriesGroupBy:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1588,6 +1588,11 @@ class Resampler(BaseGroupBy, PandasObject):
         core.resample.Resampler.var : Compute variance of groups, excluding missing
             values.
 
+        Notes
+        -----
+        To use the same divisor as ``numpy.std``, use ``ddof=0`` instead of
+        the default ``ddof=1``.
+
         Examples
         --------
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -9581,6 +9581,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Series.median : Return the median of the values over the requested axis.
         Series.mode : Return the mode(s) of the Series.
 
+        Notes
+        -----
+        To have the same behaviour as ``numpy.std``, use ``ddof=0`` (instead of
+        the default ``ddof=1``) and ``skipna=False``.
+
         Examples
         --------
         >>> s = pd.Series([1, 2, 3])


### PR DESCRIPTION
Closes #56939.

This PR adds a short note to the missing-data user guide explaining that pandas reductions skip missing values by default, while NumPy reductions such as numpy.std return nan when the input contains nan values.

The change is documentation-only and does not modify pandas behavior.

Validation:
- pre-commit run --files doc/source/user_guide/missing_data.rst
- python make.py --num-jobs 1 --single user_guide/missing_data.rst