### PR TITLE
TST: show actual ymin/ymax in test_area_lim flake

### DIFF
--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -665,11 +665,11 @@ class TestDataFramePlots:
         lines = ax.get_lines()
         assert xmin <= lines[0].get_data()[0][0]
         assert xmax >= lines[0].get_data()[0][-1]
-        assert ymin == 0
+        assert ymin == 0, f"ymin={ymin!r} ymax={ymax!r}"
 
         ax = _check_plot_works(neg_df.plot.area, stacked=stacked)
         ymin, ymax = ax.get_ylim()
-        assert ymax == 0
+        assert ymax == 0, f"ymin={ymin!r} ymax={ymax!r}"
 
     def test_area_sharey_dont_overwrite(self):
         # GH37942


### PR DESCRIPTION
## Summary

- The "Without PyArrow" CI has been flaking on `test_area_lim` with a bare `AssertionError` on `assert ymin == 0` (and the analogous `assert ymax == 0` for the negative-data case), leaving no indication of the actual value.
- Add f-string messages so the next failure shows the offending `ymin` / `ymax` — this should tell us whether autoscale is slipping a small negative through, or whether something else is going on.
- Diagnostic-only — no behavior change.

## Test plan
- [x] pre-commit hooks pass
- [ ] Watch next "Without PyArrow" failure for the printed values