### PR TITLE
BUG: AreaPlot ymin baseline pin defeated by unrelated sharey'd axes

### DIFF
--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1837,7 +1837,7 @@ class AreaPlot(LinePlot):
     def _post_plot_logic(self, ax: Axes, data) -> None:
         LinePlot._post_plot_logic(self, ax, data)
 
-        is_shared_y = len(list(ax.get_shared_y_axes())) > 0
+        is_shared_y = len(ax.get_shared_y_axes().get_siblings(ax)) > 1
         # do not override the default axis behaviour in case of shared y axes
         if self.ylim is None and not is_shared_y:
             if (data >= 0).all().all():

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -682,6 +682,24 @@ class TestDataFramePlots:
         assert get_y_axis(ax1).joined(ax1, ax2)
         assert get_y_axis(ax2).joined(ax1, ax2)
 
+    def test_area_lim_unaffected_by_unrelated_sharey(self):
+        # Unrelated sharey'd axes elsewhere in the process must not defeat
+        # the ymin=0 baseline pin for an all-positive area plot.
+        unrelated_fig, unrelated_axes = mpl.pyplot.subplots(1, 2, sharey=True)
+
+        df = DataFrame(
+            np.random.default_rng(2).random((6, 4)), columns=["x", "y", "z", "four"]
+        )
+        _fig, ax = mpl.pyplot.subplots()
+        df.plot.area(ax=ax, stacked=True)
+        ymin, _ymax = ax.get_ylim()
+        assert ymin == 0
+
+        # keep the sharey'd axes alive until after the assertion so the
+        # class-level Grouper still contains them at check time
+        assert unrelated_fig is not None
+        assert unrelated_axes is not None
+
     @pytest.mark.parametrize("stacked", [True, False])
     def test_bar_linewidth(self, stacked):
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))


### PR DESCRIPTION
## Summary
- `AreaPlot._post_plot_logic` pins `ymin=0` for all-positive data unless the axes shares y with another; the check was `len(list(ax.get_shared_y_axes())) > 0`, which iterates the class-level matplotlib Grouper and returns `True` whenever any sharey'd group exists *anywhere in the process* — not just when `ax` itself is in one.
- With unrelated sharey'd axes alive elsewhere, pandas would silently skip the baseline pin and matplotlib's default 5% `axes.ymargin` would leave a gap below 0.
- Fixed by switching to `len(ax.get_shared_y_axes().get_siblings(ax)) > 1`, which asks the Grouper specifically about `ax`'s siblings.
- Surfaced as a flake on the "Without PyArrow" CI run on `test_area_lim`: the pyarrow-skipped test distribution occasionally co-located `test_area_lim` in the same xdist worker as a test that left sharey'd axes alive in the class-level Grouper, exactly reproducing the bug.

## Test plan
- [x] new `test_area_lim_unaffected_by_unrelated_sharey` deterministically reproduces the bug; verified it fails on the old check and passes on the new one
- [x] full `test_frame.py -k area` (33 tests) passes
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)