### PR TITLE
BUG: Fix merge with NaN-labeled join key producing duplicate columns

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -24,6 +24,7 @@ from pandas._libs import (
     lib,
 )
 from pandas._libs.lib import is_range_indexer
+from pandas._libs.missing import is_matching_na
 from pandas.errors import MergeError
 from pandas.util._decorators import (
     cache_readonly,
@@ -1248,7 +1249,7 @@ class _MergeOperation:
                 and self.orig_right._is_level_reference(
                     right_key  # type: ignore[arg-type]
                 )
-                and left_key == right_key
+                and (left_key == right_key or is_matching_na(left_key, right_key))
                 and name not in result.index.names
             ):
                 names_to_restore.append(name)
@@ -1603,7 +1604,7 @@ class _MergeOperation:
                         else:
                             # work-around for merge_asof(right_index=True)
                             right_keys.append(right.index._values)
-                        if lk is not None and lk == rk:  # FIXME: what about other NAs?
+                        if lk is not None and (lk == rk or is_matching_na(lk, rk)):
                             right_drop.append(rk)
                     else:
                         rk = cast("ArrayLike", rk)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1520,6 +1520,16 @@ def _check_merge(x, y):
             # TODO check_names on merge?
             tm.assert_frame_equal(result, expected, check_names=False)
 
+    def test_merge_on_nan_label(self):
+        # GH#65899 - merge with NaN-labeled join key produces duplicate columns
+        left = DataFrame({np.nan: [1, 2, 3], "a": [10, 20, 30]})
+        right = DataFrame({np.nan: [1, 2, 3], "b": [40, 50, 60]})
+        result = merge(left, right, left_on=np.nan, right_on=np.nan)
+        expected = DataFrame(
+            {np.nan: [1, 2, 3], "a": [10, 20, 30], "b": [40, 50, 60]}
+        )
+        tm.assert_frame_equal(result, expected)
+
 
 class TestMergeDtypes:
     @pytest.mark.parametrize("dtype", [object, "category"])


### PR DESCRIPTION
- [x] closes #65899
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Summary

Fixes a label-equality check in `_get_merge_keys` that compared `lk == rk` directly. NaN compares unequal to itself, so `merge(left_on=np.nan, right_on=np.nan)` failed to drop the right-side duplicate column.

Uses `is_matching_na` as a fallback when `lk == rk` returns False for NA values. Also fixes the same pattern in `_maybe_restore_index_levels`.

This resolves the long-standing `# FIXME: what about other NAs?` comment introduced in GH-48590.

## Test plan
- [x] New `test_merge_on_nan_label` (NaN-vs-NaN, drop happens)

## AI assistance disclosure
This contribution was developed with assistance from an AI coding assistant (Buck). The AI was prompted to follow AGENTS.md and the pandas contribution guidelines.