### PR TITLE
TST: cover unstack default sort behavior

### DIFF
--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1386,6 +1386,20 @@ def test_unstack_sort_false(frame_or_series, dtype):
     tm.assert_frame_equal(result, expected)
 
 
+def test_unstack_default_sort_matches_sort_true(frame_or_series):
+    from pandas.core.reshape.reshape import unstack
+
+    index = MultiIndex.from_tuples(
+        [("two", "z"), ("two", "y"), ("one", "z"), ("one", "y")]
+    )
+    obj = frame_or_series(np.arange(1.0, 5.0), index=index)
+
+    result = unstack(obj, level=0)
+    expected = obj.unstack(level=0, sort=True)
+
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "levels2, expected_columns",
     [


### PR DESCRIPTION
Adds regression coverage for the mutation-testing case where the internal reshape.unstack default sort value is changed from True to False. The new parametrized test calls the internal unstack helper without passing sort and compares it against the public unstack(..., sort=True) behavior for both Series and DataFrame inputs.\n\nValidation:\n- python -m pytest pandas/tests/frame/test_stack_unstack.py::test_unstack_default_sort_matches_sort_true pandas/tests/frame/test_stack_unstack.py::test_unstack_sort_false -q\n- python -m ruff check pandas/tests/frame/test_stack_unstack.py\n- Verified the new test fails when pandas/core/reshape/reshape.py internal unstack default is temporarily mutated from sort=True to sort=False.