### PR TITLE
DOC: Add missing 'Ticket' column to tutorial

### DIFF
--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -172,7 +172,7 @@ The method :meth:`~DataFrame.info` provides technical information about a
 -  The table has 12 columns. Most columns have a value for each of the
    rows (all 891 values are ``non-null``). Some columns do have missing
    values and less than 891 ``non-null`` values.
--  The columns ``Name``, ``Sex``, ``Cabin`` and ``Embarked`` consist of
+-  The columns ``Name``, ``Sex``, ``Ticket``, ``Cabin`` and ``Embarked`` consist of
    textual data (strings, aka ``object``). The other columns are
    numerical data, some of them are whole numbers (``integer``) and
    others are real numbers (``float``).


### PR DESCRIPTION
The summary table lists Ticket as a string, but it was missing from the descriptive text below. Added for consistency.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
