### PR TITLE
BUG: read_hdf of categorical column with a category equal to nan_rep

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -351,6 +351,7 @@ I/O
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 - :meth:`DataFrame.to_hdf` now raises a clear :class:`NotImplementedError` when writing a column or :class:`Index` of an unsupported extension dtype (such as :class:`IntervalDtype`, :class:`SparseDtype`, or the nullable integer/float/boolean dtypes), instead of a low-level ``AttributeError`` or PyTables ``TypeError`` (:issue:`26144`, :issue:`38305`, :issue:`42070`)
 - Fixed ``MemoryError`` in :meth:`HDFStore.select` when iterating large tables with ``chunksize`` and no ``where`` filter (:issue:`15937`)
+- Fixed bug in :func:`read_hdf` where a categorical column containing a category equal to the ``nan_rep`` string (e.g. the default ``"nan"``) raised ``ValueError: operands could not be broadcast together`` instead of reading that category back as ``NaN`` (:issue:`21741`)
 - Fixed bug in :func:`read_hdf` where the literal string ``"nan"`` in a string :class:`Index` was incorrectly converted to ``NaN`` on read, even when a custom ``nan_rep`` was supplied (:issue:`9604`)
 - Fixed bug in :meth:`DataFrame.to_hdf` with ``format="table"`` where a :class:`TimedeltaIndex` was reconstructed as a :class:`PeriodIndex` (when ``freq`` was set) or an integer :class:`Index` (otherwise) on read-back (:issue:`21466`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2912,12 +2912,9 @@ class DataCol(IndexCol):
             else:
                 mask = isna(categories)
                 if mask.any():
-                    # Some categories are NaN, e.g. because the string used
-                    # as nan_rep was itself a genuine category and got
-                    # converted back to NaN on read. Drop those categories,
-                    # remap codes that pointed at a surviving category to its
-                    # new position, and treat codes that pointed at a dropped
-                    # (NaN) category as missing (-1). GH#21741
+                    # A category can be NaN if the nan_rep string was itself
+                    # a genuine category on write. Drop NaN categories and
+                    # remap the codes. GH#21741
                     remap = np.full(len(categories), -1, dtype=codes.dtype)
                     remap[~mask] = np.arange((~mask).sum(), dtype=codes.dtype)
                     categories = categories[~mask]

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2912,8 +2912,16 @@ class DataCol(IndexCol):
             else:
                 mask = isna(categories)
                 if mask.any():
+                    # Some categories are NaN, e.g. because the string used
+                    # as nan_rep was itself a genuine category and got
+                    # converted back to NaN on read. Drop those categories,
+                    # remap codes that pointed at a surviving category to its
+                    # new position, and treat codes that pointed at a dropped
+                    # (NaN) category as missing (-1). GH#21741
+                    remap = np.full(len(categories), -1, dtype=codes.dtype)
+                    remap[~mask] = np.arange((~mask).sum(), dtype=codes.dtype)
                     categories = categories[~mask]
-                    codes[codes != -1] -= mask.astype(int).cumsum()._values
+                    codes = np.where(codes < 0, codes, remap[codes])
 
             converted = Categorical.from_codes(
                 codes, categories=categories, ordered=ordered, validate=False

--- a/pandas/tests/io/pytables/test_categorical.py
+++ b/pandas/tests/io/pytables/test_categorical.py
@@ -173,6 +173,22 @@ def test_categorical_nan_only_columns(temp_h5_path):
     tm.assert_frame_equal(result, expected)
 
 
+def test_categorical_nan_rep_collision(temp_h5_path):
+    # GH#21741 - a category equal to the default nan_rep ("nan") used to
+    # raise a broadcasting ValueError on read. It should instead be read
+    # back as NaN, with the surviving codes renumbered correctly.
+    df = DataFrame(
+        {"A": Series(["aaa", "nan", "bbb", "aaa", "zzz", "bbb"]).astype("category")}
+    )
+    df.to_hdf(temp_h5_path, key="df", format="table")
+    result = read_hdf(temp_h5_path, key="df")
+
+    expected = DataFrame(
+        {"A": Series(["aaa", np.nan, "bbb", "aaa", "zzz", "bbb"]).astype("category")}
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize("where, expected", [["q", []], ["a", ["a"]]])
 def test_convert_value(temp_h5_path, where: str, expected):
     # GH39420


### PR DESCRIPTION
closes #21741

When a `format="table"` HDF5 file is read back, a categorical column's categories are decoded using `nan_rep` (default `"nan"`). If `"nan"` was a genuine category string, it becomes an actual `NaN` category that must be stripped. The stripping code subtracted a per-*category* cumsum from the per-*row* `codes` array:

```python
codes[codes != -1] -= mask.astype(int).cumsum()._values
```

These two arrays only line up by accident, so reading raised `ValueError: operands could not be broadcast together` whenever `#rows != #categories`, and silently mis-mapped codes when they happened to match. It also never mapped codes pointing at the dropped `NaN` category to `-1`.

Replaced with an explicit old→new code remap: surviving categories are renumbered to their compacted positions, and codes that pointed at the dropped `NaN` category map to `-1` (missing).

Note the `'nan'`-string → `NaN` conversion itself is the long-standing `nan_rep` collision (writing with a different `nan_rep` avoids it, see GH-9604); this PR only makes the read non-crashing and correct rather than changing that lossy write behavior.