### PR TITLE
BUG: Sparse min/max/sum ignore skipna=False on the Series path

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -442,8 +442,10 @@ Reshaping
 Sparse
 ^^^^^^
 - Bug in :meth:`Series.mean` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
+- Bug in :meth:`Series.sum`, :meth:`Series.min`, and :meth:`Series.max` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`SparseArray.astype` where converting a datetime64 :class:`SparseArray` with ``NaT`` fill value to ``"Sparse[int64]"`` silently replaced the fill value with ``0`` instead of ``iNaT`` (:issue:`49631`)
 - Bug in :meth:`SparseArray.mean` raising a ``TypeError`` when called with the ``skipna`` argument (:issue:`65478`)
+- Bug in :meth:`SparseArray.sum` with ``skipna=False`` returning ``NA`` for a non-null ``fill_value`` and ignoring missing values under a null ``fill_value`` (:issue:`65478`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
 
 ExtensionArray

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1560,9 +1560,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if method is None:
             raise TypeError(f"cannot perform {name} with type {self.dtype}")
 
-        if name == "mean":
-            # mean handles skipna itself; dropping NAs beforehand would hide
-            # the NA from its skipna=False short-circuit
+        if name in ("mean", "sum", "min", "max"):
+            # these methods handle skipna themselves; dropping NAs beforehand
+            # would hide the NA from their skipna=False short-circuit
             result = method(skipna=skipna, **kwargs)
         else:
             if skipna:
@@ -1637,6 +1637,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             The required number of valid values to perform the summation. If fewer
             than ``min_count`` valid values are present, the result will be the missing
             value indicator for subarray type.
+        skipna : bool, default True
+            Exclude NA/null values. If False and NA is present, return NA.
         *args, **kwargs
             Not Used. NumPy compatibility.
 
@@ -1645,11 +1647,11 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         scalar
         """
         nv.validate_sum(args, kwargs)
+        skipna = validate_bool_kwarg(skipna, "skipna")
         valid_vals = self._valid_sp_values
         sp_sum = valid_vals.sum()
-        has_na = self.sp_index.ngaps > 0 and not self._null_fill_value
 
-        if has_na and not skipna:
+        if not skipna and self._hasna:
             return na_value_for_dtype(self.dtype.subtype, compat=False)
 
         if self._null_fill_value:
@@ -1786,17 +1788,19 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if len(valid_vals) > 0:
             sp_min_max = getattr(valid_vals, kind)()
 
+            if not skipna and self._hasna:
+                return na_value_for_dtype(self.dtype.subtype, compat=False)
+
             # If a non-null fill value is currently present, it might be the min/max
             if has_nonnull_fill_vals:
                 func = max if kind == "max" else min
                 return func(sp_min_max, self.fill_value)
-            elif skipna:
-                return sp_min_max
-            elif self.sp_index.ngaps == 0:
-                # No NAs present
-                return sp_min_max
-            else:
-                return na_value_for_dtype(self.dtype.subtype, compat=False)
+
+            # A present NA with skipna=False is handled above, so the min/max of
+            # the valid sparse values is the result.
+            return sp_min_max
+        elif not skipna and self._hasna:
+            return na_value_for_dtype(self.dtype.subtype, compat=False)
         elif has_nonnull_fill_vals:
             return self.fill_value
         else:

--- a/pandas/tests/arrays/sparse/test_reductions.py
+++ b/pandas/tests/arrays/sparse/test_reductions.py
@@ -123,6 +123,17 @@ class TestReductions:
         out = SparseArray(data, fill_value=np.nan).sum()
         assert out == 40.0
 
+    def test_sum_skipna(self):
+        # GH#65478 sum honors skipna for SparseArray-backed reductions
+        arr = SparseArray([1.0, np.nan, 3.0], fill_value=np.nan)
+        assert arr.sum(skipna=True) == 4.0
+        assert isna(arr.sum(skipna=False))
+
+        # a non-null fill value is not a missing value, so skipna=False
+        # still returns the full sum
+        arr = SparseArray([1, 2, 0, 3], fill_value=0)
+        assert arr.sum(skipna=False) == 6
+
     @pytest.mark.parametrize(
         "arr",
         [[0, 1, np.nan, 1], [0, 1, 1]],
@@ -256,6 +267,17 @@ class TestMinMax:
 
         min_result = arr.min()
         assert min_result == min_expected
+
+    @pytest.mark.parametrize("method", ["min", "max"])
+    @pytest.mark.parametrize("values", [[np.nan, 0, 1, 0], [np.nan, 0, 0]])
+    def test_min_max_skipna_false_with_nonnull_fill_value(self, method, values):
+        # GH#65478 skipna=False should see explicit NA values, even when
+        # non-null fill-value gaps are also present.
+        arr = SparseArray(values, fill_value=0)
+
+        result = getattr(arr, method)(skipna=False)
+
+        assert isna(result)
 
     def test_only_fill_value(self):
         fv = 100

--- a/pandas/tests/extension/base/reduce.py
+++ b/pandas/tests/extension/base/reduce.py
@@ -134,11 +134,8 @@ class BaseReduceTests:
         ser = pd.Series(data)
 
         kwargs = {}
-        if op_name in ["mean", "any", "all"] and isinstance(
-            ser.array, pd.arrays.SparseArray
-        ):
-            # https://github.com/pandas-dev/pandas/issues/65478
-            # Methods are missing the skipna argument
+        if op_name in ["any", "all"] and isinstance(ser.array, pd.arrays.SparseArray):
+            # SparseArray.any/all do not accept a skipna argument
             pass
         elif op_name != "count":
             kwargs["skipna"] = skipna
@@ -163,17 +160,6 @@ class BaseReduceTests:
             with pytest.raises((TypeError, AttributeError), match=msg):
                 getattr(ser.array, op_name)(**kwargs)
             return
-
-        if (
-            isinstance(ser.array.dtype, pd.SparseDtype)
-            and not skipna
-            and (
-                (op_name in ["min", "max"] and data._hasna)
-                or (op_name == "sum" and not data._hasna)
-            )
-        ):
-            msg = "GH#63512: _reduce doesn't properly handle not skipna"
-            request.node.add_marker(pytest.mark.xfail(reason=msg))
 
         res_op = getattr(ser.array, op_name)
         expected = ser.array._reduce(op_name, **kwargs)

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -116,18 +116,6 @@ class TestSparseArray(base.ExtensionTests):
             return True
 
     @pytest.mark.parametrize("skipna", [True, False])
-    def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna, request):
-        if (
-            all_numeric_reductions in ["sum", "max", "min"]
-            and data.dtype.kind == "f"
-            and not skipna
-        ):
-            mark = pytest.mark.xfail(reason="getting a non-nan float")
-            request.node.add_marker(mark)
-
-        super().test_reduce_series_numeric(data, all_numeric_reductions, skipna)
-
-    @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_frame(self, data, all_numeric_reductions, skipna, request):
         if all_numeric_reductions in [
             "prod",
@@ -141,13 +129,6 @@ class TestSparseArray(base.ExtensionTests):
             mark = pytest.mark.xfail(
                 reason="This should be viable but is not implemented"
             )
-            request.node.add_marker(mark)
-        elif (
-            all_numeric_reductions in ["sum", "max", "min"]
-            and data.dtype.kind == "f"
-            and not skipna
-        ):
-            mark = pytest.mark.xfail(reason="ExtensionArray NA mask are different")
             request.node.add_marker(mark)
 
         super().test_reduce_frame(data, all_numeric_reductions, skipna)


### PR DESCRIPTION
Follow-up to #65494, addressing @jbrockmendel's request to handle the
other reductions on the Series path.

`SparseArray._reduce` only special-cased `mean`, so `Series(sparse).min/max/sum`
with `skipna=False` went through `.dropna()` and silently ignored missing
values. This routes `min`/`max`/`sum` through `_reduce` as well, passing
`skipna` through.

`SparseArray.sum` also had an inverted `skipna=False` NA check
(`has_na = ngaps > 0 and not _null_fill_value`), which flagged non-null fill
gaps as NA and missed actual NaNs under a null fill value — now uses
`self._hasna`, matching `mean`.

Also removes the now-obsolete GH#63512/GH#65478 xfails and workarounds in
the shared reduction test base and the sparse extension tests.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
