### PR TITLE
TST: constructors preserve non-native byteorder (GH#43042)

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2161,6 +2161,23 @@ class TestDataFrameConstructors:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_constructor_dict_of_series_preserves_byteorder(self):
+        # GH#43042 same-dtype Series get consolidated into one block; the
+        #  non-native byteorder (and the values) must be preserved
+        df = DataFrame(
+            {
+                "a": Series([0, 256], dtype=">i8"),
+                "b": Series([1, 257], dtype=">i4"),
+                "c": Series([2, 258], dtype=">i8"),
+            }
+        )
+        assert df["a"].dtype == np.dtype(">i8")
+        assert df["b"].dtype == np.dtype(">i4")
+        assert df["c"].dtype == np.dtype(">i8")
+        assert df["a"].tolist() == [0, 256]
+        assert df["b"].tolist() == [1, 257]
+        assert df["c"].tolist() == [2, 258]
+
     def test_constructor_list_of_ragged_arrays_first_shortest(self):
         # GH#64958 the uniform-dtype fast path must not silently truncate
         # ragged rows; they should be padded to max width with NaN

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -191,6 +191,21 @@ class TestIndexConstructorInference:
         expected = Index([dt1, dt2], dtype=object)
         tm.assert_index_equal(result, expected)
 
+    def test_constructor_preserves_byteorder(self):
+        # GH#43042 non-native byteorder (and the values) must be preserved
+        arr = np.array([0, 256, 2**40], dtype=">i8")
+        expected = [0, 256, 2**40]
+
+        # inferred from a big-endian ndarray
+        result = Index(arr)
+        assert result.dtype == np.dtype(">i8")
+        assert result.tolist() == expected
+
+        # explicit big-endian dtype from a python list
+        result = Index([0, 256, 2**40], dtype=">i8")
+        assert result.dtype == np.dtype(">i8")
+        assert result.tolist() == expected
+
 
 class TestDtypeEnforced:
     # check we don't silently ignore the dtype keyword

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -2277,3 +2277,19 @@ def test_constructor_from_series_with_incompatible_dtype_raises():
     ser = Series([1, 2, "x", 4, 5])
     with pytest.raises(ValueError, match="invalid literal"):
         Series(ser, dtype=int)
+
+
+def test_constructor_preserves_byteorder():
+    # GH#43042 non-native byteorder (and the values) must be preserved
+    arr = np.array([0, 256, 2**40], dtype=">i8")
+    expected = [0, 256, 2**40]
+
+    # inferred from a big-endian ndarray
+    result = Series(arr)
+    assert result.dtype == np.dtype(">i8")
+    assert result.tolist() == expected
+
+    # explicit big-endian dtype from a python list
+    result = Series([0, 256, 2**40], dtype=">i8")
+    assert result.dtype == np.dtype(">i8")
+    assert result.tolist() == expected


### PR DESCRIPTION
closes #43042

Add regression tests confirming the `DataFrame` (dict-of-Series), `Series`, and `Index` constructors preserve a non-native byteorder (e.g. `>i8` on a little-endian machine) along with the values. The reported `DataFrame` case—where same-dtype columns consolidate into one block—was fixed by the column-arrays construction path; these tests lock in that behavior and add matching coverage for `Series`/`Index`.