### PR TITLE
BUG: fix right-labeled CustomBusinessDay resampling

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -247,6 +247,7 @@ Datetimelike
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)
 - Bug in :func:`to_datetime` when using a low time resolution ``unit``, higher resolution in ``origin`` is now preserved instead of silently dropped (e.g. ``unit="D"`` with microsecond precision origin) (:issue:`63419`)
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``AssertionError`` instead of :class:`OutOfBoundsDatetime` when replacing with a ``datetime`` value outside the ``datetime64[ns]`` range (:issue:`61671`)
+- Bug in :meth:`DataFrame.resample` and :meth:`Series.resample` adding empty edge bins when resampling with ``closed="right"`` and ``label="right"`` using :class:`~pandas.tseries.offsets.CustomBusinessDay` (:issue:`65740`)
 - Bug in :meth:`DataFrame.to_string` and :meth:`Series.to_string` where ``na_rep`` was ignored for datetime and timedelta columns, always displaying ``NaT`` (:issue:`55426`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2698,20 +2698,26 @@ class TimeGrouper(Grouper):
     ) -> tuple[DatetimeIndex, npt.NDArray[np.int64]]:
         # Some hacks for > daily data, see #1471, #1458, #1483
 
-        if self.freq.rule_code in ("BME", "ME", "W") or self.freq.rule_code.split("-")[
-            0
-        ] in (
+        rule = self.freq.rule_code
+        rule_prefix = rule.split("-")[0]
+        adjust_to_day_end = rule in ("BME", "CBME", "ME", "W") or rule_prefix in (
             "BQE",
             "BYE",
             "QE",
+            "SME",
             "YE",
             "W",
-        ):
+        )
+
+        if rule == "C" and self.label == "right":
+            adjust_to_day_end = True
+
+        if self.closed == "right":
             # If the right end-point is on the last day of the month, roll forwards
             # until the last moment of that day. Note that we only do this for offsets
             # which correspond to the end of a super-daily period - "month start", for
             # example, is excluded.
-            if self.closed == "right":
+            if adjust_to_day_end:
                 # GH 21459, GH 9119: Adjust the bins relative to the wall time
                 edges_dti = binner.tz_localize(None)
                 edges_dti = (
@@ -2723,8 +2729,8 @@ class TimeGrouper(Grouper):
             else:
                 bin_edges = binner.asi8
 
-            # intraday values on last day
-            if bin_edges[-2] > ax_values.max():
+            # trim a trailing empty bin from right-closed grids
+            if len(bin_edges) >= 2 and bin_edges[-2] >= ax_values.max():
                 bin_edges = bin_edges[:-1]
                 binner = binner[:-1]
         else:

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -637,7 +637,7 @@ def test_resample_reresample(unit):
     s = Series(np.random.default_rng(2).random(len(dti)), dti)
     bs = s.resample("B", closed="right", label="right").mean()
     result = bs.resample("8h").mean()
-    assert len(result) == 25
+    assert len(result) == 22
     assert isinstance(result.index.freq, offsets.DateOffset)
     assert result.index.freq == offsets.Hour(8)
 
@@ -2131,6 +2131,66 @@ def test_resample_b_55282(unit):
         index=exp_dti,
     )
     tm.assert_series_equal(result, expected)
+
+
+def test_resample_custom_business_day_right_labeled_65740(unit):
+    # https://github.com/pandas-dev/pandas/issues/65740
+    cbd = offsets.CustomBusinessDay(holidays=["2022-11-24"])
+    dti = DatetimeIndex(
+        [
+            "2022-11-22",
+            "2022-11-23",
+            "2022-11-25",
+            "2022-11-28",
+            "2022-11-29",
+        ]
+    ).as_unit(unit)
+    df = DataFrame({"x": [1, 2, 3, 4, 5]}, index=dti)
+
+    result = df.resample(cbd, closed="right", label="right").last()
+
+    exp_dti = DatetimeIndex(
+        [
+            "2022-11-22",
+            "2022-11-23",
+            "2022-11-25",
+            "2022-11-28",
+            "2022-11-29",
+        ],
+        freq=cbd,
+    ).as_unit(unit)
+    expected = DataFrame({"x": [1, 2, 3, 4, 5]}, index=exp_dti)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_resample_custom_business_day_right_labeled_intraday_65740(unit):
+    # https://github.com/pandas-dev/pandas/issues/65740
+    cbd = offsets.CustomBusinessDay(holidays=["2022-11-24"])
+    dti = DatetimeIndex(
+        [
+            "2022-11-21 16:00",
+            "2022-11-22 16:00",
+            "2022-11-23 16:00",
+            "2022-11-25 16:00",
+            "2022-11-28 16:00",
+        ]
+    ).as_unit(unit)
+    df = DataFrame({"x": [1, 2, 3, 4, 5]}, index=dti)
+
+    result = df.resample(cbd, closed="right", label="right").last()
+
+    exp_dti = DatetimeIndex(
+        [
+            "2022-11-21",
+            "2022-11-22",
+            "2022-11-23",
+            "2022-11-25",
+            "2022-11-28",
+        ],
+        freq=cbd,
+    ).as_unit(unit)
+    expected = DataFrame({"x": [1, 2, 3, 4, 5]}, index=exp_dti)
+    tm.assert_frame_equal(result, expected)
 
 
 @td.skip_if_no("pyarrow")


### PR DESCRIPTION
## Summary
- trim trailing empty bins produced by right-closed resampling grids
- restore end-of-day bin-edge handling for right-labeled `CustomBusinessDay` resampling
- add regressions for both the trailing-empty-bin and intraday-shift cases from #65740

## Tests
- `python -m compileall -q pandas/core/resample.py pandas/tests/resample/test_datetime_index.py`
- `python -m ruff check pandas/core/resample.py pandas/tests/resample/test_datetime_index.py`
- `git diff --check`
- source-loaded focused harness against pandas 3.0.1 wheel:
  - `test_resample_reresample`
  - `test_resample_c_b_closed_right`
  - `test_resample_b_55282`
  - new `CustomBusinessDay` #65740 tests

Note: I could not run the normal editable pandas test target on this Windows machine because Meson could not find a C compiler (`cl`, `gcc`, `clang`, etc.).

Closes #65740
