### PR TITLE
TST: query/eval with a column named 'datetime' (GH-35695)

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1960,13 +1960,13 @@ def test_negate_lt_eq_le(engine, parser):
     "column",
     DEFAULT_GLOBALS.keys(),
 )
-def test_eval_no_support_column_name(request, column):
-    # GH 44603
+def test_eval_no_support_column_name(request, engine, parser, column):
+    # GH#44603, GH#35695
     if column in ["True", "False", "inf", "Inf"]:
         request.applymarker(
             pytest.mark.xfail(
                 raises=KeyError,
-                reason=f"GH 47859 DataFrame eval not supported with {column}",
+                reason=f"GH#47859 DataFrame eval not supported with {column}",
             )
         )
 
@@ -1975,7 +1975,7 @@ def test_eval_no_support_column_name(request, column):
         columns=[column, "col1"],
     )
     expected = df[df[column] > 6]
-    result = df.query(f"{column}>6")
+    result = df.query(f"{column}>6", engine=engine, parser=parser)
 
     tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
closes #35695

The reported `TypeError` (column named `datetime` losing out to the `datetime.datetime` entry in `DEFAULT_GLOBALS`) was already fixed by GH-47273, which made `Term._resolve_name` treat `type`-valued globals as non-local so the column resolvers win. That fix covers all the `type`-valued globals: `Timestamp`, `datetime`, `list`, `tuple`.

`test_eval_no_support_column_name` (added for GH-44603) already parametrizes over `DEFAULT_GLOBALS`, but only ran the default engine/parser. This parametrizes it over `engine` and `parser` so the case is verified under both the `python` and `numexpr` engines that the issue reported failing.

The remaining `True`/`False`/`inf`/`Inf` columns stay xfailed under the still-open enhancement GH-47859.