### PR TITLE
BUG: window corr and cov numerical instability

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -370,6 +370,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGroupBy.cumprod`, :meth:`.DataFrameGroupBy.cummin`, and :meth:`.DataFrameGroupBy.cummax` (and Series variants) returning ``Float64`` instead of preserving the nullable integer dtype (e.g. ``Int64``) when the group key contains ``NA`` (:issue:`65550`)
 - Bug in :meth:`.GroupBy.any` and :meth:`.GroupBy.all` returning ``NaN`` with ``float64`` dtype for unobserved categorical groups on NumPy ``bool`` data instead of the boolean identity value with ``bool`` dtype (:issue:`65100`)
 - Bug in :meth:`.Resampler.agg` raising ``ValueError`` with a dict of aggregations when applied to a :meth:`DataFrame.groupby` with ``as_index=False`` (:issue:`52397`)
+- Bug in :meth:`.Rolling.corr` and :meth:`.Rolling.cov` computing incorrect results on degenerate windows (:issue:`24019`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` (and their :class:`GroupBy` counterparts) returning ``0.0`` and ``-3.0`` respectively for degenerate windows or groups; these now return ``NaN`` (:issue:`62864`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
 - Bug in :meth:`.Rolling.sum`, :meth:`.Rolling.mean`, :meth:`.Rolling.median`, :meth:`.Rolling.min`, and :meth:`.Rolling.max` with ``method="table"``, ``engine="numba"``, and ``engine_kwargs={"parallel": True}`` could cause a segfault (:issue:`40454`)

--- a/pandas/_libs/window/aggregations.pyi
+++ b/pandas/_libs/window/aggregations.pyi
@@ -42,6 +42,21 @@ def roll_kurt(
     end: np.ndarray,  # np.ndarray[np.int64]
     minp: int,  # int64_t
 ) -> np.ndarray: ...  # np.ndarray[float]
+def roll_cov(
+    x: np.ndarray,  # const float64_t[:]
+    y: np.ndarray,  # const float64_t[:]
+    start: np.ndarray,  # np.ndarray[np.int64]
+    end: np.ndarray,  # np.ndarray[np.int64]
+    minp: int,  # int64_t
+    ddof: int = ...,
+) -> np.ndarray: ...  # np.ndarray[float]
+def roll_corr(
+    x: np.ndarray,  # const float64_t[:]
+    y: np.ndarray,  # const float64_t[:]
+    start: np.ndarray,  # np.ndarray[np.int64]
+    end: np.ndarray,  # np.ndarray[np.int64]
+    minp: int,  # int64_t
+) -> np.ndarray: ...  # np.ndarray[float]
 def roll_median_c(
     values: np.ndarray,  # np.ndarray[np.float64]
     start: np.ndarray,  # np.ndarray[np.int64]

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -736,6 +736,286 @@ def roll_kurt(const float64_t[:] values, ndarray[int64_t] start,
 
 
 # ----------------------------------------------------------------------
+# Rolling covariance
+
+
+cdef float64_t calc_cov(
+    float64_t nobs,
+    int ddof,
+    float64_t ssqdm_xy,
+) noexcept nogil:
+    if nobs <= ddof:
+        return NaN
+
+    return ssqdm_xy / (nobs - <float64_t>ddof)
+
+
+cdef void add_cov(
+    float64_t val_x,
+    float64_t val_y,
+    float64_t *nobs,
+    float64_t *mean_x,
+    float64_t *mean_y,
+    float64_t *ssqdm_xy,
+    bint *numerically_unstable,
+) noexcept nogil:
+    """ add a value from the cov calc """
+    cdef:
+        float64_t dx, dy, old_ssqdm_xy
+
+    if val_x != val_x or val_y != val_y:
+        return
+
+    nobs[0] += 1
+    old_ssqdm_xy = ssqdm_xy[0]
+
+    dx = val_x - mean_x[0]
+    dy = val_y - mean_y[0]
+    mean_x[0] += dx / nobs[0]
+    mean_y[0] += dy / nobs[0]
+    ssqdm_xy[0] += (val_x - mean_x[0]) * dy
+
+    if fabs(old_ssqdm_xy) * InvCondTol > fabs(ssqdm_xy[0]):
+        # possible catastrophic cancellation
+        numerically_unstable[0] = True
+
+
+cdef void remove_cov(
+    float64_t val_x,
+    float64_t val_y,
+    float64_t *nobs,
+    float64_t *mean_x,
+    float64_t *mean_y,
+    float64_t *ssqdm_xy,
+    bint *numerically_unstable,
+) noexcept nogil:
+    """ remove a value from the cov calc """
+    cdef:
+        float64_t dx, dy, old_ssqdm_xy
+
+    if val_x != val_x or val_y != val_y:
+        return
+
+    old_ssqdm_xy = ssqdm_xy[0]
+    dx = val_x - mean_x[0]
+    dy = val_y - mean_y[0]
+
+    nobs[0] -= 1
+    mean_x[0] -= dx / nobs[0]
+    mean_y[0] -= dy / nobs[0]
+    ssqdm_xy[0] -= (val_x - mean_x[0]) * dy
+
+    if fabs(old_ssqdm_xy) * InvCondTol > fabs(ssqdm_xy[0]):
+        # possible catastrophic cancellation
+        numerically_unstable[0] = True
+
+
+def roll_cov(const float64_t[:] x, const float64_t[:] y, ndarray[int64_t] start,
+             ndarray[int64_t] end, int64_t minp, int ddof=1) -> np.ndarray:
+    cdef:
+        float64_t mean_x, mean_y, ssqdm_xy, nobs
+        int64_t s, e
+        Py_ssize_t i, j, N = len(start)
+        ndarray[float64_t] output
+        bint is_monotonic_increasing_bounds
+        bint requires_recompute, numerically_unstable = False
+
+    minp = max(minp, 1)
+    is_monotonic_increasing_bounds = is_monotonic_increasing_start_end_bounds(
+        start, end
+    )
+    output = np.empty(N, dtype=np.float64)
+
+    with nogil:
+
+        for i in range(0, N):
+            s = start[i]
+            e = end[i]
+
+            requires_recompute = (
+                i == 0
+                or not is_monotonic_increasing_bounds
+                or s >= end[i - 1]
+            )
+
+            if not requires_recompute:
+                # calculate deletes
+                for j in range(start[i - 1], s):
+                    remove_cov(x[j], y[j], &nobs, &mean_x, &mean_y, &ssqdm_xy,
+                               &numerically_unstable)
+
+                # calculate adds
+                for j in range(end[i - 1], e):
+                    add_cov(x[j], y[j], &nobs, &mean_x, &mean_y, &ssqdm_xy,
+                            &numerically_unstable)
+
+            if requires_recompute or numerically_unstable:
+                mean_x = mean_y = ssqdm_xy = nobs = 0
+                for j in range(s, e):
+                    add_cov(x[j], y[j], &nobs, &mean_x, &mean_y, &ssqdm_xy,
+                            &numerically_unstable)
+                numerically_unstable = False
+
+            output[i] = NaN if nobs < minp else calc_cov(nobs, ddof, ssqdm_xy)
+
+            if not is_monotonic_increasing_bounds:
+                nobs = 0.0
+                mean_x = mean_y = ssqdm_xy = 0.0
+
+    return output
+
+
+# ----------------------------------------------------------------------
+# Rolling correlation
+
+
+cdef float64_t calc_corr(
+    float64_t nobs,
+    float64_t ssqdm_xy,
+    float64_t ssqdm_x,
+    float64_t ssqdm_y,
+) noexcept nogil:
+    cdef float64_t den, val
+    if nobs <= 0.0 or ssqdm_x == 0.0 or ssqdm_y == 0.0:
+        return NaN
+
+    den = (ssqdm_x * ssqdm_y) ** 0.5
+    val = ssqdm_xy / den
+
+    if val > 1.0:
+        val = 1.0
+    elif val < -1.0:
+        val = -1.0
+    return val
+
+
+cdef void add_corr(
+    float64_t val_x,
+    float64_t val_y,
+    float64_t *nobs,
+    float64_t *mean_x,
+    float64_t *mean_y,
+    float64_t *ssqdm_xy,
+    float64_t *ssqdm_x,
+    float64_t *ssqdm_y,
+    bint *numerically_unstable,
+) noexcept nogil:
+    """ add a value from the corr calc """
+    cdef:
+        float64_t dx, dy, old_ssqdm_xy
+
+    if val_x != val_x or val_y != val_y:
+        return
+
+    nobs[0] += 1
+    old_ssqdm_xy = ssqdm_xy[0]
+
+    dx = val_x - mean_x[0]
+    dy = val_y - mean_y[0]
+    mean_x[0] += dx / nobs[0]
+    mean_y[0] += dy / nobs[0]
+    ssqdm_xy[0] += (val_x - mean_x[0]) * dy
+    ssqdm_x[0] += (val_x - mean_x[0]) * dx
+    ssqdm_y[0] += (val_y - mean_y[0]) * dy
+
+    if fabs(old_ssqdm_xy) * InvCondTol > fabs(ssqdm_xy[0]):
+        # possible catastrophic cancellation
+        numerically_unstable[0] = True
+
+
+cdef void remove_corr(
+    float64_t val_x,
+    float64_t val_y,
+    float64_t *nobs,
+    float64_t *mean_x,
+    float64_t *mean_y,
+    float64_t *ssqdm_xy,
+    float64_t *ssqdm_x,
+    float64_t *ssqdm_y,
+    bint *numerically_unstable,
+) noexcept nogil:
+    """ remove a value from the corr calc """
+    cdef:
+        float64_t dx, dy, old_ssqdm_xy
+
+    if val_x != val_x or val_y != val_y:
+        return
+
+    old_ssqdm_xy = ssqdm_xy[0]
+    dx = val_x - mean_x[0]
+    dy = val_y - mean_y[0]
+
+    nobs[0] -= 1
+    mean_x[0] -= dx / nobs[0]
+    mean_y[0] -= dy / nobs[0]
+    ssqdm_xy[0] -= (val_x - mean_x[0]) * dy
+    ssqdm_x[0] -= (val_x - mean_x[0]) * dx
+    ssqdm_y[0] -= (val_y - mean_y[0]) * dy
+
+    if fabs(old_ssqdm_xy) * InvCondTol > fabs(ssqdm_xy[0]):
+        # possible catastrophic cancellation
+        numerically_unstable[0] = True
+
+
+def roll_corr(const float64_t[:] x, const float64_t[:] y, ndarray[int64_t] start,
+              ndarray[int64_t] end, int64_t minp) -> np.ndarray:
+    cdef:
+        float64_t mean_x, mean_y, ssqdm_xy, ssqdm_x, ssqdm_y, nobs
+        int64_t s, e
+        Py_ssize_t i, j, N = len(start)
+        ndarray[float64_t] output
+        bint is_monotonic_increasing_bounds
+        bint requires_recompute, numerically_unstable = False
+
+    minp = max(minp, 1)
+    is_monotonic_increasing_bounds = is_monotonic_increasing_start_end_bounds(
+        start, end
+    )
+    output = np.empty(N, dtype=np.float64)
+
+    with nogil:
+
+        for i in range(0, N):
+            s = start[i]
+            e = end[i]
+
+            requires_recompute = (
+                i == 0
+                or not is_monotonic_increasing_bounds
+                or s >= end[i - 1]
+            )
+
+            if not requires_recompute:
+                # calculate deletes
+                for j in range(start[i - 1], s):
+                    remove_corr(x[j], y[j], &nobs, &mean_x, &mean_y, &ssqdm_xy,
+                                &ssqdm_x, &ssqdm_y, &numerically_unstable)
+
+                # calculate adds
+                for j in range(end[i - 1], e):
+                    add_corr(x[j], y[j], &nobs, &mean_x, &mean_y, &ssqdm_xy,
+                             &ssqdm_x, &ssqdm_y, &numerically_unstable)
+
+            if requires_recompute or numerically_unstable:
+                mean_x = mean_y = ssqdm_xy = ssqdm_x = ssqdm_y = nobs = 0
+                for j in range(s, e):
+                    add_corr(x[j], y[j], &nobs, &mean_x, &mean_y, &ssqdm_xy,
+                             &ssqdm_x, &ssqdm_y, &numerically_unstable)
+                numerically_unstable = False
+
+            output[i] = (
+                NaN if nobs < minp
+                else calc_corr(nobs, ssqdm_xy, ssqdm_x, ssqdm_y)
+            )
+
+            if not is_monotonic_increasing_bounds:
+                nobs = 0.0
+                mean_x = mean_y = ssqdm_xy = ssqdm_x = ssqdm_y = 0.0
+
+    return output
+
+
+# ----------------------------------------------------------------------
 # Rolling median, min, max
 
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1901,16 +1901,9 @@ class RollingAndExpandingMixin(BaseWindow):
             )
             self._check_window_bounds(start, end, len(x_array))
 
-            with np.errstate(all="ignore"):
-                mean_x_y = window_aggregations.roll_mean(
-                    x_array * y_array, start, end, min_periods
-                )
-                mean_x = window_aggregations.roll_mean(x_array, start, end, min_periods)
-                mean_y = window_aggregations.roll_mean(y_array, start, end, min_periods)
-                count_x_y = window_aggregations.roll_sum(
-                    notna(x_array + y_array).astype(np.float64), start, end, 0
-                )
-                result = (mean_x_y - mean_x * mean_y) * (count_x_y / (count_x_y - ddof))
+            result = window_aggregations.roll_cov(
+                x_array, y_array, start, end, min_periods, ddof
+            )
             return Series(result, index=x.index, name=x.name, copy=False)
 
         return self._apply_pairwise(
@@ -1948,26 +1941,9 @@ class RollingAndExpandingMixin(BaseWindow):
             )
             self._check_window_bounds(start, end, len(x_array))
 
-            with np.errstate(all="ignore"):
-                mean_x_y = window_aggregations.roll_mean(
-                    x_array * y_array, start, end, min_periods
-                )
-                mean_x = window_aggregations.roll_mean(x_array, start, end, min_periods)
-                mean_y = window_aggregations.roll_mean(y_array, start, end, min_periods)
-                count_x_y = window_aggregations.roll_sum(
-                    notna(x_array + y_array).astype(np.float64), start, end, 0
-                )
-                x_var = window_aggregations.roll_var(
-                    x_array, start, end, min_periods, ddof
-                )
-                y_var = window_aggregations.roll_var(
-                    y_array, start, end, min_periods, ddof
-                )
-                numerator = (mean_x_y - mean_x * mean_y) * (
-                    count_x_y / (count_x_y - ddof)
-                )
-                denominator = (x_var * y_var) ** 0.5
-                result = numerator / denominator
+            result = window_aggregations.roll_corr(
+                x_array, y_array, start, end, min_periods
+            )
             return Series(result, index=x.index, name=x.name, copy=False)
 
         return self._apply_pairwise(

--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -61,6 +61,23 @@ def test_rolling_corr(series):
     tm.assert_almost_equal(result.iloc[-1], np.corrcoef(A[-50:], B[-50:])[0, 1])
 
 
+@pytest.mark.parametrize(
+    "method,expected_values",
+    [
+        ("corr", [np.nan] * 5),
+        ("cov", [np.nan, np.nan, np.nan, np.nan, 0.0]),
+    ],
+)
+def test_rolling_cov_corr_degenerate(method, expected_values):
+    # GH#24019
+    a = Series([1e5, 0, 0, 0, 0])
+    b = Series([9.45] * 5)
+    wind = a.rolling(5)
+    result = getattr(wind, method)(b)
+    expected = Series(expected_values)
+    tm.assert_series_equal(result, expected)
+
+
 def test_rolling_corr_bias_correction():
     # test for correct bias correction
     a = Series(


### PR DESCRIPTION
- [x] closes #24019 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

Implemented an [incremental algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online) to compute co-moments in Cython for numerical stability.

## Benchmark

| Change   | Before [1d03763e] <main>   | After [cf7b1424] <fix/window-corr-numerical-stability~1>   |   Ratio | Benchmark (Parameter)                                                        |
|----------|----------------------------|------------------------------------------------------------|---------|------------------------------------------------------------------------------|
| -        | 2.96±0.05ms                | 2.52±0.03ms                                                |    0.85 | rolling.Pairwise.time_pairwise(({}, 'expanding'), 'corr', True)              |
| -        | 2.66±0.02ms                | 2.20±0.04ms                                                |    0.83 | rolling.Pairwise.time_pairwise(({}, 'expanding'), 'cov', True)               |
| -        | 3.30±0.03ms                | 2.64±0.02ms                                                |    0.8  | rolling.Pairwise.time_pairwise(({'window': 1000}, 'rolling'), 'corr', True)  |
| -        | 1.61±0.01ms                | 1.09±0.05ms                                                |    0.68 | rolling.Pairwise.time_pairwise(({'window': 10}, 'rolling'), 'corr', False)   |
| -        | 1.59±0.02ms                | 988±20μs                                                   |    0.62 | rolling.Pairwise.time_pairwise(({'window': 1000}, 'rolling'), 'corr', False) |
| -        | 1.17±0.01ms                | 682±8μs                                                    |    0.58 | rolling.Pairwise.time_pairwise(({'window': 10}, 'rolling'), 'cov', False)    |
| -        | 997±50μs                   | 532±5μs                                                    |    0.53 | rolling.Pairwise.time_pairwise(({}, 'expanding'), 'cov', False)              |
