### PR TITLE
[backport 3.0.x] CI: lowercase types-pymysql/types-pyyaml to fix mamba 2.6.0 shard lookup (#65430)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -97,9 +97,9 @@ dependencies:
   # static typing
   - scipy-stubs
   - types-python-dateutil
-  - types-PyMySQL
+  - types-pymysql
   - types-pytz
-  - types-PyYAML
+  - types-pyyaml
   - types-setuptools
 
   # documentation (jupyter notebooks)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -67,9 +67,9 @@ sphinx-design
 sphinx-copybutton
 scipy-stubs
 types-python-dateutil
-types-PyMySQL
+types-pymysql
 types-pytz
-types-PyYAML
+types-pyyaml
 types-setuptools
 nbconvert>=7.11.0
 nbsphinx


### PR DESCRIPTION
(cherry picked from commit cec3575add379f1f42b2937377c3920fc22e3494)

Backport of https://github.com/pandas-dev/pandas/pull/65430