### PR TITLE
TST: to_csv does not require escapechar for null byte (GH#47871)

### DIFF
--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -949,3 +949,11 @@ def test_new_style_with_template():
     result = df.to_csv(float_format="Value: {:,.2f}", lineterminator="\n")
     expected = ',A\n0,"Value: 1,234.57"\n'
     assert result == expected
+
+
+def test_to_csv_null_byte_no_escapechar():
+    # GH#47871 a null byte does not require escapechar to be set
+    # (was a CPython _csv regression on 3.10, fixed in 3.11)
+    df = DataFrame({"A": ["\x00"]})
+    result = df.to_csv(index=False, lineterminator="\n")
+    assert result == "A\n\x00\n"


### PR DESCRIPTION
closes #47871

Add a regression test for writing a null byte (`\x00`) via `to_csv`. The reported `_csv.Error: need to escape, but no escapechar set` was a CPython `_csv` regression on Python 3.10 (upstream python/cpython#97503, fixed in 3.11). pandas now requires Python >= 3.11, so the write side no longer needs `escapechar` and there is nothing to fix in pandas — this just guards the behavior.