### PR TITLE
DOC: Fix text visibility in dark mode for getting started data cards

### DIFF
--- a/doc/source/_static/css/getting_started.css
+++ b/doc/source/_static/css/getting_started.css
@@ -8,6 +8,7 @@
 .gs-data-title {
   align-items: center;
   font-size: 0.9rem;
+  color: var(--pst-color-text-base);
 }
 
 .gs-data-header {
@@ -16,6 +17,7 @@
 
 .gs-data-list {
   background-color: var(--pst-color-on-background);
+  color: var(--pst-color-text-base);
 }
 
 .gs-data-title .badge {


### PR DESCRIPTION
Addresses #65062.

The `.gs-data-title` and `.gs-data-list` elements in the getting started tutorials did not have an explicit text color set. In dark mode, the inherited text color from Bootstrap's card components remains dark, making the "Data used for this tutorial" text invisible against dark backgrounds.

This PR adds `color: var(--pst-color-text-base)` to both selectors, which follows the pydata-sphinx-theme convention and ensures text remains visible in both light and dark modes.