### PR TITLE
CLN: drop stale pre-commit exclude for deleted code_style.rst

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,7 +180,6 @@ repos:
             # builtin filter function
             |(?<!def)[\(\s]filter\(
         types_or: [python, cython, rst]
-        exclude: ^doc/source/development/code_style\.rst  # contains examples of patterns to avoid
     -   id: incorrect-backticks
         name: Check for backticks incorrectly rendering because of missing spaces
         language: pygrep


### PR DESCRIPTION
## Summary

- The `unwanted-patterns` pre-commit hook had `exclude: ^doc/source/development/code_style\.rst`, but that file was removed in GH-46724 (2022).
- Drops the dead exclude line.

While investigating GH-33851 (request for a single code-guidelines doc), I noticed the issue is effectively resolved: `code_style.rst` was folded into `contributing_codebase.rst` by GH-46724, leaving `contributing_codebase.rst` as the single document for code standards. This stale exclude is the only loose end.

## Test plan

- [x] No files match the regex anymore — pre-commit `Unwanted patterns` hook still runs cleanly on the rest of the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)