### PR TITLE
DOC: clarify df[col]= replaces a column vs df.loc[:, col]= setting in place

### DIFF
--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -798,6 +798,14 @@ Assigning a ``Categorical`` to parts of a column of other types will use the val
     df
     df.dtypes
 
+.. note::
+
+    The examples above use ``.loc`` / ``.iloc`` to set values *within* an
+    existing categorical column, which preserves the ``category`` dtype.
+    Assigning to a full column with ``df["cats"] = value`` instead **replaces**
+    the column, so the dtype is inferred from ``value`` rather than kept. See
+    :ref:`indexing.column_assignment_vs_in_place` for details.
+
 .. _categorical.merge:
 .. _categorical.concat:
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1813,3 +1813,47 @@ Examples:
    #If you want positional assignment instead of index alignment:
    # reset the Series index to match DataFrame index
    df['s1_values'] = s1.reindex(df.index)
+
+.. _indexing.column_assignment_vs_in_place:
+
+Column assignment vs. in-place setting
+--------------------------------------
+
+While index alignment is consistent between ``df[col] = value`` and
+``df.loc[:, col] = value`` (see the previous section), the two forms differ in
+how they treat the column's existing dtype:
+
+* ``df[col] = value`` **replaces** the column. The new column's dtype is
+  inferred from ``value``, regardless of what dtype the old column had.
+* ``df.loc[:, col] = value`` (and ``df.iloc[:, i] = value``) **sets the values
+  in place** in the existing column. The original dtype is preserved, and the
+  assignment will raise ``TypeError`` if ``value`` is not compatible with it.
+
+This is most visible for :class:`~pandas.api.types.ExtensionDtype` columns
+such as ``category``, ``Int64``, ``boolean``, or ``string``, where the
+replacing form silently drops the extension dtype:
+
+.. ipython:: python
+
+   df = pd.DataFrame({"a": pd.Categorical(["x", "y"], categories=["x", "y", "z"])})
+   df["a"] = "z"          # replaces the column
+   df.dtypes
+
+   df = pd.DataFrame({"a": pd.Categorical(["x", "y"], categories=["x", "y", "z"])})
+   df.loc[:, "a"] = "z"   # sets values in place
+   df.dtypes
+
+The same distinction applies to nullable numeric and boolean dtypes:
+
+.. ipython:: python
+
+   df = pd.DataFrame({"a": pd.array([1, 2], dtype="Int64")})
+   df["a"] = 5
+   df.dtypes
+
+   df = pd.DataFrame({"a": pd.array([1, 2], dtype="Int64")})
+   df.loc[:, "a"] = 5
+   df.dtypes
+
+Use ``df.loc[:, col] = value`` (or ``.iloc``) when you want to update every
+value of an existing column while keeping its dtype.


### PR DESCRIPTION
closes #22361

GH-22361 reports that `df["col"] = scalar` on a `category`-dtype column silently
changes the dtype to object. This is the documented `__setitem__` vs
`loc.__setitem__` split (column **replacement** vs in-place **setting**), but
the distinction was nowhere explicitly stated in the user guide — and it
applies to every `ExtensionDtype`, not just `category`.

Adds a new "Column assignment vs. in-place setting" subsection to
`user_guide/indexing.rst`, placed right after the existing "Series Assignment
and Index Alignment" section (which already contrasts the two forms, but only
for alignment, and explicitly claims they are "consistent" — true for
alignment, misleading for dtype). Includes `category` and `Int64` examples to
show this is general, not categorical-specific.

Leaves a short pointer in `user_guide/categorical.rst` since that's the
section users most often consult when this bites them.

## Test plan
- [x] Verified the four `.. ipython::` examples produce the dtypes the prose claims (`str` vs `category`, `int64` vs `Int64`)
- [x] pre-commit hooks pass (sphinx-lint, rst checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)