### PR TITLE
TST: assert helpful errors for never-supported pyarrow read_csv cases

### DIFF
--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -682,21 +682,23 @@ def test_header_missing_rows(all_parsers):
         parser.read_csv(StringIO(data), header=[0, 1, 2])
 
 
-# ValueError: the 'pyarrow' engine does not support regex separators
-@xfail_pyarrow
 def test_header_multiple_whitespaces(all_parsers):
     # GH#54931
     parser = all_parsers
     data = """aa    bb(1,1)   cc(1,1)
                 0  2  3.5"""
 
+    if parser.engine == "pyarrow":
+        msg = "the 'pyarrow' engine does not support separators > 1 char"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), sep=r"\s+")
+        return
+
     result = parser.read_csv(StringIO(data), sep=r"\s+")
     expected = DataFrame({"aa": [0], "bb(1,1)": 2, "cc(1,1)": 3.5})
     tm.assert_frame_equal(result, expected)
 
 
-# ValueError: the 'pyarrow' engine does not support regex separators
-@xfail_pyarrow
 def test_header_delim_whitespace(all_parsers):
     # GH#54918
     parser = all_parsers
@@ -704,6 +706,12 @@ def test_header_delim_whitespace(all_parsers):
 1,2
 3,4
     """
+    if parser.engine == "pyarrow":
+        msg = "the 'pyarrow' engine does not support separators > 1 char"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), sep=r"\s+")
+        return
+
     result = parser.read_csv(StringIO(data), sep=r"\s+")
     expected = DataFrame({"a,b": ["1,2", "3,4"]})
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -15,8 +15,6 @@ from pandas import DataFrame
 import pandas._testing as tm
 from pandas.util.version import Version
 
-xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
-
 # We'll probably always skip these for pyarrow
 # Maybe we'll add our own tests for pyarrow too
 pytestmark = [
@@ -126,7 +124,6 @@ def _generate_multi_thread_dataframe(parser, path, num_rows, num_tasks):
     return final_dataframe
 
 
-@xfail_pyarrow  # ValueError: The 'nrows' option is not supported
 def test_multi_thread_path_multipart_read_csv(tmp_path, all_parsers):
     # see gh-11786
     num_tasks = 4
@@ -151,6 +148,12 @@ def test_multi_thread_path_multipart_read_csv(tmp_path, all_parsers):
 
     path = tmp_path / file_name
     df.to_csv(path)
+
+    if parser.engine == "pyarrow":
+        msg = "The 'nrows' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            _generate_multi_thread_dataframe(parser, path, num_rows, num_tasks)
+        return
 
     result = _generate_multi_thread_dataframe(parser, path, num_rows, num_tasks)
 

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -826,7 +826,6 @@ False
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow
 @pytest.mark.parametrize(
     "na_values",
     [[-99.0, -99], [-99, -99.0]],
@@ -838,6 +837,12 @@ def test_na_values_dict_without_dtype(all_parsers, na_values):
 -99
 -99.0
 -99.0"""
+
+    if parser.engine == "pyarrow":
+        msg = "The 'pyarrow' engine requires all na_values to be strings"
+        with pytest.raises(TypeError, match=msg):
+            parser.read_csv(StringIO(data), na_values=na_values)
+        return
 
     result = parser.read_csv(StringIO(data), na_values=na_values)
     expected = DataFrame({"A": [np.nan, np.nan, np.nan, np.nan]})

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -136,11 +136,18 @@ def test_parse_dates_string(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow
 @pytest.mark.parametrize("parse_dates", [[0, 2], ["a", "c"]])
 def test_parse_dates_column_list(all_parsers, parse_dates):
     data = "a,b,c\n01/01/2010,1,15/02/2010"
     parser = all_parsers
+
+    if parser.engine == "pyarrow":
+        msg = "The 'dayfirst' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(
+                StringIO(data), index_col=[0, 1], parse_dates=parse_dates, dayfirst=True
+            )
+        return
 
     expected = DataFrame(
         {"a": [datetime(2010, 1, 1)], "b": [1], "c": [datetime(2010, 2, 15)]}
@@ -304,7 +311,6 @@ def test_parse_dates_empty_string(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow
 @pytest.mark.parametrize(
     "data,kwargs,expected",
     [
@@ -351,6 +357,12 @@ def test_parse_dates_empty_string(all_parsers):
 def test_parse_dates_no_convert_thousands(all_parsers, data, kwargs, expected):
     # see gh-14066
     parser = all_parsers
+
+    if parser.engine == "pyarrow":
+        msg = "The 'thousands' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), thousands=".", **kwargs)
+        return
 
     result = parser.read_csv(StringIO(data), thousands=".", **kwargs)
     tm.assert_frame_equal(result, expected)
@@ -699,7 +711,6 @@ def test_infer_first_column_as_index(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # pyarrow engine doesn't support passing a dict for na_values
 def test_replace_nans_before_parsing_dates(all_parsers):
     # GH#26203
     parser = all_parsers
@@ -710,6 +721,17 @@ def test_replace_nans_before_parsing_dates(all_parsers):
 #
 2017-09-09
 """
+    if parser.engine == "pyarrow":
+        msg = "The pyarrow engine doesn't support passing a dict for na_values"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(
+                StringIO(data),
+                na_values={"Test": ["#", "0"]},
+                parse_dates=["Test"],
+                date_format="%Y-%m-%d",
+            )
+        return
+
     result = parser.read_csv(
         StringIO(data),
         na_values={"Test": ["#", "0"]},

--- a/pandas/tests/io/parser/test_quoting.py
+++ b/pandas/tests/io/parser/test_quoting.py
@@ -17,7 +17,6 @@ import pandas._testing as tm
 pytestmark = pytest.mark.filterwarnings(
     "ignore:Passing a BlockManager to DataFrame:DeprecationWarning"
 )
-xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
 skip_pyarrow = pytest.mark.usefixtures("pyarrow_skip")
 
 
@@ -92,13 +91,22 @@ def test_quote_char_various(all_parsers, quote_char):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # ValueError: The 'quoting' option is not supported
 @pytest.mark.parametrize("quoting", [csv.QUOTE_MINIMAL, csv.QUOTE_NONE])
 @pytest.mark.parametrize("quote_char", ["", None])
-def test_null_quote_char(all_parsers, quoting, quote_char):
+def test_null_quote_char(all_parsers, quoting, quote_char, request):
     kwargs = {"quotechar": quote_char, "quoting": quoting}
     data = "a,b,c\n1,2,3"
     parser = all_parsers
+
+    if parser.engine == "pyarrow":
+        if quoting != csv.QUOTE_MINIMAL:
+            # any non-default value of ``quoting`` is rejected outright
+            msg = "The 'quoting' option is not supported with the 'pyarrow' engine"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv(StringIO(data), **kwargs)
+            return
+        mark = pytest.mark.xfail(reason="pyarrow mishandles null/blank quote chars")
+        request.applymarker(mark)
 
     if quoting != csv.QUOTE_NONE:
         # Sanity checking.
@@ -137,11 +145,20 @@ def test_null_quote_char(all_parsers, quoting, quote_char):
         ({"quotechar": '"', "quoting": csv.QUOTE_NONNUMERIC}, [[1.0, 2.0, "foo"]]),
     ],
 )
-@xfail_pyarrow  # ValueError: The 'quoting' option is not supported
-def test_quoting_various(all_parsers, kwargs, exp_data):
+def test_quoting_various(all_parsers, kwargs, exp_data, request):
     data = '1,2,"foo"'
     parser = all_parsers
     columns = ["a", "b", "c"]
+
+    if parser.engine == "pyarrow":
+        if kwargs.get("quoting", csv.QUOTE_MINIMAL) != csv.QUOTE_MINIMAL:
+            # any non-default value of ``quoting`` is rejected outright
+            msg = "The 'quoting' option is not supported with the 'pyarrow' engine"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv(StringIO(data), names=columns, **kwargs)
+            return
+        mark = pytest.mark.xfail(reason="ParserError: Empty CSV file or block")
+        request.applymarker(mark)
 
     result = parser.read_csv(StringIO(data), names=columns, **kwargs)
     expected = DataFrame(exp_data, columns=columns)

--- a/pandas/tests/io/parser/test_skiprows.py
+++ b/pandas/tests/io/parser/test_skiprows.py
@@ -23,9 +23,8 @@ pytestmark = pytest.mark.filterwarnings(
 )
 
 
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 @pytest.mark.parametrize("skiprows", [list(range(6)), 6])
-def test_skip_rows_bug(all_parsers, skiprows):
+def test_skip_rows_bug(all_parsers, skiprows, request):
     # see gh-505
     parser = all_parsers
     text = """#foo,a,b,c
@@ -38,6 +37,21 @@ def test_skip_rows_bug(all_parsers, skiprows):
 1/2/2000,4,5,6
 1/3/2000,7,8,9
 """
+    if parser.engine == "pyarrow":
+        if not isinstance(skiprows, int):
+            msg = "skiprows argument must be an integer when using engine='pyarrow'"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv(
+                    StringIO(text),
+                    skiprows=skiprows,
+                    header=None,
+                    index_col=0,
+                    parse_dates=True,
+                )
+            return
+        mark = pytest.mark.xfail(reason="AssertionError: DataFrame.index are different")
+        request.applymarker(mark)
+
     result = parser.read_csv(
         StringIO(text), skiprows=skiprows, header=None, index_col=0, parse_dates=True
     )
@@ -53,7 +67,6 @@ def test_skip_rows_bug(all_parsers, skiprows):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 def test_deep_skip_rows(all_parsers):
     # see gh-4382
     parser = all_parsers
@@ -63,6 +76,12 @@ def test_deep_skip_rows(all_parsers):
     condensed_data = "a,b,c\n" + "\n".join(
         [",".join([str(i), str(i + 1), str(i + 2)]) for i in [0, 1, 2, 3, 4, 6, 8, 9]]
     )
+
+    if parser.engine == "pyarrow":
+        msg = "skiprows argument must be an integer when using engine='pyarrow'"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), skiprows=[6, 8])
+        return
 
     result = parser.read_csv(StringIO(data), skiprows=[6, 8])
     condensed_result = parser.read_csv(StringIO(condensed_data))
@@ -131,15 +150,19 @@ line 22",2
         ),
     ],
 )
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 def test_skip_row_with_newline(all_parsers, data, kwargs, expected):
     # see gh-12775 and gh-10911
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        msg = "skiprows argument must be an integer when using engine='pyarrow'"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), **kwargs)
+        return
+
     result = parser.read_csv(StringIO(data), **kwargs)
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 def test_skip_row_with_quote(all_parsers):
     # see gh-12775 and gh-10911
     parser = all_parsers
@@ -147,6 +170,12 @@ def test_skip_row_with_quote(all_parsers):
 1,"line '11' line 12",2
 2,"line '21' line 22",2
 3,"line '31' line 32",1"""
+
+    if parser.engine == "pyarrow":
+        msg = "skiprows argument must be an integer when using engine='pyarrow'"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), skiprows=[1])
+        return
 
     exp_data = [[2, "line '21' line 22", 2], [3, "line '31' line 32", 1]]
     expected = DataFrame(exp_data, columns=["id", "text", "num_lines"])
@@ -181,17 +210,21 @@ def test_skip_row_with_quote(all_parsers):
         ),
     ],
 )
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 def test_skip_row_with_newline_and_quote(all_parsers, data, exp_data):
     # see gh-12775 and gh-10911
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        msg = "skiprows argument must be an integer when using engine='pyarrow'"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), skiprows=[1])
+        return
+
     result = parser.read_csv(StringIO(data), skiprows=[1])
 
     expected = DataFrame(exp_data, columns=["id", "text", "num_lines"])
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # ValueError: the 'pyarrow' engine does not support regex separators
 @pytest.mark.parametrize(
     "lineterminator",
     ["\n", "\r\n", "\r"],  # "LF"  # "CRLF"  # "CR"
@@ -222,6 +255,17 @@ def test_skiprows_lineterminator(all_parsers, lineterminator, request):
 
     data = data.replace("\n", lineterminator)
 
+    if parser.engine == "pyarrow":
+        msg = "the 'pyarrow' engine does not support separators > 1 char"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(
+                StringIO(data),
+                skiprows=1,
+                sep=r"\s+",
+                names=["date", "time", "var", "flag", "oflag"],
+            )
+        return
+
     result = parser.read_csv(
         StringIO(data),
         skiprows=1,
@@ -242,7 +286,6 @@ def test_skiprows_infield_quote(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 @pytest.mark.parametrize(
     "kwargs,expected",
     [
@@ -254,16 +297,29 @@ def test_skip_rows_callable(all_parsers, kwargs, expected):
     parser = all_parsers
     data = "a\n1\n2\n3\n4\n5"
 
+    if parser.engine == "pyarrow":
+        msg = "skiprows argument must be an integer when using engine='pyarrow'"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), skiprows=lambda x: x % 2 == 0, **kwargs)
+        return
+
     result = parser.read_csv(StringIO(data), skiprows=lambda x: x % 2 == 0, **kwargs)
     expected = DataFrame({expected: [3, 5]})
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 def test_skip_rows_callable_not_in(all_parsers):
     parser = all_parsers
     data = "0,a\n1,b\n2,c\n3,d\n4,e"
     expected = DataFrame([[1, "b"], [3, "d"]])
+
+    if parser.engine == "pyarrow":
+        msg = "skiprows argument must be an integer when using engine='pyarrow'"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(
+                StringIO(data), header=None, skiprows=lambda x: x not in [1, 3]
+            )
+        return
 
     result = parser.read_csv(
         StringIO(data), header=None, skiprows=lambda x: x not in [1, 3]
@@ -271,27 +327,36 @@ def test_skip_rows_callable_not_in(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 def test_skip_rows_skip_all(all_parsers):
     parser = all_parsers
     data = "a\n1\n2\n3\n4\n5"
     msg = "No columns to parse from file"
 
+    if parser.engine == "pyarrow":
+        msg = "skiprows argument must be an integer when using engine='pyarrow'"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), skiprows=lambda x: True)
+        return
+
     with pytest.raises(EmptyDataError, match=msg):
         parser.read_csv(StringIO(data), skiprows=lambda x: True)
 
 
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 def test_skip_rows_bad_callable(all_parsers):
     msg = "by zero"
     parser = all_parsers
     data = "a\n1\n2\n3\n4\n5"
 
+    if parser.engine == "pyarrow":
+        msg = "skiprows argument must be an integer when using engine='pyarrow'"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), skiprows=lambda x: 1 / 0)
+        return
+
     with pytest.raises(ZeroDivisionError, match=msg):
         parser.read_csv(StringIO(data), skiprows=lambda x: 1 / 0)
 
 
-@xfail_pyarrow  # ValueError: skiprows argument must be an integer
 def test_skip_rows_and_n_rows(all_parsers):
     # GH#44021
     data = """a,b
@@ -305,12 +370,17 @@ def test_skip_rows_and_n_rows(all_parsers):
 8,h
 """
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        msg = "The 'nrows' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), nrows=5, skiprows=[2, 4, 6])
+        return
+
     result = parser.read_csv(StringIO(data), nrows=5, skiprows=[2, 4, 6])
     expected = DataFrame({"a": [1, 3, 5, 7, 8], "b": ["a", "c", "e", "g", "h"]})
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow
 def test_skip_rows_with_chunks(all_parsers):
     # GH 55677
     data = """col_a
@@ -326,6 +396,17 @@ def test_skip_rows_with_chunks(all_parsers):
 100
 """
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        msg = "The 'chunksize' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(
+                StringIO(data),
+                engine=parser,
+                skiprows=lambda x: x in [1, 4, 5],
+                chunksize=4,
+            )
+        return
+
     reader = parser.read_csv(
         StringIO(data), engine=parser, skiprows=lambda x: x in [1, 4, 5], chunksize=4
     )


### PR DESCRIPTION
Many pyarrow-engine read_csv xfails can never pass: they exercise options the engine intentionally rejects (list/callable `skiprows`, regex separators, non-default `quoting`, `thousands`, `nrows`, `chunksize`, `dayfirst`, dict/non-string `na_values`). For these, the best we can do is raise a helpful error — which we already do — so convert the xfails to assert that message, using the raises-and-return pattern already common in these files.

- 36 tests converted across test_skiprows.py, test_quoting.py, test_parse_dates.py, test_na_values.py, test_multi_thread.py, test_header.py
- Parametrized cases that fail for other (potentially fixable) reasons keep a conditional xfail via `request.applymarker` (e.g. `test_skip_rows_bug[6]`, `test_null_quote_char` with default quoting)

Test-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)