### PR TITLE
TYP: accept Mapping in Styler.format formatter parameter

### DIFF
--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1221,8 +1221,8 @@ class StylerRenderer:
         subset = non_reducing_slice(subset)
         data = self.data.loc[subset]
 
-        if not isinstance(formatter, dict):
-            formatter = dict.fromkeys(data.columns, formatter)
+        if not isinstance(formatter, Mapping):
+            formatter = {col: formatter for col in data.columns}
 
         cis = self.columns.get_indexer_for(data.columns)
         ris = self.index.get_indexer_for(data.index)
@@ -1411,8 +1411,8 @@ class StylerRenderer:
             display_funcs_.clear()
             return self  # clear the formatter / revert to default and avoid looping
 
-        if not isinstance(formatter, dict):
-            formatter = dict.fromkeys(levels_, formatter)
+        if not isinstance(formatter, Mapping):
+            formatter = {lvl: formatter for lvl in levels_}
         else:
             formatter = {
                 obj._get_level_number(level): formatter_
@@ -1712,8 +1712,8 @@ class StylerRenderer:
             display_funcs_.clear()
             return self  # clear the formatter / revert to default and avoid looping
 
-        if not isinstance(formatter, dict):
-            formatter = dict.fromkeys(levels_, formatter)
+        if not isinstance(formatter, Mapping):
+            formatter = {lvl: formatter for lvl in levels_}
         else:
             formatter = {
                 obj._get_level_number(level): formatter_

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -1222,7 +1222,7 @@ class StylerRenderer:
         data = self.data.loc[subset]
 
         if not isinstance(formatter, Mapping):
-            formatter = {col: formatter for col in data.columns}
+            formatter = dict.fromkeys(data.columns, formatter)
 
         cis = self.columns.get_indexer_for(data.columns)
         ris = self.index.get_indexer_for(data.index)
@@ -1412,7 +1412,7 @@ class StylerRenderer:
             return self  # clear the formatter / revert to default and avoid looping
 
         if not isinstance(formatter, Mapping):
-            formatter = {lvl: formatter for lvl in levels_}
+            formatter = dict.fromkeys(levels_, formatter)
         else:
             formatter = {
                 obj._get_level_number(level): formatter_
@@ -1713,7 +1713,7 @@ class StylerRenderer:
             return self  # clear the formatter / revert to default and avoid looping
 
         if not isinstance(formatter, Mapping):
-            formatter = {lvl: formatter for lvl in levels_}
+            formatter = dict.fromkeys(levels_, formatter)
         else:
             formatter = {
                 obj._get_level_number(level): formatter_

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import (
     Callable,
+    Mapping,
     Sequence,
 )
 from functools import partial
@@ -51,7 +52,7 @@ jinja2 = import_optional_dependency("jinja2", extra="DataFrame.style requires ji
 from markupsafe import escape as escape_html  # markupsafe is jinja2 dependency
 
 BaseFormatter: TypeAlias = str | Callable
-ExtFormatter: TypeAlias = BaseFormatter | dict[Any, BaseFormatter | None]
+ExtFormatter: TypeAlias = BaseFormatter | Mapping[Any, BaseFormatter | None]
 CSSPair: TypeAlias = tuple[str, str | float]
 CSSList: TypeAlias = list[CSSPair]
 CSSProperties: TypeAlias = str | CSSList

--- a/pandas/tests/io/formats/style/test_format.py
+++ b/pandas/tests/io/formats/style/test_format.py
@@ -1,3 +1,5 @@
+from types import MappingProxyType
+
 import numpy as np
 import pytest
 
@@ -83,10 +85,26 @@ def test_format_dict(styler):
     assert ctx["body"][0][2]["display_value"] == "-60.90%"
 
 
+def test_format_mapping(styler: Styler) -> None:
+    """Accept read-only mappings for column formatters."""
+    formatter = MappingProxyType({"A": "{:0.1f}", "B": "{0:.2%}"})
+    ctx = styler.format(formatter)._translate(True, True)
+    assert ctx["body"][0][1]["display_value"] == "0.0"
+    assert ctx["body"][0][2]["display_value"] == "-60.90%"
+
+
 def test_format_index_dict(styler):
     ctx = styler.format_index({0: lambda v: v.upper()})._translate(True, True)
     for i, val in enumerate(["X", "Y"]):
         assert ctx["body"][i][0]["display_value"] == val
+
+
+def test_format_index_mapping(styler: Styler) -> None:
+    """Accept read-only mappings for index formatters."""
+    formatter = MappingProxyType({0: lambda value: value.upper()})
+    ctx = styler.format_index(formatter)._translate(True, True)
+    for row_idx, value in enumerate(["X", "Y"]):
+        assert ctx["body"][row_idx][0]["display_value"] == value
 
 
 def test_format_string(styler):
@@ -635,6 +653,19 @@ def test_format_index_names_dict(styler_multi):
     ctx = (
         styler_multi.format_index_names({"0_0": "{:<<5}"})
         .format_index_names({"1_1": "{:>>4}"}, axis=1)
+        ._translate(True, True)
+    )
+    assert ctx["head"][2][0]["display_value"] == "0_0<<"
+    assert ctx["head"][1][1]["display_value"] == ">1_1"
+
+
+def test_format_index_names_mapping(styler_multi: Styler) -> None:
+    """Accept read-only mappings for index-name formatters."""
+    index_formatter = MappingProxyType({"0_0": "{:<<5}"})
+    column_formatter = MappingProxyType({"1_1": "{:>>4}"})
+    ctx = (
+        styler_multi.format_index_names(index_formatter)
+        .format_index_names(column_formatter, axis=1)
         ._translate(True, True)
     )
     assert ctx["head"][2][0]["display_value"] == "0_0<<"


### PR DESCRIPTION
## Summary
- Widen `ExtFormatter` from `dict` to `Mapping` so narrower mapping value types are accepted by static type checkers.
- Treat any `Mapping` as a formatter mapping in `Styler.format`, `Styler.format_index`, and `Styler.format_index_names`.
- Add regression coverage with `MappingProxyType` for data, index, and index-name formatters.

Replaces closed PR https://github.com/pandas-dev/pandas/pull/65267.

## Test plan
- `python -m py_compile pandas/io/formats/style_render.py pandas/tests/io/formats/style/test_format.py`
- Focused pytest could not run locally because this fresh clone has not built pandas C extensions (`pandas._libs.pandas_parser` missing).
- Manual `mypy` hook could not run locally because `mypy` is not installed in the active environment.