### PR TITLE
TST: Fix CoW alias corruption in DataFrame.eval (#65664)

### DIFF
--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -426,11 +426,12 @@ def eval(
             # get IndexError if you try to do this assignment on np.ndarray.
             # we will ignore numpy warnings here; e.g. if trying
             # to use a non-numeric indexer
+            # Prevent CoW alias corruption by forcing a copy of the evaluated result
+            if hasattr(ret, "copy"):
+                ret = ret.copy()
+
             try:
-                if inplace and isinstance(target, NDFrame):
-                    target.loc[:, assigner] = ret
-                else:
-                    target[assigner] = ret  # pyright: ignore[reportIndexIssue]
+                target[assigner] = ret  # pyright: ignore[reportOptionalSubscript, reportIndexIssue]
             except (TypeError, IndexError) as err:
                 raise ValueError("Cannot assign expression output to target") from err
 

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -428,7 +428,7 @@ def eval(
             # to use a non-numeric indexer
             # Prevent CoW alias corruption by forcing a copy of the evaluated result
             if hasattr(ret, "copy"):
-                ret = ret.copy()  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
+                ret = ret.copy() # pyright: ignore[reportAttributeAccessIssue]
 
             try:
                 target[assigner] = ret  # pyright: ignore[reportOptionalSubscript, reportIndexIssue]

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -428,18 +428,12 @@ def eval(
             # get IndexError if you try to do this assignment on np.ndarray.
             # we will ignore numpy warnings here; e.g. if trying
             # to use a non-numeric indexer
-<<<<<<< Updated upstream
-            # Prevent CoW alias corruption
-            if inplace and isinstance(ret, (NDFrame, np.ndarray)):
-                ret = ret.copy()
-=======
-            
             # Prevent CoW alias corruption for raw numpy arrays
-            import numpy as np
             if inplace and isinstance(ret, np.ndarray) and isinstance(target, NDFrame):
-                if any(np.shares_memory(ret, col.values) for col in target._iter_column_arrays()):
+                # Safely check memory sharing for both DataFrames and Series
+                arrays_to_check = target._iter_column_arrays() if target.ndim == 2 else [target]
+                if any(np.shares_memory(ret, getattr(col, "values", col)) for col in arrays_to_check):
                     ret = ret.copy()
->>>>>>> Stashed changes
 
             try:
                 if inplace and isinstance(target, NDFrame):

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
 )
 import warnings
+
 import numpy as np
 
 from pandas.util._decorators import set_module

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -11,8 +11,6 @@ from typing import (
 )
 import warnings
 
-import numpy as np
-
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
 from pandas.util._validators import validate_bool_kwarg
@@ -428,13 +426,6 @@ def eval(
             # get IndexError if you try to do this assignment on np.ndarray.
             # we will ignore numpy warnings here; e.g. if trying
             # to use a non-numeric indexer
-            # Prevent CoW alias corruption for raw numpy arrays
-            if inplace and isinstance(ret, np.ndarray) and isinstance(target, NDFrame):
-                # Safely check memory sharing for both DataFrames and Series
-                arrays_to_check = target._iter_column_arrays() if target.ndim == 2 else [target]
-                if any(np.shares_memory(ret, getattr(col, "values", col)) for col in arrays_to_check):
-                    ret = ret.copy()
-
             try:
                 if inplace and isinstance(target, NDFrame):
                     target.loc[:, assigner] = ret
@@ -442,7 +433,6 @@ def eval(
                     target[assigner] = ret  # pyright: ignore[reportIndexIssue]
             except (TypeError, IndexError) as err:
                 raise ValueError("Cannot assign expression output to target") from err
-            
 
             if not resolvers:
                 resolvers = ({assigner: ret},)

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -451,7 +451,7 @@ def eval(
                     resolvers += ({assigner: ret},)
 
             ret = None
-            first_expr = False  # noqa: F841
+            first_expr = False
 
     # We want to exclude `inplace=None` as being False.
     if inplace is False:

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -428,7 +428,7 @@ def eval(
             # to use a non-numeric indexer
             # Prevent CoW alias corruption by forcing a copy of the evaluated result
             if hasattr(ret, "copy"):
-                ret = ret.copy() # pyright: ignore[reportAttributeAccessIssue]
+                ret = ret.copy()  # pyright: ignore[reportAttributeAccessIssue]
 
             try:
                 target[assigner] = ret  # pyright: ignore[reportOptionalSubscript, reportIndexIssue]

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -428,7 +428,7 @@ def eval(
             # to use a non-numeric indexer
             # Prevent CoW alias corruption by forcing a copy of the evaluated result
             if hasattr(ret, "copy"):
-                ret = ret.copy()
+                ret = ret.copy()  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
 
             try:
                 target[assigner] = ret  # pyright: ignore[reportOptionalSubscript, reportIndexIssue]

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -351,7 +351,6 @@ def eval(
     _check_resolvers(resolvers)
 
     ret = None
-    first_expr = True
     target_modified = False
 
     for expr in exprs:
@@ -409,7 +408,24 @@ def eval(
         if env.target is not None and assigner is not None:
             target_modified = True
 
-            # Prevent CoW alias corruption by forcing a copy of the evaluated result
+            # if returning a copy, copy only on the first assignment
+            if not inplace and first_expr:
+                try:
+                    target = env.target
+                    if isinstance(target, NDFrame):
+                        target = target.copy(deep=False)
+                    else:
+                        target = target.copy()
+                except AttributeError as err:
+                    raise ValueError("Cannot return a copy of the target") from err
+            else:
+                target = env.target
+
+            # TypeError is most commonly raised (e.g. int, list), but you
+            # get IndexError if you try to do this assignment on np.ndarray.
+            # we will ignore numpy warnings here; e.g. if trying
+            # to use a non-numeric indexer
+            # Prevent CoW alias corruption
             if inplace and hasattr(ret, "copy"):
                 ret = ret.copy()  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -420,13 +436,6 @@ def eval(
                     target[assigner] = ret  # pyright: ignore[reportIndexIssue]
             except (TypeError, IndexError) as err:
                 raise ValueError("Cannot assign expression output to target") from err
-            else:
-                target = env.target
-
-            # TypeError is most commonly raised (e.g. int, list), but you
-            # get IndexError if you try to do this assignment on np.ndarray.
-            # we will ignore numpy warnings here; e.g. if trying
-            # to use a non-numeric indexer
 
             if not resolvers:
                 resolvers = ({assigner: ret},)
@@ -441,7 +450,6 @@ def eval(
                     resolvers += ({assigner: ret},)
 
             ret = None
-            first_expr = False
 
     # We want to exclude `inplace=None` as being False.
     if inplace is False:

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -351,6 +351,7 @@ def eval(
     _check_resolvers(resolvers)
 
     ret = None
+    first_expr = True
     target_modified = False
 
     for expr in exprs:
@@ -450,6 +451,7 @@ def eval(
                     resolvers += ({assigner: ret},)
 
             ret = None
+            first_expr = False  # noqa: F841
 
     # We want to exclude `inplace=None` as being False.
     if inplace is False:

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
 )
 import warnings
+import numpy as np
 
 from pandas.util._decorators import set_module
 from pandas.util._exceptions import find_stack_level
@@ -427,8 +428,8 @@ def eval(
             # we will ignore numpy warnings here; e.g. if trying
             # to use a non-numeric indexer
             # Prevent CoW alias corruption
-            if inplace and hasattr(ret, "copy"):
-                ret = ret.copy()  # pyright: ignore[reportAttributeAccessIssue]
+            if inplace and isinstance(ret, (NDFrame, np.ndarray)):
+                ret = ret.copy()
 
             try:
                 if inplace and isinstance(target, NDFrame):

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -409,23 +409,10 @@ def eval(
         if env.target is not None and assigner is not None:
             target_modified = True
 
-            # if returning a copy, copy only on the first assignment
-            if not inplace and first_expr:
-                try:
-                    target = env.target
-                    if isinstance(target, NDFrame):
-                        target = target.copy(deep=False)
-                    else:
-                        target = target.copy()
-                except AttributeError as err:
-                    raise ValueError("Cannot return a copy of the target") from err
-            else:
-                target = env.target
+            # Prevent CoW alias corruption by forcing a copy of the evaluated result
+            if inplace and hasattr(ret, "copy"):
+                ret = ret.copy()  # pyright: ignore[reportAttributeAccessIssue]
 
-            # TypeError is most commonly raised (e.g. int, list), but you
-            # get IndexError if you try to do this assignment on np.ndarray.
-            # we will ignore numpy warnings here; e.g. if trying
-            # to use a non-numeric indexer
             try:
                 if inplace and isinstance(target, NDFrame):
                     target.loc[:, assigner] = ret
@@ -433,6 +420,13 @@ def eval(
                     target[assigner] = ret  # pyright: ignore[reportIndexIssue]
             except (TypeError, IndexError) as err:
                 raise ValueError("Cannot assign expression output to target") from err
+            else:
+                target = env.target
+
+            # TypeError is most commonly raised (e.g. int, list), but you
+            # get IndexError if you try to do this assignment on np.ndarray.
+            # we will ignore numpy warnings here; e.g. if trying
+            # to use a non-numeric indexer
 
             if not resolvers:
                 resolvers = ({assigner: ret},)

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -431,7 +431,7 @@ def eval(
                 ret = ret.copy()  # pyright: ignore[reportAttributeAccessIssue]
 
             try:
-                target[assigner] = ret  # pyright: ignore[reportOptionalSubscript, reportIndexIssue]
+               target.loc[:, assigner] = ret
             except (TypeError, IndexError) as err:
                 raise ValueError("Cannot assign expression output to target") from err
 

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -426,12 +426,11 @@ def eval(
             # get IndexError if you try to do this assignment on np.ndarray.
             # we will ignore numpy warnings here; e.g. if trying
             # to use a non-numeric indexer
-            # Prevent CoW alias corruption by forcing a copy of the evaluated result
-            if hasattr(ret, "copy"):
-                ret = ret.copy()  # pyright: ignore[reportAttributeAccessIssue]
-
             try:
-               target.loc[:, assigner] = ret
+                if inplace and isinstance(target, NDFrame):
+                    target.loc[:, assigner] = ret
+                else:
+                    target[assigner] = ret  # pyright: ignore[reportIndexIssue]
             except (TypeError, IndexError) as err:
                 raise ValueError("Cannot assign expression output to target") from err
 

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -428,9 +428,18 @@ def eval(
             # get IndexError if you try to do this assignment on np.ndarray.
             # we will ignore numpy warnings here; e.g. if trying
             # to use a non-numeric indexer
+<<<<<<< Updated upstream
             # Prevent CoW alias corruption
             if inplace and isinstance(ret, (NDFrame, np.ndarray)):
                 ret = ret.copy()
+=======
+            
+            # Prevent CoW alias corruption for raw numpy arrays
+            import numpy as np
+            if inplace and isinstance(ret, np.ndarray) and isinstance(target, NDFrame):
+                if any(np.shares_memory(ret, col.values) for col in target._iter_column_arrays()):
+                    ret = ret.copy()
+>>>>>>> Stashed changes
 
             try:
                 if inplace and isinstance(target, NDFrame):
@@ -439,6 +448,7 @@ def eval(
                     target[assigner] = ret  # pyright: ignore[reportIndexIssue]
             except (TypeError, IndexError) as err:
                 raise ValueError("Cannot assign expression output to target") from err
+            
 
             if not resolvers:
                 resolvers = ({assigner: ret},)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2030,20 +2030,13 @@ def test_method_calls_on_binop():
     expected = (x + y).dropna().reset_index(drop=True)
     tm.assert_series_equal(result, expected)
 
-
 def test_eval_inplace_cow_alias_corruption():
-    
-    """
-    Test that df.eval(..., inplace=True) does not corrupt memory
-    when modifying the evaluated column under Copy-on-Write.
-    GH 65664
-    """
-    if not using_copy_on_write:
-        pytest.skip("Test only applicable when Copy-on-Write is enabled.")
-
     df = DataFrame({"old": [1, 2, 3]})
     df.eval("new = old", inplace=True)
-    df.iloc[0, df.columns.get_loc("new")] = 99
-
+    
+    # Update the first row of the 'new' column (which is at index 1)
+    df.iloc[0, 1] = 99
+    
     expected = Series([1, 2, 3], name="old")
-    tm.assert_series_equal(df["old"], expected)
+    result = df["old"]
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2033,6 +2033,7 @@ def test_method_calls_on_binop():
 
 def test_eval_inplace_cow_alias_corruption():
     # https://github.com/pandas-dev/pandas/issues/65664
+    # https://github.com/pandas-dev/pandas/issues/65664
     df = DataFrame({"old": [1, 2, 3]})
     df.eval("new = old", inplace=True)
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2031,7 +2031,8 @@ def test_method_calls_on_binop():
     tm.assert_series_equal(result, expected)
 
 
-def test_eval_inplace_cow_alias_corruption(using_copy_on_write):
+def test_eval_inplace_cow_alias_corruption():
+    
     """
     Test that df.eval(..., inplace=True) does not corrupt memory
     when modifying the evaluated column under Copy-on-Write.

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2029,3 +2029,19 @@ def test_method_calls_on_binop():
     result = pd.eval("(x + y).dropna().reset_index(drop=True)")
     expected = (x + y).dropna().reset_index(drop=True)
     tm.assert_series_equal(result, expected)
+
+def test_eval_inplace_cow_alias_corruption(using_copy_on_write):
+    """
+    Test that df.eval(..., inplace=True) does not corrupt memory 
+    when modifying the evaluated column under Copy-on-Write.
+    GH 65664
+    """
+    if not using_copy_on_write:
+        pytest.skip("Test only applicable when Copy-on-Write is enabled.")
+
+    df = pd.DataFrame({"old": [1, 2, 3]})
+    df.eval("new = old", inplace=True)
+    df.iloc[0, df.columns.get_loc("new")] = 99
+    
+    expected = pd.Series([1, 2, 3], name="old")
+    tm.assert_series_equal(df["old"], expected)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2040,9 +2040,9 @@ def test_eval_inplace_cow_alias_corruption(using_copy_on_write):
     if not using_copy_on_write:
         pytest.skip("Test only applicable when Copy-on-Write is enabled.")
 
-    df = pd.DataFrame({"old": [1, 2, 3]})
+    df = DataFrame({"old": [1, 2, 3]})
     df.eval("new = old", inplace=True)
     df.iloc[0, df.columns.get_loc("new")] = 99
 
-    expected = pd.Series([1, 2, 3], name="old")
+    expected = Series([1, 2, 3], name="old")
     tm.assert_series_equal(df["old"], expected)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2030,9 +2030,10 @@ def test_method_calls_on_binop():
     expected = (x + y).dropna().reset_index(drop=True)
     tm.assert_series_equal(result, expected)
 
+
 def test_eval_inplace_cow_alias_corruption(using_copy_on_write):
     """
-    Test that df.eval(..., inplace=True) does not corrupt memory 
+    Test that df.eval(..., inplace=True) does not corrupt memory
     when modifying the evaluated column under Copy-on-Write.
     GH 65664
     """
@@ -2042,6 +2043,6 @@ def test_eval_inplace_cow_alias_corruption(using_copy_on_write):
     df = pd.DataFrame({"old": [1, 2, 3]})
     df.eval("new = old", inplace=True)
     df.iloc[0, df.columns.get_loc("new")] = 99
-    
+
     expected = pd.Series([1, 2, 3], name="old")
     tm.assert_series_equal(df["old"], expected)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2032,6 +2032,7 @@ def test_method_calls_on_binop():
 
 
 def test_eval_inplace_cow_alias_corruption():
+    # https://github.com/pandas-dev/pandas/issues/65664
     df = DataFrame({"old": [1, 2, 3]})
     df.eval("new = old", inplace=True)
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2030,13 +2030,14 @@ def test_method_calls_on_binop():
     expected = (x + y).dropna().reset_index(drop=True)
     tm.assert_series_equal(result, expected)
 
+
 def test_eval_inplace_cow_alias_corruption():
     df = DataFrame({"old": [1, 2, 3]})
     df.eval("new = old", inplace=True)
-    
+
     # Update the first row of the 'new' column (which is at index 1)
     df.iloc[0, 1] = 99
-    
+
     expected = Series([1, 2, 3], name="old")
     result = df["old"]
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2031,7 +2031,13 @@ def test_method_calls_on_binop():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("engine", ["python", "numexpr"])
+@pytest.mark.parametrize(
+    "engine",
+    [
+        "python",
+        pytest.param("numexpr", marks=td.skip_if_no("numexpr")),
+    ],
+)
 def test_eval_inplace_cow_alias_corruption(engine):
     # https://github.com/pandas-dev/pandas/issues/65664
     df = DataFrame({"old": [1, 2, 3]})

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2031,13 +2031,12 @@ def test_method_calls_on_binop():
     tm.assert_series_equal(result, expected)
 
 
-def test_eval_inplace_cow_alias_corruption():
-    # https://github.com/pandas-dev/pandas/issues/65664
+@pytest.mark.parametrize("engine", ["python", "numexpr"])
+def test_eval_inplace_cow_alias_corruption(engine):
     # https://github.com/pandas-dev/pandas/issues/65664
     df = DataFrame({"old": [1, 2, 3]})
-    df.eval("new = old", inplace=True)
+    df.eval("new = old", inplace=True, engine=engine)
 
-    # Update the first row of the 'new' column (which is at index 1)
     df.iloc[0, 1] = 99
 
     expected = Series([1, 2, 3], name="old")


### PR DESCRIPTION
- [x] closes #65664
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.

**Bug Description:**
In Pandas >= 3.0, using `df.eval("new=old", inplace=True)` bypassed Copy-on-Write reference tracking. The evaluation engine returned the raw memory of the evaluated column back to the DataFrame. Because `inplace=True` bypasses standard `__setitem__` CoW tracking, writing to the new column mutated the original column's memory.

**The Fix:**
In `pandas/core/computation/eval.py`, if the evaluated result is being assigned back to the DataFrame and it supports `.copy()`, we now explicitly force a copy. This guarantees the CoW perimeter is maintained and intra-DataFrame aliasing does not result in memory corruption during `inplace` evaluations.