### PR TITLE
TST: scalar setitem of tuple into object column (GH#26333)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -330,7 +330,7 @@ Indexing
 - Bug in :meth:`Index.where` and :meth:`Index.putmask` preserving ``numpy.datetime64`` / ``numpy.timedelta64`` ``NaT`` scalars in the object-dtype result for mismatched-dtype inputs, instead of normalizing to :attr:`pandas.NaT` as :meth:`Series.where` does (:issue:`55174`)
 - Bug in :meth:`MultiIndex.get_loc` returning a slice instead of an integer for a unique key when the :class:`MultiIndex` contained duplicates elsewhere, causing ``.loc`` to return a :class:`Series` instead of a scalar (:issue:`42102`)
 - Bug in :meth:`Series.where` and :meth:`Series.mask` raising ``ValueError`` when ``other`` is a tuple on object-dtype :class:`Series` (:issue:`37681`)
-- Fixed bug in :meth:`DataFrame.loc` where assigning an iterable to a single cell in an ``object`` dtype column incorrectly raised a ``ValueError`` (:issue:`57962`)
+- Fixed bug in :meth:`DataFrame.loc` where assigning an iterable to a single cell in an ``object`` dtype column incorrectly raised a ``ValueError`` (:issue:`26333`, :issue:`57962`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
 - Fixed segfault in :meth:`DataFrame.loc` when repeatedly adding new rows to an object-dtype-indexed :class:`DataFrame` (:issue:`21968`)
 -

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1144,6 +1144,22 @@ def test_scalar_setitem_series_with_nested_value_length1(value, indexer_sli):
         assert ser.loc[0] == value
 
 
+def test_scalar_setitem_tuple_into_object_column():
+    # GH#26333 - assigning a tuple to a single cell of an object-dtype column
+    #  that already holds tuples should store it as-is, not raise on length
+    df = DataFrame({"a": [1, 2, 3], "b": [(1, 2), (1, 2, 3), (3, 4)]})
+
+    df.loc[0, "b"] = (7, 8, 9)
+    assert df.loc[0, "b"] == (7, 8, 9)
+
+    # .at takes the same path
+    df.at[1, "b"] = (4, 5)
+    assert df.at[1, "b"] == (4, 5)
+
+    expected = DataFrame({"a": [1, 2, 3], "b": [(7, 8, 9), (4, 5), (3, 4)]})
+    tm.assert_frame_equal(df, expected)
+
+
 def test_loc_setitem_list_of_tuples_on_object_column():
     # GH#37629 - assigning list of tuples to object-dtype column
     # with a boolean mask on a mixed-dtype DataFrame


### PR DESCRIPTION
closes #26333

Regression test for assigning a tuple to a single cell of an object-dtype column via `.loc`/`.at`. The behavior was fixed by GH-65396 (which closed the duplicate GH-57962); this adds a test using the issue's exact shape — an object column that already holds tuples — and references GH-26333 on the existing whatsnew entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)