### PR TITLE
TST: pd.NA preserved through Series.map for nullable/Arrow dtypes (GH#57390)

### DIFF
--- a/pandas/tests/series/methods/test_map.py
+++ b/pandas/tests/series/methods/test_map.py
@@ -702,3 +702,42 @@ def test_map_retains_dtype_with_na(dtype):
     ser = Series([1, 2, 3, pd.NA, 10], dtype=dtype)
     result = ser.map(lambda x: x)
     tm.assert_series_equal(result, ser)
+
+
+@pytest.mark.parametrize(
+    "dtype, non_na",
+    [
+        ("Int64", 1),
+        ("Float64", 1.5),
+        ("boolean", True),
+        pytest.param("int64[pyarrow]", 1, marks=td.skip_if_no("pyarrow")),
+        pytest.param("double[pyarrow]", 1.5, marks=td.skip_if_no("pyarrow")),
+        pytest.param("string[pyarrow]", "a", marks=td.skip_if_no("pyarrow")),
+    ],
+)
+def test_map_na_identity(dtype, non_na):
+    # GH#57390 - pd.NA is passed to the mapper as pd.NA, not coerced to NaN,
+    # so an identity check (x is pd.NA) inside the mapper works
+    ser = Series([pd.NA, non_na], dtype=dtype)
+    result = ser.map(lambda x: x is pd.NA)
+    assert result.tolist() == [True, False]
+
+
+@pytest.mark.parametrize(
+    "dtype, non_na",
+    [
+        ("Int64", 1),
+        ("Float64", 1.5),
+        ("boolean", True),
+        pytest.param("int64[pyarrow]", 1, marks=td.skip_if_no("pyarrow")),
+        pytest.param("double[pyarrow]", 1.5, marks=td.skip_if_no("pyarrow")),
+        pytest.param("string[pyarrow]", "a", marks=td.skip_if_no("pyarrow")),
+    ],
+)
+def test_map_na_action_ignore_not_called_on_na(dtype, non_na):
+    # GH#57390 - na_action="ignore" propagates NA without passing it to the mapper
+    ser = Series([pd.NA, non_na], dtype=dtype)
+    seen = []
+    result = ser.map(lambda x: seen.append(x) or x, na_action="ignore")
+    assert not any(x is pd.NA for x in seen)
+    tm.assert_series_equal(result, ser)


### PR DESCRIPTION
closes #57390

Adds regression tests guarding that `pd.NA` is passed through to the mapper as `pd.NA` (not coerced to `NaN`) for masked and Arrow-backed dtypes, so an identity check inside the mapper works:

```python
pd.Series([pd.NA], dtype="Int64").map(lambda x: 1 if x is pd.NA else 2)  # -> 1
```

The underlying bug was fixed on main by GH-63925 (which removed the eager `to_numpy()` coercion in the masked `map` override) and the now-redundant override was dropped in GH-63925/follow-up cleanup, but that PR referenced GH-63903 and left no test tied to this issue. These tests cover both `na_action=None` (identity preserved) and `na_action="ignore"` (NA propagated without calling the mapper, per GH-57388) across `Int64`/`Float64`/`boolean` and the pyarrow-backed equivalents.