### PR TITLE
BUG: HDFStore.select bus error on strict-alignment platforms (GH-54396)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -354,6 +354,7 @@ I/O
 - Fixed bug in :func:`read_hdf` where the literal string ``"nan"`` in a string :class:`Index` was incorrectly converted to ``NaN`` on read, even when a custom ``nan_rep`` was supplied (:issue:`9604`)
 - Fixed bug in :meth:`DataFrame.to_hdf` with ``format="table"`` where a :class:`TimedeltaIndex` was reconstructed as a :class:`PeriodIndex` (when ``freq`` was set) or an integer :class:`Index` (otherwise) on read-back (:issue:`21466`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
+- Fixed bug in :meth:`HDFStore.select` with ``format="table"`` where reading a frame with a string :class:`Index` could crash with a bus error on strict-alignment platforms such as 32-bit ARM (:issue:`54396`)
 - Storing a :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` level named ``'index'`` via :meth:`HDFStore.put` or :meth:`HDFStore.append` with ``format='table'`` now raises a clear ``ValueError`` instead of an opaque reshape error (:issue:`6208`)
 
 Period

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2842,11 +2842,8 @@ class DataCol(IndexCol):
         if values.dtype.fields is not None:
             values = values[self.cname]
             if not values.flags["ALIGNED"]:
-                # GH#54396: PyTables packs compound types, so a field that
-                # follows an odd-width field (e.g. a string index) can be
-                # byte-unaligned. take and other kernels assume aligned
-                # buffers and SIGBUS on strict-alignment platforms (e.g.
-                # 32-bit ARM); copy to realign.
+                # GH#54396 copy to realign; unaligned buffers SIGBUS
+                #  on strict-alignment platforms (e.g. 32-bit ARM)
                 values = values.copy()
 
         assert self.typ is not None

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2841,6 +2841,13 @@ class DataCol(IndexCol):
         # values is a recarray
         if values.dtype.fields is not None:
             values = values[self.cname]
+            if not values.flags["ALIGNED"]:
+                # GH#54396: PyTables packs compound types, so a field that
+                # follows an odd-width field (e.g. a string index) can be
+                # byte-unaligned. take and other kernels assume aligned
+                # buffers and SIGBUS on strict-alignment platforms (e.g.
+                # 32-bit ARM); copy to realign.
+                values = values.copy()
 
         assert self.typ is not None
         if self.dtype is None:

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -883,10 +883,8 @@ def test_select_filter_corner(temp_hdfstore):
 
 
 def test_select_string_index_aligned(temp_hdfstore):
-    # GH#54396: PyTables packs compound types, so a float64 values block that
-    # follows an odd-width string-index field is byte-unaligned. The read-back
-    # block must be realigned, otherwise take/other kernels SIGBUS on
-    # strict-alignment platforms (e.g. 32-bit ARM).
+    # GH#54396 string index -> byte-unaligned values block; the read-back
+    #  block must be realigned to avoid SIGBUS on strict-alignment platforms
     df = DataFrame(np.random.default_rng(2).standard_normal((10, 4)))
     df.index = [f"{c:3d}" for c in df.index]
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -882,6 +882,21 @@ def test_select_filter_corner(temp_hdfstore):
     tm.assert_frame_equal(result, df.loc[:, df.columns[:75:2]])
 
 
+def test_select_string_index_aligned(temp_hdfstore):
+    # GH#54396: PyTables packs compound types, so a float64 values block that
+    # follows an odd-width string-index field is byte-unaligned. The read-back
+    # block must be realigned, otherwise take/other kernels SIGBUS on
+    # strict-alignment platforms (e.g. 32-bit ARM).
+    df = DataFrame(np.random.default_rng(2).standard_normal((10, 4)))
+    df.index = [f"{c:3d}" for c in df.index]
+
+    temp_hdfstore.put("frame", df, format="table", track_times=False)
+    result = temp_hdfstore.select("frame")
+    tm.assert_frame_equal(result, df)
+    for blk in result._mgr.blocks:
+        assert blk.values.flags["ALIGNED"]
+
+
 def test_path_pathlib(temp_h5_path):
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),


### PR DESCRIPTION
closes #54396

PyTables stores HDF5 compound types **packed** (no inter-field padding). When a frame's index serializes to an odd-width leading field (e.g. a string `Index` → `S3`), the `float64` `values_block_*` field lands at an unaligned byte offset:

```
[('index', 'S3'), ('values_block_0', '<f8', (100,))]   # values_block_0 at byte offset 3
```

`DataCol.convert` extracted that field as a numpy **view** (no copy), so the unaligned buffer (`ALIGNED=False`, `ptr % 8 == 3`) propagated all the way into the result `DataFrame`'s block. A subsequent boolean `.loc` filter calls the Cython `take_2d` kernel, which does raw 8-byte `float64` loads via pointer arithmetic. On x86 those unaligned loads just work; on strict-alignment **32-bit ARM** (AArch32 `LDRD`/`VLDR.64`) they alignment-fault → **SIGBUS**, matching the odd addresses in the reporter's UBSAN trace. The sibling `IndexCol.convert` already copies, which is why only the data block crashed.

The fix realigns the extracted field with a copy, but only when it is actually unaligned. Int/Datetime-index tables put the float block at offset 8 (already aligned), so the common path is unchanged — the copy only fires for the rarer unaligned layouts.

The new regression test is platform-independent: it asserts the read-back block is aligned, which fails on `main` and passes here, so no ARM hardware is needed to guard against this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
