### PR TITLE
BUG: read_csv c engine loses float precision with thousands separator (GH#44145)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -362,6 +362,7 @@ I/O
 ^^^
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
+- :func:`read_csv` with the ``c`` engine now parses high-precision floats to the correctly-rounded ``float64`` (matching the Python ``float`` builtin) when a ``thousands`` separator is given, instead of a value off by up to a couple of ULP (:issue:`44145`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1390,19 +1390,84 @@ int to_boolean(const char *item, uint8_t *val) {
 int fast_float_strtod(const char *start, const char *end, double *value,
                       const char **endptr, char decimal);
 
+// A thousands separator is only valid in the integer part of a number, where
+// it immediately follows a digit; one elsewhere (in the fractional part or the
+// exponent) makes the token invalid. Return whether the separator at `c` should
+// be dropped, matching the acceptance of the bespoke fallback below.
+static inline int skip_tsep(const char *c, const char *start, char tsep,
+                            int integer_part) {
+  return *c == tsep && integer_part && c > start && isdigit_ascii(c[-1]);
+}
+
+// fast_float has no thousands-separator concept, so for a token that may
+// contain a `tsep` we copy it into a scratch buffer with the integer-part
+// separators removed before handing it to fast_float. On success this writes
+// the correctly-rounded value, the number of *original* characters consumed,
+// and (optionally) maybe_int, then returns 0. It returns -1 when the token does
+// not fit the scratch buffer or fast_float rejects it, leaving the caller to
+// fall back to its slower parser (GH 44145).
+static int fast_float_strtod_tsep(const char *start, const char *end,
+                                  char decimal, char tsep, double *value,
+                                  size_t *consumed, int *maybe_int) {
+  char scratch[256];
+  if ((size_t)(end - start) >= sizeof(scratch))
+    return -1;
+
+  // Strip integer-part separators; keep any others so fast_float stops there.
+  size_t n = 0;
+  int integer_part = 1;
+  for (const char *c = start; c < end; c++) {
+    if (*c == decimal || *c == 'e' || *c == 'E')
+      integer_part = 0;
+    if (!skip_tsep(c, start, tsep, integer_part))
+      scratch[n++] = *c;
+  }
+
+  const char *parsed_end;
+  if (fast_float_strtod(scratch, scratch + n, value, &parsed_end, decimal) != 0)
+    return -1;
+
+  if (maybe_int != NULL) {
+    *maybe_int = 1;
+    for (const char *c = scratch; c < parsed_end; c++) {
+      if (*c == decimal || *c == 'e' || *c == 'E') {
+        *maybe_int = 0;
+        break;
+      }
+    }
+  }
+
+  // Translate the count of consumed scratch chars back to original chars by
+  // replaying the same separator-skipping walk.
+  const size_t clean_consumed = (size_t)(parsed_end - scratch);
+  size_t seen = 0;
+  const char *c = start;
+  integer_part = 1;
+  while (seen < clean_consumed && c < end) {
+    if (*c == decimal || *c == 'e' || *c == 'E')
+      integer_part = 0;
+    if (!skip_tsep(c, start, tsep, integer_part))
+      seen++;
+    c++;
+  }
+  *consumed = (size_t)(c - start);
+  return 0;
+}
+
 double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
                        char tsep, int skip_trailing, int *error,
                        int *maybe_int) {
-  // Use fast_float for standard format (no tsep, sci='e'/'E').
-  // fast_float provides IEEE 754 correctly-rounded parsing.
-  if (tsep == '\0' && (sci == 'e' || sci == 'E')) {
+  // Use fast_float for correctly-rounded IEEE 754 parsing whenever the exponent
+  // marker is the standard 'e'/'E'. Thousands separators are stripped first by
+  // fast_float_strtod_tsep, since fast_float cannot skip them itself.
+  if (sci == 'e' || sci == 'E') {
     const char *p = str;
     while (isspace_ascii(*p))
       p++;
 
     // Only try fast_float for numeric-looking input (digit, sign+digit,
     // or decimal point). This avoids fast_float parsing "nan"/"inf" which
-    // the original precise_xstrtod did not handle.
+    // the fallback below does not handle.
     const char *q = p;
     if (*q == '-' || *q == '+')
       q++;
@@ -1415,8 +1480,17 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
       end++;
 
     double value;
-    const char *parsed_end;
-    if (fast_float_strtod(p, end, &value, &parsed_end, decimal) == 0) {
+    const char *result_end;
+    if (tsep != '\0') {
+      size_t consumed;
+      if (fast_float_strtod_tsep(p, end, decimal, tsep, &value, &consumed,
+                                 maybe_int) != 0)
+        goto fallback;
+      result_end = p + consumed;
+    } else {
+      const char *parsed_end;
+      if (fast_float_strtod(p, end, &value, &parsed_end, decimal) != 0)
+        goto fallback;
       // Determine maybe_int by checking if we saw decimal or 'e'/'E'.
       if (maybe_int != NULL) {
         *maybe_int = 1;
@@ -1427,17 +1501,19 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
           }
         }
       }
-      if (skip_trailing)
-        while (isspace_ascii(*parsed_end))
-          parsed_end++;
-      if (endptr)
-        *endptr = (char *)parsed_end;
-      return value;
+      result_end = parsed_end;
     }
+
+    if (skip_trailing)
+      while (isspace_ascii(*result_end))
+        result_end++;
+    if (endptr)
+      *endptr = (char *)result_end;
+    return value;
   }
 
 fallback:
-    // Fallback for non-standard formats (custom tsep, or sci char).
+    // Fallback for non-standard formats (e.g. a custom sci char).
     ;
   const char *p = str;
   const int max_digits = 17;

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -675,6 +675,25 @@ def test_1000_sep_with_decimal(
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "value, thousands, decimal",
+    [
+        ("1,234.567890123456789", ",", "."),
+        ("60,329,669.631706690743915", ",", "."),
+        ("1.234,567890123456789", ".", ","),
+    ],
+)
+def test_1000_sep_correctly_rounded(c_parser_only, value, thousands, decimal):
+    # GH 44145 - stripping the thousands separator must still hand the token to
+    # the correctly-rounded float parser, not the legacy off-by-an-ULP path.
+    parser = c_parser_only
+    plain = value.replace(thousands, "").replace(decimal, ".")
+    result = parser.read_csv(
+        StringIO(f"A\n{value}\n"), sep="|", thousands=thousands, decimal=decimal
+    )
+    assert result["A"].iloc[0] == float(plain)
+
+
 def test_float_precision_options(c_parser_only):
     # GH 17154, 36228
     parser = c_parser_only

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -684,6 +684,22 @@ def test_precision_float_conversion(strrep):
 
 
 @pytest.mark.parametrize(
+    "strrep",
+    [
+        "0.01234567890123456789",
+        "0.00498124967521367",
+        "1234.567890123456789",
+        "123456789012345.6789",
+        "9.999999999999999e-5",
+    ],
+)
+def test_to_numeric_correctly_rounded(strrep):
+    # GH 44145 - long-mantissa strings should round-trip to the same float64
+    # as the Python builtin (correctly rounded), not a value off by a few ULP.
+    assert to_numeric(strrep) == float(strrep)
+
+
+@pytest.mark.parametrize(
     "values, expected",
     [
         (["1", "2", None], Series([1, 2, pd.NA], dtype="Int64")),


### PR DESCRIPTION
closes #44145

`to_numeric` already parses high-precision float strings to the correctly-rounded `float64` (matching the Python `float` builtin) via fast_float, but `read_csv` with a `thousands` separator did not. `precise_xstrtod` only dispatched to fast_float when no thousands separator was set, so `read_csv(thousands=...)` fell back to the bespoke parser, which could be off by up to a couple of ULP on long-mantissa floats (~12% of random long-mantissa values in a fuzz).

The fix strips the integer-part separators into a scratch buffer and hands the token to fast_float. A thousands separator is only valid in the integer part where it follows a digit, so the strip is position-aware (separators elsewhere are kept, causing fast_float to stop there) — this preserves the strict acceptance of the old fallback for malformed input like `1,_2`, `1_000,000_000`, and `1,e1_2`. The consumed length is mapped back to the original string so `endptr`/trailing-character handling stays correct. The no-thousands path is unchanged.