### PR TITLE
DEPR: Deprecate CachedAccessor

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -124,6 +124,7 @@ Deprecations
 - Deprecated :meth:`ExcelFile.parse`, use :func:`read_excel` instead (:issue:`58247`)
 - Deprecated :meth:`Series.fillna`, :meth:`DataFrame.fillna`, and :meth:`Index.fillna` with an incompatible value that requires dtype casting. In a future version, this will raise instead. Explicitly cast to a common dtype before filling (:issue:`45153`)
 - Deprecated ``engine="fastparquet"`` and ``engine="auto"`` in :func:`read_parquet` and :meth:`DataFrame.to_parquet`. The ``fastparquet`` library has been retired; use ``engine="pyarrow"`` or do not pass ``engine`` to use the default. (:issue:`64597`)
+- Deprecated ``pandas.core.accessor.CachedAccessor``, use ``pandas.core.accessor.Accessor`` instead (:issue:`66215`).
 - Deprecated arithmetic operations between pandas objects (:class:`DataFrame`, :class:`Series`, :class:`Index`, and pandas-implemented :class:`ExtensionArray` subclasses) and list-likes other than ``list``, ``np.ndarray``, :class:`ExtensionArray`, :class:`Index`, :class:`Series`, :class:`DataFrame`. For e.g. ``tuple`` or ``range``, explicitly cast these to a supported object instead. In a future version, these will be treated as scalar-like for pointwise operation (:issue:`62423`)
 - Deprecated automatic dtype promotion when reindexing with a ``fill_value`` that cannot be held by the original dtype. Explicitly cast to a common dtype instead (:issue:`53910`)
 - Deprecated grouping by an index level name when the name matches multiple levels of a :class:`MultiIndex`. Use the level number instead (:issue:`49434`)

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -231,8 +231,21 @@ class Accessor:
 
 
 # Alias kept for downstream libraries
-# TODO: Deprecate as name is now misleading
-CachedAccessor = Accessor
+def __getattr__(name: str):
+    if name == "CachedAccessor":
+        import warnings
+
+        from pandas.util._exceptions import find_stack_level
+
+        warnings.warn(
+            f"{name} is deprecated and will be removed in a future version. "
+            "Use pandas.core.accessor.Accessor instead.",
+            FutureWarning,  # pdlint: ignore[warning_class]
+            stacklevel=find_stack_level(),
+        )
+        return Accessor
+
+    raise AttributeError(f"module 'pandas.core.accessor' has no attribute '{name}'")
 
 
 def _register_accessor(

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -231,9 +231,9 @@ class Accessor:
         return self._accessor(obj)
 
 
-# Alias kept for downstream libraries
 def __getattr__(name: str):
     if name == "CachedAccessor":
+        # Alias kept for downstream libraries
         warnings.warn(
             f"{name} is deprecated and will be removed in a future version. "
             "Use pandas.core.accessor.Accessor instead.",

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -14,6 +14,7 @@ from typing import (
 )
 import warnings
 
+from pandas.errors import Pandas4Warning
 from pandas.util._decorators import (
     set_module,
 )
@@ -233,14 +234,10 @@ class Accessor:
 # Alias kept for downstream libraries
 def __getattr__(name: str):
     if name == "CachedAccessor":
-        import warnings
-
-        from pandas.util._exceptions import find_stack_level
-
         warnings.warn(
             f"{name} is deprecated and will be removed in a future version. "
             "Use pandas.core.accessor.Accessor instead.",
-            FutureWarning,  # pdlint: ignore[warning_class]
+            Pandas4Warning,
             stacklevel=find_stack_level(),
         )
         return Accessor

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -121,3 +121,13 @@ def test_no_circular_reference(klass, registrar):
         assert obj.access.obj is obj
         del obj
         assert ref() is None
+
+
+def test_cached_accessor_deprecation():
+    # GH#66215
+    with tm.assert_produces_warning(
+        FutureWarning, match="CachedAccessor is deprecated"
+    ):
+        from pandas.core.accessor import CachedAccessor
+
+        _ = CachedAccessor

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -4,6 +4,8 @@ import weakref
 
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 import pandas._testing as tm
 from pandas.core import accessor
@@ -125,13 +127,9 @@ def test_no_circular_reference(klass, registrar):
 
 def test_cached_accessor_deprecation():
     # GH#66215
-    from pandas.errors import Pandas4Warning
-
     with tm.assert_produces_warning(
         Pandas4Warning, match="CachedAccessor is deprecated"
     ):
         from pandas.core.accessor import CachedAccessor
-
-        _ = CachedAccessor
 
     assert CachedAccessor is accessor.Accessor

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -125,9 +125,13 @@ def test_no_circular_reference(klass, registrar):
 
 def test_cached_accessor_deprecation():
     # GH#66215
+    from pandas.errors import Pandas4Warning
+
     with tm.assert_produces_warning(
-        FutureWarning, match="CachedAccessor is deprecated"
+        Pandas4Warning, match="CachedAccessor is deprecated"
     ):
         from pandas.core.accessor import CachedAccessor
 
         _ = CachedAccessor
+
+    assert CachedAccessor is accessor.Accessor


### PR DESCRIPTION
Closes #66215. Deprecates CachedAccessor as requested in the issue.