### PR TITLE
PERF: Frequency determination when concatting datetimes

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -1431,7 +1431,9 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         ):
             freq = obj.freq
             tz = getattr(self.dtype, "tz", None)
-            if isinstance(freq, Tick) or (tz is None and isinstance(freq, Day)):
+            if (
+                isinstance(freq, Tick) or (tz is None and isinstance(freq, Day))
+            ) and all(idx.unit == self.unit for idx in to_concat_nonempty):
                 # freq is a fixed delta in the stored i8 representation, so we
                 # can check boundary continuity without boxing endpoints to
                 # Timestamps and doing per-pair offset arithmetic.

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -1429,9 +1429,22 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             and obj.freq is not None
             and all(idx.freq == obj.freq for idx in to_concat_nonempty)
         ):
-            pairs = pairwise(to_concat_nonempty)
-            if all(pair[0][-1] + obj.freq == pair[1][0] for pair in pairs):
-                result._freq = obj.freq
+            freq = obj.freq
+            tz = getattr(self.dtype, "tz", None)
+            if isinstance(freq, Tick) or (tz is None and isinstance(freq, Day)):
+                # freq is a fixed delta in the stored i8 representation, so we
+                # can check boundary continuity without boxing endpoints to
+                # Timestamps and doing per-pair offset arithmetic.
+                step = Timedelta(freq).as_unit(self.unit)._value
+                i8s = [idx._data._ndarray.view("i8") for idx in to_concat_nonempty]
+                evenly_spaced = all(a[-1] + step == b[0] for a, b in pairwise(i8s))
+            else:
+                evenly_spaced = all(
+                    pair[0][-1] + freq == pair[1][0]
+                    for pair in pairwise(to_concat_nonempty)
+                )
+            if evenly_spaced:
+                result._freq = freq
 
         return result
 

--- a/pandas/tests/reshape/concat/test_datetimes.py
+++ b/pandas/tests/reshape/concat/test_datetimes.py
@@ -125,6 +125,17 @@ class TestDatetimeConcat:
         expected = DataFrame(data[50:] + data[:50], index=dr[50:].append(dr[:50]))
         tm.assert_frame_equal(result, expected)
 
+    def test_concat_datetimeindex_freq_mixed_unit(self):
+        # GH#65920 - retain freq when concatting contiguous, evenly spaced
+        # DatetimeIndexes that share a freq but differ in unit
+        idx1 = date_range("2024-01-01", periods=3, freq="s", unit="s")
+        idx2 = date_range("2024-01-01 00:00:03", periods=3, freq="s", unit="ns")
+        result = idx1.append(idx2)
+        expected = date_range("2024-01-01", periods=6, freq="s", unit="ns")
+        tm.assert_index_equal(result, expected)
+        # Not checked by assert_index_equal
+        assert result.freq == "s"
+
     def test_concat_datetimeindex_tz_convert_freq(self):
         # GH#41585 - concat after tz_convert should not raise when
         # the converted timestamps no longer conform to the original freq


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/125

Addresses the bottom 4 benchmarks there.

```python
import pandas as pd

idx = pd.date_range("2024-01-01", periods=30 * 24 * 3600, freq="s")
chunks = [
    pd.Series(range(len(c)), index=c) 
    for c in (idx[i:i + 2592] for i in range(0, len(idx), 2592))
]
%timeit pd.concat(chunks)
# 23.4 ms ± 186 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)   <--- main
# 16.8 ms ± 119 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <--- PR
```