### PR TITLE
DOC: remove cookbook "First Pull Request" invitation

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -7,9 +7,6 @@ Cookbook
 ********
 
 This is a repository for *short and sweet* examples and links for useful pandas recipes.
-We encourage users to add to this documentation.
-
-Adding interesting links and/or inline examples to this section is a great *First Pull Request*.
 
 Simplified, condensed, new-user friendly, in-line examples have been inserted where possible to
 augment the Stack-Overflow and GitHub links.  Many of the links contain expanded information,


### PR DESCRIPTION
## Summary
- Drops the two sentences in `cookbook.rst` that encouraged adding to the cookbook and framed it as a great *First Pull Request*, to discourage drive-by recipe additions.

## Test plan
- [x] `grep` across `doc/` for "first pull request", "good first", "drive-by", "newcomer", "encourage users to add" — no other instances pointing at the cookbook.
- [x] pre-commit hooks pass on the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)