### PR TITLE
Backport PR #66169 on branch 3.0.x (CI: Fix pyarrow-nightly job (stale nightly wheel + feather deprecations))

### DIFF
--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -74,7 +74,15 @@ def to_feather(
     with get_handle(
         path, "wb", storage_options=storage_options, is_text=False
     ) as handles:
-        feather.write_feather(df, handles.handle, **kwargs)
+        # pyarrow>=24 deprecates feather.write_feather in favor of pyarrow.ipc;
+        # suppress until we migrate the implementation (GH#66169)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                "pyarrow.feather.write_feather is deprecated",
+                FutureWarning,
+            )
+            feather.write_feather(df, handles.handle, **kwargs)
 
 
 @set_module("pandas")
@@ -164,6 +172,14 @@ def read_feather(
                     "make_block is deprecated",
                     Pandas4Warning,
                 )
+                # pyarrow>=24 deprecates feather.read_feather in favor of
+                # pyarrow.ipc; suppress until we migrate the implementation
+                # (GH#66169)
+                warnings.filterwarnings(
+                    "ignore",
+                    "pyarrow.feather.read_feather is deprecated",
+                    FutureWarning,
+                )
 
                 df = feather.read_feather(
                     handles.handle, columns=columns, use_threads=bool(use_threads)
@@ -175,7 +191,15 @@ def read_feather(
                         df[col] = df[col].astype("object")
                 return df
 
-        pa_table = feather.read_table(
-            handles.handle, columns=columns, use_threads=bool(use_threads)
-        )
+        # pyarrow>=24 deprecates feather.read_table in favor of pyarrow.ipc;
+        # suppress until we migrate the implementation (GH#66169)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                "pyarrow.feather.read_table is deprecated",
+                FutureWarning,
+            )
+            pa_table = feather.read_table(
+                handles.handle, columns=columns, use_threads=bool(use_threads)
+            )
         return arrow_table_to_pandas(pa_table, dtype_backend=dtype_backend)


### PR DESCRIPTION
Backport of GH-66169 to `3.0.x`.

Manual backport: `3.0.x` still has the default-args `read_feather` fast path (calling `pyarrow.feather.read_feather` directly) that was refactored away on `main`, so the cherry-pick conflicted. Resolution keeps that fast path and applies the deprecation suppressions from the original PR.

One addition beyond the original: `pyarrow.feather.read_feather` is *also* deprecated as of pyarrow 24.0.0, so its `FutureWarning` is suppressed inside the fast path's existing `catch_warnings` block — otherwise the pyarrow-nightly job would stay red on `test_read_fspath_all[read_feather-...]` on this branch. `main` didn't need this since it has no such call.

Local `pandas/tests/io/test_feather.py`: 19 passed.
