### PR TITLE
DOC: Fix iloc value swapping example to prevent axis alignment #65446

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -175,15 +175,21 @@ columns.
       df.loc[:, ['B', 'A']] = df[['A', 'B']].to_numpy()
       df[['A', 'B']]
 
-   However, pandas does not align AXES when setting ``Series`` and ``DataFrame`` from ``.iloc``
-   because ``.iloc`` operates by position.
+   Similarly, pandas aligns AXES when setting ``Series`` and ``DataFrame`` from ``.iloc``.
 
-   This will modify ``df`` because the column alignment is not done before value assignment.
+   This will **not** modify ``df`` because the column alignment is before value assignment.
 
    .. ipython:: python
 
       df[['A', 'B']]
       df.iloc[:, [1, 0]] = df[['A', 'B']]
+      df[['A','B']]
+
+   The correct way to swap column values with ``.iloc`` is also by using raw values:
+
+   .. ipython:: python
+
+      df.iloc[:, [1, 0]] = df[['A', 'B']].to_numpy()
       df[['A','B']]
 
 


### PR DESCRIPTION
Resolves #65446.
Updated the iloc warning in indexing.rst. The documentation previously stated that .iloc does not align axes during assignment, which is no longer true. I corrected the text and added .to_numpy() to the iloc swapping example so that the assignment strips the index and successfully swaps the values.