### PR TITLE
DOC: clarify scalar vs list-like return types for .loc and []

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -120,6 +120,16 @@ indexing pandas objects with ``[]``:
 
     Series, ``series[label]``, scalar value
     DataFrame, ``frame[colname]``, ``Series`` corresponding to colname
+    DataFrame, ``frame[[colname]]``, ``DataFrame`` with columns corresponding to ``[colname]``
+    DataFrame, ``frame[list_of_colnames]``, ``DataFrame`` with columns corresponding to ``list_of_colnames``
+
+The same principle applies to label-based selection with ``.loc``: a
+list-like of labels preserves the corresponding axis (so
+``df.loc[:, ["A"]]`` returns a ``DataFrame``, even when the list contains a
+single label), while a scalar label reduces the axis when labels on that
+axis are unique (so ``df.loc[:, "A"]`` typically returns a ``Series``; if
+``"A"`` is duplicated on the axis, a ``DataFrame`` is returned instead).
+See :ref:`indexing.label` for details.
 
 Here we construct a simple time series data set to use for illustrating the
 indexing functionality:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1333,14 +1333,6 @@ class _LocIndexer(_LocationIndexer):
     - A ``callable`` function with one argument (the calling Series or
       DataFrame) and that returns valid output for indexing (one of the above)
 
-    The *form* of the indexer, not the number of items it selects,
-    determines the return type. A list-like of labels preserves the
-    corresponding axis, so ``df.loc[:, ["A"]]`` returns a ``DataFrame``
-    even when the list contains a single label. A scalar label reduces
-    the axis when labels on that axis are unique, so ``df.loc[:, "A"]``
-    typically returns a ``Series`` (if ``"A"`` is duplicated, the axis
-    is preserved and a ``DataFrame`` is returned instead).
-
     See more at :ref:`Selection by Label <indexing.label>`.
 
     Raises
@@ -1386,6 +1378,22 @@ class _LocIndexer(_LocationIndexer):
                 max_speed  shield
     viper               4       5
     sidewinder          7       8
+
+    Single column label. Note this returns the column as a Series.
+
+    >>> df.loc[:, "max_speed"]
+    cobra         1
+    viper         4
+    sidewinder    7
+    Name: max_speed, dtype: int64
+
+    List with a single column label. Note this returns a DataFrame.
+
+    >>> df.loc[:, ["max_speed"]]
+                max_speed
+    cobra               1
+    viper               4
+    sidewinder          7
 
     Single label for row and column
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1333,6 +1333,14 @@ class _LocIndexer(_LocationIndexer):
     - A ``callable`` function with one argument (the calling Series or
       DataFrame) and that returns valid output for indexing (one of the above)
 
+    The *form* of the indexer, not the number of items it selects,
+    determines the return type. A list-like of labels preserves the
+    corresponding axis, so ``df.loc[:, ["A"]]`` returns a ``DataFrame``
+    even when the list contains a single label. A scalar label reduces
+    the axis when labels on that axis are unique, so ``df.loc[:, "A"]``
+    typically returns a ``Series`` (if ``"A"`` is duplicated, the axis
+    is preserved and a ``DataFrame`` is returned instead).
+
     See more at :ref:`Selection by Label <indexing.label>`.
 
     Raises


### PR DESCRIPTION
closes #46593

## Summary
- Add two rows to the indexing basics table for `frame[[colname]]` and `frame[list_of_colnames]` (per @CloseChoice's suggestion in GH-46593).
- Add a short note to the `.loc` docstring explaining that the *form* of the indexer (scalar vs. list-like) determines the return type, with the duplicate-labels exception spelled out.

## Test plan
- [x] Doctests pass for `pandas/core/indexing.py` (9 passed)
- [x] `pre-commit` clean on changed files