### PR TITLE
DOC: fix docstring typos, stale references, and broken reST

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6753,6 +6753,10 @@ class DataFrame(NDFrame, OpsMixin):
 
             .. deprecated:: 3.0.0
 
+                The ``verify_integrity`` keyword is deprecated and will be
+                removed in a future version. Check ``result.index.is_unique``
+                directly instead.
+
         Returns
         -------
         DataFrame or None
@@ -14164,10 +14168,10 @@ class DataFrame(NDFrame, OpsMixin):
             Choose the execution engine to use. If not provided the function
             will be executed by the regular Python interpreter.
 
-            Other options include JIT compilers such Numba and Bodo, which in some
+            Other options include JIT compilers such as Numba and Bodo, which in some
             cases can speed up the execution. To use an executor you can provide
             the decorators ``numba.jit``, ``numba.njit`` or ``bodo.jit``. You can
-            also provide the decorator with parameters, like ``numba.jit(nogit=True)``.
+            also provide the decorator with parameters, like ``numba.jit(nogil=True)``.
 
             Not all functions can be executed with all execution engines. In general,
             JIT compilers will require type stability in the function (no variable

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4737,7 +4737,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         **kwargs
             Additional keyword arguments to pass as keywords arguments to
-            `func`.
+            ``func``.
 
             .. versionadded:: 3.0.0
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2019,30 +2019,25 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             If ``by`` is a function, it's called on each value of the object's
             index. If a dict or Series is passed, the Series or dict VALUES
             will be used to determine the groups (the Series' values are first
-            aligned; see ``.align()`` method). If a list or ndarray of length
-            equal to the selected axis is passed (see the `groupby user guide
+            aligned; see ``.align()`` method). If a list or ndarray of the
+            same length as the Series is passed (see the `groupby user guide
             <https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html#splitting-an-object-into-groups>`_),
-            the values are used as-is to determine the groups. A label or list
-            of labels may be passed to group by the columns in ``self``.
+            the values are used as-is to determine the groups. An index level
+            name may also be passed to group by a level of the Series' index.
             Notice that a tuple is interpreted as a (single) key.
         level : int, level name, or sequence of such, default None
             If the axis is a MultiIndex (hierarchical), group by a particular
             level or levels. Do not specify both ``by`` and ``level``.
         as_index : bool, default True
-            Return object with group labels as the
-            index. Only relevant for DataFrame input. as_index=False is
-            effectively "SQL-style" grouped output. This argument has no effect
-            on filtrations (see the `filtrations in the user guide
-            <https://pandas.pydata.org/docs/dev/user_guide/groupby.html#filtration>`_),
-            such as ``head()``, ``tail()``, ``nth()`` and in transformations
-            (see the `transformations in the user guide
-            <https://pandas.pydata.org/docs/dev/user_guide/groupby.html#transformation>`_).
+            Return object with group labels as the index. This argument is
+            retained for compatibility with :meth:`DataFrame.groupby` and has
+            no effect on Series.
         sort : bool, default True
             Sort group keys. Get better performance by turning this off.
             Note this does not influence the order of observations within each
             group. Groupby preserves the order of rows within each group. If False,
             the groups will appear in the same order as they did in the original
-            DataFrame.
+            Series.
             This argument has no effect on filtrations (see the `filtrations in the user
             guide
             <https://pandas.pydata.org/docs/dev/user_guide/groupby.html#filtration>`_),
@@ -4731,7 +4726,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             cases can speed up the execution. To use an executor you can provide the
             decorators ``numba.jit``, ``numba.njit``, ``bodo.jit`` or ``blosc2.jit``.
             You can also provide the decorator with parameters, like
-            ``numba.jit(nogit=True)``.
+            ``numba.jit(nogil=True)``.
 
             Not all functions can be executed with all execution engines. In general,
             JIT compilers will require type stability in the function (no variable
@@ -4742,7 +4737,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         **kwargs
             Additional keyword arguments to pass as keywords arguments to
-            `arg`.
+            `func`.
 
             .. versionadded:: 3.0.0
 
@@ -4760,7 +4755,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         Notes
         -----
-        When ``arg`` is a dictionary, values in Series that are not in the
+        When ``func`` is a dictionary, values in Series that are not in the
         dictionary (as keys) are converted to ``NaN``. However, if the
         dictionary is a ``dict`` subclass that defines ``__missing__`` (i.e.
         provides a method for default values), then this default is used

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -399,9 +399,8 @@ def read_excel(
         is as follows:
 
         * ``"numpy_nullable"``: returns nullable-dtype-backed :class:`DataFrame`
-        * ``"pyarrow"``: returns pyarrow-backed nullable
-
-        :class:`ArrowDtype` :class:`DataFrame`
+        * ``"pyarrow"``: returns pyarrow-backed nullable :class:`ArrowDtype`
+          :class:`DataFrame`
 
         .. versionadded:: 2.0
 

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -1084,7 +1084,7 @@ def read_html(
         The column (or list of columns) to use to create the index.
 
     skiprows : int, list-like or slice, optional
-        Number of rows to skip after parsing the column integer. 0-based. If a
+        Number of rows to skip after parsing the header. 0-based. If a
         sequence of integers or a slice is given, will skip the rows indexed by
         that sequence.  Note that a single element sequence means 'skip the nth
         row' whereas an integer means 'skip n rows'.

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -69,12 +69,9 @@ def to_pickle(
         ``compression={'method': 'gzip', 'compresslevel': 1, 'mtime': 1}``.
     protocol : int
         Int which indicates which protocol should be used by the pickler,
-        default HIGHEST_PROTOCOL (see [1], paragraph 12.1.2). The possible
-        values for this parameter depend on the version of Python. For Python
-        2.x, possible values are 0, 1, 2. For Python>=3.0, 3 is a valid value.
-        For Python >= 3.4, 4 is a valid value. A negative value for the
-        protocol parameter is equivalent to setting its value to
-        HIGHEST_PROTOCOL.
+        default ``pickle.HIGHEST_PROTOCOL`` (see [1]_). A negative value for
+        the protocol parameter is equivalent to setting its value to
+        ``pickle.HIGHEST_PROTOCOL``.
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
         host, port, username, password, etc. For HTTP(S) URLs the key-value pairs
@@ -149,7 +146,7 @@ def read_pickle(
     ----------
     filepath_or_buffer : str, path object, or file-like object
         String, path object (implementing ``os.PathLike[str]``), or file-like
-        object implementing a binary ``readlines()`` function.
+        object implementing a binary ``read()`` function.
         Also accepts URL. URL is not limited to S3 and GCS.
 
         Certain URL schemes may require additional packages. For example, S3

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -570,6 +570,9 @@ def read_sql(
         for engine disposal and connection closure for the ADBC connection and
         SQLAlchemy connectable; str connections are closed automatically. See
         `here <https://docs.sqlalchemy.org/en/20/core/connections.html>`_.
+
+        .. versionadded:: 2.2.0
+            Support for ADBC drivers.
     index_col : str or list of str, optional, default: None
         Column(s) to set as index(MultiIndex).
     coerce_float : bool, default True
@@ -680,9 +683,7 @@ def read_sql(
     0           0  2012-11-10
     1           1  2010-11-12
 
-    .. versionadded:: 2.2.0
-
-       pandas now supports reading via ADBC drivers
+    pandas supports reading via ADBC drivers:
 
     >>> from adbc_driver_postgresql import dbapi  # doctest:+SKIP
     >>> with dbapi.connect("postgres:///db_name") as conn:  # doctest:+SKIP

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -920,8 +920,7 @@ def read_xml(
     dtype : Type name or dict of column -> type, optional
         Data type for data or columns. E.g. {'a': np.float64, 'b': np.int32,
         'c': 'Int64'}
-        Use `str` or `object` together with suitable `na_values` settings
-        to preserve and not interpret dtype.
+        Use `str` or `object` to preserve and not interpret dtype.
         If converters are specified, they will be applied INSTEAD
         of dtype conversion.
 

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -920,7 +920,7 @@ def read_xml(
     dtype : Type name or dict of column -> type, optional
         Data type for data or columns. E.g. {'a': np.float64, 'b': np.int32,
         'c': 'Int64'}
-        Use `str` or `object` to preserve and not interpret dtype.
+        Use ``str`` or ``object`` to preserve and not interpret dtype.
         If converters are specified, they will be applied INSTEAD
         of dtype conversion.
 


### PR DESCRIPTION
## Summary

A handful of small, independent docstring fixes surfaced by an audit of the public API. All changes are in docstrings only — no behavior changes.

- **`DataFrame.apply` / `Series.map`**: fix `numba.jit(nogit=True)` typo to `nogil=True`; add missing "as" in "such Numba".
- **`read_pickle`**: file-like object must implement `read()`, not `readlines()` — pickle calls `read()`.
- **`to_pickle`**: drop the Python 2.x protocol enumeration; just describe the current default.
- **`read_xml.dtype`**: drop reference to a non-existent `na_values` parameter (`read_xml` has none).
- **`read_html.skiprows`**: replace garbled phrase "after parsing the column integer" with "after parsing the header".
- **`Series.map`**: replace lingering `arg` references with `func` in the `**kwargs` description and Notes section.
- **`read_excel.dtype_backend`**: remove blank line that was breaking the rendering of the `pyarrow` bullet's continuation.
- **`DataFrame.set_index.verify_integrity`**: fill in the empty `.. deprecated:: 3.0.0` block with the same text used by the runtime `Pandas4Warning`.
- **`read_sql`**: move the `.. versionadded:: 2.2.0` directive out of the Examples section (where it was wedged between two doctests) into the `con` parameter description, where ADBC is first introduced.
- **`Series.groupby`**: fix DataFrame-isms in `by`, `as_index`, and `sort` parameter descriptions — these were copied verbatim from `DataFrame.groupby` and referenced "selected axis", "Only relevant for DataFrame input", and "the original DataFrame".

## Test plan

- [ ] CI passes
- [ ] No doctest changes needed (text-only edits to descriptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)