### PR TITLE
fix: handle np.uint64 wrapping in Series.to_json()

### DIFF
--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -1625,6 +1625,29 @@ static void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
     pc->longValue = value;
     return;
   } else if (PyArray_IsScalar(obj, Integer)) {
+    PyArray_Descr *idtype = PyArray_DescrFromScalar(obj);
+    if (idtype != NULL && PyTypeNum_ISUNSIGNED(idtype->type_num)) {
+      npy_uint64 uval;
+      PyArray_Descr *u64 = PyArray_DescrFromType(NPY_UINT64);
+      PyArray_CastScalarToCtype(obj, &uval, u64);
+      Py_DECREF(u64);
+      Py_DECREF(idtype);
+
+      PyObject *pyint = PyLong_FromUnsignedLongLong(uval);
+      if (pyint == NULL) {
+        goto INVALID;
+      }
+      tc->type = JT_LONG;
+      int overflow = 0;
+      pc->longValue = PyLong_AsLongLongAndOverflow(pyint, &overflow);
+      if (overflow) {
+        tc->type = JT_BIGNUM;
+      }
+      Py_DECREF(pyint);
+      return;
+    }
+    Py_DECREF(idtype);
+
     tc->type = JT_LONG;
     PyArray_CastScalarToCtype(obj, &(pc->longValue),
                               PyArray_DescrFromType(NPY_INT64));

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2333,6 +2333,20 @@ class TestPandasContainer:
         result = df.to_json(orient="split")
         assert result == expected
 
+
+    def test_json_uint64_object_dtype(self):
+        # GH#66142
+        result = Series([np.uint64(2**63)], dtype=object).to_json()
+        assert result == '{"0":9223372036854775808}'
+
+        result = Series([np.uint64(2**64 - 1)], dtype=object).to_json()
+        assert result == '{"0":18446744073709551615}'
+
+        result = Series(
+            [np.uint64(2**63), np.uint64(2**64 - 1)], dtype=object
+        ).to_json()
+        assert result == '{"0":9223372036854775808,"1":18446744073709551615}'
+
     def test_read_json_dtype_backend(
         self, string_storage, dtype_backend, orient, using_infer_string
     ):


### PR DESCRIPTION
Closes #66142

When np.uint64 scalars are stored in an object-dtype Series, the ujson C encoder casts them to NPY_INT64, causing values >= 2^63 to wrap to negative numbers.

This fix detects unsigned integer scalars in objToJSON.c via PyTypeNum_ISUNSIGNED and converts them through PyLong_FromUnsignedLongLong, letting ujson existing JT_BIGNUM path handle values that overflow int64.