### PR TITLE
TYP: annotate pandas/_config/config.py

### DIFF
--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -192,7 +192,7 @@ def get_option(pat: str) -> Any:
     return root[k]
 
 
-def set_option(*args) -> None:
+def set_option(*args: Any) -> None:
     """
     Set the value of the specified option or options.
 
@@ -285,7 +285,7 @@ def set_option(*args) -> None:
         root, k_root = _get_root(key)
         root[k_root] = v
 
-        if opt.cb:
+        if opt is not None and opt.cb:
             opt.cb(key)
 
 
@@ -399,9 +399,11 @@ def reset_option(pat: str) -> None:
         set_option(k, _registered_options[k].defval)
 
 
-def get_default_val(pat: str):
+def get_default_val(pat: str) -> Any:
     key = _get_single_key(pat)
-    return _get_registered_option(key).defval
+    opt = _get_registered_option(key)
+    assert opt is not None
+    return opt.defval
 
 
 class DictWrapper:
@@ -425,7 +427,7 @@ class DictWrapper:
         else:
             raise OptionError("You can only set the value of existing options")
 
-    def __getattr__(self, key: str):
+    def __getattr__(self, key: str) -> Any:
         prefix = object.__getattribute__(self, "prefix")
         if prefix:
             prefix += "."
@@ -452,7 +454,7 @@ object.__setattr__(options, "__module__", "pandas")
 
 
 @contextmanager
-def option_context(*args) -> Generator[None]:
+def option_context(*args: Any) -> Generator[None]:
     """
     Context manager to temporarily set options in a ``with`` statement.
 
@@ -674,7 +676,7 @@ def _get_root(key: str) -> tuple[dict[str, Any], str]:
     return cursor, path[-1]
 
 
-def _get_deprecated_option(key: str):
+def _get_deprecated_option(key: str) -> DeprecatedOption | None:
     """
     Retrieves the metadata for a deprecated option, if `key` is deprecated.
 
@@ -690,7 +692,7 @@ def _get_deprecated_option(key: str):
         return d
 
 
-def _get_registered_option(key: str):
+def _get_registered_option(key: str) -> RegisteredOption | None:
     """
     Retrieves the option metadata if `key` is a registered option.
 
@@ -751,6 +753,7 @@ def _build_option_description(k: str) -> str:
     """Builds a formatted description of a registered option and prints it"""
     o = _get_registered_option(k)
     d = _get_deprecated_option(k)
+    assert o is not None
 
     s = f"{k} "
 
@@ -808,7 +811,7 @@ def config_prefix(prefix: str) -> Generator[None]:
     global register_option, get_option, set_option
 
     def wrap(func: F) -> F:
-        def inner(key: str, *args, **kwds):
+        def inner(key: str, *args: object, **kwds: object) -> object:
             pkey = f"{prefix}.{key}"
             return func(pkey, *args, **kwds)
 
@@ -846,7 +849,7 @@ def is_type_factory(_type: type[Any]) -> Callable[[Any], None]:
 
     """
 
-    def inner(x) -> None:
+    def inner(x: object) -> None:
         if type(x) != _type:
             raise ValueError(f"Value must have type '{_type}'")
 
@@ -871,7 +874,7 @@ def is_instance_factory(_type: type | tuple[type, ...]) -> Callable[[Any], None]
     else:
         type_repr = f"'{_type}'"
 
-    def inner(x) -> None:
+    def inner(x: object) -> None:
         if not isinstance(x, _type):
             raise ValueError(f"Value must be an instance of {type_repr}")
 
@@ -882,7 +885,7 @@ def is_one_of_factory(legal_values: Sequence) -> Callable[[Any], None]:
     callables = [c for c in legal_values if callable(c)]
     legal_values = [c for c in legal_values if not callable(c)]
 
-    def inner(x) -> None:
+    def inner(x: object) -> None:
         if x not in legal_values:
             if not any(c(x) for c in callables):
                 uvals = [str(lval) for lval in legal_values]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -527,7 +527,6 @@ show_error_codes = true
 
 [[tool.mypy.overrides]]
 module = [
-  "pandas._config.config", # TODO
   "pandas._libs.*",
   "pandas._testing.*", # TODO
   "pandas.compat.numpy.function", # TODO


### PR DESCRIPTION
## Summary

- Add the missing type annotations in `pandas/_config/config.py` and drop the module from the mypy `[[tool.mypy.overrides]]` list (the override disabled `disallow_untyped_defs/calls/incomplete_defs`).
- The diff is almost entirely annotations. Three substantive lines:
  - `set_option`: `if opt.cb:` → `if opt is not None and opt.cb:` (the validator branch above already guarded with `if opt and ...`; the `cb` branch did not).
  - `_build_option_description`: one-line `assert o is not None` so the existing `o.doc` access is type-safe (the function is only ever called with keys returned by `_select_options`, which filters to registered options).
  - `get_default_val`: same `assert opt is not None` pattern.
- Inner validators in `is_type_factory` / `is_instance_factory` / `is_one_of_factory` take `x: object`, matching `RegisteredOption.validator: Callable[[object], Any] | None`. `*args` for `set_option` / `option_context` stayed `Any` because the alternating `(str, value, ...)` contract isn't expressible without overloads.

## Test plan

- [x] `mypy pandas/` clean (1458 files)
- [x] `pyright pandas/_config/` clean
- [x] `pre-commit run --files pandas/_config/config.py pyproject.toml`
- [x] `pytest pandas/tests/config/` (55 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)