### PR TITLE
CI: fix pytest cache issue in wheel build for pyodide

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,9 +197,10 @@ build-verbosity = 1
 build-frontend = "build"
 # pytest-xdist cannot be used on Pyodide
 # OSError: [Errno 138] emscripten does not support processes
+# nocacheprovider is needed to avoid cleaning up pytest cache failing with PermissionError
 test-command = """
   python -c 'import pandas as pd; \
-  pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db", "--no-strict-data-files"]);' \
+  pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db", "--no-strict-data-files", "-p no:cacheprovider"]);' \
   """
 
 [tool.ruff]


### PR DESCRIPTION
To see if this fixes the wheel failures (e.g. https://github.com/pandas-dev/pandas/actions/runs/28147592296/job/83358086451):


Error after building and testing finished successfully:

```

Traceback (most recent call last):
  File "/home/runner/work/_temp/cibw/bin/cibuildwheel", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runner/work/_temp/cibw/lib/python3.14/site-packages/cibuildwheel/__main__.py", line 62, in main
    main_inner(global_options)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/runner/work/_temp/cibw/lib/python3.14/site-packages/cibuildwheel/__main__.py", line 279, in main_inner
    build_in_directory(args)
    ~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/runner/work/_temp/cibw/lib/python3.14/site-packages/cibuildwheel/__main__.py", line 393, in build_in_directory
    shutil.rmtree(tmp_path, ignore_errors=sys.platform.startswith("win"))
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/shutil.py", line 852, in rmtree
    _rmtree_impl(path, dir_fd, onexc)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/shutil.py", line 721, in _rmtree_safe_fd
    _rmtree_safe_fd_step(stack, onexc)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/shutil.py", line 802, in _rmtree_safe_fd_step
    onexc(func, path, err)
    ~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/shutil.py", line 765, in _rmtree_safe_fd_step
    topfd = os.open(name, os.O_RDONLY | os.O_NONBLOCK, dir_fd=dirfd)
PermissionError: [Errno 13] Permission denied: '/tmp/cibw-run-b5_huwc7/cp312-pyodide_wasm32/venv-test/lib/python3.12/site-packages/pandas/pytest-cache-files-vok1ek18'


```