### PR TITLE
[backport 3.0.x] CI: fix pytest cache issue in wheel build for pyodide (#66018)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ repair-wheel-command = ""
 build-verbosity = 1
 test-command = """
   PANDAS_CI='1' python -c 'import pandas as pd; \
-  pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db", "--no-strict-data-files"]);' \
+  pd.test(extra_args=["-m not clipboard and not single_cpu and not slow and not network and not db", "--no-strict-data-files", "-p no:cacheprovider"]);' \
   """
 
 [tool.ruff]


### PR DESCRIPTION
(cherry picked from commit 10f75b6c20a5c950e05b96a1d39a474013b210d6)

Backport of https://github.com/pandas-dev/pandas/pull/66018