### PR TITLE
BUG: to_json segfault on datetime/timedelta subclass without _creso (GH#65904)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -398,6 +398,7 @@ I/O
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
+- Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -284,6 +284,9 @@ static npy_int64 get_long_attr(PyObject *o, const char *attr) {
 
   // ensure we are in nanoseconds, similar to Timestamp._as_creso or _as_unit
   PyObject *reso = PyObject_GetAttrString(o, "_creso");
+  if (reso == NULL) {
+    return -1;
+  }
   if (!PyLong_Check(reso)) {
     // https://github.com/pandas-dev/pandas/pull/49034#discussion_r1023165139
     Py_DECREF(reso);

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1380,6 +1380,22 @@ class TestPandasContainer:
         expected = '{"42":42}'
         assert result == expected
 
+    @pytest.mark.parametrize("base_typ", [datetime.date, datetime.timedelta])
+    def test_to_json_datetimelike_subclass_missing_creso(self, base_typ):
+        # GH#65904 a datetime.date/timedelta subclass carrying a "_value"
+        # attribute but no "_creso" reached get_long_attr and segfaulted; it
+        # should raise cleanly instead
+        class Fake(base_typ):
+            _value = 5
+
+        obj = Fake(2020, 1, 1) if base_typ is datetime.date else Fake(5)
+        # dtype=object keeps the subclass instance for the timedelta case, which
+        # would otherwise be inferred to timedelta64
+        index = Index([obj], dtype=object)
+        ser = Series([1], index=index)
+        with pytest.raises(AttributeError, match="_creso"):
+            ser.to_json(date_format="iso")
+
     def test_default_handler(self):
         value = object()
         frame = DataFrame({"a": [7, value]})


### PR DESCRIPTION
closes #65904

Follow-up to GH-65956, which hardened the first `getattr` in `get_long_attr` but left the second one — for `_creso` — unguarded. When an object passes `PyDate_Check`/`PyDelta_Check` and carries a `_value` attribute but no `_creso` (e.g. an object-dtype `datetime.date`/`datetime.timedelta` subclass), `PyObject_GetAttrString(o, "_creso")` returns `NULL` and `PyLong_Check(NULL)` dereferences NULL, segfaulting straight from public `to_json`.

NULL-check `reso` and return `-1`, matching the convention the first getattr and both call sites already use so the `AttributeError` propagates instead of crashing.