### PR TITLE
BUG: Register SQLite adapters only once per process (GH#64337)

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2544,6 +2544,11 @@ def _quote_identifier(name: object) -> str:
     return '"' + uname.replace('"', '""') + '"'
 
 
+# Guard to avoid overwriting user-registered SQLite adapters/converters
+# on every to_sql() call.  See GH#64337.
+_SQLITE_ADAPTERS_REGISTERED: bool = False
+
+
 class SQLiteTable(SQLTable):
     """
     Patch the SQLTable for fallback support.
@@ -2556,9 +2561,15 @@ class SQLiteTable(SQLTable):
         self._register_date_adapters()
 
     def _register_date_adapters(self) -> None:
-        # GH 8341
-        # register an adapter callable for datetime.time object
+        # GH 8341 — register adapter callable for datetime.time object
+        # GH 61092 — register adapters for date/datetime (Python 3.12+)
+        # GH 64337 — only register once per process to avoid overwriting
+        # user-registered adapters on subsequent to_sql() calls.
         import sqlite3
+
+        global _SQLITE_ADAPTERS_REGISTERED
+        if _SQLITE_ADAPTERS_REGISTERED:
+            return
 
         # this will transform time(12,34,56,789) into '12:34:56.000789'
         # (this is what sqlalchemy does)
@@ -2583,6 +2594,8 @@ class SQLiteTable(SQLTable):
 
         sqlite3.register_converter("date", convert_date)
         sqlite3.register_converter("timestamp", convert_timestamp)
+
+        _SQLITE_ADAPTERS_REGISTERED = True
 
     def sql_schema(self) -> str:
         return str(";\n".join(self.table))

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -4414,6 +4414,32 @@ def test_xsqlite_if_exists(sqlite_buildin):
         (2, "B"),
         (3, "C"),
         (4, "D"),
-        (5, "E"),
+         (5, "E"),
     ]
     drop_table(table_name, sqlite_buildin)
+
+
+def test_to_sql_preserves_user_sqlite_adapters(sqlite_buildin):
+    """
+    GH#64337 — DataFrame.to_sql() should not overwrite user-registered
+    SQLite adapters on subsequent calls.
+    """
+    import sqlite3
+
+    # First to_sql call — pandas registers its adapters
+    df = DataFrame({"t": [time(12, 30)]})
+    df.to_sql("test_adapter_1", sqlite_buildin, if_exists="replace", index=False)
+
+    # User registers a custom adapter for time
+    def custom_time_adapter(t):
+        return f"CUSTOM:{t.hour:02d}:{t.minute:02d}:{t.second:02d}"
+
+    sqlite3.register_adapter(time, custom_time_adapter)
+
+    # Second to_sql call — must NOT overwrite the user's adapter
+    df2 = DataFrame({"t": [time(14, 0)]})
+    df2.to_sql("test_adapter_2", sqlite_buildin, if_exists="replace", index=False)
+
+    # Verify user's adapter is still registered
+    registered = sqlite3.adapters.get((time, sqlite3.PrepareProtocol))
+    assert registered is custom_time_adapter

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -4414,7 +4414,7 @@ def test_xsqlite_if_exists(sqlite_buildin):
         (2, "B"),
         (3, "C"),
         (4, "D"),
-         (5, "E"),
+        (5, "E"),
     ]
     drop_table(table_name, sqlite_buildin)
 


### PR DESCRIPTION

Every call to `DataFrame.to_sql()` with a SQLite connection creates a new `SQLiteTable`
instance, whose `__init__` unconditionally calls `sqlite3.register_adapter()` and
`sqlite3.register_converter()` — **global** mutations. After Python 3.12 removed the
default adapters for datetime types, pandas added its own (commit `c9a8f95f`).
But re-registering them on every `to_sql()` call overwrites any custom adapters or
converters the user may have registered.

### Side-effect analysis

Without pandas' adapters, `to_sql()` crashes on Python 3.12+ when inserting
`datetime.time`, `datetime.date`, or `datetime.datetime` columns. The built-in
`sqlite3` module no longer provides default adapters for these types.
Therefore, we cannot simply stop registering — we must keep the registration
but make it non-destructive.

### Fix

Use a module-level `_SQLITE_ADAPTERS_REGISTERED` flag to ensure adapters and
converters are registered only **once per process lifetime**. After the first
`to_sql()` call, subsequent calls are no-ops and no longer overwrite user
handlers.

**File:** `pandas/io/sql.py`

```python
# Module-level state
_SQLITE_ADAPTERS_REGISTERED: bool = False

class SQLiteTable(SQLTable):
    def _register_date_adapters(self) -> None:
        import sqlite3

        global _SQLITE_ADAPTERS_REGISTERED
        if _SQLITE_ADAPTERS_REGISTERED:
            return

        # ... register adapters and converters as before ...

        _SQLITE_ADAPTERS_REGISTERED = True
```

### Added test

**File:** `pandas/tests/io/test_sql.py`

`test_to_sql_preserves_user_sqlite_adapters` — verifies that a custom
adapter registered after the first `to_sql()` call is NOT overwritten
by subsequent `to_sql()` calls.

### Limitations (documented)

If the user registers custom adapters **before** their first `to_sql()` call,
pandas will still overwrite them on that first call. This is the same as
current behavior. A follow-up PR can implement save/restore for full
protection.

### Checklist

- [x] Bug fix
- [x] Tests pass: `pytest pandas/tests/io/test_sql.py -k test_to_sql_preserves`
- [x] No new dependencies
- [x] Backward compatible — all existing `to_sql` behavior preserved
- [x] No performance regression (single boolean check)