### PR TITLE
BUG: raise helpful errors for unsupported pyarrow read_csv usage

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -359,6 +359,8 @@ MultiIndex
 
 I/O
 ^^^
+- :func:`read_csv` with ``engine="pyarrow"`` now raises ``ValueError`` for the unsupported ``na_filter=False`` instead of silently ignoring it (:issue:`65862`)
+- :func:`read_csv` with ``engine="pyarrow"`` now raises an informative ``ValueError`` for a list-valued ``header`` (MultiIndex columns are not supported by this engine) instead of a cryptic ``TypeError`` (:issue:`65862`)
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -56,6 +56,17 @@ class ArrowParserWrapper(ParserBase):
             )
         self.na_values = list(self.kwds["na_values"])
 
+        header = self.header
+        if lib.is_list_like(header, allow_sets=False):
+            if len(header) == 1:
+                # equivalent to passing the integer directly
+                self.header = header[0]
+            else:
+                raise ValueError(
+                    "header argument must be an integer or None when "
+                    "using engine='pyarrow'"
+                )
+
     def _get_pyarrow_options(self) -> None:
         """
         Rename some arguments to pass to pyarrow

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -183,6 +183,7 @@ _pyarrow_unsupported = {
     "dayfirst",
     "skipinitialspace",
     "low_memory",
+    "na_filter",
 }
 
 

--- a/pandas/tests/io/parser/common/test_index.py
+++ b/pandas/tests/io/parser/common/test_index.py
@@ -146,7 +146,6 @@ bar,two,12,13,14,15
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize(
     "data,columns,header",
     [
@@ -159,11 +158,22 @@ bar,two,12,13,14,15
     ],
 )
 @pytest.mark.parametrize("round_trip", [True, False])
-def test_multi_index_blank_df(all_parsers, data, columns, header, round_trip):
+def test_multi_index_blank_df(all_parsers, data, columns, header, round_trip, request):
     # see gh-14545
     parser = all_parsers
     expected = DataFrame(columns=columns)
     data = expected.to_csv(index=False) if round_trip else data
+
+    if parser.engine == "pyarrow":
+        if len(header) > 1:
+            msg = "header argument must be an integer or None"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv(StringIO(data), header=header)
+            return
+        mark = pytest.mark.xfail(
+            reason="empty frame dtypes differ; apache/arrow#38676 without newline"
+        )
+        request.applymarker(mark)
 
     result = parser.read_csv(StringIO(data), header=header)
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -375,11 +375,24 @@ def test_dtype_mangle_dup_cols_single_dtype(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.usefixtures("pyarrow_xfail")
 def test_dtype_multi_index(all_parsers):
     # GH 42446
     parser = all_parsers
     data = "A,B,B\nX,Y,Z\n1,2,3"
+
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(
+                StringIO(data),
+                header=list(range(2)),
+                dtype={
+                    ("A", "X"): np.int32,
+                    ("B", "Y"): np.int32,
+                    ("B", "Z"): np.float32,
+                },
+            )
+        return
 
     result = parser.read_csv(
         StringIO(data),

--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -26,11 +26,16 @@ xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
 skip_pyarrow = pytest.mark.usefixtures("pyarrow_skip")
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_read_with_bad_header(all_parsers):
     parser = all_parsers
-    msg = r"but only \d+ lines in file"
 
+    if parser.engine == "pyarrow":
+        msg = "Could not skip initial 10 rows"
+        with pytest.raises(ParserError, match=msg):
+            parser.read_csv(StringIO(",,"), header=[10])
+        return
+
+    msg = r"but only \d+ lines in file"
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(",,"), header=[10])
 
@@ -117,7 +122,6 @@ baz,12,13,14,15
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index(all_parsers):
     parser = all_parsers
 
@@ -134,6 +138,12 @@ R_l0_g2,R_l1_g2,R2C0,R2C1,R2C2
 R_l0_g3,R_l1_g3,R3C0,R3C1,R3C2
 R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2
 """
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), header=[0, 1, 2, 3], index_col=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1, 2, 3], index_col=[0, 1])
     data_gen_f = lambda r, c: f"R{r}C{c}"
 
@@ -342,7 +352,6 @@ q,r,s,t,u,v
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index_common_format_malformed1(all_parsers):
     parser = all_parsers
     expected = DataFrame(
@@ -359,11 +368,16 @@ q,r,s,t,u,v
 1,2,3,4,5,6
 7,8,9,10,11,12"""
 
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
     tm.assert_frame_equal(expected, result)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index_common_format_malformed2(all_parsers):
     parser = all_parsers
     expected = DataFrame(
@@ -381,11 +395,16 @@ q,r,s,t,u,v
 1,2,3,4,5,6
 7,8,9,10,11,12"""
 
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
     tm.assert_frame_equal(expected, result)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index_common_format_malformed3(all_parsers):
     parser = all_parsers
     expected = DataFrame(
@@ -402,11 +421,16 @@ q,r,s,t,u,v
 1,2,3,4,5,6
 7,8,9,10,11,12"""
 
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), header=[0, 1], index_col=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1], index_col=[0, 1])
     tm.assert_frame_equal(expected, result)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index_blank_line(all_parsers):
     # GH 40442
     parser = all_parsers
@@ -414,6 +438,13 @@ def test_header_multi_index_blank_line(all_parsers):
     columns = MultiIndex.from_tuples([("a", "A"), ("b", "B")])
     expected = DataFrame(data, columns=columns)
     data = "a,b\nA,B\n,\n1,2\n3,4"
+
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), header=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1])
     tm.assert_frame_equal(expected, result)
 
@@ -480,7 +511,6 @@ def test_non_int_header(all_parsers, header):
         parser.read_csv(StringIO(data), header=header)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_singleton_header(all_parsers):
     # see gh-7757
     data = """a,b,c\n0,1,2\n1,2,3"""
@@ -491,7 +521,6 @@ def test_singleton_header(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize(
     "data,expected",
     [
@@ -534,11 +563,16 @@ def test_mangles_multi_index(all_parsers, data, expected):
     # see gh-18062
     parser = all_parsers
 
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), header=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1])
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize("index_col", [None, [0]])
 @pytest.mark.parametrize(
     "columns", [None, (["", "Unnamed"]), (["Unnamed", ""]), (["Unnamed", "NotUnnamed"])]
@@ -559,6 +593,12 @@ def test_multi_index_unnamed(all_parsers, index_col, columns):
         data = ",".join(columns or ["", ""]) + "\n0,1\n2,3\n4,5\n"
     else:
         data = ",".join([""] + (columns or ["", ""])) + "\n,0,1\n0,2,3\n1,4,5\n"
+
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), header=header, index_col=index_col)
+        return
 
     result = parser.read_csv(StringIO(data), header=header, index_col=index_col)
     exp_columns = []
@@ -590,7 +630,6 @@ def test_names_longer_than_header_but_equal_with_data_rows(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_read_csv_multiindex_columns(all_parsers):
     # GH#6051
     parser = all_parsers
@@ -616,13 +655,18 @@ def test_read_csv_multiindex_columns(all_parsers):
         [[0.86, 0.67, 0.88, 0.78, 0.81], [0.86, 0.67, 0.88, 0.78, 0.82]], columns=mi
     )
 
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(s1), header=[0, 1])
+        return
+
     df1 = parser.read_csv(StringIO(s1), header=[0, 1])
     tm.assert_frame_equal(df1, expected.iloc[:1])
     df2 = parser.read_csv(StringIO(s2), header=[0, 1])
     tm.assert_frame_equal(df2, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_read_csv_multi_header_length_check(all_parsers):
     # GH#43102
     parser = all_parsers
@@ -631,6 +675,11 @@ def test_read_csv_multi_header_length_check(all_parsers):
 row21,row22, row23
 row31,row32
 """
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(case), header=[0, 2])
+        return
 
     with pytest.raises(
         ParserError, match="Header rows must have an equal number of columns."
@@ -670,14 +719,16 @@ def test_header_none_and_on_bad_lines_skip(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_missing_rows(all_parsers):
     # GH#47400
     parser = all_parsers
     data = """a,b
 1,2
 """
-    msg = r"Passed header=\[0,1,2\], len of 3, but only 2 lines in file"
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+    else:
+        msg = r"Passed header=\[0,1,2\], len of 3, but only 2 lines in file"
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), header=[0, 1, 2])
 

--- a/pandas/tests/io/parser/test_index_col.py
+++ b/pandas/tests/io/parser/test_index_col.py
@@ -214,7 +214,6 @@ def test_no_multi_index_level_names_empty(temp_file, all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_with_index_col(all_parsers):
     # GH 33476
     parser = all_parsers
@@ -223,6 +222,12 @@ I11,A,A
 I12,B,B
 I2,1,3
 """
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), index_col=0, header=[0, 1])
+        return
+
     midx = MultiIndex.from_tuples([("A", "B"), ("A", "B.1")], names=["I11", "I12"])
     idx = Index(["I2"])
     expected = DataFrame([[1, 3]], index=idx, columns=midx)
@@ -259,10 +264,17 @@ def test_index_col_large_csv(temp_file, all_parsers, monkeypatch):
     tm.assert_frame_equal(result, df.set_index("a"))
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_index_col_multiindex_columns_no_data(all_parsers):
     # GH#38292
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(
+                StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1], index_col=0
+            )
+        return
+
     result = parser.read_csv(
         StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1], index_col=0
     )
@@ -276,7 +288,7 @@ def test_index_col_multiindex_columns_no_data(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
+@xfail_pyarrow  # AssertionError: DataFrame.index are different (float64 vs object)
 def test_index_col_header_no_data(all_parsers):
     # GH#38292
     parser = all_parsers
@@ -289,10 +301,15 @@ def test_index_col_header_no_data(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_multiindex_columns_no_data(all_parsers):
     # GH#38292
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1])
+        return
+
     result = parser.read_csv(StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1])
     expected = DataFrame(
         [], columns=MultiIndex.from_arrays([["a0", "a1", "a2"], ["b0", "b1", "b2"]])
@@ -300,10 +317,19 @@ def test_multiindex_columns_no_data(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_multiindex_columns_index_col_with_data(all_parsers):
     # GH#38292
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(
+                StringIO("a0,a1,a2\nb0,b1,b2\ndata,data,data"),
+                header=[0, 1],
+                index_col=0,
+            )
+        return
+
     result = parser.read_csv(
         StringIO("a0,a1,a2\nb0,b1,b2\ndata,data,data"), header=[0, 1], index_col=0
     )
@@ -355,7 +381,6 @@ def test_specify_dtype_for_index_col(all_parsers, dtype, val, request):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_multiindex_columns_not_leading_index_col(all_parsers):
     # GH#38549
     parser = all_parsers
@@ -363,6 +388,12 @@ def test_multiindex_columns_not_leading_index_col(all_parsers):
 e,f,g,h
 x,y,1,2
 """
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), header=[0, 1], index_col=1)
+        return
+
     result = parser.read_csv(
         StringIO(data),
         header=[0, 1],

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -440,17 +440,23 @@ def test_na_values_na_filter_override(
     request, all_parsers, na_filter, row_data, using_infer_string
 ):
     parser = all_parsers
-    if parser.engine == "pyarrow":
-        # mismatched dtypes in both cases, FutureWarning in the True case
-        if not (using_infer_string and na_filter):
-            mark = pytest.mark.xfail(reason="pyarrow doesn't support this.")
-            request.applymarker(mark)
     data = """\
 A,B
 1,A
 nan,B
 3,C
 """
+    if parser.engine == "pyarrow":
+        if na_filter is False:
+            msg = "The 'na_filter' option is not supported with the 'pyarrow' engine"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv(StringIO(data), na_values=["B"], na_filter=na_filter)
+            return
+        if not using_infer_string:
+            # mismatched dtypes, FutureWarning
+            mark = pytest.mark.xfail(reason="pyarrow doesn't support this.")
+            request.applymarker(mark)
+
     result = parser.read_csv(StringIO(data), na_values=["B"], na_filter=na_filter)
 
     expected = DataFrame(row_data, columns=["A", "B"])
@@ -636,7 +642,7 @@ def test_empty_na_values_no_default_with_index(all_parsers):
 @pytest.mark.parametrize(
     "na_filter,index_data", [(False, ["", "5"]), (True, [np.nan, 5.0])]
 )
-def test_no_na_filter_on_index(all_parsers, na_filter, index_data, request):
+def test_no_na_filter_on_index(all_parsers, na_filter, index_data):
     # see gh-5239
     #
     # Don't parse NA-values in index unless na_filter=True
@@ -644,8 +650,10 @@ def test_no_na_filter_on_index(all_parsers, na_filter, index_data, request):
     data = "a,b,c\n1,,3\n4,5,6"
 
     if parser.engine == "pyarrow" and na_filter is False:
-        mark = pytest.mark.xfail(reason="mismatched index result")
-        request.applymarker(mark)
+        msg = "The 'na_filter' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), index_col=[1], na_filter=na_filter)
+        return
 
     expected = DataFrame({"a": [1, 4], "c": [3, 6]}, index=Index(index_data, name="b"))
     result = parser.read_csv(StringIO(data), index_col=[1], na_filter=na_filter)
@@ -671,11 +679,17 @@ def test_na_values_with_dtype_str_and_na_filter(
 ):
     # see gh-20377
     parser = all_parsers
-    if parser.engine == "pyarrow" and (na_filter is False or not using_infer_string):
-        mark = pytest.mark.xfail(reason="mismatched shape")
-        request.applymarker(mark)
-
     data = "a,b,c\n1,,3\n4,5,6"
+
+    if parser.engine == "pyarrow":
+        if na_filter is False:
+            msg = "The 'na_filter' option is not supported with the 'pyarrow' engine"
+            with pytest.raises(ValueError, match=msg):
+                parser.read_csv(StringIO(data), na_filter=na_filter, dtype=str)
+            return
+        if not using_infer_string:
+            mark = pytest.mark.xfail(reason="mismatched shape")
+            request.applymarker(mark)
 
     # na_filter=True --> missing value becomes NaN.
     # na_filter=False --> missing value remains empty string.

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -303,6 +303,13 @@ def test_parse_dates_empty_string(all_parsers):
     # see gh-2263
     parser = all_parsers
     data = "Date,test\n2012-01-01,1\n,2"
+
+    if parser.engine == "pyarrow":
+        msg = "The 'na_filter' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), parse_dates=["Date"], na_filter=False)
+        return
+
     result = parser.read_csv(StringIO(data), parse_dates=["Date"], na_filter=False)
 
     expected = DataFrame(
@@ -588,12 +595,17 @@ def test_date_parser_and_names(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_date_parser_multiindex_columns(all_parsers):
     parser = all_parsers
     data = """a,b
 1,2
 2019-12-31,6"""
+    if parser.engine == "pyarrow":
+        msg = "header argument must be an integer or None"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), parse_dates=[("a", "1")], header=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), parse_dates=[("a", "1")], header=[0, 1])
     expected = DataFrame({("a", "1"): Timestamp("2019-12-31"), ("b", "2"): [6]})
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Follow-up to the pyarrow-engine xfail cleanup (GH-65859): several of the remaining `read_csv` pyarrow xfails were cases where unsupported usage produced a cryptic exception or silently-wrong results. This PR makes those raise informative errors and converts the corresponding xfails to assert them.

- list-valued `header` (MultiIndex columns, unsupported by `pyarrow.csv`) now raises `ValueError: header argument must be an integer or None when using engine='pyarrow'` instead of `TypeError: an integer is required`; singleton `header=[N]` now behaves like `header=N`
- `na_filter=False` was silently ignored (NA filtering happened anyway); it now raises the standard unsupported-option `ValueError`

The `names`-handling behavior fixes for the pyarrow engine (names replacing an integer header, extra leading columns forming the index, too many names raising, and tuple `names` producing MultiIndex columns) are split out into GH-66048 to keep each PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)