### PR TITLE
BUG: Fix plotting with tz-aware normalized DatetimeIndex dropping tz info

### DIFF
--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -269,6 +269,14 @@ def use_dynamic_x(ax: Axes, index: Index) -> bool:
     # inspect the first element because the index has a (possibly inferred)
     # freq, so the rest are evenly spaced relative to it.
     if isinstance(index, ABCDatetimeIndex):
+        # GH#65915: Timezone-aware DatetimeIndex must not use Period-based
+        # plotting because Period has no timezone concept.  Converting a
+        # tz-aware index to Period silently drops the timezone, which makes
+        # timestamps from different timezones (e.g. UTC-06:00 and UTC+00:00)
+        # appear at the same x-position even when they represent different
+        # absolute times.  Fall back to regular datetime-based plotting.
+        if index.tz is not None:
+            return False
         # error: "BaseOffset" has no attribute "_period_dtype_code"
         freq_str = OFFSET_TO_PERIOD_FREQSTR.get(freq_str, freq_str)
         base = to_offset(freq_str, is_period=True)._period_dtype_code  # type: ignore[attr-defined]

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -64,6 +64,38 @@ class TestTSPlot:
         assert (xdata[0].hour, xdata[0].minute) == (0, 0)
         assert (xdata[-1].hour, xdata[-1].minute) == (1, 0)
 
+    def test_ts_plot_normalized_tz_aware_preserves_tz(self):
+        # GH#65915: Normalized tz-aware DatetimeIndex should preserve
+        # timezone info when plotting, not convert to Period (which drops tz).
+        idx_est = DatetimeIndex(
+            ["2000-01-01 00:00:00-06:00", "2000-01-02 00:00:00-06:00"]
+        )
+        idx_utc = DatetimeIndex(
+            ["2000-01-01 00:00:00+00:00", "2000-01-02 00:00:00+00:00"]
+        )
+        sr_est = Series(range(len(idx_est)), index=idx_est, name="EST")
+        sr_utc = Series(range(len(idx_utc)), index=idx_utc, name="UTC")
+
+        ax = sr_est.plot()
+        sr_utc.plot(ax=ax)
+
+        line_est_xdata = ax.lines[0].get_xdata()
+        line_utc_xdata = ax.lines[1].get_xdata()
+
+        # Before fix, both lines would have Period objects (no tz).
+        # After fix, both lines should have tz-aware Timestamps.
+        assert hasattr(line_est_xdata[0], "tz"), "EST line data lost timezone"
+        assert hasattr(line_utc_xdata[0], "tz"), "UTC line data lost timezone"
+
+        # The two series are 6 hours apart; verify they don't overlap.
+        # EST midnight = UTC 06:00, so EST points should be 6h ahead of UTC.
+        import matplotlib.dates as mdates
+
+        est_ordinal = mdates.date2num(line_est_xdata[0])
+        utc_ordinal = mdates.date2num(line_utc_xdata[0])
+        six_hours_in_days = 6 / 24
+        assert abs(est_ordinal - utc_ordinal - six_hours_in_days) < 1e-10
+
     def test_fontsize_set_correctly(self):
         # For issue #8765
         df = DataFrame(


### PR DESCRIPTION
## Description

When plotting with a timezone-aware `DatetimeIndex` that has been normalized (e.g., midnight timestamps), the timezone information was silently dropped. This caused timestamps from different timezones (e.g., UTC-06:00 and UTC+00:00) to appear at the same x-position, producing incorrect plots.

**Root cause:** `use_dynamic_x()` returned `True` for normalized tz-aware indexes, which triggered conversion to `Period` via `maybe_resample()`. Since `Period` has no timezone concept, the tz info was lost.

**Fix:** Return `False` from `use_dynamic_x()` when the `DatetimeIndex` has a timezone, falling back to regular datetime-based plotting that preserves timezone information.

Closes #65915

## Changes

- `pandas/plotting/_matplotlib/timeseries.py`: Added guard in `use_dynamic_x()` to return `False` for tz-aware `DatetimeIndex`
- `pandas/tests/plotting/test_datetimelike.py`: Added test `test_ts_plot_normalized_tz_aware_preserves_tz` verifying that:
  - Line data retains timezone-aware `Timestamp` objects (not `Period`)
  - Two series with different timezones (EST and UTC) are correctly separated by 6 hours on the x-axis

## Testing

All existing tests pass (217 passed, 1 skipped, 3 xfailed in `test_datetimelike.py`), and the new test verifies the fix.