### PR TITLE
BUG: bdate_range(end, periods, freq=nB) anchors stride at buffer start

### DIFF
--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -152,9 +152,11 @@ def generate_daily_offset_range(
     i8values = i8values[freq._get_daily_offset_mask(dt64)]  # type: ignore[attr-defined]
 
     if abs_n > 1:
-        # When trimming from the end (end+periods case), anchor stride on
-        # the last on-offset date so e.g. freq="2B" with end on a Sunday
-        # yields the last business day, last-2, last-4, ... (GH#64834).
+        # When trimming from the end (end+periods case), the buffer starts
+        # at an arbitrary date (end - buffer_days), so a forward [::abs_n]
+        # stride would anchor there. Reverse first so the stride is anchored
+        # on the last on-offset date <= end, e.g. freq="2B" yields
+        # ..., last-4, last-2, last business day (GH#64648).
         if trim_from_end:
             i8values = i8values[::-1][::abs_n][::-1]
         else:

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -152,7 +152,13 @@ def generate_daily_offset_range(
     i8values = i8values[freq._get_daily_offset_mask(dt64)]  # type: ignore[attr-defined]
 
     if abs_n > 1:
-        i8values = i8values[::abs_n]
+        # When trimming from the end (end+periods case), anchor stride on
+        # the last on-offset date so e.g. freq="2B" with end on a Sunday
+        # yields the last business day, last-2, last-4, ... (GH#64834).
+        if trim_from_end:
+            i8values = i8values[::-1][::abs_n][::-1]
+        else:
+            i8values = i8values[::abs_n]
 
     if trim_to is not None:
         if trim_from_end:

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1194,6 +1194,19 @@ class TestBusinessDateRange:
         result = bdate_range(end="2026-03-22", periods=3)
         tm.assert_index_equal(result, expected)
 
+    @pytest.mark.parametrize("end", ["2026-03-20", "2026-03-21", "2026-03-22"])
+    def test_bdate_range_end_periods_multiple_n(self, end):
+        # GH#64648 (post-merge): with end+periods and freq="nB" (n>=2),
+        # the on-offset stride must be anchored at the end (last business
+        # day <= end), not at the start of the internal buffer.
+        result = bdate_range(end=end, periods=3, freq="2B")
+        expected = DatetimeIndex(["2026-03-16", "2026-03-18", "2026-03-20"])
+        tm.assert_index_equal(result, expected)
+
+        result = bdate_range(end=end, periods=3, freq="3B")
+        expected = DatetimeIndex(["2026-03-12", "2026-03-17", "2026-03-20"])
+        tm.assert_index_equal(result, expected)
+
 
 class TestCustomDateRange:
     def test_constructor(self):


### PR DESCRIPTION
## Summary

Follow-up to GH-64648, addressing a regression flagged by @jorisvandenbossche in post-merge review.

When `bdate_range` / `date_range` is called with `end` + `periods` and `freq="nB"` (or `"nC"`) where `n >= 2`, the new fast path in `generate_daily_offset_range` anchored the `[::n]` stride at the start of the internal buffer instead of at `end`. The result was offset by `buffer_days % n`:

```python
>>> pd.bdate_range(end="2026-03-22", periods=3, freq="2B")
# main (before fix):  ['2026-03-13', '2026-03-17', '2026-03-19']
# expected / 3.0.x:   ['2026-03-16', '2026-03-18', '2026-03-20']
```

`n=1` was unaffected. Only `n>=2` with `end+periods` is broken.

The fix reverses the array before striding so the anchor is the last on-offset date `<= end`, then reverses back. Symmetric with the existing `trim_from_end` branch a few lines later.

This regression only exists on main — 3.0.x doesn't have GH-64648 and uses the old `_generate_range` path, which handles `nB` correctly. No 3.1.0 has been released yet, so no whatsnew entry.

## Test plan

- [x] New parametrized regression test covering `end` on Fri/Sat/Sun with `freq="2B"` and `"3B"`
- [x] Full `pandas/tests/indexes/datetimes/test_date_range.py` (421 tests) passes
- [x] Full `pandas/tests/tseries/` (6941 tests) passes
- [x] mypy and pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)