### PR TITLE
TST: add test for kendall correlation with duplicates

### DIFF
--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -252,6 +252,30 @@ class TestDataFrameCorr:
             with pytest.raises(ValueError, match="could not convert string to float"):
                 df.corr(meth, numeric_only=numeric_only)
 
+    @pytest.mark.parametrize("method", ["kendall", "spearman"])
+    def test_rank_corr_with_duplicates(self, method):
+        # GH#43401
+        st = pytest.importorskip("scipy.stats")
+        rng = np.random.default_rng(2)
+
+        data = {
+            "A": rng.integers(0, 5, 20),
+            "B": rng.integers(0, 5, 20),
+        }
+        df = DataFrame(data)
+        result = df.corr(method=method)
+
+        comparison_method = st.kendalltau if method == "kendall" else st.spearmanr
+        expected_val = comparison_method(df["A"], df["B"])[0]
+
+        expected = DataFrame(
+            {"A": [1.0, expected_val], "B": [expected_val, 1.0]},
+            index=["A", "B"],
+            columns=["A", "B"],
+        )
+
+        tm.assert_frame_equal(result, expected)
+
 
 class TestDataFrameCorrWith:
     @pytest.mark.parametrize(
@@ -493,27 +517,3 @@ class TestDataFrameCorrWith:
         result2 = df.dropna().cov()
         tm.assert_frame_equal(result1, expected)
         tm.assert_frame_equal(result2, expected)
-
-    @pytest.mark.parametrize("method", ["kendall", "spearman"])
-    def test_rank_corr_with_duplicates(self, method):
-        # GH#43401
-        st = pytest.importorskip("scipy.stats")
-        rng = np.random.default_rng(2)
-
-        data = {
-            "A": rng.integers(0, 5, 20),
-            "B": rng.integers(0, 5, 20),
-        }
-        df = DataFrame(data)
-        result = df.corr(method=method)
-
-        comparison_method = st.kendalltau if method == "kendall" else st.spearmanr
-        expected_val = comparison_method(df["A"], df["B"])[0]
-
-        expected = DataFrame(
-            {"A": [1.0, expected_val], "B": [expected_val, 1.0]},
-            index=["A", "B"],
-            columns=["A", "B"],
-        )
-
-        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -493,3 +493,27 @@ class TestDataFrameCorrWith:
         result2 = df.dropna().cov()
         tm.assert_frame_equal(result1, expected)
         tm.assert_frame_equal(result2, expected)
+
+    @pytest.mark.parametrize("method", ["kendall", "spearman"])
+    def test_rank_corr_with_duplicates(self, method):
+        # GH#43401
+        st = pytest.importorskip("scipy.stats")
+        rng = np.random.default_rng(2)
+
+        data = {
+            "A": rng.integers(0, 5, 20),
+            "B": rng.integers(0, 5, 20),
+        }
+        df = DataFrame(data)
+        result = df.corr(method=method)
+
+        comparison_method = st.kendalltau if method == "kendall" else st.spearmanr
+        expected_val = comparison_method(df["A"], df["B"])[0]
+
+        expected = DataFrame(
+            {"A": [1.0, expected_val], "B": [expected_val, 1.0]},
+            index=["A", "B"],
+            columns=["A", "B"],
+        )
+
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] xref #43401 (Replace xxxx with the GitHub issue number)
- [x] xref #28329

---

Kendall correlation with ties doesn't seem to be covered.

```console
$ git cherry-pick 57ccd2 --no-commit
$ git restore --theirs
$ pytest -k kendall
pandas/tests/frame/methods/test_cov_corr.py .............F
pandas/tests/test_nanops.py .

========================================================================================== FAILURES ===========================================================================================
________________________________________________________________ TestDataFrameCorrWith.test_rank_corr_with_duplicates[kendall] ________________________________________________________________

...
pandas/tests/frame/methods/test_cov_corr.py:519: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pandas/_libs/testing.pyx:53: in pandas._libs.testing.assert_almost_equal
    cpdef assert_almost_equal(a, b,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   raise_assert_detail(
E   AssertionError: DataFrame.iloc[:, 0] (column name="A") are different
E   
E   DataFrame.iloc[:, 0] (column name="A") values are different (50.0 %)
E   [index]: [A, B]
E   [left]:  [1.0, -0.147368]
E   [right]: [1.0, -0.006329]
E   At positional index 1, first diff: -0.14736842105263157 != -0.006329113924050632
```