### PR TITLE
TYP: enable mypy on pandas.compat.numpy.function

### DIFF
--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -52,10 +52,10 @@ if TYPE_CHECKING:
 class CompatValidator:
     def __init__(
         self,
-        defaults,
-        fname=None,
+        defaults: dict[str, Any],
+        fname: str | None = None,
         method: str | None = None,
-        max_fname_arg_count=None,
+        max_fname_arg_count: int | None = None,
     ) -> None:
         self.fname = fname
         self.method = method
@@ -64,10 +64,10 @@ class CompatValidator:
 
     def __call__(
         self,
-        args,
-        kwargs,
-        fname=None,
-        max_fname_arg_count=None,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        fname: str | None = None,
+        max_fname_arg_count: int | None = None,
         method: str | None = None,
     ) -> None:
         if not args and not kwargs:
@@ -102,7 +102,9 @@ validate_argmax = CompatValidator(
 )
 
 
-def process_skipna(skipna: bool | ndarray | None, args) -> tuple[bool, Any]:
+def process_skipna(
+    skipna: bool | ndarray | None, args: tuple[Any, ...]
+) -> tuple[bool, tuple[Any, ...]]:
     if isinstance(skipna, ndarray) or skipna is None:
         args = (skipna, *args)
         skipna = True
@@ -110,7 +112,9 @@ def process_skipna(skipna: bool | ndarray | None, args) -> tuple[bool, Any]:
     return skipna, args
 
 
-def validate_argmin_with_skipna(skipna: bool | ndarray | None, args, kwargs) -> bool:
+def validate_argmin_with_skipna(
+    skipna: bool | ndarray | None, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> bool:
     """
     If 'Series.argmin' is called via the 'numpy' library, the third parameter
     in its signature is 'out', which takes either an ndarray or 'None', so
@@ -122,7 +126,9 @@ def validate_argmin_with_skipna(skipna: bool | ndarray | None, args, kwargs) -> 
     return skipna
 
 
-def validate_argmax_with_skipna(skipna: bool | ndarray | None, args, kwargs) -> bool:
+def validate_argmax_with_skipna(
+    skipna: bool | ndarray | None, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> bool:
     """
     If 'Series.argmax' is called via the 'numpy' library, the third parameter
     in its signature is 'out', which takes either an ndarray or 'None', so
@@ -157,7 +163,9 @@ validate_argsort_kind = CompatValidator(
 )
 
 
-def validate_argsort_with_ascending(ascending: bool | int | None, args, kwargs) -> bool:
+def validate_argsort_with_ascending(
+    ascending: bool | int | None, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> bool:
     """
     If 'Categorical.argsort' is called via the 'numpy' library, the first
     parameter in its signature is 'axis', which takes either an integer or
@@ -180,15 +188,19 @@ validate_clip = CompatValidator(
 
 
 @overload
-def validate_clip_with_axis(axis: ndarray, args, kwargs) -> None: ...
+def validate_clip_with_axis(
+    axis: ndarray, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> None: ...
 
 
 @overload
-def validate_clip_with_axis(axis: AxisNoneT, args, kwargs) -> AxisNoneT: ...
+def validate_clip_with_axis(
+    axis: AxisNoneT, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> AxisNoneT: ...
 
 
 def validate_clip_with_axis(
-    axis: ndarray | AxisNoneT, args, kwargs
+    axis: ndarray | AxisNoneT, args: tuple[Any, ...], kwargs: dict[str, Any]
 ) -> AxisNoneT | None:
     """
     If 'NDFrame.clip' is called via the numpy library, the third parameter in
@@ -219,7 +231,9 @@ validate_cumsum = CompatValidator(
 )
 
 
-def validate_cum_func_with_skipna(skipna: bool, args, kwargs, name) -> bool:
+def validate_cum_func_with_skipna(
+    skipna: bool, args: tuple[Any, ...], kwargs: dict[str, Any], name: str
+) -> bool:
     """
     If this function is called via the 'numpy' library, the third parameter in
     its signature is 'dtype', which takes either a 'numpy' dtype or 'None', so
@@ -320,7 +334,12 @@ validate_transpose = CompatValidator(
 )
 
 
-def validate_groupby_func(name: str, args, kwargs, allowed=None) -> None:
+def validate_groupby_func(
+    name: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    allowed: list[str] | None = None,
+) -> None:
     """
     'args' and 'kwargs' should be empty, except for allowed kwargs because all
     of their necessary parameters are explicitly listed in the function
@@ -329,9 +348,9 @@ def validate_groupby_func(name: str, args, kwargs, allowed=None) -> None:
     if allowed is None:
         allowed = []
 
-    kwargs = set(kwargs) - set(allowed)
+    extra_kwargs = set(kwargs) - set(allowed)
 
-    if len(args) + len(kwargs) > 0:
+    if len(args) + len(extra_kwargs) > 0:
         raise UnsupportedFunctionCall(
             "numpy operations are not valid with groupby. "
             f"Use .groupby(...).{name}() instead"
@@ -368,7 +387,7 @@ _validation_funcs = {
 }
 
 
-def validate_func(fname, args, kwargs) -> None:
+def validate_func(fname: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
     if fname not in _validation_funcs:
         return validate_stat_func(args, kwargs, fname=fname)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -530,7 +530,6 @@ module = [
   "pandas._config.config", # TODO
   "pandas._libs.*",
   "pandas._testing.*", # TODO
-  "pandas.compat.numpy.function", # TODO
   "pandas.core._numba.executor", # TODO
   "pandas.core.array_algos.masked_reductions", # TODO
   "pandas.core.array_algos.replace", # TODO


### PR DESCRIPTION
## Summary

- Adds argument type annotations to the helpers in `pandas/compat/numpy/function.py` so mypy passes with default strictness.
- Removes `pandas.compat.numpy.function` from the mypy `disallow_untyped_defs`/`disallow_untyped_calls`/`disallow_incomplete_defs` exemption list.

## Test plan

- [x] `mypy` clean
- [x] `pyright` clean
- [x] pre-commit clean