### PR TITLE
DOC: clarify duplicated keep behavior

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7879,7 +7879,9 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Return boolean Series denoting duplicate rows.
 
-        Considering certain columns is optional.
+        Rows are considered duplicated when the same values appear more than
+        once across the requested columns. Considering certain columns is
+        optional.
 
         Parameters
         ----------
@@ -7896,7 +7898,8 @@ class DataFrame(NDFrame, OpsMixin):
         Returns
         -------
         Series
-            Boolean series for each duplicated rows.
+            Boolean Series indicating whether each row is a duplicated row
+            according to ``keep``.
 
         See Also
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2519,8 +2519,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Indicate duplicate Series values.
 
         Duplicated values are indicated as ``True`` values in the resulting
-        Series. Either all duplicates, all except the first or all except the
-        last occurrence of duplicates can be indicated.
+        Series. Values are considered duplicated when the same value appears
+        more than once. Either all duplicated values, all except the first, or
+        all except the last occurrence of duplicated values can be indicated.
 
         Parameters
         ----------
@@ -2536,8 +2537,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Returns
         -------
         Series[bool]
-            Series indicating whether each value has occurred in the
-            preceding values.
+            Series indicating whether each value is a duplicated value
+            according to ``keep``.
 
         See Also
         --------


### PR DESCRIPTION
- [x] closes #65320
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature (not applicable: documentation-only change)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit). (`git diff --check`)
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (not applicable)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. (not applicable: documentation clarification only)
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This updates the `Series.duplicated` and `DataFrame.duplicated` docstrings to make the `keep` semantics explicit: values/rows are duplicated when the same value/row appears more than once, and `keep` controls which occurrence, if any, is marked `False`.

The change follows the discussion in #65320 where maintainers preferred clarifying the docstrings instead of changing the default behavior.

Validation:
- `git diff --check` passed
- `python -m pytest pandas/tests/series/methods/test_duplicated.py pandas/tests/frame/methods/test_duplicated.py` was not run because this local environment does not have `pytest` installed