### PR TITLE
DOC: Fix misleading melt example in reshaping guide (#23844)

### DIFF
--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -332,17 +332,17 @@ by supplying the ``var_name`` and ``value_name`` parameters.
 
 .. ipython:: python
 
-   cheese = pd.DataFrame(
+   trial = pd.DataFrame(
        {
            "first": ["John", "Mary"],
            "last": ["Doe", "Bo"],
-           "height": [5.5, 6.0],
-           "weight": [130, 150],
+           "Treatment A": [16, 3],
+           "Treatment B": [11, 1],
        }
    )
-   cheese
-   cheese.melt(id_vars=["first", "last"])
-   cheese.melt(id_vars=["first", "last"], var_name="quantity")
+   trial
+   trial.melt(id_vars=["first", "last"])
+   trial.melt(id_vars=["first", "last"], var_name="treatment")
 
 When transforming a DataFrame using :func:`~pandas.melt`, the index will be ignored.
 The original index values can be kept by setting the ``ignore_index`` parameter to ``False`` (default is ``True``).
@@ -351,18 +351,18 @@ The original index values can be kept by setting the ``ignore_index`` parameter 
 .. ipython:: python
 
    index = pd.MultiIndex.from_tuples([("person", "A"), ("person", "B")])
-   cheese = pd.DataFrame(
+   trial = pd.DataFrame(
        {
            "first": ["John", "Mary"],
            "last": ["Doe", "Bo"],
-           "height": [5.5, 6.0],
-           "weight": [130, 150],
+           "Treatment A": [16, 3],
+           "Treatment B": [11, 1],
        },
        index=index,
    )
-   cheese
-   cheese.melt(id_vars=["first", "last"])
-   cheese.melt(id_vars=["first", "last"], ignore_index=False)
+   trial
+   trial.melt(id_vars=["first", "last"])
+   trial.melt(id_vars=["first", "last"], ignore_index=False)
 
 :func:`~pandas.wide_to_long` is similar to :func:`~pandas.melt` with more customization for
 column matching.


### PR DESCRIPTION
Closes #23844

The melt example in the user guide previously unpivoted "height" (inches) and "weight" (lbs) into a single value column, mixing two variables with different units. This matches the confusion described in the issue.

This PR swaps in a same-unit example (two treatment counts) so the resulting value column is homogeneous, per the reporter's own suggestion. Also renamed the cheese variable to trial and updated var_name="quantity" to var_name="treatment" to match.

Verified the DataFrame/melt output locally against pandas 3.0.2.

Checklist:
- closes #23844
- Docs-only change, no tests or whatsnew entry needed per contributing guide
- All code checks passed