### PR TITLE
BUG: raise consistent error for BooleanArray logical ops with dtype-less sequences (#63095)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -96,6 +96,7 @@ Other API changes
 ^^^^^^^^^^^^^^^^^
 - :meth:`.DataFrameGroupBy.sum` and :meth:`.DataFrameGroupBy.mean` on float dtypes with sorted grouping keys may differ from prior versions in the last few floating-point digits, due to a faster summation algorithm that does not use Kahan compensation (:issue:`65103`)
 - APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`64483`).
+- Logical operations (``&``, ``|``, ``^``) between a :class:`arrays.BooleanArray` and a dtype-less sequence (e.g. ``list``, ``tuple``) now raise ``TypeError``, consistent with the behavior of :class:`Series`; previously these silently coerced the values or raised a confusing ``"boolean value of NA is ambiguous"`` error when the sequence contained ``pd.NA`` (:issue:`63095`)
 - Removed the ``freq`` and ``freqstr`` attributes from :class:`.DatetimeArray` and :class:`.TimedeltaArray`. Frequency is now stored only on :class:`DatetimeIndex` and :class:`TimedeltaIndex`; access ``Series.dt.freq`` or wrap the array in an Index to retrieve a frequency. The ``check_freq`` keyword on :func:`testing.assert_extension_array_equal` for these array types has also been removed (:issue:`24566`).
 -
 

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -7,7 +7,6 @@ from typing import (
     Self,
     cast,
 )
-import warnings
 
 import numpy as np
 
@@ -15,9 +14,7 @@ from pandas._libs import (
     lib,
     missing as libmissing,
 )
-from pandas.errors import Pandas4Warning
 from pandas.util._decorators import set_module
-from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.dtypes.dtypes import register_extension_dtype
@@ -25,7 +22,6 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core import ops
 from pandas.core.array_algos import masked_accumulations
-from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays.masked import (
     BaseMaskedArray,
     BaseMaskedDtype,
@@ -398,16 +394,17 @@ class BooleanArray(BaseMaskedArray):
         if isinstance(other, BooleanArray):
             other, mask = other._data, other._mask
         elif is_list_like(other):
-            if not isinstance(
-                other, (list, ExtensionArray, np.ndarray)
-            ) and not ops.has_castable_attr(other):
-                warnings.warn(
-                    f"Operation with {type(other).__name__} is deprecated. "
-                    "In a future version these will be treated as scalar-like. "
-                    "To retain the old behavior, explicitly wrap in a Series "
-                    "instead.",
-                    Pandas4Warning,
-                    stacklevel=find_stack_level(),
+            if not hasattr(other, "dtype"):
+                # GH#52264 align with the numpy-backed Series behavior, which
+                # raises on logical ops with dtype-less sequences (e.g. list,
+                # tuple).  Previously this either silently coerced the values to
+                # bool or raised a confusing "boolean value of NA is ambiguous"
+                # error when the sequence contained ``pd.NA``.
+                raise TypeError(
+                    "Logical ops (and, or, xor) between Pandas objects and "
+                    "dtype-less sequences (e.g. list, tuple) are no longer "
+                    "supported. Wrap the object in a Series, Index, or "
+                    "np.array before operating instead."
                 )
 
             other = np.asarray(other, dtype="bool")

--- a/pandas/tests/arrays/boolean/test_logical.py
+++ b/pandas/tests/arrays/boolean/test_logical.py
@@ -67,13 +67,23 @@ class TestLogicalOps(BaseOpsUtil):
         msg = "Lengths must match"
 
         with pytest.raises(ValueError, match=msg):
-            getattr(a, op_name)(other)
-
-        with pytest.raises(ValueError, match=msg):
             getattr(a, op_name)(np.array(other))
 
         with pytest.raises(ValueError, match=msg):
             getattr(a, op_name)(pd.array(other, dtype="boolean"))
+
+    @pytest.mark.parametrize("other", [[True, False], [pd.NA, False], (True, False)])
+    def test_logical_dtypeless_sequence_raises(self, other, all_logical_operators):
+        # GH#63095 logical ops with a dtype-less sequence (e.g. list, tuple)
+        # should raise consistently with the numpy-backed Series behavior,
+        # instead of silently coercing or raising a confusing
+        # "boolean value of NA is ambiguous" error when it contains pd.NA.
+        op_name = all_logical_operators
+        a = pd.array([True, False], dtype="boolean")
+        msg = "dtype-less sequences"
+
+        with pytest.raises(TypeError, match=msg):
+            getattr(a, op_name)(other)
 
     def test_logical_nan_raises(self, all_logical_operators):
         op_name = all_logical_operators


### PR DESCRIPTION
- [x] closes #63095
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Developed with AI coding assistance; reviewed and submitted by the author.

## Bug

```python
import pandas as pd

b = pd.array([True, False])
b & pd.NA            # works -> [<NA>, False]
b & [pd.NA, False]   # TypeError: boolean value of NA is ambiguous
```

`BooleanArray.__and__` (and `|`, `^`) work with a scalar `pd.NA` but raise a confusing
low-level `"boolean value of NA is ambiguous"` error when the right operand is a
dtype-less sequence (e.g. `list`/`tuple`) that contains `pd.NA`. A dtype-less sequence
of plain bools (`b & [True, False]`) was instead silently accepted, while the
equivalent operation on a `Series` already raises a clear error.

## Root cause

In `BooleanArray._logical_method`, a list-like operand is coerced with
`np.asarray(other, dtype="bool")`. When the sequence contains `pd.NA`, NumPy evaluates
`bool(pd.NA)`, which raises `TypeError: boolean value of NA is ambiguous`. The
numpy-backed `Series` path (`ops.array_ops.logical_op`) instead raises a dedicated,
descriptive `TypeError` for any dtype-less sequence (GH#52264).

## Fix

Align `BooleanArray` logical ops with the `Series` behavior: raise the same
`TypeError` for dtype-less sequences, matching the direction agreed on in the issue
and in the previous (stale) PR discussion (#63127):

```python
b & [pd.NA, False]
# TypeError: Logical ops (and, or, xor) between Pandas objects and dtype-less
# sequences (e.g. list, tuple) are no longer supported. Wrap the object in a
# Series, Index, or np.array before operating instead.
```

Scalar `pd.NA`, `np.ndarray`, and `ExtensionArray` operands are unaffected.

## Testing

- Added `test_logical_dtypeless_sequence_raises` covering all logical operators with
  `list`, `list` containing `pd.NA`, and `tuple`. Verified it fails before the change
  and passes after.
- Updated `test_logical_length_mismatch_raises` to use array-like operands, since plain
  lists are no longer accepted.
- `pandas/tests/arrays/boolean/`, `pandas/tests/series/test_logical_ops.py`,
  `pandas/tests/frame/test_logical_ops.py`, `pandas/tests/extension/test_masked.py`,
  and `pandas/tests/arithmetic/` all pass; `ruff` lint/format clean.