### PR TITLE
TYP: fix frame apply reduction typing

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -844,73 +844,13 @@ class NDFrameApply(Apply):
         if getattr(obj, "axis", 0) == 1:
             raise NotImplementedError("axis other than 0 is not supported")
 
-        if op_name == "agg" and obj.ndim == 2:
+        if op_name == "agg" and isinstance(self, FrameApply):
             result = self._agg_list_like_frame_reductions()
             if result is not None:
                 return result
 
         keys, results = self.compute_list_like(op_name, obj, kwargs)
         result = self.wrap_results_list_like(keys, results)
-        return result
-
-    def _agg_list_like_frame_reductions(self) -> DataFrame | None:
-        """
-        Aggregate a list of named functions using DataFrame-level reductions.
-
-        Instead of extracting each column as a Series and calling
-        Series.agg per column, call DataFrame-level reductions directly.
-        Operates per dtype group to preserve per-column dtypes.
-
-        Returns None if the fast path cannot be used (e.g. non-string
-        functions, functions that aren't valid DataFrame methods, or
-        functions that don't return a reduction result).
-        """
-        func = cast("list[AggFuncTypeBase]", self.func)
-
-        if not all(isinstance(f, str) for f in func):
-            return None
-
-        # Caller restricts this path to ndim == 2 (DataFrame); narrow for mypy.
-        obj = cast("DataFrame", self.obj)
-        func_names = cast("list[str]", func)
-
-        # Cannot reindex with duplicate column names
-        if not obj.columns.is_unique:
-            return None
-
-        for func_name in func_names:
-            if not hasattr(obj, func_name):
-                return None
-
-        if self.kwargs.get("numeric_only"):
-            obj = obj._get_numeric_data()
-        elif self.kwargs.get("bool_only"):
-            obj = obj._get_bool_data()
-
-        if obj.columns.empty:
-            return obj._constructor(index=func_names, columns=obj.columns)
-
-        # Compute reductions per dtype group to preserve per-column dtypes.
-        groups = obj.columns.groupby(obj.dtypes)
-        pieces = []
-        for dtype in groups:
-            cols = groups[dtype]
-            sub = obj[cols]
-            group_pieces = []
-            for func_name in func_names:
-                try:
-                    row = getattr(sub, func_name)(*self.args, **self.kwargs)
-                except TypeError:
-                    return None
-                if not isinstance(row, ABCSeries):
-                    # Not a reduction (e.g. returns DataFrame), fall back
-                    return None
-                # to_frame().T avoids the slow DataFrame(list-of-Series) path
-                group_pieces.append(row.to_frame(func_name).T)
-            pieces.append(concat(group_pieces))
-
-        result = concat(pieces, axis=1)
-        result = result.reindex(columns=obj.columns)
         return result
 
     def agg_or_apply_dict_like(
@@ -1104,6 +1044,65 @@ class FrameApply(NDFrameApply):
         if result is None:
             result = self.obj.apply(self.func, axis, args=self.args, **self.kwargs)
 
+        return result
+
+    def _agg_list_like_frame_reductions(self) -> DataFrame | None:
+        """
+        Aggregate a list of named functions using DataFrame-level reductions.
+
+        Instead of extracting each column as a Series and calling
+        Series.agg per column, call DataFrame-level reductions directly.
+        Operates per dtype group to preserve per-column dtypes.
+
+        Returns None if the fast path cannot be used (e.g. non-string
+        functions, functions that aren't valid DataFrame methods, or
+        functions that don't return a reduction result).
+        """
+        func = cast("list[AggFuncTypeBase]", self.func)
+
+        if not all(isinstance(f, str) for f in func):
+            return None
+
+        obj = self.obj
+        func_names = cast("list[str]", func)
+
+        # Cannot reindex with duplicate column names
+        if not obj.columns.is_unique:
+            return None
+
+        for func_name in func_names:
+            if not hasattr(obj, func_name):
+                return None
+
+        if self.kwargs.get("numeric_only"):
+            obj = obj._get_numeric_data()
+        elif self.kwargs.get("bool_only"):
+            obj = obj._get_bool_data()
+
+        if obj.columns.empty:
+            return obj._constructor(index=func_names, columns=obj.columns)
+
+        # Compute reductions per dtype group to preserve per-column dtypes.
+        groups = obj.columns.groupby(obj.dtypes)
+        pieces: list[DataFrame] = []
+        for dtype in groups:
+            cols = groups[dtype]
+            sub = obj[cols]
+            group_pieces: list[DataFrame] = []
+            for func_name in func_names:
+                try:
+                    row = getattr(sub, func_name)(*self.args, **self.kwargs)
+                except TypeError:
+                    return None
+                if not isinstance(row, ABCSeries):
+                    # Not a reduction (e.g. returns DataFrame), fall back
+                    return None
+                # to_frame().T avoids the slow DataFrame(list-of-Series) path
+                group_pieces.append(row.to_frame(func_name).T)
+            pieces.append(concat(group_pieces))
+
+        result = concat(pieces, axis=1)
+        result = result.reindex(columns=obj.columns)
         return result
 
     def apply_empty_result(self):


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Split out from review feedback on #65428.

This narrows `NDFrameApply._agg_list_like_frame_reductions` to `FrameApply` before using the DataFrame-only fast path, and removes the now-redundant `DataFrame` cast. This is a typing-only cleanup with no intended behavior change.

Validation:

- `python -m pytest pandas/tests/apply/test_frame_apply.py -k "agg_multiple_mixed"` passed.

