### PR TITLE
DEPR: by_blocks in tm.assert_frame_equal

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -134,6 +134,7 @@ Deprecations
 - Deprecated the ``xlrd`` and ``pyxlsb`` engines in :func:`read_excel`. Use ``engine="calamine"`` instead (:issue:`56542`)
 - Deprecated the default value of ``exact`` in :func:`assert_index_equal`; in a future version this will default to ``True`` instead of "equiv" (:issue:`57436`)
 - Deprecated the default value of ``track_times`` in :meth:`HDFStore.put`. In a future version, the default will change from ``True`` to ``False`` so that HDF5 files are deterministic by default (:issue:`51456`)
+- Deprecated the keyword ``by_blocks`` in :func:`testing.assert_frame_equal` (:issue:`65911`)
 - Deprecated passing a non-boolean value for ``numeric_only`` to :meth:`DataFrame.mean`,
   :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`DataFrame.median`,
   :meth:`DataFrame.skew`, :meth:`DataFrame.kurt`, :meth:`DataFrame.std`,

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1221,6 +1221,8 @@ def assert_series_equal(
 # This could be refactored to use the NDFrame.equals method
 @set_module("pandas.testing")
 @deprecate_kwarg(Pandas4Warning, "check_datetimelike_compat", new_arg_name=None)
+# stacklevel=3 to account for the extra frame from the stacked decorator above
+@deprecate_kwarg(Pandas4Warning, "by_blocks", new_arg_name=None, stacklevel=3)
 def assert_frame_equal(
     left: DataFrame,
     right: DataFrame,
@@ -1271,6 +1273,8 @@ def assert_frame_equal(
     by_blocks : bool, default False
         Specify how to compare internal data. If False, compare by columns.
         If True, compare by blocks.
+
+        .. deprecated:: 3.1
     check_exact : bool, default False
         Whether to compare number exactly. If False, the comparison uses the
         relative tolerance (``rtol``) and absolute tolerance (``atol``)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1156,7 +1156,7 @@ def test_groupby_dtype_inference_empty():
     result = df.groupby("x").first()
     exp_index = Index([], name="x", dtype=np.float64)
     expected = DataFrame({"range": Series([], index=exp_index, dtype="int64")})
-    tm.assert_frame_equal(result, expected, by_blocks=True)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_groupby_unit64_float_conversion():

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -632,7 +632,6 @@ class TestPandasContainer:
             df_roundtrip,
             check_index_type=True,
             check_column_type=True,
-            by_blocks=True,
             check_exact=True,
         )
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -632,7 +632,6 @@ class TestPandasContainer:
             df_roundtrip,
             check_index_type=True,
             check_column_type=True,
-            check_exact=True,
         )
 
     def test_frame_nonprintable_bytes(self):

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -89,11 +89,11 @@ def test_select_with_dups(temp_hdfstore):
 
     result = temp_hdfstore.select("df")
     expected = df
-    tm.assert_frame_equal(result, expected, by_blocks=True)
+    tm.assert_frame_equal(result, expected)
 
     result = temp_hdfstore.select("df", columns=df.columns)
     expected = df
-    tm.assert_frame_equal(result, expected, by_blocks=True)
+    tm.assert_frame_equal(result, expected)
 
     result = temp_hdfstore.select("df", columns=["A"])
     expected = df.loc[:, ["A"]]
@@ -120,19 +120,19 @@ def test_select_with_dups_across_dtypes(temp_hdfstore):
 
     result = temp_hdfstore.select("df")
     expected = df
-    tm.assert_frame_equal(result, expected, by_blocks=True)
+    tm.assert_frame_equal(result, expected)
 
     result = temp_hdfstore.select("df", columns=df.columns)
     expected = df
-    tm.assert_frame_equal(result, expected, by_blocks=True)
+    tm.assert_frame_equal(result, expected)
 
     expected = df.loc[:, ["A"]]
     result = temp_hdfstore.select("df", columns=["A"])
-    tm.assert_frame_equal(result, expected, by_blocks=True)
+    tm.assert_frame_equal(result, expected)
 
     expected = df.loc[:, ["B", "A"]]
     result = temp_hdfstore.select("df", columns=["B", "A"])
-    tm.assert_frame_equal(result, expected, by_blocks=True)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_select_with_dups_across_index_and_columns(temp_hdfstore):
@@ -156,7 +156,7 @@ def test_select_with_dups_across_index_and_columns(temp_hdfstore):
     expected = df.loc[:, ["B", "A"]]
     expected = concat([expected, expected])
     result = temp_hdfstore.select("df", columns=["B", "A"])
-    tm.assert_frame_equal(result, expected, by_blocks=True)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_select(temp_hdfstore):

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -8,11 +8,6 @@ from pandas import DataFrame
 import pandas._testing as tm
 
 
-@pytest.fixture(params=[True, False])
-def by_blocks_fixture(request):
-    return request.param
-
-
 def _assert_frame_equal_both(a, b, **kwargs):
     """
     Check that two DataFrame equal.
@@ -155,7 +150,7 @@ def test_frame_equal_columns_mismatch(check_like, frame_or_series, using_infer_s
         )
 
 
-def test_frame_equal_block_mismatch(by_blocks_fixture, frame_or_series):
+def test_frame_equal_block_mismatch(frame_or_series):
     obj = frame_or_series.__name__
     msg = f"""{obj}\\.iloc\\[:, 1\\] \\(column name="B"\\) are different
 
@@ -168,7 +163,7 @@ def test_frame_equal_block_mismatch(by_blocks_fixture, frame_or_series):
     df2 = DataFrame({"A": [1, 2, 3], "B": [4, 5, 7]})
 
     with pytest.raises(AssertionError, match=msg):
-        tm.assert_frame_equal(df1, df2, by_blocks=by_blocks_fixture, obj=obj)
+        tm.assert_frame_equal(df1, df2, obj=obj)
 
 
 @pytest.mark.parametrize(
@@ -196,7 +191,7 @@ def test_frame_equal_block_mismatch(by_blocks_fixture, frame_or_series):
         ),
     ],
 )
-def test_frame_equal_unicode(df1, df2, msg, by_blocks_fixture, frame_or_series):
+def test_frame_equal_unicode(df1, df2, msg, frame_or_series):
     # see gh-20503
     #
     # Test ensures that `tm.assert_frame_equals` raises the right exception
@@ -205,9 +200,7 @@ def test_frame_equal_unicode(df1, df2, msg, by_blocks_fixture, frame_or_series):
     df2 = DataFrame(df2)
     msg = msg.format(obj=frame_or_series.__name__)
     with pytest.raises(AssertionError, match=msg):
-        tm.assert_frame_equal(
-            df1, df2, by_blocks=by_blocks_fixture, obj=frame_or_series.__name__
-        )
+        tm.assert_frame_equal(df1, df2, obj=frame_or_series.__name__)
 
 
 def test_assert_frame_equal_extension_dtype_mismatch():
@@ -414,6 +407,17 @@ def test_datetimelike_compat_deprecated():
         tm.assert_series_equal(df["a"], df["a"], check_datetimelike_compat=True)
     with tm.assert_produces_warning(Pandas4Warning, match=msg):
         tm.assert_series_equal(df["a"], df["a"], check_datetimelike_compat=False)
+
+
+def test_by_blocks_deprecated():
+    # GH#65911
+    df = DataFrame({"a": [1]})
+
+    msg = "the 'by_blocks' keyword is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        tm.assert_frame_equal(df, df, by_blocks=True)
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        tm.assert_frame_equal(df, df, by_blocks=False)
 
 
 def test_assert_frame_equal_int_near_bounds():


### PR DESCRIPTION
closes #65911

The ``by_blocks=True`` path in :func:`testing.assert_frame_equal` only groups the per-column comparison by dtype (via ``_to_dict_of_blocks``); it does not verify that ``left`` and ``right`` share the same block structure, so it offers no real robustness over the default by-column comparison. Deprecate the keyword (xref GH-65798).

Internal callers passing ``by_blocks=True`` are updated to use the default comparison.