### PR TITLE
DOC: warn raw=True ndarray lacks .iloc/.index in Rolling/Expanding.apply (GH-38809)

### DIFF
--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -276,6 +276,9 @@ class Expanding(RollingAndExpandingMixin):
             * ``False`` : passes each row or column as a Series to the
               function.
             * ``True`` : the passed function will receive ndarray objects instead.
+              Pandas-only attributes such as ``.iloc`` or ``.index`` are not
+              available on ndarrays and will raise ``AttributeError`` if used
+              inside ``func``.
 
             If you are just applying a NumPy reduction function this will
             achieve much better performance.

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2213,7 +2213,9 @@ class Rolling(RollingAndExpandingMixin):
             * ``False`` : passes each row or column as a Series to the
               function.
             * ``True`` : the passed function will receive ndarray
-              objects instead.
+              objects instead. Pandas-only attributes such as ``.iloc``
+              or ``.index`` are not available on ndarrays and will raise
+              ``AttributeError`` if used inside ``func``.
 
             If you are just applying a NumPy reduction function this will
             achieve much better performance.


### PR DESCRIPTION
## Summary
- Adds a one-line note to the `raw` parameter of `Rolling.apply` and `Expanding.apply` clarifying that pandas-only attributes (`.iloc`, `.index`, etc.) are unavailable on the ndarray passed under `raw=True` and will raise `AttributeError`.
- Addresses the documentation lean from GH-38809: numpy's `AttributeError` is reasonably clear once you know what's happening, but the docstring didn't previously warn about the failure mode.

closes #38809

## Test plan
- [x] Pre-commit hooks pass.
- No behavior change, no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)