### PR TITLE
PERF: GIL-free loop and fixed-layout fast path for the read_csv parse_dates fastpath

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -186,7 +186,7 @@ Performance improvements
 - Performance improvement in :func:`merge` with ``how="left"`` and ``sort=False`` when joining on a right index with unique keys (:issue:`65160`)
 - Performance improvement in :func:`merge` with ``sort=False`` for single-key ``how="left"``/``how="right"`` joins when the opposite join key is sorted, unique, and range-like (:issue:`64146`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` (:issue:`64515`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` and ``parse_dates`` for columns containing ISO8601 datetime strings, which now parse directly into ``datetime64`` without an intermediate object array of Python strings (:issue:`65353`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` and ``parse_dates`` for columns containing ISO8601 datetime strings, which now parse directly into ``datetime64`` without an intermediate object array of Python strings, and no longer block other threads while parsing, so concurrent reads scale better across CPU cores (:issue:`65353`, :issue:`66278`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` during dtype inference: columns that do not parse as numeric or boolean (e.g. string columns) are now rejected before allocating a result buffer for the attempt (:issue:`66273`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns (:issue:`65767`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns with default settings (:issue:`66239`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -186,7 +186,7 @@ Performance improvements
 - Performance improvement in :func:`merge` with ``how="left"`` and ``sort=False`` when joining on a right index with unique keys (:issue:`65160`)
 - Performance improvement in :func:`merge` with ``sort=False`` for single-key ``how="left"``/``how="right"`` joins when the opposite join key is sorted, unique, and range-like (:issue:`64146`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` (:issue:`64515`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` and ``parse_dates`` for columns containing ISO8601 datetime strings, which now parse directly into ``datetime64`` without an intermediate object array of Python strings, and no longer block other threads while parsing, so concurrent reads scale better across CPU cores (:issue:`65353`, :issue:`66278`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` and ``parse_dates`` for columns containing ISO8601 datetime strings; concurrent reads from multiple threads also scale better (:issue:`65353`, :issue:`66278`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` during dtype inference: columns that do not parse as numeric or boolean (e.g. string columns) are now rejected before allocating a result buffer for the attempt (:issue:`66273`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns (:issue:`65767`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns with default settings (:issue:`66239`)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1990,9 +1990,9 @@ _days_per_month_array[:] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
 cdef inline bint _all_digits(const char *chars, int start,
                              int stop) noexcept nogil:
-    cdef int k
-    for k in range(start, stop):
-        if chars[k] < b"0" or chars[k] > b"9":
+    cdef int idx
+    for idx in range(start, stop):
+        if chars[idx] < b"0" or chars[idx] > b"9":
             return False
     return True
 
@@ -2009,6 +2009,10 @@ cdef inline int _parse_iso_fixed(const char *word, Py_ssize_t word_len,
     fixed-width layouts: `YYYY-MM-DD` and `YYYY-MM-DD[ T]HH:MM:SS` (always
     timezone-naive). Returns 0 on success, -1 to defer to the general
     parser, applying the same calendar/range validation it would.
+
+    This arguably belongs in tslibs alongside `string_to_dts`, but is kept
+    here so it stays inlined into the loop below; reached as a cross-module
+    cdef it measured ~5% slower on this fastpath.
     """
     cdef:
         int year, month, day, days_in_month
@@ -2064,14 +2068,23 @@ cdef inline int _parse_iso_fixed(const char *word, Py_ssize_t word_len,
     return 0
 
 
+cdef inline int _layout_code(const char *word,
+                             Py_ssize_t word_len) noexcept nogil:
+    """
+    Layout of a string already known to parse via `_parse_iso_fixed`:
+    1 (YYYY-MM-DD), 2 (space-separated) or 3 (T-separated). Two such strings
+    share a format shape exactly when their codes match, giving an O(1)
+    equivalent of `_same_format_shape` on the fastpath.
+    """
+    if word_len == 10:
+        return 1
+    return 2 if word[10] == b" " else 3
+
+
 cdef inline int _fixed_shape_code(const char *word,
                                   Py_ssize_t word_len) noexcept nogil:
     """
-    Classify a datetime string that parses via `_parse_iso_fixed`: 0 when it
-    is not one of the fixed layouts, else 1 (YYYY-MM-DD), 2 (space-separated
-    datetime) or 3 (T-separated datetime). Two fixed-layout strings share a
-    format shape exactly when their codes are equal, giving an O(1)
-    equivalent of `_same_format_shape` on the fastpath.
+    `_layout_code` for an unvalidated string, or 0 if it is not fixed-layout.
     """
     cdef:
         npy_datetimestruct dts
@@ -2079,9 +2092,7 @@ cdef inline int _fixed_shape_code(const char *word,
 
     if _parse_iso_fixed(word, word_len, &dts, &unit) != 0:
         return 0
-    if word_len == 10:
-        return 1
-    return 2 if word[10] == b" " else 3
+    return _layout_code(word, word_len)
 
 
 cdef inline bint _same_format_shape(const char *left, Py_ssize_t left_len,
@@ -2300,9 +2311,8 @@ cdef _datetime_box_utf8(parser_t *parser, int64_t col,
     coliter_setup(&it, parser, col, line_start)
 
     # nogil here helps only caller-managed threads; read_csv's own parallel
-    # path is disabled when parse_dates is set.  No early returns inside the
-    # block: bail-outs set `fallback` (or `bump_reso`) and break, and the
-    # except-block folds npy_datetimestruct_to_datetime's raise into one too.
+    # path is disabled when parse_dates is set.  Bail-outs must set `fallback`
+    # (or `bump_reso`) and break rather than return from inside the block.
     try:
         with nogil:
             for i in range(lines):
@@ -2314,8 +2324,7 @@ cdef _datetime_box_utf8(parser_t *parser, int64_t col,
                     continue
 
                 # _token_len, not strlen: an embedded NUL must reach the ISO
-                # parser (and fail) so the column falls back like the object
-                # path.
+                # parser and fail, so the column falls back like the object path.
                 word_len = _token_len(parser, token_idx)
                 arena_size += word_len + 1
                 if word_len == 0:
@@ -2328,24 +2337,14 @@ cdef _datetime_box_utf8(parser_t *parser, int64_t col,
 
                 if require_consistent_format:
                     if template_word == NULL:
-                        # Word pointers stay valid for the duration of this
-                        # chunk's conversion, so we can hold on to the first.
+                        # Word pointers stay valid for this chunk's conversion.
                         template_word = word
                         template_len = word_len
-                        if fixed_ok:
-                            template_fixed = (
-                                1 if word_len == 10
-                                else (2 if word[10] == b" " else 3)
-                            )
-                        else:
-                            template_fixed = 0
+                        template_fixed = (
+                            _layout_code(word, word_len) if fixed_ok else 0
+                        )
                     elif fixed_ok:
-                        # Fixed-layout rows share a shape exactly when their
-                        # layout codes match; O(1) vs the per-byte scan.
-                        if template_fixed != (
-                            1 if word_len == 10
-                            else (2 if word[10] == b" " else 3)
-                        ):
+                        if template_fixed != _layout_code(word, word_len):
                             fallback = True
                             break
                     elif not _same_format_shape(template_word, template_len,
@@ -2362,15 +2361,13 @@ cdef _datetime_box_utf8(parser_t *parser, int64_t col,
                         NULL, 0, INFER_FORMAT,
                     )
                     if ret:
-                        # Not ISO8601 — signal caller to fall back to the
-                        # object path.
                         fallback = True
                         break
 
                 if out_local:
-                    # Tracked here so we can uniformly shift to UTC after the
-                    # loop.  Mixed naive+aware or differing offsets defer to
-                    # the slow path, matching the existing error behavior.
+                    # Offsets are collected here and applied after the loop.
+                    # Mixed naive+aware or differing offsets defer to the slow
+                    # path, matching the existing error behavior.
                     if saw_naive:
                         fallback = True
                         break
@@ -2395,11 +2392,9 @@ cdef _datetime_box_utf8(parser_t *parser, int64_t col,
                     creso = item_reso
                     creso_set = True
                 elif item_reso > creso:
-                    # Higher-resolution row encountered mid-column — the
-                    # whole column is reparsed at the new resolution below.
+                    # Higher-resolution row: reparse the column below.
                     bump_reso = item_reso
                     break
-                # else: item_reso <= creso; fine to write at the higher creso.
 
                 iresult[i] = npy_datetimestruct_to_datetime(creso, &dts)
     except OverflowError:

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -69,6 +69,7 @@ from libc.stdlib cimport (
 )
 from libc.string cimport (
     memcpy,
+    memset,
     strcasecmp,
     strlen,
     strncpy,
@@ -1983,8 +1984,109 @@ cdef _string_box_utf8(parser_t *parser, int64_t col,
     return result, na_count
 
 
+cdef int _days_per_month_array[12]
+_days_per_month_array[:] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+
+cdef inline bint _all_digits(const char *chars, int start,
+                             int stop) noexcept nogil:
+    cdef int k
+    for k in range(start, stop):
+        if chars[k] < b"0" or chars[k] > b"9":
+            return False
+    return True
+
+
+cdef inline int _two_digits(const char *chars, int pos) noexcept nogil:
+    return (chars[pos] - ord("0")) * 10 + (chars[pos + 1] - ord("0"))
+
+
+cdef inline int _parse_iso_fixed(const char *word, Py_ssize_t word_len,
+                                 npy_datetimestruct *dts,
+                                 NPY_DATETIMEUNIT *out_bestunit) noexcept nogil:
+    """
+    Faster equivalent to `parse_iso_8601_datetime` for the two dominant
+    fixed-width layouts: `YYYY-MM-DD` and `YYYY-MM-DD[ T]HH:MM:SS` (always
+    timezone-naive). Returns 0 on success, -1 to defer to the general
+    parser, applying the same calendar/range validation it would.
+    """
+    cdef:
+        int year, month, day, days_in_month
+        char sep
+
+    if word_len != 19 and word_len != 10:
+        return -1
+    if word[4] != b"-" or word[7] != b"-":
+        return -1
+    if not _all_digits(word, 0, 4):
+        return -1
+    if not _all_digits(word, 5, 7) or not _all_digits(word, 8, 10):
+        return -1
+
+    year = (
+        (word[0] - ord("0")) * 1000 + (word[1] - ord("0")) * 100
+        + (word[2] - ord("0")) * 10 + (word[3] - ord("0"))
+    )
+    month = _two_digits(word, 5)
+    day = _two_digits(word, 8)
+    if month < 1 or month > 12:
+        return -1
+    days_in_month = _days_per_month_array[month - 1]
+    if month == 2 and year % 4 == 0 and (year % 100 != 0 or year % 400 == 0):
+        days_in_month = 29
+    if day < 1 or day > days_in_month:
+        return -1
+
+    memset(dts, 0, sizeof(npy_datetimestruct))
+    dts.year = year
+    dts.month = month
+    dts.day = day
+
+    if word_len == 10:
+        out_bestunit[0] = NPY_DATETIMEUNIT.NPY_FR_D
+        return 0
+
+    sep = word[10]
+    if sep != b" " and sep != b"T":
+        return -1
+    if word[13] != b":" or word[16] != b":":
+        return -1
+    if not _all_digits(word, 11, 13):
+        return -1
+    if not _all_digits(word, 14, 16) or not _all_digits(word, 17, 19):
+        return -1
+    dts.hour = _two_digits(word, 11)
+    dts.min = _two_digits(word, 14)
+    dts.sec = _two_digits(word, 17)
+    if dts.hour > 23 or dts.min > 59 or dts.sec > 59:
+        return -1
+    out_bestunit[0] = NPY_DATETIMEUNIT.NPY_FR_s
+    return 0
+
+
+cdef inline int _fixed_shape_code(const char *word,
+                                  Py_ssize_t word_len) noexcept nogil:
+    """
+    Classify a datetime string that parses via `_parse_iso_fixed`: 0 when it
+    is not one of the fixed layouts, else 1 (YYYY-MM-DD), 2 (space-separated
+    datetime) or 3 (T-separated datetime). Two fixed-layout strings share a
+    format shape exactly when their codes are equal, giving an O(1)
+    equivalent of `_same_format_shape` on the fastpath.
+    """
+    cdef:
+        npy_datetimestruct dts
+        NPY_DATETIMEUNIT unit
+
+    if _parse_iso_fixed(word, word_len, &dts, &unit) != 0:
+        return 0
+    if word_len == 10:
+        return 1
+    return 2 if word[10] == b" " else 3
+
+
 cdef inline bint _same_format_shape(const char *left, Py_ssize_t left_len,
-                                    const char *right, Py_ssize_t right_len) noexcept:
+                                    const char *right,
+                                    Py_ssize_t right_len) noexcept nogil:
     """
     Check whether two datetime strings share a layout: same length, digits and
     non-digits in the same positions, and identical non-digit characters.
@@ -2158,11 +2260,15 @@ cdef _datetime_box_utf8(parser_t *parser, int64_t col,
         npy_datetimestruct dts
         NPY_DATETIMEUNIT out_bestunit, item_reso
         NPY_DATETIMEUNIT creso = NPY_DATETIMEUNIT.NPY_FR_us
+        NPY_DATETIMEUNIT bump_reso = NPY_DATETIMEUNIT.NPY_FR_GENERIC
         int out_local = 0, out_tzoffset = 0
         int ret
         bint creso_set = False
         bint tz_set = False
         bint saw_tz = False, saw_naive = False
+        bint fallback = False
+        bint fixed_ok = False
+        int template_fixed = -1
         int first_tzoffset = 0
         int64_t offset_in_unit, tz_offset_mult
         const char *template_word = NULL
@@ -2183,6 +2289,7 @@ cdef _datetime_box_utf8(parser_t *parser, int64_t col,
         if state_template is not None:
             template_word = state_template
             template_len = len(state_template)
+            template_fixed = _fixed_shape_code(template_word, template_len)
 
     lines = line_end - line_start
     # Output buffer holds int64s at `creso` resolution; the final dtype is
@@ -2192,83 +2299,124 @@ cdef _datetime_box_utf8(parser_t *parser, int64_t col,
     iresult = result.view("i8")
     coliter_setup(&it, parser, col, line_start)
 
-    for i in range(lines):
-        word = coliter_next_with_idx(&it, &token_idx)
+    # nogil here helps only caller-managed threads; read_csv's own parallel
+    # path is disabled when parse_dates is set.  No early returns inside the
+    # block: bail-outs set `fallback` (or `bump_reso`) and break, and the
+    # except-block folds npy_datetimestruct_to_datetime's raise into one too.
+    try:
+        with nogil:
+            for i in range(lines):
+                word = coliter_next_with_idx(&it, &token_idx)
 
-        if na_filter and kh_get_str_starts_item(na_hashset, word):
-            na_count += 1
-            iresult[i] = NPY_NAT
-            continue
+                if na_filter and kh_get_str_starts_item(na_hashset, word):
+                    na_count += 1
+                    iresult[i] = NPY_NAT
+                    continue
 
-        # _token_len, not strlen: an embedded NUL must reach the ISO parser
-        # (and fail) so the column falls back like the object path.
-        word_len = _token_len(parser, token_idx)
-        arena_size += word_len + 1
-        if word_len == 0:
-            na_count += 1
-            iresult[i] = NPY_NAT
-            continue
+                # _token_len, not strlen: an embedded NUL must reach the ISO
+                # parser (and fail) so the column falls back like the object
+                # path.
+                word_len = _token_len(parser, token_idx)
+                arena_size += word_len + 1
+                if word_len == 0:
+                    na_count += 1
+                    iresult[i] = NPY_NAT
+                    continue
 
-        if require_consistent_format:
-            if template_word == NULL:
-                # Word pointers stay valid for the duration of this chunk's
-                # conversion, so we can hold on to the first one.
-                template_word = word
-                template_len = word_len
-            elif not _same_format_shape(template_word, template_len,
-                                        word, word_len):
-                return None, 0
+                fixed_ok = _parse_iso_fixed(word, word_len,
+                                            &dts, &out_bestunit) == 0
 
-        ret = parse_iso_8601_datetime(
-            word, <int>word_len, 0,
-            &dts, &out_bestunit, &out_local, &out_tzoffset,
-            NULL, 0, INFER_FORMAT,
+                if require_consistent_format:
+                    if template_word == NULL:
+                        # Word pointers stay valid for the duration of this
+                        # chunk's conversion, so we can hold on to the first.
+                        template_word = word
+                        template_len = word_len
+                        if fixed_ok:
+                            template_fixed = (
+                                1 if word_len == 10
+                                else (2 if word[10] == b" " else 3)
+                            )
+                        else:
+                            template_fixed = 0
+                    elif fixed_ok:
+                        # Fixed-layout rows share a shape exactly when their
+                        # layout codes match; O(1) vs the per-byte scan.
+                        if template_fixed != (
+                            1 if word_len == 10
+                            else (2 if word[10] == b" " else 3)
+                        ):
+                            fallback = True
+                            break
+                    elif not _same_format_shape(template_word, template_len,
+                                                word, word_len):
+                        fallback = True
+                        break
+
+                if fixed_ok:
+                    out_local = 0
+                else:
+                    ret = parse_iso_8601_datetime(
+                        word, <int>word_len, 0,
+                        &dts, &out_bestunit, &out_local, &out_tzoffset,
+                        NULL, 0, INFER_FORMAT,
+                    )
+                    if ret:
+                        # Not ISO8601 — signal caller to fall back to the
+                        # object path.
+                        fallback = True
+                        break
+
+                if out_local:
+                    # Tracked here so we can uniformly shift to UTC after the
+                    # loop.  Mixed naive+aware or differing offsets defer to
+                    # the slow path, matching the existing error behavior.
+                    if saw_naive:
+                        fallback = True
+                        break
+                    if not tz_set:
+                        first_tzoffset = out_tzoffset
+                        tz_set = True
+                    elif out_tzoffset != first_tzoffset:
+                        fallback = True
+                        break
+                    saw_tz = True
+                else:
+                    if saw_tz:
+                        fallback = True
+                        break
+                    saw_naive = True
+
+                item_reso = get_supported_reso(out_bestunit)
+                if item_reso < NPY_DATETIMEUNIT.NPY_FR_us:
+                    item_reso = NPY_DATETIMEUNIT.NPY_FR_us
+
+                if not creso_set:
+                    creso = item_reso
+                    creso_set = True
+                elif item_reso > creso:
+                    # Higher-resolution row encountered mid-column — the
+                    # whole column is reparsed at the new resolution below.
+                    bump_reso = item_reso
+                    break
+                # else: item_reso <= creso; fine to write at the higher creso.
+
+                iresult[i] = npy_datetimestruct_to_datetime(creso, &dts)
+    except OverflowError:
+        return None, 0
+
+    if bump_reso != NPY_DATETIMEUNIT.NPY_FR_GENERIC:
+        # Mirrors array_strptime's recursive reparse on `creso_ever_changed`
+        # and keeps output values consistent with one another.
+        return _datetime_box_utf8(
+            parser, col, line_start, line_end,
+            na_filter, na_hashset, require_consistent_format,
+            state, chunk_idx, use_dtype_backend,
+            force_creso=bump_reso,
         )
-        if ret:
-            # Not ISO8601 — signal caller to fall back to the object path.
-            return None, 0
 
-        if out_local:
-            # Tracked here so we can uniformly shift to UTC after the loop.
-            # Mixed naive+aware or differing offsets defer to the slow path,
-            # matching the existing error behavior.
-            if saw_naive:
-                return None, 0
-            if not tz_set:
-                first_tzoffset = out_tzoffset
-                tz_set = True
-            elif out_tzoffset != first_tzoffset:
-                return None, 0
-            saw_tz = True
-        else:
-            if saw_tz:
-                return None, 0
-            saw_naive = True
-
-        item_reso = get_supported_reso(out_bestunit)
-        if item_reso < NPY_DATETIMEUNIT.NPY_FR_us:
-            item_reso = NPY_DATETIMEUNIT.NPY_FR_us
-
-        if not creso_set:
-            creso = item_reso
-            creso_set = True
-        elif item_reso > creso:
-            # Higher-resolution row encountered mid-column — reparse the whole
-            # column at the new resolution. Mirrors array_strptime's recursive
-            # reparse on `creso_ever_changed` and keeps output values
-            # consistent with one another.
-            return _datetime_box_utf8(
-                parser, col, line_start, line_end,
-                na_filter, na_hashset, require_consistent_format,
-                state, chunk_idx, use_dtype_backend,
-                force_creso=item_reso,
-            )
-        # else: item_reso <= creso; fine to write at the higher creso.
-
-        try:
-            iresult[i] = npy_datetimestruct_to_datetime(creso, &dts)
-        except OverflowError:
-            return None, 0
+    if fallback:
+        return None, 0
 
     if not creso_set:
         if state is not None and state.creso_seen != -1:

--- a/pandas/_libs/tslibs/dtypes.pxd
+++ b/pandas/_libs/tslibs/dtypes.pxd
@@ -8,7 +8,7 @@ cpdef NPY_DATETIMEUNIT abbrev_to_npy_unit(str abbrev)
 cdef NPY_DATETIMEUNIT freq_group_code_to_npy_unit(int freq) noexcept nogil
 cpdef int64_t periods_per_day(NPY_DATETIMEUNIT reso=*) except? -1
 cpdef int64_t periods_per_second(NPY_DATETIMEUNIT reso) except? -1
-cdef NPY_DATETIMEUNIT get_supported_reso(NPY_DATETIMEUNIT reso)
+cdef NPY_DATETIMEUNIT get_supported_reso(NPY_DATETIMEUNIT reso) noexcept nogil
 cdef bint is_supported_unit(NPY_DATETIMEUNIT reso)
 
 cdef dict c_OFFSET_TO_PERIOD_FREQSTR

--- a/pandas/_libs/tslibs/dtypes.pyx
+++ b/pandas/_libs/tslibs/dtypes.pyx
@@ -509,7 +509,7 @@ class NpyDatetimeUnit(Enum):
     NPY_FR_GENERIC = NPY_DATETIMEUNIT.NPY_FR_GENERIC
 
 
-cdef NPY_DATETIMEUNIT get_supported_reso(NPY_DATETIMEUNIT reso):
+cdef NPY_DATETIMEUNIT get_supported_reso(NPY_DATETIMEUNIT reso) noexcept nogil:
     # If we have an unsupported reso, return the nearest supported reso.
     if reso == NPY_DATETIMEUNIT.NPY_FR_GENERIC:
         # TODO: or raise ValueError? trying this gives unraisable errors, but


### PR DESCRIPTION
Rebased onto `main` now that GH-65353 has merged — this is now a single commit on top of it, no longer stacked.

The per-row loop in `_datetime_box_utf8` is now pure C and runs without the GIL. The two dominant fixed-width layouts (`YYYY-MM-DD` and `YYYY-MM-DD[ T]HH:MM:SS`) parse through a dedicated validator instead of the general ISO parser, and format-consistency checks between fixed-layout rows collapse to an O(1) layout-code comparison. The receipts / all-or-nothing fallback semantics of GH-65353 are preserved; `get_supported_reso` becomes `noexcept nogil` in tslibs.

### What the GIL release does and does not buy

`read_csv`'s own parallel path is disabled whenever `parse_dates` is set, because per-chunk datetime format inference can disagree with serial whole-column inference. So dropping the GIL buys nothing *there* yet — it is the prerequisite for parallelizing `parse_dates` reads once GH-66275 lands.

What it does buy today is caller-managed concurrency: `read_csv` driven from a user's own thread pool no longer serializes on this loop.

### Benchmarks

vs `main` @ `4b7971977a`, M3 Pro, min-of-N.

Serial, 2M rows, one datetime column:

| format | main | PR | speedup |
|---|---|---|---|
| `YYYY-MM-DD` | 205 ms | 177 ms | 1.16x |
| `YYYY-MM-DD`, all distinct dates | 206 ms | 169 ms | 1.22x |
| `YYYY-MM-DD HH:MM:SS` | 243 ms | 182 ms | 1.34x |
| `YYYY-MM-DD HH:MM:SS`, all distinct | 247 ms | 182 ms | 1.36x |
| `YYYY-MM-DDTHH:MM:SS` | 242 ms | 180 ms | 1.35x |

Caller-managed concurrency, 4 files x 1.5M rows read via `ThreadPoolExecutor`:

| | main | PR | speedup |
|---|---|---|---|
| sequential | 759 ms | 549 ms | 1.38x |
| 4 workers | 464 ms | 213 ms | 2.18x |
| scaling gained from threading | 1.64x | 2.58x | |

An earlier revision of this PR also carried a same-date cache, reusing the year/month/day -> epoch conversion across consecutive timestamps sharing a calendar date. It has been dropped: it was worth ~3% at best on repeated dates and was measurably *negative* on distinct dates, where the extra branch and carried state cost more than the cache saved. All of the serial gain above comes from the fixed-layout validator.

Note that these margins are narrower than the numbers previously quoted here, which were measured against the pre-merge GH-65353 branch; GH-66273 has since improved the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
