### PR TITLE
PERF: read_csv fast paths for nullable and pyarrow-backed EA dtypes

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -188,7 +188,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for integer and string columns (:issue:`65350`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for large uncompressed local files, which are now read in parallel across multiple CPU cores; this is enabled by default except on Windows and can be controlled with the ``mode.max_threads`` option (:issue:`64347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` when an extension dtype is requested (e.g. ``dtype="Int64"``, ``dtype="boolean"``, or ``dtype="int64[pyarrow]"``) (:issue:`XXXXX`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` when an extension dtype is requested (e.g. ``dtype="Int64"``, ``dtype="boolean"``, or ``dtype="int64[pyarrow]"``) (:issue:`66279`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing integer columns (:issue:`65347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading from binary file-like objects (e.g. PyArrow S3 file handles) by avoiding unnecessary ``TextIOWrapper`` wrapping (:issue:`46823`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading in parallel: closing a parser no longer blocks the other parser threads while its buffers are freed (:issue:`66272`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -188,6 +188,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for integer and string columns (:issue:`65350`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for large uncompressed local files, which are now read in parallel across multiple CPU cores; this is enabled by default except on Windows and can be controlled with the ``mode.max_threads`` option (:issue:`64347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` when an extension dtype is requested (e.g. ``dtype="Int64"``, ``dtype="boolean"``, or ``dtype="int64[pyarrow]"``) (:issue:`XXXXX`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing integer columns (:issue:`65347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading from binary file-like objects (e.g. PyArrow S3 file handles) by avoiding unnecessary ``TextIOWrapper`` wrapping (:issue:`46823`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading in parallel: closing a parser no longer blocks the other parser threads while its buffers are freed (:issue:`66272`)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -107,6 +107,7 @@ from pandas.errors import (
 )
 
 from pandas.core.dtypes.dtypes import (
+    BaseMaskedDtype,
     CategoricalDtype,
     ExtensionDtype,
 )
@@ -1219,6 +1220,43 @@ cdef class TextReader:
             return cat, na_count
 
         elif isinstance(dtype, ExtensionDtype):
+            if isinstance(dtype, BaseMaskedDtype) and dtype.kind in "iuf":
+                # Fast path for nullable Integer/Floating dtypes: parse straight
+                # from the C buffers via the nogil numeric converters, instead
+                # of materializing an intermediate ndarray[object] of strings
+                # and re-parsing it through to_numeric in
+                # _from_sequence_of_strings.
+                masked = self._convert_masked_numeric(
+                    dtype, i, start, end, na_filter, na_hashset, na_fset)
+                if masked is not None:
+                    return masked
+                # Not confidently numeric-parseable (e.g. values that overflow
+                # uint64, or non-numeric data); fall through to the generic
+                # _from_sequence_of_strings path, which handles it identically
+                # to before.
+            elif isinstance(dtype, BooleanDtype):
+                # Fast path for the nullable boolean dtype.
+                boolean = self._convert_boolean_masked(
+                    i, start, end, na_filter, na_hashset)
+                if boolean is not None:
+                    return boolean
+                # An unrecognized token spelling; fall through to the generic
+                # path (which raises the canonical error, or applies
+                # user-supplied none_values).
+            elif (isinstance(dtype, ArrowDtype)
+                    and HAS_PYARROW
+                    and self.encoding_errors == b"strict"):
+                # Fast path for pyarrow-backed dtypes: build a pyarrow
+                # large_string array from the C buffers (nogil) and convert it
+                # with pyarrow compute, instead of materializing an
+                # ndarray[object] and re-parsing via to_numeric / to_datetime.
+                arrow = self._convert_arrow(dtype, i, start, end,
+                                            na_filter, na_hashset, na_fset)
+                if arrow is not None:
+                    return arrow
+                # Invalid UTF-8 or a conversion pyarrow could not perform;
+                # fall through to the generic path for identical behavior.
+
             result, na_count = self._string_convert(i, start, end, na_filter,
                                                     na_hashset)
 
@@ -1343,6 +1381,183 @@ cdef class TextReader:
 
         return _string_box_utf8(self.parser, i, start, end, na_filter,
                                 na_hashset, self.encoding_errors)
+
+    # -> ExtensionArray | None
+    cdef _parse_numeric_natural(self, Py_ssize_t i, int64_t start,
+                                int64_t end, bint na_filter,
+                                kh_str_starts_t *na_hashset, set na_fset):
+        # Parse a column with the same nogil converters the col_dtype=None
+        # inference path uses (int64 -> uint64 -> float64) and build the natural
+        # numpy-nullable array (IntegerArray / FloatingArray) -- i.e. what
+        # ``read_csv(dtype_backend="numpy_nullable")`` produces.  Returns that
+        # array, or None to signal "not confidently numeric" (non-numeric data,
+        # or ints wider than uint64 which the string path renders as Python
+        # ints), in which case the caller should fall back to the string path.
+        cdef:
+            object ivals = None
+            # NA count from the int64 parse; -1 == unknown (uint64 path),
+            # None if the int64 parse bailed (falls through to the float parse)
+            object int_na_count = -1
+
+        try:
+            ivals, int_na_count = _try_int64(self.parser, i, start, end,
+                                             na_filter, na_hashset, True)
+        except OverflowError:
+            try:
+                ivals = _try_uint64(self.parser, i, start, end,
+                                    na_filter, na_hashset, True)
+            except (OverflowError, ValueError):
+                return None
+            if ivals is None:
+                return None
+        except ValueError as err:
+            if str(err) != "Number is not int":
+                return None
+            # decimal / exponent form -> fall through to the float parse
+            ivals = None
+
+        if ivals is not None:
+            # Build the NA mask from the actual NA positions rather than from
+            # the integer sentinel value, so a legitimate int64-min / uint64-max
+            # token is preserved instead of being mistaken for NA (which the
+            # sentinel-based _maybe_upcast inference path gets wrong).  The
+            # common no-NA case skips the extra scan.
+            if not na_filter or int_na_count == 0:
+                mask = np.zeros(len(ivals), dtype=bool)
+            else:
+                mask = self._na_bool_mask(i, start, end, na_filter, na_hashset)
+            return IntegerArray(ivals, mask)
+
+        fvals, _ = _try_double(self.parser, i, start, end,
+                               na_filter, na_hashset, na_fset)
+        if fvals is None:
+            return None
+        return _maybe_upcast(fvals, use_dtype_backend=True,
+                             dtype_backend="numpy_nullable")
+
+    # -> tuple[ExtensionArray, int] | None
+    cdef _reconcile_numeric(self, natural, array_type, dtype):
+        # Reconcile the natural nullable array to the requested nullable /
+        # pyarrow dtype through _from_sequence -- exactly what
+        #   _from_sequence_of_strings(to_numeric(strings, "numpy_nullable"))
+        # does after parsing.  Returns (ExtensionArray, na_count), or None so
+        # the caller falls back to the generic string path when the requested
+        # dtype cannot hold the parsed values -- so the raised error matches
+        # legacy behavior exactly.
+        try:
+            result = array_type._from_sequence(natural, dtype=dtype)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        return result, int(natural._mask.sum())
+
+    # -> tuple[ExtensionArray, int] | None
+    cdef _convert_masked_numeric(self, dtype, Py_ssize_t i, int64_t start,
+                                 int64_t end, bint na_filter,
+                                 kh_str_starts_t *na_hashset, set na_fset):
+        # Fast path for numpy-nullable Integer/Floating dtypes, bypassing the
+        # ndarray[object] + to_numeric round-trip in _from_sequence_of_strings.
+        natural = self._parse_numeric_natural(
+            i, start, end, na_filter, na_hashset, na_fset)
+        if natural is None:
+            return None
+        return self._reconcile_numeric(natural, dtype.construct_array_type(),
+                                       dtype)
+
+    # -> tuple[BooleanArray, int] | None
+    cdef _convert_boolean_masked(self, Py_ssize_t i, int64_t start,
+                                 int64_t end, bint na_filter,
+                                 kh_str_starts_t *na_hashset):
+        # Fast path for the nullable "boolean" dtype, bypassing the
+        # ndarray[object] + Python map() round-trip in _from_sequence_of_strings.
+        cdef:
+            Py_ssize_t lines = end - start
+            ndarray[uint8_t] data = np.empty(lines, dtype=np.uint8)
+            ndarray[uint8_t] mask = np.zeros(lines, dtype=np.uint8)
+            int error
+
+        with nogil:
+            error = _try_boolean_masked_nogil(
+                self.parser, i, start, end, na_filter, na_hashset,
+                self.true_set, self.false_set,
+                <uint8_t *>data.data, <uint8_t *>mask.data)
+        if error != 0:
+            # Unrecognized token spelling; defer to the generic string path so
+            # the raised error (and any user none_values) matches legacy exactly.
+            return None
+        return (BooleanArray(data.view(np.bool_), mask.view(np.bool_)),
+                int(mask.sum()))
+
+    cdef _na_bool_mask(self, Py_ssize_t i, int64_t start, int64_t end,
+                       bint na_filter, kh_str_starts_t *na_hashset):
+        # Boolean mask of the NA rows in a column, derived from the NA hashset.
+        cdef:
+            Py_ssize_t j, lines = end - start
+            coliter_t it
+            const char *word = NULL
+            ndarray[uint8_t, cast=True] mask = np.zeros(lines, dtype=bool)
+            uint8_t *mptr = <uint8_t *>mask.data
+
+        if na_filter:
+            coliter_setup(&it, self.parser, i, start)
+            with nogil:
+                for j in range(lines):
+                    word = coliter_next(&it)
+                    if kh_get_str_starts_item(na_hashset, word):
+                        mptr[j] = 1
+        return mask
+
+    # -> tuple[ExtensionArray, int] | None
+    cdef _convert_arrow(self, dtype, Py_ssize_t i, int64_t start,
+                        int64_t end, bint na_filter,
+                        kh_str_starts_t *na_hashset, set na_fset):
+        # Fast path for pyarrow-backed (:class:`ArrowDtype`) columns.
+        import pyarrow as pa
+
+        pa_type = dtype.pyarrow_dtype
+        if pa.types.is_integer(pa_type) or pa.types.is_floating(pa_type):
+            # Parse with the same C converters as dtype_backend="pyarrow"
+            # inference (and the nullable fast path above), then wrap as pyarrow.
+            # This keeps explicit "int64[pyarrow]" parsing identical to
+            # dtype_backend="pyarrow" rather than adopting pyarrow's more lenient
+            # string casting (which would e.g. accept "0x1F").
+            natural = self._parse_numeric_natural(
+                i, start, end, na_filter, na_hashset, na_fset)
+            if natural is None:
+                return None
+            return self._reconcile_numeric(
+                natural, dtype.construct_array_type(), dtype)
+
+        if not (pa.types.is_timestamp(pa_type)
+                or pa.types.is_date(pa_type)
+                or pa.types.is_duration(pa_type)
+                or pa.types.is_time(pa_type)
+                or pa.types.is_boolean(pa_type)
+                or pa.types.is_string(pa_type)
+                or pa.types.is_large_string(pa_type)
+                or pa.types.is_binary(pa_type)):
+            # decimal and any other type keep the generic path (unchanged).
+            return None
+
+        # Build a pyarrow large_string array straight from the C buffers (nogil)
+        # and let _from_sequence_of_strings convert it with pyarrow compute
+        # (to_datetime / cast, nogil C++).  These conversions use the same
+        # engine as the generic object path, so results are unchanged.
+        strings, na_count = _string_pyarrow_utf8(
+            self.parser, i, start, end, na_filter, na_hashset, "str_nan")
+        if isinstance(strings, np.ndarray):
+            # _string_pyarrow_utf8 fell back to the object path (invalid UTF-8)
+            return None
+
+        array_type = dtype.construct_array_type()
+        try:
+            result = array_type._from_sequence_of_strings(
+                strings._pa_array, dtype=dtype)
+        except (ValueError, TypeError, NotImplementedError):
+            # pyarrow raises ArrowInvalid (a ValueError) / ArrowNotImplemented
+            # (a NotImplementedError) on values it cannot convert; defer to the
+            # generic path so the error matches legacy behavior.
+            return None
+        return result, na_count
 
     cdef void _validate_usecols_and_names(self, int num_cols):
         usecols_not_callable_and_exists = not callable(self.usecols) and self.usecols
@@ -2328,6 +2543,61 @@ cdef int _try_bool_flex_nogil(parser_t *parser, int64_t col,
             if error != 0:
                 return error
             data += 1
+
+    return 0
+
+
+cdef inline int _bool_numeric_literal(const char *word) noexcept nogil:
+    # The numeric boolean spellings BooleanArray accepts by default:
+    # "1"/"1.0" -> 1, "0"/"0.0" -> 0, anything else -> -1.
+    if word[0] == ord("1"):
+        if word[1] == 0:
+            return 1
+        if word[1] == ord(".") and word[2] == ord("0") and word[3] == 0:
+            return 1
+    elif word[0] == ord("0"):
+        if word[1] == 0:
+            return 0
+        if word[1] == ord(".") and word[2] == ord("0") and word[3] == 0:
+            return 0
+    return -1
+
+
+cdef int _try_boolean_masked_nogil(parser_t *parser, int64_t col,
+                                   int64_t line_start, int64_t line_end,
+                                   bint na_filter,
+                                   const kh_str_starts_t *na_hashset,
+                                   const kh_str_starts_t *true_hashset,
+                                   const kh_str_starts_t *false_hashset,
+                                   uint8_t *data, uint8_t *mask) noexcept nogil:
+    # Fill data (0/1) and mask (1 == NA) for a nullable "boolean" column,
+    # recognizing the true/false hash sets plus the "1"/"1.0"/"0"/"0.0" numeric
+    # spellings -- i.e. BooleanArray._from_sequence_of_strings' token set.  The
+    # true set is tested before the false set, matching map_string()'s ordering.
+    # Returns -1 on the first unrecognized token so the caller falls back to the
+    # generic path (which raises the canonical error).
+    cdef:
+        Py_ssize_t i, lines = line_end - line_start
+        coliter_t it
+        const char *word = NULL
+        int numeric
+
+    coliter_setup(&it, parser, col, line_start)
+    for i in range(lines):
+        word = coliter_next(&it)
+
+        if na_filter and kh_get_str_starts_item(na_hashset, word):
+            mask[i] = 1
+            data[i] = 0
+            continue
+
+        numeric = _bool_numeric_literal(word)
+        if kh_get_str_starts_item(true_hashset, word) or numeric == 1:
+            data[i] = 1
+        elif kh_get_str_starts_item(false_hashset, word) or numeric == 0:
+            data[i] = 0
+        else:
+            return -1
 
     return 0
 

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -418,10 +418,10 @@ class ArrowExtensionArray(
         """
         Construct a new ExtensionArray from a sequence of strings.
         """
-        mask = isna(strings)
-
         if isinstance(strings, cls):
             strings = strings._pa_array
+
+        is_pa_array = isinstance(strings, (pa.Array, pa.ChunkedArray))
 
         pa_type = to_pyarrow_type(dtype)
         if (
@@ -441,7 +441,7 @@ class ArrowExtensionArray(
             from pandas.core.tools.datetimes import to_datetime
 
             scalars = to_datetime(strings, errors="raise").date
-            scalars = pa.array(scalars, type=pa_type, mask=mask)
+            scalars = pa.array(scalars, type=pa_type, mask=isna(strings))
         elif pa.types.is_duration(pa_type):
             from pandas.core.tools.timedeltas import to_timedelta
 
@@ -452,7 +452,7 @@ class ArrowExtensionArray(
                 # attempt to parse as int64 reflecting pyarrow's
                 # duration to string casting behavior
                 mask = isna(scalars)
-                if not isinstance(strings, (pa.Array, pa.ChunkedArray)):
+                if not is_pa_array:
                     strings = pa.array(strings, type=pa.string(), mask=mask)
                 strings = pc.if_else(mask, None, strings)
                 try:
@@ -471,10 +471,10 @@ class ArrowExtensionArray(
             # Note: BooleanArray was previously used to parse these strings
             #   and allows "1.0" and "0.0". Pyarrow casting does not support
             #   this, but we allow it here.
-            if isinstance(strings, (pa.Array, pa.ChunkedArray)):
+            if is_pa_array:
                 scalars = strings
             else:
-                scalars = pa.array(strings, type=pa.string(), mask=mask)
+                scalars = pa.array(strings, type=pa.string(), mask=isna(strings))
             scalars = pc.if_else(pc.equal(scalars, "1.0"), "1", scalars)
             scalars = pc.if_else(pc.equal(scalars, "0.0"), "0", scalars)
             scalars = scalars.cast(pa.bool_())
@@ -486,10 +486,12 @@ class ArrowExtensionArray(
             from pandas.core.tools.numeric import to_numeric
 
             scalars = to_numeric(strings, errors="raise")
-            if isinstance(strings, (pa.Array, pa.ChunkedArray)):
+            if is_pa_array:
                 scalars = strings.cast(pa_type)
-            elif mask is not None:
-                scalars = pa.array(scalars, mask=mask, type=pa_type)
+            else:
+                mask = isna(strings)
+                if mask is not None:
+                    scalars = pa.array(scalars, mask=mask, type=pa_type)
 
         else:
             raise NotImplementedError(

--- a/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
+++ b/pandas/tests/io/parser/dtypes/test_dtypes_basic.py
@@ -453,6 +453,81 @@ def test_nullable_int_dtype(all_parsers, any_int_ea_dtype):
     tm.assert_frame_equal(actual, expected)
 
 
+@xfail_pyarrow  # pyarrow engine reads uint64-max via float64 and cannot cast it
+def test_nullable_int_dtype_boundary_values(all_parsers):
+    # A nullable-integer dtype whose boundary value coincides with the C
+    # parser's internal NA sentinel (int64 min / uint64 max) must be kept,
+    # not silently turned into NA.
+    parser = all_parsers
+    data = "a,b\n-9223372036854775808,18446744073709551615\n0,0\n"
+    result = parser.read_csv(StringIO(data), dtype={"a": "Int64", "b": "UInt64"})
+    expected = DataFrame(
+        {
+            "a": pd.array([-9223372036854775808, 0], dtype="Int64"),
+            "b": pd.array([18446744073709551615, 0], dtype="UInt64"),
+        }
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+@xfail_pyarrow  # pyarrow engine handles explicit ArrowDtype differently
+def test_explicit_arrow_numeric_dtype(all_parsers):
+    # Explicitly requesting a pyarrow-backed numeric dtype parses identically to
+    # dtype_backend="pyarrow" (e.g. it does not adopt pyarrow's more lenient
+    # string casting).
+    pytest.importorskip("pyarrow")
+    parser = all_parsers
+    data = "a,b\n1,2.5\n,\n-3,4\n"
+    result = parser.read_csv(
+        StringIO(data), dtype={"a": "int64[pyarrow]", "b": "double[pyarrow]"}
+    )
+    expected = DataFrame(
+        {
+            "a": pd.array([1, pd.NA, -3], dtype="int64[pyarrow]"),
+            "b": pd.array([2.5, pd.NA, 4.0], dtype="double[pyarrow]"),
+        }
+    )
+    tm.assert_frame_equal(result, expected)
+
+    # hex is rejected, matching dtype="int64" (not silently parsed as 31)
+    with pytest.raises(ValueError, match="Unable to parse string"):
+        parser.read_csv(StringIO("a\n0x1F\n"), dtype={"a": "int64[pyarrow]"})
+
+
+def test_explicit_arrow_temporal_dtype(all_parsers):
+    # Non-numeric pyarrow-backed dtypes round-trip through read_csv.
+    pytest.importorskip("pyarrow")
+    parser = all_parsers
+    data = "a,b\n2020-01-01,1\n,2\n2021-06-15,3\n"
+    result = parser.read_csv(StringIO(data), dtype={"a": "timestamp[ns][pyarrow]"})
+    expected = DataFrame(
+        {
+            "a": pd.array(
+                ["2020-01-01", None, "2021-06-15"], dtype="timestamp[ns][pyarrow]"
+            ),
+            "b": [1, 2, 3],
+        }
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+@xfail_pyarrow  # true_values/false_values not supported by the pyarrow engine
+def test_nullable_boolean_dtype_with_true_false_values(all_parsers):
+    # User-supplied true_values/false_values augment the default token set.
+    parser = all_parsers
+    data = "a,b\nyes,1\nno,2\nTrue,3\n"
+    result = parser.read_csv(
+        StringIO(data),
+        dtype={"a": "boolean"},
+        true_values=["yes"],
+        false_values=["no"],
+    )
+    expected = DataFrame(
+        {"a": pd.array([True, False, True], dtype="boolean"), "b": [1, 2, 3]}
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize("default", ["float", "float64"])
 def test_dtypes_defaultdict(all_parsers, default):
     # GH#41574


### PR DESCRIPTION
Requesting an ExtensionArray dtype explicitly (e.g. `dtype="Int64"`, `dtype="int64[pyarrow]"`, `dtype="boolean"`) is currently 5–9x slower than the equivalent `dtype_backend` inference, because the `c` engine materializes an intermediate `ndarray[object]` of Python strings and then re-parses it (via `to_numeric` / `_from_sequence_of_strings`). This routes those dtypes through the nogil C converters instead.

- **nullable Integer/Floating** (e.g. `Int64`, `Float64`): parse with the same C converters `dtype_backend="numpy_nullable"` uses, building the NA mask from the actual NA positions rather than the integer sentinel, so legitimate `int64`-min / `uint64`-max values are preserved (the sentinel-based inference path masks them).
- **pyarrow-backed numeric** (e.g. `int64[pyarrow]`): the same C-converter parse, then wrapped as pyarrow — this keeps explicit `int64[pyarrow]` parsing identical to `dtype_backend="pyarrow"` rather than adopting pyarrow's more lenient string casting (which would e.g. accept `"0x1F"`). Temporal / boolean / string `ArrowDtype` build a pyarrow `large_string` array straight from the buffers and hand it to `_from_sequence_of_strings` (same conversion engine as before).
- **nullable boolean** (`boolean`): a nogil pass recognizing the true/false sets plus the `"1"/"1.0"/"0"/"0.0"` spellings, testing the true set before the false set to match `map_string`'s ordering (so it stays correct even with overlapping user `true_values`/`false_values`).

Every fast path falls back to the generic string path on anything it cannot confidently handle (non-numeric data, ints wider than `uint64`, invalid UTF-8, an unrecognized boolean token, a dtype the requested type can't hold), so behavior — including raised errors — is unchanged. Also makes `ArrowExtensionArray._from_sequence_of_strings` compute its `isna` mask lazily so a pyarrow-array input isn't scanned unnecessarily.

Timings (1M rows × 10 cols, single-threaded), against current main — the baseline has moved since this was opened, as main has picked up GH-65350, GH-65767 and GH-66239:

| dtype | before | after |
|---|---|---|
| `Int64` / `Float64` | 2772 / 3123 ms | 322 / 518 ms |
| `int64[pyarrow]` / `double[pyarrow]` | 2918 / 3134 ms | 316 / 492 ms |
| `bool[pyarrow]` | 788 ms | 536 ms |
| `boolean` | 1514 ms | 294 ms |

Validated with per-family differential tests (random + adversarial inputs, custom `na_values`, the parallel-read path) against the legacy path; whole result and raised errors match.
