### PR TITLE
TST: Timestamp.to_period raises helpful error for unsupported freq (GH-38914)

### DIFF
--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -521,6 +521,16 @@ class TestTimestampConversion:
         with tm.assert_produces_warning(UserWarning, match="drop timezone information"):
             ts.to_period("D")
 
+    def test_to_period_unsupported_freq(self):
+        # GH#38914 unsupported freqs should raise a helpful error, not AttributeError
+        ts = Timestamp("2018-12-01")
+        msg = "for Period, please use 'M' instead of 'MS'"
+        with pytest.raises(ValueError, match=msg):
+            ts.to_period("MS")
+        msg = "<MonthBegin> is not supported as period frequency"
+        with pytest.raises(ValueError, match=msg):
+            ts.to_period(offsets.MonthBegin())
+
     def test_to_numpy_alias(self):
         # GH 24653: alias .to_numpy() for scalars
         ts = Timestamp(datetime.now())


### PR DESCRIPTION
closes #38914

The `AttributeError` reported in GH-38914 was already fixed (by GH-37602 and GH-55844): `Timestamp.to_period` now delegates to `Period`, which raises a helpful `ValueError` for both the freq-string and offset-object cases. This adds a scalar regression test pinning that behavior, since the existing coverage only exercised the `Period(...)` constructor and `DatetimeIndex.to_period()` directly.