### PR TITLE
BUG: bare DateOffset(n) a no-op on vectorized path near DST (GH#61870)

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2008,6 +2008,11 @@ cdef class RelativeDeltaOffset(BaseOffset):
                     delta = delta.as_unit("ms")
                 else:
                     delta = delta.as_unit("s")
+            elif not kwds:
+                # GH#61870: bare DateOffset(n) with no keywords defaults to
+                # n days (matching the scalar path); without this branch it
+                # would incorrectly become a no-op on the vectorized path.
+                delta = Timedelta(days=1).as_unit("s")
             else:
                 delta = Timedelta(0).as_unit("s")
 

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -1281,6 +1281,23 @@ def test_dateoffset_days_vs_n_near_dst_transition():
     assert offset_days == offset_n
 
 
+@pytest.mark.parametrize("n", [1, 2, -1])
+@pytest.mark.parametrize("box", [DatetimeIndex, Series])
+def test_dateoffset_n_vectorized_near_dst_transition(box, n):
+    # GH#61870 bare DateOffset(n) was a no-op on the vectorized (array) path
+    # while the scalar path correctly added n days; results must agree with
+    # both the scalar path and DateOffset(days=n).
+    ts = Timestamp("2021-11-06 12:00", tz="US/Pacific")
+    obj = box([ts])
+
+    result = obj + offsets.DateOffset(n)
+    expected = obj + offsets.DateOffset(days=n)
+    tm.assert_equal(result, expected)
+
+    scalar = ts + offsets.DateOffset(n)
+    assert result[0] == scalar
+
+
 @pytest.mark.parametrize("n", [1, 2])
 @pytest.mark.parametrize(
     "unit",


### PR DESCRIPTION
Follow-up to GH-61870 / GH-61862, which aligned scalar `Timestamp + DateOffset(n)` with `DateOffset(days=n)` near DST but left the vectorized path broken.

Adding a keyword-less `DateOffset(n)` (integer `n`, no temporal kwds) to a `DatetimeIndex`/`Series` was a **complete no-op**, while scalar `Timestamp + DateOffset(n)` correctly added `n` days:

```python
ts = pd.Timestamp("2021-11-06 12:00", tz="US/Pacific")
ts + pd.DateOffset(1)                       # 2021-11-07 12:00 -08:00  (correct)
pd.DatetimeIndex([ts]) + pd.DateOffset(1)   # 2021-11-06 12:00 -07:00  (unchanged — bug)
pd.Series([ts]) + pd.DateOffset(1)          # unchanged — bug
```

`.shift(freq=DateOffset(n))` was likewise a silent no-op.

`RelativeDeltaOffset._pd_timedelta` builds its delta from `kwds` only. A bare `DateOffset` has empty `kwds` (with `_offset=relativedelta(days=1)`, `_use_relativedelta=True`), so `td_kwds` came out empty and the delta fell through to `Timedelta(0)` — the array path then added zero. The scalar path sidesteps this via its own `other + timedelta(self._n)` branch, hence the divergence.

Default the empty-kwds case to `n` days, so the vectorized path matches both the scalar path and `DateOffset(days=n)` (the years/months-only case still yields `Timedelta(0)`, since months are applied separately via `shift_months`). Since a bare `DateOffset` has `_use_relativedelta=True`, the array path runs on wall-clock values, keeping the result DST-consistent.

No whatsnew entry: GH-61870 is unreleased (3.1.0 dev), so this is a within-cycle regression; the existing `:issue:`61862`` note is now fully accurate.