### PR TITLE
PERF: use Index._id for axis-identity checks in concat fast paths

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -145,6 +145,7 @@ Performance improvements
 - Performance improvement in :class:`DataFrame` repr by avoiding redundant formatting when columns exceed terminal width (:issue:`64863`)
 - Performance improvement in :class:`GroupBy` reductions and transformations for :class:`SparseDtype` columns (:issue:`36123`)
 - Performance improvement in :func:`bdate_range` and :func:`date_range` with ``freq="B"`` or ``freq="C"`` (business day frequencies) (:issue:`16463`)
+- Performance improvement in :func:`concat` and :meth:`DataFrame.astype` to extension dtypes (:issue:`65672`)
 - Performance improvement in :func:`infer_freq` (:issue:`64463`)
 - Performance improvement in :func:`merge` and :meth:`DataFrame.join` for many-to-many joins with ``sort=False`` (:issue:`56564`)
 - Performance improvement in :func:`merge` for many-to-one joins with unique right keys (:issue:`38418`)

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -97,11 +97,11 @@ def _get_distinct_objs(objs: list[Index]) -> list[Index]:
     Return a list with distinct elements of "objs" (different ids).
     Preserves order.
     """
-    ids: set[int] = set()
+    ids: set = set()
     res = []
     for obj in objs:
-        if id(obj) not in ids:
-            ids.add(id(obj))
+        if obj._id not in ids:
+            ids.add(obj._id)
             res.append(obj)
     return res
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -97,7 +97,7 @@ def _get_distinct_objs(objs: list[Index]) -> list[Index]:
     Return a list with distinct elements of "objs" (different ids).
     Preserves order.
     """
-    ids: set = set()
+    ids = set()
     res = []
     for obj in objs:
         if obj._id not in ids:

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -565,7 +565,7 @@ def _homogenize(
         if isinstance(val, (ABCSeries, Index)):
             if dtype is not None:
                 val = val.astype(dtype)
-            if isinstance(val, ABCSeries) and val.index is not index:
+            if isinstance(val, ABCSeries) and val.index._id is not index._id:
                 # Forces alignment. No need to copy data since we
                 # are putting it into an ndarray later
                 val = val.reindex(index)


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/90