### PR TITLE
BUG: fix row-wise min/max for mixed-timezone datetimes with NaT

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1101,6 +1101,36 @@ def nansem(
 
 
 def _nanminmax(meth, fill_value_typ):
+    def _nanminmax_object(
+        values: np.ndarray,
+        mask: npt.NDArray[np.bool_],
+        axis: AxisInt | None,
+    ) -> Any:
+        if axis is None:
+            non_na = values.ravel()[~mask.ravel()]
+            if len(non_na) == 0:
+                return np.nan
+            return getattr(non_na, meth)()
+
+        if values.ndim == 1:
+            non_na = values[~mask]
+            if len(non_na) == 0:
+                return np.nan
+            return getattr(non_na, meth)()
+
+        moved_values = np.moveaxis(values, axis, -1)
+        moved_mask = np.moveaxis(mask, axis, -1)
+
+        result = np.empty(moved_values.shape[:-1], dtype=object)
+        for idx in np.ndindex(result.shape):
+            non_na = moved_values[idx][~moved_mask[idx]]
+            if len(non_na) == 0:
+                result[idx] = np.nan
+            else:
+                result[idx] = getattr(non_na, meth)()
+
+        return result
+
     @bottleneck_switch(name=f"nan{meth}")
     @_datetimelike_compat
     def reduction(
@@ -1114,6 +1144,18 @@ def _nanminmax(meth, fill_value_typ):
             return _na_for_min_count(values, axis)
 
         dtype = values.dtype
+        if skipna and dtype == object:
+            mask = _maybe_get_mask(values, skipna, mask)
+            inferred = lib.infer_dtype(values, skipna=True)
+            if (
+                mask is not None
+                and mask.any()
+                and inferred
+                in {"datetime", "datetime64", "date", "timedelta", "timedelta64"}
+            ):
+                result = _nanminmax_object(values, mask, axis)
+                return _maybe_null_out(result, axis, mask, values.shape)
+
         values, mask = _get_values(
             values, skipna, fill_value_typ=fill_value_typ, mask=mask
         )

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1734,6 +1734,30 @@ class TestDataFrameReductions:
             expected = Series([pd.NaT, pd.NaT, val])
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "method, first_expected",
+        [("min", "time2"), ("max", "time1")],
+    )
+    def test_minmax_tzaware_mixed_tz_with_nat_axis1(self, method, first_expected):
+        # GH#65500
+        one_tz = Timestamp("2026-01-01 15:13:44.01234567", tz="Europe/Budapest")
+        other_tz = Timestamp("2026-01-01 15:13:44.01234567", tz="Europe/Moscow")
+        df = DataFrame({"time1": [one_tz, one_tz], "time2": [other_tz, pd.NaT]})
+
+        result = getattr(df, method)(axis=1)
+        expected = Series(
+            [df.loc[0, first_expected], one_tz],
+            dtype=df[first_expected].dtype,
+        )
+        tm.assert_series_equal(result, expected)
+
+        result = getattr(df, method)(axis=1, skipna=False)
+        expected = Series(
+            [df.loc[0, first_expected], pd.NaT],
+            dtype=df[first_expected].dtype,
+        )
+        tm.assert_series_equal(result, expected)
+
     @pytest.fixture(
         params=[
             DataFrame(

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -176,6 +176,19 @@ class TestSeriesStatReductions:
         string_series = Series(range(20), dtype=np.float64, name="series")
         self._check_stat_op("max", np.max, string_series, check_objects=True)
 
+    @pytest.mark.parametrize("method", ["min", "max"])
+    def test_minmax_object_timestamp_nat_returns_scalar(self, method):
+        # GH#65500
+        val = pd.Timestamp("2026-01-01 15:13:44.01234567", tz="Europe/Budapest")
+        ser = Series([val, pd.NaT], dtype=object)
+
+        result = getattr(ser, method)()
+        assert isinstance(result, pd.Timestamp)
+        assert result == val
+
+        result = getattr(ser, method)(skipna=False)
+        assert result is pd.NaT
+
     def test_var_std(self):
         string_series = Series(range(20), dtype=np.float64, name="series")
         datetime_series = Series(


### PR DESCRIPTION
- [x] closes #65500
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This avoids filling missing object-dtype datetimelike values with numeric infinities during `nanmin` and `nanmax`. That keeps row-wise `DataFrame.min` and `DataFrame.max` on mixed timezone-aware columns with `NaT` from comparing `Timestamp` values with floats.

I added regression coverage for the row-wise mixed-timezone case and for object-dtype `Timestamp` reductions returning scalar values.

Local checks:

- `python3 -m compileall pandas/core/nanops.py pandas/tests/frame/test_reductions.py pandas/tests/reductions/test_stat_reductions.py`
- `git diff --check -- pandas/core/nanops.py pandas/tests/frame/test_reductions.py pandas/tests/reductions/test_stat_reductions.py`