### PR TITLE
PERF: avoid argsort of uniques in safe_sort

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -263,6 +263,25 @@ class Int64:
         self.df.groupby(self.cols).max()
 
 
+class SortHighCardinality:
+    # with many unique keys, sorting the uniques (safe_sort) dominates
+    # the sort=True groupby
+    param_names = ["sort"]
+    params = [True, False]
+
+    def setup(self, sort):
+        N = 10**6
+        self.df = DataFrame(
+            {
+                "key": np.random.randint(0, 2 * N, size=N),
+                "value": np.random.randn(N),
+            }
+        )
+
+    def time_sum(self, sort):
+        self.df.groupby("key", sort=sort)["value"].sum()
+
+
 class CountMultiDtype:
     def setup_cache(self):
         n = 10000

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -164,6 +164,7 @@ Deprecations
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - Performance improvement in :class:`.DataFrameGroupBy` aggregations (``sum``, ``mean``, ``min``, ``max``, ``prod``) when the grouping keys are already sorted (:issue:`65103`)
+- Performance improvement in :class:`.DataFrameGroupBy` and :class:`.SeriesGroupBy` with ``sort=True``, as well as :func:`factorize` and :func:`merge` with ``sort=True``, when the keys are integers with many unique values (:issue:`66129`)
 - Performance improvement in casting integer and boolean dtypes to ``string[pyarrow]`` by using PyArrow's native cast instead of element-wise conversion (:issue:`56505`)
 - Performance improvement in :meth:`DataFrame.__getitem__` when selecting a
   single column by label on a :class:`DataFrame` with duplicate column names.

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1609,6 +1609,11 @@ def diff(arr, n: int | float | np.integer | np.floating, axis: AxisInt = 0):
 # Helper functions
 
 
+# Minimum number of values before safe_sort's counting-sort path is worth it.
+# Below this, argsort's n*log(n) is cheaper than the linear counting work.
+_MIN_COUNTING_SORT_LEN = 5_000
+
+
 # Note: safe_sort is in algorithms.py instead of sorting.py because it is
 #  low-dependency, is used in this module, and used private methods from
 #  this module.
@@ -1669,7 +1674,24 @@ def safe_sort(
     sorter = None
     ordered: AnyArrayLike
 
+    # For integer values spanning a modest range, the codes remapping below
+    #  can rank each value within that range (a counting sort) instead of
+    #  argsorting.
+    use_counting = False
+    vmin = rng_size = 0
     if (
+        codes is not None
+        and isinstance(values, np.ndarray)
+        and values.dtype.kind in "iu"
+        and len(values) >= _MIN_COUNTING_SORT_LEN
+    ):
+        vmin = int(values.min())
+        rng_size = int(values.max()) - vmin + 1
+        use_counting = rng_size <= 4 * len(values)
+
+    if use_counting:
+        ordered = np.sort(cast("np.ndarray", values))
+    elif (
         not isinstance(values.dtype, ExtensionDtype)
         and lib.infer_dtype(values, skipna=False) == "mixed-integer"
     ):
@@ -1711,27 +1733,46 @@ def safe_sort(
         )
     codes = ensure_platform_int(np.asarray(codes))
 
-    if not assume_unique and not len(unique(values)) == len(values):
-        raise ValueError("values should be unique if codes is not None")
-
     # ranks[i] gives the position of values[i] in `ordered`
-    if sorter is not None:
-        # sorter is a permutation, so scatter is a faster equivalent to
-        #  `ranks = sorter.argsort()`
-        ranks = np.empty(len(sorter), dtype=np.intp)
-        ranks[sorter] = np.arange(len(sorter), dtype=np.intp)
+    if use_counting:
+        arr = cast("np.ndarray", values)
+        if arr.dtype.kind == "i":
+            # go through int64 so differences don't overflow narrower signed
+            #  dtypes; int64 wraparound is exact since the true differences
+            #  are within rng_size
+            shifted = arr.astype(np.int64, copy=False) - vmin
+        else:
+            # unsigned: differences always fit the unsigned dtype
+            shifted = arr - vmin
+        present = np.zeros(rng_size, dtype=bool)
+        present[shifted] = True
+        counts = present.cumsum(dtype=np.intp)
+        # the counting pass gives the uniqueness check for free
+        if not assume_unique and counts[-1] != len(values):
+            raise ValueError("values should be unique if codes is not None")
+        ranks = counts[shifted]
+        ranks -= 1
     else:
-        # mixed types
-        # error: Argument 1 to "_get_hashtable_algo" has incompatible type
-        # "Union[Index, ExtensionArray, ndarray[Any, Any]]"; expected
-        # "ndarray[Any, Any]"
-        hash_klass, values = _get_hashtable_algo(values)  # type: ignore[arg-type]
-        t = hash_klass(len(values))
-        # error: Argument 1 to "map_locations" of "HashTable" has incompatible
-        # type "ExtensionArray | ndarray[Any, Any] | Index | Series";
-        # expected "ndarray"
-        t.map_locations(ordered)  # type: ignore[arg-type]
-        ranks = ensure_platform_int(t.lookup(values))
+        if not assume_unique and not len(unique(values)) == len(values):
+            raise ValueError("values should be unique if codes is not None")
+
+        if sorter is not None:
+            # sorter is a permutation, so scatter is a faster equivalent to
+            #  `ranks = sorter.argsort()`
+            ranks = np.empty(len(sorter), dtype=np.intp)
+            ranks[sorter] = np.arange(len(sorter), dtype=np.intp)
+        else:
+            # mixed types
+            # error: Argument 1 to "_get_hashtable_algo" has incompatible type
+            # "Union[Index, ExtensionArray, ndarray[Any, Any]]"; expected
+            # "ndarray[Any, Any]"
+            hash_klass, values = _get_hashtable_algo(values)  # type: ignore[arg-type]
+            t = hash_klass(len(values))
+            # error: Argument 1 to "map_locations" of "HashTable" has incompatible
+            # type "ExtensionArray | ndarray[Any, Any] | Index | Series";
+            # expected "ndarray"
+            t.map_locations(ordered)  # type: ignore[arg-type]
+            ranks = ensure_platform_int(t.lookup(values))
 
     if use_na_sentinel:
         # take_nd is faster, but only works for na_sentinels of -1

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -16,6 +16,7 @@ from pandas import (
     merge,
 )
 import pandas._testing as tm
+from pandas.core import algorithms
 from pandas.core.algorithms import safe_sort
 import pandas.core.common as com
 from pandas.core.sorting import (
@@ -427,6 +428,17 @@ def test_decons(codes_list, shape):
         tm.assert_numpy_array_equal(a, b)
 
 
+@pytest.fixture(params=[5_000, 1], ids=["argsort", "counting"])
+def switch_counting_sort_min_len(request, monkeypatch):
+    # GH#66129 safe_sort ranks integer values spanning a modest range with a
+    #  counting sort rather than an argsort, but only above a length gate.
+    #  Lowering the gate runs the shared tests below down both paths, which
+    #  have to agree.
+    with monkeypatch.context() as m:
+        m.setattr(algorithms, "_MIN_COUNTING_SORT_LEN", request.param)
+        yield request.param
+
+
 class TestSafeSort:
     @pytest.mark.parametrize(
         "arg, exp",
@@ -444,6 +456,7 @@ class TestSafeSort:
         expected = np.array(exp)
         tm.assert_numpy_array_equal(result, expected)
 
+    @pytest.mark.parametrize("dtype", ["int64", "uint64", "float64", "object"])
     @pytest.mark.parametrize("verify", [True, False])
     @pytest.mark.parametrize(
         "codes, exp_codes",
@@ -452,9 +465,9 @@ class TestSafeSort:
             [[], []],
         ],
     )
-    def test_codes(self, verify, codes, exp_codes):
-        values = np.array([3, 1, 2, 0, 4])
-        expected = np.array([0, 1, 2, 3, 4])
+    def test_codes(self, verify, codes, exp_codes, dtype, switch_counting_sort_min_len):
+        values = np.array([3, 1, 2, 0, 4], dtype=dtype)
+        expected = np.array([0, 1, 2, 3, 4], dtype=dtype)
 
         result, result_codes = safe_sort(
             values, codes, use_na_sentinel=True, verify=verify
@@ -463,9 +476,10 @@ class TestSafeSort:
         tm.assert_numpy_array_equal(result, expected)
         tm.assert_numpy_array_equal(result_codes, expected_codes)
 
-    def test_codes_out_of_bound(self):
-        values = np.array([3, 1, 2, 0, 4])
-        expected = np.array([0, 1, 2, 3, 4])
+    @pytest.mark.parametrize("dtype", ["int64", "uint64", "float64", "object"])
+    def test_codes_out_of_bound(self, dtype, switch_counting_sort_min_len):
+        values = np.array([3, 1, 2, 0, 4], dtype=dtype)
+        expected = np.array([0, 1, 2, 3, 4], dtype=dtype)
 
         # out of bound indices
         codes = [0, 101, 102, 2, 3, 0, 99, 4]
@@ -473,6 +487,69 @@ class TestSafeSort:
         expected_codes = np.array([3, -1, -1, 2, 0, 3, -1, 4], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
         tm.assert_numpy_array_equal(result_codes, expected_codes)
+
+    @pytest.mark.parametrize("dtype", ["int64", "uint64"])
+    def test_codes_out_of_bound_wrap(self, dtype, switch_counting_sort_min_len):
+        # out of bound indices wrap when there is no sentinel to mask them with
+        values = np.array([3, 1, 2, 0, 4], dtype=dtype)
+        # wrapping these lands on 0, 1, 3, 2, 4 respectively
+        codes = [0, 6, 8, 2, -1]
+
+        _, result_codes = safe_sort(values, codes, use_na_sentinel=False)
+        expected_codes = np.array([3, 1, 0, 2, 4], dtype=np.intp)
+        tm.assert_numpy_array_equal(result_codes, expected_codes)
+
+    @pytest.mark.parametrize("dtype", ["int64", "int32", "int16", "uint64"])
+    @pytest.mark.parametrize("anchor", ["min", "max"])
+    @pytest.mark.parametrize("assume_unique", [True, False])
+    def test_codes_counting_sort_dtype_bounds(
+        self, dtype, anchor, assume_unique, switch_counting_sort_min_len
+    ):
+        # GH#66129 anchor the values at either end of the dtype so that shifting
+        #  by the minimum is exercised for large-negative and large-positive bases
+        info = np.iinfo(dtype)
+        num = 5
+        base = info.min if anchor == "min" else info.max - num + 1
+        values = np.arange(base, base + num, dtype=dtype)[::-1].copy()
+        codes = np.array([0, 3, 4, 1], dtype=np.intp)
+
+        result, result_codes = safe_sort(values, codes, assume_unique=assume_unique)
+        tm.assert_numpy_array_equal(result, np.sort(values))
+        tm.assert_numpy_array_equal(result_codes, np.array([4, 1, 0, 3], dtype=np.intp))
+
+    def test_codes_counting_sort_duplicates(self, switch_counting_sort_min_len):
+        # GH#66129 the counting pass doubles as the uniqueness check
+        values = np.array([3, 1, 2, 0, 3], dtype="int64")
+        codes = np.arange(len(values), dtype=np.intp)
+        with pytest.raises(ValueError, match="values should be unique"):
+            safe_sort(values, codes)
+
+    def test_codes_counting_sort_wide_range(self, switch_counting_sort_min_len):
+        # GH#66129 too wide a range declines the counting path; the results have
+        #  to match the argsort path it falls back to
+        values = np.array([300, 1, 20000, 0, 4], dtype="int64")
+        codes = np.array([0, 2, 4, -1, 1], dtype=np.intp)
+
+        result, result_codes = safe_sort(values, codes)
+        tm.assert_numpy_array_equal(result, np.sort(values))
+        tm.assert_numpy_array_equal(
+            result_codes, np.array([3, 4, 2, -1, 1], dtype=np.intp)
+        )
+
+    def test_codes_counting_sort_above_real_min_len(self):
+        # GH#66129 the unpatched cutoff has to actually reach the counting path
+        num = algorithms._MIN_COUNTING_SORT_LEN + 1
+        rng = np.random.default_rng(2)
+        values = rng.permutation(np.arange(num, dtype="int64"))
+        codes = rng.integers(0, num, size=500).astype(np.intp)
+
+        result, result_codes = safe_sort(values, codes.copy())
+
+        # ranks[i] is the position of values[i] once sorted
+        ranks = np.empty(num, dtype=np.intp)
+        ranks[values.argsort()] = np.arange(num, dtype=np.intp)
+        tm.assert_numpy_array_equal(result, np.sort(values))
+        tm.assert_numpy_array_equal(result_codes, ranks.take(codes))
 
     @pytest.mark.parametrize("codes", [[-1, -1], [2, -1], [2, 2]])
     def test_codes_empty_array_out_of_bound(self, codes):


### PR DESCRIPTION
Speeds up `safe_sort` (and therefore `factorize(sort=True)`, `groupby(sort=True)`, and `merge(sort=True)`) when the keys are integers with many unique values.

With high-cardinality keys, the sorted-groupby path spends most of its time in `safe_sort` reordering the factorized codes, and the bulk of that is an argsort of the uniques. For integer uniques whose value range is at most 4x their length, this skips the argsort entirely: `np.sort` the uniques and rank them with a counting pass over the range. The counting pass also validates uniqueness for free, so the `merge` path avoids its separate hashtable `unique()` check.

The path is gated on ≥5000 uniques; below that the plain argsort is faster, so low-cardinality keys don't regress. Too wide a value range also declines it and falls back to the argsort path.

Rebased on top of GH-66127, which landed the other two pieces this PR originally carried (the O(n) scatter inverse of the argsort permutation, and the `np.sort` fast path when `codes is None`). Only the counting-sort path is new here, so the diff is considerably smaller than it was.

Benchmarks on 1M rows of int64 keys drawn from `range(2_000_000)` (~790k observed uniques), measured against current main:

| | main | this PR |
|---|---|---|
| `safe_sort(uniques, codes)` | 61.0 ms | 30.9 ms |
| `df.groupby("k", sort=True)["v"].sum()` | 79.9 ms | 65.4 ms |
| low-cardinality (1k uniques) `sort=True` | 6.2 ms | 6.4 ms |
| declined path (1M uniques, wide range) | 78.3 ms | 75.8 ms |

The `sort=False` floor for that groupby is ~28ms. The last two rows check for regressions in the cases the gate is meant to protect; both are within noise.

New `SortHighCardinality` ASV benchmark added under `groupby`.

The ≥5000 gate is now the module-level `_MIN_COUNTING_SORT_LEN` in `algorithms.py`, matching the existing `_MINIMUM_COMP_ARR_LEN` / `_MIN_ELEMENTS` convention. Tests monkeypatch it via a `switch_counting_sort_min_len` fixture (modelled on `switch_numexpr_min_elements`) that runs the shared `safe_sort` code tests down both the argsort and counting paths, so the two are asserted to agree on identical inputs rather than the counting path having its own hand-written expectations.

On top of that: the counting path is covered across int64/int32/int16/uint64 anchored at both ends of each dtype's range (so the shift by the minimum is exercised for large-negative and large-positive bases), with `assume_unique` both ways, the free uniqueness check, sentinel and out-of-bound/wrap handling, and the wide-range fallback. One test deliberately skips the fixture to confirm the real unpatched cutoff still reaches the path.