### PR TITLE
BUG: IntervalArray hashing nondeterministic across processes (GH#64605)

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -114,6 +114,10 @@ if TYPE_CHECKING:
 IntervalSide: TypeAlias = TimeArrayLike | np.ndarray
 IntervalOrNA: TypeAlias = Interval | float
 
+# Fixed salts for the four VALID_CLOSED values, used in _hash_pandas_object so
+# the result is deterministic across processes (unlike the builtin str hash).
+_CLOSED_HASH_VALUES = {"left": 0, "right": 1, "both": 2, "neither": 3}
+
 
 @set_module("pandas.arrays")
 class IntervalArray(IntervalMixin, ExtensionArray):
@@ -1024,7 +1028,10 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         right_hash = hash_array(
             self._right, encoding=encoding, hash_key=hash_key, categorize=categorize
         )
-        closed_val = np.uint64(hash(self.closed) % (2**63))
+        # Use a fixed mapping rather than hash(self.closed): the builtin str
+        # hash is salted per process (PYTHONHASHSEED), which would make the
+        # result nondeterministic across processes. GH#64605
+        closed_val = np.uint64(_CLOSED_HASH_VALUES[self.closed])
         closed_hash = hash_array(
             np.full(len(self), closed_val, dtype=np.uint64),
             encoding=encoding,

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -76,12 +76,12 @@ def test_interval_array_hash_stable_across_processes():
     out0 = subprocess.check_output(
         [sys.executable, "-c", code],
         env={**os.environ, "PYTHONHASHSEED": "0"},
-        text=True,
+        encoding="utf-8",
     )
     out1 = subprocess.check_output(
         [sys.executable, "-c", code],
         env={**os.environ, "PYTHONHASHSEED": "1"},
-        text=True,
+        encoding="utf-8",
     )
     assert out0 == out1
 

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -6,6 +6,7 @@ import textwrap
 import numpy as np
 import pytest
 
+from pandas.compat import WASM
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -60,6 +61,7 @@ def test_consistency():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.skipif(WASM, reason="Can't start subprocesses in WASM")
 def test_interval_array_hash_stable_across_processes():
     # GH#64605 IntervalArray hashing must not depend on the per-process-salted
     # builtin hash() of the "closed" string, otherwise hashes differ across

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -1,3 +1,8 @@
+import os
+import subprocess
+import sys
+import textwrap
+
 import numpy as np
 import pytest
 
@@ -53,6 +58,32 @@ def test_consistency():
         index=["foo", "bar", "baz"],
     )
     tm.assert_series_equal(result, expected)
+
+
+def test_interval_array_hash_stable_across_processes():
+    # GH#64605 IntervalArray hashing must not depend on the per-process-salted
+    # builtin hash() of the "closed" string, otherwise hashes differ across
+    # processes (e.g. breaking dask shuffles on interval data).
+    code = textwrap.dedent(
+        """\
+        import pandas as pd
+        from pandas.util import hash_array
+        for closed in ["left", "right", "both", "neither"]:
+            ia = pd.arrays.IntervalArray.from_breaks(range(6), closed=closed)
+            print(",".join(str(val) for val in hash_array(ia)))
+        """
+    )
+    out0 = subprocess.check_output(
+        [sys.executable, "-c", code],
+        env={**os.environ, "PYTHONHASHSEED": "0"},
+        text=True,
+    )
+    out1 = subprocess.check_output(
+        [sys.executable, "-c", code],
+        env={**os.environ, "PYTHONHASHSEED": "1"},
+        text=True,
+    )
+    assert out0 == out1
 
 
 def test_hash_array(series):

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -62,6 +62,7 @@ def test_consistency():
 
 
 @pytest.mark.skipif(WASM, reason="Can't start subprocesses in WASM")
+@pytest.mark.single_cpu
 def test_interval_array_hash_stable_across_processes():
     # GH#64605 IntervalArray hashing must not depend on the per-process-salted
     # builtin hash() of the "closed" string, otherwise hashes differ across


### PR DESCRIPTION
Follow-up to GH-64605. `IntervalArray._hash_pandas_object` salted the hash with `np.uint64(hash(self.closed) % (2**63))`. The builtin `str` hash is randomized per process (`PYTHONHASHSEED`), so `hash_array` on interval data produced different values in different processes — breaking any cross-process consumer of the hash (e.g. dask shuffles on interval data).

Replace the salt with a fixed mapping over the four `VALID_CLOSED` values. The value is still siphashed through `hash_array`, so the four `closed` variants remain distinct and well-distributed.

Categorical-of-`Interval` hashing was unaffected: `Categorical._hash_pandas_object` goes through `np.asarray` → object array of `Interval` scalars, which stringifies deterministically and never reaches `IntervalArray._hash_pandas_object`.

No whatsnew entry: GH-64605 is unreleased (3.1.0.dev), so this bug never shipped.