### PR TITLE
BUG: Ensure consistent index naming when merging with empty DataFrames

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -354,6 +354,7 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
+- Bug in :meth:`DataFrame.merge` returning an incorrect index name when merging an empty DataFrame with a non-empty DataFrame on an index (:issue:`22921`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)
 -

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1423,10 +1423,15 @@ class _MergeOperation:
                         left_indexer,
                         how="right",
                     )
-                elif right_indexer is None:
-                    join_index = right_ax.copy()
                 else:
-                    join_index = right_ax.take(right_indexer)
+                    # When left is empty, create default index based on merge type
+                    if self.how in ("right", "outer"):
+                        n = len(right_ax) if right_indexer is None else len(right_indexer)
+                    elif self.how == "inner":
+                        n = 0
+                    else:  # left
+                        n = 0
+                    join_index = default_index(n)
             elif self.left_index:
                 if self.how == "asof":
                     # GH#33463 asof should always behave like a left merge
@@ -1444,10 +1449,17 @@ class _MergeOperation:
                         right_indexer,
                         how="left",
                     )
-                elif left_indexer is None:
-                    join_index = left_ax.copy()
                 else:
-                    join_index = left_ax.take(left_indexer)
+                    # When right is empty, create default index based on merge type
+                    if self.how == "right":
+                        n = len(right_ax) if right_indexer is None else len(right_indexer)
+                    elif self.how == "inner":
+                        n = 0
+                    elif self.how == "left":
+                        n = len(left_ax) if left_indexer is None else len(left_indexer)
+                    else:  # outer
+                        n = len(left_ax) if left_indexer is None else len(left_indexer)
+                    join_index = default_index(n)
             else:
                 n = len(left_ax) if left_indexer is None else len(left_indexer)
                 join_index = default_index(n)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1431,9 +1431,7 @@ class _MergeOperation:
                             if right_indexer is None
                             else len(right_indexer)
                         )
-                    elif self.how == "inner":
-                        n = 0
-                    else:  # left
+                    else:
                         n = 0
                     join_index = default_index(n)
             elif self.left_index:
@@ -1455,18 +1453,15 @@ class _MergeOperation:
                     )
                 else:
                     # When right is empty, create default index based on merge type
-                    if self.how == "right":
+                    if self.how in ("left", "outer"):
                         n = (
-                            len(right_ax)
-                            if right_indexer is None
-                            else len(right_indexer)
+                            len(left_ax)
+                            if left_indexer is None
+                            else len(left_indexer)
                         )
-                    elif self.how == "inner":
+                    else:
                         n = 0
-                    elif self.how == "left":
-                        n = len(left_ax) if left_indexer is None else len(left_indexer)
-                    else:  # outer
-                        n = len(left_ax) if left_indexer is None else len(left_indexer)
+                        
                     join_index = default_index(n)
             else:
                 n = len(left_ax) if left_indexer is None else len(left_indexer)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1426,7 +1426,11 @@ class _MergeOperation:
                 else:
                     # When left is empty, create default index based on merge type
                     if self.how in ("right", "outer"):
-                        n = len(right_ax) if right_indexer is None else len(right_indexer)
+                        n = (
+                            len(right_ax)
+                            if right_indexer is None
+                            else len(right_indexer)
+                        )
                     elif self.how == "inner":
                         n = 0
                     else:  # left
@@ -1452,7 +1456,11 @@ class _MergeOperation:
                 else:
                     # When right is empty, create default index based on merge type
                     if self.how == "right":
-                        n = len(right_ax) if right_indexer is None else len(right_indexer)
+                        n = (
+                            len(right_ax)
+                            if right_indexer is None
+                            else len(right_indexer)
+                        )
                     elif self.how == "inner":
                         n = 0
                     elif self.how == "left":

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1454,14 +1454,10 @@ class _MergeOperation:
                 else:
                     # When right is empty, create default index based on merge type
                     if self.how in ("left", "outer"):
-                        n = (
-                            len(left_ax)
-                            if left_indexer is None
-                            else len(left_indexer)
-                        )
+                        n = len(left_ax) if left_indexer is None else len(left_indexer)
                     else:
                         n = 0
-                        
+
                     join_index = default_index(n)
             else:
                 n = len(left_ax) if left_indexer is None else len(left_indexer)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2792,6 +2792,34 @@ def test_merge_result_empty_index_and_on():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("how", ["inner", "left", "right", "outer"])
+def test_merge_empty_dataframe_index_name_consistency(how):
+    # GH 22921: Test for consistency in index naming when merging with empty DataFrames
+    # using left_on/right_index or left_index/right_on patterns
+
+    # Case 1: left_on/right_index with empty left DataFrame
+    b = DataFrame({"dataB": ["pff"]}, index=Index([1], name="refB"))
+    a_full = DataFrame({"refA": [1], "dataA": ["bla"]})
+    m_full = a_full.merge(b, left_on="refA", right_index=True, how=how)
+
+    a_empty = DataFrame(columns=["refA", "dataA"])
+    m_empty = a_empty.merge(b, left_on="refA", right_index=True, how=how)
+
+    # Index names should be consistent
+    assert m_full.index.name == m_empty.index.name
+
+    # Case 2: left_index/right_on with empty right DataFrame
+    a = DataFrame({"dataA": ["bla"]}, index=Index([1], name="refA"))
+    b_full = DataFrame({"refB": [1], "dataB": ["pff"]})
+    m_full = a.merge(b_full, left_index=True, right_on="refB", how=how)
+
+    b_empty = DataFrame(columns=["refB", "dataB"])
+    m_empty = a.merge(b_empty, left_index=True, right_on="refB", how=how)
+
+    # Index names should be consistent
+    assert m_full.index.name == m_empty.index.name
+
+
 def test_merge_suffixes_produce_dup_columns_raises():
     # GH#22818; Enforced in 2.0
     left = DataFrame({"a": [1, 2, 3], "b": 1, "b_x": 2})


### PR DESCRIPTION
This PR fixes an inconsistency reported in #22921 where merging an empty DataFrame with a non-empty DataFrame via `left_on`/`right_index` (or `left_index`/`right_on`) inadvertently preserved the named index from the non-empty DataFrame. 

Previously, when one side was empty, `_get_join_info` bypassed standard join index creation and fell back to `copy()`/`take()` on the populated axis, dragging along its index metadata. This updates the logic to construct a fresh `default_index(n)` when one side is empty. The length `n` is correctly calculated based on the `how` parameter (e.g., `n = len(right)` for an outer join with an empty left DataFrame).

Parametrized tests have been added to ensure consistency across all join types (`inner`, `left`, `right`, `outer`).

- [x] closes #22921 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. *(Note: No new arguments added)*
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
