### PR TITLE
BUG: loc/iloc split-path 2D setitem with a list of 1-D arrays silently transposed (GH#64230)

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -3409,7 +3409,7 @@ class _iAtIndexer(_ScalarAccessIndexer):
 def _is_2d_value(value) -> bool:
     """Check if value is 2-dimensional, avoiding np.asarray for plain lists."""
     if isinstance(value, list):
-        return len(value) > 0 and isinstance(value[0], (list, tuple))
+        return len(value) > 0 and isinstance(value[0], (list, tuple, np.ndarray))
     return np.ndim(value) == 2
 
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -3409,7 +3409,13 @@ class _iAtIndexer(_ScalarAccessIndexer):
 def _is_2d_value(value) -> bool:
     """Check if value is 2-dimensional, avoiding np.asarray for plain lists."""
     if isinstance(value, list):
-        return len(value) > 0 and isinstance(value[0], (list, tuple, np.ndarray))
+        if len(value) == 0:
+            return False
+        first = value[0]
+        if isinstance(first, np.ndarray):
+            # a 0-d element is a scalar and a 2-D element makes value 3D
+            return first.ndim == 1
+        return isinstance(first, (list, tuple))
     return np.ndim(value) == 2
 
 

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -813,8 +813,25 @@ class TestiLocBaseIndependent:
         else:
             df.iloc[:, [0, 2]] = value
 
-        expected = DataFrame(np.array(value, dtype="float64"), columns=["a", "c"])
-        tm.assert_frame_equal(df[["a", "c"]], expected)
+        arr = np.array(value, dtype="float64")
+        expected = DataFrame(
+            {"a": arr[:, 0], "b": np.zeros(nrows, dtype="int64"), "c": arr[:, 1]}
+        )
+        tm.assert_frame_equal(df, expected)
+
+    @pytest.mark.parametrize("indexer", ["loc", "iloc"])
+    def test_setitem_split_path_list_of_arrays_single_column(self, indexer):
+        # GH#64230 a list of 1-D arrays targeting a single column is a shape
+        # mismatch, same as a list of lists; unlike mismatched-length tuples
+        # (GH#65264) arrays are not scalar-like, so no per-cell storage
+        df = DataFrame({"a": np.zeros(2, dtype=object), "b": [0, 0]})
+        value = [np.array([1, 2]), np.array([3, 4])]
+        msg = "Must have equal len keys and value when setting with an ndarray"
+        with pytest.raises(ValueError, match=msg):
+            if indexer == "loc":
+                df.loc[:, ["a"]] = value
+            else:
+                df.iloc[:, [0]] = value
 
     @pytest.mark.parametrize("indexer", ["loc", "iloc"])
     def test_setitem_split_path_list_of_0d_arrays(self, indexer):

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -794,6 +794,28 @@ class TestiLocBaseIndependent:
             else:
                 df.iloc[:, [0, 2]] = value
 
+    @pytest.mark.parametrize("indexer", ["loc", "iloc"])
+    @pytest.mark.parametrize("nrows", [2, 3])
+    def test_setitem_split_path_list_of_arrays_is_2d(self, indexer, nrows):
+        # GH#64230 a list of 1-D arrays is a 2D value (a list of rows), just
+        # like a list of lists / an ndarray; the split path used to transpose
+        # it into columns instead.
+        df = DataFrame(
+            {
+                "a": np.zeros(nrows),
+                "b": np.zeros(nrows, dtype="int64"),
+                "c": np.zeros(nrows),
+            }
+        )
+        value = [np.array([2 * i + 1, 2 * i + 2]) for i in range(nrows)]
+        if indexer == "loc":
+            df.loc[:, ["a", "c"]] = value
+        else:
+            df.iloc[:, [0, 2]] = value
+
+        expected = DataFrame(np.array(value, dtype="float64"), columns=["a", "c"])
+        tm.assert_frame_equal(df[["a", "c"]], expected)
+
     @pytest.mark.parametrize("has_ref", [True, False])
     @pytest.mark.parametrize("indexer", [[0], slice(None, 1, None), np.array([0])])
     @pytest.mark.parametrize("value", [["Z"], np.array(["Z"])])

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -816,6 +816,36 @@ class TestiLocBaseIndependent:
         expected = DataFrame(np.array(value, dtype="float64"), columns=["a", "c"])
         tm.assert_frame_equal(df[["a", "c"]], expected)
 
+    @pytest.mark.parametrize("indexer", ["loc", "iloc"])
+    def test_setitem_split_path_list_of_0d_arrays(self, indexer):
+        # GH#64230 0-d array elements are scalars, not rows, so a list of
+        # them is not a 2D value; set one scalar per column
+        df = DataFrame({"a": [0.0, 0.0], "b": [0, 0], "c": [0.0, 0.0]})
+        value = [np.array(1.0), np.array(2.0)]
+        if indexer == "loc":
+            df.loc[0, ["a", "c"]] = value
+        else:
+            df.iloc[0, [0, 2]] = value
+
+        expected = DataFrame({"a": [1.0, 0.0], "b": [0, 0], "c": [2.0, 0.0]})
+        tm.assert_frame_equal(df, expected)
+
+    @pytest.mark.parametrize("indexer", ["loc", "iloc"])
+    def test_setitem_split_path_list_of_2d_arrays(self, indexer):
+        # GH#64230 2-D array elements make the value 3D, not 2D; they get
+        # stored per-cell in an object column
+        df = DataFrame({"a": np.zeros(2, dtype=object), "b": [0, 0]})
+        value = [np.ones((2, 2)), np.zeros((2, 2))]
+        if indexer == "loc":
+            df.loc[:, ["a"]] = value
+        else:
+            df.iloc[:, [0]] = value
+
+        result = df["a"].tolist()
+        assert len(result) == 2
+        tm.assert_numpy_array_equal(result[0], value[0])
+        tm.assert_numpy_array_equal(result[1], value[1])
+
     @pytest.mark.parametrize("has_ref", [True, False])
     @pytest.mark.parametrize("indexer", [[0], slice(None, 1, None), np.array([0])])
     @pytest.mark.parametrize("value", [["Z"], np.array(["Z"])])


### PR DESCRIPTION
A list of equal-length 1-D arrays is a 2D value — a list of rows — just like a list of lists or a 2D ndarray. On the split (mixed-dtype) path, `_is_2d_value` only treated a `list` as 2D when its first element was a `list`/`tuple`, missing `ndarray`. As a result:

```python
df = pd.DataFrame({"a": [0.0, 0.0], "b": [0, 0], "c": [0.0, 0.0]})
df.loc[:, ["a", "c"]] = [np.array([1, 2]), np.array([3, 4])]
# a=[1, 2], c=[3, 4]  -- silently transposed
```

The equivalent `np.array([[1, 2], [3, 4]])` value, and the uniform-dtype (single-block) path, both correctly give `a=[1, 3], c=[2, 4]`. A non-square value (e.g. 3×2) wrongly raised `ValueError`.

This is a regression from GH-64230, which replaced `np.ndim(value) == 2` with the `_is_2d_value` fast path (`np.ndim` had treated a list of equal-length 1-D arrays as 2D). Fix by recognizing `ndarray` as a valid row type, restoring the prior behavior while keeping the fast path's avoidance of `np.asarray` on plain lists.

GH-64230 is unreleased (in the `3.1.0.dev0` whatsnew), so no whatsnew entry is added.