### PR TITLE
TST: improve pytest configuration to run tests of installed package with --pyargs

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -105,6 +105,8 @@ def pytest_addoption(parser) -> None:
     parser.addoption(
         "--no-strict-data-files",
         action="store_false",
+        dest="strict_data_files",
+        default=True,
         help="Don't fail if a test is skipped for missing data file.",
     )
 
@@ -1217,7 +1219,7 @@ def strict_data_files(pytestconfig):
     """
     Returns the configuration for the test setting `--no-strict-data-files`.
     """
-    return pytestconfig.getoption("--no-strict-data-files")
+    return pytestconfig.getoption("strict_data_files")
 
 
 @pytest.fixture

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -100,6 +100,15 @@ pytz = import_optional_dependency("pytz", errors="ignore")
 # ----------------------------------------------------------------
 # pytest
 
+PANDAS_MARKERS = [
+    "single_cpu: tests that should run on a single cpu only",
+    "slow: mark a test as slow",
+    "network: mark a test as network",
+    "db: tests requiring a database (mysql or postgres)",
+    "clipboard: mark a pd.read_clipboard test",
+    "arm_slow: mark a test as slow for arm64 architecture",
+]
+
 
 def pytest_addoption(parser) -> None:
     parser.addoption(
@@ -109,6 +118,11 @@ def pytest_addoption(parser) -> None:
         default=True,
         help="Don't fail if a test is skipped for missing data file.",
     )
+
+
+def pytest_configure(config) -> None:
+    for marker in PANDAS_MARKERS:
+        config.addinivalue_line("markers", marker)
 
 
 def pytest_sessionstart(session):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -474,14 +474,6 @@ filterwarnings = [
   "ignore:DatetimeTZBlock is deprecated and will be removed in a future version:pandas.errors.Pandas4Warning:pyarrow",
 ]
 junit_family = "xunit2"
-markers = [
-  "single_cpu: tests that should run on a single cpu only",
-  "slow: mark a test as slow",
-  "network: mark a test as network",
-  "db: tests requiring a database (mysql or postgres)",
-  "clipboard: mark a pd.read_clipboard test",
-  "arm_slow: mark a test as slow for arm64 architecture",
-]
 
 [tool.mypy]
 # Import discovery


### PR DESCRIPTION
Triggered by https://github.com/pandas-dev/pandas/pull/65455 (and the issues to get this working in the pyodide build), looking into ways to make it a bit easier to run the pandas tests of an installed package using `pytest --pyargs pandas`.

