### PR TITLE
PERF: Improve performance of groupby.size

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -180,6 +180,7 @@ Performance improvements
 - Performance improvement in :meth:`GroupBy.any` and :meth:`GroupBy.all` for boolean-dtype columns (:issue:`37850`)
 - Performance improvement in :meth:`GroupBy.first` and :meth:`GroupBy.last` for Extension Array dtypes, which no longer fall back to a slow ``apply``-based implementation (:issue:`57591`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
+- Performance improvement in :meth:`GroupBy.size` by avoiding an intermediate boolean mask and copy of the group codes (:issue:`51750`)
 - Performance improvement in :meth:`Index.get_indexer` for large monotonic indexes, which now uses binary search instead of building a hash table when the number of targets is small (:issue:`14273`)
 - Performance improvement in :meth:`Index.join` and :meth:`Index.union` for :class:`RangeIndex` by avoiding unnecessary memory allocation in the libjoin fastpath (:issue:`54646`)
 - Performance improvement in :meth:`IntervalIndex.get_indexer` for monotonic non-overlapping indexes, which now uses binary search instead of the interval tree (:issue:`47614`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -180,7 +180,7 @@ Performance improvements
 - Performance improvement in :meth:`GroupBy.any` and :meth:`GroupBy.all` for boolean-dtype columns (:issue:`37850`)
 - Performance improvement in :meth:`GroupBy.first` and :meth:`GroupBy.last` for Extension Array dtypes, which no longer fall back to a slow ``apply``-based implementation (:issue:`57591`)
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
-- Performance improvement in :meth:`GroupBy.size` by avoiding an intermediate boolean mask and copy of the group codes (:issue:`51750`)
+- Performance improvement in :meth:`GroupBy.size` (:issue:`51750`)
 - Performance improvement in :meth:`Index.get_indexer` for large monotonic indexes, which now uses binary search instead of building a hash table when the number of targets is small (:issue:`14273`)
 - Performance improvement in :meth:`Index.join` and :meth:`Index.union` for :class:`RangeIndex` by avoiding unnecessary memory allocation in the libjoin fastpath (:issue:`54646`)
 - Performance improvement in :meth:`IntervalIndex.get_indexer` for monotonic non-overlapping indexes, which now uses binary search instead of the interval tree (:issue:`47614`)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -734,7 +734,10 @@ class BaseGrouper:
         ngroups = self.ngroups
         out: np.ndarray | list
         if ngroups:
-            out = np.bincount(ids[ids != -1], minlength=ngroups)
+            if self.has_dropped_na:
+                out = np.bincount(ids + 1, minlength=ngroups + 1)[1:]
+            else:
+                out = np.bincount(ids, minlength=ngroups)
         else:
             out = []
         return Series(out, index=self.result_index, dtype="int64", copy=False)


### PR DESCRIPTION
- [x] closes #51750

```python
size = 10_000_000
df = pd.DataFrame(
    {
        "a": np.random.randint(0, 10000, size),
        "b": np.random.randint(0, 100000, size),
        "c": np.random.randint(0, 1000000, size),
    }
)
for column in list("abc"):
    gb = df.groupby(column)
    gb.size()
    %timeit gb.size()

# main
# 28.5 ms ± 1.34 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
# 33.3 ms ± 1.53 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
# 48.4 ms ± 12.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# PR
# 10.4 ms ± 498 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# 13.1 ms ± 63 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# 18.5 ms ± 44.6 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```