### PR TITLE
BUG: Add skipna argument to SparseArray.mean

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -438,9 +438,10 @@ Reshaping
 
 Sparse
 ^^^^^^
+- Bug in :meth:`Series.mean` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`SparseArray.astype` where converting a datetime64 :class:`SparseArray` with ``NaT`` fill value to ``"Sparse[int64]"`` silently replaced the fill value with ``0`` instead of ``iNaT`` (:issue:`49631`)
+- Bug in :meth:`SparseArray.mean` raising a ``TypeError`` when called with the ``skipna`` argument (:issue:`65478`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
--
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1560,12 +1560,16 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if method is None:
             raise TypeError(f"cannot perform {name} with type {self.dtype}")
 
-        if skipna:
-            arr = self
+        if name == "mean":
+            # mean handles skipna itself; dropping NAs beforehand would hide
+            # the NA from its skipna=False short-circuit
+            result = method(skipna=skipna, **kwargs)
         else:
-            arr = self.dropna()
-
-        result = getattr(arr, name)(**kwargs)
+            if skipna:
+                arr = self
+            else:
+                arr = self.dropna()
+            result = getattr(arr, name)(**kwargs)
 
         if keepdims:
             return type(self)([result], dtype=self.dtype)
@@ -1690,24 +1694,42 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             fill_value=self.fill_value,
         )
 
-    def mean(self, axis: Axis = 0, *args, **kwargs):
+    def mean(self, axis: Axis = 0, *args, skipna: bool = True, **kwargs):
         """
-        Mean of non-NA/null values
+        Mean of non-NA/null values.
+
+        Parameters
+        ----------
+        axis : int, default 0
+            Not Used. NumPy compatibility.
+        skipna : bool, default True
+            Exclude NA/null values. If False and NA is present, return NA.
+        *args, **kwargs
+            Not Used. NumPy compatibility.
 
         Returns
         -------
         mean : float
         """
         nv.validate_mean(args, kwargs)
+        skipna = validate_bool_kwarg(skipna, "skipna")
         valid_vals = self._valid_sp_values
         sp_sum = valid_vals.sum()
         ct = len(valid_vals)
 
+        # Compute the reduction before the skipna=False NA short-circuit so
+        # unsupported dtypes still raise during the operation validation.
+
         if self._null_fill_value:
-            return sp_sum / ct
+            mean = sp_sum / ct
         else:
             nsparse = self.sp_index.ngaps
-            return (sp_sum + self.fill_value * nsparse) / (ct + nsparse)
+            mean = (sp_sum + self.fill_value * nsparse) / (ct + nsparse)
+
+        if not skipna and self._hasna:
+            return na_value_for_dtype(self.dtype.subtype, compat=False)
+
+        return mean
 
     def max(self, *, axis: AxisInt | None = None, skipna: bool = True):
         """

--- a/pandas/tests/arrays/sparse/test_reductions.py
+++ b/pandas/tests/arrays/sparse/test_reductions.py
@@ -174,6 +174,27 @@ class TestReductions:
         out = SparseArray(data).mean()
         assert out == 40.0 / 9
 
+        out = SparseArray(data).mean(skipna=True)
+        assert out == 40.0 / 9
+
+        out = SparseArray(data).mean(skipna=False)
+        assert isna(out)
+
+        arr = SparseArray([1.0, np.nan, 3.0], fill_value=np.nan)
+        out = arr.mean(skipna=True)
+        assert out == 2.0
+
+        out = arr.mean(skipna=False)
+        assert isna(out)
+
+    @pytest.mark.parametrize("skipna", [True, False])
+    def test_mean_raises_for_unsupported_object_dtype_with_na(self, skipna):
+        arr = SparseArray(["a", np.nan], dtype=SparseDtype(object))
+
+        msg = "unsupported operand type"
+        with pytest.raises(TypeError, match=msg):
+            arr.mean(skipna=skipna)
+
     def test_numpy_mean(self):
         data = np.arange(10).astype(float)
         out = np.mean(SparseArray(data))

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -118,7 +118,7 @@ class TestSparseArray(base.ExtensionTests):
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna, request):
         if (
-            all_numeric_reductions in ["sum", "max", "min", "mean"]
+            all_numeric_reductions in ["sum", "max", "min"]
             and data.dtype.kind == "f"
             and not skipna
         ):
@@ -143,7 +143,7 @@ class TestSparseArray(base.ExtensionTests):
             )
             request.node.add_marker(mark)
         elif (
-            all_numeric_reductions in ["sum", "max", "min", "mean"]
+            all_numeric_reductions in ["sum", "max", "min"]
             and data.dtype.kind == "f"
             and not skipna
         ):


### PR DESCRIPTION
Closes #65478

## Summary

This PR adds `skipna` support to `SparseArray.mean`.

Previously, calling `SparseArray.mean(skipna=False)` raised a `TypeError` because `skipna` was not accepted. This change updates `SparseArray.mean` to accept the argument and adds regression coverage for the default, `skipna=True`, and `skipna=False` behavior.

## Tests

Passed locally:

```bash
pytest -q pandas/tests/arrays/sparse/test_reductions.py::TestReductions::test_mean
pytest -q pandas/tests/arrays/sparse
pre-commit run --files pandas/core/arrays/sparse/array.py pandas/tests/arrays/sparse/test_reductions.py
pytest pandas -m "not db" -q
```

- [x] closes #65478
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] I used AI(GPT 5.5) to assist in developing this pull request, and I prompted it to follow `AGENTS.md`.