### PR TITLE
DOC: address getting started tutorials feedback (GH#32283)

### DIFF
--- a/doc/source/getting_started/comparison/comparison_with_r.rst
+++ b/doc/source/getting_started/comparison/comparison_with_r.rst
@@ -27,7 +27,8 @@ Quick reference
 
 We'll start off with a quick reference guide pairing some common R
 operations using `dplyr
-<https://cran.r-project.org/web/packages/dplyr/index.html>`__ with
+<https://cran.r-project.org/web/packages/dplyr/index.html>`__, one of the
+core packages of the `tidyverse <https://www.tidyverse.org/>`__, with
 pandas equivalents.
 
 

--- a/doc/source/getting_started/intro_tutorials/01_table_oriented.rst
+++ b/doc/source/getting_started/intro_tutorials/01_table_oriented.rst
@@ -183,7 +183,7 @@ pandas ``Series`` or a pandas ``DataFrame``.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 Check more options on ``describe`` in the user guide section about :ref:`aggregations with describe <basics.describe>`
 
@@ -215,7 +215,7 @@ Check more options on ``describe`` in the user guide section about :ref:`aggrega
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 A more extended explanation of ``DataFrame`` and ``Series`` is provided in the :ref:`introduction to data structures <dsintro>` page.
 

--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -205,7 +205,7 @@ The method :meth:`~DataFrame.info` provides technical information about a
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 For a complete overview of the input and output possibilities from and to pandas, see the user guide section about :ref:`reader and writer functions <io>`.
 

--- a/doc/source/getting_started/intro_tutorials/03_subset_data.rst
+++ b/doc/source/getting_started/intro_tutorials/03_subset_data.rst
@@ -122,7 +122,7 @@ The selection returned a ``DataFrame`` with 891 rows and 2 columns. Remember, a
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 For basic information on indexing, see the user guide section on :ref:`indexing and selecting data <indexing.basics>`.
 
@@ -223,7 +223,7 @@ operator:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 See the dedicated section in the user guide about :ref:`boolean indexing <indexing.boolean>` or about the :ref:`isin function <indexing.basics.indexing_isin>`.
 
@@ -262,7 +262,7 @@ the same values. One way to verify is to check if the shape has changed:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 For more dedicated functions on missing values, see the user guide section about :ref:`handling missing data <missing_data>`.
 
@@ -342,7 +342,7 @@ the name ``anonymous`` to the first 3 elements of the fourth column:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 See the user guide section on :ref:`different choices for indexing <indexing.choice>` to get more insight into the usage of ``loc`` and ``iloc``.
 
@@ -370,7 +370,7 @@ See the user guide section on :ref:`different choices for indexing <indexing.cho
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 A full overview of indexing is provided in the user guide pages on :ref:`indexing and selecting data <indexing>`.
 

--- a/doc/source/getting_started/intro_tutorials/04_plotting.rst
+++ b/doc/source/getting_started/intro_tutorials/04_plotting.rst
@@ -147,7 +147,7 @@ method is applicable on the air quality example data:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 For an introduction to plots other than the default line plot, see the user guide section about :ref:`supported plot styles <visualization.other>`.
 
@@ -181,7 +181,7 @@ functions are worth reviewing.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 Some more formatting options are explained in the user guide section on :ref:`plot formatting <visualization.formatting>`.
 
@@ -250,7 +250,7 @@ This strategy is applied in the previous example:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 A full overview of plotting in pandas is provided in the :ref:`visualization pages <visualization>`.
 

--- a/doc/source/getting_started/intro_tutorials/05_add_columns.rst
+++ b/doc/source/getting_started/intro_tutorials/05_add_columns.rst
@@ -138,7 +138,7 @@ lowercase letters can be done using a function as well:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 Details about column or row label renaming is provided in the user guide section on :ref:`renaming labels <basics.rename>`.
 
@@ -164,7 +164,7 @@ Details about column or row label renaming is provided in the user guide section
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 The user guide contains a separate section on :ref:`column addition and deletion <basics.dataframe.sel_add_del>`.
 

--- a/doc/source/getting_started/intro_tutorials/06_calculate_statistics.rst
+++ b/doc/source/getting_started/intro_tutorials/06_calculate_statistics.rst
@@ -104,7 +104,7 @@ aggregating statistics for given columns can be defined using the
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 Details about descriptive statistics are provided in the user guide section on :ref:`descriptive statistics <basics.stats>`.
 
@@ -202,7 +202,7 @@ column names as a list to the :meth:`~DataFrame.groupby` method.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 A full description on the split-apply-combine approach is provided in the user guide section on :ref:`groupby operations <groupby>`.
 
@@ -252,7 +252,7 @@ within each group:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 The user guide has a dedicated section on ``value_counts`` , see the page on :ref:`discretization <basics.discretization>`.
 
@@ -277,7 +277,7 @@ The user guide has a dedicated section on ``value_counts`` , see the page on :re
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 A full description on the split-apply-combine approach is provided in the user guide pages about :ref:`groupby operations <groupby>`.
 

--- a/doc/source/getting_started/intro_tutorials/07_reshape_table_layout.rst
+++ b/doc/source/getting_started/intro_tutorials/07_reshape_table_layout.rst
@@ -128,7 +128,7 @@ defined column(s). The index will follow the row order.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 More details about sorting of tables is provided in the user guide section on :ref:`sorting data <basics.sorting>`.
 
@@ -197,7 +197,7 @@ series at the same time:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 For more information about :meth:`~DataFrame.pivot`, see the user guide section on :ref:`pivoting DataFrame objects <reshaping.reshaping>`.
 
@@ -251,7 +251,7 @@ the ``margins`` parameter to ``True``:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 For more information about :meth:`~DataFrame.pivot_table`, see the user guide section on :ref:`pivot tables <reshaping.pivot>`.
 
@@ -271,7 +271,7 @@ For more information about :meth:`~DataFrame.pivot_table`, see the user guide se
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 .. raw:: html
 
@@ -345,7 +345,7 @@ are defined by ``id_vars`` and ``value_vars``.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 Conversion from wide to long format with :func:`pandas.melt` is explained in the user guide section on :ref:`reshaping by melt <reshaping.melt>`.
 
@@ -371,7 +371,7 @@ Conversion from wide to long format with :func:`pandas.melt` is explained in the
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 A full overview is available in the user guide on the pages about :ref:`reshaping and pivoting <reshaping>`.
 

--- a/doc/source/getting_started/intro_tutorials/08_combine_dataframes.rst
+++ b/doc/source/getting_started/intro_tutorials/08_combine_dataframes.rst
@@ -172,7 +172,7 @@ index. For example:
     .. raw:: html
 
         <div class="d-flex flex-row  gs-torefguide">
-            <span class="badge badge-info">To user guide</span>
+            <span class="badge badge-info">Want more information?</span>
 
     Feel free to dive into the world of multi-indexing at the user guide section on :ref:`advanced indexing <advanced>`.
 
@@ -183,7 +183,7 @@ index. For example:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 More options on table concatenation (row and column
 wise) and how ``concat`` can be used to define the logic (union or
@@ -284,7 +284,7 @@ between the two tables.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 pandas also supports inner, outer, and right joins.
 More information on join/merge of tables is provided in the user guide section on
@@ -312,7 +312,7 @@ More information on join/merge of tables is provided in the user guide section o
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 See the user guide for a full description of the various :ref:`facilities to combine data tables <merging>`.
 

--- a/doc/source/getting_started/intro_tutorials/09_timeseries.rst
+++ b/doc/source/getting_started/intro_tutorials/09_timeseries.rst
@@ -122,7 +122,7 @@ from the standard Python library which defines a time duration.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 The various time concepts supported by pandas are explained in the user guide section on :ref:`time related concepts <timeseries.overview>`.
 
@@ -155,7 +155,7 @@ accessible by the ``dt`` accessor.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 An overview of the existing date properties is given in the
 :ref:`time and date components overview table <timeseries.components>`. More details about the ``dt`` accessor
@@ -275,7 +275,7 @@ By providing a **string that parses to a datetime**, a specific subset of the da
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 More information on the ``DatetimeIndex`` and the slicing by using strings is provided in the section on :ref:`time series indexing <timeseries.datetimeindex>`.
 
@@ -316,7 +316,7 @@ The :meth:`~Series.resample` method is similar to a groupby operation:
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 An overview of the aliases used to define time series frequencies is given in the :ref:`offset aliases overview table <timeseries.offset_aliases>`.
 
@@ -352,7 +352,7 @@ Make a plot of the daily mean :math:`NO_2` value in each of the stations.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 More details on the power of time series ``resampling`` is provided in the user guide section on :ref:`resampling <timeseries.resampling>`.
 
@@ -381,7 +381,7 @@ More details on the power of time series ``resampling`` is provided in the user 
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 A full overview on time series is given on the pages on :ref:`time series and date functionality <timeseries>`.
 

--- a/doc/source/getting_started/intro_tutorials/10_text_data.rst
+++ b/doc/source/getting_started/intro_tutorials/10_text_data.rst
@@ -93,7 +93,7 @@ concatenated to combine multiple functions at once!
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 More information on extracting parts of strings is available in the user guide section on :ref:`splitting and replacing strings <text.split>`.
 
@@ -140,7 +140,7 @@ only one countess on the Titanic, we get one row as a result.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 More information on extracting parts of strings is available in the user guide section on :ref:`string matching and extracting <text.extract>`.
 
@@ -239,7 +239,7 @@ a ``dictionary`` to define the mapping ``{from: to}``.
 .. raw:: html
 
     <div class="d-flex flex-row gs-torefguide">
-        <span class="badge badge-info">To user guide</span>
+        <span class="badge badge-info">Want more information?</span>
 
 A full overview is provided in the user guide pages on :ref:`working with text data <text>`.
 


### PR DESCRIPTION
closes #32283

Addresses the remaining actionable items from the EOSS tutorial-feedback issue. Most of the original feedback was already resolved by the pydata-sphinx-theme migration and the one-section-per-page restructure; this PR handles the two outstanding content tweaks:

- Rename the in-tutorial "To user guide" callout badges to "Want more information?" (item 2). The landing-page card badges are intentionally left as-is, since there each "To user guide" badge is paired with a "To introduction tutorial" badge and the parallel phrasing reads better.
- Mention the `tidyverse` (with a link) where the R comparison page introduces `dplyr` (item 7).

Status of the other items, for reference: whitespace / heading-size / section separation (items 1, 3, 5) are handled by the current theme plus the page restructure; the cheat sheet is already linked from the Getting started landing page (item 6); item 4 (domain-specific data) is subjective. The pivot-table diagram redraw (item 8 — use values instead of colors) remains as potential follow-up.