### PR TITLE
TST: clip int data with tiny float bound preserves float (GH#25066)

### DIFF
--- a/pandas/tests/frame/methods/test_clip.py
+++ b/pandas/tests/frame/methods/test_clip.py
@@ -188,6 +188,16 @@ class TestDataFrameClip:
         expected = DataFrame({"a": [1.5, 2.0, 3.0]})
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("bound", [1e-8, 1e-15])
+    def test_clip_int_data_with_tiny_float_bound(self, bound):
+        # GH#25066 clipping int data with a tiny float bound (1e-8 lands exactly
+        # on the old downcast atol) must keep the float values, not round them
+        # back to int
+        df = DataFrame({"a": [0, 1, 0, 1]})
+        result = df.clip(bound, 1)
+        expected = DataFrame({"a": [bound, 1.0, bound, 1.0]})
+        tm.assert_frame_equal(result, expected)
+
     def test_clip_with_list_bound(self):
         # GH#54817
         df = DataFrame([1, 5])

--- a/pandas/tests/series/methods/test_clip.py
+++ b/pandas/tests/series/methods/test_clip.py
@@ -163,3 +163,15 @@ class TestSeriesClip:
         result = ser.clip(lower=lower)
         expected = Series([0, 2, 3])
         tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("bound", [1e-8, 1e-15])
+    def test_clip_int_with_tiny_float_bound(self, bound):
+        # GH#25066 clipping an int Series with a tiny float bound (1e-8 lands
+        # exactly on the old downcast atol) must keep the float values, not
+        # silently round them back to int
+        ser = Series([0, 1, 0, 1])
+        result = ser.clip(bound, 1)
+        expected = Series([bound, 1.0, bound, 1.0])
+        tm.assert_series_equal(result, expected)
+        # the np.clip ufunc dispatches to Series.clip
+        tm.assert_series_equal(np.clip(ser, bound, 1), expected)


### PR DESCRIPTION
closes #25066

The regression reported in GH-25066 (clipping an int Series with a tiny float bound such as `1e-8` silently rounding the result back to int) was fixed when the silent downcasting in `where`/`mask`/`fillna` was removed in 2.0. Adds Series and DataFrame regression tests so it stays fixed.

The existing `test_clip_int_data_with_float_bound` (GH-51472) only covers an int-stays-float case; these pin the distinct tolerance edge — `1e-8` lands exactly on the old downcast `atol`, the precise value that used to round back to int.