### PR TITLE
BUG: pyarrow-nightly CI fails during Pixi install due to stale locked nightly wheel

### DIFF
--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -8,6 +8,7 @@ runs:
   using: composite
   steps:
     - name: Install ${{ inputs.environment }}
+      if: ${{ inputs.environment != 'pyarrow-nightly' }}
       uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
       with:
         pixi-version: v0.66.0
@@ -16,3 +17,20 @@ runs:
         environments: ${{ inputs.environment }}
         cache: true
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+
+    - name: Install Pixi
+      if: ${{ inputs.environment == 'pyarrow-nightly' }}
+      uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
+      with:
+        pixi-version: v0.66.0
+        log-level: vv
+        manifest-path: pixi.toml
+        run-install: false
+        cache: false
+
+    - name: Install ${{ inputs.environment }}
+      if: ${{ inputs.environment == 'pyarrow-nightly' }}
+      shell: bash
+      run: |
+        pixi update --manifest-path pixi.toml --environment pyarrow-nightly --platform linux-64 pyarrow
+        pixi install --manifest-path pixi.toml --environment pyarrow-nightly --locked


### PR DESCRIPTION
- [x] closes #65690 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
