### PR TITLE
DOC: add method="table" example to Rolling.apply docstring

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2249,6 +2249,26 @@ class Rolling(RollingAndExpandingMixin):
         2    6.0
         3    5.0
         dtype: float64
+
+        By default ``func`` is applied to each column independently. Use
+        ``method="table"`` (which requires ``engine="numba"`` and ``raw=True``) to
+        instead pass the whole :class:`DataFrame` window to ``func`` as a single 2D
+        ndarray, so the function can combine multiple columns. Here a rolling dot
+        product of columns ``A`` and ``B`` is computed; the scalar result is
+        broadcast across the columns.
+
+        >>> df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": [5, 4, 3, 2, 1]})
+        >>> def dot(window):
+        ...     return (window[:, 0] * window[:, 1]).sum()
+        >>> df.rolling(3, method="table").apply(
+        ...     dot, engine="numba", raw=True
+        ... )  # doctest: +SKIP
+              A     B
+        0   NaN   NaN
+        1   NaN   NaN
+        2  22.0  22.0
+        3  25.0  25.0
+        4  22.0  22.0
         """
         return super().apply(
             func,


### PR DESCRIPTION
closes #40374

Adds a `method="table"` example to the `Rolling.apply` docstring (API reference). Previously this was only documented in the windowing user guide; the docstring's Examples section showed only a single-column Series case, so the multi-column capability that GH-40374 asked about wasn't discoverable from the API reference.

The new example:
- contrasts the default per-column behavior with `method="table"`,
- notes the `engine="numba"` + `raw=True` requirement (also answering the issue's "is there a non-numba way?" follow-up — there isn't),
- shows a multi-column UDF (rolling dot product of two columns), mirroring the use case in the original report.

The numba line carries `# doctest: +SKIP` (matching the existing pattern in this file) since numba may be absent in the doctest environment; the captured output is accurate against a real run.

This finishes the work started in the long-stalled GH-40519, which was closed unmerged on CI/formatting issues rather than content.