### PR TITLE
BUG: str.match() preserve compiled regex flags when flags not explicitly given (GH#66138)

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1518,8 +1518,16 @@ class StringMethods(NoNewAttributesMixin):
             Character sequence or regular expression.
         case : bool, default True
             If True, case sensitive.
+            When a compiled regex is passed and ``case`` is not specified,
+            case sensitivity is inferred from the pattern's flags
+            (i.e. ``False`` if ``re.IGNORECASE`` is set, ``True`` otherwise).
+            Raises ``ValueError`` if ``case`` conflicts with the compiled
+            pattern's case sensitivity.
         flags : int, default 0 (no flags)
-            Regex module flags, e.g. re.IGNORECASE.
+            Regex module flags, e.g. ``re.IGNORECASE``.
+            When a compiled regex is passed and ``flags`` is not specified,
+            the pattern's own flags are used. Raises ``ValueError`` if
+            ``flags`` conflicts with the compiled pattern's flags.
         na : scalar, optional
             Fill value for missing values. The default depends on dtype of the
             array. For the ``"str"`` dtype, ``False`` is used. For object
@@ -1539,6 +1547,12 @@ class StringMethods(NoNewAttributesMixin):
         contains : Analogous, but less strict, relying on re.search instead of
             re.match.
         extract : Extract matched groups.
+
+        .. versionchanged:: 3.1.0
+            ``pat`` now accepts compiled regular expressions. When a compiled
+            regex is passed without explicit ``case`` or ``flags`` arguments,
+            those values are inferred from the pattern. Conflicting values
+            raise ``ValueError``.
 
         Examples
         --------
@@ -1565,7 +1579,9 @@ class StringMethods(NoNewAttributesMixin):
             #  re.compile(pat, flags=flags) the constructor does not raise.
             flags = 0
         else:
-            flags = 0
+            # Preserve compiled pattern flags when the user did not explicitly
+            # provide the flags argument.
+            flags = pat.flags if is_re(pat) else 0
 
         if case is lib.no_default:
             if is_re(pat):

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1196,6 +1196,21 @@ def test_match_compiled_regex(any_string_dtype):
     values.str.match(re.compile("ab", flags=re.IGNORECASE), flags=re.IGNORECASE)
 
 
+@pytest.mark.parametrize("compiled_flags", [re.ASCII, re.MULTILINE, re.DOTALL])
+def test_match_compiled_regex_default_flags_preserves_pattern_flags(
+    any_string_dtype, compiled_flags
+):
+    # GH#66138
+    values = Series(["ab", "AB", "abc", "ABC"], dtype=any_string_dtype)
+    result = values.str.match(re.compile("ab", flags=compiled_flags))
+
+    expected_dtype = (
+        np.bool_ if is_object_or_nan_string_dtype(any_string_dtype) else "boolean"
+    )
+    expected = Series([True, False, True, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "pat, case, exp",
     [


### PR DESCRIPTION
## Description
Fixes a regression where str.match with a compiled regex could raise a false conflicting flags ValueError when flags were not explicitly provided.

## Root cause
Conflict checking compared compiled-pattern flags against default flags, even when the caller did not pass flags.

## Fix
- Use no_default semantics for case and flags
- Preserve compiled pattern flags when flags is omitted
- Infer case from compiled pattern when case is omitted
- Keep explicit conflict checks for truly conflicting inputs

## Tests
- Updated compiled-regex match coverage
- Added regression test for default compiled-flag behavior

Closes #66138