### PR TITLE
BUG: fix np_datetime.c include order to avoid numpy nightly segfault

### DIFF
--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -20,9 +20,15 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 #  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif // NPY_NO_DEPRECATED_API
 
-#include "pandas/vendored/numpy/datetime/np_datetime.h"
+// GH-65569: NO_IMPORT_ARRAY and PY_ARRAY_UNIQUE_SYMBOL must be defined before
+// any header transitively pulls in numpy/ndarraytypes.h. On numpy >= 2.5 that
+// header includes __multiarray_api.h where the rename machinery for
+// PyArray_RUNTIME_VERSION fires; defining them too late leaves it a TU-local
+// static int=0 that the compiler constant-folds, breaking
+// PyDataType_C_METADATA.
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL PANDAS_DATETIME_NUMPY
+#include "pandas/vendored/numpy/datetime/np_datetime.h"
 #include "pandas/portable.h"
 #include <numpy/ndarrayobject.h>
 #include <numpy/npy_common.h>

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -20,12 +20,9 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 #  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif // NPY_NO_DEPRECATED_API
 
-// GH-65569: NO_IMPORT_ARRAY and PY_ARRAY_UNIQUE_SYMBOL must be defined before
-// any header transitively pulls in numpy/ndarraytypes.h. On numpy >= 2.5 that
-// header includes __multiarray_api.h where the rename machinery for
-// PyArray_RUNTIME_VERSION fires; defining them too late leaves it a TU-local
-// static int=0 that the compiler constant-folds, breaking
-// PyDataType_C_METADATA.
+// GH#65569: NO_IMPORT_ARRAY and PY_ARRAY_UNIQUE_SYMBOL must be defined before
+// the np_datetime.h include, otherwise the numpy C-API symbol import breaks
+// on numpy >= 2.5.
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL PANDAS_DATETIME_NUMPY
 #include "pandas/vendored/numpy/datetime/np_datetime.h"


### PR DESCRIPTION
## Summary

- On numpy nightly (>= 2.5), pandas's vendored `pandas/_libs/src/vendored/numpy/datetime/np_datetime.c` segfaults on every `datetime64`/`timedelta64` dtype access, crashing during `conftest.py` collection.
- Root cause is an include ordering bug: `NO_IMPORT_ARRAY` and `PY_ARRAY_UNIQUE_SYMBOL` were defined *after* pandas's own `np_datetime.h` had already transitively pulled in `numpy/ndarraytypes.h`. Defining them is reordered to before that include.

## Details

[numpy/numpy#31091](https://github.com/numpy/numpy/pull/31091) moved `#include \"__multiarray_api.h\"` from `ndarrayobject.h` into `ndarraytypes.h`. That header is where the `PY_ARRAY_UNIQUE_SYMBOL` rename machinery activates: it textually rewrites the `PyArray_RUNTIME_VERSION` references to a unique extern symbol that the corresponding `import_array()`-calling TU initializes at runtime.

With `PY_ARRAY_UNIQUE_SYMBOL` *not yet* defined when `ndarraytypes.h` is first included in this TU, the rename does not fire. `PyArray_RUNTIME_VERSION` falls through to the default branch and becomes a TU-local `static int = 0`, never modified within the TU. At `-O3` the compiler constant-folds it, and the runtime check inside numpy's `PyDataType_C_METADATA` accessor is eliminated — leaving an unconditional load of `c_metadata` at the numpy 1.x `PyArray_DescrProto` offset (80) rather than the actual numpy 2.x `_PyArray_LegacyDescr_fields` offset (112). For a real `M8[ns]` dtype that offset is `NULL`, so dereferencing it crashes.

Disassembly evidence (macOS arm64, identical pattern on Linux x86_64):

\`\`\`asm
; before fix (numpy 2.5.0.dev0 nightly): unconditional, wrong offset
ldr x8, [x0, #0x50]    ; offset 80 → NULL
ldr x0, [x8, #0x20]    ; SIGSEGV
ret

; after fix: runtime check restored
adrp x8, 0
ldr  w8, [x8]          ; load PANDAS_DATETIME_NUMPYPyArray_RUNTIME_VERSION
cmp  w8, #0x11
mov  w8, #0x50
mov  w9, #0x70
csel x8, x9, x8, gt    ; pick offset 80 vs 112 based on runtime version
ldr  x8, [x0, x8]
ldr  x0, [x8, #0x20]
ret
\`\`\`

The three other pandas TUs that use \`PY_ARRAY_UNIQUE_SYMBOL\` (\`pd_datetime.c\`, \`objToJSON.c\`, \`ujson.c\`) already follow the correct order; \`np_datetime.c\` was the only outlier.

## Test plan

- [x] \`pd.Timestamp(\"2020-01-01\").as_unit(\"ns\", round_ok=False)\` no longer segfaults against numpy 2.5.0.dev0
- [x] \`pd.date_range\` works across all units
- [x] \`DataFrame.to_json\` works (exercises the ujson path through the same vendored CAPI dispatcher)
- [x] Still works against numpy 2.4.4 stable
- [x] pre-commit passes
- [ ] CI: numpy-nightly job

🤖 Generated with [Claude Code](https://claude.com/claude-code)