### PR TITLE
BUG: Fix cummax/cummin on floating ArrowDtype returning sentinel values

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -499,6 +499,7 @@ ExtensionArray
 - Bug in :meth:`DataFrame.any` and :meth:`DataFrame.all` with ``skipna=False`` not propagating ``pd.NA`` on numpy-nullable columns (``boolean``, ``Int*``, ``UInt*``, ``Float*``); ``axis=0`` raised ``ValueError`` and ``axis=1`` returned a concrete ``True``/``False`` (:issue:`65710`)
 - Bug in numpy ufuncs like :func:`numpy.isnan` raising ``TypeError`` on :class:`Series` or :class:`Index` backed by PyArrow dtypes when ``future.distinguish_nan_and_na`` is ``True`` (:issue:`62506`)
 - Fixed bug in :meth:`Series.apply` and :meth:`Series.map` where nullable integer dtypes were converted to float, causing precision loss for large integers; now the nullable dtype will be preserved (:issue:`63903`).
+- Fixed bug in :meth:`Series.cummax` and :meth:`Series.cummin` (and their :class:`DataFrame` counterparts) with floating-point :class:`ArrowDtype` returning a finite sentinel value instead of the correct running maximum/minimum (:issue:`66257`)
 - Fixed the :attr:`~Series.is_monotonic_increasing` and :attr:`~Series.is_monotonic_decreasing` properties to dispatch to the underlying :class:`ExtensionArray` implementation (:issue:`65585`)
 -
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2375,6 +2375,9 @@ class ArrowExtensionArray(
             else:
                 data_to_accum = data_to_accum.cast(pa.int64())
 
+        if name in ("cummax", "cummin") and pa.types.is_floating(data_to_accum.type):
+            kwargs["start"] = float("-inf") if name == "cummax" else float("inf")
+
         try:
             result = pyarrow_meth(data_to_accum, skip_nulls=skipna, **kwargs)
         except pa.ArrowNotImplementedError as err:

--- a/pandas/tests/frame/test_cumulative.py
+++ b/pandas/tests/frame/test_cumulative.py
@@ -105,3 +105,12 @@ class TestDataFrameCumulativeOps:
         result = getattr(df, method)(axis=axis, numeric_only=True)
         expected = getattr(df_numeric_only, method)(axis)
         tm.assert_frame_equal(result, expected)
+
+    def test_cummax_pyarrow_float_negative(self):
+        # GH#66257
+        pytest.importorskip("pyarrow")
+        df = DataFrame({"a": [-4.0, -3.0, -2.0]}, dtype="float64[pyarrow]")
+
+        result = df.cummax()
+        expected = DataFrame({"a": [-4.0, -3.0, -2.0]}, dtype="float64[pyarrow]")
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/series/test_cumulative.py
+++ b/pandas/tests/series/test_cumulative.py
@@ -282,3 +282,47 @@ class TestSeriesCumulativeOps:
         msg = re.escape(f"operation 'cumprod' not supported for dtype '{ser.dtype}'")
         with pytest.raises(TypeError, match=msg):
             ser.cumprod(skipna=skipna)
+
+    @pytest.mark.parametrize("dtype", ["float64[pyarrow]", "float32[pyarrow]"])
+    @pytest.mark.parametrize(
+        "values, expected",
+        [
+            ([-4.0, -3.0, -2.0], [-4.0, -3.0, -2.0]),
+            ([float("-inf"), -1.0], [float("-inf"), -1.0]),
+            ([-4.0, -3.0, 5.0, -2.0], [-4.0, -3.0, 5.0, 5.0]),
+        ],
+    )
+    def test_cummax_pyarrow_float_uses_negative_infinity_start(
+        self, dtype, values, expected
+    ):
+        # GH#66257
+        pytest.importorskip("pyarrow")
+        ser = pd.Series(values, dtype=dtype)
+
+        result = ser.cummax()
+        expected = pd.Series(expected, dtype=dtype)
+        tm.assert_series_equal(result, expected)
+
+    def test_cummin_pyarrow_float_uses_infinity_start(self):
+        # GH#66257
+        pytest.importorskip("pyarrow")
+        ser = pd.Series([float("inf"), float("inf"), 1.0], dtype="float64[pyarrow]")
+
+        result = ser.cummin()
+        expected = pd.Series(
+            [float("inf"), float("inf"), 1.0], dtype="float64[pyarrow]"
+        )
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("skipna", [True, False])
+    def test_cummax_pyarrow_float_with_nulls(self, skipna):
+        # GH#66257
+        pytest.importorskip("pyarrow")
+        ser = pd.Series([-4.0, None, -2.0], dtype="float64[pyarrow]")
+
+        result = ser.cummax(skipna=skipna)
+        if skipna:
+            expected = pd.Series([-4.0, None, -2.0], dtype="float64[pyarrow]")
+        else:
+            expected = pd.Series([-4.0, None, None], dtype="float64[pyarrow]")
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Passed an explicit start (-inf for cummax, +inf for cummin) to pyarrow's float accumulator instead of its default, which used the largest/smallest finite float and clamped the running extreme. 

- [X] closes #66257 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
