### PR TITLE
DOC: document CSV round-trip limitation with MultiIndex columns and unnamed index (GH#56929)

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1406,6 +1406,15 @@ of multi-columns indices.
    with ``df.to_csv(..., index=False)``), then any ``names`` on the columns index will
    be *lost*.
 
+.. warning::
+   When a ``DataFrame`` with ``MultiIndex`` columns has an *unnamed* index, the row
+   that would hold the index names is omitted on write. If the first data row then
+   consists entirely of missing values, it is written identically to that omitted
+   row, and on read ``read_csv`` cannot tell the two apart: it consumes the first
+   data row as the index names, silently dropping that row. Avoid this by writing
+   missing values with a non-empty ``na_rep`` (e.g. ``df.to_csv(na_rep="NaN")``) or
+   by giving the index a name.
+
 .. ipython:: python
    :suppress:
 


### PR DESCRIPTION
closes #56929

When a `DataFrame` with `MultiIndex` columns has an unnamed index, `to_csv` omits the row that would hold the index names. If the first data row is then entirely missing, it is written identically to that omitted row, so `read_csv` cannot tell them apart and consumes the first data row as the column index names, silently dropping that row.

A reader-side fix is not possible (the two rows are byte-identical in pandas' own format, so any heuristic that fixes the unnamed case breaks the named-index case — see the stale attempt in GH-57070), and the only writer-side fix regresses the default `index_col=None` read. This documents the limitation in the IO user guide along with the workarounds (non-empty `na_rep`, or naming the index).