### PR TITLE
DOC: clarify that to_parquet/to_orc path accepts remote URLs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2843,8 +2843,17 @@ class DataFrame(NDFrame, OpsMixin):
         path : str, path object, file-like object, or None, default None
             String, path object (implementing ``os.PathLike[str]``), or file-like
             object implementing a binary ``write()`` function. If None, the result is
-            returned as bytes. If a string or path, it will be used as Root Directory
-            path when writing a partitioned dataset.
+            returned as bytes. If a string or path, it will be used as the root
+            directory path when writing a partitioned dataset.
+
+            The string could be a URL. Valid URL schemes include http, ftp, s3,
+            gs, and file. For file URLs, a host is expected. A local file could be:
+            ``file://localhost/path/to/table.parquet``. A remote example could be:
+            ``s3://bucket/path/to/table.parquet``.
+
+            Certain URL schemes may require additional packages. For example, S3
+            URLs require the ``s3fs`` library. See
+            :ref:`install.optional_dependencies` for a full list.
         engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
             Parquet library to use. If 'auto', then the option
             ``io.parquet.engine`` is used. The default ``io.parquet.engine``
@@ -3000,11 +3009,20 @@ class DataFrame(NDFrame, OpsMixin):
         Parameters
         ----------
         path : str, file-like object or None, default None
-            If a string, it will be used as Root Directory path
+            If a string, it will be used as the root directory path
             when writing a partitioned dataset. By file-like object,
             we refer to objects with a write() method, such as a file handle
             (e.g. via builtin open function). If path is None,
             a bytes object is returned.
+
+            The string could be a URL. Valid URL schemes include http, ftp, s3,
+            gs, and file. For file URLs, a host is expected. A local file could be:
+            ``file://localhost/path/to/table.orc``. A remote example could be:
+            ``s3://bucket/path/to/table.orc``.
+
+            Certain URL schemes may require additional packages. For example, S3
+            URLs require the ``s3fs`` library. See
+            :ref:`install.optional_dependencies` for a full list.
         engine : {'pyarrow'}, default 'pyarrow'
             ORC library to use.
         index : bool, optional

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -160,11 +160,20 @@ def to_orc(
         if dtype of one or more columns is category, unsigned integers,
         intervals, periods or sparse.
     path : str, file-like object or None, default None
-        If a string, it will be used as Root Directory path
+        If a string, it will be used as the root directory path
         when writing a partitioned dataset. By file-like object,
         we refer to objects with a write() method, such as a file handle
         (e.g. via builtin open function). If path is None,
         a bytes object is returned.
+
+        The string could be a URL. Valid URL schemes include http, ftp, s3,
+        gs, and file. For file URLs, a host is expected. A local file could be:
+        ``file://localhost/path/to/table.orc``. A remote example could be:
+        ``s3://bucket/path/to/table.orc``.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
     engine : str, default 'pyarrow'
         ORC library to use.
     index : bool, optional

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -433,9 +433,18 @@ def to_parquet(
     path : str, path object, file-like object, or None, default None
         String, path object (implementing ``os.PathLike[str]``), or file-like
         object implementing a binary ``write()`` function. If None, the result
-        is returned as bytes. If a string, it will be used as Root Directory
+        is returned as bytes. If a string, it will be used as the root directory
         path when writing a partitioned dataset. The engine fastparquet does
         not accept file-like objects.
+
+        The string could be a URL. Valid URL schemes include http, ftp, s3,
+        gs, and file. For file URLs, a host is expected. A local file could be:
+        ``file://localhost/path/to/table.parquet``. A remote example could be:
+        ``s3://bucket/path/to/table.parquet``.
+
+        Certain URL schemes may require additional packages. For example, S3
+        URLs require the ``s3fs`` library. See
+        :ref:`install.optional_dependencies` for a full list.
     engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
         Parquet library to use. If 'auto', then the option
         ``io.parquet.engine`` is used. The default ``io.parquet.engine``


### PR DESCRIPTION
closes #44976

## Summary
- Document that the `path` argument to `to_parquet` and `to_orc` accepts URLs (http, ftp, s3, gs, file), mirroring the existing wording in `read_parquet`. The previous text mentioned "Root Directory path" only, which led users to assume local-filesystem paths only. The `s3://` capability was previously only hinted at indirectly via `storage_options`.
- Updated both the functional API (`pandas.io.parquet.to_parquet`, `pandas.io.orc.to_orc`) and the method-bound copies on `DataFrame` so the rendered docs match in both places.
- Lowercased "Root Directory" → "root directory" since it isn't a proper noun.

## Test plan
- [x] `python -c "import pandas as pd; print(pd.DataFrame.to_parquet.__doc__)"` renders the new paragraph correctly.
- [x] `python -c "import pandas as pd; print(pd.DataFrame.to_orc.__doc__)"` renders the new paragraph correctly.
- [x] pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)