### PR TITLE
DOC: fix pyenv path example in contributing_environment

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -126,7 +126,7 @@ Consult the `docs <https://github.com/pyenv/pyenv>`_ for setting up pyenv.
 .. code-block:: bash
 
    # Create a virtual environment
-   # Use an ENV_DIR of your choice. We'll use ~/Users/<yourname>/.pyenv/versions/pandas-dev
+   # Use an ENV_DIR of your choice. We'll use ~/.pyenv/versions/pandas-dev
    pyenv virtualenv 3.11 pandas-dev
 
    # Activate the virtualenv


### PR DESCRIPTION
## Summary

The example ENV_DIR for the pyenv flow read `~/Users/<yourname>/.pyenv/versions/pandas-dev`, which double-prepends the home directory: `~` already expands to `/Users/<yourname>` on macOS, so the literal path resolves to `/Users/<yourname>/Users/<yourname>/.pyenv/...`. Drop the redundant `Users/<yourname>` so it just reads `~/.pyenv/versions/pandas-dev`.

Long-standing typo, unrelated to the in-flight Windows-build-tools cleanup in GH-64651.

## Test plan
- [x] Pre-commit hooks pass
- [ ] Doc build renders the corrected path