### PR TITLE
BUG: equals failed for nested Series/DataFrame (GH#43008)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -448,6 +448,7 @@ Other
 ^^^^^
 
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
+- Bug in :meth:`Series.equals` and :meth:`DataFrame.equals` raising ``ValueError`` or returning ``False`` when an element was itself a :class:`Series` or :class:`DataFrame`, even when the nested objects were equal (:issue:`43008`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
 
 .. ***DO NOT USE THIS SECTION***

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -532,7 +532,12 @@ def _array_equivalent_object(
         left_remaining = left
         right_remaining = right
 
-    for left_value, right_value in zip(left_remaining, right_remaining, strict=True):
+    # left_remaining/right_remaining may be 2-D here (e.g. DataFrame block
+    # values that reached this fallback); use .flat to compare element-wise
+    # rather than row-wise (GH#43008)
+    for left_value, right_value in zip(
+        left_remaining.flat, right_remaining.flat, strict=True
+    ):
         if left_value is NaT and right_value is not NaT:
             return False
 
@@ -541,6 +546,12 @@ def _array_equivalent_object(
 
         elif isinstance(left_value, float) and np.isnan(left_value):
             if not isinstance(right_value, float) or not np.isnan(right_value):
+                return False
+        elif isinstance(left_value, (ABCSeries, ABCDataFrame)):
+            # GH#43008 nested Series/DataFrame: recurse via equals so that NaNs
+            # in the same location compare equal (a plain `!=` treats NaN as
+            # unequal to NaN). equals also returns False for a type mismatch.
+            if not left_value.equals(right_value):
                 return False
         else:
             with warnings.catch_warnings():

--- a/pandas/tests/frame/methods/test_equals.py
+++ b/pandas/tests/frame/methods/test_equals.py
@@ -3,6 +3,7 @@ import numpy as np
 from pandas import (
     Categorical,
     DataFrame,
+    Series,
     date_range,
 )
 import pandas._testing as tm
@@ -88,6 +89,16 @@ class TestEquals:
         df3 = df1.set_index(["floats"], append=True)
         df2 = df1.set_index(["floats"], append=True)
         assert df3.equals(df2)
+
+    def test_equals_nested_pandas_object(self):
+        # GH#43008 equals() with a column of nested Series, including NaNs in
+        # a matching location
+        df1 = DataFrame({"x": [Series([1.0, np.nan]), Series([3.0])]}, dtype=object)
+        df2 = df1.copy()
+        assert df1.equals(df2)
+
+        df3 = DataFrame({"x": [Series([1.0, np.nan]), Series([9.0])]}, dtype=object)
+        assert not df1.equals(df3)
 
     def test_equals_categorical_categories_order(self):
         cat1 = Categorical(["a", "b", "a"], categories=["a", "b"])

--- a/pandas/tests/series/methods/test_equals.py
+++ b/pandas/tests/series/methods/test_equals.py
@@ -8,6 +8,7 @@ from pandas._libs.missing import is_matching_na
 from pandas.core.dtypes.common import is_float
 
 from pandas import (
+    DataFrame,
     Index,
     MultiIndex,
     Series,
@@ -116,6 +117,27 @@ def test_equals_none_vs_nan():
     assert ser.equals(ser2)
     assert Index(ser, dtype=ser.dtype).equals(Index(ser2, dtype=ser2.dtype))
     assert ser.array.equals(ser2.array)
+
+
+@pytest.mark.parametrize("box", [Series, DataFrame])
+def test_equals_nested_pandas_object(box):
+    # GH#43008 equals() failed for a nested Series/DataFrame
+    inner = box(np.array([1.0, np.nan]))
+    ser = Series([inner.copy()], dtype=object)
+    ser2 = Series([inner.copy()], dtype=object)
+    assert ser.equals(ser2)
+
+    # NaN in a matching location compares equal
+    other = Series([box(np.array([1.0, 2.0]))], dtype=object)
+    assert not ser.equals(other)
+
+
+def test_equals_nested_empty_series():
+    # GH#43008
+    inner = Series(dtype=float)
+    ser = Series({0: inner})
+    ser2 = Series({0: inner.copy()})
+    assert ser.equals(ser2)
 
 
 def test_equals_None_vs_float():


### PR DESCRIPTION
closes #43008

`Series.equals` / `DataFrame.equals` raised `ValueError: The truth value of a Series is ambiguous` (or, after that was papered over, silently returned `False`) when an element was itself a `Series` or `DataFrame`, even when the nested objects were equal.

Two fixes in `_array_equivalent_object`:

- Recurse via `left_value.equals(right_value)` for nested `Series`/`DataFrame`, so NaNs in a matching location compare equal (a plain `!=` treats `NaN != NaN` as unequal) and a type mismatch returns `False`. This mirrors what the Cython path already does for nested numpy arrays.
- Iterate the fallback loop element-wise with `.flat`, so 2-D `DataFrame` block values are compared per-element rather than per-row.

```python
foo = pd.Series([pd.Series([1.0, np.nan])], dtype=object)
bar = pd.Series([pd.Series([1.0, np.nan])], dtype=object)
foo.equals(bar)   # was False, now True
```