### PR TITLE
BUG: track CoW references through Index.where

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5488,7 +5488,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         from pandas import Series
 
-        ser = Series(self._values, copy=False, dtype=self.dtype)
+        # Pass pandas objects (not their underlying arrays) so that CoW
+        #  references are tracked in the no-copy cases (GH#65265).
+        ser = Series(self, copy=False)
         try:
             result_ser = ser.where(cond, other)
         except (TypeError, ValueError):
@@ -5498,9 +5500,7 @@ class Index(IndexOpsMixin, PandasObject):
             if dtype == self.dtype:
                 raise
             return self.astype(dtype).where(cond, other)
-        return Index(
-            result_ser._values, dtype=result_ser.dtype, name=self.name, copy=False
-        )
+        return Index(result_ser, dtype=result_ser.dtype, name=self.name, copy=False)
 
     # construction helpers
     @final

--- a/pandas/tests/copy_view/index/test_index.py
+++ b/pandas/tests/copy_view/index/test_index.py
@@ -155,8 +155,8 @@ def test_index_where_noop():
     assert result._references.has_reference()
 
     expected = idx.copy(deep=True)
-    ser = Series(result)
-    ser.iloc[0] = 100
+    result = Series(result)
+    result.iloc[0] = 100
     tm.assert_index_equal(idx, expected)
 
 

--- a/pandas/tests/copy_view/index/test_index.py
+++ b/pandas/tests/copy_view/index/test_index.py
@@ -147,6 +147,19 @@ def test_index_to_frame():
     tm.assert_index_equal(idx, expected)
 
 
+def test_index_where_noop():
+    # GH#65265 CoW references should be tracked through Index.where
+    idx = Index([1, 2, 3])
+    result = idx.where([True] * 3, 100)
+    assert np.shares_memory(get_array(idx), get_array(result))
+    assert result._references.has_reference()
+
+    expected = idx.copy(deep=True)
+    ser = Series(result)
+    ser.iloc[0] = 100
+    tm.assert_index_equal(idx, expected)
+
+
 def test_index_values():
     idx = Index([1, 2, 3])
     result = idx.values


### PR DESCRIPTION
Follow-up to post-merge review comments on GH-65265 (cc @jorisvandenbossche).

`Index.where` constructed the intermediate Series and the result Index from raw `._values`, so CoW references were not tracked when `Series.where` took a no-copy path. Passing the pandas objects through the constructors (which pick up `_references` when `copy=False`) restores correct tracking; unreleased regression, so no whatsnew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)