### PR TITLE
BUG: iloc on DataFrame with reference is a silent no-op with unsorted indexes

### DIFF
--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -21,6 +21,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
+- Bug in :meth:`DataFrame.iloc` silently ignoring the assignment when setting values with an unordered or duplicated column indexer on a :class:`DataFrame` whose values are referenced by another object (:issue:`65446`)
 - Bug in :meth:`Series.str.__getitem__` raising ``AttributeError`` when underlying array is :class:`ArrowExtensionArray` (:issue:`65112`)
 
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1614,6 +1614,8 @@ class Block(PandasObject, libinternals.Block):
         We split the block to avoid copying the underlying data. We create new
         blocks for every connected segment of the initial block that is not deleted.
         The new blocks point to the initial array.
+
+        Assumes `loc` is sorted when list-like.
         """
         if not is_list_like(loc):
             loc = [loc]

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1615,7 +1615,7 @@ class Block(PandasObject, libinternals.Block):
         blocks for every connected segment of the initial block that is not deleted.
         The new blocks point to the initial array.
 
-        Assumes `loc` is sorted when list-like.
+        Assumes `loc` is strictly increasing when list-like.
         """
         if not is_list_like(loc):
             loc = [loc]

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -587,8 +587,8 @@ class BaseBlockManager(PandasObject):
                     # first block equals values we are setting to -> set to all columns
                     if lib.is_integer(indexer[1]):
                         col_indexer = 0
-                    elif len(inverse) > 1 and np.array_equal(
-                        inverse, np.arange(len(blk_loc))
+                    elif len(inverse) > 1 and lib.is_range_indexer(
+                        inverse, len(blk_loc)
                     ):
                         col_indexer = slice(None)  # type: ignore[assignment]
                     else:
@@ -596,7 +596,14 @@ class BaseBlockManager(PandasObject):
                     indexer[1] = col_indexer
 
                     row_indexer = indexer[0]
-                    if isinstance(row_indexer, np.ndarray) and row_indexer.ndim == 2:
+                    if isinstance(col_indexer, np.ndarray):
+                        if (
+                            isinstance(row_indexer, np.ndarray)
+                            and row_indexer.ndim == 1
+                        ):
+                            # GH#65446: Make the row indexer 2d to take a cross product
+                            row_indexer = row_indexer[:, None]
+                    elif isinstance(row_indexer, np.ndarray) and row_indexer.ndim == 2:
                         # numpy cannot handle a 2d indexer in combo with a slice
                         row_indexer = np.squeeze(row_indexer, axis=1)
                     if isinstance(row_indexer, np.ndarray) and len(row_indexer) == 0:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -573,6 +573,10 @@ class BaseBlockManager(PandasObject):
 
                 values = self.blocks[0].values
                 if values.ndim == 2:
+                    # Block.delete in _iset_split_block requires sorted unique
+                    # locs; inverse maps the requested column order onto the
+                    # new block (GH#65446)
+                    blk_loc, inverse = np.unique(blk_loc, return_inverse=True)
                     values = values[blk_loc]
                     # "T" has no attribute "_iset_split_block"
                     self._iset_split_block(  # type: ignore[attr-defined]
@@ -583,10 +587,12 @@ class BaseBlockManager(PandasObject):
                     # first block equals values we are setting to -> set to all columns
                     if lib.is_integer(indexer[1]):
                         col_indexer = 0
-                    elif len(blk_loc) > 1:
+                    elif len(inverse) > 1 and np.array_equal(
+                        inverse, np.arange(len(blk_loc))
+                    ):
                         col_indexer = slice(None)  # type: ignore[assignment]
                     else:
-                        col_indexer = np.arange(len(blk_loc))  # type: ignore[assignment]
+                        col_indexer = inverse  # type: ignore[assignment]
                     indexer[1] = col_indexer
 
                     row_indexer = indexer[0]

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -561,6 +561,36 @@ class TestiLocBaseIndependent:
 
         tm.assert_frame_equal(df, expected)
 
+    def test_iloc_setitem_unordered_column_indexer_referenced_block(self):
+        # GH#65446 assignment was silently lost when the block was referenced
+        #  by another object and the column indexer was not sorted
+        df = DataFrame({"A": [1, 2], "B": [3, 4]})
+        df_orig = df.copy()
+        ref = df[["A", "B"]]
+        df.iloc[:, [1, 0]] = DataFrame({"A": [10, 20], "B": [30, 40]})
+        df._mgr._verify_integrity()
+        expected = DataFrame({"A": [30, 40], "B": [10, 20]})
+        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(ref, df_orig)
+
+    def test_iloc_setitem_duplicate_column_indexer_referenced_block(self):
+        # GH#65446
+        df = DataFrame({"A": [1, 2], "B": [3, 4]})
+        df_orig = df.copy()
+        ref = df[["A", "B"]]
+        df.iloc[:, [0, 0]] = np.array([[10, 30], [20, 40]])
+        df._mgr._verify_integrity()
+        expected = DataFrame({"A": [30, 40], "B": [3, 4]})
+        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(ref, df_orig)
+
+    def test_iloc_setitem_frame_swap_columns(self):
+        # GH#65446 positional swap when the RHS shares data with the target
+        df = DataFrame({"A": [1, 2], "B": [3, 4]})
+        df.iloc[:, [1, 0]] = df[["A", "B"]]
+        expected = DataFrame({"A": [3, 4], "B": [1, 2]})
+        tm.assert_frame_equal(df, expected)
+
     # TODO: GH#27620 this test used to compare iloc against ix; check if this
     #  is redundant with another test comparing iloc against loc
     def test_iloc_getitem_frame(self):

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -591,6 +591,18 @@ class TestiLocBaseIndependent:
         expected = DataFrame({"A": [3, 4], "B": [1, 2]})
         tm.assert_frame_equal(df, expected)
 
+    def test_iloc_setitem_unordered_row_and_column_indexer_referenced_block(self):
+        # GH#65446 a list row indexer combined with an unsorted column indexer
+        #  must set the full cross product
+        df = DataFrame({"A": [1, 2], "B": [3, 4]})
+        df_orig = df.copy()
+        ref = df[["A", "B"]]
+        df.iloc[[1, 0], [1, 0]] = np.array([[10, 20], [30, 40]])
+        df._mgr._verify_integrity()
+        expected = DataFrame({"A": [40, 20], "B": [30, 10]})
+        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(ref, df_orig)
+
     # TODO: GH#27620 this test used to compare iloc against ix; check if this
     #  is redundant with another test comparing iloc against loc
     def test_iloc_getitem_frame(self):


### PR DESCRIPTION
- [x] closes #65446 (Replace xxxx with the GitHub issue number)

This appears to me to be a somewhat severe bug - using iloc has no impact when there is another reference to the DataFrame.

```python
df = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
ref = df[['A', 'B']]  # Create a reference
df.iloc[:, [1, 0]] = np.array([[10, 30], [20, 40]])
print(df)
#    A  B
# 0  1  3
# 1  2  4
```

The only thing that makes it not so severe is that the indices have to be not strictly increasing. I believe this was introduced in 2.1 with CoW enabled in https://github.com/pandas-dev/pandas/pull/51435 but haven't run a git bisect here.