### PR TITLE
DOC: clarify column-wise NA-skipping behavior of GroupBy.first/last

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3175,7 +3175,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         """
         Compute the first entry of each column within each group.
 
-        Defaults to skipping NA elements.
+        NA values are skipped by default, so the result is the first non-NA
+        value per column; this may differ from the first row of the group. Use
+        :meth:`~.DataFrameGroupBy.nth` with ``n=0`` or
+        :meth:`~.DataFrameGroupBy.head` with ``n=1`` to take the first row
+        instead, or pass ``skipna=False`` to keep NAs.
 
         Parameters
         ----------
@@ -3185,7 +3189,7 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             The required number of valid values to perform the operation. If fewer
             than ``min_count`` valid values are present the result will be NA.
         skipna : bool, default True
-            Exclude NA/null values. If an entire group is NA, the result will be NA.
+            Exclude NA values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 2.2.1
 
@@ -3198,9 +3202,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         --------
         DataFrame.groupby : Apply a function groupby to each row or column of a
             DataFrame.
-        core.groupby.DataFrameGroupBy.last : Compute the last non-null entry
-            of each column.
+        core.groupby.DataFrameGroupBy.last : Compute the last entry of each
+            column within each group.
         core.groupby.DataFrameGroupBy.nth : Take the nth row from each group.
+        core.groupby.DataFrameGroupBy.head : Return the first ``n`` rows from
+            each group.
 
         Examples
         --------
@@ -3260,7 +3266,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         """
         Compute the last entry of each column within each group.
 
-        Defaults to skipping NA elements.
+        NA values are skipped by default, so the result is the last non-NA
+        value per column; this may differ from the last row of the group. Use
+        :meth:`~.DataFrameGroupBy.nth` with ``n=-1`` or
+        :meth:`~.DataFrameGroupBy.tail` with ``n=1`` to take the last row
+        instead, or pass ``skipna=False`` to keep NAs.
 
         Parameters
         ----------
@@ -3271,22 +3281,24 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             The required number of valid values to perform the operation. If fewer
             than ``min_count`` valid values are present the result will be NA.
         skipna : bool, default True
-            Exclude NA/null values. If an entire group is NA, the result will be NA.
+            Exclude NA values. If an entire group is NA, the result will be NA.
 
             .. versionadded:: 2.2.1
 
         Returns
         -------
         Series or DataFrame
-            Last of values within each group.
+            Last values within each group.
 
         See Also
         --------
         DataFrame.groupby : Apply a function groupby to each row or column of a
             DataFrame.
-        core.groupby.DataFrameGroupBy.first : Compute the first non-null entry
-            of each column.
+        core.groupby.DataFrameGroupBy.first : Compute the first entry of each
+            column within each group.
         core.groupby.DataFrameGroupBy.nth : Take the nth row from each group.
+        core.groupby.DataFrameGroupBy.tail : Return the last ``n`` rows from
+            each group.
 
         Examples
         --------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -3176,10 +3176,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Compute the first entry of each column within each group.
 
         NA values are skipped by default, so the result is the first non-NA
-        value per column; this may differ from the first row of the group. Use
-        :meth:`~.DataFrameGroupBy.nth` with ``n=0`` or
-        :meth:`~.DataFrameGroupBy.head` with ``n=1`` to take the first row
-        instead, or pass ``skipna=False`` to keep NAs.
+        value per column — which may differ from the first row of the group.
+        Pass ``skipna=False`` to keep NAs.
 
         Parameters
         ----------
@@ -3202,11 +3200,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         --------
         DataFrame.groupby : Apply a function groupby to each row or column of a
             DataFrame.
-        core.groupby.DataFrameGroupBy.last : Compute the last entry of each
+        api.typing.DataFrameGroupBy.last : Compute the last entry of each
             column within each group.
-        core.groupby.DataFrameGroupBy.nth : Take the nth row from each group.
-        core.groupby.DataFrameGroupBy.head : Return the first ``n`` rows from
-            each group.
+        api.typing.DataFrameGroupBy.nth : Take the nth row from each group.
 
         Examples
         --------
@@ -3267,10 +3263,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         Compute the last entry of each column within each group.
 
         NA values are skipped by default, so the result is the last non-NA
-        value per column; this may differ from the last row of the group. Use
-        :meth:`~.DataFrameGroupBy.nth` with ``n=-1`` or
-        :meth:`~.DataFrameGroupBy.tail` with ``n=1`` to take the last row
-        instead, or pass ``skipna=False`` to keep NAs.
+        value per column — which may differ from the last row of the group.
+        Pass ``skipna=False`` to keep NAs.
 
         Parameters
         ----------
@@ -3294,11 +3288,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         --------
         DataFrame.groupby : Apply a function groupby to each row or column of a
             DataFrame.
-        core.groupby.DataFrameGroupBy.first : Compute the first entry of each
+        api.typing.DataFrameGroupBy.first : Compute the first entry of each
             column within each group.
-        core.groupby.DataFrameGroupBy.nth : Take the nth row from each group.
-        core.groupby.DataFrameGroupBy.tail : Return the last ``n`` rows from
-            each group.
+        api.typing.DataFrameGroupBy.nth : Take the nth row from each group.
 
         Examples
         --------


### PR DESCRIPTION
closes #27578

The current `GroupBy.first` / `GroupBy.last` docstrings say "Defaults to skipping NA elements" but do not make it obvious that the skip is performed **independently per column**, so the returned row can differ from the literal first/last row of the group — which is what GH-27578 originally asked us to clarify.

The leading description for each method now spells that out and points readers at `nth(0)` / `head(1)` (resp. `nth(-1)` / `tail(1)`) for the row-based behavior, plus `skipna=False` to keep NAs. `head` and `tail` are also added to See Also.

Picks up from the now-stale GH-61345, with @rhshadrach's feedback applied: "NA" instead of "null", no extra cross-method examples, `DataFrameGroupBy` cross-refs rather than the non-public `GroupBy`.

## Test plan

- [x] doctests for `pandas.core.groupby.groupby.GroupBy.{first,last}` pass
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)