### PR TITLE
DOC: un-skip describe doctest now that top is deterministic (GH#32528)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -15378,11 +15378,11 @@ class DataFrame(NDFrame, OpsMixin):
 
         All columns regardless of dtype.
 
-        >>> df.describe(include="all")  # doctest: +SKIP
+        >>> df.describe(include="all")
                categorical  numeric object
         count            3      3.0      3
         unique           3      NaN      3
-        top              f      NaN      a
+        top              d      NaN      a
         freq             1      NaN      1
         mean           NaN      2.0    NaN
         std            NaN      1.0    NaN
@@ -15403,11 +15403,11 @@ class DataFrame(NDFrame, OpsMixin):
 
         Exclude a specific dtype.
 
-        >>> df.describe(exclude=[np.number])  # doctest: +SKIP
+        >>> df.describe(exclude=[np.number])
                categorical object
         count            3      3
         unique           3      3
-        top              f      a
+        top              d      a
         freq             1      1
         """
         return super().describe(

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -138,6 +138,20 @@ class TestDataFrameDescribe:
         assert np.isnan(result.iloc[2, 0])
         assert np.isnan(result.iloc[3, 0])
 
+    def test_describe_categorical_object_tie_is_deterministic(self):
+        # GH#32528 when every value is unique, "top" must be deterministic
+        # (first occurrence) rather than depend on hashtable iteration order
+        df = DataFrame(
+            {
+                "categorical": Categorical(["d", "e", "f"]),
+                "numeric": [1, 2, 3],
+                "object": ["a", "b", "c"],
+            }
+        )
+        result = df.describe(include="all")
+        assert result.loc["top", "categorical"] == "d"
+        assert result.loc["top", "object"] == "a"
+
     def test_describe_categorical_columns(self):
         # GH#11558
         columns = pd.CategoricalIndex(["int1", "int2", "obj"], ordered=True, name="XXX")


### PR DESCRIPTION
closes #32528

`DataFrame.describe(include="all")` previously produced a non-deterministic `top` for object/categorical columns when every value tied for the highest frequency — the winner depended on hashtable iteration order. The two affected docstring examples were marked `# doctest: +SKIP` to work around this.

The root cause was fixed by GH-63158 (stable sort in `value_counts`), so `top` is now deterministically the first-occurrence value. This removes the now-unnecessary `+SKIP` directives, corrects the categorical `top` shown in the examples (`f` → `d`), and adds a regression test.