### PR TITLE
CLN: Address actionable FIXMEs in vendored ujson

### DIFF
--- a/pandas/_libs/src/vendored/ujson/lib/ultrajsondec.c
+++ b/pandas/_libs/src/vendored/ujson/lib/ultrajsondec.c
@@ -246,7 +246,6 @@ DECODE_FRACTION:
   }
 
 BREAK_FRC_LOOP:
-  // FIXME: Check for arithmetic overflow here
   ds->lastType = JT_DOUBLE;
   ds->start = offset;
   return ds->dec->newDouble(
@@ -345,7 +344,6 @@ SET_INF_ERROR:
   }
 
 BREAK_EXP_LOOP:
-  // FIXME: Check for arithmetic overflow here
   ds->lastType = JT_DOUBLE;
   ds->start = offset;
   return ds->dec->newDouble(
@@ -1166,7 +1164,8 @@ JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer,
                         size_t cbBuffer) {
   /*
   FIXME: Base the size of escBuffer of that of cbBuffer so that the unicode
-  escaping doesn't run into the wall each time */
+  escaping doesn't run into the wall each time
+  (comment also present in upstream ultrajson) */
   char *locale;
   struct DecoderState ds;
   wchar_t escBuffer[(JSON_MAX_STACK_BUFFER_SIZE / sizeof(wchar_t))];

--- a/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
@@ -95,7 +95,8 @@ static const char g_escapeChars[] = "0123456789\\b\\t\\n\\f\\r\\\"\\\\\\/";
 /*
 FIXME: While this is fine dandy and working it's a magic value mess which
 probably only the author understands.
-Needs a cleanup and more documentation */
+Needs a cleanup and more documentation
+(comment also present in upstream ultrajson) */
 
 /*
 Table for pure ascii output escaping all characters above 127 to \uXXXX */
@@ -365,7 +366,8 @@ static void SetError(JSOBJ obj, JSONObjectEncoder *enc, const char *message) {
 /*
 FIXME: Keep track of how big these get across several encoder calls and try to
 make an estimate
-That way we won't run our head into the wall each call */
+That way we won't run our head into the wall each call
+(comment also present in upstream ultrajson) */
 void Buffer_Realloc(JSONObjectEncoder *enc, size_t cbNeeded) {
   size_t curSize = enc->end - enc->start;
   size_t newSize = curSize * 2;
@@ -911,11 +913,8 @@ int Buffer_AppendDoubleUnchecked(JSOBJ obj, JSONObjectEncoder *enc,
 
 /*
 FIXME:
-Handle integration functions returning NULL here */
-
-/*
-FIXME:
-Perhaps implement recursion detection */
+Handle integration functions returning NULL here
+(comment also present in upstream ultrajson) */
 
 void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
             size_t cbName) {

--- a/pandas/_libs/src/vendored/ujson/python/JSONtoObj.c
+++ b/pandas/_libs/src/vendored/ujson/python/JSONtoObj.c
@@ -154,11 +154,13 @@ PyObject *JSONToObj(PyObject *Py_UNUSED(self), PyObject *args,
   }
 
   if (dec.errorStr) {
-    /*
-    FIXME: It's possible to give a much nicer error message here with actual
-    failing element in input etc*/
-
-    PyErr_Format(PyExc_ValueError, "%s", dec.errorStr);
+    if (dec.errorOffset != NULL && dec.errorOffset >= buf &&
+        dec.errorOffset <= buf + len) {
+      Py_ssize_t pos = (Py_ssize_t)(dec.errorOffset - buf);
+      PyErr_Format(PyExc_ValueError, "%s at position %zd", dec.errorStr, pos);
+    } else {
+      PyErr_Format(PyExc_ValueError, "%s", dec.errorStr);
+    }
 
     if (ret) {
       Py_DECREF((PyObject *)ret);

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -412,6 +412,18 @@ class TestUltraJSONTests:
             ujson.ujson_loads(jibberish)
 
     @pytest.mark.parametrize(
+        "bad_input, expected_pos",
+        [
+            ("[1, 2,", 5),
+            ('{"a": fzz}', 5),
+            ("[[[true", 7),
+        ],
+    )
+    def test_decode_error_includes_position(self, bad_input, expected_pos):
+        with pytest.raises(ValueError, match=f"at position {expected_pos}$"):
+            ujson.ujson_loads(bad_input)
+
+    @pytest.mark.parametrize(
         "broken_json",
         [
             "[",  # Broken array start.


### PR DESCRIPTION
## Summary

Cleans up FIXME comments inherited from upstream ujson. Three are dropped as obsolete, one is repurposed into an actual user-facing improvement, and the remaining four are annotated as upstream-origin so they don't read as pandas-specific TODOs.

- `JSONtoObj.c`: decode errors now include a byte offset, e.g. `Expected object or value at position 5`. The `errorOffset` field was already populated by `SetError`; we just weren't surfacing it.
- `ultrajsondec.c`: drop the two `BREAK_FRC_LOOP` / `BREAK_EXP_LOOP` "Check for arithmetic overflow" FIXMEs. `intValue` overflow is already guarded in the integer loop above; `expValue` is a `double`, so `pow(10, huge)` yields `inf` rather than UB.
- `ultrajsonenc.c`: drop the obsolete "Perhaps implement recursion detection" FIXME — `encode()` already enforces `enc->recursionMax`.
- Remaining four FIXMEs (`escBuffer` pre-sizing, `g_asciiOutputTable` magic values, `Buffer_Realloc` cross-call sizing, "Handle integration functions returning NULL") are still present verbatim in upstream ultrajson `main` and are now annotated as such.

## Test plan

- [x] `pandas/tests/io/json/test_ujson.py` — 218 passed
- [x] `pandas/tests/io/json/` — 1068 passed, 15 skipped, 60 xfailed
- [x] New parametrized test pinning the `at position N` suffix for three known bad inputs
- [x] `pre-commit` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)