### PR TITLE
BUG: DataFrame repr honors display.width with max_columns=0 (GH#21337)

### DIFF
--- a/doc/source/user_guide/dsintro.rst
+++ b/doc/source/user_guide/dsintro.rst
@@ -800,7 +800,7 @@ option:
 
 .. ipython:: python
 
-   pd.set_option("display.width", 40)  # default is 80
+   pd.set_option("display.width", 40)  # default is None (auto-detect)
 
    pd.DataFrame(np.random.randn(3, 12))
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -103,7 +103,7 @@ Other API changes
 - :meth:`DataFrame.to_hdf` no longer writes a ``pandas_version`` attribute into the HDF5 file. The value was hardcoded to ``"0.15.2"`` and was only used internally to detect files written by pandas versions older than 0.10.1 (:issue:`62792`)
 - APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`64483`).
 - Removed the ``freq`` and ``freqstr`` attributes from :class:`.DatetimeArray` and :class:`.TimedeltaArray`. Frequency is now stored only on :class:`DatetimeIndex` and :class:`TimedeltaIndex`; access ``Series.dt.freq`` or wrap the array in an Index to retrieve a frequency. The ``check_freq`` keyword on :func:`testing.assert_extension_array_equal` for these array types has also been removed (:issue:`24566`).
--
+- The default of the ``display.width`` option is now ``None``: the terminal width is auto-detected in interactive sessions, and wide output is no longer truncated to 80 columns in non-interactive sessions (e.g. scripts and redirected output). Set ``display.width`` to an integer to force a specific width (:issue:`21337`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.deprecations:
@@ -357,6 +357,7 @@ I/O
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - :meth:`HDFStore.put` and :meth:`HDFStore.append` now support storing :class:`Series` and :class:`DataFrame` columns with :class:`PeriodDtype` in both ``"fixed"`` and ``"table"`` formats (:issue:`41978`)
 - Bug in :meth:`DataFrame.__repr__` raising ``TypeError`` for a column with a NumPy structured dtype (e.g. produced by :meth:`DataFrame.from_records` from a structured ``ndarray``) (:issue:`55011`)
+- Bug in :meth:`DataFrame.__repr__` where an explicitly set ``display.width`` was ignored when ``display.max_columns`` was ``0`` (the default), so the output was truncated to the detected terminal width regardless (:issue:`21337`)
 - Bug in :meth:`DataFrame.__repr__` where horizontally truncated output could exceed the terminal width by up to 4 characters (:issue:`32461`)
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)
 - Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -242,10 +242,11 @@ pc_max_dir_items = """\
 """
 
 pc_width_doc = """
-: int
-    Width of the display in characters. In case python/IPython is running in
-    a terminal this can be set to None and pandas will correctly auto-detect
-    the width.
+: int or None
+    Width of the display in characters. The default of None means that when
+    python/IPython is running in a terminal the width is auto-detected, and
+    that wide output is not wrapped or truncated in non-interactive sessions.
+    Set to an int to force a specific width.
     Note that the IPython notebook, IPython qtconsole, or IDLE do not run in a
     terminal and hence it is not possible to correctly detect the width.
 """
@@ -370,7 +371,7 @@ with cf.config_prefix("display"):
     cf.register_option("chop_threshold", None, pc_chop_threshold_doc)
     cf.register_option("max_seq_items", 100, pc_max_seq_items)
     cf.register_option(
-        "width", 80, pc_width_doc, validator=is_instance_factory((type(None), int))
+        "width", None, pc_width_doc, validator=is_instance_factory((type(None), int))
     )
     cf.register_option(
         "memory_usage",

--- a/pandas/io/formats/console.py
+++ b/pandas/io/formats/console.py
@@ -30,11 +30,11 @@ def get_console_size() -> tuple[int | None, int | None]:
 
     if in_interactive_session():
         if in_ipython_frontend():
-            # sane defaults for interactive non-shell terminal
-            # match default for width,height in config_init
+            # sane defaults for interactive non-shell terminal, which cannot
+            # auto-detect a width (GH#21337)
             from pandas._config.config import get_default_val
 
-            terminal_width = get_default_val("display.width")
+            terminal_width = 80
             terminal_height = get_default_val("display.max_rows")
         else:
             # pure terminal

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -86,6 +86,7 @@ from pandas.io.common import (
     stringify_path,
 )
 from pandas.io.formats import printing
+from pandas.io.formats.console import get_console_size
 
 if TYPE_CHECKING:
     from pandas._typing import (
@@ -583,8 +584,10 @@ class DataFrameFormatter:
         if not self._is_in_terminal():
             return self.max_cols
 
-        width, _ = get_terminal_size()
-        if self._is_screen_narrow(width):
+        # GH#21337 honor the configured display.width (resolved via
+        # get_console_size) rather than the raw terminal size
+        width, _ = get_console_size()
+        if width is not None and self._is_screen_narrow(width):
             return width
         else:
             return self.max_cols

--- a/pandas/io/formats/string.py
+++ b/pandas/io/formats/string.py
@@ -4,7 +4,6 @@ Module for formatting output data in console (to string).
 
 from __future__ import annotations
 
-from shutil import get_terminal_size
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -156,7 +155,11 @@ class StringFormatter:
         # total width = sum of column widths + adjoin spacing (1 per gap)
         total_width = sum(col_lens) + n_cols - 1
 
-        width, _ = get_terminal_size()
+        # GH#21337 fit to the configured display.width (resolved into
+        # line_width via get_console_size); this method is only reached when
+        # line_width is not None.
+        width = self.line_width
+        assert width is not None
         dif = total_width - width
         # '+ 1' to avoid too wide repr (GH PR #17023)
         adj_dif = dif + 1

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -285,17 +285,13 @@ class TestDataFrameFormatting:
         )
         assert "..." not in str(df)
 
-    def test_repr_truncation_accounts_for_dot_separator(self, monkeypatch):
-        # GH#32461 - repr should not exceed terminal width after inserting
+    def test_repr_truncation_accounts_for_dot_separator(self):
+        # GH#32461 - repr should not exceed display.width after inserting
         # the " ..." separator column during horizontal truncation.
         # Width 82 hits the boundary where the unfixed code overflows by 4
         # because the " ..." separator column (4 chars + 1 adjoin spacing)
         # was not budgeted.
-        terminal_width = 82
-        monkeypatch.setattr(
-            "pandas.io.formats.string.get_terminal_size",
-            lambda: (terminal_width, 24),
-        )
+        width = 82
 
         ncols = 20
         df = DataFrame(
@@ -305,10 +301,40 @@ class TestDataFrameFormatting:
             }
         )
 
-        with option_context("display.width", terminal_width, "display.max_columns", 0):
+        with option_context("display.width", width, "display.max_columns", 0):
             result = repr(df)
             for line in result.split("\n"):
-                assert len(line) <= terminal_width
+                assert len(line) <= width
+
+    def test_repr_honors_display_width_with_max_columns_zero(self, monkeypatch):
+        # GH#21337 with max_columns=0 an explicitly set display.width must be
+        # honored instead of being overridden by the detected terminal width.
+        monkeypatch.setattr(
+            "pandas.io.formats.console.get_terminal_size", lambda: (80, 24)
+        )
+        df = DataFrame(np.arange(40).reshape(2, 20))
+
+        with option_context("mode.sim_interactive", True, "display.max_columns", 0):
+            # default width (None) auto-detects the narrow terminal -> truncates
+            with option_context("display.width", None):
+                assert "..." in repr(df)
+            # a large explicit width is honored -> no truncation
+            with option_context("display.width", 10000):
+                assert "..." not in repr(df)
+
+        # a small explicit width is honored even when the terminal is wide
+        monkeypatch.setattr(
+            "pandas.io.formats.console.get_terminal_size", lambda: (10000, 24)
+        )
+        with option_context(
+            "mode.sim_interactive",
+            True,
+            "display.max_columns",
+            0,
+            "display.width",
+            40,
+        ):
+            assert "..." in repr(df)
 
     def test_repr_truncation_column_size(self):
         # dataframe with last column very wide -> check it is not used to
@@ -1242,26 +1268,29 @@ class TestDataFrameFormatting:
 
     def test_info_repr(self):
         # GH#21746 For tests inside a terminal (i.e. not CI) we need to detect
-        # the terminal size to ensure that we try to print something "too big"
+        # the terminal size to ensure that we try to print something "too big".
+        # GH#21337 auto-detection of the terminal width only happens in an
+        # interactive session, so simulate one here.
         term_width, term_height = get_terminal_size()
 
         max_rows = 60
         max_cols = 20 + (max(term_width, 80) - 80) // 4
-        # Long
-        h, w = max_rows + 1, max_cols - 1
-        df = DataFrame({k: np.arange(1, 1 + h) for k in np.arange(w)})
-        assert has_vertically_truncated_repr(df)
-        with option_context("display.large_repr", "info"):
-            assert has_info_repr(df)
+        with option_context("mode.sim_interactive", True):
+            # Long
+            h, w = max_rows + 1, max_cols - 1
+            df = DataFrame({k: np.arange(1, 1 + h) for k in np.arange(w)})
+            assert has_vertically_truncated_repr(df)
+            with option_context("display.large_repr", "info"):
+                assert has_info_repr(df)
 
-        # Wide
-        h, w = max_rows - 1, max_cols + 1
-        df = DataFrame({k: np.arange(1, 1 + h) for k in np.arange(w)})
-        assert has_horizontally_truncated_repr(df)
-        with option_context(
-            "display.large_repr", "info", "display.max_columns", max_cols
-        ):
-            assert has_info_repr(df)
+            # Wide
+            h, w = max_rows - 1, max_cols + 1
+            df = DataFrame({k: np.arange(1, 1 + h) for k in np.arange(w)})
+            assert has_horizontally_truncated_repr(df)
+            with option_context(
+                "display.large_repr", "info", "display.max_columns", max_cols
+            ):
+                assert has_info_repr(df)
 
     def test_info_repr_max_cols(self):
         # GH #6939


### PR DESCRIPTION
closes #21337

When `display.max_columns` is `0` (the default since 0.23), the `DataFrame.__repr__` horizontal-fit logic re-read the physical terminal width via `shutil.get_terminal_size()` and ignored an explicitly set `display.width`. This was a regression from the 0.22→0.23 change of the `max_columns` default from 20 to 0; the `max_columns > 0` path already honored the width.

Changes:
- `display.width` now defaults to `None`, matching its documented "set to None to auto-detect" semantics. The terminal width is auto-detected in interactive sessions, and wide output is no longer truncated in non-interactive sessions (scripts, redirected output).
- Both the string-level (`_fit_strcols_to_terminal_width`) and format-level (`_calc_max_cols_fitted`) fit paths now use the resolved width (`line_width` / `get_console_size()`) instead of re-reading the raw terminal size.
- The IPython-frontend branch of `get_console_size` keeps an 80-column fallback, since a width cannot be auto-detected there.

This also activates the previously-dead auto-detect branch in `DataFrame._repr_fits_horizontal_` that its own comments describe (the `display.width is not None` check now correctly means "user set an explicit width"). A regression test is added; the only pre-existing tests affected were two in `test_format.py`, updated accordingly.