### PR TITLE
BUG: Fix nanany/nanall raising ValueError with skipna=False on nullable dtypes

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -531,6 +531,13 @@ def nanany(
 
     values, _ = _get_values(values, skipna, fill_value=False, mask=mask)
 
+    # GH#65710: when skipna=False and NaN values are present (e.g. from nullable
+    # dtypes), return NaN instead of trying to convert NaN to bool.
+    if not skipna:
+        nans = np.isnan(values)
+        if nans.any():
+            return np.nan
+
     # For object type, any won't necessarily return
     # boolean values (numpy/numpy#4352)
     if values.dtype == object:
@@ -586,6 +593,13 @@ def nanall(
         raise TypeError("datetime64 type does not support operation 'all'")
 
     values, _ = _get_values(values, skipna, fill_value=True, mask=mask)
+
+    # GH#65710: when skipna=False and NaN values are present (e.g. from nullable
+    # dtypes), return NaN instead of trying to convert NaN to bool.
+    if not skipna:
+        nans = np.isnan(values)
+        if nans.any():
+            return np.nan
 
     # For object type, all won't necessarily return
     # boolean values (numpy/numpy#4352)


### PR DESCRIPTION
## Summary

Fixes #65710: `DataFrame.any(skipna=False)` and `DataFrame.all(skipna=False)` raise `ValueError: cannot convert float NaN to bool` on nullable dtypes (`boolean`, `Int*`, `Float*`), while `Series.any/all(skipna=False)` correctly returns `pd.NA`.

## Root Cause

In `nanops.nanany` and `nanops.nanall`, when `skipna=False` and NA values are present, `_get_values` preserves NaN values in the array. Then `values.astype(bool)` tries to convert NaN to bool, which raises `ValueError`.

## Fix

Check for NaN values when `skipna=False` before attempting `astype(bool)`, and return `np.nan` directly instead.

## Changes

- `pandas/core/nanops.py`: 6 lines each in `nanany` and `nanall`

Fixes #65710

Co-authored-by: Claude <noreply@anthropic.com>