### PR TITLE
DOC: explain why and/or/not cannot be used with pd.NA

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -219,6 +219,22 @@ potentially be :class:`NA`. In such cases, :func:`isna` can be used to check
 for :class:`NA` or ``condition`` being :class:`NA` can be avoided, for example by
 filling missing values beforehand.
 
+For the same reason, the Python keywords ``and``, ``or``, and ``not`` cannot be
+used with :class:`NA`: these keywords always call ``bool()`` on their operands
+and cannot be overridden, so they will raise the same ``TypeError``. This
+manifests as an asymmetry depending on operand position, since ``and`` and
+``or`` only call ``bool()`` on the left operand:
+
+.. ipython:: python
+   :okexcept:
+
+   True and pd.NA
+   pd.NA and True
+
+Use the bitwise operators ``&``, ``|``, and ``~`` instead, which dispatch to
+``__and__``, ``__or__``, and ``__invert__`` and follow Kleene logic as
+described above.
+
 A similar situation occurs when using :class:`Series` or :class:`DataFrame` objects in ``if``
 statements, see :ref:`gotchas.truth`.
 


### PR DESCRIPTION
- closes #49828

## Summary

GH-49828 reports that `pd.NA and X`, `pd.NA or X`, and `not pd.NA` all raise `TypeError: boolean value of NA is ambiguous`, while the mirrored forms (`True and pd.NA`, `False or pd.NA`, etc.) sometimes succeed. This is not a bug — it's the unavoidable interaction of two design points:

1. `bool(pd.NA)` raises by design (GH-38224) — pandas refuses to guess truthiness of an unknown.
2. Python's `and`/`or`/`not` keywords always call `bool()` on their operand and cannot be overridden via dunders.

The asymmetry users see is just Python short-circuiting: `and`/`or` only call `bool()` on the **left** operand, so when `pd.NA` happens to be on the right, `bool()` is never invoked.

`&`/`|`/`~` work correctly via `__and__`/`__or__`/`__invert__` and already implement Kleene logic.

This PR adds a paragraph to the `NA in a boolean context` section of the user guide spelling out exactly this: why the keywords can't work, why the position-dependent behavior happens, and that `&`/`|`/`~` are the supported alternatives.

I considered also expanding the `TypeError` message itself with the `&`/`|`/`~` hint, but `bool(pd.NA)` is hit from many contexts (`if pd.NA:`, `assert pd.NA`, library code doing `if x == y:`, etc.) where that hint would be misleading. The docs are the right venue for the explanation.

## Test plan

- [x] No code/runtime change, so existing tests still pass
- [x] `pre-commit` passes (sphinx-lint, rst lint, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)