### PR TITLE
BUG: fix regression in DataFrame setitem with MultiIndex columns being a silent no-op with object-dtype level

### DIFF
--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -16,6 +16,7 @@ Fixed regressions
 
 - Fixed a regression in setting into a DataFrame with MultiIndex columns and mixed-dtype level silently doing nothing (:issue:`65118`)
 - Fixed performance regression in :meth:`Series.searchsorted` and :meth:`Index.searchsorted` with the string dtype, where a full ``O(n)`` NA scan made the operation much slower than the binary search itself (:issue:`65837`)
+
 .. ---------------------------------------------------------------------------
 .. _whatsnew_304.bug_fixes:
 

--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -14,8 +14,8 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
+- Fixed a regression in setting into a DataFrame with MultiIndex columns and mixed-dtype level silently doing nothing (:issue:`65118`)
 - Fixed performance regression in :meth:`Series.searchsorted` and :meth:`Index.searchsorted` with the string dtype, where a full ``O(n)`` NA scan made the operation much slower than the binary search itself (:issue:`65837`)
-
 .. ---------------------------------------------------------------------------
 .. _whatsnew_304.bug_fixes:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4728,17 +4728,19 @@ class DataFrame(NDFrame, OpsMixin):
                 loc, (slice, Series, np.ndarray, Index)
             ):
                 cols_droplevel = maybe_droplevels(cols, key)
-                if (
-                    not isinstance(cols_droplevel, MultiIndex)
-                    and is_string_dtype(cols_droplevel.dtype)
-                    and not cols_droplevel.any()
-                ):
-                    # if cols_droplevel contains only empty strings,
-                    # value.reindex(cols_droplevel, axis=1) would be full of NaNs
-                    # see GH#62518 and GH#61841
-                    return
                 if len(cols_droplevel) and not cols_droplevel.equals(value.columns):
-                    value = value.reindex(cols_droplevel, axis=1)
+                    if (
+                        not isinstance(cols_droplevel, MultiIndex)
+                        and is_string_dtype(cols_droplevel.dtype)
+                        and (cols_droplevel == "").all()
+                    ):
+                        # if cols_droplevel contains only empty strings,
+                        # value.reindex(cols_droplevel, axis=1) would be full of NaNs
+                        # see GH#62518 and GH#61841
+                        value = value.copy(deep=False)
+                        value.columns = cols_droplevel
+                    else:
+                        value = value.reindex(cols_droplevel, axis=1)
 
                 if not cols_droplevel.equals(cols):
                     # Levels were actually dropped, so we can safely use

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -269,9 +269,8 @@ class TestMultiIndexBasic:
         tm.assert_frame_equal(df1, df2)
         tm.assert_frame_equal(df1, df3)
 
-        df1["C"] = s1
-        tm.assert_frame_equal(df1, df2)
-        tm.assert_frame_equal(df1, df3)
+        df1["C"] = s1 * 2
+        tm.assert_series_equal(df1["C"], df2["C"] * 2)
 
     def test_multiindex_assign_alignment_with_non_string_dtype(self):
         # GH 62518
@@ -293,3 +292,23 @@ class TestMultiIndexBasic:
         )
 
         tm.assert_frame_equal(meta, result)
+
+    def test_multiindex_assign_alignment_with_object_dtype(self):
+        # https://github.com/pandas-dev/pandas/issues/65118
+        # second level of the multiindex is object dtype, and the value of
+        # that level is 0 for the single column we are setting
+
+        columns = MultiIndex.from_tuples(
+            [("A", "M"), ("A", 0), ("B", 1), ("B", 2), ("C", 0)]
+        )
+        df = DataFrame(np.arange(20, dtype=float).reshape(4, 5), columns=columns)
+
+        df["A"] = df["A"] / 100
+        df["B"] = df["B"] / 100
+        # this case specifically was the buggy one
+        df["C"] = df["C"] / 100
+
+        expected = DataFrame(
+            np.arange(20, dtype=float).reshape(4, 5) / 100, columns=columns
+        )
+        tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
This fixed the linked bug report, but actually also fixes the original bug that was intended to be fixed by https://github.com/pandas-dev/pandas/pull/62404 (see inline comment and updated test)



- [x] closes #65118
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
