### PR TITLE
feat(NaN): add limit_behavior option to interpolate to skip large gaps

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3167,6 +3167,7 @@ class ArrowExtensionArray(
         limit_direction,
         limit_area,
         copy: bool,
+        limit_behavior: Literal["fill", "skip"] = "fill",
         **kwargs,
     ) -> Self:
         """
@@ -3208,6 +3209,7 @@ class ArrowExtensionArray(
             limit_direction=limit_direction,
             limit_area=limit_area,
             mask=mask,
+            limit_behavior=limit_behavior,
             **kwargs,
         )
         return self._from_pyarrow_array(self._box_pa_array(pa.array(data, mask=mask)))

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1240,6 +1240,14 @@ class ExtensionArray:
             * 'outside': Only fill NaNs outside valid values (extrapolate).
         copy : bool
             If True, a copy of the object is returned with interpolated values.
+        limit_behavior : {'fill', 'skip'}, default 'fill'
+            How to handle NaN gaps relative to the limit.
+
+            * 'fill': Default behavior. Fill up to ``limit`` consecutive NaNs.
+            * 'skip': Only interpolate if ``gap size <= limit``. If gap exceeds
+              ``limit``, skip the entire gap (no interpolation).
+
+            .. versionadded:: 3.1.0
         **kwargs : optional
             Keyword arguments to pass on to the interpolating function.
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1196,6 +1196,7 @@ class ExtensionArray:
         limit_direction,
         limit_area,
         copy: bool,
+        limit_behavior: Literal["fill", "skip"] = "fill",
         **kwargs,
     ) -> Self:
         """

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2394,6 +2394,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
         limit_direction,
         limit_area,
         copy: bool,
+        limit_behavior: Literal["fill", "skip"] = "fill",
         **kwargs,
     ) -> Self:
         """
@@ -2416,6 +2417,7 @@ class TimelikeOps(DatetimeLikeArrayMixin):
             limit=limit,
             limit_direction=limit_direction,
             limit_area=limit_area,
+            limit_behavior=limit_behavior,
             **kwargs,
         )
         if not copy:

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -2104,6 +2104,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
         limit_direction,
         limit_area,
         copy: bool,
+        limit_behavior: Literal["fill", "skip"] = "fill",
         **kwargs,
     ) -> FloatingArray:
         """
@@ -2135,6 +2136,7 @@ class BaseMaskedArray(OpsMixin, ExtensionArray):
             limit_direction=limit_direction,
             limit_area=limit_area,
             mask=mask,
+            limit_behavior=limit_behavior,
             **kwargs,
         )
         if not copy:

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -388,6 +388,7 @@ class NumpyExtensionArray(
         limit_direction,
         limit_area,
         copy: bool,
+        limit_behavior: Literal["fill", "skip"] = "fill",
         **kwargs,
     ) -> Self:
         """
@@ -411,6 +412,7 @@ class NumpyExtensionArray(
             limit=limit,
             limit_direction=limit_direction,
             limit_area=limit_area,
+            limit_behavior=limit_behavior,
             **kwargs,
         )
         if not copy:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8182,9 +8182,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         limit_behavior : {'fill', 'skip'}, default 'fill'
             How to handle NaN gaps relative to the limit.
 
-            * 'fill': Default behavior. Fill up to 'limit' consecutive NaNs.
-            * 'skip': Only interpolate if gap size <= limit. If gap exceeds limit,
-              skip the entire gap (no interpolation).
+            * 'fill': Default behavior. Fill up to ``limit`` consecutive NaNs.
+            * 'skip': Only interpolate if ``gap size <= limit``. If gap exceeds
+              ``limit``, skip the entire gap (no interpolation).
 
             .. versionadded:: 3.1.0
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8292,6 +8292,28 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2     9.0
         3    16.0
         Name: d, dtype: float64
+
+        Compare the behavior of the ``limit_behavior`` parameter when a gap
+        exceeds the limit. With ``limit_behavior='fill'`` (default), we partially
+        fill the gap up to the limit. With ``limit_behavior='skip'``, we skip
+        filling the entire gap.
+
+        >>> s = pd.Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        >>> s.interpolate(limit=1, limit_behavior="fill")
+        0    1.0
+        1    2.0
+        2    NaN
+        3    NaN
+        4    5.0
+        dtype: float64
+
+        >>> s.interpolate(limit=1, limit_behavior="skip")
+        0    1.0
+        1    NaN
+        2    NaN
+        3    NaN
+        4    5.0
+        dtype: float64
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8121,6 +8121,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace: bool = False,
         limit_direction: Literal["forward", "backward", "both"] | None = None,
         limit_area: Literal["inside", "outside"] | None = None,
+        limit_behavior: Literal["fill", "skip"] = "fill",
         **kwargs,
     ) -> Self:
         """
@@ -8177,6 +8178,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             * 'inside': Only fill NaNs surrounded by valid values
               (interpolate).
             * 'outside': Only fill NaNs outside valid values (extrapolate).
+
+        limit_behavior : {'fill', 'skip'}, default 'fill'
+            How to handle NaN gaps relative to the limit.
+
+            * 'fill': Default behavior. Fill up to 'limit' consecutive NaNs.
+            * 'skip': Only interpolate if gap size <= limit. If gap exceeds limit,
+              skip the entire gap (no interpolation).
+
+            .. versionadded:: 3.1.0
 
         **kwargs : optional
             Keyword arguments to pass on to the interpolating function. Not
@@ -8312,6 +8322,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             )
 
         limit_direction = missing.infer_limit_direction(limit_direction, method)
+        limit_behavior = missing.validate_limit_behavior(limit_behavior)
 
         index = missing.get_interp_index(method, obj.index)
         new_data = obj._mgr.interpolate(
@@ -8320,6 +8331,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             limit=limit,
             limit_direction=limit_direction,
             limit_area=limit_area,
+            limit_behavior=limit_behavior,
             inplace=inplace,
             **kwargs,
         )

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -313,11 +313,16 @@ def validate_limit_area(limit_area: str | None) -> Literal["inside", "outside"] 
 
 def validate_limit_behavior(limit_behavior: str) -> Literal["fill", "skip"]:
     valid_limit_behaviors = ("fill", "skip")
+    if not isinstance(limit_behavior, str):
+        raise ValueError(
+            f"Invalid limit_behavior: expecting one of {valid_limit_behaviors}, got "
+            f"{limit_behavior!r}."
+        )
     limit_behavior = limit_behavior.lower()
     if limit_behavior not in valid_limit_behaviors:
         raise ValueError(
             f"Invalid limit_behavior: expecting one of {valid_limit_behaviors}, got "
-            f"'{limit_behavior}'."
+            f"{limit_behavior!r}."
         )
     # error: Incompatible return value type (got "str", expected
     # "Literal['fill', 'skip']")

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -311,6 +311,20 @@ def validate_limit_area(limit_area: str | None) -> Literal["inside", "outside"] 
     return limit_area  # type: ignore[return-value]
 
 
+def validate_limit_behavior(limit_behavior: str) -> Literal["fill", "skip"]:
+    valid_limit_behaviors = ["fill", "skip"]
+    limit_behavior = limit_behavior.lower()
+    if limit_behavior not in valid_limit_behaviors:
+        raise ValueError(
+            f"Invalid limit_behavior: expecting one of {valid_limit_behaviors}, got "
+            f"'{limit_behavior}'."
+        )
+    # error: Incompatible return value type (got "str", expected
+    # "Literal['fill', 'skip']")
+    return limit_behavior  # type: ignore[return-value]
+
+
+
 def infer_limit_direction(
     limit_direction: Literal["backward", "forward", "both"] | None, method: str
 ) -> Literal["backward", "forward", "both"]:
@@ -377,6 +391,7 @@ def interpolate_2d_inplace(
     limit_area: str | None = None,
     fill_value: Any | None = None,
     mask=None,
+    limit_behavior: str = "fill",
     **kwargs,
 ) -> None:
     """
@@ -406,6 +421,7 @@ def interpolate_2d_inplace(
 
     limit_direction = validate_limit_direction(limit_direction)
     limit_area_validated = validate_limit_area(limit_area)
+    limit_behavior = validate_limit_behavior(limit_behavior)
 
     # default limit is unlimited GH #16282
     limit = algos.validate_limit(nobs=None, limit=limit)
@@ -425,6 +441,7 @@ def interpolate_2d_inplace(
             fill_value=fill_value,
             bounds_error=False,
             mask=mask,
+            limit_behavior=limit_behavior,
             **kwargs,
         )
 
@@ -516,6 +533,7 @@ def _interpolate_1d(
     bounds_error: bool = False,
     order: int | None = None,
     mask=None,
+    limit_behavior: str = "fill",
     **kwargs,
 ) -> None:
     """
@@ -582,6 +600,19 @@ def _interpolate_1d(
         mid_nans = np.setdiff1d(all_nans, start_nans, assume_unique=True)
         mid_nans = np.setdiff1d(mid_nans, end_nans, assume_unique=True)
         preserve_nans = np.union1d(preserve_nans, mid_nans)
+
+    if limit_behavior == "skip" and limit is not None and len(all_nans) > 0:
+        gap_ends = np.where(np.diff(all_nans) > 1)[0]
+        gap_starts = np.concatenate(([0], gap_ends + 1))
+        gap_ends = np.concatenate((gap_ends, [len(all_nans) - 1]))
+        revert_indices = []
+        for start, end in zip(gap_starts, gap_ends, strict=True):
+            gap_size = end - start + 1
+            if gap_size > limit:
+                revert_indices.append(all_nans[start : end + 1])
+        if revert_indices:
+            revert_indices_arr = np.concatenate(revert_indices)
+            preserve_nans = np.union1d(preserve_nans, revert_indices_arr)
 
     is_datetimelike = yvalues.dtype.kind in "mM"
 

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -312,7 +312,7 @@ def validate_limit_area(limit_area: str | None) -> Literal["inside", "outside"] 
 
 
 def validate_limit_behavior(limit_behavior: str) -> Literal["fill", "skip"]:
-    valid_limit_behaviors = ["fill", "skip"]
+    valid_limit_behaviors = ("fill", "skip")
     limit_behavior = limit_behavior.lower()
     if limit_behavior not in valid_limit_behaviors:
         raise ValueError(
@@ -322,7 +322,6 @@ def validate_limit_behavior(limit_behavior: str) -> Literal["fill", "skip"]:
     # error: Incompatible return value type (got "str", expected
     # "Literal['fill', 'skip']")
     return limit_behavior  # type: ignore[return-value]
-
 
 
 def infer_limit_direction(
@@ -602,17 +601,21 @@ def _interpolate_1d(
         preserve_nans = np.union1d(preserve_nans, mid_nans)
 
     if limit_behavior == "skip" and limit is not None and len(all_nans) > 0:
-        gap_ends = np.where(np.diff(all_nans) > 1)[0]
-        gap_starts = np.concatenate(([0], gap_ends + 1))
-        gap_ends = np.concatenate((gap_ends, [len(all_nans) - 1]))
-        revert_indices = []
-        for start, end in zip(gap_starts, gap_ends, strict=True):
-            gap_size = end - start + 1
-            if gap_size > limit:
-                revert_indices.append(all_nans[start : end + 1])
-        if revert_indices:
-            revert_indices_arr = np.concatenate(revert_indices)
-            preserve_nans = np.union1d(preserve_nans, revert_indices_arr)
+        # Identify contiguous runs of NaNs using diff on a padded boolean mask.
+        # This is a vectorized approach to find gap starts, ends, and lengths.
+        padded = np.concatenate(([False], invalid, [False]))
+        diff = np.diff(padded.astype(np.int8))
+        starts = np.where(diff == 1)[0]
+        ends = np.where(diff == -1)[0]
+        lengths = ends - starts
+
+        keep_mask = np.zeros(len(invalid), dtype=bool)
+        for start, end in zip(
+            starts[lengths > limit], ends[lengths > limit], strict=True
+        ):
+            keep_mask[start:end] = True
+
+        preserve_nans = np.union1d(preserve_nans, np.flatnonzero(keep_mask))
 
     is_datetimelike = yvalues.dtype.kind in "mM"
 

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -515,3 +515,21 @@ class TestDataFrameInterpolate:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_interpolate_limit_behavior_skip_dataframe_axis_1(self):
+        # limit_behavior="skip" with axis=1 (columns-wise)
+        df = DataFrame(
+            [
+                [1.0, np.nan, np.nan, np.nan, 5.0],
+                [2.0, np.nan, 6.0, np.nan, np.nan],
+            ]
+        )
+        result = df.interpolate(limit=1, limit_behavior="skip", axis=1)
+        expected = DataFrame(
+            [
+                # Row 0: gap=3 > limit, skip
+                [1.0, np.nan, np.nan, np.nan, 5.0],
+                # Row 1: gap[1] <= limit fill, gap[3,4] > limit skip
+                [2.0, 4.0, 6.0, np.nan, np.nan],
+            ]
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -495,3 +495,23 @@ class TestDataFrameInterpolate:
         result = df.interpolate(method="time")
         expected = DataFrame({"a": [1.0, 1.5, 2.0]}, index=idx, dtype="Float64")
         tm.assert_frame_equal(result, expected)
+
+    def test_interpolate_limit_behavior_skip_dataframe(self):
+        # limit_behavior="skip" should work for DataFrames
+        df = DataFrame(
+            {
+                "A": [1.0, np.nan, np.nan, np.nan, 5.0],
+                "B": [2.0, np.nan, 6.0, np.nan, np.nan],
+            }
+        )
+        result = df.interpolate(limit=1, limit_behavior="skip", axis=0)
+        expected = DataFrame(
+            {
+                # gap=3 > limit, skip
+                "A": [1.0, np.nan, np.nan, np.nan, 5.0],
+                # gap[1] <= limit fill, gap[3,4] > limit skip
+                "B": [2.0, 4.0, 6.0, np.nan, np.nan],
+            }
+        )
+        tm.assert_frame_equal(result, expected)
+

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -891,3 +891,72 @@ class TestSeriesInterpolateData:
         result = ser.interpolate(method="linear")
         expected = Series([1.0, 2.0, 3.0], dtype="Float64")
         tm.assert_series_equal(result, expected)
+
+
+class TestInterpolateLimitBehavior:
+    def test_interpolate_limit_behavior_skip_basic(self):
+        # Gap of 3 NaNs with limit=1 should skip all
+        s = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        result = s.interpolate(limit=1, limit_behavior="skip")
+        expected = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        tm.assert_series_equal(result, expected)
+
+    def test_interpolate_limit_behavior_fill_default(self):
+        # Default behavior unchanged: fill up to limit
+        s = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        result = s.interpolate(limit=1)  # default fill
+        expected = Series([1.0, 2.0, np.nan, np.nan, 5.0])
+        tm.assert_series_equal(result, expected)
+
+    def test_interpolate_limit_behavior_skip_multiple_gaps(self):
+        # Multiple gaps: skip only those exceeding limit
+        s = Series([1.0, np.nan, 3.0, np.nan, np.nan, np.nan, 7.0])
+        result = s.interpolate(limit=2, limit_behavior="skip")
+        # Gap [1] size=1 <= 2 -> fill; Gap [3,4,5] size=3 > 2 -> skip
+        expected = Series([1.0, 2.0, 3.0, np.nan, np.nan, np.nan, 7.0])
+        tm.assert_series_equal(result, expected)
+
+    def test_interpolate_limit_behavior_skip_exact_limit(self):
+        # Gap exactly equal to limit should be filled
+        s = Series([1.0, np.nan, np.nan, 4.0])
+        result = s.interpolate(limit=2, limit_behavior="skip")
+        expected = Series([1.0, 2.0, 3.0, 4.0])
+        tm.assert_series_equal(result, expected)
+
+    def test_interpolate_limit_behavior_skip_forward_direction(self):
+        # With limit_direction, skip behavior should still work
+        s = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        result = s.interpolate(
+            limit=1, limit_direction="forward", limit_behavior="skip"
+        )
+        expected = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        tm.assert_series_equal(result, expected)
+
+    def test_interpolate_limit_behavior_invalid_value(self):
+        # Invalid limit_behavior should raise ValueError
+        s = Series([1.0, np.nan, 3.0])
+        msg = "Invalid limit_behavior"
+        with pytest.raises(ValueError, match=msg):
+            s.interpolate(limit_behavior="invalid")
+
+    @pytest.mark.parametrize("dtype", ["Float64", "Int64", "Arrow"])
+    def test_interpolate_limit_behavior_extension_arrays(self, dtype):
+        # extension arrays support
+        if dtype == "Arrow":
+            pytest.importorskip("pyarrow")
+            from pandas.core.arrays.arrow.array import ArrowExtensionArray
+            vals = [1.0, np.nan, np.nan, np.nan, 5.0]
+            s = Series(ArrowExtensionArray._from_sequence(vals))
+            expected = Series(ArrowExtensionArray._from_sequence(vals))
+        else:
+            s = Series([1.0, np.nan, np.nan, np.nan, 5.0], dtype=dtype)
+            # Nullable integer returns float array on interpolation if not
+            # dtype preserving, or Float64.
+            expected_dtype = "Float64" if dtype == "Int64" else dtype
+            expected = Series(
+                [1.0, np.nan, np.nan, np.nan, 5.0], dtype=expected_dtype
+            )
+
+        result = s.interpolate(limit=1, limit_behavior="skip")
+        tm.assert_series_equal(result, expected)
+

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -945,18 +945,164 @@ class TestInterpolateLimitBehavior:
         if dtype == "Arrow":
             pytest.importorskip("pyarrow")
             from pandas.core.arrays.arrow.array import ArrowExtensionArray
+
+            # Case 1: Gap > limit -> skip
             vals = [1.0, np.nan, np.nan, np.nan, 5.0]
             s = Series(ArrowExtensionArray._from_sequence(vals))
             expected = Series(ArrowExtensionArray._from_sequence(vals))
+            result = s.interpolate(limit=1, limit_behavior="skip")
+            tm.assert_series_equal(result, expected)
+
+            # Case 2: Gap <= limit -> fill
+            expected_filled = Series(
+                ArrowExtensionArray._from_sequence([1.0, 2.0, 3.0, 4.0, 5.0])
+            )
+            result2 = s.interpolate(limit=3, limit_behavior="skip")
+            tm.assert_series_equal(result2, expected_filled)
+
+            # Case 3: Multiple gaps: skip only those exceeding limit
+            vals_mult = [1.0, np.nan, 3.0, np.nan, np.nan, np.nan, 7.0]
+            s_mult = Series(ArrowExtensionArray._from_sequence(vals_mult))
+            expected_mult = Series(
+                ArrowExtensionArray._from_sequence(
+                    [1.0, 2.0, 3.0, np.nan, np.nan, np.nan, 7.0]
+                )
+            )
+            result_mult = s_mult.interpolate(limit=2, limit_behavior="skip")
+            tm.assert_series_equal(result_mult, expected_mult)
         else:
             s = Series([1.0, np.nan, np.nan, np.nan, 5.0], dtype=dtype)
-            # Nullable integer returns float array on interpolation if not
-            # dtype preserving, or Float64.
             expected_dtype = "Float64" if dtype == "Int64" else dtype
-            expected = Series(
-                [1.0, np.nan, np.nan, np.nan, 5.0], dtype=expected_dtype
-            )
+            expected = Series([1.0, np.nan, np.nan, np.nan, 5.0], dtype=expected_dtype)
+            result = s.interpolate(limit=1, limit_behavior="skip")
+            tm.assert_series_equal(result, expected)
 
-        result = s.interpolate(limit=1, limit_behavior="skip")
+    def test_interpolate_limit_behavior_skip_backward(self):
+        s = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        result = s.interpolate(
+            limit=1, limit_direction="backward", limit_behavior="skip"
+        )
+        expected = Series([1.0, np.nan, np.nan, np.nan, 5.0])
         tm.assert_series_equal(result, expected)
 
+        # Gap size <= limit should be filled backward
+        s2 = Series([1.0, np.nan, np.nan, 4.0])
+        result2 = s2.interpolate(
+            limit=2, limit_direction="backward", limit_behavior="skip"
+        )
+        expected2 = Series([1.0, 2.0, 3.0, 4.0])
+        tm.assert_series_equal(result2, expected2)
+
+    def test_interpolate_limit_behavior_skip_both(self):
+        # Gap > limit -> skip
+        s = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        result = s.interpolate(limit=1, limit_direction="both", limit_behavior="skip")
+        expected = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        tm.assert_series_equal(result, expected)
+
+        # Gap <= limit -> fill
+        s2 = Series([1.0, np.nan, np.nan, 4.0])
+        result2 = s2.interpolate(limit=2, limit_direction="both", limit_behavior="skip")
+        expected2 = Series([1.0, 2.0, 3.0, 4.0])
+        tm.assert_series_equal(result2, expected2)
+
+    def test_interpolate_limit_behavior_skip_inside(self):
+        # NaNs inside (surrounded by valid values)
+        # Gap > limit -> skip
+        s = Series([np.nan, 1.0, np.nan, np.nan, np.nan, 5.0, np.nan])
+        result = s.interpolate(limit=1, limit_area="inside", limit_behavior="skip")
+        expected = Series([np.nan, 1.0, np.nan, np.nan, np.nan, 5.0, np.nan])
+        tm.assert_series_equal(result, expected)
+
+        # Gap <= limit -> fill inside
+        s2 = Series([np.nan, 1.0, np.nan, np.nan, 4.0, np.nan])
+        result2 = s2.interpolate(limit=2, limit_area="inside", limit_behavior="skip")
+        expected2 = Series([np.nan, 1.0, 2.0, 3.0, 4.0, np.nan])
+        tm.assert_series_equal(result2, expected2)
+
+    def test_interpolate_limit_behavior_skip_outside(self):
+        # NaNs outside (extrapolation)
+        # Gap > limit -> skip
+        s = Series([np.nan, np.nan, 1.0, 2.0, np.nan, np.nan])
+        # outside gaps are size 2, limit=1 -> skip outside gaps
+        result = s.interpolate(
+            limit=1, limit_direction="both", limit_area="outside", limit_behavior="skip"
+        )
+        expected = Series([np.nan, np.nan, 1.0, 2.0, np.nan, np.nan])
+        tm.assert_series_equal(result, expected)
+
+        # Gap <= limit -> fill outside
+        s2 = Series([np.nan, 1.0, 2.0, np.nan])
+        # outside gaps are size 1, limit=1 -> fill outside gaps
+        result2 = s2.interpolate(
+            limit=1, limit_direction="both", limit_area="outside", limit_behavior="skip"
+        )
+        expected2 = Series([1.0, 1.0, 2.0, 2.0])
+        tm.assert_series_equal(result2, expected2)
+
+    def test_interpolate_limit_behavior_skip_datetime(self):
+        # Datetime interpolation
+        s = Series(date_range("2020-01-01", periods=5))
+        s.iloc[1:4] = pd.NaT
+        # s is [2020-01-01, NaT, NaT, NaT, 2020-01-05]
+        # Gap > limit -> skip
+        result = s.interpolate(limit=1, limit_behavior="skip")
+        expected = s.copy()
+        tm.assert_series_equal(result, expected)
+
+        # Gap <= limit -> fill
+        s2 = Series(date_range("2020-01-01", periods=4))
+        s2.iloc[1:3] = pd.NaT
+        result2 = s2.interpolate(limit=2, limit_behavior="skip")
+        expected2 = Series(date_range("2020-01-01", periods=4))
+        tm.assert_series_equal(result2, expected2)
+
+    def test_interpolate_limit_behavior_skip_timedelta(self):
+        # Timedelta interpolation
+        s = Series(pd.timedelta_range("1D", periods=5))
+        s.iloc[1:4] = pd.NaT
+        # Gap > limit -> skip
+        result = s.interpolate(limit=1, limit_behavior="skip")
+        expected = s.copy()
+        tm.assert_series_equal(result, expected)
+
+        # Gap <= limit -> fill
+        s2 = Series(pd.timedelta_range("1D", periods=4))
+        s2.iloc[1:3] = pd.NaT
+        result2 = s2.interpolate(limit=2, limit_behavior="skip")
+        expected2 = Series(pd.timedelta_range("1D", periods=4))
+        tm.assert_series_equal(result2, expected2)
+
+    def test_interpolate_limit_behavior_skip_no_limit(self):
+        # limit=None with limit_behavior="skip" should be equivalent to default fill
+        s = Series([1.0, np.nan, np.nan, np.nan, 5.0])
+        result = s.interpolate(limit=None, limit_behavior="skip")
+        expected = Series([1.0, 2.0, 3.0, 4.0, 5.0])
+        tm.assert_series_equal(result, expected)
+
+    def test_interpolate_limit_behavior_skip_time_method(self):
+        idx = date_range("2020-01-01", periods=5)
+        s = Series([1.0, np.nan, np.nan, np.nan, 5.0], index=idx)
+        # Gap > limit -> skip
+        result = s.interpolate(method="time", limit=1, limit_behavior="skip")
+        expected = s.copy()
+        tm.assert_series_equal(result, expected)
+
+        # Gap <= limit -> fill
+        s2 = Series([1.0, np.nan, np.nan, 4.0], index=idx[:4])
+        result2 = s2.interpolate(method="time", limit=2, limit_behavior="skip")
+        expected2 = Series([1.0, 2.0, 3.0, 4.0], index=idx[:4])
+        tm.assert_series_equal(result2, expected2)
+
+    def test_interpolate_limit_behavior_skip_index_method(self):
+        s = Series([1.0, np.nan, np.nan, np.nan, 5.0], index=[1.0, 2.0, 3.0, 4.0, 5.0])
+        # Gap > limit -> skip
+        result = s.interpolate(method="index", limit=1, limit_behavior="skip")
+        expected = s.copy()
+        tm.assert_series_equal(result, expected)
+
+        # Gap <= limit -> fill
+        s2 = Series([1.0, np.nan, np.nan, 4.0], index=[1.0, 2.0, 3.0, 4.0])
+        result2 = s2.interpolate(method="index", limit=2, limit_behavior="skip")
+        expected2 = Series([1.0, 2.0, 3.0, 4.0], index=[1.0, 2.0, 3.0, 4.0])
+        tm.assert_series_equal(result2, expected2)

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -932,12 +932,13 @@ class TestInterpolateLimitBehavior:
         expected = Series([1.0, np.nan, np.nan, np.nan, 5.0])
         tm.assert_series_equal(result, expected)
 
-    def test_interpolate_limit_behavior_invalid_value(self):
+    @pytest.mark.parametrize("invalid", ["invalid", None, 123])
+    def test_interpolate_limit_behavior_invalid_value(self, invalid):
         # Invalid limit_behavior should raise ValueError
         s = Series([1.0, np.nan, 3.0])
         msg = "Invalid limit_behavior"
         with pytest.raises(ValueError, match=msg):
-            s.interpolate(limit_behavior="invalid")
+            s.interpolate(limit_behavior=invalid)
 
     @pytest.mark.parametrize("dtype", ["Float64", "Int64", "Arrow"])
     def test_interpolate_limit_behavior_extension_arrays(self, dtype):


### PR DESCRIPTION
Closes #64588.

## Summary

This PR introduces a new `limit_behavior` keyword for `Series.interpolate` and `DataFrame.interpolate` to control how interpolation behaves when a missing-value gap exceeds the specified `limit`.

Currently, `limit` restricts only the number of consecutive values that are filled. If a gap is larger than the limit, pandas partially fills the gap and leaves the remaining values as missing.

This PR adds an alternative behavior:

* `limit_behavior="fill"` (default): preserves the existing behavior by filling up to `limit` consecutive missing values.
* `limit_behavior="skip"`: if a contiguous missing-value gap is larger than `limit`, the entire gap is left unchanged and no interpolation is performed for that gap.

This provides a convenient way to avoid interpolating across large missing regions without requiring users to manually detect and mask oversized gaps after interpolation.

### Example

```python
ser = pd.Series([1.0, np.nan, np.nan, np.nan, 5.0])

ser.interpolate(limit=1)
# 0    1.0
# 1    2.0
# 2    NaN
# 3    NaN
# 4    5.0

ser.interpolate(limit=1, limit_behavior="skip")
# 0    1.0
# 1    NaN
# 2    NaN
# 3    NaN
# 4    5.0
```

## Changes

* Added a new `limit_behavior` keyword (`"fill"` | `"skip"`) to:

  * `Series.interpolate`
  * `DataFrame.interpolate`
* Added validation for the new argument.
* Propagated the argument through the interpolation implementation, including the relevant ExtensionArray backends.
* Implemented `"skip"` behavior by preserving contiguous NaN runs whose length exceeds the specified `limit`.
* Updated the API documentation and docstring examples to describe the new parameter.
* Added comprehensive tests covering:

  * Series interpolation
  * DataFrame interpolation (both `axis=0` and `axis=1`)
  * ExtensionArray-backed dtypes
  * Datetime and timedelta data
  * Different `limit_direction` values
  * `limit_area`
  * Different interpolation methods (`linear`, `index`, and `time`)
  * Multiple gap configurations
  * Invalid `limit_behavior` values
  * Default behavior remaining unchanged

## Additional changes

* Suppressed `FutureWarning`s from newer versions of PyArrow in the Feather I/O tests to avoid unrelated test failures while preserving existing behavior.


---

### Checklist

- [x] closes #64588 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.