### PR TITLE
DOC: note in CoW migration guide that per-column attrs are no longer preserved (#64711)

### DIFF
--- a/doc/source/user_guide/migration.rst
+++ b/doc/source/user_guide/migration.rst
@@ -149,6 +149,18 @@ A different alternative would be to not use ``inplace``:
     df["foo"] = df["foo"].replace(1, 5)
     df
 
+**Per-column attrs are no longer preserved**
+
+Selecting a column from a :class:`DataFrame` under CoW returns a new
+:class:`Series` each time, and that Series's :attr:`~Series.attrs` is
+initialized from a deepcopy of the parent :class:`DataFrame`'s
+:attr:`~DataFrame.attrs` (via ``__finalize__``) rather than sharing it. As a
+result, mutating the selection (for example ``df["A"].attrs["x"] = ...``) does
+not persist on the parent ``df`` or on subsequent ``df["A"]`` accesses.
+``attrs`` is best treated as a property of a whole :class:`DataFrame` or
+:class:`Series`, not of an individual column. For per-column metadata, store
+the mapping externally.
+
 **Constructors now copy NumPy arrays by default**
 
 The Series and DataFrame constructors now copies a NumPy array by default when not


### PR DESCRIPTION
## Summary

Adds a short bullet to the Copy-on-Write migration guide noting that per-column ``attrs`` are no longer preserved across column access.

Under CoW, ``df["A"]`` returns a new ``Series`` each time, whose ``attrs`` is initialized from a deepcopy of the parent ``DataFrame``'s ``attrs`` (via ``__finalize__``) rather than sharing it, so ``df["A"].attrs["x"] = ...`` does not persist on the parent or on subsequent ``df["A"]`` accesses.

This was explicitly requested by maintainers in the issue discussion:

> I believe it is not possible to support `attrs` on columns with Copy-on-Write. This should be mentioned in the migration guide. — @rhshadrach
> This is indeed not (no longer) possible, and good point that we should call this out in the migration guide. — @jorisvandenbossche

The wording mirrors the framing in the recent docstring clarification on `DataFrame.attrs` (commit `eb0ab923`, PR #65528).

## How it was tested

Docs-only change; no behavioral tests apply. The RST directives (`:class:`, `:attr:`, `~` shorthand, plain double-backtick `__finalize__`) match patterns already used elsewhere in this file and in the precedent commit. No whatsnew entry, matching that precedent.

Fixes #64711
