### PR TITLE
BUG: DataFrame.update warns when index dtype mismatch causes silent no-op

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -218,6 +218,9 @@ Bug fixes
 ~~~~~~~~~
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
+- :meth:`DataFrame.update` now raises a ``FutureWarning`` when the index
+  of ``other`` has a different dtype than the calling DataFrame's index,
+  which would previously cause the update to silently do nothing (:issue:`19905`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12503,6 +12503,16 @@ class DataFrame(NDFrame, OpsMixin):
 
         index_intersection = other.index.intersection(self.index)
         if index_intersection.empty:
+            if self.index.dtype != other.index.dtype:
+                warnings.warn(
+                    f"DataFrame.update did not update any values because the index "
+                    f"of 'other' has dtype '{other.index.dtype}' while the index of "
+                    f"this DataFrame has dtype '{self.index.dtype}'. Indices must be "
+                    f"of the same dtype to match. Cast the index of 'other' to match "
+                    f"before calling update.",
+                    FutureWarning,
+                    stacklevel=find_stack_level(),
+                )
             return
         other = other.reindex(index_intersection)
         this_data = self.loc[index_intersection]

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -259,3 +259,23 @@ class TestDataFrameUpdate:
         expected = DataFrame({"date": [pd.Timestamp("2026-02-05")]}, dtype=object)
 
         tm.assert_frame_equal(other, expected)
+    
+    def test_update_raises_on_index_dtype_mismatch():
+        # GH#19905 - warn when index dtypes differ and update does nothing
+        df_int = pd.DataFrame({"col": ["foo", "bar", np.nan]}, index=[1, 2, 3])
+        df_str = pd.DataFrame({"col": [np.nan, np.nan, "baz"]}, index=["1", "2", "3"])
+
+        with tm.assert_produces_warning(FutureWarning, match="dtype"):
+            df_int.update(df_str)
+
+        # The DataFrame should be unchanged since no indices matched
+        expected = pd.DataFrame({"col": ["foo", "bar", np.nan]}, index=[1, 2, 3])
+        tm.assert_frame_equal(df_int, expected)
+
+    def test_update_no_warning_same_dtype_no_overlap():
+        # GH#19905 - no warning when dtypes are the same (even if no overlap)
+        df1 = pd.DataFrame({"col": ["foo", "bar"]}, index=[1, 2])
+        df2 = pd.DataFrame({"col": ["baz"]}, index=[3])
+
+        with tm.assert_produces_warning(None):
+            df1.update(df2)

--- a/pandas/tests/frame/methods/test_update.py
+++ b/pandas/tests/frame/methods/test_update.py
@@ -260,7 +260,7 @@ class TestDataFrameUpdate:
 
         tm.assert_frame_equal(other, expected)
     
-    def test_update_raises_on_index_dtype_mismatch():
+    def test_update_raises_on_index_dtype_mismatch(self):
         # GH#19905 - warn when index dtypes differ and update does nothing
         df_int = pd.DataFrame({"col": ["foo", "bar", np.nan]}, index=[1, 2, 3])
         df_str = pd.DataFrame({"col": [np.nan, np.nan, "baz"]}, index=["1", "2", "3"])
@@ -272,7 +272,7 @@ class TestDataFrameUpdate:
         expected = pd.DataFrame({"col": ["foo", "bar", np.nan]}, index=[1, 2, 3])
         tm.assert_frame_equal(df_int, expected)
 
-    def test_update_no_warning_same_dtype_no_overlap():
+    def test_update_no_warning_same_dtype_no_overlap(self):
         # GH#19905 - no warning when dtypes are the same (even if no overlap)
         df1 = pd.DataFrame({"col": ["foo", "bar"]}, index=[1, 2])
         df2 = pd.DataFrame({"col": ["baz"]}, index=[3])


### PR DESCRIPTION


- [X] closes #19905

## What does this fix?

When `DataFrame.update(other)` is called and the two DataFrames have
indices of differing dtypes (e.g. `int64` vs `str`), the index
intersection is empty and the update silently does nothing. This is
very confusing since the index *values* may look identical.

This PR adds a `FutureWarning` when the intersection is empty AND the
index dtypes differ, telling the user exactly why the update did nothing
and how to fix it.

- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
    -  `test_update_raises_on_index_dtype_mismatch` — confirms warning is raised  
    - `test_update_no_warning_same_dtype_no_overlap` — confirms no false positives
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [X] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
