### PR TITLE
DOC: document Rolling.apply Series index when on= is specified

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12104,6 +12104,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Provided integer column is ignored and excluded from result since
             an integer index is not used to calculate the rolling window.
 
+            When ``on`` is specified, the values of that column also become the
+            index of the :class:`Series` passed to :meth:`Rolling.apply` when
+            ``raw=False``, in place of the original :class:`DataFrame` index.
+
         closed : str, default None
             Determines the inclusivity of points in the window
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2253,6 +2253,15 @@ class Rolling(RollingAndExpandingMixin):
         Series.apply : Aggregating apply for Series.
         DataFrame.apply : Aggregating apply for DataFrame.
 
+        Notes
+        -----
+        When ``raw=False``, the :class:`Series` passed to ``func`` is indexed by the
+        column or :class:`Index` used to compute the rolling window. If
+        :meth:`DataFrame.rolling` was called with ``on=col``, the index of the
+        passed :class:`Series` will be the values of ``col`` rather than the
+        original :class:`DataFrame` index. When ``on`` is not specified, the
+        index of the passed :class:`Series` is the original index of the input.
+
         Examples
         --------
         >>> ser = pd.Series([1, 6, 5, 4])


### PR DESCRIPTION
## Summary

- Documents the behavior reported in GH-47494: when `DataFrame.rolling(on=col).apply(func)` is called with `raw=False`, the Series passed to `func` is indexed by the values of `col` rather than the original DataFrame index.
- Per @mroeschke's resolution on the issue, this is intentional (consistent with iterating over the rolling object) and the fix is to document it.
- Adds a Notes section to `Rolling.apply` and a clarifying paragraph to the `on` parameter description on `DataFrame.rolling` / `Series.rolling`.

## Test plan

- [x] `pbuild && pytest pandas/tests/window/test_apply.py` — 80 passed
- [x] `help(pd.api.typing.Rolling.apply)` and `help(pd.DataFrame.rolling)` render the new sections cleanly

closes #47494