### PR TITLE
TST: regression tests for Timestamp.fromisoformat tz preservation (GH-56398)

### DIFF
--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -362,6 +362,40 @@ class TestTimestampClassMethodConstructors:
         assert result == expected_stdlib
         assert isinstance(result, Timestamp)
 
+    @pytest.mark.parametrize(
+        "date_string",
+        [
+            "2023-11-05T08:30:00Z",
+            "2023-11-05T08:30:00+0000",
+            "2023-11-05T08:30:00+00:00",
+            "2024-08-02T00:00:00-04:00",
+        ],
+    )
+    def test_constructor_fromisoformat_preserves_tz(self, date_string):
+        # GH#56398 fromisoformat used to drop tz info due to args offset
+        #  in Timestamp.__new__ when the inherited datetime classmethod
+        #  called cls(year, month, day, ..., tzinfo).
+        result = Timestamp.fromisoformat(date_string)
+        expected_stdlib = datetime.fromisoformat(date_string)
+        assert isinstance(result, Timestamp)
+        assert result.tzinfo is not None
+        assert result == expected_stdlib
+        assert result == Timestamp(date_string)
+
+    def test_constructor_fromisoformat_naive(self):
+        # GH#56398 the tz-naive case should remain tz-naive
+        result = Timestamp.fromisoformat("2023-01-15T10:30:00")
+        assert isinstance(result, Timestamp)
+        assert result.tzinfo is None
+        assert result == Timestamp("2023-01-15T10:30:00")
+
+    def test_constructor_fromisoformat_roundtrip_isoformat(self):
+        # GH#56398 fromisoformat(ts.isoformat()) should round-trip
+        original = Timestamp.now("UTC")
+        result = Timestamp.fromisoformat(original.isoformat())
+        assert result == original
+        assert result.tzinfo is not None
+
     def test_constructor_fromordinal(self):
         base = datetime(2000, 1, 1)
 


### PR DESCRIPTION
## Summary

- The bug reported in GH-56398 — `Timestamp.fromisoformat` dropping ISO 8601 timezone information — was implicitly fixed by GH-64501, which added an explicit `Timestamp.fromisoformat` classmethod that wraps `datetime.fromisoformat` and passes the result as a single `ts_input` to `Timestamp(...)`. That bypasses the inherited C-level path that triggered the args-offset bug in `Timestamp.__new__` (GH-52343).
- No regression test was added at the time. This PR adds one in `pandas/tests/scalar/timestamp/test_constructors.py::TestTimestampClassMethodConstructors`:
  - `test_constructor_fromisoformat_preserves_tz` — parametrized over `Z`, `+0000`, `+00:00`, and `-04:00` offset forms.
  - `test_constructor_fromisoformat_naive` — guards the tz-naive case.
  - `test_constructor_fromisoformat_roundtrip_isoformat` — the `Timestamp.now("UTC").isoformat()` round-trip from the original report.

closes #56398

## Test plan

- [x] `pytest pandas/tests/scalar/timestamp/test_constructors.py -k fromisoformat` — 6 passed
- [x] pre-commit on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)