### PR TITLE
TST: address resolvable FIXMEs in tests

### DIFF
--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -223,7 +223,6 @@ def test_multifunc_numba_vs_cython_frame_noskipna(func):
     "agg_kwargs,expected_func",
     [
         ({"func": lambda values, index: values.sum()}, "sum"),
-        # FIXME
         pytest.param(
             {
                 "func": [

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -441,8 +441,8 @@ def test_agg_over_numpy_arrays():
     result = gb.agg("sum", numeric_only=False)
     tm.assert_frame_equal(result, expected)
 
-    # FIXME: the original version of this test called `gb.agg(sum)`
-    #  and that raises TypeError if `numeric_only=False` is passed
+    result = gb.agg(sum)
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize("as_period", [True, False])

--- a/pandas/tests/indexes/multi/test_reshape.py
+++ b/pandas/tests/indexes/multi/test_reshape.py
@@ -66,9 +66,7 @@ def test_insert(idx):
         columns=["1st", "2nd", "3rd"],
     )
     right.set_index(["1st", "2nd"], inplace=True)
-    # FIXME data types changes to float because
-    # of intermediate nan insertion;
-    tm.assert_frame_equal(left, right, check_dtype=False)
+    tm.assert_frame_equal(left, right)
     tm.assert_series_equal(ts, right["3rd"])
 
 

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -205,8 +205,11 @@ def test_encoding_temp_file(
     encoding = encoding_fmt.format(utf_value)
 
     if parser.engine == "pyarrow" and pass_encoding is True and utf_value in [16, 32]:
-        # FIXME: this is bad!
-        pytest.skip("These cases freeze")
+        # GH#24130: pyarrow's CSV reader splits the input into byte-blocks
+        # before decoding, which corrupts multi-byte utf-16/utf-32 sequences
+        # (raises "straddling object straddles two block boundaries"). The
+        # error path is slow (~9s per case), so skip rather than xfail.
+        pytest.skip("pyarrow utf-16/32 block-boundary error is slow to surface")
 
     expected = DataFrame({"foo": ["bar"]})
 


### PR DESCRIPTION
## Summary

A handful of test FIXMEs other than the "don't leave commented-out" batch were addressable. The remainder are still load-bearing (real bugs / open issues / architectural inconsistencies) and were left in place.

### Addressed
- **`groupby/aggregate/test_other.py`** — restored `gb.agg(sum)` coverage. The FIXME's claim that this raises when `numeric_only=False` is passed no longer applies (verified: `gb.agg(sum)` returns the expected result).
- **`groupby/aggregate/test_numba.py`** — removed bare `# FIXME` next to a `pytest.param`; the adjacent `xfail(reason=...)` already documents the missing feature.
- **`indexes/multi/test_reshape.py`** — both sides of the comparison are now `int64` (no float coercion from intermediate NaN insertion); dropped the FIXME and `check_dtype=False`.
- **`io/parser/test_encoding.py`** — pyarrow no longer *freezes* on utf-16/32 with `pass_encoding=True`; verified it now raises a `ParserError` ("straddling object straddles two block boundaries"). Replaced the "this is bad!" FIXME with a concrete description. Kept as `skip` rather than `xfail` because the failure path takes ~9s per case (~110s × 12 cases).

### Left in place (still load-bearing)
- `io/test_orc.py:322` — ORC roundtrip still loses non-ns resolution; the cast is a real workaround.
- `frame/test_constructors.py:2655/2666` — verified empirically that with CoW, `df.iloc[:, 2] = ...` for an EA column still mutates the original `c` when `copy=False`. GH-35417 was about `df[col] = arr`, not iloc.
- `arrays/period/test_constructors.py:124` — `_from_sequence(asi8.astype(object))` still treats ints as years rather than ordinals (GH-64227 still open).
- `indexes/test_any_index.py:54` — stylistic note; the object-dtype string branch is still needed because `.map` infers to `str`.
- `indexes/datetimes/test_constructors.py:996` — xfail still applies (dateutil/zoneinfo implicitly get `fold=0`).

## Test plan
- [x] `pytest pandas/tests/io/parser/test_encoding.py pandas/tests/groupby/aggregate/test_other.py::test_agg_over_numpy_arrays pandas/tests/groupby/aggregate/test_numba.py::test_multifunc_numba_udf_frame pandas/tests/indexes/multi/test_reshape.py::test_insert` — all pass.
- [x] `pre-commit run --files <changed files>` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)