### PR TITLE
[backport 3.0.x] BUG: support for operations with custom objects / object dtype (#65677)

### DIFF
--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -15,6 +15,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed performance regression in :meth:`Series.searchsorted` and :meth:`Index.searchsorted` with the string dtype, where a full ``O(n)`` NA scan made the operation much slower than the binary search itself (:issue:`65837`)
+- Fixed regression in arithmetic operations involving :class:`StringDtype` and custom Python objects incorrectly raising instead of returning object-dtype results (:issue:`64107`)
 - Fixed regression in localizing timestamps beyond the year 2100 when using ``zoneinfo`` timezones (:issue:`65733`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -6,7 +6,6 @@ from datetime import (
 )
 import functools
 import operator
-from pathlib import Path
 import re
 import textwrap
 from typing import (
@@ -1070,25 +1069,42 @@ class ArrowExtensionArray(
         else:
             return self._evaluate_op_method(other, op, ARROW_LOGICAL_FUNCS)
 
-    def _arith_method(self, other, op) -> Self | npt.NDArray[np.object_]:
-        if (
-            op in [operator.truediv, roperator.rtruediv]
-            and isinstance(other, Path)
-            and (
-                pa.types.is_string(self._pa_array.type)
-                or pa.types.is_large_string(self._pa_array.type)
-            )
-        ):
-            # GH#61940
-            return np.array(
-                [
-                    op(x, other) if isinstance(x, str) else self.dtype.na_value
-                    for x in self
-                ],
-                dtype=object,
-            )
+    def _str_arith_method_object_fallback(
+        self, other, op
+    ) -> Self | npt.NDArray[np.object_]:
+        mask = isna(self) | isna(other)
+        valid = ~mask
 
-        result = self._evaluate_op_method(other, op, ARROW_ARITHMETIC_FUNCS)
+        if is_list_like(other):
+            if len(other) != len(self):
+                raise ValueError(
+                    f"Lengths of operands do not match: {len(self)} != {len(other)}"
+                )
+            if not is_array_like(other):
+                other = np.asarray(other)
+            other = other[valid]
+
+        result = np.empty(len(self), dtype=object)
+        result[mask] = self.dtype.na_value
+        result[valid] = op(np.asarray(self, dtype=object)[valid], other)
+
+        if not lib.is_string_array(result, skipna=True):
+            return result
+        return type(self)._from_sequence(result, dtype=self.dtype)
+
+    def _arith_method(self, other, op) -> Self | npt.NDArray[np.object_]:
+        result: Self | npt.NDArray[np.object_]
+        if pa.types.is_string(self._pa_array.type) or pa.types.is_large_string(
+            self._pa_array.type
+        ):
+            try:
+                result = self._evaluate_op_method(other, op, ARROW_ARITHMETIC_FUNCS)
+            except (pa.ArrowInvalid, pa.ArrowTypeError):
+                result = self._str_arith_method_object_fallback(other, op)
+        else:
+            result = self._evaluate_op_method(other, op, ARROW_ARITHMETIC_FUNCS)
+        if isinstance(result, np.ndarray):
+            return result
         if is_nan_na() and result.dtype.kind == "f":
             parr = result._pa_array
             mask = pc.is_nan(parr).fill_null(False).to_numpy()

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from functools import partial
 import operator
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1232,8 +1231,7 @@ class StringArray(BaseStringArray, NumpyExtensionArray):  # type: ignore[misc]
             result = np.empty_like(self._ndarray, dtype="object")
             result[mask] = self.dtype.na_value
             result[valid] = op(self._ndarray[valid], other)
-            if isinstance(other, Path):
-                # GH#61940
+            if not lib.is_string_array(result, skipna=True):
                 return result
             return self._from_backing_data(result)
         else:

--- a/pandas/tests/arithmetic/test_string.py
+++ b/pandas/tests/arithmetic/test_string.py
@@ -91,6 +91,45 @@ def test_pathlib_path_division(any_string_dtype, request):
     tm.assert_series_equal(result, expected)
 
 
+def test_arithmetic_custom_object(any_string_dtype):
+    # GH#64107
+    class CustomObject:
+        def __init__(self, val):
+            self.val = val
+
+        def __add__(self, other):
+            if hasattr(other, "dtype"):
+                return NotImplemented
+            return CustomObject(self.val + other)
+
+        def __radd__(self, other):
+            if hasattr(other, "dtype"):
+                return NotImplemented
+            return CustomObject(other + self.val)
+
+        def __eq__(self, other):
+            return isinstance(other, CustomObject) and self.val == other.val
+
+        def __repr__(self):
+            return f"<CustomObject({self.val})>"
+
+    arr = np.array([CustomObject("a"), CustomObject("b")], dtype=object)
+    ser = Series(["1", "2"], dtype=any_string_dtype)
+    obj_ser = Series(arr)
+
+    cases = [
+        (ser + arr[0], [CustomObject("1a"), CustomObject("2a")]),
+        (ser + arr, [CustomObject("1a"), CustomObject("2b")]),
+        (ser + obj_ser, [CustomObject("1a"), CustomObject("2b")]),
+        (arr[0] + ser, [CustomObject("a1"), CustomObject("a2")]),
+        (arr + ser, [CustomObject("a1"), CustomObject("b2")]),
+        (obj_ser + ser, [CustomObject("a1"), CustomObject("b2")]),
+    ]
+    for result, expected_values in cases:
+        expected = Series(expected_values, dtype=object)
+        tm.assert_series_equal(result, expected)
+
+
 def test_mixed_object_comparison(any_string_dtype):
     # GH#60228
     dtype = any_string_dtype
@@ -198,7 +237,7 @@ def test_add(any_string_dtype, request):
 def test_add_2d(any_string_dtype, request):
     dtype = any_string_dtype
 
-    if dtype == object or dtype.storage == "pyarrow":
+    if dtype == object:
         reason = "Failed: DID NOT RAISE <class 'ValueError'>"
         mark = pytest.mark.xfail(raises=None, reason=reason)
         request.applymarker(mark)


### PR DESCRIPTION
(cherry picked from commit d41d1808ab17e14ae2d69f8d03b36f3495b2e939)

Backport of https://github.com/pandas-dev/pandas/pull/65677