### PR TITLE
BUG: Fix Memory Leak in read_csv

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -360,6 +360,7 @@ I/O
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
+- Fixed memory leak in :func:`read_csv` (:issue:`19941`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -32,7 +32,6 @@ from cpython.exc cimport (
 from cpython.long cimport PyLong_FromString
 from cpython.object cimport PyObject
 from cpython.ref cimport (
-    Py_INCREF,
     Py_XDECREF,
 )
 from cpython.unicode cimport (
@@ -325,6 +324,7 @@ cdef class TextReader:
         bint allow_leading_cols
         uint64_t parser_start  # this is modified after __init__
         const char *encoding_errors
+        object _encoding_errors
         kh_str_starts_t *false_set
         kh_str_starts_t *true_set
         int64_t buffer_lines, skipfooter
@@ -386,7 +386,8 @@ cdef class TextReader:
             encoding_errors = encoding_errors.encode("utf-8")
         elif encoding_errors is None:
             encoding_errors = b"strict"
-        Py_INCREF(encoding_errors)
+        # store encoding_errors in `self` for Cython to manage its lifetime.
+        self._encoding_errors = encoding_errors
         self.encoding_errors = PyBytes_AsString(encoding_errors)
 
         self.parser = parser_new()


### PR DESCRIPTION
- [x] closes #19941 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

I used the reproduction from https://github.com/pandas-dev/pandas/issues/19941#issuecomment-392848566 to start solving the problem, after solving that, couldn't reproduce the original issue with the `ThreadPool`.

---

## Reproduction

```python
import io
from pandas import read_csv

s = """item_id,user_id,region,city,parent_category_name,category_name,param_1,param_2,param_3,title,description,price,item_seq_number,activation_date,user_type,image,image_top_1,deal_probability
ba83aefab5dc,91e2f88dd6e3,Ростовская область,Ростов-на-Дону,Бытовая электроника,Аудио и видео,"Видео, DVD и Blu-ray плееры",,,Philips bluray,"В хорошем состоянии, домашний кинотеатр с blu ray, USB. Если настроить, то работает смарт тв Торг",4000.0,9,2017-03-20,Private,b7f250ee3f39e1fedd77c141f273703f4a9be59db4b48a8713f112c67e29bb42,3032.0,0.43177"""

buf = io.StringIO(s)

read_csv(buf)
```

LSan report:

```
Direct leak of 39 byte(s) in 1 object(s) allocated from:
    #0 0x0000004a9478 in malloc (/home/alvaro/opt/python-asan/bin/python3.14+0x4a9478) (BuildId: d34f3059a20abaa7865a706a3f4007981ffba2c9)
    #1 0x0000005d2e72 in _PyBytes_FromSize /home/alvaro/opt/Python-3.14.6/Objects/bytesobject.c:125:31
    #2 0x0000005d2e72 in PyBytes_FromStringAndSize /home/alvaro/opt/Python-3.14.6/Objects/bytesobject.c:155:27
    #3 0x0000007acdb8 in unicode_encode_utf8 /home/alvaro/opt/Python-3.14.6/Objects/unicodeobject.c:5865:16
    #4 0x0000007ad565 in _PyUnicode_AsUTF8String /home/alvaro/opt/Python-3.14.6/Objects/unicodeobject.c:5954:12
    #5 0x0000007ad565 in PyUnicode_AsEncodedString /home/alvaro/opt/Python-3.14.6/Objects/unicodeobject.c:3959:24
    #6 0x000000807aae in unicode_encode_impl /home/alvaro/opt/Python-3.14.6/Objects/unicodeobject.c:11867:12
    #7 0x000000807aae in unicode_encode /home/alvaro/opt/Python-3.14.6/Objects/clinic/unicodeobject.c.h:293:20
    #8 0x0000005f642b in _PyObject_VectorcallTstate /home/alvaro/opt/Python-3.14.6/./Include/internal/pycore_call.h:177:11
    #9 0x0000005f642b in PyObject_VectorcallMethod /home/alvaro/opt/Python-3.14.6/Objects/call.c:918:18
    #10 0x7b6b428ebd45 in __pyx_pf_6pandas_5_libs_7parsers_10TextReader___cinit__ /home/alvaro/projects/oss/pandas/build/clang-asan/pandas/_libs/parsers.cpython-314-x86_64-linux-gnu.so.p/pandas/_libs/parsers.pyx.c:7861:19
    #11 0x7b6b428e7ea2 in __pyx_pw_6pandas_5_libs_7parsers_10TextReader_1__cinit__ /home/alvaro/projects/oss/pandas/build/clang-asan/pandas/_libs/parsers.cpython-314-x86_64-linux-gnu.so.p/pandas/_libs/parsers.pyx.c:7785:13
    #12 0x7b6b428be7c8 in __pyx_tp_new_6pandas_5_libs_7parsers_TextReader /home/alvaro/projects/oss/pandas/build/clang-asan/pandas/_libs/parsers.cpython-314-x86_64-linux-gnu.so.p/pandas/_libs/parsers.pyx.c:31489:16
    #13 0x00000075ccfe in type_call /home/alvaro/opt/Python-3.14.6/Objects/typeobject.c:2372:11
...

SUMMARY: AddressSanitizer: 39 byte(s) leaked in 1 allocation(s).
```
