### PR TITLE
BUG: fix NULL dereference and use-after-free in ujson C encoder (GH#65903, GH#65904, GH#65905)

### DIFF
--- a/pandas/_libs/src/datetime/date_conversions.c
+++ b/pandas/_libs/src/datetime/date_conversions.c
@@ -61,6 +61,7 @@ char *int64ToIso(int64_t value, NPY_DATETIMEUNIT valueUnit,
     PyErr_SetString(PyExc_ValueError,
                     "Could not convert datetime value to string");
     PyObject_Free(result);
+    return NULL;
   }
 
   // Note that get_datetime_iso_8601_strlen just gives a generic size

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -269,6 +269,9 @@ static npy_int64 get_long_attr(PyObject *o, const char *attr) {
   // NB we are implicitly assuming that o is a Timedelta or Timestamp, or NaT
 
   PyObject *value = PyObject_GetAttrString(o, attr);
+  if (value == NULL) {
+    return NPY_MIN_INT64;
+  }
   const npy_int64 long_val =
       (PyLong_Check(value) ? PyLong_AsLongLong(value) : PyLong_AsLong(value));
 
@@ -306,7 +309,10 @@ static npy_int64 get_long_attr(PyObject *o, const char *attr) {
 
 static npy_float64 total_seconds(PyObject *td) {
   PyObject *value = PyObject_CallMethod(td, "total_seconds", NULL);
-  const npy_float64 double_val = PyFloat_AS_DOUBLE(value);
+  if (value == NULL) {
+    return -1.0;
+  }
+  const npy_float64 double_val = PyFloat_AsDouble(value);
   Py_DECREF(value);
   return double_val;
 }


### PR DESCRIPTION
## What this fixes

Three related memory-safety bugs in the vendored ujson C encoder and the datetime C extension. All three are open issues with 0 comments and no existing PRs.

---

### 1. Use-after-free in `int64ToIso` — closes #65903

**File:** `pandas/_libs/src/datetime/date_conversions.c`

When `make_iso_8601_datetime` returns a non-zero error code, `result` is freed via `PyObject_Free`, but execution falls through to `strlen(result)` on the now-freed pointer — undefined behaviour and a potential crash.

```c
// Before
if (ret_code != 0) {
    PyErr_SetString(...);
    PyObject_Free(result);   // freed here ...
}
*len = strlen(result);       // ... but used here — use-after-free!

// After
if (ret_code != 0) {
    PyErr_SetString(...);
    PyObject_Free(result);
    return NULL;             // early return prevents use-after-free
}
*len = strlen(result);
```

---

### 2. NULL dereference in `get_long_attr` — closes #65904

**File:** `pandas/_libs/src/vendored/ujson/python/objToJSON.c`

`PyObject_GetAttrString` can return `NULL` when the attribute lookup raises. The result was passed directly to `PyLong_Check` / `PyLong_AsLongLong` without a NULL guard.

```c
// Before
PyObject *value = PyObject_GetAttrString(o, attr);
const npy_int64 long_val =
    (PyLong_Check(value) ? ...);  // crashes if value == NULL

// After
PyObject *value = PyObject_GetAttrString(o, attr);
if (value == NULL) {
    return NPY_MIN_INT64;  // propagates error gracefully
}
const npy_int64 long_val = ...;
```

---

### 3. NULL dereference in `total_seconds` — closes #65905

**File:** `pandas/_libs/src/vendored/ujson/python/objToJSON.c`

`PyObject_CallMethod` returns `NULL` when `total_seconds()` raises an exception. The NULL value was then passed to `PyFloat_AS_DOUBLE` — an **unsafe macro** that directly accesses struct fields without any NULL or type check — and subsequently to `Py_DECREF`, both of which crash on `NULL`. Additionally, `PyFloat_AS_DOUBLE` skips type verification even for non-NULL values.

```c
// Before
PyObject *value = PyObject_CallMethod(td, "total_seconds", NULL);
const npy_float64 double_val = PyFloat_AS_DOUBLE(value); // unsafe macro, no NULL check
Py_DECREF(value);  // also crashes on NULL

// After
PyObject *value = PyObject_CallMethod(td, "total_seconds", NULL);
if (value == NULL) {
    return -1.0;   // propagate the exception
}
const npy_float64 double_val = PyFloat_AsDouble(value);  // safe function with type check
Py_DECREF(value);
```

---

## Files changed

| File | Changes |
|---|---|
| `pandas/_libs/src/datetime/date_conversions.c` | Add `return NULL` in error path of `int64ToIso` |
| `pandas/_libs/src/vendored/ujson/python/objToJSON.c` | NULL guards in `get_long_attr` and `total_seconds`; `PyFloat_AS_DOUBLE` → `PyFloat_AsDouble` |