### PR TITLE
BUG: prevent DataFrame from mutating original Index when constructed from Index data

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -549,11 +549,17 @@ class DataFrame(NDFrame, OpsMixin):
                     dtype,
                     copy,
                 )
-            elif isinstance(data, (ABCSeries, ABCIndex)) and data.name is not None:
-                # i.e. Series/Index with non-None name
+            elif isinstance(data, Index):
+                # GH#65889: always copy Index data to avoid mutating the original
+                mgr = ndarray_to_mgr(
+                    data,
+                    index,
+                    columns,
+                    dtype=dtype,
+                    copy=True,
+                )
+            elif isinstance(data, ABCSeries) and data.name is not None:
                 mgr = dict_to_mgr(
-                    # error: Item "ndarray" of "Union[ndarray, Series, Index]" has no
-                    # attribute "name"
                     {data.name: data},
                     index,
                     columns,


### PR DESCRIPTION
Fixes #65889

## Summary

`pd.DataFrame(data=some_index)` shares the underlying array with `some_index`, so modifications to the new DataFrame mutate the original Index.

## Root Cause

The DataFrame constructor sets `copy=False` for Index inputs, and `Index.copy()` defaults to `deep=False` (shallow copy). Both layers share the same numpy array.

## Fix

Force `copy=True` when `data` is an Index. This ensures the DataFrame owns an independent copy of the data without changing broader copy defaults.

## Test Plan

```python
import pandas as pd
df = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
columns = pd.DataFrame(data=df.columns.copy())
columns.loc[0, 0] = 'C'
assert df.columns[0] == 'A'  # passes after fix
```