### PR TITLE
PERF: Use is_monotonic in ExtensionArray._monotonic_check

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1118,6 +1118,30 @@ def rank(
     return ranks
 
 
+def is_monotonic(values: ArrayLike) -> tuple[bool, bool, bool]:
+    """
+    Determine whether values are monotonic increasing/decreasing.
+
+    Parameters
+    ----------
+    values : np.ndarray or ExtensionArray
+
+    Returns
+    -------
+    tuple[bool, bool, bool]
+        (is_monotonic_increasing, is_monotonic_decreasing, is_strict_monotonic)
+
+    Raises
+    ------
+    TypeError
+        If the dtype is not orderable by the underlying routine (e.g. complex).
+    """
+    timelike = needs_i8_conversion(values.dtype)
+    values = _ensure_data(values)
+    inc, dec, strict = algos.is_monotonic(values, timelike=timelike)
+    return bool(inc), bool(dec), bool(strict)
+
+
 # ---- #
 # take #
 # ---- #

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -2760,13 +2760,17 @@ class ExtensionArray:
         if self._hasna:
             return False, False
         values = self._values_for_argsort()
+        timelike = False
         if values.dtype.kind == "b":
             values = values.view("uint8")
+        elif values.dtype.kind in "mM":
+            values = values.view("i8")
+            timelike = True
         try:
-            inc, dec, _ = libalgos.is_monotonic(values, timelike=False)
+            inc, dec, _ = libalgos.is_monotonic(values, timelike=timelike)
         except TypeError:
             # ``is_monotonic`` only supports numeric and object dtypes; for
-            # other dtypes (e.g. datetime64, timedelta64) fall back to ranks.
+            # other dtypes (e.g. complex, float16) fall back to ranks.
             try:
                 ranks = self._rank()
             except TypeError:

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -2753,15 +2753,25 @@ class ExtensionArray:
         """
         Return (is_monotonic_increasing, is_monotonic_decreasing).
 
-        Default implementation using ranks. Subclasses should override
-        ``_is_monotonic_increasing`` and ``_is_monotonic_decreasing``
-        instead of this method.
+        Default implementation using ``_values_for_argsort``. Subclasses
+        should override ``_is_monotonic_increasing`` and
+        ``_is_monotonic_decreasing`` instead of this method.
         """
-        try:
-            ranks = self._rank()
-        except TypeError:
+        if self._hasna:
             return False, False
-        inc, dec, _ = libalgos.is_monotonic(ranks, timelike=False)
+        values = self._values_for_argsort()
+        if values.dtype.kind == "b":
+            values = values.view("uint8")
+        try:
+            inc, dec, _ = libalgos.is_monotonic(values, timelike=False)
+        except TypeError:
+            # ``is_monotonic`` only supports numeric and object dtypes; for
+            # other dtypes (e.g. datetime64, timedelta64) fall back to ranks.
+            try:
+                ranks = self._rank()
+            except TypeError:
+                return False, False
+            inc, dec, _ = libalgos.is_monotonic(ranks, timelike=False)
         return bool(inc), bool(dec)
 
     def _rank(

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -2759,7 +2759,11 @@ class ExtensionArray:
         """
         if self._hasna:
             return False, False
-        values = self._values_for_argsort()
+        try:
+            values = self._values_for_argsort()
+        except TypeError:
+            return False, False
+
         timelike = False
         if values.dtype.kind == "b":
             values = values.view("uint8")

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -69,6 +69,7 @@ from pandas.core import (
 from pandas.core.algorithms import (
     duplicated,
     factorize_array,
+    is_monotonic,
     isin,
     map_array,
     mode,
@@ -2761,26 +2762,12 @@ class ExtensionArray:
             return False, False
         try:
             values = self._values_for_argsort()
+            inc, dec, _ = is_monotonic(values)
         except TypeError:
+            # Either ``_values_for_argsort`` is not implemented or the dtype is
+            # not orderable by ``is_monotonic`` (e.g. complex).
             return False, False
-
-        timelike = False
-        if values.dtype.kind == "b":
-            values = values.view("uint8")
-        elif values.dtype.kind in "mM":
-            values = values.view("i8")
-            timelike = True
-        try:
-            inc, dec, _ = libalgos.is_monotonic(values, timelike=timelike)
-        except TypeError:
-            # ``is_monotonic`` only supports numeric and object dtypes; for
-            # other dtypes (e.g. complex, float16) fall back to ranks.
-            try:
-                ranks = self._rank()
-            except TypeError:
-                return False, False
-            inc, dec, _ = libalgos.is_monotonic(ranks, timelike=False)
-        return bool(inc), bool(dec)
+        return inc, dec
 
     def _rank(
         self,

--- a/pandas/tests/extension/test_common.py
+++ b/pandas/tests/extension/test_common.py
@@ -86,8 +86,8 @@ def test_monotonic_check_unsupported_argsort_dtype():
     # GH#65585
     # Test fallback in ExtensionArray._monotonic_check when is_monotonic can't be used
     arr = pd.array(np.array([1, 2, 3], dtype="float16"))
-    assert ExtensionArray._monotonic_check(arr) == (True, False)
-    assert ExtensionArray._monotonic_check(arr[::-1]) == (False, True)
+    assert arr._monotonic_check() == (True, False)
+    assert arr[::-1]._monotonic_check() == (False, True)
 
 
 class CapturingStringArray(pd.arrays.StringArray):

--- a/pandas/tests/extension/test_common.py
+++ b/pandas/tests/extension/test_common.py
@@ -82,6 +82,20 @@ def test_is_extension_array_dtype(dtype):
     assert is_extension_array_dtype(dtype)
 
 
+def test_monotonic_check_unsupported_argsort_dtype():
+    # GH#65585
+    # Test ExtensionArray._monotonic_check on non-numeric and non-object dtypes
+    arr = pd.array(pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]))
+    assert arr._values_for_argsort().dtype.kind == "M"
+
+    assert ExtensionArray._monotonic_check(arr) == (True, False)
+    assert ExtensionArray._monotonic_check(arr[::-1]) == (False, True)
+
+    td = pd.array(pd.to_timedelta([1, 2, 3], unit="D"))
+    assert td._values_for_argsort().dtype.kind == "m"
+    assert ExtensionArray._monotonic_check(td) == (True, False)
+
+
 class CapturingStringArray(pd.arrays.StringArray):
     """Extend StringArray to capture arguments to __getitem__"""
 

--- a/pandas/tests/extension/test_common.py
+++ b/pandas/tests/extension/test_common.py
@@ -84,16 +84,10 @@ def test_is_extension_array_dtype(dtype):
 
 def test_monotonic_check_unsupported_argsort_dtype():
     # GH#65585
-    # Test ExtensionArray._monotonic_check on non-numeric and non-object dtypes
-    arr = pd.array(pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]))
-    assert arr._values_for_argsort().dtype.kind == "M"
-
+    # Test fallback in ExtensionArray._monotonic_check when is_monotonic can't be used
+    arr = pd.array(np.array([1, 2, 3], dtype="float16"))
     assert ExtensionArray._monotonic_check(arr) == (True, False)
     assert ExtensionArray._monotonic_check(arr[::-1]) == (False, True)
-
-    td = pd.array(pd.to_timedelta([1, 2, 3], unit="D"))
-    assert td._values_for_argsort().dtype.kind == "m"
-    assert ExtensionArray._monotonic_check(td) == (True, False)
 
 
 class CapturingStringArray(pd.arrays.StringArray):

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1863,6 +1863,58 @@ class TestRank:
         assert result == 1
 
 
+class TestIsMonotonic:
+    @pytest.mark.parametrize(
+        "arr, expected",
+        [
+            ([1, 2, 3], (True, False, True)),
+            ([3, 2, 1], (False, True, True)),
+            ([1, 2, 2, 3], (True, False, False)),
+            ([3, 2, 2, 1], (False, True, False)),
+            ([5, 5, 5], (True, True, False)),
+            ([1, 3, 2], (False, False, False)),
+            ([7], (True, True, True)),
+            ([], (True, True, True)),
+        ],
+    )
+    def test_numeric(self, arr, expected, any_real_numpy_dtype):
+        # https://github.com/pandas-dev/pandas/pull/65803
+        values = np.array(arr, dtype=any_real_numpy_dtype)
+        assert algos.is_monotonic(values) == expected
+
+    def test_float16(self):
+        # https://github.com/pandas-dev/pandas/pull/65803
+        # float16 is not supported by libalgos.is_monotonic directly;
+        # _ensure_data converts it to float64
+        values = np.array([1, 2, 3], dtype="float16")
+        assert algos.is_monotonic(values) == (True, False, True)
+        assert algos.is_monotonic(values[::-1]) == (False, True, True)
+
+    def test_bool(self):
+        # https://github.com/pandas-dev/pandas/pull/65803
+        assert algos.is_monotonic(np.array([False, True, True])) == (True, False, False)
+        assert algos.is_monotonic(np.array([True, False])) == (False, True, True)
+
+    def test_object(self):
+        # https://github.com/pandas-dev/pandas/pull/65803
+        values = np.array(["a", "b", "c"], dtype=object)
+        assert algos.is_monotonic(values) == (True, False, True)
+
+    @pytest.mark.parametrize("dtype", ["datetime64[ns]", "timedelta64[ns]"])
+    def test_datetimelike(self, dtype):
+        # https://github.com/pandas-dev/pandas/pull/65803
+        values = np.array([1, 2, 3], dtype="int64").view(dtype)
+        assert algos.is_monotonic(values) == (True, False, True)
+        assert algos.is_monotonic(values[::-1]) == (False, True, True)
+
+    def test_complex_raises(self):
+        # https://github.com/pandas-dev/pandas/pull/65803
+        # complex is not orderable
+        values = np.array([1 + 0j, 2 + 0j], dtype="complex128")
+        with pytest.raises(TypeError, match="No matching signature found"):
+            algos.is_monotonic(values)
+
+
 class TestMode:
     def test_no_mode(self):
         exp = Series([], dtype=np.float64, index=Index([], dtype=int))


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/141

Since `_rank` already uses `_values_for_argsort`, this has the same requirements for third party EAs.

```python
import pandas as pd

idx = pd.Index([f"i-{i}" for i in range(1_000_000)], dtype="string[python]").sort_values()
%timeit idx.is_monotonic_increasing
# 97.6 ms ± 989 μs per loop (mean ± std. dev. of 7 runs, 10 loops each) <--- main
# 43.7 ms ± 602 μs per loop (mean ± std. dev. of 7 runs, 10 loops each) <--- PR
%timeit pd.Series(idx).is_monotonic_increasing
# 97.2 ms ± 609 μs per loop (mean ± std. dev. of 7 runs, 10 loops each) <--- main
# 43.7 ms ± 591 μs per loop (mean ± std. dev. of 7 runs, 10 loops each) <--- PR
```

An index backed by `string[python]` doesn't have e.g. `is_monotonic_increaing` cached - I'm thinking it should, but leaving that for another issue/PR.