### PR TITLE
BUG: assert_series_equal respects check_series_type for ndarray subclasses

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -413,6 +413,8 @@ Other
 ^^^^^
 
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
+- Bug in :func:`testing.assert_series_equal` where the ``check_series_type`` parameter was not respected for :class:`numpy.ndarray` subclass-backed Series in the exact comparison path (:issue:`65770`)
+- Added ``check_class`` parameter to :func:`testing.assert_numpy_array_equal` to allow skipping exact class comparison for :class:`numpy.ndarray` subclasses (:issue:`65770`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -684,6 +684,7 @@ def assert_numpy_array_equal(
     check_same: Literal["copy", "same"] | None = None,
     obj: str = "numpy array",
     index_values: Index | np.ndarray | None = None,
+    check_class: bool = True,
 ) -> None:
     """
     Check that 'np.ndarray' is equivalent.
@@ -705,12 +706,17 @@ def assert_numpy_array_equal(
         assertion message.
     index_values : Index | numpy.ndarray, default None
         optional index (shared by both left and right), used in output.
+    check_class : bool, default True
+        Whether to check the exact class of left and right. If False,
+        ``np.ndarray`` subclasses are considered equivalent to the base
+        ``np.ndarray``.
     """
     __tracebackhide__ = True
 
     # instance validation
     # Show a detailed error message when classes are different
-    assert_class_equal(left, right, obj=obj)
+    if check_class:
+        assert_class_equal(left, right, obj=obj)
     # both classes must be an np.ndarray
     _check_isinstance(left, right, np.ndarray)
 
@@ -1126,6 +1132,7 @@ def assert_series_equal(
                 check_dtype=check_dtype,
                 obj=str(obj),
                 index_values=left.index,
+                check_class=check_series_type,
             )
     elif check_datetimelike_compat and (
         needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype)

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -221,3 +221,21 @@ numpy array values are different \\(100.0 %\\)
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_numpy_array_equal(a, b)
+
+
+def test_numpy_array_equal_check_class_ndarray_subclass():
+    # GH#65770 - check_class=False should allow ndarray subclasses
+    arr = np.array([1])
+
+    class OtherArray(np.ndarray):
+        pass
+
+    other = arr.view(OtherArray)
+
+    # With check_class=False, subclasses are allowed
+    tm.assert_numpy_array_equal(arr, other, check_class=False)
+
+    # With check_class=True (default), the class difference is caught
+    msg = "numpy array classes are different"
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_numpy_array_equal(arr, other, check_class=True)

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -543,3 +543,24 @@ def test_assert_series_equal_int_near_bounds():
     msg = "Series are different"
     with pytest.raises(AssertionError, match=msg):
         tm.assert_series_equal(ser1, ser2)
+
+
+def test_assert_series_equal_ndarray_subclass_check_series_type():
+    # GH#65770 - assert_series_equal with check_series_type=False should
+    # not fail on ndarray subclass-backed Series
+    arr = np.array([1])
+
+    class OtherArray(np.ndarray):
+        pass
+
+    left = Series(arr)
+    right = Series(arr.view(OtherArray))
+
+    # Series are equal when check_series_type is False
+    assert left.equals(right)
+    tm.assert_series_equal(left, right, check_series_type=False)
+
+    # With check_series_type=True (default), the test should still catch
+    # real class differences
+    with pytest.raises(AssertionError, match="Series classes are different"):
+        tm.assert_series_equal(left, right, check_series_type=True)


### PR DESCRIPTION
Fixes #65770

assert_series_equal had check_series_type parameter but it was not passed through to assert_numpy_array_equal when comparing values. This meant ndarray subclasses would always trigger a class mismatch error, even when check_series_type=False.

Added check_class parameter to assert_numpy_array_equal (default True for backward compat) and passed check_series_type through from assert_series_equal.