### PR TITLE
PERF: Cythonize kendall correlation

### DIFF
--- a/LICENSES/STATSBASE_JL_LICENSE
+++ b/LICENSES/STATSBASE_JL_LICENSE
@@ -1,0 +1,23 @@
+StatsBase.jl is licensed under the MIT License:
+
+> Copyright (c) 2012-2016: Dahua Lin, Simon Byrne, Andreas Noack,
+> Douglas Bates, John Myles White, Simon Kornblith, and other contributors.
+
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -172,7 +172,7 @@ Performance improvements
 - Performance improvement in :meth:`.DataFrameGroupBy.agg` and :meth:`.SeriesGroupBy.agg` with user-defined functions (:issue:`46505`)
 - Performance improvement in :meth:`DataFrame.apply` with ``axis=1`` when the :class:`DataFrame` has :class:`ExtensionDtype` columns (e.g. :class:`ArrowDtype`) (:issue:`61747`)
 - Performance improvement in :meth:`DataFrame.corr` and :meth:`DataFrame.cov` when data contains no NaN values (:issue:`64857`)
-- Performance improvement in :meth:`DataFrame.corr` for ``method=kendall`` (:issue:`28329`)
+- Performance improvement in :meth:`DataFrame.corr` for ``method="kendall"`` (:issue:`28329`)
 - Performance improvement in :meth:`DataFrame.equals`, :meth:`DataFrame.select_dtypes`, and other operations performing shallow column slicing on Arrow-backed columns (:issue:`58966`)
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -172,6 +172,7 @@ Performance improvements
 - Performance improvement in :meth:`.DataFrameGroupBy.agg` and :meth:`.SeriesGroupBy.agg` with user-defined functions (:issue:`46505`)
 - Performance improvement in :meth:`DataFrame.apply` with ``axis=1`` when the :class:`DataFrame` has :class:`ExtensionDtype` columns (e.g. :class:`ArrowDtype`) (:issue:`61747`)
 - Performance improvement in :meth:`DataFrame.corr` and :meth:`DataFrame.cov` when data contains no NaN values (:issue:`64857`)
+- Performance improvement in :meth:`DataFrame.corr` for ``method=kendall`` (:issue:`28329`)
 - Performance improvement in :meth:`DataFrame.equals`, :meth:`DataFrame.select_dtypes`, and other operations performing shallow column slicing on Arrow-backed columns (:issue:`58966`)
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)

--- a/pandas/_libs/algos.pyi
+++ b/pandas/_libs/algos.pyi
@@ -52,6 +52,10 @@ def nancorr_spearman(
     mat: npt.NDArray[np.float64],  # ndarray[float64_t, ndim=2]
     minp: int = ...,
 ) -> npt.NDArray[np.float64]: ...  # ndarray[float64_t, ndim=2]
+def nancorr_kendall(
+    mat: npt.NDArray[np.float64],  # ndarray[float64_t, ndim=2]
+    minp: int = ...,
+) -> npt.NDArray[np.float64]: ...  # ndarray[float64_t, ndim=2]
 
 # ----------------------------------------------------------------------
 

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -7,6 +7,7 @@ from libc.math cimport (
 from libc.stdlib cimport (
     free,
     malloc,
+    qsort,
 )
 from libc.string cimport memcpy
 
@@ -1758,6 +1759,220 @@ def axis_kurt(
             result[i] = calc_kurt(nobs[i], m2[i], m4[i])
 
     return result_arr
+
+
+# ----------------------------------------------------------------------
+# Pairwise Kendall correlation
+#
+# References:
+# - Knight, W. R. (1966).
+#   A computer method for calculating Kendall's tau with ungrouped data.
+#   Journal of the American Statistical Association, 61(314), 436-439.
+#
+# - rankcorr.jl
+#   https://github.com/JuliaStats/StatsBase.jl/blob/3e5382fa6b6ac90cf3d0b1904484668714d0e220/src/rankcorr.jl
+
+cdef struct Pair:
+    float64_t x
+    float64_t y
+
+cdef int compare_pair_aux(const void* a, const void* b) noexcept nogil:
+    cdef:
+        Pair *p1 = <Pair*>a
+        Pair *p2 = <Pair*>b
+    if p1.x < p2.x:
+        return -1
+    if p1.x > p2.x:
+        return 1
+    if p1.y < p2.y:
+        return -1
+    if p1.y > p2.y:
+        return 1
+    return 0
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef int64_t insertion_sort(
+    float64_t[:] v,
+    Py_ssize_t lo,
+    Py_ssize_t hi
+) noexcept nogil:
+    cdef:
+        int64_t nswaps = 0
+        Py_ssize_t i, j
+        float64_t x
+
+    for i in range(lo + 1, hi + 1):
+        j = i
+        x = v[i]
+        while j > lo and x < v[j - 1]:
+            nswaps += 1
+            v[j] = v[j - 1]
+            j -= 1
+        v[j] = x
+    return nswaps
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef int64_t merge_sort(
+    float64_t[:] v,
+    float64_t[:] t,
+    Py_ssize_t lo,
+    Py_ssize_t hi
+) noexcept nogil:
+    cdef:
+        int64_t nswaps = 0
+        Py_ssize_t m, i, j, k
+
+    if lo < hi:
+        if hi - lo <= 64:
+            return insertion_sort(v, lo, hi)
+
+        m = lo + (hi - lo) // 2
+        nswaps = merge_sort(v, t, lo, m)
+        nswaps += merge_sort(v, t, m + 1, hi)
+
+        for i in range(lo, m + 1):
+            t[i - lo] = v[i]
+
+        i = 0
+        j = m + 1
+        k = lo
+        while k < j <= hi and i <= m - lo:
+            if v[j] < t[i]:
+                v[k] = v[j]
+                j += 1
+                nswaps += (m - lo + 1 - i)
+            else:
+                v[k] = t[i]
+                i += 1
+            k += 1
+
+        while i <= m - lo:
+            v[k] = t[i]
+            k += 1
+            i += 1
+    return nswaps
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef int64_t count_ties(
+    const float64_t[:] v,
+    Py_ssize_t lo,
+    Py_ssize_t hi
+) noexcept nogil:
+    cdef:
+        int64_t result = 0
+        int64_t tie_count = 0
+        Py_ssize_t i
+
+    for i in range(lo + 1, hi + 1):
+        if v[i] == v[i - 1]:
+            tie_count += 1
+        elif tie_count > 0:
+            result += tie_count * (tie_count + 1) // 2
+            tie_count = 0
+    if tie_count > 0:
+        result += tie_count * (tie_count + 1) // 2
+    return result
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef float64_t compute_kendall_corr_1d(
+    const float64_t[:] x,
+    float64_t[:] y,
+    float64_t[:] temp_t
+) noexcept nogil:
+    cdef:
+        Py_ssize_t n = len(x)
+        int64_t npairs = <int64_t>n * (n - 1) // 2
+        int64_t ntiesx = 0
+        int64_t ntiesy = 0
+        int64_t ndoubleties = 0
+        int64_t nswaps = 0
+        Py_ssize_t i, k = 0
+        float64_t divisor
+
+    if n < 2:
+        return NaN
+
+    for i in range(1, n):
+        if x[i] == x[i-1]:
+            k += 1
+        elif k > 0:
+            ndoubleties += count_ties(y, i - k - 1, i - 1)
+            ntiesx += <int64_t>k * (k + 1) // 2
+            k = 0
+    if k > 0:
+        ndoubleties += count_ties(y, n - k - 1, n - 1)
+        ntiesx += <int64_t>k * (k + 1) // 2
+
+    nswaps = merge_sort(y, temp_t, 0, n - 1)
+    ntiesy = count_ties(y, 0, n - 1)
+
+    divisor = sqrt(<float64_t>(npairs - ntiesx) * <float64_t>(npairs - ntiesy))
+    if divisor == 0:
+        return NaN
+
+    return (npairs + ndoubleties - ntiesx - ntiesy - 2 * nswaps) / divisor
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def nancorr_kendall(const float64_t[:, :] mat, Py_ssize_t minp=1):
+    cdef:
+        Py_ssize_t i, xi, yi, N, K, nobs
+        ndarray[float64_t, ndim=2] result
+        ndarray[uint8_t, ndim=2] mask
+        float64_t[::1] x_obs, y_obs, temp_t
+        Pair *pairs = NULL
+        float64_t val
+
+    N, K = (<object>mat).shape
+    result = np.empty((K, K), dtype=np.float64)
+    mask = np.isfinite(mat).view(np.uint8)
+
+    pairs = <Pair*>malloc(N * sizeof(Pair))
+    if pairs is NULL:
+        raise MemoryError()
+
+    x_obs = np.empty(N, dtype=np.float64)
+    y_obs = np.empty(N, dtype=np.float64)
+    temp_t = np.empty(N, dtype=np.float64)
+
+    with nogil:
+        for xi in range(K):
+            for yi in range(xi + 1):
+                nobs = 0
+                for i in range(N):
+                    if mask[i, xi] and mask[i, yi]:
+                        pairs[nobs].x = mat[i, xi]
+                        pairs[nobs].y = mat[i, yi]
+                        nobs += 1
+
+                if nobs < minp:
+                    result[xi, yi] = result[yi, xi] = NaN
+                    continue
+
+                if xi == yi:
+                    result[xi, yi] = 1.0
+                    continue
+
+                qsort(pairs, nobs, sizeof(Pair), compare_pair_aux)
+
+                for i in range(nobs):
+                    x_obs[i] = pairs[i].x
+                    y_obs[i] = pairs[i].y
+
+                val = compute_kendall_corr_1d(x_obs[:nobs], y_obs[:nobs], temp_t[:nobs])
+                result[xi, yi] = result[yi, xi] = val
+        free(pairs)
+
+    return result
 
 
 # generated from template

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -15405,8 +15405,7 @@ class DataFrame(NDFrame, OpsMixin):
                 regardless of the callable's behavior.
         min_periods : int, optional
             Minimum number of observations required per pair of columns
-            to have a valid result. Currently only available for Pearson
-            and Spearman correlation.
+            to have a valid result.
         numeric_only : bool, default False
             Include only `float`, `int` or `boolean` data.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -15463,7 +15463,9 @@ class DataFrame(NDFrame, OpsMixin):
             correl = libalgos.nancorr(mat, minp=min_periods)
         elif method == "spearman":
             correl = libalgos.nancorr_spearman(mat, minp=min_periods)
-        elif method == "kendall" or callable(method):
+        elif method == "kendall":
+            correl = libalgos.nancorr_kendall(mat, minp=min_periods)
+        elif callable(method):
             if min_periods is None:
                 min_periods = 1
             mat = mat.T

--- a/pandas/tests/frame/methods/test_cov_corr.py
+++ b/pandas/tests/frame/methods/test_cov_corr.py
@@ -253,14 +253,15 @@ class TestDataFrameCorr:
                 df.corr(meth, numeric_only=numeric_only)
 
     @pytest.mark.parametrize("method", ["kendall", "spearman"])
-    def test_rank_corr_with_duplicates(self, method):
+    @pytest.mark.parametrize("size", [20, 65, 129])
+    def test_rank_corr_with_duplicates(self, method, size):
         # GH#43401
         st = pytest.importorskip("scipy.stats")
         rng = np.random.default_rng(2)
 
         data = {
-            "A": rng.integers(0, 5, 20),
-            "B": rng.integers(0, 5, 20),
+            "A": rng.integers(0, 5, size),
+            "B": rng.integers(0, 5, size),
         }
         df = DataFrame(data)
         result = df.corr(method=method)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ license-files = [
   "LICENSES/PYPERCLIP_LICENSE", # BSD-3-Clause
   "LICENSES/PYUPGRADE_LICENSE", # MIT
   "LICENSES/SAS7BDAT_LICENSE", # MIT
+  "LICENSES/STATSBASE_JL_LICENSE", # MIT
   "LICENSES/ULTRAJSON_LICENSE", # BSD-3-Clause AND TCL
   "subprojects/fast_float-*/LICENSE-APACHE", # Apache-2.0
   "subprojects/fast_float-*/LICENSE-BOOST", # BSL


### PR DESCRIPTION
- [x] closes #28329 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

This implementation is mainly an adaptation of [Julia's implementation](https://github.com/JuliaStats/StatsBase.jl/blob/3e5382fa6b6ac90cf3d0b1904484668714d0e220/src/rankcorr.jl).

## Benchmark results

| Change   | Before [e49b4e04] <main>   | After [3cde96d7] <perf/kendall>   |   Ratio | Benchmark (Parameter)                               |
|----------|----------------------------|-----------------------------------|---------|-----------------------------------------------------|
| -        | 291M                       | 234M                              |    0.81 | stat_ops.Correlation.peakmem_corr_wide('kendall')   |
| -        | 46.8±2ms                   | 10.9±1ms                          |    0.23 | stat_ops.Correlation.time_corr('kendall')           |
| -        | 2.55±0.2s                  | 372±5ms                           |    0.15 | stat_ops.Correlation.time_corr_wide_nans('kendall') |
| -        | 2.51±0.1s                  | 352±4ms                           |    0.14 | stat_ops.Correlation.time_corr_wide('kendall')      |

