### PR TITLE
BUG: rolling cov/corr NaN poisoning after empty window (GH#65739)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -464,6 +464,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.GroupBy.any` and :meth:`.GroupBy.all` returning ``NaN`` with ``float64`` dtype for unobserved categorical groups on NumPy ``bool`` data instead of the boolean identity value with ``bool`` dtype (:issue:`65100`)
 - Bug in :meth:`.Resampler.agg` raising ``ValueError`` with a dict of aggregations when applied to a :meth:`DataFrame.groupby` with ``as_index=False`` (:issue:`52397`)
 - Bug in :meth:`.Rolling.corr` and :meth:`.Rolling.cov` computing incorrect results on degenerate windows (:issue:`24019`)
+- Bug in :meth:`.Rolling.corr` and :meth:`.Rolling.cov` returning ``NaN`` for all later windows once a window contained no valid pairs, e.g. due to ``NaN`` values (:issue:`65739`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` (and their :class:`GroupBy` counterparts) returning ``0.0`` and ``-3.0`` respectively for degenerate windows or groups; these now return ``NaN`` (:issue:`62864`)
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
 - Bug in :meth:`.Rolling.sum`, :meth:`.Rolling.mean`, :meth:`.Rolling.median`, :meth:`.Rolling.min`, and :meth:`.Rolling.max` with ``method="table"``, ``engine="numba"``, and ``engine_kwargs={"parallel": True}`` could cause a segfault (:issue:`40454`)

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -801,13 +801,20 @@ cdef void remove_cov(
     dy = val_y - mean_y[0]
 
     nobs[0] -= 1
-    mean_x[0] -= dx / nobs[0]
-    mean_y[0] -= dy / nobs[0]
-    ssqdm_xy[0] -= (val_x - mean_x[0]) * dy
+    if nobs[0]:
+        mean_x[0] -= dx / nobs[0]
+        mean_y[0] -= dy / nobs[0]
+        ssqdm_xy[0] -= (val_x - mean_x[0]) * dy
 
-    if fabs(old_ssqdm_xy) * InvCondTol > fabs(ssqdm_xy[0]):
-        # possible catastrophic cancellation
-        numerically_unstable[0] = True
+        if fabs(old_ssqdm_xy) * InvCondTol > fabs(ssqdm_xy[0]):
+            # possible catastrophic cancellation
+            numerically_unstable[0] = True
+    else:
+        # GH#65739 avoid 0/0 -> NaN poisoning subsequent windows
+        mean_x[0] = 0
+        mean_y[0] = 0
+        ssqdm_xy[0] = 0
+        numerically_unstable[0] = False
 
 
 def roll_cov(const float64_t[:] x, const float64_t[:] y, ndarray[int64_t] start,
@@ -946,15 +953,24 @@ cdef void remove_corr(
     dy = val_y - mean_y[0]
 
     nobs[0] -= 1
-    mean_x[0] -= dx / nobs[0]
-    mean_y[0] -= dy / nobs[0]
-    ssqdm_xy[0] -= (val_x - mean_x[0]) * dy
-    ssqdm_x[0] -= (val_x - mean_x[0]) * dx
-    ssqdm_y[0] -= (val_y - mean_y[0]) * dy
+    if nobs[0]:
+        mean_x[0] -= dx / nobs[0]
+        mean_y[0] -= dy / nobs[0]
+        ssqdm_xy[0] -= (val_x - mean_x[0]) * dy
+        ssqdm_x[0] -= (val_x - mean_x[0]) * dx
+        ssqdm_y[0] -= (val_y - mean_y[0]) * dy
 
-    if fabs(old_ssqdm_xy) * InvCondTol > fabs(ssqdm_xy[0]):
-        # possible catastrophic cancellation
-        numerically_unstable[0] = True
+        if fabs(old_ssqdm_xy) * InvCondTol > fabs(ssqdm_xy[0]):
+            # possible catastrophic cancellation
+            numerically_unstable[0] = True
+    else:
+        # GH#65739 avoid 0/0 -> NaN poisoning subsequent windows
+        mean_x[0] = 0
+        mean_y[0] = 0
+        ssqdm_xy[0] = 0
+        ssqdm_x[0] = 0
+        ssqdm_y[0] = 0
+        numerically_unstable[0] = False
 
 
 def roll_corr(const float64_t[:] x, const float64_t[:] y, ndarray[int64_t] start,

--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -78,6 +78,20 @@ def test_rolling_cov_corr_degenerate(method, expected_values):
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "method,expected_last",
+    [("cov", 50.0), ("corr", 1.0)],
+)
+def test_rolling_cov_corr_nan_gap_recovery(method, expected_last):
+    # GH#65739 a window whose valid-pair count drops to 0 must not poison
+    # subsequent overlapping windows with NaN
+    a = Series([1.0, 10.0, 20.0, 30.0])
+    b = Series([1.0, np.nan, 20.0, 30.0])
+    result = getattr(a.rolling(2), method)(b)
+    expected = Series([np.nan, np.nan, np.nan, expected_last])
+    tm.assert_series_equal(result, expected)
+
+
 def test_rolling_corr_bias_correction():
     # test for correct bias correction
     a = Series(


### PR DESCRIPTION
Follow-up to GH-65739. The numerical-stability rewrite of rolling `cov`/`corr` introduced a regression: `remove_cov`/`remove_corr` divide by `nobs` without the `nobs==0` guard that `remove_var` already has. When a rolling window's valid-pair count drops to 0, the running mean becomes `0/0 -> NaN`, which then poisons every subsequent overlapping window (the instability-recompute check `fabs(old)*tol > fabs(NaN)` is `False`, so it never clears).

```python
x = pd.Series([1.0, 10.0, 20.0, 30.0])
y = pd.Series([1.0, np.nan, 20.0, 30.0])
x.rolling(2).cov(y)   # was all-NaN incl. i=3 (expected 50.0)
x.rolling(2).corr(y)  # was all-NaN incl. i=3 (expected 1.0)
```

Guarded `if nobs[0]:` around the Welford downdate in both helpers, mirroring `remove_var` exactly — when `nobs` hits 0, reset the running mean/co-moment accumulators to 0 and clear the instability flag instead of dividing by zero.

Verified against a brute-force per-window reference over 2000 randomized trials (random windows / `min_periods` with NaN gaps): 0 mismatches.