### PR TITLE
BUG: Raise ValueError when var_name collides with id_vars in melt()

### DIFF
--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -240,6 +240,17 @@ def melt(
     else:
         var_name = [var_name]
 
+    # GH#65654 - prevent silent data corruption when var_name collides with id_vars
+    var_name_set = set(var_name)
+    id_vars_set = set(id_vars)
+    collisions = var_name_set & id_vars_set
+    if collisions:
+        raise ValueError(
+            f"var_name ({collisions}) cannot match an element in "
+            "id_vars. This would cause the id_vars data to be "
+            "silently overwritten."
+        )
+
     num_rows, K = frame.shape
     num_cols_adjusted = K - len(id_vars)
 

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -1224,6 +1224,26 @@ class TestWideToLong:
         ):
             df.melt(id_vars="value", value_name="value")
 
+    def test_raise_of_var_name_in_id_vars(self):
+        # GH#65654
+        # raise a ValueError if var_name matches an element in id_vars
+        df = DataFrame({"id": [1, 2], "a": [10, 20], "b": [100, 200]})
+
+        with pytest.raises(
+            ValueError, match=re.escape("var_name ({'id'}) cannot match")
+        ):
+            df.melt(id_vars="id", var_name="id")
+
+    def test_raise_of_var_name_in_id_vars_list(self):
+        # GH#65654
+        # raise a ValueError if var_name matches any element in id_vars list
+        df = DataFrame({"id1": [1, 2], "id2": [3, 4], "a": [10, 20]})
+
+        with pytest.raises(
+            ValueError, match=re.escape("var_name ({'id1'}) cannot match")
+        ):
+            df.melt(id_vars=["id1", "id2"], var_name="id1")
+
     def test_missing_stubname(self, any_string_dtype):
         # GH46044
         df = DataFrame({"id": ["1", "2"], "a-1": [100, 200], "a-2": [300, 400]})


### PR DESCRIPTION
## Description

Fixes #65654

`DataFrame.melt` silently corrupts data when `var_name` matches an `id_vars` column. The original `id_vars` data gets overwritten with the variable labels.

**Before (silent corruption):**
```python
df = pd.DataFrame({"id": [1, 2], "a": [10, 20], "b": [100, 200]})
out = df.melt(id_vars="id", var_name="id")
#   id id  value
# 0  a  a     10
# 1  a  a     20
# 2  b  b    100
# 3  b  b    200
```

**After (ValueError raised):**
```python
ValueError: var_name ({'id'}) cannot match an element in id_vars. This would cause the id_vars data to be silently overwritten.
```

## Changes

- **`pandas/core/reshape/melt.py`**: Added validation check after `var_name` is resolved to detect collisions with `id_vars`. Raises `ValueError` with a clear message explaining the issue.
- **`pandas/tests/reshape/test_melt.py`**: Added two test cases:
  - `test_raise_of_var_name_in_id_vars`: Tests scalar `id_vars` collision
  - `test_raise_of_var_name_in_id_vars_list`: Tests list-like `id_vars` collision

## Testing

```python
import pandas as pd

# Test 1: Collision detected
try:
    df = pd.DataFrame({"id": [1, 2], "a": [10, 20], "b": [100, 200]})
    pd.melt(df, id_vars="id", var_name="id")
except ValueError as e:
    print(f"PASS: {e}")

# Test 2: No collision works fine
df = pd.DataFrame({"id": [1, 2], "a": [10, 20], "b": [100, 200]})
result = pd.melt(df, id_vars="id", var_name="variable")
print(result)
```

This fix is consistent with the existing `value_name` collision check (line 179-183 in the original code).