### PR TITLE
BUG: query/eval datetime ==/in against a date string returned wrong results

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -445,6 +445,7 @@ Other
 ^^^^^
 
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
+- Bug in :meth:`DataFrame.query` and :meth:`DataFrame.eval` where ``==``, ``!=``, ``in``, and ``not in`` comparisons of a datetime column or index against a date string silently returned wrong results instead of matching (:issue:`35595`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
 
 .. ***DO NOT USE THIS SECTION***

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -445,25 +445,32 @@ class BinOp(Op):
                 encoder = pprint_thing
             return encoder(value)
 
+        def convert(value):
+            if isinstance(value, (int, float)):
+                value = stringify(value)
+            value = Timestamp(ensure_decoded(value))
+            if value.tz is not None:
+                value = value.tz_convert("UTC")
+            return value
+
+        def convert_term(term) -> None:
+            value = term.value
+            if term.is_scalar:
+                term.update(convert(value))
+            elif isinstance(value, list):
+                # ``==``/``in`` comparisons are rewritten to membership ops
+                # with the right-hand side wrapped in a list (see
+                # _rewrite_membership_op), so convert the elements too
+                # (GH#35595)
+                term.update([convert(element) for element in value])
+
         lhs, rhs = self.lhs, self.rhs
 
-        if is_term(lhs) and lhs.is_datetime and is_term(rhs) and rhs.is_scalar:
-            v = rhs.value
-            if isinstance(v, (int, float)):
-                v = stringify(v)
-            v = Timestamp(ensure_decoded(v))
-            if v.tz is not None:
-                v = v.tz_convert("UTC")
-            self.rhs.update(v)
+        if is_term(lhs) and lhs.is_datetime and is_term(rhs):
+            convert_term(self.rhs)
 
-        if is_term(rhs) and rhs.is_datetime and is_term(lhs) and lhs.is_scalar:
-            v = lhs.value
-            if isinstance(v, (int, float)):
-                v = stringify(v)
-            v = Timestamp(ensure_decoded(v))
-            if v.tz is not None:
-                v = v.tz_convert("UTC")
-            self.lhs.update(v)
+        if is_term(rhs) and rhs.is_datetime and is_term(lhs):
+            convert_term(self.lhs)
 
     def _disallow_scalar_only_bool_ops(self) -> None:
         rhs = self.rhs

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -574,6 +574,39 @@ class TestDataFrameQueryNumExprPandas:
             with pytest.raises(TypeError, match=msg):
                 df.query(f"dates {op} nondate", parser=parser, engine=engine)
 
+    def test_date_query_eq_ne_with_str(self, engine, parser):
+        # GH#35595 equality/membership against a date string was not converted
+        # to a Timestamp, silently returning wrong results
+        skip_if_no_pandas_parser(parser)
+        df = DataFrame({"dates": date_range("1/1/2012", periods=5)})
+
+        res = df.query('dates == "2012-01-03"', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, df[df["dates"] == "2012-01-03"])
+
+        res = df.query('dates != "2012-01-03"', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, df[df["dates"] != "2012-01-03"])
+
+        res = df.query(
+            'dates in ["2012-01-02", "2012-01-04"]', engine=engine, parser=parser
+        )
+        expec = df[
+            df["dates"].isin([pd.Timestamp("2012-01-02"), pd.Timestamp("2012-01-04")])
+        ]
+        tm.assert_frame_equal(res, expec)
+
+    def test_date_index_named_datetime_query(self, engine, parser):
+        # GH#35595 a datetime index level named "datetime" shadowed the
+        # ``datetime`` builtin and was compared against an unconverted string
+        skip_if_no_pandas_parser(parser)
+        mi = MultiIndex.from_product(
+            [date_range("2020-01-01", periods=3), ["A", "B"]],
+            names=["datetime", "count"],
+        )
+        df = DataFrame({"val": range(len(mi))}, index=mi)
+        res = df.query('datetime == "2020-01-01"', engine=engine, parser=parser)
+        expec = df[df.index.get_level_values("datetime") == "2020-01-01"]
+        tm.assert_frame_equal(res, expec)
+
     def test_query_syntax_error(self, engine, parser):
         df = DataFrame({"i": range(10), "+": range(3, 13), "r": range(4, 14)})
         msg = "invalid syntax"


### PR DESCRIPTION
closes #35595

`DataFrame.query`/`DataFrame.eval` silently returned wrong results when comparing a datetime column or index against a date string with `==`, `!=`, `in`, or `not in`:

```python
df = pd.DataFrame({"dates": pd.date_range("2012-01-01", periods=5)})
df.query('dates == "2012-01-03"')   # returned 0 rows, expected 1
df.query('dates in ["2012-01-02"]') # returned 0 rows, expected 1
```

`<`/`>` worked; only equality/membership was affected, and it was not specific to a column named `datetime` as GH-35595 suggested — any datetime column/index was affected.

**Cause:** `==`/`!=`/`in` get rewritten to membership ops with the scalar wrapped in a length-1 list (`_rewrite_membership_op`) *before* `BinOp.convert_values` runs. `convert_values` only converted the operand to a `Timestamp` when `is_scalar` was true, so the list-wrapped date string was left as a raw string and compared element-wise against the datetime array, yielding all-`False`.

**Fix:** convert list-wrapped operands too, so datetime equality/membership matches.

The original issue's string-level case (an index level named `datetime` with string values) already works on `main` via the `_resolve_name` type-shadowing handling; this PR fixes the remaining datetime-dtype case.

Note: tz-aware datetime columns compared to a date string remain unsupported — that is a pre-existing limitation that also affects `<`/`>` (the converted Timestamp is tz-naive) and is left for a separate change.