### PR TITLE
DOC: Fix outdated matplotlib link in visualization.rst

### DIFF
--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -1371,8 +1371,7 @@ Automatic date tick adjustment
 tick locator methods, it is useful to call the automatic
 date tick adjustment from matplotlib for figures whose ticklabels overlap.
 
-See the :meth:`autofmt_xdate <matplotlib.figure.autofmt_xdate>` method and the
-`matplotlib documentation <https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure.autofmt_xdate>`__ for more.
+See the :meth:`autofmt_xdate <matplotlib.figure.autofmt_xdate>` method.
 
 Subplots
 ~~~~~~~~

--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -1372,7 +1372,7 @@ tick locator methods, it is useful to call the automatic
 date tick adjustment from matplotlib for figures whose ticklabels overlap.
 
 See the :meth:`autofmt_xdate <matplotlib.figure.autofmt_xdate>` method and the
-`matplotlib documentation <https://matplotlib.org/2.0.2/users/recipes.html#fixing-common-date-annoyances>`__ for more.
+`matplotlib documentation <https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure.autofmt_xdate>`__ for more.
 
 Subplots
 ~~~~~~~~


### PR DESCRIPTION
- [x] closes #65737 
- [ ] Tests added and passed if fixing a bug or adding a new feature — N/A
- [x] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions — N/A
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file — N/A
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.

Replaces a hardcoded matplotlib v2.0.2 link in `doc/source/user_guide/visualization.rst` 
with the current stable API reference for `Figure.autofmt_xdate`.