### PR TITLE
DOC: document infer_nrows=np.inf for read_fwf (GH-21970)

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1281,6 +1281,16 @@ is whitespace).
    df = pd.read_fwf("bar.csv", header=None, index_col=0)
    df
 
+The number of rows used for inference is controlled by the ``infer_nrows``
+parameter. If a column contains values wider than anything appearing in the
+first ``infer_nrows`` rows, those values may be truncated. To infer column
+specifications from the entire file, pass ``infer_nrows=np.inf``:
+
+.. ipython:: python
+
+   df = pd.read_fwf("bar.csv", header=None, index_col=0, infer_nrows=np.inf)
+   df
+
 ``read_fwf`` supports the ``dtype`` parameter for specifying the types of
 parsed columns to be different from the inferred type.
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1547,7 +1547,10 @@ def read_fwf(
         the intervals are contiguous.
     infer_nrows : int, default 100
         The number of rows to consider when letting the parser determine the
-        `colspecs`.
+        ``colspecs``. Pass ``np.inf`` to infer column specifications from the
+        entire file, which is useful when columns vary in width and a value
+        wider than anything in the first ``infer_nrows`` rows would otherwise
+        be truncated.
     iterator : bool, default False
         Return ``TextFileReader`` object for iteration or getting chunks with
         ``get_chunk()``.


### PR DESCRIPTION
## Summary

- Extend the ``infer_nrows`` docstring in ``read_fwf`` to mention that ``np.inf`` infers column specifications from the entire file, avoiding truncation when columns vary in width.
- Add a paragraph + ``ipython`` example to the IO user guide describing the same.

Closes #21970 by documenting the existing escape hatch the issue thread converged on, without changing default behavior.

## Test plan

- [x] Verified locally that ``read_fwf(..., infer_nrows=np.inf)`` reads the full file and picks up wider trailing values that the default ``infer_nrows=100`` would truncate.
- [x] ``pre-commit`` (including Sphinx Lint) passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)