### PR TITLE
BUG: groupby(as_index=False).resample().agg(dict) raises (GH-52397)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -335,6 +335,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)
 - Bug in :meth:`.GroupBy.any` and :meth:`.GroupBy.all` returning ``NaN`` with ``float64`` dtype for unobserved categorical groups on NumPy ``bool`` data instead of the boolean identity value with ``bool`` dtype (:issue:`65100`)
+- Bug in :meth:`.Resampler.agg` raising ``ValueError`` with a dict of aggregations when applied to a :meth:`DataFrame.groupby` with ``as_index=False`` (:issue:`52397`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` (and their :class:`GroupBy` counterparts) returning ``0.0`` and ``-3.0`` respectively for degenerate windows or groups; these now return ``NaN`` (:issue:`62864`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
 - Bug in :meth:`.Rolling.sum`, :meth:`.Rolling.mean`, :meth:`.Rolling.median`, :meth:`.Rolling.min`, and :meth:`.Rolling.max` with ``method="table"``, ``engine="numba"``, and ``engine_kwargs={"parallel": True}`` could cause a segfault (:issue:`40454`)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -604,9 +604,6 @@ class SeriesGroupBy(GroupBy[Series]):
             )
             if isinstance(result, Series):
                 result.name = self.obj.name
-            if not self.as_index and not_indexed_same:
-                result = self._insert_inaxis_grouper(result)
-                result.index = default_index(len(result))
             return result.__finalize__(self.obj, method="groupby")
         else:
             # GH #6265 #24880

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -672,3 +672,16 @@ def test_groupby_resample_on_index_with_list_of_keys_missing_column():
     rs = gb.resample("2D")
     with pytest.raises(KeyError, match="Columns not found"):
         rs[["val_not_in_dataframe"]]
+
+
+def test_groupby_resample_agg_dict_as_index_false():
+    # GH#52397 dict-style agg used to raise on as_index=False; should now
+    # match the shape of calling the reduction directly on the resampler
+    df = DataFrame(
+        {"a": np.repeat([0, 1, 2, 3, 4], 10), "b": range(50, 100)},
+        index=date_range("2023-01-01", freq="1min", periods=50),
+    )
+    gb = df.groupby("a", as_index=False).resample("2min")
+    result = gb.agg({"b": "min"})
+    expected = gb.min()
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #52397 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest ``doc/source/whatsnew/vX.X.X.rst`` file if fixing a bug or adding a new feature.

## Summary

`SeriesGroupBy._wrap_applied_output`'s Series/DataFrame branch tried to insert the grouper as a column when `as_index=False and not_indexed_same`, but after `_concat_objects` the result has more rows than groups (e.g. `n_groups * n_resample_bins` for `groupby().resample()`), so `DataFrame.insert` raised `ValueError: Length of values (5) does not match length of index (25)`.

`DataFrameGroupBy._wrap_applied_output_series` already returns straight from `_concat_objects` in this same situation (see GH-8467); mirror that here.

After the fix, `gb.agg({"b": "min"})` matches `gb.min()`'s shape on the same `groupby(as_index=False).resample(...)` object — both drop the group key from the index. As discussed on the issue (GH-52397), how `as_index=False` should interact with resampler is itself a separate question; this PR only stops the raise.

## Test plan

- [x] Added `test_groupby_resample_agg_dict_as_index_false` in `pandas/tests/resample/test_resampler_grouper.py`
- [x] Full `pandas/tests` (minus slow/db) passes — 229,172 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)