### PR TITLE
DOC: fix incorrect alignment description in where/mask docstrings

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10304,7 +10304,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The where method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``True`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with axis of
+        ``other`` is used. If the axis of ``self`` does not align with axis of
         ``cond`` Series/DataFrame, the values of ``cond`` on misaligned index positions
         will be filled with False.
 
@@ -10472,7 +10472,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         The mask method is an application of the if-then idiom. For each
         element in the caller, if ``cond`` is ``False`` the
         element is used; otherwise the corresponding element from
-        ``other`` is used. If the axis of ``other`` does not align with axis of
+        ``other`` is used. If the axis of ``self`` does not align with axis of
         ``cond`` Series/DataFrame, the values of ``cond`` on misaligned index positions
         will be filled with True.
 


### PR DESCRIPTION
The Notes section for `Series.where`, `DataFrame.where`, `Series.mask`,
and `DataFrame.mask` incorrectly stated that alignment is done between
`other` and `cond`. The actual behavior is that `self` is aligned
against `cond` — misaligned index positions between `self` and `cond`
are filled with `False` (for `where`) or `True` (for `mask`).

Closes #61781

**Checklist**
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed
- [x] I had no conflicts that needed to be fixed

---

*This contribution was prepared with AI assistance and reviewed for correctness, in accordance with the pandas automated contributions policy.*