### PR TITLE
Add blosc dependency version 1.21.3

### DIFF
--- a/ci/deps/actions-312.yaml
+++ b/ci/deps/actions-312.yaml
@@ -26,6 +26,7 @@ dependencies:
   - adbc-driver-postgresql>=1.2.0
   - adbc-driver-sqlite>=1.2.0
   - beautifulsoup4>=4.12.3
+  - blosc>=1.21.3
   - bottleneck>=1.4.2
   - fastparquet>=2024.11.0
   - fsspec>=2024.10.0


### PR DESCRIPTION
**###** Issue #2: Missing `blosc` dependency in Python 3.12 configuration   **File:** `ci/deps/actions-312.yaml`
- **Problem:** `blosc>=1.21.3` is present in Python 3.13 and 3.14 configs but missing from Python 3.12 config
- **Impact:** Inconsistent test environments; Python 3.12 testing lacks compression library coverage
- **Fix:** Added `blosc>=1.21.3` to optional dependencies (line 29)

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
