### PR TITLE
BUG: to_dict(orient='index') ignores into for nested mappings

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -280,6 +280,7 @@ Conversion
 - Bug in :class:`DataFrame` constructor where ``NaT`` in a :class:`TimedeltaIndex` row was incorrectly inferred as ``datetime64`` instead of ``timedelta64`` (:issue:`23985`)
 - Bug in :class:`DataFrame` constructor where constructing from a list of uniform-dtype arrays (e.g. pyarrow, :class:`CategoricalDtype`, nullable dtypes) lost the dtype (:issue:`49593`)
 - Bug in :func:`pd.array` silently converting NaN to a nonsensical integer when given float data containing NaN and a NumPy integer dtype (:issue:`41724`)
+- Bug in :meth:`DataFrame.to_dict` with ``orient="index"`` not applying the ``into`` mapping type to the nested per-row mappings, which were always returned as plain ``dict`` (:issue:`65778`)
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`).
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 

--- a/pandas/core/methods/to_dict.py
+++ b/pandas/core/methods/to_dict.py
@@ -261,9 +261,7 @@ def to_dict(
             return into_c(
                 (
                     t[0],
-                    into_c(
-                        zip(df.columns, map(maybe_box_native, t[1:]), strict=True)
-                    ),
+                    into_c(zip(df.columns, map(maybe_box_native, t[1:]), strict=True)),
                 )
                 for t in df.itertuples(name=None)
             )

--- a/pandas/core/methods/to_dict.py
+++ b/pandas/core/methods/to_dict.py
@@ -259,7 +259,12 @@ def to_dict(
         columns = df.columns.tolist()
         if are_all_object_dtype_cols:
             return into_c(
-                (t[0], dict(zip(df.columns, map(maybe_box_native, t[1:]), strict=True)))
+                (
+                    t[0],
+                    into_c(
+                        zip(df.columns, map(maybe_box_native, t[1:]), strict=True)
+                    ),
+                )
                 for t in df.itertuples(name=None)
             )
         elif box_native_indices:
@@ -267,20 +272,23 @@ def to_dict(
             return into_c(
                 (
                     t[0],
-                    {
-                        column: maybe_box_native(v)
-                        if i in object_dtype_indices_as_set
-                        else v
+                    into_c(
+                        (
+                            column,
+                            maybe_box_native(v)
+                            if i in object_dtype_indices_as_set
+                            else v,
+                        )
                         for i, (column, v) in enumerate(
                             zip(columns, t[1:], strict=True)
                         )
-                    },
+                    ),
                 )
                 for t in df.itertuples(name=None)
             )
         else:
             return into_c(
-                (t[0], dict(zip(columns, t[1:], strict=True)))
+                (t[0], into_c(zip(columns, t[1:], strict=True)))
                 for t in df.itertuples(name=None)
             )
 

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -271,6 +271,24 @@ class TestDataFrameToDict:
         expected = DataFrame.from_dict(expected, orient="index")[cols]
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("into", [OrderedDict, defaultdict(dict)])
+    @pytest.mark.parametrize(
+        "df",
+        [
+            DataFrame({"A": [1, 2], "B": ["x", "y"]}),  # mixed dtypes
+            DataFrame({"A": ["p", "q"], "B": ["x", "y"]}),  # all object dtypes
+            DataFrame({"A": [1, 2], "B": [3, 4]}),  # all numeric dtypes
+        ],
+    )
+    def test_to_dict_index_nested_into(self, df, into):
+        # GH#65778
+        # orient="index" must apply ``into`` to the nested row mappings too
+        result = df.to_dict(orient="index", into=into)
+        expected_type = type(into) if isinstance(into, defaultdict) else into
+        assert isinstance(result, expected_type)
+        for row in result.values():
+            assert isinstance(row, expected_type)
+
     def test_to_dict_numeric_names(self):
         # GH#24940
         df = DataFrame({str(i): [i] for i in range(5)})


### PR DESCRIPTION
Fixes #65778

`DataFrame.to_dict(orient="index", into=...)` applied the `into` mapping type to the outer mapping but built the nested per-row mappings with a plain `dict`. The `dict` and `records` orients already wrap their nested mappings with the standardized `into` type, so `orient="index"` was inconsistent and contradicted the `into` docstring, which says it applies to all Mappings in the return value.

This wraps the three nested-mapping constructions in the `orient="index"` branch with `into_c`, mirroring the `records` orient. The `tight` and `split` orients are unaffected since their nested structures are lists, not mappings.

Added a regression test parametrized over OrderedDict and defaultdict across the three dtype paths, plus a whatsnew entry.
