### PR TITLE
BUG: avoid materializing full arange in HDFStore chunked iteration (GH-15937)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -335,6 +335,7 @@ I/O
 - Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 - :meth:`DataFrame.to_hdf` now raises a clear :class:`NotImplementedError` when writing a column or :class:`Index` of an unsupported extension dtype (such as :class:`IntervalDtype`, :class:`SparseDtype`, or the nullable integer/float/boolean dtypes), instead of a low-level ``AttributeError`` or PyTables ``TypeError`` (:issue:`26144`, :issue:`38305`, :issue:`42070`)
+- Fixed ``MemoryError`` in :meth:`HDFStore.select` when iterating large tables with ``chunksize`` and no ``where`` filter (:issue:`15937`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 
 Period

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2188,6 +2188,7 @@ class TableIterator:
         self.stop = stop
 
         self.coordinates = None
+        self._called_get_result = False
         if iterator or chunksize is not None:
             if chunksize is None:
                 chunksize = 100000
@@ -2199,12 +2200,18 @@ class TableIterator:
 
     def __iter__(self) -> Iterator:
         # iterate
-        current = self.start
-        if self.coordinates is None:
+        if not self._called_get_result:
             raise ValueError("Cannot iterate until get_result is called.")
+        current = self.start
         while current < self.stop:
             stop = min(current + self.chunksize, self.stop)
-            value = self.func(None, None, self.coordinates[current:stop])
+            if self.coordinates is None:
+                # no `where` filter: iterate by (start, stop) directly so we
+                # don't materialize an np.arange(0, nrows) coordinate array,
+                # which can exhaust memory on very large tables (GH#15937)
+                value = self.func(current, stop, None)
+            else:
+                value = self.func(None, None, self.coordinates[current:stop])
             current = stop
             if value is None or not len(value):
                 continue
@@ -2219,11 +2226,13 @@ class TableIterator:
 
     def get_result(self, coordinates: bool = False):
         #  return the actual iterator
+        self._called_get_result = True
         if self.chunksize is not None:
             if not isinstance(self.s, Table):
                 raise TypeError("can only use an iterator or chunksize on a table")
 
-            self.coordinates = self.s.read_coordinates(where=self.where)
+            if self.where is not None:
+                self.coordinates = self.s.read_coordinates(where=self.where)
 
             return self
 

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -356,6 +356,27 @@ def test_select_iterator(temp_hdfstore):
     tm.assert_frame_equal(result, expected)
 
 
+def test_select_iterator_no_where_skips_coordinates(temp_hdfstore):
+    # GH#15937 chunked iteration without a `where` filter should not
+    # materialize an np.arange(0, nrows) coordinate array, which can
+    # exhaust memory on very large tables.
+    df = DataFrame(
+        np.random.default_rng(2).standard_normal((10, 4)),
+        columns=Index(list("ABCD")),
+        index=date_range("2000-01-01", periods=10, freq="B", unit="ns"),
+    )
+    temp_hdfstore.append("df", df)
+
+    it = temp_hdfstore.select("df", chunksize=2)
+    it.get_result()
+    assert it.coordinates is None
+
+    where = "index >= '2000-01-01'"
+    it_where = temp_hdfstore.select("df", where=where, chunksize=2)
+    it_where.get_result()
+    assert it_where.coordinates is not None
+
+
 def test_select_iterator2(temp_h5_path):
     df = DataFrame(
         np.random.default_rng(2).standard_normal((10, 4)),


### PR DESCRIPTION
## Summary

- Fixes GH-15937: `HDFStore.select(..., chunksize=N)` raised `MemoryError` on large tables when no `where` filter was supplied because `TableIterator.get_result()` unconditionally materialized `np.arange(0, nrows)` (8 bytes per row) before yielding any chunk.
- The chunked-iteration path now skips coordinate materialization when `where is None` and reads each chunk by `(start, stop)` slices instead. Filtered iteration is unchanged.
- Disambiguated the previous "`self.coordinates is None` means get_result not called" sentinel with an explicit `_called_get_result` flag, since `None` now legitimately means "no filter, no coords needed."

closes #15937

## Test plan

- [x] Added `test_select_iterator_no_where_skips_coordinates` asserting `it.coordinates is None` after `get_result()` when no `where` is passed, and non-None when a `where` is passed.
- [x] Existing `pandas/tests/io/pytables/` suite passes (563 passed, 1 skipped).