### PR TITLE
TST: Fix some issues with Matplotlib 3.11

### DIFF
--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -297,7 +297,7 @@ class TestDataFramePlots:
         plt.style.use(scheme)
         result = df.plot.box(return_type="dict")
         for k, v in expected.items():
-            assert result[k][0].get_color() == v
+            assert mpl.colors.same_color(result[k][0].get_color(), v)
 
     @pytest.mark.parametrize(
         "dict_colors, msg",

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -30,6 +30,7 @@ from pandas.tests.plotting.common import (
     _unpack_cycler,
     get_y_axis,
 )
+from pandas.util.version import Version
 
 from pandas.tseries.offsets import CustomBusinessDay
 
@@ -434,7 +435,11 @@ class TestSeriesPlots:
             series.plot.pie, colors=color_args, autopct="%.2f", fontsize=7
         )
         pcts = [f"{s * 100:.2f}" for s in series.values / series.sum()]
-        expected_texts = list(chain.from_iterable(zip(series.index, pcts, strict=True)))
+        expected_texts = (
+            list(chain.from_iterable(zip(series.index, pcts, strict=True)))
+            if Version(mpl.__version__) < Version("3.11.0rc1")
+            else list(chain.from_iterable((series.index, pcts)))
+        )
         _check_text_labels(ax.texts, expected_texts)
         for t in ax.texts:
             assert t.get_fontsize() == 7

--- a/pandas/tests/plotting/test_style.py
+++ b/pandas/tests/plotting/test_style.py
@@ -24,7 +24,7 @@ class TestGetStandardColors:
         }
         with mpl.rc_context(rc=mpl_params):
             result = get_standard_colors(num_colors=num_colors)
-            assert result == expected
+            assert mpl.colors.same_color(result, expected)
 
     @pytest.mark.parametrize(
         "num_colors, expected",
@@ -42,10 +42,10 @@ class TestGetStandardColors:
         }
         with mpl.rc_context(rc=mpl_params):
             result = get_standard_colors(num_colors=num_colors)
-            assert result == expected
+            assert mpl.colors.same_color(result, expected)
 
     @pytest.mark.parametrize(
-        "num_colors, expected_name",
+        "num_colors, expected",
         [
             (1, ["C0"]),
             (3, ["C0", "C1", "C2"]),
@@ -68,11 +68,10 @@ class TestGetStandardColors:
             ),
         ],
     )
-    def test_default_colors_named_undefined_prop_cycle(self, num_colors, expected_name):
+    def test_default_colors_named_undefined_prop_cycle(self, num_colors, expected):
         with mpl.rc_context(rc={}):
-            expected = [mpl.colors.to_hex(x) for x in expected_name]
             result = get_standard_colors(num_colors=num_colors)
-            assert result == expected
+            assert mpl.colors.same_color(result, expected)
 
     @pytest.mark.parametrize(
         "num_colors, expected",


### PR DESCRIPTION
1. Instead of hard-coding a colour in a specific form, use `same_color` which will convert to some common form. Matplotlib 3.11 changes how some results are exported from rcParams, so this makes the tests work across versions.
2. Re-order some texts in a `pie` test, as they are not generated in the same order with 3.11.

- [n/a] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [n/a] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [n/a] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
