### PR TITLE
TYP: enable mypy checking for pandas._testing

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -8,6 +8,7 @@ from sys import byteorder
 import threading
 from typing import (
     TYPE_CHECKING,
+    Any,
     ContextManager,
 )
 
@@ -83,12 +84,18 @@ from pandas.core.arrays._mixins import NDArrayBackedExtensionArray
 from pandas.core.construction import extract_array
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Sequence,
+    )
 
     from pandas._typing import (
         Dtype,
         NpDtype,
     )
+
+    from pandas.core.arrays import ExtensionArray
 
 
 UNSIGNED_INT_NUMPY_DTYPES: list[NpDtype] = ["uint8", "uint16", "uint32", "uint64"]
@@ -271,7 +278,7 @@ comparison_dunder_methods = ["__eq__", "__ne__", "__le__", "__lt__", "__ge__", "
 # Comparators
 
 
-def box_expected(expected, box_cls, transpose: bool = True):
+def box_expected(expected: Any, box_cls: Any, transpose: bool = True) -> Any:
     """
     Helper function to wrap the expected output of a test in a given box_class.
 
@@ -312,7 +319,7 @@ def box_expected(expected, box_cls, transpose: bool = True):
     return expected
 
 
-def to_array(obj):
+def to_array(obj: Any) -> ExtensionArray | np.ndarray:
     """
     Similar to pd.array, but does not cast numpy dtypes to nullable dtypes.
     """
@@ -329,7 +336,7 @@ class SubclassedSeries(Series):
     _metadata = ["testattr", "name"]
 
     @property
-    def _constructor(self):
+    def _constructor(self) -> Callable:  # type: ignore[override]
         # For testing, those properties return a generic callable, and not
         # the actual class. In this case that is equivalent, but it is to
         # ensure we don't rely on the property returning a class
@@ -338,7 +345,7 @@ class SubclassedSeries(Series):
         return lambda *args, **kwargs: SubclassedSeries(*args, **kwargs)
 
     @property
-    def _constructor_expanddim(self):
+    def _constructor_expanddim(self) -> Callable:
         return lambda *args, **kwargs: SubclassedDataFrame(*args, **kwargs)
 
 
@@ -346,12 +353,12 @@ class SubclassedDataFrame(DataFrame):
     _metadata = ["testattr"]
 
     @property
-    def _constructor(self):
+    def _constructor(self) -> Callable:  # type: ignore[override]
         return lambda *args, **kwargs: SubclassedDataFrame(*args, **kwargs)
 
     # error: Cannot override writeable attribute with read-only property
     @property
-    def _constructor_sliced(self):  # type: ignore[override]
+    def _constructor_sliced(self) -> Callable:  # type: ignore[override]
         return lambda *args, **kwargs: SubclassedSeries(*args, **kwargs)
 
 
@@ -394,7 +401,10 @@ def external_error_raised(expected_exception: type[Exception]) -> ContextManager
     return pytest.raises(expected_exception, match=None)
 
 
-def get_cython_table_params(ndframe, func_names_and_expected):
+def get_cython_table_params(
+    ndframe: DataFrame | Series,
+    func_names_and_expected: Iterable[Sequence[Any]],
+) -> list[tuple[DataFrame | Series, str, Any]]:
     """
     Combine frame, functions from com._cython_table
     keys and expected result.
@@ -446,27 +456,27 @@ def get_op_from_name(op_name: str) -> Callable:
 # Indexing test helpers
 
 
-def getitem(x):
+def getitem(x: Any) -> Any:
     return x
 
 
-def setitem(x):
+def setitem(x: Any) -> Any:
     return x
 
 
-def loc(x):
+def loc(x: Any) -> Any:
     return x.loc
 
 
-def iloc(x):
+def iloc(x: Any) -> Any:
     return x.iloc
 
 
-def at(x):
+def at(x: Any) -> Any:
     return x.at
 
 
-def iat(x):
+def iat(x: Any) -> Any:
     return x.iat
 
 
@@ -484,7 +494,7 @@ def get_finest_unit(left: str, right: str) -> str:
     return right
 
 
-def shares_memory(left, right) -> bool:
+def shares_memory(left: Any, right: Any) -> bool:
     """
     Pandas-compat for np.shares_memory.
     """
@@ -537,7 +547,12 @@ def shares_memory(left, right) -> bool:
     raise NotImplementedError(type(left), type(right))
 
 
-def run_multithreaded(closure, max_workers, arguments=None, pass_barrier=False):
+def run_multithreaded(
+    closure: Callable,
+    max_workers: int,
+    arguments: Iterable | None = None,
+    pass_barrier: bool = False,
+) -> None:
     with ThreadPoolExecutor(max_workers=max_workers) as tpe:
         if arguments is None:
             arguments = []

--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -46,7 +46,9 @@ def round_trip_pickle(obj: Any, tmp_path: Path) -> DataFrame | Series:
     return pd.read_pickle(tmp_path)
 
 
-def round_trip_pathlib(writer, reader, tmp_path: Path):
+def round_trip_pathlib(
+    writer: Callable, reader: Callable, tmp_path: Path
+) -> DataFrame | Series:
     """
     Write an object to file specified by a pathlib.Path and read it back
 
@@ -69,7 +71,9 @@ def round_trip_pathlib(writer, reader, tmp_path: Path):
     return obj
 
 
-def write_to_compressed(compression, path: str, data, dest: str = "test") -> None:
+def write_to_compressed(
+    compression: str, path: str, data: bytes, dest: str = "test"
+) -> None:
     """
     Write data to a compressed file.
 

--- a/pandas/_testing/_warnings.py
+++ b/pandas/_testing/_warnings.py
@@ -10,6 +10,7 @@ import re
 import sys
 from typing import (
     TYPE_CHECKING,
+    Any,
     Literal,
     Union,
     cast,
@@ -143,7 +144,7 @@ def assert_produces_warning(
 
 
 def maybe_produces_warning(
-    warning: type[Warning], condition: bool, **kwargs
+    warning: type[Warning], condition: bool, **kwargs: Any
 ) -> AbstractContextManager:
     """
     Return a context manager that possibly checks a warning based on the condition

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import operator
 from typing import (
     TYPE_CHECKING,
+    Any,
     Literal,
     NoReturn,
     cast,
@@ -42,6 +43,7 @@ from pandas.core.dtypes.missing import array_equivalent
 import pandas as pd
 from pandas import (
     Categorical,
+    CategoricalIndex,
     DataFrame,
     DatetimeIndex,
     Index,
@@ -67,16 +69,21 @@ from pandas.core.indexes.api import safe_sort_index
 from pandas.io.formats.printing import pprint_thing
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Container,
+        Iterable,
+    )
+
     from pandas._typing import DtypeObj
 
 
 def assert_almost_equal(
-    left,
-    right,
+    left: Any,
+    right: Any,
     check_dtype: bool | Literal["equiv"] = "equiv",
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     """
     Check that the left and right objects are approximately equal.
@@ -152,7 +159,7 @@ def assert_almost_equal(
         )
 
 
-def _check_isinstance(left, right, cls) -> None:
+def _check_isinstance(left: Any, right: Any, cls: type) -> None:
     """
     Helper method for our assert_* methods that ensures that
     the two objects being compared have the right type before
@@ -180,7 +187,7 @@ def _check_isinstance(left, right, cls) -> None:
         )
 
 
-def assert_dict_equal(left, right, compare_keys: bool = True) -> None:
+def assert_dict_equal(left: dict, right: dict, compare_keys: bool = True) -> None:
     _check_isinstance(left, right, dict)
     _testing.assert_dict_equal(left, right, compare_keys=compare_keys)
 
@@ -255,7 +262,7 @@ def assert_index_equal(
     if obj is None:
         obj = "MultiIndex" if isinstance(left, MultiIndex) else "Index"
 
-    def _check_rangeindex_index_int(left, right) -> bool:
+    def _check_rangeindex_index_int(left: Index, right: Index) -> bool:
         return (
             isinstance(left, RangeIndex)
             and isinstance(right, Index)
@@ -279,7 +286,7 @@ def assert_index_equal(
             )
         exact = "equiv"
 
-    def _check_types(left, right, obj: str = "Index") -> None:
+    def _check_types(left: Index, right: Index, obj: str = "Index") -> None:
         if not exact:
             return
 
@@ -292,7 +299,11 @@ def assert_index_equal(
         ):
             if check_categorical:
                 assert_attr_equal("dtype", left, right, obj=obj)
-                assert_index_equal(left.categories, right.categories, exact=exact)
+                assert_index_equal(
+                    cast("CategoricalIndex", left).categories,
+                    cast("CategoricalIndex", right).categories,
+                    exact=exact,
+                )
             return
 
         assert_attr_equal("dtype", left, right, obj=obj)
@@ -401,24 +412,31 @@ def assert_index_equal(
     if isinstance(left, PeriodIndex) or isinstance(right, PeriodIndex):
         assert_attr_equal("dtype", left, right, obj=obj)
     if isinstance(left, IntervalIndex) or isinstance(right, IntervalIndex):
-        assert_interval_array_equal(left._values, right._values)
+        assert_interval_array_equal(
+            cast("IntervalArray", left._values),
+            cast("IntervalArray", right._values),
+        )
 
     if check_categorical:
         if isinstance(left.dtype, CategoricalDtype) or isinstance(
             right.dtype, CategoricalDtype
         ):
-            assert_categorical_equal(left._values, right._values, obj=f"{obj} category")
+            assert_categorical_equal(
+                cast("Categorical", left._values),
+                cast("Categorical", right._values),
+                obj=f"{obj} category",
+            )
 
 
 def assert_class_equal(
-    left, right, exact: bool | str = True, obj: str = "Input"
+    left: Any, right: Any, exact: bool | str = True, obj: str = "Input"
 ) -> None:
     """
     Checks classes are equal.
     """
     __tracebackhide__ = True
 
-    def repr_class(x):
+    def repr_class(x: Any) -> Any:
         if isinstance(x, Index):
             # return Index as it is to include values in the error message
             return x
@@ -444,7 +462,9 @@ def assert_class_equal(
     raise_assert_detail(obj, msg, repr_class(left), repr_class(right))
 
 
-def assert_attr_equal(attr: str, left, right, obj: str = "Attributes") -> None:
+def assert_attr_equal(
+    attr: str, left: Any, right: Any, obj: str = "Attributes"
+) -> None:
     """
     Check attributes are equal. Both objects must have attribute.
 
@@ -483,7 +503,7 @@ def assert_attr_equal(attr: str, left, right, obj: str = "Attributes") -> None:
     return None
 
 
-def assert_is_sorted(seq) -> None:
+def assert_is_sorted(seq: Index | Series | np.ndarray | ExtensionArray) -> None:
     """Assert that the sequence is sorted."""
     if isinstance(seq, (Index, Series)):
         seq = seq.values
@@ -495,8 +515,8 @@ def assert_is_sorted(seq) -> None:
 
 
 def assert_categorical_equal(
-    left,
-    right,
+    left: Categorical,
+    right: Categorical,
     check_dtype: bool = True,
     check_category_order: bool = True,
     obj: str = "Categorical",
@@ -556,7 +576,10 @@ def assert_categorical_equal(
 
 
 def assert_interval_array_equal(
-    left, right, exact: bool | Literal["equiv"] = "equiv", obj: str = "IntervalArray"
+    left: IntervalArray,
+    right: IntervalArray,
+    exact: bool | Literal["equiv"] = "equiv",
+    obj: str = "IntervalArray",
 ) -> None:
     """
     Test that two IntervalArrays are equivalent.
@@ -581,14 +604,18 @@ def assert_interval_array_equal(
     assert_attr_equal("closed", left, right, obj=obj)
 
 
-def assert_period_array_equal(left, right, obj: str = "PeriodArray") -> None:
+def assert_period_array_equal(
+    left: PeriodArray, right: PeriodArray, obj: str = "PeriodArray"
+) -> None:
     _check_isinstance(left, right, PeriodArray)
 
     assert_numpy_array_equal(left._ndarray, right._ndarray, obj=f"{obj}._ndarray")
     assert_attr_equal("dtype", left, right, obj=obj)
 
 
-def assert_datetime_array_equal(left, right, obj: str = "DatetimeArray") -> None:
+def assert_datetime_array_equal(
+    left: DatetimeArray, right: DatetimeArray, obj: str = "DatetimeArray"
+) -> None:
     __tracebackhide__ = True
     _check_isinstance(left, right, DatetimeArray)
 
@@ -596,14 +623,22 @@ def assert_datetime_array_equal(left, right, obj: str = "DatetimeArray") -> None
     assert_attr_equal("tz", left, right, obj=obj)
 
 
-def assert_timedelta_array_equal(left, right, obj: str = "TimedeltaArray") -> None:
+def assert_timedelta_array_equal(
+    left: TimedeltaArray, right: TimedeltaArray, obj: str = "TimedeltaArray"
+) -> None:
     __tracebackhide__ = True
     _check_isinstance(left, right, TimedeltaArray)
     assert_numpy_array_equal(left._ndarray, right._ndarray, obj=f"{obj}._ndarray")
 
 
 def raise_assert_detail(
-    obj, message, left, right, diff=None, first_diff=None, index_values=None
+    obj: Any,
+    message: str,
+    left: Any,
+    right: Any,
+    diff: Any = None,
+    first_diff: Any = None,
+    index_values: Index | np.ndarray | None = None,
 ) -> NoReturn:
     __tracebackhide__ = True
 
@@ -641,14 +676,14 @@ def raise_assert_detail(
 
 
 def assert_numpy_array_equal(
-    left,
-    right,
+    left: Any,
+    right: Any,
     strict_nan: bool = False,
     check_dtype: bool | Literal["equiv"] = True,
-    err_msg=None,
-    check_same=None,
+    err_msg: str | None = None,
+    check_same: Literal["copy", "same"] | None = None,
     obj: str = "numpy array",
-    index_values=None,
+    index_values: Index | np.ndarray | None = None,
 ) -> None:
     """
     Check that 'np.ndarray' is equivalent.
@@ -679,7 +714,7 @@ def assert_numpy_array_equal(
     # both classes must be an np.ndarray
     _check_isinstance(left, right, np.ndarray)
 
-    def _get_base(obj):
+    def _get_base(obj: np.ndarray) -> Any:
         return obj.base if getattr(obj, "base", None) is not None else obj
 
     left_base = _get_base(left)
@@ -692,14 +727,14 @@ def assert_numpy_array_equal(
         if left_base is right_base:
             raise AssertionError(f"{left_base!r} is {right_base!r}")
 
-    def _raise(left, right, err_msg) -> NoReturn:
+    def _raise(left: np.ndarray, right: np.ndarray, err_msg: str | None) -> NoReturn:
         if err_msg is None:
             if left.shape != right.shape:
                 raise_assert_detail(
                     obj, f"{obj} shapes are different", left.shape, right.shape
                 )
 
-            diff = 0
+            diff = 0.0
             for left_arr, right_arr in zip(left, right, strict=True):
                 # count up differences
                 if not array_equivalent(left_arr, right_arr, strict_nan=strict_nan):
@@ -722,10 +757,10 @@ def assert_numpy_array_equal(
 
 @set_module("pandas.testing")
 def assert_extension_array_equal(
-    left,
-    right,
+    left: ExtensionArray,
+    right: ExtensionArray,
     check_dtype: bool | Literal["equiv"] = True,
-    index_values=None,
+    index_values: Index | np.ndarray | None = None,
     check_exact: bool | lib.NoDefault = lib.no_default,
     rtol: float | lib.NoDefault = lib.no_default,
     atol: float | lib.NoDefault = lib.no_default,
@@ -879,8 +914,8 @@ def assert_extension_array_equal(
 @set_module("pandas.testing")
 @deprecate_kwarg(Pandas4Warning, "check_datetimelike_compat", new_arg_name=None)
 def assert_series_equal(
-    left,
-    right,
+    left: Series,
+    right: Series,
     check_dtype: bool | Literal["equiv"] = True,
     check_index_type: bool | Literal["equiv"] = "equiv",
     check_series_type: bool = True,
@@ -982,10 +1017,14 @@ def assert_series_equal(
             is_numeric_dtype(left.dtype) and not is_float_dtype(left.dtype)
         ) or (is_numeric_dtype(right.dtype) and not is_float_dtype(right.dtype))
         left_index_dtypes = (
-            [left.index.dtype] if left.index.nlevels == 1 else left.index.dtypes
+            [left.index.dtype]
+            if left.index.nlevels == 1
+            else cast("MultiIndex", left.index).dtypes
         )
         right_index_dtypes = (
-            [right.index.dtype] if right.index.nlevels == 1 else right.index.dtypes
+            [right.index.dtype]
+            if right.index.nlevels == 1
+            else cast("MultiIndex", right.index).dtypes
         )
         check_exact_index = all(
             dtype.kind in "iu" for dtype in left_index_dtypes
@@ -1037,7 +1076,7 @@ def assert_series_equal(
 
     if check_freq and isinstance(left.index, (DatetimeIndex, TimedeltaIndex)):
         lidx = left.index
-        ridx = right.index
+        ridx = cast("DatetimeIndex | TimedeltaIndex", right.index)
         assert lidx.freq == ridx.freq, (lidx.freq, ridx.freq)
 
     if check_dtype:
@@ -1098,7 +1137,9 @@ def assert_series_equal(
     elif isinstance(left.dtype, IntervalDtype) and isinstance(
         right.dtype, IntervalDtype
     ):
-        assert_interval_array_equal(left.array, right.array)
+        assert_interval_array_equal(
+            cast("IntervalArray", left.array), cast("IntervalArray", right.array)
+        )
     elif isinstance(left.dtype, CategoricalDtype) or isinstance(
         right.dtype, CategoricalDtype
     ):
@@ -1173,8 +1214,8 @@ def assert_series_equal(
 @set_module("pandas.testing")
 @deprecate_kwarg(Pandas4Warning, "check_datetimelike_compat", new_arg_name=None)
 def assert_frame_equal(
-    left,
-    right,
+    left: DataFrame,
+    right: DataFrame,
     check_dtype: bool | Literal["equiv"] = True,
     check_index_type: bool | Literal["equiv"] = "equiv",
     check_column_type: bool | Literal["equiv"] = "equiv",
@@ -1387,7 +1428,7 @@ def assert_frame_equal(
                 )
 
 
-def assert_equal(left, right, **kwargs) -> None:
+def assert_equal(left: Any, right: Any, **kwargs: Any) -> None:
     """
     Wrapper for tm.assert_*_equal to dispatch to the appropriate test function.
 
@@ -1428,7 +1469,7 @@ def assert_equal(left, right, **kwargs) -> None:
         assert_almost_equal(left, right)
 
 
-def assert_sp_array_equal(left, right) -> None:
+def assert_sp_array_equal(left: Any, right: Any) -> None:
     """
     Check that the left and right SparseArray are equal.
 
@@ -1461,12 +1502,12 @@ def assert_sp_array_equal(left, right) -> None:
     assert_numpy_array_equal(left.to_dense(), right.to_dense())
 
 
-def assert_contains_all(iterable, dic) -> None:
+def assert_contains_all(iterable: Iterable, dic: Container) -> None:
     for k in iterable:
         assert k in dic, f"Did not contain item: {k!r}"
 
 
-def assert_copy(iter1, iter2, **eql_kwargs) -> None:
+def assert_copy(iter1: Iterable, iter2: Iterable, **eql_kwargs: Any) -> None:
     """
     iter1, iter2: iterables that produce elements
     comparable with assert_almost_equal

--- a/pandas/_testing/compat.py
+++ b/pandas/_testing/compat.py
@@ -11,8 +11,10 @@ from pandas import DataFrame
 if TYPE_CHECKING:
     from pandas._typing import DtypeObj
 
+    from pandas import Series
 
-def get_dtype(obj) -> DtypeObj:
+
+def get_dtype(obj: DataFrame | Series) -> DtypeObj:
     if isinstance(obj, DataFrame):
         # Note: we are assuming only one column
         return obj.dtypes.iat[0]
@@ -20,7 +22,7 @@ def get_dtype(obj) -> DtypeObj:
         return obj.dtype
 
 
-def get_obj(df: DataFrame, klass):
+def get_obj(df: DataFrame, klass: type) -> DataFrame | Series:
     """
     For sharing tests using frame_or_series, either return the DataFrame
     unchanged or return its first column as a Series.

--- a/pandas/_testing/contexts.py
+++ b/pandas/_testing/contexts.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import (
+    AbstractContextManager,
+    contextmanager,
+)
 import os
 import sys
 from typing import (
     IO,
     TYPE_CHECKING,
+    Any,
 )
 
 from pandas.compat import CHAINED_WARNING_DISABLED
@@ -69,7 +73,7 @@ def set_timezone(tz: str) -> Generator[None]:
     """
     import time
 
-    def setTZ(tz) -> None:
+    def setTZ(tz: str | None) -> None:
         if hasattr(time, "tzset"):
             if tz is None:
                 try:
@@ -91,7 +95,7 @@ def set_timezone(tz: str) -> Generator[None]:
 
 
 @contextmanager
-def with_csv_dialect(name: str, **kwargs) -> Generator[None]:
+def with_csv_dialect(name: str, **kwargs: Any) -> Generator[None]:
     """
     Context manager to temporarily register a CSV dialect for parsing CSV.
 
@@ -124,7 +128,10 @@ def with_csv_dialect(name: str, **kwargs) -> Generator[None]:
         csv.unregister_dialect(name)
 
 
-def raises_chained_assignment_error(extra_warnings=(), extra_match=()):
+def raises_chained_assignment_error(
+    extra_warnings: tuple[type[Warning], ...] = (),
+    extra_match: tuple[str | None, ...] = (),
+) -> AbstractContextManager:
     from pandas._testing import assert_produces_warning
 
     if CHAINED_WARNING_DISABLED:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -18852,7 +18852,7 @@ class DataFrame(NDFrame, OpsMixin):
     # ----------------------------------------------------------------------
     # Internal Interface Methods
 
-    def _to_dict_of_blocks(self):
+    def _to_dict_of_blocks(self) -> dict[str, DataFrame]:
         """
         Return a dict of dtype -> Constructor Types that
         each is a homogeneous dtype.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -528,7 +528,6 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = [
   "pandas._libs.*",
-  "pandas._testing.*", # TODO
   "pandas.core._numba.executor", # TODO
   "pandas.core.array_algos.masked_reductions", # TODO
   "pandas.core.array_algos.replace", # TODO


### PR DESCRIPTION
## Summary

- Removes `pandas._testing.*` from the mypy `[[tool.mypy.overrides]]` exclude list and adds the type annotations needed to type-check it cleanly.
- Most changes are filling in missing parameter / return annotations on public helpers (`assert_*_equal`, `box_expected`, `to_array`, `shares_memory`, ...) and inner functions.
- A handful of `cast()` calls where mypy couldn't narrow through `isinstance(left.dtype, CategoricalDtype)` / `IntervalDtype` to the corresponding `_values` / `array` type, and for `MultiIndex.dtypes` access.
- Adds a `-> dict[str, DataFrame]` return type to `DataFrame._to_dict_of_blocks` so the typed call from `assert_frame_equal(by_blocks=True)` no longer trips `no-untyped-call`.

## Test plan

- [x] `mypy pandas/` → success on 1458 source files
- [x] `pyright pandas/_testing/ pandas/core/frame.py` → 0 errors
- [x] `pre-commit run` on the changed files → all hooks pass
- [x] `pytest pandas/tests/util/` → 981 passed, 2 skipped, 2 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)