### PR TITLE
DOC: Clarify forward-looking rolling window behavior with offset stri…

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12059,6 +12059,21 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         2013-01-01 09:00:05  NaN
         2013-01-01 09:00:06  4.0
 
+        Rolling sum with forward-looking windows with 3 seconds.
+
+        >>> df_time.iloc[::-1].rolling("3s").sum().iloc[::-1]
+                               B
+        2013-01-01 09:00:00  1.0
+        2013-01-01 09:00:02  3.0
+        2013-01-01 09:00:03  2.0
+        2013-01-01 09:00:05  4.0
+        2013-01-01 09:00:06  4.0
+
+        .. note::
+
+            Negative offset strings (e.g., ``"-5h"``) do not create forward-looking
+            windows and should be avoided. They collapse to single-element windows.
+
         Rolling sum with forward looking windows with 2 observations.
 
         >>> indexer = pd.api.indexers.FixedForwardWindowIndexer(window_size=2)


### PR DESCRIPTION
- [x] closes #65050
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Description
This PR addresses issue #65050 by clarifying how to perform a forward-looking rolling window using offset strings.
It adds a new example using `.iloc[::-1]` to reverse the Series/DataFrame along with a note explaining that negative offset strings should be avoided as they collapse into single-element windows.
