### PR TITLE
DOC: Fix malformed layout for quoting parameter in read_csv and read_…

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -672,14 +672,8 @@ def read_csv(
     quotechar : str (length 1), optional
         Character used to denote the start and end of a quoted item. Quoted
         items can include the ``delimiter`` and it will be ignored.
-    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL,
-        2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
-        Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is
-        ``csv.QUOTE_MINIMAL`` (i.e., 0) which implies that
-        only fields containing special
-        characters are quoted (e.g., characters defined
-        in ``quotechar``, ``delimiter``,
-        or ``lineterminator``.
+    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL,2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
+        Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is ``csv.QUOTE_MINIMAL`` (i.e., 0) which implies that only fields containing special characters are quoted (e.g., characters defined in ``quotechar``, ``delimiter``, or ``lineterminator``.
     doublequote : bool, default True
         When ``quotechar`` is specified and ``quoting`` is not ``QUOTE_NONE``, indicate
         whether or not to interpret two consecutive ``quotechar`` elements INSIDE a
@@ -1255,14 +1249,8 @@ def read_table(
     quotechar : str (length 1), optional
         Character used to denote the start and end of a quoted item. Quoted
         items can include the ``delimiter`` and it will be ignored.
-    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL, 2 or
-        csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
-        Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is
-        ``csv.QUOTE_MINIMAL`` (i.e., 0) which
-        implies that only fields containing special
-        characters are quoted (e.g., characters defined
-        in ``quotechar``, ``delimiter``,
-        or ``lineterminator``.
+    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL, 2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
+    Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is ``csv.QUOTE_MINIMAL`` (i.e., 0) which implies that only fields containing special characters are quoted (e.g., characters defined in ``quotechar``, ``delimiter``, or ``lineterminator``.
     doublequote : bool, default True
        When ``quotechar`` is specified and ``quoting`` is not ``QUOTE_NONE``, indicate
        whether or not to interpret two consecutive ``quotechar`` elements INSIDE a


### PR DESCRIPTION
…table

Removed line breaks in quoting parameter documentation for clarity.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
