### PR TITLE
TYP: enable mypy checks on pandas.core.dtypes.generic

### DIFF
--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
+    Any,
     Type,
     cast,
 )
@@ -34,18 +35,20 @@ if TYPE_CHECKING:
 
 # define abstract base classes to enable isinstance type checking on our
 # objects
-def create_pandas_abc_type(name, attr, comp) -> type:
-    def _check(inst) -> bool:
+def create_pandas_abc_type(
+    name: str, attr: str, comp: tuple[str, ...] | set[str]
+) -> type:
+    def _check(inst: Any) -> bool:
         return getattr(inst, attr, "_typ") in comp
 
     # https://github.com/python/mypy/issues/1006
     # error: 'classmethod' used with a non-method
     @classmethod  # type: ignore[misc]
-    def _instancecheck(cls, inst) -> bool:
+    def _instancecheck(cls: type, inst: Any) -> bool:
         return _check(inst) and not isinstance(inst, type)
 
     @classmethod  # type: ignore[misc]
-    def _subclasscheck(cls, inst) -> bool:
+    def _subclasscheck(cls: type, inst: Any) -> bool:
         # Raise instead of returning False
         # This is consistent with default __subclasscheck__ behavior
         if not isinstance(inst, type):
@@ -119,15 +122,15 @@ ABCDataFrame = cast(
 
 ABCCategorical = cast(
     "Type[Categorical]",
-    create_pandas_abc_type("ABCCategorical", "_typ", ("categorical")),
+    create_pandas_abc_type("ABCCategorical", "_typ", ("categorical",)),
 )
 ABCDatetimeArray = cast(
     "Type[DatetimeArray]",
-    create_pandas_abc_type("ABCDatetimeArray", "_typ", ("datetimearray")),
+    create_pandas_abc_type("ABCDatetimeArray", "_typ", ("datetimearray",)),
 )
 ABCTimedeltaArray = cast(
     "Type[TimedeltaArray]",
-    create_pandas_abc_type("ABCTimedeltaArray", "_typ", ("timedeltaarray")),
+    create_pandas_abc_type("ABCTimedeltaArray", "_typ", ("timedeltaarray",)),
 )
 ABCPeriodArray = cast(
     "Type[PeriodArray]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -539,7 +539,6 @@ module = [
   "pandas.core.computation.*", # TODO
   "pandas.core.dtypes.common", # TODO
   "pandas.core.dtypes.dtypes", # TODO
-  "pandas.core.dtypes.generic", # TODO
   "pandas.core.dtypes.missing", # TODO
   "pandas.core.groupby.generic", # TODO
   "pandas.core.groupby.grouper", # TODO


### PR DESCRIPTION
## Summary

- Removed `pandas.core.dtypes.generic` from the `disallow_untyped_*` mypy override list and added type annotations to `create_pandas_abc_type` and its inner `_check`/`_instancecheck`/`_subclasscheck` helpers.
- Fixed three latent bugs the typed signature surfaced: `("categorical")`, `("datetimearray")`, and `("timedeltaarray")` were bare strings, not single-element tuples, so the `_typ in comp` check was a substring lookup rather than equality. No real `_typ` value is a substring of any of those three, so this is observably a no-op in practice — but it was a foot-gun waiting for someone to add a short `_typ`.
- Single-element tuple `in` is actually a touch faster than substring `in` (one interned-string `==` vs char-by-char scan), so no perf regression.

## Test plan

- [x] `mypy pandas` — success, no issues across 1458 source files
- [x] `pyright pandas/core/dtypes/generic.py` — 0 errors
- [x] `pre-commit run --files pandas/core/dtypes/generic.py pyproject.toml` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)