### PR TITLE
TYP: enable pyright checking for pandas.compat.pickle_compat

### DIFF
--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -101,12 +101,12 @@ class Unpickler(pickle._Unpickler):
         # compat
         if issubclass(cls, DatetimeArray) and not args:
             arr = np.array([], dtype="M8[ns]")
-            obj = cls.__new__(cls, arr, arr.dtype)
+            obj = cls.__new__(cls, arr, arr.dtype)  # pyright: ignore[reportCallIssue]
         elif issubclass(cls, TimedeltaArray) and not args:
             arr = np.array([], dtype="m8[ns]")
-            obj = cls.__new__(cls, arr, arr.dtype)
+            obj = cls.__new__(cls, arr, arr.dtype)  # pyright: ignore[reportCallIssue]
         elif cls is BlockManager and not args:
-            obj = cls.__new__(cls, (), [], False)
+            obj = cls.__new__(cls, (), [], False)  # pyright: ignore[reportCallIssue]
         else:
             obj = cls.__new__(cls, *args)
         self.append(obj)  # type: ignore[attr-defined]

--- a/pyright_reportGeneralTypeIssues.json
+++ b/pyright_reportGeneralTypeIssues.json
@@ -27,7 +27,6 @@
 
         "pandas/_testing/__init__.py",
         "pandas/_testing/_io.py",
-        "pandas/compat/pickle_compat.py",
         "pandas/core/_numba/extensions.py",
         "pandas/core/_numba/kernels/sum_.py",
         "pandas/core/_numba/kernels/var_.py",


### PR DESCRIPTION
## Summary

- Remove `pandas/compat/pickle_compat.py` from the pyright exclude list in `pyright_reportGeneralTypeIssues.json`.
- Add three narrow `# pyright: ignore[reportCallIssue]` suppressions on the `cls.__new__(cls, ...)` calls in `load_newobj` — these reconstruct Cython-defined `NDArrayBacked` subclasses (`DatetimeArray`/`TimedeltaArray`) and `BlockManager` during unpickle. Their `__new__` signatures come from Cython and aren't visible to pyright.

mypy already checked this file cleanly; this brings pyright to parity.

## Test plan

- [x] `pyright --project pyright_reportGeneralTypeIssues.json` — 0 errors
- [x] `mypy pandas/compat/pickle_compat.py` — clean
- [x] `pytest pandas/tests/io/test_pickle.py` — 753 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)