### PR TITLE
TST: fix Numpy Nightly CI failure in test_dti_union_mixed

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -13,6 +13,7 @@ np_version_gt2 = _nlv >= Version("2.0.0")
 np_version_gt2_2 = _nlv >= Version("2.2.0")
 np_version_gt2_3 = _nlv >= Version("2.3.0")
 np_version_gt2_5 = _nlv >= Version("2.5.0")
+np_version_gt2_6 = _nlv >= Version("2.6.0.dev0")
 is_numpy_dev = _nlv.dev is not None
 _min_numpy_ver = "1.26.0"
 

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -7,6 +7,7 @@ from datetime import (
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import np_version_gt2_6
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -527,7 +528,11 @@ class TestDatetimeIndexSetOps:
         # GH#21671
         rng = DatetimeIndex([Timestamp("2011-01-01"), pd.NaT])
         rng2 = DatetimeIndex(["2012-01-01", "2012-01-02"], tz="Asia/Tokyo")
-        result = rng.union(rng2)
+        # numpy>=2.6 object-dtype sort compares the tz-naive and tz-aware
+        #  Timestamps directly, so safe_sort fails and union warns
+        warn = RuntimeWarning if np_version_gt2_6 else None
+        with tm.assert_produces_warning(warn, match="sort order is undefined"):
+            result = rng.union(rng2)
         expected = Index(
             [
                 Timestamp("2011-01-01"),


### PR DESCRIPTION
The Numpy Nightly job on main is failing in `test_dti_union_mixed` since numpy/numpy#31431 (new-style object sorting with NaN handling, in 2.6.0.dev0). The new sort compares the tz-naive and tz-aware Timestamps directly, so `safe_sort` raises and `union` emits its "sort order is undefined for incomparable objects" RuntimeWarning, which errors under `-W error`.

The old silent pass was an accident of quicksort's comparison order: the reversed operand order `aware.union(naive)` has always emitted this warning on released numpy, and the union result is unchanged (unsorted, matching the existing `expected`). So the warning is the designed behavior for incomparable objects (GH-21671 test) and the test now expects it under numpy>=2.6 via a new `np_version_gt2_6` compat flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)