### PR TITLE
Backport PR #65436 on branch 3.0.x (Account for privatization of matplotlib `Formatter.locs` attribute)

### DIFF
--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -182,7 +182,7 @@ class TimeConverter(munits.ConversionInterface):
 # time formatter
 class TimeFormatter(mpl.ticker.Formatter):  # pyright: ignore[reportAttributeAccessIssue]
     def __init__(self, locs) -> None:
-        self.locs = locs
+        self.set_locs(locs)
 
     def __call__(self, x, pos: int | None = 0) -> str:
         """
@@ -1046,7 +1046,7 @@ class TimeSeries_DateFormatter(mpl.ticker.Formatter):  # pyright: ignore[reportA
         freq = to_offset(freq, is_period=True)
         self.format = None
         self.freq = freq
-        self.locs: list[Any] = []  # unused, for matplotlib compat
+        super().set_locs([])  # unused, for matplotlib compat
         self.formatdict: dict[Any, Any] | None = None
         self.isminor = minor_locator
         self.isdynamic = dynamic_mode
@@ -1070,7 +1070,7 @@ class TimeSeries_DateFormatter(mpl.ticker.Formatter):  # pyright: ignore[reportA
         # don't actually use the locs. This is just needed to work with
         # matplotlib. Force to use vmin, vmax
 
-        self.locs = locs
+        super().set_locs(locs)
 
         (vmin, vmax) = tuple(self.axis.get_view_interval())
         if vmax < vmin:


### PR DESCRIPTION
This is a manual backport of PR #65436, expanded to handle the additional access of `Formatter.locs` on `3.0.x` that is not on `main`.

- [N/A] closes #xxxx (Replace xxxx with the GitHub issue number)
- [N/A] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [N/A] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [N/A] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [N/A] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
