### PR TITLE
BUG: logical ops between uneven-length sparse Series raise (GH#32119)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -495,11 +495,13 @@ Reshaping
 Sparse
 ^^^^^^
 - Bug in :meth:`Series.mean` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
+- Bug in :meth:`Series.reindex` and alignment raising when extending a boolean :class:`SparseDtype`-backed :class:`Series`; missing entries now upcast to ``object`` to match the dense behavior (:issue:`32119`)
 - Bug in :meth:`Series.sum`, :meth:`Series.min`, and :meth:`Series.max` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`SparseArray.astype` where converting a datetime64 :class:`SparseArray` with ``NaT`` fill value to ``"Sparse[int64]"`` silently replaced the fill value with ``0`` instead of ``iNaT`` (:issue:`49631`)
 - Bug in :meth:`SparseArray.mean` raising a ``TypeError`` when called with the ``skipna`` argument (:issue:`65478`)
 - Bug in :meth:`SparseArray.sum` with ``skipna=False`` returning ``NA`` for a non-null ``fill_value`` and ignoring missing values under a null ``fill_value`` (:issue:`65478`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
+- Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a differently-indexed :class:`Series` raising an uninformative error instead of aligning and returning the expected result (:issue:`32119`)
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1201,6 +1201,10 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         elif self.sp_index.npoints == 0:
             # Use the old fill_value unless we took for an index of -1
             _dtype = np.result_type(self.dtype.subtype, type(fill_value))
+            if self.dtype.subtype.kind == "b" and _dtype.kind != "b":
+                # GH#32119 numpy bool can't hold a non-bool (e.g. NA) fill;
+                #  match the dense reindex behavior and upcast to object
+                _dtype = np.dtype(object)
             taken = np.full(sp_indexer.shape, fill_value=fill_value, dtype=_dtype)
             taken[old_fill_indices] = self.fill_value
         else:
@@ -1223,6 +1227,10 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
             if m1.any():
                 result_type = np.result_type(result_type, type(fill_value))
+                if taken.dtype.kind == "b" and result_type.kind != "b":
+                    # GH#32119 numpy bool can't hold a non-bool (e.g. NA)
+                    #  fill; match the dense reindex behavior (bool -> object)
+                    result_type = np.dtype(object)
                 taken = taken.astype(result_type)
                 taken[new_fill_indices] = fill_value
 
@@ -2007,7 +2015,37 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 dtype=np.bool_,
             )
 
-    _logical_method = _cmp_method
+    def _logical_method(self, other, op) -> SparseArray:
+        # GH#32119 the sparse fast path (see _sparse_array_op / splib) only
+        #  implements and/or/xor for boolean and integer subtypes. When
+        #  alignment upcasts an operand to object/float -- e.g. NA introduced
+        #  by reindexing a boolean SparseArray to a longer index -- fall back
+        #  to a dense computation so the result matches the non-sparse path.
+        if not self._logical_needs_dense(other):
+            return self._cmp_method(other, op)
+
+        from pandas.core.ops.array_ops import logical_op
+
+        lvalues = np.asarray(self)
+        rvalues = other if is_scalar(other) else np.asarray(other)
+        result = logical_op(lvalues, rvalues, op)
+        return type(self)(result)
+
+    def _logical_needs_dense(self, other) -> bool:
+        # The and/or/xor sparse kernels only support boolean/integer subtypes;
+        #  everything else (object/float produced by NA upcasting) must be
+        #  computed densely. Inspect dtypes without materializing so the fast
+        #  path still receives the original operand (and its warnings).
+        if self.dtype.subtype.kind not in "biu":
+            return True
+        other_dtype = getattr(other, "dtype", None)
+        if other_dtype is None:
+            # scalar or a dtype-less sequence (e.g. list); the fast path
+            #  handles these, including raising on length mismatch
+            return False
+        if isinstance(other_dtype, SparseDtype):
+            return other_dtype.subtype.kind not in "biu"
+        return other_dtype.kind not in "biu"
 
     def _unary_method(self, op) -> SparseArray:
         fill_value = op(np.array(self.fill_value)).item()

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -468,6 +468,21 @@ def test_mismatched_length_cmp_op(cons):
         left & right
 
 
+@pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
+def test_logical_op_uneven_length_series(op):
+    # GH#32119 a logical op between a sparse Series and a differently-indexed
+    #  Series aligns (introducing NA) and must match the non-sparse result
+    #  instead of raising an uninformative error.
+    sparse = pd.Series(SparseArray(np.arange(10)))
+    dense = pd.Series(np.arange(11))
+
+    result = op(sparse == 5, dense == 5)
+    expected = op(pd.Series(np.arange(10)) == 5, dense == 5)
+
+    assert isinstance(result.dtype, SparseDtype)
+    tm.assert_series_equal(result.astype(bool), expected)
+
+
 @pytest.mark.parametrize(
     "a, b",
     [

--- a/pandas/tests/arrays/sparse/test_indexing.py
+++ b/pandas/tests/arrays/sparse/test_indexing.py
@@ -177,6 +177,24 @@ class TestTake:
         expected = pd.array([0, np.nan], dtype=sparse.dtype)
         tm.assert_sp_array_equal(expected, result)
 
+    def test_take_fill_bool_upcasts_to_object(self):
+        # GH#32119 numpy bool can't hold NA, so taking a fill position from a
+        #  boolean SparseArray upcasts to object (matching dense reindex)
+        #  rather than raising.
+        sparse = SparseArray([False, False, True], fill_value=False)
+        result = sparse.take([0, 2, -1], allow_fill=True)
+        expected = SparseArray([False, True, np.nan], fill_value=False)
+        assert result.dtype == SparseDtype(object, False)
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_take_fill_bool_all_fill_upcasts_to_object(self):
+        # GH#32119 same as above for an all-fill (sp_index.npoints == 0) array
+        sparse = SparseArray([False, False], fill_value=False)
+        result = sparse.take([0, -1], allow_fill=True)
+        expected = SparseArray([False, np.nan], fill_value=False)
+        assert result.dtype == SparseDtype(object, False)
+        tm.assert_sp_array_equal(result, expected)
+
     def test_take_fill_value(self):
         data = np.array([1, np.nan, 0, 3, 0])
         sparse = SparseArray(data, fill_value=0)


### PR DESCRIPTION
closes #32119

Logical ops (`&`, `|`, `^`) between a sparse `Series` and a differently-indexed `Series` raised an uninformative error instead of aligning and returning the expected result. Two layered bugs were involved:

1. **Reindex/alignment crashed for boolean sparse.** Aligning a `Sparse[bool, False]` Series to a longer index introduces an NA fill. numpy `bool` can't hold NA, so `_take_with_fill` upcast the values to `float64` but reconstructed the array with the original bool `fill_value`, which is invalid for a float64 subtype. This crashed even a plain `Series(Sparse[bool]).reindex(...)`. Fixed by upcasting to `object` instead — matching the dense `Series[bool].reindex()` behavior.

2. **The sparse `and`/`or`/`xor` kernels only support bool/integer subtypes.** Once alignment upcasts to `object`/`float`, there's no matching `splib.sparse_<op>_<dtype>` (the original `sparse_and_object` `AttributeError`). `SparseArray._logical_method` now falls back to a dense `logical_op` computation when an operand's subtype isn't bool/integer, so the result matches the non-sparse path. The bool/integer fast path (and its length-mismatch error and deprecation warnings) is preserved.

The reported example now returns the same values as the equivalent dense computation, as a sparsity-preserving `Sparse[bool, False]` (consistent with the even-length case). As a bonus this also fixes `Sparse[bool] & BooleanArray`.