### PR TITLE
TST: ufunc with pandas object as out= no longer recurses (GH-43190)

### DIFF
--- a/pandas/tests/frame/test_ufunc.py
+++ b/pandas/tests/frame/test_ufunc.py
@@ -97,6 +97,21 @@ def test_ufunc_passes_args(func, arg, expected):
     tm.assert_frame_equal(result, expected)
 
 
+def test_binary_ufunc_out_pandas_object():
+    # GH#43190 passing a DataFrame as the ufunc `out` argument used to recurse
+    #  infinitely (RecursionError / segfault) instead of writing the result.
+    a = pd.DataFrame([[1, 2]])
+    b = pd.DataFrame([[3, 4]])
+    out = pd.DataFrame([[0, 0]])
+
+    result = np.fmin(a, b, out=out)
+
+    expected = pd.DataFrame([[1, 2]])
+    tm.assert_frame_equal(result, expected)
+    # the result is also written into `out` in place
+    tm.assert_frame_equal(out, expected)
+
+
 @pytest.mark.parametrize("dtype_a", dtypes)
 @pytest.mark.parametrize("dtype_b", dtypes)
 def test_binary_input_aligns_columns(request, dtype_a, dtype_b):

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -230,6 +230,21 @@ def test_binary_ufunc_drops_series_name(ufunc, sparse, arrays_for_binary_ufunc):
     assert result.name is None
 
 
+def test_binary_ufunc_out_pandas_object():
+    # GH#43190 passing a Series as the ufunc `out` argument used to recurse
+    #  infinitely (RecursionError / segfault) instead of writing the result.
+    a = pd.Series([1, 2])
+    b = pd.Series([3, 4])
+    out = pd.Series([0, 0])
+
+    result = np.fmin(a, b, out=out)
+
+    expected = pd.Series([1, 2])
+    tm.assert_series_equal(result, expected)
+    # the result is also written into `out` in place
+    tm.assert_series_equal(out, expected)
+
+
 def test_object_series_ok():
     class Dummy:
         def __init__(self, value) -> None:


### PR DESCRIPTION
closes #43190

Regression test only. Passing a `Series`/`DataFrame` as a ufunc's `out` argument (e.g. `np.fmin(a, b, c)`, where the third positional is `out`) used to recurse infinitely — the `out` pandas object stayed in `kwargs`, so NumPy re-dispatched into its `__array_ufunc__`, which extracted the inputs and re-called with the same `out`, and so on (manifesting as a `RecursionError`, or a segfault in the reporter's app).

This was fixed by GH-43856, which added the `if "out" in kwargs` branch / `dispatch_ufunc_with_out` helper in `arraylike.py` that pops `out` before calling the ufunc. There was no regression test tied to this issue, and the existing `out=` tests only pass a NumPy array as `out` — never a pandas object, which is the case that recursed. These tests cover that gap for both `Series` and `DataFrame`, asserting the returned value and the in-place write into `out`.
