### PR TITLE
TST: add regression test for non-nano datetime to_json with epoch date format

### DIFF
--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1111,6 +1111,32 @@ class TestPandasContainer:
         result = read_json(StringIO(json), convert_dates=["date", "date_obj"])
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+    def test_epoch_non_nano_datetimes(self, unit):
+        # GH#57738 a non-nano datetime column or index serialized with the
+        # (deprecated) "epoch" date format must use the underlying integer
+        # values in ``unit``, not values rescaled as if they were nanoseconds
+        index = DatetimeIndex(
+            ["2023-09-29 02:55:54", "2023-09-29 02:56:03"],
+            dtype=f"datetime64[{unit}]",
+        )
+        df = DataFrame({"date": Series(index, index=index)})
+
+        msg = "'epoch' date format is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            result = df.to_json(date_format="epoch", date_unit=unit)
+
+        # both the column values and the index labels are the underlying i8
+        # values expressed in ``unit`` (the two timestamps stay distinct)
+        i8 = list(index.asi8)
+        parsed = json.loads(result)["date"]
+        assert [int(key) for key in parsed] == i8
+        assert list(parsed.values()) == i8
+
+        # and the frame round-trips, preserving the original resolution (GH#55827)
+        roundtripped = read_json(StringIO(result), convert_dates=["date"])
+        tm.assert_frame_equal(roundtripped, df)
+
     def test_weird_nested_json(self):
         # this used to core dump the parser
         s = r"""{


### PR DESCRIPTION
closes #57738

The underlying bug — serializing a non-nano (e.g. `datetime64[ms]`) column or index with `to_json` produced integers rescaled as if they were nanoseconds — was fixed by GH-63666. This adds the missing regression test for the `epoch` date format; the existing non-nano JSON test (`test_iso_non_nano_datetimes`) only exercised the `iso` path.

Parametrized over `s`/`ms`/`us`/`ns`, the test asserts that the serialized epoch integers match the underlying i8 values — for both the column values and the index labels — and that the frame round-trips while preserving the original resolution (GH-55827).