### PR TITLE
DOC: clarify interpolate kwargs

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7996,7 +7996,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             * 'outside': Only fill NaNs outside valid values (extrapolate).
 
         **kwargs : optional
-            Keyword arguments to pass on to the interpolating function.
+            Keyword arguments to pass on to SciPy interpolation methods.
+            These arguments are not passed to ``numpy.interp`` for
+            ``method='linear'``.
 
         Returns
         -------


### PR DESCRIPTION
Clarifies that interpolate kwargs are passed to SciPy interpolation methods, not to numpy.interp for method='linear'.

This follows the maintainer guidance in #55144 that the functional extrapolation behavior is more complex and should not be documented as simple passthrough to NumPy.

Closes #55144.

Validation:
- git diff --check
- python -m py_compile pandas/core/generic.py