### PR TITLE
BUG: select_dtypes ExtensionDtype matching (GH#40234, GH#59888)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -449,6 +449,8 @@ Reshaping
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
 - Bug in :meth:`DataFrame.melt` where ``var_name`` colliding with an ``id_vars`` column or ``value_name`` silently overwrote the affected column data instead of raising (:issue:`65654`)
 - Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)
+- Bug in :meth:`DataFrame.select_dtypes` where ``"Int64"`` and :class:`Int64Dtype` also matched numpy ``int64`` columns (and analogously for other nullable integer and floating dtypes) (:issue:`40234`)
+- Bug in :meth:`DataFrame.select_dtypes` where passing a parameterized :class:`ExtensionDtype` subclass (e.g. :class:`ArrowDtype`, :class:`DatetimeTZDtype`) emitted a spurious ``UserWarning`` about instantiating the dtype without arguments; passing such a class is now supported as a "kind" request matching any instance of that class
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5428,14 +5428,16 @@ class DataFrame(NDFrame, OpsMixin):
         if not any(selection):
             raise ValueError("at least one of include or exclude must be nonempty")
 
-        # Convert the myriad valid dtype specs into a numpy-scalar set plus an
-        # ExtensionDtype-request bucket. An EA spec is matched by identity --
-        # an instance by equality, a class (or bare class-name string) as a
-        # "kind" matching any instance of it -- rather than being collapsed to
-        # the numpy scalar type it shares with numpy columns. This fixes GH#40234
-        # ("Int64"/Int64Dtype no longer also match numpy int64) and the EA-class
-        # half of GH#59888 (e.g. ArrowDtype/DatetimeTZDtype). The kind-string
-        # cross-backend bucket and the numpy-type tightening remain in GH#65366.
+        # Convert user-facing dtype specs into two buckets:
+        #  * numpy scalar types (matched via issubclass on dtype.type) -- both
+        #    explicit numpy types like np.int64 and kind strings like
+        #    "int64"/"datetime", which still resolve to numpy scalars here;
+        #  * ExtensionDtype requests (matched via isinstance for classes and
+        #    bare class-name strings, by equality for instances).
+        # This fixes GH#40234 (Int64Dtype no longer matches int64 by class
+        # identity) and the ExtensionDtype-spec part of GH#59888; the
+        # (kind char, itemsize) cross-backend kind-string bucket and the
+        # numpy-type tightening remain in GH#65366.
         def check_int_infer_dtype(dtypes):
             converted_dtypes: list[type] = []
             ea_requests: list = []
@@ -5449,10 +5451,12 @@ class DataFrame(NDFrame, OpsMixin):
                     # GH#42452 : np.dtype("float") coerces to np.float64 from Numpy 1.20
                     converted_dtypes.extend([np.float64, np.float32])
                 elif isinstance(dtype, ExtensionDtype):
-                    # an EA instance matches by equality
+                    # GH#40234: EA instances match by equality
                     ea_requests.append(dtype)
                 elif isinstance(dtype, type) and issubclass(dtype, ExtensionDtype):
-                    # an EA class names a kind -> match any instance of it
+                    # EA subclass (possibly parameterized like ArrowDtype) matches
+                    # by isinstance. Avoid calling pandas_dtype(cls) which emits
+                    # "Instantiating X without any arguments" for parameterized EAs.
                     ea_requests.append(dtype)
                 elif isinstance(dtype, str):
                     # a bare EA class-name ("Int64", "string", "category") is a
@@ -5531,11 +5535,19 @@ class DataFrame(NDFrame, OpsMixin):
 
             return True
 
-        blk_dtypes = [blk.dtype for blk in self._mgr.blocks]
+        blk_dtypes = self._mgr.get_unique_dtypes()
+
+        def _requests_string_dtype(reqs: tuple) -> bool:
+            return any(
+                req is StringDtype or isinstance(req, StringDtype) for req in reqs
+            )
+
         if (
             np.object_ in include_np
             and str not in include_np
             and str not in exclude_np
+            and not _requests_string_dtype(include_ea)
+            and not _requests_string_dtype(exclude_ea)
             and any(
                 isinstance(dtype, StringDtype) and dtype.na_value is np.nan
                 for dtype in blk_dtypes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -104,7 +104,6 @@ from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.dtypes import (
     ArrowDtype,
     BaseMaskedDtype,
-    CategoricalDtype,
     ExtensionDtype,
 )
 from pandas.core.dtypes.generic import (
@@ -261,24 +260,6 @@ if TYPE_CHECKING:
     from pandas.core.interchange.dataframe_protocol import DataFrame as DataFrameXchg
 
     from pandas.io.formats.style import Styler
-
-
-def _select_dtypes_arrow_kind_match(dtype: ArrowDtype, req: type) -> bool:
-    # An EA class request names a kind, and Arrow string/dictionary columns
-    # belong to the string/categorical kinds, so e.g. select_dtypes("string")
-    # selects ArrowDtype(pa.string()) columns.
-    import pyarrow as pa
-
-    pa_type = dtype.pyarrow_dtype
-    if req is StringDtype:
-        return (
-            pa.types.is_string(pa_type)
-            or pa.types.is_large_string(pa_type)
-            or pa.types.is_string_view(pa_type)
-        )
-    if req is CategoricalDtype:
-        return pa.types.is_dictionary(pa_type)
-    return False
 
 
 # -----------------------------------------------------------------------
@@ -5495,9 +5476,6 @@ class DataFrame(NDFrame, OpsMixin):
                     # class -> "any dtype of this class"
                     if isinstance(dtype, req):
                         return True
-                    if isinstance(dtype, ArrowDtype):
-                        if _select_dtypes_arrow_kind_match(dtype, req):
-                            return True
                 # instance -> exact-dtype match
                 elif dtype == req:
                     return True

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -264,11 +264,9 @@ if TYPE_CHECKING:
 
 
 def _select_dtypes_arrow_kind_match(dtype: ArrowDtype, req: type) -> bool:
-    # An ExtensionDtype class request names a kind, and Arrow string/dictionary
-    # columns belong to the string/categorical kinds, so e.g.
-    # select_dtypes(StringDtype) also selects ArrowDtype(pa.string()) columns
-    # and select_dtypes(CategoricalDtype) selects ArrowDtype(pa.dictionary())
-    # columns (as on main, where the numpy_dtype unwrap provided this).
+    # An EA class request names a kind, and Arrow string/dictionary columns
+    # belong to the string/categorical kinds, so e.g. select_dtypes("string")
+    # selects ArrowDtype(pa.string()) columns.
     import pyarrow as pa
 
     pa_type = dtype.pyarrow_dtype

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -104,6 +104,7 @@ from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.dtypes import (
     ArrowDtype,
     BaseMaskedDtype,
+    CategoricalDtype,
     ExtensionDtype,
 )
 from pandas.core.dtypes.generic import (
@@ -260,6 +261,26 @@ if TYPE_CHECKING:
     from pandas.core.interchange.dataframe_protocol import DataFrame as DataFrameXchg
 
     from pandas.io.formats.style import Styler
+
+
+def _select_dtypes_arrow_kind_match(dtype: ArrowDtype, req: type) -> bool:
+    # An ExtensionDtype class request names a kind, and Arrow string/dictionary
+    # columns belong to the string/categorical kinds, so e.g.
+    # select_dtypes(StringDtype) also selects ArrowDtype(pa.string()) columns
+    # and select_dtypes(CategoricalDtype) selects ArrowDtype(pa.dictionary())
+    # columns (as on main, where the numpy_dtype unwrap provided this).
+    import pyarrow as pa
+
+    pa_type = dtype.pyarrow_dtype
+    if req is StringDtype:
+        return (
+            pa.types.is_string(pa_type)
+            or pa.types.is_large_string(pa_type)
+            or pa.types.is_string_view(pa_type)
+        )
+    if req is CategoricalDtype:
+        return pa.types.is_dictionary(pa_type)
+    return False
 
 
 # -----------------------------------------------------------------------
@@ -5407,9 +5428,17 @@ class DataFrame(NDFrame, OpsMixin):
         if not any(selection):
             raise ValueError("at least one of include or exclude must be nonempty")
 
-        # convert the myriad valid dtypes object to a single representation
+        # Convert the myriad valid dtype specs into a numpy-scalar set plus an
+        # ExtensionDtype-request bucket. An EA spec is matched by identity --
+        # an instance by equality, a class (or bare class-name string) as a
+        # "kind" matching any instance of it -- rather than being collapsed to
+        # the numpy scalar type it shares with numpy columns. This fixes GH#40234
+        # ("Int64"/Int64Dtype no longer also match numpy int64) and the EA-class
+        # half of GH#59888 (e.g. ArrowDtype/DatetimeTZDtype). The kind-string
+        # cross-backend bucket and the numpy-type tightening remain in GH#65366.
         def check_int_infer_dtype(dtypes):
             converted_dtypes: list[type] = []
+            ea_requests: list = []
             for dtype in dtypes:
                 # Numpy maps int to different types (int32, in64) on Windows and Linux
                 # see https://github.com/numpy/numpy/issues/9464
@@ -5419,27 +5448,66 @@ class DataFrame(NDFrame, OpsMixin):
                 elif dtype == "float" or dtype is float:
                     # GH#42452 : np.dtype("float") coerces to np.float64 from Numpy 1.20
                     converted_dtypes.extend([np.float64, np.float32])
+                elif isinstance(dtype, ExtensionDtype):
+                    # an EA instance matches by equality
+                    ea_requests.append(dtype)
+                elif isinstance(dtype, type) and issubclass(dtype, ExtensionDtype):
+                    # an EA class names a kind -> match any instance of it
+                    ea_requests.append(dtype)
+                elif isinstance(dtype, str):
+                    # a bare EA class-name ("Int64", "string", "category") is a
+                    # class (kind) request; bracketed strings (a specific
+                    # parametrization) and non-EA strings stay on the numpy path
+                    try:
+                        parsed = pandas_dtype(dtype)
+                    except TypeError:
+                        parsed = None
+                    if isinstance(parsed, ExtensionDtype) and "[" not in dtype:
+                        ea_requests.append(type(parsed))
+                    else:
+                        converted_dtypes.append(infer_dtype_from_object(dtype))
                 else:
                     converted_dtypes.append(infer_dtype_from_object(dtype))
-            return frozenset(converted_dtypes)
+            return frozenset(converted_dtypes), tuple(ea_requests)
 
-        include = check_int_infer_dtype(include)
-        exclude = check_int_infer_dtype(exclude)
+        include_np, include_ea = check_int_infer_dtype(include)
+        exclude_np, exclude_ea = check_int_infer_dtype(exclude)
 
-        for dtypes in (include, exclude):
+        for dtypes in (include_np, exclude_np):
             invalidate_string_dtypes(dtypes)
 
         # can't both include AND exclude!
-        if not include.isdisjoint(exclude):
-            raise ValueError(f"include and exclude overlap on {(include & exclude)}")
+        if not include_np.isdisjoint(exclude_np):
+            raise ValueError(
+                f"include and exclude overlap on {(include_np & exclude_np)}"
+            )
+        ea_overlap = set(include_ea) & set(exclude_ea)
+        if ea_overlap:
+            raise ValueError(f"include and exclude overlap on {ea_overlap}")
 
-        def dtype_predicate(dtype: DtypeObj, dtypes_set) -> bool:
+        def _matches_ea(dtype: DtypeObj, ea_reqs: tuple) -> bool:
+            for req in ea_reqs:
+                if isinstance(req, type):
+                    # class -> "any dtype of this class"
+                    if isinstance(dtype, req):
+                        return True
+                    if isinstance(dtype, ArrowDtype):
+                        if _select_dtypes_arrow_kind_match(dtype, req):
+                            return True
+                # instance -> exact-dtype match
+                elif dtype == req:
+                    return True
+            return False
+
+        def dtype_predicate(dtype: DtypeObj, numpy_set, ea_reqs) -> bool:
+            if _matches_ea(dtype, ea_reqs):
+                return True
             # GH 46870: BooleanDtype._is_numeric == True but should be excluded
             dtype = dtype if not isinstance(dtype, ArrowDtype) else dtype.numpy_dtype
             return (
-                issubclass(dtype.type, tuple(dtypes_set))
+                issubclass(dtype.type, tuple(numpy_set))
                 or (
-                    np.number in dtypes_set
+                    np.number in numpy_set
                     and getattr(dtype, "_is_numeric", False)
                     and not is_bool_dtype(dtype)
                 )
@@ -5447,27 +5515,27 @@ class DataFrame(NDFrame, OpsMixin):
                 or (
                     isinstance(dtype, StringDtype)
                     and dtype.na_value is np.nan
-                    and np.object_ in dtypes_set
+                    and np.object_ in numpy_set
                 )
             )
 
         def predicate(arr: ArrayLike) -> bool:
             dtype = arr.dtype
-            if include:
-                if not dtype_predicate(dtype, include):
+            if include_np or include_ea:
+                if not dtype_predicate(dtype, include_np, include_ea):
                     return False
 
-            if exclude:
-                if dtype_predicate(dtype, exclude):
+            if exclude_np or exclude_ea:
+                if dtype_predicate(dtype, exclude_np, exclude_ea):
                     return False
 
             return True
 
         blk_dtypes = [blk.dtype for blk in self._mgr.blocks]
         if (
-            np.object_ in include
-            and str not in include
-            and str not in exclude
+            np.object_ in include_np
+            and str not in include_np
+            and str not in exclude_np
             and any(
                 isinstance(dtype, StringDtype) and dtype.na_value is np.nan
                 for dtype in blk_dtypes

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat.pyarrow import pa_version_under16p0
 from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.dtypes import ExtensionDtype
@@ -526,3 +527,188 @@ class TestSelectDtypes:
         else:
             expected = df[["c"]]
         tm.assert_frame_equal(result, expected)
+
+
+# GH#40234
+@pytest.mark.parametrize("spec", ["Int64", pd.Int64Dtype, pd.Int64Dtype()])
+def test_select_dtypes_int64_ea_does_not_match_numpy_int64(spec):
+    df = DataFrame({"A": [1, 2], "B": pd.array([1, 2], dtype="Int64")})
+    result = df.select_dtypes(spec)
+    tm.assert_frame_equal(result, df[["B"]])
+
+
+def test_select_dtypes_arrow_int_instance_matches_exact():
+    # GH#59888: an Arrow dtype instance matches that exact dtype
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {
+            "np": [1, 2],
+            "arrow": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int64())),
+        }
+    )
+    result = df.select_dtypes(include=[pd.ArrowDtype(pa.int64())])
+    tm.assert_frame_equal(result, df[["arrow"]])
+
+
+def test_select_dtypes_arrow_dtype_class_matches_all_arrow():
+    # Passing the ArrowDtype class as a "kind" request matches every
+    # Arrow-backed column regardless of the inner pyarrow type.
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {
+            "a": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int64())),
+            "b": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string())),
+            "c": [1.0, 2.0],
+        }
+    )
+    result = df.select_dtypes(include=pd.ArrowDtype)
+    tm.assert_frame_equal(result, df[["a", "b"]])
+
+
+def test_select_dtypes_parameterized_ea_class_does_not_warn():
+    # Passing a parameterized EA class (ArrowDtype, DatetimeTZDtype, ...)
+    # as a spec previously emitted a UserWarning from pandas_dtype.
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame({"x": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int64()))})
+    with tm.assert_produces_warning(None):
+        df.select_dtypes(pd.ArrowDtype)
+
+    df2 = DataFrame({"t": pd.to_datetime(["2020-01-01"]).tz_localize("UTC")})
+    with tm.assert_produces_warning(None):
+        df2.select_dtypes(pd.DatetimeTZDtype)
+
+
+def test_select_dtypes_datetimetz_class_matches_any_tz():
+    df = DataFrame(
+        {
+            "utc": pd.to_datetime(["2020-01-01"]).tz_localize("UTC"),
+            "est": pd.to_datetime(["2020-01-01"]).tz_localize("US/Eastern"),
+            "naive": pd.to_datetime(["2020-01-01"]),
+        }
+    )
+    expected = df[["utc", "est"]]
+    tm.assert_frame_equal(df.select_dtypes(pd.DatetimeTZDtype), expected)
+    tm.assert_frame_equal(df.select_dtypes("datetimetz"), expected)
+    tm.assert_frame_equal(df.select_dtypes("datetime64tz"), expected)
+
+
+def test_select_dtypes_category_class_matches_any_categories():
+    df = DataFrame(
+        {
+            "cat1": pd.Categorical(["a", "b"], categories=["a", "b", "c"]),
+            "cat2": pd.Categorical([1, 2], categories=[1, 2, 3]),
+            "num": [1, 2],
+        }
+    )
+    expected = df[["cat1", "cat2"]]
+    tm.assert_frame_equal(df.select_dtypes(pd.CategoricalDtype), expected)
+    tm.assert_frame_equal(df.select_dtypes("category"), expected)
+
+
+def test_select_dtypes_include_exclude_overlap_raises():
+    df = DataFrame({"a": [1, 2], "b": pd.array([1, 2], dtype="Int64")})
+
+    # numpy-set overlap
+    with pytest.raises(ValueError, match="include and exclude overlap"):
+        df.select_dtypes(include=[np.int64], exclude=[np.int64])
+
+    # EA-class overlap
+    with pytest.raises(ValueError, match="include and exclude overlap"):
+        df.select_dtypes(include=pd.Int64Dtype, exclude=pd.Int64Dtype)
+
+    # EA-instance overlap
+    with pytest.raises(ValueError, match="include and exclude overlap"):
+        df.select_dtypes(include=pd.Int64Dtype(), exclude=pd.Int64Dtype())
+
+    # kind-string overlap
+    with pytest.raises(ValueError, match="include and exclude overlap"):
+        df.select_dtypes(include="int64", exclude="int64")
+
+
+def test_select_dtypes_string_class_matches_arrow_strings():
+    # GH#59888: the StringDtype class names the string kind and also matches
+    # Arrow-backed string columns
+    pa = pytest.importorskip("pyarrow")
+    data = {
+        # NaN-variant StringDtype (the default "str" dtype under the future
+        # string option); construct explicitly so the test does not depend on
+        # PANDAS_FUTURE_INFER_STRING (with which off, dtype="str" is object)
+        "default": pd.array(["x", "y"], dtype=pd.StringDtype(na_value=np.nan)),
+        "nullable": pd.array(["x", "y"], dtype="string"),
+        "arrow": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string())),
+        "large": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.large_string())),
+        "num": [1, 2],
+    }
+    string_cols = ["default", "nullable", "arrow", "large"]
+    if not pa_version_under16p0:
+        # pa.string_view requires pyarrow>=16
+        data["view"] = pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string_view()))
+        string_cols.append("view")
+    df = DataFrame(data)
+    # compare columns, not frames: assert_frame_equal raises for string_view
+    # columns (ArrowDtype.type is not implemented for string_view)
+    result = df.select_dtypes(include=pd.StringDtype)
+    assert list(result.columns) == string_cols
+    result = df.select_dtypes(exclude=pd.StringDtype)
+    assert list(result.columns) == ["num"]
+
+
+def test_select_dtypes_string_kind_matches_arrow_strings():
+    # GH#59888: the "string" kind name also matches Arrow-backed string columns
+    pa = pytest.importorskip("pyarrow")
+    data = {
+        # NaN-variant StringDtype (the default "str" dtype under the future
+        # string option); construct explicitly so the test does not depend on
+        # PANDAS_FUTURE_INFER_STRING (with which off, dtype="str" is object)
+        "default": pd.array(["x", "y"], dtype=pd.StringDtype(na_value=np.nan)),
+        "nullable": pd.array(["x", "y"], dtype="string"),
+        "arrow": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string())),
+        "large": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.large_string())),
+        "num": [1, 2],
+    }
+    string_cols = ["default", "nullable", "arrow", "large"]
+    if not pa_version_under16p0:
+        # pa.string_view requires pyarrow>=16
+        data["view"] = pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string_view()))
+        string_cols.append("view")
+    df = DataFrame(data)
+    # compare columns, not frames: assert_frame_equal raises for string_view
+    # columns (ArrowDtype.type is not implemented for string_view)
+    result = df.select_dtypes(include="string")
+    assert list(result.columns) == string_cols
+    result = df.select_dtypes(exclude="string")
+    assert list(result.columns) == ["num"]
+
+
+def test_select_dtypes_category_class_matches_arrow_dictionary():
+    # GH#59888: the CategoricalDtype class also matches Arrow dictionary columns
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {
+            "cat": pd.Categorical(["a", "b"]),
+            "arrow": pd.array(
+                ["a", "b"],
+                dtype=pd.ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
+            ),
+            "num": [1, 2],
+        }
+    )
+    expected = df[["cat", "arrow"]]
+    tm.assert_frame_equal(df.select_dtypes(include=pd.CategoricalDtype), expected)
+
+
+def test_select_dtypes_category_kind_matches_arrow_dictionary():
+    # GH#59888: the "category" kind name also matches Arrow dictionary columns
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {
+            "cat": pd.Categorical(["a", "b"]),
+            "arrow": pd.array(
+                ["a", "b"],
+                dtype=pd.ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
+            ),
+            "num": [1, 2],
+        }
+    )
+    expected = df[["cat", "arrow"]]
+    tm.assert_frame_equal(df.select_dtypes(include="category"), expected)

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -712,3 +712,19 @@ def test_select_dtypes_category_kind_matches_arrow_dictionary():
     )
     expected = df[["cat", "arrow"]]
     tm.assert_frame_equal(df.select_dtypes(include="category"), expected)
+
+
+@pytest.mark.parametrize(
+    "string_spec", ["string", "str", str, pd.StringDtype, pd.StringDtype()]
+)
+def test_select_dtypes_object_with_explicit_string_does_not_warn(string_spec):
+    # GH#61916: requesting "object" alongside an explicit string spec must not
+    # emit the str-backcompat warning -- the user asked for the string columns
+    df = DataFrame(
+        {
+            "s": pd.array(["x", "y"], dtype=pd.StringDtype(na_value=np.nan)),
+            "n": [1, 2],
+        }
+    )
+    with tm.assert_produces_warning(None):
+        df.select_dtypes(include=["object", string_spec])

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat.pyarrow import pa_version_under16p0
 from pandas.errors import Pandas4Warning
 
 from pandas.core.dtypes.dtypes import ExtensionDtype
@@ -623,95 +622,6 @@ def test_select_dtypes_include_exclude_overlap_raises():
     # kind-string overlap
     with pytest.raises(ValueError, match="include and exclude overlap"):
         df.select_dtypes(include="int64", exclude="int64")
-
-
-def test_select_dtypes_string_class_matches_arrow_strings():
-    # GH#59888: the StringDtype class names the string kind and also matches
-    # Arrow-backed string columns
-    pa = pytest.importorskip("pyarrow")
-    data = {
-        # NaN-variant StringDtype (the default "str" dtype under the future
-        # string option); construct explicitly so the test does not depend on
-        # PANDAS_FUTURE_INFER_STRING (with which off, dtype="str" is object)
-        "default": pd.array(["x", "y"], dtype=pd.StringDtype(na_value=np.nan)),
-        "nullable": pd.array(["x", "y"], dtype="string"),
-        "arrow": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string())),
-        "large": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.large_string())),
-        "num": [1, 2],
-    }
-    string_cols = ["default", "nullable", "arrow", "large"]
-    if not pa_version_under16p0:
-        # pa.string_view requires pyarrow>=16
-        data["view"] = pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string_view()))
-        string_cols.append("view")
-    df = DataFrame(data)
-    # compare columns, not frames: assert_frame_equal raises for string_view
-    # columns (ArrowDtype.type is not implemented for string_view)
-    result = df.select_dtypes(include=pd.StringDtype)
-    assert list(result.columns) == string_cols
-    result = df.select_dtypes(exclude=pd.StringDtype)
-    assert list(result.columns) == ["num"]
-
-
-def test_select_dtypes_string_kind_matches_arrow_strings():
-    # GH#59888: the "string" kind name also matches Arrow-backed string columns
-    pa = pytest.importorskip("pyarrow")
-    data = {
-        # NaN-variant StringDtype (the default "str" dtype under the future
-        # string option); construct explicitly so the test does not depend on
-        # PANDAS_FUTURE_INFER_STRING (with which off, dtype="str" is object)
-        "default": pd.array(["x", "y"], dtype=pd.StringDtype(na_value=np.nan)),
-        "nullable": pd.array(["x", "y"], dtype="string"),
-        "arrow": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string())),
-        "large": pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.large_string())),
-        "num": [1, 2],
-    }
-    string_cols = ["default", "nullable", "arrow", "large"]
-    if not pa_version_under16p0:
-        # pa.string_view requires pyarrow>=16
-        data["view"] = pd.array(["x", "y"], dtype=pd.ArrowDtype(pa.string_view()))
-        string_cols.append("view")
-    df = DataFrame(data)
-    # compare columns, not frames: assert_frame_equal raises for string_view
-    # columns (ArrowDtype.type is not implemented for string_view)
-    result = df.select_dtypes(include="string")
-    assert list(result.columns) == string_cols
-    result = df.select_dtypes(exclude="string")
-    assert list(result.columns) == ["num"]
-
-
-def test_select_dtypes_category_class_matches_arrow_dictionary():
-    # GH#59888: the CategoricalDtype class also matches Arrow dictionary columns
-    pa = pytest.importorskip("pyarrow")
-    df = DataFrame(
-        {
-            "cat": pd.Categorical(["a", "b"]),
-            "arrow": pd.array(
-                ["a", "b"],
-                dtype=pd.ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
-            ),
-            "num": [1, 2],
-        }
-    )
-    expected = df[["cat", "arrow"]]
-    tm.assert_frame_equal(df.select_dtypes(include=pd.CategoricalDtype), expected)
-
-
-def test_select_dtypes_category_kind_matches_arrow_dictionary():
-    # GH#59888: the "category" kind name also matches Arrow dictionary columns
-    pa = pytest.importorskip("pyarrow")
-    df = DataFrame(
-        {
-            "cat": pd.Categorical(["a", "b"]),
-            "arrow": pd.array(
-                ["a", "b"],
-                dtype=pd.ArrowDtype(pa.dictionary(pa.int32(), pa.string())),
-            ),
-            "num": [1, 2],
-        }
-    )
-    expected = df[["cat", "arrow"]]
-    tm.assert_frame_equal(df.select_dtypes(include="category"), expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #40234

`select_dtypes` reduced every `ExtensionDtype` spec to the numpy scalar type it shares (via `infer_dtype_from_object`), which caused two bugs:

- `"Int64"` / `Int64Dtype` / `Int64Dtype()` also matched numpy `int64` columns (GH-40234), and analogously for the other nullable integer, floating, and boolean dtypes.
- Passing a parameterized EA class such as `pd.ArrowDtype` or `pd.DatetimeTZDtype` emitted a spurious `UserWarning: Instantiating X without any arguments` and matched the wrong columns (GH-59888).

EA specs are now matched by **identity**:

- an **instance** matches by equality (`pd.ArrowDtype(pa.int64())` → exactly that dtype; `pd.DatetimeTZDtype("UTC")` → that tz);
- a **class** -- or a bare class-name string (`"Int64"`, `"string"`, `"category"`) -- names a *kind* and matches any instance of that class, with a small Arrow bridge so `pd.StringDtype` / `pd.CategoricalDtype` keep matching Arrow `string`/`large_string`/`string_view` and `dictionary` columns (as on main). No spurious warning.

The numpy path is unchanged: numpy types (`np.int64`), kind-name strings (`"int64"`, `"datetime"`, which still match numpy + masked + Arrow alike), and parametrized numpy strings (`"datetime64[ns]"`) behave exactly as before.

Split off from GH-65366; the kind-string cross-backend bucket, the `np.int64`/Arrow tightening (so e.g. `np.int64` and `"datetime64[ns]"` stop matching EA/Arrow), the bracketed-Arrow-string form (`"timestamp[ns][pyarrow]"`), and the `describe()`/scatter fallout remain there. Supersedes GH-66097.
