### PR TITLE
BUG: unstack corrupting source DataFrame via Copy-on-Write aliasing

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1083,9 +1083,21 @@ class Block(PandasObject, libinternals.Block):
             New blocks of unstacked values.
         """
         new_values = unstacker.get_new_values(self.values.T, fill_value=fill_value)
+        new_values = new_values.T
+
+        # get_new_values can return a view of self.values on the identity-indexer
+        #  fast path (see _Unstacker._make_sorted_values); every other path copies
+        #  via take_nd.  Gate on that, then the O(1) may_share_memory, so CoW
+        #  tracks the reference.  GH#65107
+        if unstacker._indexer_is_identity and np.may_share_memory(
+            new_values, self.values
+        ):
+            refs = self.refs
+        else:
+            refs = None
 
         bp = BlockPlacement(new_placement)
-        blocks = [new_block_2d(new_values.T, placement=bp)]
+        blocks = [new_block_2d(new_values, placement=bp, refs=refs)]
         return blocks
 
     # ---------------------------------------------------------------------

--- a/pandas/tests/copy_view/test_methods.py
+++ b/pandas/tests/copy_view/test_methods.py
@@ -1483,6 +1483,21 @@ def test_transpose_ea_single_column():
     assert not np.shares_memory(get_array(df, "a"), get_array(result, 0))
 
 
+def test_unstack_multiblock():
+    # GH#65107 the zero-copy fast path for a sorted MultiIndex returns a view
+    #  of the source for non-consolidated (multi-block) frames; ensure CoW
+    #  still tracks the reference so mutating the result leaves the source
+    #  unchanged.
+    idx = MultiIndex.from_product([["a", "b"], [1, 2]])
+    df = DataFrame({"x": [1.0, 2.0, 3.0, 4.0], "y": ["p", "q", "r", "s"]}, index=idx)
+    df_orig = df.copy()
+    result = df.unstack()
+
+    assert np.shares_memory(get_array(df, "x"), get_array(result, ("x", 1)))
+    result.iloc[0, 0] = 999.0
+    tm.assert_frame_equal(df, df_orig)
+
+
 def test_transform_frame():
     df = DataFrame({"a": [1, 2, 3], "b": 1})
     df_orig = df.copy()


### PR DESCRIPTION
Fixes a Copy-on-Write aliasing regression introduced by GH-65107.

GH-65107 added a zero-copy fast path: when the `MultiIndex` is already sorted and the unstacked level is the last level, `_Unstacker.get_new_values` returns a *view* of the block values rather than a `take_nd` copy. For single-block frames and `Series`, the view is tracked via `_Unstacker.get_result`'s `add_references` logic. But for multi-block (non-consolidated) frames, unstack goes through `BlockManager.unstack` → `Block._unstack`, which built the result block with `refs=None`. CoW therefore never tracked the sharing, and mutating the unstack result wrote through to the source `DataFrame`:

```python
idx = pd.MultiIndex.from_product([["a", "b"], [1, 2]])
df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0], "y": ["p", "q", "r", "s"]}, index=idx)
res = df.unstack()
res.iloc[0, 0] = 999.0
df["x"].tolist()  # [999.0, 2.0, 3.0, 4.0] -- source corrupted
```

This fixes `Block._unstack` to track the reference when the unstacked values alias `self.values`, mirroring the `add_references` logic in `get_result`. The zero-copy view from GH-65107 is preserved; CoW now triggers a copy before either object is mutated.

No whatsnew entry: GH-65107 landed in the unreleased 3.1.0 dev cycle, so this regression was never in a released pandas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
