### PR TITLE
TST: add regression test and whatsnew for GH#63078 (MultiIndex datetime64[ns] pickle)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -343,8 +343,8 @@ Missing
 
 MultiIndex
 ^^^^^^^^^^
-- Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :class:`MultiIndex` where pickling a :class:`DataFrame` with a ``datetime64[ns]`` level raised ``NotImplementedError`` (:issue:`63078`)
+- Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.get_loc` where looking up a tuple key containing a scalar inside an :class:`IntervalIndex` level with overlapping intervals raised ``KeyError`` or returned incorrect results (:issue:`27456`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -345,7 +345,7 @@ MultiIndex
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.get_loc` where looking up a tuple key containing a scalar inside an :class:`IntervalIndex` level with overlapping intervals raised ``KeyError`` or returned incorrect results (:issue:`27456`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
--
+- Bug in :class:`MultiIndex` where pickling a :class:`DataFrame` with a ``datetime64[ns]`` level raised ``NotImplementedError`` (:issue:`63078`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -344,9 +344,9 @@ Missing
 MultiIndex
 ^^^^^^^^^^
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
+- Bug in :class:`MultiIndex` where pickling a :class:`DataFrame` with a ``datetime64[ns]`` level raised ``NotImplementedError`` (:issue:`63078`)
 - Bug in :meth:`MultiIndex.get_loc` where looking up a tuple key containing a scalar inside an :class:`IntervalIndex` level with overlapping intervals raised ``KeyError`` or returned incorrect results (:issue:`27456`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
-- Bug in :class:`MultiIndex` where pickling a :class:`DataFrame` with a ``datetime64[ns]`` level raised ``NotImplementedError`` (:issue:`63078`)
 
 I/O
 ^^^

--- a/pandas/tests/indexes/multi/test_pickle.py
+++ b/pandas/tests/indexes/multi/test_pickle.py
@@ -24,5 +24,5 @@ def test_multiindex_datetime64ns_pickle_roundtrip(tmp_path):
         }
     ).set_index(["date", "id"])
 
-    result = tm.round_trip_pickle(df, tmp_path)
+    result = tm.round_trip_pickle(df, tmp_path / "test.pkl")
     tm.assert_frame_equal(result, df)

--- a/pandas/tests/indexes/multi/test_pickle.py
+++ b/pandas/tests/indexes/multi/test_pickle.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 import pandas as pd
-import pandas._testing as tm
 from pandas import MultiIndex
+import pandas._testing as tm
 
 
 def test_pickle_compat_construction():

--- a/pandas/tests/indexes/multi/test_pickle.py
+++ b/pandas/tests/indexes/multi/test_pickle.py
@@ -13,7 +13,7 @@ def test_pickle_compat_construction():
         MultiIndex()
 
 
-def test_multiindex_datetime64ns_pickle_roundtrip():
+def test_multiindex_datetime64ns_pickle_roundtrip(tmp_path):
     # GH#63078 - pickling a MultiIndex with datetime64[ns] level raised
     # NotImplementedError in NDArrayBacked.__setstate__
     df = pd.DataFrame(
@@ -24,5 +24,5 @@ def test_multiindex_datetime64ns_pickle_roundtrip():
         }
     ).set_index(["date", "id"])
 
-    result = tm.round_trip_pickle(df)
+    result = tm.round_trip_pickle(df, tmp_path)
     tm.assert_frame_equal(result, df)

--- a/pandas/tests/indexes/multi/test_pickle.py
+++ b/pandas/tests/indexes/multi/test_pickle.py
@@ -1,5 +1,8 @@
+import numpy as np
 import pytest
 
+import pandas as pd
+import pandas._testing as tm
 from pandas import MultiIndex
 
 
@@ -8,3 +11,18 @@ def test_pickle_compat_construction():
     # need an object to create with
     with pytest.raises(TypeError, match="Must pass both levels and codes"):
         MultiIndex()
+
+
+def test_multiindex_datetime64ns_pickle_roundtrip():
+    # GH#63078 - pickling a MultiIndex with datetime64[ns] level raised
+    # NotImplementedError in NDArrayBacked.__setstate__
+    df = pd.DataFrame(
+        {
+            "date": [np.datetime64("20110101", "ns")],
+            "id": [1],
+            "val": [1],
+        }
+    ).set_index(["date", "id"])
+
+    result = tm.round_trip_pickle(df)
+    tm.assert_frame_equal(result, df)


### PR DESCRIPTION
The underlying fix was applied in GH#62832 but without a targeted regression test or changelog entry. This PR adds both.

- Adds `test_multiindex_datetime64ns_pickle_roundtrip` in `pandas/tests/indexes/multi/test_pickle.py`
- Adds a whatsnew entry in `doc/source/whatsnew/v3.1.0.rst`

Closes #63078