### PR TITLE
BUG: Arrow interpolate fast path skips consecutive NAs (GH#65345)

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2883,11 +2883,28 @@ class ArrowExtensionArray(
             and limit_direction == "forward"
         ):
             values = self._pa_array.combine_chunks()
-            na_value = pa.array([None], type=values.type)
-            y_diff_2 = pc.fill_null_backward(pc.pairwise_diff_checked(values, period=2))
-            prev_values = pa.concat_arrays([na_value, values[:-2], na_value])
-            interps = pc.add_checked(prev_values, pc.divide_checked(y_diff_2, 2))
-            return self._from_pyarrow_array(pc.coalesce(self._pa_array, interps))
+            # The PyArrow-native fast path uses pairwise_diff(period=2),
+            # which only handles isolated single NAs correctly.  When
+            # consecutive NAs are present the computation silently
+            # produces wrong results (GH#65345).  Fall through to the
+            # generic masked-array path for those cases.
+            if len(values) > 1:
+                nulls = pc.is_null(values)
+                consecutive_nulls = pc.and_kleene(nulls[:-1], nulls[1:])
+                if not pc.any(consecutive_nulls).as_py():
+                    na_value = pa.array([None], type=values.type)
+                    y_diff_2 = pc.fill_null_backward(
+                        pc.pairwise_diff_checked(values, period=2)
+                    )
+                    prev_values = pa.concat_arrays([na_value, values[:-2], na_value])
+                    interps = pc.add_checked(
+                        prev_values, pc.divide_checked(y_diff_2, 2)
+                    )
+                    return self._from_pyarrow_array(
+                        pc.coalesce(self._pa_array, interps)
+                    )
+            # Fall through to generic path for consecutive NAs
+            # or single-element arrays.
 
         mask = self.isna()
         if self.dtype.kind == "f":
@@ -2910,7 +2927,23 @@ class ArrowExtensionArray(
             mask=mask,
             **kwargs,
         )
-        return self._from_pyarrow_array(self._box_pa_array(pa.array(data, mask=mask)))
+        pa_arr = pa.array(data, mask=mask)
+        result = self._from_pyarrow_array(self._box_pa_array(pa_arr))
+        # The generic masked-array path works in float64, so integer input
+        # comes back as double[pyarrow].  Cast back to the original dtype
+        # when the interpolation is complete (no remaining NAs and no limit
+        # truncation) so the caller gets the same type it started with
+        # (GH#65345).  If values were skipped because of `limit` or
+        # `limit_area`, keep the float result to avoid truncating
+        # fractional interpolated values.
+        if (
+            self.dtype.kind in "iu"
+            and limit is None
+            and limit_area is None
+            and not result.isna().any()
+        ):
+            result = result.astype(self.dtype)
+        return result
 
     @classmethod
     def _if_else(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -4228,3 +4228,12 @@ def test_date32_pyarrow_dateoffset_with_nulls(dtype):
     result = ser + pd.offsets.MonthEnd()
     assert result[0] == date(2022, 12, 31)
     assert pd.isna(result[1])  # handles NA, NaT, None uniformly
+
+
+@pytest.mark.parametrize("dtype", ["int64[pyarrow]", "float64[pyarrow]"])
+def test_interpolate_linear_consecutive_na(dtype):
+    # GH#65345
+    ser = pd.Series([1, None, None, 4], dtype=dtype)
+    result = ser.interpolate()
+    expected = pd.Series([1, 2, 3, 4], dtype=dtype)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Fixes #65345

The PyArrow-native fast path in ArrowExtensionArray._interpolate uses pairwise_diff(period=2), which only handles isolated single NAs correctly. When consecutive NAs are present, the computation silently produces wrong results.

Changes:
- Fall through to the generic masked-array path when consecutive NAs are detected
- Cast the interpolated result back to the original integer Arrow dtype when the input was int/uint and interpolation is complete (no remaining NAs, no limit truncation)
- Add test_interpolate_linear_consecutive_na for ArrowExtensionArray

The cast-back is conditional: only when limit is None, limit_area is None, and no values remain NA. This preserves float output when limit truncation leaves fractional values.