### PR TITLE
BUG: clearer error for unsupported dtypes in HDFStore

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -4959,6 +4959,16 @@ object : ``strings``                                    ``np.nan``
 
 ``unicode`` columns are not supported, and **WILL FAIL**.
 
+Several extension dtypes are not supported as DataFrame columns or Series
+values and will raise :class:`NotImplementedError` on write. In particular,
+:class:`IntervalDtype`, :class:`SparseDtype`, and the nullable
+integer/float/boolean dtypes (``Int8``, ``Float64``, ``boolean``, ...) cannot
+be stored. Convert such columns to a NumPy dtype (for example
+``df["col"] = df["col"].astype("float64")``) before writing. The same
+restriction applies to using these dtypes as the row :class:`Index`; a
+:class:`Series` or :class:`DataFrame` whose index is one of these dtypes
+likewise cannot be written.
+
 .. _io.hdf5-categorical:
 
 Categorical data

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -332,6 +332,7 @@ I/O
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)
 - Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
+- :meth:`DataFrame.to_hdf` now raises a clear :class:`NotImplementedError` when writing a column or :class:`Index` of an unsupported extension dtype (such as :class:`IntervalDtype`, :class:`SparseDtype`, or the nullable integer/float/boolean dtypes), instead of a low-level ``AttributeError`` or PyTables ``TypeError`` (:issue:`26144`, :issue:`38305`, :issue:`42070`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 
 Period

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2686,9 +2686,17 @@ class DataCol(IndexCol):
         Get an appropriately typed and shaped pytables.Col object for values.
         """
         dtype = values.dtype
-        # error: Item "ExtensionDtype" of "Union[ExtensionDtype, dtype[Any]]" has no
-        # attribute "itemsize"
-        itemsize = dtype.itemsize  # type: ignore[union-attr]
+        # GH#26144, GH#38305, GH#42070. CategoricalDtype/DatetimeTZDtype have
+        # working code paths below; PeriodDtype is handled in a separate effort.
+        if isinstance(dtype, ExtensionDtype) and not isinstance(
+            dtype, (CategoricalDtype, DatetimeTZDtype, PeriodDtype)
+        ):
+            raise NotImplementedError(
+                f"Cannot store a column with dtype {dtype} in an HDF5 file. "
+                "HDFStore supports NumPy dtypes, datetime64 with timezone, "
+                "categorical, and string extension types."
+            )
+        itemsize = dtype.itemsize
 
         shape = values.shape
         if values.ndim == 1:
@@ -3465,6 +3473,17 @@ class GenericFixed(Fixed):
             elif empty_array:
                 self.write_array_empty(key, value)
             else:
+                # GH#26144, GH#38305, GH#42070. PeriodDtype intentionally falls
+                # through here; it is handled in a separate effort.
+                if isinstance(value.dtype, ExtensionDtype) and not isinstance(
+                    value.dtype, PeriodDtype
+                ):
+                    raise NotImplementedError(
+                        f"Cannot store a column with dtype {value.dtype} in "
+                        'an HDF5 file with format="fixed". HDFStore supports '
+                        "NumPy dtypes, datetime64 with timezone, categorical, "
+                        "and string extension types."
+                    )
                 self._handle.create_array(self.group, key, value)
 
         getattr(self.group, key)._v_attrs.transposed = transposed
@@ -5245,6 +5264,25 @@ def _convert_index(name: str, index: Index, encoding: str, errors: str) -> Index
     assert isinstance(name, str)
 
     index_name = index.name
+    # GH#26144, GH#38305, GH#42070: most extension dtypes cannot be stored as
+    # an Index in HDF5. Allow the ones that have working code paths below
+    # (DatetimeTZ/Period via i8 conversion, BooleanDtype via is_bool_dtype,
+    # StringDtype, CategoricalDtype) and reject everything else early before
+    # _dtype_to_kind / _get_atom choke with a low-level error.
+    # CategoricalDtype is intentionally not caught here; that is handled in
+    # a separate effort. BooleanDtype round-trips lossily but does not error
+    # on main, so it remains carved out here.
+    if (
+        isinstance(index.dtype, ExtensionDtype)
+        and not needs_i8_conversion(index.dtype)
+        and not is_bool_dtype(index.dtype)
+        and not isinstance(index.dtype, (StringDtype, CategoricalDtype))
+    ):
+        raise NotImplementedError(
+            f"Cannot store an Index with dtype {index.dtype} in an HDF5 file. "
+            "HDFStore supports NumPy dtypes, datetime64 with timezone, "
+            "categorical, and string extension types."
+        )
     # error: Argument 1 to "_get_data_and_dtype_name" has incompatible type "Index";
     # expected "Union[ExtensionArray, ndarray]"
     converted, dtype_name = _get_data_and_dtype_name(index)  # type: ignore[arg-type]

--- a/pandas/tests/io/pytables/test_errors.py
+++ b/pandas/tests/io/pytables/test_errors.py
@@ -6,6 +6,7 @@ import uuid
 import numpy as np
 import pytest
 
+import pandas as pd
 from pandas import (
     CategoricalIndex,
     DataFrame,
@@ -207,6 +208,50 @@ def test_to_hdf_multiindex_extension_dtype(idx, temp_h5_path):
     df = DataFrame(0, index=mi, columns=["a"])
     with pytest.raises(NotImplementedError, match="Saving a MultiIndex"):
         df.to_hdf(temp_h5_path, key="df")
+
+
+@pytest.mark.parametrize(
+    "values, dtype_match",
+    [
+        # GH#42070
+        (pd.arrays.SparseArray([1.0, 2.0, None, 3.0]), r"Sparse\[float64"),
+        # GH#26144
+        (pd.array([1, 2, None], dtype="Int32"), "Int32"),
+        (pd.array([1.0, None, 3.0], dtype="Float64"), "Float64"),
+        (pd.array([True, False, None], dtype="boolean"), "boolean"),
+        # GH#38305
+        (pd.IntervalIndex.from_arrays([0.5, 1.5], [0.9, 1.9]), r"interval\["),
+    ],
+)
+@pytest.mark.parametrize("fmt", ["fixed", "table"])
+def test_to_hdf_unsupported_extension_dtype_column(
+    values, dtype_match, fmt, temp_h5_path
+):
+    df = DataFrame({"a": values})
+    msg = rf"Cannot store a column with dtype {dtype_match}"
+    with pytest.raises(NotImplementedError, match=msg):
+        df.to_hdf(temp_h5_path, key="df", format=fmt)
+
+
+@pytest.mark.parametrize(
+    "idx, dtype_match",
+    [
+        # GH#38305
+        (pd.IntervalIndex.from_arrays([0.5, 1.5], [0.9, 1.9]), r"interval\["),
+        # GH#42070
+        (Index(pd.arrays.SparseArray([1.0, 2.0])), r"Sparse\[float64"),
+        # GH#26144
+        (Index(pd.array([1, 2], dtype="Int32")), "Int32"),
+        (Index(pd.array([1.0, 2.0], dtype="Float64")), "Float64"),
+    ],
+)
+@pytest.mark.parametrize("fmt", ["fixed", "table"])
+def test_to_hdf_unsupported_extension_dtype_index(idx, dtype_match, fmt, temp_h5_path):
+    # GH#26144, GH#38305, GH#42070
+    df = DataFrame({"a": [1, 2]}, index=idx)
+    msg = rf"Cannot store an Index with dtype {dtype_match}"
+    with pytest.raises(NotImplementedError, match=msg):
+        df.to_hdf(temp_h5_path, key="df", format=fmt)
 
 
 def test_unsupported_hdf_file_error(datapath):


### PR DESCRIPTION
## Summary

- Replace low-level `AttributeError` / PyTables `flavor_of` `TypeError` / `AssertionError` with a uniform `NotImplementedError` when `to_hdf` is called with an unsupported extension dtype as a column or Index — covering `IntervalDtype`, `SparseDtype`, nullable masked integer/float/boolean dtypes (all widths), and `ArrowDtype`.
- Three surgical sites: `_get_atom` (table-format columns), `GenericFixed.write_array` catch-all (fixed-format columns), and an early guard in `_convert_index` (Index path).
- `PeriodDtype` and `CategoricalDtype` are intentionally not covered here — they'll be addressed in a separate effort. `BooleanDtype` as an Index is carved out so the existing (lossy) behavior on main is preserved.

Closes GH-26144 (nullable Int/Float)
Closes GH-38305 (IntervalIndex / IntervalArray)
Closes GH-42070 (SparseArray)

GH-31199 (StringDtype) was already fixed by GH-60663 and has been closed separately.

## Test plan

- [x] 10 new parametrized tests in \`pandas/tests/io/pytables/test_errors.py\` covering Sparse / Int32 / Float64 / boolean / IntervalArray as columns and Sparse / Int32 / Float64 / IntervalIndex as Index, in both fixed and table formats
- [x] Full pytables suite: 580 passed, 1 skipped
- [x] mypy / pyright / pre-commit clean