### PR TITLE
BUG: DataFrame(list_of_arrays) with ragged same-dtype rows

### DIFF
--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -825,9 +825,15 @@ def to_arrays(
         # last ditch effort
         # GH#23985, GH#49593: if all rows are arrays with a uniform
         # dtype, construct columns directly to preserve that dtype
-        # (e.g. timedelta64, pyarrow, Int64, Categorical)
+        # (e.g. timedelta64, pyarrow, Int64, Categorical). Only take this
+        # path for non-ragged rows; ragged rows fall through to the
+        # object/pad path below so they are padded to max width with NaN.
         row_dtypes = {row.dtype for row in data if hasattr(row, "dtype")}
-        if len(row_dtypes) == 1 and all(hasattr(row, "dtype") for row in data):
+        if (
+            len(row_dtypes) == 1
+            and all(hasattr(row, "dtype") for row in data)
+            and len({len(row) for row in data}) == 1
+        ):
             common_dtype = row_dtypes.pop()
             ncols = len(data[0])
             arrays = [

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2161,6 +2161,20 @@ class TestDataFrameConstructors:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_constructor_list_of_ragged_arrays_first_shortest(self):
+        # GH#64958 the uniform-dtype fast path must not silently truncate
+        # ragged rows; they should be padded to max width with NaN
+        result = DataFrame([np.array([1, 2]), np.array([3, 4, 5])])
+        expected = DataFrame([[1, 2, np.nan], [3, 4, 5]])
+        tm.assert_frame_equal(result, expected)
+
+    def test_constructor_list_of_ragged_arrays_first_longest(self):
+        # GH#64958 a longer first row must not raise IndexError; ragged rows
+        # should be padded to max width with NaN
+        result = DataFrame([np.array([1, 2, 3]), np.array([4, 5])])
+        expected = DataFrame([[1, 2, 3], [4, 5, np.nan]])
+        tm.assert_frame_equal(result, expected)
+
     def test_constructor_for_list_with_dtypes(self, using_infer_string):
         # test list of lists/ndarrays
         df = DataFrame([np.arange(5) for x in range(5)])

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2164,14 +2164,19 @@ class TestDataFrameConstructors:
     def test_constructor_list_of_ragged_arrays_first_shortest(self):
         # GH#64958 the uniform-dtype fast path must not silently truncate
         # ragged rows; they should be padded to max width with NaN
-        result = DataFrame([np.array([1, 2]), np.array([3, 4, 5])])
+        # (pin int64 so the result dtype matches on 32- and 64-bit platforms)
+        result = DataFrame(
+            [np.array([1, 2], dtype=np.int64), np.array([3, 4, 5], dtype=np.int64)]
+        )
         expected = DataFrame([[1, 2, np.nan], [3, 4, 5]])
         tm.assert_frame_equal(result, expected)
 
     def test_constructor_list_of_ragged_arrays_first_longest(self):
         # GH#64958 a longer first row must not raise IndexError; ragged rows
         # should be padded to max width with NaN
-        result = DataFrame([np.array([1, 2, 3]), np.array([4, 5])])
+        result = DataFrame(
+            [np.array([1, 2, 3], dtype=np.int64), np.array([4, 5], dtype=np.int64)]
+        )
         expected = DataFrame([[1, 2, 3], [4, 5, np.nan]])
         tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
The uniform-dtype fast path added in GH-64958 assumed every row had the
same length: it took the column count from the first row only
(`ncols = len(data[0])`) and indexed every row by that width.

For ragged rows of a single dtype this misbehaved in two ways:

```python
pd.DataFrame([np.array([1, 2]), np.array([3, 4, 5])]).to_numpy().tolist()
# -> [[1, 2], [3, 4]]   # the 5 was silently dropped

pd.DataFrame([np.array([1, 2, 3]), np.array([4, 5])])
# -> IndexError: index 2 is out of bounds for axis 0 with size 2
```

The entry condition (`treat_as_nested`) only inspects `data[0]`, so
same-dtype arrays of differing lengths still reach this path.

This gates the fast path on uniform row lengths; ragged rows now fall
through to the existing object/pad path and are padded to the longest
row with `NaN`, matching list-of-lists behavior (and the existing
`test_construct_from_listlikes_mismatched_lengths`).

No whatsnew: GH-64958 is unreleased, so this regression never shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)