### PR TITLE
TST add shares_memory coverage

### DIFF
--- a/pandas/tests/util/test_shares_memory.py
+++ b/pandas/tests/util/test_shares_memory.py
@@ -40,6 +40,36 @@ def test_shares_memory_numpy():
     assert not tm.shares_memory(arr, arr2)
 
 
+def test_shares_memory_series_index_and_frame():
+    arr = np.arange(4)
+    ser = pd.Series(arr, copy=False)
+    idx = pd.Index(np.arange(4))
+    df = pd.DataFrame(arr.reshape(2, 2), copy=False)
+
+    assert tm.shares_memory(ser, arr)
+    assert tm.shares_memory(idx, idx[:2])
+    assert tm.shares_memory(df, arr)
+
+    arr2 = np.arange(4)
+    assert not tm.shares_memory(ser, arr2)
+    assert not tm.shares_memory(idx, arr2)
+    assert not tm.shares_memory(df, arr2)
+
+
+def test_shares_memory_masked_array():
+    obj = pd.array([1, None], dtype="Int64")
+
+    assert tm.shares_memory(obj, obj[:])
+    assert not tm.shares_memory(obj, obj.copy())
+
+
+def test_shares_memory_sparse_array():
+    obj = pd.arrays.SparseArray([0, 1, 0])
+
+    assert tm.shares_memory(obj, obj)
+    assert not tm.shares_memory(obj, obj.copy())
+
+
 def test_shares_memory_rangeindex():
     idx = pd.RangeIndex(10)
     arr = np.arange(10)


### PR DESCRIPTION
- [x] closes #55372
- [ ] Tests added and passed
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This adds focused test coverage for `tm.shares_memory`.

The new tests cover `Series`, `Index`, single-block `DataFrame`, nullable masked
arrays, and sparse arrays.

Checks run:

- `python -m ruff check pandas\tests\util\test_shares_memory.py`
- `python -m ruff format --check pandas\tests\util\test_shares_memory.py`
- `git diff --check`

I did not run the targeted pytest locally because this checkout was not built for
local test imports.