### PR TITLE
TYP: enable mypy checking for pandas.util._decorators

### DIFF
--- a/pandas/tests/io/parser/test_quoting.py
+++ b/pandas/tests/io/parser/test_quoting.py
@@ -64,7 +64,7 @@ def test_bad_quoting(all_parsers, quoting, msg):
     if parser.engine == "pyarrow":
         # pyarrow rejects ``quoting`` outright before any value validation.
         msg = "The 'quoting' option is not supported with the 'pyarrow' engine"
-        err: type[Exception] = ValueError
+        err = ValueError
     else:
         err = TypeError
     with pytest.raises(err, match=msg):

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Any,
+    cast,
 )
 import warnings
 
@@ -484,6 +485,6 @@ def set_module(module: str | None) -> Callable[[F], F]:
                     pass
 
             func.__module__ = module
-        return func
+        return cast("F", func)  # type: ignore[redundant-cast]
 
     return decorator

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -6,7 +6,6 @@ from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Any,
-    cast,
 )
 import warnings
 
@@ -21,6 +20,7 @@ if TYPE_CHECKING:
 
     from pandas._typing import (
         F,
+        P,
         T,
     )
     from pandas.errors import PandasChangeWarning
@@ -29,12 +29,12 @@ if TYPE_CHECKING:
 def deprecate(
     klass: type[Warning],
     name: str,
-    alternative: Callable[..., Any],
+    alternative: Callable[P, T],
     version: str,
     alt_name: str | None = None,
     stacklevel: int = 2,
     msg: str | None = None,
-) -> Callable[[F], F]:
+) -> Callable[P, T]:
     """
     Return a new function that emits a deprecation warning on use.
 
@@ -65,7 +65,7 @@ def deprecate(
     warning_msg = msg or f"{name} is deprecated, use {alt_name} instead."
 
     @wraps(alternative)
-    def wrapper(*args, **kwargs) -> Callable[..., Any]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         warnings.warn(warning_msg, klass, stacklevel=stacklevel)
         return alternative(*args, **kwargs)
 
@@ -96,9 +96,7 @@ def deprecate(
 
         {dedent(doc_string)}"""
         )
-    # error: Incompatible return value type (got "Callable[[VarArg(Any), KwArg(Any)],
-    # Callable[...,Any]]", expected "Callable[[F], F]")
-    return wrapper  # type: ignore[return-value]
+    return wrapper
 
 
 def deprecate_kwarg(
@@ -107,7 +105,7 @@ def deprecate_kwarg(
     new_arg_name: str | None,
     mapping: Mapping[Any, Any] | Callable[[Any], Any] | None = None,
     stacklevel: int = 2,
-) -> Callable[[F], F]:
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
     Decorator to deprecate a keyword argument of a function.
 
@@ -174,9 +172,9 @@ def deprecate_kwarg(
             "mapping from old to new argument values must be dict or callable!"
         )
 
-    def _deprecate_kwarg(func: F) -> F:
+    def _deprecate_kwarg(func: Callable[P, T]) -> Callable[P, T]:
         @wraps(func)
-        def wrapper(*args, **kwargs) -> Callable[..., Any]:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             __tracebackhide__ = True
 
             old_arg_value = kwargs.pop(old_arg_name, None)
@@ -219,7 +217,7 @@ def deprecate_kwarg(
                 kwargs[new_arg_name] = new_arg_value
             return func(*args, **kwargs)
 
-        return cast("F", wrapper)
+        return wrapper
 
     return _deprecate_kwarg
 
@@ -274,7 +272,7 @@ def deprecate_nonkeyword_arguments(
     klass: type[PandasChangeWarning],
     allowed_args: list[str] | None = None,
     name: str | None = None,
-) -> Callable[[F], F]:
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
     Decorator to deprecate a use of non-keyword arguments of a function.
 
@@ -294,7 +292,7 @@ def deprecate_nonkeyword_arguments(
         is used.
     """
 
-    def decorate(func):
+    def decorate(func: Callable[P, T]) -> Callable[P, T]:
         old_sig = inspect.signature(func)
 
         if allowed_args is not None:
@@ -326,7 +324,7 @@ def deprecate_nonkeyword_arguments(
         )
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             if len(args) > num_allow_args:
                 warnings.warn(
                     msg.format(arguments=_format_argument_list(allow_args)),
@@ -335,8 +333,7 @@ def deprecate_nonkeyword_arguments(
                 )
             return func(*args, **kwargs)
 
-        # error: "Callable[[VarArg(Any), KwArg(Any)], Any]" has no
-        # attribute "__signature__"
+        # error: "Callable[P, T]" has no attribute "__signature__"
         wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
         return wrapper
 
@@ -376,7 +373,7 @@ class Substitution:
         "%s %s wrote the Raven"
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         from pandas.errors import Pandas4Warning
 
         warnings.warn(
@@ -387,13 +384,13 @@ class Substitution:
         if args and kwargs:
             raise AssertionError("Only positional or keyword args are allowed")
 
-        self.params = args or kwargs
+        self.params: tuple[object, ...] | dict[str, object] = args or kwargs
 
     def __call__(self, func: F) -> F:
         func.__doc__ = func.__doc__ and func.__doc__ % self.params
         return func
 
-    def update(self, *args, **kwargs) -> None:
+    def update(self, *args: object, **kwargs: object) -> None:
         """
         Update self.params with supplied args.
         """
@@ -463,7 +460,7 @@ __all__ = [
 ]
 
 
-def set_module(module) -> Callable[[F], F]:
+def set_module(module: str | None) -> Callable[[F], F]:
     """Private decorator for overriding __module__ on a function or class.
 
     Example usage::
@@ -487,6 +484,6 @@ def set_module(module) -> Callable[[F], F]:
                     pass
 
             func.__module__ = module
-        return cast("F", func)  # type: ignore[redundant-cast]
+        return func
 
     return decorator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -618,7 +618,6 @@ module = [
   "pandas.tests.*",
   "pandas.tseries.frequencies", # TODO
   "pandas.tseries.holiday", # TODO
-  "pandas.util._decorators", # TODO
   "pandas.util._doctools", # TODO
   "pandas.util._validators", # TODO
   "pandas.util", # TODO


### PR DESCRIPTION
## Summary

- Removes `pandas.util._decorators` from the mypy `overrides` list so it's covered by the standard strict settings.
- Tightens annotations in `_decorators.py`: `deprecate`, `deprecate_kwarg`, and `deprecate_nonkeyword_arguments` now use `ParamSpec` (`P` from `pandas._typing`) + `TypeVar` so the wrapped function's signature flows through to callers, instead of being erased to `Callable[..., Any]`. Two pre-existing `# type: ignore[return-value]` / `cast("F", ...)` workarounds become unnecessary and are removed. Also fixes the genuinely-wrong return type on `deprecate` (it returned the wrapped function, but was annotated as `Callable[[F], F]` — i.e. as if it were a decorator).
- Drops an inert `err: type[Exception]` annotation in `pandas/tests/io/parser/test_quoting.py` that triggered an `[annotation-unchecked]` note (the file is in the `check_untyped_defs = false` override, so the annotation wasn't doing anything).

No user-visible behavior change; mypy + pyright both clean across the repo.

## Test plan

- [x] `mypy pandas` — clean across 1458 source files
- [x] `pyright` (full repo, basic mode) — 0 errors / 0 warnings / 0 informations
- [x] `pre-commit run` on all touched files
- [x] `pytest pandas/tests/util/test_deprecate.py pandas/tests/util/test_deprecate_kwarg.py pandas/tests/util/test_deprecate_nonkeyword_arguments.py pandas/tests/io/parser/test_quoting.py::test_bad_quoting` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)