### PR TITLE
BUG: Arrow as_unit truncated toward zero and silenced overflow

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -37,7 +37,11 @@ from pandas.compat import (
     pa_version_under25p0,
 )
 from pandas.compat.numpy import function as nv
-from pandas.errors import Pandas4Warning
+from pandas.errors import (
+    OutOfBoundsDatetime,
+    OutOfBoundsTimedelta,
+    Pandas4Warning,
+)
 from pandas.util._decorators import (
     cache_readonly,
     set_module,
@@ -3695,8 +3699,37 @@ class ArrowExtensionArray(
             target_type = pa.duration(unit)
         else:
             raise NotImplementedError(f"as_unit not implemented for {pa_type}")
-        # Use safe=False to allow truncation, matching pandas as_unit behavior
-        result = pc.cast(self._pa_array, target_type, safe=False)
+
+        nanos_per_unit = {"s": 1_000_000_000, "ms": 1_000_000, "us": 1_000, "ns": 1}
+        from_nanos = nanos_per_unit[pa_type.unit]
+        to_nanos = nanos_per_unit[unit]
+        if to_nanos <= from_nanos:
+            # Same or finer resolution: exact upscale. Use safe=True so that
+            # out-of-bounds values raise instead of silently wrapping, matching
+            # numpy/pandas as_unit.
+            try:
+                result = pc.cast(self._pa_array, target_type)
+            except pa.ArrowInvalid as err:
+                err_type = (
+                    OutOfBoundsDatetime
+                    if pa.types.is_timestamp(pa_type)
+                    else OutOfBoundsTimedelta
+                )
+                raise err_type(
+                    f"Cannot convert {pa_type} to {target_type} without overflow"
+                ) from err
+        else:
+            # Coarser resolution: floor toward -inf like numpy/pandas. pc.cast
+            # truncates toward zero, which is wrong for negative timedeltas and
+            # pre-epoch timestamps (GH#63573).
+            ratio = pa.scalar(to_nanos // from_nanos, type=pa.int64())
+            i8 = pc.cast(self._pa_array, pa.int64())
+            quotient = pc.divide(i8, ratio)
+            remainder = pc.subtract(i8, pc.multiply(quotient, ratio))
+            floored = pc.if_else(
+                pc.less(remainder, 0), pc.subtract(quotient, 1), quotient
+            )
+            result = pc.cast(floored, target_type)
         return self._from_pyarrow_array(result)
 
     @property

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -43,7 +43,11 @@ from pandas.compat import (
     pa_version_under21p0,
 )
 from pandas.compat.pyarrow import pa_version_under22p0
-from pandas.errors import Pandas4Warning
+from pandas.errors import (
+    OutOfBoundsDatetime,
+    OutOfBoundsTimedelta,
+    Pandas4Warning,
+)
 
 from pandas.core.dtypes.common import pandas_dtype
 from pandas.core.dtypes.dtypes import (
@@ -3049,6 +3053,59 @@ def test_as_unit_date_raises():
     # as_unit should raise for date types
     ser = pd.Series([1, 2], dtype=ArrowDtype(pa.date32()))
     with pytest.raises(NotImplementedError, match="as_unit not implemented"):
+        ser.dt.as_unit("ns")
+
+
+@pytest.mark.parametrize(
+    "from_unit, to_unit",
+    [("ns", "s"), ("ns", "ms"), ("ns", "us"), ("us", "s"), ("ms", "s")],
+)
+def test_as_unit_duration_negative_floors(from_unit, to_unit):
+    # GH#63573 downcasting a negative duration must floor toward -inf like
+    # numpy, not truncate toward zero
+    values = [93784567890123, -93784567890123, None]
+    ser_arrow = pd.Series(pd.to_timedelta(values, unit="ns").as_unit(from_unit)).astype(
+        f"duration[{from_unit}][pyarrow]"
+    )
+
+    result = ser_arrow.dt.as_unit(to_unit)
+    expected = pd.Series(
+        pd.to_timedelta(values, unit="ns").as_unit(from_unit).as_unit(to_unit)
+    ).astype(f"duration[{to_unit}][pyarrow]")
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("to_unit", ["s", "ms", "us"])
+def test_as_unit_timestamp_pre_epoch_floors(to_unit):
+    # GH#63573 downcasting a pre-epoch timestamp must floor toward -inf like
+    # numpy, not truncate toward zero (which would cross the epoch)
+    ser_arrow = pd.Series(
+        [pd.Timestamp("1969-12-31 23:59:59.123456789"), None],
+        dtype="timestamp[ns][pyarrow]",
+    )
+    result = ser_arrow.dt.as_unit(to_unit)
+    expected = pd.Series(ser_arrow.astype("datetime64[ns]").dt.as_unit(to_unit)).astype(
+        f"timestamp[{to_unit}][pyarrow]"
+    )
+    tm.assert_series_equal(result, expected)
+
+
+def test_as_unit_timestamp_overflow_raises():
+    # GH#63573 upcasting out-of-bounds values must raise instead of silently
+    # wrapping via int64 overflow
+    ser = pd.Series(
+        [pd.Timestamp("2600-01-01").as_unit("s"), None],
+        dtype="timestamp[s][pyarrow]",
+    )
+    with pytest.raises(OutOfBoundsDatetime, match="overflow"):
+        ser.dt.as_unit("ns")
+
+
+def test_as_unit_duration_overflow_raises():
+    # GH#63573 upcasting out-of-bounds durations must raise instead of silently
+    # wrapping via int64 overflow
+    ser = pd.Series([19880899200, None], dtype="duration[s][pyarrow]")
+    with pytest.raises(OutOfBoundsTimedelta, match="overflow"):
         ser.dt.as_unit("ns")
 
 


### PR DESCRIPTION
Regression from GH-63573, which switched `ArrowExtensionArray._dt_as_unit` to `pc.cast(..., safe=False)`. That truncates toward zero and silently wraps on int64 overflow, whereas numpy/pandas `as_unit` floors toward -inf and raises on out-of-bounds.

Consequences before this PR:
- Negative durations rounded the wrong way, e.g. `-93784567890123ns -> s` gave `-93784s` instead of `-93785s`.
- Pre-epoch timestamps crossed the epoch, e.g. `1969-12-31 23:59:59.123456789ns -> s` gave `1970-01-01 00:00:00` instead of `1969-12-31 23:59:59`.
- Out-of-bounds upcasts (e.g. year-2600 `timestamp[s] -> ns`) silently returned int64-wrapped garbage instead of raising.

The `safe=False` path was only exercised by tests using positive, in-range values, where truncation and floor happen to coincide.

Fix keeps the Arrow-native fast path but makes it direction-aware: downcasts floor toward -inf via int64 arithmetic, and same/finer-resolution casts use `safe=True` so overflow raises `OutOfBoundsDatetime`/`OutOfBoundsTimedelta`, matching the numpy-backed behavior. Adds regression tests covering negative durations, pre-epoch timestamps, and overflow.