### PR TITLE
DOC: Clarify aliasing and alignment fallback in .iloc assignment

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -182,7 +182,7 @@ columns.
 
   .. note::
       ``.copy()`` is used on the right-hand side to avoid aliasing with ``df``.
-      Without it, referencing the exact same memory causes pandas to fall back 
+      Without it, referencing the exact same memory causes pandas to fall back
       to aligning the axes.
 
    .. ipython:: python

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -180,10 +180,15 @@ columns.
 
    This will modify ``df`` because the column alignment is not done before value assignment.
 
+  .. note::
+      ``.copy()`` is used on the right-hand side to avoid aliasing with ``df``.
+      Without it, referencing the exact same memory causes pandas to fall back 
+      to aligning the axes.
+
    .. ipython:: python
 
       df[['A', 'B']]
-      df.iloc[:, [1, 0]] = df[['A', 'B']]
+      df.iloc[:, [1, 0]] = df[['A', 'B']].copy()
       df[['A','B']]
 
 


### PR DESCRIPTION
- [x] closes #65446
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Fix
Clarified that .iloc in combination with aliasing falls back to axes alignment .
