### PR TITLE
Remove Source Files From gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,16 +110,6 @@ pandas/io/*.dat
 pandas/io/*.json
 scikits
 
-# Generated Sources #
-#####################
-!skts.c
-*.c
-*.cpp
-!pandas/_libs/src/**/*.c
-!pandas/_libs/src/**/*.cpp
-!pandas/_libs/src/**/*.h
-!pandas/_libs/include/**/*.h
-
 # Unit / Performance Testing #
 ##############################
 asv_bench/env/


### PR DESCRIPTION
These files probably were ignored because were generated by Cython. It's not necessary anymore, because builds are out of source.