### PR TITLE
BUG: HDFStore min_itemsize={'index': N} rejected with MultiIndex columns (GH#12154)

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -4580,7 +4580,9 @@ class Table(Fixed):
         """return the data for this obj"""
         return obj
 
-    def validate_data_columns(self, data_columns, min_itemsize, non_index_axes) -> list:
+    def validate_data_columns(
+        self, data_columns, min_itemsize, non_index_axes, index_cnames=()
+    ) -> list:
         """
         take the input data_columns and min_itemize and create a data
         columns spec
@@ -4597,7 +4599,11 @@ class Table(Fixed):
                     f"data_columns {data_columns}"
                 )
             if isinstance(min_itemsize, dict):
-                mi_keys = [k for k in min_itemsize if k != "values"]
+                # GH#12154 'values' sizes every string column and the index
+                # cname(s) size the row index; both are legal here. Only
+                # per-column keys are unsupported for MultiIndex columns.
+                allowed = {"values", *index_cnames}
+                mi_keys = [k for k in min_itemsize if k not in allowed]
                 if mi_keys:
                     raise ValueError(
                         f"cannot use min_itemsize keys {mi_keys} on axis "
@@ -4759,7 +4765,7 @@ class Table(Fixed):
 
         # figure out data_columns and get out blocks
         data_columns = self.validate_data_columns(
-            data_columns, min_itemsize, new_non_index_axes
+            data_columns, min_itemsize, new_non_index_axes, (new_index.cname,)
         )
 
         if new_index.cname in data_columns:

--- a/pandas/tests/io/pytables/test_append.py
+++ b/pandas/tests/io/pytables/test_append.py
@@ -461,6 +461,28 @@ def test_append_min_itemsize_multiindex_columns(temp_hdfstore):
     tm.assert_frame_equal(temp_hdfstore.select("df"), df)
 
 
+def test_append_min_itemsize_index_multiindex_columns(temp_hdfstore):
+    # GH#12154 the row-index key ('index') is not a per-column request and must
+    # still reserve the index string width, even with MultiIndex columns.
+    columns = MultiIndex.from_tuples([(1, "a"), (1, "b"), (2, "c")])
+    df = DataFrame(
+        [["xx", "yy", "zz"], ["aa", "bb", "cc"]],
+        columns=columns,
+        index=["s1", "s2"],
+    )
+    temp_hdfstore.append("df", df, min_itemsize={"index": 50})
+
+    # appending a longer index label than the initial rows would overflow the
+    # index column had min_itemsize={'index': 50} not sized it.
+    df2 = DataFrame(
+        [["dd", "ee", "ff"]],
+        columns=columns,
+        index=["a_long_index_label_over_default_width"],
+    )
+    temp_hdfstore.append("df", df2)
+    tm.assert_frame_equal(temp_hdfstore.select("df"), concat([df, df2]))
+
+
 def test_append_with_empty_string(temp_hdfstore):
     # with all empty strings (GH 12242)
     df = DataFrame({"x": ["a", "b", "c", "d", "e", "f", ""]})


### PR DESCRIPTION
The MultiIndex-columns `min_itemsize` guard added in GH-65602 (for GH-12154) rejected *every* non-`'values'` key, including the reserved row-index key `'index'`. But `'index'` is not a per-column data request — it sizes the row-index string column (via `IndexCol.maybe_set_size`). So `append(min_itemsize={'index': 50})` on a MultiIndex-columns frame raised `ValueError`, and the suggested `{'values': N}` workaround can't size the index, so the capability was lost and a later append with longer index labels would overflow.

Fix: thread the reserved index cname into `validate_data_columns` and exempt it alongside `'values'`. Genuine per-column keys (e.g. `{1: N}`, `{(1, 'a'): N}`) still raise the clear error.

Confirmed the index is always keyed by `'index'` in table format (never its actual name, before or after this change), so `new_index.cname` is the exact exemption. Regression only exists in the unreleased 3.1.0.dev, so no whatsnew entry.