### PR TITLE
DOC: clarify that DataFrame does not collect attrs from columns (GH-35425)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -319,6 +319,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         present dataset. :func:`pandas.concat` and :func:`pandas.merge` will
         only copy ``attrs`` if all input datasets have the same ``attrs``.
 
+        ``attrs`` is a property of a :class:`Series` or :class:`DataFrame` as a
+        whole, not of an individual column. The :class:`DataFrame` constructor
+        does not extract ``attrs`` from a :class:`Series` it is built from, and
+        assigning a :class:`Series` as a column of an existing
+        :class:`DataFrame` (e.g. ``df[col] = ser``) does not modify
+        :attr:`DataFrame.attrs`. Methods that build a new :class:`DataFrame`
+        from a single :class:`Series` (such as :meth:`Series.to_frame`) do
+        propagate the source ``attrs``.
+
         Examples
         --------
         For Series:


### PR DESCRIPTION
## Summary

- Clarifies in the `attrs` docstring that `attrs` is per-object, not per-column: the `DataFrame` constructor does not extract `attrs` from a `Series` it is built from, and `df[col] = ser` does not modify `DataFrame.attrs`.
- Notes that methods that build a new `DataFrame` from a single `Series` (e.g. `Series.to_frame`) do propagate the source `attrs`.

Addresses the doc clarification requested in GH-35425. The original attempt at this (GH-35456) was closed-stale; reviewer feedback there asked for the note to live in the docstring (or user guide) rather than the reference `.rst`, and to focus the wording on the constructor / column-assignment cases rather than implying broader propagation breakage.

closes #35425

## Test plan

- [x] `pytest --doctest-modules pandas/core/generic.py -k attrs` passes
- [x] Rendered docstring inspected via `help(pd.DataFrame.attrs)`