### PR TITLE
BUG: concat with keys mixing a single Index and a MultiIndex raised AssertionError

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -416,6 +416,7 @@ Groupby/resample/rolling
 
 Reshaping
 ^^^^^^^^^
+- :func:`concat` with ``keys`` now succeeds when the objects mix a single-level :class:`Index` with a :class:`MultiIndex`, instead of raising ``AssertionError`` (:issue:`25413`)
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
 - Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -45,7 +45,6 @@ from pandas.core.indexes.api import (
     default_index,
     ensure_index,
     get_objs_combined_axis,
-    get_unanimous_names,
     union_indexes,
 )
 from pandas.core.indexes.datetimes import DatetimeIndex
@@ -945,14 +944,10 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
         if len(names) == len(levels):
             names = list(names)
         else:
-            # make sure that all of the passed indices have the same nlevels
-            if not len({idx.nlevels for idx in indexes}) == 1:
-                raise AssertionError(
-                    "Cannot concat indices that do not have the same number of levels"
-                )
-
-            # also copies
-            names = list(names) + list(get_unanimous_names(*indexes))
+            # The inner level(s) come from concat_index; their names match
+            # whatever survived the append (None when the pieces disagree, e.g.
+            # mixing a single Index with a MultiIndex). GH#25413
+            names = list(names) + list(concat_index.names)
 
         return MultiIndex(
             levels=levels, codes=codes_list, names=names, verify_integrity=False

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -231,18 +231,15 @@ def test_indices_concatenation_order():
     result2 = df2.groupby("a").apply(f1)
     tm.assert_frame_equal(result1, result2)
 
-    # should fail (not the same number of levels)
-    msg = "Cannot concat indices that do not have the same number of levels"
-    with pytest.raises(AssertionError, match=msg):
-        df.groupby("a").apply(f2)
-    with pytest.raises(AssertionError, match=msg):
-        df2.groupby("a").apply(f2)
-
-    # should fail (incorrect shape)
-    with pytest.raises(AssertionError, match=msg):
-        df.groupby("a").apply(f3)
-    with pytest.raises(AssertionError, match=msg):
-        df2.groupby("a").apply(f3)
+    # GH#25413 these used to raise AssertionError "Cannot concat indices that
+    # do not have the same number of levels" because the per-group results mix
+    # single-level and MultiIndex indexes. That is now concatenated into an
+    # object level instead of raising. The exact result is order-dependent for
+    # such degenerate inputs, so we only check that it no longer raises.
+    df.groupby("a").apply(f2)
+    df2.groupby("a").apply(f2)
+    df.groupby("a").apply(f3)
+    df2.groupby("a").apply(f3)
 
 
 def test_attr_wrapper(ts):

--- a/pandas/tests/reshape/concat/test_index.py
+++ b/pandas/tests/reshape/concat/test_index.py
@@ -224,6 +224,28 @@ class TestMultiIndexConcat:
         expected = DataFrame({"col": no_name}, index=index, dtype=np.int32)
         tm.assert_frame_equal(result, expected)
 
+    def test_concat_keys_mixed_single_and_multiindex(self):
+        # GH#25413 concatenating a single-level Index with a MultiIndex and
+        # passing keys used to raise AssertionError. It now mirrors the no-keys
+        # behavior (mixed object level) as the inner level of the result.
+        df1 = DataFrame({"A": [1, 2]}, index=Index(["x", "y"]))
+        df2 = DataFrame(
+            {"A": [3, 4]}, index=MultiIndex.from_tuples([("a", 1), ("b", 2)])
+        )
+
+        result = concat([df1, df2], keys=[1, 2])
+
+        expected_index = MultiIndex.from_tuples(
+            [(1, "x"), (1, "y"), (2, ("a", 1)), (2, ("b", 2))]
+        )
+        expected = DataFrame({"A": [1, 2, 3, 4]}, index=expected_index)
+        tm.assert_frame_equal(result, expected)
+
+        # the inner level matches what concat without keys produces
+        tm.assert_index_equal(
+            result.index.get_level_values(1), concat([df1, df2]).index
+        )
+
     def test_concat_multiindex_rangeindex(self):
         # GH13542
         # when multi-index levels are RangeIndex objects


### PR DESCRIPTION
closes #25413

`concat` with `keys=` already builds the inner level fine when the objects mix a single-level `Index` with a `MultiIndex` — `_concat_indexes` appends them into a flat object `Index` of mixed scalars/tuples, exactly as the no-`keys` path does. The only failure was in the *names* bookkeeping: it used `get_unanimous_names(*indexes)`, which returns one name per *max* `nlevels` (2 here) even though a single flat level was appended, and the resulting length mismatch was "guarded" by `raise AssertionError(...)`.

Using `concat_index.names` instead always matches the number of levels that were appended and yields `None` when the pieces disagree. This is equivalent to the old behavior on every homogeneous case and makes the mixed case produce a clean 2-level `MultiIndex` whose inner level is the mixed object index — consistent with `concat(...)` without `keys`.

```python
df1 = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["x", "y"]))
df2 = pd.DataFrame({"A": [3, 4]}, index=pd.MultiIndex.from_tuples([("a", 1), ("b", 2)]))
pd.concat([df1, df2], keys=[1, 2])  # previously AssertionError
```

### Note on behavior change
`groupby.apply` callbacks that return inconsistently-shaped frames used to hit this same `AssertionError`. They no longer raise — they concatenate into an object level (the result is order-dependent for such degenerate inputs). `tests/groupby/test_groupby.py::test_indices_concatenation_order` (GH-2808) is updated accordingly to check that those cases no longer raise rather than pin the degenerate output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)