### PR TITLE
TST: groupby boxplot honors column selection (GH#41124)

### DIFF
--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -730,6 +730,31 @@ class TestDataFrameGroupByPlots:
         result_xticklabel = [x.get_text() for x in axes.get_xticklabels()]
         assert expected_xticklabel == result_xticklabel
 
+    @pytest.mark.parametrize("subplots", [True, False])
+    def test_groupby_boxplot_subset_columns(self, subplots):
+        # GH#41124 a column selection on the groupby is honored
+        df = DataFrame(
+            {
+                "cat": np.repeat([0, 1, 2, 3], 25),
+                "data": np.random.default_rng(2).random(100),
+                "other": np.random.default_rng(2).random(100),
+            }
+        )
+        grouped = df.groupby("cat")[["data"]]
+
+        if subplots:
+            axes = _check_plot_works(
+                grouped.boxplot, default_axes=True, subplots=True, return_type="axes"
+            )
+            for ax in axes:
+                assert [x.get_text() for x in ax.get_xticklabels()] == ["data"]
+        else:
+            axes = _check_plot_works(
+                grouped.boxplot, default_axes=True, subplots=False, return_type="axes"
+            )
+            expected = ["(0, data)", "(1, data)", "(2, data)", "(3, data)"]
+            assert [x.get_text() for x in axes.get_xticklabels()] == expected
+
     def test_groupby_boxplot_object(self, hist_df):
         # GH 43480
         df = hist_df.astype("object")


### PR DESCRIPTION
closes #41124

`DataFrameGroupBy.boxplot()` ignored a `gb[["col"]]` column selection and plotted every column. This was fixed in 1.4.0 by GH-44947 (GH-44821), which made `GroupBy.__iter__` iterate over `_selected_obj`. Add a regression test covering both `subplots=True` and `subplots=False`.