### PR TITLE
BUG: Fix rolling dropping inf values when window is Timedelta

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -470,6 +470,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.SeriesGroupBy.ohlc` ignoring ``as_index=False`` (:issue:`65140`)
 - Bug in :meth:`DataFrame.groupby` with a :class:`Grouper` with ``freq`` raising ``AttributeError`` when all grouping keys are ``NaT`` (:issue:`43486`)
 - Bug in :meth:`DataFrame.resample` dropping the result index name when resampling ``on`` a column with a pyarrow-backed datetime or duration dtype (:issue:`59823`)
+- Bug in :meth:`DataFrame.rolling` dropping ``inf`` values when ``window`` is a :class:`Timedelta` (:issue:`57549`)
 - Bug in :meth:`Series.resample` and :meth:`DataFrame.resample` where same-frequency resampling with monthly, quarterly, or annual frequencies bypassed aggregation, returning the original values instead of the aggregation result (:issue:`18553`)
 
 Reshaping

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -356,11 +356,6 @@ class BaseWindow(SelectionMixin):
         except (ValueError, TypeError) as err:
             raise TypeError(f"cannot handle this type -> {values.dtype}") from err
 
-        # Convert inf to nan for C funcs
-        inf = np.isinf(values)
-        if inf.any():
-            values = np.where(inf, np.nan, values)
-
         return values
 
     def _insert_on_column(self, result: DataFrame, obj: DataFrame) -> None:

--- a/pandas/tests/window/test_rolling_inf.py
+++ b/pandas/tests/window/test_rolling_inf.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+import pandas as pd
+import pandas._testing as tm
+
+
+def test_rolling_timedelta_inf():
+    # GH 57549
+    idx = pd.date_range("2024-02-01", "2024-02-21", freq="1d")
+    df = pd.DataFrame(index=idx)
+    df["A"] = df.index.day.astype(float)
+    df.iloc[-2, 0] = np.inf
+    df.iloc[-9, 0] = np.nan
+
+    res1 = df.rolling(window=pd.Timedelta("4d"), min_periods=1).mean()
+    res2 = df.rolling(window=4, min_periods=1).mean()
+
+    tm.assert_frame_equal(res1, res2)

--- a/pandas/tests/window/test_rolling_inf.py
+++ b/pandas/tests/window/test_rolling_inf.py
@@ -6,13 +6,13 @@ import pandas._testing as tm
 
 def test_rolling_timedelta_inf():
     # GH 57549
-    idx = pd.date_range("2024-02-01", "2024-02-21", freq="1d")
+    idx = pd.date_range("2024-02-01", "2024-02-21", freq="D")
     df = pd.DataFrame(index=idx)
     df["A"] = df.index.day.astype(float)
     df.iloc[-2, 0] = np.inf
     df.iloc[-9, 0] = np.nan
 
-    res1 = df.rolling(window=pd.Timedelta("4d"), min_periods=1).mean()
+    res1 = df.rolling(window=pd.Timedelta("4D"), min_periods=1).mean()
     res2 = df.rolling(window=4, min_periods=1).mean()
 
     tm.assert_frame_equal(res1, res2)


### PR DESCRIPTION
Closes #57549.

I used an AI agent (Claude) for writing tests for this PR.
