### PR TITLE
TST/CLN: Remove unnecessary test on EA._monotonic_check

### DIFF
--- a/pandas/tests/extension/test_common.py
+++ b/pandas/tests/extension/test_common.py
@@ -82,14 +82,6 @@ def test_is_extension_array_dtype(dtype):
     assert is_extension_array_dtype(dtype)
 
 
-def test_monotonic_check_unsupported_argsort_dtype():
-    # GH#65585
-    # Test fallback in ExtensionArray._monotonic_check when is_monotonic can't be used
-    arr = pd.array(np.array([1, 2, 3], dtype="float16"))
-    assert arr._monotonic_check() == (True, False)
-    assert arr[::-1]._monotonic_check() == (False, True)
-
-
 class CapturingStringArray(pd.arrays.StringArray):
     """Extend StringArray to capture arguments to __getitem__"""
 


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/pandas/pull/65803/changes#r3386720427

The test here is unnecessary - `float16` is explicitly tested in `test_algos.py` and the fallback this was testing no longer exists.
