### PR TITLE
BUG: PeriodIndex silently truncated out-of-bounds integer input (GH#64158)

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1644,6 +1644,11 @@ def from_calendar_ordinals(const int64_t[:] values, PeriodDtypeBase dtype):
         else:
             # equiv Period(val, freq=dtype.unit).ordinal, specialized
             #  bc we know val is an integer
+            if not INT32_MIN <= val <= INT32_MAX:
+                # val is used as the year, which lands in the int32
+                #  npy_datetimestruct.year field; out-of-range would silently
+                #  wrap, so raise to match the scalar Period(int) path.
+                raise OutOfBoundsDatetime(f"Out of bounds year: {val}")
             result[i] = period_ordinal(val, 1, 1, 0, 0, 0, 0, 0, dtype._dtype_code)
 
     return result.base

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -2,7 +2,10 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs.period import IncompatibleFrequency
-from pandas.errors import Pandas4Warning
+from pandas.errors import (
+    OutOfBoundsDatetime,
+    Pandas4Warning,
+)
 
 from pandas.core.dtypes.dtypes import PeriodDtype
 
@@ -363,6 +366,25 @@ class TestPeriodIndex:
 
         expected = PeriodIndex(vals.astype("M8[ns]"), freq="D")
         tm.assert_index_equal(pi, expected)
+
+    def test_constructor_int_array_out_of_bounds(self):
+        # GH#64158 integer values are interpreted as years; out-of-int32-range
+        #  values used to silently wrap instead of raising like Period(int)
+        arr = np.array([2**32 + 1985], dtype=np.int64)
+        msg = "Out of bounds year: 4294969281"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            PeriodIndex(arr, freq="Y")
+
+        # negative out-of-range and a nanosecond-epoch-like value also raise
+        for val in [-(2**32), 10**18]:
+            with pytest.raises(OutOfBoundsDatetime, match="Out of bounds year"):
+                PeriodIndex(np.array([val], dtype=np.int64), freq="Y")
+
+        # int32 boundaries and >4-digit years remain valid; for freq="Y" the
+        #  ordinal is year - 1970
+        for val in [2**31 - 1, -(2**31), 100000]:
+            result = PeriodIndex(np.array([val], dtype=np.int64), freq="Y")
+            assert result.asi8[0] == val - 1970
 
     @pytest.mark.parametrize("box", [None, "series", "index"])
     def test_constructor_datetime64arr_ok(self, box):


### PR DESCRIPTION
Regression from GH-64158. `PeriodIndex(integer_array, freq=freq)` interprets each integer as a year and feeds it into `period_ordinal`'s 32-bit `int` year parameter. Values outside the int32 range were silently wrapped into that field, so e.g. `PeriodIndex([2**32 + 1985], freq="Y")` returned year `1985` instead of raising — while the scalar `Period(2**32 + 1985, freq="Y")` path raises `OutOfBoundsDatetime`.

Validate the range and raise `OutOfBoundsDatetime` to match the scalar path, mirroring the guard `period_ordinals_from_fields` already applies to its year field.