### PR TITLE
BUG: DataFrame.loc/iloc setitem with empty or boolean column indexer on EA dtypes (GH#66255)

### DIFF
--- a/doc/source/whatsnew/v3.0.4.rst
+++ b/doc/source/whatsnew/v3.0.4.rst
@@ -27,6 +27,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Fixed a bug in :meth:`DataFrame.iloc` silently ignoring the assignment when setting values with an unordered or duplicated column indexer on a :class:`DataFrame` whose values are referenced by another object (:issue:`65446`)
+- Fixed a bug in :meth:`DataFrame.loc` and :meth:`DataFrame.iloc` when setting values with an empty or length-one boolean column indexer on a column with an extension array dtype (e.g. ``Float64``): an all-False mask wrongly set the entire column, ``iloc[:, []]`` raised ``IndexError``, and an all-True mask raised ``NotImplementedError`` (:issue:`66255`)
 - Fixed a bug in :meth:`DataFrame.to_sql` and :func:`read_sql_table` when using an ADBC engine where table and schema names were not quoted as SQL identifiers, causing failures for identifiers containing spaces or reserved words, and making it vulnerable to SQL injection (:issue:`65065`)
 - Fixed a bug in :meth:`Series.str.__getitem__` raising ``AttributeError`` when underlying array is :class:`ArrowExtensionArray` (:issue:`65112`)
 - Fixed a bug in :meth:`Series.str.match` and :meth:`Index.str.match` with PyArrow-backed string dtypes where a leading ``^`` only anchored the first branch of an alternation pattern (e.g. ``r"^foo|bar"``) (:issue:`66069`)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1731,6 +1731,10 @@ class EABackedBlock(Block):
         orig_value = value
 
         indexer = self._unwrap_setitem_indexer(indexer)
+        if indexer is lib.no_default:
+            # GH#66255 no columns of this block were selected; there is
+            #  nothing to set, matching the numpy-backed behavior
+            return self
         value = self._maybe_squeeze_arg(value)
 
         values = self.values
@@ -2094,6 +2098,10 @@ class ExtensionBlock(EABackedBlock):
             if all(isinstance(x, np.ndarray) and x.ndim == 2 for x in indexer):
                 # GH#44703 went through indexing.maybe_convert_ix
                 first, second = indexer
+                if second.size == 0:
+                    # GH#66255 no columns selected, e.g. iloc[[0], []];
+                    #  there is nothing to set
+                    return lib.no_default
                 if not (
                     second.size == 1 and (second == 0).all() and first.shape[1] == 1
                 ):
@@ -2110,25 +2118,44 @@ class ExtensionBlock(EABackedBlock):
             elif com.is_null_slice(indexer[1]):
                 indexer = indexer[0]
 
-            elif is_list_like(indexer[1]) and len(indexer[1]) == 0:
-                # GH#66255 no columns selected, e.g. iloc[:, []]; there is
-                #  nothing to set
-                indexer = np.array([], dtype=np.intp)
-
-            elif (
-                is_list_like(indexer[1])
-                and len(indexer[1]) == 1
-                and np.asarray(indexer[1]).dtype == np.bool_
-            ):
-                # GH#66255 boolean mask over this block's single column; an
-                #  all-False mask means there is nothing to set
-                if indexer[1][0]:
+            elif isinstance(indexer[1], slice):
+                # GH#66255 non-null slice over this block's single column
+                if 0 in range(*indexer[1].indices(1)):
                     indexer = indexer[0]
                 else:
-                    indexer = np.array([], dtype=np.intp)
+                    return lib.no_default
 
-            elif is_list_like(indexer[1]) and indexer[1][0] == 0:
-                indexer = indexer[0]
+            elif is_list_like(indexer[1]):
+                col_indexer = np.asarray(indexer[1])
+                if col_indexer.size == 0:
+                    # GH#66255 no columns selected, e.g. iloc[:, []]; there
+                    #  is nothing to set
+                    return lib.no_default
+                elif col_indexer.dtype == np.bool_:
+                    # GH#66255 boolean mask over this block's single column;
+                    #  an all-False mask means there is nothing to set
+                    if not col_indexer.any():
+                        return lib.no_default
+                    elif col_indexer.size == 1:
+                        indexer = indexer[0]
+                    else:
+                        raise NotImplementedError(
+                            "This should not be reached. Please report a bug at "
+                            "github.com/pandas-dev/pandas/"
+                        )
+                elif col_indexer.dtype == object:
+                    # match the numpy-backed behavior for object-dtype
+                    #  indexer arrays
+                    raise IndexError(
+                        "arrays used as indices must be of integer (or boolean) type"
+                    )
+                elif indexer[1][0] == 0:
+                    indexer = indexer[0]
+                else:
+                    raise NotImplementedError(
+                        "This should not be reached. Please report a bug at "
+                        "github.com/pandas-dev/pandas/"
+                    )
 
             else:
                 raise NotImplementedError(

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2110,6 +2110,23 @@ class ExtensionBlock(EABackedBlock):
             elif com.is_null_slice(indexer[1]):
                 indexer = indexer[0]
 
+            elif is_list_like(indexer[1]) and len(indexer[1]) == 0:
+                # GH#66255 no columns selected, e.g. iloc[:, []]; there is
+                #  nothing to set
+                indexer = np.array([], dtype=np.intp)
+
+            elif (
+                is_list_like(indexer[1])
+                and len(indexer[1]) == 1
+                and np.asarray(indexer[1]).dtype == np.bool_
+            ):
+                # GH#66255 boolean mask over this block's single column; an
+                #  all-False mask means there is nothing to set
+                if indexer[1][0]:
+                    indexer = indexer[0]
+                else:
+                    indexer = np.array([], dtype=np.intp)
+
             elif is_list_like(indexer[1]) and indexer[1][0] == 0:
                 indexer = indexer[0]
 

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1084,6 +1084,13 @@ class TestiLocBaseIndependent:
         with pytest.raises(ValueError, match=msg):
             obj.iloc[nd3] = 0
 
+    def test_iloc_setitem_empty_column_indexer_ea(self):
+        # GH#66255 this raised IndexError for extension array dtypes
+        df = DataFrame({"col": [1, 2]}, dtype="Float64")
+        expected = df.copy()
+        df.iloc[:, []] = 99
+        tm.assert_frame_equal(df, expected)
+
     def test_iloc_getitem_read_only_values(self, indexer_li):
         # GH#10043 this is fundamentally a test for iloc, but test loc while
         #  we're here

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -1091,6 +1091,42 @@ class TestiLocBaseIndependent:
         df.iloc[:, []] = 99
         tm.assert_frame_equal(df, expected)
 
+    @pytest.mark.parametrize("dtype", ["float64", "Float64"])
+    def test_iloc_setitem_empty_column_selections_noop(self, dtype):
+        # GH#66255 empty column selections are no-ops and do not validate
+        #  the value, matching numpy-backed columns
+        df = DataFrame({"col": [1.0, 2.0]}, dtype=dtype)
+        expected = df.copy()
+
+        df.iloc[:, :0] = 99
+        tm.assert_frame_equal(df, expected)
+
+        df.iloc[[0], []] = 99
+        tm.assert_frame_equal(df, expected)
+
+        df.iloc[:, []] = np.empty((2, 0))
+        tm.assert_frame_equal(df, expected)
+
+    @pytest.mark.parametrize("dtype", ["float64", "Float64"])
+    def test_iloc_setitem_object_dtype_column_mask_raises(self, dtype):
+        # GH#66255 object-dtype indexer arrays raise for numpy-backed
+        #  columns; extension array columns must match
+        df = DataFrame({"col": [1.0, 2.0]}, dtype=dtype)
+        msg = "arrays used as indices must be of integer"
+        with pytest.raises(IndexError, match=msg):
+            df.iloc[:, np.array([False], dtype=object)] = 99
+
+    def test_iloc_setitem_boolean_column_mask_ea(self):
+        # GH#66255 boolean column masks with iloc on EA dtypes
+        df = DataFrame({"col": [1, 2]}, dtype="Float64")
+        expected = df.copy()
+
+        df.iloc[:, np.array([False])] = 99
+        tm.assert_frame_equal(df, expected)
+
+        df.iloc[:, np.array([True])] = 99
+        tm.assert_frame_equal(df, DataFrame({"col": [99, 99]}, dtype="Float64"))
+
     def test_iloc_getitem_read_only_values(self, indexer_li):
         # GH#10043 this is fundamentally a test for iloc, but test loc while
         #  we're here

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -908,6 +908,14 @@ class TestLocBaseIndependent:
         expected = DataFrame({"col": [99, 99]}, dtype="Float64")
         tm.assert_frame_equal(df, expected)
 
+    def test_loc_setitem_all_false_column_mask_invalid_value_ea(self):
+        # GH#66255 nothing is selected, so the value is not validated,
+        #  matching numpy-backed columns
+        df = DataFrame({"col": [1, 2]}, dtype="Float64")
+        expected = df.copy()
+        df.loc[:, np.array([False])] = "bad"
+        tm.assert_frame_equal(df, expected)
+
     @pytest.mark.parametrize("has_ref", [True, False])
     def test_loc_setitem_frame(self, has_ref):
         df = DataFrame(

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -885,6 +885,29 @@ class TestLocBaseIndependent:
         )
         tm.assert_frame_equal(df, expected)
 
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            "Float64",
+            "Int64",
+            pytest.param("float64[pyarrow]", marks=td.skip_if_no("pyarrow")),
+        ],
+    )
+    def test_loc_setitem_all_false_boolean_column_mask_ea(self, dtype):
+        # GH#66255 an all-False boolean column indexer wrongly set the
+        #  whole column for extension array dtypes
+        df = DataFrame({"col": [1, 2, 3, 4]}, dtype=dtype)
+        expected = df.copy()
+        df.loc[:, df.columns == "nope"] = pd.NA
+        tm.assert_frame_equal(df, expected)
+
+    def test_loc_setitem_all_true_boolean_column_mask_ea(self):
+        # GH#66255 this raised NotImplementedError
+        df = DataFrame({"col": [1, 2]}, dtype="Float64")
+        df.loc[:, np.array([True])] = 99
+        expected = DataFrame({"col": [99, 99]}, dtype="Float64")
+        tm.assert_frame_equal(df, expected)
+
     @pytest.mark.parametrize("has_ref", [True, False])
     def test_loc_setitem_frame(self, has_ref):
         df = DataFrame(


### PR DESCRIPTION
- [x] closes #66255 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

`EABackedBlock._unwrap_setitem_indexer` interpreted a boolean column indexer as a positional one: `indexer[1][0] == 0` is true for `np.array([False])`, so an all-False column mask unwrapped to the row indexer and set the entire column. The same branch raised `IndexError` for an empty positional indexer (`iloc[:, []]`) and `NotImplementedError` for an all-True mask. All three now behave like the numpy-dtype path:

```
df = pd.DataFrame({"col": [1, 2, 3, 4]}, dtype="Float64")
df.loc[:, df.columns == "nope"] = pd.NA   # before: whole column set to NA; after: no-op
df.iloc[:, []] = 99                        # before: IndexError; after: no-op
df.loc[:, np.array([True])] = 99           # before: NotImplementedError; after: sets the column
```

Affects all extension array dtypes (masked and arrow-backed). The bool handling is restricted to length-1 masks so multi-column 2D EA blocks keep their current behavior. loc/iloc/masked/internals suites pass (8089 tests).