### PR TITLE
TYP: enable mypy for pandas.core.computation.common

### DIFF
--- a/pandas/core/computation/common.py
+++ b/pandas/core/computation/common.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 from functools import reduce
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
 
 import numpy as np
 
 from pandas._config.config import _global_config as config
 
+if TYPE_CHECKING:
+    from pandas._typing import DtypeObj
 
-def ensure_decoded(s) -> str:
+
+def ensure_decoded(s: str | bytes) -> str:
     """
     If we have bytes, decode them to unicode.
     """
@@ -16,7 +23,7 @@ def ensure_decoded(s) -> str:
     return s
 
 
-def result_type_many(*arrays_and_dtypes):
+def result_type_many(*arrays_and_dtypes: Any) -> DtypeObj:
     """
     Wrapper around numpy.result_type which overcomes the NPY_MAXARGS (32)
     argument limit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -534,7 +534,14 @@ module = [
   "pandas.core.array_algos.replace", # TODO
   "pandas.core.array_algos.take", # TODO
   "pandas.core.arrays.*", # TODO
-  "pandas.core.computation.*", # TODO
+  "pandas.core.computation.align", # TODO
+  "pandas.core.computation.engines", # TODO
+  "pandas.core.computation.eval", # TODO
+  "pandas.core.computation.expr", # TODO
+  "pandas.core.computation.expressions", # TODO
+  "pandas.core.computation.ops", # TODO
+  "pandas.core.computation.pytables", # TODO
+  "pandas.core.computation.scope", # TODO
   "pandas.core.dtypes.common", # TODO
   "pandas.core.dtypes.dtypes", # TODO
   "pandas.core.dtypes.missing", # TODO


### PR DESCRIPTION
## Summary
- Replace the wildcard `pandas.core.computation.*` mypy override with explicit per-file entries, so newly typed files automatically get checked.
- Type `ensure_decoded` and `result_type_many` in `pandas/core/computation/common.py` so it passes mypy with the strict project settings.
- Eight files in `pandas.core.computation` (align, engines, eval, expr, expressions, ops, pytables, scope) remain on the override list; they can be tackled in follow-ups, one per PR.

## Test plan
- [x] `mypy pandas/` clean across 1458 source files
- [x] `pre-commit run --files pandas/core/computation/common.py pyproject.toml`
- [x] Manual smoke test of `ensure_decoded` (str / bytes / np.bytes_) and `result_type_many` (typical and >NPY_MAXARGS args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)