### PR TITLE
DOC: Fix read_csv 'quoting' docstring formatting (#65813)

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -673,9 +673,11 @@ def read_csv(
     quotechar : str (length 1), optional
         Character used to denote the start and end of a quoted item. Quoted
         items can include the ``delimiter`` and it will be ignored.
-    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL, 2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
-        Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is
-        ``csv.QUOTE_MINIMAL`` (i.e., 0) which implies that
+    quoting : {0, 1, 2, 3}, default csv.QUOTE_MINIMAL
+        Control field quoting behavior per ``csv.QUOTE_*`` constants. Use one of
+        ``0`` or ``csv.QUOTE_MINIMAL``, ``1`` or ``csv.QUOTE_ALL``,
+        ``2`` or ``csv.QUOTE_NONNUMERIC``, or ``3`` or ``csv.QUOTE_NONE``.
+        Default is ``csv.QUOTE_MINIMAL`` (i.e., 0) which implies that
         only fields containing special
         characters are quoted (e.g., characters defined
         in ``quotechar``, ``delimiter``,
@@ -1255,9 +1257,11 @@ def read_table(
     quotechar : str (length 1), optional
         Character used to denote the start and end of a quoted item. Quoted
         items can include the ``delimiter`` and it will be ignored.
-    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL, 2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
-        Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is
-        ``csv.QUOTE_MINIMAL`` (i.e., 0) which
+    quoting : {0, 1, 2, 3}, default csv.QUOTE_MINIMAL
+        Control field quoting behavior per ``csv.QUOTE_*`` constants. Use one of
+        ``0`` or ``csv.QUOTE_MINIMAL``, ``1`` or ``csv.QUOTE_ALL``,
+        ``2`` or ``csv.QUOTE_NONNUMERIC``, or ``3`` or ``csv.QUOTE_NONE``.
+        Default is ``csv.QUOTE_MINIMAL`` (i.e., 0) which
         implies that only fields containing special
         characters are quoted (e.g., characters defined
         in ``quotechar``, ``delimiter``,

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -673,8 +673,7 @@ def read_csv(
     quotechar : str (length 1), optional
         Character used to denote the start and end of a quoted item. Quoted
         items can include the ``delimiter`` and it will be ignored.
-    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL,
-        2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
+    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL, 2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
         Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is
         ``csv.QUOTE_MINIMAL`` (i.e., 0) which implies that
         only fields containing special
@@ -1256,8 +1255,7 @@ def read_table(
     quotechar : str (length 1), optional
         Character used to denote the start and end of a quoted item. Quoted
         items can include the ``delimiter`` and it will be ignored.
-    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL, 2 or
-        csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
+    quoting : {0 or csv.QUOTE_MINIMAL, 1 or csv.QUOTE_ALL, 2 or csv.QUOTE_NONNUMERIC, 3 or csv.QUOTE_NONE}, default csv.QUOTE_MINIMAL
         Control field quoting behavior per ``csv.QUOTE_*`` constants. Default is
         ``csv.QUOTE_MINIMAL`` (i.e., 0) which
         implies that only fields containing special


### PR DESCRIPTION
- [x] closes #65813
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Description
This PR fixes a minor docstring formatting issue for the `quoting` parameter in the `read_csv` function. 
Previously, a line break inside the type signature caused the description to bleed into the type information in the rendered documentation. By wrapping the type signature to a single line, Sphinx/NumPy doc parser can now correctly format the description block.

