### PR TITLE
BUG: repr with 0-d ndarray in object column raises (GH#64638)

### DIFF
--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -253,6 +253,8 @@ def pprint_thing(
                 ABCNDFrame,
             ),
         )
+        # GH#64638 0-d arrays are not iterable; fall through to str()
+        and not (isinstance(thing, np.ndarray) and thing.ndim == 0)
         and _nest_lvl < config["display"]["pprint_nest_depth"]
     ):
         result = _pprint_seq(

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -3,6 +3,7 @@
 from collections.abc import Mapping
 import string
 
+import numpy as np
 import pytest
 
 import pandas._config.config as cf
@@ -88,6 +89,17 @@ class TestPPrintThing:
     def test_repr_seq_float_precision(self):
         with cf.option_context("display.precision", 3):
             assert printing.pprint_thing([3.14159265, 3.14159265]) == "[3.142, 3.142]"
+
+    def test_repr_0d_array(self):
+        # GH#64638 0-d arrays are not iterable and must fall through to str()
+        assert printing.pprint_thing(np.array(5)) == "5"
+
+
+@pytest.mark.parametrize("box", [pd.Series, pd.Index, lambda vals: pd.DataFrame(vals)])
+def test_repr_object_dtype_0d_array(box):
+    # GH#64638 repr of a container holding a 0-d ndarray should not raise
+    obj = box(pd.array([np.array(5)], dtype=object))
+    assert "5" in repr(obj)
 
 
 class TestFormatBase:

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -95,11 +95,15 @@ class TestPPrintThing:
         assert printing.pprint_thing(np.array(5)) == "5"
 
 
-@pytest.mark.parametrize("box", [pd.Series, pd.Index, lambda vals: pd.DataFrame(vals)])
+@pytest.mark.parametrize("box", [pd.Series, pd.Index, pd.DataFrame])
 def test_repr_object_dtype_0d_array(box):
-    # GH#64638 repr of a container holding a 0-d ndarray should not raise
+    # GH#64638 repr of a container holding a 0-d ndarray should not raise, and
+    # the array should be unwrapped to its scalar value ("5") rather than shown
+    # via its own ndarray repr ("array(5)")
     obj = box(pd.array([np.array(5)], dtype=object))
-    assert "5" in repr(obj)
+    result = repr(obj)
+    assert "5" in result
+    assert "array(5)" not in result
 
 
 class TestFormatBase:


### PR DESCRIPTION
`repr`/`to_string` of a Series/DataFrame/Index holding a 0-d ndarray in an object-dtype column raised `TypeError: iteration over a 0-d array`.

The `isinstance` allowlist added to `pprint_thing` in GH-64638 matches `np.ndarray` without an `ndim == 0` guard, so a 0-d array (which is not iterable) reached `_pprint_seq` and raised on `iter()`. The prior `is_sequence` check excluded 0-d arrays because `iter()` raises, letting them fall through to `str()`. This restores that behavior with an explicit guard.

The regression is unreleased (introduced in 3.1.0 dev by GH-64638), so no whatsnew entry.