### PR TITLE
BUG: clearer error for HDFStore MultiIndex level named 'index' (GH-6208)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -336,6 +336,7 @@ I/O
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 - :meth:`DataFrame.to_hdf` now raises a clear :class:`NotImplementedError` when writing a column or :class:`Index` of an unsupported extension dtype (such as :class:`IntervalDtype`, :class:`SparseDtype`, or the nullable integer/float/boolean dtypes), instead of a low-level ``AttributeError`` or PyTables ``TypeError`` (:issue:`26144`, :issue:`38305`, :issue:`42070`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
+- Storing a :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` level named ``'index'`` via :meth:`HDFStore.put` or :meth:`HDFStore.append` with ``format='table'`` now raises a clear ``ValueError`` instead of an opaque reshape error (:issue:`6208`)
 
 Period
 ^^^^^^

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3799,6 +3799,13 @@ class Table(Fixed):
         new object
         """
         levels = com.fill_missing_names(obj.index.names)
+        if "index" in levels:
+            # GH#6208 'index' is reserved as the implicit row-index name
+            # in the table format and collides with a level named 'index'.
+            raise ValueError(
+                "cannot store a MultiIndex with a level named 'index' as a "
+                "table; 'index' is reserved for the implicit row index"
+            )
         try:
             reset_obj = obj.reset_index()
         except ValueError as err:

--- a/pandas/tests/io/pytables/test_errors.py
+++ b/pandas/tests/io/pytables/test_errors.py
@@ -13,6 +13,7 @@ from pandas import (
     HDFStore,
     Index,
     MultiIndex,
+    Series,
     date_range,
     read_hdf,
 )
@@ -252,6 +253,25 @@ def test_to_hdf_unsupported_extension_dtype_index(idx, dtype_match, fmt, temp_h5
     msg = rf"Cannot store an Index with dtype {dtype_match}"
     with pytest.raises(NotImplementedError, match=msg):
         df.to_hdf(temp_h5_path, key="df", format=fmt)
+
+
+def test_to_hdf_multiindex_level_named_index_raises(temp_hdfstore):
+    # GH#6208 a MultiIndex level named 'index' collides with the table
+    # format's implicit row index; surface a clear error instead of the
+    # confusing reshape failure that used to come from write_data
+    mi = MultiIndex.from_tuples(
+        [("foo", "one"), ("foo", "two"), ("bar", "one")],
+        names=["index", "second"],
+    )
+    df = DataFrame({"A": [1, 2, 3]}, index=mi)
+    msg = "cannot store a MultiIndex with a level named 'index' as a table"
+    with pytest.raises(ValueError, match=msg):
+        temp_hdfstore.put("df", df, format="table", track_times=False)
+    with pytest.raises(ValueError, match=msg):
+        temp_hdfstore.append("df", df, format="table")
+    series = Series([1, 2, 3], index=mi, name="vals")
+    with pytest.raises(ValueError, match=msg):
+        temp_hdfstore.put("s", series, format="table", track_times=False)
 
 
 def test_unsupported_hdf_file_error(datapath):


### PR DESCRIPTION
## Summary
- Raise a clear `ValueError` in `Table.validate_multiindex` when any `MultiIndex` level is named `'index'`, instead of failing later in `write_data` with `cannot reshape array of size N into shape (M,)`. The name `'index'` is reserved for the implicit row-index column in the table format and collides with a level of the same name (GH-6208).
- Covers `HDFStore.put`, `HDFStore.append`, and the Series equivalent.

closes #6208

## Test plan
- [x] New `test_to_hdf_multiindex_level_named_index_raises` in `pandas/tests/io/pytables/test_errors.py`
- [x] Full `pandas/tests/io/pytables/` suite (563 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)