### PR TITLE
BUG: assert_series_equal reports misleading 'Series classes are different' for backing-array subclass mismatch

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -514,6 +514,7 @@ Other
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
 - Bug in :meth:`DataFrame.select_dtypes` with an :class:`~pandas.api.extensions.ExtensionDtype` subclass such as :class:`ArrowDtype` or :class:`DatetimeTZDtype` raising ``TypeError``, emitting a spurious ``UserWarning``, or selecting the wrong columns; passing such a class now selects every column whose dtype is an instance of that class (:issue:`65366`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
+- Bug in :func:`testing.assert_series_equal` where a mismatch between the backing array classes (e.g. an :class:`numpy.ndarray` subclass) produced a misleading ``"Series classes are different"`` error message; the message now correctly refers to the numpy array classes (:issue:`65770`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -709,8 +709,12 @@ def assert_numpy_array_equal(
     __tracebackhide__ = True
 
     # instance validation
-    # Show a detailed error message when classes are different
-    assert_class_equal(left, right, obj=obj)
+    # Show a detailed error message when classes are different. Always describe
+    # this as a numpy array class mismatch instead of using ``obj``, so that
+    # callers passing e.g. ``obj="Series"`` do not produce a misleading
+    # "Series classes are different" message when it is only the backing array
+    # classes (e.g. an ``np.ndarray`` subclass) that differ (GH#65770).
+    assert_class_equal(left, right, obj="numpy array")
     # both classes must be an np.ndarray
     _check_isinstance(left, right, np.ndarray)
 

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -324,6 +324,22 @@ def test_series_equal_series_type():
         tm.assert_series_equal(s3, s1, check_series_type=True)
 
 
+def test_series_equal_array_subclass_message():
+    # GH#65770 - when only the backing array classes differ (e.g. an
+    # ``np.ndarray`` subclass), the error must not be reported as a mismatch of
+    # the Series classes; the message should make clear it refers to the
+    # (backing) numpy array classes instead.
+    class OtherArray(np.ndarray):
+        pass
+
+    arr = np.array([1])
+    left = Series(arr)
+    right = Series(arr.view(OtherArray))
+
+    with pytest.raises(AssertionError, match="numpy array classes are different"):
+        tm.assert_series_equal(left, right, check_series_type=False)
+
+
 def test_series_equal_exact_for_nonnumeric():
     # https://github.com/pandas-dev/pandas/issues/35446
     s1 = Series(["a", "b"])


### PR DESCRIPTION
- [x] closes #65770
- [x] Tests added and passed
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.

On the exact-comparison path, `assert_series_equal` compares the two Series' backing arrays via `assert_numpy_array_equal(..., obj="Series")`. When those arrays differ only by class (e.g. an `np.ndarray` subclass), the internal `assert_class_equal` call formatted the message with `obj="Series"`, producing a misleading `"Series classes are different"` even though the `Series` classes were identical.

Per the issue discussion (keep raising, clarify the message), `assert_numpy_array_equal` now runs its internal class check with a fixed `obj="numpy array"`, so the message accurately refers to the numpy array classes for any caller. The legitimate `check_series_type=True` Series-class check is unaffected, and this matches the existing `test_assert_numpy_array_equal_class_mismatch` expectation.