### PR TITLE
BUG: read_excel with openpyxl engine sets sheet.max_row/max_column to…

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -391,6 +391,7 @@ I/O
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where an empty ``usecols`` (e.g. ``usecols=[]``) was ignored and returned all columns instead of an empty frame, unlike the other engines (:issue:`66056`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
+- Fixed bug in :func:`read_excel` with the ``openpyxl`` engine where reading a sheet set its ``max_row`` and ``max_column`` to ``None`` on the workbook exposed through ``ExcelFile.book`` (:issue:`63010`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -731,21 +731,31 @@ class OpenpyxlReader(BaseExcelReader["Workbook"]):
     def get_sheet_data(
         self, sheet, file_rows_needed: int | None = None
     ) -> list[list[Scalar]]:
+        saved_dimensions: tuple[int | None, int | None] | None = None
         if self.book.read_only:
+            # Declared sheet dimensions can be incorrect, so have openpyxl
+            # infer the real extent while iterating (GH 39486); save them to
+            # restore the user's worksheet handle afterwards (GH 63010)
+            saved_dimensions = (sheet.max_row, sheet.max_column)
             sheet.reset_dimensions()
 
         data: list[list[Scalar]] = []
         last_row_with_data = -1
-        for row_number, row in enumerate(sheet.rows):
-            converted_row = [self._convert_cell(cell) for cell in row]
-            while converted_row and converted_row[-1] == "":
-                # trim trailing empty elements
-                converted_row.pop()
-            if converted_row:
-                last_row_with_data = row_number
-            data.append(converted_row)
-            if file_rows_needed is not None and len(data) >= file_rows_needed:
-                break
+        try:
+            for row_number, row in enumerate(sheet.rows):
+                converted_row = [self._convert_cell(cell) for cell in row]
+                while converted_row and converted_row[-1] == "":
+                    # trim trailing empty elements
+                    converted_row.pop()
+                if converted_row:
+                    last_row_with_data = row_number
+                data.append(converted_row)
+                if file_rows_needed is not None and len(data) >= file_rows_needed:
+                    break
+        finally:
+            if saved_dimensions is not None:
+                # max_row/max_column of a read-only worksheet have no setters
+                sheet._max_row, sheet._max_column = saved_dimensions
 
         # Trim trailing empty rows
         data = data[: last_row_with_data + 1]

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -447,6 +447,23 @@ def test_read_multiindex_header_no_index_names(datapath, ext):
     tm.assert_frame_equal(result, expected)
 
 
+def test_read_excel_book_dimensions_preserved(tmp_excel):
+    # GH#63010 - reading should not permanently reset the dimensions of the
+    # worksheet handle available through ExcelFile.book
+    df = DataFrame({"a": [1, 2], "b": [3, 4]})
+    df.to_excel(tmp_excel, index=False)
+
+    with pd.ExcelFile(tmp_excel, engine="openpyxl") as excel_file:
+        sheet = excel_file.book["Sheet1"]
+        assert (sheet.max_row, sheet.max_column) == (3, 2)
+
+        result = pd.read_excel(excel_file, sheet_name="Sheet1")
+
+        assert (sheet.max_row, sheet.max_column) == (3, 2)
+
+    tm.assert_frame_equal(result, df)
+
+
 class TestWriteOnly:
     """Tests for write_only mode (GH#41681)."""
 


### PR DESCRIPTION
- [x] closes #63010
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Implements the approach approved in #63010: `OpenpyxlReader.get_sheet_data` saves the worksheet's declared dimensions before calling `reset_dimensions()` and restores them in a `try`/`finally` after row iteration. This keeps the robustness against incorrectly declared dimensions added in #39486, while no longer permanently mutating `max_row`/`max_column` of the worksheet handle reachable through `ExcelFile.book`.

The restore assigns `sheet._max_row`/`sheet._max_column` directly because openpyxl's `ReadOnlyWorksheet` exposes these only as getter properties; `reset_dimensions()` mutates the same private attributes.
