### PR TITLE
DOC: Remove older versions from documentation switcher

### DIFF
--- a/web/pandas/versions.json
+++ b/web/pandas/versions.json
@@ -34,30 +34,5 @@
         "name": "1.5",
         "version": "1.5",
         "url": "https://pandas.pydata.org/pandas-docs/version/1.5/"
-    },
-    {
-        "name": "1.4",
-        "version": "1.4",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.4/"
-    },
-    {
-        "name": "1.3",
-        "version": "1.3",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.3/"
-    },
-    {
-        "name": "1.2",
-        "version": "1.2",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.2/"
-    },
-    {
-        "name": "1.1",
-        "version": "1.1",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.1/"
-    },
-    {
-        "name": "1.0",
-        "version": "1.0",
-        "url": "https://pandas.pydata.org/pandas-docs/version/1.0/"
     }
 ]


### PR DESCRIPTION
Resolves #65891

**What changed:**
I've removed versions 1.4, 1.3, 1.2, 1.1, and 1.0 from `web/pandas/versions.json`. 

**Why:**
As reported in the issue, selecting these older versions from the switcher on a newly-created documentation page results in a `404 Page Not Found` error because those specific pages didn't exist in the older documentation structure. Since pandas generally only maintains active documentation links for the last few minor versions, removing them from the switcher entirely resolves the 404 issue and cleans up the dropdown menu.