### PR TITLE
DOC: Include `AbstractHolidayCalendar`, `Holiday`, and `JsonReader` in the API reference

### DIFF
--- a/doc/source/reference/io.rst
+++ b/doc/source/reference/io.rst
@@ -90,6 +90,7 @@ JSON
 .. autosummary::
    :toctree: api/
 
+   JsonReader
    build_table_schema
 
 .. currentmodule:: pandas

--- a/doc/source/reference/io.rst
+++ b/doc/source/reference/io.rst
@@ -90,8 +90,14 @@ JSON
 .. autosummary::
    :toctree: api/
 
-   JsonReader
    build_table_schema
+
+.. currentmodule:: pandas.api.typing
+
+.. autosummary::
+   :toctree: api/
+
+   JsonReader
 
 .. currentmodule:: pandas
 

--- a/doc/source/reference/offset_frequency.rst
+++ b/doc/source/reference/offset_frequency.rst
@@ -1461,3 +1461,16 @@ Frequencies
    :toctree: api/
 
    to_offset
+
+.. _api.holiday:
+
+==================
+Holiday calendars
+==================
+.. currentmodule:: pandas.tseries.holiday
+
+.. autosummary::
+   :toctree: api/
+
+   AbstractHolidayCalendar
+   Holiday

--- a/pandas/io/json/__init__.py
+++ b/pandas/io/json/__init__.py
@@ -1,5 +1,4 @@
 from pandas.io.json._json import (
-    JsonReader,
     read_json,
     to_json,
     ujson_dumps,
@@ -8,7 +7,6 @@ from pandas.io.json._json import (
 from pandas.io.json._table_schema import build_table_schema
 
 __all__ = [
-    "JsonReader",
     "build_table_schema",
     "read_json",
     "to_json",

--- a/pandas/io/json/__init__.py
+++ b/pandas/io/json/__init__.py
@@ -1,4 +1,5 @@
 from pandas.io.json._json import (
+    JsonReader,
     read_json,
     to_json,
     ujson_dumps,
@@ -7,6 +8,7 @@ from pandas.io.json._json import (
 from pandas.io.json._table_schema import build_table_schema
 
 __all__ = [
+    "JsonReader",
     "build_table_schema",
     "read_json",
     "to_json",

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -964,11 +964,14 @@ class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
     Parameters
     ----------
     filepath_or_buffer : a str path, path object or file-like object
-        Any valid string path, ``os.PathLike``, or file-like object with a
-        ``read()`` method.
+        Any valid string path is acceptable. The string could be a URL. Valid
+        URL schemes include http, ftp, s3, and file. pandas accepts any
+        ``os.PathLike``, or file-like object with a ``read()`` method, such
+        as a file handle or ``StringIO``.
     orient : str
-        Indication of expected JSON string format. See
-        :func:`~pandas.read_json` for the set of possible orients.
+        Indication of expected JSON string format. Compatible JSON strings
+        can be produced by ``to_json()`` with a corresponding orient value.
+        See :func:`~pandas.read_json` for the set of possible orients.
     typ : {"frame", "series"}
         The type of object to recover.
     dtype : bool or dict
@@ -978,39 +981,52 @@ class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
         Try to convert the axes to the proper dtypes.
     convert_dates : bool or list of str
         If True then default datelike columns may be converted (depending on
-        ``keep_default_dates``). If a list of column names, then those
-        columns will be converted in addition to any default datelike
-        columns.
+        ``keep_default_dates``). If False, no dates will be converted. If a
+        list of column names, then those columns will be converted and
+        default datelike columns may also be converted (depending on
+        ``keep_default_dates``).
     keep_default_dates : bool
         If parsing dates (``convert_dates`` is not False), then try to parse
-        the default datelike columns.
+        the default datelike columns. See :func:`~pandas.read_json` for the
+        criteria used to determine whether a column label is datelike.
     precise_float : bool
         Set to enable usage of higher precision (strtod) function when
         decoding string to double values.
     date_unit : str or None
-        The timestamp unit to detect if converting dates.
+        The timestamp unit to detect if converting dates. The default
+        behaviour is to try and detect the correct precision, but if this
+        is not desired then pass one of 's', 'ms', 'us' or 'ns' to force
+        parsing only seconds, milliseconds, microseconds or nanoseconds
+        respectively.
     encoding : str or None
         The encoding to use to decode py3 bytes.
     lines : bool
         Read the file as a json object per line.
     chunksize : int or None
         Return a ``JsonReader`` for iteration, yielding ``chunksize`` lines
-        at a time. Can only be passed if ``lines=True``.
+        at a time. Can only be passed if ``lines=True``. If this is None,
+        the file will be read into memory all at once.
     compression : str or dict
         For on-the-fly decompression of on-disk data, see
         :func:`~pandas.read_json` for the accepted values.
     nrows : int or None
         The number of lines from the line-delimited json file that has to
-        be read. Can only be passed if ``lines=True``.
+        be read. Can only be passed if ``lines=True``. If this is None, all
+        the rows will be returned.
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection,
-        e.g. host, port, username, password, etc.
+        e.g. host, port, username, password, etc. See
+        :func:`~pandas.read_json` for more details.
     encoding_errors : str, optional, default "strict"
-        How encoding errors are treated.
+        How encoding errors are treated. `List of possible values
+        <https://docs.python.org/3/library/codecs.html#error-handlers>`_ .
     dtype_backend : {"numpy_nullable", "pyarrow"}
-        Back-end data type applied to the resultant :class:`DataFrame`.
+        Back-end data type applied to the resultant :class:`DataFrame`
+        (still experimental). See :func:`~pandas.read_json` for more
+        details.
     engine : {"ujson", "pyarrow"}, default "ujson"
-        Parser engine to use.
+        Parser engine to use. See :func:`~pandas.read_json` for the
+        restrictions on the ``"pyarrow"`` engine.
 
     See Also
     --------
@@ -1154,6 +1170,34 @@ class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
     def read(self) -> DataFrame | Series:
         """
         Read the whole JSON input into a pandas object.
+
+        Unlike iterating over the reader, this reads the entire underlying
+        JSON input in a single call, regardless of whether ``chunksize``
+        was specified when this reader was created.
+
+        Returns
+        -------
+        DataFrame or Series
+            The parsed pandas object, depending on the ``typ`` passed when
+            this reader was created.
+
+        See Also
+        --------
+        read_json : Convert a JSON string to pandas object.
+
+        Examples
+        --------
+        >>> from io import StringIO
+        >>> df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        >>> reader = pd.read_json(
+        ...     StringIO(df.to_json(orient="records", lines=True)),
+        ...     lines=True,
+        ...     chunksize=2,
+        ... )
+        >>> reader.read()
+           a  b
+        0  1  3
+        1  2  4
         """
         obj: DataFrame | Series
         with self:
@@ -1246,10 +1290,26 @@ class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
 
     def close(self) -> None:
         """
-        If we opened a stream earlier, in _get_data_from_filepath, we should
+        Close the underlying file handle, if one was opened by the reader.
+
+        If an open stream or file-like object was passed to the reader
+        rather than a path, it is left open and this method does not
         close it.
 
-        If an open stream or file was passed, we leave it open.
+        See Also
+        --------
+        read_json : Convert a JSON string to pandas object.
+
+        Examples
+        --------
+        >>> from io import StringIO
+        >>> df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        >>> reader = pd.read_json(
+        ...     StringIO(df.to_json(orient="records", lines=True)),
+        ...     lines=True,
+        ...     chunksize=1,
+        ... )
+        >>> reader.close()
         """
         if self.handles is not None:
             self.handles.close()

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -957,6 +957,80 @@ class JsonReader(abc.Iterator, Generic[FrameSeriesStrT]):
     If initialized with ``lines=True`` and ``chunksize``, can be iterated over
     ``chunksize`` lines at a time. Otherwise, calling ``read`` reads in the
     whole document.
+
+    A ``JsonReader`` is returned by :func:`~pandas.read_json` when
+    ``chunksize`` is passed; it is not usually instantiated directly.
+
+    Parameters
+    ----------
+    filepath_or_buffer : a str path, path object or file-like object
+        Any valid string path, ``os.PathLike``, or file-like object with a
+        ``read()`` method.
+    orient : str
+        Indication of expected JSON string format. See
+        :func:`~pandas.read_json` for the set of possible orients.
+    typ : {"frame", "series"}
+        The type of object to recover.
+    dtype : bool or dict
+        If True, infer dtypes; if a dict of column to dtype, then use those;
+        if False, then don't infer dtypes at all, applies only to the data.
+    convert_axes : bool or None
+        Try to convert the axes to the proper dtypes.
+    convert_dates : bool or list of str
+        If True then default datelike columns may be converted (depending on
+        ``keep_default_dates``). If a list of column names, then those
+        columns will be converted in addition to any default datelike
+        columns.
+    keep_default_dates : bool
+        If parsing dates (``convert_dates`` is not False), then try to parse
+        the default datelike columns.
+    precise_float : bool
+        Set to enable usage of higher precision (strtod) function when
+        decoding string to double values.
+    date_unit : str or None
+        The timestamp unit to detect if converting dates.
+    encoding : str or None
+        The encoding to use to decode py3 bytes.
+    lines : bool
+        Read the file as a json object per line.
+    chunksize : int or None
+        Return a ``JsonReader`` for iteration, yielding ``chunksize`` lines
+        at a time. Can only be passed if ``lines=True``.
+    compression : str or dict
+        For on-the-fly decompression of on-disk data, see
+        :func:`~pandas.read_json` for the accepted values.
+    nrows : int or None
+        The number of lines from the line-delimited json file that has to
+        be read. Can only be passed if ``lines=True``.
+    storage_options : dict, optional
+        Extra options that make sense for a particular storage connection,
+        e.g. host, port, username, password, etc.
+    encoding_errors : str, optional, default "strict"
+        How encoding errors are treated.
+    dtype_backend : {"numpy_nullable", "pyarrow"}
+        Back-end data type applied to the resultant :class:`DataFrame`.
+    engine : {"ujson", "pyarrow"}, default "ujson"
+        Parser engine to use.
+
+    See Also
+    --------
+    read_json : Convert a JSON string to pandas object.
+
+    Examples
+    --------
+    >>> from io import StringIO
+    >>> df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    >>> reader = pd.read_json(
+    ...     StringIO(df.to_json(orient="records", lines=True)),
+    ...     lines=True,
+    ...     chunksize=1,
+    ... )
+    >>> for chunk in reader:
+    ...     print(chunk)
+       a  b
+    0  1  3
+       a  b
+    1  2  4
     """
 
     def __init__(

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -172,9 +172,9 @@ class Holiday:
         Month of the holiday.
     day : int, default None
         Day of the holiday.
-    offset : list of pandas.tseries.offsets or
-            class from pandas.tseries.offsets, default None
-        Computes offset from date.
+    offset : BaseOffset or list of BaseOffset, default None
+        Computes offset from date. See :mod:`pandas.tseries.offsets` for the
+        available offset classes.
     observance : function, default None
         Computes when holiday is given a pandas Timestamp.
     start_date : datetime-like, default None

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -172,7 +172,7 @@ class Holiday:
         Month of the holiday.
     day : int, default None
         Day of the holiday.
-    offset : BaseOffset or list of BaseOffset, default None
+    offset : DateOffset or list of DateOffset, default None
         Computes offset from date. See :mod:`pandas.tseries.offsets` for the
         available offset classes.
     observance : function, default None

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -154,8 +154,83 @@ def after_nearest_workday(dt: datetime) -> datetime:
 
 class Holiday:
     """
-    Class that defines a holiday with start/end dates and rules
-    for observance.
+    Class that defines a holiday with start/end dates and rules for observance.
+
+    A ``Holiday`` can either be defined by a fixed ``year``/``month``/``day``,
+    or, more commonly, by a recurring ``month``/``day`` combined with an
+    ``offset`` or ``observance`` rule that adjusts the date in each year it
+    is calculated for. Instances of ``Holiday`` are typically collected in
+    the ``rules`` of an :class:`~pandas.tseries.holiday.AbstractHolidayCalendar`.
+
+    Parameters
+    ----------
+    name : str
+        Name of the holiday, defaults to class name.
+    year : int, default None
+        Year of the holiday.
+    month : int, default None
+        Month of the holiday.
+    day : int, default None
+        Day of the holiday.
+    offset : list of pandas.tseries.offsets or
+            class from pandas.tseries.offsets, default None
+        Computes offset from date.
+    observance : function, default None
+        Computes when holiday is given a pandas Timestamp.
+    start_date : datetime-like, default None
+        First date the holiday is observed.
+    end_date : datetime-like, default None
+        Last date the holiday is observed.
+    days_of_week : tuple of int or dateutil.relativedelta weekday strs, default None
+        Provide a tuple of days e.g  (0,1,2,3,) for Monday through Thursday
+        Monday=0,..,Sunday=6
+        Only instances of the holiday included in days_of_week will be computed.
+    exclude_dates : DatetimeIndex or default None
+        Specific dates to exclude e.g. skipping a specific year's holiday.
+
+    See Also
+    --------
+    tseries.holiday.AbstractHolidayCalendar : Abstract interface to create
+        holidays following certain rules.
+    tseries.holiday.Holiday.dates : Calculate holidays observed between
+        start date and end date.
+
+    Examples
+    --------
+    >>> from dateutil.relativedelta import MO
+
+    >>> USMemorialDay = pd.tseries.holiday.Holiday(
+    ...     "Memorial Day", month=5, day=31, offset=pd.DateOffset(weekday=MO(-1))
+    ... )
+    >>> USMemorialDay
+    Holiday: Memorial Day (month=5, day=31, offset=<DateOffset: weekday=MO(-1)>)
+
+    >>> USLaborDay = pd.tseries.holiday.Holiday(
+    ...     "Labor Day", month=9, day=1, offset=pd.DateOffset(weekday=MO(1))
+    ... )
+    >>> USLaborDay
+    Holiday: Labor Day (month=9, day=1, offset=<DateOffset: weekday=MO(+1)>)
+
+    >>> July3rd = pd.tseries.holiday.Holiday("July 3rd", month=7, day=3)
+    >>> July3rd
+    Holiday: July 3rd (month=7, day=3, )
+
+    >>> NewYears = pd.tseries.holiday.Holiday(
+    ...     "New Years Day",
+    ...     month=1,
+    ...     day=1,
+    ...     observance=pd.tseries.holiday.nearest_workday,
+    ... )
+    >>> NewYears  # doctest: +SKIP
+    Holiday: New Years Day (
+        month=1, day=1, observance=<function nearest_workday at 0x66545e9bc440>
+    )
+
+    >>> July3rd = pd.tseries.holiday.Holiday(
+    ...     "July 3rd", month=7, day=3, days_of_week=(0, 1, 2, 3)
+    ... )
+    >>> July3rd
+    Holiday: July 3rd (month=7, day=3, )
     """
 
     start_date: Timestamp | None
@@ -175,70 +250,6 @@ class Holiday:
         days_of_week: tuple | None = None,
         exclude_dates: DatetimeIndex | None = None,
     ) -> None:
-        """
-        Parameters
-        ----------
-        name : str
-            Name of the holiday , defaults to class name
-        year : int, default None
-            Year of the holiday
-        month : int, default None
-            Month of the holiday
-        day : int, default None
-            Day of the holiday
-        offset : list of pandas.tseries.offsets or
-                class from pandas.tseries.offsets, default None
-            Computes offset from date
-        observance : function, default None
-            Computes when holiday is given a pandas Timestamp
-        start_date : datetime-like, default None
-            First date the holiday is observed
-        end_date : datetime-like, default None
-            Last date the holiday is observed
-        days_of_week : tuple of int or dateutil.relativedelta weekday strs, default None
-            Provide a tuple of days e.g  (0,1,2,3,) for Monday through Thursday
-            Monday=0,..,Sunday=6
-            Only instances of the holiday included in days_of_week will be computed
-        exclude_dates : DatetimeIndex or default None
-            Specific dates to exclude e.g. skipping a specific year's holiday
-
-        Examples
-        --------
-        >>> from dateutil.relativedelta import MO
-
-        >>> USMemorialDay = pd.tseries.holiday.Holiday(
-        ...     "Memorial Day", month=5, day=31, offset=pd.DateOffset(weekday=MO(-1))
-        ... )
-        >>> USMemorialDay
-        Holiday: Memorial Day (month=5, day=31, offset=<DateOffset: weekday=MO(-1)>)
-
-        >>> USLaborDay = pd.tseries.holiday.Holiday(
-        ...     "Labor Day", month=9, day=1, offset=pd.DateOffset(weekday=MO(1))
-        ... )
-        >>> USLaborDay
-        Holiday: Labor Day (month=9, day=1, offset=<DateOffset: weekday=MO(+1)>)
-
-        >>> July3rd = pd.tseries.holiday.Holiday("July 3rd", month=7, day=3)
-        >>> July3rd
-        Holiday: July 3rd (month=7, day=3, )
-
-        >>> NewYears = pd.tseries.holiday.Holiday(
-        ...     "New Years Day",
-        ...     month=1,
-        ...     day=1,
-        ...     observance=pd.tseries.holiday.nearest_workday,
-        ... )
-        >>> NewYears  # doctest: +SKIP
-        Holiday: New Years Day (
-            month=1, day=1, observance=<function nearest_workday at 0x66545e9bc440>
-        )
-
-        >>> July3rd = pd.tseries.holiday.Holiday(
-        ...     "July 3rd", month=7, day=3, days_of_week=(0, 1, 2, 3)
-        ... )
-        >>> July3rd
-        Holiday: July 3rd (month=7, day=3, )
-        """
         if offset is not None:
             if observance is not None:
                 raise NotImplementedError("Cannot use both offset and observance.")
@@ -300,12 +311,19 @@ class Holiday:
         self, start_date, end_date, return_name: bool = False
     ) -> Series | DatetimeIndex:
         """
-        Calculate holidays observed between start date and end date
+        Calculate holidays observed between start date and end date.
+
+        Dates are computed from the rules defined for this holiday, i.e. its
+        fixed ``year``/``month``/``day``, or its ``offset``/``observance``
+        applied to each occurrence of ``month``/``day`` between the year
+        before ``start_date`` and the year after ``end_date``.
 
         Parameters
         ----------
         start_date : starting date, datetime-like, optional
+            The earliest date to consider in the search.
         end_date : ending date, datetime-like, optional
+            The latest date to consider in the search.
         return_name : bool, optional, default=False
             If True, return a series that has dates and holiday names.
             False will only return dates.
@@ -313,7 +331,22 @@ class Holiday:
         Returns
         -------
         Series or DatetimeIndex
-            Series if return_name is True
+            Series if return_name is True, otherwise a DatetimeIndex of
+            the holiday's dates.
+
+        See Also
+        --------
+        tseries.holiday.AbstractHolidayCalendar.holidays : Return a curve
+            with holidays between start_date and end_date.
+
+        Examples
+        --------
+        >>> from dateutil.relativedelta import MO
+        >>> USMemorialDay = pd.tseries.holiday.Holiday(
+        ...     "Memorial Day", month=5, day=31, offset=pd.DateOffset(weekday=MO(-1))
+        ... )
+        >>> USMemorialDay.dates("2020-01-01", "2021-12-31")
+        DatetimeIndex(['2020-05-25', '2021-05-31'], dtype='datetime64[us]', freq=None)
         """
         start_date = Timestamp(start_date)
         end_date = Timestamp(end_date)
@@ -458,6 +491,35 @@ class HolidayCalendarMetaClass(type):
 class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
     """
     Abstract interface to create holidays following certain rules.
+
+    A subclass normally defines its holidays by setting ``rules`` to a list
+    of :class:`~pandas.tseries.holiday.Holiday` instances directly on the
+    class body. Alternatively, a set of rules can be passed to the
+    constructor. The calendar can then be used to compute the holiday
+    dates falling within a given date range via
+    :meth:`~pandas.tseries.holiday.AbstractHolidayCalendar.holidays`.
+
+    Parameters
+    ----------
+    name : str
+        Name of the holiday calendar, defaults to class name.
+    rules : array of Holiday objects
+        A set of rules used to create the holidays.
+
+    See Also
+    --------
+    tseries.holiday.Holiday : Class that defines a holiday with start/end
+        dates and rules for observance.
+    tseries.offsets.CustomBusinessDay : DateOffset subclass representing
+        possibly n business days excluding holidays.
+
+    Examples
+    --------
+    >>> from pandas.tseries.holiday import AbstractHolidayCalendar, USLaborDay
+    >>> class MyCalendar(AbstractHolidayCalendar):
+    ...     rules = [USLaborDay]
+    >>> MyCalendar().holidays(start="2020-01-01", end="2020-12-31")
+    DatetimeIndex(['2020-09-07'], dtype='datetime64[us]', freq=None)
     """
 
     rules: list[Holiday] = []
@@ -466,17 +528,6 @@ class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
     _cache: tuple[Timestamp, Timestamp, Series] | None = None
 
     def __init__(self, name: str = "", rules=None) -> None:
-        """
-        Initializes holiday object with a given set a rules.  Normally
-        classes just have the rules defined within them.
-
-        Parameters
-        ----------
-        name : str
-            Name of the holiday calendar, defaults to class name
-        rules : array of Holiday objects
-            A set of rules used to create the holidays.
-        """
         super().__init__()
         if not name:
             name = type(self).__name__
@@ -486,6 +537,36 @@ class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
             self.rules = rules
 
     def rule_from_name(self, name: str) -> Holiday | None:
+        """
+        Return the rule for the holiday with the given name.
+
+        Searches ``self.rules`` for a :class:`~pandas.tseries.holiday.Holiday`
+        whose ``name`` attribute matches exactly.
+
+        Parameters
+        ----------
+        name : str
+            Name of the holiday whose rule should be returned.
+
+        Returns
+        -------
+        Holiday or None
+            The matching rule from ``self.rules``, or None if no rule with
+            the given name is found.
+
+        See Also
+        --------
+        tseries.holiday.AbstractHolidayCalendar.holidays : Return a curve
+            with holidays between start_date and end_date.
+
+        Examples
+        --------
+        >>> from pandas.tseries.holiday import AbstractHolidayCalendar, USLaborDay
+        >>> class MyCalendar(AbstractHolidayCalendar):
+        ...     rules = [USLaborDay]
+        >>> MyCalendar().rule_from_name("Labor Day")
+        Holiday: Labor Day (month=9, day=1, offset=<DateOffset: weekday=MO(+1)>)
+        """
         for rule in self.rules:
             if rule.name == name:
                 return rule
@@ -496,19 +577,43 @@ class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
         self, start=None, end=None, return_name: bool = False
     ) -> DatetimeIndex | Series:
         """
-        Returns a curve with holidays between start_date and end_date
+        Return a curve with holidays between start_date and end_date.
+
+        The holidays for the calendar are computed by evaluating the
+        ``dates`` of each rule in ``self.rules`` and merging the results,
+        caching them so that repeated calls covering a previously
+        requested date range do not need to be recomputed.
 
         Parameters
         ----------
         start : starting date, datetime-like, optional
+            The earliest date to consider, defaults to
+            :attr:`AbstractHolidayCalendar.start_date`.
         end : ending date, datetime-like, optional
+            The latest date to consider, defaults to
+            :attr:`AbstractHolidayCalendar.end_date`.
         return_name : bool, optional
             If True, return a series that has dates and holiday names.
             False will only return a DatetimeIndex of dates.
 
         Returns
         -------
-            DatetimeIndex of holidays
+        DatetimeIndex or Series
+            DatetimeIndex of holidays, or a Series mapping holiday dates to
+            their names if ``return_name`` is True.
+
+        See Also
+        --------
+        tseries.holiday.Holiday.dates : Calculate holidays observed between
+            start date and end date.
+
+        Examples
+        --------
+        >>> from pandas.tseries.holiday import AbstractHolidayCalendar, USLaborDay
+        >>> class MyCalendar(AbstractHolidayCalendar):
+        ...     rules = [USLaborDay]
+        >>> MyCalendar().holidays(start="2020-01-01", end="2020-12-31")
+        DatetimeIndex(['2020-09-07'], dtype='datetime64[us]', freq=None)
         """
         if self.rules is None:
             raise Exception(
@@ -548,16 +653,44 @@ class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
     @staticmethod
     def merge_class(base, other):
         """
-        Merge holiday calendars together. The base calendar
-        will take precedence to other. The merge will be done
-        based on each holiday's name.
+        Merge holiday calendars together.
+
+        The base calendar will take precedence to other. The merge will be
+        done based on each holiday's name.
 
         Parameters
         ----------
         base : AbstractHolidayCalendar
-          instance/subclass or array of Holiday objects
+            Instance/subclass or array of Holiday objects.
         other : AbstractHolidayCalendar
-          instance/subclass or array of Holiday objects
+            Instance/subclass or array of Holiday objects.
+
+        Returns
+        -------
+        list of Holiday
+            Combined list of holidays from both calendars, with ``base``
+            taking precedence over ``other`` for holidays sharing the
+            same name.
+
+        See Also
+        --------
+        tseries.holiday.AbstractHolidayCalendar.merge : Merge holiday
+            calendars together.
+
+        Examples
+        --------
+        >>> from pandas.tseries.holiday import (
+        ...     AbstractHolidayCalendar,
+        ...     USLaborDay,
+        ...     USMemorialDay,
+        ... )
+        >>> class Calendar1(AbstractHolidayCalendar):
+        ...     rules = [USMemorialDay]
+        >>> class Calendar2(AbstractHolidayCalendar):
+        ...     rules = [USLaborDay]
+        >>> merged = AbstractHolidayCalendar.merge_class(Calendar1, Calendar2)
+        >>> [holiday.name for holiday in merged]
+        ['Labor Day', 'Memorial Day']
         """
         try:
             other = other.rules
@@ -582,15 +715,45 @@ class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
 
     def merge(self, other, inplace: bool = False):
         """
-        Merge holiday calendars together.  The caller's class
-        rules take precedence.  The merge will be done
+        Merge holiday calendars together.
+
+        The caller's class rules take precedence. The merge will be done
         based on each holiday's name.
 
         Parameters
         ----------
         other : holiday calendar
+            Calendar, instance/subclass, or array of Holiday objects to
+            merge into this calendar's rules.
         inplace : bool (default=False)
-            If True set rule_table to holidays, else return array of Holidays
+            If True set rule_table to holidays, else return array of
+            Holidays.
+
+        Returns
+        -------
+        list of Holiday or None
+            The combined list of holidays if ``inplace`` is False,
+            otherwise None.
+
+        See Also
+        --------
+        tseries.holiday.AbstractHolidayCalendar.merge_class : Merge holiday
+            calendars together.
+
+        Examples
+        --------
+        >>> from pandas.tseries.holiday import (
+        ...     AbstractHolidayCalendar,
+        ...     USLaborDay,
+        ...     USMemorialDay,
+        ... )
+        >>> class Calendar1(AbstractHolidayCalendar):
+        ...     rules = [USMemorialDay]
+        >>> class Calendar2(AbstractHolidayCalendar):
+        ...     rules = [USLaborDay]
+        >>> merged = Calendar1().merge(Calendar2())
+        >>> [holiday.name for holiday in merged]
+        ['Labor Day', 'Memorial Day']
         """
         holidays = self.merge_class(self, other)
         if inplace:


### PR DESCRIPTION
None of these appear in the API docs. But:

- `JsonReader` is documented to be the return type of `read_json` https://pandas.pydata.org/docs/reference/api/pandas.read_json.html. It is also re-exported in `pandas-stubs/api/typing/__init__.pyi`
- `Holiday` and `AbstractHolidayCalendar` appears in https://pandas.pydata.org/docs/user_guide/timeseries.html#holidays-holiday-calendars

so perhaps they should?

pandas-stubs issue: https://github.com/pandas-dev/pandas-stubs/issues/1814

some screenshots

<img width="800" height="879" alt="image" src="https://github.com/user-attachments/assets/0ce9d471-8eed-4a0d-afaf-df3f29a7ea88" />

<img width="724" height="849" alt="image" src="https://github.com/user-attachments/assets/d60b51e4-7364-470b-aaee-52b1d535d6d5" />

<img width="759" height="780" alt="image" src="https://github.com/user-attachments/assets/3a72f37a-ed97-4635-85fd-9a6cf6730e3c" />


- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
