### PR TITLE
BUG: to_hdf PerformanceWarning names columns that are not mixed (GH-28460)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -355,6 +355,7 @@ I/O
 - Fixed bug in :meth:`DataFrame.to_hdf` with ``format="table"`` where a :class:`TimedeltaIndex` was reconstructed as a :class:`PeriodIndex` (when ``freq`` was set) or an integer :class:`Index` (otherwise) on read-back (:issue:`21466`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 - Storing a :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` level named ``'index'`` via :meth:`HDFStore.put` or :meth:`HDFStore.append` with ``format='table'`` now raises a clear ``ValueError`` instead of an opaque reshape error (:issue:`6208`)
+- The :class:`~pandas.errors.PerformanceWarning` emitted by :meth:`DataFrame.to_hdf` for object columns now names only the columns that cannot be mapped to a c-type, instead of every object column sharing the same block (:issue:`28460`)
 
 Period
 ^^^^^^

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3504,6 +3504,16 @@ class GenericFixed(Fixed):
                 elif inferred_type == "string":
                     pass
                 elif config["mode"]["performance_warnings"]:
+                    # GH#28460 a single object block may hold several columns;
+                    #  only flag the ones that are not plain strings, since a
+                    #  string-only column would not warn on its own.
+                    if value.ndim == 2 and items is not None:
+                        block = cast("np.ndarray", value)
+                        mask = [
+                            not lib.is_string_array(block[:, j], skipna=False)
+                            for j in range(block.shape[1])
+                        ]
+                        items = items[mask]
                     ws = performance_doc % (inferred_type, key, items)
                     warnings.warn(ws, PerformanceWarning, stacklevel=find_stack_level())
 

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -219,6 +219,24 @@ def test_put_mixed_type(temp_hdfstore, performance_warning, using_infer_string):
     tm.assert_frame_equal(expected, df)
 
 
+def test_put_mixed_object_block_warns_only_non_string_columns(temp_hdfstore):
+    # GH#28460 when several object columns are consolidated into one block,
+    #  the PerformanceWarning must name only the columns that are not plain
+    #  strings; a string-only column would not warn on its own.
+    df = DataFrame(
+        {"string": ["a", "b"], "number": [1.0, 2.0], "mix": ["a", 2.0]}
+    ).astype({"string": object, "mix": object})
+
+    with tm.assert_produces_warning(
+        pd.errors.PerformanceWarning, match=r"items->Index\(\['mix'\]"
+    ) as record:
+        temp_hdfstore.put("df", df, track_times=False)
+
+    messages = " ".join(str(warning.message) for warning in record)
+    assert "'mix'" in messages
+    assert "'string'" not in messages
+
+
 def test_put_str_frame(temp_hdfstore, performance_warning, string_dtype_arguments):
     # https://github.com/pandas-dev/pandas/pull/60663
     dtype = pd.StringDtype(*string_dtype_arguments)

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -229,12 +229,8 @@ def test_put_mixed_object_block_warns_only_non_string_columns(temp_hdfstore):
 
     with tm.assert_produces_warning(
         pd.errors.PerformanceWarning, match=r"items->Index\(\['mix'\]"
-    ) as record:
+    ):
         temp_hdfstore.put("df", df, track_times=False)
-
-    messages = " ".join(str(warning.message) for warning in record)
-    assert "'mix'" in messages
-    assert "'string'" not in messages
 
 
 def test_put_str_frame(temp_hdfstore, performance_warning, string_dtype_arguments):


### PR DESCRIPTION
closes #28460

When `DataFrame.to_hdf` writes the fixed format, same-dtype columns are consolidated into a single block. For object blocks the `PerformanceWarning` inferred the dtype of the *whole* block, so if any column was non-string the block inferred as `mixed` and **every** column in the block was listed in the message — including pure-string columns that, written on their own, take the `inferred_type == "string"` branch and emit no warning.

This infers per column on the warning path and lists only the columns that are not plain strings (using `lib.is_string_array` rather than `lib.infer_dtype`).

Note the pandas-3.0 string dtype default already mitigates the issue's canonical example — a plain string column now gets its own `str`-dtype block and the dedicated VLArray write path, so it is never falsely flagged. The bug remains reachable whenever multiple genuine object columns share a block (forced `astype(object)`, or `future.infer_string=False`), and becomes obsolete once object string columns are gone (GH-8640).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
