### PR TITLE
BUG: Correct Formating of empty `frozenset` in object Series

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -249,6 +249,7 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
+- Fixed bug in :class:`Series` where empty frozensets were formatted incorrectly (:issue:`66192`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
 
 Categorical

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -123,7 +123,7 @@ def _pprint_seq(
     if isinstance(seq, set):
         fmt = "{{{body}}}"
     elif isinstance(seq, frozenset):
-        fmt = "frozenset({{{body}}})"
+        fmt = "frozenset()" if not seq else "frozenset({{{body}}})"
     else:
         fmt = "[{body}]" if hasattr(seq, "__setitem__") else "({body})"
 

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -85,6 +85,9 @@ class TestPPrintThing:
     def test_repr_frozenset(self):
         assert printing.pprint_thing(frozenset([1, 2])) == "frozenset({1, 2})"
 
+    def test_repr_empty_frozenset(self):
+        assert printing.pprint_thing(frozenset()) == "frozenset()"
+
     def test_repr_seq_float_precision(self):
         with cf.option_context("display.precision", 3):
             assert printing.pprint_thing([3.14159265, 3.14159265]) == "[3.142, 3.142]"

--- a/pandas/tests/series/test_formats.py
+++ b/pandas/tests/series/test_formats.py
@@ -88,11 +88,8 @@ class TestSeriesRepr:
         str(Series(dtype=object))
 
     def test_empty_frozenset(self):
-        s = Series([frozenset()])
-        result = repr(s)
-
-        assert "{" and "}" not in result
-        assert "frozenset" in result
+        ser = Series([frozenset()])
+        result = repr(ser)
 
         expected = "0    frozenset()\ndtype: object"
         assert result == expected

--- a/pandas/tests/series/test_formats.py
+++ b/pandas/tests/series/test_formats.py
@@ -87,6 +87,16 @@ class TestSeriesRepr:
         # empty
         str(Series(dtype=object))
 
+    def test_empty_frozenset(self):
+        s = Series([frozenset()])
+        result = repr(s)
+
+        assert "{" and "}" not in result
+        assert "frozenset" in result
+
+        expected = "0    frozenset()\ndtype: object"
+        assert result == expected
+
     def test_string(self, string_series):
         str(string_series)
         str(string_series.astype(int))


### PR DESCRIPTION
- [x] closes #66192 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

