### PR TITLE
DOC: refresh deprecation/version policy doc for PDEP-17

### DIFF
--- a/doc/source/development/policies.rst
+++ b/doc/source/development/policies.rst
@@ -22,18 +22,44 @@ Whenever possible, a deprecation path will be provided rather than an outright
 breaking change.
 
 pandas will introduce deprecations in **minor** releases. These deprecations
-will preserve the existing behavior while emitting a warning that provide
+will preserve the existing behavior while emitting a warning that provides
 guidance on:
 
-* How to achieve similar behavior if an alternative is available
+* How to achieve similar behavior if an alternative is available.
 * The pandas version in which the deprecation will be enforced.
 
 We will not introduce new deprecations in patch releases.
 
 Deprecations will only be enforced in **major** releases. For example, if a
-behavior is deprecated in pandas 1.2.0, it will continue to work, with a
-warning, for all releases in the 1.x series. The behavior will change and the
-deprecation removed in the next major release (2.0.0).
+behavior is deprecated in pandas 3.1.0, it will continue to work, with a
+warning, for all releases in the 3.x series. The behavior will change and the
+deprecation removed in the next major release (4.0.0).
+
+Deprecation warnings
+^^^^^^^^^^^^^^^^^^^^
+
+Following `PDEP-17`_, pandas uses a three-stage deprecation policy:
+
+1. When a deprecation is first introduced in a minor release, it emits a
+   :class:`~pandas.errors.PandasDeprecationWarning`. By default, Python hides
+   ``DeprecationWarning`` outside the ``__main__`` module, so end users
+   typically will not see these warnings unless they explicitly opt in. This
+   gives downstream libraries time to migrate before their users are notified.
+2. In the final minor release before the next major version, the warning is
+   promoted to :class:`~pandas.errors.PandasFutureWarning`, which Python shows
+   by default. End users see these warnings and have one minor release in
+   which to update their code.
+3. The deprecated behavior is removed in the next major release.
+
+All warnings about upcoming changes inherit from
+:class:`~pandas.errors.PandasChangeWarning`. Users can filter or surface
+warnings using the following subclasses:
+
+* :class:`~pandas.errors.Pandas4Warning` — changes that will be enforced in pandas 4.0.
+* :class:`~pandas.errors.Pandas5Warning` — changes that will be enforced in pandas 5.0.
+* :class:`~pandas.errors.PandasPendingDeprecationWarning` — emits a ``PendingDeprecationWarning``, regardless of target version.
+* :class:`~pandas.errors.PandasDeprecationWarning` — emits a ``DeprecationWarning``, regardless of target version.
+* :class:`~pandas.errors.PandasFutureWarning` — emits a ``FutureWarning``, regardless of target version.
 
 .. note::
 
@@ -59,3 +85,4 @@ Security policy
 To report a security vulnerability to pandas, please go to https://github.com/pandas-dev/pandas/security/policy and see the instructions there.
 
 .. _SemVer: https://semver.org
+.. _PDEP-17: https://pandas.pydata.org/pdeps/0017-backwards-compatibility-and-deprecation-policy.html


### PR DESCRIPTION
## Summary

`doc/source/development/policies.rst` was last meaningfully updated before PDEP-17 landed in 3.0 and still describes the old single-stage deprecation flow with a 1.x → 2.0 example. This PR brings it in line with current behavior:

- Document the three-stage deprecation flow (`PandasDeprecationWarning` → `PandasFutureWarning` → removal) with a link to PDEP-17.
- List the `PandasChangeWarning` subclass hierarchy users can filter on (`Pandas4Warning`, `Pandas5Warning`, `PandasPendingDeprecationWarning`, `PandasDeprecationWarning`, `PandasFutureWarning`).
- Refresh the worked example from 1.2.0/1.x/2.0.0 to 3.1.0/3.x/4.0.0.
- Fix a small grammar slip ("warning that provide" → "provides") and an inconsistent trailing period in the bullet list.

The Python support and security policy sections are unchanged.

## Test plan

- [ ] `policies.rst` renders cleanly in the docs build (Sphinx Lint and the doc pre-commit hooks pass locally).
- [ ] `:class:` cross-references resolve to `pandas.errors.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)