### PR TITLE
BUG: idxmax/idxmin wrong row for nullable UInt64 with NA, and when all values tie the NA sentinel fill (GH#64478)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -311,6 +311,7 @@ Numeric
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` returning incorrect row labels for nullable ``UInt64`` columns containing missing values alongside values above ``2**53`` (:issue:`64478`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` with ``axis=1`` and ``skipna=False`` returning incorrect column labels for extension array dtypes (e.g. :class:`BooleanDtype`, nullable integer/float, :class:`ArrowDtype`) (:issue:`56903`)
 - Fixed bug in :meth:`Series.clip` where passing a scalar numpy array (e.g. ``np.array(0)``) would raise a ``TypeError`` (:issue:`59053`)
+- Fixed bug in :meth:`Series.idxmax`, :meth:`Series.idxmin`, :meth:`DataFrame.idxmax`, and :meth:`DataFrame.idxmin` returning the label of a missing-value row when every non-missing value equals the dtype's minimum (for ``idxmax``) or maximum (for ``idxmin``), e.g. a float column containing only ``-inf`` and NaN (:issue:`64478`)
 - Fixed bug in :meth:`Series.mean` and :meth:`Series.sum` (and their :class:`DataFrame` counterparts) overflowing for ``float16`` dtypes instead of upcasting to ``float64`` (:issue:`43929`)
 - Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) returning ``0.0`` for degenerate distributions; these now return ``NaN`` (:issue:`62864`)
 - Fixed bug in complex-dtype :meth:`Series.duplicated` and :meth:`Series.unique` (and related hashtable-backed methods) raising ``TypeError`` when backed by a :class:`NumpyExtensionArray` (:issue:`54761`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -308,6 +308,7 @@ Numeric
 ^^^^^^^
 - Bug in :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`Series.min`, and :meth:`Series.max` on object-dtype data raising ``TypeError`` when missing values were present alongside values that do not support comparison with ``float`` (e.g. strings or mixed-timezone :class:`Timestamp` objects) (:issue:`65500`)
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
+- Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` returning incorrect row labels for nullable ``UInt64`` columns containing missing values alongside values above ``2**53`` (:issue:`64478`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` with ``axis=1`` and ``skipna=False`` returning incorrect column labels for extension array dtypes (e.g. :class:`BooleanDtype`, nullable integer/float, :class:`ArrowDtype`) (:issue:`56903`)
 - Fixed bug in :meth:`Series.clip` where passing a scalar numpy array (e.g. ``np.array(0)``) would raise a ``TypeError`` (:issue:`59053`)
 - Fixed bug in :meth:`Series.mean` and :meth:`Series.sum` (and their :class:`DataFrame` counterparts) overflowing for ``float16`` dtypes instead of upcasting to ``float64`` (:issue:`43929`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1205,9 +1205,10 @@ def nanargmax(
     """
     values, mask = _get_values(values, True, fill_value_typ="-inf", mask=mask)
     result = values.argmax(axis)
-    # error: Argument 1 to "_maybe_arg_null_out" has incompatible type "Any |
+    # error: Argument 1 to "_maybe_fix_arg_at_na" has incompatible type "Any |
     # signedinteger[Any]"; expected "ndarray[Any, Any]"
-    result = _maybe_arg_null_out(result, axis, mask, skipna)  # type: ignore[arg-type]
+    result = _maybe_fix_arg_at_na(result, mask, axis)  # type: ignore[arg-type]
+    result = _maybe_arg_null_out(result, axis, mask, skipna)
     return result
 
 
@@ -1251,9 +1252,10 @@ def nanargmin(
     """
     values, mask = _get_values(values, True, fill_value_typ="+inf", mask=mask)
     result = values.argmin(axis)
-    # error: Argument 1 to "_maybe_arg_null_out" has incompatible type "Any |
+    # error: Argument 1 to "_maybe_fix_arg_at_na" has incompatible type "Any |
     # signedinteger[Any]"; expected "ndarray[Any, Any]"
-    result = _maybe_arg_null_out(result, axis, mask, skipna)  # type: ignore[arg-type]
+    result = _maybe_fix_arg_at_na(result, mask, axis)  # type: ignore[arg-type]
+    result = _maybe_arg_null_out(result, axis, mask, skipna)
     return result
 
 
@@ -1414,6 +1416,30 @@ def nanprod(
     return _maybe_null_out(  # type: ignore[return-value]
         result, axis, mask, values.shape, min_count=min_count
     )
+
+
+def _maybe_fix_arg_at_na(
+    result: np.ndarray,
+    mask: npt.NDArray[np.bool_] | None,
+    axis: AxisInt | None,
+) -> np.ndarray:
+    # helper function for nanargmin/nanargmax: an argmin/argmax that landed on
+    # a masked position means the extremum equals the sentinel fill, so every
+    # unmasked value ties with the fill; the first unmasked position is the
+    # correct result (GH#64478)
+    if mask is None or not mask.any():
+        return result
+    if axis is None or mask.ndim == 1:
+        if mask.ravel()[result] and not mask.all():
+            # error: Incompatible return value type (got "signedinteger[_32Bit
+            # | _64Bit]", expected "ndarray[tuple[Any, ...], dtype[Any]]")
+            return (~mask).ravel().argmax()  # type: ignore[return-value]
+    else:
+        indexer = np.expand_dims(result, axis)
+        arg_is_na = np.take_along_axis(mask, indexer, axis).squeeze(axis)
+        if arg_is_na.any():
+            result = np.where(arg_is_na, (~mask).argmax(axis), result)
+    return result
 
 
 def _maybe_arg_null_out(

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -203,6 +203,15 @@ def _get_fill_value(
             return np.inf
         else:
             return -np.inf
+    elif dtype.kind == "u":
+        # Unsigned ints: use a uint64 sentinel so np.where keeps the values
+        # unsigned.  An int64 fill would force a uint64/int64 mix to promote to
+        # float64, losing precision for values above 2**53 and giving the wrong
+        # idxmin/idxmax/min/max (GH#64478).  u8max/0 also bracket the full
+        # uint64 range, unlike i8max which real values can exceed.
+        if fill_value_typ == "+inf":
+            return np.uint64(lib.u8max)
+        return np.uint64(0)
     elif fill_value_typ == "+inf":
         # need the max int here
         # Return as np.int64 so that np.where promotes the dtype

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1411,3 +1411,46 @@ def test_idxminmax_uint64_with_na():
     df = pd.DataFrame({"a": values})
     assert df.idxmax().tolist() == [2]
     assert df.idxmin().tolist() == [0]
+
+
+@pytest.mark.parametrize("tie_value", [0, 2**64 - 1])
+def test_nanargminmax_uint64_na_tie(tie_value):
+    # GH#64478 the NA fill values equal the dtype extremes; when every
+    # unmasked value ties with the fill, the NA position must not win
+    values = np.full(3, tie_value, dtype=np.uint64)
+    mask = np.array([True, False, False])
+    assert nanops.nanargmax(values, mask=mask) == 1
+    assert nanops.nanargmin(values, mask=mask) == 1
+
+
+def test_nanargminmax_int64_na_tie():
+    # GH#64478 same tie at the signed extremes
+    mask = np.array([True, False, False])
+    int64_info = np.iinfo(np.int64)
+    values = np.full(3, int64_info.min, dtype=np.int64)
+    assert nanops.nanargmax(values, mask=mask) == 1
+    values = np.full(3, int64_info.max, dtype=np.int64)
+    assert nanops.nanargmin(values, mask=mask) == 1
+
+
+def test_nanargminmax_float_inf_tie():
+    # GH#64478 NaN filled with -inf/+inf ties real infinities
+    assert nanops.nanargmax(np.array([np.nan, -np.inf, -np.inf])) == 1
+    assert nanops.nanargmin(np.array([np.nan, np.inf, np.inf])) == 1
+
+
+def test_idxminmax_uint64_all_zero_with_na():
+    # GH#64478 all-zero UInt64 column with a leading NA: idxmax must not
+    # return the NA row
+    df = pd.DataFrame({"a": pd.array([pd.NA, 0, 0], dtype="UInt64")})
+    assert df.idxmax().tolist() == [1]
+    assert df.idxmin().tolist() == [1]
+
+
+def test_idxminmax_float_inf_tie():
+    # GH#64478 2-D path: NaN filled with -inf/+inf ties real infinities
+    df = pd.DataFrame({"a": [np.nan, -np.inf, -np.inf], "b": [1.0, 3.0, 2.0]})
+    assert df.idxmax().tolist() == [1, 1]
+    assert df.idxmin().tolist() == [1, 0]
+    assert df["a"].idxmax() == 1
+    assert df["a"].idxmin() == 1

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1384,3 +1384,30 @@ def test_returned_dtype(disable_bottleneck, dtype, method, using_python_scalars)
         assert result.dtype == np.float64
     else:
         assert result.dtype == dtype
+
+
+@pytest.mark.parametrize("na_pos", [0, 3])
+def test_nanargminmax_uint64_with_mask(na_pos):
+    # GH#64478 the +/-inf fill for masked uint64 values must stay uint64;
+    # an int64 fill promotes uint64/int64 to float64 and loses precision above
+    # 2**53, and i8max cannot bracket uint64 values above 2**63.
+    values = np.array([2**63 + 1, 2**63 + 2, 2**63 + 3, 0], dtype=np.uint64)
+    mask = np.zeros(4, dtype=bool)
+    mask[na_pos] = True
+    valid = np.flatnonzero(~mask)
+
+    argmax = nanops.nanargmax(values, mask=mask)
+    argmin = nanops.nanargmin(values, mask=mask)
+    assert argmax == valid[values[valid].argmax()]
+    assert argmin == valid[values[valid].argmin()]
+
+    assert nanops.nanmax(values, mask=mask) == values[valid].max()
+    assert nanops.nanmin(values, mask=mask) == values[valid].min()
+
+
+def test_idxminmax_uint64_with_na():
+    # GH#64478 idxmax/idxmin on a nullable UInt64 column with values above 2**53
+    values = pd.array([2**63 + 1, 2**63 + 2, 2**63 + 3, pd.NA], dtype="UInt64")
+    df = pd.DataFrame({"a": values})
+    assert df.idxmax().tolist() == [2]
+    assert df.idxmin().tolist() == [0]


### PR DESCRIPTION
Fixes a regression introduced in GH-64478, plus the family of argmin/argmax sentinel-tie bugs it surfaced.

**Precision regression (GH-64478):** that PR changed the `+/-inf` sentinel fill in `nanops._get_fill_value` from a Python `int` to `np.int64(...)`. For `uint64` masked arrays this promotes the array to `float64` in `np.where` under NEP 50 (no common integer type for `uint64` + `int64`), silently losing precision for values above `2**53` — so `DataFrame.idxmax`/`idxmin` on a nullable `UInt64` column with missing values returned the wrong row. Fixed by returning `uint64` sentinels for unsigned dtypes (`u8max` for the min-fill, `0` for the max-fill), which keeps the array unsigned and also brackets the full `uint64` range (previously real values above `i8max` made the NA-fill the "minimum").

**Sentinel ties:** the NA fill values equal the dtype extremes, so real values can tie the fill, and `argmin`/`argmax` then return an NA position that precedes them. The `uint64` max-fill of `0` makes this common (e.g. an all-zero column with a leading NA). Fixed in `nanargmin`/`nanargmax`: a winner landing on a masked position means every unmasked value ties the fill, so the first unmasked position is returned instead. This also fixes the pre-existing analogues on main:

- `idxmax` on a float column containing only `-inf` and NaN returned the NaN row (`idxmin` with `+inf` likewise; both `Series` and `DataFrame`)
- `DataFrame.idxmax`/`idxmin` on nullable integer columns whose values all equal the dtype extreme (`i8min`/`i8max`/`u8max`) returned the NA row

🤖 Generated with [Claude Code](https://claude.com/claude-code)