### PR TITLE
BUG: assert_index_equal forwards params in CategoricalIndex categories recursion

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -303,6 +303,11 @@ def assert_index_equal(
                     cast("CategoricalIndex", left).categories,
                     cast("CategoricalIndex", right).categories,
                     exact=exact,
+                    check_names=check_names,
+                    check_exact=check_exact,
+                    check_categorical=check_categorical,
+                    rtol=rtol,
+                    atol=atol,
                 )
             return
 


### PR DESCRIPTION
In assert_index_equal, when recursively comparing CategoricalIndex categories, check_names, check_exact, check_categorical, rtol, and atol were silently dropped. These are now forwarded to the recursive call.