### PR TITLE
BUG: to_julian_date ignored timezone (GH-54763)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -239,6 +239,7 @@ Timedelta
 Timezones
 ^^^^^^^^^
 - Bug in :class:`DatetimeIndex` addition with a :class:`DateOffset` that has only timedelta components (e.g. ``DateOffset(hours=-2)``) raising ``ValueError`` near DST transitions, while scalar :class:`Timestamp` addition worked correctly (:issue:`28610`)
+- Bug in :meth:`Timestamp.to_julian_date` and :meth:`DatetimeIndex.to_julian_date` returning the Julian date of the local wall clock for timezone-aware inputs instead of the underlying UTC instant (:issue:`54763`)
 -
 
 Numeric

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -3715,6 +3715,10 @@ default 'raise'
         """
         from pandas.core.dtypes.cast import maybe_unbox_numpy_scalar
 
+        if self.tzinfo is not None:
+            # GH#54763 JD is absolute-time, so use the UTC instant
+            return self.tz_convert("UTC").tz_localize(None).to_julian_date()
+
         year = self._year
         month = self.month
         day = self.day

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2485,6 +2485,9 @@ default 'raise'
         >>> idx.to_julian_date()
         Index([2461995.5375, 2461995.5875], dtype='float64')
         """
+        if self.tz is not None:
+            # GH#54763 JD is absolute-time, so use the UTC instant
+            return self.tz_convert("UTC").tz_localize(None).to_julian_date()
 
         # http://mysite.verizon.net/aesir_research/date/jdalg2.htm
         year = np.asarray(self.year)

--- a/pandas/tests/indexes/datetimes/methods/test_to_julian_date.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_julian_date.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from pandas import (
     Index,
@@ -43,3 +44,15 @@ class TestDateTimeIndexToJulianDate:
         r2 = dr.to_julian_date()
         assert isinstance(r2, Index) and r2.dtype == np.float64
         tm.assert_index_equal(r1, r2)
+
+    @pytest.mark.parametrize("tz", ["UTC", "US/Pacific", "Europe/London"])
+    def test_tz_aware_uses_utc_instant(self, tz):
+        # GH#54763 to_julian_date should reflect the UTC instant, not wall clock
+        dr = date_range(start="2000-02-27", periods=5, freq="h", tz=tz)
+        result = dr.to_julian_date()
+        expected = Index([ts.to_julian_date() for ts in dr])
+        tm.assert_index_equal(result, expected)
+        # also matches converting to naive UTC up front
+        tm.assert_index_equal(
+            result, dr.tz_convert("UTC").tz_localize(None).to_julian_date()
+        )

--- a/pandas/tests/scalar/timestamp/methods/test_to_julian_date.py
+++ b/pandas/tests/scalar/timestamp/methods/test_to_julian_date.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pandas import Timestamp
 
 
@@ -26,3 +28,24 @@ class TestTimestampToJulianDate:
         ts = Timestamp("2000-08-12T13:00:00")
         res = ts.to_julian_date()
         assert res == 2_451_769.0416666666666666
+
+    @pytest.mark.parametrize(
+        "tz, utc_hour",
+        [
+            ("UTC", 13),
+            ("US/Pacific", 20),  # PDT, UTC-7
+            ("Europe/London", 12),  # BST, UTC+1
+        ],
+    )
+    def test_tz_aware_uses_utc_instant(self, tz, utc_hour):
+        # GH#54763 to_julian_date should reflect the UTC instant, not wall clock
+        ts = Timestamp("2000-08-12T13:00:00", tz=tz)
+        # JD 2451769.0 == 2000-08-12 12:00 UTC (JD epoch is noon)
+        expected = 2_451_769.0 + (utc_hour - 12) / 24
+        assert ts.to_julian_date() == expected
+
+    def test_tz_aware_matches_utc_conversion(self):
+        # GH#54763 result must agree with manually converting to UTC first
+        ts = Timestamp("2020-03-14T15:32:52", tz="US/Eastern")
+        expected = ts.tz_convert("UTC").tz_localize(None).to_julian_date()
+        assert ts.to_julian_date() == expected


### PR DESCRIPTION
- closes #54763

## Summary

`Timestamp.to_julian_date` and `DatetimeIndex.to_julian_date` were computing the Julian date from the **local wall-clock** representation, so two timestamps referring to the same UTC instant in different timezones returned different values:

```python
>>> pd.Timestamp("1858-11-17", tz="UTC").to_julian_date()
2400000.5
>>> pd.Timestamp("1858-11-17", tz="US/Mountain").to_julian_date()
2400000.5  # wrong; should be ~2400000.79 (00:00 Mountain == 07:00 UTC)
```

JD is an absolute-time concept (cf. `Timestamp.timestamp` / POSIX seconds, which already returns the UTC instant), so the fix routes tz-aware inputs through the naive UTC instant before computing. Behavior for tz-naive inputs is unchanged.

The implementation is a single early-return in each method — naturally vectorized for the array path via `tz_convert("UTC").tz_localize(None)`, no per-element Python loop. Supersedes the stale GH-60280.

## Test plan

- [x] New parametrized scalar tests covering UTC / US/Pacific / Europe/London
- [x] New parametrized array tests, including agreement with element-wise `Timestamp.to_julian_date`
- [x] Existing naive-only tests in `test_to_julian_date.py` (scalar + array) still pass
- [x] Full sweep of `pandas/tests/scalar/timestamp/`, `pandas/tests/indexes/datetimes/methods/`, and `pandas/tests/tools/test_to_datetime.py` — 4439 passed (the latter exercises `Timestamp(0).to_julian_date()` inside `to_datetime`)
- [x] pre-commit clean on the touched files