### PR TITLE
TST: compat with matplotlib 3.11 log-axis tick changes

### DIFF
--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -20,6 +20,7 @@ from pandas.tests.plotting.common import (
     _check_visible,
     _flatten_visible,
 )
+from pandas.util.version import Version
 
 from pandas.io.formats.printing import pprint_thing
 
@@ -422,7 +423,13 @@ class TestDataFramePlotsSubplots:
     def test_bar_log_no_subplots(self):
         # GH3254, GH3298 matplotlib/matplotlib#1882, #1892
         # regressions in 1.2.1
-        expected = np.array([0.1, 1.0, 10.0, 100])
+        # matplotlib 3.11 no longer pads log-axis ticks a decade past the
+        #  view limits, so the outermost tick is dropped (GH#65918)
+        expected = (
+            np.array([0.1, 1.0, 10.0, 100])
+            if Version(mpl.__version__) < Version("3.11.0rc1")
+            else np.array([0.1, 1.0, 10.0])
+        )
 
         # no subplots
         df = DataFrame({"A": [3] * 5, "B": list(range(1, 6))}, index=range(5))
@@ -434,7 +441,13 @@ class TestDataFramePlotsSubplots:
         tm.assert_almost_equal(result, expected, atol=1e-15)
 
     def test_bar_log_subplots(self):
-        expected = np.array([0.1, 1.0, 10.0, 100.0, 1000.0, 1e4])
+        # matplotlib 3.11 no longer pads log-axis ticks a decade past the
+        #  view limits, so the outermost tick is dropped (GH#65918)
+        expected = (
+            np.array([0.1, 1.0, 10.0, 100.0, 1000.0, 1e4])
+            if Version(mpl.__version__) < Version("3.11.0rc1")
+            else np.array([0.1, 1.0, 10.0, 100.0, 1000.0])
+        )
 
         ax = DataFrame([Series([200, 300]), Series([300, 500])]).plot.bar(
             log=True, subplots=True

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -286,7 +286,13 @@ class TestSeriesPlots:
 
     @pytest.mark.parametrize("axis, meth", [("yaxis", "bar"), ("xaxis", "barh")])
     def test_bar_log(self, axis, meth):
-        expected = np.array([1e-1, 1e0, 1e1, 1e2, 1e3, 1e4])
+        # matplotlib 3.11 no longer pads log-axis ticks a decade past the
+        #  view limits, so the outermost tick is dropped (GH#65918)
+        expected = (
+            np.array([1e-1, 1e0, 1e1, 1e2, 1e3, 1e4])
+            if Version(mpl.__version__) < Version("3.11.0rc1")
+            else np.array([1e-1, 1e0, 1e1, 1e2, 1e3])
+        )
 
         _, ax = mpl.pyplot.subplots()
         ax = getattr(Series([200, 500]).plot, meth)(log=True, ax=ax)
@@ -302,7 +308,13 @@ class TestSeriesPlots:
     )
     def test_bar_log_kind_bar(self, axis, kind, res_meth):
         # GH 9905
-        expected = np.array([1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1])
+        # matplotlib 3.11 no longer pads log-axis ticks a decade past the
+        #  view limits, so the outermost ticks are dropped (GH#65918)
+        expected = (
+            np.array([1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1])
+            if Version(mpl.__version__) < Version("3.11.0rc1")
+            else np.array([1e-4, 1e-3, 1e-2, 1e-1, 1e0])
+        )
 
         _, ax = mpl.pyplot.subplots()
         ax = Series([0.1, 0.01, 0.001]).plot(log=True, kind=kind, ax=ax)


### PR DESCRIPTION
Surfaced by the matplotlib 3.11.0 bump in GH-65918.

matplotlib 3.11 changed `LogLocator` to no longer pad ticks a decade past the axis view limits, so the outermost tick(s) of bar log plots are dropped — the axis view limits themselves are unchanged. This broke six `test_bar_log*` assertions that compare `get_ticklocs()` against hard-coded arrays.

Version-gate the expected tick arrays (reusing the existing `Version("3.11.0rc1")` boundary already used elsewhere in `test_series.py`) so the tests pass on both matplotlib 3.10 and 3.11. Verified locally against matplotlib 3.10.8 and 3.11.0.