### PR TITLE
DOC: clarify PeriodIndex.is_full behavior with duplicate periods

### DIFF
--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -565,7 +565,7 @@ class PeriodIndex(DatetimeIndexOpsMixin):
     def is_full(self) -> bool:
         """
         Returns True if this PeriodIndex is range-like in that all Periods
-        between start and end are present, in order.
+        between start and end are present, in order. Duplicate periods are allowed.
         """
         if len(self) == 0:
             return True

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -564,8 +564,10 @@ class PeriodIndex(DatetimeIndexOpsMixin):
     @property
     def is_full(self) -> bool:
         """
-        Returns True if this PeriodIndex is range-like in that all Periods
-        between start and end are present, in order. Duplicate periods are allowed.
+        Return True if the index contains all periods from start to end
+        (inclusive) with no gaps.
+
+        Requires monotonic increasing order. Duplicate periods are allowed.
         """
         if len(self) == 0:
             return True


### PR DESCRIPTION
Supersedes #64063.

the previous PR proposed changing the behavior of `PeriodIndex.is_full`,
but that would require a deprecation cycle. This PR instead updates the
docstring to clarify the current behavior.

in particular, it makes clear that duplicate periods are considered
valid, which matches the existing implementation but may not be obvious
from the wording ("range-like").

addresses the discussion in #64063 and #64938. A deprecation path could
still be considered separately if needed.