### PR TITLE
BUG: use tables on ASV benchmark on non-conda environment types

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -14,7 +14,8 @@
         "scipy": [],
         "numba": [],
         "numexpr": [],
-        "pytables": [],
+        "pytables": [null, ""],
+        "tables": [null, ""],
         "pyarrow": [],
         "openpyxl": [],
         "xlsxwriter": [],
@@ -24,6 +25,12 @@
         "meson-python": [],
         "python-build": []
     },
+    "exclude": [
+        {"environment_type": "conda|rattler", "tables": ""},
+        {"environment_type": "conda|rattler", "pytables": null},
+        {"environment_type": "(?!(?:conda|rattler)).*", "tables": null},
+        {"environment_type": "(?!(?:conda|rattler)).*", "pytables": ""}
+    ],
     "conda_channels": ["conda-forge"],
     "build_cache_size": 8,
     "regressions_first_commits": {


### PR DESCRIPTION
`pytables` isn't available on PyPI, causing this error when setting up the ASV environment when running the benchmark with `-E virtualenv:3.14`.

```
·· Running '/home/user/pandas/asv_bench/env/07b8f52265a9b249c27ac7a76c1e5551/bin/python -m pip install -v --upgrade pytables'
   OUTPUT -------->
   Using pip 26.0.1 from /home/user/pandas/asv_bench/env/07b8f52265a9b249c27ac7a76c1e5551/lib/python3.14/site-packages/pip (python 3.14)
   ERROR: Could not find a version that satisfies the requirement pytables (from versions: none)
   [notice] A new release of pip is available: 26.0.1 -> 26.1
   [notice] To update, run: pip install --upgrade pip
   ERROR: No matching distribution found for pytables

·· Error running /home/user/pandas/asv_bench/env/07b8f52265a9b249c27ac7a76c1e5551/bin/python -m pip install -v --upgrade pytables (exit status 1)
·· Failure creating environment for virtualenv-py3.14-Cython-jinja2-matplotlib-meson-meson-python-numba-numexpr-odfpy-openpyxl-pyarrow-pytables-python-build-scipy-sqlalchemy-xlsxwriter
```

This change adds back `pytables` and `tables` environment handling omitted in #65153.