### PR TITLE
DOC: explain Index.slice_locs missing-label behavior (GH-32680)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7241,16 +7241,28 @@ class Index(IndexOpsMixin, PandasObject):
         See Also
         --------
         Index.get_loc : Get location for a single label.
+        Index.get_slice_bound : Calculate the slice bound for a single label;
+            used internally by ``slice_locs`` for each of ``start`` and ``end``.
 
         Notes
         -----
         This method only works if the index is monotonic or unique.
+
+        If ``start`` or ``end`` is not present in a monotonic index, the
+        returned position is the insertion point that preserves ordering
+        (analogous to :func:`numpy.searchsorted`); no error is raised. If the
+        index is not monotonic and the label is missing, a ``KeyError`` is
+        raised.
 
         Examples
         --------
         >>> idx = pd.Index(list("abcd"))
         >>> idx.slice_locs(start="b", end="c")
         (1, 3)
+
+        ``start`` and ``end`` need not be present in the index; for a
+        monotonic index they are mapped to the appropriate insertion
+        positions:
 
         >>> idx = pd.Index(list("bcde"))
         >>> idx.slice_locs(start="a", end="c")


### PR DESCRIPTION
- [x] closes #32680 (Docs portion. The follow-up feature request for a `method=` kwarg analogous to `get_loc` is out of scope.)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

## Summary

GH-32680 asked for two doc clarifications on `Index.slice_locs`:

1. What happens when `start`/`end` aren't in the index?
2. The docstring should reference `get_slice_bound` (the method actually doing the work).

PR GH-58135 added a missing-label example but left the prose unaddressed, so the issue stayed open. This PR finishes it:

- Adds `Index.get_slice_bound` to **See Also**.
- Expands **Notes** to state that on a monotonic index a missing label maps to the searchsorted insertion point (no error), and that a missing label on a non-monotonic index raises `KeyError`.
- Adds a caption to the second example so the reader sees *why* it's there.

No runtime changes.