### PR TITLE
BUG: keep groupby apply return type consistent

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -367,6 +367,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)
 - Bug in :meth:`.DataFrameGroupBy.apply` with ``as_index=False`` where applying on an empty :class:`DataFrame` returned inconsistent index metadata compared to non-empty results (:issue:`48135`)
+- Bug in :meth:`.DataFrameGroupBy.apply` returning a :class:`DataFrame` instead of a :class:`Series` when the applied function returned a :class:`Series` indexed like the input object and only one group was present (:issue:`54992`)
 - Bug in :meth:`.DataFrameGroupBy.cumprod`, :meth:`.DataFrameGroupBy.cummin`, and :meth:`.DataFrameGroupBy.cummax` (and Series variants) returning ``Float64`` instead of preserving the nullable integer dtype (e.g. ``Int64``) when the group key contains ``NA`` (:issue:`65550`)
 - Bug in :meth:`.GroupBy.any` and :meth:`.GroupBy.all` returning ``NaN`` with ``float64`` dtype for unobserved categorical groups on NumPy ``bool`` data instead of the boolean identity value with ``bool`` dtype (:issue:`65100`)
 - Bug in :meth:`.Resampler.agg` raising ``ValueError`` with a dict of aggregations when applied to a :meth:`DataFrame.groupby` with ``as_index=False`` (:issue:`52397`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -366,8 +366,8 @@ Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)
-- Bug in :meth:`.DataFrameGroupBy.apply` with ``as_index=False`` where applying on an empty :class:`DataFrame` returned inconsistent index metadata compared to non-empty results (:issue:`48135`)
 - Bug in :meth:`.DataFrameGroupBy.apply` returning a :class:`DataFrame` instead of a :class:`Series` when the applied function returned a :class:`Series` indexed like the input object and only one group was present (:issue:`54992`)
+- Bug in :meth:`.DataFrameGroupBy.apply` with ``as_index=False`` where applying on an empty :class:`DataFrame` returned inconsistent index metadata compared to non-empty results (:issue:`48135`)
 - Bug in :meth:`.DataFrameGroupBy.cumprod`, :meth:`.DataFrameGroupBy.cummin`, and :meth:`.DataFrameGroupBy.cummax` (and Series variants) returning ``Float64`` instead of preserving the nullable integer dtype (e.g. ``Int64``) when the group key contains ``NA`` (:issue:`65550`)
 - Bug in :meth:`.GroupBy.any` and :meth:`.GroupBy.all` returning ``NaN`` with ``float64`` dtype for unobserved categorical groups on NumPy ``bool`` data instead of the boolean identity value with ``bool`` dtype (:issue:`65100`)
 - Bug in :meth:`.Resampler.agg` raising ``ValueError`` with a dict of aggregations when applied to a :meth:`DataFrame.groupby` with ``as_index=False`` (:issue:`52397`)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -2478,7 +2478,11 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 not_indexed_same=True,
                 is_transform=is_transform,
             )
-        elif len(values) == 1 and first_not_none.index.equals(self._selected_obj.index):
+        elif (
+            len(values) == 1
+            and first_not_none.index.equals(self._selected_obj.index)
+            and not first_not_none.index.equals(self._selected_obj.columns)
+        ):
             # GH 54992
             # With a single group, a Series result indexed like the selected object
             # should follow the same concatenation path as multiple groups.

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -2478,6 +2478,15 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 not_indexed_same=True,
                 is_transform=is_transform,
             )
+        elif len(values) == 1 and first_not_none.index.equals(self._selected_obj.index):
+            # GH 54992
+            # With a single group, a Series result indexed like the selected object
+            # should follow the same concatenation path as multiple groups.
+            return self._concat_objects(
+                values,
+                not_indexed_same=True,
+                is_transform=is_transform,
+            )
 
         # Combine values
         # vstack+constructor is faster than concat and handles MI-columns

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1484,6 +1484,24 @@ def test_inconsistent_return_type():
     tm.assert_series_equal(result, e)
 
 
+def test_apply_single_group_returns_series_like_multiple_groups():
+    # GH 54992
+    def func(group):
+        return Series([group["A"] + group["B"]], index=group.index)
+
+    df = DataFrame(
+        {
+            "A": [1, 2],
+            "B": [2, 2],
+            "C": ["c", "d"],
+        }
+    )
+    result = df.iloc[:1].groupby("C").apply(func)
+    expected = df.groupby("C").apply(func).iloc[:1]
+
+    tm.assert_series_equal(result, expected)
+
+
 def test_nonreducer_nonstransform():
     # GH3380, GH60619
     # Was originally testing mutating in a UDF; now kept as an example


### PR DESCRIPTION
﻿- closes #54992
- keep DataFrameGroupBy.apply on the concat path when a single group returns a Series indexed like the selected object
- avoid treating column-indexed reduction results as transform-like when row and column labels overlap
- add a regression test covering the one-group vs multiple-groups return type consistency

Tests:
- docker exec pandas-gh54992-test bash -lc "cd /workspace && python -m pytest pandas/tests/groupby/test_apply.py::test_apply_single_group_returns_series_like_multiple_groups -q"
- docker exec pandas-gh54992-test bash -lc "cd /workspace && python -m pytest pandas/tests/groupby/test_apply.py -q"
- docker exec pandas-gh54992-test bash -lc "cd /workspace && python -m pytest pandas/tests/groupby -q"
