### PR TITLE
BUG: handle chained Path division with Arrow strings

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -286,6 +286,7 @@ Conversion
 Strings
 ^^^^^^^
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
+- Bug in chained division between :class:`pathlib.Path` objects and PyArrow-backed string :class:`Series` raising ``ArrowInvalid`` (:issue:`63832`)
 
 Interval
 ^^^^^^^^

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1154,22 +1154,39 @@ class ArrowExtensionArray(
             return self._evaluate_op_method(other, op, ARROW_LOGICAL_FUNCS)
 
     def _arith_method(self, other, op) -> Self | npt.NDArray[np.object_]:
-        if (
-            op in [operator.truediv, roperator.rtruediv]
-            and isinstance(other, Path)
-            and (
-                pa.types.is_string(self._pa_array.type)
-                or pa.types.is_large_string(self._pa_array.type)
-            )
+        if op in [operator.truediv, roperator.rtruediv] and (
+            pa.types.is_string(self._pa_array.type)
+            or pa.types.is_large_string(self._pa_array.type)
         ):
-            # GH#61940
-            return np.array(
-                [
-                    op(x, other) if isinstance(x, str) else self.dtype.na_value
-                    for x in self
-                ],
-                dtype=object,
-            )
+            if isinstance(other, Path):
+                # GH#61940
+                return np.array(
+                    [
+                        op(x, other) if isinstance(x, str) else self.dtype.na_value
+                        for x in self
+                    ],
+                    dtype=object,
+                )
+            elif is_array_like(other):
+                other_array = np.asarray(
+                    extract_array(other, extract_numpy=True), dtype=object
+                )
+                if other_array.ndim == 1 and len(other_array) == len(self):
+                    other_mask = isna(other_array)
+                    other_path = np.array(
+                        [isinstance(x, Path) for x in other_array], dtype=bool
+                    )
+                    if other_path.any() and (other_path | other_mask).all():
+                        # GH#63832
+                        return np.array(
+                            [
+                                op(x, y)
+                                if isinstance(x, str) and isinstance(y, Path)
+                                else self.dtype.na_value
+                                for x, y in zip(self, other_array, strict=True)
+                            ],
+                            dtype=object,
+                        )
 
         result = self._evaluate_op_method(other, op, ARROW_ARITHMETIC_FUNCS)
         if is_nan_na() and result.dtype.kind == "f":

--- a/pandas/tests/arithmetic/test_string.py
+++ b/pandas/tests/arithmetic/test_string.py
@@ -91,6 +91,21 @@ def test_pathlib_path_division(any_string_dtype, request):
     tm.assert_series_equal(result, expected)
 
 
+def test_pathlib_path_division_chained_series():
+    # GH#63832
+    pytest.importorskip("pyarrow")
+    item = Path("/Users/Irv/")
+    suffix1 = Series(["A", "B", NA], dtype=StringDtype("pyarrow"))
+    suffix2 = Series(["C", "D", "E"], dtype=StringDtype("pyarrow"))
+
+    result = item / suffix1 / suffix2
+    expected = Series(
+        [item / "A" / "C", item / "B" / "D", suffix2.dtype.na_value],
+        dtype=object,
+    )
+    tm.assert_series_equal(result, expected)
+
+
 def test_mixed_object_comparison(any_string_dtype):
     # GH#60228
     dtype = any_string_dtype


### PR DESCRIPTION
Closes #63832.

This fixes chained `pathlib.Path / Series / Series` operations when the string suffixes are backed by PyArrow. Arrow string arithmetic now handles aligned arrays of `Path` values in the same object-result path used for scalar `Path` division, avoiding PyArrow coercion of `Path` objects.

- [x] closes #63832
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Tests run:

- `python -m pytest pandas/tests/arithmetic/test_string.py::test_pathlib_path_division pandas/tests/arithmetic/test_string.py::test_pathlib_path_division_chained_series -q`
- `python -m pytest pandas/tests/arithmetic/test_string.py -q`
- `python -m ruff check pandas/core/arrays/arrow/array.py pandas/tests/arithmetic/test_string.py`
- `python -m ruff format --check pandas/core/arrays/arrow/array.py pandas/tests/arithmetic/test_string.py`
- `python -m compileall -q pandas/core/arrays/arrow/array.py pandas/tests/arithmetic/test_string.py`
- `git diff --check`

AI disclosure: I used an AI coding assistant during issue inspection and patch drafting. I reviewed and tested the changes locally, and I prompted it to follow `AGENTS.md`.
