### PR TITLE
DOC: fix outdated matplotlib link in visualization.rst

### DIFF
--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -1372,7 +1372,7 @@ tick locator methods, it is useful to call the automatic
 date tick adjustment from matplotlib for figures whose ticklabels overlap.
 
 See the :meth:`autofmt_xdate <matplotlib.figure.autofmt_xdate>` method and the
-`matplotlib documentation <https://matplotlib.org/2.0.2/users/recipes.html#fixing-common-date-annoyances>`__ for more.
+`matplotlib documentation <https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure.autofmt_xdate>`__ for more.
 
 Subplots
 ~~~~~~~~


### PR DESCRIPTION
Updating a hardcoded matplotlib v2.0.2 link to the stable API reference for autofmt_xdate, as noted in issue #65737. The old link is a dead end on the archived docs site.