### PR TITLE
TST: read_excel with duplicate MultiIndex columns (GH#19395)

### DIFF
--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1202,6 +1202,20 @@ class TestExcelWriter:
         expected = DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]])
         tm.assert_frame_equal(result, expected)
 
+    def test_duplicated_multiindex_columns(self, tmp_excel):
+        # GH#19395 reading a sheet with duplicate MultiIndex columns used to
+        # raise an uninformative "Length of new names must be 1" ValueError;
+        # now the duplicate is mangled like read_csv does.
+        df = DataFrame([[0, 1], [2, 3]], columns=[["A", "A"], ["A", "A"]])
+        df.to_excel(tmp_excel)
+
+        result = pd.read_excel(tmp_excel, header=[0, 1], index_col=0)
+        expected = DataFrame(
+            [[0, 1], [2, 3]],
+            columns=MultiIndex.from_tuples([("A", "A"), ("A", "A.1")]),
+        )
+        tm.assert_frame_equal(result, expected)
+
     def test_swapped_columns(self, tmp_excel):
         # Test for issue #5427.
         write_frame = DataFrame({"A": [1, 1, 1], "B": [2, 2, 2]})


### PR DESCRIPTION
closes #19395

Regression test only. Reading a sheet with duplicate MultiIndex columns
(`read_excel(..., header=[0, 1], index_col=0)`) used to raise an
uninformative `ValueError: Length of new names must be 1, got 2`. It now
matches `read_csv`, mangling the duplicate with a `.1` suffix while
preserving the 2-level `MultiIndex`. The behavior was fixed some time ago
(the Excel reader routes through the shared `TextParser`); this just adds
the missing coverage so the issue can be closed.

No whatsnew entry since there is no user-visible code change.