### PR TITLE
TST: empty timedelta column sum (GH#50628)

### DIFF
--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -2287,6 +2287,30 @@ def test_sum_timedelta64_skipna_false():
     tm.assert_series_equal(result, expected)
 
 
+def test_sum_empty_timedelta_column():
+    # GH#50628 summing an empty timedelta column used to raise
+    #  "Cannot cast TimedeltaArray to dtype float64"
+    df = DataFrame({"b": np.array([], dtype="m8[ns]")})
+    result = df.sum()
+    expected = Series([pd.Timedelta(0)], index=["b"], dtype="m8[ns]")
+    tm.assert_series_equal(result, expected)
+
+
+def test_sum_empty_mixed_with_timedelta_column():
+    # GH#50628 sum over an empty mixed-dtype frame keeps per-column dtypes
+    #  rather than force-casting to float64 (which raised for timedelta)
+    df = DataFrame(
+        {
+            "a": np.array([], dtype="float64"),
+            "b": np.array([], dtype="m8[ns]"),
+            "c": np.array([], dtype="int64"),
+        }
+    )
+    result = df.sum()
+    expected = Series([0.0, pd.Timedelta(0), 0], index=["a", "b", "c"], dtype=object)
+    tm.assert_series_equal(result, expected)
+
+
 def test_mixed_frame_with_integer_sum():
     # https://github.com/pandas-dev/pandas/issues/34520
     df = DataFrame([["a", 1]], columns=list("ab"))


### PR DESCRIPTION
closes #50628

Summing an empty timedelta column used to raise `TypeError: Cannot cast TimedeltaArray to dtype float64` (print 4 in the issue) — the only actionable bug in GH-50628 per the triage discussion. It was fixed by GH-51335 (which dropped the `astype(np.float64)` cast on empty `sum`/`prod` results), but no regression test was added and the issue was never closed.

This adds coverage for the empty timedelta column case, both standalone (result keeps `timedelta64[ns]` dtype, matching the empty-`Series` `sum`) and in a mixed-dtype frame (per-column dtypes preserved instead of force-casting to float).

The remaining dtype-consistency points raised in the issue (`.apply(np.sum)` / `.apply(np.mean)` over empty frames) are part of the broader empty-object discussion in GH-47959 and are out of scope here.