### PR TITLE
TST: read_json from binary/S3 stream with chunksize (GH#47659)

### DIFF
--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1485,6 +1485,22 @@ class TestPandasContainer:
         expected = DataFrame([[1, 2], [1, 2]], columns=["a", "b"])
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.single_cpu
+    @pytest.mark.network
+    @td.skip_if_not_us_locale
+    def test_read_s3_jsonl_chunksize(self, s3_bucket_public_with_data, s3so):
+        # GH47659 - reading a binary (e.g. S3) stream in chunks used to raise
+        # "TypeError: initial_value must be str or None, not bytes"
+        with read_json(
+            f"s3n://{s3_bucket_public_with_data.name}/items.jsonl",
+            lines=True,
+            chunksize=1,
+            storage_options=s3so,
+        ) as reader:
+            result = pd.concat(reader)
+        expected = DataFrame([[1, 2], [1, 2]], columns=["a", "b"])
+        tm.assert_frame_equal(result, expected)
+
     def test_read_local_jsonl(self, temp_file):
         # GH17200
         with open(temp_file, "w", encoding="utf-8") as infile:

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -221,6 +221,16 @@ def test_readjson_chunks_from_file(request, engine, temp_file):
     tm.assert_frame_equal(unchunked, chunked)
 
 
+def test_readjson_chunks_from_binary_stream():
+    # GH47659 - reading a binary stream (e.g. from S3) in chunks used to raise
+    # "TypeError: initial_value must be str or None, not bytes"
+    df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    data = df.to_json(lines=True, orient="records").encode("utf-8")
+    with read_json(BytesIO(data), lines=True, chunksize=1) as reader:
+        chunked = pd.concat(reader)
+    tm.assert_frame_equal(chunked, df)
+
+
 @pytest.mark.parametrize("chunksize", [None, 1])
 def test_readjson_chunks_closes(chunksize, temp_file):
     df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})


### PR DESCRIPTION
closes #47659

`read_json(..., lines=True, chunksize=...)` over a binary stream (e.g. an S3 URL via `s3fs`) used to raise `TypeError: initial_value must be str or None, not bytes`. This was fixed by the IO-reader cleanup in GH-57307, which dropped the old `StringIO(data)` path in favor of letting `get_handle(..., "r")` text-wrap the stream — but there was no test exercising the chunked + binary combination (existing chunksize tests use `StringIO`/text buffers or local text files).

Adds two regression tests:
- `test_read_s3_jsonl_chunksize` — the on-point S3 case, alongside the existing `test_read_s3_jsonl` (GH-17200, the null-chunksize companion).
- `test_readjson_chunks_from_binary_stream` — a network-free `BytesIO` variant covering the same root cause.

Test-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)