### PR TITLE
BUG: respect skipna=False in SparseArray.mean

### DIFF
--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1680,7 +1680,13 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             fill_value=self.fill_value,
         )
 
-    def mean(self, axis: Axis = 0, *args, **kwargs):
+    def mean(
+        self,
+        axis: Axis = 0,
+        skipna: bool = True,
+        *args,
+        **kwargs,
+):
         """
         Mean of non-NA/null values
 
@@ -1689,6 +1695,11 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         mean : float
         """
         nv.validate_mean(args, kwargs)
+        has_na = self.sp_index.ngaps > 0 and not self._null_fill_value
+
+        if has_na and not skipna:
+            return na_value_for_dtype(self.dtype.subtype, compat=False)
+        
         valid_vals = self._valid_sp_values
         sp_sum = valid_vals.sum()
         ct = len(valid_vals)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -498,6 +498,11 @@ class TestDataFrameAnalytics:
         result = df.mean()
         expected = Series([1.0, Timestamp("2000", tz=tz)], index=["A", "B"])
         tm.assert_series_equal(result, expected)
+        
+    def test_mean_skipna_false(self):
+        arr = SparseArray([1, np.nan, 3])
+        result = arr.mean(skipna=False)
+        assert np.isnan(result)
 
     @pytest.mark.parametrize("tz", [None, "UTC"])
     def test_mean_includes_datetimes(self, tz):


### PR DESCRIPTION
Closes #65478
Adds support for skipna=False in SparseArray.mean().

Previously, SparseArray.mean() ignored the skipna argument and always skipped missing values. This change updates the implementation so that when skipna=False and the array contains missing values, the result is NaN, matching expected pandas behavior.

Also adds a regression test covering this case.
