### PR TITLE
TST: DataFrame.equals array-vs-scalar object element (GH#43867)

### DIFF
--- a/pandas/tests/frame/methods/test_equals.py
+++ b/pandas/tests/frame/methods/test_equals.py
@@ -15,6 +15,16 @@ class TestEquals:
         df2 = DataFrame({"a": ["s", "d"], "b": [1, 2]})
         assert df1.equals(df2) is False
 
+    def test_equals_object_array_vs_scalar(self):
+        # GH#43867 one object-dtype element is a numpy array, the other a
+        #  scalar; these must not compare equal
+        df = DataFrame({"x": ["a"]}, dtype=object)
+        other = df.copy()
+        other["x"] = [np.array(["a"], dtype=object)]
+        assert df["x"].dtype == other["x"].dtype == object
+        assert not df.equals(other)
+        assert not other.equals(df)
+
     def test_equals_different_blocks(self):
         # GH#9330
         df0 = DataFrame(


### PR DESCRIPTION
closes #43867

`DataFrame.equals` used to return `True` when an object-dtype element was a numpy array in one frame and a scalar in the other (e.g. `np.array(["a"])` vs `"a"`). This was fixed by the `PyArray_Check` guard added to `array_equivalent_object` in GH-59778; this adds a regression test for the exact repro.

The test pins both columns to `object` dtype so it exercises the array-vs-scalar element comparison rather than a `str`-vs-`object` dtype mismatch.