### PR TITLE
ASV: Run inplace fillna once per setup

### DIFF
--- a/asv_bench/benchmarks/replace.py
+++ b/asv_bench/benchmarks/replace.py
@@ -6,6 +6,7 @@ import pandas as pd
 class FillNa:
     params = [True, False]
     param_names = ["inplace"]
+    # inplace=True can only run once as it mutates the data
     number = 1
 
     def setup(self, inplace):

--- a/asv_bench/benchmarks/replace.py
+++ b/asv_bench/benchmarks/replace.py
@@ -6,6 +6,7 @@ import pandas as pd
 class FillNa:
     params = [True, False]
     param_names = ["inplace"]
+    number = 1
 
     def setup(self, inplace):
         N = 10**6

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1372,9 +1372,6 @@ class Block(PandasObject, libinternals.Block):
             except (LossySetitemError, NotImplementedError):
                 pass
             else:
-                if values.dtype.kind == "f" and not np.isnan(values).any():
-                    return [self.copy(deep=False)]
-
                 copy, refs = self._get_refs_and_copy(inplace)
                 new_values = values.copy() if copy else values
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1372,6 +1372,9 @@ class Block(PandasObject, libinternals.Block):
             except (LossySetitemError, NotImplementedError):
                 pass
             else:
+                if values.dtype.kind == "f" and not np.isnan(values).any():
+                    return [self.copy(deep=False)]
+
                 copy, refs = self._get_refs_and_copy(inplace)
                 new_values = values.copy() if copy else values
 


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/115

It's not clear to me the check to short-circuit is worth it here; I imagine the common case of calling fillna is on data that likely has NAs. Can revert that bit if desired, but would like to make the change to the ASV in any case.
