### PR TITLE
ENH: Add errors='coerce' to DataFrame.astype / Series.astype (GH#48781)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -14,6 +14,8 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
+- :meth:`DataFrame.astype` and :meth:`Series.astype` now accept ``errors='coerce'``, which replaces unconvertible values with the appropriate NA sentinel (``NaN``, ``NaT``, or ``pd.NA``) instead of raising (:issue:`48781`)
+
 .. _whatsnew_310.enhancements.enhancement1:
 
 enhancement1

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -400,6 +400,7 @@ TakeIndexer: TypeAlias = Sequence[int] | Sequence[np.integer] | npt.NDArray[np.i
 
 # Shared by functions such as drop and astype
 IgnoreRaise: TypeAlias = Literal["ignore", "raise"]
+IgnoreRaiseCoerce: TypeAlias = Literal["ignore", "raise", "coerce"]
 
 # Windowing rank methods
 WindowingRankType: TypeAlias = Literal["average", "min", "max"]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -400,7 +400,7 @@ TakeIndexer: TypeAlias = Sequence[int] | Sequence[np.integer] | npt.NDArray[np.i
 
 # Shared by functions such as drop and astype
 IgnoreRaise: TypeAlias = Literal["ignore", "raise"]
-IgnoreRaiseCoerce: TypeAlias = IgnoreRaise |  Literal["coerce"]
+IgnoreRaiseCoerce: TypeAlias = IgnoreRaise | Literal["coerce"]
 
 # Windowing rank methods
 WindowingRankType: TypeAlias = Literal["average", "min", "max"]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -400,7 +400,7 @@ TakeIndexer: TypeAlias = Sequence[int] | Sequence[np.integer] | npt.NDArray[np.i
 
 # Shared by functions such as drop and astype
 IgnoreRaise: TypeAlias = Literal["ignore", "raise"]
-IgnoreRaiseCoerce: TypeAlias = Literal["ignore", "raise", "coerce"]
+IgnoreRaiseCoerce: TypeAlias = IgnoreRaise |  Literal["coerce"]
 
 # Windowing rank methods
 WindowingRankType: TypeAlias = Literal["average", "min", "max"]

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -19,8 +19,10 @@ from pandas._libs.tslibs.timedeltas import array_to_timedelta64
 from pandas.errors import IntCastingNaNError
 
 from pandas.core.dtypes.common import (
+    is_datetime64_any_dtype,
     is_object_dtype,
     is_string_dtype,
+    is_timedelta64_dtype,
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import (
@@ -37,7 +39,7 @@ if TYPE_CHECKING:
         ArrayLike,
         Dtype,
         DtypeObj,
-        IgnoreRaise,
+        IgnoreRaiseCoerce,
     )
 
     from pandas.core.arrays import ExtensionArray
@@ -193,7 +195,10 @@ def astype_array(values: ArrayLike, dtype: DtypeObj, copy: bool = False) -> Arra
 
 
 def astype_array_safe(
-    values: ArrayLike, dtype: Dtype, copy: bool = False, errors: IgnoreRaise = "raise"
+    values: ArrayLike,
+    dtype: Dtype,
+    copy: bool = False,
+    errors: IgnoreRaiseCoerce = "raise",
 ) -> ArrayLike:
     """
     Cast array (ndarray or ExtensionArray) to the new dtype.
@@ -211,12 +216,14 @@ def astype_array_safe(
     errors : str, {'raise', 'ignore'}, default 'raise'
         - ``raise`` : allow exceptions to be raised
         - ``ignore`` : suppress exceptions. On error return original object
+        - ``coerce`` : on error, replace unconvertible values with the
+                       dtype's NA sentinel (NaN, NaT, or pd.NA)
 
     Returns
     -------
     ndarray or ExtensionArray
     """
-    errors_legal_values = ("raise", "ignore")
+    errors_legal_values = ("raise", "ignore", "coerce")
 
     if errors not in errors_legal_values:
         invalid_arg = (
@@ -244,10 +251,62 @@ def astype_array_safe(
         #  trying to convert to float
         if errors == "ignore":
             new_values = values
+        elif errors == "coerce":
+            return _coerce_to_na(values, dtype)
         else:
             raise
 
     return new_values
+
+
+def _coerce_to_na(values: ArrayLike, dtype: DtypeObj) -> ArrayLike:
+    """
+    Element-wise coerce: cast each value to ``dtype``; replace failures
+    with the dtype's NA sentinel.  Called only when a bulk astype has
+    already failed, so this is the intentional slow path.
+    """
+    from pandas.core.construction import array as pd_array
+    from pandas.core.series import Series
+    from pandas.core.tools.datetimes import to_datetime
+    from pandas.core.tools.numeric import to_numeric
+    from pandas.core.tools.timedeltas import to_timedelta
+
+    shape = values.shape
+    flat = values.ravel() if values.ndim == 2 else values
+
+    # numeric numpy dtypes
+    if isinstance(dtype, np.dtype) and dtype.kind in "iufcb":
+        result = to_numeric(Series(flat), errors="coerce").to_numpy()
+        # If the target is an integer kind but NaNs are present, to_numeric
+        # returns float64.
+        if dtype.kind in "iu" and np.isnan(result).any():
+            # Keep as float; caller should use a nullable Int dtype instead.
+            return result.reshape(shape)
+        try:
+            return result.astype(dtype).reshape(shape)
+        except (ValueError, TypeError):
+            return result.reshape(shape)  # float fallback
+
+    # datetime64
+    if is_datetime64_any_dtype(dtype):
+        result = to_datetime(Series(flat), errors="coerce").to_numpy().astype(dtype)
+        return result.reshape(shape)
+
+    # timedelta64
+    if is_timedelta64_dtype(dtype):
+        result = to_timedelta(Series(flat), errors="coerce").to_numpy().astype(dtype)
+        return result.reshape(shape)
+
+    # Determine the NA sentinel for the target dtype.
+    na_val = dtype.na_value if isinstance(dtype, ExtensionDtype) else np.nan
+    result_list = []
+    for val in flat:
+        try:
+            converted = pd_array([val], dtype=dtype)[0]
+        except (ValueError, TypeError):
+            converted = na_val
+        result_list.append(converted)
+    return pd_array(result_list, dtype=dtype)
 
 
 def astype_is_view(dtype: DtypeObj, new_dtype: DtypeObj) -> bool:

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -19,10 +19,8 @@ from pandas._libs.tslibs.timedeltas import array_to_timedelta64
 from pandas.errors import IntCastingNaNError
 
 from pandas.core.dtypes.common import (
-    is_datetime64_any_dtype,
     is_object_dtype,
     is_string_dtype,
-    is_timedelta64_dtype,
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import (
@@ -276,7 +274,7 @@ def _coerce_to_na(values: ArrayLike, dtype: DtypeObj) -> ArrayLike:
 
     # numeric numpy dtypes
     if isinstance(dtype, np.dtype) and dtype.kind in "iufcb":
-        result = to_numeric(Series(flat), errors="coerce").to_numpy()
+        result = np.asarray(to_numeric(Series(flat), errors="coerce"))
         # If the target is an integer kind but NaNs are present, to_numeric
         # returns float64.
         if dtype.kind in "iu" and np.isnan(result).any():
@@ -287,14 +285,16 @@ def _coerce_to_na(values: ArrayLike, dtype: DtypeObj) -> ArrayLike:
         except (ValueError, TypeError):
             return result.reshape(shape)  # float fallback
 
-    # datetime64
-    if is_datetime64_any_dtype(dtype):
-        result = to_datetime(Series(flat), errors="coerce").to_numpy().astype(dtype)
+    if lib.is_np_dtype(dtype, "M"):
+        result = to_datetime(Series(flat), errors="coerce")._values._ndarray.astype(
+            dtype
+        )
         return result.reshape(shape)
 
-    # timedelta64
-    if is_timedelta64_dtype(dtype):
-        result = to_timedelta(Series(flat), errors="coerce").to_numpy().astype(dtype)
+    if lib.is_np_dtype(dtype, "m"):
+        result = to_timedelta(Series(flat), errors="coerce")._values._ndarray.astype(
+            dtype
+        )
         return result.reshape(shape)
 
     # Determine the NA sentinel for the target dtype.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -167,6 +167,7 @@ if TYPE_CHECKING:
         FormattersType,
         Frequency,
         IgnoreRaise,
+        IgnoreRaiseCoerce,
         IndexKeyFunc,
         IndexLabel,
         InterpolateOptions,
@@ -6403,7 +6404,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         self,
         dtype,
         copy: bool | lib.NoDefault = lib.no_default,
-        errors: IgnoreRaise = "raise",
+        errors: IgnoreRaiseCoerce = "raise",
     ) -> Self:
         """
         Cast a pandas object to a specified dtype ``dtype``.
@@ -6439,6 +6440,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
             - ``raise`` : allow exceptions to be raised
             - ``ignore`` : suppress exceptions. On error return original object.
+            - ``coerce`` : coerce unconvertible values to the dtype's NA sentinel
+                   (NaN for numpy float dtypes, NaT for datetime/timedelta,
+                   pd.NA for nullable extension dtypes).
+                   For integer dtypes that cannot hold NA values (e.g.
+                   ``int64``), the result is upcast to ``float64``.
+                   Use a nullable integer dtype (e.g. ``Int64``) to
+                   preserve integer semantics.
 
         Returns
         -------
@@ -6523,6 +6531,21 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         1   2020-01-02
         2   2020-01-03
         dtype: datetime64[us]
+
+        Use `errors='coerce'` to convert invalid values to NA/NaN:
+
+        >>> df = pd.DataFrame({"a": [1, 2, "ERR"], "b": [3.0, "bad", 5.0]})
+        >>> df.astype(float, errors="coerce")
+            a    b
+        0  1.0  3.0
+        1  2.0  NaN
+        2  NaN  5.0
+
+        >>> df.astype("Float64", errors="coerce")
+            a     b
+        0   1.0   3.0
+        1   2.0  <NA>
+        2  <NA>   5.0
         """
         self._check_copy_deprecation(copy)
         if is_dict_like(dtype):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -127,7 +127,7 @@ if TYPE_CHECKING:
         DtypeBackend,
         DtypeObj,
         FillnaOptions,
-        IgnoreRaise,
+        IgnoreRaiseCoerce,
         InterpolateOptions,
         QuantileInterpolation,
         Shape,
@@ -594,7 +594,7 @@ class Block(PandasObject, libinternals.Block):
     def astype(
         self,
         dtype: DtypeObj,
-        errors: IgnoreRaise = "raise",
+        errors: IgnoreRaiseCoerce = "raise",
         squeeze: bool = False,
     ) -> Block:
         """

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -583,7 +583,7 @@ class TestAstype:
 
         msg = (
             "Expected value of kwarg 'errors' to be one of "
-            "['raise', 'ignore']. Supplied value is 'True'"
+            "['raise', 'ignore', 'coerce']. Supplied value is 'True'"
         )
         with pytest.raises(ValueError, match=re.escape(msg)):
             df.astype(np.float64, errors=True)
@@ -918,3 +918,66 @@ def test_astype_to_string_dtype_not_modifying_input(any_string_dtype, val):
     expected = df.copy()
     df.astype(any_string_dtype)
     tm.assert_frame_equal(df, expected)
+
+
+class TestAstypeCoerce:
+    """Tests for errors='coerce' in DataFrame.astype (GH#48781)."""
+
+    def test_coerce_numeric_dtype(self):
+        # object column with strings -> float64 with NaN for bad values
+        df = DataFrame({"a": [1, 2, "bad", None], "b": [3.0, "err", 5.0, 6.0]})
+        result = df.astype(float, errors="coerce")
+        expected = DataFrame(
+            {"a": [1.0, 2.0, np.nan, np.nan], "b": [3.0, np.nan, 5.0, 6.0]}
+        )
+        tm.assert_frame_equal(result, expected)
+
+    def test_coerce_nullable_float_dtype(self):
+        df = DataFrame({"a": [1, 2, "bad", None]})
+        result = df.astype("Float64", errors="coerce")
+        expected = DataFrame({"a": pd.array([1.0, 2.0, pd.NA, pd.NA], dtype="Float64")})
+        tm.assert_frame_equal(result, expected)
+
+    def test_coerce_nullable_int_dtype(self):
+        # int64 can't hold NA; coerce to Float64 (same as to_numeric behaviour)
+        df = DataFrame({"a": [1, 2, "bad"]})
+        result = df.astype("int64", errors="coerce")
+        # "bad" -> NaN -> float64 result (numpy int can't hold NaN)
+        assert result["a"].dtype == np.dtype("float64")
+        assert np.isnan(result["a"].iloc[2])
+
+    def test_coerce_nullable_Int64_dtype(self):
+        # nullable Int64 CAN hold pd.NA
+        df = DataFrame({"a": [1, 2, "bad"]})
+        result = df.astype("Int64", errors="coerce")
+        expected = DataFrame({"a": pd.array([1, 2, pd.NA], dtype="Int64")})
+        tm.assert_frame_equal(result, expected)
+
+    def test_coerce_datetime_dtype(self):
+        df = DataFrame({"d": ["2021-01-01", "not-a-date", "2021-03-01"]})
+        result = df.astype("datetime64[us]", errors="coerce")
+        expected = DataFrame(
+            {"d": pd.to_datetime(["2021-01-01", NaT, "2021-03-01"])}
+        ).astype("datetime64[us]")
+        tm.assert_frame_equal(result, expected)
+
+    def test_coerce_dict_dtype(self):
+        # Per-column dtype mapping with errors='coerce'
+        df = DataFrame({"a": [1, "bad", 3], "b": ["2021-01-01", "nope", "2021-03-01"]})
+        result = df.astype({"a": float, "b": "datetime64[us]"}, errors="coerce")
+        assert result["a"].dtype == np.dtype("float64")
+        assert pd.isna(result["a"].iloc[1])
+        assert pd.isna(result["b"].iloc[1])
+
+    def test_coerce_all_valid_unchanged(self):
+        # When all values are valid, coerce behaves identically to raise
+        df = DataFrame({"a": [1, 2, 3]})
+        result = df.astype(float, errors="coerce")
+        expected = df.astype(float, errors="raise")
+        tm.assert_frame_equal(result, expected)
+
+    def test_coerce_invalid_value_raises(self):
+        # errors='coerce' still validates the errors kwarg itself
+        df = DataFrame({"a": [1, 2]})
+        with pytest.raises(ValueError, match="Expected value of kwarg 'errors'"):
+            df.astype(float, errors="bad_value")

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -13,6 +13,7 @@ from pandas._libs.tslibs import iNaT
 from pandas.errors import Pandas4Warning
 import pandas.util._test_decorators as td
 
+import pandas as pd
 from pandas import (
     NA,
     Categorical,
@@ -63,7 +64,7 @@ class TestAstypeAPI:
 
         msg = (
             r"Expected value of kwarg 'errors' to be one of \['raise', "
-            r"'ignore'\]\. Supplied value is 'False'"
+            r"'ignore'\, 'coerce']\. Supplied value is 'False'"
         )
         with pytest.raises(ValueError, match=msg):
             ser.astype(np.float64, errors=False)
@@ -707,3 +708,34 @@ def test_astype_to_datetimelike_unit(arr_dtype, kind, unit):
         assert expected.dtype == f"{kind}8[s]"
 
     tm.assert_series_equal(result, expected)
+
+
+class TestSeriesAstypeCoerce:
+    """Tests for errors='coerce' in Series.astype (GH#48781)."""
+
+    def test_coerce_object_to_float(self):
+        ser = Series([1, 2, "bad", None], dtype=object)
+        result = ser.astype(float, errors="coerce")
+        expected = Series([1.0, 2.0, np.nan, np.nan])
+        tm.assert_series_equal(result, expected)
+
+    def test_coerce_object_to_Float64(self):
+        ser = Series(["1.1", "2.2", "oops", None], dtype=object)
+        result = ser.astype("Float64", errors="coerce")
+        expected = Series(pd.array([1.1, 2.2, NA, NA], dtype="Float64"))
+        tm.assert_series_equal(result, expected)
+
+    def test_coerce_object_to_datetime(self):
+        ser = Series(["2021-01-01", "not-a-date", "2021-06-15"])
+        result = ser.astype("datetime64[us]", errors="coerce")
+        expected = to_datetime(["2021-01-01", NaT, "2021-06-15"]).astype(
+            "datetime64[us]"
+        )
+        tm.assert_series_equal(result, Series(expected))
+
+    def test_coerce_no_errors_same_as_raise(self):
+        ser = Series([1, 2, 3])
+        tm.assert_series_equal(
+            ser.astype(float, errors="coerce"),
+            ser.astype(float, errors="raise"),
+        )


### PR DESCRIPTION
Closes #48781

---

Add `errors='coerce'` as a option. Unconvertible values are replaced with the dtype's NA sentinel instead of raising:

```python
df = pd.DataFrame({"a": [1, 2, "ERR"], "b": [3.0, "bad", 5.0]})

df.astype(float, errors="coerce")
#      a    b
# 0  1.0  3.0
# 1  2.0  NaN
# 2  NaN  5.0

df.astype("Float64", errors="coerce")
#       a     b
# 0   1.0   3.0
# 1   2.0  <NA>
# 2  <NA>   5.0

df.astype({"a": "Int64", "b": "datetime64[us]"}, errors="coerce")
# per-column dict form also supported
```

**Files changed**

- `pandas/_typing.py` — add `IgnoreRaiseCoerce`
- `pandas/core/dtypes/astype.py` — `astype_array_safe` coerce branch + `_coerce_to_na` helper
- `pandas/core/generic.py` — widen `errors` type + docstring + examples
- `pandas/core/internals/blocks.py` — widen `errors` type
- `pandas/tests/frame/methods/test_astype.py` — `TestAstypeCoerce`
- `pandas/tests/series/methods/test_astype.py` — `TestSeriesAstypeCoerce`
- `doc/source/whatsnew/v3.1.0.rst` — enhancement entry

---

**Checklist**

- [x] Tests added in `TestAstypeCoerce` (DataFrame) and `TestSeriesAstypeCoerce` (Series) covering: float coerce, nullable `Float64`/`Int64`, datetime, dict-dtype, all-valid parity with `errors='raise'`, and invalid `errors=` kwarg
- [x] Whatsnew entry added
- [x] Docstring updated with new `errors` option description and examples