### PR TITLE
BUG: groupby quantile with non-null NaN and all-NaT groups (GH#64330)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -444,6 +444,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.DataFrameGroupBy.apply` with ``as_index=False`` where applying on an empty :class:`DataFrame` returned inconsistent index metadata compared to non-empty results (:issue:`48135`)
 - Bug in :meth:`.DataFrameGroupBy.cumprod`, :meth:`.DataFrameGroupBy.cummin`, and :meth:`.DataFrameGroupBy.cummax` (and Series variants) returning ``Float64`` instead of preserving the nullable integer dtype (e.g. ``Int64``) when the group key contains ``NA`` (:issue:`65550`)
 - Bug in :meth:`.GroupBy.any` and :meth:`.GroupBy.all` returning ``NaN`` with ``float64`` dtype for unobserved categorical groups on NumPy ``bool`` data instead of the boolean identity value with ``bool`` dtype (:issue:`65100`)
+- Bug in :meth:`.GroupBy.quantile` returning incorrect results for groups containing a non-null ``NaN`` value (e.g. from a pyarrow or masked float array), and returning the Unix epoch instead of ``NaT`` for all-``NaT`` datetime-like groups on some platforms (:issue:`64330`)
 - Bug in :meth:`.Resampler.agg` raising ``ValueError`` with a dict of aggregations when applied to a :meth:`DataFrame.groupby` with ``as_index=False`` (:issue:`52397`)
 - Bug in :meth:`.Rolling.corr` and :meth:`.Rolling.cov` computing incorrect results on degenerate windows (:issue:`24019`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` (and their :class:`GroupBy` counterparts) returning ``0.0`` and ``-3.0`` respectively for degenerate windows or groups; these now return ``NaN`` (:issue:`62864`)

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1453,11 +1453,17 @@ def group_quantile(
             end = ends[i]
 
             # Count non-NA elements in this group using direct indexing
-            # (avoids memoryview slicing, which is not nogil-safe).
+            # (avoids memoryview slicing, which is not nogil-safe). A float
+            # NaN that is not flagged by ``mask`` (e.g. a non-null NaN in a
+            # pyarrow/masked float array, GH#64330) must be treated as NA too:
+            # it would corrupt kth_smallest_c's ordering comparisons below.
             grp_size = end - start
             non_na_sz = 0
             for j in range(grp_size):
                 if mask[start + j] == 0:
+                    if numeric_t is float32_t or numeric_t is float64_t:
+                        if values[start + j] != values[start + j]:
+                            continue
                     non_na_sz += 1
 
             if non_na_sz == 0:
@@ -1467,10 +1473,10 @@ def group_quantile(
                     else:
                         out[i, k] = NaN
             else:
-                # Copy non-NA values into a temporary mutable buffer.
-                # Pre-filtering NAs means kth_smallest_c's comparisons are
-                # always valid (no NaN/NaT values), so is_datetimelike needs
-                # no special handling here.
+                # Copy non-NA values into a temporary mutable buffer. NAs are
+                # pre-filtered (using the same condition as the count above) so
+                # that kth_smallest_c's comparisons are always valid (no NaN/NaT
+                # values), meaning is_datetimelike needs no special handling.
                 tmp = <numeric_t*>malloc(non_na_sz * sizeof(numeric_t))
                 if tmp is NULL:
                     raise MemoryError()
@@ -1478,6 +1484,9 @@ def group_quantile(
                 j = 0
                 for k in range(grp_size):
                     if mask[start + k] == 0:
+                        if numeric_t is float32_t or numeric_t is float64_t:
+                            if values[start + k] != values[start + k]:
+                                continue
                         tmp[j] = values[start + k]
                         j += 1
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1747,7 +1747,13 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         else:
             out = out.reshape(ncols, ngroups * nqs)  # type: ignore[assignment]
 
-        out = out.astype("i8").view(self._ndarray.dtype)
+        # All-NA groups come back as NaN; casting NaN to i8 is platform
+        # dependent (0 on some architectures), so map them to iNaT explicitly.
+        na_mask = np.isnan(out)
+        out[na_mask] = 0
+        out = out.astype("i8")
+        out[na_mask] = iNaT
+        out = out.view(self._ndarray.dtype)
         return self._from_backing_data(out)
 
 

--- a/pandas/tests/groupby/methods/test_quantile.py
+++ b/pandas/tests/groupby/methods/test_quantile.py
@@ -457,3 +457,59 @@ def test_groupby_quantile_nonmulti_levels_order():
     # We need to check that index levels are not sorted
     expected_levels = pd.core.indexes.frozen.FrozenList([["B", "A"], [0.2, 0.8]])
     tm.assert_equal(result.index.levels, expected_levels)
+
+
+def test_groupby_quantile_nonnull_nan_pyarrow():
+    # GH#64330 a non-null NaN (mask == 0) must be treated as NA, otherwise it
+    # corrupts the quickselect buffer and yields non-monotonic quantiles.
+    pa = pytest.importorskip("pyarrow")
+
+    pa_arr = pa.array(
+        [5.0, float("nan"), 1.0, 3.0, 2.0, 4.0], type=pa.float64(), from_pandas=False
+    )
+    arr = pd.arrays.ArrowExtensionArray(pa_arr)
+    assert not arr.isna().any()  # the NaN is a value, not null
+
+    df = DataFrame({"key": ["a"] * 6, "val": arr})
+    qs = [0.0, 0.25, 0.5, 0.75, 1.0]
+    result = df.groupby("key")["val"].quantile(qs)
+
+    # The NaN is skipped, matching the non-grouped Series.quantile result.
+    expected_vals = pd.Series(arr).quantile(qs).to_numpy()
+    tm.assert_numpy_array_equal(result.to_numpy().astype(float), expected_vals)
+
+
+def test_groupby_quantile_nonnull_nan_masked():
+    # GH#64330 same as above for a masked float array carrying a non-null NaN.
+    arr = pd.arrays.FloatingArray(
+        np.array([5.0, np.nan, 1.0, 3.0, 2.0, 4.0]), np.zeros(6, dtype=bool)
+    )
+    df = DataFrame({"key": ["a"] * 6, "val": arr})
+    result = df.groupby("key")["val"].quantile([0.0, 0.25, 0.5, 0.75, 1.0])
+    expected = pd.Series(
+        [1.0, 2.0, 3.0, 4.0, 5.0],
+        dtype="Float64",
+        index=pd.MultiIndex.from_product(
+            [["a"], [0.0, 0.25, 0.5, 0.75, 1.0]], names=["key", None]
+        ),
+        name="val",
+    )
+    tm.assert_series_equal(result, expected)
+
+
+def test_groupby_quantile_all_nat_group():
+    # GH#64330 an all-NaT group must return NaT; casting NaN -> i8 is platform
+    # dependent (epoch on some architectures) if not mapped to iNaT explicitly.
+    df = DataFrame(
+        {
+            "key": ["a", "a", "b", "b"],
+            "val": pd.to_datetime(["NaT", "NaT", "2020-01-01", "2020-01-02"]),
+        }
+    )
+    result = df.groupby("key")["val"].quantile(0.5)
+    expected = pd.Series(
+        [pd.NaT, pd.Timestamp("2020-01-01 12:00:00")],
+        index=Index(["a", "b"], name="key"),
+        name="val",
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Follow-up fixing two defects in :meth:`GroupBy.quantile`, both surfaced by the quickselect rewrite in GH-64330.

- A float ``NaN`` that is *not* flagged by the null mask (a non-null ``NaN`` in a pyarrow or masked float array) was copied into the quickselect buffer, where it corrupts ``kth_smallest_c``'s ordering comparisons and produces non-monotonic garbage. It is now skipped like any other NA, matching the non-grouped ``Series.quantile`` result.
- An all-``NaT`` datetime-like group came back as ``NaN`` and was cast to ``i8``. That cast is platform dependent — ``INT64_MIN`` (== ``NaT``) on x86 but ``0`` (the Unix epoch) on arm64 — so all-``NaT`` groups silently became ``1970-01-01`` on Apple Silicon / Graviton. Those positions are now mapped to ``iNaT`` explicitly (also silencing an "invalid value encountered in cast" warning).

Verified no measurable perf impact (best-of-7): the added ``val != val`` check is compile-time removed for integer/datetime-like dtypes and is lost in the noise for float dtypes.