### PR TITLE
BUG: assert_series_equal forwards check_exact/rtol/atol to assert_extension_array_equal

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -413,6 +413,7 @@ Other
 ^^^^^
 
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
+- Bug in :func:`testing.assert_series_equal` where ``check_exact`` was not passed through to the ExtensionArray comparison path, causing it to be silently ignored for ExtensionArray-backed Series (:issue:`XXXX`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1112,6 +1112,9 @@ def assert_series_equal(
                 check_dtype=check_dtype,
                 index_values=left.index,
                 obj=str(obj),
+                check_exact=check_exact,
+                rtol=rtol,
+                atol=atol,
             )
         else:
             # convert both to NumPy if not, check_dtype would raise earlier

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -543,3 +543,20 @@ def test_assert_series_equal_int_near_bounds():
     msg = "Series are different"
     with pytest.raises(AssertionError, match=msg):
         tm.assert_series_equal(ser1, ser2)
+
+
+def test_assert_series_equal_check_exact_extension_array():
+    # GH#XXXX - check_exact was not being passed through to
+    # assert_extension_array_equal in the ExtensionArray exact comparison path.
+    # This caused check_exact=True to be silently ignored for float
+    # ExtensionArrays.
+    left = Series([1.0, 2.000001], dtype="Float64")
+    right = Series([1.0, 2.0], dtype="Float64")
+
+    # With check_exact=True, the difference should be caught
+    msg = "Series values are different"
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_series_equal(left, right, check_exact=True)
+
+    # Without check_exact, the default rtol should allow the small difference
+    tm.assert_series_equal(left, right, check_exact=False)


### PR DESCRIPTION
In assert_series_equal, when comparing ExtensionArray values, the check_exact, rtol, and atol parameters were silently dropped instead of being forwarded to assert_extension_array_equal. This meant that check_exact=True was ignored for ExtensionArray-backed Series.