### PR TITLE
TST: read_csv pyarrow engine handles missing values in parse_dates (GH-47950)

### DIFF
--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -311,6 +311,23 @@ def test_parse_dates_empty_string(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
+def test_parse_dates_missing_value(all_parsers):
+    # GH#47950 a missing value in a parse_dates column should become NaT,
+    # not be left as the string "None" (which the pyarrow engine used to do)
+    parser = all_parsers
+    data = "idx,date\n2,2000-01-01\n,\n"
+    result = parser.read_csv(StringIO(data), parse_dates=["date"])
+
+    expected = DataFrame(
+        {
+            "idx": [2.0, np.nan],
+            "date": [Timestamp("2000-01-01"), pd.NaT],
+        }
+    )
+    expected["date"] = expected["date"].astype("M8[us]")
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "data,kwargs,expected",
     [


### PR DESCRIPTION
closes #47950

The reported bug — `read_csv(..., engine="pyarrow", parse_dates=[...])` leaving
missing values as the string `"None"` (object dtype) instead of `NaT` — was
already fixed by GH-52087, which set `strings_can_be_null` on the pyarrow
convert options so empty fields infer as null and the column comes back as a
proper `datetime64` with `NaT`. That PR didn't reference this issue, so it
stayed open and had no dedicated regression test.

This adds `test_parse_dates_missing_value`, mirroring the issue's repro and
running across all parser engines (c, python, pyarrow). The `concat_date_cols`
behavior also mentioned in the thread is moot — that helper was removed when
multi-column `parse_dates` was dropped.
