### PR TITLE
BUG: memory leak in json serialization for timestamp with timezone

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -383,7 +383,7 @@ I/O
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)
-- Fixed memory leak in in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
+- Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -383,6 +383,7 @@ I/O
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)
+- Fixed memory leak in in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)

--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime.c
@@ -322,10 +322,7 @@ PyObject *extract_utc_offset(PyObject *obj) {
   }
   if (tmp != Py_None) {
     PyObject *offset = PyObject_CallMethod(tmp, "utcoffset", "O", obj);
-    if (offset == NULL) {
-      Py_DECREF(tmp);
-      return NULL;
-    }
+    Py_DECREF(tmp);
     return offset;
   }
   return tmp;


### PR DESCRIPTION
- [x] closes #54865 (Replace xxxx with the GitHub issue number)
  - This is the only leak reported by LSan that I found when running the JSON tests, so the issue is probably safe to close.
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

Fix memory leak when executing

```python
from pandas import Timestamp, Series

Series([Timestamp("2013-01-10 00:00:00-0500")]).to_json()
```


<details><summary>LSan stacktrace</summary>
<p>

```
=================================================================
==204932==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x0000004a9478 in malloc (/home/alvaro/opt/python-asan/bin/python3.14+0x4a9478) (BuildId: d34f3059a20abaa7865a706a3f4007981ffba2c9)
    #1 0x000000752714 in _PyObject_MallocWithType /home/alvaro/opt/Python-3.14.6/./Include/internal/pycore_object_alloc.h:46:17
    #2 0x000000752714 in _PyType_AllocNoTrack /home/alvaro/opt/Python-3.14.6/Objects/typeobject.c:2428:19
    #3 0x00000075247d in PyType_GenericAlloc /home/alvaro/opt/Python-3.14.6/Objects/typeobject.c:2459:21
    #4 0x000000b4cda7 in create_timezone /home/alvaro/opt/Python-3.14.6/./Modules/_datetimemodule.c:1433:36
    #5 0x000000b4cda7 in new_timezone /home/alvaro/opt/Python-3.14.6/./Modules/_datetimemodule.c:1465:12
    #6 0x000000b59678 in timezone_new /home/alvaro/opt/Python-3.14.6/./Modules/_datetimemodule.c:4296:16
    #7 0x00000075ccfe in type_call /home/alvaro/opt/Python-3.14.6/Objects/typeobject.c:2372:11
    #8 0x0000005f0e0f in _PyObject_MakeTpCall /home/alvaro/opt/Python-3.14.6/Objects/call.c:242:18
    #9 0x7b3e2e40d77a in __pyx_f_6pandas_5_libs_6tslibs_10conversion_convert_str_to_tsobject /home/alvaro/projects/oss/pandas/build/clang-asan/pandas/_libs/tslibs/conversion.cpython-314-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/conversion.pyx.c:15413:25
    #10 0x7b3e2e4062b1 in __pyx_f_6pandas_5_libs_6tslibs_10conversion_convert_to_tsobject /home/alvaro/projects/oss/pandas/build/clang-asan/pandas/_libs/tslibs/conversion.cpython-314-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/conversion.pyx.c:12853:30
    #11 0x7b3e2dd1a80d in __pyx_pf_6pandas_5_libs_6tslibs_10timestamps_9Timestamp_46__new__ /home/alvaro/projects/oss/pandas/build/clang-asan/pandas/_libs/tslibs/timestamps.cpython-314-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/timestamps.pyx.c:31923:29
    #12 0x7b3e2dd161a9 in __pyx_pw_6pandas_5_libs_6tslibs_10timestamps_9Timestamp_47__new__ /home/alvaro/projects/oss/pandas/build/clang-asan/pandas/_libs/tslibs/timestamps.cpython-314-x86_64-linux-gnu.so.p/pandas/_libs/tslibs/timestamps.pyx.c:30444:13
    #13 0x0000005f0a43 in _PyObject_VectorcallDictTstate /home/alvaro/opt/Python-3.14.6/Objects/call.c:135:15
    #14 0x0000005f31bf in _PyObject_Call_Prepend /home/alvaro/opt/Python-3.14.6/Objects/call.c:504:24
...
```

</p>
</details> 

With this patch, LSan doesn't detect any leaks when running `pytest pandas/tests/io/json/ -m 'not network'`.