### PR TITLE
BUG: DataFrame.loc partial assignment upcasting dtype of untouched columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -352,6 +352,7 @@ Indexing
 - Bug in :meth:`RangeIndex.memory_usage` and :attr:`RangeIndex.nbytes` raising ``TypeError`` on PyPy (:issue:`46176`)
 - Bug in :meth:`Series.where` and :meth:`Series.mask` raising ``ValueError`` when ``other`` is a tuple on object-dtype :class:`Series` (:issue:`37681`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning an iterable to a single cell in an ``object`` dtype column incorrectly raised a ``ValueError`` (:issue:`26333`, :issue:`57962`)
+- Fixed bug in :meth:`DataFrame.loc` where assigning a :class:`Series` to a subset of rows of one column upcast the dtype of other columns in a single-dtype :class:`DataFrame` (:issue:`66105`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
 - Fixed segfault in :meth:`DataFrame.loc` when repeatedly adding new rows to an object-dtype-indexed :class:`DataFrame` (:issue:`21968`)
 -

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2850,6 +2850,20 @@ class _iLocIndexer(_LocationIndexer):
                     self._setitem_single_column(loc, value, indexer[0])
                     return
 
+            if (
+                self.ndim == 2
+                and len(indexer) == 2
+                and self.obj.shape[1] > 1
+                and not com.is_null_slice(indexer[1])
+                and not isinstance(value, ABCDataFrame)
+                and not can_hold_element(
+                    self.obj._mgr.blocks[0].values,
+                    extract_array(value, extract_numpy=True),
+                )
+            ):
+                self._setitem_with_indexer_split_path(indexer, value, name)
+                return
+
             indexer = maybe_convert_ix(*indexer)  # e.g. test_setitem_frame_align
 
         if isinstance(value, ABCDataFrame) and name != "iloc":

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -502,6 +502,20 @@ class TestLocBaseIndependent:
         )
         tm.assert_frame_equal(df, expected)
 
+    def test_loc_setitem_partial_series_multiple_columns(self):
+        # GH#66105
+        df = DataFrame({"A": [1, 2, 3, 4], "B": [5, 6, 7, 8], "C": [9, 10, 11, 12]})
+        df.loc[df["A"] > 1, ["B", "C"]] = Series([99], index=[2])
+
+        expected = DataFrame(
+            {
+                "A": [1, 2, 3, 4],
+                "B": [5.0, np.nan, 99.0, np.nan],
+                "C": [9.0, np.nan, 99.0, np.nan],
+            }
+        )
+        tm.assert_frame_equal(df, expected)
+
     def test_getitem_label_list_with_missing(self):
         s = Series(range(3), index=["a", "b", "c"])
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -475,6 +475,33 @@ class TestLocBaseIndependent:
 
         tm.assert_frame_equal(df, expected)
 
+    def test_loc_setitem_partial_series_preserves_other_columns_dtype(self):
+        # GH#66105
+        df = DataFrame({"A": [1, 2, 3, 4], "B": [5, 6, 7, 8], "C": [9, 10, 11, 12]})
+        df.loc[df["A"] > 1, "B"] = Series([99], index=[2])
+
+        expected = DataFrame(
+            {
+                "A": [1, 2, 3, 4],
+                "B": [5.0, np.nan, 99.0, np.nan],
+                "C": [9, 10, 11, 12],
+            }
+        )
+        tm.assert_frame_equal(df, expected)
+
+    def test_loc_setitem_partial_series_preserves_large_int_values(self):
+        # GH#66105
+        df = DataFrame({"A": [2**53 + 1, 2**53 + 3, 2**53 + 5], "B": [1, 2, 3]})
+        df.loc[df.index > 0, "B"] = Series([99], index=[1])
+
+        expected = DataFrame(
+            {
+                "A": [2**53 + 1, 2**53 + 3, 2**53 + 5],
+                "B": [1.0, 99.0, np.nan],
+            }
+        )
+        tm.assert_frame_equal(df, expected)
+
     def test_getitem_label_list_with_missing(self):
         s = Series(range(3), index=["a", "b", "c"])
 


### PR DESCRIPTION
I added a dtype check after index-alignment, so when a `.loc` assignment would upcast a shared block I route it through the per column path. That way only the targeted column changes dtype, not its siblings.

- [X] closes #66105
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
