### PR TITLE
BUG: Preserve None when replacing NaN in string data

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -293,6 +293,7 @@ Conversion
 
 Strings
 ^^^^^^^
+- Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` not preserving explicit ``None`` values when replacing ``NaN`` values in ``str`` dtype data (:issue:`65892`)
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 
 Interval

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -724,7 +724,9 @@ class Block(PandasObject, libinternals.Block):
             #  bc _can_hold_element is incorrect.
             return [self._maybe_copy(inplace, deep=False)]
 
-        elif self._can_hold_element(value) or (self.dtype == "string" and is_re(value)):
+        elif (value is not None or self.is_object) and (
+            self._can_hold_element(value) or (self.dtype == "string" and is_re(value))
+        ):
             # TODO(CoW): Maybe split here as well into columns where mask has True
             # and rest?
             blk = self._maybe_copy(inplace)

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -682,6 +682,24 @@ class TestDataFrameReplace:
         expected = DataFrame({"value": [42, None]}, dtype=object)
         tm.assert_frame_equal(result, expected)
 
+    def test_replace_nan_with_none_string_dtype(self):
+        # GH#65892
+        df = DataFrame(
+            {
+                "a": Series([np.nan, "a"], dtype="str"),
+                "b": [1, 2],
+            }
+        )
+        result = df.replace(np.nan, None)
+        expected = DataFrame(
+            {
+                "a": Series([None, "a"], dtype=object),
+                "b": [1, 2],
+            }
+        )
+        assert result.loc[0, "a"] is None
+        tm.assert_frame_equal(result, expected)
+
     def test_replace_NAT_with_None(self):
         # gh-45836
         df = DataFrame([pd.NaT, pd.NaT])

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -41,6 +41,13 @@ class TestSeriesReplace:
         assert expected.iloc[-1] is None
         tm.assert_series_equal(result, expected)
 
+        # GH#65892 scalar replace should preserve explicit None for "str" dtype
+        ser = pd.Series([np.nan, "a"], dtype="str")
+        result = ser.replace(np.nan, None)
+        expected = pd.Series([None, "a"], dtype=object)
+        assert result.iloc[0] is None
+        tm.assert_series_equal(result, expected)
+
     def test_replace_noop_doesnt_downcast(self):
         # GH#44498
         ser = pd.Series([None, None, pd.Timestamp("2021-12-16 17:31")], dtype=object)


### PR DESCRIPTION
Closes #65892.

`Series.replace(np.nan, None)` and `DataFrame.replace(np.nan, None)` were not preserving explicit `None` values for `str` dtype data. The scalar replacement path wrote `None` directly into the existing block, where string extension arrays normalize it back to their dtype missing value. The list-like replacement path already casts to object for explicit `None`, so it produced the expected result.

This updates the scalar replacement path to use the same object-cast behavior for explicit `None` on non-object blocks. That makes the scalar and list-like forms consistent and preserves `None` in the result.

Tests:
```
- `pytest pandas/tests/series/methods/test_replace.py pandas/tests/frame/methods/test_replace.py -q`
- `pytest pandas/tests/copy_view/test_replace.py pandas/tests/arrays/categorical/test_replace.py -q`

```
- [x] closes #65892
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)