### PR TITLE
TST: replace does not coerce np.nan to NaT (GH#48034)

### DIFF
--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -649,6 +649,27 @@ class TestSeriesReplace:
         result = series.replace(to_replace="0", value=1, regex=regex)
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("regex", [False, True])
+    def test_replace_no_replacement_keeps_nan(self, regex):
+        # GH#48034 a non-matching replace on an object Series of Timestamp + NaN
+        #  should be a no-op and must not coerce np.nan to NaT
+        ser = pd.Series([pd.Timestamp(1000223), np.nan], dtype=object)
+        result = ser.replace("abcdef", pd.NaT, regex=regex)
+        tm.assert_series_equal(result, ser)
+        assert result.dtype == object
+        assert result[1] is np.nan
+
+    def test_replace_keeps_nan_no_downcast(self):
+        # GH#48034 replacing a value should not downcast object dtype and
+        #  thereby convert np.nan to NaT
+        ser = pd.Series([pd.Timedelta("PT1H"), np.nan, 1], dtype=object)
+        result = ser.replace(1, pd.Timedelta("PT1H"), regex=False)
+        expected = pd.Series(
+            [pd.Timedelta("PT1H"), np.nan, pd.Timedelta("PT1H")], dtype=object
+        )
+        tm.assert_series_equal(result, expected)
+        assert result[1] is np.nan
+
     def test_replace_different_int_types(self, any_int_numpy_dtype):
         # GH#45311
         labs = pd.Series([1, 1, 1, 0, 0, 2, 2, 2], dtype=any_int_numpy_dtype)


### PR DESCRIPTION
closes #48034

Adds regression coverage for `Series.replace` no longer silently downcasting an object-dtype Series of `Timestamp`/`Timedelta` + `np.nan` to `datetime64`/`timedelta64`, which used to convert `np.nan` into `NaT`. The behavior was fixed when silent downcasting in `replace` was enforced (GH-54710), but no test guarded it.