### PR TITLE
BUG: support PeriodDtype values in HDFStore (GH-41978)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -327,6 +327,7 @@ I/O
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
+- :meth:`HDFStore.put` and :meth:`HDFStore.append` now support storing :class:`Series` and :class:`DataFrame` columns with :class:`PeriodDtype` in both ``"fixed"`` and ``"table"`` formats (:issue:`41978`)
 - Bug in :meth:`DataFrame.__repr__` raising ``TypeError`` for a column with a NumPy structured dtype (e.g. produced by :meth:`DataFrame.from_records` from a structured ``ndarray``) (:issue:`55011`)
 - Bug in :meth:`DataFrame.__repr__` where horizontally truncated output could exceed the terminal width by up to 4 characters (:issue:`32461`)
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2823,6 +2823,13 @@ class DataCol(IndexCol):
                 converted = np.asarray(converted, dtype="m8[ns]")
             else:
                 converted = np.asarray(converted, dtype=dtype)
+        elif dtype.startswith("period"):
+            # GH#41978 PeriodArray values are stored as i8 ordinals; the
+            # PyTables atom has shape (1,) per row, so ravel before wrapping.
+            pdtype = PeriodDtype.construct_from_string(dtype)
+            converted = PeriodArray._simple_new(
+                np.asarray(converted, dtype="i8").ravel(), dtype=pdtype
+            )
         elif dtype == "date":
             try:
                 converted = np.asarray(
@@ -3215,6 +3222,10 @@ class GenericFixed(Fixed):
                 else:
                     ret = np.asarray(ret, dtype=dtype)
 
+            elif dtype and dtype.startswith("period"):
+                pdtype = PeriodDtype.construct_from_string(dtype)
+                ret = PeriodArray._simple_new(np.asarray(ret, dtype="i8"), dtype=pdtype)
+
         if transposed:
             return ret.T
         else:
@@ -3462,6 +3473,16 @@ class GenericFixed(Fixed):
             elif lib.is_np_dtype(value.dtype, "m"):
                 self._handle.create_array(self.group, key, value.view("i8"))
                 getattr(self.group, key)._v_attrs.value_type = str(value.dtype)
+            elif isinstance(value.dtype, PeriodDtype):
+                # GH#41978 store PeriodArray as i8 ordinals + freq attr
+                # error: "ExtensionArray" has no attribute "asi8"
+                self._handle.create_array(
+                    self.group,
+                    key,
+                    value.asi8,  # type: ignore[attr-defined]
+                )
+                node = getattr(self.group, key)
+                node._v_attrs.value_type = str(value.dtype)
             elif empty_array:
                 self.write_array_empty(key, value)
             else:
@@ -5592,7 +5613,7 @@ def _get_data_and_dtype_name(data: ArrayLike):
         # TODO: we used to reshape for the dt64tz case, but no longer
         #  doing that doesn't seem to break anything.  why?
 
-    elif isinstance(data, PeriodIndex):
+    elif isinstance(data, (PeriodIndex, PeriodArray)):
         data = data.asi8
 
     data = np.asarray(data)

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -407,3 +407,45 @@ def test_store_periodindex(temp_h5_path, format):
     df.to_hdf(temp_h5_path, key="df", mode="w", format=format)
     expected = pd.read_hdf(temp_h5_path, "df")
     tm.assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize("format", ["fixed", "table"])
+def test_store_period_values_series(temp_hdfstore, format):
+    # GH#41978 storing a Series whose values are a PeriodArray
+    series = Series(
+        pd.period_range("2020-01", periods=12, freq="M"),
+        name="p",
+    )
+    temp_hdfstore.put("s", series, format=format, track_times=False)
+    result = temp_hdfstore.select("s")
+    tm.assert_series_equal(result, series)
+
+
+@pytest.mark.parametrize("format", ["fixed", "table"])
+def test_store_period_values_with_nat(temp_hdfstore, format):
+    # GH#41978 NaT round-trips for PeriodArray values
+    arr = pd.array(["2020-01", "NaT", "2020-03"], dtype="period[M]")
+    series = Series(arr, name="p")
+    temp_hdfstore.put("s", series, format=format, track_times=False)
+    result = temp_hdfstore.select("s")
+    tm.assert_series_equal(result, series)
+
+
+@pytest.mark.parametrize("format", ["fixed", "table"])
+def test_store_period_values_dataframe_mixed_freq(temp_hdfstore, format):
+    # GH#41978 multiple Period columns with different freqs
+    pi = pd.period_range("2020-01", periods=6, freq="M")
+    df = DataFrame({"a": pi, "b": pi.asfreq("D")})
+    temp_hdfstore.put("df", df, format=format, track_times=False)
+    result = temp_hdfstore.select("df")
+    tm.assert_frame_equal(result, df)
+
+
+def test_append_period_values_table(temp_hdfstore):
+    # GH#41978 appending PeriodArray-valued frames to table format
+    series = Series(pd.period_range("2020-01", periods=4, freq="M"), name="p")
+    temp_hdfstore.append("s", series, format="table")
+    temp_hdfstore.append("s", series, format="table")
+    result = temp_hdfstore.select("s")
+    expected = concat([series, series], ignore_index=True)
+    tm.assert_series_equal(result.reset_index(drop=True), expected)


### PR DESCRIPTION
## Summary
Closes #41978
- Closes the secondary part of GH-41978: storing a Series/DataFrame with ``PeriodDtype`` *values* (not just a ``PeriodIndex``) now round-trips through both ``format=\"fixed\"`` and ``format=\"table\"``.
- Previously the table-format write raised ``TypeError: int() argument ... not 'Period'`` from ``write_data_chunk``, and fixed-format raised a PyTables ``TypeError: objects of type 'PeriodArray' are not supported``.
- ``_get_data_and_dtype_name`` now converts ``PeriodArray`` (not just ``PeriodIndex``) to its i8 ordinal storage form. ``DataCol.convert`` and ``GenericFixed.read_array`` reconstruct ``PeriodArray`` via ``_simple_new`` from the i8 ordinals plus the stored ``period[freq]`` dtype string. ``GenericFixed.write_array`` gained a ``PeriodDtype`` branch mirroring ``DatetimeTZDtype``.

The original part of GH-41978 (table-format ``PeriodIndex`` deserialization returning ``Int64Index``) was already fixed by GH-44314 in 2021; this PR handles the leftover values-side issue raised in the same ticket.

## Test plan

- [x] New tests in ``pandas/tests/io/pytables/test_put.py`` covering both formats: Series with ``PeriodArray`` values, Series with ``NaT``, DataFrame with mixed-freq period columns, and ``HDFStore.append`` round-trip on table format
- [x] Existing pytables suite still passes (569 passed, 1 skipped)