### PR TITLE
BUG: read_csv(engine="pyarrow") ignores an empty usecols

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -362,8 +362,8 @@ I/O
 ^^^
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
+- Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where an empty ``usecols`` (e.g. ``usecols=[]``) was ignored and returned all columns instead of an empty frame, unlike the other engines (:issue:`66056`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
-- Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where an empty ``usecols`` (e.g. ``usecols=[]``) was ignored and returned all columns instead of an empty frame, unlike the other engines (:issue:`PRNUM`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -363,6 +363,7 @@ I/O
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
+- Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where an empty ``usecols`` (e.g. ``usecols=[]``) was ignored and returned all columns instead of an empty frame, unlike the other engines (:issue:`PRNUM`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -291,6 +291,11 @@ class ArrowParserWrapper(ParserBase):
         except pa.ArrowInvalid as e:
             raise ParserError(e) from e
 
+        if self.usecols_dtype == "empty":
+            # GH#PRNUM pyarrow ignores an empty ``include_columns`` and returns
+            # every column; match the other engines by returning an empty frame.
+            table = table.select([]).slice(0, 0)
+
         dtype_backend = self.kwds["dtype_backend"]
 
         # Convert all pa.null() cols -> float64 (non nullable)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -292,7 +292,7 @@ class ArrowParserWrapper(ParserBase):
             raise ParserError(e) from e
 
         if self.usecols_dtype == "empty":
-            # GH#PRNUM pyarrow ignores an empty ``include_columns`` and returns
+            # GH#66056 pyarrow ignores an empty ``include_columns`` and returns
             # every column; match the other engines by returning an empty frame.
             table = table.select([]).slice(0, 0)
 

--- a/pandas/tests/io/parser/usecols/test_usecols_basic.py
+++ b/pandas/tests/io/parser/usecols/test_usecols_basic.py
@@ -292,7 +292,6 @@ def test_usecols_with_integer_like_header(all_parsers, usecols, expected, reques
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # mismatched shape
 def test_empty_usecols(all_parsers):
     data = "a,b,c\n1,2,3\n4,5,6"
     expected = DataFrame(columns=Index([]))


### PR DESCRIPTION
Reading a CSV with the pyarrow engine and an empty ``usecols`` (e.g. ``usecols=[]`` or ``usecols=set()``) returned the full frame instead of an empty one, unlike the C and python engines. pyarrow treats an empty ``include_columns`` as "all columns", so the selection was silently ignored. We now reduce the result to zero columns and rows to match the other engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)