### PR TITLE
TST: read_json keeps unparseable heuristic-date column as str (GH-59227)

### DIFF
--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -953,6 +953,14 @@ class TestPandasContainer:
         result = read_json(StringIO(ujson_dumps(data)))[["id", infer_word]]
         tm.assert_frame_equal(result, expected)
 
+    def test_convert_dates_infer_unparseable_kept_as_str(self):
+        # GH#59227 a column whose name matches the date-inference heuristic
+        #  (ends in "_time") but whose values are not parseable dates must be
+        #  left untouched rather than raising
+        data = [{"id": 1, "event_time": "Thursday, 10:00 p.m."}]
+        result = read_json(StringIO(ujson_dumps(data)))
+        assert (result["event_time"] == "Thursday, 10:00 p.m.").all()
+
     @pytest.mark.parametrize(
         "date,date_unit",
         [


### PR DESCRIPTION
- [x] closes #59227 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

closes #59227

Regression test only — the underlying bug was already fixed in 2.1.0 by GH-52659, which replaced the broken `relativedelta.relativedelta(...)` call in `dateutil_parse` with a clean `ValueError`.

The original report was a `read_json` call raising `AttributeError: type object 'relativedelta' has no attribute 'relativedelta'`. The trigger: a column named like `*_time` matched `read_json`'s `convert_dates` heuristic, and its weekday-only string values (`"Thursday, 10:00 p.m."`) hit the buggy weekday-no-day branch in `dateutil_parse`. That branch raised `AttributeError`, which is outside `_try_convert_to_date`'s `(TypeError, ValueError, OverflowError)` catch tuple, so it propagated instead of leaving the column as a string.

GH-52659's scalar test (`test_weekday_but_no_day_raises`) guards the parsing-level `ValueError`, but nothing exercised the `read_json` integration that actually broke. This adds that regression test: a heuristic-matched date column with an unparseable value is kept as a string rather than raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)