### PR TITLE
ENH: Support %N directive in strptime parsing (#65863)

### DIFF
--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -171,7 +171,8 @@ cdef dict _parse_code_table = {"y": 0,
                                "z": 19,
                                "G": 20,
                                "V": 21,
-                               "u": 22}
+                               "u": 22,
+                               "N": 23}
 
 
 cdef _validate_fmt(str fmt):
@@ -755,6 +756,13 @@ cdef tzinfo _parse_with_format(
             us = int(s)
             ns = us % 1000
             us = us // 1000
+        elif parse_code == 23:
+            # e.g. val='123456789'; fmt='%H:%M:%S.%N'
+            s = group_val
+            item_reso[0] = NPY_FR_ns
+            us = int(s)
+            ns = us % 1000
+            us = us // 1000
         elif parse_code == 11:
             # e.g val='Tuesday 24 Aug 2021 01:30:48 AM'; fmt='%A %d %b %Y %I:%M:%S %p'
             weekday = f_weekday_lookup[group_val.lower()]
@@ -859,7 +867,8 @@ class TimeRE(_TimeRE):
         super().__init__(locale_time=locale_time)
         # GH 48767: Overrides for cpython's TimeRE
         #  1) Parse up to nanos instead of micros
-        self.update({"f": r"(?P<f>[0-9]{1,9})"}),
+        self.update({"f": r"(?P<f>[0-9]{1,9})"})
+        self.update({"N": r"(?P<N>[0-9]{9})"})
 
     def __getitem__(self, key):
         if key == "Z":

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3978,3 +3978,20 @@ def test_to_datetime_missing_component_no_runtime_warning():
         result = to_datetime(df)
 
     assert result.iloc[1] is NaT
+
+
+def test_to_datetime_format_N_directive():
+    # GH 65863
+    result = to_datetime("2024-05-01 12:00:00.123456789", format="%Y-%m-%d %H:%M:%S.%N")
+    expected = Timestamp("2024-05-01 12:00:00.123456789")
+    tm.assert_equal(result, expected)
+
+    # %N must be exactly 9 digits
+    msg = 'time data "2024-05-01 12:00:00.12345" doesn\'t match format'
+    with pytest.raises(ValueError, match=msg):
+        to_datetime("2024-05-01 12:00:00.12345", format="%Y-%m-%d %H:%M:%S.%N")
+
+    # While %f can be fewer:
+    result_f = to_datetime("2024-05-01 12:00:00.12345", format="%Y-%m-%d %H:%M:%S.%f")
+    expected_f = Timestamp("2024-05-01 12:00:00.123450")
+    tm.assert_equal(result_f, expected_f)


### PR DESCRIPTION
Closes #65863

This PR adds support for the `%N` parsing directive in `to_datetime` to capture exactly 9 digits (nanoseconds) for formatting symmetry with the `strftime` string formatting capabilities.

- Added `N` to `TimeRE` matching exactly 9 digits.
- Mapped `N` to code `23` in `strptime.pyx` and added the corresponding parsing logic exactly as `%f` is handled but ensuring it expects exactly 9 digits.
- Added tests to assert exact match requirements for `%N` vs the flexible `%f`.