### PR TITLE
BUG: sort_values/argsort with ascending=None or integer (GH-41318)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -418,6 +418,7 @@ Reshaping
 ^^^^^^^^^
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
 - Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)
+- Bug in :meth:`Index.sort_values` where ``ascending=None`` silently sorted in descending order or raised a confusing error mentioning ``axis``, and in :meth:`Index.sort_values` and :meth:`DataFrame.sort_values` where an integer ``ascending`` raised on extension-array data (:issue:`41318`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)

--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -153,18 +153,20 @@ def validate_argsort_with_ascending(
     ascending: bool | int | None, args: tuple[Any, ...], kwargs: dict[str, Any]
 ) -> bool:
     """
-    If 'Categorical.argsort' is called via the 'numpy' library, the first
-    parameter in its signature is 'axis', which takes either an integer or
-    'None', so check if the 'ascending' parameter has either integer type or is
-    None, since 'ascending' itself should be a boolean
-    """
-    if is_integer(ascending) or ascending is None:
-        args = (ascending, *args)
-        ascending = True
+    Validate the 'ascending' argument to 'ExtensionArray.argsort'.
 
+    'argsort' is keyword-only, so when it is reached via NumPy (e.g.
+    'np.argsort(cat, axis=0)') the 'axis'/'order'/'kind' arguments arrive in
+    'kwargs' and are validated here. 'ascending' itself should be a boolean, so
+    coerce integers to bool (GH#41318) and reject 'None' and other types.
+    """
     validate_argsort_kind(args, kwargs, max_fname_arg_count=3)
-    ascending = cast("bool", ascending)
-    return ascending
+    if not is_bool(ascending) and not is_integer(ascending):
+        raise ValueError(
+            f'For argument "ascending" expected type bool, received '
+            f"type {type(ascending).__name__}."
+        )
+    return bool(ascending)
 
 
 CLIP_DEFAULTS: dict[str, Any] = {"out": None}

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -60,6 +60,7 @@ from pandas.util._exceptions import (
     find_stack_level,
     rewrite_exception,
 )
+from pandas.util._validators import validate_ascending
 
 from pandas.core.dtypes.astype import (
     astype_array,
@@ -6177,6 +6178,8 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx.sort_values(ascending=False, return_indexer=True)
         (Index([1000, 100, 10, 1], dtype='int64'), array([3, 1, 0, 2]))
         """
+        ascending = validate_ascending(ascending)
+
         if key is None and (
             (ascending and self.is_monotonic_increasing)
             or (not ascending and self.is_monotonic_decreasing)

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -907,3 +907,12 @@ class TestSortValuesLevelAsStr:
         expected = df.loc[df.index[indexer]]
         result = df.sort_values(by="D", ascending=ascending)
         tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("ascending, order", [(1, [1, 2, 0]), (0, [0, 2, 1])])
+def test_sort_values_ascending_integer_extension_column(ascending, order):
+    # GH#41318 an integer ascending on a single extension-array column is
+    # coerced to bool; previously it raised a confusing "axis" error
+    df = DataFrame({"a": pd.array([3, 1, 2], dtype="Int64")})
+    result = df.sort_values("a", ascending=ascending)
+    tm.assert_frame_equal(result, df.iloc[order])

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -475,6 +475,26 @@ def test_sort_values_natsort_key():
     tm.assert_index_equal(result, expected)
 
 
+@pytest.mark.parametrize("dtype", ["int64", "Int64", "category"])
+def test_sort_values_ascending_none_raises(dtype):
+    # GH#41318 ascending=None raises a clear error instead of silently sorting
+    # descending (numpy-backed) or raising a confusing "axis" error (EA-backed)
+    idx = pd.Index([2, 51, 17], dtype=dtype)
+    msg = 'For argument "ascending" expected type bool, received type NoneType.'
+    with pytest.raises(ValueError, match=msg):
+        idx.sort_values(ascending=None)
+
+
+@pytest.mark.parametrize("dtype", ["int64", "Int64"])
+@pytest.mark.parametrize("ascending, expected", [(1, [2, 17, 51]), (0, [51, 17, 2])])
+def test_sort_values_ascending_integer(dtype, ascending, expected):
+    # GH#41318 an integer ascending is coerced to bool (previously raised a
+    # confusing "axis" error for EA-backed indexes)
+    idx = pd.Index([2, 51, 17], dtype=dtype)
+    result = idx.sort_values(ascending=ascending)
+    tm.assert_index_equal(result, pd.Index(expected, dtype=dtype))
+
+
 def test_ndarray_compat_properties(index):
     if isinstance(index, PeriodIndex) and not IS64:
         pytest.skip("Overflow")


### PR DESCRIPTION
closes #41318

`ascending=None` was only validated for `DataFrame`/`Series`/`sort_index`. `Index.sort_values(ascending=None)` silently sorted **descending** on numpy-backed indexes and raised a confusing `"the 'axis' parameter is not supported"` error on extension-array-backed indexes. The same confusing error appeared for an **integer** `ascending` on a single extension-array column (`DataFrame.sort_values`), on `Index.sort_values`, or on `ExtensionArray.argsort` directly.

**Root cause:** a non-bool `ascending` (`None` or an int) reaching `ExtensionArray.argsort` was routed by `validate_argsort_with_ascending` into the positional `axis` slot. That shift dates to when NumPy passed `axis` positionally into the first argument, but `argsort` is now keyword-only, so NumPy routes `axis` through `**kwargs` instead.

**This PR:**
- `validate_argsort_with_ascending` now coerces an integer `ascending` to bool and raises a clear `expected type bool` error for `None`/other types. NumPy `axis` compat is unchanged (e.g. `np.argsort(cat, axis=0)` still validates via `kwargs`).
- `Index.sort_values` now validates `ascending`, matching `Series`/`DataFrame`/`sort_index`.

**Behavior change to note:** `Index.sort_values(ascending=None)` on a numpy-backed index previously returned a descending sort and now raises. `ascending` is documented as `bool`, and the other three methods have raised on `None` since GH-42684 / GH-39451, so this removes an inconsistency rather than adding a new restriction.
