### PR TITLE
BUG: preserve index in Arrow isocalendar

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -244,6 +244,7 @@ Datetimelike
 - Bug in :class:`ArrowExtensionArray` where adding a :class:`DateOffset` to a ``date32[pyarrow]`` or ``date64[pyarrow]`` Series raised an ``ArrowTypeError`` (:issue:`57168`)
 - Bug in :class:`DatetimeIndex` constructor raising ``ValueError`` when passing equivalent but not equal frequencies (e.g. ``QS-FEB`` vs ``QS-MAY``) (:issue:`61086`)
 - Bug in :class:`DatetimeIndex` raising ``AttributeError`` when comparing against Arrow date types (date32, date64) (:issue:`62051`)
+- Bug in :meth:`Series.dt.isocalendar` not preserving the :class:`Series` index for PyArrow-backed date data (:issue:`65894`)
 - Bug in :class:`Timestamp` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timestamp` constructor where strings with a negative year of fewer than 4 digits (e.g. ``"-111-01-01"``) silently dropped the leading ``"-"`` and were parsed as a positive year; BC dates with 1-4 digit years now parse correctly, matching :class:`numpy.datetime64` (:issue:`55954`)
 - Bug in :class:`Timestamp` constructor, :class:`Timedelta` constructor, :func:`to_datetime`, and :func:`to_timedelta` with non-round ``float`` input and ``unit`` failing to raise when the value is just outside the representable bounds (:issue:`57366`)

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -242,7 +242,7 @@ class ArrowTemporalProperties(PandasDelegate, PandasObject, NoNewAttributesMixin
                 for i, col in enumerate(["year", "week", "day"])
             }
         )
-        return iso_calendar_df
+        return iso_calendar_df.set_index(self._parent.index)
 
     @property
     def components(self) -> DataFrame:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2739,13 +2739,15 @@ def test_dt_tz(tz):
 
 def test_dt_isocalendar():
     ser = pd.Series(
-        [datetime(year=2023, month=1, day=2, hour=3), None],
-        dtype=ArrowDtype(pa.timestamp("ns")),
+        [date(2023, 1, 2), None],
+        index=pd.Index(["a", "b"], name="idx"),
+        dtype=ArrowDtype(pa.date32()),
     )
     result = ser.dt.isocalendar()
     expected = pd.DataFrame(
         [[2023, 1, 1], [0, 0, 0]],
         columns=["year", "week", "day"],
+        index=ser.index,
         dtype="int64[pyarrow]",
     )
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #65894
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This fixes `Series.dt.isocalendar()` for PyArrow-backed date data so the result keeps the original Series index.

Without that, assigning one of the returned columns back to a DataFrame with a non-default index aligns on `RangeIndex` and produces missing values.

The change matches the regular datetime accessor path by setting the result index from the parent Series. I also updated the Arrow isocalendar test to cover a named non-default index and added a whatsnew entry.

Checks run locally:

```text
git diff --check -- doc/source/whatsnew/v3.1.0.rst pandas/core/indexes/accessors.py pandas/tests/extension/test_arrow.py
python3 -m py_compile pandas/core/indexes/accessors.py pandas/tests/extension/test_arrow.py
```