### PR TITLE
BUG: setitem-with-expansion casting regressions from GH#62523

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -571,14 +571,29 @@ class ArrowExtensionArray(
             self._pa_array.type
         ):
             if arr.type.tz == self._pa_array.type.tz:
-                arr = arr.cast(self._pa_array.type)
+                try:
+                    arr = arr.cast(self._pa_array.type)
+                except pa.lib.ArrowInvalid:
+                    # GH#62523 a finer-resolution result can't be cast down to
+                    #  the original coarser unit without losing data; keep the
+                    #  inferred unit rather than raising
+                    pass
 
         elif pa.types.is_date(arr.type) and pa.types.is_date(self._pa_array.type):
             arr = arr.cast(self._pa_array.type)
         elif pa.types.is_time(arr.type) and pa.types.is_time(self._pa_array.type):
-            arr = arr.cast(self._pa_array.type)
+            try:
+                arr = arr.cast(self._pa_array.type)
+            except pa.lib.ArrowInvalid:
+                # GH#62523 as above for the timestamp branch
+                pass
         elif pa.types.is_decimal(arr.type) and pa.types.is_decimal(self._pa_array.type):
-            arr = arr.cast(self._pa_array.type)
+            try:
+                arr = arr.cast(self._pa_array.type)
+            except pa.lib.ArrowInvalid:
+                # GH#62523 rescaling to the original decimal type would lose
+                #  data; keep the inferred precision/scale rather than raising
+                pass
         elif pa.types.is_integer(arr.type) and pa.types.is_integer(self._pa_array.type):
             try:
                 arr = arr.cast(self._pa_array.type)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -68,6 +68,7 @@ from pandas.core import algorithms as algos
 import pandas.core.common as com
 from pandas.core.construction import (
     array as pd_array,
+    ensure_wrapped_if_datetimelike,
     extract_array,
     sanitize_array,
 )
@@ -2912,6 +2913,11 @@ class _iLocIndexer(_LocationIndexer):
             if len(self.obj._values):
                 # GH#22717 handle casting compatibility that np.concatenate
                 #  does incorrectly
+                # GH#62523 infer_and_maybe_downcast may return a raw M8/m8
+                #  ndarray for datetimelike; wrap it so concat_compat does not
+                #  mix a bare ndarray with the DatetimeArray/TimedeltaArray
+                #  _values
+                new_values = ensure_wrapped_if_datetimelike(new_values)
                 new_values = concat_compat([self.obj._values, new_values])
             self.obj._mgr = self.obj._constructor(
                 new_values, index=new_index, name=self.obj.name

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -4060,6 +4060,44 @@ def test_map_numeric_na_action():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "dtype, func, expected_dtype",
+    [
+        (
+            ArrowDtype(pa.timestamp("s")),
+            lambda x: x + timedelta(microseconds=123456),
+            ArrowDtype(pa.timestamp("us")),
+        ),
+        (
+            ArrowDtype(pa.time32("s")),
+            lambda x: x.replace(microsecond=123456),
+            ArrowDtype(pa.time64("us")),
+        ),
+        (
+            ArrowDtype(pa.decimal128(3, 1)),
+            lambda x: x + Decimal("0.01"),
+            ArrowDtype(pa.decimal128(3, 2)),
+        ),
+    ],
+)
+def test_map_finer_resolution_no_arrowinvalid(dtype, func, expected_dtype):
+    # GH#62523 mapping to a finer resolution/precision that cannot be cast
+    #  down to the original dtype should keep the finer dtype rather than
+    #  raising ArrowInvalid
+    if pa.types.is_timestamp(dtype.pyarrow_dtype):
+        data = [datetime(2020, 1, 1), datetime(2020, 1, 2)]
+    elif pa.types.is_time(dtype.pyarrow_dtype):
+        data = [time(1, 2, 3), time(4, 5, 6)]
+    else:
+        data = [Decimal("1.5"), Decimal("2.5")]
+
+    ser = pd.Series(data, dtype=dtype)
+    result = ser.map(func)
+    assert result.dtype == expected_dtype
+    expected = pd.Series([func(x) for x in data], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
 def test_categorical_from_arrow_dictionary():
     # GH 60563
     df = pd.DataFrame(

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -2481,6 +2481,49 @@ class TestLocSetitemWithExpansion:
         expected = Series([ts1, ts2], dtype="date32[pyarrow]")
         tm.assert_series_equal(ser, expected)
 
+    @pytest.mark.parametrize(
+        "values, item",
+        [
+            (
+                to_datetime(["2020-01-01", "2020-01-02"]).as_unit("us"),
+                Timestamp("2020-01-03"),
+            ),
+            (to_timedelta([1, 2], unit="D").as_unit("us"), Timedelta(days=3)),
+        ],
+    )
+    def test_loc_setitem_with_expansion_datetimelike_retains_dtype(self, values, item):
+        # GH#62523 naive datetime64/timedelta64 setitem-with-expansion used to
+        #  raise AttributeError instead of retaining dtype
+        ser = Series(values)
+        ser.loc[2] = item
+        expected = Series([*values, item], dtype=values.dtype)
+        tm.assert_series_equal(ser, expected)
+
+        # a missing (NaT) value should behave the same way
+        ser2 = Series(values)
+        ser2.loc[2] = pd.NaT
+        expected2 = Series([*values, pd.NaT], dtype=values.dtype)
+        tm.assert_series_equal(ser2, expected2)
+
+    @td.skip_if_no("pyarrow")
+    def test_loc_setitem_with_expansion_pyarrow_finer_resolution(self):
+        # GH#62523 expanding with a finer-resolution value that cannot be cast
+        #  down to the original coarser unit should keep the finer unit rather
+        #  than raising ArrowInvalid
+        ser = Series(
+            to_datetime(["2020-01-01", "2020-01-02"]), dtype="timestamp[s][pyarrow]"
+        )
+        ser.loc[2] = Timestamp("2020-01-03 00:00:00.123456")
+        expected = Series(
+            [
+                Timestamp("2020-01-01"),
+                Timestamp("2020-01-02"),
+                Timestamp("2020-01-03 00:00:00.123456"),
+            ],
+            dtype="timestamp[us][pyarrow]",
+        )
+        tm.assert_series_equal(ser, expected)
+
     def test_loc_setitem_with_expansion_multiindex_retains_dtypes(self):
         # GH#17026
         mi = MultiIndex.from_tuples([("a", "c"), ("b", "c"), ("c", "d")])


### PR DESCRIPTION
Follow-up to GH-62523, fixing two live defects it left behind. Both only affect the unreleased 3.1.0 development line, so no whatsnew entry is added.

**1. Naive `datetime64`/`timedelta64` setitem-with-expansion crashed.** `ser.loc[new_label] = value` on a naive datetimelike Series raised `AttributeError: 'numpy.ndarray' object has no attribute '_ndarray'` for any value. `infer_and_maybe_downcast` returns a raw M8/m8 ndarray for these dtypes, which `concat_compat` then mixed with the `DatetimeArray`/`TimedeltaArray` `_values` in its homogeneity-assuming fastpath. Fixed by wrapping the result with `ensure_wrapped_if_datetimelike` before the concat. (tz-aware and `Period` were unaffected because their `ExtensionDtype` avoids that fastpath.)

**2. Arrow `_cast_pointwise_result` raised `ArrowInvalid` on cross-resolution results.** The `timestamp`/`time`/`decimal` branches cast the inferred result back to the original type with no guard, so a finer-resolution/precision result that could not be cast down (e.g. `timestamp[us]` into a `timestamp[s]` column, or a rescaled `decimal`) raised instead of retaining the finer type. This affected both setitem-with-expansion and `map`/`agg`. Fixed by catching `ArrowInvalid` and keeping the inferred type, matching the existing `integer`/`floating` branches. (The `date` branch is safe — dates are whole days.)

Regression tests added in `test_loc.py` (setitem-with-expansion) and `test_arrow.py` (map path).