### PR TITLE
BUG: Fix to_dict(orient='index') to apply 'into' to nested mappings

### DIFF
--- a/pandas/core/methods/to_dict.py
+++ b/pandas/core/methods/to_dict.py
@@ -259,7 +259,16 @@ def to_dict(
         columns = df.columns.tolist()
         if are_all_object_dtype_cols:
             return into_c(
-                (t[0], dict(zip(df.columns, map(maybe_box_native, t[1:]), strict=True)))
+                (
+                    t[0],
+                    into_c(
+                        zip(
+                            df.columns,
+                            map(maybe_box_native, t[1:]),
+                            strict=True,
+                        )
+                    ),
+                )
                 for t in df.itertuples(name=None)
             )
         elif box_native_indices:
@@ -267,20 +276,23 @@ def to_dict(
             return into_c(
                 (
                     t[0],
-                    {
-                        column: maybe_box_native(v)
-                        if i in object_dtype_indices_as_set
-                        else v
+                    into_c(
+                        (
+                            column,
+                            maybe_box_native(v)
+                            if i in object_dtype_indices_as_set
+                            else v,
+                        )
                         for i, (column, v) in enumerate(
                             zip(columns, t[1:], strict=True)
                         )
-                    },
+                    ),
                 )
                 for t in df.itertuples(name=None)
             )
         else:
             return into_c(
-                (t[0], dict(zip(columns, t[1:], strict=True)))
+                (t[0], into_c(zip(columns, t[1:], strict=True)))
                 for t in df.itertuples(name=None)
             )
 

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -529,6 +529,38 @@ class TestDataFrameToDict:
         }
         assert result == expected
 
+    def test_to_dict_index_into_nested(self):
+        # GH#65778
+        df = DataFrame({"A": [1, 2], "B": ["x", "y"]})
+
+        result = df.to_dict(orient="index", into=OrderedDict)
+        assert isinstance(result, OrderedDict)
+        assert all(isinstance(v, OrderedDict) for v in result.values())
+
+        result = df.to_dict(orient="index", into=defaultdict(dict))
+        assert isinstance(result, defaultdict)
+        assert all(isinstance(v, defaultdict) for v in result.values())
+
+    def test_to_dict_index_into_nested_mixed_dtypes(self):
+        # GH#65778
+        df = DataFrame({"A": [1, 2], "B": ["x", "y"], "C": [1.0, 2.0]})
+
+        result = df.to_dict(orient="index", into=OrderedDict)
+        assert isinstance(result, OrderedDict)
+        assert all(isinstance(v, OrderedDict) for v in result.values())
+        assert result[0] == OrderedDict([("A", 1), ("B", "x"), ("C", 1.0)])
+        assert result[1] == OrderedDict([("A", 2), ("B", "y"), ("C", 2.0)])
+
+    def test_to_dict_index_into_nested_all_object(self):
+        # GH#65778
+        df = DataFrame({"A": ["a", "b"], "B": ["x", "y"]})
+
+        result = df.to_dict(orient="index", into=OrderedDict)
+        assert isinstance(result, OrderedDict)
+        assert all(isinstance(v, OrderedDict) for v in result.values())
+        assert result[0] == OrderedDict([("A", "a"), ("B", "x")])
+        assert result[1] == OrderedDict([("A", "b"), ("B", "y")])
+
 
 @pytest.mark.parametrize(
     "val", [Timestamp(2020, 1, 1), Timedelta(1), Period("2020"), Interval(1, 2)]


### PR DESCRIPTION
## What does this PR do?

Fixes #65778

This PR fixes a bug where `DataFrame.to_dict(orient='index', into=MyDict)` only applied the `into` parameter to the outer mapping, leaving nested row mappings as plain `dict`.

## Example

```python
from collections import OrderedDict
import pandas as pd

df = pd.DataFrame({"A": [1, 2], "B": ["x", "y"]})
result = df.to_dict(orient="index", into=OrderedDict)

# Before fix: result[0] is dict
# After fix: result[0] is OrderedDict
assert isinstance(result[0], OrderedDict)  # Now passes
```

## Changes

- Modified all three return paths in the `orient='index'` branch to use `into_c` for nested mappings instead of `dict()`
- Added tests for:
  - OrderedDict with basic DataFrame
  - defaultdict with basic DataFrame
  - Mixed dtypes (object and non-object columns)
  - All object dtype columns

## Testing

Added comprehensive tests covering:
1. `test_to_dict_index_into_nested` - Tests OrderedDict and defaultdict
2. `test_to_dict_index_into_nested_mixed_dtypes` - Tests with mixed column types
3. `test_to_dict_index_into_nested_all_object` - Tests with all object columns

All new tests pass.
