### PR TITLE
CI: pin pytest to <9.1

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -290,7 +290,7 @@ jobs:
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
-          python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4,<9.1 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
+          python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil "pytest>=8.3.4,<9.1" pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
 
@@ -333,7 +333,7 @@ jobs:
           /opt/python/cp313-cp313/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel meson-python==0.18.0 meson[ninja]==1.2.3
-          python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=8.3.4,<9.1 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
+          python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil "pytest>=8.3.4,<9.1" pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
       - name: Run Tests
@@ -428,7 +428,7 @@ jobs:
           python --version
           python -m pip install --upgrade pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-          python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.116.0 pytest>=8.3.4,<9.1 pytest-xdist>=3.6.1 pytest-cov
+          python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.116.0 "pytest>=8.3.4,<9.1" pytest-xdist>=3.6.1 pytest-cov
           python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
           python -m pip list
 
@@ -490,7 +490,7 @@ jobs:
       - name: Test pandas for Pyodide
         run: |
           source .venv-pyodide/bin/activate
-          python -m pip install pytest<9.1 hypothesis pytest-cov
+          python -m pip install "pytest>=8.3.4,<9.1" hypothesis pytest-cov
           # do not import pandas from the checked out repo
           cd ../..
           pytest -m 'not slow and not network and not clipboard and not single_cpu' --pyargs pandas

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -290,7 +290,7 @@ jobs:
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
-          python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
+          python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil pytest>=8.3.4,<9.1 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
 
@@ -333,7 +333,7 @@ jobs:
           /opt/python/cp313-cp313/bin/python -m venv ~/virtualenvs/pandas-dev
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel meson-python==0.18.0 meson[ninja]==1.2.3
-          python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=8.3.4 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
+          python -m pip install --no-cache-dir versioneer[toml] cython numpy python-dateutil pytest>=8.3.4,<9.1 pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
       - name: Run Tests
@@ -428,7 +428,7 @@ jobs:
           python --version
           python -m pip install --upgrade pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
           python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-          python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.116.0 pytest>=8.3.4 pytest-xdist>=3.6.1 pytest-cov
+          python -m pip install versioneer[toml] python-dateutil tzdata cython hypothesis>=6.116.0 pytest>=8.3.4,<9.1 pytest-xdist>=3.6.1 pytest-cov
           python -m pip install -ve . --no-build-isolation --no-index --no-deps -Csetup-args="--werror"
           python -m pip list
 
@@ -490,7 +490,7 @@ jobs:
       - name: Test pandas for Pyodide
         run: |
           source .venv-pyodide/bin/activate
-          python -m pip install pytest hypothesis pytest-cov
+          python -m pip install pytest<9.1 hypothesis pytest-cov
           # do not import pandas from the checked out repo
           cd ../..
           pytest -m 'not slow and not network and not clipboard and not single_cpu' --pyargs pandas


### PR DESCRIPTION
Awaiting properly fixing the deprecations (and upstream fix for regression), already pinning in the few builds where we install pytest manually (not through lock file), to have CI green