### PR TITLE
BUG: Categorical.map() errors when mapping categories to tuples

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -233,6 +233,7 @@ Categorical
 ^^^^^^^^^^^
 - Bug in :meth:`Categorical.__repr__` where the values and categories lines could exceed ``display.width`` (:issue:`12066`)
 - Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory by using ``dict.get``, causing ``NA`` values to be replaced with ``NaN`` instead of the mapper's default value (:issue:`62710`)
+- Bug in :meth:`Categorical.map` and :meth:`Series.map` raising ``NotImplementedError`` when the mapper returned tuples for the categories, instead of returning an :class:`Index` of tuples (:issue:`51488`)
 - Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
 - Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
 -

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -232,8 +232,8 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 - Bug in :meth:`Categorical.__repr__` where the values and categories lines could exceed ``display.width`` (:issue:`12066`)
-- Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory by using ``dict.get``, causing ``NA`` values to be replaced with ``NaN`` instead of the mapper's default value (:issue:`62710`)
 - Bug in :meth:`Categorical.map` and :meth:`Series.map` raising ``NotImplementedError`` when the mapper returned tuples for the categories, instead of returning an :class:`Index` of tuples (:issue:`51488`)
+- Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory by using ``dict.get``, causing ``NA`` values to be replaced with ``NaN`` instead of the mapper's default value (:issue:`62710`)
 - Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
 - Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
 -

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1652,6 +1652,9 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 except KeyError:
                     na_val = np.nan
 
+        # A MultiIndex (i.e. mapper returned tuples) can't back a
+        # CategoricalDtype, so it must take the slow path below regardless
+        # of uniqueness/na checks.
         if (
             not isinstance(new_categories, ABCMultiIndex)
             and new_categories.is_unique

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1662,8 +1662,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             return self.from_codes(self._codes.copy(), dtype=new_dtype, validate=False)
 
         if isinstance(new_categories, ABCMultiIndex):
-            # GH#51488 mapper returned tuples; a CategoricalDtype/Series cannot
-            # be constructed from a MultiIndex, so fall back to a flat
+            # mapper returned tuples; a CategoricalDtype/Categorical cannot be
+            # constructed from a MultiIndex, so fall back to a flat
             # object-dtype Index of tuples.
             new_categories = new_categories.to_flat_index()
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -55,6 +55,7 @@ from pandas.core.dtypes.dtypes import (
 )
 from pandas.core.dtypes.generic import (
     ABCIndex,
+    ABCMultiIndex,
     ABCSeries,
 )
 from pandas.core.dtypes.missing import (
@@ -1651,9 +1652,20 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 except KeyError:
                     na_val = np.nan
 
-        if new_categories.is_unique and not new_categories.hasnans and na_val is np.nan:
+        if (
+            not isinstance(new_categories, ABCMultiIndex)
+            and new_categories.is_unique
+            and not new_categories.hasnans
+            and na_val is np.nan
+        ):
             new_dtype = CategoricalDtype(new_categories, ordered=self.ordered)
             return self.from_codes(self._codes.copy(), dtype=new_dtype, validate=False)
+
+        if isinstance(new_categories, ABCMultiIndex):
+            # GH#51488 mapper returned tuples; a CategoricalDtype/Series cannot
+            # be constructed from a MultiIndex, so fall back to a flat
+            # object-dtype Index of tuples.
+            new_categories = new_categories.to_flat_index()
 
         if has_nans:
             new_categories = new_categories.insert(len(new_categories), na_val)

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -154,3 +154,31 @@ def test_map_defaultdict_na_action_ignore():
     result = cat.map(mapper, na_action="ignore")
     expected = Index([True, True, np.nan])
     tm.assert_index_equal(result, expected)
+
+
+def test_map_to_tuples(na_action):
+    # GH#51488 mapping categories to tuples used to raise NotImplementedError
+    # because the mapped categories formed a MultiIndex.
+    cat = Categorical(["a", "a", "b", "c"])
+    mapper = {"a": ("x",), "b": ("y",), "c": ("z",)}
+    result = cat.map(mapper, na_action=na_action)
+    expected = Index([("x",), ("x",), ("y",), ("z",)], tupleize_cols=False)
+    tm.assert_index_equal(result, expected)
+
+
+def test_map_to_tuples_with_na(na_action):
+    # GH#51488
+    cat = Categorical(["a", "a", None, "b"])
+    mapper = {"a": ("x",), "b": ("y",)}
+    result = cat.map(mapper, na_action=na_action)
+    expected = Index([("x",), ("x",), np.nan, ("y",)], tupleize_cols=False)
+    tm.assert_index_equal(result, expected)
+
+
+def test_map_to_multi_element_tuples(na_action):
+    # GH#51488
+    cat = Categorical(["a", "b"])
+    mapper = {"a": ("x", 1), "b": ("y", 2)}
+    result = cat.map(mapper, na_action=na_action)
+    expected = Index([("x", 1), ("y", 2)], tupleize_cols=False)
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -157,8 +157,8 @@ def test_map_defaultdict_na_action_ignore():
 
 
 def test_map_to_tuples(na_action):
-    # GH#51488 mapping categories to tuples used to raise NotImplementedError
-    # because the mapped categories formed a MultiIndex.
+    # mapping categories to tuples used to raise NotImplementedError because
+    # the mapped categories formed a MultiIndex.
     cat = Categorical(["a", "a", "b", "c"])
     mapper = {"a": ("x",), "b": ("y",), "c": ("z",)}
     result = cat.map(mapper, na_action=na_action)
@@ -167,7 +167,6 @@ def test_map_to_tuples(na_action):
 
 
 def test_map_to_tuples_with_na(na_action):
-    # GH#51488
     cat = Categorical(["a", "a", None, "b"])
     mapper = {"a": ("x",), "b": ("y",)}
     result = cat.map(mapper, na_action=na_action)
@@ -176,7 +175,6 @@ def test_map_to_tuples_with_na(na_action):
 
 
 def test_map_to_multi_element_tuples(na_action):
-    # GH#51488
     cat = Categorical(["a", "b"])
     mapper = {"a": ("x", 1), "b": ("y", 2)}
     result = cat.map(mapper, na_action=na_action)

--- a/pandas/tests/series/methods/test_map.py
+++ b/pandas/tests/series/methods/test_map.py
@@ -526,6 +526,16 @@ def test_map_categorical_na_action(na_action, expected):
     tm.assert_series_equal(result, expected)
 
 
+def test_map_categorical_to_tuples(na_action):
+    # GH#51488 mapping a categorical Series to tuples used to raise
+    # NotImplementedError because the mapped categories formed a MultiIndex.
+    s = Series(pd.Categorical(["a", "a", "b", "c"]))
+    mapper = {"a": ("x",), "b": ("y",), "c": ("z",)}
+    result = s.map(mapper, na_action=na_action)
+    expected = Series([("x",), ("x",), ("y",), ("z",)])
+    tm.assert_series_equal(result, expected)
+
+
 def test_map_datetimetz():
     values = date_range("2011-01-01", "2011-01-02", freq="h").tz_localize("Asia/Tokyo")
     s = Series(values, name="XX")


### PR DESCRIPTION
Closes #51488

`Categorical.map()` (and by extension `Series.map()` on a categorical
Series) raised a `NotImplementedError` when the mapper produced tuple
values for the categories. Mapping the categories through `Index.map()`
returns a `MultiIndex` for tuple results, and a `CategoricalDtype`/
`Categorical` can't be built from a `MultiIndex`.

Detect that case and fall back to a flat object-dtype `Index` of tuples
(via `to_flat_index()`), matching how `Index.map()` already behaves when
a mapper returns tuples - so a categorical Series and a regular Series
now behave consistently here.

- [x] closes #51488
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed.
- [x] Added type annotations to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
