### PR TITLE
DOC: fix factual errors in development/internals.rst

### DIFF
--- a/doc/source/development/internals.rst
+++ b/doc/source/development/internals.rst
@@ -18,8 +18,8 @@ containers for the axis labels:
 * :class:`Index`: the generic "ordered set" object, holding axis labels of
   any supported dtype (numpy numeric dtypes, ``object``, ``str``, or an
   :class:`ExtensionArray` dtype). The labels must be hashable (and
-  likely immutable) and unique. Populates a dict of label to location in
-  Cython to do ``O(1)`` lookups.
+  likely immutable) but need not be unique. Populates a dict of label
+  to location in Cython to do ``O(1)`` lookups.
 * :class:`MultiIndex`: the standard hierarchical index object
 * :class:`DatetimeIndex`: An :class:`Index` object backed by a :class:`DatetimeArray`, exposing :class:`Timestamp` boxed elements
 * :class:`TimedeltaIndex`: An :class:`Index` object backed by a :class:`TimedeltaArray`, exposing :class:`Timedelta` boxed elements

--- a/doc/source/development/internals.rst
+++ b/doc/source/development/internals.rst
@@ -15,21 +15,22 @@ Indexing
 In pandas there are a few objects implemented which can serve as valid
 containers for the axis labels:
 
-* :class:`Index`: the generic "ordered set" object, an ndarray of object dtype
-  assuming nothing about its contents. The labels must be hashable (and
+* :class:`Index`: the generic "ordered set" object, holding axis labels of
+  any supported dtype (numpy numeric dtypes, ``object``, ``str``, or an
+  :class:`ExtensionArray` dtype). The labels must be hashable (and
   likely immutable) and unique. Populates a dict of label to location in
   Cython to do ``O(1)`` lookups.
 * :class:`MultiIndex`: the standard hierarchical index object
-* :class:`DatetimeIndex`: An Index object with :class:`Timestamp` boxed elements (impl are the int64 values)
-* :class:`TimedeltaIndex`: An Index object with :class:`Timedelta` boxed elements (impl are the in64 values)
-* :class:`PeriodIndex`: An Index object with Period elements
+* :class:`DatetimeIndex`: An :class:`Index` object backed by a :class:`DatetimeArray`, exposing :class:`Timestamp` boxed elements
+* :class:`TimedeltaIndex`: An :class:`Index` object backed by a :class:`TimedeltaArray`, exposing :class:`Timedelta` boxed elements
+* :class:`PeriodIndex`: An :class:`Index` object backed by a :class:`PeriodArray`, exposing :class:`Period` boxed elements
 
 There are functions that make the creation of a regular index easy:
 
 * :func:`date_range`: fixed frequency date range generated from a time rule or
-  DateOffset. An ndarray of Python datetime objects
+  DateOffset. Returns a :class:`DatetimeIndex`.
 * :func:`period_range`: fixed frequency date range generated from a time rule or
-  DateOffset. An ndarray of :class:`Period` objects, representing timespans
+  DateOffset. Returns a :class:`PeriodIndex` of :class:`Period` objects, representing timespans.
 
 .. warning::
 
@@ -65,7 +66,7 @@ pandas extends NumPy's type system with custom types, like :class:`Categorical` 
 datetimes with a timezone, so we have multiple notions of "values". For 1-D
 containers (``Index`` classes and ``Series``) we have the following convention:
 
-* ``cls._values`` refers is the "best possible" array. This could be an
+* ``cls._values`` is the "best possible" array. This could be an
   ``ndarray`` or ``ExtensionArray``.
 
 So, for example, ``Series[category]._values`` is a ``Categorical``.


### PR DESCRIPTION
## Summary
Audit pass over `doc/source/development/internals.rst` — the page hadn't been touched substantively since 2023 and several claims are now wrong.

- `Index` was described as *"an ndarray of object dtype assuming nothing about its contents"*. Since 2.0 (GH-51111) `Index` holds any supported dtype natively (e.g. `pd.Index([1,2,3]).dtype == int64`).
- `DatetimeIndex` / `TimedeltaIndex` were described as having *"impl are the int64 values"* (with `in64` typo on the TDI line). They're backed by `DatetimeArray` / `TimedeltaArray`. `PeriodIndex` is on the same model and is now described in parallel.
- `date_range` and `period_range` were described as returning *"An ndarray of Python datetime objects"* / *"An ndarray of Period objects"*. They return `DatetimeIndex` and `PeriodIndex` respectively.
- Fix `cls._values` **refers is** the "best possible" array → `cls._values` **is** the "best possible" array.

Scope was kept tight to corrections only; no rewrite of the Values section or new BlockManager content.

## Test plan
- [ ] Sphinx build of `doc/source/development/internals.rst` renders without warnings.
- [ ] Spot-check rendered cross-references to `DatetimeArray`, `TimedeltaArray`, `PeriodArray`, `ExtensionArray`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)