### PR TITLE
BUG: assert_series_equal(check_dtype=False) raises on masked pd.NA vs object pd.NA (#61473)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -432,6 +432,7 @@ Styler
 Other
 ^^^^^
 
+- Bug in :func:`testing.assert_series_equal` and :func:`testing.assert_frame_equal` with ``check_dtype=False`` raising for masked arrays (e.g. ``Int32``) containing ``pd.NA`` when compared against an equal object-dtype array (:issue:`61473`)
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1114,12 +1114,14 @@ def assert_series_equal(
                 obj=str(obj),
             )
         else:
-            # convert both to NumPy if not, check_dtype would raise earlier
+            # convert both to NumPy if not, check_dtype would raise earlier.
+            # GH#61473 use object dtype so masked pd.NA is preserved rather
+            # than coerced to nan, which wouldn't match the object-array NA
             lv, rv = left_values, right_values
             if isinstance(left_values, ExtensionArray):
-                lv = left_values.to_numpy()
+                lv = left_values.to_numpy(dtype=object)
             if isinstance(right_values, ExtensionArray):
-                rv = right_values.to_numpy()
+                rv = right_values.to_numpy(dtype=object)
             assert_numpy_array_equal(
                 lv,
                 rv,

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -366,6 +366,16 @@ def test_assert_series_equal_ignore_extension_dtype_mismatch_cross_class():
     tm.assert_series_equal(left, right, check_dtype=False)
 
 
+@pytest.mark.parametrize("dtype", ["Int32", "Float64", "boolean"])
+def test_assert_series_equal_masked_na_ignore_dtype(dtype):
+    # GH#61473 pd.NA must not be coerced to nan when comparing a masked
+    # array against an object array holding the same pd.NA
+    left = Series([pd.NA], dtype=dtype)
+    right = Series([pd.NA], dtype="object")
+    tm.assert_series_equal(left, right, check_dtype=False)
+    tm.assert_series_equal(right, left, check_dtype=False)
+
+
 def test_allows_duplicate_labels():
     left = Series([1])
     right = Series([1]).set_flags(allows_duplicate_labels=False)


### PR DESCRIPTION
- [x] closes #61473 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest ``doc/source/whatsnew/vX.X.X.rst`` file if fixing a bug or adding a new feature.

Comparing two Series that both hold ``pd.NA`` but differ only in dtype
(e.g. ``Int32`` vs ``object``) wrongly failed under ``check_dtype=False``:

```python
df1 = pd.DataFrame({"x": pd.Series([pd.NA], dtype="Int32")})
df2 = pd.DataFrame({"x": pd.Series([pd.NA], dtype="object")})
tm.assert_frame_equal(df1, df2, check_dtype=False)  # AssertionError
```

In the ``check_exact`` branch the masked array was converted with plain
``to_numpy()``, which turns ``pd.NA`` into ``nan`` and returns a float
array. The resulting ``nan`` no longer matched the ``pd.NA`` held in the
object array, so the comparison reported the values as different even
though they are equal.

Passing ``dtype=object`` to ``to_numpy()`` keeps ``pd.NA`` intact on both
sides. This branch only runs when ``check_dtype=False`` (a genuine dtype
mismatch is caught earlier), so widening to object dtype can't hide a
dtype difference a caller asked to check.