### PR TITLE
DOC: note pyarrow uint32 round-trip requires parquet version>=2.4 (GH-37327)

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5176,7 +5176,9 @@ Several caveats.
 * The ``pyarrow`` engine preserves extension data types such as the nullable integer and string data
   type (this can also work for external extension types, requiring the extension type to implement the needed protocols,
   see the :ref:`extension types documentation <extending.extension.arrow>`).
-* With the ``pyarrow`` engine, unsigned integer dtypes narrower than 64 bits (e.g. ``uint32``) require parquet format ``version="2.4"`` or later; pass ``version`` through ``to_parquet``'s additional keyword arguments if your ``pyarrow`` defaults to an older version (:issue:`37327`).
+* With the ``pyarrow`` engine, ``uint32`` data written with parquet format ``version="1.0"``
+  is stored as ``int64``, so it does not survive a round trip. The default format version
+  (``"2.4"`` or higher) preserves ``uint32`` (:issue:`37327`).
 
 You can specify an ``engine`` to direct the serialization. This can be one of ``pyarrow``, or ``fastparquet``, or ``auto``.
 If the engine is NOT specified, then the ``pd.options.io.parquet.engine`` option is checked; if this is also ``auto``,

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5176,6 +5176,7 @@ Several caveats.
 * The ``pyarrow`` engine preserves extension data types such as the nullable integer and string data
   type (this can also work for external extension types, requiring the extension type to implement the needed protocols,
   see the :ref:`extension types documentation <extending.extension.arrow>`).
+* With the ``pyarrow`` engine, unsigned integer dtypes narrower than 64 bits (e.g. ``uint32``) require parquet format ``version="2.4"`` or later; pass ``version`` through ``to_parquet``'s additional keyword arguments if your ``pyarrow`` defaults to an older version (:issue:`37327`).
 
 You can specify an ``engine`` to direct the serialization. This can be one of ``pyarrow``, or ``fastparquet``, or ``auto``.
 If the engine is NOT specified, then the ``pd.options.io.parquet.engine`` option is checked; if this is also ``auto``,


### PR DESCRIPTION
closes #37327

Adds a caveat to the parquet section of the IO user guide: with the ``pyarrow`` engine, ``uint32`` data written with parquet format ``version="1.0"`` is stored as ``int64`` and does not survive a round trip; the default format version (``"2.4"`` or higher) preserves it.

Verified against pyarrow 23.0.1: only ``uint32`` is affected (``uint8``/``uint16``/``uint64`` round-trip fine even with ``version="1.0"``), and every pyarrow version pandas supports defaults to ``"2.4"`` or higher, so the loss only occurs when explicitly passing ``version="1.0"`` (e.g. for compatibility with old readers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)