### PR TITLE
BUG: fix is_monotonic_increasing/decreasing properties for ExtensionArrays

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -380,7 +380,7 @@ ExtensionArray
 ^^^^^^^^^^^^^^
 - Bug in numpy ufuncs like :func:`numpy.isnan` raising ``TypeError`` on :class:`Series` or :class:`Index` backed by PyArrow dtypes when ``future.distinguish_nan_and_na`` is ``True`` (:issue:`62506`)
 - Fixed bug in :meth:`Series.apply` and :meth:`Series.map` where nullable integer dtypes were converted to float, causing precision loss for large integers; now the nullable dtype will be preserved (:issue:`63903`).
--
+- Fixed the :attr:`~Series.is_monotonic_increasing` and :attr:`~Series.is_monotonic_decreasing` properties to dispatch to the underlying :class:`ExtensionArray` implementation (:issue:`65585`)
 -
 
 Styler

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2673,7 +2673,11 @@ class ArrowExtensionArray(
             return False
         if len(pa_array) <= 1:
             return True
-        return pc.all(pc.greater_equal(pa_array[1:], pa_array[:-1])).as_py()
+        try:
+            return pc.all(pc.greater_equal(pa_array[1:], pa_array[:-1])).as_py()
+        except pa.ArrowNotImplementedError:
+            # If the type doesn't support comparison, e.g. list types
+            return False
 
     @property
     def _is_monotonic_decreasing(self) -> bool:
@@ -2682,7 +2686,11 @@ class ArrowExtensionArray(
             return False
         if len(pa_array) <= 1:
             return True
-        return pc.all(pc.less_equal(pa_array[1:], pa_array[:-1])).as_py()
+        try:
+            return pc.all(pc.less_equal(pa_array[1:], pa_array[:-1])).as_py()
+        except pa.ArrowNotImplementedError:
+            # If the type doesn't support comparison, e.g. list types
+            return False
 
     def _rank(
         self,

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2472,6 +2472,8 @@ class Index(IndexOpsMixin, PandasObject):
         if isinstance(self._values, ExtensionArray) and isinstance(
             self._engine, libindex.ObjectEngine
         ):
+            # For custom EAs we use ObjectEngine by default, which gets the EA as
+            # object ndarray -> use the EA's implementation directly instead of engine
             return self._values._is_monotonic_increasing
         return self._engine.is_monotonic_increasing
 
@@ -2504,6 +2506,8 @@ class Index(IndexOpsMixin, PandasObject):
         if isinstance(self._values, ExtensionArray) and isinstance(
             self._engine, libindex.ObjectEngine
         ):
+            # For custom EAs we use ObjectEngine by default, which gets the EA as
+            # object ndarray -> use the EA's implementation directly instead of engine
             return self._values._is_monotonic_decreasing
         return self._engine.is_monotonic_decreasing
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2469,6 +2469,10 @@ class Index(IndexOpsMixin, PandasObject):
         >>> pd.Index([1, 3, 2]).is_monotonic_increasing
         False
         """
+        if isinstance(self._values, ExtensionArray) and isinstance(
+            self._engine, libindex.ObjectEngine
+        ):
+            return self._values._is_monotonic_increasing
         return self._engine.is_monotonic_increasing
 
     @property
@@ -2497,6 +2501,10 @@ class Index(IndexOpsMixin, PandasObject):
         >>> pd.Index([3, 1, 2]).is_monotonic_decreasing
         False
         """
+        if isinstance(self._values, ExtensionArray) and isinstance(
+            self._engine, libindex.ObjectEngine
+        ):
+            return self._values._is_monotonic_decreasing
         return self._engine.is_monotonic_decreasing
 
     @final

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -227,14 +227,6 @@ class TestJSONArray(base.ExtensionTests):
         super().test_where_series(data, na_value)
 
     @pytest.mark.xfail(reason="Can't compare dicts.")
-    def test_is_monotonic_increasing(self, data_for_sorting):
-        super().test_is_monotonic_increasing(data_for_sorting)
-
-    @pytest.mark.xfail(reason="Can't compare dicts.")
-    def test_is_monotonic_decreasing(self, data_for_sorting):
-        super().test_is_monotonic_decreasing(data_for_sorting)
-
-    @pytest.mark.xfail(reason="Can't compare dicts.")
     def test_searchsorted(self, data_for_sorting):
         super().test_searchsorted(data_for_sorting)
 


### PR DESCRIPTION
The base class `ExtensionArray` has a working implementation for `_is_monotonic_increasing`/`_is_monotonic_decreasing` by reusing `_rank()`/`_values_for_argsort()`. 

However, for the public property on a Series or Index, we currently don't use this EA method, because for those EAs the default index engine is still the ObjectEngine, and at that point the low-level monotonic algo sees just the object ndarray, which is not necessarily sortable.

 
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
