### PR TITLE
BUG: read_csv(engine="pyarrow") silently ignores non-string na_values

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -360,6 +360,7 @@ MultiIndex
 
 I/O
 ^^^
+- :func:`read_csv` with ``engine="pyarrow"`` now raises an informative ``TypeError`` for non-string ``na_values`` instead of silently ignoring them (:issue:`66061`)
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -54,6 +54,10 @@ class ArrowParserWrapper(ParserBase):
             raise ValueError(
                 "The pyarrow engine doesn't support passing a dict for na_values"
             )
+        # pyarrow's null_values only accepts strings, so reject any non-string
+        #  na_values up front instead of silently ignoring them.
+        if not all(isinstance(na_value, str) for na_value in na_values):
+            raise TypeError("The 'pyarrow' engine requires all na_values to be strings")
         self.na_values = list(self.kwds["na_values"])
 
     def _get_pyarrow_options(self) -> None:
@@ -152,18 +156,12 @@ class ArrowParserWrapper(ParserBase):
 
         try:
             convert_options = pyarrow_csv.ConvertOptions(**self.convert_options)
-        except TypeError as err:
+        except TypeError:
+            # Non-string na_values are rejected in _parse_kwds, so any remaining
+            #  TypeError here is from invalid usecols/include_columns.
             include = self.convert_options.get("include_columns", None)
             if include is not None:
                 self._validate_usecols(include)
-
-            nulls = self.convert_options.get("null_values", set())
-            if not lib.is_list_like(nulls) or not all(
-                isinstance(x, str) for x in nulls
-            ):
-                raise TypeError(
-                    "The 'pyarrow' engine requires all na_values to be strings"
-                ) from err
 
             raise
 


### PR DESCRIPTION
Validates ``na_values`` up front in the pyarrow ``read_csv`` wrapper so that any non-string entry reliably raises the existing ``"The 'pyarrow' engine requires all na_values to be strings"`` ``TypeError`` for the ``pyarrow`` engine, instead of relying on pyarrow's ``ConvertOptions`` to raise.

Previously the check lived only in an ``except TypeError`` handler around ``ConvertOptions``, which could be bypassed for non-string types that pyarrow happens to accept (e.g. ``bytes``). The C and Python engines are unchanged.

Existing tests in ``test_na_values.py`` already cover non-string ``na_values`` (scalar/list/set) and continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)