### PR TITLE
CLN: Reduce and cleanup benchmarks/algorithms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -186,12 +186,6 @@ repos:
         entry: '[a-zA-Z0-9]\`\`?[a-zA-Z0-9]'
         types: [rst]
         files: ^doc/source/
-    -   id: seed-check-asv
-        name: Check for unnecessary random seeds in asv benchmarks
-        language: pygrep
-        entry: 'np\.random\.seed'
-        files: ^asv_bench/benchmarks
-        exclude: ^asv_bench/benchmarks/pandas_vb_common\.py
     -   id: unwanted-patterns-in-tests
         name: Unwanted patterns in tests
         language: pygrep

--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -12,48 +12,50 @@ for imp in ["pandas.util", "pandas.tools.hashing"]:
         pass
 
 
+def _make_factorize_data(dtype, N):
+    if dtype in ("int64", "Int64", "object"):
+        data = pd.Index(np.arange(N), dtype=dtype)
+    elif dtype == "float64":
+        data = pd.Index(np.random.randn(N), dtype=dtype)
+    elif dtype == "datetime64[ns]":
+        data = pd.date_range("2011-01-01", freq="h", periods=N)
+    elif dtype == "datetime64[ns, tz]":
+        data = pd.date_range("2011-01-01", freq="h", periods=N, tz="Asia/Tokyo")
+    elif dtype == "object_str":
+        data = pd.Index([f"i-{i}" for i in range(N)], dtype=object)
+    elif dtype == "string[pyarrow]":
+        data = pd.array(
+            pd.Index([f"i-{i}" for i in range(N)], dtype=object),
+            dtype="string[pyarrow]",
+        )
+    else:
+        raise NotImplementedError
+    return data
+
+
+_FACTORIZE_DTYPES = [
+    "int64",
+    "float64",
+    "object",
+    "object_str",
+    "datetime64[ns]",
+    "datetime64[ns, tz]",
+    "Int64",
+    "string[pyarrow]",
+]
+
+
 class Factorize:
     params = [
         [True, False],
         [True, False],
-        [
-            "int64",
-            "uint64",
-            "float64",
-            "object",
-            "object_str",
-            "datetime64[ns]",
-            "datetime64[ns, tz]",
-            "Int64",
-            "boolean",
-            "string[pyarrow]",
-        ],
+        _FACTORIZE_DTYPES,
     ]
     param_names = ["unique", "sort", "dtype"]
 
     def setup(self, unique, sort, dtype):
         N = 10**5
-
-        if dtype in ["int64", "uint64", "Int64", "object"]:
-            data = pd.Index(np.arange(N), dtype=dtype)
-        elif dtype == "float64":
-            data = pd.Index(np.random.randn(N), dtype=dtype)
-        elif dtype == "boolean":
-            data = pd.array(np.random.randint(0, 2, N), dtype=dtype)
-        elif dtype == "datetime64[ns]":
-            data = pd.date_range("2011-01-01", freq="h", periods=N)
-        elif dtype == "datetime64[ns, tz]":
-            data = pd.date_range("2011-01-01", freq="h", periods=N, tz="Asia/Tokyo")
-        elif dtype == "object_str":
-            data = pd.Index([f"i-{i}" for i in range(N)], dtype=object)
-        elif dtype == "string[pyarrow]":
-            data = pd.array(
-                pd.Index([f"i-{i}" for i in range(N)], dtype=object),
-                dtype="string[pyarrow]",
-            )
-        else:
-            raise NotImplementedError
-
+        data = _make_factorize_data(dtype, N)
         if not unique:
             data = data.repeat(5)
         self.data = data
@@ -61,14 +63,25 @@ class Factorize:
     def time_factorize(self, unique, sort, dtype):
         pd.factorize(self.data, sort=sort)
 
-    def peakmem_factorize(self, unique, sort, dtype):
-        pd.factorize(self.data, sort=sort)
+
+class FactorizePeakmem:
+    # peakmem is driven by allocation patterns that vary by dtype; unique/sort
+    # are held fixed to keep this benchmark small.
+    params = _FACTORIZE_DTYPES
+    param_names = ["dtype"]
+
+    def setup(self, dtype):
+        N = 10**5
+        self.data = _make_factorize_data(dtype, N).repeat(5)
+
+    def peakmem_factorize(self, dtype):
+        pd.factorize(self.data, sort=False)
 
 
 class Duplicated:
     params = [
         [True, False],
-        ["first", "last", False],
+        ["first", False],
         [
             "int64",
             "uint64",
@@ -101,7 +114,7 @@ class Duplicated:
         if not unique:
             data = data.repeat(5)
         self.idx = data
-        # cache is_unique
+        # cache is_unique so its cost isn't measured in time_duplicated
         self.idx.is_unique
 
     def time_duplicated(self, unique, keep, dtype):
@@ -111,7 +124,7 @@ class Duplicated:
 class DuplicatedMaskedArray:
     params = [
         [True, False],
-        ["first", "last", False],
+        ["first", False],
         ["Int64", "Float64"],
     ]
     param_names = ["unique", "keep", "dtype"]
@@ -123,7 +136,7 @@ class DuplicatedMaskedArray:
         if not unique:
             data = data.repeat(5)
         self.ser = data
-        # cache is_unique
+        # cache is_unique so its cost isn't measured in time_duplicated
         self.ser.is_unique
 
     def time_duplicated(self, unique, keep, dtype):
@@ -132,6 +145,10 @@ class DuplicatedMaskedArray:
 
 class Hashing:
     def setup_cache(self):
+        # setup_cache runs in a different sub-process where module-level setup is
+        # never called,so seed locally to keep the cached frame reproducible
+        # across runs.
+        # np.random.seed(1234)
         N = 10**5
 
         df = pd.DataFrame(
@@ -175,15 +192,15 @@ class Hashing:
 
 class Quantile:
     params = [
-        [0, 0.5, 1],
+        [0, 0.5],
         ["linear", "nearest", "lower", "higher", "midpoint"],
-        ["float64", "int64", "uint64"],
+        ["float64", "int64"],
     ]
     param_names = ["quantile", "interpolation", "dtype"]
 
     def setup(self, quantile, interpolation, dtype):
         N = 10**5
-        if dtype in ["int64", "uint64"]:
+        if dtype == "int64":
             data = np.arange(N, dtype=dtype)
         elif dtype == "float64":
             data = np.random.randn(N)

--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -148,7 +148,7 @@ class Hashing:
         # setup_cache runs in a different sub-process where module-level setup is
         # never called,so seed locally to keep the cached frame reproducible
         # across runs.
-        # np.random.seed(1234)
+        np.random.seed(1234)
         N = 10**5
 
         df = pd.DataFrame(

--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -81,7 +81,7 @@ class FactorizePeakmem:
 class Duplicated:
     params = [
         [True, False],
-        ["first", False],
+        ["first", "last", False],
         [
             "int64",
             "uint64",

--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -114,7 +114,7 @@ class Duplicated:
         if not unique:
             data = data.repeat(5)
         self.idx = data
-        # cache is_unique so its cost isn't measured in time_duplicated
+        # cache is_unique
         self.idx.is_unique
 
     def time_duplicated(self, unique, keep, dtype):
@@ -124,7 +124,7 @@ class Duplicated:
 class DuplicatedMaskedArray:
     params = [
         [True, False],
-        ["first", False],
+        ["first", "last", False],
         ["Int64", "Float64"],
     ]
     param_names = ["unique", "keep", "dtype"]
@@ -136,7 +136,7 @@ class DuplicatedMaskedArray:
         if not unique:
             data = data.repeat(5)
         self.ser = data
-        # cache is_unique so its cost isn't measured in time_duplicated
+        # cache is_unique
         self.ser.is_unique
 
     def time_duplicated(self, unique, keep, dtype):
@@ -192,7 +192,7 @@ class Hashing:
 
 class Quantile:
     params = [
-        [0, 0.5],
+        [0, 0.5, 1],
         ["linear", "nearest", "lower", "higher", "midpoint"],
         ["float64", "int64"],
     ]

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5493,7 +5493,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         from pandas import Series
 
-        ser = Series(self._values, copy=False)
+        ser = Series(self._values, copy=False, dtype=self.dtype)
         try:
             result_ser = ser.where(cond, other)
         except (TypeError, ValueError):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5493,7 +5493,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         from pandas import Series
 
-        ser = Series(self._values, copy=False, dtype=self.dtype)
+        ser = Series(self._values, copy=False)
         try:
             result_ser = ser.where(cond, other)
         except (TypeError, ValueError):


### PR DESCRIPTION
Any time we need to set a seed for `setup_cache`, we'd violate the current linting done by pre-commit. So I've removed it for now, but asked in https://github.com/airspeed-velocity/asv/issues/1592 whether skipping module-level `setup` was intentional. If this gets fixed upstream, we can restore the linting then.