### PR TITLE
BUG: IntervalTree raises on 32-bit when n_elements > leaf_size (GH#44075)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -302,7 +302,7 @@ Strings
 Interval
 ^^^^^^^^
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors unnecessarily upcasting sub-64-bit numeric dtypes (e.g. ``float32``, ``int32``) to 64-bit (:issue:`45412`)
--
+- Bug in :func:`cut` and other operations building an :class:`IntervalIndex` engine raising ``TypeError`` on 32-bit platforms when there were more than 100 intervals (:issue:`44075`, :issue:`23440`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -193,7 +193,10 @@ cdef class IntervalTree(IntervalMixin):
 cdef take(ndarray source, ndarray indices):
     """Take the given positions from a 1D ndarray
     """
-    return PyArray_Take(source, indices, 0)
+    # GH#23440, GH#44075: the positions we build are int64, but PyArray_Take
+    #  requires intp indices and rejects the int64->int32 "safe" cast on 32-bit
+    #  platforms.  On 64-bit intp is int64, so this is a no-op there.
+    return PyArray_Take(source, indices.astype(np.intp, copy=False), 0)
 
 
 cdef sort_values_and_indices(all_values, all_indices, subset):

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -4,24 +4,11 @@ import numpy as np
 import pytest
 
 from pandas._libs.interval import IntervalTree
-from pandas.compat import (
-    IS64,
-    WASM,
-)
 
 import pandas._testing as tm
 
 
-def skipif_32bit(param):
-    """
-    Skip parameters in a parametrize on 32bit systems. Specifically used
-    here to skip leaf_size parameters related to GH 23440.
-    """
-    marks = pytest.mark.skipif(not IS64, reason="GH 23440: int type mismatch on 32bit")
-    return pytest.param(param, marks=marks)
-
-
-@pytest.fixture(params=[skipif_32bit(1), skipif_32bit(2), 10])
+@pytest.fixture(params=[1, 2, 10])
 def leaf_size(request):
     """
     Fixture to specify IntervalTree leaf_size parameter; to be used with the
@@ -120,9 +107,7 @@ class TestIntervalTree:
         expected = np.array([], dtype="intp")
         tm.assert_numpy_array_equal(result, expected)
 
-    @pytest.mark.parametrize(
-        "leaf_size", [skipif_32bit(1), skipif_32bit(10), skipif_32bit(100), 10000]
-    )
+    @pytest.mark.parametrize("leaf_size", [1, 10, 100, 10000])
     def test_get_indexer_closed(self, closed, leaf_size):
         x = np.arange(1000, dtype="float64")
         found = x.astype("intp")
@@ -178,7 +163,6 @@ class TestIntervalTree:
         tree = IntervalTree(left, right, closed=closed)
         assert tree.is_overlapping is False
 
-    @pytest.mark.skipif(not IS64, reason="GH 23440")
     def test_construction_overflow(self):
         # GH 25485
         left, right = np.arange(101, dtype="int64"), [np.iinfo(np.int64).max] * 101
@@ -189,7 +173,6 @@ class TestIntervalTree:
         expected = (50 + np.iinfo(np.int64).max) / 2
         assert result == expected
 
-    @pytest.mark.xfail(WASM, reason="GH 23440")
     @pytest.mark.parametrize(
         "left, right, expected",
         [

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pandas._libs import index as libindex
-from pandas.compat import WASM
 
 import pandas as pd
 from pandas import (
@@ -210,7 +209,6 @@ class TestIntervalIndexInsideMultiIndex:
         expected = Series([1, 6, 2, 8, 7], index=expected_index, name="value")
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.xfail(WASM, reason="GH 23440")
     @pytest.mark.parametrize("base", [101, 1010])
     def test_reindex_behavior_with_interval_index(self, base):
         # GH 51826

--- a/pandas/tests/indexing/interval/test_interval_new.py
+++ b/pandas/tests/indexing/interval/test_interval_new.py
@@ -3,8 +3,6 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import WASM
-
 from pandas import (
     Index,
     Interval,
@@ -214,7 +212,6 @@ class TestIntervalIndex:
             obj.loc[[4, 5, 6]]
 
 
-@pytest.mark.xfail(WASM, reason="GH 23440")
 @pytest.mark.parametrize(
     "intervals",
     [

--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -861,3 +861,17 @@ def test_cut_datetime_array_no_attributeerror():
     tm.assert_categorical_equal(
         result, expected, check_dtype=True, check_category_order=True
     )
+
+
+def test_cut_int64_intervalindex_more_bins_than_leaf_size():
+    # GH#44075 building the IntervalTree engine for >100 integer bins used to
+    #  raise on 32-bit platforms (int64 indices could not be safely cast to
+    #  intp inside PyArray_Take).
+    bins = IntervalIndex.from_breaks(
+        range(0, 102, 1), closed="left", dtype="interval[int64]"
+    )
+    data = [1.2, np.nan, 10.2]
+    result = cut(data, bins)
+
+    expected_codes = np.array([1, -1, 10], dtype=result.codes.dtype)
+    tm.assert_numpy_array_equal(result.codes, expected_codes)


### PR DESCRIPTION
closes #44075

Also closes GH-23440 (same root cause).

Building the ``IntervalTree`` engine for an ``IntervalIndex`` with more than ``leaf_size`` (100) intervals raised ``TypeError: Cannot cast array data from dtype('int64') to dtype('int32') according to the rule 'safe'`` on 32-bit platforms — surfacing in the wild via :func:`cut`. ``take`` passes int64 position arrays to ``PyArray_Take``, which requires ``intp``; on 32-bit ``intp`` is int32 and the safe cast is rejected. It only triggered on the recursive (non-leaf) path, which is why >100 bins failed but ≤100 worked.

Fix casts the positions to ``intp`` in ``take`` (a no-op on 64-bit, where ``intp`` is int64). This also lets us drop the 32-bit ``skipif``/WASM ``xfail`` workarounds that were added for GH-23440, so those tests now run on the 32-bit CI.