### PR TITLE
[backport 3.0.x] BUG: keep fsspec OpenFile alive for chained URL reads (#65470)

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -48,6 +48,7 @@ Bug fixes
   raising an error instead of propagating the missing value (:issue:`64968`)
 - Fixed a bug in :meth:`Series.rank` with period dtype and missing values, always sorting missing values at the top, regardless of the ``na_option`` value (:issue:`64976`)
 
+- Fixed a bug in reading files with a chained URL scheme (e.g. ``tar://``) with the latest version of ``fsspec`` (:issue:`65462`).
 - Fixed a hang in :meth:`Series.str.replace` for PyArrow-backed string data when replacing an empty pattern; behavior now matches Python's ``str.replace`` (:issue:`64941`).
 
 .. ---------------------------------------------------------------------------

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -99,6 +99,7 @@ class IOArgs:
     mode: str
     compression: CompressionDict
     should_close: bool = False
+    close_handles: list[Any] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
@@ -447,9 +448,10 @@ def _get_filepath_or_buffer(
             pass
 
         try:
-            file_obj = fsspec.open(
+            open_file = fsspec.open(
                 filepath_or_buffer, mode=fsspec_mode, **(storage_options or {})
-            ).open()
+            )
+            file_obj = open_file.open()
         # GH 34626 Reads from Public Buckets without Credentials needs anon=True
         except tuple(err_types_to_retry_with_anon):
             if storage_options is None:
@@ -458,14 +460,16 @@ def _get_filepath_or_buffer(
                 # don't mutate user input.
                 storage_options = dict(storage_options)
                 storage_options["anon"] = True
-            file_obj = fsspec.open(
+            open_file = fsspec.open(
                 filepath_or_buffer, mode=fsspec_mode, **(storage_options or {})
-            ).open()
+            )
+            file_obj = open_file.open()
 
         return IOArgs(
             filepath_or_buffer=file_obj,
             encoding=encoding,
             compression=compression,
+            close_handles=[open_file],
             should_close=True,
             mode=fsspec_mode,
         )
@@ -976,6 +980,7 @@ def get_handle(
     if ioargs.should_close:
         assert not isinstance(ioargs.filepath_or_buffer, str)
         handles.append(ioargs.filepath_or_buffer)
+        handles.extend(ioargs.close_handles)
 
     return IOHandles(
         # error: Argument "handle" to "IOHandles" has incompatible type


### PR DESCRIPTION
(cherry picked from commit a6908677ffb7e4e1e8967d9d754ac44b1279c211)

Backport of https://github.com/pandas-dev/pandas/pull/65470