### PR TITLE
PERF: Fix performance regression in to_julian_date

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -3715,15 +3715,32 @@ default 'raise'
         >>> ts.to_julian_date()
         2458923.147824074
         """
+        cdef:
+            npy_datetimestruct dts
+            int64_t year
+            int month, day, hour, minute, second, microsecond
+
         from pandas.core.dtypes.cast import maybe_unbox_numpy_scalar
 
         if self.tzinfo is not None:
             # GH#54763 JD is absolute-time, so use the UTC instant
-            return self.tz_convert("UTC").tz_localize(None).to_julian_date()
+            pandas_datetime_to_datetimestruct(self._value, self._creso, &dts)
+            year = dts.year
+            month = dts.month
+            day = dts.day
+            hour = dts.hour
+            minute = dts.min
+            second = dts.sec
+            microsecond = dts.us
+        else:
+            year = self._year
+            month = self.month
+            day = self.day
+            hour = self.hour
+            minute = self.minute
+            second = self.second
+            microsecond = self.microsecond
 
-        year = self._year
-        month = self.month
-        day = self.day
         if month <= 2:
             year -= 1
             month += 12
@@ -3735,10 +3752,10 @@ default 'raise'
             np.floor(year / 100) +
             np.floor(year / 400) +
             1721118.5 +
-            (self.hour +
-             self.minute / 60.0 +
-             self.second / 3600.0 +
-             self.microsecond / 3600.0 / 1e+6 +
+            (hour +
+             minute / 60.0 +
+             second / 3600.0 +
+             microsecond / 3600.0 / 1e+6 +
              self._nanosecond / 3600.0 / 1e+9
              ) / 24.0
         )


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/117

<details>
<summary>Timing code</summary>

```python
import timeit
from datetime import timedelta, timezone
import zoneinfo

import pandas as pd
from pandas import Timestamp

tzs = {
    "None": None,
    "UTC": timezone.utc,
    "fixed +60min": timezone(timedelta(minutes=60)),
    "US/Pacific": zoneinfo.ZoneInfo("US/Pacific"),
    "Asia/Tokyo": zoneinfo.ZoneInfo("Asia/Tokyo"),
}

N = 200_000
for name, tz in tzs.items():
    ts = Timestamp("2017-08-25 08:16:14", tz=tz)
    ts.to_julian_date()
    print(name)
    %timeit ts.to_julian_date()
```

</details>

```
None
1.86 μs ± 15.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <-- main
1.77 μs ± 22.7 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <-- PR
UTC
3.65 μs ± 31.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  <-- main
1.5 μs ± 18.5 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <-- PR
fixed +60min
3.67 μs ± 40.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  <-- main
1.47 μs ± 7.09 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <-- PR
US/Pacific
3.71 μs ± 37.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)  <-- main
1.47 μs ± 6.17 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <-- PR
```
