### PR TITLE
DEPR: Treat tuple keys consistently in Resampler.__getitem__

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -235,6 +235,10 @@ Deprecations
 - Deprecated ``inplace`` keyword for :meth:`DataFrame.rename` and :meth:`DataFrame.drop`. This keyword will be removed in a future version (:issue:`63207`); see also `PDEP-8 <https://pandas.pydata.org/pdeps/0008-inplace-methods-in-pandas.html>`_
 - Deprecated the ``infer_objects``, ``convert_string``, ``convert_integer``, ``convert_boolean``, and ``convert_floating`` keywords in :meth:`DataFrame.convert_dtypes` and :meth:`Series.convert_dtypes` (:issue:`62022`)
 - Deprecated using ``isinstance(obj, DateOffset)`` and ``issubclass(cls, DateOffset)`` to check for offset types that are not :class:`DateOffset`; these will return ``False`` in a future version. Use ``pd.offsets.BaseOffset`` instead (:issue:`48262`)
+- Deprecated passing tuple keys to :meth:`Resampler.__getitem__` and other
+  ``SelectionMixin``-based objects (e.g. ``Rolling.__getitem__``) for
+  selecting multiple columns; use a list instead. In a future version,
+  tuple keys will raise ``KeyError`` (:issue:`66266`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.performance:

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -219,25 +219,15 @@ class SelectionMixin(Generic[NDFrameT]):
             raise IndexError(f"Column(s) {self._selection} already selected")
 
         if isinstance(key, tuple):
-            # Correct MultiIndex semantics
-            if isinstance(self.obj.columns, ABCMultiIndex):
-                try:
-                    subset = self.obj[key]
-                except (KeyError, TypeError):
-                    pass
-                else:
-                    return self._gotitem(key, ndim=subset.ndim, subset=subset)
-
-            # Legacy tuple-as-list path (to be deprecated)
             warnings.warn(
                 "Passing a tuple to __getitem__ is deprecated and "
                 "will raise a KeyError in a future version. Use a list instead.",
                 Pandas4Warning,
                 stacklevel=find_stack_level(),
             )
-            raise KeyError(key)
+            key = list(key)
 
-        elif isinstance(key, (list, ABCSeries, ABCIndex, np.ndarray)):
+        if isinstance(key, (list, ABCSeries, ABCIndex, np.ndarray)):
             if len(self.obj.columns.intersection(key)) != len(set(key)):
                 bad_keys = list(set(key).difference(self.obj.columns))
                 raise KeyError(f"Columns not found: {str(bad_keys)[1:-1]}")

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -14,6 +14,7 @@ from typing import (
     final,
     overload,
 )
+import warnings
 
 import numpy as np
 
@@ -28,8 +29,12 @@ from pandas._typing import (
 )
 from pandas.compat import PYPY
 from pandas.compat.numpy import function as nv
-from pandas.errors import AbstractMethodError
+from pandas.errors import (
+    AbstractMethodError,
+    Pandas4Warning,
+)
 from pandas.util._decorators import cache_readonly
+from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.cast import can_hold_element
 from pandas.core.dtypes.common import (
@@ -213,15 +218,36 @@ class SelectionMixin(Generic[NDFrameT]):
         if self._selection is not None:
             raise IndexError(f"Column(s) {self._selection} already selected")
 
-        if isinstance(key, (list, tuple, ABCSeries, ABCIndex, np.ndarray)):
+        if isinstance(key, tuple):
+            # Correct MultiIndex semantics
+            if isinstance(self.obj.columns, ABCMultiIndex):
+                try:
+                    subset = self.obj[key]
+                except (KeyError, TypeError):
+                    pass
+                else:
+                    return self._gotitem(key, ndim=subset.ndim, subset=subset)
+
+            # Legacy tuple-as-list path (to be deprecated)
+            warnings.warn(
+                "Passing a tuple to __getitem__ is deprecated and "
+                "will raise a KeyError in a future version. Use a list instead.",
+                Pandas4Warning,
+                stacklevel=find_stack_level(),
+            )
+            raise KeyError(key)
+
+        elif isinstance(key, (list, ABCSeries, ABCIndex, np.ndarray)):
             if len(self.obj.columns.intersection(key)) != len(set(key)):
                 bad_keys = list(set(key).difference(self.obj.columns))
                 raise KeyError(f"Columns not found: {str(bad_keys)[1:-1]}")
+
             return self._gotitem(list(key), ndim=2)
 
         else:
             if key not in self.obj:
                 raise KeyError(f"Column not found: {key}")
+
             ndim = self.obj[key].ndim
             return self._gotitem(key, ndim=ndim)
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -231,13 +231,11 @@ class SelectionMixin(Generic[NDFrameT]):
             if len(self.obj.columns.intersection(key)) != len(set(key)):
                 bad_keys = list(set(key).difference(self.obj.columns))
                 raise KeyError(f"Columns not found: {str(bad_keys)[1:-1]}")
-
             return self._gotitem(list(key), ndim=2)
 
         else:
             if key not in self.obj:
                 raise KeyError(f"Column not found: {key}")
-
             ndim = self.obj[key].ndim
             return self._gotitem(key, ndim=ndim)
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -204,18 +204,6 @@ class Resampler(BaseGroupBy, PandasObject):
 
         return object.__getattribute__(self, attr)
 
-    # def __getitem__(self, key):
-    #     if isinstance(key, tuple) and len(key) > 1:
-    #         warnings.warn(
-    #             "Passing a tuple to Resampler.__getitem__ is deprecated and "
-    #             "will raise a KeyError in a future version. Use a list instead.",
-    #             FutureWarning,
-    #             stacklevel=find_stack_level(),
-    #         )
-    #         return super().__getitem__(list(key))
-
-    #     return super().__getitem__(key)
-
     def __getitem__(self, key):
         return super().__getitem__(key)
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -204,6 +204,13 @@ class Resampler(BaseGroupBy, PandasObject):
 
         return object.__getattribute__(self, attr)
 
+    def __getitem__(self, key):
+        if isinstance(key, tuple) and len(key) > 1:
+            subset = self.obj[key]
+            return self._gotitem(key, ndim=subset.ndim, subset=subset)
+
+        return super().__getitem__(key)
+
     @final
     @property
     def _from_selection(self) -> bool:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -204,11 +204,19 @@ class Resampler(BaseGroupBy, PandasObject):
 
         return object.__getattribute__(self, attr)
 
-    def __getitem__(self, key):
-        if isinstance(key, tuple) and len(key) > 1:
-            subset = self.obj[key]
-            return self._gotitem(key, ndim=subset.ndim, subset=subset)
+    # def __getitem__(self, key):
+    #     if isinstance(key, tuple) and len(key) > 1:
+    #         warnings.warn(
+    #             "Passing a tuple to Resampler.__getitem__ is deprecated and "
+    #             "will raise a KeyError in a future version. Use a list instead.",
+    #             FutureWarning,
+    #             stacklevel=find_stack_level(),
+    #         )
+    #         return super().__getitem__(list(key))
 
+    #     return super().__getitem__(key)
+
+    def __getitem__(self, key):
         return super().__getitem__(key)
 
     @final

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -204,9 +204,6 @@ class Resampler(BaseGroupBy, PandasObject):
 
         return object.__getattribute__(self, attr)
 
-    def __getitem__(self, key):
-        return super().__getitem__(key)
-
     @final
     @property
     def _from_selection(self) -> bool:

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -148,31 +148,19 @@ def test_getitem(test_frame):
     r = test_frame.resample("h")["B"]
     assert r._selected_obj.name == test_frame.columns[1]
 
-    # tuple keys should no longer be treated as a list of columns
-    # with pytest.raises(KeyError, match=r"\('A', 'B'\)"):
-    #     test_frame.resample("h")["A", "B"]
-
+    # tuple keys are deprecated but should preserve the current behavior
     with tm.assert_produces_warning(
         Pandas4Warning,
         match="Passing a tuple to __getitem__ is deprecated",
     ):
-        with pytest.raises(KeyError, match=r"\('A', 'B'\)"):
-            test_frame.resample("h")[("A", "B")]
+        r = test_frame.resample("h")[("A", "B")]
 
+    expected = test_frame[["A", "B"]]
 
-def test_getitem_tuple_multiindex_columns():
-    index = date_range("2024-01-01", periods=10, freq="h")
-
-    df = DataFrame(
-        np.arange(20).reshape(10, 2),
-        index=index,
-        columns=pd.MultiIndex.from_tuples([("A", "B"), ("A", "C")]),
+    tm.assert_index_equal(
+        r._selected_obj.columns,
+        expected.columns,
     )
-
-    result = df.resample("2h")[("A", "B")].sum()
-    expected = df[("A", "B")].resample("2h").sum()
-
-    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("key", [["D"], ["A", "D"]])

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -149,8 +149,15 @@ def test_getitem(test_frame):
     assert r._selected_obj.name == test_frame.columns[1]
 
     # tuple keys should no longer be treated as a list of columns
-    with pytest.raises(KeyError, match=r"\('A', 'B'\)"):
-        test_frame.resample("h")["A", "B"]
+    # with pytest.raises(KeyError, match=r"\('A', 'B'\)"):
+    #     test_frame.resample("h")["A", "B"]
+
+    with tm.assert_produces_warning(
+        Pandas4Warning,
+        match="Passing a tuple to __getitem__ is deprecated",
+    ):
+        with pytest.raises(KeyError, match=r"\('A', 'B'\)"):
+            test_frame.resample("h")[("A", "B")]
 
 
 def test_getitem_tuple_multiindex_columns():

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -148,12 +148,24 @@ def test_getitem(test_frame):
     r = test_frame.resample("h")["B"]
     assert r._selected_obj.name == test_frame.columns[1]
 
-    # technically this is allowed
-    r = test_frame.resample("h")["A", "B"]
-    tm.assert_index_equal(r._selected_obj.columns, test_frame.columns[[0, 1]])
+    # tuple keys should no longer be treated as a list of columns
+    with pytest.raises(KeyError, match=r"\('A', 'B'\)"):
+        test_frame.resample("h")["A", "B"]
 
-    r = test_frame.resample("h")["A", "B"]
-    tm.assert_index_equal(r._selected_obj.columns, test_frame.columns[[0, 1]])
+
+def test_getitem_tuple_multiindex_columns():
+    index = date_range("2024-01-01", periods=10, freq="h")
+
+    df = DataFrame(
+        np.arange(20).reshape(10, 2),
+        index=index,
+        columns=pd.MultiIndex.from_tuples([("A", "B"), ("A", "C")]),
+    )
+
+    result = df.resample("2h")[("A", "B")].sum()
+    expected = df[("A", "B")].resample("2h").sum()
+
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("key", [["D"], ["A", "D"]])

--- a/pandas/tests/window/test_api.py
+++ b/pandas/tests/window/test_api.py
@@ -3,6 +3,7 @@ import pytest
 
 from pandas.errors import (
     DataError,
+    Pandas4Warning,
     SpecificationError,
 )
 
@@ -29,8 +30,12 @@ def test_getitem(step):
     assert r._selected_obj.name == frame[::step].columns[1]
 
     # technically this is allowed
-    r = frame.rolling(window=5, step=step)[1, 3]
-    tm.assert_index_equal(r._selected_obj.columns, frame[::step].columns[[1, 3]])
+    with tm.assert_produces_warning(
+        Pandas4Warning,
+        match="Passing a tuple to __getitem__ is deprecated",
+    ):
+        with pytest.raises(KeyError, match=r"\(1, 3\)"):
+            frame.rolling(window=5, step=step)[1, 3]
 
     r = frame.rolling(window=5, step=step)[[1, 3]]
     tm.assert_index_equal(r._selected_obj.columns, frame[::step].columns[[1, 3]])

--- a/pandas/tests/window/test_api.py
+++ b/pandas/tests/window/test_api.py
@@ -29,13 +29,17 @@ def test_getitem(step):
     r = frame.rolling(window=5, step=step)[1]
     assert r._selected_obj.name == frame[::step].columns[1]
 
-    # technically this is allowed
+    # tuple keys are deprecated but should preserve the current behavior
     with tm.assert_produces_warning(
         Pandas4Warning,
         match="Passing a tuple to __getitem__ is deprecated",
     ):
-        with pytest.raises(KeyError, match=r"\(1, 3\)"):
-            frame.rolling(window=5, step=step)[1, 3]
+        r = frame.rolling(window=5, step=step)[1, 3]
+
+    tm.assert_index_equal(
+        r._selected_obj.columns,
+        frame[::step].columns[[1, 3]],
+    )
 
     r = frame.rolling(window=5, step=step)[[1, 3]]
     tm.assert_index_equal(r._selected_obj.columns, frame[::step].columns[[1, 3]])


### PR DESCRIPTION
Closes #66266.

## Summary

This PR deprecates passing tuple keys to `SelectionMixin.__getitem__` for selecting multiple columns.

Currently, tuple keys are treated the same as lists by SelectionMixin-based objects such as Resampler and Rolling. This behavior is now deprecated in favor of explicitly using a list. Passing a tuple emits a Pandas4Warning while preserving the existing behavior. In a future version, tuple keys will raise a KeyError.

## Changes:
- Deprecate tuple keys for multi-column selection in `SelectionMixin.__getitem__`
- Emit a `Pandas4Warning` when a tuple key is passed.
- Reuse the existing list-selection path by converting tuple keys to lists.
- Update the existing `Resampler` tests to verify the deprecation behavior.
- Add a `v3.1.0` `whatsnew` entry documenting the deprecation.

Example

Instead of:
```python
df.resample("h")[("A", "B")]
```
use:
```python
df.resample("h")[["A", "B"]]
```

Tuple keys continue to work in pandas 3.1 with a Pandas4Warning and will raise a KeyError in a future version.