### PR TITLE
DOC: document compiled regex with flags in replace (GH-32233)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7514,7 +7514,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Whether to interpret `to_replace` and/or `value` as regular
             expressions. Alternatively, this could be a regular expression or a
             list, dict, or array of regular expressions in which case
-            `to_replace` must be ``None``.
+            `to_replace` must be ``None``. Patterns may be passed either as
+            strings or as compiled regex objects (``re.compile(...)``); use a
+            compiled object when you need to set flags such as ``re.IGNORECASE``,
+            since ``replace`` does not accept a separate ``flags`` argument.
 
         Returns
         -------
@@ -7675,6 +7678,18 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         0   new  abc
         1   new  new
         2  bait  xyz
+
+        To match case-insensitively (or apply any other ``re`` flag), pass a
+        compiled regex object. ``replace`` does not take a separate ``flags``
+        argument, so the flags must be baked into the compiled pattern:
+
+        >>> import re
+        >>> df = pd.DataFrame({"A": ["Foo", "FOO", "bar"], "B": ["foo", "Bar", "BAR"]})
+        >>> df.replace(re.compile(r"foo", flags=re.IGNORECASE), "new", regex=True)
+             A    B
+        0  new  new
+        1  new  Bar
+        2  bar  BAR
 
         Compare the behavior of ``s.replace({'a': None})`` and
         ``s.replace('a', None)`` to understand the peculiarities


### PR DESCRIPTION
## Summary

- Note in the `regex` parameter description that compiled `re.Pattern` objects are accepted, and that this is how to set flags such as `re.IGNORECASE` (since `replace` has no `flags=` argument).
- Add a short worked example demonstrating case-insensitive replacement with `re.compile(..., flags=re.IGNORECASE)`.

Closes #32233 documentation-side. Behavior is unchanged.

## Test plan

- [x] `pytest --doctest-modules pandas/core/generic.py::pandas.core.generic.NDFrame.replace` passes
- [x] `pre-commit run --files pandas/core/generic.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)