### PR TITLE
TST: bar plot color maps per column for single-column frame (GH#18006)

### DIFF
--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -132,6 +132,24 @@ class TestDataFrameColor:
         ax = df.loc[:, [0]].plot.bar(color="DodgerBlue")
         _check_colors([ax.patches[0]], facecolors=["DodgerBlue"])
 
+    def test_bar_colors_single_col_list(self):
+        # GH#18006 color maps per column, so a single-column frame uses only
+        # the first color of the list; use a Series or y= (see
+        # test_bar_colors_single_col_y_list) for one color per bar
+        df = DataFrame({"Test": [1, 3, 5, 7]})
+        colors = [(0.9, 0.9, 0.4), (0.8, 0.4, 0.6), (0.2, 0.7, 0.9), (0.4, 0.4, 0.5)]
+        ax = df.plot.bar(color=colors)
+        _check_colors(ax.patches, facecolors=[colors[0]] * 4)
+
+    def test_bar_colors_single_col_y_list(self):
+        # GH#18006 selecting a single column with y= colors each bar
+        # individually, unlike the per-column behavior in
+        # test_bar_colors_single_col_list
+        df = DataFrame({"Test": [1, 3, 5, 7]})
+        colors = [(0.9, 0.9, 0.4), (0.8, 0.4, 0.6), (0.2, 0.7, 0.9), (0.4, 0.4, 0.5)]
+        ax = df.plot.bar(y="Test", color=colors)
+        _check_colors(ax.patches, facecolors=colors)
+
     def test_bar_colors_green(self):
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
         ax = df.plot(kind="bar", color="green")


### PR DESCRIPTION
closes #18006

A single-column `DataFrame` passed a *list* of colors to `plot.bar` uses only the **first** color, because `color` maps per column rather than per bar. This is intentional and already documented in the `.line`/`.bar`/`.barh` docstrings, but was not directly tested — the existing `*_single_col` tests only pass a single color *string*, which exercises a different branch.

These tests pin the documented behavior and the per-bar workaround:

- `test_bar_colors_single_col_list` — single-column frame + color list uses only the first color.
- `test_bar_colors_single_col_y_list` — selecting the column via `y=` reduces to a Series internally, so each bar gets its own color.

The original reporter complaint (`Series.plot.bar(color=[...])`) was fixed back in 0.21.0 and is already covered by `test_series.py::test_bar_user_colors`; the `y=` per-bar path on a multi-column frame is covered by the existing `test_bar_user_colors` here.

Test-only; no whatsnew entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)