### PR TITLE
BUG: HDFStore.select where query on categorical column matched NaN rows (GH-22977)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -350,6 +350,7 @@ I/O
 - Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)
 - :meth:`DataFrame.to_hdf` now raises a clear :class:`NotImplementedError` when writing a column or :class:`Index` of an unsupported extension dtype (such as :class:`IntervalDtype`, :class:`SparseDtype`, or the nullable integer/float/boolean dtypes), instead of a low-level ``AttributeError`` or PyTables ``TypeError`` (:issue:`26144`, :issue:`38305`, :issue:`42070`)
+- Bug in :meth:`HDFStore.select` where a ``where`` query on a categorical data column for a value that is not one of the categories incorrectly matched rows with missing (``NaN``) values (:issue:`22977`)
 - Fixed ``MemoryError`` in :meth:`HDFStore.select` when iterating large tables with ``chunksize`` and no ``where`` filter (:issue:`15937`)
 - Fixed bug in :func:`read_hdf` where the literal string ``"nan"`` in a string :class:`Index` was incorrectly converted to ``NaN`` on read, even when a custom ``nan_rep`` was supplied (:issue:`9604`)
 - Fixed bug in :meth:`DataFrame.to_hdf` with ``format="table"`` where a :class:`TimedeltaIndex` was reconstructed as a :class:`PeriodIndex` (when ``freq`` was set) or an integer :class:`Index` (otherwise) on read-back (:issue:`21466`)

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -250,7 +250,15 @@ class BinOp(ops.BinOp):
             metadata = extract_array(self.metadata, extract_numpy=True)
             result: npt.NDArray[np.intp] | np.intp | int
             if conv_val not in metadata:
-                result = -1
+                # GH#22977 the queried value is not one of the categories. In
+                # memory Categorical._cmp_method routes this through
+                # ops.invalid_comparison (== matches nothing, != matches
+                # everything). We reproduce that here as a condition on the
+                # stored codes: -2 can never equal a real code, and crucially is
+                # distinct from the -1 code marking missing (NaN) values, so the
+                # query does not incorrectly match NaN rows. -2 always fits the
+                # signed codes dtype (which holds -1 by construction).
+                result = -2
             else:
                 # Find the index of the first match of conv_val in metadata
                 result = np.flatnonzero(metadata == conv_val)[0]

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -264,14 +264,8 @@ class BinOp(ops.BinOp):
             metadata = extract_array(self.metadata, extract_numpy=True)
             result: npt.NDArray[np.intp] | np.intp | int
             if conv_val not in metadata:
-                # GH#22977 the queried value is not one of the categories. In
-                # memory Categorical._cmp_method routes this through
-                # ops.invalid_comparison (== matches nothing, != matches
-                # everything). We reproduce that here as a condition on the
-                # stored codes: -2 can never equal a real code, and crucially is
-                # distinct from the -1 code marking missing (NaN) values, so the
-                # query does not incorrectly match NaN rows. -2 always fits the
-                # signed codes dtype (which holds -1 by construction).
+                # GH#22977 value is not a category; use -2 as a code that
+                # matches no row, unlike -1 which is the code for NaN values.
                 result = -2
             else:
                 # Find the index of the first match of conv_val in metadata

--- a/pandas/tests/io/pytables/test_categorical.py
+++ b/pandas/tests/io/pytables/test_categorical.py
@@ -202,3 +202,23 @@ def test_categorical_select_non_sorted_categories(temp_h5_path):
 
     expected = df[df["col1"] == "a"]
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "where, mask",
+    [
+        ('col == "z"', lambda col: col == "z"),
+        ('col in ["z", "y"]', lambda col: col.isin(["z", "y"])),
+        ('col in ["a", "z"]', lambda col: col.isin(["a", "z"])),
+        ('col != "z"', lambda col: col != "z"),
+    ],
+)
+def test_categorical_where_non_category_with_nan(temp_h5_path, where, mask):
+    # GH#22977 - querying for a value that is not one of the categories must
+    # not match NaN rows (whose code is also -1)
+    df = DataFrame({"col": Categorical(["a", "b", np.nan, "a"])})
+    df.to_hdf(temp_h5_path, key="df", format="table", data_columns=["col"])
+
+    result = read_hdf(temp_h5_path, "df", where=where)
+    expected = df[mask(df["col"])]
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #22977

A `where` query on a categorical data column for a value that is **not one of the categories** was translated to the code `-1` — which is also the sentinel code pandas uses for missing (`NaN`) values. As a result the query incorrectly matched `NaN` rows the user never requested (and, symmetrically, dropped them from `!=` queries).

```python
df = pd.DataFrame({"col": pd.Categorical(["a", "b", np.nan, "a"])})
df.to_hdf(path, key="df", format="table", data_columns=["col"])

pd.read_hdf(path, "df", where='col == "z"')   # "z" not a category
# before: returns the NaN row
# after:  empty, matching `df[df["col"] == "z"]`
```

The exact example in the issue was already addressed by GH-57608 / GH-39420; this fixes the remaining manifestation when the categorical column contains missing values. A non-category value is now mapped to a sentinel distinct from `-1`, so such a query matches no rows for `==`/`in` and all rows for `!=`, matching in-memory `Categorical` comparison semantics (`ops.invalid_comparison`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
