### PR TITLE
BUG: to_timedelta Day offset mixed with sub-second element (GH#64306)

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -523,11 +523,22 @@ def array_to_timedelta64(
 
             elif isinstance(item, Day):
                 # GH#64240: support Day offsets in list-like conversion
-                ival = item.n * 86400
                 item_reso = NPY_DATETIMEUNIT.NPY_FR_s
                 state.update_creso(item_reso)
                 if infer_reso:
                     creso = state.creso
+                try:
+                    # GH#64306 rescale to the array's resolution; when mixed
+                    #  with a finer-reso element the seconds value must be
+                    #  converted, not stored as-is.
+                    ival = convert_reso(
+                        item.n * 86400,
+                        NPY_DATETIMEUNIT.NPY_FR_s,
+                        creso,
+                        round_ok=True,
+                    )
+                except (OverflowError, OutOfBoundsDatetime) as err:
+                    raise OutOfBoundsTimedelta(item) from err
 
             else:
                 raise TypeError(f"Invalid type for timedelta scalar: {type(item)}")

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -406,6 +406,15 @@ class TestTimedeltas:
         expected = to_timedelta(["1D", "2D"]).as_unit("s")
         tm.assert_index_equal(result, expected)
 
+    @pytest.mark.parametrize("finer", ["ms", "us", "ns"])
+    def test_to_timedelta_day_offset_mixed_reso(self, finer):
+        # GH#64306 a Day offset mixed with a finer-resolution element must be
+        #  rescaled to the array's resolution, not stored as a raw seconds value
+        result = to_timedelta([to_offset("2D"), pd.Timedelta(1, unit=finer)])
+        expected = to_timedelta(["2D", f"1{finer}"]).as_unit(finer)
+        tm.assert_index_equal(result, expected)
+        assert result[0] == pd.Timedelta(2, unit="D")
+
     def test_float_to_timedelta_raise_oob_ns(self):
         value = np.float64(2**63)
         arr = np.array([value], dtype=np.float64)


### PR DESCRIPTION
The list-like path of :func:`to_timedelta` computed a ``Day`` offset as a raw seconds value (``item.n * 86400``) but never rescaled it to the array's inferred resolution. When a ``Day`` was mixed with any finer-resolution element, the resolution-inference second pass ran at the finer unit while the seconds value was stored verbatim, silently producing a wrong ``Day`` value:

```python
>>> to_timedelta([to_offset("D"), Timedelta(1, "ns")])
TimedeltaIndex(['0 days 00:00:00.000086400', '0 days 00:00:00.000000001'], dtype='timedelta64[ns]', freq=None)  # before
TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000000001'], dtype='timedelta64[ns]', freq=None)  # after
```

All-``Day`` lists stayed at seconds resolution, so the test added with the original feature (GH-64240, PR GH-64306) never exercised this path.

The ``Day`` branch now rescales through ``convert_reso``, mirroring the ``timedelta64`` branch, and raises ``OutOfBoundsTimedelta`` on overflow instead of silently wrapping.

No whatsnew entry: the Day-offset feature (GH-64240) is unreleased, so this defect never shipped.