### PR TITLE
BUG: read_csv(engine="pyarrow") with dtype="category" produces wrong categories

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -362,6 +362,7 @@ I/O
 ^^^
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
+- Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` and ``dtype="category"`` (or ``CategoricalDtype()``) where columns were categorized from pyarrow-inferred values instead of the raw string values, producing categories that differed from the ``c`` and ``python`` engines (:issue:`10153`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -17,6 +17,7 @@ from pandas.util._exceptions import (
 from pandas.core.dtypes.common import (
     pandas_dtype,
 )
+from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.core.dtypes.inference import is_integer
 
 from pandas.io._util import arrow_table_to_pandas
@@ -28,6 +29,21 @@ if TYPE_CHECKING:
     from pandas._typing import ReadBuffer
 
     from pandas import DataFrame
+
+
+def _is_inferred_categorical(dtype) -> bool:
+    """
+    Whether ``dtype`` is a categorical dtype whose categories should be
+    inferred from the data (``"category"`` or ``CategoricalDtype()``), as
+    opposed to a CategoricalDtype with explicit categories.
+    """
+    if dtype is None:
+        return False
+    try:
+        resolved = pandas_dtype(dtype)
+    except (TypeError, ValueError):
+        return False
+    return isinstance(resolved, CategoricalDtype) and resolved.categories is None
 
 
 class ArrowParserWrapper(ParserBase):
@@ -232,6 +248,38 @@ class ArrowParserWrapper(ParserBase):
                 raise ValueError(str(err)) from err
         return frame
 
+    def _cast_categorical_to_string(self, table: pa.Table) -> pa.Table:
+        """
+        Read columns targeted by an inferred categorical dtype (``"category"``
+        or ``CategoricalDtype()``) as raw strings rather than letting pyarrow
+        infer their type, so the resulting categories match the other engines
+        (GH#10153). Columns with explicit categories are left untouched.
+        """
+        pa = import_optional_dependency("pyarrow")
+
+        dtype = self.dtype
+        if isinstance(dtype, dict):
+            columns = [
+                col
+                for col, col_dtype in dtype.items()
+                if _is_inferred_categorical(col_dtype) and col in table.column_names
+            ]
+        elif _is_inferred_categorical(dtype):
+            columns = list(table.column_names)
+        else:
+            columns = []
+
+        if not columns:
+            return table
+
+        new_schema = table.schema
+        for col in columns:
+            idx = table.schema.get_field_index(col)
+            new_schema = new_schema.set(
+                idx, new_schema.field(idx).with_type(pa.string())
+            )
+        return table.cast(new_schema)
+
     def _finalize_pandas_output(
         self, frame: DataFrame, multi_index_named: bool
     ) -> DataFrame:
@@ -290,6 +338,10 @@ class ArrowParserWrapper(ParserBase):
             )
         except pa.ArrowInvalid as e:
             raise ParserError(e) from e
+
+        # GH#10153 read columns targeted by an inferred categorical dtype as
+        # raw strings so their categories match the other engines
+        table = self._cast_categorical_to_string(table)
 
         dtype_backend = self.kwds["dtype_backend"]
 

--- a/pandas/tests/io/parser/dtypes/test_categorical.py
+++ b/pandas/tests/io/parser/dtypes/test_categorical.py
@@ -26,10 +26,7 @@ pytestmark = pytest.mark.filterwarnings(
     "ignore:Passing a BlockManager to DataFrame:DeprecationWarning"
 )
 
-xfail_pyarrow = pytest.mark.usefixtures("pyarrow_xfail")
 
-
-@xfail_pyarrow  # AssertionError: Attributes of DataFrame.iloc[:, 0] are different
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -77,7 +74,6 @@ def test_categorical_dtype_single(all_parsers, dtype, request):
     tm.assert_frame_equal(actual, expected)
 
 
-@xfail_pyarrow  # AssertionError: Attributes of DataFrame.iloc[:, 0] are different
 def test_categorical_dtype_unsorted(all_parsers):
     # see gh-10153
     parser = all_parsers
@@ -96,7 +92,6 @@ def test_categorical_dtype_unsorted(all_parsers):
     tm.assert_frame_equal(actual, expected)
 
 
-@xfail_pyarrow  # AssertionError: Attributes of DataFrame.iloc[:, 0] are different
 def test_categorical_dtype_missing(all_parsers):
     # see gh-10153
     parser = all_parsers
@@ -115,7 +110,6 @@ def test_categorical_dtype_missing(all_parsers):
     tm.assert_frame_equal(actual, expected)
 
 
-@xfail_pyarrow  # AssertionError: Attributes of DataFrame.iloc[:, 0] are different
 @pytest.mark.slow
 def test_categorical_dtype_high_cardinality_numeric(all_parsers, monkeypatch):
     # see gh-18186


### PR DESCRIPTION
When ``read_csv(engine="pyarrow")`` is given ``dtype="category"`` (or a bare ``CategoricalDtype()``), the pyarrow engine first type-infers each column and only then applies the categorical cast. For an integer column ``1,1,2`` this produced ``Int64``-typed categories, whereas the ``c`` and ``python`` engines categorize the raw string values and produce ``Categorical(["1", "1", "2"])``.

This reads columns targeted by an inferred categorical dtype (``"category"`` / ``CategoricalDtype()``, scalar or via a ``dict``) as raw strings before the categorical cast, so the pyarrow engine matches the other engines. Columns given a ``CategoricalDtype`` with explicit categories are left untouched.

Un-xfails the affected cases in ``test_categorical.py``. The ``{1: "category"}`` int-key case stays xfailed (pyarrow does not support specifying dtype by column index). Reference: GH-10153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)