### PR TITLE
CI: Cap hypothesis <6.156 on 32-bit build (missing i686 wheel needs Rust)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -290,7 +290,9 @@ jobs:
           . ~/virtualenvs/pandas-dev/bin/activate
           python -m pip install --no-cache-dir -U pip wheel meson[ninja]==1.2.3 meson-python==0.18.0
           python -m pip install numpy -Csetup-args="-Dallow-noblas=true"
-          python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil "pytest>=8.3.4,<9.1" pytest-xdist>=3.6.1 hypothesis>=6.116.0 pytest-cov
+          # hypothesis 6.156+ ships a compiled extension with no i686 wheel, and
+          # its sdist needs a Rust target rustup lacks on 32-bit. Cap until fixed.
+          python -m pip install --no-cache-dir versioneer[toml] cython python-dateutil "pytest>=8.3.4,<9.1" pytest-xdist>=3.6.1 "hypothesis>=6.116.0,<6.156" pytest-cov
           python -m pip install --no-cache-dir --no-build-isolation -e . -Csetup-args="--werror"
           python -m pip list --no-cache-dir
 


### PR DESCRIPTION
The `Linux-32-bit` job started failing on `main` at dependency install (not in pandas code). hypothesis 6.156.1 (2026-07-03) began shipping a compiled extension with platform wheels but **no i686 wheel**. On 32-bit Linux pip falls back to building the sdist, which needs a Rust target that rustup doesn't support:

```
Target triple not supported by rustup: i386-unknown-linux-gnu
Rust not found, installing into a temporary directory
```

Cap hypothesis to `<6.156` for the 32-bit job only. The Musl (x86_64), Python-dev (x86_64), and Pyodide (wasm32) jobs all have prebuilt 6.156.x wheels and are unaffected, so they're left unpinned. The cap can be lifted once hypothesis publishes an i686 wheel or makes the compiled extension optional.