### PR TITLE
BUG: PeriodArray._from_sequence integer interpretation flipped by NA (GH#64227)

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1691,8 +1691,12 @@ cdef int64_t _extract_ordinal(object item, PeriodDtypeBase dtype) except? -1:
     if checknull_with_nat(item) or item is C_NA:
         ordinal = NPY_NAT
     elif util.is_integer_object(item):
-        # GH#64227 treat ints as ordinals, matching PeriodIndex/period_array
-        ordinal = item
+        if item == NPY_NAT:
+            ordinal = NPY_NAT
+        else:
+            # GH#64227 treat integers as calendar years, matching the
+            #  int-array path (from_calendar_ordinals) and Period(int, freq)
+            ordinal = Period(item, freq=dtype).ordinal
     else:
         try:
             ordinal = item.ordinal

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -294,6 +294,12 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
             # test_constructor_empty_special has a case with an iter object
             scalars = list(scalars)
 
+        if isinstance(scalars, ExtensionArray) and scalars.dtype.kind in "iu":
+            # e.g. masked or arrow-backed integer array; np.asarray would cast
+            #  integers-with-NA to float and raise a misleading "floating point"
+            #  error below, so route through object dtype to keep the integers.
+            scalars = scalars.to_numpy(dtype=object, na_value=NaT)
+
         arrdata = np.asarray(scalars)
         if arrdata.dtype.kind == "f" and len(arrdata) > 0:
             if not lib.all_nans(arrdata):

--- a/pandas/tests/arrays/period/test_constructors.py
+++ b/pandas/tests/arrays/period/test_constructors.py
@@ -136,15 +136,45 @@ def test_from_sequence_allows_i8():
     result1 = pd.PeriodIndex(arr.asi8, dtype=arr.dtype).array
     result2 = period_array(arr.asi8, dtype=arr.dtype)
     result3 = PeriodArray._from_sequence(arr.asi8, dtype=arr.dtype)
-    # FIXME: GH#64227 this goes through a different path and gives different behavior
-    # result4 = PeriodArray._from_sequence(arr.asi8.astype(object), dtype=arr.dtype)
+    result4 = PeriodArray._from_sequence(arr.asi8.astype(object), dtype=arr.dtype)
     result5 = PeriodArray._from_sequence(list(arr.asi8), dtype=arr.dtype)
 
     tm.assert_period_array_equal(result1, expected)
     tm.assert_period_array_equal(result2, expected)
     tm.assert_period_array_equal(result3, expected)
-    # tm.assert_period_array_equal(result4, expected)
+    tm.assert_period_array_equal(result4, expected)
     tm.assert_period_array_equal(result5, expected)
+
+
+def test_from_sequence_integers_with_na_consistent():
+    # GH#64227 an int is interpreted as a calendar year regardless of whether
+    #  an NA is present; previously a None flipped ints to raw-ordinal values
+    expected = PeriodArray._from_sequence([2000, 2001], dtype="period[D]")
+    assert expected.tolist() == [pd.Period("2000", "D"), pd.Period("2001", "D")]
+
+    result = PeriodArray._from_sequence([2000, None], dtype="period[D]")
+    tm.assert_period_array_equal(result[:1], expected[:1])
+    assert result[1] is pd.NaT
+
+    # the integer NaT sentinel is still respected in the object path
+    result = PeriodArray._from_sequence([iNaT, 2001], dtype="period[D]")
+    assert result[0] is pd.NaT
+    tm.assert_period_array_equal(result[1:], expected[1:])
+
+
+@pytest.mark.parametrize("dtype", ["Int64", "UInt32", "int64[pyarrow]"])
+def test_from_sequence_masked_arrow_integers_with_na(dtype):
+    # GH#64227 masked/arrow integer arrays with NA used to raise a misleading
+    #  "does not allow floating point" TypeError from the np.asarray-float path
+    if "pyarrow" in dtype:
+        pytest.importorskip("pyarrow")
+    values = pd.array([2000, None], dtype=dtype)
+    result = PeriodArray._from_sequence(values, dtype="period[D]")
+
+    expected = PeriodArray._from_sequence(
+        [pd.Period("2000", "D"), None], dtype="period[D]"
+    )
+    tm.assert_period_array_equal(result, expected)
 
 
 def test_from_td64nat_sequence_raises():


### PR DESCRIPTION
Follow-up to GH-64231, which added integer support to `PeriodArray._from_sequence` but left two inconsistencies:

- **Integer interpretation flipped by NA.** The object path (`_extract_ordinal`) read integers as *raw ordinals* while the int-array path (`from_calendar_ordinals`) reads them as *calendar years*. Since an NA forces object dtype, adding a `None` silently flipped the interpretation:

  ```python
  pd.Series([2000, 2001], dtype="period[D]")  # -> 2000-01-01, 2001-01-01
  pd.Series([2000, None], dtype="period[D]")  # was -> 1975-06-24, NaT
  ```

  Year-like is canonical (matches scalar `Period(2000, freq="D")` and the examples in GH-64227), so object-path integers are now routed through `Period(item, freq)`, preserving the `NaT` sentinel.

- **Masked/arrow integer arrays with NA.** `PeriodArray._from_sequence(pd.array([2000, None], dtype="Int64"), dtype="period[D]")` raised a misleading `TypeError: PeriodArray does not allow floating point in construction`, because `np.asarray` casts integers-with-NA to float. These are now routed through object dtype so the integers survive; genuine float EAs are still rejected.