### PR TITLE
BUG: select_dtypes ExtensionDtype instance and bracketed-string matching (GH#59888)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -451,6 +451,7 @@ Reshaping
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
 - Bug in :meth:`DataFrame.melt` where ``var_name`` colliding with an ``id_vars`` column or ``value_name`` silently overwrote the affected column data instead of raising (:issue:`65654`)
 - Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)
+- Bug in :meth:`DataFrame.select_dtypes` where the string form of an :class:`ArrowDtype` (e.g. ``"timestamp[ns][pyarrow]"``) failed to select columns of that dtype; an :class:`ExtensionDtype` instance or bracketed extension string now selects only columns of exactly that dtype (:issue:`59888`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -262,6 +262,35 @@ if TYPE_CHECKING:
     from pandas.io.formats.style import Styler
 
 
+def _select_dtypes_ea_instance(dtype) -> ExtensionDtype | None:
+    """
+    Return the ExtensionDtype instance named by a ``select_dtypes`` spec that
+    should be matched by exact dtype equality.
+
+    A non-masked :class:`ExtensionDtype` instance (e.g. ``DatetimeTZDtype("UTC")``,
+    ``ArrowDtype(pa.int64())``) or a bracketed extension string (e.g.
+    ``"datetime64[ns, UTC]"``, ``"timestamp[ns][pyarrow]"``) names one specific
+    parametrization, so it selects only columns of exactly that dtype (GH#59888)
+    rather than being collapsed to the scalar type it shares with columns of
+    other backends. Masked instances are handled separately (GH#40234); classes
+    and bracket-free kind strings return ``None``.
+    """
+    if isinstance(dtype, BaseMaskedDtype):
+        return None
+    if isinstance(dtype, ExtensionDtype):
+        return dtype
+    if isinstance(dtype, str) and "[" in dtype:
+        try:
+            parsed = pandas_dtype(dtype)
+        except TypeError:
+            return None
+        if isinstance(parsed, ExtensionDtype) and not isinstance(
+            parsed, BaseMaskedDtype
+        ):
+            return parsed
+    return None
+
+
 # -----------------------------------------------------------------------
 # DataFrame class
 
@@ -5410,6 +5439,11 @@ class DataFrame(NDFrame, OpsMixin):
         # convert the myriad valid dtypes object to a single representation
         def check_int_infer_dtype(dtypes):
             converted_dtypes: list[type] = []
+            # GH#59888: a non-masked EA *instance* or a bracketed extension
+            # string names one specific parametrization and is matched by exact
+            # dtype equality, rather than collapsed to the scalar type it shares
+            # with columns of other backends.
+            ea_instance_requests: list[ExtensionDtype] = []
             for dtype in dtypes:
                 # Numpy maps int to different types (int32, in64) on Windows and Linux
                 # see https://github.com/numpy/numpy/issues/9464
@@ -5419,12 +5453,14 @@ class DataFrame(NDFrame, OpsMixin):
                 elif dtype == "float" or dtype is float:
                     # GH#42452 : np.dtype("float") coerces to np.float64 from Numpy 1.20
                     converted_dtypes.extend([np.float64, np.float32])
+                elif (ea_inst := _select_dtypes_ea_instance(dtype)) is not None:
+                    ea_instance_requests.append(ea_inst)
                 else:
                     converted_dtypes.append(infer_dtype_from_object(dtype))
-            return frozenset(converted_dtypes)
+            return frozenset(converted_dtypes), tuple(ea_instance_requests)
 
-        include = check_int_infer_dtype(include)
-        exclude = check_int_infer_dtype(exclude)
+        include, include_ea = check_int_infer_dtype(include)
+        exclude, exclude_ea = check_int_infer_dtype(exclude)
 
         for dtypes in (include, exclude):
             invalidate_string_dtypes(dtypes)
@@ -5432,8 +5468,15 @@ class DataFrame(NDFrame, OpsMixin):
         # can't both include AND exclude!
         if not include.isdisjoint(exclude):
             raise ValueError(f"include and exclude overlap on {(include & exclude)}")
+        ea_overlap = set(include_ea) & set(exclude_ea)
+        if ea_overlap:
+            raise ValueError(f"include and exclude overlap on {ea_overlap}")
 
-        def dtype_predicate(dtype: DtypeObj, dtypes_set) -> bool:
+        def dtype_predicate(dtype: DtypeObj, dtypes_set, ea_reqs) -> bool:
+            # GH#59888: an EA-instance / bracketed-string request matches a
+            # column only when its dtype is exactly equal.
+            if ea_reqs and any(dtype == req for req in ea_reqs):
+                return True
             # GH 46870: BooleanDtype._is_numeric == True but should be excluded
             dtype = dtype if not isinstance(dtype, ArrowDtype) else dtype.numpy_dtype
             return (
@@ -5453,12 +5496,12 @@ class DataFrame(NDFrame, OpsMixin):
 
         def predicate(arr: ArrayLike) -> bool:
             dtype = arr.dtype
-            if include:
-                if not dtype_predicate(dtype, include):
+            if include or include_ea:
+                if not dtype_predicate(dtype, include, include_ea):
                     return False
 
-            if exclude:
-                if dtype_predicate(dtype, exclude):
+            if exclude or exclude_ea:
+                if dtype_predicate(dtype, exclude, exclude_ea):
                     return False
 
             return True

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -526,3 +526,122 @@ class TestSelectDtypes:
         else:
             expected = df[["c"]]
         tm.assert_frame_equal(result, expected)
+
+
+def test_select_dtypes_datetimetz_instance_matches_exact_tz():
+    # GH#59888: a DatetimeTZDtype instance selects only columns of exactly that
+    # dtype (tz and unit), not every tz-aware column
+    idx = pd.to_datetime(["2020-01-01"]).as_unit("ns")
+    df = DataFrame(
+        {
+            "utc": idx.tz_localize("UTC"),
+            "est": idx.tz_localize("US/Eastern"),
+            "naive": idx,
+        }
+    )
+    result = df.select_dtypes(include=pd.DatetimeTZDtype(unit="ns", tz="UTC"))
+    tm.assert_frame_equal(result, df[["utc"]])
+
+
+def test_select_dtypes_arrow_instance_matches_exact():
+    # GH#59888: an ArrowDtype instance selects only the matching Arrow column,
+    # not the numpy or masked column sharing its scalar type
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {
+            "np": np.array([1, 2], dtype="int64"),
+            "ea": pd.array([1, 2], dtype="Int64"),
+            "arrow": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int64())),
+            "arrow32": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int32())),
+        }
+    )
+    result = df.select_dtypes(include=pd.ArrowDtype(pa.int64()))
+    tm.assert_frame_equal(result, df[["arrow"]])
+
+
+def test_select_dtypes_arrow_timestamp_instance_matches_exact():
+    # GH#59888: an ArrowDtype timestamp instance does not cross-match numpy
+    # datetime64 columns
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {
+            "naive": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+            "arrow": pd.array(
+                pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                dtype=pd.ArrowDtype(pa.timestamp("ns")),
+            ),
+        }
+    )
+    result = df.select_dtypes(include=pd.ArrowDtype(pa.timestamp("ns")))
+    tm.assert_frame_equal(result, df[["arrow"]])
+
+
+def test_select_dtypes_categorical_instance_matches_exact_categories():
+    # GH#59888: a parametrized CategoricalDtype instance matches only columns
+    # with exactly those categories
+    df = DataFrame(
+        {
+            "ab": pd.Categorical(["a", "b"], categories=["a", "b"]),
+            "abc": pd.Categorical(["a", "b"], categories=["a", "b", "c"]),
+            "num": [1, 2],
+        }
+    )
+    result = df.select_dtypes(include=pd.CategoricalDtype(["a", "b"]))
+    tm.assert_frame_equal(result, df[["ab"]])
+
+
+def test_select_dtypes_arrow_bracketed_string_matches_arrow():
+    # GH#59888: the string form of an Arrow dtype matches the Arrow column
+    # (previously returned no/wrong columns)
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {
+            "naive": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+            "ts": pd.array(
+                pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                dtype=pd.ArrowDtype(pa.timestamp("ns")),
+            ),
+            "np_int": np.array([1, 2], dtype="int64"),
+            "arrow_int": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int64())),
+        }
+    )
+    tm.assert_frame_equal(
+        df.select_dtypes(include=["timestamp[ns][pyarrow]"]), df[["ts"]]
+    )
+    tm.assert_frame_equal(
+        df.select_dtypes(include=["int64[pyarrow]"]), df[["arrow_int"]]
+    )
+
+
+def test_select_dtypes_datetimetz_bracketed_string_matches_exact_tz():
+    # GH#59888: the bracketed numpy-style tz string names a specific tz (and unit)
+    idx = pd.to_datetime(["2020-01-01"]).as_unit("ns")
+    df = DataFrame(
+        {
+            "utc": idx.tz_localize("UTC"),
+            "est": idx.tz_localize("US/Eastern"),
+        }
+    )
+    result = df.select_dtypes(include=["datetime64[ns, UTC]"])
+    tm.assert_frame_equal(result, df[["utc"]])
+
+
+def test_select_dtypes_ea_instance_exclude():
+    # GH#59888: equality matching also drives exclude
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame(
+        {
+            "np": np.array([1, 2], dtype="int64"),
+            "arrow": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int64())),
+        }
+    )
+    result = df.select_dtypes(exclude=pd.ArrowDtype(pa.int64()))
+    tm.assert_frame_equal(result, df[["np"]])
+
+
+def test_select_dtypes_ea_instance_include_exclude_overlap_raises():
+    pa = pytest.importorskip("pyarrow")
+    df = DataFrame({"arrow": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int64()))})
+    arrow_int = pd.ArrowDtype(pa.int64())
+    with pytest.raises(ValueError, match="include and exclude overlap"):
+        df.select_dtypes(include=arrow_int, exclude=arrow_int)


### PR DESCRIPTION
Split off from GH-65366; independent of GH-66096 (masked dtype matching) and GH-66097 (EA class spec matching).

Passing an `ExtensionDtype` *instance* or a bracketed extension string to `select_dtypes` collapsed the spec to the scalar type it shares with other backends, so it matched unrelated columns. In particular the string form of an `ArrowDtype` was broken: `"timestamp[ns][pyarrow]"` selected the wrong (tz-aware) columns and `"int64[pyarrow]"` selected none.

A non-masked EA instance (e.g. `pd.DatetimeTZDtype("UTC")`, `pd.ArrowDtype(pa.int64())`) or a bracketed extension string (e.g. `"datetime64[ns, UTC]"`, `"timestamp[ns][pyarrow]"`) now names one specific parametrization and matches only columns of exactly that dtype.

Scope is intentionally narrow — only EA *instance* and bracketed-string specs change. Verified byte-identical to main:

- EA classes (`pd.ArrowDtype`, `pd.DatetimeTZDtype`) — handled by GH-66097
- masked specs (`"Int64"`, `pd.Int64Dtype`, `Int64Dtype()`) — handled by GH-66096
- kind strings (`"int64"`, `"datetime"`, `"string"`, `"category"`)
- numpy types and bracketed numpy strings (`np.int64`, `"datetime64[ns]"`)

The kind-string cross-backend bucket, the `np.int64` tightening, and the `describe()`/scatter fallout remain in GH-65366. This PR fixes only the instance/bracketed-string corner of GH-59888, so it does not close the issue.

Matching is by exact dtype equality, which includes resolution: e.g. `pd.DatetimeTZDtype(tz="UTC")` (unit `ns`) does not match a `datetime64[us, UTC]` column. The bracket-free `"datetimetz"` string remains the any-unit/any-tz request.

## Test plan

- [x] New module-level tests for EA instance equality (`DatetimeTZDtype`, `ArrowDtype` int/timestamp, parametrized `CategoricalDtype`), the bracketed Arrow string fixes (`"timestamp[ns][pyarrow]"`, `"int64[pyarrow]"`), the bracketed tz string, exclude, and include/exclude overlap
- [x] Existing `test_select_dtypes.py` suite passes
- [x] Broad pass across `frame/`, `dtypes/`, `extension/` (arrow, masked, datetime, categorical), `reshape/test_get_dummies.py`, `plotting/` — no regressions
- [x] `pre-commit`, `mypy`, `pyright` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
