### PR TITLE
TST: tz-aware grouper/map returning tz-naive (GH#57192)

### DIFF
--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -313,6 +313,22 @@ class TestGrouping:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_grouper_func_returning_tz_naive(self):
+        # GH#57192 grouping by a function that strips the tz should give
+        #  tz-naive group keys, not keys re-localized to the original tz
+        index = date_range("2024-02-01", "2024-02-03", freq="8h", tz="UTC")
+        df = DataFrame({"A": 1}, index=index)
+
+        gb = df.groupby(by=lambda ts: ts.normalize().tz_convert(None))
+        keys = list(gb.groups.keys())
+        assert all(key.tz is None for key in keys)
+        expected = [
+            Timestamp("2024-02-01"),
+            Timestamp("2024-02-02"),
+            Timestamp("2024-02-03"),
+        ]
+        assert keys == expected
+
     def test_grouper_column_and_index(self):
         # GH 14327
 

--- a/pandas/tests/indexes/datetimes/methods/test_map.py
+++ b/pandas/tests/indexes/datetimes/methods/test_map.py
@@ -36,6 +36,18 @@ class TestMap:
         expected = Index([f(index[0])])
         tm.assert_index_equal(result, expected)
 
+    def test_map_tz_aware_to_tz_naive(self):
+        # GH#57192 a function that strips the tz should give a tz-naive result,
+        #  not silently re-localize back to the original tz
+        dti = date_range("2024-02-01", "2024-02-03", freq="8h", tz="UTC")
+
+        result = dti.map(lambda ts: ts.normalize().tz_convert(None))
+        expected = DatetimeIndex(
+            [ts.normalize().tz_convert(None) for ts in dti], dtype="M8[us]"
+        )
+        tm.assert_index_equal(result, expected)
+        assert result.tz is None
+
     @pytest.mark.parametrize("name", [None, "name"])
     def test_index_map(self, name):
         # see GH#20990


### PR DESCRIPTION
closes #57192

Grouping a tz-aware `DatetimeIndex` by a function that strips the tz (e.g. `ts.normalize().tz_convert(None)`) used to give back group keys re-localized to the original tz instead of the tz-naive values the function returned. Same for `DatetimeIndex.map`.

This was a regression introduced by `EA._from_scalars` (GH-53089) and already fixed by the `EA._cast_pointwise_result` refactor (GH-62105), which no longer routes the `NDArrayBacked` map path through `_from_scalars`. Adding regression tests at both the `map` (root cause) and groupby (reported) levels.