### PR TITLE
TYP: type-check pandas.core.sample

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -50,6 +50,7 @@ from pandas._typing import (
     ArrayLike,
     IndexLabel,
     IntervalClosedType,
+    ListLike,
     NDFrameT,
     PositionalIndexer,
     RandomState,
@@ -5761,7 +5762,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         n: int | None = None,
         frac: float | None = None,
         replace: bool = False,
-        weights: Sequence | Series | None = None,
+        weights: ListLike | None = None,
         random_state: RandomState | None = None,
     ):
         """

--- a/pandas/core/sample.py
+++ b/pandas/core/sample.py
@@ -16,12 +16,17 @@ from pandas.core.dtypes.generic import (
 )
 
 if TYPE_CHECKING:
-    from pandas._typing import AxisInt
+    from pandas._typing import (
+        AxisInt,
+        ListLike,
+    )
 
     from pandas.core.generic import NDFrame
 
 
-def preprocess_weights(obj: NDFrame, weights, axis: AxisInt) -> np.ndarray:
+def preprocess_weights(
+    obj: NDFrame, weights: str | ListLike, axis: AxisInt
+) -> np.ndarray:
     """
     Process and validate the `weights` argument to `NDFrame.sample` and
     `.GroupBy.sample`.
@@ -59,23 +64,23 @@ def preprocess_weights(obj: NDFrame, weights, axis: AxisInt) -> np.ndarray:
     else:
         func = obj._constructor_sliced
 
-    weights = func(weights, dtype="float64")._values
+    weights_arr = np.asarray(func(weights, dtype="float64")._values, dtype=np.float64)
 
-    if len(weights) != obj.shape[axis]:
+    if len(weights_arr) != obj.shape[axis]:
         raise ValueError("Weights and axis to be sampled must be of same length")
 
-    if lib.has_infs(weights):
+    if lib.has_infs(weights_arr):
         raise ValueError("weights vector may not include `inf` values")
 
-    if (weights < 0).any():
+    if (weights_arr < 0).any():
         raise ValueError("weights vector may not include negative values")
 
-    missing = np.isnan(weights)
+    missing = np.isnan(weights_arr)
     if missing.any():
         # Don't modify weights in place
-        weights = weights.copy()
-        weights[missing] = 0
-    return weights
+        weights_arr = weights_arr.copy()
+        weights_arr[missing] = 0
+    return weights_arr
 
 
 def process_sampling_size(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -584,7 +584,6 @@ module = [
   "pandas.core.missing", # TODO
   "pandas.core.nanops", # TODO
   "pandas.core.resample", # TODO
-  "pandas.core.sample", # TODO
   "pandas.core.series", # TODO
   "pandas.io.clipboard", # TODO
   "pandas.io.excel._base", # TODO


### PR DESCRIPTION
## Summary
- Drop the mypy exemption for `pandas.core.sample` and add the annotation needed for strict checking.
- Tighten `GroupBy.sample`'s `weights` parameter from `Sequence | Series` to `ListLike` — groupby sampling does not accept column-name strings, so this both matches behavior and lets the call site type-check against `preprocess_weights`.

## Test plan
- [x] `mypy pandas` passes cleanly
- [x] `pytest pandas/tests/frame/methods/test_sample.py pandas/tests/groupby/methods/test_sample.py` (78 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)