### PR TITLE
TST: Speed up test_read_excel_skiprows_callable_all

### DIFF
--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -12,6 +12,7 @@ import pandas._testing as tm
 
 from pandas.io.excel import (
     ExcelWriter,
+    _base as _excel_base,
     _OpenpyxlWriter,
 )
 from pandas.io.excel._openpyxl import OpenpyxlReader
@@ -346,10 +347,14 @@ def test_read_with_bad_dimension(
 @pytest.mark.parametrize(
     "filename", ["dimension_missing", "dimension_small", "dimension_large"]
 )
-def test_read_with_bad_dimension_skiprows_callable_all(datapath, ext, filename):
+def test_read_with_bad_dimension_skiprows_callable_all(
+    datapath, ext, filename, monkeypatch
+):
     # GH 64027
     path = datapath("io", "data", "excel", f"{filename}{ext}")
-    result = pd.read_excel(path, skiprows=lambda _: True, nrows=1)
+    with monkeypatch.context() as m:
+        m.setattr(_excel_base, "EXCEL_ROWS_MAX", 10)
+        result = pd.read_excel(path, skiprows=lambda _: True, nrows=1)
     expected = DataFrame()
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -30,6 +30,8 @@ from pandas import (
 )
 import pandas._testing as tm
 
+import pandas.io.excel._base as _excel_base
+
 read_ext_params = [".xls", ".xlsx", ".xlsm", ".xlsb", ".ods"]
 engine_params = [
     # Add any engines to test here
@@ -1372,9 +1374,11 @@ class TestReaders:
         expected["c"] = expected["c"].astype(f"M8[{unit}]")
         tm.assert_frame_equal(actual, expected)
 
-    def test_read_excel_skiprows_callable_all(self, read_ext):
+    def test_read_excel_skiprows_callable_all(self, read_ext, monkeypatch):
         # GH 64027
-        actual = pd.read_excel("test1" + read_ext, skiprows=lambda _: True, nrows=1)
+        with monkeypatch.context() as m:
+            m.setattr(_excel_base, "EXCEL_ROWS_MAX", 10)
+            actual = pd.read_excel("test1" + read_ext, skiprows=lambda _: True, nrows=1)
         expected = DataFrame()
         tm.assert_frame_equal(actual, expected)
 


### PR DESCRIPTION
Before this test would need to iterate over `range(1_048_576)` for multiple engines 