### PR TITLE
PERF: limit ADBC table existence metadata

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -167,6 +167,7 @@ Performance improvements
 - Performance improvement in :func:`read_sas` for SAS7BDAT files with full-precision (8-byte) numeric columns, with up to ~2x speedup on bulk reads (:issue:`47339`)
 - Performance improvement in :func:`read_sas` for compressed SAS7BDAT files by reusing the decompression buffer instead of allocating per row (:issue:`47339`)
 - Performance improvement in :func:`read_sas` when decoding strings (:issue:`47339`)
+- Performance improvement in :func:`read_sql` with ADBC connections by requesting only table metadata when checking whether an input string names a table (:issue:`65652`)
 - Performance improvement in :func:`tseries.frequencies.to_offset` parsing of frequency strings, especially for tick-resolution offsets (e.g. ``"h"``, ``"5min"``, ``"3s"``) and compound expressions (e.g. ``"1D1h"``) (:issue:`65395`)
 - Performance improvement in :func:`util.hash_pandas_object` for PyArrow-backed string and binary types by using PyArrow's ``dictionary_encode`` instead of converting to NumPy for factorization (:issue:`48964`)
 - Performance improvement in :meth:`.DataFrameGroupBy.agg` and :meth:`.SeriesGroupBy.agg` with user-defined functions (:issue:`46505`)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2427,7 +2427,7 @@ class ADBCDatabase(PandasSQL):
 
     def has_table(self, name: str, schema: str | None = None) -> bool:
         meta = self.con.adbc_get_objects(
-            db_schema_filter=schema, table_name_filter=name
+            depth="tables", db_schema_filter=schema, table_name_filter=name
         ).read_all()
 
         for catalog_schema in meta["catalog_db_schemas"].to_pylist():

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1104,39 +1104,6 @@ def test_to_sql_exist_fail(conn, test_frame1, request):
             pandasSQL.to_sql(test_frame1, "test_frame", if_exists="fail")
 
 
-def test_adbc_has_table_requests_table_metadata_only():
-    class FakeADBCObjects:
-        def read_all(self):
-            return self
-
-        def __getitem__(self, key):
-            assert key == "catalog_db_schemas"
-            return self
-
-        def to_pylist(self):
-            return [[{"db_schema_tables": [{"table_name": "test_frame"}]}]]
-
-    class FakeConnection:
-        def __init__(self) -> None:
-            self.calls: list[dict[str, object]] = []
-
-        def adbc_get_objects(self, **kwargs):
-            self.calls.append(kwargs)
-            return FakeADBCObjects()
-
-    con = FakeConnection()
-    pandas_sql = sql.ADBCDatabase(con)
-
-    assert pandas_sql.has_table("test_frame", schema="test_schema")
-    assert con.calls == [
-        {
-            "depth": "tables",
-            "db_schema_filter": "test_schema",
-            "table_name_filter": "test_frame",
-        }
-    ]
-
-
 @pytest.mark.parametrize("conn", all_connectable_iris)
 def test_read_iris_query(conn, request):
     conn = request.getfixturevalue(conn)

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1104,6 +1104,39 @@ def test_to_sql_exist_fail(conn, test_frame1, request):
             pandasSQL.to_sql(test_frame1, "test_frame", if_exists="fail")
 
 
+def test_adbc_has_table_requests_table_metadata_only():
+    class FakeADBCObjects:
+        def read_all(self):
+            return self
+
+        def __getitem__(self, key):
+            assert key == "catalog_db_schemas"
+            return self
+
+        def to_pylist(self):
+            return [[{"db_schema_tables": [{"table_name": "test_frame"}]}]]
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def adbc_get_objects(self, **kwargs):
+            self.calls.append(kwargs)
+            return FakeADBCObjects()
+
+    con = FakeConnection()
+    pandas_sql = sql.ADBCDatabase(con)
+
+    assert pandas_sql.has_table("test_frame", schema="test_schema")
+    assert con.calls == [
+        {
+            "depth": "tables",
+            "db_schema_filter": "test_schema",
+            "table_name_filter": "test_frame",
+        }
+    ]
+
+
 @pytest.mark.parametrize("conn", all_connectable_iris)
 def test_read_iris_query(conn, request):
     conn = request.getfixturevalue(conn)


### PR DESCRIPTION
- [x] closes #65652
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. Not applicable; no new public API was added.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This limits the ADBC `has_table` metadata lookup to `depth="tables"` so `read_sql` does not request column-level metadata while it is only deciding whether the input string is a table name.

Added a focused fake-ADBC regression test that asserts pandas requests table metadata only, plus a whatsnew entry.

Tests run:

- `/private/tmp/pandas-65652-venv/bin/python -m pytest pandas/tests/io/test_sql.py::test_adbc_has_table_requests_table_metadata_only -q`
- `/private/tmp/pandas-65652-venv/bin/python -m pytest pandas/tests/io/test_sql.py -q -k 'sqlite_adbc and (test_to_sql or test_to_sql_exist or test_to_sql_exist_fail or test_api_to_sql)'`
- `/private/tmp/pandas-65652-venv/bin/python -m ruff check pandas/io/sql.py pandas/tests/io/test_sql.py`
- `/private/tmp/pandas-65652-venv/bin/python -m ruff format --check pandas/io/sql.py pandas/tests/io/test_sql.py`
- `/private/tmp/pandas-65652-venv/bin/python -m compileall -q pandas/io/sql.py pandas/tests/io/test_sql.py`
- `git diff --check`
