### PR TITLE
BUG: MultiIndex.get_locs wrong rows for list-like partial-string keys

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4198,32 +4198,51 @@ class MultiIndex(Index):
                     # KeyError it can be ambiguous if this is a label or sequence
                     #  of labels
                     #  github.com/pandas-dev/pandas/issues/39424#issuecomment-871626708
-
-                    # GH#55786 Vectorized path: use the level's hashtable to
-                    # map all labels to codes at once, then use algos.isin
-                    # instead of looping with per-element _get_level_indexer.
                     if any(not is_hashable(x) for x in k):
+                        # e.g. slice
                         raise err
-                    level_codes = self.codes[i]
-                    k_codes = self.levels[i].get_indexer(k)
-                    # NaN labels are stored as code -1 and are absent
-                    # from levels, so get_indexer returns -1 for them.
-                    # Separate true missing labels from NaN labels.
-                    k_isna = isna(k if not isinstance(k, tuple) else list(k))
-                    na_count = k_isna.sum()
-                    missing_mask = k_codes == -1
-                    if na_count:
-                        if missing_mask.sum() > na_count:
+
+                    if self.levels[i]._supports_partial_string_indexing:
+                        # GH#64807 A level that supports partial indexing (e.g.
+                        #  DatetimeIndex/PeriodIndex) can map a single label to a
+                        #  *range* of positions (partial-string/partial-date
+                        #  slicing). The exact-match vectorized path below cannot
+                        #  express that, so resolve each label individually.
+                        for x in k:
+                            # GH 42351: not-founds raise KeyError (enforced in 2.0)
+                            item_indexer = self._get_level_indexer(
+                                x, level=i, indexer=indexer
+                            )
+                            if lvl_indexer is None:
+                                lvl_indexer = _to_bool_indexer(item_indexer)
+                            elif isinstance(item_indexer, slice):
+                                lvl_indexer[item_indexer] = True  # type: ignore[index]
+                            else:
+                                lvl_indexer |= item_indexer
+                    else:
+                        # GH#55786 Vectorized path: use the level's hashtable to
+                        # map all labels to codes at once, then use algos.isin
+                        # instead of looping with per-element _get_level_indexer.
+                        level_codes = self.codes[i]
+                        k_codes = self.levels[i].get_indexer(k)
+                        # NaN labels are stored as code -1 and are absent
+                        # from levels, so get_indexer returns -1 for them.
+                        # Separate true missing labels from NaN labels.
+                        k_isna = isna(k if not isinstance(k, tuple) else list(k))
+                        na_count = k_isna.sum()
+                        missing_mask = k_codes == -1
+                        if na_count:
+                            if missing_mask.sum() > na_count:
+                                raise KeyError(k) from None
+                            # NaN is in k but must also be present in the data
+                            if not lib.has_sentinel(level_codes, -1):
+                                raise KeyError(k) from None
+                        elif missing_mask.any():
                             raise KeyError(k) from None
-                        # NaN is in k but must also be present in the data
-                        if not lib.has_sentinel(level_codes, -1):
-                            raise KeyError(k) from None
-                    elif missing_mask.any():
-                        raise KeyError(k) from None
-                    k_codes = k_codes[~missing_mask]
-                    lvl_indexer = algos.isin(level_codes, k_codes)
-                    if na_count:
-                        lvl_indexer = lvl_indexer | (level_codes == -1)
+                        k_codes = k_codes[~missing_mask]
+                        lvl_indexer = algos.isin(level_codes, k_codes)
+                        if na_count:
+                            lvl_indexer = lvl_indexer | (level_codes == -1)
 
                 if lvl_indexer is None:
                     # no matches we are done

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -15,6 +15,7 @@ from pandas import (
     Index,
     MultiIndex,
     date_range,
+    period_range,
 )
 import pandas._testing as tm
 
@@ -1049,6 +1050,34 @@ def test_get_locs_list_like_nan_not_in_level():
     idx = MultiIndex.from_product([["a"], [1, 2]])
     with pytest.raises(KeyError, match="nan"):
         idx.get_locs((["a"], [np.nan]))
+
+
+@pytest.mark.parametrize(
+    "level",
+    [
+        date_range("2020-01-01", "2020-03-31", freq="D"),
+        period_range("2020-01-01", "2020-03-31", freq="D"),
+    ],
+)
+@pytest.mark.parametrize("keys", [["2020-02"], ["2020-02", "2020-03"]])
+def test_get_locs_list_like_partial_string(level, keys):
+    # GH#64807 - a list-like of partial-string keys on a level that supports
+    #  partial indexing (Datetime/Period) must match the same rows as the
+    #  scalar key, not just the exact-coerced timestamp.
+    idx = MultiIndex.from_product([level, ["a", "b"]])
+
+    result = idx.get_locs([keys])
+    expected = np.concatenate([idx.get_locs([key]) for key in keys])
+    expected.sort()
+    tm.assert_numpy_array_equal(result, expected)
+
+
+def test_get_locs_list_like_partial_string_missing_raises():
+    # GH#64807 - a partial-string key absent from the level still raises KeyError
+    level = date_range("2020-01-01", "2020-03-31", freq="D")
+    idx = MultiIndex.from_product([level, ["a", "b"]])
+    with pytest.raises(KeyError, match="2021-01"):
+        idx.get_locs([["2021-01"]])
 
 
 def test_get_indexer_for_multiindex_with_nans(nulls_fixture):


### PR DESCRIPTION
Regression from GH-64807: the vectorized list-like path in `MultiIndex.get_locs` used the level's exact-match `get_indexer`, so a list-like of partial-string keys on a Datetime/Period level silently matched only the exact-coerced timestamp (or raised `KeyError`) instead of the full partial-date range that the equivalent scalar key matches.

```python
mi = pd.MultiIndex.from_product([pd.date_range("2020-01-01", "2020-03-31"), ["a", "b"]])
mi.get_locs(["2020-02"])      # 58 rows
mi.get_locs([["2020-02"]])    # was 2 rows, now 58
```

Gate the fast `get_indexer` + `isin` path on `_supports_partial_string_indexing`: partial-indexing levels (Datetime/Period) fall back to per-element `_get_level_indexer` resolution; all other levels keep the fast path. The introducing PR is unreleased, so no whatsnew entry.