### PR TITLE
WEB: use correct email for CoC reporting everywhere

### DIFF
--- a/web/pandas/about/team.md
+++ b/web/pandas/about/team.md
@@ -59,7 +59,7 @@ If you want to support pandas development, you can find information in the [dona
 > We have identified visible gaps and obstacles in sustaining diversity and inclusion in the open-source communities and we are proactive in increasing
 > the diversity of our team.
 > We have a [code of conduct]({{ base_url }}community/coc.html) to ensure a friendly and welcoming environment.
-> Please send an email to [pandas-code-of-conduct-committee](mailto:pandas-coc@googlegroups.com), if you think we can do a
+> Please send an email to [pandas-code-of-conduct-committee](mailto:coc@pandas.pydata.org), if you think we can do a
 > better job at achieving this goal.
 
 ## Governance

--- a/web/pandas/community/coc.md
+++ b/web/pandas/community/coc.md
@@ -40,7 +40,7 @@ when an individual is representing the project or its community.
 A working group of community members is committed to promptly addressing any
 reported issues. The working group is made up of pandas contributors and users.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the working group by e-mail (pandas-coc@googlegroups.com).
+reported by contacting the working group by e-mail (coc@pandas.pydata.org).
 Messages sent to this e-mail address will not be publicly visible but only to
 the working group members. The working group currently includes
 


### PR DESCRIPTION
pandas-coc@googlegroups.com is the old google group, and coc@pandas.pydata.org is the one set up more recently. 
Both addresses were still active, but we should update to use the newer one everywhere, so we can actually deactivate or delete the old group.