### PR TITLE
BUG: clearer read_sql_table errors when SQLAlchemy unavailable

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -350,6 +350,7 @@ MultiIndex
 I/O
 ^^^
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
+- :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -901,8 +901,8 @@ def pandasSQL_builder(
 
     if isinstance(con, str) and sqlalchemy is None:
         raise ImportError(
-            f"Using URI string without version '{VERSIONS['sqlalchemy']}' or newer "
-            "of 'sqlalchemy' installed."
+            "Using a URI string requires 'sqlalchemy' version "
+            f"'{VERSIONS['sqlalchemy']}' or newer."
         )
 
     if sqlalchemy is not None and isinstance(con, (str, sqlalchemy.engine.Connectable)):
@@ -1477,7 +1477,10 @@ class PandasSQL(PandasObject, ABC):
         chunksize: int | None = None,
         dtype_backend: DtypeBackend | Literal["numpy"] = "numpy",
     ) -> DataFrame | Iterator[DataFrame]:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "read_sql_table not supported for a DBAPI connection. Use "
+            "read_sql_query, or pass a SQLAlchemy connectable."
+        )
 
     @abstractmethod
     def read_query(

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -2224,7 +2224,8 @@ def test_api_chunksize_read(conn, request):
 
     # reading the query in chunks with read_sql_query
     if conn_name == "sqlite_buildin":
-        with pytest.raises(NotImplementedError, match="^$"):
+        msg = "read_sql_table not supported for a DBAPI connection"
+        with pytest.raises(NotImplementedError, match=msg):
             sql.read_sql_table("test_chunksize", conn, chunksize=5)
     else:
         res3 = DataFrame()
@@ -2595,7 +2596,7 @@ def test_sql_open_close(temp_file, test_frame3):
 @td.skip_if_installed("sqlalchemy")
 def test_con_string_import_error():
     conn = "mysql://root@localhost/pandas"
-    msg = "Using URI string without sqlalchemy installed"
+    msg = "Using a URI string requires 'sqlalchemy'"
     with pytest.raises(ImportError, match=msg):
         sql.read_sql("SELECT * FROM iris", conn)
 


### PR DESCRIPTION
closes #41237

Two rough edges in `read_sql_table` left by past refactors:

- Passing a DBAPI connection (e.g. a plain `sqlite3.Connection`) raised a `NotImplementedError` with **no message** — the base `PandasSQL.read_table` fallback `raise NotImplementedError` (introduced in GH-49587) lost the descriptive message it used to carry, and `SQLiteDatabase` doesn't override it. It now explains the connection type isn't supported and points to `read_sql_query`.
- Reading from a URI string without a usable `sqlalchemy` install raised a grammatically broken `ImportError` ("Using URI string without version '...' or newer of 'sqlalchemy' installed."). Reworded.

Updated the two tests asserting on these messages (one previously matched the empty message via `match="^$"`; the other had a stale substring masked by `skip_if_installed("sqlalchemy")`).