### PR TITLE
DOC: document column attrs with Copy-on-Write

### DIFF
--- a/doc/source/user_guide/migration.rst
+++ b/doc/source/user_guide/migration.rst
@@ -149,6 +149,18 @@ A different alternative would be to not use ``inplace``:
     df["foo"] = df["foo"].replace(1, 5)
     df
 
+**Column attributes cannot be used to store column-level metadata**
+
+``DataFrame.attrs`` and ``Series.attrs`` remain available for metadata on the
+object itself. With CoW, setting ``attrs`` on a ``Series`` returned by selecting
+a :class:`DataFrame` column is not a supported way to attach metadata to that
+column. A future access to the same column may return a different ``Series``
+object without those attributes.
+
+If you need column-level metadata, store it on the parent :class:`DataFrame`
+(for example in ``df.attrs["columns"]`` keyed by column name) or in a separate
+metadata object that you manage alongside the :class:`DataFrame`.
+
 **Constructors now copy NumPy arrays by default**
 
 The Series and DataFrame constructors now copies a NumPy array by default when not


### PR DESCRIPTION
Closes #64711

- add Copy-on-Write migration guidance that column-selected `Series.attrs` is not supported for column-level metadata
- suggest storing column metadata explicitly on `DataFrame.attrs` or in a separate metadata object

Checks:
- `git diff --check`
- `python3` content assertion for the new migration-guide note