### PR TITLE
BUG: strftime %Y not zero-padded for years before 1000

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -115,7 +115,9 @@ def _test_parse_iso8601(ts: str):
 
 
 _STRFTIME_FORMAT_MAP = {
-    "%Y": "{0}",
+    # %Y is zero-padded to a minimum of 4 digits to match datetime.strftime
+    #  (and Timestamp.strftime) for years < 1000; see GH#58179.
+    "%Y": "{0:04d}",
     "%m": "{1:02d}",
     "%d": "{2:02d}",
     "%H": "{3:02d}",

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -601,6 +601,24 @@ class TestSeriesDatetimeValues:
         expected = Series(["{2024}", "{2024}", "{2024}"])
         tm.assert_series_equal(result, expected)
 
+    def test_strftime_dt64_year_lt_1000(self):
+        # GH#58179, GH#64609 the directive-map fast path must zero-pad %Y to
+        #  a minimum of 4 digits for years < 1000, matching datetime.strftime
+        ser = Series(
+            np.array(
+                ["0005-06-15", "0099-01-01", "0999-12-31", "2024-03-02"],
+                dtype="M8[s]",
+            )
+        )
+        result = ser.dt.strftime("%Y")
+        expected = Series(["0005", "0099", "0999", "2024"])
+        tm.assert_series_equal(result, expected)
+
+        # composite format still routes through the directive-map fast path
+        result = ser.dt.strftime("%Y/%m/%d")
+        expected = Series(["0005/06/15", "0099/01/01", "0999/12/31", "2024/03/02"])
+        tm.assert_series_equal(result, expected)
+
     def test_strftime_dt64_microsecond_resolution(self):
         ser = Series([datetime(2013, 1, 1, 2, 32, 59), datetime(2013, 1, 2, 14, 32, 1)])
         result = ser.dt.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Restores 4-digit-minimum zero-padding for the `%Y` directive in the array `strftime` fast path.

The directive-map optimization added in GH-64609 mapped `%Y` to `{0}` (no padding), so `Series.dt.strftime` / `DatetimeIndex.strftime` rendered years before 1000 without zero-padding:

```python
>>> ser = pd.Series(np.array(["0005-06-15", "0999-01-01"], dtype="M8[s]"))
>>> ser.dt.strftime("%Y").tolist()
['5', '999']        # main; this PR -> ['0005', '0999']
>>> ser.dt.strftime("%Y/%m/%d").tolist()
['5/06/15', '999/01/01']   # main; this PR -> ['0005/06/15', '0999/01/01']
```

`%Y` now maps to `{0:04d}`, matching `datetime.strftime` / `Timestamp.strftime` and `str(Timestamp(...))`, which already zero-pad the year to 4 digits. Other directives (`%m %d %H %M %S %f`) were already padded and are unchanged; 4-digit years are unaffected.

### Scope

This fixes the directive-map (custom-format) path — the regression introduced by GH-64609. The broader cross-platform consistency tracked in GH-58179 is **not** fully resolved here: the default repr and the `%Y-%m-%d` / `%Y-%m-%d %H:%M:%S` `basic_format` paths still render years before 1000 unpadded, and the scalar `Timestamp.strftime` slow path remains OS-dependent for `%Y`. Those are left for a follow-up.

No whatsnew entry: GH-64609 has not shipped in a release (it is only in `3.1.0.dev0`; latest release is `v3.0.2`), so this regression was introduced and fixed within the same unreleased cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
