### PR TITLE
DOC: make andrews_curves/parallel_coordinates plot examples self-contained

### DIFF
--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -417,10 +417,26 @@ def andrews_curves(
     .. plot::
         :context: close-figs
 
-        >>> df = pd.read_csv(
-        ...     "https://raw.githubusercontent.com/pandas-dev/"
-        ...     "pandas/main/pandas/tests/io/data/csv/iris.csv"
-        ... )  # doctest: +SKIP
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "SepalLength": [6.5, 7.7, 5.1, 5.8, 7.6, 5.0, 5.4, 4.6, 6.7, 4.6],
+        ...         "SepalWidth": [3.0, 3.8, 3.8, 2.7, 3.0, 2.3, 3.0, 3.2, 3.3, 3.6],
+        ...         "PetalLength": [5.5, 6.7, 1.9, 5.1, 6.6, 3.3, 4.5, 1.4, 5.7, 1.0],
+        ...         "PetalWidth": [1.8, 2.2, 0.4, 1.9, 2.1, 1.0, 1.5, 0.2, 2.1, 0.2],
+        ...         "Name": [
+        ...             "virginica",
+        ...             "virginica",
+        ...             "setosa",
+        ...             "virginica",
+        ...             "virginica",
+        ...             "versicolor",
+        ...             "versicolor",
+        ...             "setosa",
+        ...             "virginica",
+        ...             "setosa",
+        ...         ],
+        ...     }
+        ... )
         >>> pd.plotting.andrews_curves(df, "Name")  # doctest: +SKIP
     """
     plot_backend = _get_plot_backend("matplotlib")
@@ -563,10 +579,26 @@ def parallel_coordinates(
     .. plot::
         :context: close-figs
 
-        >>> df = pd.read_csv(
-        ...     "https://raw.githubusercontent.com/pandas-dev/"
-        ...     "pandas/main/pandas/tests/io/data/csv/iris.csv"
-        ... )  # doctest: +SKIP
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "SepalLength": [6.5, 7.7, 5.1, 5.8, 7.6, 5.0, 5.4, 4.6, 6.7, 4.6],
+        ...         "SepalWidth": [3.0, 3.8, 3.8, 2.7, 3.0, 2.3, 3.0, 3.2, 3.3, 3.6],
+        ...         "PetalLength": [5.5, 6.7, 1.9, 5.1, 6.6, 3.3, 4.5, 1.4, 5.7, 1.0],
+        ...         "PetalWidth": [1.8, 2.2, 0.4, 1.9, 2.1, 1.0, 1.5, 0.2, 2.1, 0.2],
+        ...         "Name": [
+        ...             "virginica",
+        ...             "virginica",
+        ...             "setosa",
+        ...             "virginica",
+        ...             "virginica",
+        ...             "versicolor",
+        ...             "versicolor",
+        ...             "setosa",
+        ...             "virginica",
+        ...             "setosa",
+        ...         ],
+        ...     }
+        ... )
         >>> pd.plotting.parallel_coordinates(
         ...     df, "Name", color=("#556270", "#4ECDC4", "#C7F464")
         ... )  # doctest: +SKIP


### PR DESCRIPTION
The `.. plot::` examples for `pandas.plotting.andrews_curves` and `pandas.plotting.parallel_coordinates` fetched `iris.csv` from `raw.githubusercontent.com`. Sphinx *executes* `.. plot::` directives to render the image (the `# doctest: +SKIP` only suppresses the doctest runner), so every docbuild made two live network calls to GitHub. When GitHub rate-limited the CI runner, the build failed with `HTTPError: HTTP Error 429: Too Many Requests` — and since docs are built with `--warnings-are-errors`, that intermittently broke the Doc Build CI across unrelated PRs.

These were the only two docstrings in pandas that fetched data over the network in a plot directive. The other 66 `.. plot::` examples in `pandas/plotting/_core.py` build data inline, and the sibling `radviz` example in the same file already does. This brings the two anomalies in line: inline the iris data so the plots render offline and the docbuild no longer depends on the network.