### PR TITLE
DEPR: warn for non-standard listlikes in numpy-dtype Series/Index arithmetic (GH#62423)

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -179,6 +179,10 @@ def _cat_compare_op(op):
         else:
             # allow categorical vs object dtype array comparisons for equality
             # these are only positional comparisons
+            # (hashable list-likes such as tuple/range take the branch above and
+            #  are already treated as scalar-like, so only non-standard
+            #  positional list-likes like ``deque`` warn here, GH#62423)
+            ops.maybe_warn_listlike(other)
             if opname not in ["__eq__", "__ne__"]:
                 raise TypeError(
                     f"Cannot compare a Categorical for op {opname} with "

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1680,6 +1680,11 @@ class IndexOpsMixin(OpsMixin):
         res_name = ops.get_op_result_name(self, other)
 
         lvalues = self._values
+        if not isinstance(lvalues, ExtensionArray) or isinstance(other, range):
+            # For EA-backed values the warning is emitted by the EA's own
+            # _arith_method; the exception is ``range``, which is converted to
+            # an ndarray below before it reaches the EA (GH#62423).
+            ops.maybe_warn_listlike(other)
         rvalues = extract_array(other, extract_numpy=True, extract_range=True)
         rvalues = ops.maybe_prepare_scalar_for_op(rvalues, lvalues.shape)
         rvalues = ensure_wrapped_if_datetimelike(rvalues)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7686,6 +7686,16 @@ class Index(IndexOpsMixin, PandasObject):
         ) != len(other):
             raise ValueError("Lengths must match to compare")
 
+        if (
+            not isinstance(self, ABCMultiIndex)
+            and not isinstance(self._values, ExtensionArray)
+            and self._values.dtype != object
+        ):
+            # MultiIndex and object dtype already treat a non-standard listlike
+            # as scalar-like; for EA-backed values the warning is emitted
+            # downstream by the EA (GH#62423).
+            ops.maybe_warn_listlike(other)
+
         if not isinstance(other, ABCMultiIndex):
             other = extract_array(other, extract_numpy=True)
         else:

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -18,6 +18,7 @@ from pandas.core.ops.array_ops import (
 from pandas.core.ops.common import (
     get_op_result_name,
     has_castable_attr,
+    maybe_warn_listlike,
     unpack_zerodim_and_defer,
 )
 from pandas.core.ops.invalid import invalid_comparison
@@ -78,6 +79,7 @@ __all__ = [
     "kleene_xor",
     "logical_op",
     "maybe_prepare_scalar_for_op",
+    "maybe_warn_listlike",
     "radd",
     "rand_",
     "rdiv",

--- a/pandas/core/ops/common.py
+++ b/pandas/core/ops/common.py
@@ -6,11 +6,20 @@ from __future__ import annotations
 
 from functools import wraps
 from typing import TYPE_CHECKING
+import warnings
 
-from pandas._libs.lib import item_from_zerodim
+import numpy as np
+
+from pandas._libs.lib import (
+    is_list_like,
+    item_from_zerodim,
+)
 from pandas._libs.missing import is_matching_na
+from pandas.errors import Pandas4Warning
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.generic import (
+    ABCDataFrame,
     ABCExtensionArray,
     ABCIndex,
     ABCSeries,
@@ -30,6 +39,32 @@ if TYPE_CHECKING:
 def has_castable_attr(obj) -> bool:
     attrs = ["__array__", "__dlpack__", "__arrow_c_array__", "__arrow_c_stream__"]
     return any(hasattr(obj, name) for name in attrs)
+
+
+def maybe_warn_listlike(other) -> None:
+    """
+    Warn when operating against a list-like that is neither a standard container
+    (``list``, ``np.ndarray``) nor a pandas object nor array-castable.
+
+    Such operations (e.g. with ``tuple``, ``range``, ``deque``) are deprecated
+    (GH#62423) and will treat ``other`` as scalar-like in a future version.
+    """
+    if (
+        is_list_like(other)
+        and not isinstance(
+            other,
+            (list, np.ndarray, ABCExtensionArray, ABCIndex, ABCSeries, ABCDataFrame),
+        )
+        and not has_castable_attr(other)
+    ):
+        warnings.warn(
+            f"Operation with {type(other).__name__} are deprecated. "
+            "In a future version these will be treated as scalar-like. "
+            "To retain the old behavior, explicitly wrap in a Series "
+            "instead.",
+            Pandas4Warning,
+            stacklevel=find_stack_level(),
+        )
 
 
 def unpack_zerodim_and_defer(name: str) -> Callable[[F], F]:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -7164,6 +7164,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             raise ValueError("Can only compare identically-labeled Series objects")
 
         lvalues = self._values
+        if not isinstance(lvalues, ExtensionArray) and lvalues.dtype != object:
+            # For EA-backed values the warning is emitted by the EA's own
+            # _cmp_method; object dtype already treats a non-standard listlike
+            # as scalar-like, so it needs no warning either (GH#62423).
+            ops.maybe_warn_listlike(other)
         rvalues = extract_array(other, extract_numpy=True, extract_range=True)
 
         res_values = ops.comparison_op(lvalues, rvalues, op)

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -1,3 +1,4 @@
+from collections import deque
 from datetime import (
     date,
     timedelta,
@@ -947,7 +948,14 @@ class TestNamePreservation:
                     # GH#52264 logical ops with dtype-less sequences deprecated
                     op(left, right)
                 return
-            result = op(left, right)
+
+            warn = None
+            depr_msg = "In a future version these will be treated as scalar-like"
+            if box is tuple:
+                # GH#62423 dunder ops with a tuple are deprecated
+                warn = Pandas4Warning
+            with tm.assert_produces_warning(warn, match=depr_msg):
+                result = op(left, right)
 
         assert isinstance(result, Series)
         if box in [Index, Series]:
@@ -1155,3 +1163,65 @@ def test_multiindex_single_entry_arith_preserves_all_levels():
     # division
     result_div = s1 / s2
     tm.assert_series_equal(result_div, Series([1.0], index=expected_index))
+
+
+# ----------------------------------------------------------------------
+# GH#62423 deprecate non-standard listlikes in arithmetic/comparison ops
+
+depr_msg = "In a future version these will be treated as scalar-like"
+
+# factories for non-standard listlikes holding [4, 5, 6]
+non_standard_listlikes = [
+    pytest.param(lambda: (4, 5, 6), id="tuple"),
+    pytest.param(lambda: range(4, 7), id="range"),
+    pytest.param(lambda: deque([4, 5, 6]), id="deque"),
+]
+
+
+@pytest.mark.parametrize("box", non_standard_listlikes)
+@pytest.mark.parametrize("klass", [Series, Index])
+def test_arith_cmp_non_standard_listlike_deprecated(klass, box):
+    # GH#62423 numpy-dtype Series/Index dunder ops with a non-standard listlike
+    #  (tuple/range/deque) are deprecated in favor of scalar-like treatment
+    obj = klass([1, 2, 3])
+
+    with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+        obj + box()
+    with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+        obj == box()
+
+
+def test_arith_ea_backed_range_deprecated():
+    # GH#62423 range is converted to an ndarray before it reaches the EA, so
+    #  the Series-level arith path is responsible for the warning
+    ser = Series([1, 2, 3], dtype="Int64")
+    with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+        ser + range(4, 7)
+
+
+@pytest.mark.parametrize("box", non_standard_listlikes)
+def test_cmp_object_dtype_non_standard_listlike_not_deprecated(box):
+    # GH#62423 object dtype already treats a non-standard listlike as scalar-like
+    #  on comparison, so it must not warn
+    for obj in [Series([1, 2, 3], dtype=object), Index([1, 2, 3], dtype=object)]:
+        with tm.assert_produces_warning(None):
+            obj == box()
+
+
+def test_cmp_multiindex_tuple_not_deprecated():
+    # GH#62423 MultiIndex already treats a tuple as a single (scalar) entry
+    mi = pd.MultiIndex.from_tuples([("a", 1), ("b", 2), ("c", 3)])
+    with tm.assert_produces_warning(None):
+        mi == ("a", 1)
+
+
+def test_cmp_categorical_positional_listlike_deprecated():
+    # GH#62423 a non-standard non-hashable listlike (deque) reaches the
+    #  positional comparison branch and is deprecated; a hashable tuple/range is
+    #  already treated as scalar-like and must not warn
+    cat = Categorical([1, 2, 3])
+    with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+        cat == deque([1, 2, 3])
+    for other in [(1, 2, 3), range(3)]:
+        with tm.assert_produces_warning(None):
+            cat == other

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -5,6 +5,8 @@ import string
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.arrays import SparseArray
@@ -402,7 +404,11 @@ def test_binary_ufunc_other_types(type_):
     a = pd.Series([1, 2, 3], name="name")
     b = type_([3, 4, 5])
 
-    result = np.add(a, b)
+    # GH#62423 tuple/deque operands are deprecated in favor of scalar-like
+    warn = None if type_ is list else Pandas4Warning
+    depr_msg = "In a future version these will be treated as scalar-like"
+    with tm.assert_produces_warning(warn, match=depr_msg):
+        result = np.add(a, b)
     expected = pd.Series(np.add(a.to_numpy(), b), name="name")
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
xref GH-62423

Follow-up to GH-62560, which deprecated arithmetic/comparison between pandas objects and non-standard list-likes (``tuple``, ``range``, ``deque`` → scalar-like in a future version) but did not fire for the most common spelling: numpy-dtype ``Series``/``Index`` **dunder** ops (``ser + tup``, ``ser == tup``, ``idx + range(...)`` were all silent).

Adds the warning via a shared ``ops.maybe_warn_listlike`` helper at the four uninstrumented sites: ``IndexOpsMixin._arith_method``, ``Series._cmp_method``, ``Index._cmp_method``, and ``Categorical._cat_compare_op``.

Deliberately left unwarned because the current behavior is *already* scalar-like (so nothing changes in the future):
- object-dtype comparison (routes a tuple through ``comp_method_OBJECT_ARRAY`` → ``scalar_compare``)
- ``MultiIndex`` comparison (a tuple is a single entry)
- hashable list-likes on ``Categorical`` (only the positional/non-hashable branch warns)

``range`` in arithmetic is caught before it is converted to an ndarray for the EA path, so it warns once (no double-warning for EA-backed values, which warn downstream).