### PR TITLE
TYP: enable mypy checks for pandas.util

### DIFF
--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -82,12 +82,12 @@ class CompatValidator:
         method = self.method if method is None else method
 
         if method == "args":
-            validate_args(fname, args, max_fname_arg_count, self.defaults)
+            validate_args(fname, args, cast("int", max_fname_arg_count), self.defaults)
         elif method == "kwargs":
             validate_kwargs(fname, kwargs, self.defaults)
         elif method == "both":
             validate_args_and_kwargs(
-                fname, args, kwargs, max_fname_arg_count, self.defaults
+                fname, args, kwargs, cast("int", max_fname_arg_count), self.defaults
             )
         else:
             raise ValueError(f"invalid validation method '{method}'")

--- a/pandas/util/__init__.py
+++ b/pandas/util/__init__.py
@@ -1,4 +1,4 @@
-def __getattr__(key: str):
+def __getattr__(key: str) -> object:
     # These imports need to be lazy to avoid circular import errors
     if key == "hash_array":
         from pandas.core.util.hashing import hash_array

--- a/pandas/util/_doctools.py
+++ b/pandas/util/_doctools.py
@@ -9,6 +9,7 @@ import pandas as pd
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from matplotlib.axes import Axes
     from matplotlib.figure import Figure
 
 
@@ -35,7 +36,9 @@ class TablePlotter:
         row, col = df.shape
         return row + df.columns.nlevels, col + df.index.nlevels
 
-    def _get_cells(self, left, right, vertical) -> tuple[int, int]:
+    def _get_cells(
+        self, left: list[pd.DataFrame], right: pd.DataFrame, vertical: bool
+    ) -> tuple[int, int]:
         """
         Calculate appropriate figure size based on left and right data.
         """
@@ -49,7 +52,11 @@ class TablePlotter:
         return hcells, vcells
 
     def plot(
-        self, left, right, labels: Iterable[str] = (), vertical: bool = True
+        self,
+        left: pd.DataFrame | pd.Series | list[pd.DataFrame | pd.Series],
+        right: pd.DataFrame | pd.Series,
+        labels: Iterable[str] = (),
+        vertical: bool = True,
     ) -> Figure:
         """
         Plot left / right DataFrames in specified layout.
@@ -66,11 +73,13 @@ class TablePlotter:
         import matplotlib.pyplot as plt
 
         if not isinstance(left, list):
-            left = [left]
-        left = [self._conv(df) for df in left]
-        right = self._conv(right)
+            left_raw = [left]
+        else:
+            left_raw = left
+        left_dfs = [self._conv(df) for df in left_raw]
+        right_df = self._conv(right)
 
-        hcells, vcells = self._get_cells(left, right, vertical)
+        hcells, vcells = self._get_cells(left_dfs, right_df, vertical)
 
         if vertical:
             figsize = self.cell_width * hcells, self.cell_height * vcells
@@ -80,36 +89,36 @@ class TablePlotter:
         fig = plt.figure(figsize=figsize)
 
         if vertical:
-            gs = gridspec.GridSpec(len(left), hcells)
+            gs = gridspec.GridSpec(len(left_dfs), hcells)
             # left
-            max_left_cols = max(self._shape(df)[1] for df in left)
-            max_left_rows = max(self._shape(df)[0] for df in left)
-            for i, (_left, _label) in enumerate(zip(left, labels, strict=True)):
+            max_left_cols = max(self._shape(df)[1] for df in left_dfs)
+            max_left_rows = max(self._shape(df)[0] for df in left_dfs)
+            for i, (_left, _label) in enumerate(zip(left_dfs, labels, strict=True)):
                 ax = fig.add_subplot(gs[i, 0:max_left_cols])
                 self._make_table(ax, _left, title=_label, height=1.0 / max_left_rows)
             # right
             ax = plt.subplot(gs[:, max_left_cols:])
-            self._make_table(ax, right, title="Result", height=1.05 / vcells)
+            self._make_table(ax, right_df, title="Result", height=1.05 / vcells)
             fig.subplots_adjust(top=0.9, bottom=0.05, left=0.05, right=0.95)
         else:
-            max_rows = max(self._shape(df)[0] for df in [*left, right])
+            max_rows = max(self._shape(df)[0] for df in [*left_dfs, right_df])
             height = 1.0 / np.max(max_rows)
             gs = gridspec.GridSpec(1, hcells)
             # left
             i = 0
-            for df, _label in zip(left, labels, strict=True):
+            for df, _label in zip(left_dfs, labels, strict=True):
                 sp = self._shape(df)
                 ax = fig.add_subplot(gs[0, i : i + sp[1]])
                 self._make_table(ax, df, title=_label, height=height)
                 i += sp[1]
             # right
             ax = plt.subplot(gs[0, i:])
-            self._make_table(ax, right, title="Result", height=height)
+            self._make_table(ax, right_df, title="Result", height=height)
             fig.subplots_adjust(top=0.85, bottom=0.05, left=0.05, right=0.95)
 
         return fig
 
-    def _conv(self, data):
+    def _conv(self, data: pd.DataFrame | pd.Series) -> pd.DataFrame:
         """
         Convert each input to appropriate format for table output.
         """
@@ -121,7 +130,7 @@ class TablePlotter:
         data = data.fillna("NaN")
         return data
 
-    def _insert_index(self, data):
+    def _insert_index(self, data: pd.DataFrame) -> pd.DataFrame:
         # insert is destructive
         data = data.copy()
         idx_nlevels = data.index.nlevels
@@ -143,7 +152,13 @@ class TablePlotter:
             data.columns = col
         return data
 
-    def _make_table(self, ax, df, title: str, height: float | None = None) -> None:
+    def _make_table(
+        self,
+        ax: Axes,
+        df: pd.DataFrame | None,
+        title: str,
+        height: float | None = None,
+    ) -> None:
         if df is None:
             ax.set_visible(False)
             return

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -10,6 +10,8 @@ from collections.abc import (
     Sequence,
 )
 from typing import (
+    TYPE_CHECKING,
+    Any,
     TypeVar,
     overload,
 )
@@ -24,11 +26,19 @@ from pandas.core.dtypes.common import (
     is_integer,
 )
 
+if TYPE_CHECKING:
+    from pandas._typing import DtypeBackend
+
 BoolishT = TypeVar("BoolishT", bool, int)
 BoolishNoneT = TypeVar("BoolishNoneT", bool, int, None)
 
 
-def _check_arg_length(fname, args, max_fname_arg_count, compat_args) -> None:
+def _check_arg_length(
+    fname: str | None,
+    args: tuple[Any, ...],
+    max_fname_arg_count: int,
+    compat_args: dict[str, Any],
+) -> None:
     """
     Checks whether 'args' has length of at most 'compat_args'. Raises
     a TypeError if that is not the case, similar to in Python when a
@@ -48,7 +58,11 @@ def _check_arg_length(fname, args, max_fname_arg_count, compat_args) -> None:
         )
 
 
-def _check_for_default_values(fname, arg_val_dict, compat_args) -> None:
+def _check_for_default_values(
+    fname: str | None,
+    arg_val_dict: dict[str, Any],
+    compat_args: dict[str, Any],
+) -> None:
     """
     Check that the keys in `arg_val_dict` are mapped to their
     default values as specified in `compat_args`.
@@ -56,14 +70,12 @@ def _check_for_default_values(fname, arg_val_dict, compat_args) -> None:
     Note that this function is to be called only when it has been
     checked that arg_val_dict.keys() is a subset of compat_args
     """
-    for key in arg_val_dict:
+    for key, v1 in arg_val_dict.items():
+        v2 = compat_args[key]
         # try checking equality directly with '=' operator,
         # as comparison may have been overridden for the left
         # hand object
         try:
-            v1 = arg_val_dict[key]
-            v2 = compat_args[key]
-
             # check for None-ness otherwise we could end up
             # comparing a numpy array vs None
             if (v1 is not None and v2 is None) or (v1 is None and v2 is not None):
@@ -77,7 +89,7 @@ def _check_for_default_values(fname, arg_val_dict, compat_args) -> None:
         # could not compare them directly, so try comparison
         # using the 'is' operator
         except ValueError:
-            match = arg_val_dict[key] is compat_args[key]
+            match = v1 is v2
 
         if not match:
             raise ValueError(
@@ -86,7 +98,12 @@ def _check_for_default_values(fname, arg_val_dict, compat_args) -> None:
             )
 
 
-def validate_args(fname, args, max_fname_arg_count, compat_args) -> None:
+def validate_args(
+    fname: str | None,
+    args: tuple[Any, ...],
+    max_fname_arg_count: int,
+    compat_args: dict[str, Any],
+) -> None:
     """
     Checks whether the length of the `*args` argument passed into a function
     has at most `len(compat_args)` arguments and whether or not all of these
@@ -127,7 +144,11 @@ def validate_args(fname, args, max_fname_arg_count, compat_args) -> None:
     _check_for_default_values(fname, kwargs, compat_args)
 
 
-def _check_for_invalid_keys(fname, kwargs, compat_args) -> None:
+def _check_for_invalid_keys(
+    fname: str | None,
+    kwargs: dict[str, Any],
+    compat_args: dict[str, Any],
+) -> None:
     """
     Checks whether 'kwargs' contains any keys that are not
     in 'compat_args' and raises a TypeError if there is one.
@@ -140,7 +161,11 @@ def _check_for_invalid_keys(fname, kwargs, compat_args) -> None:
         raise TypeError(f"{fname}() got an unexpected keyword argument '{bad_arg}'")
 
 
-def validate_kwargs(fname, kwargs, compat_args) -> None:
+def validate_kwargs(
+    fname: str | None,
+    kwargs: dict[str, Any],
+    compat_args: dict[str, Any],
+) -> None:
     """
     Checks whether parameters passed to the **kwargs argument in a
     function `fname` are valid parameters as specified in `*compat_args`
@@ -168,7 +193,11 @@ def validate_kwargs(fname, kwargs, compat_args) -> None:
 
 
 def validate_args_and_kwargs(
-    fname, args, kwargs, max_fname_arg_count, compat_args
+    fname: str | None,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    max_fname_arg_count: int,
+    compat_args: dict[str, Any],
 ) -> None:
     """
     Checks whether parameters passed to the *args and **kwargs argument in a
@@ -270,7 +299,7 @@ def validate_bool_kwarg(
     return value
 
 
-def validate_na_arg(value, name: str):
+def validate_na_arg(value: object, name: str) -> None:
     """
     Validate na arguments.
 
@@ -434,7 +463,7 @@ def validate_insert_loc(loc: int, length: int) -> int:
     return loc  # pyright: ignore[reportReturnType]
 
 
-def check_dtype_backend(dtype_backend) -> None:
+def check_dtype_backend(dtype_backend: DtypeBackend | lib.NoDefault) -> None:
     if dtype_backend is not lib.no_default:
         if dtype_backend not in ["numpy_nullable", "pyarrow"]:
             raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -615,9 +615,6 @@ module = [
   "pandas.tests.*",
   "pandas.tseries.frequencies", # TODO
   "pandas.tseries.holiday", # TODO
-  "pandas.util._doctools", # TODO
-  "pandas.util._validators", # TODO
-  "pandas.util", # TODO
   "pandas.conftest",
   "pandas"
 ]


### PR DESCRIPTION
## Summary
- Annotates `pandas.util.__init__`, `pandas.util._doctools`, and `pandas.util._validators` so they satisfy mypy under the project's strict flags
- Drops the three matching entries from the `pyproject.toml` mypy override block
- Inserts `cast("int", max_fname_arg_count)` at the two `CompatValidator.__call__` call sites that hand `max_fname_arg_count` to `validate_args`/`validate_args_and_kwargs` (the field is `int | None` for deferred initialization, but is always non-`None` by the time those branches run)

## Test plan
- [x] `mypy pandas` passes (1458 source files)
- [x] `pyright` clean on the touched files
- [x] `pytest pandas/tests/util` passes (981 passed, 2 skipped, 2 xfailed)
- [x] `pre-commit` passes