### PR TITLE
BLD: honor numpy-include-dir Meson property for cross-compilation (GH#62883)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -303,6 +303,64 @@ jobs:
       group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-32bit
       cancel-in-progress: true
 
+  Linux-numpy-include-dir:
+    # Regression guard for GH#62883. pandas/meson.build must honor the
+    # `numpy-include-dir` cross/native-file property so cross-compilers can point
+    # the build at the *target* numpy headers instead of the build host's. When
+    # cross-compiling, running numpy.get_include() picks up the host numpy and
+    # bakes in the wrong ABI (e.g. int64_t sized as a 32-bit long), which then
+    # fails at import with "Buffer dtype mismatch, expected 'const int64_t' but
+    # got 'long long'". A configure-only check is enough: point the property at a
+    # distinct copy of the headers and assert it reaches the numpy include flags.
+    # Full cross-compilation is intentionally not exercised.
+    name: numpy-include-dir meson property
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.13'
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip meson[ninja]==1.2.3 meson-python==0.18.0 versioneer[toml] cython numpy
+
+      - name: Assert meson honors numpy-include-dir
+        run: |
+          # Point the property at a *distinct* copy of the numpy headers. If the
+          # property is honored these headers (not numpy.get_include()) end up in
+          # the compile flags; if support regresses to the get_include() fallback
+          # the copy is never referenced and the assertion below fails.
+          NUMPY_INCDIR=$(python -c "import numpy; print(numpy.get_include())")
+          ALT_INCDIR="${RUNNER_TEMP}/target-numpy/include"
+          mkdir -p "$ALT_INCDIR"
+          cp -r "$NUMPY_INCDIR/numpy" "$ALT_INCDIR/"
+
+          cat > "${RUNNER_TEMP}/numpy-include-dir.ini" <<EOF
+          [properties]
+          numpy-include-dir = '${ALT_INCDIR}'
+          EOF
+
+          meson setup "${RUNNER_TEMP}/build" --native-file "${RUNNER_TEMP}/numpy-include-dir.ini"
+
+          echo "::group::numpy include flags"
+          grep -o -- "-I[^\" ]*numpy[^\" ]*" "${RUNNER_TEMP}/build/compile_commands.json" | sort -u || true
+          echo "::endgroup::"
+
+          if ! grep -q "$ALT_INCDIR" "${RUNNER_TEMP}/build/compile_commands.json"; then
+            echo "ERROR: meson ignored the numpy-include-dir property (GH#62883 regression)"
+            exit 1
+          fi
+          echo "OK: numpy-include-dir property is honored"
+    concurrency:
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-numpy-include-dir
+      cancel-in-progress: true
+
   Linux-Musl:
     runs-on: ubuntu-24.04
     permissions:

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -486,6 +486,7 @@ Other
 
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
+- Fixed cross-compilation (e.g. to 32-bit ARM) building against the build machine's NumPy headers instead of the target's, producing an extension that failed to import with ``ValueError: Buffer dtype mismatch``; the target NumPy include directory can now be set with the ``numpy-include-dir`` Meson property (:issue:`62883`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/meson.build
+++ b/pandas/meson.build
@@ -1,8 +1,15 @@
-incdir_numpy = run_command(
-    py,
-    [
-        '-c',
-        '''
+# Allow the numpy include directory to be supplied explicitly via a cross/native
+# file property. This is required when cross-compiling: running numpy.get_include()
+# below executes the build (native) Python, which returns the *host* numpy headers
+# rather than the target's, silently baking in the wrong ABI (e.g. int64_t sized as
+# a 32-bit long). Matches the mechanism used by numpy and scipy. See GH#62883.
+incdir_numpy = meson.get_external_property('numpy-include-dir', 'not-given')
+if incdir_numpy == 'not-given'
+    incdir_numpy = run_command(
+        py,
+        [
+            '-c',
+            '''
 import os
 import numpy as np
 try:
@@ -14,9 +21,10 @@ except Exception:
     incdir = np.get_include()
 print(incdir)
      ''',
-    ],
-    check: true,
-).stdout().strip()
+        ],
+        check: true,
+    ).stdout().strip()
+endif
 
 inc_np = include_directories(incdir_numpy)
 inc_pd = include_directories('_libs/include')


### PR DESCRIPTION
closes #62883

``pandas/meson.build`` resolved the NumPy include directory by running ``numpy.get_include()`` through the build (native) Python. When cross-compiling that returns the *host* NumPy headers, where ``int64_t`` is a 64-bit ``long``; on a 32-bit target ``long`` is only 4 bytes, so pandas' compiled ``int64_t`` memoryviews disagree with the runtime NumPy's genuine 8-byte int64 arrays and import fails at the first ``int64_t[::1]`` view (``tzconversion.pyx``) with ``ValueError: Buffer dtype mismatch, expected 'const int64_t' but got 'long long'``.

Read the ``numpy-include-dir`` Meson external property first — matching what NumPy and SciPy do — and fall back to ``numpy.get_include()`` when it is unset, so cross-compilers can point pandas at the *target* NumPy headers. The reporter (Buildroot, armv7l) was already passing this property; pandas just wasn't reading it.

Also adds a configure-only CI job (``Linux-numpy-include-dir``) that sets the property to a distinct copy of the NumPy headers and asserts that path reaches the compile include flags, guarding against the property support regressing. Full cross-compilation (crossenv/qemu) is intentionally not exercised.