### PR TITLE
DOC: Quote identifiers in psql_insert_copy user-guide example (#53942)

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5819,10 +5819,13 @@ Example of a callable using PostgreSQL `COPY clause
           s_buf.seek(0)
 
           columns = ', '.join(['"{}"'.format(k) for k in keys])
+          # Quote the schema and table identifiers so PostgreSQL preserves
+          # the original casing (unquoted identifiers are folded to lower
+          # case, which breaks COPY against capitalized names).
           if table.schema:
-              table_name = '{}.{}'.format(table.schema, table.name)
+              table_name = '"{}"."{}"'.format(table.schema, table.name)
           else:
-              table_name = table.name
+              table_name = '"{}"'.format(table.name)
 
           sql = 'COPY {} ({}) FROM STDIN WITH CSV'.format(
               table_name, columns)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -389,6 +389,7 @@ Other
 ^^^^^
 
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
+- Updated the ``psql_insert_copy`` user-guide example to quote the schema and table identifiers, so the snippet works against PostgreSQL tables with capitalized names (:issue:`53942`)
 
 .. ***DO NOT USE THIS SECTION***
 


### PR DESCRIPTION
- [x] closes #53942
- [x] Tests added and passed — N/A (user-guide example only; the snippet itself isn't part of the test suite)
- [x] All code checks passed (`.rst` syntax preserved; identical bracket count, indentation matches the surrounding fenced block)
- [x] Added type annotations — N/A
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file (Other section)
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Summary

The `psql_insert_copy` example in `doc/source/user_guide/io.rst`
(SQL > "Insertion method") builds a `COPY <table> ...` SQL statement
but does not quote the schema/table identifiers. PostgreSQL folds
unquoted identifiers to lower case (see [SQL Identifiers and Key Words](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)),
so the snippet fails for tables created with capitalized or mixed-case
names (the original report in #53942).

The same example **already** double-quotes its column-name identifiers
on the line immediately above the fix:

```python
columns = ', '.join(['"{}"'.format(k) for k in keys])
```

so quoting the schema/table is the consistent and minimal change.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# One-time setup (no build required — .rst-only change)
cd /tmp && rm -rf repro && git clone https://github.com/jbbqqf/pandas.git repro
cd /tmp/repro

# BEFORE (origin/main): unquoted table identifier
git checkout origin/main -- doc/source/user_guide/io.rst
grep -n "table_name = " doc/source/user_guide/io.rst
# Expected:
#   table_name = '{}.{}'.format(table.schema, table.name)
#   table_name = table.name

# AFTER (fix branch): quoted table identifier
git checkout feat/53942-psql-insert-copy-quote-identifiers -- doc/source/user_guide/io.rst
grep -n "table_name = " doc/source/user_guide/io.rst
# Expected:
#   table_name = '"{}"."{}"'.format(table.schema, table.name)
#   table_name = '"{}"'.format(table.name)

# Behavioral verification (with Postgres + pandas in any env): the
# BEFORE recipe raises something like
#   psycopg.errors.UndefinedTable: relation "myschema.mytable" does not exist
# whereas the AFTER recipe runs cleanly against a table created as
#   CREATE TABLE "MySchema"."MyTable" (...);
# (a live-DB demonstration is out of scope for this docs-only PR; the
# claim follows directly from PostgreSQL's documented identifier-folding
# behaviour cited in the Summary above)
```

## What I ran locally

| Check | Result |
|---|---|
| `.rst` indentation matches surrounding `::` fenced block | OK |
| `python -c "table_name = '\"{}\".\"{}\"'.format('MySchema', 'MyTable'); print(table_name)"` | `"MySchema"."MyTable"` (legal PostgreSQL) |
| Manual diff of the two lines vs the existing column-quoting line | Now consistent |

## Edge cases addressed

| Scenario | BEFORE | AFTER |
|---|---|---|
| Table `mytable`, no schema | `mytable` (works — already lowercase) | `"mytable"` (still works; explicit quoting is a no-op for lower-case names) |
| Table `MyTable`, no schema | `MyTable` → folded to `mytable` → `UndefinedTable` | `"MyTable"` → matches as-created |
| Schema `MySchema`, table `MyTable` | `MySchema.MyTable` → folded → `UndefinedTable` | `"MySchema"."MyTable"` → matches |
| Schema/table containing characters that would normally need quoting (e.g. starting digit, hyphens) | Fails | Works — quoting handles all valid SQL identifiers |

## AI assistance disclosure

This pull request was prepared with assistance from an AI coding agent
(Claude). The agent was prompted to follow `AGENTS.md` and the linked
`contributing_codebase.rst` / `contributing_documentation.rst` guidelines.
Every change was reviewed by the human author before submission.
