### PR TITLE
TST: indexing with tuple-of-tuples label (GH#35434)

### DIFF
--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -240,6 +240,15 @@ class TestIsBoolIndexer:
         arr = pd.arrays.NumpyExtensionArray(np.array([scalar]))
         assert com.is_bool_indexer(arr) is isinstance(scalar, bool)
 
+    def test_tuple_of_tuples_label(self):
+        # GH#35434 indexing with a tuple-of-tuples label must not build a
+        #  ragged ndarray (warned on numpy<2, errors on numpy>=2)
+        tup = ("A", ("B", 2))
+        assert not com.is_bool_indexer([tup])
+
+        ser = Series([42], index=[tup])
+        tm.assert_series_equal(ser[[tup]], ser)
+
 
 @pytest.mark.parametrize("with_exception", [True, False])
 def test_temp_setattr(with_exception):


### PR DESCRIPTION
closes #35434

Indexing with a tuple-of-tuples label (e.g. `ser[[("A", ("B", 2))]]`) used to reach `is_bool_indexer`, whose list branch did `np.asarray(key)`. With a ragged key that emitted a `VisibleDeprecationWarning` on numpy<2 — and would now raise `ValueError` on numpy>=2.

Already fixed by GH-41861, which rewrote the list branch to use `lib.is_bool_list` (short-circuits on the first non-bool item, never building an array). This adds a regression test to lock in the behavior.