### PR TITLE
[3.0.x] BUG: fix CoW issue in eval()

### DIFF
--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -26,8 +26,8 @@ Bug fixes
 - Bug in :meth:`DataFrame.iloc` silently ignoring the assignment when setting values with an unordered or duplicated column indexer on a :class:`DataFrame` whose values are referenced by another object (:issue:`65446`)
 - Bug in :meth:`DataFrame.to_sql` and :func:`read_sql_table` when using an ADBC engine where table and schema names were not quoted as SQL identifiers, causing failures for identifiers containing spaces or reserved words, and making it vulnerable to SQL injection (:issue:`65065`)
 - Bug in :meth:`Series.str.__getitem__` raising ``AttributeError`` when underlying array is :class:`ArrowExtensionArray` (:issue:`65112`)
+- Bug in :meth:`~DataFrame.eval` not honoring Copy-on-Write with the Python engine when columns were reused in the expression, causing unexpected mutation of the original :class:`DataFrame` (:issue:`65664`)
 - Bug in arithmetic adding or subtracting a non-tick :class:`DateOffset` (e.g. :class:`offsets.MonthEnd`, :class:`offsets.QuarterEnd`) to datetime data that could cause a segmentation fault when another thread was running concurrently, e.g. under ``pytest-xdist`` (:issue:`66031`)
-
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_304.contributors:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -600,23 +600,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Used in :meth:`DataFrame.eval`.
         """
         from pandas.core.computation.parsing import clean_column_name
-        from pandas.core.series import Series
 
         if isinstance(self, ABCSeries):
             return {clean_column_name(self.name): self}
 
-        dtypes = self.dtypes
-        return {
-            clean_column_name(k): Series(
-                v, copy=False, index=self.index, name=k, dtype=dtype
-            ).__finalize__(self)
-            for k, v, dtype in zip(
-                self.columns,
-                self._iter_column_arrays(),
-                dtypes,
-                strict=True,
-            )
-        }
+        return {clean_column_name(k): v for k, v in self.items()}
 
     @final
     @property

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -2042,3 +2042,26 @@ def test_method_calls_on_binop():
     result = pd.eval("(x + y).dropna().reset_index(drop=True)")
     expected = (x + y).dropna().reset_index(drop=True)
     tm.assert_series_equal(result, expected)
+
+
+def test_eval_inplace_cow_alias_corruption(engine):
+    # https://github.com/pandas-dev/pandas/issues/65664
+    df = DataFrame({"old": [1, 2, 3]})
+    df.eval("new = old", inplace=True, engine=engine)
+
+    # Update the first row of the 'new' column (which is at index 1)
+    df.iloc[0, 1] = 99
+
+    expected = Series([1, 2, 3], name="old")
+    result = df["old"]
+    tm.assert_series_equal(result, expected)
+
+    # same but without inplace
+    df = DataFrame({"old": [1, 2, 3]})
+    df_orig = df.copy()
+
+    result = df.eval("new = old", engine=engine)
+
+    result.iloc[0, 1] = 99
+    tm.assert_series_equal(result["old"], expected)
+    tm.assert_series_equal(df_orig["old"], expected)


### PR DESCRIPTION
This is a kind of adapted backport of https://github.com/pandas-dev/pandas/pull/65656. I noticed that on main, https://github.com/pandas-dev/pandas/issues/65664 was already fixed by https://github.com/pandas-dev/pandas/pull/65656.

This backports a slightly modified version of that PR that also removes this custom reconstruction of the Series objects (which is losing track of CoW refs), but without "fixing" the duplicate columns issue as the original PR did (since that is also a kind of behaviour change, don't want to include that in 3.0.4).

And on top of that added a test for the original issue.

Closes https://github.com/pandas-dev/pandas/issues/65664