### PR TITLE
BUG: Timedelta(np.str_) raising TypeError (GH#48974)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -283,8 +283,8 @@ Timedelta
 ^^^^^^^^^
 - Bug in :attr:`TimedeltaIndex.resolution` raising when the index has no frequency (:issue:`65186`)
 - Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
+- Bug in :class:`Timedelta` constructor and :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timedelta` constructor where keyword arguments (e.g. ``days=365000``) that exceeded nanosecond int64 bounds raised ``OutOfBoundsTimedelta`` instead of falling back to a coarser resolution (:issue:`46587`)
-- Bug in :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :meth:`Series.sum` on an overflowing ``timedelta64`` series raising a plain ``ValueError`` instead of :class:`OutOfBoundsTimedelta` (:issue:`43178`)
 - Bug in ``Series.dt.seconds`` and ``Series.dt.microseconds`` with :class:`ArrowDtype` durations returning the ``Series.dt.components`` field values (e.g. 0-59 for seconds, or 0 for ``microseconds`` on a ``"ms"`` unit) instead of the totals within each day and second respectively, inconsistent with NumPy-backed timedeltas (:issue:`63470`)
 

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -2267,6 +2267,9 @@ class Timedelta(_Timedelta):
                 )
             return value
         elif isinstance(value, str):
+            if type(value) is not str:
+                # GH#48974 np.str_ object
+                value = str(value)
             if unit is not None:
                 raise ValueError("unit must not be specified if the value is a str")
             if (len(value) > 0 and value[0] == "P") or (

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -486,6 +486,19 @@ def test_to_timedelta_np_str():
     tm.assert_index_equal(result, expected)
 
 
+def test_to_timedelta_scalar_np_str():
+    # GH#48974 scalar np.str_ should also not break timedelta parsing
+    scalar = np.array(["1 day"])[0]
+    assert isinstance(scalar, np.str_)
+
+    expected = pd.Timedelta("1 day")
+    assert to_timedelta(scalar) == expected
+    assert pd.Timedelta(scalar) == expected
+
+    # ISO format
+    assert pd.Timedelta(np.str_("P1DT1H")) == pd.Timedelta("1 days 01:00:00")
+
+
 @pytest.mark.parametrize("dtype", [np.int16, np.int32, np.uint32, np.int64])
 def test_to_timedelta_subint64_with_unit(dtype):
     # GH#56996 NumPy 2 / NEP 50 made `np.int32(x) - py_int` return np.int32,


### PR DESCRIPTION
GH-48974 was only partially fixed by GH-64754: the array path (`array_to_timedelta64`) cast `np.str_` to `str` before the Cython typed-str parse helpers, but the scalar `Timedelta.__new__` str branch did not. As a result:

```python
>>> pd.Timedelta(np.str_("1 day"))
TypeError: Expected str, got numpy.str_
>>> pd.to_timedelta(np.str_("1 day"))   # scalar path
TypeError: Expected str, got numpy.str_
```

`np.str_` arises naturally from e.g. `np.array(["1 day"])[0]`. This adds the same cast at the top of the scalar str branch, extends the regression test to cover scalars (regular + ISO), and updates the whatsnew entry (which already claimed `to_timedelta` was fixed) to also name the `Timedelta` constructor.