### PR TITLE
DOC: add dict example for DataFrame.fillna

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -382,6 +382,12 @@ Replace NA with a scalar value
    df
    df.fillna(0)
 
+Replace NA with column-specific values using a dict
+
+.. ipython:: python
+
+   df.fillna({"np": 0, "arrow": 1})
+
 When the data has object dtype, you can control what type of NA values are present.
 
 .. ipython:: python


### PR DESCRIPTION
## Summary

Adds an example showing how to use DataFrame.fillna with a dictionary to fill different columns with different values.

## Motivation

This is a common real-world use case and improves discoverability for users reading the missing data guide.