### PR TITLE
DOC: Fix malformed type for read_csv/read_table quoting parameter

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -672,14 +672,13 @@ def read_csv(
     quotechar : str (length 1), optional
         Character used to denote the start and end of a quoted item. Quoted
         items can include the ``delimiter`` and it will be ignored.
-    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL,
-        2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
-        Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is
-        ``csv.QUOTE_MINIMAL`` (i.e., 0) which implies that
-        only fields containing special
-        characters are quoted (e.g., characters defined
-        in ``quotechar``, ``delimiter``,
-        or ``lineterminator``.
+    quoting : {0, 1, 2, 3} or csv.QUOTE_* constant, default csv.QUOTE_MINIMAL
+        Control field quoting behavior per ``csv.QUOTE_*`` constants:
+        ``0`` or ``csv.QUOTE_MINIMAL``, ``1`` or ``csv.QUOTE_ALL``,
+        ``2`` or ``csv.QUOTE_NONNUMERIC``, ``3`` or ``csv.QUOTE_NONE``.
+        Default is ``csv.QUOTE_MINIMAL`` (i.e., 0), which implies that only
+        fields containing special characters are quoted (e.g., characters
+        defined in ``quotechar``, ``delimiter``, or ``lineterminator``).
     doublequote : bool, default True
         When ``quotechar`` is specified and ``quoting`` is not ``QUOTE_NONE``, indicate
         whether or not to interpret two consecutive ``quotechar`` elements INSIDE a
@@ -1255,14 +1254,13 @@ def read_table(
     quotechar : str (length 1), optional
         Character used to denote the start and end of a quoted item. Quoted
         items can include the ``delimiter`` and it will be ignored.
-    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL, 2 or
-        csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
-        Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is
-        ``csv.QUOTE_MINIMAL`` (i.e., 0) which
-        implies that only fields containing special
-        characters are quoted (e.g., characters defined
-        in ``quotechar``, ``delimiter``,
-        or ``lineterminator``.
+    quoting : {0, 1, 2, 3} or csv.QUOTE_* constant, default csv.QUOTE_MINIMAL
+        Control field quoting behavior per ``csv.QUOTE_*`` constants:
+        ``0`` or ``csv.QUOTE_MINIMAL``, ``1`` or ``csv.QUOTE_ALL``,
+        ``2`` or ``csv.QUOTE_NONNUMERIC``, ``3`` or ``csv.QUOTE_NONE``.
+        Default is ``csv.QUOTE_MINIMAL`` (i.e., 0), which implies that only
+        fields containing special characters are quoted (e.g., characters
+        defined in ``quotechar``, ``delimiter``, or ``lineterminator``).
     doublequote : bool, default True
        When ``quotechar`` is specified and ``quoting`` is not ``QUOTE_NONE``, indicate
        whether or not to interpret two consecutive ``quotechar`` elements INSIDE a


### PR DESCRIPTION
- [x] closes #65813
- [x] All code checks passed (`ruff check`, line length within 88).

## Problem

In the `read_csv` and `read_table` docstrings, the `quoting` parameter's type spec was wrapped across two physical lines:

```
quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL,
    2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
    Control field quoting behavior per ``csv.QUOTE_*`` constants. ...
```

numpydoc only treats the **first** line after `name :` as the type, so the overflow (`2 or csv.QUOTE_NONNUMERIC, ...`) was parsed as the start of the *description*. The type therefore bled into the description in the rendered docs (see the issue for the rendered output).

## Fix

The full enumeration cannot fit on a single line within the 88-char limit, so the type is written in a compact `{0, 1, 2, 3} or csv.QUOTE_* constant` form and the explicit value/constant mapping is moved into the description, where it renders correctly:

```
quoting : {0, 1, 2, 3} or csv.QUOTE_* constant, default csv.QUOTE_MINIMAL
    Control field quoting behavior per ``csv.QUOTE_*`` constants:
    ``0`` or ``csv.QUOTE_MINIMAL``, ``1`` or ``csv.QUOTE_ALL``,
    ``2`` or ``csv.QUOTE_NONNUMERIC``, ``3`` or ``csv.QUOTE_NONE``.
    Default is ``csv.QUOTE_MINIMAL`` (i.e., 0), which implies that only
    fields containing special characters are quoted (e.g., characters
    defined in ``quotechar``, ``delimiter``, or ``lineterminator``).
```

The same fix is applied to both `read_csv` and `read_table` (which share this parameter documentation). I also balanced the trailing parenthesis in the description, which was previously left unclosed.

I verified with numpydoc's `NumpyDocString` parser that the type and description now parse into separate fields (no bleed), and that all changed lines are ≤ 88 characters. No whatsnew note is added, per the contributing guide's guidance for documentation-only changes.