### PR TITLE
PERF: Fix performance regression in ZoneInfo

### DIFF
--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -182,12 +182,6 @@ def _p_tz_cache_key(tz: tzinfo):
 # Timezone data caches, key is the pytz string or dateutil file name.
 dst_cache = {}
 
-# Cache of whether a ZoneInfo (keyed by its IANA key) is a fixed-offset zone.
-# Computing this requires constructing the pure-Python ZoneInfo to read its
-# private ``_fixed_offset`` attribute, which is comparatively expensive; the
-# answer never changes for a given key, so we memoize it.
-_zoneinfo_fixed_offset_cache = {}
-
 
 cdef object tz_cache_key(tzinfo tz):
     """
@@ -248,13 +242,11 @@ cpdef inline bint is_fixed_offset(tzinfo tz):
         else:
             return 0
     elif is_zoneinfo(tz):
-        cached = _zoneinfo_fixed_offset_cache.get(tz.key, -1)
-        if cached != -1:
-            return cached
         tz_py = _ZoneInfo(tz.key)
-        result = 1 if tz_py._fixed_offset else 0
-        _zoneinfo_fixed_offset_cache[tz.key] = result
-        return result
+        if tz_py._fixed_offset:
+            return 1
+        else:
+            return 0
     # This also implicitly accepts datetime.timezone objects which are
     # considered fixed
     return 1

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -182,6 +182,12 @@ def _p_tz_cache_key(tz: tzinfo):
 # Timezone data caches, key is the pytz string or dateutil file name.
 dst_cache = {}
 
+# Cache of whether a ZoneInfo (keyed by its IANA key) is a fixed-offset zone.
+# Computing this requires constructing the pure-Python ZoneInfo to read its
+# private ``_fixed_offset`` attribute, which is comparatively expensive; the
+# answer never changes for a given key, so we memoize it.
+_zoneinfo_fixed_offset_cache = {}
+
 
 cdef object tz_cache_key(tzinfo tz):
     """
@@ -242,11 +248,13 @@ cpdef inline bint is_fixed_offset(tzinfo tz):
         else:
             return 0
     elif is_zoneinfo(tz):
+        cached = _zoneinfo_fixed_offset_cache.get(tz.key, -1)
+        if cached != -1:
+            return cached
         tz_py = _ZoneInfo(tz.key)
-        if tz_py._fixed_offset:
-            return 1
-        else:
-            return 0
+        result = 1 if tz_py._fixed_offset else 0
+        _zoneinfo_fixed_offset_cache[tz.key] = result
+        return result
     # This also implicitly accepts datetime.timezone objects which are
     # considered fixed
     return 1

--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -120,6 +120,17 @@ def ints_to_pydatetime(
     -------
     ndarray[object] of type specified by box
     """
+    if box not in ("datetime", "timestamp", "date", "time"):
+        raise ValueError(
+            "box must be one of 'datetime', 'date', 'time' or 'timestamp'"
+        )
+    if box == "date":
+        assert (tz is None), "tz should be None when converting to date"
+
+    if stamps.size == 0:
+        # Avoid the cost of initializing Localizer when there's nothing to do.
+        return cnp.PyArray_EMPTY(stamps.ndim, stamps.shape, cnp.NPY_OBJECT, 0)
+
     cdef:
         Localizer info = Localizer(tz, creso=reso)
         int64_t utc_val, local_val
@@ -141,16 +152,11 @@ def ints_to_pydatetime(
         cnp.flatiter it = cnp.PyArray_IterNew(stamps)
 
     if box == "date":
-        assert (tz is None), "tz should be None when converting to date"
         use_date = True
     elif box == "timestamp":
         use_ts = True
     elif box == "datetime":
         use_pydt = True
-    elif box != "time":
-        raise ValueError(
-            "box must be one of 'datetime', 'date', 'time' or 'timestamp'"
-        )
 
     for i in range(n):
         # Analogous to: utc_val = stamps[i]
@@ -222,6 +228,10 @@ def get_resolution(
     ndarray stamps, tzinfo tz=None, NPY_DATETIMEUNIT reso=NPY_FR_ns
 ) -> Resolution:
     # stamps is int64_t, any ndim
+    if stamps.size == 0:
+        # Avoid the cost of initializing Localizer when there's nothing to do.
+        return Resolution(c_Resolution.RESO_DAY)
+
     cdef:
         Localizer info = Localizer(tz, creso=reso)
         int64_t utc_val, local_val
@@ -275,6 +285,10 @@ cpdef ndarray normalize_i8_timestamps(ndarray stamps, tzinfo tz, NPY_DATETIMEUNI
     -------
     result : int64 ndarray of converted of normalized nanosecond timestamps
     """
+    if stamps.size == 0:
+        # Avoid the cost of initializing Localizer when there's nothing to do.
+        return cnp.PyArray_EMPTY(stamps.ndim, stamps.shape, cnp.NPY_INT64, 0)
+
     cdef:
         Localizer info = Localizer(tz, creso=reso)
         int64_t utc_val, local_val, res_val
@@ -326,6 +340,10 @@ def is_date_array_normalized(ndarray stamps, tzinfo tz, NPY_DATETIMEUNIT reso) -
     -------
     is_normalized : bool True if all stamps are normalized
     """
+    if stamps.size == 0:
+        # Avoid the cost of initializing Localizer when there's nothing to do.
+        return True
+
     cdef:
         Localizer info = Localizer(tz, creso=reso)
         int64_t utc_val, local_val
@@ -357,6 +375,10 @@ def dt64arr_to_periodarr(
     ndarray stamps, int freq, tzinfo tz, NPY_DATETIMEUNIT reso=NPY_FR_ns
 ):
     # stamps is int64_t, arbitrary ndim
+    if stamps.size == 0:
+        # Avoid the cost of initializing Localizer when there's nothing to do.
+        return cnp.PyArray_EMPTY(stamps.ndim, stamps.shape, cnp.NPY_INT64, 0)
+
     cdef:
         Localizer info = Localizer(tz, creso=reso)
         Py_ssize_t i, n = stamps.size

--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -128,7 +128,7 @@ def ints_to_pydatetime(
         assert (tz is None), "tz should be None when converting to date"
 
     if stamps.size == 0:
-        # Avoid the cost of initializing Localizer when there's nothing to do.
+        # Avoid the cost of initializing Localizer
         return cnp.PyArray_EMPTY(stamps.ndim, stamps.shape, cnp.NPY_OBJECT, 0)
 
     cdef:
@@ -229,7 +229,7 @@ def get_resolution(
 ) -> Resolution:
     # stamps is int64_t, any ndim
     if stamps.size == 0:
-        # Avoid the cost of initializing Localizer when there's nothing to do.
+        # Avoid the cost of initializing Localizer
         return Resolution(c_Resolution.RESO_DAY)
 
     cdef:
@@ -286,7 +286,7 @@ cpdef ndarray normalize_i8_timestamps(ndarray stamps, tzinfo tz, NPY_DATETIMEUNI
     result : int64 ndarray of converted of normalized nanosecond timestamps
     """
     if stamps.size == 0:
-        # Avoid the cost of initializing Localizer when there's nothing to do.
+        # Avoid the cost of initializing Localizer
         return cnp.PyArray_EMPTY(stamps.ndim, stamps.shape, cnp.NPY_INT64, 0)
 
     cdef:
@@ -341,7 +341,7 @@ def is_date_array_normalized(ndarray stamps, tzinfo tz, NPY_DATETIMEUNIT reso) -
     is_normalized : bool True if all stamps are normalized
     """
     if stamps.size == 0:
-        # Avoid the cost of initializing Localizer when there's nothing to do.
+        # Avoid the cost of initializing Localizer
         return True
 
     cdef:
@@ -376,7 +376,7 @@ def dt64arr_to_periodarr(
 ):
     # stamps is int64_t, arbitrary ndim
     if stamps.size == 0:
-        # Avoid the cost of initializing Localizer when there's nothing to do.
+        # Avoid the cost of initializing Localizer
         return cnp.PyArray_EMPTY(stamps.ndim, stamps.shape, cnp.NPY_INT64, 0)
 
     cdef:


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/127

Adds some short-circuits to avoid construction of unnecessary objects. This doesn't fix all the benchmarks in the linked issue, but other fixes seem too heavy for the regression (all regression there are < 11us). E.g.

```python
import zoneinfo
import numpy as np
from pandas._libs.tslibs import get_resolution

zi = zoneinfo.ZoneInfo("US/Pacific")
empty = np.array([], dtype="i8")

%timeit get_resolution(empty, zi)
# 896 ns ± 5.67 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <-- main
# 235 ns ± 3.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)  <-- PR
```

No objection if even this is deemed not worth it.