### PR TITLE
DOC: clarify result_type has no effect for ufuncs in DataFrame.apply

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -14150,6 +14150,16 @@ class DataFrame(NDFrame, OpsMixin):
             applied function: list-like results will be returned as a Series
             of those. However if the apply function returns a Series these
             are expanded to columns.
+
+            .. note::
+
+                ``result_type`` has no effect when ``func`` is a NumPy
+                universal function (e.g. ``np.sqrt``). In that case the
+                ufunc is applied directly to the underlying values and the
+                result has the same shape as the input, regardless of
+                ``axis`` or ``result_type``. To use ``result_type`` with a
+                ufunc, wrap it in a Python function (e.g.
+                ``lambda x: np.sqrt(x)``).
         args : tuple
             Positional arguments to pass to `func` in addition to the
             array/series.


### PR DESCRIPTION
## Summary

- Adds a note to the `result_type` parameter description in `DataFrame.apply` documenting that the option is silently bypassed when `func` is a NumPy universal function.
- Suggests wrapping the ufunc in a Python function (e.g. `lambda x: np.sqrt(x)`) as a workaround.

closes #49190

## Test plan
- [x] `DataFrame.apply` doctests still pass (11 attempted, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)