### PR TITLE
BUG: round-trip TimedeltaIndex through to_hdf(format="table") (GH-21466)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -340,6 +340,7 @@ I/O
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 - :meth:`DataFrame.to_hdf` now raises a clear :class:`NotImplementedError` when writing a column or :class:`Index` of an unsupported extension dtype (such as :class:`IntervalDtype`, :class:`SparseDtype`, or the nullable integer/float/boolean dtypes), instead of a low-level ``AttributeError`` or PyTables ``TypeError`` (:issue:`26144`, :issue:`38305`, :issue:`42070`)
 - Fixed ``MemoryError`` in :meth:`HDFStore.select` when iterating large tables with ``chunksize`` and no ``where`` filter (:issue:`15937`)
+- Fixed bug in :meth:`DataFrame.to_hdf` with ``format="table"`` where a :class:`TimedeltaIndex` was reconstructed as a :class:`PeriodIndex` (when ``freq`` was set) or an integer :class:`Index` (otherwise) on read-back (:issue:`21466`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 - Storing a :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` level named ``'index'`` via :meth:`HDFStore.put` or :meth:`HDFStore.append` with ``format='table'`` now raises a clear ``ValueError`` instead of an opaque reshape error (:issue:`6208`)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2381,11 +2381,21 @@ class IndexCol:
         if self.freq is not None:
             kwargs["freq"] = self.freq
 
-        factory: type[Index | DatetimeIndex] = Index
+        factory: type[Index | DatetimeIndex | TimedeltaIndex] = Index
         if lib.is_np_dtype(values.dtype, "M") or isinstance(
             values.dtype, DatetimeTZDtype
         ):
             factory = DatetimeIndex
+        elif val_kind.startswith("timedelta64"):
+            # GH#21466 timedelta values are stored as i8; restore the original
+            #  m8[unit] view so we round-trip to TimedeltaIndex (and not to
+            #  PeriodIndex/Index via the i8 branches below).
+            if val_kind == "timedelta64":
+                # legacy file: written before we stored timedelta64 resolution
+                values = values.view("m8[ns]")
+            else:
+                values = values.view(val_kind)
+            factory = TimedeltaIndex
         elif values.dtype == "i8" and "freq" in kwargs:
             # PeriodIndex data is stored as i8
             # error: Incompatible types in assignment (expression has type

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -1001,6 +1001,19 @@ def test_preserve_timedeltaindex_type(temp_hdfstore, unit):
     tm.assert_frame_equal(temp_hdfstore["df"], df)
 
 
+@pytest.mark.parametrize("freq", ["1s", None])
+def test_preserve_timedeltaindex_type_table_format(temp_h5_path, unit, freq):
+    # GH#21466 with format="table", a TimedeltaIndex used to round-trip as
+    #  PeriodIndex (when freq was set) or Int64Index (otherwise)
+    df = DataFrame(np.random.default_rng(2).normal(size=(10, 5)))
+    df.index = timedelta_range(
+        start="0s", periods=10, freq=freq, name="example", unit=unit
+    )
+    df.to_hdf(temp_h5_path, key="df", format="table")
+    result = read_hdf(temp_h5_path, "df")
+    tm.assert_frame_equal(result, df)
+
+
 def test_columns_multiindex_modified(temp_h5_path):
     # BUG: 7212
 


### PR DESCRIPTION
- closes #21466

## Summary

`DataFrame.to_hdf(..., format="table")` did not round-trip a `TimedeltaIndex`. With `freq` set, the index came back as a `PeriodIndex` (with garbled values reinterpreted as period ordinals); without `freq`, it came back as an integer `Index`.

In `IndexCol.convert`, the index factory was selected from `values.dtype`, but timedelta values land as `i8` after the disk read (same as period ordinals). The `i8 + freq → PeriodIndex` branch fired for any timedelta with freq, and the no-freq case fell through to the default `Index`. Dispatch on `val_kind` (`"timedelta64[..]"`) and view the buffer as `m8[unit]` before constructing `TimedeltaIndex`. A legacy `kind == "timedelta64"` (no unit) fallback mirrors the existing handling in `_unconvert_index`.

The data-column path was unaffected — it goes through `read_array` (fixed) / `DataCol` (table), both of which already record and restore dtype via `value_type`/dtype attrs.

## Test plan

- [x] New `test_preserve_timedeltaindex_type_table_format` parametrized over `unit` × `{freq="1s", freq=None}` (8 combos) — all pass after the fix, all fail before
- [x] Existing `test_preserve_timedeltaindex_type` (fixed format) still passes
- [x] Full `pandas/tests/io/pytables/` suite passes (570 passed, 1 skipped)
- [x] Ad-hoc 40-combination matrix (Series/DataFrame × index/values/both × 4 units × 2 formats) round-trips cleanly