### PR TITLE
API: equals tolerant of datetimelike resolution mismatch at EA level

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -101,6 +101,7 @@ Other API changes
 ^^^^^^^^^^^^^^^^^
 - :meth:`.DataFrameGroupBy.sum` and :meth:`.DataFrameGroupBy.mean` on float dtypes with sorted grouping keys may differ from prior versions in the last few floating-point digits, due to a faster summation algorithm that does not use Kahan compensation (:issue:`65103`)
 - :meth:`DataFrame.to_hdf` no longer writes a ``pandas_version`` attribute into the HDF5 file. The value was hardcoded to ``"0.15.2"`` and was only used internally to detect files written by pandas versions older than 0.10.1 (:issue:`62792`)
+- :meth:`Series.equals` and :meth:`DataFrame.equals` now return ``True`` when comparing datetime or timedelta values that differ only in their resolution (e.g. ``datetime64[s]`` versus ``datetime64[ns]``), consistent with :meth:`Index.equals` (:issue:`55694`)
 - APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`64483`).
 - Removed the ``freq`` and ``freqstr`` attributes from :class:`.DatetimeArray` and :class:`.TimedeltaArray`. Frequency is now stored only on :class:`DatetimeIndex` and :class:`TimedeltaIndex`; access ``Series.dt.freq`` or wrap the array in an Index to retrieve a frequency. The ``check_freq`` keyword on :func:`testing.assert_extension_array_equal` for these array types has also been removed (:issue:`24566`).
 -

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -79,6 +79,8 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import (
     AbstractMethodError,
     InvalidComparison,
+    OutOfBoundsDatetime,
+    OutOfBoundsTimedelta,
     Pandas4Warning,
     PerformanceWarning,
 )
@@ -108,6 +110,7 @@ from pandas.core.dtypes.generic import (
     ABCMultiIndex,
 )
 from pandas.core.dtypes.missing import (
+    array_equivalent,
     is_valid_na_for_dtype,
     isna,
 )
@@ -1982,6 +1985,20 @@ class TimelikeOps(DatetimeLikeArrayMixin):
             new_values,
             dtype=new_dtype,
         )
+
+    def equals(self, other) -> bool:
+        if type(self) is not type(other):
+            return False
+        if self.dtype != other.dtype:
+            if self.dtype.kind == "M" and self.tz != other.tz:  # type: ignore[attr-defined]
+                # tz-aware datetimes with mismatched tz are never equal
+                return False
+            # GH#55694 values differing only in resolution compare as equal
+            try:
+                self, other = self._ensure_matching_resos(other)
+            except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
+                return False
+        return bool(array_equivalent(self._ndarray, other._ndarray, dtype_equal=True))
 
     # TODO: annotate other as DatetimeArray | TimedeltaArray | Timestamp | Timedelta
     #  with the return type matching input type.  TypeVar?

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -564,10 +564,12 @@ def array_equals(left: ArrayLike, right: ArrayLike) -> bool:
     """
     ExtensionArray-compatible implementation of array_equivalent.
     """
-    if left.dtype != right.dtype:
-        return False
-    elif isinstance(left, ABCExtensionArray):
+    if isinstance(left, ABCExtensionArray):
+        # let the EA decide its own equality semantics (e.g. datetimelike
+        #  arrays treat values differing only in resolution as equal)
         return left.equals(right)
+    elif left.dtype != right.dtype:
+        return False
     else:
         return array_equivalent(left, right, dtype_equal=True)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -45,8 +45,6 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import (
     InvalidIndexError,
     NullFrequencyError,
-    OutOfBoundsDatetime,
-    OutOfBoundsTimedelta,
     Pandas4Warning,
 )
 from pandas.util._decorators import (
@@ -377,18 +375,22 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex, ABC):
 
         if type(self) != type(other):
             return False
-        elif self.dtype == other.dtype:
-            return lib.array_equivalent_bytes(self.asi8, other.asi8)
-        elif (self.dtype.kind == "M" and self.tz == other.tz) or self.dtype.kind == "m":  # type: ignore[attr-defined]
-            # different units, otherwise matching
-            try:
-                # TODO: do this at the EA level?
-                left, right = self._data._ensure_matching_resos(other._data)  # type: ignore[union-attr]
-            except (OutOfBoundsDatetime, OutOfBoundsTimedelta):
-                return False
-            else:
-                return lib.array_equivalent_bytes(left.view("i8"), right.view("i8"))
-        return False
+
+        if (
+            self.dtype.kind in "mM"
+            and self.freq is not None
+            and self.freq == other.freq
+            and len(self) == len(other)
+            # for tz-aware, equal freq+first only generalizes when tz matches
+            and (self.dtype.kind == "m" or self.tz == other.tz)  # type: ignore[attr-defined]
+        ):
+            # Fastpath: regularly-spaced DatetimeIndex/TimedeltaIndex with a
+            #  matching freq are equal iff they have the same length and first
+            #  entry. (Not valid for PeriodIndex, where freq is the period
+            #  resolution rather than the step between entries.)
+            return len(self) == 0 or self[0] == other[0]
+
+        return self._data.equals(other._data)
 
     def __contains__(self, key: Any) -> bool:
         """

--- a/pandas/tests/frame/methods/test_equals.py
+++ b/pandas/tests/frame/methods/test_equals.py
@@ -89,6 +89,15 @@ class TestEquals:
         df2 = df1.set_index(["floats"], append=True)
         assert df3.equals(df2)
 
+    def test_equals_mismatched_datetimelike_resolution(self):
+        # GH#55694 columns differing only in resolution compare as equal
+        dti = date_range("2016-01-01", periods=3)
+        df1 = DataFrame({"a": dti, "b": dti - dti[0]})
+        df2 = DataFrame({"a": dti.as_unit("s"), "b": (dti - dti[0]).as_unit("s")})
+        assert df1["a"].dtype != df2["a"].dtype
+        assert df1.equals(df2)
+        assert df2.equals(df1)
+
     def test_equals_categorical_categories_order(self):
         cat1 = Categorical(["a", "b", "a"], categories=["a", "b"])
         cat2 = Categorical(["a", "b", "a"], categories=["b", "a"])

--- a/pandas/tests/indexes/datetimelike_/test_equals.py
+++ b/pandas/tests/indexes/datetimelike_/test_equals.py
@@ -48,6 +48,24 @@ class EqualsTests:
         other = Index(list("abc"))
         assert not index.equals(other)
 
+    def test_equals_mismatched_reso(self, index):
+        # GH#55694 entries differing only in resolution compare as equal,
+        #  consistently across Index, the underlying array, and Series
+        if not hasattr(index._data, "as_unit"):
+            pytest.skip("PeriodIndex has no resolution to mismatch")
+
+        other = index.as_unit("s" if index.unit != "s" else "ns")
+        assert index.dtype != other.dtype
+        assert index.equals(other)
+        assert other.equals(index)
+        assert index._data.equals(other._data)
+        assert pd.Series(index).equals(pd.Series(other))
+
+        # element-wise path (freq dropped) still compares equal
+        noff = index._with_freq(None)
+        assert noff.freq is None
+        assert noff.equals(noff.as_unit("s" if noff.unit != "s" else "ns"))
+
 
 class TestPeriodIndexEquals(EqualsTests):
     @pytest.fixture
@@ -140,6 +158,26 @@ class TestDatetimeIndexEquals(EqualsTests):
     def test_not_equals_bday(self, freq):
         rng = date_range("2009-01-01", "2010-01-01", freq=freq)
         assert not rng.equals(list(rng))
+
+    def test_equals_freq_fastpath(self):
+        # GH#55694 regularly-spaced indexes compare via length + freq + first
+        #  entry, including across a resolution mismatch
+        rng = date_range("2020-01-01", periods=1000, freq="D")
+        assert rng.equals(rng.as_unit("s"))
+        assert not rng.equals(date_range("2020-01-02", periods=1000, freq="D"))
+        assert not rng.equals(rng[:-1])
+
+        # tz-aware spanning a DST transition compares correctly
+        dti = date_range("2021-03-01", periods=30, freq="D", tz="US/Eastern")
+        assert dti.equals(dti.as_unit("s"))
+
+        # matching freq/length and equal first instant but different tz: the
+        #  sequences diverge across DST, so these must not compare equal
+        left = date_range("2021-03-01 00:00", periods=30, freq="D", tz="UTC")
+        right = date_range("2021-02-28 19:00", periods=30, freq="D", tz="US/Eastern")
+        assert left[0] == right[0]
+        assert left.freq == right.freq
+        assert not left.equals(right)
 
 
 class TestTimedeltaIndexEquals(EqualsTests):

--- a/pandas/tests/series/methods/test_equals.py
+++ b/pandas/tests/series/methods/test_equals.py
@@ -11,6 +11,8 @@ from pandas import (
     Index,
     MultiIndex,
     Series,
+    date_range,
+    timedelta_range,
 )
 
 
@@ -116,6 +118,27 @@ def test_equals_none_vs_nan():
     assert ser.equals(ser2)
     assert Index(ser, dtype=ser.dtype).equals(Index(ser2, dtype=ser2.dtype))
     assert ser.array.equals(ser2.array)
+
+
+@pytest.mark.parametrize("unit", ["s", "ms", "us"])
+def test_equals_mismatched_datetimelike_resolution(unit):
+    # GH#55694 datetimes/timedeltas differing only in resolution are equal
+    dti = date_range("2016-01-01", periods=3).as_unit("ns")
+    left = Series(dti)
+    right = Series(dti.as_unit(unit))
+    assert left.dtype != right.dtype
+    assert left.equals(right)
+    assert right.equals(left)
+
+    tdi = timedelta_range("1 day", periods=3).as_unit("ns")
+    assert Series(tdi).equals(Series(tdi.as_unit(unit)))
+
+    # tz-aware with a matching tz is also equal
+    dti_tz = dti.tz_localize("US/Pacific")
+    assert Series(dti_tz).equals(Series(dti_tz.as_unit(unit)))
+
+    # same instants but a different tz are not equal
+    assert not Series(dti_tz).equals(Series(dti_tz.tz_convert("UTC")))
 
 
 def test_equals_None_vs_float():


### PR DESCRIPTION
closes #55694

Pushes the unit-tolerant comparison from `DatetimeIndex.equals` (added in GH-63656) down to the array level, so `Series.equals` and `DataFrame.equals` also treat datetimes/timedeltas that differ only in resolution as equal — resolving the inconsistency reported in GH-55694. `PeriodArray` stays strict (freq is part of its identity), and tz-aware datetimes with mismatched tz remain unequal.

Also adds a freq fastpath to `DatetimeIndex`/`TimedeltaIndex.equals`: regularly-spaced indexes with a matching `freq` are equal iff they have the same length and first entry, which avoids the O(n) elementwise scan. The tz check in that fastpath is load-bearing — without it, two `freq='D'` indexes with the same first instant but different tz would wrongly compare equal (they diverge across a DST transition).

Retires the `# TODO: do this at the EA level?` left behind in GH-63656. Related discussion in GH-33940 and GH-63459.
