### PR TITLE
[backport 3.0.x] TST: remove xfail on downstream test_pandas_datareader (#66020)

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -162,10 +162,7 @@ def test_seaborn(mpl_cleanup):
     seaborn.stripplot(x="day", y="total_bill", data=tips)
 
 
-@pytest.mark.xfail(reason="pandas_datareader uses old variant of deprecate_kwarg")
 def test_pandas_datareader():
-    # https://github.com/pandas-dev/pandas/pull/61468
-    # https://github.com/pydata/pandas-datareader/issues/1005
     pytest.importorskip("pandas_datareader")
 
 


### PR DESCRIPTION
(cherry picked from commit 5e2c31ff378110b25d856b6ce16f2fa14e6579e5)

Backport of https://github.com/pandas-dev/pandas/pull/66020