### PR TITLE
BUG: to_datetime origin path silently ignored errors='coerce' (GH-63419)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -231,6 +231,7 @@ Datetimelike
 - Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)
 - Bug in :func:`to_datetime` when using a low time resolution ``unit``, higher resolution in ``origin`` is now preserved instead of silently dropped (e.g. ``unit="D"`` with microsecond precision origin) (:issue:`63419`)
+- Bug in :func:`to_datetime` with ``origin`` and ``errors="coerce"`` raising on values out of bounds for the result resolution instead of returning ``NaT`` (:issue:`63419`)
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``AssertionError`` instead of :class:`OutOfBoundsDatetime` when replacing with a ``datetime`` value outside the ``datetime64[ns]`` range (:issue:`61671`)
 - Bug in :meth:`DataFrame.to_string` and :meth:`Series.to_string` where ``na_rep`` was ignored for datetime and timedelta columns, always displaying ``NaT`` (:issue:`55426`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -231,7 +231,6 @@ Datetimelike
 - Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)
 - Bug in :func:`to_datetime` when using a low time resolution ``unit``, higher resolution in ``origin`` is now preserved instead of silently dropped (e.g. ``unit="D"`` with microsecond precision origin) (:issue:`63419`)
-- Bug in :func:`to_datetime` with ``origin`` and ``errors="coerce"`` raising on values out of bounds for the result resolution instead of returning ``NaT`` (:issue:`63419`)
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``AssertionError`` instead of :class:`OutOfBoundsDatetime` when replacing with a ``datetime`` value outside the ``datetime64[ns]`` range (:issue:`61671`)
 - Bug in :meth:`DataFrame.to_string` and :meth:`Series.to_string` where ``na_rep`` was ignored for datetime and timedelta columns, always displaying ``NaT`` (:issue:`55426`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -585,7 +585,7 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
     return result
 
 
-def _adjust_to_origin(arg, origin, unit):
+def _adjust_to_origin(arg, origin, unit, errors: DateTimeErrorChoices = "raise"):
     """
     Helper function for to_datetime.
     Adjust input argument to the specified origin
@@ -598,6 +598,9 @@ def _adjust_to_origin(arg, origin, unit):
         origin offset for the arg
     unit : str
         passed unit from to_datetime, must be 'D'
+    errors : {'raise', 'coerce'}, default 'raise'
+        propagated to ``to_timedelta`` for the non-julian path so values that
+        would overflow the chosen resolution become ``NaT`` under ``"coerce"``.
 
     Returns
     -------
@@ -647,7 +650,7 @@ def _adjust_to_origin(arg, origin, unit):
 
         if offset.tz is not None:
             raise ValueError(f"origin offset {offset} must be tz-naive")
-        arg = offset + extract_array(to_timedelta(arg, unit=unit))
+        arg = offset + extract_array(to_timedelta(arg, unit=unit, errors=errors))
     return arg
 
 
@@ -1048,25 +1051,21 @@ def to_datetime(
         return NaT
 
     if origin != "unix":
-        from pandas import Series
-
+        # Capture name/index before _adjust_to_origin replaces arg with a
+        # DatetimeArray (or Timestamp scalar) for non-julian origins.
         arg_name = getattr(arg, "name", None)
-        is_series = False
-        if isinstance(arg, Series):
-            arg_idx = getattr(arg, "index", None)
-            is_series = True
-        arg = _adjust_to_origin(arg, origin, unit)
+        arg_index = arg.index if isinstance(arg, ABCSeries) else None
+        is_series = isinstance(arg, ABCSeries)
+        arg = _adjust_to_origin(arg, origin, unit, errors=errors)
         if origin != "julian":
-            # GH#63419 _adjust_to_origin returned the final datetime result
+            # GH#63419 _adjust_to_origin already produced the final datetime
+            # result; localize and re-wrap into the input's container type.
             if utc:
-                if isinstance(arg, Timestamp):
-                    arg = arg.tz_localize("utc")
-                elif isinstance(arg, ABCSeries):
-                    arg = arg.dt.tz_localize("utc")
-                elif hasattr(arg, "tz_localize"):
-                    arg = arg.tz_localize("utc")  # type: ignore[union-attr]
+                arg = arg.tz_localize("utc")  # type: ignore[union-attr]
             if is_series:
-                return Series(arg, index=arg_idx, name=arg_name)
+                from pandas import Series
+
+                return Series(arg, index=arg_index, name=arg_name)
             if is_list_like(arg):
                 return DatetimeIndex(arg, name=arg_name)
             else:

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -23,10 +23,14 @@ from pandas._libs import (
 from pandas._libs.tslibs import (
     NaT,
     OutOfBoundsDatetime,
+    OutOfBoundsTimedelta,
+    Timedelta,
     Timestamp,
     astype_overflowsafe,
     get_supported_dtype,
+    iNaT,
     is_supported_dtype,
+    periods_per_second,
     timezones as libtimezones,
 )
 from pandas._libs.tslibs.conversion import cast_from_unit_vectorized
@@ -92,7 +96,10 @@ if TYPE_CHECKING:
         DataFrame,
         Series,
     )
-    from pandas.core.arrays import ArrowExtensionArray
+    from pandas.core.arrays import (
+        ArrowExtensionArray,
+        TimedeltaArray,
+    )
 
 # ---------------------------------------------------------------------
 # types used in annotations
@@ -599,8 +606,8 @@ def _adjust_to_origin(arg, origin, unit, errors: DateTimeErrorChoices = "raise")
     unit : str
         passed unit from to_datetime, must be 'D'
     errors : {'raise', 'coerce'}, default 'raise'
-        propagated to ``to_timedelta`` for the non-julian path so values that
-        would overflow the chosen resolution become ``NaT`` under ``"coerce"``.
+        under ``"coerce"``, values for which ``origin + value`` overflows
+        datetime64 become ``NaT`` instead of raising.
 
     Returns
     -------
@@ -650,8 +657,54 @@ def _adjust_to_origin(arg, origin, unit, errors: DateTimeErrorChoices = "raise")
 
         if offset.tz is not None:
             raise ValueError(f"origin offset {offset} must be tz-naive")
-        arg = offset + extract_array(to_timedelta(arg, unit=unit, errors=errors))
+        tda = extract_array(to_timedelta(arg, unit=unit, errors=errors))
+        try:
+            arg = offset + tda
+        except (OutOfBoundsDatetime, OutOfBoundsTimedelta, OverflowError) as err:
+            # GH#63419 the timedeltas fit their own resolution, but
+            # offset + tda overflows datetime64
+            if errors == "raise":
+                if isinstance(err, OutOfBoundsDatetime):
+                    raise
+                raise OutOfBoundsDatetime(
+                    f"cannot add values to origin {origin} without overflow"
+                ) from err
+            if isinstance(tda, Timedelta):
+                arg = NaT
+            else:
+                arg = _coerce_origin_overflow(offset, tda)
     return arg
+
+
+def _coerce_origin_overflow(offset: Timestamp, tda: TimedeltaArray) -> DatetimeArray:
+    """
+    Redo ``offset + tda`` with entries that cannot be represented in the
+    resolution the addition would produce coerced to NaT.
+    """
+    res_unit = tda.unit if tda._creso >= offset._creso else offset.unit
+    pps_res = periods_per_second(max(tda._creso, offset._creso))
+    # exact conversion factors as Python ints to avoid intermediate overflow
+    td_factor = pps_res // periods_per_second(tda._creso)
+    off_factor = pps_res // periods_per_second(offset._creso)
+    offset_i8 = int(offset._value) * off_factor
+
+    i8max = np.iinfo(np.int64).max
+    if not -i8max <= offset_i8 <= i8max:
+        # the origin itself is not representable in the result resolution,
+        # so no entry can be computed
+        nat_vals = np.full(len(tda), iNaT).view(f"M8[{res_unit}]")
+        return DatetimeArray._simple_new(nat_vals, dtype=nat_vals.dtype)
+
+    # valid iff the sum stays within [-i8max, i8max] (-2**63 is the NaT
+    # sentinel) and the timedelta itself is castable to the result unit
+    hi = min((i8max - offset_i8) // td_factor, i8max // td_factor)
+    lo = max(-((i8max + offset_i8) // td_factor), -(i8max // td_factor))
+
+    i8vals = tda.asi8
+    mask = (i8vals < lo) | (i8vals > hi)
+    new_vals = np.where(mask, iNaT, i8vals).view(tda.dtype)
+    tda = type(tda)._simple_new(new_vals, dtype=tda.dtype)
+    return offset + tda
 
 
 @overload

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -40,6 +40,7 @@ from pandas import (
     Index,
     NaT,
     Series,
+    Timedelta,
     Timestamp,
     date_range,
     isna,
@@ -3324,7 +3325,7 @@ class TestOrigin:
             max(reso_order.index(origin_unit), reso_order.index(unit_reso))
         ]
         expected = Series(
-            [pd.Timedelta(x, unit=units) + epoch_1960 for x in units_from_epochs],
+            [Timedelta(x, unit=units) + epoch_1960 for x in units_from_epochs],
             dtype=f"M8[{exp_unit}]",
         )
 
@@ -3457,18 +3458,62 @@ class TestOrigin:
 
     def test_origin_errors_coerce_overflow(self):
         # GH#63419: errors="coerce" should turn out-of-bounds offsets into NaT
-        # rather than raising
+        # rather than raising.  10**8 days is in bounds; 10**9 overflows the
+        # us-resolution result; 10**18 overflows to_timedelta itself
         origin = Timestamp("2016-01-01")
-        result = to_datetime([1, 2, 10**18], unit="D", origin=origin, errors="coerce")
+        vals = [1, 2, 10**8, 10**9, 10**18]
+        result = to_datetime(vals, unit="D", origin=origin, errors="coerce")
         expected = DatetimeIndex(
-            ["2016-01-02", "2016-01-03", "NaT"], dtype="datetime64[us]"
+            [
+                origin + Timedelta(days=1),
+                origin + Timedelta(days=2),
+                origin + Timedelta(days=10**8),
+                NaT,
+                NaT,
+            ],
+            dtype="datetime64[us]",
         )
         tm.assert_index_equal(result, expected)
+
+        result = to_datetime(Series(vals), unit="D", origin=origin, errors="coerce")
+        tm.assert_series_equal(result, Series(expected))
+
+        assert to_datetime(10**9, unit="D", origin=origin, errors="coerce") is NaT
 
         # errors="raise" still raises
         msg = "Cannot cast .* without overflow"
         with pytest.raises(OutOfBoundsTimedelta, match=msg):
             to_datetime([1, 2, 10**18], unit="D", origin=origin)
+
+        msg = "cannot add values to origin"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            to_datetime([1, 2, 10**9], unit="D", origin=origin)
+
+    def test_origin_errors_coerce_overflow_boundary(self):
+        # GH#63419 exact boundary: with origin 16801 days past the epoch, the
+        # largest value representable in the us-resolution result is
+        # (2**63 - 1) // (86400 * 10**6) - 16801 days
+        origin = Timestamp("2016-01-01")
+        bound = (2**63 - 1) // (86400 * 10**6) - 16801
+        result = to_datetime(
+            [bound, bound + 1], unit="D", origin=origin, errors="coerce"
+        )
+        assert result[0] == origin + Timedelta(days=bound)
+        assert result[1] is NaT
+
+        # values just past the boundary raise OutOfBoundsDatetime (not a bare
+        # OverflowError) under errors="raise"
+        with pytest.raises(OutOfBoundsDatetime, match="cannot add values"):
+            to_datetime([bound + 1], unit="D", origin=origin)
+
+    def test_origin_oob_for_unit_coerce(self):
+        # GH#63419 origin not representable in the result resolution; under
+        # errors="coerce" all entries become NaT instead of raising
+        result = to_datetime(
+            list(range(5)), unit="ns", origin=datetime(1, 1, 1), errors="coerce"
+        )
+        expected = DatetimeIndex([NaT] * 5, dtype="datetime64[ns]")
+        tm.assert_index_equal(result, expected)
 
 
 class TestShouldCache:

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3455,6 +3455,21 @@ class TestOrigin:
         expected = DatetimeIndex(data, dtype="datetime64[us]", name="foo")
         tm.assert_index_equal(result, expected)
 
+    def test_origin_errors_coerce_overflow(self):
+        # GH#63419: errors="coerce" should turn out-of-bounds offsets into NaT
+        # rather than raising
+        origin = Timestamp("2016-01-01")
+        result = to_datetime([1, 2, 10**18], unit="D", origin=origin, errors="coerce")
+        expected = DatetimeIndex(
+            ["2016-01-02", "2016-01-03", "NaT"], dtype="datetime64[us]"
+        )
+        tm.assert_index_equal(result, expected)
+
+        # errors="raise" still raises
+        msg = "Cannot cast .* without overflow"
+        with pytest.raises(OutOfBoundsTimedelta, match=msg):
+            to_datetime([1, 2, 10**18], unit="D", origin=origin)
+
 
 class TestShouldCache:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Follow-up to GH-63915. The coerce handling here amends that unreleased fix, so there is no whatsnew entry.

- ``_adjust_to_origin`` now forwards ``errors`` to ``to_timedelta`` so out-of-bounds offsets become ``NaT`` under ``errors="coerce"`` instead of raising.
- Forwarding alone only coerced values that overflow ``to_timedelta`` itself (beyond ~1.07e14 days with ``unit="D"``); values that fit a timedelta but where ``origin + value`` overflows the result resolution still raised, making coercion magnitude-dependent. The addition is now wrapped:
  - under ``errors="coerce"``, entries whose sum cannot be represented in the addition's resolution become ``NaT`` (all-``NaT`` when the origin itself is not representable in the result resolution, e.g. ``origin=datetime(1, 1, 1)`` with ``unit="ns"``);
  - under ``errors="raise"``, the bare ``OverflowError``/``OutOfBoundsTimedelta`` escaping the addition is translated to ``OutOfBoundsDatetime``.
- Tidied the wrapper at the ``to_datetime`` call site:
  - dropped the dead ``ABCSeries`` branch in the ``utc`` block — after ``_adjust_to_origin``, ``arg`` is always a ``DatetimeArray`` or scalar ``Timestamp``, never a ``Series``;
  - dropped the redundant ``Timestamp`` ``isinstance`` check, since ``Timestamp.tz_localize`` covers it;
  - moved the lazy ``from pandas import Series`` import inside the ``is_series`` branch where it is actually needed.

## Test plan

- [x] ``test_origin_errors_coerce_overflow`` covers ``errors="coerce"`` across magnitude bands (in-bounds, addition overflow, ``to_timedelta`` overflow) for list/Series/scalar inputs, and ``errors="raise"`` exception types.
- [x] ``test_origin_errors_coerce_overflow_boundary`` asserts the exact cutoff value: last representable day succeeds, the next becomes ``NaT`` (coerce) or raises ``OutOfBoundsDatetime`` (raise).
- [x] ``test_origin_oob_for_unit_coerce`` covers the unrepresentable-origin all-``NaT`` case.
- [x] Full ``pandas/tests/tools/test_to_datetime.py`` passes (940 passed, 2 xfailed).
- [x] mypy, pyright, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
