### PR TITLE
TST: groupby.apply preserves each group's Index in a returned object (GH#41477)

### DIFF
--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1543,6 +1543,21 @@ def test_groupby_apply_store_copy():
     tm.assert_frame_equal(store[1], expected_out_1)
 
 
+def test_groupby_apply_return_object_holding_index():
+    # GH#41477 when the UDF returns an arbitrary object that holds a reference
+    #  to the group's Index, each result must keep its own group's Index
+    #  rather than all sharing a single one.
+    class Wrapper:
+        def __init__(self, value):
+            self.value = value
+
+    df = DataFrame({"key": ["a", "b"]}, index=["foo", "bar"])
+    result = df.groupby("key").apply(lambda group: Wrapper(group.index))
+
+    tm.assert_index_equal(result.loc["a"].value, Index(["foo"]))
+    tm.assert_index_equal(result.loc["b"].value, Index(["bar"]))
+
+
 @pytest.mark.parametrize("test_empty", [False, True])
 def test_apply_as_index_false_empty_index_name(test_empty):
     # https://github.com/pandas-dev/pandas/issues/48135


### PR DESCRIPTION
closes #41477

`DataFrame.groupby(...).apply(f)` where `f` returns an arbitrary object holding a reference to the group's `Index` used to leave every returned object sharing a single `Index` (only one group's), rather than each keeping its own. This was fixed by the apply rewrite that builds every group as a fresh object with its own axes, so this is a test-only PR adding a regression guard and closing the issue.

The new test deliberately holds a live reference to `group.index` (no `.copy()`), which the nearby GH-40673 `test_groupby_apply_store_copy` would not catch.