### PR TITLE
BUG: raise on melt output column collisions

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -380,8 +380,8 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
-- Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)
 - Bug in :meth:`DataFrame.melt` silently overwriting data when output column names from ``id_vars``, ``var_name``, or ``value_name`` collided; this now raises a ``ValueError`` (:issue:`65654`)
+- Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)
 -

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -381,6 +381,7 @@ Reshaping
 ^^^^^^^^^
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
 - Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)
+- Bug in :meth:`DataFrame.melt` silently overwriting data when output column names from ``id_vars``, ``var_name``, or ``value_name`` collided; this now raises a ``ValueError`` (:issue:`65654`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)
 -

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -15,7 +15,10 @@ from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.missing import notna
 
 import pandas.core.algorithms as algos
-from pandas.core.indexes.api import MultiIndex
+from pandas.core.indexes.api import (
+    Index,
+    MultiIndex,
+)
 from pandas.core.reshape.concat import concat
 from pandas.core.tools.numeric import to_numeric
 
@@ -240,6 +243,11 @@ def melt(
     else:
         var_name = [var_name]
 
+    mcolumns = id_vars + var_name + [value_name]
+
+    if not Index(mcolumns).is_unique:
+        raise ValueError("melt output column names must be unique.")
+
     num_rows, K = frame.shape
     num_cols_adjusted = K - len(id_vars)
 
@@ -255,8 +263,6 @@ def melt(
                 mdata[col] = type(id_data)([], name=id_data.name, dtype=id_data.dtype)
         else:
             mdata[col] = np.tile(id_data._values, num_cols_adjusted)
-
-    mcolumns = id_vars + var_name + [value_name]
 
     if frame.shape[1] > 0 and not any(
         not isinstance(dt, np.dtype) and dt._supports_2d for dt in frame.dtypes

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -555,6 +555,27 @@ class TestMelt:
         ):
             df.melt(var_name=["first", "second", "third"])
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"id_vars": "id", "var_name": "id"},
+            {"var_name": "value", "value_name": "value"},
+        ],
+    )
+    def test_melt_duplicate_output_columns_raises(self, kwargs):
+        # GH 65654
+        df = DataFrame({"id": [1, 2], "a": [10, 20], "b": [100, 200]})
+
+        with pytest.raises(ValueError, match="melt output column names must be unique"):
+            df.melt(**kwargs)
+
+    def test_melt_multiindex_columns_duplicate_var_name_raises(self):
+        # GH 65654
+        df = DataFrame({("A", "a"): [1], ("A", "b"): [2]})
+
+        with pytest.raises(ValueError, match="melt output column names must be unique"):
+            df.melt(var_name=["first", "first"])
+
     def test_melt_duplicate_column_header_raises(self):
         # GH61475
         df = DataFrame([[1, 2, 3], [3, 4, 5]], columns=["A", "A", "B"])


### PR DESCRIPTION
Closes #65654.

- Raise a ValueError when DataFrame.melt would produce duplicate output column names from id_vars, var_name, or value_name.
- Add coverage for id_vars/var_name collisions, var_name/value_name collisions, and duplicate MultiIndex var_name entries.
- Add a v3.1.0 whatsnew entry.

Tests:
- python -m pytest -q pandas/tests/reshape/test_melt.py