### PR TITLE
BUG: respect check_series_type=False for ndarray subclass-backed Series (#65770)

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1112,6 +1112,10 @@ def assert_series_equal(
                 lv = left_values.to_numpy()
             if isinstance(right_values, ExtensionArray):
                 rv = right_values.to_numpy()
+            if not check_series_type:
+                # GH#65770
+                lv = np.asarray(lv)
+                rv = np.asarray(rv)
             assert_numpy_array_equal(
                 lv,
                 rv,

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -324,6 +324,18 @@ def test_series_equal_series_type():
         tm.assert_series_equal(s3, s1, check_series_type=True)
 
 
+def test_series_equal_check_series_type_false_ndarray_subclass():
+    # GH#65770
+    class OtherArray(np.ndarray):
+        pass
+
+    arr = np.array([1])
+    left = Series(arr)
+    right = Series(arr.view(OtherArray))
+
+    tm.assert_series_equal(left, right, check_series_type=False)
+
+
 def test_series_equal_exact_for_nonnumeric():
     # https://github.com/pandas-dev/pandas/issues/35446
     s1 = Series(["a", "b"])


### PR DESCRIPTION
- [x] closes #65770
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Change Summary

When `check_series_type=False` is passed to `assert_series_equal`, the exact comparison path still fails if one Series is backed by a plain `np.ndarray` and the other by an `np.ndarray` subclass (e.g., from `np.array(...).view(...)`).

This PR converts the backing arrays to plain `np.ndarray` via `np.asarray(...)` in the exact comparison path when `check_series_type=False`, so the type mismatch is ignored as expected.

## Related issue number

fix #65770