### PR TITLE
DOC: batch of documentation clarifications

### DIFF
--- a/doc/source/user_guide/advanced.rst
+++ b/doc/source/user_guide/advanced.rst
@@ -330,6 +330,13 @@ As usual, **both sides** of the slicers are included as this is label indexing.
 
       df.loc[(slice("A1", "A3"), ...)]  # noqa: E999
 
+   The same ambiguity arises with integer labels. ``df.loc[0, 0]`` is
+   first tried as ``df.loc[(0, 0)]`` -- a single key into the row
+   ``MultiIndex`` -- and is only interpreted as row label ``0`` of column
+   label ``0`` when that lookup fails. Use :class:`pandas.IndexSlice`, e.g.
+   ``df.loc[pd.IndexSlice[0, :], 0]``, or pass a length-1 tuple for the rows,
+   e.g. ``df.loc[(0,), 0]``, to disambiguate.
+
 .. ipython:: python
 
    def mklbl(prefix, n):

--- a/doc/source/user_guide/migration.rst
+++ b/doc/source/user_guide/migration.rst
@@ -149,6 +149,14 @@ A different alternative would be to not use ``inplace``:
     df["foo"] = df["foo"].replace(1, 5)
     df
 
+**Attributes set on a selected column do not persist**
+
+Selecting a column now returns a new :class:`Series` object each time rather
+than a cached one, so setting :attr:`Series.attrs` on a selected column
+(for example ``df["foo"].attrs[...] = ...``) is no longer visible on
+subsequent selections of that column. Store such metadata on the parent
+:class:`DataFrame`'s :attr:`~DataFrame.attrs` instead.
+
 **Constructors now copy NumPy arrays by default**
 
 The Series and DataFrame constructors now copies a NumPy array by default when not

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -394,6 +394,15 @@ We subtract the epoch (midnight at January 1, 1970 UTC) and then floor divide by
 
    (stamps - pd.Timestamp("1970-01-01")) // pd.Timedelta("1s")
 
+.. note::
+
+   You may also see :meth:`Timestamp.timestamp` used for this conversion.
+   The explicit subtraction above is recommended because it is unambiguous
+   about treating a timezone-naive value as UTC: :meth:`Timestamp.timestamp`
+   treats a naive ``Timestamp`` as UTC, which does *not* match the standard
+   library ``datetime.datetime.timestamp``, where a naive value is
+   interpreted as local time.
+
 Another common way to perform this conversion is to convert directly to an integer dtype. Note that the exact integers this produces will depend on the specific unit
 or resolution of the datetime64 dtype:
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2224,6 +2224,16 @@ class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
         to be applied to an existing datetime and can replace specific components of
         that datetime, or represents an interval of time.
 
+    Notes
+    -----
+    When added to a :class:`DatetimeIndex` or datetime :class:`Series`, a
+    ``DateOffset`` is applied to each entry independently. Calendar components
+    such as ``months`` and ``years`` do not represent a fixed duration, so
+    evenly spaced input dates are not guaranteed to remain evenly spaced: dates
+    that would fall on a nonexistent day are clamped to the end of the month.
+    For example, adding ``DateOffset(months=1)`` to both ``2018-01-30`` and
+    ``2018-01-31`` yields ``2018-02-28`` in each case.
+
     Examples
     --------
     >>> from pandas.tseries.offsets import DateOffset

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -297,7 +297,9 @@ class DataFrame(NDFrame, OpsMixin):
         will perform column selection instead.
     dtype : dtype, default None
         Data type to force. Only a single dtype is allowed. If None, infer.
-        If ``data`` is DataFrame then is ignored.
+        If ``data`` is DataFrame then is ignored. Missing values in ``data``
+        are not cast: for example, with ``dtype=str`` a ``NaN`` entry stays
+        missing rather than becoming the string ``"nan"``.
     copy : bool or None, default None
         Copy data from inputs.
         For dict data, the default of None behaves like ``copy=True``.  For DataFrame
@@ -6101,7 +6103,8 @@ class DataFrame(NDFrame, OpsMixin):
             passed MultiIndex level. The new labels are aligned against the
             values of that single level while the other levels are left
             unchanged; passing a flat index with ``level`` does not form the
-            Cartesian product of the remaining levels.
+            Cartesian product of the remaining levels. See
+            :ref:`advanced.advanced_reindex` for the intended use.
         fill_value : scalar, default np.nan
             Value to use for missing values. Defaults to NaN, but can be any
             "compatible" value.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6069,6 +6069,13 @@ class DataFrame(NDFrame, OpsMixin):
             Method to use for filling holes in reindexed DataFrame.
             Please note: this is only applicable to DataFrames/Series with a
             monotonically increasing/decreasing index.
+            Filling is based on the position of each new label relative to the
+            existing labels, and applies to both the index and the columns.
+            For example, with ``method='ffill'`` and a monotonically
+            increasing index, a new label is filled from the nearest existing
+            label that sorts before it, so a new column whose label falls
+            between two existing columns takes its values from the preceding
+            column.
 
             * None (default): don't fill gaps
             * pad / ffill: Propagate last valid observation forward to next
@@ -6091,7 +6098,10 @@ class DataFrame(NDFrame, OpsMixin):
 
         level : int or name
             Broadcast across a level, matching Index values on the
-            passed MultiIndex level.
+            passed MultiIndex level. The new labels are aligned against the
+            values of that single level while the other levels are left
+            unchanged; passing a flat index with ``level`` does not form the
+            Cartesian product of the remaining levels.
         fill_value : scalar, default np.nan
             Value to use for missing values. Defaults to NaN, but can be any
             "compatible" value.
@@ -6254,6 +6264,12 @@ class DataFrame(NDFrame, OpsMixin):
         does not look at DataFrame values, but only compares the original and
         desired indexes. If you do want to fill in the ``NaN`` values present
         in the original DataFrame, use the ``fillna()`` method.
+
+        Because ``method="bfill"`` fills each new label from the next entry
+        present in the original index, the trailing entry at 2010-01-07 stays
+        ``NaN``: there is no original index entry after it. Conversely,
+        ``method="ffill"`` would leave the leading entries (before the first
+        original index entry) unfilled.
 
         See the :ref:`user guide <basics.reindexing>` for more.
         """
@@ -14427,7 +14443,9 @@ class DataFrame(NDFrame, OpsMixin):
 
         Objects passed to the function are Series objects whose index is
         either the DataFrame's index (``axis=0``) or the DataFrame's columns
-        (``axis=1``). However, by default (``by_row="compat"``), if ``func``
+        (``axis=1``); the ``name`` attribute of each passed Series is the label
+        of the column (``axis=0``) or row (``axis=1``) currently being
+        processed. However, by default (``by_row="compat"``), if ``func``
         is a list-like or dict-like of functions, each function is first
         applied to the individual values of the Series rather than the Series
         itself; if this fails, pandas retries by passing the entire Series.
@@ -14465,7 +14483,10 @@ class DataFrame(NDFrame, OpsMixin):
         result_type : {'expand', 'reduce', 'broadcast', None}, default None
             How to interpret list-like results from `func`:
 
-            * 'expand' : list-like results will be turned into columns.
+            * 'expand' : list-like results will be turned into columns. Whether
+              a result is list-like is inferred from the first computed result;
+              if that result is not list-like, ``'expand'`` has no effect and a
+              Series is returned.
             * 'reduce' : returns a Series if possible rather than expanding
               list-like results. This is the opposite of 'expand'.
             * 'broadcast' : results will be broadcast to the original shape

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6489,7 +6489,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             cast entire pandas object to the same type. Alternatively, use a
             mapping, e.g. {col: dtype, ...}, where col is a column label and dtype is
             a numpy.dtype or Python type to cast one or more of the DataFrame's
-            columns to column-specific types.
+            columns to column-specific types. The mapping may be a ``dict`` or a
+            :class:`Series` indexed by column label; columns whose labels are
+            absent from the mapping are left unchanged. A Python type (e.g.
+            ``int``, ``float``, ``str``, ``bool``) is mapped to the corresponding
+            dtype; a type with no such mapping, such as ``datetime.datetime``,
+            raises ``TypeError``.
         copy : bool, default False
             This keyword is now ignored; changing its value will have no
             impact on the method.
@@ -8074,7 +8079,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             * 'outside': Only fill NaNs outside valid values (extrapolate).
 
         **kwargs : optional
-            Keyword arguments to pass on to the interpolating function.
+            Keyword arguments to pass on to the interpolating function. Not
+            all methods use them: the ``'linear'``, ``'time'``, ``'index'``,
+            and ``'values'`` methods use NumPy and ignore any extra keyword
+            arguments (for example, ``left`` and ``right``).
 
         Returns
         -------
@@ -11925,6 +11933,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             If a timedelta, str, or offset, the time period of each window. Each
             window will be a variable sized based on the observations included in
             the time-period. This is only valid for datetimelike indexes.
+            The offset must correspond to a fixed frequency (for example, ``'2D'``
+            or ``'1h'``); non-fixed frequencies such as ``'B'`` (business day) or
+            ``'ME'`` (month end) are not supported and raise ``ValueError``.
             To learn more about the offsets & frequency strings, please see
             :ref:`this link<timeseries.offset_aliases>`.
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -264,6 +264,10 @@ class SeriesGroupBy(GroupBy[Series]):
         behavior or errors and are not supported. See :ref:`gotchas.udf-mutation`
         for more details.
 
+        Each group passed to ``func`` has a ``name`` attribute set to the group
+        key (the value of the grouping for that group). This is useful for
+        identifying the current group, as in the examples below.
+
         Examples
         --------
         >>> s = pd.Series([0, 1, 2], index="a a b".split())

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1299,6 +1299,11 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         behavior or errors and are not supported. See :ref:`gotchas.udf-mutation`
         for more details.
 
+        Each group passed to ``func`` has a ``name`` attribute set to the group
+        key (the value of the grouping for that group). This is useful for
+        identifying the current group, for example when grouping by an external
+        grouper rather than by a column of the object.
+
         Examples
         --------
         >>> df = pd.DataFrame({"A": "a a b".split(), "B": [1, 2, 3], "C": [4, 6, 5]})
@@ -3683,6 +3688,9 @@ class GroupBy(BaseGroupBy[NDFrameT]):
             If a timedelta, str, or offset, the time period of each window. Each
             window will be a variable sized based on the observations included in
             the time-period. This is only valid for datetimelike indexes.
+            The offset must correspond to a fixed frequency (for example, ``'2D'``
+            or ``'1h'``); non-fixed frequencies such as ``'B'`` (business day) or
+            ``'ME'`` (month end) are not supported and raise ``ValueError``.
             To learn more about the offsets & frequency strings, please see
             :ref:`this link<timeseries.offset_aliases>`.
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -856,6 +856,13 @@ class MultiIndex(Index):
         it filters out all rows of the level C, MultiIndex.levels will still
         return A, B, C.
 
+        When a ``MultiIndex`` is built by the standard constructors (e.g.
+        :meth:`MultiIndex.from_arrays`, :meth:`MultiIndex.from_tuples`),
+        missing values (``NaN``) are not stored in ``levels``; they are
+        represented by a code of ``-1`` in :attr:`MultiIndex.codes`, so
+        ``levels`` does not contain ``NaN`` even when the corresponding
+        level of the ``MultiIndex`` does.
+
         See Also
         --------
         MultiIndex.codes : The codes of the levels in the MultiIndex.

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -152,8 +152,10 @@ def cut(
 
     Notes
     -----
-    Any NA values will be NA in the result. Out of bounds values will be NA in
-    the resulting Series or Categorical object.
+    Any NA values will be NA in the result. Values that fall outside the range
+    of `bins` (or, when `bins` is a non-contiguous IntervalIndex, between two
+    bins) are not assigned to any bin and will be NA in the resulting Series or
+    Categorical object.
 
     ``numpy.histogram_bin_edges`` can be used along with cut to calculate bins according
     to some predefined methods.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2417,6 +2417,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             * Interval
             * Sparse
             * IntegerNA
+            * String
 
         See Examples section.
 
@@ -5674,6 +5675,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             Method to use for filling holes in reindexed DataFrame.
             Please note: this is only applicable to DataFrames/Series with a
             monotonically increasing/decreasing index.
+            Filling is based on the position of each new label relative to the
+            existing labels. For example, with ``method='ffill'`` and a
+            monotonically increasing index, a new label is filled from the
+            nearest existing label that sorts before it.
 
             * None (default): don't fill gaps
             * pad / ffill: Propagate last valid observation forward to next
@@ -5696,7 +5701,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         level : int or name
             Broadcast across a level, matching Index values on the
-            passed MultiIndex level.
+            passed MultiIndex level. The new labels are aligned against the
+            values of that single level while the other levels are left
+            unchanged; passing a flat index with ``level`` does not form the
+            Cartesian product of the remaining levels.
         fill_value : scalar, default np.nan
             Value to use for missing values. Defaults to NaN, but can be any
             "compatible" value.
@@ -5859,6 +5867,12 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         does not look at DataFrame values, but only compares the original and
         desired indexes. If you do want to fill in the ``NaN`` values present
         in the original DataFrame, use the ``fillna()`` method.
+
+        Because ``method="bfill"`` fills each new label from the next entry
+        present in the original index, the trailing entry at 2010-01-07 stays
+        ``NaN``: there is no original index entry after it. Conversely,
+        ``method="ffill"`` would leave the leading entries (before the first
+        original index entry) unfilled.
 
         See the :ref:`user guide <basics.reindexing>` for more.
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5704,7 +5704,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             passed MultiIndex level. The new labels are aligned against the
             values of that single level while the other levels are left
             unchanged; passing a flat index with ``level`` does not form the
-            Cartesian product of the remaining levels.
+            Cartesian product of the remaining levels. See
+            :ref:`advanced.advanced_reindex` for the intended use.
         fill_value : scalar, default np.nan
             Value to use for missing values. Defaults to NaN, but can be any
             "compatible" value.

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -275,6 +275,10 @@ def read_excel(
         Data type for data or columns. E.g. {'a': np.float64, 'b': np.int32}
         Use ``object`` to preserve data as stored in Excel and not interpret dtype,
         which will necessarily result in ``object`` dtype.
+        Specifying a ``dtype`` does not change how missing values are parsed;
+        values recognized as missing (see ``na_values`` and ``keep_default_na``)
+        are still read as ``NaN`` (or the dtype's NA value) rather than cast to
+        the requested ``dtype``.
         If converters are specified, they will be applied INSTEAD
         of dtype conversion.
         If you use ``None``, it will infer the dtype of each column based on the data.

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -997,6 +997,10 @@ def read_csv(
         E.g., ``{'a': np.float64, 'b': np.int32, 'c': 'Int64'}``
         Use ``str`` or ``object`` together with suitable ``na_values`` settings
         to preserve and not interpret ``dtype``.
+        Specifying a ``dtype`` does not change how missing values are parsed;
+        values recognized as missing (see ``na_values`` and ``keep_default_na``)
+        are still read as ``NaN`` (or the dtype's NA value) rather than cast to
+        the requested ``dtype``.
         If ``converters`` are specified, they will be applied INSTEAD
         of ``dtype`` conversion. Specify a ``defaultdict`` as input where
         the default determines the ``dtype``
@@ -1589,6 +1593,10 @@ def read_table(
         E.g., ``{'a': np.float64, 'b': np.int32, 'c': 'Int64'}``
         Use ``str`` or ``object`` together with suitable ``na_values`` settings
         to preserve and not interpret ``dtype``.
+        Specifying a ``dtype`` does not change how missing values are parsed;
+        values recognized as missing (see ``na_values`` and ``keep_default_na``)
+        are still read as ``NaN`` (or the dtype's NA value) rather than cast to
+        the requested ``dtype``.
         If ``converters`` are specified, they will be applied INSTEAD
         of ``dtype`` conversion. Specify a ``defaultdict`` as input where
         the default determines the ``dtype`` of the columns which

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1576,6 +1576,14 @@ class PlotAccessor(PandasObject):
         DataFrame.plot : Make plots of a DataFrame.
         matplotlib.pyplot.bar : Make a bar plot with matplotlib.
 
+        Notes
+        -----
+        A bar plot draws one tick label per bar, i.e. one per row of the data.
+        This differs from a line plot, where the axis uses an automatic locator
+        that shows only a subset of evenly spaced ticks. With many bars the
+        labels may therefore overlap; set the tick positions and labels manually
+        (e.g. via ``ax.set_xticks``) if a sparser axis is desired.
+
         Examples
         --------
         Basic plot.


### PR DESCRIPTION
Closes the following documentation issues (all prose-only docstring / user-guide clarifications, no behavior changes):

closes #9545
closes #14969
closes #17001
closes #17576
closes #21429
closes #22929
closes #24900
closes #25730
closes #27319
closes #30191
closes #30291
closes #40690
closes #46353
closes #46371
closes #55144
closes #56343
closes #59170
closes #61057
closes #64711

## Summary

A batch of small, self-contained documentation clarifications:

- **Indexing / reindex**: document that `MultiIndex.levels` excludes `NaN` (GH-17576); clarify `reindex` fill-by-position and that leading/trailing gaps can stay unfilled (GH-40690, GH-21429); clarify the `level` argument does not form a Cartesian product (GH-59170); note the `df.loc[0, 0]` integer-label ambiguity (GH-14969).
- **apply / groupby**: document the `.name` attribute of objects passed to `DataFrame.apply` (GH-30191) and to `GroupBy.apply` / `transform` (GH-9545); clarify `result_type="expand"` inference (GH-61057).
- **astype / dtypes**: clarify accepted `astype` types and dict/Series mappings (GH-25730, GH-46353); note `read_csv` / `read_table` still parse missing values as `NaN` under an explicit `dtype` (GH-30291); note string-dtype `unique` returns an ExtensionArray (GH-46371).
- **Datetime / offsets / rolling**: document `DateOffset` element-wise application (GH-22929); clarify `rolling` requires a fixed-frequency offset (GH-24900); explain epoch conversion vs `Timestamp.timestamp` (GH-56343).
- **Misc**: clarify `interpolate` `**kwargs` handling (GH-55144); `cut` out-of-range / gap values (GH-27319); bar-plot tick labels (GH-17001); Copy-on-Write and column `attrs` (GH-64711).

All additions are prose-only (no new doctests). Every factual claim was verified against runtime behavior, all touched docstrings pass numpydoc validation, and pre-commit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
