### PR TITLE
DOC: Fix incomplete docstring in _open_browser

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -152,7 +152,7 @@ class DocBuilder:
 
     def _open_browser(self, single_doc_html) -> None:
         """
-        Open a browser tab showing single
+        Open a browser tab showing a single document.
         """
         url = os.path.join("file://", DOC_PATH, "build", "html", single_doc_html)
         webbrowser.open(url, new=2)


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Summary

This PR fixes an incomplete docstring in the `_open_browser` method.

### Changes
- Replaced the incomplete docstring text.
- Improved clarity of the method description.
