### PR TITLE
BUG: Fix Series.combine_first silently ignoring duplicate indices (#66009)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -336,7 +336,10 @@ Indexing
 - Fixed bug in :meth:`DataFrame.loc` where assigning an iterable to a single cell in an ``object`` dtype column incorrectly raised a ``ValueError`` (:issue:`57962`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
 - Fixed segfault in :meth:`DataFrame.loc` when repeatedly adding new rows to an object-dtype-indexed :class:`DataFrame` (:issue:`21968`)
--
+- Bug in :meth:`Series.combine_first` where duplicate index labels were silently
+  positionally aligned instead of raising, when both Series shared the same
+  dtype and index; this is now consistent with the existing behavior for
+  mismatched dtypes, which already raised ``ValueError`` (:issue:`66009`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3742,7 +3742,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         from pandas.core.reshape.concat import concat
 
         if self.dtype == other.dtype:
-            if self.index.equals(other.index):
+            if self.index.equals(other.index) and self.index.is_unique:
                 return self.mask(self.isna(), other)
 
         new_index = self.index.union(other.index)

--- a/pandas/tests/series/methods/test_combine_first.py
+++ b/pandas/tests/series/methods/test_combine_first.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import numpy as np
-
 import pytest
 
 from pandas.errors import Pandas4Warning

--- a/pandas/tests/series/methods/test_combine_first.py
+++ b/pandas/tests/series/methods/test_combine_first.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 import numpy as np
 
+import pytest
+
 from pandas.errors import Pandas4Warning
 
 import pandas as pd
@@ -162,6 +164,19 @@ class TestCombineFirst:
         result = s1.combine_first(s2)
         expected = Series([None] * 4, index=["a", "b", "c", "d"])
         tm.assert_series_equal(result, expected)
+
+    def test_combine_first_duplicate_index_raises(self):
+        # GH#66009
+        # The fast path (matching dtype, matching index) used to skip the
+        # duplicate-label check that the slower reindex-based path already
+        # enforces, silently returning a positionally-misaligned result
+        # instead of raising.
+        s1 = Series([1.0, np.nan, 3.0], index=[0, 0, 1])
+        s2 = Series([10.0, 20.0, 30.0], index=[0, 0, 1])
+
+        msg = "cannot reindex on an axis with duplicate labels"
+        with pytest.raises(ValueError, match=msg):
+            s1.combine_first(s2)
 
 
 def test_combine_first_timestamp_names_anterior():


### PR DESCRIPTION
The fastpath in Series.combine_first (triggered when dtypes and indices match) was skipping the duplicate label check that normally occurs during .reindex(). This caused the method to silently return positionally misaligned results instead of correctly raising a ValueError.

Modifications:
- `pandas/core/series.py`: Added an `is_unique` check to the fastpath to route duplicate indices to the standard error raising path.
- `pandas/tests/series/methods/test_combine_first.py`: Added a test to ensure duplicate indices raise a ValueError.
- `doc/source/whatsnew/v3.1.0.rst`: Added a release note under the Indexing section.

Closes #66009

*(Note: As a first time contributor, I used an LLM as a pair programming tutor to help me navigate the codebase and structure this PR. All logic, testing, and sandbox verifications were executed and validated manually locally before submission.)*