### PR TITLE
fix dataframe flex arith preserving nullable int dtype with fill_value

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -275,6 +275,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
+- Fixed bug in :meth:`DataFrame.add` and other flexible arithmetic methods where columns exclusive to one operand were upcast to ``Float64`` instead of preserving their nullable integer dtype when ``fill_value`` was given (:issue:`65805`)
 - Fixed bug in :meth:`Series.clip` where passing a scalar numpy array (e.g. ``np.array(0)``) would raise a ``TypeError`` (:issue:`59053`)
 - Fixed bug in :meth:`Series.mean` and :meth:`Series.sum` (and their :class:`DataFrame` counterparts) overflowing for ``float16`` dtypes instead of upcasting to ``float64`` (:issue:`43929`)
 - Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) returning ``0.0`` for degenerate distributions; these now return ``NaN`` (:issue:`62864`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9528,6 +9528,25 @@ class DataFrame(NDFrame, OpsMixin):
             return self._arith_method_with_reindex(other, op)
 
         other = ops.maybe_prepare_scalar_for_op(other, self.shape)
+
+        # GH#65805 capture original dtypes before alignment so columns that are
+        # exclusive to one frame don't silently upcast (e.g. UInt8 -> Float64)
+        # when reindex introduces an all-NA column with no dtype to inherit.
+        _orig_dtypes = None
+        # truediv always yields float, so don't restore integer dtypes for it
+        if (
+            fill_value is not None
+            and isinstance(other, DataFrame)
+            and op not in (operator.truediv, roperator.rtruediv)
+        ):
+            _orig_dtypes = {}
+            for col, dt in self.dtypes.items():
+                if col not in other.columns:
+                    _orig_dtypes[col] = dt
+            for col, dt in other.dtypes.items():
+                if col not in self.columns:
+                    _orig_dtypes[col] = dt
+
         self, other = self._align_for_op(other, axis, flex=True, level=level)
 
         with np.errstate(all="ignore"):
@@ -9544,7 +9563,35 @@ class DataFrame(NDFrame, OpsMixin):
 
                 new_data = self._dispatch_frame_op(other, op)
 
-        return self._construct_result(new_data, other=other)
+        result = self._construct_result(new_data, other=other)
+
+        # GH#65805 restore the original extension dtype for columns that were
+        # exclusive to one frame and got upcast to float during alignment.
+        # Only do so when the cast back is lossless: a fractional fill_value
+        # (or op result) must not be silently truncated, so we round-trip and
+        # keep the restored dtype only if values are unchanged.
+        if _orig_dtypes:
+            from pandas.core.dtypes.common import is_extension_array_dtype
+
+            for col, dt in _orig_dtypes.items():
+                if not (
+                    col in result.columns
+                    and is_extension_array_dtype(dt)
+                    and result[col].dtype != dt
+                ):
+                    continue
+                original = result[col]
+                try:
+                    casted = original.astype(dt)
+                except (ValueError, TypeError):
+                    # values not castable to the target dtype at all
+                    continue
+                # verify lossless: round-trip back and compare, NA-aware
+                roundtrip = casted.astype(original.dtype)
+                if roundtrip.equals(original):
+                    result[col] = casted
+
+        return result
 
     def _construct_result(self, result, other) -> DataFrame:
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -9529,23 +9529,44 @@ class DataFrame(NDFrame, OpsMixin):
 
         other = ops.maybe_prepare_scalar_for_op(other, self.shape)
 
-        # GH#65805 capture original dtypes before alignment so columns that are
-        # exclusive to one frame don't silently upcast (e.g. UInt8 -> Float64)
-        # when reindex introduces an all-NA column with no dtype to inherit.
-        _orig_dtypes = None
-        # truediv always yields float, so don't restore integer dtypes for it
+        # GH#65805 An outer alignment introduces columns present in only one
+        # frame as all-NaN float64, dropping nullable ExtensionArray dtypes
+        # (unlike Series ops, which preserve the dtype when only the index is
+        # extended). Record the counterpart dtype of those EA-only columns so
+        # we can restore it after aligning; combined with fill_value this keeps
+        # the EA dtype in the result. truediv always yields float, so it is
+        # excluded.
+        _orig_dtypes: dict = {}
         if (
             fill_value is not None
             and isinstance(other, DataFrame)
             and op not in (operator.truediv, roperator.rtruediv)
         ):
-            _orig_dtypes = {}
-            for col, dt in self.dtypes.items():
-                if col not in other.columns:
-                    _orig_dtypes[col] = dt
-            for col, dt in other.dtypes.items():
-                if col not in self.columns:
-                    _orig_dtypes[col] = dt
+
+            def _ea_only(missing_cols, source_dtypes) -> dict:
+                # Under duplicate labels source_dtypes[col] is a Series, so
+                # restore only when the label maps to a single EA dtype.
+                restore = {}
+                for col in missing_cols:
+                    dtype = source_dtypes[col]
+                    if isinstance(dtype, ABCSeries):
+                        unique_dtypes = set(dtype)
+                        if len(unique_dtypes) == 1:
+                            dtype = unique_dtypes.pop()
+                        else:
+                            # duplicate label with differing dtypes: cannot
+                            # tell which to preserve, leave the float64 result
+                            continue
+                    if isinstance(dtype, ExtensionDtype):
+                        restore[col] = dtype
+                return restore
+
+            _orig_dtypes.update(
+                _ea_only(other.columns.difference(self.columns), other.dtypes)
+            )
+            _orig_dtypes.update(
+                _ea_only(self.columns.difference(other.columns), self.dtypes)
+            )
 
         self, other = self._align_for_op(other, axis, flex=True, level=level)
 
@@ -9565,31 +9586,24 @@ class DataFrame(NDFrame, OpsMixin):
 
         result = self._construct_result(new_data, other=other)
 
-        # GH#65805 restore the original extension dtype for columns that were
-        # exclusive to one frame and got upcast to float during alignment.
-        # Only do so when the cast back is lossless: a fractional fill_value
-        # (or op result) must not be silently truncated, so we round-trip and
-        # keep the restored dtype only if values are unchanged.
-        if _orig_dtypes:
-            from pandas.core.dtypes.common import is_extension_array_dtype
-
-            for col, dt in _orig_dtypes.items():
-                if not (
-                    col in result.columns
-                    and is_extension_array_dtype(dt)
-                    and result[col].dtype != dt
-                ):
-                    continue
-                original = result[col]
-                try:
-                    casted = original.astype(dt)
-                except (ValueError, TypeError):
-                    # values not castable to the target dtype at all
-                    continue
-                # verify lossless: round-trip back and compare, NA-aware
-                roundtrip = casted.astype(original.dtype)
-                if roundtrip.equals(original):
-                    result[col] = casted
+        # GH#65805 restore the recorded ExtensionArray dtype for the EA-only
+        # columns the alignment upcast to float. Only do so when the cast back
+        # is lossless: a fractional fill_value (or op result) must not be
+        # silently truncated, nor a negative value wrapped under an unsigned
+        # dtype, so we round-trip and keep the restored dtype only if the
+        # values are unchanged.
+        for col, dt in _orig_dtypes.items():
+            if col not in result.columns or result[col].dtype == dt:
+                continue
+            original = result[col]
+            try:
+                casted = original.astype(dt)
+            except (ValueError, TypeError):
+                # values not castable to the target dtype at all
+                continue
+            # verify lossless: round-trip back and compare, NA-aware
+            if casted.astype(original.dtype).equals(original):
+                result[col] = casted
 
         return result
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -2391,3 +2391,59 @@ def test_sum_mixed_empty(any_string_dtype):
     )
     result = empty_df.sum()
     tm.assert_series_equal(result, expected)
+
+
+def test_flex_arith_fill_value_preserves_nullable_dtype():
+    # GH#65805 columns exclusive to one frame should keep their nullable
+    # integer dtype instead of being upcast to Float64 during alignment
+    left = DataFrame(
+        {
+            "a": pd.array([1, 2], dtype="UInt8"),
+            "b": pd.array([3, 4], dtype="UInt8"),
+        }
+    )
+    right = DataFrame(
+        {
+            "b": pd.array([5, 6], dtype="UInt8"),
+            "c": pd.array([7, 8], dtype="UInt8"),
+        }
+    )
+    result = left.add(right, fill_value=0)
+    expected = DataFrame(
+        {
+            "a": pd.array([1, 2], dtype="UInt8"),
+            "b": pd.array([8, 10], dtype="UInt8"),
+            "c": pd.array([7, 8], dtype="UInt8"),
+        }
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_flex_arith_fill_value_truediv_stays_float():
+    # GH#65805 truediv always produces float, exclusive columns must not be
+    # restored to the original integer dtype
+    left = DataFrame({"a": pd.array([1, 2], dtype="UInt8")})
+    right = DataFrame(
+        {
+            "a": pd.array([1, 2], dtype="UInt8"),
+            "b": pd.array([4, 8], dtype="UInt8"),
+        }
+    )
+    result = left.truediv(right, fill_value=1)
+    assert result["b"].dtype == "Float64"
+
+
+def test_flex_arith_fill_value_no_lossy_cast():
+    # GH#65805 a fractional fill_value must not be silently truncated when
+    # restoring the original integer dtype
+    left = DataFrame({"a": pd.array([7, 8], dtype="UInt8")})
+    right = DataFrame(
+        {
+            "a": pd.array([1, 1], dtype="UInt8"),
+            "b": pd.array([2, 2], dtype="UInt8"),
+        }
+    )
+    result = left.add(right, fill_value=0.5)
+    # "b" is exclusive to right -> 2 + 0.5 = 2.5, cannot be UInt8 without loss
+    assert result["b"].dtype == "Float64"
+    assert result["b"].tolist() == [2.5, 2.5]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -2447,3 +2447,22 @@ def test_flex_arith_fill_value_no_lossy_cast():
     # "b" is exclusive to right -> 2 + 0.5 = 2.5, cannot be UInt8 without loss
     assert result["b"].dtype == "Float64"
     assert result["b"].tolist() == [2.5, 2.5]
+
+
+def test_flex_arith_fill_value_duplicate_labels_differing_dtype():
+    # GH#65805 a column label that is duplicated with differing dtypes in the
+    # other frame cannot be unambiguously restored, so it stays float rather
+    # than guessing which dtype to inherit
+    left = DataFrame({"z": pd.array([9, 9], dtype="UInt8")})
+    right = DataFrame(
+        {
+            "_a": pd.array([1, 2], dtype="UInt8"),
+            "_b": pd.array([3, 4], dtype="UInt16"),
+        }
+    )
+    right.columns = ["x", "x"]
+    result = left.add(right, fill_value=0)
+    # "z" is exclusive to left and integer-valued -> restored to UInt8
+    assert result["z"].dtype == "UInt8"
+    # duplicate "x" labels with differing dtypes -> left as float
+    assert (result["x"].dtypes == "Float64").all()


### PR DESCRIPTION
- [x] closes #65805
- [x] Tests added and passed
- [x] All code checks passed (pre-commit)
- [x] Added a whatsnew entry in v3.1.0.rst

Digging into this, the `fill_value` turned out to be a red herring — the dtype is already lost before any arithmetic happens.

When you do `df.add(other, fill_value=0)` with non-overlapping columns, `_align_for_op` reindexes each frame to the union of columns. A column that only exists in one frame gets pulled into the other as all-NA, and since there's no dtype to inherit, the reindex falls back to numpy `float64`. So by the time the op runs, `UInt8` is already `Float64`. Columns in both frames survive because they're never all-NA. Series doesn't hit this since it reindexes an existing nullable array (NA inserted, dtype kept).

I didn't want to touch core `align` for this — it's used everywhere and changing its NA-introduction behavior felt way out of scope for this bug. So the fix stays in `_flex_arith_method`: grab the original dtypes of the exclusive columns before alignment, then after the op cast them back — but only if the cast is actually lossless. I round-trip and compare rather than trusting `astype`, because `astype` silently truncates.

That lossless check ended up pulling its weight in a few spots:
- `truediv`/`rtruediv` are excluded outright (always float), so division stays `Float64`
- a fractional `fill_value` like `0.5` won't get truncated back to int — it stays float
- it also catches the unsigned case, e.g. `0 - 7` under `UInt8` would wrap to 249, so the round-trip fails and we correctly leave it float

Ran the full `pandas/tests/arithmetic/` + `test_combine_first` suite, all green, no regressions.

One thing I left out of scope: the same upcast happens *without* `fill_value` too (where the introduced column is genuinely all-NA). That feels like it might be intended behavior / different semantics though, so I didn't touch it — happy to do a separate PR if you'd rather that be fixed too. Lmk if the post-hoc-restore approach isn't the direction you want and I'll rework it.