### PR TITLE
BUG: fixed-format HDFStore storer shape reports phantom row for empty objects

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -353,6 +353,7 @@ I/O
 - Fixed ``MemoryError`` in :meth:`HDFStore.select` when iterating large tables with ``chunksize`` and no ``where`` filter (:issue:`15937`)
 - Fixed bug in :func:`read_hdf` where the literal string ``"nan"`` in a string :class:`Index` was incorrectly converted to ``NaN`` on read, even when a custom ``nan_rep`` was supplied (:issue:`9604`)
 - Fixed bug in :meth:`DataFrame.to_hdf` with ``format="table"`` where a :class:`TimedeltaIndex` was reconstructed as a :class:`PeriodIndex` (when ``freq`` was set) or an integer :class:`Index` (otherwise) on read-back (:issue:`21466`)
+- Fixed bug in :meth:`HDFStore.get_storer` where ``.shape`` reported a phantom row for a fixed-format :class:`Series` or :class:`DataFrame` stored with no rows (:issue:`37235`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 - Storing a :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` level named ``'index'`` via :meth:`HDFStore.put` or :meth:`HDFStore.append` with ``format='table'`` now raises a clear ``ValueError`` instead of an opaque reshape error (:issue:`6208`)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3571,7 +3571,12 @@ class SeriesFixed(GenericFixed):
     @property
     def shape(self) -> tuple[int] | None:
         try:
-            return (len(self.group.values),)
+            node = self.group.values
+            if "shape" in node._v_attrs:
+                # GH#37235 an empty array is stored as a length-1 sentinel
+                # (see write_array_empty); the true shape is in this attr.
+                return tuple(node._v_attrs.shape)
+            return (len(node),)
         except (TypeError, AttributeError):
             return None
 
@@ -3632,9 +3637,17 @@ class BlockManagerFixed(GenericFixed):
 
             # data shape
             node = self.group.block0_values
-            shape = getattr(node, "shape", None)
-            if shape is not None:
-                shape = list(shape[0 : (ndim - 1)])
+            data_shape: tuple[Any, ...] | None
+            if "shape" in node._v_attrs:
+                # GH#37235 an empty block is stored un-transposed as a
+                # (1,)*ndim sentinel (see write_array_empty), with the true
+                # shape in this attr. Reverse it to match the transposed
+                # layout used for non-empty blocks.
+                data_shape = tuple(reversed(node._v_attrs.shape))
+            else:
+                data_shape = getattr(node, "shape", None)
+            if data_shape is not None:
+                shape = list(data_shape[0 : (ndim - 1)])
             else:
                 shape = []
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -172,6 +172,22 @@ def test_repr_get_storer(temp_hdfstore):
     str(s)
 
 
+@pytest.mark.parametrize(
+    "obj, expected",
+    [
+        (DataFrame(range(10)).iloc[:0], [0, 1]),
+        (DataFrame(np.zeros((5, 3))).iloc[:0], [0, 3]),
+        (DataFrame({"a": np.arange(5), "b": np.arange(5.0)}).iloc[:0], [0, 2]),
+        (Series(range(10), dtype="int64").iloc[:0], (0,)),
+    ],
+)
+def test_get_storer_shape_empty(temp_hdfstore, obj, expected):
+    # GH#37235 fixed-format storer reported a phantom length-1 axis for
+    # objects with no rows
+    temp_hdfstore.put("obj", obj, format="fixed", track_times=False)
+    assert temp_hdfstore.get_storer("obj").shape == expected
+
+
 def test_contains(temp_hdfstore):
     store = temp_hdfstore
     store["a"] = Series(

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -175,10 +175,13 @@ def test_repr_get_storer(temp_hdfstore):
 @pytest.mark.parametrize(
     "obj, expected",
     [
-        (DataFrame(range(10)).iloc[:0], [0, 1]),
-        (DataFrame(np.zeros((5, 3))).iloc[:0], [0, 3]),
-        (DataFrame({"a": np.arange(5), "b": np.arange(5.0)}).iloc[:0], [0, 2]),
-        (Series(range(10), dtype="int64").iloc[:0], (0,)),
+        (DataFrame(np.zeros((0, 1), dtype=np.int64)), [0, 1]),
+        (DataFrame(np.zeros((0, 3))), [0, 3]),
+        (
+            DataFrame({"a": Series(dtype=np.int64), "b": Series(dtype=np.float64)}),
+            [0, 2],
+        ),
+        (Series(dtype=np.int64), (0,)),
     ],
 )
 def test_get_storer_shape_empty(temp_hdfstore, obj, expected):


### PR DESCRIPTION
closes #37235

`HDFStore.get_storer(...).shape` returned `(1, N)` for a fixed-format `Series` or `DataFrame` stored with zero rows, instead of `(0, N)`.

Empty arrays are written *un-transposed* as a `(1,)*ndim` sentinel placeholder (see `write_array_empty`), with the true shape stashed in the `_v_attrs.shape` attribute — while non-empty arrays are stored transposed with their real shape on disk. `SeriesFixed.shape` and `BlockManagerFixed.shape` read the on-disk sentinel and never consulted `_v_attrs.shape`, so they reported the phantom length-1 axis.

Both properties now detect the empty sentinel (the same `_v_attrs.shape` marker `read_array`/`read_index_node` already rely on) and use the true stored shape, reversing it in the block-manager case to match the transposed layout used for non-empty blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)