### PR TITLE
DOC: clarify read_fwf filepath_or_buffer description (GH-55790)

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1523,16 +1523,19 @@ def read_fwf(
     Parameters
     ----------
     filepath_or_buffer : str, path object, or file-like object
-        String, path object (implementing ``os.PathLike[str]``), or file-like
-        object implementing a text ``read()`` function that accepts an optional
-        size argument. The string could be a URL.
-        Valid URL schemes include http, ftp, s3, and file. For file URLs, a host is
-        expected. A local file could be:
-        ``file://localhost/path/to/table.csv``.
+        Any valid string path is acceptable. The string could be a URL. Valid
+        URL schemes include http, ftp, s3, and file. For file URLs, a host is
+        expected. A local file could be: ``file://localhost/path/to/table.csv``.
 
         Certain URL schemes may require additional packages. For example, S3
         URLs require the ``s3fs`` library. See
         :ref:`install.optional_dependencies` for a full list.
+
+        If you want to pass in a path object, pandas accepts any ``os.PathLike``.
+
+        By file-like object, we refer to objects with a ``read()`` method that
+        accepts an optional size argument, such as a file handle (e.g. via
+        builtin ``open`` function) or ``StringIO``.
     colspecs : list of tuple (int, int) or 'infer'. optional
         A list of tuples giving the extents of the fixed-width
         fields of each line as half-open intervals (i.e.,  [from, to] ).


### PR DESCRIPTION
- closes #55790

## Summary

The reporter of GH-55790 read the `str` in `read_fwf`'s `filepath_or_buffer` type as if it could be the file's raw text content and asked for `str` to be removed. `read_fwf` does accept a string path (just like `read_csv`), so removing it would be wrong — but the existing wording (`"String, path object..."`) is terser and less explicit than `read_csv`'s.

This aligns `read_fwf`'s description with `read_csv` / `read_table`: explicitly says "Any valid string path is acceptable" and breaks out the path-object and file-like-object explanations into their own paragraphs.

## Test plan
- [x] pre-commit hooks pass
- [ ] doc preview renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)