### PR TITLE
TYP: enable mypy disallow_untyped_defs for pandas.core.roperator

### DIFF
--- a/pandas/core/roperator.py
+++ b/pandas/core/roperator.py
@@ -6,33 +6,34 @@ Defining these instead of using lambdas allows us to reference them by name.
 from __future__ import annotations
 
 import operator
+from typing import Any
 
 
-def radd(left, right):
+def radd(left: Any, right: Any) -> Any:
     return right + left
 
 
-def rsub(left, right):
+def rsub(left: Any, right: Any) -> Any:
     return right - left
 
 
-def rmul(left, right):
+def rmul(left: Any, right: Any) -> Any:
     return right * left
 
 
-def rdiv(left, right):
+def rdiv(left: Any, right: Any) -> Any:
     return right / left
 
 
-def rtruediv(left, right):
+def rtruediv(left: Any, right: Any) -> Any:
     return right / left
 
 
-def rfloordiv(left, right):
+def rfloordiv(left: Any, right: Any) -> Any:
     return right // left
 
 
-def rmod(left, right):
+def rmod(left: Any, right: Any) -> Any:
     # check if right is a string as % is the string
     # formatting operation; this is a TypeError
     # otherwise perform the op
@@ -43,21 +44,21 @@ def rmod(left, right):
     return right % left
 
 
-def rdivmod(left, right):
+def rdivmod(left: Any, right: Any) -> tuple[Any, Any]:
     return divmod(right, left)
 
 
-def rpow(left, right):
+def rpow(left: Any, right: Any) -> Any:
     return right**left
 
 
-def rand_(left, right):
+def rand_(left: Any, right: Any) -> Any:
     return operator.and_(right, left)
 
 
-def ror_(left, right):
+def ror_(left: Any, right: Any) -> Any:
     return operator.or_(right, left)
 
 
-def rxor(left, right):
+def rxor(left: Any, right: Any) -> Any:
     return operator.xor(right, left)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -589,7 +589,6 @@ module = [
   "pandas.core.missing", # TODO
   "pandas.core.nanops", # TODO
   "pandas.core.resample", # TODO
-  "pandas.core.roperator", # TODO
   "pandas.core.sample", # TODO
   "pandas.core.series", # TODO
   "pandas.core.sorting", # TODO


### PR DESCRIPTION
## Summary
- Annotate the reverse-operator helpers in `pandas/core/roperator.py` with `Any` (and `tuple[Any, Any]` for `rdivmod`)
- Drop the `pandas.core.roperator` TODO entry from the mypy `disallow_untyped_defs = false` override list in `pyproject.toml`

These functions are intentionally generic dispatchers — they delegate to whatever dunder methods the operands implement — so `Any` is the appropriate annotation rather than something narrower.

## Test plan
- [x] `mypy pandas` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)