### PR TITLE
BUG: cast_from_unit_vectorized near-bounds float overflow (GH#57366)

### DIFF
--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -154,13 +154,20 @@ def cast_from_unit_vectorized(
     if p:
         frac = np.round(frac, p)
 
-    # Overflow check: 2**63 and -(2**63) are exactly representable in float64
-    # so this comparison is exact at the boundary. The actual integer result
-    # base * m + int64(frac * m) cannot exceed the float result (truncation
-    # toward zero), so if the float result is in bounds, the int result is too.
+    out = base * np.int64(m) + (frac * m).astype("i8")
+
+    # Overflow check. When base * m + int64(frac * m) leaves the int64 range the
+    # integer result silently wraps modulo 2**64. A float bound check on the
+    # analytic result (result_f >= 2**63) is unreliable near the boundary: even
+    # though +-2**63 are exactly representable, result_f is itself rounded, so
+    # for values within half an ULP of the boundary it lands on the wrong side,
+    # both missing real overflows (negative near-bound floats wrapped to huge
+    # positive timestamps) and rejecting in-bounds values (GH#57366). Detect the
+    # wrap directly instead: the exact integer result agrees with its float64
+    # estimate to within a few ULP when it fits, but a wrap shifts it by ~2**64.
     if m != 1:
         result_f = base.astype("f8") * m + frac * m
-        oob = (result_f >= 2**63) | (result_f < -(2**63))
+        oob = np.abs(result_f - out.astype("f8")) >= np.float64(2**63)
         non_nat = ~nat_mask
         if (oob & non_nat).any():
             bad_idx = int(np.where(oob & non_nat)[0][0])
@@ -168,7 +175,6 @@ def cast_from_unit_vectorized(
                 f"cannot convert input {values[bad_idx]} with the unit '{unit}'"
             )
 
-    out = base * np.int64(m) + (frac * m).astype("i8")
     out[nat_mask] = NPY_NAT
     return out
 

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -156,15 +156,12 @@ def cast_from_unit_vectorized(
 
     out = base * np.int64(m) + (frac * m).astype("i8")
 
-    # Overflow check. When base * m + int64(frac * m) leaves the int64 range the
-    # integer result silently wraps modulo 2**64. A float bound check on the
-    # analytic result (result_f >= 2**63) is unreliable near the boundary: even
-    # though +-2**63 are exactly representable, result_f is itself rounded, so
-    # for values within half an ULP of the boundary it lands on the wrong side,
-    # both missing real overflows (negative near-bound floats wrapped to huge
-    # positive timestamps) and rejecting in-bounds values (GH#57366). Detect the
-    # wrap directly instead: the exact integer result agrees with its float64
-    # estimate to within a few ULP when it fits, but a wrap shifts it by ~2**64.
+    # Overflow check. On overflow base * m + int64(frac * m) wraps modulo 2**64.
+    # A float bound check on the analytic result (result_f >= 2**63) is unreliable
+    # near the boundary because result_f is itself rounded, landing on the wrong
+    # side within half an ULP. Detect the wrap directly instead: the exact integer
+    # result tracks its float64 estimate to within a few ULP when it fits, but a
+    # wrap shifts it by ~2**64. (GH#57366)
     if m != 1:
         result_f = base.astype("f8") * m + frac * m
         oob = np.abs(result_f - out.astype("f8")) >= np.float64(2**63)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -164,13 +164,18 @@ def cast_from_unit_vectorized(
     # wrap shifts it by ~2**64. (GH#57366)
     if m != 1:
         result_f = base.astype("f8") * m + frac * m
-        oob = np.abs(result_f - out.astype("f8")) >= np.float64(2**63)
-        non_nat = ~nat_mask
-        if (oob & non_nat).any():
-            bad_idx = int(np.where(oob & non_nat)[0][0])
-            raise OutOfBoundsDatetime(
-                f"cannot convert input {values[bad_idx]} with the unit '{unit}'"
-            )
+        # Detecting the wrap costs an extra pass over the data, so gate it behind
+        # a cheap bound. result_f tracks the true result to ~2**-50 relative, well
+        # inside this margin, so a wrap can never land outside it.
+        near_bound = np.float64(2**63) * (1 - 2**-30)
+        if ((result_f >= near_bound) | (result_f <= -near_bound)).any():
+            oob = np.abs(result_f - out.astype("f8")) >= np.float64(2**63)
+            non_nat = ~nat_mask
+            if (oob & non_nat).any():
+                bad_idx = int(np.where(oob & non_nat)[0][0])
+                raise OutOfBoundsDatetime(
+                    f"cannot convert input {values[bad_idx]} with the unit '{unit}'"
+                )
 
     out[nat_mask] = NPY_NAT
     return out

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2050,6 +2050,22 @@ class TestToDatetimeUnit:
         with pytest.raises(OutOfBoundsDatetime, match=msg3):
             Timestamp(should_fail2[1], unit="D")
 
+    def test_float_to_datetime_near_int64_boundary(self):
+        # GH#57366 within a few ULP of +/-2**63 ns the float bound check must be
+        # exact. A negative float whose ns value lands just past int64 min must
+        # raise instead of silently wrapping to a positive timestamp...
+        wrapped = np.array([-(2**63 + 200) / 1e9], dtype="float64")
+        with pytest.raises(OutOfBoundsDatetime, match="cannot convert input"):
+            to_datetime(wrapped, unit="s", errors="raise")
+        assert to_datetime(wrapped, unit="s", errors="coerce")[0] is NaT
+
+        # ...and an in-bounds float just shy of int64 max must not spuriously
+        # raise (it did for units D/W, diverging from the scalar path).
+        oneday_in_ns = 1e9 * 60 * 60 * 24
+        val = (2**63 - 1 - 100) / oneday_in_ns
+        arr = np.array([val], dtype="float64")
+        assert to_datetime(arr, unit="D")[0] == Timestamp(val, unit="D")
+
     def test_float_to_datetime_raise_oob_ns(self):
         value = np.float64(2**63)
         arr = np.array([value], dtype=np.float64)

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -392,6 +392,21 @@ class TestTimedeltas:
         with pytest.raises(OutOfBoundsTimedelta, match=scalar_msg2):
             pd.Timedelta(should_fail2[1], unit="D")
 
+    def test_float_to_timedelta_near_int64_boundary(self):
+        # GH#57366 within a few ULP of +/-2**63 ns the float bound check must be
+        # exact. A negative float whose ns value lands just past int64 min must
+        # raise instead of silently wrapping to a large positive timedelta...
+        wrapped = np.array([-(2**63 + 200) / 1e9], dtype="float64")
+        with pytest.raises(OutOfBoundsTimedelta, match="cannot convert input"):
+            to_timedelta(wrapped, unit="s")
+
+        # ...and an in-bounds float just shy of int64 max must not spuriously
+        # raise (it did for units D/W, diverging from the scalar path).
+        oneday_in_ns = 1e9 * 60 * 60 * 24
+        val = (2**63 - 1 - 100) / oneday_in_ns
+        arr = np.array([val], dtype="float64")
+        assert to_timedelta(arr, unit="D")[0] == pd.Timedelta(val, unit="D")
+
     def test_to_timedelta_day_offset(self):
         # GH#64240
         result = to_timedelta(to_offset("D"))

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import (
+    OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
     astype_overflowsafe,
     conversion,
@@ -17,6 +18,7 @@ from pandas._libs.tslibs import (
 )
 
 from pandas import (
+    Timedelta,
     Timestamp,
     date_range,
 )
@@ -165,3 +167,36 @@ def test_localize_pydatetime_dt_types(dt, expected):
     # localize_pydatetime
     result = conversion.localize_pydatetime(dt, timezone.utc)
     assert result == expected
+
+
+@pytest.mark.parametrize("unit", ["us", "ms", "s", "m", "h", "D", "W"])
+def test_cast_from_unit_vectorized_near_int64_boundary(unit):
+    # GH#57366 within a few ULP of +/-2**63 ns the array cast must agree with
+    # the scalar cast. A float bound check on the analytic result is unreliable
+    # here because the rounded float lands on the wrong side of the boundary:
+    # negative near-bound floats used to wrap to large positive values, and
+    # in-bounds floats just shy of int64 max used to spuriously raise.
+    ns_per_unit = np.timedelta64(1, unit).astype("timedelta64[ns]").astype(np.int64)
+
+    # walk every representable float straddling each int64 bound
+    values = []
+    for bound in (-(2**63), 2**63 - 1):
+        low = high = np.float64(bound / ns_per_unit)
+        for _ in range(60):
+            low = np.nextafter(low, -np.inf)
+            high = np.nextafter(high, np.inf)
+        walker = low
+        while walker <= high:
+            values.append(walker)
+            walker = np.nextafter(walker, np.inf)
+
+    for val in values:
+        arr = np.array([val], dtype="float64")
+        # Timedelta(...).value is the scalar cast_from_unit result in ns
+        try:
+            expected = Timedelta(val, unit=unit).value
+        except (OutOfBoundsDatetime, OutOfBoundsTimedelta, OverflowError):
+            with pytest.raises(OutOfBoundsDatetime):
+                conversion.cast_from_unit_vectorized(arr, unit)
+        else:
+            assert conversion.cast_from_unit_vectorized(arr, unit)[0] == expected

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -171,14 +171,11 @@ def test_localize_pydatetime_dt_types(dt, expected):
 
 @pytest.mark.parametrize("unit", ["us", "ms", "s", "m", "h", "D", "W"])
 def test_cast_from_unit_vectorized_near_int64_boundary(unit):
-    # GH#57366 within a few ULP of +/-2**63 ns the array cast must agree with
-    # the scalar cast. A float bound check on the analytic result is unreliable
-    # here because the rounded float lands on the wrong side of the boundary:
-    # negative near-bound floats used to wrap to large positive values, and
-    # in-bounds floats just shy of int64 max used to spuriously raise.
+    # GH#57366 near +/-2**63 ns the array cast must agree with the scalar cast;
+    # near-bound floats used to wrap or spuriously raise. Walk every representable
+    # float straddling each int64 bound and check the two match.
     ns_per_unit = np.timedelta64(1, unit).astype("timedelta64[ns]").astype(np.int64)
 
-    # walk every representable float straddling each int64 bound
     values = []
     for bound in (-(2**63), 2**63 - 1):
         low = high = np.float64(bound / ns_per_unit)


### PR DESCRIPTION
Follow-up to GH-57366 / #64438, which fixed most of the near-bounds float overflow in `cast_from_unit_vectorized` but left an exact-boundary gap.

The overflow check compared the analytic `result_f = base*m + frac*m` against the exactly-representable ±2\*\*63 boundary. But `result_f` is itself a rounded float, so a value whose exact ns result is within half a ULP of the boundary lands on the wrong side of the comparison:

- **Silent data corruption:** a negative float whose exact ns value is just past `INT64_MIN` rounds *to* `-2**63`, escapes the check, and the integer `base*m + int64(frac*m)` then wraps modulo 2\*\*64 to a large **positive** timestamp; `errors="coerce"` returned garbage instead of `NaT`. Affects units us/s/m/h/W.
- **Spurious raise:** an in-bounds float just shy of `INT64_MAX` rounds *up* to `2**63` and raised `OutOfBoundsDatetime`, diverging from the scalar `cast_from_unit` path. Affects units D/W.

Now the int64 wrap is detected directly — a valid result agrees with its float64 estimate to within a few ULP, while a wrap shifts it by ~2\*\*64. The vectorized path again matches the exact scalar cast (verified against it over 85k boundary-adjacent values). No perf impact (net-neutral: the added int64→float64 cast offsets the removed float comparisons).

No whatsnew entry: both directions were introduced by #64438 within the same unreleased 3.1.0 cycle, and the existing GH-57366 entry already describes the intended behavior.