### PR TITLE
BUG: Fix misleading ValueError in str.match with precompiled regex fl…

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -322,6 +322,7 @@ Interval
 ^^^^^^^^
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors unnecessarily upcasting sub-64-bit numeric dtypes (e.g. ``float32``, ``int32``) to 64-bit (:issue:`45412`)
 - Bug in :func:`cut` and other operations building an :class:`IntervalIndex` engine raising ``TypeError`` on 32-bit platforms when there were more than 100 intervals (:issue:`44075`, :issue:`23440`)
+- Bug in :meth:`Series.str.match` and :meth:`Series.str.fullmatch` incorrectly raising ``ValueError`` when passed a compiled regex with standard flags (e.g. ``re.MULTILINE``) without conflicting method-level flags (:issue:`66138`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -240,13 +240,16 @@ class ObjectStringArrayMixin:
             flags |= re.IGNORECASE
 
         if isinstance(pat, re.Pattern):
-            # We need to check that flags matches pat.flags.
-            # pat.flags will have re.U regardless, so we need to add it here
-            # before checking for a match
-            flags = flags | re.U
+            # Only check for conflicts if the user explicitly provided flags
+            # (or passed case=False, which modifies the flags variable)
+            if flags != 0:
+                # We need to check that flags matches pat.flags.
+                # pat.flags will have re.U regardless, so we need to add it here
+                # before checking for a match
+                flags = flags | re.U
 
-            if flags != pat.flags:
-                raise ValueError("Cannot pass flags that do not match pat.flags")
+                if flags != pat.flags:
+                    raise ValueError("Cannot pass flags that do not match pat.flags")
             regex = pat
         else:
             regex = re.compile(pat, flags=flags)

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -240,15 +240,11 @@ class ObjectStringArrayMixin:
             flags |= re.IGNORECASE
 
         if isinstance(pat, re.Pattern):
-            # Only check for conflicts if the user explicitly provided flags
-            # (or passed case=False, which modifies the flags variable)
             if flags != 0:
-                # We need to check that flags matches pat.flags.
-                # pat.flags will have re.U regardless, so we need to add it here
-                # before checking for a match
-                flags = flags | re.U
-
-                if flags != pat.flags:
+                # Check if user-provided flags conflict with the compiled pattern.
+                # A conflict means user specified a flag the pattern doesn't have.
+                # Extra flags in pat beyond what user specified are fine.
+                if flags & ~pat.flags:
                     raise ValueError("Cannot pass flags that do not match pat.flags")
             regex = pat
         else:

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1196,6 +1196,23 @@ def test_match_compiled_regex(any_string_dtype):
     values.str.match(re.compile("ab", flags=re.IGNORECASE), flags=re.IGNORECASE)
 
 
+def test_match_compiled_regex_with_standard_flags(any_string_dtype):
+    # GH#66138: compiled regex with standard flags should not raise
+    expected_dtype = (
+        np.bool_ if is_object_or_nan_string_dtype(any_string_dtype) else "boolean"
+    )
+
+    values = Series(["ab", "AB", "abc", "ABC"], dtype=any_string_dtype)
+
+    result = values.str.match(re.compile("ab", flags=re.MULTILINE))
+    expected = Series([True, False, True, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+    result = values.str.fullmatch(re.compile("ab", flags=re.MULTILINE))
+    expected = Series([True, False, False, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "pat, case, exp",
     [

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -2,7 +2,6 @@ from datetime import (
     datetime,
     timedelta,
 )
-import re
 
 import numpy as np
 import pytest
@@ -952,27 +951,3 @@ def test_setitem_with_different_string_storage():
 def test_has_regex_unsupported_code(pat, expected):
     # https://github.com/pandas-dev/pandas/issues/60833
     assert ArrowStringArrayMixin._has_unsupported_regex(pat) == expected
-
-
-def test_match_compiled_regex_with_flags(any_string_dtype):
-    # GH 66138: Ensure compiled regex with flags doesn't crash str.match/fullmatch
-    s = Series(["A", "B"], dtype=any_string_dtype)
-
-    # We use MULTILINE because it is a standard flag that
-    # previously triggered the ValueError
-    pat = re.compile(r"A", flags=re.MULTILINE)
-
-    # Test str.match
-    result_match = s.str.match(pat)
-    expected = Series([True, False], dtype="bool")
-
-    # If the dtype is a nullable boolean (string[pyarrow] or string[python]),
-    # we need to ensure the expected series matches that exact nullable type.
-    if s.dtype.name in ("string", "string[pyarrow]", "string[python]"):
-        expected = expected.astype("boolean")
-
-    tm.assert_series_equal(result_match, expected)
-
-    # Test str.fullmatch (as mentioned in the issue)
-    result_fullmatch = s.str.fullmatch(pat)
-    tm.assert_series_equal(result_fullmatch, expected)

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -2,6 +2,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+import re
 
 import numpy as np
 import pytest
@@ -951,3 +952,27 @@ def test_setitem_with_different_string_storage():
 def test_has_regex_unsupported_code(pat, expected):
     # https://github.com/pandas-dev/pandas/issues/60833
     assert ArrowStringArrayMixin._has_unsupported_regex(pat) == expected
+
+
+def test_match_compiled_regex_with_flags(any_string_dtype):
+    # GH 66138: Ensure compiled regex with flags doesn't crash str.match/fullmatch
+    s = Series(["A", "B"], dtype=any_string_dtype)
+
+    # We use MULTILINE because it is a standard flag that
+    # previously triggered the ValueError
+    pat = re.compile(r"A", flags=re.MULTILINE)
+
+    # Test str.match
+    result_match = s.str.match(pat)
+    expected = Series([True, False], dtype="bool")
+
+    # If the dtype is a nullable boolean (string[pyarrow] or string[python]),
+    # we need to ensure the expected series matches that exact nullable type.
+    if s.dtype.name in ("string", "string[pyarrow]", "string[python]"):
+        expected = expected.astype("boolean")
+
+    tm.assert_series_equal(result_match, expected)
+
+    # Test str.fullmatch (as mentioned in the issue)
+    result_fullmatch = s.str.fullmatch(pat)
+    tm.assert_series_equal(result_fullmatch, expected)


### PR DESCRIPTION
This PR fixes a bug where str.match and str.fullmatch incorrectly raise a ValueError when evaluating a precompiled regex pattern with standard flags (like re.MULTILINE), even when the user does not explicitly pass conflicting flags to the method.
The strict flag comparison (flags != pat.flags) is now safely wrapped inside an if flags != 0: block. This ensures the error only triggers if the user actually overrides the default flags and creates a genuine conflict.
[x] closes #66138
[x] Tests added and passed if fixing a bug or adding a new feature
[x] All code checks passed.

