### PR TITLE
DOC: fix broken "See Also" cross-reference links in API docs (GH#31661)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1100,11 +1100,42 @@ def rstjinja(app, docname, source) -> None:
     source[0] = rendered
 
 
+def resolve_pandas_toplevel_xref(app, env, node, contnode):
+    """
+    Resolve cross-references to top-level ``pandas`` objects that are written
+    without the ``pandas.`` prefix.
+
+    numpydoc emits "See Also" entries such as ``DataFrame.pipe`` as
+    non-module-qualified ``:py:obj:`` references. For methods documented under a
+    non-``pandas`` module (e.g. ``pandas.api.typing.DataFrameGroupBy``), Sphinx
+    prepends the current module and never falls back to the top-level ``pandas``
+    namespace, so these links silently render as plain text (GH#31661). This
+    fires only on otherwise-unresolved references; we retry the lookup with a
+    ``pandas.`` prefix and return the resolved node if one is found.
+    """
+    if node.get("refdomain") != "py":
+        return None
+    target = node.get("reftarget", "")
+    if not target or target.startswith("pandas."):
+        return None
+    py_domain = env.get_domain("py")
+    return py_domain.resolve_xref(
+        env,
+        node.get("refdoc"),
+        app.builder,
+        node.get("reftype", "obj"),
+        f"pandas.{target}",
+        node,
+        contnode,
+    )
+
+
 def setup(app) -> None:
     app.connect("source-read", rstjinja)
     app.connect("autodoc-process-docstring", remove_flags_docstring)
     app.connect("autodoc-process-docstring", process_class_docstrings)
     app.connect("autodoc-process-docstring", process_business_alias_docstrings)
+    app.connect("missing-reference", resolve_pandas_toplevel_xref)
     app.add_autodocumenter(AccessorDocumenter)
     app.add_autodocumenter(AccessorAttributeDocumenter)
     app.add_autodocumenter(AccessorMethodDocumenter)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -475,6 +475,7 @@ Other
 
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
+- Fixed the "See Also" section of the API reference where references to top-level objects (such as :class:`Series` and :class:`DataFrame` methods) from :class:`.DataFrameGroupBy`, :class:`.Resampler`, and rolling/expanding/ewm documentation rendered as plain text instead of clickable links (:issue:`31661`)
 
 .. ***DO NOT USE THIS SECTION***
 


### PR DESCRIPTION
closes #31661

numpydoc emits "See Also" entries such as `DataFrame.pipe` as non-module-qualified `:py:obj:` references. For methods documented under a non-`pandas` module (e.g. `pandas.api.typing.DataFrameGroupBy`, real module `pandas.core.groupby`), Sphinx prepends the current module and never falls back to the top-level `pandas` namespace — so same-class refs (e.g. `apply`) link fine, but cross-module refs to top-level objects (`Series.pipe`, `DataFrame.pipe`, …) silently rendered as plain text.

This adds a `missing-reference` handler in `doc/source/conf.py` that retries unresolved `py` references with a `pandas.` prefix and returns the resolved node. It is purely additive: it only fires on references that already failed normal resolution, and only returns a node when `pandas.<target>` actually resolves, so it cannot create wrong links. The displayed text stays bare (`DataFrame.pipe`, not `pandas.DataFrame.pipe`), and no docstrings change.

Affects GroupBy, Resampler, and rolling/expanding/ewm reference pages (~349 such See Also entries across those modules alone).

Verified the mechanism with a minimal standalone Sphinx project (sphinx 8.2.3 / numpydoc 1.8.0, matching the unpinned doc env): a cross-module ref renders with no `<a href>` before the change and as a working internal link after.