### PR TITLE
BUG: inplace where/mask corrupting multi-column 2D datetimelike blocks

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1828,9 +1828,17 @@ class EABackedBlock(Block):
         self = self._maybe_copy(inplace=True)
         values = self.values
         if values.ndim == 2:
-            # GH#45419 Transpose the mask to storage layout instead of
-            #  transposing values, since EA.T may not be a view.
+            # GH#64620 Reorient the read-only inputs to the block's storage
+            #  layout and putmask into self.values in place. We must not
+            #  transpose self.values: EA.T is only zero-copy when
+            #  dtype._can_fast_transpose, so a transpose could yield a copy and
+            #  _putmask would silently mutate that throwaway instead of self.
+            #  mask/new are read-only, so transposing them is always correct
+            #  (mirrors value = value.T in EABackedBlock.setitem); failing to
+            #  transpose new fills masked cells from the wrong column.
             mask = mask.T
+            if isinstance(new, (np.ndarray, ExtensionArray)) and new.ndim == 2:
+                new = new.T
 
         try:
             # Caller is responsible for ensuring matching lengths

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -1105,3 +1105,34 @@ def test_where_series_cond_with_axis1():
         [[0.0, 0.5, np.nan], [0.1, 0.0, np.nan], [0.2, 0.0, np.nan]],
     )
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("method", ["where", "mask"])
+@pytest.mark.parametrize("dtype", ["M8[ns]", "m8[ns]", "M8[ns, UTC]"])
+def test_where_mask_inplace_2d_ea_other(method, dtype):
+    # GH#64620 inplace where/mask on a multi-column 2D extension block must
+    #  transpose `new` to storage layout (like setitem), otherwise masked cells
+    #  get filled from the wrong column. The bug needs a single block spanning
+    #  >1 column. Building from a 2D ExtensionArray covers tz-aware datetime
+    #  (which never consolidates) alongside tz-naive datetime64 / timedelta64.
+    base = "m8[ns]" if dtype == "m8[ns]" else "M8[ns]"
+
+    def to_frame(start):
+        arr = pd.array(np.arange(start, start + 6).astype(base), dtype=dtype)
+        return DataFrame(arr.reshape(3, 2))
+
+    df = to_frame(0)
+    other = to_frame(100)
+    cond = DataFrame([[True, False], [False, True], [True, False]])
+
+    # the values must share a single multi-column 2D block to hit the bug
+    assert len(df._mgr.blocks) == 1
+    assert df._mgr.blocks[0].values.ndim == 2
+    assert df._mgr.blocks[0].values.shape[0] == 2
+
+    expected = getattr(df, method)(cond, other)
+
+    result = df.copy()
+    getattr(result, method)(cond, other, inplace=True)
+
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Regression from GH-64620 (unreleased), so no whatsnew entry.

`EABackedBlock.putmask` reorients `mask` to the block's storage layout (`mask = mask.T`) but never did the same for `new`. On a multi-column 2D extension block (datetime64 / timedelta64 / datetime64tz / period), an inplace `where`/`mask` therefore filled masked cells from the wrong column:

```python
df = pd.DataFrame({"a": pd.date_range("2000-01-01", periods=3),
                   "b": pd.date_range("2010-01-01", periods=3)})
other = pd.DataFrame({"a": pd.date_range("2020-01-01", periods=3),
                      "b": pd.date_range("2030-01-01", periods=3)})
cond = pd.DataFrame({"a": [True, False, True], "b": [False, True, False]})

ref = df.where(cond, other)                          # correct (non-inplace)
d2 = df.copy(); d2.where(cond, other, inplace=True)
ref.equals(d2)        # False before this PR, True after
```

The fix transposes `new` alongside `mask`, mirroring the `value = value.T` that `EABackedBlock.setitem` already applies. `new` is a read-only input, so transposing it is correct regardless of whether `.T` is zero-copy (`dtype._can_fast_transpose`) — transposing the destination `values` is what GH-64620 deliberately avoided, and this PR still doesn't.

The non-inplace `where`/`mask` path goes through `EABackedBlock.where` (which transposes `values` into a fresh block) and was never affected.
