### PR TITLE
BUG: tz_localize/tz_convert wrong for non-nanosecond resolution before 1677

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -301,6 +301,7 @@ Timedelta
 Timezones
 ^^^^^^^^^
 - Bug in :class:`DatetimeIndex` addition with a :class:`DateOffset` that has only timedelta components (e.g. ``DateOffset(hours=-2)``) raising ``ValueError`` near DST transitions, while scalar :class:`Timestamp` addition worked correctly (:issue:`28610`)
+- Bug in :meth:`Series.dt.tz_localize` and :meth:`Series.dt.tz_convert` (and their :class:`DatetimeIndex` counterparts) returning incorrect results for non-nanosecond resolutions (e.g. ``"s"``, ``"ms"``, ``"us"``) on timestamps before roughly 1677 (:issue:`66252`)
 - Bug in :meth:`Timestamp.to_julian_date` and :meth:`DatetimeIndex.to_julian_date` returning the Julian date of the local wall clock for timezone-aware inputs instead of the underlying UTC instant (:issue:`54763`)
 -
 

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -96,16 +96,22 @@ cdef class Localizer:
                 #  of seconds.
                 # TODO: avoid these np.array calls
                 if creso == NPY_DATETIMEUNIT.NPY_FR_us:
-                    trans = np.array(trans) // 1_000
-                    deltas = np.array(deltas) // 1_000
+                    divisor = 1_000
                 elif creso == NPY_DATETIMEUNIT.NPY_FR_ms:
-                    trans = np.array(trans) // 1_000_000
-                    deltas = np.array(deltas) // 1_000_000
+                    divisor = 1_000_000
                 elif creso == NPY_DATETIMEUNIT.NPY_FR_s:
-                    trans = np.array(trans) // 1_000_000_000
-                    deltas = np.array(deltas) // 1_000_000_000
+                    divisor = 1_000_000_000
                 else:
                     raise NotImplementedError(creso)
+
+                trans = np.array(trans)
+                # trans[0] is the NPY_NAT+1 "beginning of time" sentinel; a
+                #  plain floordiv would scale it up to a real (~1677) value,
+                #  mislocalizing earlier timestamps, so preserve it exactly.
+                trans_sentinel = trans == NPY_NAT + 1
+                trans = trans // divisor
+                trans[trans_sentinel] = NPY_NAT + 1
+                deltas = np.array(deltas) // divisor
 
             self.trans = trans
             self.ntrans = self.trans.shape[0]

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -130,6 +130,29 @@ class TestNonNano:
         assert res._creso == dta._creso
         assert res == dti.std().floor(unit)
 
+    def test_tz_convert_localize_pre_1677_non_nano(self, unit):
+        # GH#66252 the NPY_NAT+1 "beginning of time" transition sentinel was
+        #  scaled along with the real transitions when localizing a non-nano
+        #  resolution, so tz-aware values before ~1677 (not representable in
+        #  nanoseconds) bisected past the transitions and got a garbage offset
+        #  from an out-of-bounds read.
+        arr = np.array(["1600-01-01"], dtype=f"M8[{unit}]")
+        dta = DatetimeArray._simple_new(arr, dtype=arr.dtype)
+
+        # Asia/Kolkata observed LMT (UTC+05:53:28) for all dates before 1854
+        result = dta.tz_localize("UTC").tz_convert("Asia/Kolkata")
+        assert result[0].tz_localize(None) == pd.Timestamp("1600-01-01 05:53:28")
+        # and the original UTC instant is recovered
+        assert result.tz_convert("UTC").tz_localize(None)[0] == pd.Timestamp(
+            "1600-01-01"
+        )
+
+        # localize direction is affected by the same sentinel
+        localized = dta.tz_localize("Asia/Kolkata")
+        assert localized.tz_convert("UTC").tz_localize(None)[0] == pd.Timestamp(
+            "1599-12-31 18:06:32"
+        )
+
     @pytest.mark.filterwarnings("ignore:Converting to PeriodArray.*:UserWarning")
     def test_to_period(self, dta_dti):
         dta, dti = dta_dti


### PR DESCRIPTION
Non-nanosecond ``Localizer.__cinit__`` scales the timezone transition/offset arrays from nanoseconds down to the target resolution with floordiv. The first transition is the ``NPY_NAT + 1`` ("beginning of time") sentinel, and floor-dividing it turns it into a real value around 1677 — essentially the nanosecond floor, which is why nanosecond resolution never hit this.

For ``s``/``ms``/``us`` resolutions, any tz-aware value before ~1677 then sorts *before* the corrupted sentinel, so ``bisect_right(...) - 1`` yields ``pos == -1`` and ``deltas[-1]`` is read out of bounds (wraparound is disabled), giving non-deterministic garbage. The same ``Localizer`` drives both directions, so ``tz_convert`` returned garbage wall times and ``tz_localize`` raised spurious "nonexistent time" errors.

Repro:

```python
pd.Series(np.array(["1600-01-01"], "M8[s]")).dt.tz_localize("UTC").dt.tz_convert("Asia/Kolkata")
```

Fix: preserve the ``NPY_NAT + 1`` sentinel exactly through the scaling (a real transition can never equal ``INT64_MIN + 1``). Verified that non-nanosecond results now match nanosecond ground truth and stdlib ``zoneinfo`` across a range of timezones and dates spanning 1678–2262.

Pre-existing since GH-47299 (non-nanosecond support). No standalone issue was filed; opening as a draft.