### PR TITLE
BUG: Timedelta/to_timedelta raise bare OverflowError for inf/overflowing floats (GH#63275)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -293,6 +293,7 @@ Timedelta
 ^^^^^^^^^
 - Bug in :attr:`TimedeltaIndex.resolution` raising when the index has no frequency (:issue:`65186`)
 - Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
+- Bug in :class:`Timedelta` constructor and :func:`to_timedelta` raising a bare ``OverflowError`` instead of :class:`OutOfBoundsTimedelta` for infinite or overflowing float input, which also prevented ``errors="coerce"`` from returning ``NaT`` (:issue:`63275`)
 - Bug in :class:`Timedelta` constructor and :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timedelta` constructor where keyword arguments (e.g. ``days=365000``) that exceeded nanosecond int64 bounds raised ``OutOfBoundsTimedelta`` instead of falling back to a coarser resolution (:issue:`46587`)
 - Bug in :meth:`Series.sum` on an overflowing ``timedelta64`` series raising a plain ``ValueError`` instead of :class:`OutOfBoundsTimedelta` (:issue:`43178`)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -498,11 +498,13 @@ def array_to_timedelta64(
                     ival = _numeric_to_td64ns(item, parsed_unit, creso)
 
             elif is_float_object(item):
-                int_item = int(item)
-                if item == int_item:
+                # GH#63275 use is_integer() (not int(item)) so that non-finite
+                #  floats fall through to _numeric_to_td64ns, which raises a
+                #  clear OutOfBoundsTimedelta rather than a bare OverflowError.
+                if item.is_integer():
                     # round float -> treat this like an int, giving
                     #  int_reso where possible
-                    item = int_item
+                    item = int(item)
 
                     if item == NPY_NAT:
                         ival = NPY_NAT
@@ -2348,15 +2350,25 @@ class Timedelta(_Timedelta):
                 if unit != "ns":
                     # Return with the closest-to-supported unit by going through
                     #  the timedelta64 path
-                    td = np.timedelta64(value, unit)
+                    try:
+                        td = np.timedelta64(value, unit)
+                    except OverflowError as err:
+                        # GH#63275 e.g. Timedelta(10**19, unit="s"); numpy
+                        #  raises a bare OverflowError, so re-raise as
+                        #  OutOfBoundsTimedelta for consistency.
+                        raise OutOfBoundsTimedelta(
+                            f"Cannot cast {value} from '{unit}' without overflow."
+                        ) from err
                     return cls(td)
                 value = _numeric_to_td64ns(value, unit)
 
         elif is_float_object(value):
-            int_item = int(value)
-            if value == int_item:
+            # GH#63275 use is_integer() (not int(value)) so that non-finite
+            #  floats fall through to _numeric_to_td64ns, which raises a clear
+            #  OutOfBoundsTimedelta rather than a bare OverflowError.
+            if value.is_integer():
                 # round float -> treat like an int, try to preserve unit
-                return cls(int_item, unit=unit)
+                return cls(int(value), unit=unit)
 
             # unit=None is de-facto 'ns'
             unit = parse_timedelta_unit(unit)

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -226,6 +226,32 @@ class TestTimedeltaConstructorUnitKeyword:
         assert td.unit == "ns"
         assert td == Timedelta(45_500, unit="ms")
 
+    @pytest.mark.parametrize("val", [np.inf, -np.inf])
+    def test_float_inf_raises(self, val):
+        # GH#63275 non-finite floats used to raise a bare OverflowError from
+        #  int(item); they should raise OutOfBoundsTimedelta (a ValueError)
+        #  so that errors="coerce" can catch them.
+        msg = "without overflow"
+        with pytest.raises(OutOfBoundsTimedelta, match=msg):
+            Timedelta(val)
+
+        with pytest.raises(OutOfBoundsTimedelta, match=msg):
+            to_timedelta(val)
+
+        assert to_timedelta(val, errors="coerce") is NaT
+
+    def test_round_float_overflow_unit(self):
+        # GH#63275 a round float whose value overflows int64 at the requested
+        #  unit should raise OutOfBoundsTimedelta, not a bare OverflowError
+        #  (the round float is routed through the integer path).
+        msg = "without overflow"
+        with pytest.raises(OutOfBoundsTimedelta, match=msg):
+            Timedelta(1e19, unit="s")
+
+        # matching integer behavior
+        with pytest.raises(OutOfBoundsTimedelta, match=msg):
+            Timedelta(10**19, unit="s")
+
 
 def test_construct_from_kwargs_overflow():
     # GH#55503

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -354,6 +354,20 @@ class TestTimedeltas:
         result2 = to_timedelta(arr2, unit="s")
         assert result2.unit == "ns"
 
+    @pytest.mark.parametrize("val", [np.inf, -np.inf])
+    def test_to_timedelta_object_inf(self, val):
+        # GH#63275 non-finite floats in an object array used to raise a bare
+        #  OverflowError from int(item); coerce should give NaT and the
+        #  default should raise OutOfBoundsTimedelta.
+        arr = np.array([1.0, val, 3.0], dtype=object)
+
+        result = to_timedelta(arr, errors="coerce")
+        expected = TimedeltaIndex([1, "NaT", 3])
+        tm.assert_index_equal(result, expected)
+
+        with pytest.raises(OutOfBoundsTimedelta, match="without overflow"):
+            to_timedelta(arr)
+
     def test_to_timedelta_unit_mixed_round_and_non_round_floats(self):
         # GH#65150 - round floats mixed with non-round floats should
         # respect the unit for all values


### PR DESCRIPTION
closes #63275

Non-finite float input (``inf``/``-inf``) to :class:`Timedelta` and :func:`to_timedelta` was routed through ``int(item)``, raising a bare ``OverflowError``. Since that isn't a ``ValueError``, ``errors="coerce"`` couldn't catch it either, so it also broke coercion to ``NaT``. Pandas 2.3.x gave ``NaT``/``OutOfBoundsTimedelta``.

- Both the object-array path (``array_to_timedelta64``) and the scalar ``Timedelta.__new__`` float branch now gate on ``item.is_integer()`` instead of ``int(item) == item`` (mirroring the existing pattern in ``tslib.pyx``). ``float("inf").is_integer()`` is ``False``, so non-finite floats fall through to ``_numeric_to_td64ns`` → ``OutOfBoundsTimedelta`` (a ``ValueError``, so ``coerce`` gives ``NaT``). NaN never reaches this branch — it's caught earlier by ``checknull_with_nat_and_na``.
- Folded in a related pre-existing quirk the round-float change routed floats into: an overflowing round float / integer with a coarse unit (e.g. ``Timedelta(1e19, unit="s")`` and ``Timedelta(10**19, unit="s")``) went through ``np.timedelta64(value, unit)``, which raises a bare ``OverflowError``. That call is now wrapped to re-raise ``OutOfBoundsTimedelta``.

The float64-dtype (non-object) array path goes through ``cast_from_unit_vectorized`` and is unaffected — its handling of out-of-bounds values under ``coerce`` is pre-existing and out of scope here.