### PR TITLE
DOC: clarify from_spmatrix converts to CSC, not COO (GH-43419)

### DIFF
--- a/doc/source/user_guide/sparse.rst
+++ b/doc/source/user_guide/sparse.rst
@@ -192,7 +192,7 @@ Use :meth:`DataFrame.sparse.from_spmatrix` to create a :class:`DataFrame` with s
    sdf.head()
    sdf.dtypes
 
-All sparse formats are supported, but matrices that are not in :class:`~scipy.sparse.csc_matrix` format will be converted, copying data as needed.
+All sparse formats are supported, but matrices that are not in Compressed Sparse Column (CSC) matrix format will be converted, copying data as needed.
 To convert a :class:`DataFrame` back to a sparse SciPy matrix in COO format, you can use the :meth:`DataFrame.sparse.to_coo` method:
 
 .. ipython:: python

--- a/doc/source/user_guide/sparse.rst
+++ b/doc/source/user_guide/sparse.rst
@@ -192,8 +192,8 @@ Use :meth:`DataFrame.sparse.from_spmatrix` to create a :class:`DataFrame` with s
    sdf.head()
    sdf.dtypes
 
-All sparse formats are supported, but matrices that are not in ``COOrdinate`` format will be converted, copying data as needed.
-To convert back to sparse SciPy matrix in COO format, you can use the :meth:`DataFrame.sparse.to_coo` method:
+All sparse formats are supported, but matrices that are not in :class:`~scipy.sparse.csc_matrix` format will be converted, copying data as needed.
+To convert a :class:`DataFrame` back to a sparse SciPy matrix in COO format, you can use the :meth:`DataFrame.sparse.to_coo` method:
 
 .. ipython:: python
 


### PR DESCRIPTION
## Summary

- The sparse user guide claimed that input matrices not in COOrdinate format would be converted, but `DataFrame.sparse.from_spmatrix` actually converts to CSC (`data.tocsc()` in `pandas/core/arrays/sparse/accessor.py`). The `from_spmatrix` docstring already correctly says "Must be convertible to csc format."
- Update the user guide wording to reference ``csc_matrix`` instead of ``COOrdinate``, and reword the follow-on sentence so "back" no longer implies the input was COO.

closes #43419

## Test plan

- [ ] Doc-only change; rendered HTML reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)