### PR TITLE
BUG: clearer error for HDFStore data column named 'index' (GH-41437)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -355,6 +355,7 @@ I/O
 - Fixed bug in :meth:`DataFrame.to_hdf` with ``format="table"`` where a :class:`TimedeltaIndex` was reconstructed as a :class:`PeriodIndex` (when ``freq`` was set) or an integer :class:`Index` (otherwise) on read-back (:issue:`21466`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 - Storing a :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` level named ``'index'`` via :meth:`HDFStore.put` or :meth:`HDFStore.append` with ``format='table'`` now raises a clear ``ValueError`` instead of an opaque reshape error (:issue:`6208`)
+- Writing a :class:`DataFrame` with ``format='table'`` and a column named ``'index'`` as a ``data_columns`` entry (including ``data_columns=True``) now raises a clear ``ValueError`` instead of an opaque reshape error (:issue:`41437`)
 
 Period
 ^^^^^^

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -4410,6 +4410,16 @@ class Table(Fixed):
             data_columns, min_itemsize, new_non_index_axes
         )
 
+        if new_index.cname in data_columns:
+            # GH#41437 the implicit row index is stored under the reserved
+            # cname (typically 'index') and a data column of the same name
+            # would collide with it in the table description.
+            raise ValueError(
+                f"cannot use a column named {new_index.cname!r} as a "
+                f"data_column; {new_index.cname!r} is reserved for the "
+                "implicit row index"
+            )
+
         frame = self.get_object(obj, transposed)._consolidate()
 
         blocks, blk_items = self._get_blocks_and_items(

--- a/pandas/tests/io/pytables/test_errors.py
+++ b/pandas/tests/io/pytables/test_errors.py
@@ -17,6 +17,7 @@ from pandas import (
     date_range,
     read_hdf,
 )
+import pandas._testing as tm
 
 from pandas.io.pytables import (
     Term,
@@ -272,6 +273,32 @@ def test_to_hdf_multiindex_level_named_index_raises(temp_hdfstore):
     series = Series([1, 2, 3], index=mi, name="vals")
     with pytest.raises(ValueError, match=msg):
         temp_hdfstore.put("s", series, format="table", track_times=False)
+
+
+@pytest.mark.parametrize("data_columns", [["index"], True, ["column_1", "index"]])
+def test_to_hdf_data_column_named_index_raises(temp_hdfstore, data_columns):
+    # GH#41437 a data column named 'index' collides with the table format's
+    # implicit row index; surface a clear error instead of the confusing
+    # reshape failure that used to come from write_data
+    df = DataFrame({"column_1": [1, 2], "index": [3, 4]})
+    df.index.name = "something_else"
+    msg = "cannot use a column named 'index' as a data_column"
+    with pytest.raises(ValueError, match=msg):
+        temp_hdfstore.put(
+            "df", df, format="table", data_columns=data_columns, track_times=False
+        )
+    with pytest.raises(ValueError, match=msg):
+        temp_hdfstore.append("df", df, format="table", data_columns=data_columns)
+
+
+def test_to_hdf_column_named_index_without_data_columns(temp_h5_path):
+    # GH#41437 a column named 'index' is fine as long as it is not a
+    # data_column; it round-trips like any other column
+    df = DataFrame({"column_1": [1, 2], "index": [3, 4]})
+    df.index.name = "something_else"
+    df.to_hdf(temp_h5_path, key="df", format="table")
+    result = read_hdf(temp_h5_path, "df")
+    tm.assert_frame_equal(result, df)
 
 
 def test_unsupported_hdf_file_error(datapath):


### PR DESCRIPTION
closes #41437

Writing a `DataFrame` with `format='table'` and a column named `'index'` as a `data_columns` entry (including `data_columns=True`) raised an opaque `IndexError: tuple index out of range` from deep inside `write_data`.

The implicit row index is stored under the reserved cname `'index'`, so a data column of the same name collides with it in the table description dict. The duplicate key silently dropped a column, leaving `self.dtype.names` one entry short and overrunning during the reshape.

This is the single-index analogue of GH-6208 (a `MultiIndex` level named `'index'`), which already raises a clear error. This PR raises a parallel `ValueError` instead:

```
cannot use a column named 'index' as a data_column; 'index' is reserved for the implicit row index
```

A plain (non-data) column named `'index'` is unaffected and still round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)