### PR TITLE
REF: decouple get_dummies column selection from select_dtypes

### DIFF
--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -159,12 +159,32 @@ def get_dummies(
     """
     from pandas.core.reshape.concat import concat
 
-    dtypes_to_encode = ["object", "string", "category"]
+    def _is_encodable(arr) -> bool:
+        # The columns get_dummies encodes by default: object, string (any
+        # storage), categorical, and the Arrow-backed string/dictionary
+        # equivalents (GH#56273).
+        dtype = arr.dtype
+        if isinstance(dtype, (StringDtype, CategoricalDtype)):
+            return True
+        if isinstance(dtype, ArrowDtype):
+            import pyarrow as pa
+
+            pa_type = dtype.pyarrow_dtype
+            return (
+                pa.types.is_string(pa_type)
+                or pa.types.is_large_string(pa_type)
+                or pa.types.is_string_view(pa_type)
+                or pa.types.is_dictionary(pa_type)
+            )
+        # is_object_dtype last: it raises for ArrowDtypes whose `.type` is
+        # not implemented (e.g. string_view)
+        return is_object_dtype(dtype)
 
     if isinstance(data, DataFrame):
         # determine columns being encoded
         if columns is None:
-            data_to_encode = data.select_dtypes(include=dtypes_to_encode)
+            mgr = data._mgr._get_data_subset(_is_encodable).copy(deep=False)
+            data_to_encode = data._constructor_from_mgr(mgr, axes=mgr.axes)
         elif not is_list_like(columns):
             raise TypeError("Input must be a list-like for parameter `columns`")
         else:
@@ -209,7 +229,10 @@ def get_dummies(
         else:
             # Encoding only object and category dtype columns. Get remaining
             # columns to prepend to result.
-            with_dummies = [data.select_dtypes(exclude=dtypes_to_encode)]
+            rest_mgr = data._mgr._get_data_subset(
+                lambda arr: not _is_encodable(arr)
+            ).copy(deep=False)
+            with_dummies = [data._constructor_from_mgr(rest_mgr, axes=rest_mgr.axes)]
 
         for col, pre, sep in zip(
             data_to_encode.items(), prefix, prefix_sep, strict=True


### PR DESCRIPTION
Behavior-preserving refactor split off from GH-65366 to keep that PR small.

`get_dummies` determined which columns to encode via `select_dtypes(include=["object", "string", "category"])`, relying on `select_dtypes`' internal `ArrowDtype.numpy_dtype` unwrap to also pick up Arrow-backed string/dictionary columns (GH-56273). This expresses the intended column set directly with a local `_is_encodable` predicate fed to `BlockManager._get_data_subset`, so `get_dummies` no longer depends on `select_dtypes`' string-alias matching of EA/Arrow columns.

This is also a prerequisite for GH-65366: once `select_dtypes` stops unwrapping `ArrowDtype` to its numpy dtype, `include=["object"]` would no longer catch Arrow strings, so `get_dummies` needs its own predicate to preserve GH-56273 behavior.

No user-visible change; verified the predicate selects exactly the same include/exclude columns as the old call across numpy/masked/Arrow string, categorical, object, and Arrow string/large_string/string_view/dictionary dtypes (default and `future.infer_string`). Existing `get_dummies` suite passes.