### PR TITLE
DOC: relax MultiIndex.from_tuples 'tuples' parameter description

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -538,7 +538,7 @@ class MultiIndex(Index):
 
         Parameters
         ----------
-        tuples : list / sequence of tuple-likes
+        tuples : list-like of tuples
             Each tuple is the index of one row/column.
         sortorder : int or None
             Level of sortedness (must be lexicographically sorted by that
@@ -568,7 +568,7 @@ class MultiIndex(Index):
                    names=['number', 'color'])
         """
         if not is_list_like(tuples):
-            raise TypeError("Input must be a list / sequence of tuple-likes.")
+            raise TypeError("Input must be list-like of tuples.")
         if is_iterator(tuples):
             tuples = list(tuples)
         tuples = cast("Collection[tuple[Hashable, ...]]", tuples)

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -372,7 +372,7 @@ def test_from_tuples_iterator():
     tm.assert_index_equal(result, expected)
 
     # input non-iterables
-    msg = "Input must be a list / sequence of tuple-likes."
+    msg = "Input must be list-like of tuples."
     with pytest.raises(TypeError, match=msg):
         MultiIndex.from_tuples(0)
 


### PR DESCRIPTION
closes #61357

## Summary
- Change `tuples` param doc in `MultiIndex.from_tuples` from `list / sequence of tuple-likes` to `list-like of tuples`, matching the runtime `Iterable[tuple[...]]` annotation and pandas' definition of list-like (which includes generators like `zip(...)`).
- Update the matching `TypeError` message and its test for consistency.

Per discussion in GH-61357 (rhshadrach, Dr-Irv): the "tuple-like" wording was the only occurrence in the codebase and was ill-defined; "list-like" is the right term. Behavior change around rejecting `set` is a separate question (see GH-55425) and not in scope here.

## Test plan
- [x] `pytest pandas/tests/indexes/multi/test_constructors.py` (101 passed)
- [x] pre-commit on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)