### PR TITLE
Improve KeyError message in DataFrame indexingImprove keyerror message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ doc/source/savefig/
 # Pyodide/WASM related files #
 ##############################
 /.pyodide-xbuildenv-*
+pandas-dev/

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4257,7 +4257,13 @@ class DataFrame(NDFrame, OpsMixin):
         if is_single_key:
             if self.columns.nlevels > 1:
                 return self._getitem_multilevel(key)
-            indexer = self.columns.get_loc(key)
+            try:
+                indexer = self.columns.get_loc(key)
+            except KeyError:
+                raise KeyError(
+                        f"Column '{key}' not found in DataFrame. "
+                        f"Available columns: {list(self.columns)}"
+                    )
             if is_integer(indexer):
                 indexer = [indexer]  # type: ignore[assignment]
         else:

--- a/pandas/tests/frame/indexing/test_getitem.py
+++ b/pandas/tests/frame/indexing/test_getitem.py
@@ -177,6 +177,14 @@ class TestGetitemListLike:
         with pytest.raises(KeyError, match=r"\['y'\] not in index"):
             df[["x", "y", "z"]]
 
+    def test_getitem_missing_column_error_message(self):
+        df = DataFrame({"Name": ["Pradip"]})
+
+        with pytest.raises(KeyError) as exc:
+            df["Age"]
+
+        assert "Age" in str(exc.value)
+
     def test_getitem_list_duplicates(self):
         # GH#1943
         df = DataFrame(


### PR DESCRIPTION
closes #65553
- This PR improves the KeyError message raised when accessing missing columns in DataFrame indexing.

The goal is to make the error clearer and more helpful for debugging missing keys.

Changes:
- Improved KeyError message in pandas/core/frame.py
- Updated test coverage in test_getitem.py
- Added minor cleanup in gitignore (local environment ignored)

This improves developer experience when working with DataFrames.  closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
