### PR TITLE
BUG: assert_series_equal ignores check_series_type=False for ndarray subclass-backed Series on exact comparison path  #65770

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -684,6 +684,7 @@ def assert_numpy_array_equal(
     check_same: Literal["copy", "same"] | None = None,
     obj: str = "numpy array",
     index_values: Index | np.ndarray | None = None,
+    check_class: bool = True,
 ) -> None:
     """
     Check that 'np.ndarray' is equivalent.
@@ -710,7 +711,8 @@ def assert_numpy_array_equal(
 
     # instance validation
     # Show a detailed error message when classes are different
-    assert_class_equal(left, right, obj=obj)
+    if check_class:
+        assert_class_equal(left, right, obj=obj)
     # both classes must be an np.ndarray
     _check_isinstance(left, right, np.ndarray)
 
@@ -1126,6 +1128,7 @@ def assert_series_equal(
                 check_dtype=check_dtype,
                 obj=str(obj),
                 index_values=left.index,
+                check_class=check_series_type,
             )
     elif check_datetimelike_compat and (
         needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype)
@@ -1228,6 +1231,7 @@ def assert_frame_equal(
     check_index_type: bool | Literal["equiv"] = "equiv",
     check_column_type: bool | Literal["equiv"] = "equiv",
     check_frame_type: bool = True,
+    check_series_type: bool = True,
     check_names: bool = True,
     by_blocks: bool = False,
     check_exact: bool | lib.NoDefault = lib.no_default,
@@ -1444,7 +1448,8 @@ def assert_frame_equal(
                     atol=atol,
                     check_index=False,
                     check_flags=False,
-                )
+                    check_series_type=check_series_type,
+                     )
 
 
 def assert_equal(left: Any, right: Any, **kwargs: Any) -> None:

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1451,7 +1451,7 @@ def assert_frame_equal(
                     check_index=False,
                     check_flags=False,
                     check_series_type=check_series_type,
-                     )
+                )
 
 
 def assert_equal(left: Any, right: Any, **kwargs: Any) -> None:

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -706,6 +706,8 @@ def assert_numpy_array_equal(
         assertion message.
     index_values : Index | numpy.ndarray, default None
         optional index (shared by both left and right), used in output.
+        check_class : bool, default True
+        Whether to check that left and right are the same class
     """
     __tracebackhide__ = True
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1271,6 +1271,8 @@ def assert_frame_equal(
         :func:`assert_index_equal`.
     check_frame_type : bool, default True
         Whether to check the DataFrame class is identical.
+    check_series_type : bool, default True
+        Whether to check that each column Series class is identical.
     check_names : bool, default True
         Whether to check that the `names` attribute for both the `index`
         and `column` attributes of the DataFrame is identical.


### PR DESCRIPTION
Here you go:

---

Title

BUG: assert_series_equal fails with ndarray subclass when check_series_type=False

---

Description

Closes #65770

Problem

pd.testing.assert_series_equal raised an AssertionError when comparing two Series that had the same values, dtype, and index but one was backed by a plain np.ndarray and the other by an np.ndarray subclass, even when check_series_type=False was passed.

This happened because inside assert_numpy_array_equal, the function assert_class_equal was called unconditionally with no way for check_series_type=False to flow down and skip it.

The error message was also misleading. It said "Series classes are different" but was actually showing the backing array classes like ndarray vs OtherArray, not the Series classes.

```
Reproduction

import pandas as pd
import numpy as np

class OtherArray(np.ndarray):
    pass

arr = np.array([1])
left = pd.Series(arr)
right = pd.Series(arr.view(OtherArray))

assert left.equals(right)
pd.testing.assert_series_equal(left, right, check_series_type=False)
```

What I Did To Fix It

1. Added a check_class parameter to assert_numpy_array_equal with default True for backward compatibility

2. Made assert_class_equal conditional on check_class inside assert_numpy_array_equal

3. Passed check_class=check_series_type when calling assert_numpy_array_equal inside assert_series_equal so the flag properly propagates down

4. Added check_series_type parameter to assert_frame_equal and passed it down to assert_series_equal so DataFrame column comparisons are also fixed