### PR TITLE
CLN: drop removed .bool() from __bool__ ambiguous-truth message (GH-61417)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1502,7 +1502,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     def __bool__(self) -> NoReturn:
         raise ValueError(
             f"The truth value of a {type(self).__name__} is ambiguous. "
-            "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+            "Use a.empty, a.item(), a.any() or a.all()."
         )
 
     @final

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3074,7 +3074,7 @@ class Index(IndexOpsMixin, PandasObject):
     def __bool__(self) -> NoReturn:
         raise ValueError(
             f"The truth value of a {type(self).__name__} is ambiguous. "
-            "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+            "Use a.empty, a.item(), a.any() or a.all()."
         )
 
     # --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The `__bool__` ValueError on Series/DataFrame/Index suggested `a.bool()` as a workaround, but `.bool()` was removed in pandas 2.1. Drop it from the message.

closes #61417

## Test plan
- [x] Existing tests in `pandas/tests/generic/`, `pandas/tests/indexes/test_any_index.py`, and `pandas/tests/frame/test_arithmetic.py` only match the `"The truth value of a"` prefix and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)