### PR TITLE
BUG: `to_json` wraps large `np.uint64` object-dtype scalars as negative ints (#66142)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -393,6 +393,7 @@ I/O
 - :meth:`HDFStore.put` and :meth:`HDFStore.append` now support storing :class:`Series` and :class:`DataFrame` columns with :class:`PeriodDtype` in both ``"fixed"`` and ``"table"`` formats (:issue:`41978`)
 - Bug in :meth:`DataFrame.__repr__` raising ``TypeError`` for a column with a NumPy structured dtype (e.g. produced by :meth:`DataFrame.from_records` from a structured ``ndarray``) (:issue:`55011`)
 - Bug in :meth:`DataFrame.__repr__` where horizontally truncated output could exceed the terminal width by up to 4 characters (:issue:`32461`)
+- Bug in :meth:`DataFrame.to_json` and :meth:`Series.to_json` where object-dtype :class:`numpy.uint64` scalars greater than or equal to ``2**63`` were serialized as negative integers (:issue:`66142`)
 - Bug in :meth:`DataFrame.to_json` and :meth:`Series.to_json` with ``orient="table"`` silently dropping the timezone of columns with a fixed-offset timezone (e.g. ``datetime.timezone(timedelta(hours=1))``), so the offset was lost on round-trip through :func:`read_json` (:issue:`39537`)
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)
 - Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -1625,14 +1625,50 @@ static void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
     pc->longValue = value;
     return;
   } else if (PyArray_IsScalar(obj, Integer)) {
-    tc->type = JT_LONG;
-    PyArray_CastScalarToCtype(obj, &(pc->longValue),
-                              PyArray_DescrFromType(NPY_INT64));
+    // np.uint64 values above signed int64 max cannot be cast to JT_LONG
+    // without wraparound; route those through JT_BIGNUM (PyObject_Str).
+    PyArray_Descr *dtype = PyArray_DescrFromScalar(obj);
+    if (dtype == NULL) {
+      goto INVALID;
+    }
+
+    if (dtype->type_num == NPY_UINT64) {
+      npy_uint64 uintValue;
+      PyArray_Descr *outcode = PyArray_DescrFromType(NPY_UINT64);
+      if (outcode == NULL) {
+        Py_DECREF(dtype);
+        goto INVALID;
+      }
+      PyArray_CastScalarToCtype(obj, &uintValue, outcode);
+      Py_DECREF(outcode);
+      Py_DECREF(dtype);
+
+      if (PyErr_Occurred()) {
+        goto INVALID;
+      }
+
+      if (uintValue > (npy_uint64)NPY_MAX_INT64) {
+        tc->type = JT_BIGNUM;
+      } else {
+        pc->longValue = (JSINT64)uintValue;
+        tc->type = JT_LONG;
+      }
+      return;
+    }
+    Py_DECREF(dtype);
+
+    PyArray_Descr *outcode = PyArray_DescrFromType(NPY_INT64);
+    if (outcode == NULL) {
+      goto INVALID;
+    }
+    PyArray_CastScalarToCtype(obj, &(pc->longValue), outcode);
+    Py_DECREF(outcode);
 
     if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_OverflowError)) {
       goto INVALID;
     }
 
+    tc->type = JT_LONG;
     return;
   } else if (PyArray_IsScalar(obj, Bool)) {
     PyArray_CastScalarToCtype(obj, &(pc->longValue),

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1647,6 +1647,22 @@ class TestPandasContainer:
         expected = '{"0":{"articleId":' + str(bigNum) + "}}"
         assert json == expected
 
+    @pytest.mark.parametrize("bigNum", [np.uint64(2**63), np.iinfo(np.uint64).max])
+    def test_to_json_object_dtype_numpy_uint64_scalar(self, bigNum):
+        # Object-dtype containers store the numpy scalar directly, which
+        # previously went through a signed int64 cast in ujson and wrapped.
+        expected_num = str(int(bigNum))
+
+        series = Series([bigNum], dtype=object, index=["articleId"])
+        assert series.to_json() == '{"articleId":' + expected_num + "}"
+
+        # Scalar constructor path should match the list path.
+        series_scalar = Series(bigNum, dtype=object, index=["articleId"])
+        assert series_scalar.to_json() == '{"articleId":' + expected_num + "}"
+
+        df = DataFrame({"a": [bigNum]}, dtype=object)
+        assert df.to_json() == '{"a":{"0":' + expected_num + "}}"
+
     @pytest.mark.parametrize("bigNum", [-(2**63) - 1, 2**64])
     def test_read_json_large_numbers(self, bigNum):
         # GH20599, 26068

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1647,7 +1647,7 @@ class TestPandasContainer:
         expected = '{"0":{"articleId":' + str(bigNum) + "}}"
         assert json == expected
 
-    @pytest.mark.parametrize("bigNum", [np.uint64(2**63), np.iinfo(np.uint64).max])
+    @pytest.mark.parametrize("bigNum", [np.uint64(2**63), np.uint64(2**64 - 1)])
     def test_to_json_object_dtype_numpy_uint64_scalar(self, bigNum):
         # Object-dtype containers store the numpy scalar directly, which
         # previously went through a signed int64 cast in ujson and wrapped.

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -714,13 +714,7 @@ class TestNumpyJSONTests:
             pytest.skip("Cannot test 64-bit integer on 32-bit platform")
 
         klass = np.dtype(any_int_numpy_dtype).type
-
-        # uint64 max will always overflow,
-        # as it's encoded to signed.
-        if any_int_numpy_dtype == "uint64":
-            num = np.iinfo("int64").max
-        else:
-            num = np.iinfo(any_int_numpy_dtype).max
+        num = np.iinfo(any_int_numpy_dtype).max
 
         assert klass(ujson.ujson_loads(ujson.ujson_dumps(num))) == num
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -714,7 +714,7 @@ class TestNumpyJSONTests:
             pytest.skip("Cannot test 64-bit integer on 32-bit platform")
 
         klass = np.dtype(any_int_numpy_dtype).type
-        num = np.iinfo(any_int_numpy_dtype).max
+        num = klass(np.iinfo(any_int_numpy_dtype).max)
 
         assert klass(ujson.ujson_loads(ujson.ujson_dumps(num))) == num
 


### PR DESCRIPTION
**Summary**
`Series.to_json()` / `DataFrame.to_json()` could silently corrupt large unsigned 64-bit integers when they were stored as **numpy scalars in an object-dtype column**.

For example:
```python
>>> pd.Series([np.uint64(2**63)], dtype=object).to_json()
# before: '{"0":-9223372036854775808}'   # wrong (signed wrap)
# after:  '{"0":9223372036854775808}'    # correct
```
This only affected the **object-dtype + `np.uint64` scalar** path. These cases already worked:
- plain Python `int` values (e.g. `2**63`) in object dtype
- a real `uint64` Series/array (not object dtype)

**Why it happened:** the ujson encoder treated every numpy integer scalar as a signed 64-bit value (`int64`). Values from `2**63` through `2**64 - 1` do not fit in signed `int64`, so they wrapped to negative numbers.
**Fix:** detect `np.uint64` scalars explicitly. If the value still fits in signed `int64`, keep the fast integer path; if it is larger, encode it via the existing big-integer (`JT_BIGNUM`) path, same as oversized Python ints. That preserves the exact decimal digits in JSON.

**Files changed**
- `pandas/_libs/src/vendored/ujson/python/objToJSON.c`: special-case `NPY_UINT64` in the numpy integer-scalar branch; route values `> INT64_MAX` through `JT_BIGNUM`
- `pandas/tests/io/json/test_pandas.py`: regression tests for object-dtype Series/DataFrame with large `np.uint64` scalars
- `pandas/tests/io/json/test_ujson.py`: stop capping `uint64` at `int64` max in the scalar max round-trip test
- `doc/source/whatsnew/v3.1.0.rst`: release note under Bug fixes / I/O

**Fixes**
- [x] closes #66142