### PR TITLE
PERF: render to_csv chunks natively, bypassing csv.writer

### DIFF
--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -53,6 +53,34 @@ class ToCSV(BaseIO):
         self.df.to_csv(self.fname)
 
 
+class ToCSVDtypes(BaseIO):
+    fname = "__test__.csv"
+    params = ["float", "float32", "int", "string", "datetime", "bool"]
+    param_names = ["dtype"]
+
+    def setup(self, dtype):
+        N = 100_000
+        data = {
+            "float": DataFrame(np.random.randn(N, 3)),
+            "float32": DataFrame(np.random.randn(N, 3).astype(np.float32)),
+            "int": DataFrame(np.random.randint(-(10**9), 10**9, (N, 3))),
+            "string": DataFrame(
+                {i: [f"value-{i}-{j}" for j in range(N)] for i in range(3)}
+            ),
+            "datetime": DataFrame(
+                {i: date_range("2000", freq="37s", periods=N) for i in range(3)}
+            ),
+            "bool": DataFrame(np.random.randint(0, 2, (N, 3)).astype(bool)),
+        }
+        self.df = data[dtype]
+
+    def time_frame(self, dtype):
+        self.df.to_csv(self.fname)
+
+    def time_frame_no_index(self, dtype):
+        self.df.to_csv(self.fname, index=False)
+
+
 class ToCSVFloatFormatVariants(BaseIO):
     fname = "__test__.csv"
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -198,6 +198,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.sort_values` with multiple numeric columns by avoiding unnecessary :class:`Categorical` conversion (:issue:`15389`)
 - Performance improvement in :meth:`DataFrame.sum`, :meth:`DataFrame.prod`, :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`DataFrame.mean`, :meth:`DataFrame.any`, and :meth:`DataFrame.all` with ``axis=1`` for multi-block DataFrames by avoiding a transpose (:issue:`51474`)
 - Performance improvement in :meth:`DataFrame.take`, :meth:`Series.take`, :meth:`DataFrame.reindex`, :meth:`Series.reindex`, and boolean-array indexing for NumPy-backed dtypes (:issue:`65295`)
+- Performance improvement in :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` with the default ``quoting``, ``doublequote``, and ``escapechar`` options, up to 10x faster on numeric, datetime, boolean, and string data (:issue:`XXXXX`)
 - Performance improvement in :meth:`DataFrame.to_excel` with the ``openpyxl`` engine when using ``engine_kwargs={"write_only": True}``, reducing memory consumption (:issue:`41681`)
 - Performance improvement in :meth:`DataFrame.to_hdf` and :meth:`HDFStore.append` for table format when appending to an existing wide table with many ``data_columns`` (:issue:`25839`)
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -198,7 +198,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.sort_values` with multiple numeric columns by avoiding unnecessary :class:`Categorical` conversion (:issue:`15389`)
 - Performance improvement in :meth:`DataFrame.sum`, :meth:`DataFrame.prod`, :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`DataFrame.mean`, :meth:`DataFrame.any`, and :meth:`DataFrame.all` with ``axis=1`` for multi-block DataFrames by avoiding a transpose (:issue:`51474`)
 - Performance improvement in :meth:`DataFrame.take`, :meth:`Series.take`, :meth:`DataFrame.reindex`, :meth:`Series.reindex`, and boolean-array indexing for NumPy-backed dtypes (:issue:`65295`)
-- Performance improvement in :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` with the default ``quoting``, ``doublequote``, and ``escapechar`` options, up to 10x faster on numeric, datetime, boolean, and string data (:issue:`XXXXX`)
+- Performance improvement in :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` with the default ``quoting``, ``doublequote``, and ``escapechar`` options, up to 10x faster on numeric, datetime, boolean, and string data (:issue:`66126`)
 - Performance improvement in :meth:`DataFrame.to_excel` with the ``openpyxl`` engine when using ``engine_kwargs={"write_only": True}``, reducing memory consumption (:issue:`41681`)
 - Performance improvement in :meth:`DataFrame.to_hdf` and :meth:`HDFStore.append` for table format when appending to an existing wide table with many ``data_columns`` (:issue:`25839`)
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)

--- a/pandas/_libs/include/pandas/double_repr.h
+++ b/pandas/_libs/include/pandas/double_repr.h
@@ -13,8 +13,9 @@ extern "C" {
 Shortest round-trip float formatting matching numpy scalar str().
 
 Notation choice replicates numpy (value-based, not digit-exponent-based):
-fixed iff 1e-4 <= |val| < 1e16 for float64, 1e-4 <= |val| < 1e6 for float32,
-compared in double precision. Scientific style matches Python/numpy:
+fixed iff 1e-4 <= |val| < 1e16 for float64. For float32 the upper cutoff is
+supplied by the caller (fixed_hi) because numpy changed it in 2.3.0 (1e16 ->
+1e6). Compared in double precision. Scientific style matches Python/numpy:
 "d[.digits]e[+-]XX" with a sign and at least two exponent digits.
 */
 
@@ -32,8 +33,10 @@ int pd_double_repr(double val, char *out);
 /*
 float32 analogue of pd_double_repr; only usable when
 pd_float32_repr_available() returns nonzero (requires std::to_chars).
+fixed_hi is the value-based fixed/scientific cutoff (1e16 for numpy < 2.3,
+1e6 for numpy >= 2.3).
 */
-int pd_float32_repr(float val, char *out);
+int pd_float32_repr(float val, double fixed_hi, char *out);
 int pd_float32_repr_available(void);
 
 #ifdef __cplusplus

--- a/pandas/_libs/include/pandas/double_repr.h
+++ b/pandas/_libs/include/pandas/double_repr.h
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2026, PyData Development Team
+All rights reserved.
+Distributed under the terms of the BSD Simplified License.
+*/
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+Shortest round-trip float formatting matching numpy scalar str().
+
+Notation choice replicates numpy (value-based, not digit-exponent-based):
+fixed iff 1e-4 <= |val| < 1e16 for float64, 1e-4 <= |val| < 1e6 for float32,
+compared in double precision. Scientific style matches Python/numpy:
+"d[.digits]e[+-]XX" with a sign and at least two exponent digits.
+*/
+
+/* Enough for sign + 17 digits + dot + zeros/exponent, with headroom. */
+#define PD_DOUBLE_REPR_BUFSIZE 40
+
+/*
+Write the repr of val to out (not NUL-terminated), returning the length
+written, or -1 on error. out must have room for PD_DOUBLE_REPR_BUFSIZE bytes.
+When floating-point std::to_chars is unavailable (PD_HAVE_FP_TO_CHARS not
+defined) this falls back to PyOS_double_to_string and requires the GIL.
+*/
+int pd_double_repr(double val, char *out);
+
+/*
+float32 analogue of pd_double_repr; only usable when
+pd_float32_repr_available() returns nonzero (requires std::to_chars).
+*/
+int pd_float32_repr(float val, char *out);
+int pd_float32_repr_available(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -54,6 +54,37 @@ m_dep = cc.find_library('m', required: false)
 fast_float = subproject('fast_float')
 fast_float_dep = fast_float.get_variable('fast_float_dep')
 
+# Floating-point std::to_chars needs libc++ >= deployment-target ~13.3 on
+# macOS, and __cpp_lib_to_chars is unreliable on Apple clang, so try-compile
+# instead of checking the feature-test macro. Without it, double_repr.cpp
+# falls back to PyOS_double_to_string.
+cpp = meson.get_compiler('cpp')
+if cpp.get_argument_syntax() == 'msvc'
+    _fp_to_chars_std_args = ['/std:c++17']
+else
+    _fp_to_chars_std_args = ['-std=c++17']
+endif
+fp_to_chars_test = '''
+#include <charconv>
+int main() {
+    char buf[64];
+    auto res = std::to_chars(buf, buf + sizeof(buf), 1.5,
+                             std::chars_format::scientific);
+    auto res32 = std::to_chars(buf, buf + sizeof(buf), 1.5f,
+                               std::chars_format::scientific);
+    return (res.ec == std::errc() && res32.ec == std::errc()) ? 0 : 1;
+}
+'''
+if cpp.links(
+    fp_to_chars_test,
+    name: 'floating-point std::to_chars',
+    args: _fp_to_chars_std_args,
+)
+    double_repr_cpp_args = ['-DPD_HAVE_FP_TO_CHARS=1']
+else
+    double_repr_cpp_args = []
+endif
+
 subdir('tslibs')
 
 libs_sources = {
@@ -145,7 +176,10 @@ libs_sources = {
     'sparse': {'sources': ['sparse.pyx', _sparse_op_helper], 'deps': [m_dep]},
     'tslib': {'sources': ['tslib.pyx']},
     'testing': {'sources': ['testing.pyx']},
-    'writers': {'sources': ['writers.pyx']},
+    'writers': {
+        'sources': ['writers.pyx', 'src/writer/double_repr.cpp'],
+        'cpp_args': double_repr_cpp_args,
+    },
 }
 
 cython_args = [
@@ -168,6 +202,7 @@ foreach ext_name, ext_dict : libs_sources
         ext_name,
         ext_dict.get('sources'),
         cython_args: cython_args,
+        cpp_args: ext_dict.get('cpp_args', []),
         include_directories: [inc_np, inc_pd],
         dependencies: ext_dict.get('deps', []),
         subdir: 'pandas/_libs',

--- a/pandas/_libs/src/writer/double_repr.cpp
+++ b/pandas/_libs/src/writer/double_repr.cpp
@@ -168,8 +168,8 @@ int pd_double_repr(double val, char *out) {
   return repr_to_chars(val, 1e-4, 1e16, out);
 }
 
-int pd_float32_repr(float val, char *out) {
-  return repr_to_chars(val, 1e-4, 1e6, out);
+int pd_float32_repr(float val, double fixed_hi, char *out) {
+  return repr_to_chars(val, 1e-4, fixed_hi, out);
 }
 
 int pd_float32_repr_available(void) { return 1; }
@@ -238,8 +238,9 @@ int pd_double_repr(double val, char *out) {
                      out);
 }
 
-int pd_float32_repr(float val, char *out) {
+int pd_float32_repr(float val, double fixed_hi, char *out) {
   (void)val;
+  (void)fixed_hi;
   (void)out;
   return -1;
 }

--- a/pandas/_libs/src/writer/double_repr.cpp
+++ b/pandas/_libs/src/writer/double_repr.cpp
@@ -1,0 +1,249 @@
+/*
+Copyright (c) 2026, PyData Development Team
+All rights reserved.
+Distributed under the terms of the BSD Simplified License.
+
+Shortest round-trip float formatting matching numpy scalar str(): shortest
+digits (via std::to_chars, or PyOS_double_to_string as fallback) laid out
+with numpy's value-based fixed/scientific cutoffs.
+*/
+
+#include "pandas/double_repr.h"
+
+#include <cmath>
+#include <cstring>
+
+#ifdef PD_HAVE_FP_TO_CHARS
+#  include <charconv>
+#  include <system_error>
+#else
+#  define PY_SSIZE_T_CLEAN
+#  include <Python.h>
+#endif
+
+namespace {
+
+// Handle nan/inf/zero; returns length written or 0 if val needs digits.
+int emit_special(double val, char *out) {
+  if (std::isnan(val)) {
+    std::memcpy(out, "nan", 3);
+    return 3;
+  }
+  char *p = out;
+  if (std::signbit(val)) {
+    *p++ = '-';
+  }
+  if (std::isinf(val)) {
+    std::memcpy(p, "inf", 3);
+    return static_cast<int>(p - out) + 3;
+  }
+  if (val == 0.0) {
+    std::memcpy(p, "0.0", 3);
+    return static_cast<int>(p - out) + 3;
+  }
+  return 0;
+}
+
+// Lay out shortest-round-trip digits (value = d.igits x 10^exp10) in numpy
+// scalar-str notation.
+int emit_digits(bool neg, const char *digits, int ndigits, int exp10,
+                bool use_fixed, char *out) {
+  char *p = out;
+  if (neg) {
+    *p++ = '-';
+  }
+  if (use_fixed) {
+    if (exp10 >= 0) {
+      int int_digits = exp10 + 1;
+      if (int_digits >= ndigits) {
+        std::memcpy(p, digits, ndigits);
+        p += ndigits;
+        for (int i = ndigits; i < int_digits; i++) {
+          *p++ = '0';
+        }
+        *p++ = '.';
+        *p++ = '0';
+      } else {
+        std::memcpy(p, digits, int_digits);
+        p += int_digits;
+        *p++ = '.';
+        std::memcpy(p, digits + int_digits, ndigits - int_digits);
+        p += ndigits - int_digits;
+      }
+    } else {
+      *p++ = '0';
+      *p++ = '.';
+      for (int i = 0; i < -exp10 - 1; i++) {
+        *p++ = '0';
+      }
+      std::memcpy(p, digits, ndigits);
+      p += ndigits;
+    }
+  } else {
+    *p++ = digits[0];
+    if (ndigits > 1) {
+      *p++ = '.';
+      std::memcpy(p, digits + 1, ndigits - 1);
+      p += ndigits - 1;
+    }
+    *p++ = 'e';
+    int aexp = exp10;
+    if (exp10 < 0) {
+      *p++ = '-';
+      aexp = -exp10;
+    } else {
+      *p++ = '+';
+    }
+    char ebuf[8];
+    int elen = 0;
+    do {
+      ebuf[elen++] = static_cast<char>('0' + aexp % 10);
+      aexp /= 10;
+    } while (aexp != 0);
+    while (elen < 2) {
+      ebuf[elen++] = '0';
+    }
+    while (elen > 0) {
+      *p++ = ebuf[--elen];
+    }
+  }
+  return static_cast<int>(p - out);
+}
+
+#ifdef PD_HAVE_FP_TO_CHARS
+
+// Format via shortest-scientific to_chars, then re-layout.
+template <typename T>
+int repr_to_chars(T val, double fixed_lo, double fixed_hi, char *out) {
+  int res = emit_special(static_cast<double>(val), out);
+  if (res != 0) {
+    return res;
+  }
+  char sci[PD_DOUBLE_REPR_BUFSIZE];
+  const auto conv =
+      std::to_chars(sci, sci + sizeof(sci), val, std::chars_format::scientific);
+  if (conv.ec != std::errc()) {
+    return -1;
+  }
+  const char *q = sci;
+  const bool neg = (*q == '-');
+  if (neg) {
+    q++;
+  }
+  char digits[24];
+  int ndigits = 0;
+  digits[ndigits++] = *q++;
+  if (*q == '.') {
+    q++;
+    while (q < conv.ptr && *q != 'e') {
+      digits[ndigits++] = *q++;
+    }
+  }
+  // q now points at 'e'
+  q++;
+  bool exp_neg = false;
+  if (*q == '+' || *q == '-') {
+    exp_neg = (*q == '-');
+    q++;
+  }
+  int exp10 = 0;
+  while (q < conv.ptr) {
+    exp10 = exp10 * 10 + (*q++ - '0');
+  }
+  if (exp_neg) {
+    exp10 = -exp10;
+  }
+  const double aval = std::fabs(static_cast<double>(val));
+  const bool use_fixed = (aval >= fixed_lo) && (aval < fixed_hi);
+  return emit_digits(neg, digits, ndigits, exp10, use_fixed, out);
+}
+
+#endif
+
+} // namespace
+
+#ifdef PD_HAVE_FP_TO_CHARS
+
+int pd_double_repr(double val, char *out) {
+  return repr_to_chars(val, 1e-4, 1e16, out);
+}
+
+int pd_float32_repr(float val, char *out) {
+  return repr_to_chars(val, 1e-4, 1e6, out);
+}
+
+int pd_float32_repr_available(void) { return 1; }
+
+#else
+
+// Fallback: PyOS_double_to_string repr mode gives the same shortest digits;
+// re-layout them with numpy's value-based notation choice. Requires the GIL.
+int pd_double_repr(double val, char *out) {
+  int res = emit_special(val, out);
+  if (res != 0) {
+    return res;
+  }
+  char *pyrepr = PyOS_double_to_string(val, 'r', 0, 0, NULL);
+  if (pyrepr == NULL) {
+    return -1;
+  }
+  const char *q = pyrepr;
+  const bool neg = (*q == '-');
+  if (neg) {
+    q++;
+  }
+  char digits[32];
+  int ndigits = 0;
+  int int_len = -1;
+  int exp_part = 0;
+  bool exp_neg = false;
+  for (; *q != '\0'; q++) {
+    if (*q == '.') {
+      int_len = ndigits;
+    } else if (*q == 'e') {
+      q++;
+      if (*q == '+' || *q == '-') {
+        exp_neg = (*q == '-');
+        q++;
+      }
+      for (; *q != '\0'; q++) {
+        exp_part = exp_part * 10 + (*q - '0');
+      }
+      break;
+    } else {
+      digits[ndigits++] = *q;
+    }
+  }
+  PyMem_Free(pyrepr);
+  if (int_len == -1) {
+    int_len = ndigits;
+  }
+  if (exp_neg) {
+    exp_part = -exp_part;
+  }
+  int exp10 = exp_part + int_len - 1;
+  // normalize: strip leading zeros ("0.0001" -> digits "1", exp10 -4) and
+  // trailing zeros ("1.0" -> digits "1")
+  int start = 0;
+  while (start < ndigits - 1 && digits[start] == '0') {
+    start++;
+    exp10--;
+  }
+  while (ndigits - start > 1 && digits[ndigits - 1] == '0') {
+    ndigits--;
+  }
+  const double aval = std::fabs(val);
+  const bool use_fixed = (aval >= 1e-4) && (aval < 1e16);
+  return emit_digits(neg, digits + start, ndigits - start, exp10, use_fixed,
+                     out);
+}
+
+int pd_float32_repr(float val, char *out) {
+  (void)val;
+  (void)out;
+  return -1;
+}
+
+int pd_float32_repr_available(void) { return 0; }
+
+#endif

--- a/pandas/_libs/writers.pyi
+++ b/pandas/_libs/writers.pyi
@@ -2,6 +2,15 @@ import numpy as np
 
 from pandas._typing import ArrayLike
 
+CSV_KIND_OBJ: int
+CSV_KIND_FLOAT64: int
+CSV_KIND_FLOAT32: int
+CSV_KIND_INT64: int
+CSV_KIND_UINT64: int
+CSV_KIND_BOOL: int
+CSV_KIND_DT64: int
+FLOAT32_NATIVE: bool
+
 def write_csv_rows(
     data: list[ArrayLike],
     data_index: np.ndarray,
@@ -9,6 +18,14 @@ def write_csv_rows(
     cols: np.ndarray,
     writer: object,  # _csv.writer
 ) -> None: ...
+def write_csv_chunk(
+    cols: list[tuple[int, np.ndarray, int, int, bool]],
+    nrows: int,
+    sep: str,
+    quotechar: str,
+    lineterminator: str,
+    na_rep: str,
+) -> str: ...
 def convert_json_to_lines(arr: str) -> str: ...
 def max_len_string_array(
     arr: np.ndarray,  # pandas_string[:]

--- a/pandas/_libs/writers.pyi
+++ b/pandas/_libs/writers.pyi
@@ -25,6 +25,7 @@ def write_csv_chunk(
     quotechar: str,
     lineterminator: str,
     na_rep: str,
+    crlf_always: bool,
 ) -> str: ...
 def convert_json_to_lines(arr: str) -> str: ...
 def max_len_string_array(

--- a/pandas/_libs/writers.pyx
+++ b/pandas/_libs/writers.pyx
@@ -1,15 +1,51 @@
 cimport cython
 from cython cimport Py_ssize_t
+
 import numpy as np
 
+cimport numpy as cnp
 from cpython cimport (
     PyBytes_GET_SIZE,
     PyUnicode_GET_LENGTH,
 )
+from cpython.mem cimport (
+    PyMem_Free,
+    PyMem_Malloc,
+    PyMem_Realloc,
+)
+from cpython.object cimport PyObject
+from cpython.unicode cimport PyUnicode_DecodeUTF8
+from libc.string cimport (
+    memchr,
+    memcpy,
+    strchr,
+)
 from numpy cimport (
+    int64_t,
     ndarray,
     uint8_t,
+    uint64_t,
 )
+
+cnp.import_array()
+
+from pandas._libs.tslibs.nattype cimport NPY_NAT
+from pandas._libs.tslibs.np_datetime cimport (
+    NPY_DATETIMEUNIT,
+    import_pandas_datetime,
+    npy_datetimestruct,
+    pandas_datetime_to_datetimestruct,
+)
+
+import_pandas_datetime()
+
+cdef extern from "Python.h":
+    const char* PyUnicode_AsUTF8AndSize(object unicode, Py_ssize_t* size) except NULL
+
+cdef extern from "pandas/double_repr.h":
+    int pd_double_repr(double val, char *out)
+    int pd_float32_repr(float val, char *out)
+    int pd_float32_repr_available()
 
 ctypedef fused pandas_string:
     str
@@ -74,6 +110,489 @@ def write_csv_rows(
 
     if j >= 0 and (j < N - 1 or (j % N) != N - 1):
         writer.writerows(rows[:((j + 1) % N)])
+
+
+# ------------------------------------------------------------------
+# Fast whole-chunk CSV rendering (bypasses csv.writer)
+
+# Column kind codes understood by write_csv_chunk; mirrored in
+# pandas.io.formats.csvs. CSV_KIND_OBJ columns hold pre-converted cells
+# (via get_values_for_csv); the other kinds are rendered natively here.
+CSV_KIND_OBJ = 0
+CSV_KIND_FLOAT64 = 1
+CSV_KIND_FLOAT32 = 2
+CSV_KIND_INT64 = 3
+CSV_KIND_UINT64 = 4
+CSV_KIND_BOOL = 5
+CSV_KIND_DT64 = 6
+
+# float32 rendering needs floating-point std::to_chars (no fallback)
+FLOAT32_NATIVE = bool(pd_float32_repr_available())
+
+cdef enum:
+    KIND_OBJ = 0
+    KIND_FLOAT64 = 1
+    KIND_FLOAT32 = 2
+    KIND_INT64 = 3
+    KIND_UINT64 = 4
+    KIND_BOOL = 5
+    KIND_DT64 = 6
+
+# All bytes a natively-rendered field can contain, per kind. If the
+# delimiter/quotechar cannot occur in the rendered text, the per-cell
+# quoting scan is skipped ('\r'/'\n' can never occur).
+cdef const char* KIND_CHARSET_FLOAT = "0123456789.+-einfa"
+cdef const char* KIND_CHARSET_INT = "-0123456789"
+cdef const char* KIND_CHARSET_UINT = "0123456789"
+cdef const char* KIND_CHARSET_BOOL = "TrueFals"
+cdef const char* KIND_CHARSET_DT64 = "0123456789-: ."
+
+
+cdef struct CsvBuf:
+    char* data
+    size_t size
+    size_t cap
+
+
+cdef int buf_grow(CsvBuf* buf, size_t needed) except -1:
+    cdef:
+        size_t new_cap = buf.cap
+        char* new_data
+    while new_cap < buf.size + needed:
+        new_cap += new_cap // 2 + 64
+    new_data = <char*>PyMem_Realloc(buf.data, new_cap)
+    if new_data == NULL:
+        raise MemoryError()
+    buf.data = new_data
+    buf.cap = new_cap
+    return 0
+
+
+cdef inline int buf_reserve(CsvBuf* buf, size_t needed) except -1:
+    if buf.cap - buf.size < needed:
+        buf_grow(buf, needed)
+    return 0
+
+
+cdef inline void buf_append_raw(CsvBuf* buf, const char* src, size_t n) noexcept:
+    memcpy(buf.data + buf.size, src, n)
+    buf.size += n
+
+
+cdef int append_field(CsvBuf* buf, const char* field, Py_ssize_t n,
+                      char sep, char quote, bint lone_field) except -1:
+    """
+    Append one field with csv.writer QUOTE_MINIMAL semantics: quote (doubling
+    embedded quotechars) iff the field contains the delimiter, the quotechar,
+    or a literal CR/LF; quote an empty field iff it is the row's only field.
+    """
+    cdef:
+        Py_ssize_t i
+        bint need_quote
+
+    if n == 0:
+        if lone_field:
+            buf_reserve(buf, 2)
+            buf.data[buf.size] = quote
+            buf.data[buf.size + 1] = quote
+            buf.size += 2
+        return 0
+
+    need_quote = (
+        memchr(field, sep, n) != NULL
+        or memchr(field, quote, n) != NULL
+        or memchr(field, c"\r", n) != NULL
+        or memchr(field, c"\n", n) != NULL
+    )
+    if not need_quote:
+        buf_reserve(buf, n)
+        buf_append_raw(buf, field, n)
+    else:
+        buf_reserve(buf, 2 * n + 2)
+        buf.data[buf.size] = quote
+        buf.size += 1
+        for i in range(n):
+            if field[i] == quote:
+                buf.data[buf.size] = quote
+                buf.size += 1
+            buf.data[buf.size] = field[i]
+            buf.size += 1
+        buf.data[buf.size] = quote
+        buf.size += 1
+    return 0
+
+
+cdef int append_obj_cell(CsvBuf* buf, object cell, char sep, char quote,
+                         bint lone_field) except -1:
+    """
+    Append a pre-converted cell like csv.writer would: str used as-is,
+    None as empty, anything else via str().
+    """
+    cdef:
+        const char* cstr
+        Py_ssize_t length
+        object tmp
+
+    if cell is None:
+        return append_field(buf, NULL, 0, sep, quote, lone_field)
+    if isinstance(cell, str):
+        cstr = PyUnicode_AsUTF8AndSize(cell, &length)
+        return append_field(buf, cstr, length, sep, quote, lone_field)
+    tmp = str(cell)
+    cstr = PyUnicode_AsUTF8AndSize(tmp, &length)
+    return append_field(buf, cstr, length, sep, quote, lone_field)
+
+
+cdef inline int u64toa(uint64_t val, char* out) noexcept:
+    cdef:
+        char tmp[20]
+        int pos = 0, i = 0
+
+    if val == 0:
+        out[0] = c"0"
+        return 1
+    while val != 0:
+        tmp[pos] = <char>(c"0" + val % 10)
+        val //= 10
+        pos += 1
+    while pos > 0:
+        pos -= 1
+        out[i] = tmp[pos]
+        i += 1
+    return i
+
+
+cdef inline int i64toa(int64_t val, char* out) noexcept:
+    cdef uint64_t uval
+    if val >= 0:
+        return u64toa(<uint64_t>val, out)
+    out[0] = c"-"
+    # two's complement negation handles INT64_MIN
+    uval = ~(<uint64_t>val) + 1
+    return 1 + u64toa(uval, out + 1)
+
+
+cdef inline void write2(char* out, int val) noexcept:
+    out[0] = <char>(c"0" + val // 10)
+    out[1] = <char>(c"0" + val % 10)
+
+
+cdef inline void write_padded(char* out, int64_t val, int width) noexcept:
+    cdef int i
+    for i in range(width - 1, -1, -1):
+        out[i] = <char>(c"0" + val % 10)
+        val //= 10
+
+
+cdef int render_dt64(int64_t val, NPY_DATETIMEUNIT reso, int frac_digits,
+                     bint dates_only, char* out) noexcept:
+    """
+    Render a datetime64 the way tslib.format_array_from_datetime does for
+    tz-naive values: "YYYY-MM-DD[ HH:MM:SS[.fff[fff[fff]]]]" with an
+    unpadded (possibly negative) year and 0/3/6/9 fractional digits.
+    """
+    cdef:
+        npy_datetimestruct dts
+        int64_t frac
+        int pos
+
+    pandas_datetime_to_datetimestruct(val, reso, &dts)
+    pos = i64toa(dts.year, out)
+    out[pos] = c"-"
+    write2(out + pos + 1, dts.month)
+    out[pos + 3] = c"-"
+    write2(out + pos + 4, dts.day)
+    pos += 6
+    if dates_only:
+        return pos
+    out[pos] = c" "
+    write2(out + pos + 1, dts.hour)
+    out[pos + 3] = c":"
+    write2(out + pos + 4, dts.min)
+    out[pos + 6] = c":"
+    write2(out + pos + 7, dts.sec)
+    pos += 9
+    if frac_digits == 0:
+        return pos
+    if frac_digits == 9:
+        frac = dts.us * 1000 + dts.ps // 1000
+    elif frac_digits == 6:
+        frac = dts.us
+    else:
+        frac = dts.us // 1000
+    out[pos] = c"."
+    write_padded(out + pos + 1, frac, frac_digits)
+    return pos + 1 + frac_digits
+
+
+cdef inline bint kind_needs_scan(int kind, char sep, char quote) noexcept:
+    """
+    Whether natively-rendered fields of this kind can contain the delimiter
+    or quotechar and therefore need the per-cell quoting scan.
+    """
+    cdef const char* charset
+    if kind == KIND_FLOAT64 or kind == KIND_FLOAT32:
+        charset = KIND_CHARSET_FLOAT
+    elif kind == KIND_INT64:
+        charset = KIND_CHARSET_INT
+    elif kind == KIND_UINT64:
+        charset = KIND_CHARSET_UINT
+    elif kind == KIND_BOOL:
+        charset = KIND_CHARSET_BOOL
+    else:
+        charset = KIND_CHARSET_DT64
+    return strchr(charset, sep) != NULL or strchr(charset, quote) != NULL
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def write_csv_chunk(
+    list cols,
+    Py_ssize_t nrows,
+    str sep,
+    str quotechar,
+    str lineterminator,
+    str na_rep,
+) -> str:
+    """
+    Render a chunk of to_csv output to a single str, replicating
+    csv.writer(..., quoting=QUOTE_MINIMAL, doublequote=True) byte for byte.
+
+    Parameters
+    ----------
+    cols : list of (kind, ndarray, creso, frac_digits, dates_only) tuples,
+        one per output field (index column, if any, first). kind is one of
+        the CSV_KIND_* constants; creso/frac_digits/dates_only are only
+        meaningful for CSV_KIND_DT64.
+    nrows : int
+    sep : str
+        Single ASCII character.
+    quotechar : str
+        Single ASCII character.
+    lineterminator : str
+        One or two ASCII characters.
+    na_rep : str
+        Written for NaN/NaT in natively-rendered columns.
+
+    Returns
+    -------
+    str
+
+    Raises
+    ------
+    UnicodeEncodeError
+        For strings that cannot be encoded to UTF-8 (lone surrogates);
+        the caller falls back to the legacy writer for the chunk.
+    """
+    cdef:
+        Py_ssize_t nfields = len(cols), j, k
+        bint lone_field = nfields == 1
+        char csep = <char>ord(sep)
+        char cquote = <char>ord(quotechar)
+        char lt0 = 0, lt1 = 0
+        int lt_len, kind, slen
+        bytes na_field_b
+        const char* na_ptr
+        Py_ssize_t na_len
+        int* kinds = NULL
+        char** data_ptrs = NULL
+        Py_ssize_t* strides = NULL
+        int* resos = NULL
+        int* fracs = NULL
+        char* donly = NULL
+        char* scans = NULL
+        CsvBuf buf
+        char scratch[64]
+        double dval
+        float fval
+        int64_t ival
+        ndarray arr
+        object cell, result
+
+    lt_bytes = lineterminator.encode("ascii")
+    lt_len = len(lt_bytes)
+    if lt_len < 1 or lt_len > 2:
+        raise ValueError(f"invalid lineterminator: {lineterminator!r}")
+    lt0 = (<const char*>lt_bytes)[0]
+    if lt_len == 2:
+        lt1 = (<const char*>lt_bytes)[1]
+
+    # pre-render the field emitted for missing values, quoting rules applied
+    if na_rep == "":
+        na_field_b = (quotechar * 2).encode("utf-8") if lone_field else b""
+    elif (
+        sep in na_rep
+        or quotechar in na_rep
+        or "\r" in na_rep
+        or "\n" in na_rep
+    ):
+        na_field_b = (
+            quotechar + na_rep.replace(quotechar, quotechar * 2) + quotechar
+        ).encode("utf-8")
+    else:
+        na_field_b = na_rep.encode("utf-8")
+    na_ptr = <const char*>na_field_b
+    na_len = len(na_field_b)
+
+    buf.data = NULL
+    buf.size = 0
+    buf.cap = 0
+
+    kinds = <int*>PyMem_Malloc(nfields * sizeof(int))
+    data_ptrs = <char**>PyMem_Malloc(nfields * sizeof(char*))
+    strides = <Py_ssize_t*>PyMem_Malloc(nfields * sizeof(Py_ssize_t))
+    resos = <int*>PyMem_Malloc(nfields * sizeof(int))
+    fracs = <int*>PyMem_Malloc(nfields * sizeof(int))
+    donly = <char*>PyMem_Malloc(nfields * sizeof(char))
+    scans = <char*>PyMem_Malloc(nfields * sizeof(char))
+    if (
+        (nfields > 0)
+        and (
+            kinds == NULL or data_ptrs == NULL or strides == NULL or resos == NULL
+            or fracs == NULL or donly == NULL or scans == NULL
+        )
+    ):
+        PyMem_Free(kinds)
+        PyMem_Free(data_ptrs)
+        PyMem_Free(strides)
+        PyMem_Free(resos)
+        PyMem_Free(fracs)
+        PyMem_Free(donly)
+        PyMem_Free(scans)
+        raise MemoryError()
+
+    try:
+        for k in range(nfields):
+            kind, arr, creso, frac_digits, dates_only = cols[k]
+            if arr.ndim != 1 or nrows > arr.shape[0]:
+                raise ValueError("invalid column array")
+            if kind == KIND_OBJ:
+                if arr.dtype != object:
+                    raise ValueError("CSV_KIND_OBJ requires object dtype")
+            elif kind == KIND_FLOAT64:
+                if arr.dtype != np.float64:
+                    raise ValueError("CSV_KIND_FLOAT64 requires float64")
+            elif kind == KIND_FLOAT32:
+                if arr.dtype != np.float32:
+                    raise ValueError("CSV_KIND_FLOAT32 requires float32")
+                if not FLOAT32_NATIVE:
+                    raise ValueError("float32 rendering unavailable")
+            elif kind == KIND_INT64:
+                if arr.dtype != np.int64:
+                    raise ValueError("CSV_KIND_INT64 requires int64")
+            elif kind == KIND_UINT64:
+                if arr.dtype != np.uint64:
+                    raise ValueError("CSV_KIND_UINT64 requires uint64")
+            elif kind == KIND_BOOL:
+                if arr.dtype != np.bool_:
+                    raise ValueError("CSV_KIND_BOOL requires bool")
+            elif kind == KIND_DT64:
+                if arr.dtype != np.int64:
+                    raise ValueError("CSV_KIND_DT64 requires int64 view")
+            else:
+                raise ValueError(f"unknown column kind {kind}")
+            kinds[k] = kind
+            data_ptrs[k] = <char*>cnp.PyArray_DATA(arr)
+            strides[k] = cnp.PyArray_STRIDE(arr, 0)
+            resos[k] = creso
+            fracs[k] = frac_digits
+            donly[k] = dates_only
+            scans[k] = kind != KIND_OBJ and kind_needs_scan(kind, csep, cquote)
+
+        buf.cap = <size_t>nrows * (<size_t>nfields * 8 + 8) + 64
+        buf.data = <char*>PyMem_Malloc(buf.cap)
+        if buf.data == NULL:
+            raise MemoryError()
+
+        for j in range(nrows):
+            for k in range(nfields):
+                if k > 0:
+                    buf_reserve(&buf, 1)
+                    buf.data[buf.size] = csep
+                    buf.size += 1
+                kind = kinds[k]
+                if kind == KIND_OBJ:
+                    cell = <object>(
+                        (<PyObject**>(data_ptrs[k] + j * strides[k]))[0]
+                    )
+                    append_obj_cell(&buf, cell, csep, cquote, lone_field)
+                    continue
+
+                slen = -1
+                if kind == KIND_FLOAT64:
+                    dval = (<double*>(data_ptrs[k] + j * strides[k]))[0]
+                    if dval != dval:
+                        slen = 0
+                    else:
+                        slen = pd_double_repr(dval, scratch)
+                        if slen < 0:
+                            raise ValueError("float formatting failed")
+                elif kind == KIND_FLOAT32:
+                    fval = (<float*>(data_ptrs[k] + j * strides[k]))[0]
+                    if fval != fval:
+                        slen = 0
+                    else:
+                        slen = pd_float32_repr(fval, scratch)
+                        if slen < 0:
+                            raise ValueError("float formatting failed")
+                elif kind == KIND_INT64:
+                    ival = (<int64_t*>(data_ptrs[k] + j * strides[k]))[0]
+                    slen = i64toa(ival, scratch)
+                elif kind == KIND_UINT64:
+                    slen = u64toa(
+                        (<uint64_t*>(data_ptrs[k] + j * strides[k]))[0], scratch
+                    )
+                elif kind == KIND_BOOL:
+                    if (<uint8_t*>(data_ptrs[k] + j * strides[k]))[0]:
+                        memcpy(scratch, b"True", 4)
+                        slen = 4
+                    else:
+                        memcpy(scratch, b"False", 5)
+                        slen = 5
+                else:  # KIND_DT64
+                    ival = (<int64_t*>(data_ptrs[k] + j * strides[k]))[0]
+                    if ival == NPY_NAT:
+                        slen = 0
+                    else:
+                        slen = render_dt64(
+                            ival,
+                            <NPY_DATETIMEUNIT>resos[k],
+                            fracs[k],
+                            donly[k],
+                            scratch,
+                        )
+
+                if slen == 0:
+                    # missing value: na_field_b already has quoting (and the
+                    # lone-empty-field rule) applied
+                    if na_len > 0:
+                        buf_reserve(&buf, na_len)
+                        buf_append_raw(&buf, na_ptr, na_len)
+                elif scans[k]:
+                    append_field(&buf, scratch, slen, csep, cquote, lone_field)
+                else:
+                    buf_reserve(&buf, slen)
+                    buf_append_raw(&buf, scratch, slen)
+
+            buf_reserve(&buf, 2)
+            buf.data[buf.size] = lt0
+            buf.size += 1
+            if lt_len == 2:
+                buf.data[buf.size] = lt1
+                buf.size += 1
+
+        result = PyUnicode_DecodeUTF8(buf.data, buf.size, NULL)
+    finally:
+        PyMem_Free(buf.data)
+        PyMem_Free(kinds)
+        PyMem_Free(data_ptrs)
+        PyMem_Free(strides)
+        PyMem_Free(resos)
+        PyMem_Free(fracs)
+        PyMem_Free(donly)
+        PyMem_Free(scans)
+
+    return result
 
 
 @cython.boundscheck(False)

--- a/pandas/_libs/writers.pyx
+++ b/pandas/_libs/writers.pyx
@@ -187,11 +187,13 @@ cdef inline void buf_append_raw(CsvBuf* buf, const char* src, size_t n) noexcept
 
 
 cdef int append_field(CsvBuf* buf, const char* field, Py_ssize_t n,
-                      char sep, char quote, bint lone_field) except -1:
+                      char sep, char quote, char qe0, char qe1,
+                      bint lone_field) except -1:
     """
     Append one field with csv.writer QUOTE_MINIMAL semantics: quote (doubling
     embedded quotechars) iff the field contains the delimiter, the quotechar,
-    or a literal CR/LF; quote an empty field iff it is the row's only field.
+    or a line-ending trigger char (qe0/qe1); quote an empty field iff it is
+    the row's only field.
     """
     cdef:
         Py_ssize_t i
@@ -208,8 +210,8 @@ cdef int append_field(CsvBuf* buf, const char* field, Py_ssize_t n,
     need_quote = (
         memchr(field, sep, n) != NULL
         or memchr(field, quote, n) != NULL
-        or memchr(field, c"\r", n) != NULL
-        or memchr(field, c"\n", n) != NULL
+        or memchr(field, qe0, n) != NULL
+        or memchr(field, qe1, n) != NULL
     )
     if not need_quote:
         buf_reserve(buf, n)
@@ -230,7 +232,7 @@ cdef int append_field(CsvBuf* buf, const char* field, Py_ssize_t n,
 
 
 cdef int append_obj_cell(CsvBuf* buf, object cell, char sep, char quote,
-                         bint lone_field) except -1:
+                         char qe0, char qe1, bint lone_field) except -1:
     """
     Append a pre-converted cell like csv.writer would: str used as-is,
     None as empty, anything else via str().
@@ -241,13 +243,13 @@ cdef int append_obj_cell(CsvBuf* buf, object cell, char sep, char quote,
         object tmp
 
     if cell is None:
-        return append_field(buf, NULL, 0, sep, quote, lone_field)
+        return append_field(buf, NULL, 0, sep, quote, qe0, qe1, lone_field)
     if isinstance(cell, str):
         cstr = PyUnicode_AsUTF8AndSize(cell, &length)
-        return append_field(buf, cstr, length, sep, quote, lone_field)
+        return append_field(buf, cstr, length, sep, quote, qe0, qe1, lone_field)
     tmp = str(cell)
     cstr = PyUnicode_AsUTF8AndSize(tmp, &length)
-    return append_field(buf, cstr, length, sep, quote, lone_field)
+    return append_field(buf, cstr, length, sep, quote, qe0, qe1, lone_field)
 
 
 cdef inline int u64toa(uint64_t val, char* out) noexcept:
@@ -360,6 +362,7 @@ def write_csv_chunk(
     str quotechar,
     str lineterminator,
     str na_rep,
+    bint crlf_always,
 ) -> str:
     """
     Render a chunk of to_csv output to a single str, replicating
@@ -380,6 +383,10 @@ def write_csv_chunk(
         One or two ASCII characters.
     na_rep : str
         Written for NaN/NaT in natively-rendered columns.
+    crlf_always : bool
+        Whether the running csv.writer quotes fields containing CR or LF
+        regardless of the line terminator. CPython versions up to 3.11.1
+        quoted them only when they were part of the line terminator.
 
     Returns
     -------
@@ -397,6 +404,7 @@ def write_csv_chunk(
         char csep = <char>ord(sep)
         char cquote = <char>ord(quotechar)
         char lt0 = 0, lt1 = 0
+        char qe0, qe1
         int lt_len, kind, slen
         bytes na_field_b
         const char* na_ptr
@@ -424,14 +432,22 @@ def write_csv_chunk(
     if lt_len == 2:
         lt1 = (<const char*>lt_bytes)[1]
 
+    # csv.writer quotes a field iff it contains the delimiter, the quotechar,
+    # or a line-terminator character; modern CPython also always quotes \r and
+    # \n. The caller restricts the fast path to \r/\n line terminators, so the
+    # two trigger chars qe0/qe1 (duplicated when there is only one) cover it.
+    quote_extra = "\r\n" if crlf_always else lineterminator
+    qe_bytes = quote_extra.encode("ascii")
+    qe0 = (<const char*>qe_bytes)[0]
+    qe1 = (<const char*>qe_bytes)[1] if len(qe_bytes) == 2 else qe0
+
     # pre-render the field emitted for missing values, quoting rules applied
     if na_rep == "":
         na_field_b = (quotechar * 2).encode("utf-8") if lone_field else b""
     elif (
         sep in na_rep
         or quotechar in na_rep
-        or "\r" in na_rep
-        or "\n" in na_rep
+        or any(ch in na_rep for ch in quote_extra)
     ):
         na_field_b = (
             quotechar + na_rep.replace(quotechar, quotechar * 2) + quotechar
@@ -522,7 +538,7 @@ def write_csv_chunk(
                     cell = <object>(
                         (<PyObject**>(data_ptrs[k] + j * strides[k]))[0]
                     )
-                    append_obj_cell(&buf, cell, csep, cquote, lone_field)
+                    append_obj_cell(&buf, cell, csep, cquote, qe0, qe1, lone_field)
                     continue
 
                 slen = -1
@@ -576,7 +592,9 @@ def write_csv_chunk(
                         buf_reserve(&buf, na_len)
                         buf_append_raw(&buf, na_ptr, na_len)
                 elif scans[k]:
-                    append_field(&buf, scratch, slen, csep, cquote, lone_field)
+                    append_field(
+                        &buf, scratch, slen, csep, cquote, qe0, qe1, lone_field
+                    )
                 else:
                     buf_reserve(&buf, slen)
                     buf_append_raw(&buf, scratch, slen)

--- a/pandas/_libs/writers.pyx
+++ b/pandas/_libs/writers.pyx
@@ -44,7 +44,7 @@ cdef extern from "Python.h":
 
 cdef extern from "pandas/double_repr.h":
     int pd_double_repr(double val, char *out)
-    int pd_float32_repr(float val, char *out)
+    int pd_float32_repr(float val, double fixed_hi, char *out)
     int pd_float32_repr_available()
 
 ctypedef fused pandas_string:
@@ -128,6 +128,13 @@ CSV_KIND_DT64 = 6
 
 # float32 rendering needs floating-point std::to_chars (no fallback)
 FLOAT32_NATIVE = bool(pd_float32_repr_available())
+
+# numpy 2.3 lowered the float32 str() positional/scientific cutoff from 1e16
+# (shared with float64) to 1e6; match the running numpy so native float32
+# rendering stays byte-identical to ndarray.astype(str).
+cdef double FLOAT32_FIXED_HI = 1e16
+if tuple(int(x) for x in np.__version__.split(".")[:2]) >= (2, 3):
+    FLOAT32_FIXED_HI = 1e6
 
 cdef enum:
     KIND_OBJ = 0
@@ -532,7 +539,7 @@ def write_csv_chunk(
                     if fval != fval:
                         slen = 0
                     else:
-                        slen = pd_float32_repr(fval, scratch)
+                        slen = pd_float32_repr(fval, FLOAT32_FIXED_HI, scratch)
                         if slen < 0:
                             raise ValueError("float formatting failed")
                 elif kind == KIND_INT64:

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -11,6 +11,7 @@ from collections.abc import (
     Sequence,
 )
 import csv as csvlib
+from io import StringIO
 import os
 from typing import (
     TYPE_CHECKING,
@@ -58,6 +59,21 @@ if TYPE_CHECKING:
 
 
 _DEFAULT_CHUNKSIZE_CELLS = 100_000
+
+
+def _csv_quotes_crlf_unconditionally() -> bool:
+    """
+    Whether the running csv.writer quotes fields containing CR or LF
+    regardless of the line terminator. CPython versions up to 3.11.1 quoted
+    them only when they were part of the line terminator; the fast writer
+    probes the running module so its output stays byte-identical.
+    """
+    buf = StringIO()
+    csvlib.writer(buf, lineterminator="\r").writerow(["\n"])
+    return '"' in buf.getvalue()
+
+
+_CSV_QUOTES_CRLF = _csv_quotes_crlf_unconditionally()
 
 
 class CSVFormatter:
@@ -366,7 +382,10 @@ class CSVFormatter:
             and ord(self.quotechar) < 128
             and isinstance(self.lineterminator, str)
             and 1 <= len(self.lineterminator) <= 2
-            and all(ord(ch) < 128 for ch in self.lineterminator)
+            # only \r/\n line terminators: the native writer's per-field
+            # quoting scan assumes non-numeric output is all that can contain a
+            # line-ending char, and numeric/datetime output never does
+            and all(ch in "\r\n" for ch in self.lineterminator)
             and self.nlevels <= 1
         )
 
@@ -392,6 +411,7 @@ class CSVFormatter:
                 # na_rep is not necessarily a str, e.g. na_rep=999; the
                 # legacy paths stringify it downstream
                 str(self.na_rep),
+                _CSV_QUOTES_CRLF,
             )
         except UnicodeEncodeError:
             # e.g. lone surrogates, which csv.writer passes through

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -426,9 +426,9 @@ class CSVFormatter:
                     # assigning into the '<U32' array from astype(str)
                     and len(str(self.na_rep)) <= 32
                 ):
-                    if dtype.itemsize == 8:
+                    if values.dtype.itemsize == 8:
                         return (libwriters.CSV_KIND_FLOAT64, values, 0, 0, False)
-                    if dtype.itemsize == 4 and libwriters.FLOAT32_NATIVE:
+                    if values.dtype.itemsize == 4 and libwriters.FLOAT32_NATIVE:
                         return (libwriters.CSV_KIND_FLOAT32, values, 0, 0, False)
             elif dtype.kind == "i":
                 return (

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -389,7 +389,9 @@ class CSVFormatter:
                 # _initialize_quotechar only returns None for QUOTE_NONE
                 cast("str", self.quotechar),
                 self.lineterminator,
-                self.na_rep,
+                # na_rep is not necessarily a str, e.g. na_rep=999; the
+                # legacy paths stringify it downstream
+                str(self.na_rep),
             )
         except UnicodeEncodeError:
             # e.g. lone surrogates, which csv.writer passes through
@@ -422,7 +424,7 @@ class CSVFormatter:
                     and self.decimal == "."
                     # with a longer na_rep the legacy path truncates it when
                     # assigning into the '<U32' array from astype(str)
-                    and len(self.na_rep) <= 32
+                    and len(str(self.na_rep)) <= 32
                 ):
                     if dtype.itemsize == 8:
                         return (libwriters.CSV_KIND_FLOAT64, values, 0, 0, False)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -21,6 +21,10 @@ from typing import (
 import numpy as np
 
 from pandas._libs import writers as libwriters
+from pandas._libs.tslibs import (
+    Resolution,
+    get_resolution,
+)
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.generic import (
@@ -31,12 +35,15 @@ from pandas.core.dtypes.generic import (
 )
 from pandas.core.dtypes.missing import notna
 
+from pandas.core.construction import ensure_wrapped_if_datetimelike
 from pandas.core.indexes.api import Index
+from pandas.core.indexes.base import get_values_for_csv
 
 from pandas.io.common import get_handle
 
 if TYPE_CHECKING:
     from pandas._typing import (
+        ArrayLike,
         CompressionOptions,
         FilePath,
         FloatFormatType,
@@ -268,6 +275,7 @@ class CSVFormatter:
                 escapechar=self.escapechar,
                 quotechar=self.quotechar,
             )
+            self._handle = handles.handle
 
             self._save()
 
@@ -307,12 +315,15 @@ class CSVFormatter:
     def _save_body(self) -> None:
         nrows = len(self.data_index)
         chunks = (nrows // self.chunksize) + 1
+        save_chunk = (
+            self._save_chunk_fast if self._use_fast_writer else self._save_chunk
+        )
         for i in range(chunks):
             start_i = i * self.chunksize
             end_i = min(start_i + self.chunksize, nrows)
             if start_i >= end_i:
                 break
-            self._save_chunk(start_i, end_i)
+            save_chunk(start_i, end_i)
 
     def _save_chunk(self, start_i: int, end_i: int) -> None:
         # create the data for a chunk
@@ -334,3 +345,133 @@ class CSVFormatter:
             self.cols,
             self.writer,
         )
+
+    @cache_readonly
+    def _use_fast_writer(self) -> bool:
+        """
+        Whether the body can be rendered by libwriters.write_csv_chunk
+        instead of csv.writer. The fast writer replicates csv.writer output
+        byte for byte only for this combination of dialect options.
+        """
+        return (
+            self.quoting == csvlib.QUOTE_MINIMAL
+            and self.doublequote
+            and self.escapechar is None
+            and self.errors == "strict"
+            and isinstance(self.sep, str)
+            and len(self.sep) == 1
+            and ord(self.sep) < 128
+            and isinstance(self.quotechar, str)
+            and len(self.quotechar) == 1
+            and ord(self.quotechar) < 128
+            and isinstance(self.lineterminator, str)
+            and 1 <= len(self.lineterminator) <= 2
+            and all(ord(ch) < 128 for ch in self.lineterminator)
+            and self.nlevels <= 1
+        )
+
+    def _save_chunk_fast(self, start_i: int, end_i: int) -> None:
+        # render the chunk to a single str, bypassing csv.writer
+        slicer = slice(start_i, end_i)
+        df = self.obj.iloc[slicer]
+
+        prepared = []
+        if self.nlevels:
+            prepared.append(self._prepare_csv_index(self.data_index[slicer]))
+        prepared.extend(
+            self._prepare_csv_array(arr) for arr in df._iter_column_arrays()
+        )
+        try:
+            res = libwriters.write_csv_chunk(
+                prepared,
+                end_i - start_i,
+                self.sep,
+                # _initialize_quotechar only returns None for QUOTE_NONE
+                cast("str", self.quotechar),
+                self.lineterminator,
+                self.na_rep,
+            )
+        except UnicodeEncodeError:
+            # e.g. lone surrogates, which csv.writer passes through
+            self._save_chunk(start_i, end_i)
+            return
+        self._handle.write(res)
+
+    def _prepare_csv_index(self, idx: Index) -> tuple[int, np.ndarray, int, int, bool]:
+        if isinstance(idx, ABCMultiIndex):
+            # single-level MultiIndex; matches the legacy path, which writes
+            # it as one field per row
+            values = idx._get_values_for_csv(**self._number_format)
+            return (libwriters.CSV_KIND_OBJ, np.asarray(values), 0, 0, False)
+        return self._prepare_csv_array(idx._values)
+
+    def _prepare_csv_array(
+        self, values: ArrayLike
+    ) -> tuple[int, np.ndarray, int, int, bool]:
+        """
+        Map a column's array to a (kind, values, creso, frac_digits,
+        dates_only) tuple for libwriters.write_csv_chunk. Columns the chunk
+        writer cannot render natively are converted with get_values_for_csv,
+        exactly like the legacy path, and only assembled natively.
+        """
+        dtype = values.dtype
+        if isinstance(values, np.ndarray):
+            if dtype.kind == "f":
+                if (
+                    self.float_format is None
+                    and self.decimal == "."
+                    # with a longer na_rep the legacy path truncates it when
+                    # assigning into the '<U32' array from astype(str)
+                    and len(self.na_rep) <= 32
+                ):
+                    if dtype.itemsize == 8:
+                        return (libwriters.CSV_KIND_FLOAT64, values, 0, 0, False)
+                    if dtype.itemsize == 4 and libwriters.FLOAT32_NATIVE:
+                        return (libwriters.CSV_KIND_FLOAT32, values, 0, 0, False)
+            elif dtype.kind == "i":
+                return (
+                    libwriters.CSV_KIND_INT64,
+                    values.astype(np.int64, copy=False),
+                    0,
+                    0,
+                    False,
+                )
+            elif dtype.kind == "u":
+                return (
+                    libwriters.CSV_KIND_UINT64,
+                    values.astype(np.uint64, copy=False),
+                    0,
+                    0,
+                    False,
+                )
+            elif dtype.kind == "b":
+                return (libwriters.CSV_KIND_BOOL, values, 0, 0, False)
+
+        if (
+            dtype.kind == "M"
+            and isinstance(dtype, np.dtype)
+            and self.date_format is None
+        ):
+            # tz-naive datetime64; replicate the per-chunk formatting
+            # decisions DatetimeArray._format_native_types makes
+            dta = ensure_wrapped_if_datetimelike(values)  # type: ignore[no-untyped-call]
+            asi8 = dta.asi8
+            creso = dta._creso
+            if dta._is_dates_only:
+                return (libwriters.CSV_KIND_DT64, asi8, creso, 0, True)
+            reso_obj = get_resolution(asi8, None, creso)
+            if reso_obj == Resolution.RESO_NS:
+                frac_digits = 9
+            elif reso_obj == Resolution.RESO_US:
+                frac_digits = 6
+            elif reso_obj == Resolution.RESO_MS:
+                frac_digits = 3
+            else:
+                frac_digits = 0
+            return (libwriters.CSV_KIND_DT64, asi8, creso, frac_digits, False)
+
+        converted = get_values_for_csv(values, **self._number_format)
+        if converted.dtype != object:
+            # e.g. the IntervalArray path returns '<U…'
+            converted = converted.astype(object, copy=False)
+        return (libwriters.CSV_KIND_OBJ, converted, 0, 0, False)

--- a/pandas/tests/io/formats/test_to_csv_fast_writer.py
+++ b/pandas/tests/io/formats/test_to_csv_fast_writer.py
@@ -22,8 +22,13 @@ def _legacy_to_csv(monkeypatch, df, **kwargs):
 
 
 def assert_fast_matches_legacy(monkeypatch, df, **kwargs):
-    result = df.to_csv(**kwargs)
-    expected = _legacy_to_csv(monkeypatch, df, **kwargs)
+    # get_values_for_csv casts some ExtensionArrays (e.g. IntervalArray) to
+    # str, which can emit a spurious "invalid value encountered in cast"
+    # RuntimeWarning on some platforms; it is shared by both writers and
+    # irrelevant to the byte comparison here.
+    with np.errstate(invalid="ignore"):
+        result = df.to_csv(**kwargs)
+        expected = _legacy_to_csv(monkeypatch, df, **kwargs)
     assert result == expected
 
 
@@ -173,13 +178,26 @@ def test_fast_writer_float_boundaries(monkeypatch):
 
 def test_fast_writer_lone_empty_field(monkeypatch):
     # csv.writer quotes an empty field iff it is the row's only field
+    # (lineterminator is pinned so the expected string is platform-independent)
     df = DataFrame({"a": ["", "x", ""]})
     assert_fast_matches_legacy(monkeypatch, df, index=False)
-    assert df.to_csv(index=False) == 'a\n""\nx\n""\n'
+    assert df.to_csv(index=False, lineterminator="\n") == 'a\n""\nx\n""\n'
     # ... including for NaN rendered with the default na_rep=""
     df = DataFrame({"a": [np.nan, 1.0]})
     assert_fast_matches_legacy(monkeypatch, df, index=False)
-    assert df.to_csv(index=False) == 'a\n""\n1.0\n'
+    assert df.to_csv(index=False, lineterminator="\n") == 'a\n""\n1.0\n'
+
+
+@pytest.mark.parametrize("lineterminator", ["\n", "\r\n", "\r"])
+def test_fast_writer_embedded_newline_quoting(monkeypatch, lineterminator):
+    # csv.writer quotes a field containing \r or \n; up to CPython 3.11.1 it
+    # did so only when the char was part of the line terminator. The fast
+    # writer must match the running module for each line terminator.
+    df = DataFrame({"a": ["plain", "has\nlf", "has\rcr", "has\r\ncrlf"]})
+    assert_fast_matches_legacy(monkeypatch, df, lineterminator=lineterminator)
+    assert_fast_matches_legacy(
+        monkeypatch, df, lineterminator=lineterminator, na_rep="a\nb"
+    )
 
 
 def test_fast_writer_long_na_rep_truncation(monkeypatch):

--- a/pandas/tests/io/formats/test_to_csv_fast_writer.py
+++ b/pandas/tests/io/formats/test_to_csv_fast_writer.py
@@ -1,0 +1,264 @@
+"""
+Differential tests for the fast to_csv chunk writer
+(libwriters.write_csv_chunk): output must be byte-identical to the legacy
+csv.writer path for every dialect the fast writer claims.
+"""
+
+import csv
+
+import numpy as np
+import pytest
+
+import pandas as pd
+from pandas import DataFrame
+
+from pandas.io.formats.csvs import CSVFormatter
+
+
+def _legacy_to_csv(monkeypatch, df, **kwargs):
+    with monkeypatch.context() as ctx:
+        ctx.setattr(CSVFormatter, "_use_fast_writer", property(lambda self: False))
+        return df.to_csv(**kwargs)
+
+
+def assert_fast_matches_legacy(monkeypatch, df, **kwargs):
+    result = df.to_csv(**kwargs)
+    expected = _legacy_to_csv(monkeypatch, df, **kwargs)
+    assert result == expected
+
+
+@pytest.fixture
+def mixed_frame():
+    return DataFrame(
+        {
+            "f8": [1.5, np.nan, -np.inf, 1e-4, 9.999999999999999e-05, 1e16, -0.0],
+            "f4": np.array([0.1, np.nan, 1e6, 999999.94, 1e-4, 5e-324, 2.5], "f4"),
+            "i8": [0, -1, 2**63 - 1, -(2**63), 3, 4, 5],
+            "u8": np.array([0, 1, 2**64 - 1, 2, 3, 4, 5], dtype=np.uint64),
+            "i4": np.array([1, 2, 3, 4, 5, 6, 7], dtype=np.int32),
+            "b": [True, False] * 3 + [True],
+            "dt": pd.to_datetime(
+                [
+                    "2020-01-01",
+                    "NaT",
+                    "2020-01-02 03:04:05",
+                    "2020-01-02 03:04:05.123",
+                    "2020-01-02 03:04:05.123456",
+                    "2020-01-02 03:04:05.123456789",
+                    "1677-09-21 00:12:43.145224193",
+                ],
+                format="ISO8601",
+            ),
+            "s": ["plain", "with,comma", 'with"quote', "with\nnewline", "", "x", "y"],
+            "o": np.array(
+                ["a", None, np.nan, 3, 2.5, pd.Timestamp("2020-01-01"), ("t", "u")],
+                dtype=object,
+            ),
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"index": False},
+        {"header": False},
+        {"sep": ";"},
+        {"sep": "."},
+        {"sep": " "},
+        {"sep": "0"},
+        {"quotechar": "'"},
+        {"lineterminator": "\r\n"},
+        {"lineterminator": "\r"},
+        {"na_rep": "NA"},
+        {"na_rep": "N,A"},
+        {"na_rep": 'N"A'},
+        {"chunksize": 2},
+        {"chunksize": 3, "na_rep": "NULL", "sep": ";"},
+        {"float_format": "%.3f"},
+        {"decimal": ","},
+        {"date_format": "%Y/%m/%d %H:%M"},
+    ],
+)
+def test_fast_writer_matches_legacy_options(monkeypatch, mixed_frame, kwargs):
+    assert_fast_matches_legacy(monkeypatch, mixed_frame, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pd.array([1, None, -3], dtype="Int64"),
+        pd.array([1.5, None, -3.25], dtype="Float64"),
+        pd.array([True, None, False], dtype="boolean"),
+        pd.array(["x", "y,z", None], dtype="str"),
+        pd.Categorical(["x", "y,z", None]),
+        pd.Categorical(pd.to_datetime(["2020-01-01", "NaT", "2021-02-03"])),
+        pd.interval_range(0.0, 3.0, periods=3),
+        pd.period_range("2020-01", periods=3, freq="M"),
+        pd.to_timedelta(["1 days 02:03:04", "NaT", "-1 days"]),
+        pd.to_datetime(
+            ["2020-01-01 01:02:03", "NaT", "2021-01-01"], format="ISO8601"
+        ).tz_localize("US/Pacific"),
+        np.array([1 + 2j, np.nan + 0j, -3.5j]),
+        np.array([1.5, np.nan, 2.5], dtype=np.float16),
+        np.array(["0045-01-02", "0999-06-07"], dtype="M8[s]"),
+        np.array(["0045-01-02T03:04:05", "0999-06-07T08:09:10"], dtype="M8[s]"),
+        pd.DatetimeIndex([pd.NaT, pd.NaT]).as_unit("us"),
+    ],
+)
+def test_fast_writer_matches_legacy_dtypes(monkeypatch, data):
+    df = DataFrame({"a": data})
+    assert_fast_matches_legacy(monkeypatch, df)
+    assert_fast_matches_legacy(monkeypatch, df, na_rep="NAVAL")
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.Index([0.5, 1e16, np.nan], name="fi"),
+        pd.Index(["a,b", 'c"d', "e"]),
+        pd.date_range("2020-01-01", periods=3, freq="12h"),
+        pd.RangeIndex(10, 40, 10),
+        pd.MultiIndex.from_tuples([("a", 1), ("b", 2), ("c,x", 3)]),
+        pd.MultiIndex.from_arrays([["p", "q,r", "s"]], names=["only"]),
+        pd.CategoricalIndex(["x", "y", None]),
+    ],
+)
+def test_fast_writer_matches_legacy_index(monkeypatch, index):
+    df = DataFrame({"val": [1.5, 2.5, np.nan]}, index=index)
+    assert_fast_matches_legacy(monkeypatch, df)
+    assert_fast_matches_legacy(monkeypatch, df, chunksize=2)
+
+
+def test_fast_writer_float_bit_patterns(monkeypatch):
+    # shortest-round-trip float formatting must match numpy's str() exactly
+    rng = np.random.default_rng(20260701)
+    f8 = rng.integers(0, 2**64, 10_000, dtype=np.uint64).view(np.float64)
+    assert_fast_matches_legacy(monkeypatch, DataFrame({"a": f8}), index=False)
+    f4 = rng.integers(0, 2**32, 10_000, dtype=np.uint32).view(np.float32)
+    assert_fast_matches_legacy(monkeypatch, DataFrame({"a": f4}), index=False)
+
+
+def test_fast_writer_float_boundaries(monkeypatch):
+    # numpy's fixed/scientific cutoff is value-based: [1e-4, 1e16) for
+    # float64, [1e-4, 1e6) for float32
+    specials = [
+        0.0,
+        -0.0,
+        np.inf,
+        -np.inf,
+        np.nan,
+        5e-324,
+        2.2250738585072014e-308,
+        1.7976931348623157e308,
+        1e-4,
+        np.nextafter(1e-4, 0),
+        9.999999999999999e-05,
+        1e16,
+        np.nextafter(1e16, 0),
+        1e15,
+        0.1,
+        1 / 3,
+        1e100,
+        1e-100,
+    ]
+    assert_fast_matches_legacy(monkeypatch, DataFrame({"a": specials}))
+    f4_specials = np.array(
+        [0.0, -0.0, 1e-4, 1e6, 999999.94, 16777217.0, 1e-45, 3.4028235e38],
+        dtype=np.float32,
+    )
+    assert_fast_matches_legacy(monkeypatch, DataFrame({"a": f4_specials}))
+
+
+def test_fast_writer_lone_empty_field(monkeypatch):
+    # csv.writer quotes an empty field iff it is the row's only field
+    df = DataFrame({"a": ["", "x", ""]})
+    assert_fast_matches_legacy(monkeypatch, df, index=False)
+    assert df.to_csv(index=False) == 'a\n""\nx\n""\n'
+    # ... including for NaN rendered with the default na_rep=""
+    df = DataFrame({"a": [np.nan, 1.0]})
+    assert_fast_matches_legacy(monkeypatch, df, index=False)
+    assert df.to_csv(index=False) == 'a\n""\n1.0\n'
+
+
+def test_fast_writer_long_na_rep_truncation(monkeypatch):
+    # the legacy float path assigns na_rep into a '<U32' array, truncating
+    # longer values; the fast writer diverts to that path to match
+    df = DataFrame({"a": [1.5, np.nan]})
+    for length in [32, 33, 40]:
+        assert_fast_matches_legacy(monkeypatch, df, na_rep="M" * length)
+
+
+def test_fast_writer_non_str_na_rep(monkeypatch):
+    df = DataFrame({"a": [1.5, np.nan], "b": [pd.NaT, pd.Timestamp("2020-01-01")]})
+    assert_fast_matches_legacy(monkeypatch, df, na_rep=999)
+
+
+def test_fast_writer_surrogate_fallback(monkeypatch):
+    # PyUnicode_AsUTF8AndSize rejects lone surrogates; the chunk falls back
+    # to the legacy writer, which passes them through
+    df = DataFrame({"a": ["ok"] * 3 + ["bad\ud800esc"] + ["ok"] * 3}, dtype=object)
+    assert_fast_matches_legacy(monkeypatch, df)
+    assert_fast_matches_legacy(monkeypatch, df, chunksize=2)
+    assert "\ud800" in df.to_csv()
+
+
+def test_fast_writer_dt64_per_chunk_resolution(monkeypatch):
+    # the fractional-digits and dates-only decisions are made per chunk,
+    # matching the legacy conversion
+    df = DataFrame(
+        {
+            "a": pd.to_datetime(
+                [
+                    "2020-01-01",
+                    "2020-01-02",
+                    "2020-01-03 00:00:00.5",
+                    "2020-01-04",
+                    "2020-01-05 00:00:00.000001",
+                    "2020-01-06",
+                ],
+                format="ISO8601",
+            )
+        }
+    )
+    for chunksize in [1, 2, 3, None]:
+        assert_fast_matches_legacy(monkeypatch, df, chunksize=chunksize)
+    result = df.to_csv(chunksize=2).splitlines()
+    # rows 0-1 render dates-only, rows 2-3 with (ms-resolution) fractional
+    # seconds, rows 4-5 with us-resolution fractional seconds
+    assert result[1] == "0,2020-01-01"
+    assert result[3] == "2,2020-01-03 00:00:00.500"
+    assert result[4] == "3,2020-01-04 00:00:00.000"
+    assert result[5] == "4,2020-01-05 00:00:00.000001"
+
+
+def test_fast_writer_used_for_default_dialect(monkeypatch, mixed_frame):
+    from pandas._libs import writers as libwriters
+
+    calls = []
+    real = libwriters.write_csv_chunk
+
+    def spy(*args, **kwargs):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(libwriters, "write_csv_chunk", spy)
+    mixed_frame.to_csv()
+    assert calls
+
+    # non-default dialects divert to the legacy writer
+    calls.clear()
+    mixed_frame.to_csv(quoting=csv.QUOTE_ALL)
+    mixed_frame.to_csv(quoting=csv.QUOTE_NONNUMERIC)
+    mixed_frame.to_csv(escapechar="\\", doublequote=False)
+    mixed_frame.to_csv(sep="\N{FULLWIDTH COMMA}")
+    assert not calls
+
+
+def test_fast_writer_quoting_dialects_match(monkeypatch, mixed_frame):
+    # diverted dialects still round-trip through the same legacy code
+    assert_fast_matches_legacy(monkeypatch, mixed_frame, quoting=csv.QUOTE_ALL)
+    assert_fast_matches_legacy(
+        monkeypatch, mixed_frame, escapechar="\\", doublequote=False
+    )


### PR DESCRIPTION
Renders each `to_csv` chunk into a single string in C via a new
`libwriters.write_csv_chunk`, bypassing `csv.writer` and the per-cell
Python conversions for the default dialect (`QUOTE_MINIMAL`, `doublequote`,
no `escapechar`, `errors="strict"`, single-char ASCII sep/quotechar,
≤2-char ASCII lineterminator, non-MultiIndex). Numeric, boolean, and
tz-naive datetime columns are formatted natively; floats use
`std::to_chars` (shortest round-trip) reformatted to match numpy's
value-based fixed/scientific notation. A meson try-compile probe
(`PD_HAVE_FP_TO_CHARS`) guards the float path, with a
`PyOS_double_to_string` `'r'`-mode fallback for toolchains (e.g. older
libc++ on macOS) that lack floating-point `std::to_chars`.

Columns the fast path can't render natively (`float_format`, `decimal`,
`date_format`, timedelta, period, tz-aware datetime, Interval, extension
arrays, …) are converted with the existing `get_values_for_csv` and only
assembled natively, so output stays byte-identical. Anything outside the
gate falls back to the existing `csv.writer` path. Chunks containing
strings that can't encode to UTF-8 (lone surrogates) fall back per chunk.

Speedups on 1M rows (vs the current writer): ~10x for float, int, and
bool columns, ~9x for datetimes, ~5x for strings, ~8x for a mixed 8-column
frame. The output is verified byte-for-byte identical to the `csv.writer`
path across a dtype/options matrix plus 400k random float64 / 200k random
float32 bit patterns.

Follow-up opportunities (not in this PR): reading `ArrowStringArray`
buffers directly to skip per-cell Python strings, per-chunk threading,
and a binary write path to avoid the buffer→str→re-encode round-trip.
