### PR TITLE
BUG: Use Windows intsafe only for MSVC

### DIFF
--- a/pandas/_libs/include/pandas/portable.h
+++ b/pandas/_libs/include/pandas/portable.h
@@ -36,7 +36,7 @@ The full license is in the LICENSE file, distributed with this software.
     } while (0) /* fallthrough */
 #endif
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 #  ifndef ENABLE_INTSAFE_SIGNED_FUNCTIONS
 #    define ENABLE_INTSAFE_SIGNED_FUNCTIONS
 #  endif

--- a/pandas/_libs/include/pandas/portable.h
+++ b/pandas/_libs/include/pandas/portable.h
@@ -36,7 +36,12 @@ The full license is in the LICENSE file, distributed with this software.
     } while (0) /* fallthrough */
 #endif
 
-#if defined(_MSC_VER)
+#if (defined(__has_builtin) && __has_builtin(__builtin_add_overflow)) ||       \
+    __GNUC__ > 7
+#  define checked_add(a, b, res) __builtin_add_overflow(a, b, res)
+#  define checked_sub(a, b, res) __builtin_sub_overflow(a, b, res)
+#  define checked_mul(a, b, res) __builtin_mul_overflow(a, b, res)
+#elif defined(_WIN32)
 #  ifndef ENABLE_INTSAFE_SIGNED_FUNCTIONS
 #    define ENABLE_INTSAFE_SIGNED_FUNCTIONS
 #  endif
@@ -74,11 +79,6 @@ The full license is in the LICENSE file, distributed with this software.
         short *: ShortMult,                                                    \
         unsigned short *: UShortMult)(a, b, res)
 
-#elif (defined(__has_builtin) && __has_builtin(__builtin_add_overflow)) ||     \
-    __GNUC__ > 7
-#  define checked_add(a, b, res) __builtin_add_overflow(a, b, res)
-#  define checked_sub(a, b, res) __builtin_sub_overflow(a, b, res)
-#  define checked_mul(a, b, res) __builtin_mul_overflow(a, b, res)
 #else
 _Static_assert(0,
                "Overflow checking not detected; please try a newer compiler");


### PR DESCRIPTION
When compiling with MSYS2, `intsafe.h` will indirectly include `wingdi.h`, in which `#define ERROR 0`, causing compiling error for `typedef enum { ERROR, WARN, SKIP } BadLineHandleMethod;`

Also, all MSYS2 compilers (GCC/Clang) supports __builtin_add_overflow, so it's safe to use these builtins.

Detailed error:
```
FAILED: [code=1] pandas/_libs/tslibs/parsing.cp314-mingw_x86_64_ucrt_gnu.pyd.p/meson-generated_pandas__libs_tslibs_parsing.pyx.c.obj
"gcc" "-Ipandas/_libs/tslibs/parsing.cp314-mingw_x86_64_ucrt_gnu.pyd.p" "-Ipandas/_libs/tslibs" "-I../pandas/_libs/tslibs" "-I../../../../../../../../ucrt64/lib/python3.14/site-packages/numpy/_core/include" "-I../pandas/_libs/include" "-ID:/msys64/ucrt64/include/python3.14" "-fvisibility=hidden" "-fdiagnostics-color=always" "-DNDEBUG" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wextra" "-std=c11" "-O3" "-DNPY_NO_DEPRECATED_API=0" "-DCYTHON_USE_TYPE_SPECS=1" "-DNPY_TARGET_VERSION=NPY_1_21_API_VERSION" "-march=nocona" "-msahf" "-mtune=generic" "-O2" "-pipe" "-Wp,-D_FORTIFY_SOURCE=2" "-fstack-protector-strong" "-Wp,-D__USE_MINGW_ANSI_STDIO=1" -MD -MQ pandas/_libs/tslibs/parsing.cp314-mingw_x86_64_ucrt_gnu.pyd.p/meson-generated_pandas__libs_tslibs_parsing.pyx.c.obj -MF "pandas/_libs/tslibs/parsing.cp314-mingw_x86_64_ucrt_gnu.pyd.p/meson-generated_pandas__libs_tslibs_parsing.pyx.c.obj.d" -o pandas/_libs/tslibs/parsing.cp314-mingw_x86_64_ucrt_gnu.pyd.p/meson-generated_pandas__libs_tslibs_parsing.pyx.c.obj "-c" pandas/_libs/tslibs/parsing.cp314-mingw_x86_64_ucrt_gnu.pyd.p/pandas/_libs/tslibs/parsing.pyx.c
In file included from D:/msys64/ucrt64/include/windows.h:71,
                 from D:/msys64/ucrt64/include/rpc.h:16,
                 from D:/msys64/ucrt64/include/wtypesbase.h:7,
                 from D:/msys64/ucrt64/include/intsafe.h:15,
                 from ../pandas/_libs/include/pandas/portable.h:43,
                 from pandas/_libs/tslibs/parsing.cp314-mingw_x86_64_ucrt_gnu.pyd.p/pandas/_libs/tslibs/parsing.pyx.c:1159:
../pandas/_libs/include/pandas/parser/tokenizer.h:81:16: error: expected identifier before numeric constant
   81 | typedef enum { ERROR, WARN, SKIP } BadLineHandleMethod;
      |                ^~~~~
```

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
