### PR TITLE
[backport 3.0.x] BUG(pandas 3.0 regression): drop(index=...) doesn't accept NA values when using arrow dtype in index (#65682)

### DIFF
--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -15,6 +15,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed performance regression in :meth:`Series.searchsorted` and :meth:`Index.searchsorted` with the string dtype, where a full ``O(n)`` NA scan made the operation much slower than the binary search itself (:issue:`65837`)
+- Fixed regression in :meth:`~Series.isin` raising an error when checking for ``pd.NA`` with ``ArrowDtype``, which also affected :meth:`DataFrame.drop` with ``ArrowDtype``-backed indexes (:issue:`63304`)
 - Fixed regression in arithmetic operations involving :class:`StringDtype` and custom Python objects incorrectly raising instead of returning object-dtype results (:issue:`64107`)
 - Fixed regression in localizing timestamps beyond the year 2100 when using ``zoneinfo`` timezones (:issue:`65733`)
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1450,7 +1450,8 @@ class ArrowExtensionArray(
         if not len(values):
             return np.zeros(len(self), dtype=bool)
 
-        result = pc.is_in(self._pa_array, value_set=pa.array(values))
+        value_set = self._box_pa(values)
+        result = pc.is_in(self._pa_array, value_set=value_set)
         # pyarrow 2.0.0 returned nulls, so we explicitly specify dtype to convert nulls
         # to False
         return np.array(result, dtype=np.bool_)

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -543,6 +543,18 @@ class TestDataFrameDrop:
         ).set_index(idx)
         tm.assert_frame_equal(result, expected)
 
+    def test_drop_index_arrow_binary_dtype_na(self):
+        # GH#63304
+        pytest.importorskip("pyarrow")
+
+        idx = Index([None, b"\xe3", b"\xe3"], dtype="binary[pyarrow]", name="bytes_col")
+        df = DataFrame(index=idx)
+
+        result = df.drop(index=[pd.NA])
+        idx = Index([b"\xe3", b"\xe3"], dtype="binary[pyarrow]", name="bytes_col")
+        expected = DataFrame(index=idx)
+        tm.assert_frame_equal(result, expected)
+
     def test_drop_parse_strings_datetime_index(self):
         # GH #5355
         df = DataFrame(

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -235,6 +235,23 @@ def test_isin_large_series_and_pdNA(dtype, data, values, expected, monkeypatch):
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "dtype, data, values, expected",
+    [
+        ("int64[pyarrow]", [1, None], [1, pd.NA], [True, True]),
+        ("binary[pyarrow]", [None, b"\xe3"], [pd.NA, b"\xe3"], [True, True]),
+    ],
+)
+def test_isin_arrow_dtype_with_na_value(dtype, data, values, expected):
+    # GH#63304
+    pytest.importorskip("pyarrow")
+
+    result = Series(data, dtype=dtype).isin(values)
+    expected = Series(expected)
+
+    tm.assert_series_equal(result, expected)
+
+
 def test_isin_complex_numbers():
     # GH 17927
     array = [0, 1j, 1j, 1, 1 + 1j, 1 + 2j, 1 + 1j]


### PR DESCRIPTION
(cherry picked from commit 4a1c7b57424248cb5cfcaf439457affeffeaed3e)

Backport of https://github.com/pandas-dev/pandas/pull/65682