### PR TITLE
BUG: DataFrame.sum on overflowing timedelta64 silently saturates (GH#43178)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -291,7 +291,7 @@ Timedelta
 - Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
 - Bug in :class:`Timedelta` constructor and :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timedelta` constructor where keyword arguments (e.g. ``days=365000``) that exceeded nanosecond int64 bounds raised ``OutOfBoundsTimedelta`` instead of falling back to a coarser resolution (:issue:`46587`)
-- Bug in :meth:`Series.sum` on an overflowing ``timedelta64`` series raising a plain ``ValueError`` instead of :class:`OutOfBoundsTimedelta` (:issue:`43178`)
+- Bug in :meth:`Series.sum` and :meth:`DataFrame.sum` on an overflowing ``timedelta64`` object where :meth:`Series.sum` raised a plain ``ValueError`` and :meth:`DataFrame.sum` silently returned a saturated result instead of raising :class:`OutOfBoundsTimedelta` (:issue:`43178`)
 - Bug in ``Series.dt.seconds`` and ``Series.dt.microseconds`` with :class:`ArrowDtype` durations returning the ``Series.dt.components`` field values (e.g. 0-59 for seconds, or 0 for ``microseconds`` on a ``"ms"`` unit) instead of the totals within each day and second respectively, inconsistent with NumPy-backed timedeltas (:issue:`63470`)
 
 Timezones

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -346,7 +346,7 @@ def _na_ok_dtype(dtype: DtypeObj) -> bool:
     return not issubclass(dtype.type, np.integer)
 
 
-def _wrap_results(result, dtype: np.dtype, fill_value=None):
+def _wrap_results(result, dtype: np.dtype, fill_value=None, result_mask=None):
     """wrap our results if needed"""
     if result is NaT:
         pass
@@ -371,7 +371,7 @@ def _wrap_results(result, dtype: np.dtype, fill_value=None):
             result = result.astype(dtype)
     elif dtype.kind == "m":
         if not isinstance(result, np.ndarray):
-            if result == fill_value or np.isnan(result):
+            if result_mask or result == fill_value or np.isnan(result):
                 unit = np.datetime_data(dtype)[0]
                 result = np.timedelta64("NaT", unit)  # type: ignore[call-overload]
 
@@ -383,6 +383,15 @@ def _wrap_results(result, dtype: np.dtype, fill_value=None):
                 result = np.int64(result).astype(dtype, copy=False)
 
         else:
+            overflow = np.abs(result) > lib.i8max
+            if result_mask is not None:
+                # GH#43178: positions that will be set to NaT (skipna=False) are
+                #  exempt from the overflow check and must not trip the cast below
+                overflow &= ~result_mask
+                result = np.where(result_mask, 0, result)
+            if overflow.any():
+                # GH#43178: raise if any result is too large for the dtype's unit
+                raise OutOfBoundsTimedelta("overflow in timedelta operation")
             result = result.astype("m8[ns]").view(dtype)
 
     return result
@@ -412,7 +421,18 @@ def _datetimelike_compat(func: F) -> F:
         result = func(values, axis=axis, skipna=skipna, mask=mask, **kwargs)
 
         if datetimelike:
-            result = _wrap_results(result, orig_values.dtype, fill_value=iNaT)
+            result_mask = None
+            if not skipna:
+                assert mask is not None  # checked above
+                # positions with any NA reduce to NaT, so exempt them from the
+                # timedelta overflow guard in _wrap_results
+                if isinstance(result, np.ndarray):
+                    result_mask = mask.any(axis=axis)
+                else:
+                    result_mask = mask.any()
+            result = _wrap_results(
+                result, orig_values.dtype, fill_value=iNaT, result_mask=result_mask
+            )
             if not skipna:
                 assert mask is not None  # checked above
                 result = _mask_datetimelike_result(result, axis, mask, orig_values)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -2416,6 +2416,33 @@ def test_sum_empty_mixed_with_timedelta_column():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("skipna", [True, False])
+def test_sum_timedelta64_overflow_raises(axis, skipna):
+    # GH#43178: DataFrame.sum on an overflowing timedelta64 frame should raise
+    #  OutOfBoundsTimedelta, consistent with Series.sum, rather than silently
+    #  returning a saturated result.
+    half = np.iinfo(np.int64).max // 2
+    arr = np.array([half, half, half], dtype="m8[ns]")
+    df = DataFrame({"a": arr, "b": arr, "c": arr})
+
+    msg = "overflow in timedelta operation"
+    with pytest.raises(pd.errors.OutOfBoundsTimedelta, match=msg):
+        df.sum(axis=axis, skipna=skipna)
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+def test_sum_timedelta64_all_nat_skipna_false(axis):
+    # GH#43178: an all-NaT reduction with skipna=False must return NaT, not be
+    #  mistaken for an overflow (the NaT sentinels accumulate past int64 bounds)
+    nat = np.array(["NaT", "NaT", "NaT"], dtype="m8[ns]")
+    df = DataFrame({"a": nat, "b": nat, "c": nat})
+
+    result = df.sum(axis=axis, skipna=False)
+    assert result.dtype == "m8[ns]"
+    assert result.isna().all()
+
+
 def test_mixed_frame_with_integer_sum():
     # https://github.com/pandas-dev/pandas/issues/34520
     df = DataFrame([["a", 1]], columns=list("ab"))

--- a/pandas/tests/series/test_reductions.py
+++ b/pandas/tests/series/test_reductions.py
@@ -128,6 +128,13 @@ def test_td64_summation_overflow():
     (s2 - s2.min()).sum()
 
 
+def test_td64_sum_all_nat_skipna_false():
+    # GH#43178: an all-NaT sum with skipna=False must return NaT rather than be
+    #  mistaken for an overflow (the NaT sentinels accumulate past int64 bounds)
+    ser = Series(np.array(["NaT", "NaT", "NaT"], dtype="m8[ns]"))
+    assert ser.sum(skipna=False) is pd.NaT
+
+
 def test_prod_numpy16_bug():
     ser = Series([1.0, 1.0, 1.0], index=range(3))
     result = ser.prod()


### PR DESCRIPTION
closes #43178

Follow-up to GH-65926, which added the timedelta-overflow guard only to the scalar branch of `nanops._wrap_results`. As a result `Series.sum` raised `OutOfBoundsTimedelta`, but `DataFrame.sum` (both `axis=0` and `axis=1`) silently returned an `int64`-max-saturated result with only a `RuntimeWarning`.

This guards the ndarray branch as well. A naive guard would regress `skipna=False`: the `NaT` sentinels (`iNaT`) are summed into the float result *before* `_mask_datetimelike_result` overwrites those positions with `NaT`, so two or more `NaT` accumulate past `int64` bounds and trip a false overflow. The same latent bug already affected the scalar branch (`Series([NaT, NaT]).sum(skipna=False)` wrongly raised).

The fix makes the guard mask-aware via a `masked` parameter on `_wrap_results`: positions destined to become `NaT` are exempt from both the raise and the `m8` cast. This makes `Series.sum` and `DataFrame.sum` consistent for genuine overflow and fixes the `skipna=False` all-`NaT` false-raise for both.

Note: `groupby.sum` / `resample.sum` on overflowing `timedelta64` still saturate silently — that is a separate Cython `group_sum` int64-accumulation path with no float intermediate for `_wrap_results` to guard, and is left for a follow-up.