### PR TITLE
CI: Scope forkserver launch method to ASV CI task (GH#66193)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -70,7 +70,7 @@ dependencies:
   - moto
 
   # benchmarks
-  - asv>=0.6.5
+  - asv>=0.6.6
   - py-rattler
 
   ## The compiler packages are meta-packages and install the correct compiler (activation) packages on the respective platforms.

--- a/pixi.toml
+++ b/pixi.toml
@@ -151,7 +151,7 @@ pyyaml = "*"
 xarray = ">=2024.10.0"
 
 [feature.benchmarks.dependencies]
-asv = ">=0.6.5"
+asv = ">=0.6.6"
 py-rattler = "*"  # for environment_type in asv.conf.json
 
 [feature.documentation.dependencies]
@@ -316,6 +316,9 @@ cmd = [
   "run",
   "--quick",
   "--dry-run",
+  # Fork server imports pandas once instead of re-importing it per
+  # benchmark; asv >=0.6.6 defaults to "spawn" which does not (GH#66193).
+  "--launch-method=forkserver",
   "--durations=30",
   "--python=same",
   "--show-stderr",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -52,7 +52,7 @@ dask
 seaborn
 ipython
 moto
-asv>=0.6.5
+asv>=0.6.6
 py-rattler
 mypy==2.1.0
 tokenize-rt


### PR DESCRIPTION
closes #66193

asv 0.6.6 (pulled in by GH-66147) changed the default benchmark launch method from `forkserver` to `spawn` on all platforms. Under `spawn` every benchmark runs in a fresh interpreter that re-imports pandas, so the `asv run --quick --dry-run` smoke test in the ASV Benchmarks CI job ballooned from minutes to ~4 hours (pandas has ~940 benchmark functions, most parameterized).

This passes `--launch-method=forkserver` in the `ci-asv` Pixi task, restoring the pre-0.6.6 behavior for the CI job: pandas is imported once in a fork server and each benchmark is a cheap `fork()`.

Scoping the flag to the (Linux) CI task — rather than setting `launch_method` in `asv.conf.json` — leaves asv's default untouched for everyone else, so local `asv run` keeps working on Windows, where `forkserver` is unavailable. Also bumps the asv floor to `>=0.6.6`.
