### PR TITLE
DOC: Add list and struct Arrow accessors to Series docs table (#64910)

### DIFF
--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -291,6 +291,8 @@ to specific data types.
     Series.sparse
     DataFrame.sparse
     Index.str
+    Series.list
+    Series.struct
 
 
 =========================== =================================
@@ -300,6 +302,8 @@ Datetime, Timedelta, Period :ref:`dt <api.series.dt>`
 String                      :ref:`str <api.series.str>`
 Categorical                 :ref:`cat <api.series.cat>`
 Sparse                      :ref:`sparse <api.series.sparse>`
+PyArrow list                :ref:`list <api.series.list>`
+PyArrow struct              :ref:`struct <api.series.struct>`
 =========================== =================================
 
 .. _api.series.dt:

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -291,8 +291,6 @@ to specific data types.
     Series.sparse
     DataFrame.sparse
     Index.str
-    Series.list
-    Series.struct
 
 
 =========================== =================================


### PR DESCRIPTION
- [x] closes #64910
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Description
This PR adds the missing PyArrow `list` and `struct` accessors to the Series accessors autosummary and table in `doc/source/reference/series.rst`, fixing issue #64910.
