### PR TITLE
BUG: avoid caller dtype cast for Series.map mapper

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -2901,6 +2901,8 @@ class ExtensionArray:
         """
         result = map_array(self, mapper, na_action=na_action)
         if isinstance(result, np.ndarray):
+            if isinstance(mapper, ABCSeries):
+                return result
             return self._cast_pointwise_result(result)
         return result
 

--- a/pandas/tests/series/methods/test_map.py
+++ b/pandas/tests/series/methods/test_map.py
@@ -702,3 +702,36 @@ def test_map_retains_dtype_with_na(dtype):
     ser = Series([1, 2, 3, pd.NA, 10], dtype=dtype)
     result = ser.map(lambda x: x)
     tm.assert_series_equal(result, ser)
+
+
+@pytest.mark.parametrize(
+    "values, mapper, expected",
+    [
+        ([1, 2], Series([10, 20], index=[2, 3]), Series([np.nan, 10.0])),
+        (
+            Series([1, None], dtype="Int16"),
+            Series([10, 20], index=[2, 1]),
+            Series([20.0, np.nan]),
+        ),
+        (
+            Series([None, None], dtype="Int16"),
+            Series([10, 20], index=[2, 1]),
+            Series([np.nan, np.nan]),
+        ),
+    ],
+)
+def test_map_series_mapper_with_missing_uses_mapper_dtype(values, mapper, expected):
+    # GH#65735
+    result = Series(values).map(mapper)
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("mapper_values", [[10, 20], [260, 20]])
+def test_map_series_mapper_full_match_uses_mapper_dtype(mapper_values):
+    # GH#65735
+    ser = Series([1, 2], dtype="Int8")
+    mapper = Series(mapper_values, index=[1, 2], dtype="int32")
+
+    result = ser.map(mapper)
+    expected = Series(mapper_values, dtype="int32")
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Closes #65735.

When mapping an ExtensionArray-backed Series with another Series, the result from take_nd was being passed through the caller array's _cast_pointwise_result. This made the output dtype depend on the caller dtype and sometimes on the mapped values.

For Series mappers, return the mapped ndarray result directly so the dtype follows the mapper/take result consistently. Dict and callable mapper behavior is unchanged.

Tests cover missing keys, all-NA values, and full matches with an int32 Series mapper.

- [x] xref #65735
- [x] Added tests
- [x] python -m pytest pandas/tests/series/methods/test_map.py