### PR TITLE
TYP: widen duplicated() input type to AnyArrayLike (GH 42604)

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -109,7 +109,7 @@ if TYPE_CHECKING:
 # --------------- #
 # dtype access    #
 # --------------- #
-def _ensure_data(values: ArrayLike) -> np.ndarray:
+def _ensure_data(values: AnyArrayLike) -> np.ndarray:
     """
     routine to ensure that our data is of the correct
     input dtype for lower-level routines
@@ -124,7 +124,7 @@ def _ensure_data(values: ArrayLike) -> np.ndarray:
 
     Parameters
     ----------
-    values : np.ndarray or ExtensionArray
+    values : np.ndarray, ExtensionArray, Index, or Series
 
     Returns
     -------
@@ -980,7 +980,7 @@ def value_counts_arraylike(
 
 
 def duplicated(
-    values: ArrayLike,
+    values: AnyArrayLike,
     keep: Literal["first", "last", False] = "first",
     mask: npt.NDArray[np.bool_] | None = None,
 ) -> npt.NDArray[np.bool_]:
@@ -989,7 +989,7 @@ def duplicated(
 
     Parameters
     ----------
-    values : np.ndarray or ExtensionArray
+    values : np.ndarray, ExtensionArray, Index, or Series
         Array over which to check for duplicate values.
     keep : {'first', 'last', False}, default 'first'
         - ``first`` : Mark duplicates as ``True`` except for the first


### PR DESCRIPTION
- [x] closes #42604
- [ ] Tests added and passed — N/A (type-only change; existing tests for `test_algos.py` and Series `duplicated`/`drop_duplicates` continue to pass)
- [x] All code checks passed (ruff lint+format, mypy, pyright — 0 new findings on the modified file).
- [x] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file — omitted, following the convention of recent internal TYP PRs (e.g. #65465, #65555, #65533, #65549) which did not add whatsnew entries.
- [x] I have reviewed and followed all the contribution guidelines.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Summary

`pandas.core.algorithms.duplicated()` already accepts `Series` and `Index` at runtime (its internal call to `_ensure_data` unwraps them via `extract_array`), and its user-facing docs reflected this since #41985. Only the type annotation and docstring lagged behind. This widens both `duplicated()` and `_ensure_data()` from `ArrayLike` to `AnyArrayLike` (which adds `Index | Series`) and updates the parameter docstrings to match.

Widening a parameter type is backward-compatible — existing callers passing `ArrayLike` continue to type-check unchanged.

## Note

This PR was developed with AI assistance (Claude); the agent was given `AGENTS.md` as guidance.