### PR TITLE
BUG: raise in Series.combine_first with duplicate index

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3742,7 +3742,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         from pandas.core.reshape.concat import concat
 
         if self.dtype == other.dtype:
-            if self.index.equals(other.index):
+            if self.index.is_unique and self.index.equals(other.index):
                 return self.mask(self.isna(), other)
 
         new_index = self.index.union(other.index)

--- a/pandas/tests/series/methods/test_combine_first.py
+++ b/pandas/tests/series/methods/test_combine_first.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import numpy as np
+import pytest
 
 from pandas.errors import Pandas4Warning
 
@@ -162,6 +163,15 @@ class TestCombineFirst:
         result = s1.combine_first(s2)
         expected = Series([None] * 4, index=["a", "b", "c", "d"])
         tm.assert_series_equal(result, expected)
+
+    def test_combine_first_duplicate_index_raises(self):
+        # GH#66009
+        s1 = Series([1.0, np.nan, 3.0], index=[0, 0, 1])
+        s2 = Series([10.0, 20.0, 30.0], index=[0, 0, 1])
+
+        msg = "cannot reindex on an axis with duplicate labels"
+        with pytest.raises(ValueError, match=msg):
+            s1.combine_first(s2)
 
 
 def test_combine_first_timestamp_names_anterior():


### PR DESCRIPTION
Closes #66009.

- Require the `Series.combine_first` identical-index fast path to have a unique index, so duplicate-label cases use the normal reindexing path and raise consistently.
- Add a regression test for duplicate indices with matching dtypes and identical labels.

Tests:
- `python -m pytest pandas/tests/series/methods/test_combine_first.py -x -q`