### PR TITLE
PERF: groupby _factorize_monotonic with freq attribute

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -205,6 +205,7 @@ Performance improvements
 - Performance improvement in :meth:`GroupBy.quantile` (:issue:`64330`)
 - Performance improvement in :meth:`GroupBy.size` (:issue:`51750`)
 - Performance improvement in :meth:`HDFStore.select_as_multiple` when no ``where`` clause is given, by avoiding a coordinate-based read (:issue:`26771`)
+- Performance improvement in :meth:`Index.factorize` for a monotonic :class:`DatetimeIndex` or :class:`TimedeltaIndex` without a ``freq`` (:issue:`66046`)
 - Performance improvement in :meth:`Index.get_indexer` for large monotonic indexes, which now uses binary search instead of building a hash table when the number of targets is small (:issue:`14273`)
 - Performance improvement in :meth:`Index.join` and :meth:`Index.union` for :class:`RangeIndex` by avoiding unnecessary memory allocation in the libjoin fastpath (:issue:`54646`)
 - Performance improvement in :meth:`IntervalIndex.get_indexer` for monotonic non-overlapping indexes, which now uses binary search instead of the interval tree (:issue:`47614`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -662,6 +662,54 @@ def factorize_array(
     return codes, uniques
 
 
+def factorize_monotonic_codes(
+    arr: np.ndarray,
+    ascending: bool,
+    sort: bool,
+) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
+    """
+    Factorize an array known to be monotonic and of length >= 2.
+
+    Uses adjacent-element comparison instead of hash table construction.
+    The caller is responsible for having verified monotonicity; monotonic
+    arrays contain no NA values (NAs break monotonicity checks), so NA
+    handling is not needed.
+
+    Parameters
+    ----------
+    arr : ndarray
+    ascending : bool
+        Whether `arr` is monotonic increasing (otherwise decreasing).
+    sort : bool
+        Whether the uniques should be in sorted order.
+
+    Returns
+    -------
+    codes : ndarray[np.intp]
+    uniques_indexer : ndarray[np.intp]
+        Positions in `arr` of the unique values, ordered to match `codes`.
+    """
+    n = len(arr)
+
+    # Find group transitions via adjacent-element comparison.
+    transitions = np.empty(n, dtype=bool)
+    transitions[0] = True
+    transitions[1:] = arr[1:] != arr[:-1]
+
+    # Build codes using repeat (faster than cumsum on bool).
+    group_starts = np.flatnonzero(transitions)
+    ngroups = len(group_starts)
+    run_lengths = np.diff(group_starts, append=n)
+    codes = np.repeat(np.arange(ngroups, dtype=np.intp), run_lengths)
+
+    if sort and not ascending:
+        # Reverse uniques to sorted order and remap codes.
+        codes = ensure_platform_int(ngroups - 1 - codes)
+        group_starts = group_starts[::-1]
+
+    return codes, group_starts
+
+
 @set_module("pandas")
 def factorize(
     values,

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -982,8 +982,9 @@ def _factorize_monotonic(
         dtype = grouping_vector.dtype
         if not isinstance(dtype, np.dtype) or dtype.kind not in "iufmMb":
             return None
-        if getattr(grouping_vector, "freq", None) is not None:
-            # Fallback for DatetimeIndex/TimedeltaIndex/PeriodIndex is faster
+        if isinstance(grouping_vector, Index) and dtype.kind in "mM":
+            # DatetimeIndex/TimedeltaIndex.factorize has its own fastpaths
+            # (freq-based and monotonic) that retain freq and Index uniques
             return None
         ascending = grouping_vector.is_monotonic_increasing
         if not ascending and not grouping_vector.is_monotonic_decreasing:
@@ -1009,28 +1010,11 @@ def _factorize_monotonic(
     else:
         return None
 
-    n = len(arr)
-    if n <= 1:
+    if len(arr) <= 1:
         return None
 
-    # Find group transitions via adjacent-element comparison.
-    transitions = np.empty(n, dtype=bool)
-    transitions[0] = True
-    transitions[1:] = arr[1:] != arr[:-1]
-
-    # Build codes using repeat (faster than cumsum on bool).
-    group_starts = np.flatnonzero(transitions)
-    uniques = arr[group_starts]
-    ngroups = len(group_starts)
-    run_lengths = np.diff(group_starts, append=n)
-    codes = np.repeat(np.arange(ngroups, dtype=np.intp), run_lengths)
-
-    if sort and not ascending:
-        # Reverse uniques to sorted order and remap codes.
-        uniques = uniques[::-1].copy()
-        codes = ensure_platform_int(ngroups - 1 - codes)
-
-    return codes, uniques
+    codes, uniques_indexer = algorithms.factorize_monotonic_codes(arr, ascending, sort)
+    return codes, arr[uniques_indexer]
 
 
 def _convert_grouper(axis: Index, grouper):

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -983,7 +983,7 @@ def _factorize_monotonic(
         if not isinstance(dtype, np.dtype) or dtype.kind not in "iufmMb":
             return None
         if getattr(grouping_vector, "freq", None) is not None:
-            # DatetimeIndex/TimedeltaIndex/PeriodIndex are faster
+            # Fallback for DatetimeIndex/TimedeltaIndex/PeriodIndex is faster
             return None
         ascending = grouping_vector.is_monotonic_increasing
         if not ascending and not grouping_vector.is_monotonic_decreasing:

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -982,6 +982,9 @@ def _factorize_monotonic(
         dtype = grouping_vector.dtype
         if not isinstance(dtype, np.dtype) or dtype.kind not in "iufmMb":
             return None
+        if getattr(grouping_vector, "freq", None) is not None:
+            # DatetimeIndex/TimedeltaIndex/PeriodIndex are faster
+            return None
         ascending = grouping_vector.is_monotonic_increasing
         if not ascending and not grouping_vector.is_monotonic_decreasing:
             return None

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -64,7 +64,10 @@ from pandas.core.dtypes.dtypes import (
     PeriodDtype,
 )
 
-from pandas.core import roperator
+from pandas.core import (
+    algorithms,
+    roperator,
+)
 from pandas.core.arrays import (
     DatetimeArray,
     ExtensionArray,
@@ -885,6 +888,16 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
             else:
                 codes = np.arange(len(self), dtype=np.intp)
                 uniques = self.copy()
+            uniques._name = None
+            return codes, uniques
+        if len(self) > 1 and (
+            self.is_monotonic_increasing or self.is_monotonic_decreasing
+        ):
+            # Monotonic implies no NaT, so NA handling is not needed
+            codes, uniques_indexer = algorithms.factorize_monotonic_codes(
+                self._data._ndarray, self.is_monotonic_increasing, sort
+            )
+            uniques = self[uniques_indexer]
             uniques._name = None
             return codes, uniques
         return super().factorize(sort=sort, use_na_sentinel=use_na_sentinel)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -26,6 +26,7 @@ from pandas import (
     Timestamp,
     date_range,
     period_range,
+    timedelta_range,
 )
 import pandas._testing as tm
 from pandas.core.groupby.grouper import Grouping
@@ -1245,3 +1246,21 @@ def test_groupby_any_with_timedelta():
     expected.index = expected.index.astype(np.int64)
 
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "idx",
+    [
+        date_range("2020-01-01", periods=5, freq="D"),
+        timedelta_range("1 day", periods=5, freq="D"),
+    ],
+)
+def test_groupby_index_with_freq_retains_freq(idx):
+    # GH#66046 - grouping by a DatetimeIndex/TimedeltaIndex with a freq
+    # retains the freq on the result index
+    df = DataFrame({"a": range(5)})
+
+    result = df.groupby(idx).sum()
+
+    assert result.index.freq == idx.freq
+    tm.assert_index_equal(result.index, idx)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -1248,19 +1248,55 @@ def test_groupby_any_with_timedelta():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("sort", [True, False])
 @pytest.mark.parametrize(
     "idx",
     [
         date_range("2020-01-01", periods=5, freq="D"),
+        date_range("2020-01-05", periods=5, freq="-1D"),
         timedelta_range("1 day", periods=5, freq="D"),
+        timedelta_range("5 days", periods=5, freq="-1D"),
     ],
 )
-def test_groupby_index_with_freq_retains_freq(idx):
+def test_groupby_index_with_freq_retains_freq(idx, sort):
     # GH#66046 - grouping by a DatetimeIndex/TimedeltaIndex with a freq
     # retains the freq on the result index
     df = DataFrame({"a": range(5)})
 
-    result = df.groupby(idx).sum()
+    result = df.groupby(idx, sort=sort).sum()
 
-    assert result.index.freq == idx.freq
-    tm.assert_index_equal(result.index, idx)
+    expected_index = idx.sort_values() if sort else idx
+    assert result.index.freq == expected_index.freq
+    tm.assert_index_equal(result.index, expected_index)
+
+
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("ascending", [True, False])
+@pytest.mark.parametrize(
+    "klass, values",
+    [
+        (
+            pd.DatetimeIndex,
+            ["2020-01-01", "2020-01-01", "2020-01-03", "2020-01-07"],
+        ),
+        (pd.TimedeltaIndex, ["1 day", "1 day", "3 days", "7 days"]),
+    ],
+)
+def test_groupby_monotonic_datetimelike_no_freq(klass, values, ascending, sort):
+    # GH#66046 - monotonic DatetimeIndex/TimedeltaIndex without a freq
+    # with duplicates
+    idx = klass(values)
+    if not ascending:
+        idx = idx[::-1]
+    assert idx.freq is None
+    df = DataFrame({"a": [1, 2, 4, 8]})
+
+    result = df.groupby(idx, sort=sort).sum()
+
+    if ascending:
+        expected = DataFrame({"a": [3, 4, 8]}, index=klass(values[1:]))
+    elif sort:
+        expected = DataFrame({"a": [12, 2, 1]}, index=klass(values[1:]))
+    else:
+        expected = DataFrame({"a": [1, 2, 12]}, index=klass(values[1:])[::-1])
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/methods/test_factorize.py
+++ b/pandas/tests/indexes/datetimes/methods/test_factorize.py
@@ -56,6 +56,24 @@ class TestDatetimeIndexFactorize:
         tm.assert_index_equal(idx, exp_idx)
         assert idx.freq == exp_idx.freq
 
+    @pytest.mark.parametrize("tz", [None, "US/Pacific"])
+    def test_factorize_monotonic_decreasing_no_freq(self, tz):
+        # GH#66046 fastpath for a monotonic decreasing index without a freq
+        idx = DatetimeIndex(["2014-03", "2014-03", "2014-02", "2014-01"], tz=tz)
+        assert idx.freq is None
+
+        exp_arr = np.array([0, 0, 1, 2], dtype=np.intp)
+        exp_idx = DatetimeIndex(["2014-03", "2014-02", "2014-01"], tz=tz)
+        arr, result_idx = idx.factorize()
+        tm.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_index_equal(result_idx, exp_idx)
+
+        exp_arr = np.array([2, 2, 1, 0], dtype=np.intp)
+        exp_idx = DatetimeIndex(["2014-01", "2014-02", "2014-03"], tz=tz)
+        arr, result_idx = idx.factorize(sort=True)
+        tm.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_index_equal(result_idx, exp_idx)
+
     def test_factorize_preserves_freq(self):
         # GH#38120 freq should be preserved
         idx3 = date_range("2000-01", periods=4, freq="ME", tz="Asia/Tokyo")

--- a/pandas/tests/indexes/timedeltas/methods/test_factorize.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_factorize.py
@@ -25,6 +25,23 @@ class TestTimedeltaIndexFactorize:
         tm.assert_index_equal(idx, exp_idx)
         assert idx.freq == exp_idx.freq
 
+    def test_factorize_monotonic_decreasing_no_freq(self):
+        # GH#66046 fastpath for a monotonic decreasing index without a freq
+        idx = TimedeltaIndex(["3 days", "3 days", "2 days", "1 days"])
+        assert idx.freq is None
+
+        exp_arr = np.array([0, 0, 1, 2], dtype=np.intp)
+        exp_idx = TimedeltaIndex(["3 days", "2 days", "1 days"])
+        arr, result_idx = idx.factorize()
+        tm.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_index_equal(result_idx, exp_idx)
+
+        exp_arr = np.array([2, 2, 1, 0], dtype=np.intp)
+        exp_idx = TimedeltaIndex(["1 days", "2 days", "3 days"])
+        arr, result_idx = idx.factorize(sort=True)
+        tm.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_index_equal(result_idx, exp_idx)
+
     def test_factorize_preserves_freq(self):
         # GH#38120 freq should be preserved
         idx3 = timedelta_range("1 day", periods=4, freq="s")


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/145

Only addresses the first benchmark there; the others for numba seem flakey. This PR has a larger % impact on smaller data.

```python
size = 10_000
grouper = pd.date_range("1900-01-01", freq="D", periods=size)
df = pd.DataFrame(np.random.randn(size, 2))
%timeit df.groupby(grouper).sum()

# size = 10_000
# 376 μs ± 2.53 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each) <-- main
# 307 μs ± 2.82 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each) <-- PR

# size = 1_000_000
# 33.1 ms ± 1.31 ms per loop (mean ± std. dev. of 7 runs, 10 loops each) <-- main
# 30 ms ± 430 μs per loop (mean ± std. dev. of 7 runs, 10 loops each) <-- PR
```