### PR TITLE
PERF: Fix regression in DatetimeIndex.normalize

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1191,13 +1191,19 @@ default 'raise'
                        '2014-08-01 00:00:00+05:30'],
                        dtype='datetime64[us, Asia/Calcutta]', freq=None)
         """
-        new_values = normalize_i8_timestamps(self.asi8, self.tz, reso=self._creso)
-        dt64_values = new_values.view(self._ndarray.dtype)
-
-        dta = type(self)._simple_new(dt64_values, dtype=dt64_values.dtype)
+        dta = self._normalize_naive()
         if self.tz is not None:
             dta = dta.tz_localize(self.tz)
         return dta
+
+    def _normalize_naive(self) -> Self:
+        # Normalized values as a tz-naive array (local midnight). Callers that
+        # need the resulting freq can infer it from these naive values, avoiding
+        # the expensive per-element tz conversion the frequency inferer would
+        # otherwise do on tz-aware data (e.g. tzlocal).
+        new_values = normalize_i8_timestamps(self.asi8, self.tz, reso=self._creso)
+        dt64_values = new_values.view(self._ndarray.dtype)
+        return type(self)._simple_new(dt64_values, dtype=dt64_values.dtype)
 
     def to_period(self, freq=None) -> PeriodArray:
         """

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1197,10 +1197,7 @@ default 'raise'
         return dta
 
     def _normalize_naive(self) -> Self:
-        # Normalized values as a tz-naive array (local midnight). Callers that
-        # need the resulting freq can infer it from these naive values, avoiding
-        # the expensive per-element tz conversion the frequency inferer would
-        # otherwise do on tz-aware data (e.g. tzlocal).
+        """Normalize times to midnight, ignoring the timezone."""
         new_values = normalize_i8_timestamps(self.asi8, self.tz, reso=self._creso)
         dt64_values = new_values.view(self._ndarray.dtype)
         return type(self)._simple_new(dt64_values, dtype=dt64_values.dtype)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -497,6 +497,8 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                        dtype='datetime64[us, Asia/Calcutta]', freq=None)
         """
         data = self._data
+        # Inferring frequency from naive normalization is significantly
+        # cheaper than tz-aware.
         naive = data._normalize_naive()
         freq = to_offset(naive._inferred_freq_str)
         arr = naive.tz_localize(data.tz) if data.tz is not None else naive

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -496,9 +496,12 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                        '2014-08-01 00:00:00+05:30'],
                        dtype='datetime64[us, Asia/Calcutta]', freq=None)
         """
-        arr = self._data.normalize()
+        data = self._data
+        naive = data._normalize_naive()
+        freq = to_offset(naive._inferred_freq_str)
+        arr = naive.tz_localize(data.tz) if data.tz is not None else naive
         result = type(self)._simple_new(arr, name=self.name)
-        result._freq = to_offset(arr._inferred_freq_str)
+        result._freq = freq
         return result
 
     def tz_convert(self, tz) -> Self:


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/121

Introduced as part of 3.1, so no whatsnew note.