### PR TITLE
DOC: clarify sort_values determinism

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8151,9 +8151,10 @@ class DataFrame(NDFrame, OpsMixin):
              If True, perform operation in-place.
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
              Choice of sorting algorithm. See also :func:`numpy.sort` for more
-             information. `mergesort` and `stable` are the only stable algorithms. For
-             DataFrames, this option is only applied when sorting on a single
-             column or label.
+             information. The sort order is deterministic for a given input.
+             `mergesort` and `stable` are the only stable algorithms, which preserve
+             the relative order of equal keys. For DataFrames, this option is only
+             applied when sorting on a single column or label.
         na_position : {'first', 'last'}, default 'last'
              Puts NaNs at the beginning if `first`; `last` puts NaNs at the
              end.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3928,7 +3928,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             If True, perform operation in-place.
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
-            information. 'mergesort' and 'stable' are the only stable  algorithms.
+            information. The sort order is deterministic for a given input.
+            `mergesort` and `stable` are the only stable algorithms, which preserve
+            the relative order of equal keys.
         na_position : {'first' or 'last'}, default 'last'
             Argument 'first' puts NaNs at the beginning, 'last' puts NaNs at
             the end.


### PR DESCRIPTION
Refs #63154

This PR clarifies that `DataFrame.sort_values` and `Series.sort_values` produce deterministic sort order for a given input.

It also expands the existing note about `mergesort` and `stable` to explain that stable algorithms preserve the relative order of equal keys.

Only the `sort_values` docstrings are updated in this PR. `sort_index` and `value_counts` are left for separate follow-up work because they involve different wording and scope.
