### PR TITLE
TST: cut Series with NaN and integer bins (GH#55684)

### DIFF
--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -265,6 +265,18 @@ def test_na_handling(labels):
     tm.assert_almost_equal(result, expected)
 
 
+@pytest.mark.parametrize("use_bottleneck", [True, False])
+def test_cut_series_with_nan_integer_bins(use_bottleneck):
+    # GH#55684 cut on a Series with NaN and an integer number of bins raised
+    # "TypeError: putmask: first argument must be an array" when bottleneck
+    # was not in use, because nanmin/nanmax was computed on the Series itself.
+    with pd.option_context("use_bottleneck", use_bottleneck):
+        data = [1.1, 2.2, 3.3, np.nan]
+        result = cut(Series(data), 2)
+        expected = Series(cut(data, 2))
+        tm.assert_series_equal(result, expected)
+
+
 def test_inf_handling():
     data = np.arange(6)
     data_ser = Series(data, dtype="int64")


### PR DESCRIPTION
closes #55684

Adds a regression test for ``cut`` on a ``Series`` containing NaN with an
integer number of bins. This raised ``TypeError: putmask: first argument
must be an array`` on 2.1.x when bottleneck was not in use, because the
min/max for the bin edges was computed on the ``Series`` itself. The fix
landed in 2.2.0 (GH-54919, which casts the input to ``Index`` early) but
was never backported, so the bug persisted on the 2.1.x line and had no
test guarding it. The test is parametrized over ``use_bottleneck`` since
that was the dimension that originally distinguished pass from fail.