### PR TITLE
DOC: spell out low_memory split-value hazard in read_csv/read_table

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -740,8 +740,15 @@ def read_csv(
 
     low_memory : bool, default True
         Internally process the file in chunks, resulting in lower memory use
-        while parsing, but possibly mixed type inference.  To ensure no mixed
-        types either set ``False``, or specify the type with the ``dtype`` parameter.
+        while parsing, but possibly mixed type inference. Because each chunk
+        is type-inferred independently, the same literal can be parsed as an
+        ``int`` in one chunk and a ``str`` in another; after concatenation the
+        column has ``object`` dtype and contains both representations, so
+        comparisons such as ``df["col"] == 12345`` or
+        ``df["col"] == "12345"`` will match only a subset of the rows holding
+        that value. A :class:`~pandas.errors.DtypeWarning` is emitted when
+        this occurs. To ensure no mixed types either set ``False``, or specify
+        the type with the ``dtype`` parameter.
         Note that the entire file is read into a single :class:`~pandas.DataFrame`
         regardless, use the ``chunksize`` or ``iterator``
         parameter to return the data in
@@ -1316,8 +1323,15 @@ def read_table(
 
     low_memory : bool, default True
         Internally process the file in chunks, resulting in lower memory use
-        while parsing, but possibly mixed type inference.  To ensure no mixed
-        types either set ``False``, or specify the type with the ``dtype`` parameter.
+        while parsing, but possibly mixed type inference. Because each chunk
+        is type-inferred independently, the same literal can be parsed as an
+        ``int`` in one chunk and a ``str`` in another; after concatenation the
+        column has ``object`` dtype and contains both representations, so
+        comparisons such as ``df["col"] == 12345`` or
+        ``df["col"] == "12345"`` will match only a subset of the rows holding
+        that value. A :class:`~pandas.errors.DtypeWarning` is emitted when
+        this occurs. To ensure no mixed types either set ``False``, or specify
+        the type with the ``dtype`` parameter.
         Note that the entire file is read into a single :class:`~pandas.DataFrame`
         regardless, use the ``chunksize`` or ``iterator`` parameter
         to return the data in


### PR DESCRIPTION
closes #22194

## Summary
- Expand the `low_memory` parameter docstring in :func:`read_csv` and :func:`read_table` to describe the practical consequence of per-chunk type inference: the same literal can land in the resulting `object`-dtype column as both an `int` and a `str`, so equality / `drop_duplicates` / `isin` only match a subset of the rows holding that value.
- Point users at :class:`~pandas.errors.DtypeWarning`, whose own docstring already has a worked example.

## Notes
- Docstring-only — no behavior change.
- GH-22194 has been open since 2018 asking for this to be called out more clearly; the `DtypeWarning` class docstring covers it, but the `read_csv` parameter blurb (the surface most users actually read) only said "possibly mixed type inference," which is too abstract to land.

## Test plan
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)