### PR TITLE
BUG: get_indexer_non_unique raising ZeroDivisionError on empty index

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -308,6 +308,7 @@ Indexing
 - Bug in :meth:`DataFrame.rename` and :meth:`Series.rename` not preserving nullable extension dtype (e.g. ``Int64``, ``Float64``) when relabeling index or column labels (:issue:`65315`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
 - Bug in :meth:`DataFrame.xs` where ``drop_level=False`` was ignored for fully specified :class:`MultiIndex` keys when ``level`` was not explicitly provided (:issue:`6507`)
+- Bug in :meth:`Index.get_indexer_non_unique` raising ``ZeroDivisionError`` instead of returning an all-missing result when called on an empty index with a non-empty target (:issue:`54746`)
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)
 - Bug in :meth:`Index.get_loc` raising ``KeyError`` when looking up a tuple in an object-dtype :class:`Index` with duplicates (:issue:`37800`)
 - Bug in :meth:`Index.insert` silently casting booleans to numeric when used with nullable numeric dtypes like ``Float64`` or ``Int64`` (:issue:`61709`)

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -437,6 +437,11 @@ cdef class IndexEngine:
 
         n = len(values)
         n_t = len(targets)
+        if n == 0:
+            # GH#54746 empty index matches nothing; every target is missing.
+            # Early return also avoids ZeroDivisionError in the searchsorted
+            # heuristic below (n.bit_length() == 0 -> divide by zero).
+            return np.full(n_t, -1, dtype=np.intp), np.arange(n_t, dtype=np.intp)
         max_alloc = n * n_t
         if n > 10_000:
             n_alloc = 10_000
@@ -1311,6 +1316,11 @@ cdef class MaskedIndexEngine(IndexEngine):
 
         n = len(values)
         n_t = len(target_vals)
+        if n == 0:
+            # GH#64674 empty index matches nothing; every target is missing.
+            # Early return also avoids ZeroDivisionError in the searchsorted
+            # heuristic below (n.bit_length() == 0 -> divide by zero).
+            return np.full(n_t, -1, dtype=np.intp), np.arange(n_t, dtype=np.intp)
         max_alloc = n * n_t
         if n > 10_000:
             n_alloc = 10_000

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -368,3 +368,27 @@ def test_get_indexer_non_unique_nans_in_object_dtype_target(nulls_fixture):
     result_idx, result_missing = idx.get_indexer_non_unique(target)
     tm.assert_numpy_array_equal(result_idx, np.array([0, -1], dtype=np.intp))
     tm.assert_numpy_array_equal(result_missing, np.array([1], dtype=np.intp))
+
+
+@pytest.mark.parametrize(
+    "dtype, target_values",
+    [
+        ("Int64", [1, 2]),
+        ("Float64", [1.0, 2.0]),
+        ("boolean", [True, False]),
+        ("int64", [1, 2]),
+        ("float64", [1.0, 2.0]),
+        ("object", ["a", "b"]),
+    ],
+)
+def test_get_indexer_non_unique_empty_index(dtype, target_values):
+    # GH#64674 (masked) / GH#54746 (non-masked): an empty index reindexed
+    # against a non-empty target raised ZeroDivisionError in the binary-search
+    # heuristic.  An empty index matches nothing, so every target is missing.
+    index = Index([], dtype=dtype)
+    target = Index(target_values, dtype=dtype)
+
+    result_idx, result_missing = index.get_indexer_non_unique(target)
+
+    tm.assert_numpy_array_equal(result_idx, np.array([-1, -1], dtype=np.intp))
+    tm.assert_numpy_array_equal(result_missing, np.array([0, 1], dtype=np.intp))


### PR DESCRIPTION
Fixes a `ZeroDivisionError` in :meth:`Index.get_indexer_non_unique` when called on an empty index against a non-empty target.

The binary-search heuristic guard evaluates `len(stargets) < (n / (2 * n.bit_length()))`, which divides by zero when the index is empty (`n == 0`, `(0).bit_length() == 0`). The `stargets and ...` short-circuit only guards an empty *target*, not an empty *index*. An empty index matches nothing, so this now returns an all-missing result early — which also sidesteps a degenerate resize loop in the fallback path.

- The non-masked `IndexEngine.get_indexer_non_unique` has had this since GH-54746 (shipped in v2.2.0 through v3.0.2).
- The masked `MaskedIndexEngine.get_indexer_non_unique` regressed in GH-64674 (3.1-dev only, unreleased).

```python
>>> import pandas as pd
>>> pd.Index([], dtype="Int64").get_indexer_non_unique(pd.Index([1, 2], dtype="Int64"))
ZeroDivisionError: division by zero   # before
(array([-1, -1]), array([0, 1]))      # after
```

A regression test covers both the masked (`Int64`/`Float64`/`boolean`) and non-masked (`int64`/`float64`/`object`) engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)