### PR TITLE
TYP: annotate OpsMixin comparison/arith/logical dunders with Self (GH-40762)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -37,6 +37,7 @@ Other enhancements
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
+- Improved type inference of comparison and arithmetic operators on :class:`Series` and :class:`DataFrame` for static type checkers (e.g. ``ser == "a"`` is now inferred as :class:`Series` instead of ``Any``) (:issue:`40762`)
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -8,7 +8,10 @@ Methods that can be shared by many array-like classes or subclasses:
 from __future__ import annotations
 
 import operator
-from typing import Any
+from typing import (
+    Any,
+    Self,
+)
 
 import numpy as np
 
@@ -38,27 +41,27 @@ class OpsMixin:
         return NotImplemented
 
     @unpack_zerodim_and_defer("__eq__")
-    def __eq__(self, other):
+    def __eq__(self, other) -> Self:  # type: ignore[override]
         return self._cmp_method(other, operator.eq)
 
     @unpack_zerodim_and_defer("__ne__")
-    def __ne__(self, other):
+    def __ne__(self, other) -> Self:  # type: ignore[override]
         return self._cmp_method(other, operator.ne)
 
     @unpack_zerodim_and_defer("__lt__")
-    def __lt__(self, other):
+    def __lt__(self, other) -> Self:
         return self._cmp_method(other, operator.lt)
 
     @unpack_zerodim_and_defer("__le__")
-    def __le__(self, other):
+    def __le__(self, other) -> Self:
         return self._cmp_method(other, operator.le)
 
     @unpack_zerodim_and_defer("__gt__")
-    def __gt__(self, other):
+    def __gt__(self, other) -> Self:
         return self._cmp_method(other, operator.gt)
 
     @unpack_zerodim_and_defer("__ge__")
-    def __ge__(self, other):
+    def __ge__(self, other) -> Self:
         return self._cmp_method(other, operator.ge)
 
     # -------------------------------------------------------------
@@ -68,27 +71,27 @@ class OpsMixin:
         return NotImplemented
 
     @unpack_zerodim_and_defer("__and__")
-    def __and__(self, other):
+    def __and__(self, other) -> Self:
         return self._logical_method(other, operator.and_)
 
     @unpack_zerodim_and_defer("__rand__")
-    def __rand__(self, other):
+    def __rand__(self, other) -> Self:
         return self._logical_method(other, roperator.rand_)
 
     @unpack_zerodim_and_defer("__or__")
-    def __or__(self, other):
+    def __or__(self, other) -> Self:
         return self._logical_method(other, operator.or_)
 
     @unpack_zerodim_and_defer("__ror__")
-    def __ror__(self, other):
+    def __ror__(self, other) -> Self:
         return self._logical_method(other, roperator.ror_)
 
     @unpack_zerodim_and_defer("__xor__")
-    def __xor__(self, other):
+    def __xor__(self, other) -> Self:
         return self._logical_method(other, operator.xor)
 
     @unpack_zerodim_and_defer("__rxor__")
-    def __rxor__(self, other):
+    def __rxor__(self, other) -> Self:
         return self._logical_method(other, roperator.rxor)
 
     # -------------------------------------------------------------
@@ -98,7 +101,7 @@ class OpsMixin:
         return NotImplemented
 
     @unpack_zerodim_and_defer("__add__")
-    def __add__(self, other):
+    def __add__(self, other) -> Self:
         """
         Get Addition of DataFrame and other, column-wise.
 
@@ -190,63 +193,63 @@ class OpsMixin:
         return self._arith_method(other, operator.add)
 
     @unpack_zerodim_and_defer("__radd__")
-    def __radd__(self, other):
+    def __radd__(self, other) -> Self:
         return self._arith_method(other, roperator.radd)
 
     @unpack_zerodim_and_defer("__sub__")
-    def __sub__(self, other):
+    def __sub__(self, other) -> Self:
         return self._arith_method(other, operator.sub)
 
     @unpack_zerodim_and_defer("__rsub__")
-    def __rsub__(self, other):
+    def __rsub__(self, other) -> Self:
         return self._arith_method(other, roperator.rsub)
 
     @unpack_zerodim_and_defer("__mul__")
-    def __mul__(self, other):
+    def __mul__(self, other) -> Self:
         return self._arith_method(other, operator.mul)
 
     @unpack_zerodim_and_defer("__rmul__")
-    def __rmul__(self, other):
+    def __rmul__(self, other) -> Self:
         return self._arith_method(other, roperator.rmul)
 
     @unpack_zerodim_and_defer("__truediv__")
-    def __truediv__(self, other):
+    def __truediv__(self, other) -> Self:
         return self._arith_method(other, operator.truediv)
 
     @unpack_zerodim_and_defer("__rtruediv__")
-    def __rtruediv__(self, other):
+    def __rtruediv__(self, other) -> Self:
         return self._arith_method(other, roperator.rtruediv)
 
     @unpack_zerodim_and_defer("__floordiv__")
-    def __floordiv__(self, other):
+    def __floordiv__(self, other) -> Self:
         return self._arith_method(other, operator.floordiv)
 
     @unpack_zerodim_and_defer("__rfloordiv")
-    def __rfloordiv__(self, other):
+    def __rfloordiv__(self, other) -> Self:
         return self._arith_method(other, roperator.rfloordiv)
 
     @unpack_zerodim_and_defer("__mod__")
-    def __mod__(self, other):
+    def __mod__(self, other) -> Self:
         return self._arith_method(other, operator.mod)
 
     @unpack_zerodim_and_defer("__rmod__")
-    def __rmod__(self, other):
+    def __rmod__(self, other) -> Self:
         return self._arith_method(other, roperator.rmod)
 
     @unpack_zerodim_and_defer("__divmod__")
-    def __divmod__(self, other):
+    def __divmod__(self, other) -> tuple[Self, Self]:
         return self._arith_method(other, divmod)
 
     @unpack_zerodim_and_defer("__rdivmod__")
-    def __rdivmod__(self, other):
+    def __rdivmod__(self, other) -> tuple[Self, Self]:
         return self._arith_method(other, roperator.rdivmod)
 
     @unpack_zerodim_and_defer("__pow__")
-    def __pow__(self, other):
+    def __pow__(self, other) -> Self:
         return self._arith_method(other, operator.pow)
 
     @unpack_zerodim_and_defer("__rpow__")
-    def __rpow__(self, other):
+    def __rpow__(self, other) -> Self:
         return self._arith_method(other, roperator.rpow)
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11660,7 +11660,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             # We want to restore the original index
             rs = rs.loc[~rs.index.duplicated()]
             rs = rs.reindex_like(self)
-        return rs.__finalize__(self, method="pct_change")
+        return rs.__finalize__(self, method="pct_change")  # type: ignore[return-value]
 
     @final
     def _logical_func(

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1364,7 +1364,7 @@ class RangeIndex(Index):
         return type(self)._simple_new(res, name=self._name)
 
     @unpack_zerodim_and_defer("__floordiv__")
-    def __floordiv__(self, other: object) -> Index:
+    def __floordiv__(self, other: object) -> Index:  # type: ignore[override]
         if is_integer(other) and other != 0:
             if len(self) == 0 or (self.start % other == 0 and self.step % other == 0):
                 start = self.start // other
@@ -1377,7 +1377,7 @@ class RangeIndex(Index):
                 new_range = range(start, start + 1, 1)
                 return self._simple_new(new_range, name=self._name)
 
-        return super().__floordiv__(other)  # type: ignore[no-untyped-call]
+        return super().__floordiv__(other)
 
     # --------------------------------------------------------------------
     # Reductions

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -213,7 +213,7 @@ def _stata_elapsed_date_to_datetime_vec(dates: Series, fmt: str) -> Series:
         year = stata_epoch.year + dates // 52
         days = (dates % 52) * 7
         per_y = (year - 1970).array.view("Period[Y]")
-        per_d = per_y.asfreq("D", how="S")
+        per_d = per_y.asfreq("D", how="S")  # type: ignore[union-attr]
         per_d_shifted = per_d + days._values
         per_s = per_d_shifted.asfreq("s", how="S")
         conv_dates_arr = per_s.view("M8[s]")

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -2146,10 +2146,9 @@ class PiePlot(MPLPlot):
 
     def __init__(self, data: Series | DataFrame, kind=None, **kwargs) -> None:
         data = data.fillna(value=0)
-        lt_zero = data < 0
-        if isinstance(data, ABCDataFrame) and lt_zero.any().any():
+        if isinstance(data, ABCDataFrame) and (data < 0).any().any():
             raise ValueError(f"{self._kind} plot doesn't allow negative values")
-        elif isinstance(data, ABCSeries) and lt_zero.any():
+        elif isinstance(data, ABCSeries) and (data < 0).any():
             raise ValueError(f"{self._kind} plot doesn't allow negative values")
         MPLPlot.__init__(self, data, kind=kind, **kwargs)
 


### PR DESCRIPTION
## Summary
- Annotates the comparison (`__eq__`/`__ne__`/`__lt__`/...), arithmetic (`__add__`/`__radd__`/...), and logical (`__and__`/`__or__`/...) dunders on `OpsMixin` with `-> Self` (and `-> tuple[Self, Self]` for `__divmod__`/`__rdivmod__`).
- Closes #40762: mypy and pyright now infer `Series` for `ser == "a"` instead of `Any`. Same for `DataFrame`, and most `ExtensionArray` subclasses where `_cmp_method`/`_arith_method`/`_logical_method` returns `Self`.
- Three small fallout fixes for sites mypy now sees more precisely: `RangeIndex.__floordiv__` (returns parent `Index`, not `Self` — needs `# type: ignore[override]`); `pct_change` return path through `_LocIndexer` widens the type, needs `# type: ignore[return-value]`; `stata._stata_elapsed_date_to_datetime_vec` `.array.view(\"Period[Y]\")` resolves to a union that doesn't have `.asfreq`, needs `# type: ignore[union-attr]`.

`Index` and `BaseMaskedArray` (where `_cmp_method` actually returns `ndarray` / `BooleanArray`, not `Self`) get a small typing approximation under this change — `idx == x` is reported as `Index` rather than `ndarray`. This doesn't break common usage (`.any()`, boolean indexing) and keeps the change minimal; explicit overrides on those classes can be a follow-up if needed.

closes #40762

## Test plan
- [x] `mypy` on the original repro from GH-40762 (`res: pd.Series = df['kind'] == 'a'`) — error is gone, runtime returns `Series`.
- [x] `pyright` on the same repro — `res` typed as `Series`.
- [x] Net mypy error count over pandas internal source: 442 → 442 (no regressions).
- [x] `pandas/tests/series/test_arithmetic.py` + `test_logical_ops.py` — 4829 passed.
- [x] `pandas/tests/arithmetic/` + `pandas/tests/frame/test_arithmetic.py` — 21535 passed.
- [x] `pandas/tests/io/test_stata.py` + `pandas/tests/indexes/ranges/test_range.py` + `pandas/tests/series/methods/test_pct_change.py` + `pandas/tests/frame/methods/test_pct_change.py` — 925 passed.
- [x] pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)