### PR TITLE
RLS: update whatsnew for 3.0.3

### DIFF
--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -36,6 +36,7 @@ Fixed regressions
 - Fixed a regression in :func:`read_csv` with ``engine="c"`` where ``thousands=","``
   could incorrectly parse non-numeric values like ``"1 ,"`` as integers
   instead of strings (:issue:`64655`)
+- Fixed a performance regression when working with timezone-aware timeseries data using a default ``zoneinfo`` time zone, i.e. slowdown when accessing components or localizing a naive timeseries (:issue:`64363`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_303.bug_fixes:

--- a/doc/source/whatsnew/v3.0.3.rst
+++ b/doc/source/whatsnew/v3.0.3.rst
@@ -1,7 +1,7 @@
 .. _whatsnew_303:
 
-What's new in 3.0.3 (April XX, 2026)
----------------------------------------
+What's new in 3.0.3 (May 11, 2026)
+----------------------------------
 
 These are the changes in pandas 3.0.3. See :ref:`release` for a full changelog
 including other versions of pandas.
@@ -28,11 +28,11 @@ Enhancements
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
+- Fixed a regression in :func:`pandas.bdate_range` where specifying ``end`` on a weekend with ``periods`` returned fewer dates than expected (:issue:`64834`)
+- Fixed a regression in :func:`to_timedelta` ignoring the ``unit`` argument for round float values when mixed with non-round floats in a list (:issue:`65150`)
+- Fixed a regression in :meth:`Series.rank` with custom extension dtypes (:issue:`64976`)
+- Fixed a regression in :meth:`Timedelta.round`, :meth:`Timedelta.floor`, and :meth:`Timedelta.ceil` raising ``ZeroDivisionError`` for sub-second ``freq`` (:issue:`64828`)
 - Fixed reading of Parquet files with timezone-aware timestamps or localizing of a timeseries with a ``pytz`` timezone when an older version of ``pytz`` was installed (:issue:`64978`)
-- Fixed regression in :func:`pandas.bdate_range` where specifying ``end`` on a weekend with ``periods`` returned fewer dates than expected (:issue:`64834`)
-- Fixed regression in :func:`to_timedelta` ignoring the ``unit`` argument for round float values when mixed with non-round floats in a list (:issue:`65150`)
-- Fixed regression in :meth:`Series.rank` with custom extension dtypes (:issue:`64976`)
-- Fixed regression in :meth:`Timedelta.round`, :meth:`Timedelta.floor`, and :meth:`Timedelta.ceil` raising ``ZeroDivisionError`` for sub-second ``freq`` (:issue:`64828`)
 - Fixed a regression in :func:`read_csv` with ``engine="c"`` where ``thousands=","``
   could incorrectly parse non-numeric values like ``"1 ,"`` as integers
   instead of strings (:issue:`64655`)
@@ -46,7 +46,6 @@ Bug fixes
 - Fixed a bug in adding missing values (e.g. :attr:`NA`) to a pyarrow-backed string array or Series
   raising an error instead of propagating the missing value (:issue:`64968`)
 - Fixed a bug in :meth:`Series.rank` with period dtype and missing values, always sorting missing values at the top, regardless of the ``na_option`` value (:issue:`64976`)
-
 - Fixed a bug in reading files with a chained URL scheme (e.g. ``tar://``) with the latest version of ``fsspec`` (:issue:`65462`).
 - Fixed a hang in :meth:`Series.str.replace` for PyArrow-backed string data when replacing an empty pattern; behavior now matches Python's ``str.replace`` (:issue:`64941`).
 


### PR DESCRIPTION
In preparation of doing a 3.0.3 release today (to be merged as last PR before releasing, to tag the merge commit)

This also updates the date in the release notes. And added a note for https://github.com/pandas-dev/pandas/issues/64363