### PR TITLE
BUG: Index.str.split/rsplit/findall return ndarray on object path

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -262,6 +262,7 @@ Conversion
 
 Strings
 ^^^^^^^
+- :meth:`Index.str.split`, :meth:`Index.str.rsplit`, and :meth:`Index.str.findall` with ``expand=False`` now return an ``ndarray[object]`` instead of raising ``TypeError``; previously the per-row list elements could not be wrapped in an :class:`Index` (:issue:`20285`)
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 -
 

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -264,6 +264,7 @@ class StringMethods(NoNewAttributesMixin):
         expand: bool | None = None,
         fill_value=np.nan,
         returns_string: bool = True,
+        returns_list: bool = False,
         dtype=None,
     ):
         from pandas import (
@@ -368,6 +369,10 @@ class StringMethods(NoNewAttributesMixin):
                     # better represented as a regular Index.
                     out = out.get_level_values(0)
                 return out
+            elif returns_list and isinstance(result, np.ndarray):
+                # GH#20285 list elements are unhashable, so we cannot wrap
+                # them in an Index; return the underlying ndarray instead.
+                return result
             else:
                 return Index(result, name=name, dtype=dtype, copy=False)
         else:
@@ -895,7 +900,11 @@ class StringMethods(NoNewAttributesMixin):
         else:
             dtype = object if self._data.dtype == object else None
         return self._wrap_result(
-            result, expand=expand, returns_string=expand, dtype=dtype
+            result,
+            expand=expand,
+            returns_string=expand,
+            returns_list=not expand,
+            dtype=dtype,
         )
 
     @forbid_nonstring_types(["bytes"])
@@ -1024,7 +1033,11 @@ class StringMethods(NoNewAttributesMixin):
         result = self._data.array._str_rsplit(pat, n=n)
         dtype = object if self._data.dtype == object else None
         return self._wrap_result(
-            result, expand=expand, returns_string=expand, dtype=dtype
+            result,
+            expand=expand,
+            returns_string=expand,
+            returns_list=not expand,
+            dtype=dtype,
         )
 
     @forbid_nonstring_types(["bytes"])
@@ -3326,7 +3339,7 @@ class StringMethods(NoNewAttributesMixin):
         dtype: object
         """
         result = self._data.array._str_findall(pat, flags)
-        return self._wrap_result(result, returns_string=False)
+        return self._wrap_result(result, returns_string=False, returns_list=True)
 
     @forbid_nonstring_types(["bytes"])
     def extract(

--- a/pandas/tests/strings/test_api.py
+++ b/pandas/tests/strings/test_api.py
@@ -159,20 +159,6 @@ def test_api_per_method(
         mark = pytest.mark.xfail(raises=raises, reason=reason)
         request.applymarker(mark)
 
-    if (
-        box is Index
-        and method_name in ("findall", "split", "rsplit")
-        and not kwargs.get("expand", False)
-        and values.size > 0
-        and inferred_dtype not in ("bytes", "empty")
-    ):
-        mark = pytest.mark.xfail(
-            raises=TypeError,
-            reason="GH#20285 returns unhashable list elements in Index",
-            strict=False,
-        )
-        request.applymarker(mark)
-
     t = box(values, dtype=dtype)  # explicit dtype to avoid casting
     method = getattr(t.str, method_name)
 

--- a/pandas/tests/strings/test_split_partition.py
+++ b/pandas/tests/strings/test_split_partition.py
@@ -452,16 +452,17 @@ def test_split_with_name_series(any_string_dtype):
     tm.assert_frame_equal(res, exp)
 
 
-@pytest.mark.xfail(
-    reason="GH#20285 str.split on Index returns unhashable list elements"
-)
 def test_split_with_name_index():
     # GH 12617
     idx = Index(["a,b", "c,d"], name="xxx")
     res = idx.str.split(",")
-    assert res.nlevels == 1
-    assert list(res) == [["a", "b"], ["c", "d"]]
-    assert res.name == "xxx"
+    # GH#20285 list elements are unhashable, so the result is an ndarray
+    # rather than an Index.
+    assert isinstance(res, np.ndarray)
+    expected = np.empty(2, dtype=object)
+    expected[0] = ["a", "b"]
+    expected[1] = ["c", "d"]
+    tm.assert_numpy_array_equal(res, expected)
 
     res = idx.str.split(",", expand=True)
     exp = MultiIndex.from_tuples([("a", "b"), ("c", "d")])


### PR DESCRIPTION
- xref GH-64798, GH-20285

After GH-64798, `Index.str.split`, `Index.str.rsplit`, and `Index.str.findall` with `expand=False` raise `TypeError` on object/string-dtype Indexes, because the per-row Python lists are unhashable and can no longer be wrapped in an `Index`.

This restores functionality by returning an `ndarray[object]` of lists instead of attempting to construct an Index. Per Joris's suggestion in GH-64798 (returning an array, mirroring the historical precedent for some Index methods).

## Coverage

| Index dtype | Behavior |
| --- | --- |
| `object`, `string[python]`, `string[pyarrow]`, `"str"`, default | returns `ndarray[object]` |
| `ArrowDtype(pa.string())` | unchanged (returns Index of `list<string>[pyarrow]`) |

The `ArrowDtype(pa.string())` path is intentionally left untouched in this PR. That path has the same conceptual brokenness (the resulting Index of arrow lists fails on `get_loc` / `unique` / set ops), but it slipped through GH-64798 because `check_all_hashable` only fires on object dtype. We can address that separately if desired.

`expand=True` is unchanged for all dtypes (returns `MultiIndex` / `DataFrame`).

## Test plan
- [x] `Index(["a,b", "c,d"]).str.split(",")` returns `ndarray[object]` for object/`string[python]`/`string[pyarrow]`/`"str"` dtypes
- [x] `Index([...], dtype=ArrowDtype(pa.string())).str.split(",")` unchanged
- [x] `Series.str.split` unchanged for all dtypes
- [x] `expand=True` still returns `MultiIndex` / `DataFrame`
- [x] `pandas/tests/strings/` (4830 passed)
- [x] `pandas/tests/extension/test_arrow.py` (no regressions)
- [x] `pandas/tests/indexes/test_base.py`