### PR TITLE
BUG: Validate var_name doesn't collide with id_vars or value_name in melt

### DIFF
--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -182,6 +182,22 @@ def melt(
             "the DataFrame columns."
         )
     id_vars = ensure_list_vars(id_vars, "id_vars", frame.columns)
+
+    # GH#65654: validate var_name doesn't collide with id_vars or value_name
+    if var_name is not None:
+        if is_list_like(var_name):
+            var_name_list = list(var_name)
+        else:
+            var_name_list = [var_name]
+        for name in var_name_list:
+            if name in id_vars:
+                raise ValueError(
+                    f"var_name ({name}) cannot match an element in id_vars."
+                )
+            if name == value_name:
+                raise ValueError(
+                    f"var_name ({name}) cannot match value_name ({value_name})."
+                )
     value_vars_was_not_none = value_vars is not None
     value_vars = ensure_list_vars(value_vars, "value_vars", frame.columns)
 

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -422,6 +422,27 @@ class TestMelt:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_melt_var_name_collision(self):
+        # GH#65654: var_name collision with id_vars should raise
+        df = DataFrame({"id": [1, 2], "a": [10, 20], "b": [100, 200]})
+        msg = "var_name (id) cannot match an element in id_vars"
+        with pytest.raises(ValueError, match=msg):
+            df.melt(id_vars="id", var_name="id")
+
+    def test_melt_var_name_collision_value_name(self):
+        # GH#65654: var_name collision with value_name should raise
+        df = DataFrame({"a": [1, 2], "b": [10, 20]})
+        msg = r"var_name \(val\) cannot match value_name \(val\)"
+        with pytest.raises(ValueError, match=msg):
+            df.melt(var_name="val", value_name="val")
+
+    def test_melt_var_name_collision_list(self):
+        # GH#65654: list-like var_name collision with id_vars should raise
+        df = DataFrame({("A", "D"): [1, 2], ("B", "E"): [10, 20]})
+        msg = "var_name (A) cannot match an element in id_vars"
+        with pytest.raises(ValueError, match=msg):
+            df.melt(id_vars=[("A", "D")], var_name=["A", "B"])
+
     @pytest.mark.parametrize("dtype", ["Int8", "Int64"])
     def test_melt_ea_dtype(self, dtype):
         # GH#41570


### PR DESCRIPTION
## Summary

Fixes #65654: `DataFrame.melt` silently overwrites `id_vars` data when `var_name` collides with an `id_vars` column name.

```
df = pd.DataFrame({"id": [1, 2], "a": [10, 20]})
df.melt(id_vars="id", var_name="id")  # silently corrupts data!
```

## Fix

Add validation to `pd.melt()` that raises `ValueError` when:
- `var_name` collides with any `id_vars` column
- `var_name` collides with `value_name`

This is consistent with existing validation for `value_name` collision with DataFrame columns.

## Changes

- `pandas/core/reshape/melt.py`: 16 lines of validation
- `pandas/tests/reshape/test_melt.py`: 3 regression tests

## Test Plan

```
pytest pandas/tests/reshape/test_melt.py -v -k "test_melt_var_name_collision"
```