### PR TITLE
CLN: removed unnecessary `pyright: ignore[reportUnusedImport]`

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from builtins import type as type_t  # pyright: ignore[reportUnusedImport]
+from builtins import type as type_t
 from collections.abc import (
     Callable,
     Hashable,


### PR DESCRIPTION
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

`pyright` doesn't complain about `type_t` as an unused import so this ignore is unnecessary.