### PR TITLE
TST: regression test for concat preserving NaN payload bits (GH-51675)

### DIFF
--- a/pandas/tests/reshape/concat/test_empty.py
+++ b/pandas/tests/reshape/concat/test_empty.py
@@ -1,3 +1,5 @@
+import struct
+
 import numpy as np
 import pytest
 
@@ -291,3 +293,17 @@ class TestEmptyConcat:
         expected = df_new.copy()
         result = concat([df_empty, df_new])
         tm.assert_frame_equal(result, expected)
+
+
+def test_concat_preserves_nan_payload():
+    # GH#51675 concat must not replace user-supplied NaN bit patterns
+    payload_nan = struct.unpack(">d", bytes.fromhex("fffffffffffffffe"))[0]
+    values = np.array([payload_nan, np.nan], dtype=np.float64)
+
+    df = DataFrame(values)
+    empty = DataFrame([], columns=[0], dtype=np.float64)
+
+    for frames in ([df, empty], [empty, df], [df, df.iloc[:0]]):
+        result = concat(frames)[0].to_numpy()
+        result_bytes = result[: len(values)].tobytes()
+        assert result_bytes == values.tobytes()


### PR DESCRIPTION
## Summary

- GH-51675 reported that `pd.concat` was destroying user-supplied NaN bit patterns (e.g. `fffffffffffffffe`) when concatenating with an empty `DataFrame`.
- The bug is no longer reproducible on `main` — it appears to have been fixed incidentally by GH-52532 / GH-58056 (the deprecation of ignoring empty entries in `concat`), which retired the code path that built fresh NaN arrays instead of calling `np.concatenate`.
- Adds a small regression test guarding the behavior across `[df, empty]`, `[empty, df]`, and `[df, df.iloc[:0]]`.

closes #51675

## Test plan
- [x] `pytest pandas/tests/reshape/concat/test_empty.py` — 52 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)