### PR TITLE
BUG: read_csv(engine="pyarrow") ignores names passed with an integer header

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -361,6 +361,8 @@ I/O
 ^^^
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
+- Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where ``names`` was silently ignored when ``header`` was also an integer; the header row is now replaced by ``names``, extra leading columns form the index, and too many ``names`` now raise ``ValueError`` like other engines (:issue:`65862`)
+- Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where passing tuples in ``names`` produced flat columns instead of :class:`MultiIndex` columns (:issue:`65862`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -139,11 +139,17 @@ class ArrowParserWrapper(ParserBase):
                 f"f{n}" for n in self.convert_options["include_columns"]
             ]
 
+        if self.header is None:
+            skip_rows = self.kwds["skiprows"]
+        elif self.names is not None:
+            # names replace the header row, which is discarded like
+            # other engines do
+            skip_rows = self.header + 1
+        else:
+            skip_rows = self.header
         self.read_options = {
-            "autogenerate_column_names": self.header is None,
-            "skip_rows": self.header
-            if self.header is not None
-            else self.kwds["skiprows"],
+            "autogenerate_column_names": self.header is None or self.names is not None,
+            "skip_rows": skip_rows,
             "encoding": self.encoding,
         }
 
@@ -172,20 +178,33 @@ class ArrowParserWrapper(ParserBase):
     def _adjust_column_names(self, table: pa.Table) -> bool:
         num_cols = len(table.columns)
         multi_index_named = True
-        if self.header is None:
-            if self.names is None:
-                self.names = range(num_cols)
-            if len(self.names) != num_cols:
-                # usecols is passed through to pyarrow, we only handle index col here
-                # The only way self.names is not the same length as number of cols is
-                # if we have int index_col. We should just pad the names(they will get
-                # removed anyways) to expected length then.
-                columns_prefix = [str(x) for x in range(num_cols - len(self.names))]
-                self.names = columns_prefix + self.names
+        self._implicit_index_count = 0
+        if self.header is None and self.names is None:
+            self.names = range(num_cols)
+        if self.names is not None and len(self.names) != num_cols:
+            # usecols is passed through to pyarrow, so num_cols here already
+            # reflects it
+            usecols = self.kwds.get("include_columns")
+            if (self.header is not None and len(self.names) > num_cols) or (
+                usecols is not None and len(self.names) != len(usecols)
+            ):
+                raise ValueError(
+                    "Number of passed names did not match number of "
+                    "header fields in the file"
+                )
+            if len(self.names) < num_cols:
+                # Leading columns not covered by names form the index, as with
+                # other engines. Pad the names to expected length; the padded
+                # columns are moved to the index in _finalize_index.
+                self._implicit_index_count = num_cols - len(self.names)
+                columns_prefix = [str(x) for x in range(self._implicit_index_count)]
+                self.names = columns_prefix + list(self.names)
                 multi_index_named = False
         return multi_index_named
 
     def _finalize_index(self, frame: DataFrame, multi_index_named: bool) -> DataFrame:
+        if self.index_col is None and self._implicit_index_count:
+            self.index_col = list(range(self._implicit_index_count))
         if self.index_col is not None:
             index_to_set = self.index_col.copy()
             for i, item in enumerate(self.index_col):
@@ -207,8 +226,8 @@ class ArrowParserWrapper(ParserBase):
                         del self.dtype[key]
 
             frame.set_index(index_to_set, drop=True, inplace=True)
-            # Clear names if headerless and no name given
-            if self.header is None and not multi_index_named:
+            # Clear names if no name given for padded leading columns
+            if not multi_index_named:
                 frame.index.names = [None] * len(frame.index.names)
 
         return frame
@@ -252,6 +271,10 @@ class ArrowParserWrapper(ParserBase):
         frame = self._do_date_conversions(frame.columns, frame)
         frame = self._finalize_index(frame, multi_index_named)
         frame = self._finalize_dtype(frame)
+        # tuples passed via names imply MultiIndex columns, as with other engines
+        frame.columns = self._maybe_make_multi_index_columns(
+            list(frame.columns), self.col_names
+        )
         return frame
 
     def _validate_usecols(self, usecols) -> None:
@@ -322,7 +345,7 @@ class ArrowParserWrapper(ParserBase):
                 names=self.names,
             )
 
-        if self.header is None:
+        if self.names is not None:
             frame.columns = self.names
 
         return self._finalize_pandas_output(frame, multi_index_named)

--- a/pandas/tests/io/parser/common/test_read_errors.py
+++ b/pandas/tests/io/parser/common/test_read_errors.py
@@ -118,7 +118,6 @@ skip
             reader.read(nrows)
 
 
-@xfail_pyarrow  # does not raise
 def test_catch_too_many_names(all_parsers):
     # see gh-5156
     data = """\

--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -79,7 +79,6 @@ b"""
         parser.read_csv(StringIO(data), header=header)
 
 
-@xfail_pyarrow  # AssertionError: DataFrame are different
 def test_header_with_index_col(all_parsers):
     parser = all_parsers
     data = """foo,1,2,3
@@ -199,7 +198,6 @@ R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2
 _TestTuple = namedtuple("_TestTuple", ["first", "second"])
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -228,7 +226,7 @@ _TestTuple = namedtuple("_TestTuple", ["first", "second"])
         },
     ],
 )
-def test_header_multi_index_common_format1(all_parsers, kwargs):
+def test_header_multi_index_common_format1(all_parsers, kwargs, request):
     parser = all_parsers
     expected = DataFrame(
         [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
@@ -243,11 +241,16 @@ def test_header_multi_index_common_format1(all_parsers, kwargs):
 one,1,2,3,4,5,6
 two,7,8,9,10,11,12"""
 
+    if parser.engine == "pyarrow" and "header" in kwargs:
+        # list-valued header is unsupported by the pyarrow engine
+        request.applymarker(
+            pytest.mark.xfail(reason="TypeError: an integer is required")
+        )
+
     result = parser.read_csv(StringIO(data), index_col=0, **kwargs)
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -276,7 +279,7 @@ two,7,8,9,10,11,12"""
         },
     ],
 )
-def test_header_multi_index_common_format2(all_parsers, kwargs):
+def test_header_multi_index_common_format2(all_parsers, kwargs, request):
     parser = all_parsers
     expected = DataFrame(
         [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
@@ -290,11 +293,16 @@ def test_header_multi_index_common_format2(all_parsers, kwargs):
 one,1,2,3,4,5,6
 two,7,8,9,10,11,12"""
 
+    if parser.engine == "pyarrow" and "header" in kwargs:
+        # list-valued header is unsupported by the pyarrow engine
+        request.applymarker(
+            pytest.mark.xfail(reason="TypeError: an integer is required")
+        )
+
     result = parser.read_csv(StringIO(data), index_col=0, **kwargs)
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -323,7 +331,7 @@ two,7,8,9,10,11,12"""
         },
     ],
 )
-def test_header_multi_index_common_format3(all_parsers, kwargs):
+def test_header_multi_index_common_format3(all_parsers, kwargs, request):
     parser = all_parsers
     expected = DataFrame(
         [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
@@ -337,6 +345,12 @@ def test_header_multi_index_common_format3(all_parsers, kwargs):
 q,r,s,t,u,v
 1,2,3,4,5,6
 7,8,9,10,11,12"""
+
+    if parser.engine == "pyarrow" and "header" in kwargs:
+        # list-valued header is unsupported by the pyarrow engine
+        request.applymarker(
+            pytest.mark.xfail(reason="TypeError: an integer is required")
+        )
 
     result = parser.read_csv(StringIO(data), index_col=None, **kwargs)
     tm.assert_frame_equal(result, expected)
@@ -421,13 +435,9 @@ def test_header_multi_index_blank_line(all_parsers):
 @pytest.mark.parametrize(
     "data,header", [("1,2,3\n4,5,6", None), ("foo,bar,baz\n1,2,3\n4,5,6", 0)]
 )
-def test_header_names_backward_compat(all_parsers, data, header, request):
+def test_header_names_backward_compat(all_parsers, data, header):
     # see gh-2539
     parser = all_parsers
-
-    if parser.engine == "pyarrow" and header is not None:
-        mark = pytest.mark.xfail(reason="DataFrame.columns are different")
-        request.applymarker(mark)
 
     expected = parser.read_csv(StringIO("1,2,3\n4,5,6"), names=["a", "b", "c"])
 

--- a/pandas/tests/io/parser/usecols/test_usecols_basic.py
+++ b/pandas/tests/io/parser/usecols/test_usecols_basic.py
@@ -133,8 +133,6 @@ def test_usecols_relative_to_names2(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-# regex mismatch: "Length mismatch: Expected axis has 1 elements"
-@xfail_pyarrow
 def test_usecols_name_length_conflict(all_parsers):
     data = """\
 1,2,3


### PR DESCRIPTION
Split out from GH-65862 to keep each PR focused; the error-raising changes (`na_filter=False`, list-valued `header`) stay in GH-65862. This PR has the `names`-handling behavior fixes for `engine="pyarrow"`, bringing it in line with the C and python engines:

- when `names` is passed alongside an integer `header`, the header row is now replaced by `names` (previously `names` was silently ignored);
- extra leading columns not covered by `names` form the index;
- passing too many `names` raises `ValueError`;
- tuples in `names` produce MultiIndex columns instead of flat columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)