### PR TITLE
BUG: Fix length_of_indexer for negative-step slices (GH#66100)

### DIFF
--- a/pandas/core/indexers/utils.py
+++ b/pandas/core/indexers/utils.py
@@ -298,24 +298,11 @@ def length_of_indexer(indexer, target=None) -> int:
     int
     """
     if target is not None and isinstance(indexer, slice):
-        target_len = len(target)
-        start = indexer.start
-        stop = indexer.stop
-        step = indexer.step
-        if start is None:
-            start = 0
-        elif start < 0:
-            start += target_len
-        if stop is None or stop > target_len:
-            stop = target_len
-        elif stop < 0:
-            stop += target_len
-        if step is None:
-            step = 1
-        elif step < 0:
-            start, stop = stop + 1, start + 1
-            step = -step
-        return (stop - start + step - 1) // step
+        # GH#66100: Use slice.indices() which correctly handles all edge cases
+        # including negative steps, out-of-bounds, and None start/stop/step.
+        # The previous manual implementation mis-computed length for negative
+        # steps (e.g. [::-2] on length-5 returned -2 instead of 3).
+        return len(range(*indexer.indices(len(target))))
     elif isinstance(indexer, (ABCSeries, ABCIndex, np.ndarray, list)):
         if isinstance(indexer, list):
             indexer = np.array(indexer)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1603,3 +1603,18 @@ class TestILocSeries:
 
         expected = Series([7, 8, 3], dtype="int64[pyarrow]")
         tm.assert_series_equal(ser, expected)
+
+    def test_iloc_setitem_negative_step_slice(self):
+        # GH#66100 - iloc setitem with negative step slice was raising
+        # ValueError due to length_of_indexer computing wrong length
+        ser = Series([2, 13, 7, 9, 3], index=list("abcde"))
+        ser.iloc[::-2] = [11, 5, 15]
+        expected = Series([15, 13, 5, 9, 11], index=list("abcde"))
+        tm.assert_series_equal(ser, expected)
+
+    def test_iloc_setitem_negative_step_slice_step_minus1(self):
+        # GH#66100 - full reverse assignment
+        ser = Series([1, 2, 3])
+        ser.iloc[::-1] = [10, 20, 30]
+        expected = Series([30, 20, 10])
+        tm.assert_series_equal(ser, expected)

--- a/pandas/tests/indexing/test_indexers.py
+++ b/pandas/tests/indexing/test_indexers.py
@@ -73,3 +73,22 @@ class TestValidateIndices:
     def test_validate_indices_empty(self):
         with pytest.raises(IndexError, match="indices are out"):
             validate_indices(np.array([0, 1]), 0)
+
+
+@pytest.mark.parametrize(
+    "slc, target_len, expected",
+    [
+        (slice(None, None, -1), 5, 5),   # full reverse
+        (slice(None, None, -2), 5, 3),   # every other, reversed - GH#66100
+        (slice(None, None, -3), 5, 2),
+        (slice(None, None, 2), 5, 3),    # positive step
+        (slice(1, 4), 5, 3),             # normal slice
+        (slice(None, None, -1), 0, 0),   # empty target
+        (slice(None, None, -2), 1, 1),   # single element
+    ],
+)
+def test_length_of_indexer_slice(slc, target_len, expected):
+    # GH#66100 - length_of_indexer was incorrect for negative-step slices
+    target = np.zeros(target_len)
+    result = length_of_indexer(slc, target)
+    assert result == expected

--- a/pandas/tests/indexing/test_indexers.py
+++ b/pandas/tests/indexing/test_indexers.py
@@ -78,13 +78,13 @@ class TestValidateIndices:
 @pytest.mark.parametrize(
     "slc, target_len, expected",
     [
-        (slice(None, None, -1), 5, 5),   # full reverse
-        (slice(None, None, -2), 5, 3),   # every other, reversed - GH#66100
+        (slice(None, None, -1), 5, 5),  # full reverse
+        (slice(None, None, -2), 5, 3),  # every other, reversed - GH#66100
         (slice(None, None, -3), 5, 2),
-        (slice(None, None, 2), 5, 3),    # positive step
-        (slice(1, 4), 5, 3),             # normal slice
-        (slice(None, None, -1), 0, 0),   # empty target
-        (slice(None, None, -2), 1, 1),   # single element
+        (slice(None, None, 2), 5, 3),  # positive step
+        (slice(1, 4), 5, 3),  # normal slice
+        (slice(None, None, -1), 0, 0),  # empty target
+        (slice(None, None, -2), 1, 1),  # single element
     ],
 )
 def test_length_of_indexer_slice(slc, target_len, expected):


### PR DESCRIPTION
#### Code Sample

```python
import pandas as pd

s = pd.Series([2, 13, 7, 9, 3], index=['a', 'b', 'c', 'd', 'e'])
s.iloc[::-2] = [11, 5, 15]
# ValueError: cannot set using a slice indexer with a different length than the value
```

#### Problem description

`iloc.__setitem__` with a negative-step slice raises a false `ValueError` even when the
number of elements in the value matches the number of elements selected by the slice.

The bug is in `length_of_indexer` (`pandas/core/indexers/utils.py`).
The manual formula for negative-step slices:

```python
elif step < 0:
    start, stop = stop + 1, start + 1
    step = -step
return (stop - start + step - 1) // step
```

is incorrect. For `[::-2]` on a 5-element array it returns **-2** instead of **3**,
so the length check fires even though `len(value) == 3 == len(s.iloc[::-2])`.

#### Fix

Replace the error-prone manual formula with Python's built-in `slice.indices()`:

```python
if target is not None and isinstance(indexer, slice):
    return len(range(*indexer.indices(len(target))))
```

`slice.indices(n)` returns a `(start, stop, step)` triple that is already
normalised for negative steps, `None` bounds, and out-of-range values.
`len(range(...))` is O(1), so there is no performance regression.

#### Expected Output

```python
s.iloc[::-2] = [11, 5, 15]
print(s.tolist())  # [15, 13, 5, 9, 11]
```

- [x] tests added / passed
- [x] closes #66100