### PR TITLE
BUG: pd.eval silently parses Series/DataFrame repr (GH#16289)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -517,6 +517,7 @@ Other
 ^^^^^
 
 - Bug in :class:`DataFrame` constructor where passing the same :class:`Index` object as both ``index`` and ``columns`` shared a single object between the two axes, so mutating metadata such as ``names`` on one would also change the other (:issue:`42934`)
+- Bug in :func:`eval` and :meth:`DataFrame.eval` where passing a :class:`Series` or :class:`DataFrame` as ``expr`` silently parsed its (possibly truncated) repr instead of raising, producing a confusing error (:issue:`16289`)
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
 - Bug in :meth:`DataFrame.select_dtypes` with an :class:`~pandas.api.extensions.ExtensionDtype` subclass such as :class:`ArrowDtype` or :class:`DatetimeTZDtype` raising ``TypeError``, emitting a spurious ``UserWarning``, or selecting the wrong columns; passing such a class now selects every column whose dtype is an instance of that class (:issue:`65366`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -336,6 +336,10 @@ def eval(
     if isinstance(expr, str):
         _check_expression(expr)
         exprs = [e.strip() for e in expr.splitlines() if e.strip() != ""]
+    elif isinstance(expr, NDFrame):
+        # GH#16289 a Series/DataFrame would otherwise be converted to its
+        #  (possibly truncated) repr and parsed, producing a confusing error
+        raise ValueError(f"expr must be a string to be evaluated, {type(expr)} given")
     else:
         # ops.BinOp; for internal compat, not intended to be passed by users
         exprs = [expr]

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1882,6 +1882,15 @@ def test_empty_string_raises(engine, parser):
         pd.eval("", engine=engine, parser=parser)
 
 
+@pytest.mark.parametrize("box", [Series, DataFrame])
+def test_pandas_object_raises(box, engine, parser):
+    # GH#16289 passing a Series/DataFrame parsed its (possibly truncated) repr
+    obj = box(["1 == 1", "2 == 1"] * 1000)
+    msg = "expr must be a string to be evaluated"
+    with pytest.raises(ValueError, match=msg):
+        pd.eval(obj, engine=engine, parser=parser)
+
+
 def test_more_than_one_expression_raises(engine, parser):
     with pytest.raises(SyntaxError, match="only a single expression is allowed"):
         pd.eval("1 + 1; 2 + 2", engine=engine, parser=parser)


### PR DESCRIPTION
closes #16289

`pandas.eval` documents `expr` as a string but never validated it. A non-string `expr` fell through to the internal `ops.BinOp` compat branch, where it was stringified via `pprint_thing` — i.e. its repr. For a `Series`/`DataFrame` longer than the display limit, the truncated repr (`...`) was then parsed as an expression, historically raising `AttributeError: ... no attribute 'visit_Ellipsis'` (GH-16289) and more recently the equally opaque `ValueError: unknown type object`.

Reject `NDFrame` input with the same clear message `DataFrame.query` already uses, so `pd.eval`, `DataFrame.eval`, and `DataFrame.query` behave identically for this mistake. The guard is scoped to `NDFrame` so the internal recursion path (which legitimately passes `Op`/`Term`/`slice` objects) is untouched.