### PR TITLE
BUG: Fix DataFrame.any/all(skipna=False) crash with pd.NA

### DIFF
--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1683,7 +1683,9 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         mask = np.ones(mask_size, dtype=bool)
 
         float_dtyp = "float32" if self.dtype == "Float32" else "float64"
-        if name in ["mean", "median", "var", "std", "skew", "kurt", "sem"]:
+        if name in ["any", "all"]:
+            np_dtype = "bool"
+        elif name in ["mean", "median", "var", "std", "skew", "kurt", "sem"]:
             np_dtype = float_dtyp
         elif name in ["min", "max"] or self.dtype.itemsize == 8:
             np_dtype = self.dtype.numpy_dtype.name

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1314,6 +1314,14 @@ class TestDataFrameAnalytics:
     ):
         getattr(bool_frame_with_na, all_boolean_reductions)(axis=axis, bool_only=False)
 
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_any_all_boolean_na_skipna_false(self, all_boolean_reductions, axis):
+        # GH 65710
+        df = DataFrame({"a": [False, pd.NA]}, dtype="boolean")
+        result = getattr(df, all_boolean_reductions)(axis=axis, skipna=False)
+        expected = Series([pd.NA], index=["a"] if axis == 0 else [0, 1], dtype="boolean")
+        tm.assert_series_equal(result, expected)
+
     def test_any_all_bool_frame(self, all_boolean_reductions, bool_frame_with_na):
         # GH#12863: numpy gives back non-boolean data for object type
         # so fill NaNs to compare with pandas behavior


### PR DESCRIPTION
Closes #65710

When calling `DataFrame.any(skipna=False)` or `DataFrame.all(skipna=False)` with `BooleanArray` containing `pd.NA`, pandas previously crashed with a `ValueError`. This was because `BaseMaskedArray._wrap_na_result` defaulted to an `Int64` datatype for the `pd.NA` scalar for these logical reductions instead of `boolean`. The mismatched type then caused a failed downcast to numpy `bool`.

This PR explicitly assigns `"bool"` dtype for `any` and `all` reductions in `_wrap_na_result` and adds a regression test.