### PR TITLE
BUG: fix check if pyarrow is installed in cython lib - use existing constant

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -46,6 +46,7 @@ from cython cimport (
 from pandas._config import using_string_dtype
 
 from pandas._libs.missing import check_na_tuples_nonequal
+from pandas.compat import PYARROW_INSTALLED
 from pandas.util._decorators import set_module
 
 import_datetime()
@@ -127,13 +128,12 @@ i8max = <int64_t>INT64_MAX
 u8max = <uint64_t>UINT64_MAX
 
 
-cdef bint PYARROW_INSTALLED = False
+cdef bint c_PYARROW_INSTALLED = PYARROW_INSTALLED
 
-try:
+
+if c_PYARROW_INSTALLED:
     import pyarrow as pa
-
-    PYARROW_INSTALLED = True
-except ImportError:
+else:
     pa = None
 
 
@@ -1348,7 +1348,7 @@ def is_pyarrow_array(obj):
     -------
     bool
     """
-    if PYARROW_INSTALLED:
+    if c_PYARROW_INSTALLED:
         return isinstance(obj, (pa.Array, pa.ChunkedArray))
     return False
 

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -26,6 +26,7 @@ from pandas.compat._constants import (
 from pandas.compat.numpy import is_numpy_dev
 from pandas.compat.pyarrow import (
     HAS_PYARROW,
+    PYARROW_INSTALLED,
     PYARROW_MIN_VERSION,
     pa_version_under14p0,
     pa_version_under14p1,
@@ -146,6 +147,7 @@ __all__ = [
     "ISMUSL",
     "PY312",
     "PY314",
+    "PYARROW_INSTALLED",
     "PYARROW_MIN_VERSION",
     "PYPY",
     "WASM",

--- a/pandas/compat/pyarrow.py
+++ b/pandas/compat/pyarrow.py
@@ -23,6 +23,7 @@ try:
     pa_version_under21p0 = _palv < Version("21.0.0")
     pa_version_under22p0 = _palv < Version("22.0.0")
     pa_version_under23p0 = _palv < Version("23.0.0")
+    PYARROW_INSTALLED = True
     HAS_PYARROW = _palv >= Version(PYARROW_MIN_VERSION)
 except ImportError:
     pa_version_under14p0 = True
@@ -36,6 +37,7 @@ except ImportError:
     pa_version_under21p0 = True
     pa_version_under22p0 = True
     pa_version_under23p0 = True
+    PYARROW_INSTALLED = False
     HAS_PYARROW = False
 
 


### PR DESCRIPTION
In https://github.com/apache/arrow/pull/49912 it was noticed that the trick of `sys.modules["pyarrow"] = None` to let python think that pyarrow is not installed, does not work for imports in cython (while in case of a python `import pyarrow`, that gives a ModuleNotFoundError, which is an ImportError sublcass).

Now, this is not really a bug in pandas, but since we already have tried to import pyarrow in the `pandas.compat` module before we get to import `pandas._libs.lib`, we can also just reuse the knowledge of pyarrow being available or not, instead of doing a new try/except.  
And that then also makes the `sys.modules` hack work again.

