### PR TITLE
[3.0.x] CI: also pin pytest for test extra (wheel build)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ repository = 'https://github.com/pandas-dev/pandas'
 matplotlib = "pandas:plotting._matplotlib"
 
 [project.optional-dependencies]
-test = ['hypothesis>=6.116.0', 'pytest>=8.3.4', 'pytest-xdist>=3.6.1']
+test = ['hypothesis>=6.116.0', 'pytest>=8.3.4,<9.1', 'pytest-xdist>=3.6.1']
 pyarrow = ['pyarrow>=13.0.0']
 performance = ['bottleneck>=1.4.2', 'numba>=0.60.0', 'numexpr>=2.10.2']
 computation = ['scipy>=1.14.1', 'xarray>=2024.10.0']


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/65884 (https://github.com/pandas-dev/pandas/pull/65883), which missed the wheel build

(this is to avoid having to backport the changes to make the tests compatible with pytest 9.1 for now)