### PR TITLE
TST: groupby with multi-day Grouper and closed="right" on intraday data (GH#43896)

### DIFF
--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -2199,3 +2199,18 @@ def test_resample_sum_with_inat_value():
     result = df.resample("MS").apply(np.sum)
     expected = DataFrame([-1], index=date_range("2013-01-01", periods=1, freq="MS"))
     tm.assert_frame_equal(result, expected)
+
+
+def test_groupby_multiday_grouper_closed_right_intraday():
+    # GH#43896 intraday values with a multi-day Grouper and closed="right"
+    #  used to raise "Values falls before first bin"
+    index = date_range("2019-12-31 00:10:00", "2020-01-04 00:10:00", freq="12h")
+    df = DataFrame({"a": np.arange(len(index), dtype=float)}, index=index)
+    result = df.groupby(Grouper(freq="2D", closed="right")).sum()
+    expected = DataFrame(
+        {"a": [0.0, 6.0, 22.0, 8.0]},
+        index=DatetimeIndex(
+            ["2019-12-29", "2019-12-31", "2020-01-02", "2020-01-04"], freq="2D"
+        ),
+    )
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #43896

Adds a regression test for `df.groupby(Grouper(freq="2D", closed="right"))` on intraday data, which used to raise `ValueError: Values falls before first bin` from `generate_bins_dt64`.

The underlying bug was fixed by GH-55283 (released in 2.1.2), which replaced the `is_superperiod(self.freq, "D")` heuristic in `_adjust_bin_edges` with an explicit allowlist of super-daily rule codes. That heuristic only inspected the base frequency, so it misfired on multi-day freqs like `2D`, rolling the first bin edge forward to the last nanosecond of the day (ahead of the first intraday value). No regression test referenced this issue.