### PR TITLE
TST: Fix fastparquet xfail bound in test_to_parquet_new_file

### DIFF
--- a/pandas/tests/io/test_fsspec.py
+++ b/pandas/tests/io/test_fsspec.py
@@ -192,7 +192,7 @@ def test_to_parquet_new_file(cleared_fs, df1, request):
             using_string_dtype()
             and HAS_PYARROW
             and not pa_version_under14p0
-            and Version(fp.__version__) <= Version("2025.12.0"),
+            and Version(fp.__version__) < Version("2026.5.0"),
             reason="TODO(infer_string) fastparquet",
         )
     )


### PR DESCRIPTION
PR GH-65668 capped the "fastparquet can't write ArrowStringArray" xfail at fastparquet `< 2026.5.0` in `test_parquet.py`, but the matching edit in `test_fsspec.py` used `<= 2025.12.0` instead.

As a result, `test_to_parquet_new_file` fails for real (rather than xfailing) on fastparquet `>= 2025.12.0` and `< 2026.5.0` (e.g. 2026.3.0), where the ArrowStringArray write bug is still present:

```
ValueError: Error converting column "str" to bytes using encoding UTF8.
Original error: Unable to avoid copy while creating an array as requested.
```

This restores the pre-GH-65668 semantics (the fsspec test had no lower fastparquet bound — it xfailed for all versions) while keeping the `< 2026.5.0` upper bound for the version that fixes the write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)