### PR TITLE
DOC: Clarify Categorical vs Object memory usage #48438

### DIFF
--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -1041,7 +1041,7 @@ an ``object`` dtype is proportional to the size of the objects times the length 
 
 .. ipython:: python
 
-   s = pd.Series(["foo", "bar"] * 1000)
+   s = pd.Series(["foo", "bar"] * 1000, dtype="object")
 
    # object dtype
    s.memory_usage(deep=True)

--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -1036,18 +1036,18 @@ Memory usage
 
 .. _categorical.memory:
 
-The memory usage of a ``Categorical`` is proportional to the number of categories plus the length of the data. In contrast,
-an ``object`` dtype is a constant times the length of the data.
+The memory usage of a ``Categorical`` is proportional to the number *and size* of categories plus the length of the data. In contrast,
+an ``object`` dtype is proportional to the size of the objects times the length of the data.
 
 .. ipython:: python
 
    s = pd.Series(["foo", "bar"] * 1000)
 
    # object dtype
-   s.nbytes
+   s.memory_usage(deep=True)
 
    # category dtype
-   s.astype("category").nbytes
+   s.astype("category").memory_usage(deep=True)
 
 .. note::
 
@@ -1059,10 +1059,10 @@ an ``object`` dtype is a constant times the length of the data.
       s = pd.Series(["foo%04d" % i for i in range(2000)])
 
       # object dtype
-      s.nbytes
+      s.memory_usage(deep=True)
 
       # category dtype
-      s.astype("category").nbytes
+      s.astype("category").memory_usage(deep=True)
 
 
 ``Categorical`` is not a ``numpy`` array

--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -1056,7 +1056,7 @@ an ``object`` dtype is proportional to the size of the objects times the length 
 
    .. ipython:: python
 
-      s = pd.Series(["foo%04d" % i for i in range(2000)])
+      s = pd.Series(["foo%04d" % i for i in range(2000)], dtype="object")
 
       # object dtype
       s.memory_usage(deep=True)


### PR DESCRIPTION
Closes #48438

This PR updates the memory usage documentation for categoricals to explicitly mention object size, and updates the example code to use `memory_usage(deep=True)` for accurate comparisons.

- [x] I have checked that the issue still exists on the latest versions of the docs on `main`