### PR TITLE
DOC: list IntervalIndex.get_loc and get_indexer on the API reference page

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -209,6 +209,8 @@ class IntervalIndex(ExtensionIndex):
     from_arrays
     from_tuples
     from_breaks
+    get_loc
+    get_indexer
     contains
     overlaps
     set_closed


### PR DESCRIPTION
closes #31073

The per-class API page (`pandas.IntervalIndex.html`) is auto-generated from the `Methods` numpydoc block in the `IntervalIndex` class docstring. That block omitted `get_loc` and `get_indexer`, even though both methods have non-standard behavior on `IntervalIndex` — they match scalar points contained *inside* an interval, not just exact element equality — which is exactly the kind of class-specific behavior the per-class page is supposed to surface.

The reference overview page (`reference/indexing.rst`) already lists them, so no other doc plumbing is needed; adding the two names to the docstring is enough to make them appear in the rendered autosummary table.

## Test plan
- [ ] Confirm `pd.IntervalIndex.__doc__` now contains `get_loc` / `get_indexer` in the Methods section.
- [ ] After docs build on CI, confirm `pandas.IntervalIndex.html` lists `get_loc` and `get_indexer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)