### PR TITLE
TYP: enable mypy on core.internals.api

### DIFF
--- a/pandas/core/internals/api.py
+++ b/pandas/core/internals/api.py
@@ -85,7 +85,11 @@ class _DatetimeTZBlock(DatetimeLikeBlock):
 
 
 def make_block(
-    values, placement, klass=None, ndim=None, dtype: Dtype | None = None
+    values: ArrayLike,
+    placement: BlockPlacement | np.ndarray,
+    klass: type[Block] | None = None,
+    ndim: int | None = None,
+    dtype: Dtype | None = None,
 ) -> Block:
     """
     This is a pseudo-public analogue to blocks.new_block.
@@ -127,10 +131,14 @@ def make_block(
     elif klass is _DatetimeTZBlock and not isinstance(values.dtype, DatetimeTZDtype):
         # pyarrow calls get here (pyarrow<15)
         values = DatetimeArray._simple_new(
+            # error: Argument 1 to "_simple_new" of "DatetimeArray" has
+            # incompatible type "ExtensionArray | ndarray[tuple[Any, ...],
+            # dtype[Any]]"; expected
+            # "ndarray[tuple[Any, ...], dtype[datetime64[date | int | None]]]"
+            values,  # type: ignore[arg-type]
             # error: Argument "dtype" to "_simple_new" of "DatetimeArray" has
             # incompatible type "Union[ExtensionDtype, dtype[Any], None]";
             # expected "Union[dtype[datetime64], DatetimeTZDtype]"
-            values,
             dtype=dtype,  # type: ignore[arg-type]
         )
 
@@ -149,7 +157,9 @@ def make_block(
     return klass(values, ndim=ndim, placement=placement)
 
 
-def _maybe_infer_ndim(values, placement: BlockPlacement, ndim: int | None) -> int:
+def _maybe_infer_ndim(
+    values: ArrayLike, placement: BlockPlacement, ndim: int | None
+) -> int:
     """
     If `ndim` is not provided, infer it from placement and values.
     """
@@ -165,7 +175,9 @@ def _maybe_infer_ndim(values, placement: BlockPlacement, ndim: int | None) -> in
     return ndim
 
 
-def maybe_infer_ndim(values, placement: BlockPlacement, ndim: int | None) -> int:
+def maybe_infer_ndim(
+    values: ArrayLike, placement: BlockPlacement, ndim: int | None
+) -> int:
     """
     If `ndim` is not provided, infer it from placement and values.
     """

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2364,7 +2364,7 @@ def check_ndim(values, placement: BlockPlacement, ndim: int) -> None:
 
 
 def extract_pandas_array(
-    values: ArrayLike, dtype: DtypeObj | None, ndim: int
+    values: ArrayLike, dtype: DtypeObj | None, ndim: int | None
 ) -> tuple[ArrayLike, DtypeObj | None]:
     """
     Ensure that we don't allow NumpyExtensionArray / NumpyEADtype in internals.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -560,7 +560,6 @@ module = [
   "pandas.core.interchange.dataframe_protocol", # TODO
   "pandas.core.interchange.from_dataframe", # TODO
   "pandas.core.internals", # TODO
-  "pandas.core.internals.api", # TODO
   "pandas.core.internals.blocks", # TODO
   "pandas.core.internals.concat", # TODO
   "pandas.core.internals.construction", # TODO


### PR DESCRIPTION
## Summary
- Drop `pandas.core.internals.api` from the mypy `disallow-untyped-defs` exemption list in `pyproject.toml`.
- Annotate `make_block`, `_maybe_infer_ndim`, and `maybe_infer_ndim` (the three functions previously missing annotations).
- Widen `extract_pandas_array`'s `ndim` parameter from `int` to `int | None` — its body already handles None correctly (`if ndim and ndim > 1`), and `make_block` calls it before `ndim` is inferred.
- Add a `# type: ignore[arg-type]` (with descriptive error comment) on the `values` arg of the pyarrow<15 `_simple_new` call, alongside the existing one for `dtype`.

## Test plan
- [x] `mypy pandas` passes
- [x] `pyright pandas/core/internals/api.py pandas/core/internals/blocks.py` passes
- [x] pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)