### PR TITLE
BUG: bar/barh plot raises on timedelta64 data containing NaT (GH-39320)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -396,6 +396,7 @@ Period
 Plotting
 ^^^^^^^^
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
+- Bug in :meth:`Series.plot.bar`, :meth:`Series.plot.barh`, :meth:`DataFrame.plot.bar`, and :meth:`DataFrame.plot.barh` raising ``TypeError`` when the data had ``timedelta64`` dtype and contained ``NaT`` (:issue:`39320`)
 -
 
 Groupby/resample/rolling

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -23,6 +23,7 @@ import matplotlib as mpl
 import numpy as np
 
 from pandas._libs import lib
+from pandas._libs.tslibs import Timedelta
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly
 from pandas.util._exceptions import find_stack_level
@@ -1950,7 +1951,16 @@ class BarPlot(MPLPlot):
         pos_prior = neg_prior = np.zeros(len(self.data))
         K = self.nseries
 
-        data = self.data.fillna(0)
+        if any(dtype.kind == "m" for dtype in self.data.dtypes):
+            # GH#39320 plain fillna(0) casts timedelta64 columns to object
+            # dtype, which then cannot be plotted; fill those with a zero
+            # Timedelta so the dtype (and any NaT->0 bars) survive.
+            data = self.data.copy()
+            for i, (_, ser) in enumerate(self.data.items()):
+                fill_value = Timedelta(0) if ser.dtype.kind == "m" else 0
+                data.isetitem(i, ser.fillna(fill_value))
+        else:
+            data = self.data.fillna(0)
 
         _stacked_subplots_ind: dict[int, int] = {}
         _stacked_subplots_offsets: list[tuple[np.ndarray, np.ndarray]] = []

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -348,6 +348,21 @@ class TestSeriesPlots:
         ]
         assert result == expected
 
+    @pytest.mark.parametrize("kind", ["bar", "barh"])
+    def test_bar_timedelta(self, kind):
+        # GH#39320 bar/barh of timedelta data, including NaT, should not raise
+        ser = Series([pd.Timedelta(seconds=1), pd.NaT, pd.Timedelta(seconds=3)])
+        ax = ser.plot(kind=kind)
+        get_dim = "get_height" if kind == "bar" else "get_width"
+        result = [getattr(patch, get_dim)() for patch in ax.patches]
+        # NaT is plotted as a zero-length bar, matching the numeric NaN behavior
+        expected = [
+            np.timedelta64(1, "s"),
+            np.timedelta64(0, "s"),
+            np.timedelta64(3, "s"),
+        ]
+        assert result == expected
+
     def test_rotation_default(self):
         df = DataFrame(np.random.default_rng(2).standard_normal((5, 5)))
         # Default rot 0


### PR DESCRIPTION
closes #39320

`BarPlot._make_plot` fills missing values with `fillna(0)` so that `NaN`/`NaT` entries render as zero-length bars. For `timedelta64` columns, the integer `0` cast the column to `object` dtype whenever a `NaT` was present, after which matplotlib raised `TypeError: unsupported operand type(s) for +: 'numpy.int64' and 'Timedelta'`.

This fills `timedelta64` columns with a zero `Timedelta` instead, preserving the dtype so the data (and the `NaT` -> 0 bars) plot correctly. matplotlib already handles `timedelta64` axes; the only problem was the object-dtype upcast. The all-numeric fast path is unchanged.

Affects `Series.plot.bar`/`barh` and `DataFrame.plot.bar`/`barh`.

Note: stacked bars, `area`, and `pie` of timedelta data still raise (the stacking accumulator is a `float64` zeros array, so `float64 + timedelta64` fails). That is a separate, deeper change and is left out of scope here.