### PR TITLE
BUG: interpolate leaving NAs unfilled for pyarrow dtypes

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -540,6 +540,7 @@ Missing
 - Bug in :meth:`DataFrame.fillna` with a dict value raising ``RecursionError`` when columns are a :class:`MultiIndex` with duplicate entries (:issue:`53498`)
 - Bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` with ``method`` in ``"index"``, ``"values"`` or ``"time"`` raising when the index had an :class:`ArrowDtype` timestamp or duration dtype; these now match the equivalent :class:`DatetimeIndex` or :class:`TimedeltaIndex` (:issue:`66338`)
 - Bug in :meth:`Series.combine_first` crashing when Series names are :class:`Timestamp` objects (:issue:`65333`)
+- Bug in :meth:`Series.interpolate` with ``method="linear"`` and a pyarrow-backed dtype leaving consecutive and trailing missing values unfilled, and truncating interpolated values for integer dtypes; the result now matches the equivalent masked (e.g. ``Int64``) dtype, including the upcast to ``float64[pyarrow]`` (:issue:`65345`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3137,18 +3137,11 @@ class ArrowExtensionArray(
         if not self.dtype._is_numeric:
             raise TypeError(f"Cannot interpolate with {self.dtype} dtype")
 
-        if (
-            method == "linear"
-            and limit_area is None
-            and limit is None
-            and limit_direction == "forward"
-        ):
-            values = self._pa_array.combine_chunks()
-            na_value = pa.array([None], type=values.type)
-            y_diff_2 = pc.fill_null_backward(pc.pairwise_diff_checked(values, period=2))
-            prev_values = pa.concat_arrays([na_value, values[:-2], na_value])
-            interps = pc.add_checked(prev_values, pc.divide_checked(y_diff_2, 2))
-            return self._from_pyarrow_array(pc.coalesce(self._pa_array, interps))
+        # GH#65345: a pyarrow-native fast path for
+        # method="linear"/limit_direction="forward" was removed here because
+        # it only handled isolated NAs (leaving consecutive and trailing NAs
+        # unfilled), truncated interpolated values for integer dtypes, and
+        # did not upcast to float64 like the general path below.
 
         mask = self.isna()
         if self.dtype.kind == "f":

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -4082,9 +4082,28 @@ def test_interpolate_not_numeric(data):
 
 @pytest.mark.parametrize("dtype", ["int64[pyarrow]", "float64[pyarrow]"])
 def test_interpolate_linear(dtype):
+    # GH#65345 results should match the masked (e.g. Int64) dtypes:
+    # upcast to float, and fill the trailing NA going forward
     ser = pd.Series([None, 1, 2, None, 4, None], dtype=dtype)
     result = ser.interpolate()
-    expected = pd.Series([None, 1, 2, 3, 4, None], dtype=dtype)
+    expected = pd.Series([None, 1.0, 2.0, 3.0, 4.0, 4.0], dtype="float64[pyarrow]")
+    tm.assert_series_equal(result, expected)
+
+
+def test_interpolate_linear_consecutive_na():
+    # GH#65345 consecutive interior NAs were left unfilled
+    ser = pd.Series([1, 2, 3, None, None, 6, 7], dtype="int64[pyarrow]")
+    result = ser.interpolate(method="linear", limit_direction="forward")
+    expected = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], dtype="float64[pyarrow]")
+    tm.assert_series_equal(result, expected)
+
+
+def test_interpolate_linear_int_fractional():
+    # GH#65345 integer dtypes used integer division, truncating the
+    # interpolated value (1 instead of 1.5)
+    ser = pd.Series([1, None, 2], dtype="int64[pyarrow]")
+    result = ser.interpolate(method="linear")
+    expected = pd.Series([1.0, 1.5, 2.0], dtype="float64[pyarrow]")
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #65345
- [x] Tests added and passed
- [x] All [code checks passed](https://pandas.pydata.org/docs/dev/development/contributing_codebase.html#pre-commit)
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file

## Problem

As diagnosed by @jorisvandenbossche in #65345, the pyarrow-native fast path added in #56347 for `method="linear"` + `limit_direction="forward"` takes over without checking whether it can actually handle the data. It computes a two-neighbor midpoint (`prev + (next - prev)/2`), so it only fills *isolated* interior NAs. Investigating the full behavior surfaced additional problems beyond the reported one:

1. **Consecutive interior NAs left unfilled** (the report): `[1, 2, 3, NA, NA, 6, 7]` → unchanged, while `Int64` gives `[1, 2, 3, 4, 5, 6, 7]`.
2. **Trailing NAs left unfilled**: `[1, 2, NA]` with forward direction → unchanged, while `Int64` extends the last value.
3. **Integer truncation — silently wrong values**: for integer dtypes the midpoint is computed with `pc.divide_checked` on the integer type, so `[1, NA, 2]` fills with **1** instead of 1.5.
4. **Dtype inconsistency**: the fast path keeps `int64[pyarrow]`, while every other parameter combination (e.g. `limit_direction="backward"`) upcasts to `float64[pyarrow]` via the shared fallback — so the result dtype depended on which direction was requested.

## Fix

Remove the fast path so pyarrow-backed arrays always go through the shared `missing.interpolate_2d_inplace` machinery. After the change, pyarrow-backed results match the equivalent masked-dtype (`Int64`/`Float64`) results — values, NA handling, and float upcast — across all combinations of `limit_direction`, `limit`, and `limit_area` I tested (5 NA patterns × 7 parameter combinations, zero divergences).

I considered guarding the fast path instead (only isolated interior NAs + float dtype + no trailing NA), but at that point the mask analysis erases most of the benefit and it would still leave the int-truncation/upcast questions — simplest correct thing seemed to be to remove it. Happy to rework toward a guarded fast path if that's preferred.

`test_interpolate_linear` was updated for the new (masked-dtype-consistent) expectation: trailing NA now filled going forward, result upcast to `float64[pyarrow]`.

## Verification

- New regression tests: `test_interpolate_linear_consecutive_na`, `test_interpolate_linear_int_fractional` (both fail on `main`).
- `pandas/tests/extension/test_arrow.py`: 26,885 passed.
- `tests/series/methods/test_interpolate.py` + `tests/frame/methods/test_interpolate.py`: 206 passed; `tests/copy_view/test_interp_fillna.py`: 72 passed.
- `ruff check` / `ruff format` clean on changed files.

## Disclosure

This fix was developed with the assistance of an AI tool (Claude Code), with the investigation, diff and test results reviewed and owned by me — I'll respond to review feedback personally.
