### PR TITLE
BUG: fix Index.get_indexer pd.NA vs NaN inconsistency (GH#65419)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7083,6 +7083,15 @@ class Index(IndexOpsMixin, PandasObject):
         ):
             # Fill missing values to ensure consistent missing value representation
             target_index = target_index.fillna(np.nan)
+        elif (
+            hasattr(target, "dtype")
+            and self.dtype == object
+            and target.dtype == object
+        ):
+            # GH#65419: Normalize pd.NA to np.nan for consistent matching
+            # When target is an ndarray (has dtype) with object dtype,
+            # ensure pd.NA is converted to np.nan for consistent matching
+            target_index = target_index.fillna(np.nan)
         return target_index
 
     @final


### PR DESCRIPTION
## Summary
When calling `get_indexer` with an ndarray containing `pd.NA` on an index containing `np.nan`, the results were inconsistent with the list input.

## Root Cause
In `_maybe_cast_listlike_indexer`, when the target is a list, `ensure_index` normalizes `pd.NA` to `np.nan` via `Index.__new__` -> `sanitize_array`. However, when the target is already an ndarray (has `.dtype` attribute), this normalization was skipped.

## Fix
Added handling in `_maybe_cast_listlike_indexer` to fillna `pd.NA` to `np.nan` when both self and target have object dtype, ensuring consistent matching behavior.

## Example
```python
import numpy as np
import pandas as pd

idx = pd.Index([np.nan, 'b'])

# Before fix: ndarray path returned -1, list path returned 0
idx.get_indexer([pd.NA])  # array([0]) - correct
idx.get_indexer(np.array([pd.NA], dtype=object))  # array([-1]) - WRONG

# After fix: all return array([0])
idx.get_indexer(np.array([pd.NA], dtype=object))  # array([0])
```

Fixes #65419
