### PR TITLE
BUG: date_range with end off-offset and periods dropped a period for anchored offsets (GH#64834)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -278,6 +278,7 @@ Datetimelike
 - Bug in :func:`date_range` where ``inclusive`` parameter failed to filter endpoints when only ``start`` and ``periods`` or ``end`` and ``periods`` were specified (:issue:`46331`)
 - Bug in :func:`date_range` where ``periods=1`` with offsets that disallow ``n=0`` (e.g. :class:`offsets.LastWeekOfMonth`, :class:`offsets.FY5253`) raised ``ValueError`` (:issue:`41563`)
 - Bug in :func:`date_range` where calendar-based offsets (e.g. ``MS``, ``ME``, ``QS``, ``YS``) could exclude the last offset boundary when ``end``'s time-of-day was earlier than ``start``'s (:issue:`35342`)
+- Bug in :func:`date_range` where passing ``end`` off the offset together with ``periods`` and an anchored offset (e.g. ``W-SUN``, ``ME``, ``MS``, ``QS``) silently returned fewer than ``periods`` dates (:issue:`64834`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` on ARM platforms where round ``float`` values outside the int64 domain (e.g. ``float(2**63)``) could silently produce incorrect results instead of raising (:issue:`64619`)
 - Bug in :func:`to_datetime` and :func:`to_timedelta` where ``uint64`` values greater than ``int64`` max silently overflowed instead of raising :class:`OutOfBoundsDatetime` or :class:`OutOfBoundsTimedelta` (:issue:`60677`)
 - Bug in :func:`to_datetime` when using a low time resolution ``unit``, higher resolution in ``origin`` is now preserved instead of silently dropped (e.g. ``unit="D"`` with microsecond precision origin) (:issue:`63419`)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -3195,6 +3195,15 @@ def _generate_range(
     else:
         end = None
 
+    # GH#64834 When deriving start from (end, periods), roll end onto the
+    # offset first so we don't lose a period. For B/bh this is handled by the
+    # vectorized path, but anchored offsets (W, ME, MS, QS, ...) reach here.
+    if end is not None and periods is not None and not offset.is_on_offset(end):
+        if offset.n >= 0:
+            end = offset.rollback(end)  # type: ignore[assignment]
+        else:
+            end = offset.rollforward(end)  # type: ignore[assignment]
+
     if start and not offset.is_on_offset(start):
         # Incompatible types in assignment (expression has type "datetime",
         # variable has type "Optional[Timestamp]")

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -3195,9 +3195,10 @@ def _generate_range(
     else:
         end = None
 
-    # GH#64834 When deriving start from (end, periods), roll end onto the
-    # offset first so we don't lose a period. For B/bh this is handled by the
-    # vectorized path, but anchored offsets (W, ME, MS, QS, ...) reach here.
+    # GH#64834/GH#65011 When deriving start from (end, periods), roll end onto
+    # the offset first so we don't lose a period. For B/bh this is handled by
+    # the vectorized path, but anchored offsets (W, ME, MS, QS, ...) reach here.
+    # Without this, periods=1 also leaves freq pinned to an off-grid end.
     if end is not None and periods is not None and not offset.is_on_offset(end):
         if offset.n >= 0:
             end = offset.rollback(end)  # type: ignore[assignment]

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -480,6 +480,23 @@ class TestDateRanges:
         with pytest.raises(ValueError, match=msg):
             date_range("1/1/2000", "1/1/2001", freq=MonthEnd(0))
 
+    @pytest.mark.parametrize(
+        "freq, periods, expected",
+        [
+            ("W-SUN", 3, ["2019-12-29", "2020-01-05", "2020-01-12"]),
+            ("W-MON", 3, ["2019-12-30", "2020-01-06", "2020-01-13"]),
+            ("ME", 2, ["2019-11-30", "2019-12-31"]),
+            ("MS", 2, ["2019-12-01", "2020-01-01"]),
+            ("QS", 2, ["2019-10-01", "2020-01-01"]),
+        ],
+    )
+    def test_date_range_end_off_offset_periods(self, freq, periods, expected):
+        # GH#64834 with end not on the offset, deriving start from
+        # (end, periods) dropped a period for anchored offsets
+        result = date_range(end="2020-01-15", periods=periods, freq=freq)
+        expected = DatetimeIndex(expected, freq=freq)
+        tm.assert_index_equal(result, expected)
+
     def test_range_bug(self, unit):
         # GH #770
         offset = DateOffset(months=3)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1104,6 +1104,24 @@ class TestGenRangeGeneration:
         result = date_range("2018-04-01", periods=1, freq=freq)
         assert len(result) == 1
 
+    @pytest.mark.parametrize(
+        "freq",
+        ["MS", "QS", "W-SUN", "ME", offsets.LastWeekOfMonth(1), offsets.FY5253(1)],
+    )
+    @pytest.mark.parametrize("periods", [1, 2, 3])
+    def test_generate_range_end_off_offset(self, freq, periods):
+        # GH#64834/GH#65011 with only end + periods, an off-offset end is rolled
+        # onto the grid (like start), so the result has the requested length and
+        # stays a valid index; previously periods=1 gave an off-grid Timestamp
+        # with freq still pinned (an invalid index) and periods>1 gave the wrong
+        # count.
+        end = Timestamp("2018-04-17")  # a Tuesday: off every freq above
+        result = date_range(end=end, periods=periods, freq=freq)
+
+        assert len(result) == periods
+        # round-trip re-pins the freq; raises if any value is off-grid
+        tm.assert_index_equal(DatetimeIndex(list(result), freq=freq), result)
+
     dt1, dt2 = "2017-01-01", "2017-01-01"
     tz1, tz2 = "US/Eastern", "Europe/London"
 


### PR DESCRIPTION
Addresses the still-live part of GH-64834. #65356 (the main-targeted redo of #64880) kept the tests and whatsnew but dropped the actual fix, on the assumption GH-64648 covered it. That's only true for `B`/`bh`, which use the vectorized daily-offset-mask path; anchored offsets fall through to `_generate_range` and stayed broken.

On main (silently returns fewer than `periods` dates):

```python
>>> len(pd.date_range(end="2020-01-15", periods=3, freq="W-SUN"))
2   # expected 3
>>> len(pd.date_range(end="2020-01-15", periods=2, freq="ME"))
1   # expected 2
```

`_generate_range` rolls `start` onto the offset but never `end`, so when `start` is derived from `(end, periods)` an off-offset `end` yields a `start` one step short. Fix rolls `end` onto the offset first (rollback for `n>=0`, rollforward for `n<0`), mirroring the existing start-rolling logic.

Verified byte-identical to pandas 2.2.3 across a 360-case `freq × end × periods` grid (incl. time-of-day, `bh`, `B`). Note GH-64834 is already closed, so no `closes` line here.