### PR TITLE
DOC fix incorrect parameter names in docstrings

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -227,7 +227,7 @@ def _isna_array(values: ArrayLike) -> npt.NDArray[np.bool_] | NDFrame:
 
     Parameters
     ----------
-    values: ndarray or ExtensionArray
+    values : ndarray or ExtensionArray
         The input array whose elements are to be checked.
 
     Returns

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -227,7 +227,7 @@ def _isna_array(values: ArrayLike) -> npt.NDArray[np.bool_] | NDFrame:
 
     Parameters
     ----------
-    obj: ndarray or ExtensionArray
+    values: ndarray or ExtensionArray
         The input array whose elements are to be checked.
 
     Returns

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -231,8 +231,8 @@ def _format_argument_list(allow_args: list[str]) -> str:
 
     Parameters
     ----------
-    allowed_args : list, tuple or int
-        The `allowed_args` argument for `deprecate_nonkeyword_arguments`,
+    allow_args : list, tuple or int
+        The `allow_args` argument for `deprecate_nonkeyword_arguments`,
         but None value is not allowed.
 
     Returns


### PR DESCRIPTION
## Problem description

Two internal functions have docstring parameter names that do not match the actual function signatures:

| File | Function | Wrong | Correct |
|------|----------|-------|---------|
| `pandas/util/_decorators.py` | `_format_argument_list()` | `allowed_args` | `allow_args` |
| `pandas/core/dtypes/missing.py` | `_isna_array()` | `obj` | `values` |

Both appear to be stale names left over from earlier function versions.

Docstring-only changes — no logic affected.