### PR TITLE
BUG: DataFrame.resample is adding padding at the start and end

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2707,7 +2707,9 @@ class TimeGrouper(Grouper):
             # which correspond to the end of a super-daily period - "month start", for
             # example, is excluded.
             rule = self.freq.rule_code
-            if rule in _END_TYPES or ("-" in rule and rule[: rule.find("-")] in _END_TYPES):
+            if rule in _END_TYPES or (
+                "-" in rule and rule[: rule.find("-")] in _END_TYPES
+            ):
                 edges_dti = binner.tz_localize(None)
                 edges_dti = (
                     edges_dti

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -114,6 +114,9 @@ if TYPE_CHECKING:
     from pandas.core.generic import NDFrame
 
 
+_END_TYPES = {"SME", "ME", "YE", "QE", "BME", "CBME", "BYE", "BQE", "W", "C", "B"}
+
+
 @set_module("pandas.api.typing")
 class Resampler(BaseGroupBy, PandasObject):
     """
@@ -2479,9 +2482,8 @@ class TimeGrouper(Grouper):
                     stacklevel=find_stack_level(),
                 )
 
-        end_types = {"ME", "YE", "QE", "BME", "BYE", "BQE", "W"}
         rule = freq.rule_code
-        if rule in end_types or ("-" in rule and rule[: rule.find("-")] in end_types):
+        if rule in _END_TYPES or ("-" in rule and rule[: rule.find("-")] in _END_TYPES):
             if closed is None:
                 closed = "right"
             if label is None:
@@ -2698,21 +2700,14 @@ class TimeGrouper(Grouper):
     ) -> tuple[DatetimeIndex, npt.NDArray[np.int64]]:
         # Some hacks for > daily data, see #1471, #1458, #1483
 
-        if self.freq.rule_code in ("BME", "ME", "W") or self.freq.rule_code.split("-")[
-            0
-        ] in (
-            "BQE",
-            "BYE",
-            "QE",
-            "YE",
-            "W",
-        ):
+        # GH 21459, GH 9119: Adjust the bins relative to the wall time
+        if self.closed == "right":
             # If the right end-point is on the last day of the month, roll forwards
             # until the last moment of that day. Note that we only do this for offsets
             # which correspond to the end of a super-daily period - "month start", for
             # example, is excluded.
-            if self.closed == "right":
-                # GH 21459, GH 9119: Adjust the bins relative to the wall time
+            rule = self.freq.rule_code
+            if rule in _END_TYPES or ("-" in rule and rule[: rule.find("-")] in _END_TYPES):
                 edges_dti = binner.tz_localize(None)
                 edges_dti = (
                     edges_dti

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2483,7 +2483,7 @@ class TimeGrouper(Grouper):
                 )
 
         rule = freq.rule_code
-        if rule in _END_TYPES or ("-" in rule and rule[: rule.find("-")] in _END_TYPES):
+        if rule in _END_TYPES or ("-" in rule and rule.split("-", 1)[0] in _END_TYPES):
             if closed is None:
                 closed = "right"
             if label is None:
@@ -2708,7 +2708,7 @@ class TimeGrouper(Grouper):
             # example, is excluded.
             rule = self.freq.rule_code
             if rule in _END_TYPES or (
-                "-" in rule and rule[: rule.find("-")] in _END_TYPES
+                "-" in rule and rule.split("-", 1)[0] in _END_TYPES
             ):
                 edges_dti = binner.tz_localize(None)
                 edges_dti = (

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -2080,8 +2080,8 @@ def test_resample_ms_closed_right(unit):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("freq", ["B", "C", "W", "ME", "SME", "BCME", "QE", "BQE"])
-def test_resample_c_b_label_right_closed_right_default(freq: str, unit):
+@pytest.mark.parametrize("freq", ["B", "C", "W", "ME", "SME", "BME", "CBME", "QE", "BQE"])
+def test_resample_c_b_default(freq: str, unit):
     # https://github.com/pandas-dev/pandas/issues/55281
     # check the default.
     # it's very important that the default be the same direction.
@@ -2093,7 +2093,7 @@ def test_resample_c_b_label_right_closed_right_default(freq: str, unit):
     # it samples future days (Saturday Sunday) onto the previous business day (Thursday)
     # - the interval covers Thursday 23:59 to Friday 23:59 (closed=right).
     # - the label shows Thursday date (label=left), as a plain date without time.
-    dti = date_range(start="2020-01-31", freq="1hour", periods=1000, unit=unit)
+    dti = date_range(start="2020-01-31", freq="1h", periods=1000, unit=unit)
     df = DataFrame({"ts": dti}, index=dti)
     grouped_right_right = df.resample(freq, label="right", closed="right")
     grouped_default = df.resample(freq, label="right", closed="right")
@@ -2103,7 +2103,7 @@ def test_resample_c_b_label_right_closed_right_default(freq: str, unit):
 
 
 @pytest.mark.parametrize("freq", ["B", "C"])
-def test_resample_c_b_label_right_closed_right_default(freq: str, unit):
+def test_resample_c_b_label_right_closed_right(freq: str, unit):
     # https://github.com/pandas-dev/pandas/issues/55281
     dti = date_range(start="2020-01-31", freq="1min", periods=6000, unit=unit)
     df = DataFrame({"ts": dti}, index=dti)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -2080,7 +2080,9 @@ def test_resample_ms_closed_right(unit):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("freq", ["B", "C", "W", "ME", "SME", "BME", "CBME", "QE", "BQE"])
+@pytest.mark.parametrize(
+    "freq", ["B", "C", "W", "ME", "SME", "BME", "CBME", "QE", "BQE"]
+)
 def test_resample_c_b_default(freq: str, unit):
     # https://github.com/pandas-dev/pandas/issues/55281
     # check the default.

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -378,12 +378,12 @@ def test_resample_basic_from_daily(unit):
 
     # to biz day
     result = s.resample("B").last()
-    assert len(result) == 7
-    assert (result.index.day_of_week == [4, 0, 1, 2, 3, 4, 0]).all()
+    assert len(result) == 6
+    assert (result.index.day_of_week == [0, 1, 2, 3, 4, 0]).all()
 
-    assert result.iloc[0] == s["1/2/2005"]
-    assert result.iloc[1] == s["1/3/2005"]
-    assert result.iloc[5] == s["1/9/2005"]
+    assert result.iloc[0] == s["1/3/2005"]
+    assert result.iloc[1] == s["1/4/2005"]
+    assert result.iloc[5] == s["1/10/2005"]
     assert result.index.name == "index"
 
 
@@ -637,7 +637,7 @@ def test_resample_reresample(unit):
     s = Series(np.random.default_rng(2).random(len(dti)), dti)
     bs = s.resample("B", closed="right", label="right").mean()
     result = bs.resample("8h").mean()
-    assert len(result) == 25
+    assert len(result) == 22
     assert isinstance(result.index.freq, offsets.DateOffset)
     assert result.index.freq == offsets.Hour(8)
 
@@ -2080,35 +2080,126 @@ def test_resample_ms_closed_right(unit):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("freq", ["B", "C", "W", "ME", "SME", "BCME", "QE", "BQE"])
+def test_resample_c_b_label_right_closed_right_default(freq: str, unit):
+    # https://github.com/pandas-dev/pandas/issues/55281
+    # check the default.
+    # it's very important that the default be the same direction.
+    #     label=right with closed=right
+    #     label=left with closed=left
+    #
+    # the result is incomprehensible when mixing left/right.
+    # e.g. consider label=left close=right with business days.
+    # it samples future days (Saturday Sunday) onto the previous business day (Thursday)
+    # - the interval covers Thursday 23:59 to Friday 23:59 (closed=right).
+    # - the label shows Thursday date (label=left), as a plain date without time.
+    dti = date_range(start="2020-01-31", freq="1hour", periods=1000, unit=unit)
+    df = DataFrame({"ts": dti}, index=dti)
+    grouped_right_right = df.resample(freq, label="right", closed="right")
+    grouped_default = df.resample(freq, label="right", closed="right")
+
+    tm.assert_frame_equal(grouped_default.first(), grouped_right_right.first())
+    tm.assert_frame_equal(grouped_default.last(), grouped_right_right.last())
+
+
 @pytest.mark.parametrize("freq", ["B", "C"])
-def test_resample_c_b_closed_right(freq: str, unit):
+def test_resample_c_b_label_right_closed_right_default(freq: str, unit):
     # https://github.com/pandas-dev/pandas/issues/55281
     dti = date_range(start="2020-01-31", freq="1min", periods=6000, unit=unit)
     df = DataFrame({"ts": dti}, index=dti)
-    grouped = df.resample(freq, closed="right")
-    result = grouped.last()
+    grouped = df.resample(freq, label="right", closed="right")
+    result_first = grouped.first()
+    result_last = grouped.last()
 
-    exp_dti = DatetimeIndex(
+    exp_dti_first = DatetimeIndex(
         [
-            datetime(2020, 1, 30),
-            datetime(2020, 1, 31),
-            datetime(2020, 2, 3),
-            datetime(2020, 2, 4),
+            datetime(2020, 1, 31),  # Friday
+            datetime(2020, 2, 3),  # Monday
+            datetime(2020, 2, 4),  # Tuesday
         ],
         freq=freq,
     ).as_unit(unit)
-    expected = DataFrame(
+    expected_first = DataFrame(
+        {
+            "ts": [
+                datetime(2020, 1, 31),
+                datetime(2020, 2, 1),
+                datetime(2020, 2, 4),
+            ]
+        },
+        index=exp_dti_first,
+    ).astype(f"M8[{unit}]")
+
+    exp_dti_last = DatetimeIndex(
+        [
+            datetime(2020, 1, 31),  # Friday
+            datetime(2020, 2, 3),  # Monday
+            datetime(2020, 2, 4),  # Tuesday
+        ],
+        freq=freq,
+    ).as_unit(unit)
+    expected_last = DataFrame(
+        {
+            "ts": [
+                datetime(2020, 1, 31, 23, 59),
+                datetime(2020, 2, 3, 23, 59),
+                datetime(2020, 2, 4, 3, 59),
+            ]
+        },
+        index=exp_dti_last,
+    ).astype(f"M8[{unit}]")
+    tm.assert_frame_equal(result_first, expected_first)
+    tm.assert_frame_equal(result_last, expected_last)
+
+
+@pytest.mark.parametrize("freq", ["B", "C"])
+def test_resample_c_b_label_left_closed_left(freq: str, unit):
+    # https://github.com/pandas-dev/pandas/issues/55281
+    dti = date_range(start="2020-01-31", freq="1min", periods=6000, unit=unit)
+    df = DataFrame({"ts": dti}, index=dti)
+    grouped = df.resample(freq, label="left", closed="left")
+    result_first = grouped.first()
+    result_last = grouped.last()
+
+    exp_dti_first = DatetimeIndex(
+        [
+            datetime(2020, 1, 31),  # Friday
+            datetime(2020, 2, 3),  # Monday
+            datetime(2020, 2, 4),  # Tuesday
+        ],
+        freq=freq,
+    ).as_unit(unit)
+    expected_first = DataFrame(
         {
             "ts": [
                 datetime(2020, 1, 31),
                 datetime(2020, 2, 3),
                 datetime(2020, 2, 4),
+            ]
+        },
+        index=exp_dti_first,
+    ).astype(f"M8[{unit}]")
+
+    exp_dti_last = DatetimeIndex(
+        [
+            datetime(2020, 1, 31),  # Friday
+            datetime(2020, 2, 3),  # Monday
+            datetime(2020, 2, 4),  # Tuesday
+        ],
+        freq=freq,
+    ).as_unit(unit)
+    expected_last = DataFrame(
+        {
+            "ts": [
+                datetime(2020, 2, 2, 23, 59),
+                datetime(2020, 2, 3, 23, 59),
                 datetime(2020, 2, 4, 3, 59),
             ]
         },
-        index=exp_dti,
+        index=exp_dti_last,
     ).astype(f"M8[{unit}]")
-    tm.assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result_first, expected_first)
+    tm.assert_frame_equal(result_last, expected_last)
 
 
 def test_resample_b_55282(unit):
@@ -2122,14 +2213,77 @@ def test_resample_b_55282(unit):
             datetime(2023, 9, 26),
             datetime(2023, 9, 27),
             datetime(2023, 9, 28),
-            datetime(2023, 9, 29),
         ],
         freq="B",
     ).as_unit(unit)
     expected = Series(
-        [1.0, 2.5, 4.5, 6.0],
+        [1.5, 3.5, 5.5],
         index=exp_dti,
     )
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("freq", ["B", "C"])
+def test_resample_closed_right_no_leading_nan(freq: str, unit):
+    # https://github.com/pandas-dev/pandas/issues/65740
+    # Intraday timestamps (e.g. EOD 16:00) on a business-day boundary
+    # should land in the bin labeled with their own date, not the next
+    # business day. Otherwise a leading empty bin is produced and the
+    # int column is coerced to float.
+    dti = DatetimeIndex(
+        [
+            "2023-09-25 16:00",
+            "2023-09-26 16:00",
+            "2023-09-27 16:00",
+            "2023-09-28 16:00",
+            "2023-09-29 16:00",
+        ]
+    ).as_unit(unit)
+    ser = Series([1, 2, 3, 4, 5], index=dti)
+    result = ser.resample(freq, closed="right", label="right").last()
+
+    exp_dti = DatetimeIndex(
+        [
+            datetime(2023, 9, 25),
+            datetime(2023, 9, 26),
+            datetime(2023, 9, 27),
+            datetime(2023, 9, 28),
+            datetime(2023, 9, 29),
+        ],
+        freq=freq,
+    ).as_unit(unit)
+    expected = Series([1, 2, 3, 4, 5], index=exp_dti)
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("freq", ["B", "C"])
+def test_resample_closed_right_no_trailing_nan(freq: str, unit):
+    # https://github.com/pandas-dev/pandas/issues/65740
+    # When input ends exactly on a business-day boundary, no trailing
+    # empty bin should be emitted (which would coerce int -> float).
+    dti = DatetimeIndex(
+        [
+            "2023-09-25",
+            "2023-09-26",
+            "2023-09-27",
+            "2023-09-28",
+            "2023-09-29",
+        ]
+    ).as_unit(unit)
+    ser = Series([1, 2, 3, 4, 5], index=dti)
+    result = ser.resample(freq, closed="right", label="right").last()
+
+    exp_dti = DatetimeIndex(
+        [
+            datetime(2023, 9, 25),
+            datetime(2023, 9, 26),
+            datetime(2023, 9, 27),
+            datetime(2023, 9, 28),
+            datetime(2023, 9, 29),
+        ],
+        freq=freq,
+    ).as_unit(unit)
+    expected = Series([1, 2, 3, 4, 5], index=exp_dti)
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
see main discussion in ticket https://github.com/pandas-dev/pandas/issues/65740

TL;DR `resample()` has been broken for 3 years, adding empty dates with NaN before and/or after the data.

I am gonna try to get a build and linters going in this PR.
This passes all resampling and indexes tests on my machine. I need to get a CI build going to test everything.

- [X] closes #65740
- [X] closes #59620
- [X] closes #59495
- [X] closes #55284
- [X] closes #55283
- [X] closes #55282
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

