### PR TITLE
PERF: speed up nanops pearson correlation

### DIFF
--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -153,6 +153,34 @@ class Correlation:
         self.df.corrwith(self.df2, axis=1, method=method)
 
 
+class PearsonCorrelation:
+    params = [
+        ["clean", "constant", "sorted_nans", "unsorted_nans"],
+        [1_000, 1_000_000],
+    ]
+    param_names = ["scenario", "size"]
+
+    def setup(self, scenario, size):
+        rng = np.random.default_rng(2)
+        left = rng.standard_normal(size)
+        right = rng.standard_normal(size)
+
+        if scenario == "constant":
+            left[:] = 1.0
+        elif scenario == "sorted_nans":
+            left[: size // 10] = np.nan
+            right[-size // 10 :] = np.nan
+        elif scenario == "unsorted_nans":
+            left[size // 2] = np.nan
+            right[size // 3] = np.nan
+
+        self.s = pd.Series(left)
+        self.s2 = pd.Series(right)
+
+    def time_corr_series(self, scenario, size):
+        self.s.corr(self.s2, method="pearson")
+
+
 class Covariance:
     params = []
     param_names = []

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -233,6 +233,7 @@ Performance improvements
 - Performance improvement in :meth:`IntervalIndex.get_indexer` for monotonic non-overlapping indexes, which now uses binary search instead of the interval tree (:issue:`47614`)
 - Performance improvement in :meth:`NDFrame.__finalize__`, :meth:`Series.to_numpy`, :attr:`DataFrame.dtypes`, and :meth:`DataFrame.__getitem__` (:issue:`57431`)
 - Performance improvement in :meth:`PeriodIndex.from_fields` (:issue:`65921`)
+- Performance improvement in :meth:`Series.corr` with ``method="pearson"`` by avoiding an unnecessary correlation matrix calculation for 1D inputs (:issue:`65502`)
 - Performance improvement in :meth:`Series.skew`, :meth:`Series.kurt`, and their :class:`DataFrame` counterparts when axis is ``None`` or ``0`` (:issue:`64884`)
 - Performance improvement in :meth:`Series.str.isascii` for :class:`StringDtype` with storage ``"pyarrow"``, which fell back to an object-dtype implementation instead of using PyArrow's ``string_is_ascii`` kernel (:issue:`66335`)
 - Performance improvement in :meth:`Timedelta.total_seconds` (:issue:`65388`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1625,7 +1625,7 @@ def get_corr_func(
     elif method == "pearson":
 
         def func(a, b):
-            return np.corrcoef(a, b)[0, 1]
+            return _pearson_corr(a, b)
 
         return func
     elif callable(method):
@@ -1635,6 +1635,41 @@ def get_corr_func(
         f"Unknown method '{method}', expected one of "
         "'kendall', 'spearman', 'pearson', or callable"
     )
+
+
+def _pearson_corr(a: np.ndarray, b: np.ndarray) -> float:
+    if a.ndim != 1 or b.ndim != 1 or np.iscomplexobj(a) or np.iscomplexobj(b):
+        return np.corrcoef(a, b)[0, 1]
+
+    if len(a) < 2:
+        return np.nan
+
+    a = a.astype(np.float64, copy=False)
+    b = b.astype(np.float64, copy=False)
+
+    a = a - a.mean()
+    b = b - b.mean()
+    a_scale = np.max(np.abs(a))
+    b_scale = np.max(np.abs(b))
+
+    if a_scale == 0 or b_scale == 0:
+        return np.nan
+
+    a = a / a_scale
+    b = b / b_scale
+    fact = len(a) - 1
+    divisor = np.sqrt(np.dot(a, a) / fact)
+
+    if divisor == 0:
+        return np.nan
+
+    result = np.dot(a, b) / fact / divisor
+    divisor = np.sqrt(np.dot(b, b) / fact)
+
+    if divisor == 0:
+        return np.nan
+
+    return np.clip(result / divisor, -1.0, 1.0)
 
 
 @disallow("M8", "m8")

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -704,6 +704,90 @@ class TestnanopsDataFrame:
         targ1 = np.corrcoef(self.arr_float_1d.flat, self.arr_float1_1d.flat)[0, 1]
         self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1, method="pearson")
 
+    @pytest.mark.parametrize("dtype", [np.float64, np.float32, np.int64])
+    def test_nancorr_pearson_matches_corrcoef_1d_numeric(self, dtype):
+        a = np.array([1, 2, 4, 8, 16], dtype=dtype)
+        b = np.array([2, 3, 5, 9, 17], dtype=dtype)
+
+        result = nanops.nancorr(a, b, method="pearson")
+        expected = np.corrcoef(a, b)[0, 1]
+
+        assert type(result) is type(expected)
+        tm.assert_almost_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "a, b",
+        [
+            (
+                np.array([1 + 1j, 2 + 2j, 4 + 4j]),
+                np.array([2 + 2j, 3 + 3j, 5 + 5j]),
+            ),
+            (
+                np.array([[1.0, 2.0], [4.0, 8.0]]),
+                np.array([[2.0, 3.0], [5.0, 9.0]]),
+            ),
+        ],
+    )
+    def test_nancorr_pearson_fallback_matches_corrcoef(self, a, b):
+        corr_func = nanops.get_corr_func("pearson")
+
+        result = corr_func(a, b)
+        expected = np.corrcoef(a, b)[0, 1]
+
+        tm.assert_almost_equal(result, expected)
+
+    def test_nancorr_pearson_pairwise_complete_matches_corrcoef(self):
+        a = np.array([1.0, np.nan, 4.0, 8.0, 16.0])
+        b = np.array([2.0, 3.0, 5.0, 9.0, np.nan])
+        valid = ~isna(a) & ~isna(b)
+
+        result = nanops.nancorr(a, b, method="pearson")
+        expected = np.corrcoef(a[valid], b[valid])[0, 1]
+
+        tm.assert_almost_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "a, b, expected",
+        [
+            (
+                np.array([1e100, 2e100, 3e100]),
+                np.array([1e100, 2e100, 3e100]),
+                1.0,
+            ),
+            (
+                np.array([1e-160, 2e-160, 3e-160]),
+                np.array([1e-160, 2e-160, 3e-160]),
+                1.0,
+            ),
+            (
+                np.array([1e100, 2e100, 3e100]),
+                np.array([1e-160, 2e-160, 3e-160]),
+                1.0,
+            ),
+            (
+                np.array([1e100, 2e100, 3e100]),
+                np.array([3e-160, 2e-160, 1e-160]),
+                -1.0,
+            ),
+        ],
+    )
+    def test_nancorr_pearson_extreme_magnitudes(self, a, b, expected):
+        result = nanops.nancorr(a, b, method="pearson")
+
+        tm.assert_almost_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "a, b",
+        [
+            (np.array([1.0]), np.array([2.0])),
+            (np.array([1.0, 1.0, 1.0]), np.array([2.0, 3.0, 4.0])),
+        ],
+    )
+    def test_nancorr_pearson_not_well_defined(self, a, b):
+        result = nanops.nancorr(a, b, method="pearson")
+
+        assert isna(result)
+
     def test_nancorr_kendall(self):
         sp_stats = pytest.importorskip("scipy.stats")
 


### PR DESCRIPTION
Replaces the `np.corrcoef(a, b)[0, 1]` path used by `nanops.nancorr`
for 1D Pearson correlation with a direct NumPy implementation based on
centering and dot products.

This keeps the existing pandas NA handling unchanged: `nanops.nancorr`
still filters pairwise complete observations before computing the
correlation. The previous `np.corrcoef` fallback is retained for 2D and
complex inputs, with test coverage added for those branches.

A whatsnew note was also added for the performance improvement.

Microbenchmarks of the replaced kernel:

Environment: numpy 2.5.1, scipy 1.18.0, polars 1.42.1.  
Baseline is the current pandas kernel behavior using `np.corrcoef`.

| function | 1k elements | 1000k elements |
|---|---:|---:|
| current pandas kernel | 1.00x (0.06661 ms) | 1.00x (20.05 ms) |
| PR changes | 2.32x faster (0.02875 ms) | 1.21x faster (16.56 ms) |
| numpy | 1.23x faster (0.05401 ms) | 1.58x faster (12.67 ms) |
| scipy | 0.19x slower (0.3594 ms) | 0.52x slower (38.31 ms) |
| polars | 0.39x slower (0.17 ms) | 2.15x faster (9.31 ms) |

Validation:

- `git diff --check`
- `python -m py_compile pandas/tests/test_nanops.py`

Full pandas tests could not be run locally because `pytest` is not installed in
this environment and `pixi` is not available in PATH.