### PR TITLE
TYP: typing for IndexSlice

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -6,6 +6,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Self,
+    TypeAlias,
+    TypeVar,
     cast,
     final,
 )
@@ -91,6 +93,7 @@ if TYPE_CHECKING:
         Axis,
         AxisInt,
         DtypeObj,
+        Scalar,
         T,
         npt,
     )
@@ -100,6 +103,16 @@ if TYPE_CHECKING:
         Series,
     )
     from pandas.core.arrays import ExtensionArray
+    from pandas.core.base import IndexOpsMixin
+
+    _IndexSliceTuple: TypeAlias = tuple[IndexOpsMixin | Scalar | Sequence | slice, ...]
+
+    _IndexSliceUnion: TypeAlias = (
+        Scalar | Sequence | slice | _IndexSliceTuple | tuple[_IndexSliceTuple, ...]
+    )
+
+    _IndexSliceUnionT = TypeVar("_IndexSliceUnionT", bound=_IndexSliceUnion)
+
 
 # "null slice"
 _NS = slice(None, None)
@@ -154,7 +167,7 @@ class _IndexSlice:
            B1   10   11
     """
 
-    def __getitem__(self, arg):
+    def __getitem__(self, arg: _IndexSliceUnionT) -> _IndexSliceUnionT:
         return arg
 
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -2871,7 +2871,11 @@ class Styler(StylerRenderer):
         elif isinstance(table_styles, dict):
             axis = self.data._get_axis_number(axis)
             obj = self.data.index if axis == 1 else self.data.columns
-            idf = f".{self.css['row']}" if axis == 1 else f".{self.css['col']}"  # pyright: ignore[reportOptionalSubscript]
+            idf = (
+                f".{self.css['row']}"  # pyright: ignore[reportOptionalSubscript]
+                if axis == 1
+                else f".{self.css['col']}"  # pyright: ignore[reportOptionalSubscript]
+            )
 
             table_styles = [
                 {
@@ -3087,10 +3091,15 @@ class Styler(StylerRenderer):
             )
         else:
             if axis == 0:
-                subset_ = IndexSlice[subset, :]  # new var so mypy reads not Optional
+                subset_1 = IndexSlice[
+                    subset, :
+                ]  # separate var so mypy reads different type
+                subset = non_reducing_slice(subset_1)
             else:
-                subset_ = IndexSlice[:, subset]  # new var so mypy reads not Optional
-            subset = non_reducing_slice(subset_)
+                subset_2 = IndexSlice[
+                    :, subset
+                ]  # separate var so mypy reads different type
+                subset = non_reducing_slice(subset_2)
             hide = self.data.loc[subset]
             h_els = getattr(self, objs).get_indexer_for(getattr(hide, objs))
             setattr(self, f"hidden_{alt}", h_els)


### PR DESCRIPTION
See https://github.com/python/mypy/pull/21401#issuecomment-4364865818 and https://github.com/python/mypy/pull/21401#issuecomment-4374576822

A future version of `mypy` will allow us to remove some `#type: ignore` but first we have to type `IndexSlice`, so I copied relevant things from `pandas-stubs` so we are prepared for this when mypy 2.1 is released and we upgrade to support it.

