### PR TITLE
PERF: prefix bloom filters for read_csv NA-value lookups

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -203,6 +203,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` (:issue:`64515`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` and ``parse_dates`` for columns containing ISO8601 datetime strings; concurrent reads from multiple threads also scale better (:issue:`65353`, :issue:`66278`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` during dtype inference: columns that do not parse as numeric or boolean (e.g. string columns) are now rejected before allocating a result buffer for the attempt (:issue:`66273`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` for columns containing values similar to the default NA spellings (e.g. negative numbers, which share a leading ``-`` with ``"-NaN"``)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns (:issue:`65767`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns with default settings (:issue:`66239`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for integer and string columns (:issue:`65350`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -203,7 +203,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` (:issue:`64515`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` and ``parse_dates`` for columns containing ISO8601 datetime strings; concurrent reads from multiple threads also scale better (:issue:`65353`, :issue:`66278`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` during dtype inference: columns that do not parse as numeric or boolean (e.g. string columns) are now rejected before allocating a result buffer for the attempt (:issue:`66273`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` for columns containing values similar to the default NA spellings (e.g. negative numbers, which share a leading ``-`` with ``"-NaN"``)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` for columns containing values similar to the default NA spellings (e.g. negative numbers, which share a leading ``-`` with ``"-NaN"``) (:issue:`66114`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns (:issue:`65767`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns with default settings (:issue:`66239`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for integer and string columns (:issue:`65350`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -203,7 +203,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` (:issue:`64515`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` and ``parse_dates`` for columns containing ISO8601 datetime strings; concurrent reads from multiple threads also scale better (:issue:`65353`, :issue:`66278`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` during dtype inference: columns that do not parse as numeric or boolean (e.g. string columns) are now rejected before allocating a result buffer for the attempt (:issue:`66273`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` for columns containing values similar to the default NA spellings (e.g. negative numbers, which share a leading ``-`` with ``"-NaN"``) (:issue:`66114`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` for columns containing values similar to the default NA spellings (e.g. negative numbers, which share a leading ``-`` with ``"-NaN"``) (:issue:`66132`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns (:issue:`65767`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns with default settings (:issue:`66239`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for integer and string columns (:issue:`65350`)

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -385,6 +385,16 @@ KHASH_MAP_INIT_STR(strbox, kh_pyobject_t)
 typedef struct {
   kh_str_t *table;
   int starts[256];
+  // Pairwise (first byte, second byte) presence bitmap: bit ch2 of
+  // starts2[ch] marks a key starting with bytes ch, ch2. Tokens sharing
+  // only a first byte with a key (e.g. "-12" vs the "-NaN" NA spelling)
+  // then skip the full hash lookup.
+  uint8_t starts2[256][32];
+  // 8192-bit bloom filter over the first (up to) 4 bytes of each key.
+  // Two bytes are not enough for numeric tokens vs the default NA
+  // spellings ("1.23" vs "1.#IND", "-1.5" vs "-1.#QNAN"); four bytes
+  // are ("1.23" vs "1.#I", "-1.5" vs "-1.#").
+  uint8_t prefix4[1024];
 } kh_str_starts_t;
 
 typedef kh_str_starts_t *p_kh_str_starts_t;
@@ -396,21 +406,46 @@ static inline p_kh_str_starts_t kh_init_str_starts(void) {
   return result;
 }
 
+// Bloom-bit index for the first min(4, strlen) bytes of a NUL-terminated
+// key. Equal strings always map to the same bit, so the filter has no
+// false negatives.
+static inline uint32_t kh_str_starts_prefix4_bit(const char *key) {
+  uint32_t prefix = (unsigned char)key[0];
+  for (int i = 1; i < 4 && key[i] != '\0'; i++) {
+    prefix = (prefix << 8) | (unsigned char)key[i];
+  }
+  return (prefix * 2654435761u) >> 19;
+}
+
 static inline khuint_t kh_put_str_starts_item(kh_str_starts_t *table, char *key,
                                               int *ret) {
   khuint_t result = kh_put_str(table->table, key, ret);
   if (*ret != 0) {
-    table->starts[(unsigned char)key[0]] = 1;
+    const unsigned char ch = (unsigned char)key[0];
+    table->starts[ch] = 1;
+    if (ch != '\0') {
+      const unsigned char ch2 = (unsigned char)key[1];
+      table->starts2[ch][ch2 >> 3] |= (uint8_t)(1 << (ch2 & 7));
+      const uint32_t bit = kh_str_starts_prefix4_bit(key);
+      table->prefix4[bit >> 3] |= (uint8_t)(1 << (bit & 7));
+    }
   }
   return result;
 }
 
 static inline khuint_t kh_get_str_starts_item(const kh_str_starts_t *table,
                                               const char *key) {
-  unsigned char ch = *key;
+  const unsigned char ch = (unsigned char)*key;
   if (table->starts[ch]) {
-    if (ch == '\0' || kh_get_str(table->table, key) != table->table->n_buckets)
+    if (ch == '\0')
       return 1;
+    const unsigned char ch2 = (unsigned char)key[1];
+    if (table->starts2[ch][ch2 >> 3] & (1 << (ch2 & 7))) {
+      const uint32_t bit = kh_str_starts_prefix4_bit(key);
+      if ((table->prefix4[bit >> 3] & (1 << (bit & 7))) &&
+          kh_get_str(table->table, key) != table->table->n_buckets)
+        return 1;
+    }
   }
   return 0;
 }

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -433,19 +433,51 @@ static inline khuint_t kh_put_str_starts_item(kh_str_starts_t *table, char *key,
   return result;
 }
 
+#if defined(_MSC_VER)
+#  define KH_NOINLINE __declspec(noinline)
+#else
+#  define KH_NOINLINE __attribute__((noinline))
+#endif
+
+// Slow path once the first-byte table hits: the starts2/prefix4 bloom
+// layers, then the full hash lookup. Kept out of line so the common
+// first-byte reject stays a tiny inline check in the parser's per-token
+// loops.
+static inline KH_NOINLINE khuint_t
+kh_get_str_starts_item_slow(const kh_str_starts_t *table, const char *key) {
+  const unsigned char ch2 = (unsigned char)key[1];
+  if (table->starts2[(unsigned char)key[0]][ch2 >> 3] & (1 << (ch2 & 7))) {
+    const uint32_t bit = kh_str_starts_prefix4_bit(key);
+    if ((table->prefix4[bit >> 3] & (1 << (bit & 7))) &&
+        kh_get_str(table->table, key) != table->table->n_buckets)
+      return 1;
+  }
+  return 0;
+}
+
 static inline khuint_t kh_get_str_starts_item(const kh_str_starts_t *table,
                                               const char *key) {
   const unsigned char ch = (unsigned char)*key;
   if (table->starts[ch]) {
     if (ch == '\0')
       return 1;
-    const unsigned char ch2 = (unsigned char)key[1];
-    if (table->starts2[ch][ch2 >> 3] & (1 << (ch2 & 7))) {
-      const uint32_t bit = kh_str_starts_prefix4_bit(key);
-      if ((table->prefix4[bit >> 3] & (1 << (bit & 7))) &&
-          kh_get_str(table->table, key) != table->table->n_buckets)
-        return 1;
-    }
+    return kh_get_str_starts_item_slow(table, key);
+  }
+  return 0;
+}
+
+// First-byte-only variant for hit-dominated lookups (the parser's
+// true/false sets, where nearly every token is in one of the two sets):
+// the bloom layers above filter nothing on a hit and would be pure
+// overhead, while the first-byte table still rejects the opposite set
+// ("True" vs the false set) in one load.
+static inline khuint_t
+kh_get_str_starts_item_expect_hit(const kh_str_starts_t *table,
+                                  const char *key) {
+  const unsigned char ch = (unsigned char)*key;
+  if (table->starts[ch]) {
+    if (ch == '\0' || kh_get_str(table->table, key) != table->table->n_buckets)
+      return 1;
   }
   return 0;
 }

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -442,8 +442,9 @@ static inline khuint_t kh_put_str_starts_item(kh_str_starts_t *table, char *key,
 // Slow path once the first-byte table hits: the starts2/prefix4 bloom
 // layers, then the full hash lookup. Kept out of line so the common
 // first-byte reject stays a tiny inline check in the parser's per-token
-// loops.
-static inline KH_NOINLINE khuint_t
+// loops. Marked KH_NOINLINE (not "inline") since GCC rejects an inline
+// function that also carries the noinline attribute under -Werror.
+static KH_NOINLINE khuint_t
 kh_get_str_starts_item_slow(const kh_str_starts_t *table, const char *key) {
   const unsigned char ch2 = (unsigned char)key[1];
   if (table->starts2[(unsigned char)key[0]][ch2 >> 3] & (1 << (ch2 & 7))) {

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -386,14 +386,12 @@ typedef struct {
   kh_str_t *table;
   int starts[256];
   // Pairwise (first byte, second byte) presence bitmap: bit ch2 of
-  // starts2[ch] marks a key starting with bytes ch, ch2. Tokens sharing
-  // only a first byte with a key (e.g. "-12" vs the "-NaN" NA spelling)
-  // then skip the full hash lookup.
+  // starts2[ch] marks a key starting with bytes ch, ch2, so tokens
+  // sharing only a first byte with a key skip the full hash lookup.
   uint8_t starts2[256][32];
   // 8192-bit bloom filter over the first (up to) 4 bytes of each key.
-  // Two bytes are not enough for numeric tokens vs the default NA
-  // spellings ("1.23" vs "1.#IND", "-1.5" vs "-1.#QNAN"); four bytes
-  // are ("1.23" vs "1.#I", "-1.5" vs "-1.#").
+  // Two bytes do not separate numeric tokens from the default NA
+  // spellings ("1.23" vs "1.#IND", "-1.5" vs "-1.#QNAN"); four do.
   uint8_t prefix4[1024];
 } kh_str_starts_t;
 
@@ -442,8 +440,7 @@ static inline khuint_t kh_put_str_starts_item(kh_str_starts_t *table, char *key,
 // Slow path once the first-byte table hits: the starts2/prefix4 bloom
 // layers, then the full hash lookup. Kept out of line so the common
 // first-byte reject stays a tiny inline check in the parser's per-token
-// loops. Marked KH_NOINLINE (not "inline") since GCC rejects an inline
-// function that also carries the noinline attribute under -Werror.
+// loops. Not marked "inline": GCC rejects that alongside noinline.
 static KH_NOINLINE khuint_t
 kh_get_str_starts_item_slow(const kh_str_starts_t *table, const char *key) {
   const unsigned char ch2 = (unsigned char)key[1];
@@ -468,10 +465,9 @@ static inline khuint_t kh_get_str_starts_item(const kh_str_starts_t *table,
 }
 
 // First-byte-only variant for hit-dominated lookups (the parser's
-// true/false sets, where nearly every token is in one of the two sets):
-// the bloom layers above filter nothing on a hit and would be pure
-// overhead, while the first-byte table still rejects the opposite set
-// ("True" vs the false set) in one load.
+// true/false sets): on a hit the bloom layers filter nothing and are
+// pure overhead, while the first-byte table still rejects the opposite
+// set in one load.
 static inline khuint_t
 kh_get_str_starts_item_expect_hit(const kh_str_starts_t *table,
                                   const char *key) {

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -102,6 +102,8 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
     khuint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key,
                                     int* ret) nogil
     khuint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) nogil
+    khuint_t kh_get_str_starts_item_expect_hit(kh_str_starts_t* table,
+                                               char* key) nogil
     void kh_destroy_str_starts(kh_str_starts_t*) nogil
     void kh_resize_str_starts(kh_str_starts_t*, khuint_t) nogil
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -103,6 +103,7 @@ from pandas._libs.khash cimport (
     kh_get_float64,
     kh_get_str,
     kh_get_str_starts_item,
+    kh_get_str_starts_item_expect_hit,
     kh_get_strbox,
     kh_init_float64,
     kh_init_str,
@@ -3256,18 +3257,21 @@ cdef int _try_bool_flex_nogil(parser_t *parser, int64_t col,
         for _ in range(lines):
             word = coliter_next(&it)
 
-            if kh_get_str_starts_item(na_hashset, word):
+            # expect_hit for all three sets: bool tokens either reject on
+            # the first byte or are genuine hits, so the deeper filters in
+            # kh_get_str_starts_item would be pure overhead here
+            if kh_get_str_starts_item_expect_hit(na_hashset, word):
                 # in the hash table
                 na_count[0] += 1
                 data[0] = NA
                 data += 1
                 continue
 
-            if kh_get_str_starts_item(true_hashset, word):
+            if kh_get_str_starts_item_expect_hit(true_hashset, word):
                 data[0] = 1
                 data += 1
                 continue
-            if kh_get_str_starts_item(false_hashset, word):
+            if kh_get_str_starts_item_expect_hit(false_hashset, word):
                 data[0] = 0
                 data += 1
                 continue
@@ -3280,12 +3284,12 @@ cdef int _try_bool_flex_nogil(parser_t *parser, int64_t col,
         for _ in range(lines):
             word = coliter_next(&it)
 
-            if kh_get_str_starts_item(true_hashset, word):
+            if kh_get_str_starts_item_expect_hit(true_hashset, word):
                 data[0] = 1
                 data += 1
                 continue
 
-            if kh_get_str_starts_item(false_hashset, word):
+            if kh_get_str_starts_item_expect_hit(false_hashset, word):
                 data[0] = 0
                 data += 1
                 continue

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -3257,9 +3257,8 @@ cdef int _try_bool_flex_nogil(parser_t *parser, int64_t col,
         for _ in range(lines):
             word = coliter_next(&it)
 
-            # expect_hit for all three sets: bool tokens either reject on
-            # the first byte or are genuine hits, so the deeper filters in
-            # kh_get_str_starts_item would be pure overhead here
+            # bool tokens either reject on the first byte or are genuine
+            # hits; the deeper bloom filters would be pure overhead
             if kh_get_str_starts_item_expect_hit(na_hashset, word):
                 # in the hash table
                 na_count[0] += 1


### PR DESCRIPTION
With `na_filter` on (the default), every token in `read_csv`'s numeric/string converters calls `kh_get_str_starts_item` on the NA hash set. The existing filter is only a first-byte table, so default NA spellings like `"-NaN"`, `"-1.#IND"`, `"1.#QNAN"` force every `-`- or `1`-leading numeric token through a full strlen+hash lookup.

This adds two bloom layers so those tokens reject after reading 2-4 bytes:

- **starts2**: a (first byte, second byte) bitmap that rejects most tokens cheaply (`"-42"` vs `"-NaN"` differ at byte 2).
- **prefix4**: an 8192-bit bloom over the first &lt;=4 bytes, for tokens sharing 2 bytes with an NA spelling (`"1.23"` vs `"1.#IND"` share `"1."` but differ within 4 bytes; 3 bytes is not enough: `"-1.234"` vs `"-1.#IND"` share 3).

Two refinements keep this from taxing lookups the blooms can't help:

- The bloom layers + hash lookup live in an out-of-line slow path (`kh_get_str_starts_item_slow`), so the common first-byte reject stays a tiny inline check in the per-token converter loops.
- The bool converter uses a first-byte-only variant (`kh_get_str_starts_item_expect_hit`) for its NA/true/false sets: bool tokens either reject on the first byte or are genuine hits in the true/false sets, so the deeper filters would be pure overhead there.

**Correctness**: no false negatives by construction — put and get compute identical bits for equal strings, and `kh_init_str_starts` already uses calloc so the new arrays start zeroed. `kh_str_starts` is only consumed by `pandas/_libs/parsers.pyx`; the only call-site change is the bool converter switching to the `expect_hit` variant.

## Benchmarks

Shared read_csv suite (123 cases, M3 Pro) vs `main @ c0aee4cea2 (2026-07-20)`: baseline and branch measured back-to-back per case with alternating order, adaptive rounds to a ±0.75% target, 99% CIs.

This is a **trade-off**, not a uniform win — 51 wins ≥3% and 7 regressions ≥3%. The bloom layers pay off on long tokens and NA-collision-heavy numerics, and cost on short dense tokens that gain nothing from a prefix check:

| wins | speedup | 99% CI |
|---|---|---|
| uint64 (> int64 max) | 1.33x | [1.32, 1.34] |
| floats, 100% negative | 1.17x | [1.17, 1.17] |
| floats, 90% negative | 1.13x | [1.13, 1.14] |
| ints, 90% negative | 1.11x | [1.10, 1.12] |
| NA 90% (empty fields) | 1.11x | [1.10, 1.11] |

| regressions | speedup | 99% CI |
|---|---|---|
| short fields (30 tiny int cols) | 0.89x | [0.88, 0.90] |
| int col w/ sparse NA | 0.95x | [0.94, 0.96] |
| adversarial strings | 0.96x | [0.96, 0.97] |
| wide (100 cols) | 0.97x | [0.96, 0.97] |

The win is concentrated where it was designed to be: numeric columns whose tokens collide with an NA spelling on the leading byte and now reject at byte 2. The cost falls on columns of very short tokens — 1–3 digit integers across many columns — where every token pays the extra bloom layer but there is too little token to short-circuit. Positive-only integers, NA-dense columns and `na_filter=False` are parity.

- [x] Tests added and passed if fixing a bug or adding a new feature (behavior-neutral; existing `na_values` tests cover correctness)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
