### PR TITLE
TST: add regression test for validate='1:m' alias

### DIFF
--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1341,6 +1341,16 @@ class TestMerge:
         result = merge(left, right, on=["a", "b"], validate="1:1")
         tm.assert_frame_equal(result, expected_multi)
 
+    def test_merge_validate_one_to_many_alias(self):
+        left = DataFrame({"key": [1, 2]})
+        right = DataFrame({"key": [1, 1, 2]})
+
+        result = merge(left, right, on="key", validate="1:m")
+
+        expected = DataFrame({"key": [1, 1, 2]})
+
+        tm.assert_frame_equal(result, expected)
+
     def test_merge_validate_error_message(self):
         # GH#62742
         left = DataFrame({"key": [1, 1, 2]})


### PR DESCRIPTION
- closes #58517

Adds a regression test verifying that the `"1:m"` alias is accepted for
`validate` in `merge`.

The test passes on the current implementation and fails if support for
the `"1:m"` alias is removed, killing the corresponding mutation.