### PR TITLE
BUG: read_csv(engine="pyarrow") raise a helpful error for list-valued header

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -360,6 +360,7 @@ MultiIndex
 
 I/O
 ^^^
+- :func:`read_csv` with ``engine="pyarrow"`` now raises an informative ``ValueError`` for a list-valued ``header`` (MultiIndex columns are not supported by this engine) instead of a cryptic ``TypeError`` (:issue:`PRPLACEHOLDER`)
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -360,7 +360,7 @@ MultiIndex
 
 I/O
 ^^^
-- :func:`read_csv` with ``engine="pyarrow"`` now raises an informative ``ValueError`` for a list-valued ``header`` (MultiIndex columns are not supported by this engine) instead of a cryptic ``TypeError`` (:issue:`PRPLACEHOLDER`)
+- :func:`read_csv` with ``engine="pyarrow"`` now raises an informative ``ValueError`` for a list-valued ``header`` (MultiIndex columns are not supported by this engine) instead of a cryptic ``TypeError`` (:issue:`66059`)
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -139,11 +139,21 @@ class ArrowParserWrapper(ParserBase):
                 f"f{n}" for n in self.convert_options["include_columns"]
             ]
 
+        header = self.header
+        if isinstance(header, list):
+            # GH#65862 pyarrow.csv cannot produce multi-row/MultiIndex headers
+            if len(header) == 1:
+                header = header[0]
+            else:
+                raise ValueError(
+                    "The 'pyarrow' engine does not support a list of integers "
+                    "for the 'header' argument (MultiIndex columns are not "
+                    "supported)."
+                )
+
         self.read_options = {
-            "autogenerate_column_names": self.header is None,
-            "skip_rows": self.header
-            if self.header is not None
-            else self.kwds["skiprows"],
+            "autogenerate_column_names": header is None,
+            "skip_rows": header if header is not None else self.kwds["skiprows"],
             "encoding": self.encoding,
         }
 

--- a/pandas/tests/io/parser/common/test_index.py
+++ b/pandas/tests/io/parser/common/test_index.py
@@ -146,7 +146,6 @@ bar,two,12,13,14,15
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize(
     "data,columns,header",
     [
@@ -159,11 +158,23 @@ bar,two,12,13,14,15
     ],
 )
 @pytest.mark.parametrize("round_trip", [True, False])
-def test_multi_index_blank_df(all_parsers, data, columns, header, round_trip):
+def test_multi_index_blank_df(all_parsers, data, columns, header, round_trip, request):
     # see gh-14545
     parser = all_parsers
     expected = DataFrame(columns=columns)
     data = expected.to_csv(index=False) if round_trip else data
+
+    if parser.engine == "pyarrow":
+        if len(header) > 1:
+            with pytest.raises(ValueError, match="header"):
+                parser.read_csv(StringIO(data), header=header)
+            return
+        # header=[0] is a singleton, so it behaves like header=0, but the
+        # empty-frame dtypes still differ for the pyarrow engine
+        mark = pytest.mark.xfail(
+            reason="empty frame dtypes differ; apache/arrow#38676 without newline"
+        )
+        request.applymarker(mark)
 
     result = parser.read_csv(StringIO(data), header=header)
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/common/test_index.py
+++ b/pandas/tests/io/parser/common/test_index.py
@@ -166,7 +166,7 @@ def test_multi_index_blank_df(all_parsers, data, columns, header, round_trip, re
 
     if parser.engine == "pyarrow":
         if len(header) > 1:
-            with pytest.raises(ValueError, match="header"):
+            with pytest.raises(ValueError, match="does not support a list of integers"):
                 parser.read_csv(StringIO(data), header=header)
             return
         # header=[0] is a singleton, so it behaves like header=0, but the

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -381,7 +381,7 @@ def test_dtype_multi_index(all_parsers):
     data = "A,B,B\nX,Y,Z\n1,2,3"
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(
                 StringIO(data),
                 header=list(range(2)),

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -375,11 +375,23 @@ def test_dtype_mangle_dup_cols_single_dtype(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.usefixtures("pyarrow_xfail")
 def test_dtype_multi_index(all_parsers):
     # GH 42446
     parser = all_parsers
     data = "A,B,B\nX,Y,Z\n1,2,3"
+
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(
+                StringIO(data),
+                header=list(range(2)),
+                dtype={
+                    ("A", "X"): np.int32,
+                    ("B", "Y"): np.int32,
+                    ("B", "Z"): np.float32,
+                },
+            )
+        return
 
     result = parser.read_csv(
         StringIO(data),

--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -140,7 +140,7 @@ R_l0_g3,R_l1_g3,R3C0,R3C1,R3C2
 R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2
 """
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), header=[0, 1, 2, 3], index_col=[0, 1])
         return
 
@@ -369,7 +369,7 @@ q,r,s,t,u,v
 7,8,9,10,11,12"""
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
         return
 
@@ -395,7 +395,7 @@ q,r,s,t,u,v
 7,8,9,10,11,12"""
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
         return
 
@@ -420,7 +420,7 @@ q,r,s,t,u,v
 7,8,9,10,11,12"""
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), header=[0, 1], index_col=[0, 1])
         return
 
@@ -437,7 +437,7 @@ def test_header_multi_index_blank_line(all_parsers):
     data = "a,b\nA,B\n,\n1,2\n3,4"
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), header=[0, 1])
         return
 
@@ -562,7 +562,7 @@ def test_mangles_multi_index(all_parsers, data, expected):
     parser = all_parsers
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), header=[0, 1])
         return
 
@@ -592,7 +592,7 @@ def test_multi_index_unnamed(all_parsers, index_col, columns):
         data = ",".join([""] + (columns or ["", ""])) + "\n,0,1\n0,2,3\n1,4,5\n"
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), header=header, index_col=index_col)
         return
 
@@ -652,7 +652,7 @@ def test_read_csv_multiindex_columns(all_parsers):
     )
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(s1), header=[0, 1])
         return
 
@@ -672,7 +672,7 @@ row31,row32
 """
 
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(case), header=[0, 2])
         return
 
@@ -721,7 +721,7 @@ def test_header_missing_rows(all_parsers):
 1,2
 """
     if parser.engine == "pyarrow":
-        msg = "header"
+        msg = "does not support a list of integers"
     else:
         msg = r"Passed header=\[0,1,2\], len of 3, but only 2 lines in file"
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/io/parser/test_header.py
+++ b/pandas/tests/io/parser/test_header.py
@@ -26,11 +26,17 @@ xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
 skip_pyarrow = pytest.mark.usefixtures("pyarrow_skip")
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_read_with_bad_header(all_parsers):
     parser = all_parsers
-    msg = r"but only \d+ lines in file"
 
+    if parser.engine == "pyarrow":
+        # header=[10] is a singleton, so it behaves like header=10; pyarrow
+        # cannot skip 10 rows in a 1-line file
+        with pytest.raises(ParserError, match="Could not skip initial 10 rows"):
+            parser.read_csv(StringIO(",,"), header=[10])
+        return
+
+    msg = r"but only \d+ lines in file"
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(",,"), header=[10])
 
@@ -117,7 +123,6 @@ baz,12,13,14,15
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index(all_parsers):
     parser = all_parsers
 
@@ -134,6 +139,11 @@ R_l0_g2,R_l1_g2,R2C0,R2C1,R2C2
 R_l0_g3,R_l1_g3,R3C0,R3C1,R3C2
 R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2
 """
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), header=[0, 1, 2, 3], index_col=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1, 2, 3], index_col=[0, 1])
     data_gen_f = lambda r, c: f"R{r}C{c}"
 
@@ -342,7 +352,6 @@ q,r,s,t,u,v
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index_common_format_malformed1(all_parsers):
     parser = all_parsers
     expected = DataFrame(
@@ -359,11 +368,15 @@ q,r,s,t,u,v
 1,2,3,4,5,6
 7,8,9,10,11,12"""
 
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
     tm.assert_frame_equal(expected, result)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index_common_format_malformed2(all_parsers):
     parser = all_parsers
     expected = DataFrame(
@@ -381,11 +394,15 @@ q,r,s,t,u,v
 1,2,3,4,5,6
 7,8,9,10,11,12"""
 
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1], index_col=0)
     tm.assert_frame_equal(expected, result)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index_common_format_malformed3(all_parsers):
     parser = all_parsers
     expected = DataFrame(
@@ -402,11 +419,15 @@ q,r,s,t,u,v
 1,2,3,4,5,6
 7,8,9,10,11,12"""
 
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), header=[0, 1], index_col=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1], index_col=[0, 1])
     tm.assert_frame_equal(expected, result)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_multi_index_blank_line(all_parsers):
     # GH 40442
     parser = all_parsers
@@ -414,6 +435,12 @@ def test_header_multi_index_blank_line(all_parsers):
     columns = MultiIndex.from_tuples([("a", "A"), ("b", "B")])
     expected = DataFrame(data, columns=columns)
     data = "a,b\nA,B\n,\n1,2\n3,4"
+
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), header=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1])
     tm.assert_frame_equal(expected, result)
 
@@ -480,9 +507,10 @@ def test_non_int_header(all_parsers, header):
         parser.read_csv(StringIO(data), header=header)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_singleton_header(all_parsers):
     # see gh-7757
+    # header=[0] is a singleton, so for the pyarrow engine it behaves like
+    # header=0 (rather than raising for a MultiIndex header)
     data = """a,b,c\n0,1,2\n1,2,3"""
     parser = all_parsers
 
@@ -491,7 +519,6 @@ def test_singleton_header(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize(
     "data,expected",
     [
@@ -534,11 +561,15 @@ def test_mangles_multi_index(all_parsers, data, expected):
     # see gh-18062
     parser = all_parsers
 
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), header=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), header=[0, 1])
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 @pytest.mark.parametrize("index_col", [None, [0]])
 @pytest.mark.parametrize(
     "columns", [None, (["", "Unnamed"]), (["Unnamed", ""]), (["Unnamed", "NotUnnamed"])]
@@ -559,6 +590,11 @@ def test_multi_index_unnamed(all_parsers, index_col, columns):
         data = ",".join(columns or ["", ""]) + "\n0,1\n2,3\n4,5\n"
     else:
         data = ",".join([""] + (columns or ["", ""])) + "\n,0,1\n0,2,3\n1,4,5\n"
+
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), header=header, index_col=index_col)
+        return
 
     result = parser.read_csv(StringIO(data), header=header, index_col=index_col)
     exp_columns = []
@@ -590,7 +626,6 @@ def test_names_longer_than_header_but_equal_with_data_rows(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_read_csv_multiindex_columns(all_parsers):
     # GH#6051
     parser = all_parsers
@@ -616,13 +651,17 @@ def test_read_csv_multiindex_columns(all_parsers):
         [[0.86, 0.67, 0.88, 0.78, 0.81], [0.86, 0.67, 0.88, 0.78, 0.82]], columns=mi
     )
 
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(s1), header=[0, 1])
+        return
+
     df1 = parser.read_csv(StringIO(s1), header=[0, 1])
     tm.assert_frame_equal(df1, expected.iloc[:1])
     df2 = parser.read_csv(StringIO(s2), header=[0, 1])
     tm.assert_frame_equal(df2, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_read_csv_multi_header_length_check(all_parsers):
     # GH#43102
     parser = all_parsers
@@ -631,6 +670,11 @@ def test_read_csv_multi_header_length_check(all_parsers):
 row21,row22, row23
 row31,row32
 """
+
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(case), header=[0, 2])
+        return
 
     with pytest.raises(
         ParserError, match="Header rows must have an equal number of columns."
@@ -670,14 +714,16 @@ def test_header_none_and_on_bad_lines_skip(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_header_missing_rows(all_parsers):
     # GH#47400
     parser = all_parsers
     data = """a,b
 1,2
 """
-    msg = r"Passed header=\[0,1,2\], len of 3, but only 2 lines in file"
+    if parser.engine == "pyarrow":
+        msg = "header"
+    else:
+        msg = r"Passed header=\[0,1,2\], len of 3, but only 2 lines in file"
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), header=[0, 1, 2])
 

--- a/pandas/tests/io/parser/test_index_col.py
+++ b/pandas/tests/io/parser/test_index_col.py
@@ -263,7 +263,7 @@ def test_index_col_multiindex_columns_no_data(all_parsers):
     # GH#38292
     parser = all_parsers
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(
                 StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1], index_col=0
             )
@@ -301,7 +301,7 @@ def test_multiindex_columns_no_data(all_parsers):
     # GH#38292
     parser = all_parsers
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1])
         return
 
@@ -316,7 +316,7 @@ def test_multiindex_columns_index_col_with_data(all_parsers):
     # GH#38292
     parser = all_parsers
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(
                 StringIO("a0,a1,a2\nb0,b1,b2\ndata,data,data"),
                 header=[0, 1],
@@ -383,7 +383,7 @@ e,f,g,h
 x,y,1,2
 """
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), header=[0, 1], index_col=1)
         return
 

--- a/pandas/tests/io/parser/test_index_col.py
+++ b/pandas/tests/io/parser/test_index_col.py
@@ -259,10 +259,16 @@ def test_index_col_large_csv(temp_file, all_parsers, monkeypatch):
     tm.assert_frame_equal(result, df.set_index("a"))
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_index_col_multiindex_columns_no_data(all_parsers):
     # GH#38292
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(
+                StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1], index_col=0
+            )
+        return
+
     result = parser.read_csv(
         StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1], index_col=0
     )
@@ -276,7 +282,9 @@ def test_index_col_multiindex_columns_no_data(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
+# header=[0] is a singleton, so it behaves like header=0; the empty-frame
+# index dtype still differs for the pyarrow engine (float64 vs object)
+@xfail_pyarrow  # AssertionError: DataFrame.index are different
 def test_index_col_header_no_data(all_parsers):
     # GH#38292
     parser = all_parsers
@@ -289,10 +297,14 @@ def test_index_col_header_no_data(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_multiindex_columns_no_data(all_parsers):
     # GH#38292
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1])
+        return
+
     result = parser.read_csv(StringIO("a0,a1,a2\nb0,b1,b2\n"), header=[0, 1])
     expected = DataFrame(
         [], columns=MultiIndex.from_arrays([["a0", "a1", "a2"], ["b0", "b1", "b2"]])
@@ -300,10 +312,18 @@ def test_multiindex_columns_no_data(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_multiindex_columns_index_col_with_data(all_parsers):
     # GH#38292
     parser = all_parsers
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(
+                StringIO("a0,a1,a2\nb0,b1,b2\ndata,data,data"),
+                header=[0, 1],
+                index_col=0,
+            )
+        return
+
     result = parser.read_csv(
         StringIO("a0,a1,a2\nb0,b1,b2\ndata,data,data"), header=[0, 1], index_col=0
     )
@@ -355,7 +375,6 @@ def test_specify_dtype_for_index_col(all_parsers, dtype, val, request):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_multiindex_columns_not_leading_index_col(all_parsers):
     # GH#38549
     parser = all_parsers
@@ -363,6 +382,11 @@ def test_multiindex_columns_not_leading_index_col(all_parsers):
 e,f,g,h
 x,y,1,2
 """
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), header=[0, 1], index_col=1)
+        return
+
     result = parser.read_csv(
         StringIO(data),
         header=[0, 1],

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -594,7 +594,7 @@ def test_date_parser_multiindex_columns(all_parsers):
 1,2
 2019-12-31,6"""
     if parser.engine == "pyarrow":
-        with pytest.raises(ValueError, match="header"):
+        with pytest.raises(ValueError, match="does not support a list of integers"):
             parser.read_csv(StringIO(data), parse_dates=[("a", "1")], header=[0, 1])
         return
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -588,12 +588,16 @@ def test_date_parser_and_names(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-@xfail_pyarrow  # TypeError: an integer is required
 def test_date_parser_multiindex_columns(all_parsers):
     parser = all_parsers
     data = """a,b
 1,2
 2019-12-31,6"""
+    if parser.engine == "pyarrow":
+        with pytest.raises(ValueError, match="header"):
+            parser.read_csv(StringIO(data), parse_dates=[("a", "1")], header=[0, 1])
+        return
+
     result = parser.read_csv(StringIO(data), parse_dates=[("a", "1")], header=[0, 1])
     expected = DataFrame({("a", "1"): Timestamp("2019-12-31"), ("b", "2"): [6]})
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
With ``engine="pyarrow"``, a list-valued ``header`` (e.g. ``header=[0, 1]``, used for MultiIndex columns) is unsupported by ``pyarrow.csv`` and previously surfaced as a cryptic ``TypeError: an integer is required``. It now raises an informative ``ValueError`` explaining that MultiIndex columns are not supported by this engine. A singleton list such as ``header=[N]`` is treated as ``header=N``.

Splits the list-valued ``header`` portion out of GH-65862 into a focused PR; the converted xfails now assert the new error for the pyarrow engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)