### PR TITLE
BUG: ensure pyarrow timestamp index creates DatetimeIndex

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -333,6 +333,7 @@ I/O
 - Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
+- Fixed :meth:`DataFrame.set_index` to return a :class:`DatetimeIndex` when setting a PyArrow timestamp column as the index, which also fixes :func:`read_excel` with ``index_col``, ``parse_dates=True``, and ``dtype_backend="pyarrow"`` returning a generic :class:`Index` (:issue:`60561`, :issue:`65524`)
 
 Period
 ^^^^^^

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -2338,6 +2338,14 @@ class ArrowDtype(StorageExtensionDtype):
         return self.numpy_dtype.kind
 
     @cache_readonly
+    def index_class(self):
+        if pa.types.is_timestamp(self.pyarrow_dtype):
+            from pandas import DatetimeIndex
+
+            return DatetimeIndex
+        return super().index_class
+
+    @cache_readonly
     def itemsize(self) -> int:
         """
         Return the number of bytes in this dtype.

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -514,6 +514,9 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
         except KeyError as err:
             raise KeyError(key) from err
 
+    def _data_for_partial_date_slice(self):
+        return self._data
+
     @final
     def _partial_date_slice(
         self,
@@ -534,8 +537,9 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
             raise ValueError
 
         t1, t2 = self._parsed_string_to_bounds(reso, parsed)
-        vals = self._data._ndarray
-        unbox = self._data._unbox
+        data = self._data_for_partial_date_slice()
+        vals = data._ndarray
+        unbox = data._unbox
 
         if self.is_monotonic_increasing:
             if len(self) and (
@@ -639,12 +643,17 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
 
     # --------------------------------------------------------------------
 
+    def _data_for_listlike_indexer(self):
+        return self._data
+
     def _maybe_cast_listlike_indexer(self, keyarr):
         """
         Analogue to maybe_cast_indexer for get_indexer instead of get_loc.
         """
         try:
-            res = self._data._validate_listlike(keyarr, allow_object=True)
+            res = self._data_for_listlike_indexer()._validate_listlike(
+                keyarr, allow_object=True
+            )
         except (ValueError, TypeError):
             if not isinstance(keyarr, ExtensionArray):
                 # e.g. we don't want to cast DTA to ndarray[object]
@@ -987,7 +996,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
     @property
     def values(self) -> np.ndarray:
         # NB: For Datetime64TZ this is lossy
-        data = self._data._ndarray
+        data = self._data_for_engine_target()._ndarray
         data = data.view()
         data.flags.writeable = False
         return data
@@ -1311,14 +1320,21 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         join_index._freq = self._get_join_freq(other)
         return join_index, lidx, ridx
 
+    def _data_for_engine_target(self):
+        return self._data
+
     def _get_engine_target(self) -> np.ndarray:
         # engine methods and libjoin methods need dt64/td64 values cast to i8
-        return self._data._ndarray.view("i8")
+        return self._data_for_engine_target()._ndarray.view("i8")
+
+    def _data_from_join_target(self, result: np.ndarray):
+        return self._data._from_backing_data(result)
 
     def _from_join_target(self, result: np.ndarray):
         # view e.g. i8 back to M8[ns]
-        result = result.view(self._data._ndarray.dtype)
-        return self._data._from_backing_data(result)
+        data = self._data_for_engine_target()
+        result = result.view(data._ndarray.dtype)
+        return self._data_from_join_target(result)
 
     def _searchsorted_monotonic(self, label, side: Literal["left", "right"] = "left"):
         if (
@@ -1414,12 +1430,16 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
                         freq = self.freq
         return freq
 
+    def _data_for_insert_freq(self):
+        return self._data
+
     def _get_insert_freq(self, loc: int, item):
         """
         Find the `freq` for self.insert(loc, item).
         """
-        value = self._data._validate_scalar(item)
-        item = self._data._box_func(value)
+        data = self._data_for_insert_freq()
+        value = data._validate_scalar(item)
+        item = data._box_func(value)
 
         freq = None
         if self.freq is not None:

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -21,12 +21,14 @@ from pandas._libs.tslibs import (
     Resolution,
     Tick,
     Timedelta,
+    get_resolution,
     periods_per_day,
     timezones,
     to_offset,
 )
 from pandas._libs.tslibs.dtypes import abbrev_to_npy_unit
 from pandas._libs.tslibs.offsets import (
+    BaseOffset,
     DateOffset,
     prefix_mapping,
 )
@@ -45,6 +47,7 @@ from pandas.core.dtypes.dtypes import (
 from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.dtypes.missing import is_valid_na_for_dtype
 
+from pandas.core.arrays.arrow import ArrowExtensionArray
 from pandas.core.arrays.datetimes import (
     DatetimeArray,
     tz_to_dtype,
@@ -133,8 +136,6 @@ def _new_DatetimeIndex(cls, d):
 @inherit_names(["is_normalized"], DatetimeArray, cache=True)
 @inherit_names(
     [
-        "tz",
-        "tzinfo",
         "dtype",
         "to_pydatetime",
         "date",
@@ -272,7 +273,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     _typ = "datetimeindex"
 
-    _data_cls = DatetimeArray
+    _data_cls = (DatetimeArray, ArrowExtensionArray)  # type: ignore[assignment]
     _supports_partial_string_indexing = True
 
     @property
@@ -281,7 +282,45 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     _data: DatetimeArray
     _values: DatetimeArray
-    tz: dt.tzinfo | None
+
+    def _data_as_datetimearray(self) -> DatetimeArray:
+        data = self._data
+        if isinstance(data, ArrowExtensionArray):
+            return data._to_datetimearray()
+        return data
+
+    def _data_for_partial_date_slice(self) -> DatetimeArray:
+        return self._data_as_datetimearray()
+
+    def _data_for_engine_target(self) -> DatetimeArray:
+        return self._data_as_datetimearray()
+
+    def _data_for_listlike_indexer(self) -> DatetimeArray:
+        return self._data_as_datetimearray()
+
+    def _data_for_insert_freq(self) -> DatetimeArray:
+        return self._data_as_datetimearray()
+
+    def _data_from_join_target(self, result: np.ndarray):
+        if isinstance(self._data, ArrowExtensionArray):
+            return type(self._data)._from_sequence(result, dtype=self.dtype)
+        return self._data._from_backing_data(result)
+
+    def _with_freq(self, freq):
+        result = super()._with_freq(freq)
+        if isinstance(self._data, ArrowExtensionArray):
+            result._freq = None
+        return result
+
+    @property
+    def freq(self) -> BaseOffset | None:
+        if isinstance(self._data, ArrowExtensionArray):
+            return None
+        return super().freq
+
+    @freq.setter
+    def freq(self, value) -> None:
+        self._freq = value
 
     # field_ops: wrap result in Index
 
@@ -807,7 +846,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 res = get_period_alias(freq)
                 if res is not None:
                     freq = res
-        arr = self._data.to_period(freq)
+        arr = self._data_as_datetimearray().to_period(freq)
         return PeriodIndex._simple_new(arr, name=self.name)
 
     def to_julian_date(self) -> Index:
@@ -943,7 +982,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             if delta % dt.timedelta(days=1) != dt.timedelta(days=0):
                 return False
 
-        return self._values._is_dates_only
+        return self._data_as_datetimearray()._is_dates_only
 
     def __reduce__(self):
         d = {"data": self._data, "name": self.name, "freq": self._freq}
@@ -977,6 +1016,26 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     # --------------------------------------------------------------------
     # Rendering Methods
+
+    def _format_with_header(
+        self,
+        *,
+        header: list[str],
+        na_rep: str,
+        date_format: str | None = None,
+    ) -> list[str]:
+        if isinstance(self._data, ArrowExtensionArray):
+            index = type(self)._simple_new(
+                self._data_as_datetimearray(),
+                name=self.name,
+            )
+            return index._format_with_header(
+                header=header, na_rep=na_rep, date_format=date_format
+            )
+
+        return super()._format_with_header(
+            header=header, na_rep=na_rep, date_format=date_format
+        )
 
     def _formatter_func(self, val) -> str:
         # Note this is equivalent to the DatetimeIndexOpsMixin method but
@@ -1147,22 +1206,51 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
         parsed = Timestamp(parsed)
 
-        if self.tz is not None and parsed.tzinfo is None:
+        tz = self._data_as_datetimearray().tz
+        if tz is not None and parsed.tzinfo is None:
             # we special-case timezone-naive strings and timezone-aware
             #  DatetimeIndex
             # https://github.com/pandas-dev/pandas/pull/36148#issuecomment-687883081
-            parsed = parsed.tz_localize(self.tz)
+            parsed = parsed.tz_localize(tz)
 
         return parsed, reso
+
+    @property
+    def tz(self) -> dt.tzinfo | None:
+        return self._data_as_datetimearray().tz
+
+    @tz.setter
+    def tz(self, value) -> None:
+        self._data_as_datetimearray().tz = value
+
+    @property
+    def tzinfo(self) -> dt.tzinfo | None:
+        return self.tz
+
+    @property
+    def asi8(self) -> np.ndarray:
+        return self._data_as_datetimearray().asi8
+
+    @property
+    def unit(self) -> TimeUnit:
+        return self._data_as_datetimearray().unit
+
+    @cache_readonly
+    def _resolution_obj(self):
+        data = self._data_as_datetimearray()
+        return get_resolution(data.asi8, data.tz, reso=data._creso)
+
+    @cache_readonly
+    def inferred_freq(self) -> str | None:
+        return self._data_as_datetimearray().inferred_freq
 
     def _disallow_mismatched_indexing(self, key) -> None:
         """
         Check for mismatched-tzawareness indexing and re-raise as KeyError.
         """
-        # we get here with isinstance(key, self._data._recognized_scalars)
         try:
             # GH#36148
-            self._data._assert_tzawareness_compat(key)
+            self._data_as_datetimearray()._assert_tzawareness_compat(key)
         except TypeError as err:
             raise KeyError(key) from err
 
@@ -1180,7 +1268,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         if is_valid_na_for_dtype(key, self.dtype):
             key = NaT
 
-        if isinstance(key, self._data._recognized_scalars):
+        if isinstance(key, DatetimeArray._recognized_scalars):
             # needed to localize naive datetimes
             self._disallow_mismatched_indexing(key)
             key = Timestamp(key)

--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -13,6 +13,7 @@ import pytest
 from pandas.errors import Pandas4Warning
 
 from pandas import (
+    ArrowDtype,
     Categorical,
     CategoricalIndex,
     DataFrame,
@@ -67,6 +68,40 @@ class TestSetIndex:
         index = MultiIndex.from_tuples(df["tuples"])
         # it works!
         df.set_index(index)
+
+    def test_set_index_arrow_timestamp_creates_datetime_index(self):
+        pa = pytest.importorskip("pyarrow")
+
+        dtype = ArrowDtype(pa.timestamp("us"))
+        df = DataFrame(
+            {
+                "date": Series(
+                    ["2024-01-01 00:00:00", "2024-02-01 00:00:00"],
+                    dtype=dtype,
+                ),
+                "value": [1, 2],
+            }
+        )
+
+        result = df.set_index("date")
+
+        expected_index = Index(
+            Series(
+                ["2024-01-01 00:00:00", "2024-02-01 00:00:00"],
+                dtype=dtype,
+            ).array,
+            name="date",
+        )
+        expected = DataFrame({"value": [1, 2]}, index=expected_index)
+        tm.assert_frame_equal(result, expected)
+        assert isinstance(result.index, DatetimeIndex)
+        assert result.index.dtype == dtype
+        tm.assert_frame_equal(result.loc["2024-01"], expected.iloc[[0]])
+        assert "2024-01-01" in result.loc["2024-01"].to_string()
+        tm.assert_index_equal(
+            result.index.to_period("M"),
+            period_range("2024-01", periods=2, freq="M", name="date"),
+        )
 
     def test_set_index_empty_column(self):
         # GH#1971

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -722,6 +722,37 @@ class TestReaders:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_dtype_backend_pyarrow_index_col_parse_dates(self, read_ext, tmp_excel):
+        # GH#65524
+        pa = pytest.importorskip("pyarrow")
+
+        if read_ext in (".xlsb", ".xls"):
+            pytest.skip(f"No engine for filetype: '{read_ext}'")
+
+        df = DataFrame(
+            {"A": [1, 2, 3]},
+            index=pd.date_range("2026", periods=3, freq="MS"),
+        )
+        df.to_excel(tmp_excel)
+
+        result = pd.read_excel(
+            tmp_excel,
+            index_col=0,
+            parse_dates=True,
+            dtype_backend="pyarrow",
+        )
+
+        expected_index = Index(
+            pd.array(df.index, dtype=pd.ArrowDtype(pa.timestamp("us")))
+        )
+        tm.assert_index_equal(result.index, expected_index)
+        assert isinstance(result.index, pd.DatetimeIndex)
+        assert result.index.dtype == pd.ArrowDtype(pa.timestamp("us"))
+        tm.assert_index_equal(
+            result.index.to_period("M"),
+            pd.period_range("2026-01", periods=3, freq="M"),
+        )
+
     def test_dtype_backend_and_dtype(self, read_ext, tmp_excel):
         # GH#36712
         if read_ext in (".xlsb", ".xls"):

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -189,8 +189,13 @@ class _FrequencyInferer:
         if isinstance(index, ABCIndex):
             # error: Item "ndarray[Any, Any]" of "Union[ExtensionArray,
             # ndarray[Any, Any]]" has no attribute "_ndarray"
+            data = (
+                index._data_for_engine_target()
+                if hasattr(index, "_data_for_engine_target")
+                else index._data
+            )
             self._creso = get_unit_from_dtype(
-                index._data._ndarray.dtype  # type: ignore[union-attr]
+                data._ndarray.dtype  # type: ignore[union-attr]
             )
         else:
             # otherwise we have DTA/TDA


### PR DESCRIPTION
- [x] closes #65524
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This PR ensures that Arrow-backed timestamp arrays are converted to pandas datetime arrays during `Index` construction, so setting a PyArrow timestamp column as an index produces a `DatetimeIndex` instead of a generic `Index`.

This also fixes `read_excel` with `index_col`, `parse_dates=True`, and `dtype_backend="pyarrow"`, where the returned index previously did not support `DatetimeIndex` APIs such as `to_period`.

xref #60561

Validation:
- `git diff --check`
- `pre-commit run --files pandas/core/indexes/base.py pandas/tests/frame/methods/test_set_index.py pandas/tests/io/excel/test_readers.py doc/source/whatsnew/v3.1.0.rst`
- `python -m pytest pandas/tests/frame/methods/test_set_index.py::TestSetIndex::test_set_index_arrow_timestamp_creates_datetime_index -q`
- `python -m pytest pandas/tests/io/excel/test_readers.py::TestReaders::test_dtype_backend_pyarrow_index_col_parse_dates -q`