### PR TITLE
BUG: pivot_table margins drop valid rows when dropna=True and aggfunc is dict (GH#65765)

### DIFF
--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -405,7 +405,7 @@ def __internal_pivot_table(
                 key_cols.extend(index)
             if columns:
                 key_cols.extend(columns)
-                
+
             if key_cols:
                 data = data[data[key_cols].notna().all(axis=1)]
         table = _add_margins(

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -397,6 +397,17 @@ def __internal_pivot_table(
             table = table.astype(np.int64)
 
     if margins:
+        if dropna:
+            # Only drop rows where the grouping keys (index/columns) are NaN,
+            # not where unrelated value columns are NaN.
+            key_cols = []
+            if index:
+                key_cols.extend(index)
+            if columns:
+                key_cols.extend(columns)
+                
+            if key_cols:
+                data = data[data[key_cols].notna().all(axis=1)]
         table = _add_margins(
             table,
             data,

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -397,8 +397,6 @@ def __internal_pivot_table(
             table = table.astype(np.int64)
 
     if margins:
-        if dropna:
-            data = data[data.notna().all(axis=1)]
         table = _add_margins(
             table,
             data,

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -3136,3 +3136,55 @@ class TestPivot:
         )
 
         tm.assert_frame_equal(result, expected)
+
+    def test_pivot_margins_dict_aggfunc_gh65765(self):
+        # GH 65765
+        df = DataFrame(
+            {"A": [1, 1], "B": [1, 2], "C": [10.0, np.nan], "D": [100.0, 200.0]}
+        )
+        result = pivot_table(
+            df,
+            index="A",
+            columns="B",
+            values=["C", "D"],
+            aggfunc={"C": "mean", "D": "sum"},
+            margins=True,
+        )
+        # ("C", 2) is dropped because mean() of an all-NaN group returns NaN,
+        # and the resulting all-NaN column gets removed by the final
+        # dropna(how="all", axis=1) cleanup step
+        expected_columns = MultiIndex.from_tuples(
+            [("C", 1), ("C", "All"), ("D", 1), ("D", 2), ("D", "All")],
+            names=[None, "B"],
+        )
+        expected_index = Index([1, "All"], name="A")
+        expected = DataFrame(
+            [[10.0, 10.0, 100.0, 200.0, 300.0], [10.0, 10.0, 100.0, 200.0, 300.0]],
+            index=expected_index,
+            columns=expected_columns,
+        )
+        tm.assert_frame_equal(result, expected)
+
+    def test_pivot_margins_api_consistency_str_vs_dict_gh65765(self):
+        # GH 65765: Proves that string aggfunc and dict aggfunc yield identical
+        # results when applying the same mathematical operation.
+        df = DataFrame(
+            {"A": [1, 1], "B": [1, 2], "C": [10.0, np.nan], "D": [100.0, 200.0]}
+        )
+        result_dict = pivot_table(
+            df,
+            index="A",
+            columns="B",
+            values=["C", "D"],
+            aggfunc={"C": "sum", "D": "sum"},
+            margins=True,
+        )
+        result_str = pivot_table(
+            df,
+            index="A",
+            columns="B",
+            values=["C", "D"],
+            aggfunc="sum",
+            margins=True,
+        )
+        tm.assert_frame_equal(result_dict, result_str)


### PR DESCRIPTION
- [x] closes #65765 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

### Summary of Changes

* **The Fix:** Removed the overly aggressive `dropna` sweep right before `_add_margins` in `pivot.py`. Replaced it with a targeted sweep that *only* checks for NaNs in the grouping keys (`index` and `columns`).
* **Why it works:** Deferring the drop on value columns allows aggregators to handle NaNs natively per-column. This fixes the margin math for *both* `dict` and `str` `aggfuncs` consistently. By restricting the early `dropna` sweep strictly to grouping keys, we also preserve the required behavior for `crosstab`.
* **Verification:** Added a new test specifically to guarantee `str` vs `dict` API consistency. Ran `test_pivot.py` and `test_crosstab.py` locally with 100% passes.