### PR TITLE
BUG: Period.to_timestamp wrong unit for normalized freq (GH#63760)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -441,6 +441,7 @@ Period
 - Bug in :class:`Period` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :meth:`Period.strftime` where unknown format directives (e.g. ``"%Q"``) silently produced platform-dependent output and crashed the Python process on Windows; an ``Invalid format string`` ``ValueError`` is now raised on all platforms (:issue:`53562`)
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` returning wildly incorrect timestamps when the target frequency normalized to nanoseconds (e.g. ``"1ns"``) or when converting a nanosecond ``Period`` to a coarser target frequency (:issue:`63760`)
+- Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` with ``how="end"`` losing nanosecond precision when the target frequency normalized to nanoseconds (e.g. ``"1ns"``); the target frequency is now also validated when ``how="end"`` (:issue:`63760`)
 -
 
 Plotting

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -440,7 +440,7 @@ Period
 ^^^^^^
 - Bug in :class:`Period` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :meth:`Period.strftime` where unknown format directives (e.g. ``"%Q"``) silently produced platform-dependent output and crashed the Python process on Windows; an ``Invalid format string`` ``ValueError`` is now raised on all platforms (:issue:`53562`)
-- Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` returning wildly incorrect timestamps when the target frequency normalized to nanoseconds (e.g. ``"1ns"``) or when converting a nanosecond ``Period`` to a coarser target frequency (:issue:`63760`)
+- Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` returning incorrect timestamps when the target frequency normalized to nanoseconds (e.g. ``"1ns"``) or when converting a nanosecond ``Period`` to a coarser target frequency (:issue:`63760`)
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` with ``how="end"`` losing nanosecond precision when the target frequency normalized to nanoseconds (e.g. ``"1ns"``); the target frequency is now also validated when ``how="end"`` (:issue:`63760`)
 -
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -440,6 +440,7 @@ Period
 ^^^^^^
 - Bug in :class:`Period` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :meth:`Period.strftime` where unknown format directives (e.g. ``"%Q"``) silently produced platform-dependent output and crashed the Python process on Windows; an ``Invalid format string`` ``ValueError`` is now raised on all platforms (:issue:`53562`)
+- Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` returning wildly incorrect timestamps when the target frequency normalized to nanoseconds (e.g. ``"1ns"``) or when converting a nanosecond ``Period`` to a coarser target frequency (:issue:`63760`)
 -
 
 Plotting

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2250,19 +2250,15 @@ cdef class _Period(PeriodMixin):
         """
         how = validate_end_alias(how)
 
-        if self._dtype._dtype_code == PeriodDtypeCode.N or freq == "ns":
-            unit = "ns"
-        else:
-            unit = "us"
-
         end = how == "E"
         if end:
             if freq == "B" or self._freq == "B":
                 # roll forward to ensure we land on B date
-                adjust = np.timedelta64(1, "D") - np.timedelta64(1, unit)
-                return self.to_timestamp(how="start") + adjust
+                stamp = self.to_timestamp(how="start")
+                adjust = np.timedelta64(1, "D") - np.timedelta64(1, stamp.unit)
+                return stamp + adjust
             endpoint = (self + self._freq).to_timestamp(how="start")
-            return endpoint - np.timedelta64(1, unit)
+            return endpoint - np.timedelta64(1, endpoint.unit)
 
         if freq is None:
             freq_code = self._dtype._get_to_timestamp_base()
@@ -2272,6 +2268,14 @@ cdef class _Period(PeriodMixin):
         else:
             freq = self._maybe_convert_freq(freq)
             base = freq._period_dtype_code
+
+        # GH#63760 period_ordinal_to_dt64 gives nanoseconds only for the
+        #  nanosecond target base and microseconds otherwise, so the result
+        #  unit is determined by the normalized target base.
+        if base == PeriodDtypeCode.N:
+            unit = "ns"
+        else:
+            unit = "us"
 
         val = self.asfreq(freq, how)
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2252,13 +2252,21 @@ cdef class _Period(PeriodMixin):
 
         end = how == "E"
         if end:
+            if freq is not None:
+                # GH#63760 normalize so e.g. "1ns" is recognized as nanosecond
+                freq = self._maybe_convert_freq(freq)
+            ns_target = (
+                freq is not None and freq._period_dtype_code == PeriodDtypeCode.N
+            )
             if freq == "B" or self._freq == "B":
                 # roll forward to ensure we land on B date
                 stamp = self.to_timestamp(how="start")
-                adjust = np.timedelta64(1, "D") - np.timedelta64(1, stamp.unit)
+                unit = "ns" if ns_target else stamp.unit
+                adjust = np.timedelta64(1, "D") - np.timedelta64(1, unit)
                 return stamp + adjust
             endpoint = (self + self._freq).to_timestamp(how="start")
-            return endpoint - np.timedelta64(1, endpoint.unit)
+            unit = "ns" if ns_target else endpoint.unit
+            return endpoint - np.timedelta64(1, unit)
 
         if freq is None:
             freq_code = self._dtype._get_to_timestamp_base()

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -955,14 +955,20 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
 
         end = how == "E"
         if end:
+            if freq is not None:
+                # GH#63760 normalize so e.g. "1ns" is recognized as nanosecond
+                freq = Period._maybe_convert_freq(freq)
+            ns_target = freq is not None and freq.base == "ns"
             if freq == "B" or self.freq == "B":
                 # roll forward to ensure we land on B date
                 stamp = self.to_timestamp(how="start")
-                adjust = Timedelta(1, unit="D") - Timedelta(1, unit=stamp.unit)
+                unit = "ns" if ns_target else stamp.unit
+                adjust = Timedelta(1, unit="D") - Timedelta(1, unit=unit)
                 return stamp + adjust
             else:
                 stamp = (self + self.freq).to_timestamp(how="start")
-                return stamp - Timedelta(1, unit=stamp.unit)
+                unit = "ns" if ns_target else stamp.unit
+                return stamp - Timedelta(1, unit=unit)
 
         if freq is None:
             freq_code = self._dtype._get_to_timestamp_base()

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -953,20 +953,16 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
 
         how = libperiod.validate_end_alias(how)
 
-        if self.freq.base == "ns" or freq == "ns":
-            unit = "ns"
-        else:
-            unit = "us"
-
         end = how == "E"
         if end:
             if freq == "B" or self.freq == "B":
                 # roll forward to ensure we land on B date
-                adjust = Timedelta(1, unit="D") - Timedelta(1, unit=unit)
-                return self.to_timestamp(how="start") + adjust
+                stamp = self.to_timestamp(how="start")
+                adjust = Timedelta(1, unit="D") - Timedelta(1, unit=stamp.unit)
+                return stamp + adjust
             else:
-                adjust = Timedelta(1, unit=unit)
-                return (self + self.freq).to_timestamp(how="start") - adjust
+                stamp = (self + self.freq).to_timestamp(how="start")
+                return stamp - Timedelta(1, unit=stamp.unit)
 
         if freq is None:
             freq_code = self._dtype._get_to_timestamp_base()
@@ -980,8 +976,10 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
         new_parr = self.asfreq(freq, how=how)
 
         new_data = libperiod.periodarr_to_dt64arr(new_parr.asi8, base)
+        # GH#63760 periodarr_to_dt64arr gives nanoseconds only for the
+        #  nanosecond target base and microseconds otherwise, so new_data
+        #  already carries the correct resolution.
         dta = DatetimeArray._from_sequence(new_data, dtype=new_data.dtype)
-        assert dta.unit == unit
         return dta
 
     def _to_timestamp_freq(

--- a/pandas/tests/frame/methods/test_to_timestamp.py
+++ b/pandas/tests/frame/methods/test_to_timestamp.py
@@ -52,18 +52,18 @@ class TestToTimestamp:
         tm.assert_index_equal(result.index, exp_index)
 
         delta = timedelta(hours=23)
-        result = obj.to_timestamp("H", "end")
+        result = obj.to_timestamp("h", "end")
         exp_index = _get_with_delta(delta)
         exp_index = exp_index + Timedelta(1, "h") - Timedelta(1, "us")
         tm.assert_index_equal(result.index, exp_index)
 
         delta = timedelta(hours=23, minutes=59)
-        result = obj.to_timestamp("T", "end")
+        result = obj.to_timestamp("min", "end")
         exp_index = _get_with_delta(delta)
         exp_index = exp_index + Timedelta(1, "m") - Timedelta(1, "us")
         tm.assert_index_equal(result.index, exp_index)
 
-        result = obj.to_timestamp("S", "end")
+        result = obj.to_timestamp("s", "end")
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
         exp_index = exp_index + Timedelta(1, "s") - Timedelta(1, "us")
@@ -93,7 +93,7 @@ class TestToTimestamp:
         tm.assert_index_equal(result.columns, exp_index)
 
         delta = timedelta(hours=23)
-        result = df.to_timestamp("H", "end", axis=1)
+        result = df.to_timestamp("h", "end", axis=1)
         exp_index = _get_with_delta(delta)
         exp_index = exp_index + Timedelta(1, "h") - Timedelta(1, "us")
         tm.assert_index_equal(result.columns, exp_index)
@@ -104,7 +104,7 @@ class TestToTimestamp:
         exp_index = exp_index + Timedelta(1, "m") - Timedelta(1, "us")
         tm.assert_index_equal(result.columns, exp_index)
 
-        result = df.to_timestamp("S", "end", axis=1)
+        result = df.to_timestamp("s", "end", axis=1)
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
         exp_index = exp_index + Timedelta(1, "s") - Timedelta(1, "us")

--- a/pandas/tests/indexes/period/methods/test_to_timestamp.py
+++ b/pandas/tests/indexes/period/methods/test_to_timestamp.py
@@ -166,3 +166,40 @@ def test_to_timestamp_from_nanosecond_period(freq):
     result = pi.to_timestamp(freq)
     expected = DatetimeIndex(["2020-01-01"] * 3, dtype="M8[us]")
     tm.assert_index_equal(result, expected)
+
+
+@pytest.mark.parametrize("freq", ["ns", "1ns"])
+def test_to_timestamp_end_nanosecond_target(freq):
+    # GH#63760 how="end" keeps nanosecond precision for a target freq that
+    #  normalizes to nanoseconds
+    pi = period_range("2020-01-01", periods=2, freq="D")
+    result = pi.to_timestamp(freq, how="E")
+    expected = DatetimeIndex(
+        ["2020-01-01 23:59:59.999999999", "2020-01-02 23:59:59.999999999"],
+        dtype="M8[ns]",
+    )
+    tm.assert_index_equal(result, expected)
+
+
+def test_to_timestamp_end_from_nanosecond_period():
+    # GH#63760 nanosecond periods keep their nanosecond end bounds with a
+    #  coarser target freq
+    pi = period_range("2020-01-01", periods=2, freq="ns")
+    result = pi.to_timestamp("D", how="E")
+    expected = DatetimeIndex(
+        ["2020-01-01 00:00:00", "2020-01-01 00:00:00.000000001"], dtype="M8[ns]"
+    )
+    tm.assert_index_equal(result, expected)
+
+
+def test_to_timestamp_end_bday_nanosecond_target():
+    # GH#63760 the B roll-forward path keeps nanosecond precision too
+    msg = "Period with BDay freq is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
+        pi = period_range("2020-01-02", periods=2, freq="B")
+        result = pi.to_timestamp("ns", how="E")
+    expected = DatetimeIndex(
+        ["2020-01-02 23:59:59.999999999", "2020-01-03 23:59:59.999999999"],
+        dtype="M8[ns]",
+    )
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/period/methods/test_to_timestamp.py
+++ b/pandas/tests/indexes/period/methods/test_to_timestamp.py
@@ -146,3 +146,23 @@ def test_ms_to_timestamp_error_message():
     ix = period_range("2000", periods=3, freq="M")
     with pytest.raises(ValueError, match="for Period, please use 'M' instead of 'MS'"):
         ix.to_timestamp("MS")
+
+
+@pytest.mark.parametrize("freq", ["ns", "1ns"])
+def test_to_timestamp_nanosecond_target(freq):
+    # GH#63760 a target freq that normalizes to nanoseconds must give a
+    #  nanosecond-unit result rather than misinterpreting the ordinal
+    pi = period_range("2020-01-01", periods=3, freq="D")
+    result = pi.to_timestamp(freq)
+    expected = date_range("2020-01-01", periods=3, freq="D", unit="ns")
+    tm.assert_index_equal(result, expected)
+
+
+@pytest.mark.parametrize("freq", ["D", "s", "us"])
+def test_to_timestamp_from_nanosecond_period(freq):
+    # GH#63760 converting a nanosecond PeriodIndex with a coarser target must
+    #  yield a microsecond DatetimeIndex, not reinterpret the value as ns
+    pi = period_range("2020-01-01", periods=3, freq="ns")
+    result = pi.to_timestamp(freq)
+    expected = DatetimeIndex(["2020-01-01"] * 3, dtype="M8[us]")
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -812,6 +812,31 @@ class TestPeriodMethods:
         assert result.unit == unit
         assert result == Timestamp("2020-01-01")
 
+    @pytest.mark.parametrize("freq", ["ns", "1ns", offsets.Nano()])
+    def test_to_timestamp_end_nanosecond_target(self, freq):
+        # GH#63760 how="end" keeps nanosecond precision for a target freq
+        #  that normalizes to nanoseconds
+        per = Period("2020-01-01", freq="D")
+        result = per.to_timestamp(freq, how="E")
+        assert result.unit == "ns"
+        assert result == Timestamp("2020-01-01 23:59:59.999999999")
+
+    def test_to_timestamp_end_from_nanosecond_period(self):
+        # GH#63760 a nanosecond Period keeps its nanosecond end bound with a
+        #  coarser target freq
+        per = Period("2020-01-01", freq="ns")
+        result = per.to_timestamp("D", how="E")
+        assert result.unit == "ns"
+        assert result == Timestamp("2020-01-01")
+
+    def test_to_timestamp_end_bday_nanosecond_target(self):
+        # GH#63760 the B roll-forward path keeps nanosecond precision too
+        with tm.assert_produces_warning(FutureWarning, match=bday_msg):
+            per = Period("2020-01-02", freq="B")
+            result = per.to_timestamp("ns", how="E")
+        assert result.unit == "ns"
+        assert result == Timestamp("2020-01-02 23:59:59.999999999")
+
     # --------------------------------------------------------------
     # Rendering: __repr__, strftime, etc
 

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -789,6 +789,29 @@ class TestPeriodMethods:
         result = Period(ts).to_timestamp(freq=freq).microsecond
         assert result == expected
 
+    @pytest.mark.parametrize("freq", ["ns", "1ns", offsets.Nano()])
+    def test_to_timestamp_nanosecond_target(self, freq):
+        # GH#63760 the result unit is derived from the normalized target base,
+        #  so a freq that normalizes to nanoseconds (e.g. "1ns") must give a
+        #  correct nanosecond-unit Timestamp rather than misinterpreting the
+        #  nanosecond ordinal as microseconds
+        per = Period("2020-01-01", freq="D")
+        result = per.to_timestamp(freq)
+        assert result.unit == "ns"
+        assert result == Timestamp("2020-01-01")
+
+    @pytest.mark.parametrize(
+        "freq, unit", [(None, "ns"), ("D", "us"), ("s", "us"), ("us", "us")]
+    )
+    def test_to_timestamp_from_nanosecond_period(self, freq, unit):
+        # GH#63760 a nanosecond Period converted with a coarser (non-ns) target
+        #  must yield a microsecond Timestamp, not reinterpret the microsecond
+        #  value as nanoseconds
+        per = Period("2020-01-01", freq="ns")
+        result = per.to_timestamp(freq)
+        assert result.unit == unit
+        assert result == Timestamp("2020-01-01")
+
     # --------------------------------------------------------------
     # Rendering: __repr__, strftime, etc
 


### PR DESCRIPTION
GH-63760 changed ``Period.to_timestamp`` / ``PeriodIndex.to_timestamp`` to default to microsecond unit, but computed the result ``unit`` from the *raw, pre-normalization* ``freq`` argument (``freq == "ns"`` / ``self.freq.base == "ns"``). The actual dt64 resolution is decided by the *normalized target base*: ``period_ordinal_to_dt64`` / ``periodarr_to_dt64arr`` give nanoseconds only when the base is nanosecond, and microseconds otherwise. The two disagree in two cases:

- A target freq that normalizes to nanoseconds but isn't literally ``"ns"`` (e.g. ``"1ns"``, ``Nano()``): ``Period("2020", "D").to_timestamp("1ns")`` returned ``Timestamp("51969-08-29")`` (a nanosecond ordinal reinterpreted as microseconds).
- A nanosecond ``Period`` converted to a coarser target: ``Period("2020-01-01", "ns").to_timestamp("D")`` returned 1970 garbage with ``unit="ns"`` (a microsecond value reinterpreted as nanoseconds).
- The ``PeriodIndex`` array path raised a bare ``AssertionError`` (``assert dta.unit == unit``) on the same inputs.

Fix: derive ``unit`` from the normalized target ``base`` after freq normalization. The array-path assertion is now redundant (the produced data already carries the correct resolution) and is removed. For the ``how="E"`` branch — where the value ignores ``freq`` and routes through a ``how="start"`` recursion — the end-adjustment now takes its unit from the recursively computed timestamp's ``.unit``, removing the pre-normalization gate entirely.