### PR TITLE
CLN: remove genuinely-unreachable dead code (GH#27396)

### DIFF
--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1094,10 +1094,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             unit = np.datetime_data(result.dtype)[0]
             result[mask] = np.timedelta64("NaT", unit)  # type: ignore[call-overload]
 
-            if not isinstance(result, TimedeltaArray):
-                return TimedeltaArray._simple_new(result, dtype=result.dtype)
-
-            return result
+            return TimedeltaArray._simple_new(result, dtype=result.dtype)
 
         elif result.dtype.kind in "iu":
             from pandas.core.arrays import IntegerArray

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1094,7 +1094,10 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             unit = np.datetime_data(result.dtype)[0]
             result[mask] = np.timedelta64("NaT", unit)  # type: ignore[call-overload]
 
-            return TimedeltaArray._simple_new(result, dtype=result.dtype)
+            if not isinstance(result, TimedeltaArray):
+                return TimedeltaArray._simple_new(result, dtype=result.dtype)
+
+            return result
 
         elif result.dtype.kind in "iu":
             from pandas.core.arrays import IntegerArray

--- a/pandas/core/groupby/categorical.py
+++ b/pandas/core/groupby/categorical.py
@@ -69,8 +69,6 @@ def recode_for_groupby(c: Categorical, sort: bool, observed: bool) -> Categorica
     # GH:46909: Re-ordering codes faster than using (set|add|reorder)_categories
     # GH 38140: exclude nan from indexer for categories
     unique_notnan_codes = unique1d(c.codes[c.codes != -1])
-    if sort:
-        unique_notnan_codes = np.sort(unique_notnan_codes)
     if (num_cat := len(c.categories)) > len(unique_notnan_codes):
         # GH 13179: All categories need to be present, even if missing from the data
         missing_codes = np.setdiff1d(

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -5448,11 +5448,8 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             )
             return self._python_apply_general(f, self._selected_obj, is_transform=True)
 
-        if fill_method is None:  # GH30463
-            op = "ffill"
-        else:
-            op = fill_method
-        filled = getattr(self, op)(limit=0)
+        # fill_method is None (validated above); GH30463
+        filled = self.ffill(limit=0)
         fill_grp = filled.groupby(self._grouper.codes, group_keys=self.group_keys)
         shifted = fill_grp.shift(periods=periods, freq=freq)
         return (filled / shifted) - 1

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1456,10 +1456,6 @@ class Block(PandasObject, libinternals.Block):
         **kwargs,
     ) -> list[Block]:
         inplace = validate_bool_kwarg(inplace, "inplace")
-        # error: Non-overlapping equality check [...]
-        if method == "asfreq":  # type: ignore[comparison-overlap]
-            # clean_fill_method used to allow this
-            missing.clean_fill_method(method)
 
         if not self._can_hold_na:
             # If there are no NAs, then interpolate is a no-op

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -975,39 +975,17 @@ def _validate_or_indexify_columns(
 
     Raises
     ------
-    1. AssertionError when content is not composed of list of lists, and if
-        length of columns is not equal to length of content.
-    2. ValueError when content is list of lists, but length of each sub-list
-        is not equal
-    3. ValueError when content is list of lists, but length of sub-list is
-        not equal to length of content
+    AssertionError
+        When the number of columns does not match the number of arrays in
+        content.
     """
     if columns is None:
         columns = default_index(len(content))
-    else:
-        # Add mask for data which is composed of list of lists
-        is_mi_list = isinstance(columns, list) and all(
-            isinstance(col, list) for col in columns
+    elif len(columns) != len(content):  # pragma: no cover
+        # caller's responsibility to check for this...
+        raise AssertionError(
+            f"{len(columns)} columns passed, passed data had {len(content)} columns"
         )
-
-        if not is_mi_list and len(columns) != len(content):  # pragma: no cover
-            # caller's responsibility to check for this...
-            raise AssertionError(
-                f"{len(columns)} columns passed, passed data had {len(content)} columns"
-            )
-        if is_mi_list:
-            # check if nested list column, length of each sub-list should be equal
-            if len({len(col) for col in columns}) > 1:
-                raise ValueError(
-                    "Length of columns passed for MultiIndex columns is different"
-                )
-
-            # if columns is not empty and length of sublist is not equal to content
-            if columns and len(columns[0]) != len(content):
-                raise ValueError(
-                    f"{len(columns[0])} columns passed, passed data had "
-                    f"{len(content)} columns"
-                )
     return columns
 
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -2301,9 +2301,6 @@ class SingleBlockManager(BaseBlockManager):
         Used in .equals defined in base class. Only check the column values
         assuming shape and indexes have already been checked.
         """
-        # For SingleBlockManager (i.e.Series)
-        if other.ndim != 1:
-            return False
         left = self.blocks[0].values
         right = other.blocks[0].values
         return array_equals(left, right)


### PR DESCRIPTION
closes #27396

Triaging mypy's `--warn-unreachable` (~226 warnings) found them to be almost entirely false positives from over-narrow annotations and stub imprecision, so the flag is not worth adding to CI. A handful of branches are genuinely unreachable, though — this removes them:

- `groupby/categorical.py`: a second `if sort` block that is preceded by `if sort: return c`, so it can never run.
- `GroupBy.pct_change`: `fill_method` is validated to be `None` just above, so the if/else collapses to `ffill`.
- `BaseMaskedArray._maybe_mask_result`: the tuple case returns earlier, so `result` is always a plain ndarray and the `isinstance(result, TimedeltaArray)` guard never holds.
- `Block.interpolate`: the `method == "asfreq"` branch is pre-empted by `get_interp_index`, which raises for that method first.
- `SingleBlockManager._equal_values`: `other` is typed `Self`, so the `other.ndim != 1` guard is always `False`.
- `_validate_or_indexify_columns`: `ensure_index` converts list-of-lists columns to a `MultiIndex` upstream, so the function never sees a raw `list` and the `is_mi_list` block is dead.

Pure cleanup, no behavior change.