### PR TITLE
TYP: enable mypy checking for pandas.core.window.online

### DIFF
--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -1189,7 +1189,7 @@ class OnlineExponentialMovingWindow(ExponentialMovingWindow):
         result = self._mean.run_ewm(
             np_array if is_frame else np_array[:, np.newaxis],
             update_deltas,
-            self.min_periods,
+            self.min_periods,  # type: ignore[arg-type]
             ewma_func,
         )
         if not is_frame:

--- a/pandas/core/window/online.py
+++ b/pandas/core/window/online.py
@@ -6,11 +6,17 @@ import numpy as np
 
 from pandas.compat._optional import import_optional_dependency
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 
 def generate_online_numba_ewma_func(
     nogil: bool,
     parallel: bool,
-):
+) -> Callable[
+    [np.ndarray, np.ndarray, int, float, float, np.ndarray, bool, bool],
+    tuple[np.ndarray, np.ndarray],
+]:
     """
     Generate a numba jitted groupby ewma function specified by values
     from engine_kwargs.
@@ -41,7 +47,7 @@ def generate_online_numba_ewma_func(
         old_wt: np.ndarray,
         adjust: bool,
         ignore_na: bool,
-    ):
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
         Compute online exponentially weighted mean per column over 2D values.
 
@@ -84,7 +90,13 @@ def generate_online_numba_ewma_func(
 
 
 class EWMMeanState:
-    def __init__(self, com, adjust, ignore_na, shape) -> None:
+    def __init__(
+        self,
+        com: float,
+        adjust: bool,
+        ignore_na: bool,
+        shape: tuple[int, ...],
+    ) -> None:
         alpha = 1.0 / (1.0 + com)
         self.shape = shape
         self.adjust = adjust
@@ -92,9 +104,18 @@ class EWMMeanState:
         self.new_wt = 1.0 if adjust else alpha
         self.old_wt_factor = 1.0 - alpha
         self.old_wt = np.ones(self.shape[-1])
-        self.last_ewm = None
+        self.last_ewm: np.ndarray | None = None
 
-    def run_ewm(self, weighted_avg, deltas, min_periods, ewm_func):
+    def run_ewm(
+        self,
+        weighted_avg: np.ndarray,
+        deltas: np.ndarray,
+        min_periods: int,
+        ewm_func: Callable[
+            [np.ndarray, np.ndarray, int, float, float, np.ndarray, bool, bool],
+            tuple[np.ndarray, np.ndarray],
+        ],
+    ) -> np.ndarray:
         result, old_wt = ewm_func(
             weighted_avg,
             deltas,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -575,7 +575,6 @@ module = [
   "pandas.core.window.ewm", # TODO
   "pandas.core.window.expanding", # TODO
   "pandas.core.window.numba_", # TODO
-  "pandas.core.window.online", # TODO
   "pandas.core.window.rolling", # TODO
   "pandas.core.accessor", # TODO
   "pandas.core.algorithms", # TODO


### PR DESCRIPTION
## Summary
- Add type annotations to `generate_online_numba_ewma_func`, `online_ewma`, `EWMMeanState.__init__`, and `EWMMeanState.run_ewm` in `pandas/core/window/online.py`
- Drop `pandas.core.window.online` from the `disallow_untyped_defs = false` mypy override list in `pyproject.toml`
- Add a `# type: ignore[arg-type]` at the `run_ewm` call site in `ewm.py` for `self.min_periods` (typed `int | None`), matching the existing pattern at line 894

## Test plan
- [x] `mypy pandas/core/window/online.py` clean (one pre-existing unrelated error in `frame.py:17435`)
- [x] `mypy pandas/core/window/` clean
- [x] `pyright pandas/core/window/online.py` clean
- [x] `pre-commit run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)