### PR TITLE
BLD: Add --no-isolation to ASV Build Command

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -8,6 +8,7 @@
     "show_commit_url": "https://github.com/pandas-dev/pandas/commit/",
     "matrix": {
         "pip+build": [],
+        "versioneer[toml]": [],
         "Cython": [],
         "matplotlib": [],
         "sqlalchemy": [],
@@ -30,5 +31,5 @@
         ".*": "0409521665"
     },
     "build_command":
-    ["python -m build -Cbuilddir=builddir --wheel --outdir {build_cache_dir} {build_dir}"]
+    ["python -m build -Cbuilddir=builddir --no-isolation --wheel --outdir {build_cache_dir} {build_dir}"]
 }


### PR DESCRIPTION
Currently, ASV builds run in isolated environments, which causes the NumPy include directory path to change between builds. This prevents `ccache` from reusing cached compilation steps, making the benchmark build process unnecessarily slow.

This PR add the `--no-isolation` flag to the build command in `asv.conf.json`, ensuring that the same NumPy include directory is used across builds, allowing `ccache` to effectively cache and reuse build artifacts.