### PR TITLE
DOC: rewrite DataFrameGroupBy.hist docstring for groupby

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -3828,13 +3828,12 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         **kwargs,
     ):
         """
-        Make a histogram of the DataFrame's columns.
+        Draw histogram of the DataFrame's columns for each group.
 
-        A `histogram`_ is a representation of the distribution of data.
-        This function calls :meth:`matplotlib.pyplot.hist`, on each series in
-        the DataFrame, resulting in one histogram per column.
-
-        .. _histogram: https://en.wikipedia.org/wiki/Histogram
+        A separate histogram subplot is generated for each group, making it
+        easier to visually compare the distribution of each numeric column
+        across groups. Internally this calls :meth:`DataFrame.hist` on every
+        group's frame, so the same matplotlib options are accepted.
 
         Parameters
         ----------
@@ -3897,23 +3896,26 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
 
         See Also
         --------
+        DataFrame.hist : Equivalent histogram plotting method on DataFrame.
         matplotlib.pyplot.hist : Plot a histogram using matplotlib.
 
         Examples
         --------
-        This example draws a histogram based on the length and width of
-        some animals, displayed in three bins
+        For each animal category, draw a histogram of the numeric columns.
+        The grouping column is used to split the data; one set of histogram
+        subplots is produced per group.
 
         .. plot::
             :context: close-figs
 
-            >>> data = {
-            ...     "length": [1.5, 0.5, 1.2, 0.9, 3],
-            ...     "width": [0.7, 0.2, 0.15, 0.2, 1.1],
-            ... }
-            >>> index = ["pig", "rabbit", "duck", "chicken", "horse"]
-            >>> df = pd.DataFrame(data, index=index)
-            >>> hist = df.groupby("length").hist(bins=3)
+            >>> df = pd.DataFrame(
+            ...     {
+            ...         "animal": ["cat", "cat", "dog", "dog", "dog"],
+            ...         "length": [1.0, 1.2, 1.5, 1.7, 2.0],
+            ...         "weight": [4.5, 5.0, 10.0, 12.5, 15.0],
+            ...     }
+            ... )
+            >>> hist = df.groupby("animal").hist(bins=3)
         """
         result = self._op_via_apply(
             "hist",


### PR DESCRIPTION
- [x] closes #22241
- [x] Tests added and passed if fixing a bug or adding a new feature *(n/a — docs-only)*
- [x] All [code checks](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit) passed.
- [x] Added type annotations to new arguments/methods/functions *(n/a — docs-only)*
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file *(n/a — pure wording clarification, matches recent docs-only precedent)*
- [x] I have reviewed and followed all the contribution guidelines.
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.

## Summary

Rewrites `DataFrameGroupBy.hist`'s docstring to actually describe the per-group semantics, instead of carrying `DataFrame.hist`'s wording verbatim.

**Why now.** PR #57304 (2024) added the docstring inline mechanically to satisfy PR02 docstring validation, and PR #63729 (2024) removed the `@doc` decorator that previously copied it from `DataFrame.hist` — locking in the verbatim text. The sibling `SeriesGroupBy.hist` already has a properly groupby-flavored docstring (`pandas/core/groupby/generic.py:1994`). This PR brings `DataFrameGroupBy.hist` to parity, fulfilling the original ask in #22241 (\"Patch and PR are welcome!\" — gfyoung).

## What changes

- **Summary line** names the per-group semantic.
- **Extended summary** explains the per-group subplot layout and that the method dispatches to `DataFrame.hist` per group (matching the actual `_op_via_apply(\"hist\", ...)` implementation).
- **See Also** adds `DataFrame.hist` cross-reference.
- **Examples** uses `df.groupby(\"animal\").hist(bins=3)` with a string grouping column and two numeric columns, replacing the original example that grouped by a numeric column.
- **Parameters / Returns** untouched (no PR02/PR05 risk).

The new docstring mirrors `SeriesGroupBy.hist`'s structure for parity.