### PR TITLE
Backport PR #65938 on branch 3.0.x (TYP/TST: matplotlib 3.11 typing compat and 32-bit test_datetimes fix)

### DIFF
--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
+    Any,
     Literal,
     NamedTuple,
 )
@@ -452,7 +453,8 @@ def boxplot(
             raise ValueError("The 'layout' keyword is not supported when 'by' is None")
 
         if ax is None:
-            rc = {"figure.figsize": figsize} if figsize is not None else {}
+            # Any: rc_context's accepted key type narrowed in matplotlib 3.11
+            rc: Any = {"figure.figsize": figsize} if figsize is not None else {}
             with mpl.rc_context(rc):
                 ax = plt.gca()
         data = data._get_numeric_data()

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -2184,14 +2184,14 @@ class PiePlot(MPLPlot):
                 ]
             else:
                 blabels = None
-            results = ax.pie(y, labels=blabels, **kwds)
+            # Any: pie returns a 2- or 3-tuple and matplotlib's return type
+            # for it differs across versions
+            results: Any = ax.pie(y, labels=blabels, **kwds)
 
             if kwds.get("autopct", None) is not None:
-                # error: Need more than 2 values to unpack (3 expected)
-                patches, texts, autotexts = results  # type: ignore[misc]
+                patches, texts, autotexts = results
             else:
-                # error: Too many values to unpack (2 expected, 3 provided)
-                patches, texts = results  # type: ignore[misc]
+                patches, texts = results
                 autotexts = []
 
             if self.fontsize is not None:

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -663,7 +663,7 @@ class TestDatetimeArray:
             pd.Timedelta(days=2),
             "invalid",
             np.arange(10, dtype="i8") * 24 * 3600 * 10**9,
-            np.arange(10).view("timedelta64[ns]") * 24 * 3600 * 10**9,
+            np.arange(10, dtype="i8").view("timedelta64[ns]") * 24 * 3600 * 10**9,
             pd.Timestamp("2021-01-01").to_period("D"),
         ],
     )

--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -22,6 +22,7 @@ from pandas.tests.plotting.common import (
     _check_visible,
     _flatten_visible,
 )
+from pandas.util.version import Version
 
 from pandas.io.formats.printing import pprint_thing
 
@@ -429,7 +430,10 @@ class TestDataFramePlotsSubplots:
     def test_bar_log_no_subplots(self):
         # GH3254, GH3298 matplotlib/matplotlib#1882, #1892
         # regressions in 1.2.1
-        expected = np.array([0.1, 1.0, 10.0, 100])
+        if Version(mpl.__version__) < Version("3.11.0rc1"):
+            expected = np.array([0.1, 1.0, 10.0, 100])
+        else:
+            expected = np.array([0.1, 1.0, 10.0])
 
         # no subplots
         df = DataFrame({"A": [3] * 5, "B": list(range(1, 6))}, index=range(5))
@@ -442,7 +446,10 @@ class TestDataFramePlotsSubplots:
         strict=False,
     )
     def test_bar_log_subplots(self):
-        expected = np.array([0.1, 1.0, 10.0, 100.0, 1000.0, 1e4])
+        if Version(mpl.__version__) < Version("3.11.0rc1"):
+            expected = np.array([0.1, 1.0, 10.0, 100.0, 1000.0, 1e4])
+        else:
+            expected = np.array([0.1, 1.0, 10.0, 100.0, 1000.0])
 
         ax = DataFrame([Series([200, 300]), Series([300, 500])]).plot.bar(
             log=True, subplots=True

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -292,7 +292,10 @@ class TestSeriesPlots:
     )
     @pytest.mark.parametrize("axis, meth", [("yaxis", "bar"), ("xaxis", "barh")])
     def test_bar_log(self, axis, meth):
-        expected = np.array([1e-1, 1e0, 1e1, 1e2, 1e3, 1e4])
+        if Version(mpl.__version__) < Version("3.11.0rc1"):
+            expected = np.array([1e-1, 1e0, 1e1, 1e2, 1e3, 1e4])
+        else:
+            expected = np.array([1e-1, 1e0, 1e1, 1e2, 1e3])
 
         _, ax = mpl.pyplot.subplots()
         ax = getattr(Series([200, 500]).plot, meth)(log=True, ax=ax)
@@ -309,7 +312,10 @@ class TestSeriesPlots:
     )
     def test_bar_log_kind_bar(self, axis, kind, res_meth):
         # GH 9905
-        expected = np.array([1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1])
+        if Version(mpl.__version__) < Version("3.11.0rc1"):
+            expected = np.array([1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1])
+        else:
+            expected = np.array([1e-4, 1e-3, 1e-2, 1e-1, 1e0])
 
         _, ax = mpl.pyplot.subplots()
         ax = Series([0.1, 0.01, 0.001]).plot(log=True, kind=kind, ax=ax)


### PR DESCRIPTION
Manual backport of GH-65938.

Backports only the `pandas/` changes (matplotlib 3.11 typing compat in `boxplot.py`/`core.py` and the 32-bit `test_searchsorted_invalid_types` fix). The `.github/workflows/wheels.yml` change from the original PR is excluded, since 3.0.x pins a different `actions/checkout` version — per discussion in GH-65938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)