### PR TITLE
TYP: enable mypy on pandas.core._numba.executor

### DIFF
--- a/pandas/core/_numba/executor.py
+++ b/pandas/core/_numba/executor.py
@@ -8,6 +8,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
     from pandas._typing import Scalar
 
 import numpy as np
@@ -18,7 +19,9 @@ from pandas.core.util.numba_ import jit_user_function
 
 
 @functools.cache
-def generate_apply_looper(func, nogil: bool = True, parallel: bool = False):
+def generate_apply_looper(
+    func: Callable, nogil: bool = True, parallel: bool = False
+) -> Callable:
     if TYPE_CHECKING:
         import numba
     else:
@@ -26,7 +29,7 @@ def generate_apply_looper(func, nogil: bool = True, parallel: bool = False):
     nb_compat_func = jit_user_function(func)
 
     @numba.jit(nogil=nogil, parallel=parallel)
-    def nb_looper(values, axis, *args):
+    def nb_looper(values: np.ndarray, axis: int, *args: Any) -> np.ndarray:
         # Operate on the first row/col in order to get
         # the output shape
         if axis == 0:
@@ -58,7 +61,13 @@ def generate_apply_looper(func, nogil: bool = True, parallel: bool = False):
 
 
 @functools.cache
-def make_looper(func, result_dtype, is_grouped_kernel, nogil: bool, parallel: bool):
+def make_looper(
+    func: Callable,
+    result_dtype: np.dtype,
+    is_grouped_kernel: bool,
+    nogil: bool,
+    parallel: bool,
+) -> Callable:
     if TYPE_CHECKING:
         import numba
     else:
@@ -72,8 +81,8 @@ def make_looper(func, result_dtype, is_grouped_kernel, nogil: bool, parallel: bo
             labels: np.ndarray,
             ngroups: int,
             min_periods: int,
-            *args,
-        ):
+            *args: Any,
+        ) -> tuple[np.ndarray, dict[int, np.ndarray]]:
             result = np.empty((values.shape[0], ngroups), dtype=result_dtype)
             na_positions = {}
             for i in numba.prange(values.shape[0]):
@@ -90,15 +99,16 @@ def make_looper(func, result_dtype, is_grouped_kernel, nogil: bool, parallel: bo
         @numba.jit(nogil=nogil, parallel=parallel)
         # error: Incompatible redefinition (redefinition with type
         # "Callable[[ndarray[Any, Any], ndarray[Any, Any], ndarray[Any, Any],
-        # int, VarArg(Any)], Any]", original type "Callable[[ndarray[Any, Any],
-        # ndarray[Any, Any], int, int, VarArg(Any)], Any]")
+        # int, VarArg(Any)], tuple[ndarray[Any, Any], dict[int, ndarray[Any, Any]]]]",
+        # original type "Callable[[ndarray[Any, Any], ndarray[Any, Any], int, int,
+        # VarArg(Any)], tuple[ndarray[Any, Any], dict[int, ndarray[Any, Any]]]]")
         def column_looper(  # type: ignore[misc]
             values: np.ndarray,
             start: np.ndarray,
             end: np.ndarray,
             min_periods: int,
-            *args,
-        ):
+            *args: Any,
+        ) -> tuple[np.ndarray, dict[int, np.ndarray]]:
             result = np.empty((values.shape[0], len(start)), dtype=result_dtype)
             na_positions = {}
             for i in numba.prange(values.shape[0]):
@@ -168,7 +178,7 @@ def generate_shared_aggregator(
     is_grouped_kernel: bool,
     nogil: bool,
     parallel: bool,
-):
+) -> Callable:
     """
     Generate a Numba function that loops over the columns 2D object and applies
     a 1D numba kernel over each column.
@@ -201,14 +211,14 @@ def generate_shared_aggregator(
     # It also post-processes the values by inserting nans where number of observations
     # is less than min_periods
     def looper_wrapper(
-        values,
-        start=None,
-        end=None,
-        labels=None,
-        ngroups=None,
+        values: np.ndarray,
+        start: np.ndarray | None = None,
+        end: np.ndarray | None = None,
+        labels: np.ndarray | None = None,
+        ngroups: int | None = None,
         min_periods: int = 0,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> np.ndarray:
         result_dtype = dtype_mapping[values.dtype]
         column_looper = make_looper(
             func, result_dtype, is_grouped_kernel, nogil, parallel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -528,7 +528,6 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = [
   "pandas._libs.*",
-  "pandas.core._numba.executor", # TODO
   "pandas.core.array_algos.masked_reductions", # TODO
   "pandas.core.array_algos.replace", # TODO
   "pandas.core.array_algos.take", # TODO


### PR DESCRIPTION
## Summary
- Removed the `pandas.core._numba.executor` entry from the mypy override list in `pyproject.toml`
- Added type annotations to the previously-unannotated functions and inner JIT-decorated wrappers (`generate_apply_looper`, `nb_looper`, `make_looper`, both `column_looper` branches, `generate_shared_aggregator`, `looper_wrapper`)
- Updated the existing `# error: Incompatible redefinition` comment near the second `column_looper` to reflect the now-typed return

## Test plan
- [x] `mypy pandas/core/_numba/executor.py` clean (only pre-existing unrelated errors in `pandas/core/arrays/datetimes.py` remain)
- [x] `pyright pandas/core/_numba/executor.py` clean
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)