### PR TITLE
TST/CLN: salvage or remove FIXME-commented-out tests

### DIFF
--- a/pandas/tests/arrays/masked/test_indexing.py
+++ b/pandas/tests/arrays/masked/test_indexing.py
@@ -21,6 +21,13 @@ class TestSetitemValidation:
         with pytest.raises(TypeError, match=msg):
             arr[[0]] = invalid
 
+        # FIXME: don't leave commented-out
+        # with pytest.raises(TypeError):
+        #    arr[[0]] = [invalid]
+
+        # with pytest.raises(TypeError):
+        #    arr[[0]] = np.array([invalid], dtype=object)
+
         # Series non-coercion, behavior subject to change
         ser = pd.Series(arr)
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/arrays/masked/test_indexing.py
+++ b/pandas/tests/arrays/masked/test_indexing.py
@@ -21,13 +21,6 @@ class TestSetitemValidation:
         with pytest.raises(TypeError, match=msg):
             arr[[0]] = invalid
 
-        # FIXME: don't leave commented-out
-        # with pytest.raises(TypeError):
-        #    arr[[0]] = [invalid]
-
-        # with pytest.raises(TypeError):
-        #    arr[[0]] = np.array([invalid], dtype=object)
-
         # Series non-coercion, behavior subject to change
         ser = pd.Series(arr)
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -199,23 +199,29 @@ class TestDataFrameBlockInternals:
             {
                 "dt1": Timestamp("20130101").as_unit("s"),
                 "dt2": date_range("20130101", periods=3).astype("M8[s]"),
-                # 'dt3' : date_range('20130101 00:00:01',periods=3,freq='s'),
-                # FIXME: don't leave commented-out
+                "dt3": date_range("20130101 00:00:01", periods=3, freq="s").astype(
+                    "M8[s]"
+                ),
             },
             index=range(3),
         )
         assert expected.dtypes["dt1"] == "M8[s]"
         assert expected.dtypes["dt2"] == "M8[s]"
+        assert expected.dtypes["dt3"] == "M8[s]"
 
         dt1 = np.datetime64("2013-01-01")
         dt2 = np.array(
             ["2013-01-01", "2013-01-02", "2013-01-03"], dtype="datetime64[D]"
         )
-        df = DataFrame({"dt1": dt1, "dt2": dt2})
-
-        # df['dt3'] = np.array(['2013-01-01 00:00:01','2013-01-01
-        # 00:00:02','2013-01-01 00:00:03'],dtype='datetime64[s]')
-        # FIXME: don't leave commented-out
+        dt3 = np.array(
+            [
+                "2013-01-01 00:00:01",
+                "2013-01-01 00:00:02",
+                "2013-01-01 00:00:03",
+            ],
+            dtype="datetime64[s]",
+        )
+        df = DataFrame({"dt1": dt1, "dt2": dt2, "dt3": dt3})
 
         tm.assert_frame_equal(df, expected)
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1286,10 +1286,6 @@ class TestDataFrameFormatting:
         ):
             assert not has_non_verbose_info_repr(df)
 
-        # FIXME: don't leave commented-out
-        # test verbose overrides
-        # set_option('display.max_info_columns', 4)  # exceeded
-
     def test_pprint_pathological_object(self):
         """
         If the test fails, it at least won't hang.

--- a/pandas/tests/io/formats/test_to_string.py
+++ b/pandas/tests/io/formats/test_to_string.py
@@ -857,10 +857,7 @@ class TestDataFrameToString:
         tm.assert_series_equal(recons["B"], biggie["B"])
         assert recons["A"].count() == biggie["A"].count()
         assert (np.abs(recons["A"].dropna() - biggie["A"].dropna()) < 0.1).all()
-
-        # FIXME: don't leave commented-out
-        # expected = ['B', 'A']
-        # assert header == expected
+        assert header == ["B", "A"]
 
         result = biggie.to_string(columns=["A"], col_space=17)
         header = result.split("\n")[0].strip().split()

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -211,16 +211,7 @@ class TestStata:
             parsed_115 = self.read_dta(path2)
         with tm.assert_produces_warning(UserWarning, match=msg):
             parsed_117 = self.read_dta(path3)
-            # FIXME: don't leave commented-out
-            # 113 is buggy due to limits of date format support in Stata
-            # parsed_113 = self.read_dta(
-            # datapath("io", "data", "stata", "stata2_113.dta")
-            # )
 
-        # FIXME: don't leave commented-out
-        # buggy test because of the NaT comparison on certain platforms
-        # Format 113 test fails since it does not support tc and tC formats
-        # tm.assert_frame_equal(parsed_113, expected)
         tm.assert_frame_equal(parsed_114, expected)
         tm.assert_frame_equal(parsed_115, expected)
         tm.assert_frame_equal(parsed_117, expected)

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -459,10 +459,6 @@ class TestPeriodIndex:
         expected = ts.asfreq("Q-MAR", how=how)
         expected = expected.reindex(result.index, method="ffill")
 
-        # FIXME: don't leave commented-out
-        # .to_timestamp('D')
-        # expected = expected.resample('Q-MAR').ffill()
-
         tm.assert_series_equal(result, expected)
 
     def test_resample_fill_missing(self):


### PR DESCRIPTION
## Summary

Audit of the nine ``# FIXME: don't leave commented-out`` notes scattered across the test suite. Two became live assertions; the rest were dead code that's been removed.

**Salvaged into live tests:**
- ``test_to_string``: assert ``header == ["B", "A"]`` after ``to_string(columns=["B", "A"])``.
- ``test_block_internals.test_construction_with_conversions``: re-enable the ``dt3`` column on both sides of the comparison, with ``.astype("M8[s]")`` on the ``date_range`` so the units line up.

**Dropped (commented-out code unsalvageable):**
- ``test_indexing`` (masked): ``arr[[0]] = [invalid]`` / ``np.array([invalid], dtype=object)`` behavior is inconsistent across ``boolean``/``Int64``/``Float64`` (some scalars silently coerce, others raise ``ValueError`` instead of ``TypeError``).
- ``test_period_index``: stale alternative computations of ``expected``; current test passes without them.
- ``test_format.test_info_repr_max_cols``: ``# test verbose overrides`` stub — ``DataFrame.info(verbose=...)`` overriding ``display.max_info_columns`` is already covered by ``test_info.test_info_max_cols``.
- ``test_stata.test_read_dta2``: the format-113 reader genuinely returns wrong values (``datetime_c`` not converted, ``1959-01-01`` decodes to ``0002-01-01``); only expressible as an xfail that locks in the bug.

The remaining FIXME (``test_string_column_above_2GB`` in ``test_parquet.py``) is intentionally left for a separate PR.

## Test plan
- [x] ``pytest pandas/tests/io/formats/test_to_string.py``
- [x] ``pytest pandas/tests/frame/test_block_internals.py``
- [x] ``pytest`` over the other four touched files (no regressions)
- [x] ``pre-commit run`` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)