### PR TITLE
DOC: fix relativedelta link in DateOffset See Also

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -761,6 +761,7 @@ latex_documents = [
 
 if include_api:
     intersphinx_mapping = {
+        "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
         "matplotlib": ("https://matplotlib.org/stable/", None),
         "numpy": ("https://numpy.org/doc/stable/", None),
         "python": ("https://docs.python.org/3/", None),


### PR DESCRIPTION
## Summary

- Add `dateutil` to `intersphinx_mapping` in `doc/source/conf.py` so the `dateutil.relativedelta.relativedelta` cross-reference in the `DateOffset` See Also block resolves to dateutil's own docs.
- Without this, intersphinx falls back to matplotlib's `matplotlib.dates.relativedelta` re-export — confirmed against the live dev docs, where the link points to `https://matplotlib.org/stable/api/dates_api.html#matplotlib.dates.relativedelta`.

closes #52650

## Test plan

- [ ] `objects.inv` at `https://dateutil.readthedocs.io/en/stable/` registers `dateutil.relativedelta.relativedelta` as `py:class` (verified)
- [ ] Local doc build resolves the See Also link to dateutil instead of matplotlib

🤖 Generated with [Claude Code](https://claude.com/claude-code)