### PR TITLE
PERF: don't call unique on dtypes for checking if string dtype is present (select_dtypes)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5431,7 +5431,7 @@ class DataFrame(NDFrame, OpsMixin):
 
             return True
 
-        blk_dtypes = self._mgr.get_unique_dtypes()
+        blk_dtypes = [blk.dtype for blk in self._mgr.blocks]
         if (
             np.object_ in include
             and str not in include


### PR DESCRIPTION
Tiny revert of a change that got included in https://github.com/pandas-dev/pandas/pull/65134

This closes https://github.com/pandas-dev/asv-runner/issues/126

Since we get the dtypes only to check if a StringDtype is present (and only when some other conditions already hold true), in this case it is unnecessary overhead to already calculate the unique dtypes (the iteration to check for StringDtype is faster than the unique anyway)

(labeling as 3.0.3  since the linked PR that included this also got backported)