### PR TITLE
TST: loc row-subset of mixed-dtype frame preserves dtype (GH-37346)

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -891,6 +891,17 @@ class TestLocBaseIndependent:
         df.loc[0, [1, 2]] = [5, 6]
         tm.assert_frame_equal(df, expected)
 
+    def test_loc_getitem_single_row_mixed_dtype_subset(self):
+        # GH#37346 selecting a single row with a list of same-dtype columns
+        #  from a mixed-dtype frame preserves the column dtype rather than
+        #  upcasting to the frame's interleaved dtype
+        df = DataFrame({"a": [1], "b": [0.1]})
+
+        result = df.loc[0, ["a"]]
+        expected = Series([1], index=Index(["a"]), dtype="int64", name=0)
+        tm.assert_series_equal(result, expected)
+        assert result.values.dtype == np.int64
+
     def test_loc_setitem_frame_multiples(self):
         # multiple setting
         df = DataFrame(


### PR DESCRIPTION
closes #37346

Selecting a single row with a list of same-dtype columns from a mixed-dtype `DataFrame` preserves the column dtype rather than upcasting to the frame's interleaved dtype:

```python
data = pd.DataFrame({"a": [1], "b": [0.1]})
data.loc[0, ["a"]].dtype  # int64 (was float64 in the original report)
```

The behavior is already correct on `main` — the same-dtype column subset consolidates to a single block, and `BlockManager.fast_xs`'s single-block fast path returns a view without computing an interleaved dtype. This was previously unguarded by a test (the closest existing test, `test_loc_setitem_frame_mixed_labels`, covers mixed column *labels*, not mixed *dtypes*), so this adds a regression test to lock it in.