### PR TITLE
TST: .loc on MultiIndex with inf-bounded IntervalIndex level (GH#46699)

### DIFF
--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -1084,3 +1084,30 @@ def test_loc_multiindex_with_overlapping_interval_multiple_matches():
     result = ser.loc[("A", 1.5)]
     expected = np.array([10, 20], dtype=result.values.dtype)
     tm.assert_numpy_array_equal(result.values, expected)
+
+
+def test_loc_multiindex_interval_level_inf_break():
+    # GH#46699 - .loc with a tuple/list-of-tuples key on a MultiIndex whose
+    # inner IntervalIndex level has breaks at +/-inf used to raise ValueError
+    # from the engine when the scalar fell in the inf-bounded interval.
+    left = DataFrame(
+        {"Result": [101, 102, 103]},
+        index=pd.IntervalIndex.from_breaks(
+            [-np.inf, 35, 59, np.inf], closed="left", name="age"
+        ),
+    )
+    right = DataFrame(
+        {"Result": [1, 2, 3, 4]},
+        index=pd.IntervalIndex.from_breaks(
+            [-np.inf, 35, 59, 70, np.inf], closed="left", name="age"
+        ),
+    )
+    mapper = pd.concat([left, right], axis=0, keys=[False, True], names=["children"])
+
+    # scalar tuple: 99 falls in the [59, inf) interval of the False group
+    result = mapper.loc[(False, 99)]
+    tm.assert_series_equal(result, mapper.iloc[2])
+
+    # list of tuples, one of which falls in the [59, inf) interval
+    result = mapper.loc[[(False, 45), (False, 99)], :]
+    tm.assert_frame_equal(result, mapper.iloc[[1, 2]])


### PR DESCRIPTION
closes #46699

Regression test for GH-46699, where `.loc` with a tuple / list-of-tuples key on a `MultiIndex` whose inner `IntervalIndex` level had `+/-inf` breaks raised `ValueError: setting an array element with a sequence` from the engine when the scalar fell in the inf-bounded interval.

This was fixed incidentally by GH-27456 (#65239), which widened `MultiIndex._get_loc_level` / `get_loc` to route the engine's `ValueError` through `get_loc_level`. The existing GH-27456 tests cover overlapping intervals via `from_arrays`; this adds the distinct angle from GH-46699 (inf-bounded breaks + the list-of-tuples `.loc` form). No whatsnew entry — the fix is already noted under #65239.