### PR TITLE
Feature/deprecate groupby sort default##64996

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -120,6 +120,7 @@ Deprecations
 - Deprecated the ``weekday`` property on :class:`DatetimeIndex`, :class:`.DatetimeArray`, :class:`PeriodIndex`, :class:`.PeriodArray`, and :class:`Period`. Use ``day_of_week`` instead. ``Timestamp.weekday()`` remains a method consistent with :meth:`datetime.datetime.weekday` (:issue:`12816`)
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 - Deprecated the default value of ``exact`` in :func:`assert_index_equal`; in a future version this will default to ``True`` instead of "equiv" (:issue:`57436`)
+- Deprecated the default value of ``sort`` in :meth: `DataFrame.groupby` and :meth:`Series.groupby`. In a future version, the default will change from ``True`` to ``False`` so that the implicit per-call overhead is opt-in. Pass ``sort=True`` to retain the current behavior or ``sort=False`` to silence the warning (:issue:`57108`)
 - Deprecated the default value of ``track_times`` in :meth:`HDFStore.put`. In a future version, the default will change from ``True`` to ``False`` so that HDF5 files are deterministic by default (:issue:`51456`)
 - Deprecated passing a non-boolean value for ``numeric_only`` to :meth:`DataFrame.mean`,
   :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`DataFrame.median`,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12482,7 +12482,7 @@ class DataFrame(NDFrame, OpsMixin):
         by=None,
         level: IndexLabel | None = None,
         as_index: bool = True,
-        sort: bool = True,
+        sort: bool | lib.NoDefault = lib.no_default,
         group_keys: bool = True,
         observed: bool = True,
         dropna: bool = True,
@@ -12520,7 +12520,7 @@ class DataFrame(NDFrame, OpsMixin):
             such as ``head()``, ``tail()``, ``nth()`` and in transformations
             (see the `transformations in the user guide
             <https://pandas.pydata.org/docs/dev/user_guide/groupby.html#transformation>`_).
-        sort : bool, default True
+        sort : bool | lib.NoDefault, default lib.no_default
             Sort group keys. Get better performance by turning this off.
             Note this does not influence the order of observations within each
             group. Groupby preserves the order of rows within each group. If False,
@@ -12537,6 +12537,14 @@ class DataFrame(NDFrame, OpsMixin):
 
                 Specifying ``sort=False`` with an ordered categorical grouper will no
                 longer sort the values.
+                
+            .. deprecated:: 3.1.0
+                  
+                  The default value of ``sort`` will change from ``True`` to 
+                  ``False`` in pandas 4.0. Pass ``sort=True`` to retain the 
+                  current behaviour or ``sort=False`` to silence the warning and 
+                  opt into the new default.    
+    
 
         group_keys : bool, default True
             When calling apply and the ``by`` argument produces a like-indexed
@@ -12698,7 +12706,16 @@ class DataFrame(NDFrame, OpsMixin):
 
         if level is None and by is None:
             raise TypeError("You have to supply one of 'by' and 'level'")
+        
+        if sort is lib.no_default:
+            warnings.warn(
+                "The default value of sort in pd.Series.groupby is changing from True to False in a future version. "
+                "Pass sort=True to retain the current behavior or sort=False to silence this warning and opt into the new default.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
 
+            sort = True
         return DataFrameGroupBy(
             obj=self,
             keys=by,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2001,7 +2001,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         by=None,
         level: IndexLabel | None = None,
         as_index: bool = True,
-        sort: bool = True,
+        sort: bool | lib.NoDefault = lib.no_default,
         group_keys: bool = True,
         observed: bool = True,
         dropna: bool = True,
@@ -2039,7 +2039,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             such as ``head()``, ``tail()``, ``nth()`` and in transformations
             (see the `transformations in the user guide
             <https://pandas.pydata.org/docs/dev/user_guide/groupby.html#transformation>`_).
-        sort : bool, default True
+        sort : bool | lib.NoDefault, default lib.no_default
             Sort group keys. Get better performance by turning this off.
             Note this does not influence the order of observations within each
             group. Groupby preserves the order of rows within each group. If False,
@@ -2056,6 +2056,13 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
                 Specifying ``sort=False`` with an ordered categorical grouper will no
                 longer sort the values.
+            
+            .. deprecated:: 3.1.0
+                  
+                  The default value of ``sort`` will change from ``True`` to 
+                  ``False`` in pandas 4.0. Pass ``sort=True`` to retain the 
+                  current behaviour or ``sort=False`` to silence the warning and 
+                  opt into the new default.    
 
         group_keys : bool, default True
             When calling apply and the ``by`` argument produces a like-indexed
@@ -2221,7 +2228,15 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             raise TypeError("You have to supply one of 'by' and 'level'")
         if not as_index:
             raise TypeError("as_index=False only valid with DataFrame")
+        if sort is lib.no_default:
+            warnings.warn(
+                "The default value of sort in pd.Series.groupby is changing from True to False in a future version. "
+                "Pass sort=True to retain the current behavior or sort=False to silence this warning and opt into the new default.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
 
+            sort = True
         return SeriesGroupBy(
             obj=self,
             keys=by,

--- a/pandas/tests/groupby/test_api.py
+++ b/pandas/tests/groupby/test_api.py
@@ -9,10 +9,15 @@ import inspect
 
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 from pandas import (
     DataFrame,
+    Index,
     Series,
 )
+import pandas._testing as tm
+
 from pandas.core.groupby.base import (
     groupby_other_methods,
     reduction_kernels,
@@ -272,3 +277,95 @@ def test_series_consistency(request, groupby_func):
     result -= exclude_result
     expected -= exclude_expected
     assert result == expected
+    
+class TestGroupbySortDefaultDeprecation:
+
+    sort_msg = (
+        "The default value of 'sort' in "
+        "DataFrame.groupby/Series.groupby is being deprecated and "
+        "will change from True to False in pandas 4.0."
+    )
+
+    def test_dataframe_groupby_sort_default_warns(self):
+        df = DataFrame(
+            {"a": (2, 1, 2, 1), "b": (1, 2, 3, 4)}
+        )
+
+        with tm.assert_produces_warning(
+            Pandas4Warning,
+            match=self.sort_msg,
+        ):
+            df.groupby("a")
+
+    def test_series_groupby_sort_default_warns(self):
+        ser = Series(
+            [1, 2, 3, 4],
+            index=Index(["b", "a", "b", "a"]),
+        )
+
+        with tm.assert_produces_warning(
+            Pandas4Warning,
+            match=self.sort_msg,
+        ):
+            ser.groupby(level=0)
+
+    @pytest.mark.parametrize("sort", (True, False))
+    def test_dataframe_groupby_sort_explicit_does_not_warn(
+        self, sort
+    ):
+        df = DataFrame(
+            {"a": (2, 1, 2, 1), "b": (1, 2, 3, 4)}
+        )
+
+        with tm.assert_produces_warning(None):
+            df.groupby("a", sort=sort)
+
+    @pytest.mark.parametrize("sort", (True, False))
+    def test_series_groupby_sort_explicit_does_not_warn(
+        self, sort
+    ):
+        ser = Series(
+            [1, 2, 3, 4],
+            index=Index(["b", "a", "b", "a"]),
+        )
+
+        with tm.assert_produces_warning(None):
+            ser.groupby(level=0, sort=sort)
+
+    def test_dataframe_groupby_default_behavior_preserved(
+        self,
+    ):
+        """
+        During the deprecation window the resolved default
+        must still be equivalent to sort=True.
+        """
+
+        df = DataFrame(
+            {"a": (2, 1, 2, 1), "b": (1, 2, 3, 4)}
+        )
+
+        with tm.assert_produces_warning(
+            Pandas4Warning,
+            match=self.sort_msg,
+        ):
+            result = df.groupby("a").sum()
+
+        expected = df.groupby("a", sort=True).sum()
+
+        tm.assert_frame_equal(result, expected)
+
+    def test_series_groupby_default_behavior_preserved(self):
+        ser = Series(
+            [1, 2, 3, 4],
+            index=Index(["b", "a", "b", "a"]),
+        )
+
+        with tm.assert_produces_warning(
+            Pandas4Warning,
+            match=self.sort_msg,
+        ):
+            result = ser.groupby(level=0).sum()
+
+        expected = ser.groupby(level=0, sort=True).sum()
+
+        tm.assert_series_equal(result, expected)    

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -555,7 +555,9 @@ class TestDataFrameGroupByPlots:
         # _check_plot_works adds an ax so catch warning. see GH #13188 GH 6769
         with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
             _check_plot_works(
-                df.groupby(gb_key).boxplot, column="height", return_type="dict"
+                df.groupby(gb_key, sort = True).boxplot,
+                column="height",
+                return_type="dict",
             )
         _check_axes_shape(mpl.pyplot.gcf().axes, axes_num=axes_num, layout=(rows, 2))
 
@@ -588,7 +590,7 @@ class TestDataFrameGroupByPlots:
         df = hist_df
         with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
             _check_plot_works(
-                df.groupby("category").boxplot,
+                df.groupby("category", sort=True).boxplot,
                 column="height",
                 layout=(3, cols),
                 return_type="dict",
@@ -627,7 +629,7 @@ class TestDataFrameGroupByPlots:
         # which has earlier alphabetical order
         with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
             _, axes = mpl.pyplot.subplots(2, 2)
-            df.groupby("category").boxplot(column="height", return_type="axes", ax=axes)
+            df.groupby("category", sort=True).boxplot(column="height", return_type="axes", ax=axes)
             _check_axes_shape(mpl.pyplot.gcf().axes, axes_num=4, layout=(2, 2))
 
     @pytest.mark.slow
@@ -649,7 +651,7 @@ class TestDataFrameGroupByPlots:
 
         # draw on second row
         with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
-            returned = df.groupby("classroom").boxplot(
+            returned = df.groupby("classroom", sort=True).boxplot(
                 column=["height", "weight", "category"], return_type="axes", ax=axes[1]
             )
         returned = np.array(list(returned.values))
@@ -666,7 +668,7 @@ class TestDataFrameGroupByPlots:
         with pytest.raises(ValueError, match=msg):
             # pass different number of axes from required
             with tm.assert_produces_warning(UserWarning, match="sharex and sharey"):
-                axes = df.groupby("classroom").boxplot(ax=axes)
+                axes = df.groupby("classroom", sort=True).boxplot(ax=axes)
 
     def test_fontsize(self):
         df = DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [0, 0, 0, 1, 1, 1]})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -472,6 +472,15 @@ filterwarnings = [
   # Remove 2 below when pyarrow version > ??
   "ignore:make_block is deprecated and will be removed in a future version:pandas.errors.Pandas4Warning:pyarrow",
   "ignore:DatetimeTZBlock is deprecated and will be removed in a future version:pandas.errors.Pandas4Warning:pyarrow",
+  # GH#57108 default value of sort in DataFrame.groupby/Series.groupby
+  # is being deprecated; suppress for the duration of the deprecation
+  # window so that existing tests that rely on the implicit sort=True
+  # default keep passing.
+  # Tests that explicitly assert this warning use
+  # tm.assert_produces_warning, which uses filter_level="always"
+  # and overrides this filter.
+  "ignore:The default value of 'sort' in DataFrame.groupby:pandas.errors.Pandas4Warning",
+  "ignore:The default value of 'sort' in Series.groupby:pandas.errors.Pandas4Warning",
 ]
 junit_family = "xunit2"
 markers = [


### PR DESCRIPTION
- [Y ] closes #64996 (Replace xxxx with the GitHub issue number)
- [ Y] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ Y] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ Y] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ Y] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ Y] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ N] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
