### PR TITLE
DOC: document dict input to DataFrame.assign (GH-49817)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5558,13 +5558,14 @@ class DataFrame(NDFrame, OpsMixin):
 
         Parameters
         ----------
-        **kwargs : callable or Series
+        **kwargs : callable, Series, scalar, array-like, or dict
             The column names are keywords. If the values are
             callable, they are computed on the DataFrame and
             assigned to the new columns. The callable must not
             change input DataFrame (though pandas doesn't check it).
-            If the values are not callable, (e.g. a Series, scalar, or array),
-            they are simply assigned.
+            If the values are not callable (e.g. a Series, scalar, array,
+            or dict), they are simply assigned. See the Notes section for
+            details on alignment and broadcasting.
 
         Returns
         -------
@@ -5626,6 +5627,14 @@ class DataFrame(NDFrame, OpsMixin):
                   temp_c  temp_f  temp_k
         Portland    17.0    62.6  290.15
         Berkeley    25.0    77.0  298.15
+
+        A dict value is aligned to the DataFrame's index by its keys, and
+        index labels not present in the dict are filled with NaN:
+
+        >>> df.assign(temp_k={"Portland": 290.15, "Berkeley": 298.15, "Seattle": 285.0})
+                  temp_c  temp_k
+        Portland    17.0  290.15
+        Berkeley    25.0  298.15
         """
         data = self.copy(deep=False)
 


### PR DESCRIPTION
closes #49817

## Summary
- Add `dict` to the documented value types in the `**kwargs` parameter description of `DataFrame.assign`, alongside callable / Series / scalar / array-like.
- Point readers to the existing Notes line (added in GH-64998) for alignment and broadcasting details, rather than duplicating them.
- Add a doctest example showing that a dict value is aligned to the DataFrame's index by its keys, with missing labels filled with NaN.

## Test plan
- [x] Doctests on `DataFrame.assign` (7 examples) pass locally
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)