### PR TITLE
[backport 3.0.x] ENH: fallback to zoneinfo Python API (for correct tz localization) for distant dates (#65733)

### DIFF
--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -15,6 +15,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed performance regression in :meth:`Series.searchsorted` and :meth:`Index.searchsorted` with the string dtype, where a full ``O(n)`` NA scan made the operation much slower than the binary search itself (:issue:`65837`)
+- Fixed regression in localizing timestamps beyond the year 2100 when using ``zoneinfo`` timezones (:issue:`65733`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_304.bug_fixes:

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -711,7 +711,7 @@ cdef check_overflows(_TSObject obj, NPY_DATETIMEUNIT reso=NPY_FR_ns):
 # ----------------------------------------------------------------------
 # Localization
 
-cdef void _localize_tso(_TSObject obj, tzinfo tz, NPY_DATETIMEUNIT reso) noexcept:
+cdef int _localize_tso(_TSObject obj, tzinfo tz, NPY_DATETIMEUNIT reso) except -1:
     """
     Given the UTC nanosecond timestamp in obj.value, find the wall-clock
     representation of that timestamp in the given timezone.
@@ -751,6 +751,8 @@ cdef void _localize_tso(_TSObject obj, tzinfo tz, NPY_DATETIMEUNIT reso) noexcep
         pandas_datetime_to_datetimestruct(local_val, reso, &obj.dts)
 
     obj.tzinfo = tz
+
+    return 1
 
 
 cdef datetime _localize_pydatetime(datetime dt, tzinfo tz):

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -304,6 +304,9 @@ cdef tuple _get_zoneinfo_trans_and_deltas(tzinfo tz):
         Nanosecond UTC offsets corresponding to DST transitions.
     is_fixed : bint
         True if this is a fixed-offset timezone with no transitions.
+    has_tz_tule : bint
+        Bool indicating if the tz has a "rule" attached describing transitions
+        after the array of trans/deltas.
     """
     cdef:
         int64_t fixed_offset_seconds, last_hist_ts, start_utc, end_utc
@@ -316,7 +319,7 @@ cdef tuple _get_zoneinfo_trans_and_deltas(tzinfo tz):
         fixed_offset_seconds = int(tz_py._tz_after.utcoff.total_seconds())
         trans = np.array([NPY_NAT + 1], dtype=np.int64)
         deltas = np.array([fixed_offset_seconds], dtype="i8") * 1_000_000_000
-        return trans, deltas, True
+        return trans, deltas, True, False
 
     trans_utc = list(tz_py._trans_utc)
     deltas_seconds = [int(info.utcoff.total_seconds()) for info in tz_py._ttinfos]
@@ -375,7 +378,7 @@ cdef tuple _get_zoneinfo_trans_and_deltas(tzinfo tz):
     deltas = np.array(deltas_seconds, dtype="i8") * 1_000_000_000
     deltas = np.hstack([[first_offset_seconds * 1_000_000_000], deltas])
 
-    return trans, deltas, False
+    return trans, deltas, False, has_future_dst
 
 
 cdef object get_dst_info(tzinfo tz):
@@ -388,6 +391,9 @@ cdef object get_dst_info(tzinfo tz):
         Nanosecond UTC offsets corresponding to DST transitions.
     str
         Describing the type of tzinfo object.
+    has_tz_rule
+        Bool indicating if the tz has a "rule" attached describing transitions
+        after the array of transitions/deltas (only used for ZoneInfo).
     """
     cache_key = tz_cache_key(tz)
     if cache_key is None:
@@ -398,8 +404,10 @@ cdef object get_dst_info(tzinfo tz):
         #  so the total_seconds() call will raise AttributeError.
         return (np.array([NPY_NAT + 1], dtype=np.int64),
                 np.array([num], dtype=np.int64),
-                "unknown")
+                "unknown",
+                False)
 
+    has_tz_rule = False
     if cache_key not in dst_cache:
         if treat_tz_as_pytz(tz):
             trans = np.array(tz._utc_transition_times, dtype="M8[ns]")
@@ -442,7 +450,7 @@ cdef object get_dst_info(tzinfo tz):
                                      "and has an empty `_trans_list`.", tz)
 
         elif is_zoneinfo(tz):
-            trans, deltas, is_fixed = _get_zoneinfo_trans_and_deltas(tz)
+            trans, deltas, is_fixed, has_tz_rule = _get_zoneinfo_trans_and_deltas(tz)
             typ = "fixed" if is_fixed else "zoneinfo"
 
         else:
@@ -453,7 +461,7 @@ cdef object get_dst_info(tzinfo tz):
             deltas = np.array([num], dtype=np.int64)
             typ = "static"
 
-        dst_cache[cache_key] = (trans, deltas, typ)
+        dst_cache[cache_key] = (trans, deltas, typ, has_tz_rule)
 
     return dst_cache[cache_key]
 

--- a/pandas/_libs/tslibs/tzconversion.pxd
+++ b/pandas/_libs/tslibs/tzconversion.pxd
@@ -24,12 +24,14 @@ cdef class Localizer:
     cdef:
         tzinfo tz
         NPY_DATETIMEUNIT _creso
-        bint use_utc, use_fixed, use_tzlocal, use_dst, use_pytz
+        bint use_utc, use_fixed, use_tzlocal, use_dst, use_pytz, use_zoneinfo
+        bint has_tz_rule
         ndarray trans
         Py_ssize_t ntrans
         const int64_t[::1] deltas
         int64_t delta
         int64_t* tdata
+        int64_t last_trans
 
     cdef int64_t utc_val_to_local_val(
         self,

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -58,12 +58,14 @@ cdef class Localizer:
     # cdef:
     #    tzinfo tz
     #    NPY_DATETIMEUNIT _creso
-    #    bint use_utc, use_fixed, use_tzlocal, use_dst, use_pytz
+    #    bint use_utc, use_fixed, use_tzlocal, use_dst, use_pytz, use_zoneinfo
+    #    bint has_tz_rule
     #    ndarray trans
     #    Py_ssize_t ntrans
     #    const int64_t[::1] deltas
     #    int64_t delta
     #    int64_t* tdata
+    #    int64_t last_trans
 
     @cython.initializedcheck(False)
     @cython.boundscheck(False)
@@ -71,9 +73,11 @@ cdef class Localizer:
         self.tz = tz
         self._creso = creso
         self.use_utc = self.use_tzlocal = self.use_fixed = False
-        self.use_dst = self.use_pytz = False
+        self.use_dst = self.use_pytz = self.use_zoneinfo = False
+        self.has_tz_rule = False
         self.ntrans = -1  # placeholder
         self.delta = -1  # placeholder
+        self.last_trans = -1  # placeholder
         self.deltas = _deltas_placeholder
         self.tdata = NULL
 
@@ -84,7 +88,7 @@ cdef class Localizer:
             self.use_tzlocal = True
 
         else:
-            trans, deltas, typ = get_dst_info(tz)
+            trans, deltas, typ, has_tz_rule = get_dst_info(tz)
             if creso != NPY_DATETIMEUNIT.NPY_FR_ns:
                 # NB: using floordiv here is implicitly assuming we will
                 #  never see trans or deltas that are not an integer number
@@ -105,6 +109,14 @@ cdef class Localizer:
             self.trans = trans
             self.ntrans = self.trans.shape[0]
             self.deltas = deltas
+            self.has_tz_rule = has_tz_rule
+            # since we are sometimes comparing local times with UTC transitions,
+            # subtract 12 hours (12 * 60 * 60) to be safe
+            # (i.e. ensure to use correct but slower path around the last transition)
+            if has_tz_rule:
+                self.last_trans = (
+                    trans[self.ntrans - 1] - (43200 * periods_per_second(creso))
+                )
 
             if typ != "pytz" and typ != "dateutil" and typ != "zoneinfo":
                 # static/fixed; in this case we know that len(delta) == 1
@@ -114,6 +126,8 @@ cdef class Localizer:
                 self.use_dst = True
                 if typ == "pytz":
                     self.use_pytz = True
+                elif typ == "zoneinfo":
+                    self.use_zoneinfo = True
                 self.tdata = <int64_t*>cnp.PyArray_DATA(trans)
 
     @cython.boundscheck(False)
@@ -129,6 +143,15 @@ cdef class Localizer:
         elif self.use_fixed:
             return utc_val + self.delta
         else:
+            if (
+                self.use_zoneinfo
+                and self.has_tz_rule
+                and utc_val > self.last_trans
+            ):
+                return utc_val + _tz_localize_using_tzinfo_api(
+                    utc_val, self.tz, to_utc=False, creso=self._creso, fold=fold
+                )
+
             pos[0] = bisect_right_i8(self.tdata, utc_val, self.ntrans) - 1
             if fold is not NULL:
                 fold[0] = _infer_dateutil_fold(
@@ -160,7 +183,7 @@ cdef int64_t tz_localize_to_utc_single(
         return val - _tz_localize_using_tzinfo_api(val, tz, to_utc=True, creso=creso)
 
     elif is_fixed_offset(tz):
-        _, deltas, _ = get_dst_info(tz)
+        _, deltas, _, _ = get_dst_info(tz)
         delta = deltas[0]
         # TODO: de-duplicate with Localizer.__init__
         if creso != NPY_DATETIMEUNIT.NPY_FR_ns:
@@ -306,9 +329,7 @@ timedelta-like}
 
     # Determine whether each date lies left of the DST transition (store in
     # result_a) or right of the DST transition (store in result_b)
-    result_a, result_b =_get_utc_bounds(
-        vals, info.tdata, info.ntrans, info.deltas, creso=creso
-    )
+    result_a, result_b = _get_utc_bounds(vals, info)
 
     # silence false-positive compiler warning
     dst_hours = np.empty(0, dtype=np.int64)
@@ -386,17 +407,32 @@ timedelta-like}
                     # nonexistent times
                     new_local = val - remaining_mins - 1
 
-                delta_idx = bisect_right_i8(info.tdata, new_local, info.ntrans)
-                # Logic similar to the precompute section. But check the current
-                # delta in case we are moving between UTC+0 and non-zero timezone
                 if (
-                    (shift_forward or shift_delta > 0)
-                    and info.deltas[delta_idx - 1] >= 0
+                    info.use_zoneinfo
+                    and info.has_tz_rule
+                    and new_local > info.last_trans
                 ):
-                    delta_idx = delta_idx - 1
+                    if shift_forward or shift_delta > 0:
+                        delta = _tz_localize_using_tzinfo_api(
+                            new_local, tz, True, creso, NULL, 0
+                        )
+                    else:
+                        delta = _tz_localize_using_tzinfo_api(
+                            new_local, tz, True, creso, NULL, 1
+                        )
+                    result[i] = new_local - delta
                 else:
-                    delta_idx = delta_idx - delta_idx_offset
-                result[i] = new_local - info.deltas[delta_idx]
+                    delta_idx = bisect_right_i8(info.tdata, new_local, info.ntrans)
+                    # Logic similar to the precompute section. But check the current
+                    # delta in case we are moving between UTC+0 and non-zero timezone
+                    if (
+                        (shift_forward or shift_delta > 0)
+                        and info.deltas[delta_idx - 1] >= 0
+                    ):
+                        delta_idx = delta_idx - 1
+                    else:
+                        delta_idx = delta_idx - delta_idx_offset
+                    result[i] = new_local - info.deltas[delta_idx]
             elif fill_nonexist:
                 result[i] = NPY_NAT
             else:
@@ -449,20 +485,20 @@ cdef str _render_tstamp(int64_t val, NPY_DATETIMEUNIT creso):
     return str(ts)
 
 
-cdef _get_utc_bounds(
-    ndarray[int64_t] vals,
-    const int64_t* tdata,
-    Py_ssize_t ntrans,
-    const int64_t[::1] deltas,
-    NPY_DATETIMEUNIT creso,
-):
+cdef _get_utc_bounds(ndarray[int64_t] vals, Localizer info):
     # Determine whether each date lies left of the DST transition (store in
     # result_a) or right of the DST transition (store in result_b)
 
     cdef:
         ndarray[int64_t] result_a, result_b
         Py_ssize_t i, n = vals.size
-        int64_t val, v_left, v_right
+        const int64_t* tdata = info.tdata
+        const int64_t[::1] deltas = info.deltas
+        Py_ssize_t ntrans = info.ntrans
+        NPY_DATETIMEUNIT creso = info._creso
+        bint use_zoneinfo = info.use_zoneinfo
+        tzinfo tz = info.tz
+        int64_t val, v_left, v_right, delta0, delta1, local0, local1
         Py_ssize_t isl, isr, pos_left, pos_right
         int64_t ppd = periods_per_day(creso)
 
@@ -477,6 +513,29 @@ cdef _get_utc_bounds(
 
         val = vals[i]
         if val == NPY_NAT:
+            continue
+
+        if use_zoneinfo and info.has_tz_rule and val > info.last_trans:
+            # For values beyond cached transition coverage, derive the two
+            # candidate UTC instants via zoneinfo and keep whichever
+            # round-trip back to this wall time.
+            delta0 = _tz_localize_using_tzinfo_api(val, tz, True, creso, NULL, 0)
+            delta1 = _tz_localize_using_tzinfo_api(val, tz, True, creso, NULL, 1)
+
+            v_left = val - delta0
+            v_right = val - delta1
+
+            local0 = v_left + _tz_localize_using_tzinfo_api(
+                v_left, tz, to_utc=False, creso=creso
+            )
+            local1 = v_right + _tz_localize_using_tzinfo_api(
+                v_right, tz, to_utc=False, creso=creso
+            )
+
+            if local0 == val:
+                result_a[i] = v_left
+            if local1 == val:
+                result_b[i] = v_right
             continue
 
         # TODO: be careful of overflow in val-ppd
@@ -623,6 +682,7 @@ cdef int64_t _tz_localize_using_tzinfo_api(
     bint to_utc=True,
     NPY_DATETIMEUNIT creso=NPY_DATETIMEUNIT.NPY_FR_ns,
     bint* fold=NULL,
+    int fold_in=-1,
 ) except? -1:
     """
     Convert the i8 representation of a datetime from a general-case timezone to
@@ -640,7 +700,9 @@ cdef int64_t _tz_localize_using_tzinfo_api(
     fold : bint*, default NULL
         pointer to fold: whether datetime ends up in a fold or not
         after adjustment.
-        Only passed with to_utc=False.
+        Only used with to_utc=False.
+    fold_in : int, default -1
+        Input fold when to_utc=True. By default, not specified (-1).
 
     Returns
     -------
@@ -670,8 +732,18 @@ cdef int64_t _tz_localize_using_tzinfo_api(
             # NB: fold is only passed with to_utc=False
             fold[0] = dt.fold
     else:
-        dt = datetime_new(dts.year, dts.month, dts.day, dts.hour,
-                          dts.min, dts.sec, dts.us, None)
+        try:
+            if fold_in == -1:
+                dt = datetime_new(dts.year, dts.month, dts.day, dts.hour,
+                                  dts.min, dts.sec, dts.us, None)
+            else:
+                dt = datetime_new(dts.year, dts.month, dts.day, dts.hour,
+                                  dts.min, dts.sec, dts.us, None, fold=fold_in)
+        except ValueError as err:
+            raise NotImplementedError(
+                "Localizing Timestamps which are outside the range of Python's "
+                f"standard library datetime is not supported ({err})."
+            ) from err
 
     td = tz.utcoffset(dt)
     delta = int(td.total_seconds() * pps)
@@ -694,8 +766,15 @@ cdef datetime _astimezone(npy_datetimestruct dts, tzinfo tz):
     cdef:
         datetime result
 
-    result = datetime_new(dts.year, dts.month, dts.day, dts.hour,
-                          dts.min, dts.sec, dts.us, tz)
+    try:
+        result = datetime_new(dts.year, dts.month, dts.day, dts.hour,
+                              dts.min, dts.sec, dts.us, tz)
+    except ValueError as err:
+        raise NotImplementedError(
+            "Localizing Timestamps which are outside the range of Python's "
+            f"standard library datetime is not supported ({err})."
+        ) from err
+
     return tz.fromutc(result)
 
 

--- a/pandas/tests/scalar/timestamp/methods/test_tz_localize.py
+++ b/pandas/tests/scalar/timestamp/methods/test_tz_localize.py
@@ -14,6 +14,17 @@ from pandas import (
 )
 
 
+def _distant_date_only_for_zoneinfo(year, tz):
+    if int(year) >= 2200:
+        if isinstance(tz, zoneinfo.ZoneInfo):
+            return
+        elif isinstance(tz, str) and not tz.startswith(("dateutil/", "pytz/")):
+            # zoneinfo tz passed as string
+            return
+        else:
+            pytest.skip("ZoneInfo required for year >= 2200")
+
+
 class TestTimestampTZLocalize:
     def test_tz_localize_pushes_out_of_bounds(self):
         # GH#12677
@@ -66,8 +77,9 @@ class TestTimestampTZLocalize:
         assert result == expected1
         assert result._creso == getattr(NpyDatetimeUnit, f"NPY_FR_{unit}").value
 
-    def test_tz_localize_ambiguous(self):
-        ts = Timestamp("2014-11-02 01:00").as_unit("s")
+    @pytest.mark.parametrize("year", ["2014", "2200"])
+    def test_tz_localize_ambiguous(self, year):
+        ts = Timestamp(f"{year}-11-02 01:00").as_unit("s")
         ts_dst = ts.tz_localize("US/Eastern", ambiguous=True)
         ts_no_dst = ts.tz_localize("US/Eastern", ambiguous=False)
 
@@ -79,6 +91,7 @@ class TestTimestampTZLocalize:
         with pytest.raises(ValueError, match=msg):
             ts.tz_localize("US/Eastern", ambiguous="infer")
 
+    def test_tz_localize_invalid(self):
         # GH#8025
         msg = "Cannot localize tz-aware Timestamp, use tz_convert for conversions"
         with pytest.raises(TypeError, match=msg):
@@ -88,6 +101,7 @@ class TestTimestampTZLocalize:
         with pytest.raises(TypeError, match=msg):
             Timestamp("2011-01-01").tz_convert("Asia/Tokyo")
 
+    @pytest.mark.parametrize("year", ["2015", "2201"])
     @pytest.mark.parametrize(
         "stamp, tz",
         [
@@ -97,8 +111,9 @@ class TestTimestampTZLocalize:
             ("2015-03-29 02:30", "Europe/Belgrade"),
         ],
     )
-    def test_tz_localize_nonexistent(self, stamp, tz):
+    def test_tz_localize_nonexistent(self, stamp, tz, year):
         # GH#13057
+        stamp = stamp.replace("2015", year)
         ts = Timestamp(stamp)
         with pytest.raises(ValueError, match=stamp):
             ts.tz_localize(tz)
@@ -239,26 +254,27 @@ class TestTimestampTZLocalize:
         assert result.hour == expected.hour
         assert result == expected
 
+    @pytest.mark.parametrize("year", ["2018", "2204"])
     @pytest.mark.parametrize(
         "start_ts, tz, end_ts, shift",
         [
-            ["2015-03-29 02:20:00", "Europe/Warsaw", "2015-03-29 03:00:00", "forward"],
+            ["2018-03-25 02:20:00", "Europe/Warsaw", "2018-03-25 03:00:00", "forward"],
             [
-                "2015-03-29 02:20:00",
+                "2018-03-25 02:20:00",
                 "Europe/Warsaw",
-                "2015-03-29 01:59:59.999999999",
+                "2018-03-25 01:59:59.999999999",
                 "backward",
             ],
             [
-                "2015-03-29 02:20:00",
+                "2018-03-25 02:20:00",
                 "Europe/Warsaw",
-                "2015-03-29 03:20:00",
+                "2018-03-25 03:20:00",
                 timedelta(hours=1),
             ],
             [
-                "2015-03-29 02:20:00",
+                "2018-03-25 02:20:00",
                 "Europe/Warsaw",
-                "2015-03-29 01:20:00",
+                "2018-03-25 01:20:00",
                 timedelta(hours=-1),
             ],
             ["2018-03-11 02:33:00", "US/Pacific", "2018-03-11 03:00:00", "forward"],
@@ -284,9 +300,13 @@ class TestTimestampTZLocalize:
     )
     @pytest.mark.parametrize("tz_type", ["", "dateutil/"])
     def test_timestamp_tz_localize_nonexistent_shift(
-        self, start_ts, tz, end_ts, shift, tz_type, unit
+        self, start_ts, tz, end_ts, shift, year, tz_type, unit
     ):
         # GH 8917, 24466
+        if year == "2204" and tz_type == "dateutil/":
+            pytest.skip("ZoneInfo required for year >= 2200")
+        start_ts = start_ts.replace("2018", year)
+        end_ts = end_ts.replace("2018", year)
         tz = tz_type + tz
         if isinstance(shift, str):
             shift = "shift_" + shift
@@ -305,27 +325,35 @@ class TestTimestampTZLocalize:
             assert result == expected
         assert result._creso == getattr(NpyDatetimeUnit, f"NPY_FR_{unit}").value
 
+    @pytest.mark.parametrize("year", ["2015", "2201"])
     @pytest.mark.parametrize("offset", [-1, 1])
-    def test_timestamp_tz_localize_nonexistent_shift_invalid(self, offset, warsaw):
+    def test_timestamp_tz_localize_nonexistent_shift_invalid(
+        self, offset, year, warsaw
+    ):
         # GH 8917, 24466
         tz = warsaw
-        ts = Timestamp("2015-03-29 02:20:00")
+        _distant_date_only_for_zoneinfo(year, tz)
+        ts = Timestamp(f"{year}-03-29 02:20:00")
         msg = "The provided timedelta will relocalize on a nonexistent time"
         with pytest.raises(ValueError, match=msg):
             ts.tz_localize(tz, nonexistent=timedelta(seconds=offset))
 
-    def test_timestamp_tz_localize_nonexistent_NaT(self, warsaw, unit):
+    @pytest.mark.parametrize("year", ["2015", "2201"])
+    def test_timestamp_tz_localize_nonexistent_NaT(self, year, warsaw, unit):
         # GH 8917
         tz = warsaw
-        ts = Timestamp("2015-03-29 02:20:00").as_unit(unit)
+        _distant_date_only_for_zoneinfo(year, tz)
+        ts = Timestamp(f"{year}-03-29 02:20:00").as_unit(unit)
         result = ts.tz_localize(tz, nonexistent="NaT")
         assert result is NaT
 
-    def test_timestamp_tz_localize_nonexistent_raise(self, warsaw, unit):
+    @pytest.mark.parametrize("year", ["2015", "2201"])
+    def test_timestamp_tz_localize_nonexistent_raise(self, year, warsaw, unit):
         # GH 8917
         tz = warsaw
-        ts = Timestamp("2015-03-29 02:20:00").as_unit(unit)
-        msg = "2015-03-29 02:20:00"
+        _distant_date_only_for_zoneinfo(year, tz)
+        ts = Timestamp(f"{year}-03-29 02:20:00").as_unit(unit)
+        msg = f"{year}-03-29 02:20:00"
         with pytest.raises(ValueError, match=msg):
             ts.tz_localize(tz, nonexistent="raise")
         msg = (

--- a/pandas/tests/series/methods/test_tz_localize.py
+++ b/pandas/tests/series/methods/test_tz_localize.py
@@ -59,6 +59,7 @@ class TestTZLocalize:
         )
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("year", ["2015", "2201"])
     @pytest.mark.parametrize(
         "method, exp",
         [
@@ -69,11 +70,16 @@ class TestTZLocalize:
             ["foo", "invalid"],
         ],
     )
-    def test_tz_localize_nonexistent(self, warsaw, method, exp, unit):
+    def test_tz_localize_nonexistent(self, warsaw, method, exp, year, unit):
         # GH 8917
         tz = warsaw
+        if year == "2201" and (not isinstance(tz, str) or tz.startswith("dateutil/")):
+            # zoneinfo tz passed as string
+            pytest.skip("ZoneInfo required for year 2201")
         n = 60
-        dti = date_range(start="2015-03-29 02:00:00", periods=n, freq="min", unit=unit)
+        dti = date_range(
+            start=f"{year}-03-29 02:00:00", periods=n, freq="min", unit=unit
+        )
         ser = Series(1, index=dti)
         df = ser.to_frame()
 
@@ -99,6 +105,8 @@ class TestTZLocalize:
                 df.tz_localize(tz, nonexistent=method)
 
         else:
+            if isinstance(exp, str):
+                exp = exp.replace("2015", year)
             result = ser.tz_localize(tz, nonexistent=method)
             expected = Series(1, index=DatetimeIndex([exp] * n, tz=tz).as_unit(unit))
             tm.assert_series_equal(result, expected)

--- a/pandas/tests/tseries/offsets/test_common.py
+++ b/pandas/tests/tseries/offsets/test_common.py
@@ -154,9 +154,13 @@ def test_apply_out_of_range(request, tz_naive_fixture, _offset):
 
     except OutOfBoundsDatetime:
         pass
-    except (ValueError, KeyError):
+    except (ValueError, KeyError, NotImplementedError, OverflowError, OSError):
         # we are creating an invalid offset
         # so ignore
+        # - NotImplementedError is raised for tz-aware timestamps outside Python's
+        #   range that are created by adding the offset
+        # - OverflowError is raised in the same case on 32-bit systems with tzlocal
+        # - OSError is raised in the same case on Windows with tzlocal
         pass
 
 

--- a/pandas/tests/tslibs/test_timezones.py
+++ b/pandas/tests/tslibs/test_timezones.py
@@ -16,11 +16,18 @@ from pandas._libs.tslibs import (
     conversion,
     timezones,
 )
-from pandas.compat import is_platform_windows
+from pandas.compat import (
+    IS64,
+    is_platform_windows,
+)
 
+import pandas as pd
 from pandas import (
+    Index,
+    Timedelta,
     Timestamp,
     date_range,
+    to_datetime,
 )
 import pandas._testing as tm
 
@@ -231,6 +238,159 @@ def test_zoneinfo_utc_to_local_post_2037():
     tm.assert_numpy_array_equal(local.hour.to_numpy(), expected_hours)
 
 
+@pytest.mark.parametrize(
+    "tz_name", ["America/New_York", "Australia/Melbourne", "Europe/Kaliningrad"]
+)
+def test_zoneinfo_utc_to_local_post_2100(tz_name):
+    # GH#65712 - verify zoneinfo-generated future DST transitions are used
+    # beyond year 2100 for both hemispheres.
+    # Europe/Kaliningrad is a special case because it has no rule for future DST
+    # transitions (and is also not a fixed offset timezone)
+    tz = zoneinfo.ZoneInfo(tz_name)
+    # fmt: off
+    data = [
+        "2038-01-01", "2038-07-01",
+        "2100-01-01", "2100-07-01",
+        "2200-01-01", "2200-07-01",
+    ]
+    # fmt: on
+    utc_times = to_datetime(data, utc=True)
+    local = utc_times.tz_convert(tz)
+
+    expected = [
+        datetime.fromisoformat(date).replace(tzinfo=timezone.utc).astimezone(tz)
+        for date in data
+    ]
+
+    tm.assert_numpy_array_equal(local.to_pydatetime(), np.array(expected))
+    assert [ts.utcoffset() for ts in local] == [dt.utcoffset() for dt in expected]
+
+
+def test_zoneinfo_utc_to_local_far_future_seconds_resolution():
+    # GH#65712 - for dates beyond cached transition data, we should fall back
+    # to zoneinfo's API and preserve correct DST offsets.
+    utc_times = to_datetime(
+        np.array(["3000-01-01T00:00:00", "3000-07-01T00:00:00"], dtype="M8[s]"),
+        utc=True,
+    )
+    local = utc_times.tz_convert("Europe/Brussels")
+
+    tz = zoneinfo.ZoneInfo("Europe/Brussels")
+    expected = [
+        datetime(3000, 1, 1, tzinfo=timezone.utc).astimezone(tz),
+        datetime(3000, 7, 1, tzinfo=timezone.utc).astimezone(tz),
+    ]
+
+    assert local.dtype == "datetime64[s, Europe/Brussels]"
+    tm.assert_numpy_array_equal(local.to_pydatetime(), np.array(expected))
+
+
+def test_zoneinfo_local_to_utc_far_future_seconds_resolution():
+    # GH#65712 - localize should also preserve future DST rules when converting
+    # from local wall times to UTC beyond cached transition data.
+    local_times = to_datetime(
+        np.array(["3000-01-01T00:00:00", "3000-07-01T00:00:00"], dtype="M8[s]")
+    )
+    localized = local_times.tz_localize("Europe/Brussels")
+    result_utc = localized.tz_convert("UTC")
+
+    tz = zoneinfo.ZoneInfo("Europe/Brussels")
+    expected_utc = [
+        datetime(3000, 1, 1, tzinfo=tz).astimezone(timezone.utc),
+        datetime(3000, 7, 1, tzinfo=tz).astimezone(timezone.utc),
+    ]
+
+    assert result_utc.dtype == "datetime64[s, UTC]"
+    tm.assert_numpy_array_equal(result_utc.to_pydatetime(), np.array(expected_utc))
+
+
+@pytest.mark.skipif(
+    not IS64,
+    reason="stdlib datetime.fromtimestamp fails on 32-bit platforms with overflow",
+)
+@pytest.mark.parametrize(
+    "tz_name",
+    ["America/New_York", "America/Santiago", "Australia/Melbourne", "Europe/Brussels"],
+)
+def test_zoneinfo_boundary_at_last_cached_transition(tz_name):
+    # GH#65733 - target the boundary where UTC is beyond the cached transition
+    # range while local wall time can still compare below that UTC cutoff.
+    tz = zoneinfo.ZoneInfo(tz_name)
+
+    from zoneinfo._zoneinfo import ZoneInfo
+
+    trans = datetime.fromtimestamp(max(ZoneInfo(tz_name)._tz_after.transitions(2099)))
+    start = (trans - timedelta(days=1)).replace(tzinfo=timezone.utc)
+    expected_utc = [(start + timedelta(minutes=30 * i)) for i in range(24 * 2 * 2)]
+    expected_tz = [ts.astimezone(tz) for ts in expected_utc]
+    expected_str = [str(ts) for ts in expected_tz]
+
+    local = to_datetime([v[:-6] for v in expected_str])
+
+    # ambiguous keyword only needed for timezones of northern hemisphere, ignored for
+    # the others
+    result = local.tz_localize(tz_name, ambiguous="infer")
+
+    # verify local to UTC
+    tm.assert_equal(
+        result.tz_convert("UTC").to_pydatetime(), np.array(expected_utc, dtype="O")
+    )
+    # verify UTC to local by converting to pydatetime/str repr of underlying UTC value
+    tm.assert_equal(result.astype(str), Index(expected_str))
+    tm.assert_equal(result.to_pydatetime(), np.array(expected_tz, dtype="O"))
+
+
+@pytest.mark.parametrize(
+    "tz_name",
+    ["America/New_York", "America/Santiago", "Australia/Melbourne", "Europe/Brussels"],
+)
+def test_zoneinfo_nonexistent_at_last_cached_transition(tz_name):
+    # GH#65733 - target the boundary where UTC is beyond the cached transition
+    # range while local wall time can still compare below that UTC cutoff.
+    tz = zoneinfo.ZoneInfo(tz_name)
+
+    from zoneinfo._zoneinfo import ZoneInfo
+
+    start, end = ZoneInfo(tz_name)._tz_after.transitions(2099)
+    if start > end:
+        # to-dst nonexistent transition at the end of the year
+        ts = Timestamp(start, unit="s") + Timedelta(minutes=30)
+
+        with pytest.raises(ValueError, match="nonexistent time"):
+            ts.tz_localize(tz_name)
+
+        result = ts.tz_localize(tz_name, nonexistent="NaT")
+        assert result is pd.NaT
+
+        result_dst = ts.tz_localize(tz_name, nonexistent="shift_forward")
+        expected_dst = (ts.to_pydatetime() + timedelta(minutes=30)).replace(tzinfo=tz)
+        assert result_dst.to_pydatetime() == expected_dst
+
+        result_std = ts.tz_localize(tz_name, nonexistent="shift_backward")
+        expected_std = (
+            ts.to_pydatetime() - timedelta(minutes=30, microseconds=1)
+        ).replace(tzinfo=tz)
+        assert result_std.to_pydatetime() == expected_std
+
+    else:
+        # to-std ambiguous transition at the end of the year
+        ts = Timestamp(end, unit="s") - Timedelta(minutes=30)
+
+        with pytest.raises(ValueError, match="Cannot infer dst time"):
+            ts.tz_localize(tz_name)
+
+        result = ts.tz_localize(tz_name, ambiguous="NaT")
+        assert result is pd.NaT
+
+        result_dst = ts.tz_localize(tz_name, ambiguous=True)
+        expected_dst = ts.to_pydatetime().replace(fold=0, tzinfo=tz)
+        assert result_dst.to_pydatetime() == expected_dst
+
+        result_dst = ts.tz_localize(tz_name, ambiguous=False)
+        expected_dst = ts.to_pydatetime().replace(fold=1, tzinfo=tz)
+        assert result_dst.to_pydatetime() == expected_dst
+
+
 @pytest.mark.parametrize("key", ["US/Eastern", "Africa/Lusaka", "Asia/Qyzylorda"])
 def test_zoneinfo_utc_to_local_pre_first_transition(key):
     # GH#64363 - verify that ZoneInfo offsets before the first historical
@@ -242,6 +402,19 @@ def test_zoneinfo_utc_to_local_pre_first_transition(key):
 
     expected = datetime(1850, 1, 1, tzinfo=timezone.utc).astimezone(tz)
     assert ts.minute == expected.minute
+
+
+def test_zoneinfo_conversion_outside_range_stdlib():
+    # GH#65733 - verify that datetimes outside the range of Python's standard
+    # library (year > 9999) raises a proper error message
+    ts = Timestamp(np.datetime64("10000-01-01T09:00:00", "us"))
+
+    msg = "Localizing Timestamps which are outside the range of Python"
+    with pytest.raises(NotImplementedError, match=msg):
+        ts.tz_localize("Europe/Brussels")
+
+    with pytest.raises(NotImplementedError, match=msg):
+        ts = Timestamp(ts._value, unit="us", tz="Europe/Brussels")
 
 
 def test_normalize_pytz_timezone():


### PR DESCRIPTION
(cherry picked from commit b6de6c405f5a262a6e637be414a99ca4b678c952)
Backport of https://github.com/pandas-dev/pandas/pull/65733