### PR TITLE
PERF: Use engine in increasing/decreasing for subclasses of object engine

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2470,11 +2470,12 @@ class Index(IndexOpsMixin, PandasObject):
         >>> pd.Index([1, 3, 2]).is_monotonic_increasing
         False
         """
-        if isinstance(self._values, ExtensionArray) and isinstance(
-            self._engine, libindex.ObjectEngine
+        if isinstance(self._values, ExtensionArray) and (
+            type(self._engine) is libindex.ObjectEngine
         ):
             # For custom EAs we use ObjectEngine by default, which gets the EA as
-            # object ndarray -> use the EA's implementation directly instead of engine
+            # object ndarray -> use the EA's implementation directly instead of engine.
+            # Subclasses of ObjectEngine (e.g. StringObjectEngine) are excluded.
             return self._values._is_monotonic_increasing
         return self._engine.is_monotonic_increasing
 
@@ -2504,11 +2505,12 @@ class Index(IndexOpsMixin, PandasObject):
         >>> pd.Index([3, 1, 2]).is_monotonic_decreasing
         False
         """
-        if isinstance(self._values, ExtensionArray) and isinstance(
-            self._engine, libindex.ObjectEngine
+        if isinstance(self._values, ExtensionArray) and (
+            type(self._engine) is libindex.ObjectEngine
         ):
             # For custom EAs we use ObjectEngine by default, which gets the EA as
-            # object ndarray -> use the EA's implementation directly instead of engine
+            # object ndarray -> use the EA's implementation directly instead of engine.
+            # Subclasses of ObjectEngine (e.g. StringObjectEngine) are excluded.
             return self._values._is_monotonic_decreasing
         return self._engine.is_monotonic_decreasing
 


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/141

The guard added in https://github.com/pandas-dev/pandas/pull/65585 used `isinstance(..., ObjectEngine)` I believe without realizing that StringObjectEngine is a subclass providing faster `is_monotonic_*`.

```python
import numpy as np
import pandas as pd
from pandas import DataFrame, Index, Series, concat

N = 10_000

str_idx = Index([f"i-{i}" for i in range(N)], dtype="string[python]").sort_values()
%timeit str_idx.is_monotonic_increasing
# 331 μs ± 4.28 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  <--- main
# 149 ns ± 0.455 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)  <--- PR

mi = pd.MultiIndex.from_product(
  [pd.date_range("1/1/2000", freq="min", periods=N // 2), ["a", "b"]]
)
%timeit mi._cache = {}; mi.is_monotonic_increasing
# 46.2 μs ± 754 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)  <--- main
# 27 μs ± 117 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)  <--- PR

idx = Index([f"i-{i}" for i in range(N)], dtype="string[python]").sort_values()
series = [Series(i, idx[:-i]) for i in range(1, 6)]
%timeit concat(series, axis=1, sort=True)
# 2.67 ms ± 36.5 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <--- main
# 2.27 ms ± 36.5 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <--- PR

K = 10
df = DataFrame(
    {
        "key1": Index([f"i-{i}" for i in range(N)], dtype=object).values.repeat(K),
        "key2": Index([f"i-{i}" for i in range(N)], dtype=object).values.repeat(K),
        "value": np.random.randn(N * K),
    }
).set_index(["key1", "key2"])
%timeit df.sort_index()
# 1.53 ms ± 9.94 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  <--- main
# 1.26 ms ± 7.12 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)  <--- PR
```
