### PR TITLE
BUG: allow command sequence for cython

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,12 +73,11 @@ if cy.version().version_compare('>=3.1.0')
 
     # Use shared utility code to reduce wheel sizes
     # copied from https://github.com/scikit-learn/scikit-learn/pull/31151/files
-    cy = find_program(cy.cmd_array()[0])
     cython_shared_src = custom_target(
         install: false,
         output: '_cyutility.c',
         command: [
-            cy,
+            cy.cmd_array(),
             '-3',
             '-Xfreethreading_compatible=true',
             '--fast-fail',


### PR DESCRIPTION
- [ ] xref #62883 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

The current configuration prevents using a command sequence for Cython, for example, to run it thgough an emulator:

```ini
[binaries]
cython = ['qemu-arm-static', '-L' , sysroot_dir, '-E', 'PYTHONPATH=' + '@DIRNAME@' / 'pandas-arm/lib64/python3.14/site-packages', sysroot_dir / 'usr/local/bin/python3.14', '-m', 'cython']
```