### PR TITLE
BUG: Apply into parameter to nested mappings in DataFrame.to_dict(orient="index")

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -223,6 +223,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
+- Bug in :meth:`DataFrame.to_dict` with ``orient="index"`` not applying the ``into`` parameter to nested row mappings (:issue:`65778`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/methods/to_dict.py
+++ b/pandas/core/methods/to_dict.py
@@ -259,7 +259,12 @@ def to_dict(
         columns = df.columns.tolist()
         if are_all_object_dtype_cols:
             return into_c(
-                (t[0], dict(zip(df.columns, map(maybe_box_native, t[1:]), strict=True)))
+                (
+                    t[0],
+                    into_c(
+                        zip(df.columns, map(maybe_box_native, t[1:]), strict=True)
+                    ),
+                )
                 for t in df.itertuples(name=None)
             )
         elif box_native_indices:
@@ -267,20 +272,26 @@ def to_dict(
             return into_c(
                 (
                     t[0],
-                    {
-                        column: maybe_box_native(v)
-                        if i in object_dtype_indices_as_set
-                        else v
+                    into_c(
+                        (
+                            column,
+                            maybe_box_native(v)
+                            if i in object_dtype_indices_as_set
+                            else v,
+                        )
                         for i, (column, v) in enumerate(
                             zip(columns, t[1:], strict=True)
                         )
-                    },
+                    ),
                 )
                 for t in df.itertuples(name=None)
             )
         else:
             return into_c(
-                (t[0], dict(zip(columns, t[1:], strict=True)))
+                (
+                    t[0],
+                    into_c(zip(columns, t[1:], strict=True)),
+                )
                 for t in df.itertuples(name=None)
             )
 


### PR DESCRIPTION
Fixes #65778

When using DataFrame.to_dict(orient="index", into=...), the into parameter was only applied to the outer mapping. Inner row mappings were always plain dict.

This fix replaces all three dict() calls in the orient=="index" branch with into_c(), ensuring both outer and nested mappings use the specified mapping constructor.