### PR TITLE
DOC: fix iloc column swap example in indexing guide (bounty #65446)

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -180,10 +180,12 @@ columns.
 
    This will modify ``df`` because the column alignment is not done before value assignment.
 
+   To swap columns correctly with ``iloc``, use ``.to_numpy()`` to break the alignment:
+
    .. ipython:: python
 
       df[['A', 'B']]
-      df.iloc[:, [1, 0]] = df[['A', 'B']]
+      df.iloc[:, [1, 0]] = df[['A', 'B']].to_numpy()
       df[['A','B']]
 
 


### PR DESCRIPTION
## Summary
Fix for [BOUNTY #65446](https://github.com/pandas-dev/pandas/issues/65446) — DOC: Swapping values with iloc causes aligns axes, wrong example in docs

## Root cause
The documentation example  does NOT properly swap columns. Pandas aligns on column labels during assignment, even when using  for selection. The result is that columns are assigned by label match rather than position, so the swap does not occur as expected.

## Fix
Updated the documentation example to use  to break the alignment:


This ensures the assignment is done positionally, achieving the expected column swap behavior.

## Verification
Documentation now correctly shows that  is required for positional column swapping with . The corrected example produces the expected output showing columns properly swapped.

Closes #65446