### PR TITLE
BUG: Save and restore user SQLite adapters in to_sql() (GH#64337)

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2658,9 +2658,7 @@ class SQLiteTable(SQLTable):
         data_list = list(data_iter)
         try:
             flattened_data = [x for row in data_list for x in row]
-            conn.execute(
-                self.insert_statement(num_rows=len(data_list)), flattened_data
-            )
+            conn.execute(self.insert_statement(num_rows=len(data_list)), flattened_data)
         finally:
             # Restore user adapters/converters that were overridden
             # in __init__.  See GH#64337.

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2544,11 +2544,6 @@ def _quote_identifier(name: object) -> str:
     return '"' + uname.replace('"', '""') + '"'
 
 
-# Guard to avoid overwriting user-registered SQLite adapters/converters
-# on every to_sql() call.  See GH#64337.
-_SQLITE_ADAPTERS_REGISTERED: bool = False
-
-
 class SQLiteTable(SQLTable):
     """
     Patch the SQLTable for fallback support.
@@ -2556,6 +2551,22 @@ class SQLiteTable(SQLTable):
     """
 
     def __init__(self, *args, **kwargs) -> None:
+        import sqlite3
+
+        # Save user-registered adapters/converters before pandas
+        # registers its own, so they can be restored after the
+        # insert operation completes.  See GH#64337.
+        self._saved_adapters: dict = {}
+        for typ in (time, date, datetime):
+            key = (typ, sqlite3.PrepareProtocol)
+            if key in sqlite3.adapters:
+                self._saved_adapters[key] = sqlite3.adapters[key]
+
+        self._saved_converters: dict = {}
+        for name in ("date", "timestamp"):
+            if name in sqlite3.converters:
+                self._saved_converters[name] = sqlite3.converters[name]
+
         super().__init__(*args, **kwargs)
 
         self._register_date_adapters()
@@ -2563,13 +2574,7 @@ class SQLiteTable(SQLTable):
     def _register_date_adapters(self) -> None:
         # GH 8341 — register adapter callable for datetime.time object
         # GH 61092 — register adapters for date/datetime (Python 3.12+)
-        # GH 64337 — only register once per process to avoid overwriting
-        # user-registered adapters on subsequent to_sql() calls.
         import sqlite3
-
-        global _SQLITE_ADAPTERS_REGISTERED
-        if _SQLITE_ADAPTERS_REGISTERED:
-            return
 
         # this will transform time(12,34,56,789) into '12:34:56.000789'
         # (this is what sqlalchemy does)
@@ -2595,7 +2600,18 @@ class SQLiteTable(SQLTable):
         sqlite3.register_converter("date", convert_date)
         sqlite3.register_converter("timestamp", convert_timestamp)
 
-        _SQLITE_ADAPTERS_REGISTERED = True
+    def _restore_date_adapters(self) -> None:
+        """Restore user-registered adapters and converters that were
+        temporarily overridden by pandas during the insert operation.
+
+        See GH#64337.
+        """
+        import sqlite3
+
+        for (typ, _protocol), adapter in self._saved_adapters.items():
+            sqlite3.register_adapter(typ, adapter)
+        for name, converter in self._saved_converters.items():
+            sqlite3.register_converter(name, converter)
 
     def sql_schema(self) -> str:
         return str(";\n".join(self.table))
@@ -2632,12 +2648,23 @@ class SQLiteTable(SQLTable):
             conn.executemany(self.insert_statement(num_rows=1), data_list)
         except Error as exc:
             raise DatabaseError("Execution failed") from exc
+        finally:
+            # Restore user adapters/converters that were overridden
+            # in __init__.  See GH#64337.
+            self._restore_date_adapters()
         return conn.rowcount
 
     def _execute_insert_multi(self, conn, keys, data_iter) -> int:
         data_list = list(data_iter)
-        flattened_data = [x for row in data_list for x in row]
-        conn.execute(self.insert_statement(num_rows=len(data_list)), flattened_data)
+        try:
+            flattened_data = [x for row in data_list for x in row]
+            conn.execute(
+                self.insert_statement(num_rows=len(data_list)), flattened_data
+            )
+        finally:
+            # Restore user adapters/converters that were overridden
+            # in __init__.  See GH#64337.
+            self._restore_date_adapters()
         return conn.rowcount
 
     def _create_table_setup(self):

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2544,6 +2544,11 @@ def _quote_identifier(name: object) -> str:
     return '"' + uname.replace('"', '""') + '"'
 
 
+# Guard to avoid overwriting user-registered SQLite adapters/converters
+# on every to_sql() call.  See GH#64337.
+_SQLITE_ADAPTERS_REGISTERED: bool = False
+
+
 class SQLiteTable(SQLTable):
     """
     Patch the SQLTable for fallback support.
@@ -2556,9 +2561,15 @@ class SQLiteTable(SQLTable):
         self._register_date_adapters()
 
     def _register_date_adapters(self) -> None:
-        # GH 8341
-        # register an adapter callable for datetime.time object
+        # GH 8341 — register adapter callable for datetime.time object
+        # GH 61092 — register adapters for date/datetime (Python 3.12+)
+        # GH 64337 — only register once per process to avoid overwriting
+        # user-registered adapters on subsequent to_sql() calls.
         import sqlite3
+
+        global _SQLITE_ADAPTERS_REGISTERED
+        if _SQLITE_ADAPTERS_REGISTERED:
+            return
 
         # this will transform time(12,34,56,789) into '12:34:56.000789'
         # (this is what sqlalchemy does)
@@ -2583,6 +2594,8 @@ class SQLiteTable(SQLTable):
 
         sqlite3.register_converter("date", convert_date)
         sqlite3.register_converter("timestamp", convert_timestamp)
+
+        _SQLITE_ADAPTERS_REGISTERED = True
 
     def sql_schema(self) -> str:
         return str(";\n".join(self.table))

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -4414,6 +4414,32 @@ def test_xsqlite_if_exists(sqlite_buildin):
         (2, "B"),
         (3, "C"),
         (4, "D"),
-        (5, "E"),
+         (5, "E"),
     ]
     drop_table(table_name, sqlite_buildin)
+
+
+def test_to_sql_preserves_user_sqlite_adapters(sqlite_buildin):
+    """
+    GH#64337 — DataFrame.to_sql() should not overwrite user-registered
+    SQLite adapters on subsequent calls.
+    """
+    import sqlite3
+
+    # First to_sql call — pandas registers its adapters
+    df = DataFrame({"t": [time(12, 30)]})
+    df.to_sql("test_adapter_1", sqlite_buildin, if_exists="replace", index=False)
+
+    # User registers a custom adapter for time
+    def custom_time_adapter(t):
+        return f"CUSTOM:{t.hour:02d}:{t.minute:02d}:{t.second:02d}"
+
+    sqlite3.register_adapter(time, custom_time_adapter)
+
+    # Second to_sql call — must NOT overwrite the user's adapter
+    df2 = DataFrame({"t": [time(14, 0)]})
+    df2.to_sql("test_adapter_2", sqlite_buildin, if_exists="replace", index=False)
+
+    # Verify user's adapter is still registered
+    registered = sqlite3.adapters.get((time, sqlite3.PrepareProtocol))
+    assert registered is custom_time_adapter

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -4414,7 +4414,7 @@ def test_xsqlite_if_exists(sqlite_buildin):
         (2, "B"),
         (3, "C"),
         (4, "D"),
-         (5, "E"),
+        (5, "E"),
     ]
     drop_table(table_name, sqlite_buildin)
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -4419,27 +4419,57 @@ def test_xsqlite_if_exists(sqlite_buildin):
     drop_table(table_name, sqlite_buildin)
 
 
-def test_to_sql_preserves_user_sqlite_adapters(sqlite_buildin):
+def test_to_sql_restores_user_sqlite_adapters(sqlite_buildin):
     """
-    GH#64337 — DataFrame.to_sql() should not overwrite user-registered
-    SQLite adapters on subsequent calls.
+    GH#64337 — DataFrame.to_sql() should restore user-registered
+    SQLite adapters after the insert operation completes.
+
+    User registers a custom adapter BEFORE any to_sql() call.
+    After to_sql() returns, the user's adapter must still be in place.
     """
     import sqlite3
 
-    # First to_sql call — pandas registers its adapters
-    df = DataFrame({"t": [time(12, 30)]})
-    df.to_sql("test_adapter_1", sqlite_buildin, if_exists="replace", index=False)
-
-    # User registers a custom adapter for time
+    # User has a custom adapter before pandas is ever called
     def custom_time_adapter(t):
         return f"CUSTOM:{t.hour:02d}:{t.minute:02d}:{t.second:02d}"
 
     sqlite3.register_adapter(time, custom_time_adapter)
 
-    # Second to_sql call — must NOT overwrite the user's adapter
-    df2 = DataFrame({"t": [time(14, 0)]})
-    df2.to_sql("test_adapter_2", sqlite_buildin, if_exists="replace", index=False)
+    # to_sql should temporarily use pandas' adapter, then restore user's
+    df = DataFrame({"t": [time(12, 30)]})
+    df.to_sql("test_restore", sqlite_buildin, if_exists="replace", index=False)
 
-    # Verify user's adapter is still registered
+    # Verify user's adapter was restored
     registered = sqlite3.adapters.get((time, sqlite3.PrepareProtocol))
     assert registered is custom_time_adapter
+
+
+def test_to_sql_restores_user_sqlite_converters(sqlite_buildin):
+    """
+    GH#64337 — DataFrame.to_sql() should restore user-registered
+    SQLite converters after the insert operation completes.
+    """
+    import sqlite3
+
+    def custom_date_converter(val):
+        return date.fromisoformat(f"2000-{val.decode()}")
+
+    sqlite3.register_converter("date", custom_date_converter)
+
+    df = DataFrame({"d": [date(2024, 1, 15)]})
+    df.to_sql("test_conv", sqlite_buildin, if_exists="replace", index=False)
+
+    registered = sqlite3.converters.get("date")
+    assert registered is custom_date_converter
+
+
+def test_to_sql_sqlite_adapters_no_crash_without_prior_registration(sqlite_buildin):
+    """
+    GH#64337 — restore should not crash when no user adapters were
+    registered before to_sql().
+    """
+    # No prior user registration — pandas registers its own,
+    # restore is a no-op with empty saved dicts.
+    df = DataFrame({"t": [time(12, 30)]})
+    df.to_sql("test_no_prior", sqlite_buildin, if_exists="replace", index=False)
+    # Should not raise — restore with empty saved dicts is a no-op


### PR DESCRIPTION

Closes #64337

This is a more comprehensive fix that preserves user-registered adapters and
converters even when they were registered **before** the first `to_sql()` call.

### How it works

1. In `SQLiteTable.__init__()`, **save** the currently registered adapters
   (for `time`, `date`, `datetime`) and converters (for `"date"`, `"timestamp"`)
   that pandas will override.

2. Register pandas' adapters/converters as before (needed for the insert
   operation to work on Python 3.12+).

3. After `_execute_insert()` or `_execute_insert_multi()` returns, **restore**
   the user's original adapters/converters via a `finally` block.

### Changes

**File:** `pandas/io/sql.py`

- `SQLiteTable.__init__()` — save existing adapters/converters before
  registering pandas' own
- New `_restore_date_adapters()` method — restores saved handlers
- `_execute_insert()` — wraps `super()` call with try/finally that
  calls `_restore_date_adapters()`
- `_execute_insert_multi()` — same pattern

### Added tests

**File:** `pandas/tests/io/test_sql.py`

- `test_to_sql_restores_user_adapters_after_insert` — custom adapter
  registered BEFORE to_sql() is restored after the operation
- `test_to_sql_restores_user_converters_after_insert` — same for converters
- `test_to_sql_restores_no_crash_when_no_prior_registration` — edge case:
  no prior user registration, should not crash on restore

### Comparison with simple version

| Scenario                                     | Simple (once) | Full (save/restore) |
|----------------------------------------------|---------------|---------------------|
| User registers adapter AFTER first to_sql()  | ✅ preserved  | ✅ preserved        |
| User registers adapter BEFORE first to_sql() | ❌ overwritten | ✅ preserved        |
| Multiple to_sql() calls, adapter preserved   | ✅            | ✅                  |
| Code complexity                              | +5 lines      | +40 lines           |
| Risk                                         | Zero          | Low                 |

### Checklist

- [x] Bug fix
- [x] Tests pass
- [x] No new dependencies
- [x] Backward compatible