### PR TITLE
[backport 3.0.x] BUG: anchor whole alternation in Series.str.match for PyArrow string dtype (#66070)

### DIFF
--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -28,6 +28,7 @@ Bug fixes
 - Bug in :meth:`DataFrame.iloc` silently ignoring the assignment when setting values with an unordered or duplicated column indexer on a :class:`DataFrame` whose values are referenced by another object (:issue:`65446`)
 - Bug in :meth:`DataFrame.to_sql` and :func:`read_sql_table` when using an ADBC engine where table and schema names were not quoted as SQL identifiers, causing failures for identifiers containing spaces or reserved words, and making it vulnerable to SQL injection (:issue:`65065`)
 - Bug in :meth:`Series.str.__getitem__` raising ``AttributeError`` when underlying array is :class:`ArrowExtensionArray` (:issue:`65112`)
+- Bug in :meth:`Series.str.match` and :meth:`Index.str.match` on PyArrow-backed string dtypes where a leading ``^`` only anchored the first branch of an alternation pattern (e.g. ``r"^foo|bar"``) (:issue:`66069`)
 - Bug in arithmetic adding or subtracting a non-tick :class:`DateOffset` (e.g. :class:`offsets.MonthEnd`, :class:`offsets.QuarterEnd`) to datetime data that could cause a segmentation fault when another thread was running concurrently, e.g. under ``pytest-xdist`` (:issue:`66031`)
 
 

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -400,8 +400,9 @@ class ArrowStringArrayMixin:
         flags: int = 0,
         na: Scalar | lib.NoDefault = lib.no_default,
     ):
-        if not pat.startswith("^"):
-            pat = f"^({pat})"
+        if pat.startswith("^"):
+            pat = pat[1:]
+        pat = f"^({pat})"
         return ArrowStringArrayMixin._str_contains(
             self, pat, case, flags, na, regex=True
         )

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1091,6 +1091,21 @@ def test_match(any_string_dtype):
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "pat",
+    [r"^foo|bar", r"^bar|foo", r"^foo|bar$", r"^(foo)|bar"],
+)
+def test_match_anchored_alternation(any_string_dtype, pat):
+    # GH#66069
+    ser = Series(["xbar", "bar", "foo", "xfoo"], dtype=any_string_dtype)
+    result = ser.str.match(pat)
+    expected_dtype = (
+        np.bool_ if is_object_or_nan_string_dtype(any_string_dtype) else "boolean"
+    )
+    expected = Series([False, True, True, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
 def test_match_mixed_object():
     mixed = Series(
         [


### PR DESCRIPTION
(cherry picked from commit 3d52407132956f43cc8a03e7e257d2ec75cec397)

Backport of https://github.com/pandas-dev/pandas/pull/66070