### PR TITLE
BUG: DataFrame.hist(by=) plots numeric grouping column (GH#41188)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -397,8 +397,8 @@ Period
 
 Plotting
 ^^^^^^^^
+- Bug in :meth:`DataFrame.hist` with ``by`` and no ``column`` specified plotting the numeric grouping column as its own histogram (:issue:`41188`)
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
--
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -10,6 +10,7 @@ from typing import (
 import numpy as np
 
 from pandas.core.dtypes.common import (
+    is_hashable,
     is_integer,
     is_list_like,
 )
@@ -511,6 +512,15 @@ def hist_frame(
     if legend and "label" in kwds:
         raise ValueError("Cannot use both legend and label")
     if by is not None:
+        if column is None:
+            # GH#41188: when grouping by one (or more) of the frame's own
+            #  columns, exclude the grouping column(s) so a numeric ``by``
+            #  column is not plotted as its own histogram (matching the
+            #  behavior when ``by`` is non-numeric).
+            by_keys = list(by) if isinstance(by, (list, tuple)) else [by]
+            drop = [key for key in by_keys if is_hashable(key) and key in data.columns]
+            if drop:
+                column = data.columns.difference(drop, sort=False)
         axes = _grouped_hist(
             data,
             column=column,

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -695,6 +695,30 @@ class TestDataFrameGroupByPlots:
         _check_axes_shape(axes, axes_num=1, layout=(1, 1))
         _check_ticks_props(axes, xrot=30)
 
+    @pytest.mark.parametrize("by_dtype", ["int", "object"])
+    def test_grouped_hist_excludes_by_column(self, by_dtype):
+        # GH#41188 the grouping column must not be plotted alongside the
+        #  other columns, regardless of whether it is numeric
+        rng = np.random.default_rng(2)
+        df = DataFrame(
+            {
+                "length": rng.standard_normal(100),
+                "width": rng.standard_normal(100),
+                "a": rng.integers(0, 2, 100),
+            }
+        )
+        if by_dtype == "object":
+            df["a"] = df["a"].map({0: "x", 1: "y"})
+
+        bins = 5
+        axes = df.hist(by="a", bins=bins, legend=True)
+
+        _check_axes_shape(axes, axes_num=2, layout=(1, 2))
+        for ax in np.asarray(axes).ravel():
+            # only "length" and "width" are plotted, not the grouping column
+            assert len(ax.patches) == 2 * bins
+            _check_legend_labels(ax, ["length", "width"])
+
     def test_grouped_hist_legacy_grouped_hist_kwargs(self):
         rs = np.random.default_rng(2)
         df = DataFrame(rs.standard_normal((10, 1)), columns=["A"])


### PR DESCRIPTION
closes #41188

`df.hist(by="a")` with no explicit `column` plotted the grouping column `a` as its own histogram when `a` was numeric, but dropped it when non-numeric (where `_get_numeric_data` excluded it incidentally). The grouping column is constant within each group, so plotting it is meaningless.

Exclude the grouping column(s) at the `hist_frame` entry point when `column` is not given, so the result is consistent regardless of the `by` column's dtype. This mirrors the existing boxplot path (`_grouped_plot_by_column`), which already does `columns.difference(by)`. External groupers (`by=` a Series/array rather than a column label) are left untouched.

Note: the literal snippet in the issue used `column=["length", "width"]`, which already worked on `main`; the underlying inconsistency this fixes is the no-`column` case.