### PR TITLE
BUG: Preserve dtype in Index.where

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5493,7 +5493,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         from pandas import Series
 
-        ser = Series(self._values, copy=False)
+        ser = Series(self._values, copy=False, dtype=self.dtype)
         try:
             result_ser = ser.where(cond, other)
         except (TypeError, ValueError):

--- a/pandas/tests/indexes/base_class/test_where.py
+++ b/pandas/tests/indexes/base_class/test_where.py
@@ -11,3 +11,9 @@ class TestWhere:
         res = idx.where(mask, "2")
         expected = Index([0, "2", 2])
         tm.assert_index_equal(res, expected)
+
+    def test_where_preserves_object_dtype(self):
+        idx = Index(list("abc"), dtype="object")
+        res = idx.where(np.array([True, False, True]), other="x")
+        expected = Index(["a", "x", "c"], dtype="object")
+        tm.assert_index_equal(res, expected)

--- a/pandas/tests/indexes/base_class/test_where.py
+++ b/pandas/tests/indexes/base_class/test_where.py
@@ -15,6 +15,6 @@ class TestWhere:
     def test_where_preserves_object_dtype(self):
         # https://github.com/pandas-dev/pandas/pull/65653
         idx = Index(list("abc"), dtype="object")
-        res = idx.where(np.array([True, False, True]), other="x")
+        result = idx.where(np.array([True, False, True]), other="x")
         expected = Index(["a", "x", "c"], dtype="object")
-        tm.assert_index_equal(res, expected)
+        tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/base_class/test_where.py
+++ b/pandas/tests/indexes/base_class/test_where.py
@@ -13,6 +13,7 @@ class TestWhere:
         tm.assert_index_equal(res, expected)
 
     def test_where_preserves_object_dtype(self):
+        # https://github.com/pandas-dev/pandas/pull/65653
         idx = Index(list("abc"), dtype="object")
         res = idx.where(np.array([True, False, True]), other="x")
         expected = Index(["a", "x", "c"], dtype="object")


### PR DESCRIPTION
Addresses a behavior change due to https://github.com/pandas-dev/pandas/pull/65265.

```python
idx = pd.Index(list("abc"), dtype="object")
print(idx.where(np.array([True, False, True]), other="x"))
# Index(['a', 'x', 'c'], dtype='str')  <--- main
# Index(['a', 'x', 'c'], dtype='object')  <--- PR
```

This showed up as a performance regression in `str.cat` as that is faster on object dtype.