### PR TITLE
ERR: clearer messages for various cryptic errors

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -393,6 +393,7 @@ Indexing
 - Bugs in setitem-with-expansion when adding new rows failing to keep the original dtype in some cases (:issue:`32346`, :issue:`15231`, :issue:`47503`, :issue:`6485`, :issue:`25383`, :issue:`52235`, :issue:`17026`, :issue:`56010`)
 - Bug in :meth:`DataFrame.__getitem__` raising ``InvalidIndexError`` when indexing with a tuple containing a ``slice`` on a :class:`DataFrame` with :class:`MultiIndex` columns (e.g., ``df[:, "t1"]``) (:issue:`26511`)
 - Bug in :meth:`DataFrame.__setitem__` silently keeping only the first column when assigning a 2D array to an existing column label, instead of raising as the new-column and :meth:`DataFrame.loc` cases already did (:issue:`46544`)
+- Bug in :meth:`DataFrame.__setitem__` with a boolean :class:`DataFrame` mask raising a cryptic "cannot assign mismatch length to masked array"; it now raises a ``ValueError`` describing the mismatch between the number of values and the number of ``True`` entries in the mask (:issue:`45593`)
 - Bug in :meth:`DataFrame.at` raising ``TypeError`` when accessing a :class:`MultiIndex` with a partial date string on a :class:`DatetimeIndex` level (:issue:`43395`)
 - Bug in :meth:`DataFrame.duplicated` returning an empty :class:`Series` without the DataFrame's index when the DataFrame had no columns (:issue:`61191`)
 - Bug in :meth:`DataFrame.iloc` and :meth:`Series.iloc` setitem raising ``ValueError`` ("cannot set using a slice indexer with a different length than the value") when assigning to a negative-step slice with an open-ended ``start`` or ``stop`` (e.g. ``ser.iloc[::-2]``) (:issue:`66100`)
@@ -436,6 +437,8 @@ MultiIndex
 - Bug in :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` raising ``IndexError`` instead of a clear ``ValueError`` when passing an empty sequence with ``level=None`` or a list-like ``level`` (:issue:`16147`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)
 - Bug in :meth:`MultiIndex.union` raising ``InvalidIndexError`` when combining levels containing :class:`datetime.date` and :class:`Timestamp` values representing the same date (:issue:`61807`)
+- Constructing a :class:`DataFrame` that reindexes an integer :class:`MultiIndex` onto a flat integer index now raises an informative ``ValueError`` instead of a cryptic ``ValueError: Buffer dtype mismatch`` (:issue:`26460`)
+- :meth:`MultiIndex.isin` now raises an informative ``ValueError`` when the values are not tuples matching the number of levels, instead of raising a cryptic ``TypeError`` or ``AssertionError`` or silently returning incorrect results (:issue:`20252`, :issue:`26622`)
 
 I/O
 ^^^
@@ -446,6 +449,8 @@ I/O
 - :func:`read_csv` with ``memory_map=True`` and an in-memory buffer (e.g. ``BytesIO``) now raises a clear ``ValueError`` instead of a cryptic ``UnsupportedOperation: fileno`` (:issue:`45630`)
 - :func:`read_json` with ``engine="pyarrow"`` now raises ``ValueError`` when passed an option the engine cannot apply -- such as ``typ="series"``, ``convert_dates``, ``keep_default_dates``, ``date_unit``, ``precise_float``, ``convert_axes``, ``encoding``, ``encoding_errors``, ``storage_options``, an explicit ``compression``, or a non-``ArrowDtype`` ``dtype`` -- instead of silently ignoring it and returning an incorrect result (:issue:`66144`)
 - :func:`read_sql_table` now raises an informative ``NotImplementedError`` (instead of one with no message) when passed a DBAPI connection such as ``sqlite3``, and reading from a URI string without a usable ``sqlalchemy`` install now raises a clearer ``ImportError`` (:issue:`41237`)
+- :func:`read_sql` now raises an informative ``DatabaseError`` explaining that reading a table by name requires a SQLAlchemy connection when a bare table name is passed with a DBAPI connection (e.g. ``sqlite3``), instead of a cryptic SQL syntax error (:issue:`54233`)
+- :meth:`DataFrame.to_json` and :meth:`Series.to_json` now raise an informative ``ValueError`` instead of a cryptic ``OverflowError: Maximum recursion level reached`` when a column contains an unsupported object type such as :class:`pathlib.Path` (:issue:`36211`)
 - :meth:`DataFrame.to_sql` now raises a clearer ``ValueError`` when a non-string ``dtype`` is passed for a raw DB-API (e.g. sqlite3) connection (:issue:`61385`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where ``names`` was silently ignored when ``header`` was also an integer; ``names`` now replaces the header row, extra leading columns form the index, and passing too many ``names`` raises ``ValueError`` as with the other engines. ``usecols`` together with ``names`` and an integer ``header`` is not supported by this engine and now raises an informative ``ValueError`` (:issue:`65862`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where a ``defaultdict`` passed as ``dtype`` did not apply its default to columns not explicitly listed (:issue:`41574`)
@@ -520,6 +525,7 @@ Plotting
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Bug in :class:`PeriodIndex` resampling to a finer frequency where aggregation methods returned the original values instead of aggregating, e.g. ``count`` returned the data values rather than the number of observations per bin; empty bins now contain the method's identity value (e.g. ``0`` for ``sum`` instead of ``NaN``), consistent with :class:`DatetimeIndex` resampling (:issue:`42763`)
+- :meth:`DataFrame.ewm` and :meth:`Series.ewm` now raise an informative ``NotImplementedError`` instead of a confusing ``AttributeError`` when ``agg``/``aggregate`` is passed an arbitrary callable (:issue:`41700`)
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)
 - Bug in :meth:`.DataFrameGroupBy.apply` with ``as_index=False`` where applying on an empty :class:`DataFrame` returned inconsistent index metadata compared to non-empty results (:issue:`48135`)
@@ -541,6 +547,8 @@ Groupby/resample/rolling
 
 Reshaping
 ^^^^^^^^^
+- :func:`concat` with ``keys`` now raises an informative ``ValueError`` instead of an ``AssertionError`` when the concatenated objects do not all have the same number of index levels (:issue:`25413`)
+- :meth:`DataFrame.pivot` and :func:`pivot` now raise an informative ``KeyError`` naming the offending labels when ``index``, ``columns``, or ``values`` are not columns of the frame, instead of a cryptic ``TypeError`` (:issue:`35785`)
 - Bug in :func:`concat` raising ``InvalidIndexError`` when ``keys`` or the concatenated objects' index was an overlapping :class:`IntervalIndex` (:issue:`64825`)
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
 - Bug in :meth:`DataFrame.melt` where ``var_name`` colliding with an ``id_vars`` column or ``value_name`` silently overwrote the affected column data instead of raising (:issue:`65654`)
@@ -566,6 +574,7 @@ Sparse
 
 ExtensionArray
 ^^^^^^^^^^^^^^
+- :func:`api.extensions.register_extension_dtype` now raises an informative ``TypeError`` at registration when the :class:`~pandas.api.extensions.ExtensionDtype` subclass does not define a string ``name`` attribute, instead of a bare ``AssertionError`` when the dtype is later used (:issue:`46093`)
 - Bug in :meth:`DataFrame.any` and :meth:`DataFrame.all` with ``skipna=False`` not propagating ``pd.NA`` on numpy-nullable columns (``boolean``, ``Int*``, ``UInt*``, ``Float*``); ``axis=0`` raised ``ValueError`` and ``axis=1`` returned a concrete ``True``/``False`` (:issue:`65710`)
 - Bug in numpy ufuncs like :func:`numpy.isnan` raising ``TypeError`` on :class:`Series` or :class:`Index` backed by PyArrow dtypes when ``future.distinguish_nan_and_na`` is ``True`` (:issue:`62506`)
 - Fixed bug in :meth:`Series.apply` and :meth:`Series.map` where nullable integer dtypes were converted to float, causing precision loss for large integers; now the nullable dtype will be preserved (:issue:`63903`).

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -524,8 +524,8 @@ Plotting
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
-- Bug in :class:`PeriodIndex` resampling to a finer frequency where aggregation methods returned the original values instead of aggregating, e.g. ``count`` returned the data values rather than the number of observations per bin; empty bins now contain the method's identity value (e.g. ``0`` for ``sum`` instead of ``NaN``), consistent with :class:`DatetimeIndex` resampling (:issue:`42763`)
 - :meth:`DataFrame.ewm` and :meth:`Series.ewm` now raise an informative ``NotImplementedError`` instead of a confusing ``AttributeError`` when ``agg``/``aggregate`` is passed an arbitrary callable (:issue:`41700`)
+- Bug in :class:`PeriodIndex` resampling to a finer frequency where aggregation methods returned the original values instead of aggregating, e.g. ``count`` returned the data values rather than the number of observations per bin; empty bins now contain the method's identity value (e.g. ``0`` for ``sum`` instead of ``NaN``), consistent with :class:`DatetimeIndex` resampling (:issue:`42763`)
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)
 - Bug in :meth:`.DataFrameGroupBy.apply` with ``as_index=False`` where applying on an empty :class:`DataFrame` returned inconsistent index metadata compared to non-empty results (:issue:`48135`)

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -533,12 +533,8 @@ def register_extension_dtype(cls: type_t[ExtensionDtypeT]) -> type_t[ExtensionDt
     ... class MyExtensionDtype(ExtensionDtype):
     ...     name = "myextension"
     """
-    # GH#46093 a dtype that never overrides the abstract ``name`` property
-    #  cannot be constructed from a string and previously surfaced a bare
-    #  AssertionError (or an opaque "data type not understood") only when the
-    #  dtype was later used. Fail fast at registration with a clear message.
-    #  Compare identity against the base property so dtypes that define ``name``
-    #  as an instance-level property (e.g. DatetimeTZDtype) are not flagged.
+    # GH#46093 identity check against the base property, so dtypes defining
+    #  ``name`` as an instance-level property (e.g. DatetimeTZDtype) pass.
     if inspect.getattr_static(cls, "name", None) is ExtensionDtype.__dict__["name"]:
         raise TypeError(
             f"Cannot register '{cls.__name__}' because it does not define a "

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -4,6 +4,7 @@ Extend pandas with custom array types.
 
 from __future__ import annotations
 
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -303,9 +304,15 @@ class ExtensionDtype:
             raise TypeError(
                 f"'construct_from_string' expects a string, got {type(string)}"
             )
+        if not isinstance(cls.name, str):
+            # GH#46093 registered ExtensionDtype without a string `name`
+            raise TypeError(
+                f"Cannot construct a '{cls.__name__}' from a string because it "
+                "does not define a string 'name' attribute. ExtensionDtype "
+                "subclasses must set a class-level `name`."
+            )
         # error: Non-overlapping equality check (left operand type: "str", right
         #  operand type: "Callable[[ExtensionDtype], str]")  [comparison-overlap]
-        assert isinstance(cls.name, str), (cls, type(cls.name))
         if string != cls.name:
             raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
         return cls()
@@ -526,6 +533,18 @@ def register_extension_dtype(cls: type_t[ExtensionDtypeT]) -> type_t[ExtensionDt
     ... class MyExtensionDtype(ExtensionDtype):
     ...     name = "myextension"
     """
+    # GH#46093 a dtype that never overrides the abstract ``name`` property
+    #  cannot be constructed from a string and previously surfaced a bare
+    #  AssertionError (or an opaque "data type not understood") only when the
+    #  dtype was later used. Fail fast at registration with a clear message.
+    #  Compare identity against the base property so dtypes that define ``name``
+    #  as an instance-level property (e.g. DatetimeTZDtype) are not flagged.
+    if inspect.getattr_static(cls, "name", None) is ExtensionDtype.__dict__["name"]:
+        raise TypeError(
+            f"Cannot register '{cls.__name__}' because it does not define a "
+            "string 'name' attribute. ExtensionDtype subclasses must set a "
+            "class-level `name`."
+        )
     _registry.register(cls)
     return cls
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4729,10 +4729,8 @@ class DataFrame(NDFrame, OpsMixin):
         try:
             self._where(-key, value, inplace=True)
         except ValueError as err:
-            # GH#45593 the cryptic "cannot assign mismatch length to masked
-            # array" from putmask_without_repeat gives no hint that it refers
-            # to a boolean-DataFrame-mask setitem; restate it with the two
-            # mismatched lengths so the user can act on it.
+            # GH#45593 restate putmask_without_repeat's message with the
+            #  mismatched lengths.
             if "mismatch length to masked array" not in str(err):
                 raise
             num_true = int(key.to_numpy(dtype=bool, na_value=False).sum())

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4726,7 +4726,23 @@ class DataFrame(NDFrame, OpsMixin):
                 "Must pass DataFrame or 2-d ndarray with boolean values only"
             )
 
-        self._where(-key, value, inplace=True)
+        try:
+            self._where(-key, value, inplace=True)
+        except ValueError as err:
+            # GH#45593 the cryptic "cannot assign mismatch length to masked
+            # array" from putmask_without_repeat gives no hint that it refers
+            # to a boolean-DataFrame-mask setitem; restate it with the two
+            # mismatched lengths so the user can act on it.
+            if "mismatch length to masked array" not in str(err):
+                raise
+            num_true = int(key.to_numpy(dtype=bool, na_value=False).sum())
+            num_values = len(value) if is_list_like(value) else 1
+            raise ValueError(
+                f"Cannot set with a boolean DataFrame mask: the number of "
+                f"values ({num_values}) does not match the number of True "
+                f"entries in the mask ({num_true}). Provide a scalar or a "
+                f"value matching the mask."
+            ) from err
 
     def _set_item_frame_value(self, key, value: DataFrame) -> None:
         self._ensure_valid_index(value)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3333,6 +3333,17 @@ class MultiIndex(Index):
                 except TypeError:
                     # not all tuples, see test_constructor_dict_multiindex_reindex_flat
                     return target
+                except ValueError as err:
+                    # GH#26460 from_tuples was handed a non-object (e.g. integer)
+                    #  flat target, which fails the Cython buffer check with a
+                    #  cryptic "Buffer dtype mismatch" message. Re-raise something
+                    #  the user can act on.
+                    raise ValueError(
+                        "cannot reindex a MultiIndex with a flat "
+                        f"'{target.dtype}' index; the reindex target must "
+                        f"contain tuples of length {self.nlevels} (the number "
+                        "of levels)"
+                    ) from err
 
         target = self._maybe_preserve_names(target, preserve_names)
         return target
@@ -4820,6 +4831,23 @@ class MultiIndex(Index):
             if len(values) == 0:
                 return np.zeros((len(self),), dtype=np.bool_)
             if not isinstance(values, MultiIndex):
+                # GH#20252, GH#26622 validate that every element is a
+                #  tuple-like of length nlevels before handing to
+                #  from_tuples, which otherwise silently produces wrong
+                #  results or raises a cryptic error.
+                for position, value in enumerate(values):
+                    if is_list_like(value) and len(value) == self.nlevels:
+                        continue
+                    if is_list_like(value):
+                        got = f"an element of length {len(value)}"
+                    else:
+                        got = f"a scalar ({value!r})"
+                    raise ValueError(
+                        "MultiIndex.isin expects an iterable of tuples of "
+                        f"length {self.nlevels} (the number of levels); got "
+                        f"{got} at position {position}. To match on a single "
+                        "level, pass the level= argument."
+                    )
                 values = MultiIndex.from_tuples(values)
             return values.unique().get_indexer_for(self) != -1
         else:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3334,10 +3334,8 @@ class MultiIndex(Index):
                     # not all tuples, see test_constructor_dict_multiindex_reindex_flat
                     return target
                 except ValueError as err:
-                    # GH#26460 from_tuples was handed a non-object (e.g. integer)
-                    #  flat target, which fails the Cython buffer check with a
-                    #  cryptic "Buffer dtype mismatch" message. Re-raise something
-                    #  the user can act on.
+                    # GH#26460 from_tuples on a non-object (e.g. integer) flat
+                    #  target fails the Cython buffer check.
                     raise ValueError(
                         "cannot reindex a MultiIndex with a flat "
                         f"'{target.dtype}' index; the reindex target must "
@@ -4831,10 +4829,8 @@ class MultiIndex(Index):
             if len(values) == 0:
                 return np.zeros((len(self),), dtype=np.bool_)
             if not isinstance(values, MultiIndex):
-                # GH#20252, GH#26622 validate that every element is a
-                #  tuple-like of length nlevels before handing to
-                #  from_tuples, which otherwise silently produces wrong
-                #  results or raises a cryptic error.
+                # GH#20252, GH#26622 from_tuples silently gives wrong results
+                #  for elements that aren't tuple-likes of length nlevels.
                 for position, value in enumerate(values):
                     if is_list_like(value) and len(value) == self.nlevels:
                         continue

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -954,9 +954,15 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
             names = list(names)
         else:
             # make sure that all of the passed indices have the same nlevels
-            if not len({idx.nlevels for idx in indexes}) == 1:
-                raise AssertionError(
-                    "Cannot concat indices that do not have the same number of levels"
+            nlevels_set = {idx.nlevels for idx in indexes}
+            if len(nlevels_set) != 1:
+                # GH#25413 give a clear error instead of an AssertionError when
+                #  concatenating a mix of single-level and MultiIndex objects
+                #  while passing keys=.
+                raise ValueError(
+                    "Cannot concat indices that do not have the same number "
+                    f"of levels: got levels {sorted(nlevels_set)}. When passing "
+                    "keys=, all objects must have the same index nlevels."
                 )
 
             # also copies

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -956,9 +956,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
             # make sure that all of the passed indices have the same nlevels
             nlevels_set = {idx.nlevels for idx in indexes}
             if len(nlevels_set) != 1:
-                # GH#25413 give a clear error instead of an AssertionError when
-                #  concatenating a mix of single-level and MultiIndex objects
-                #  while passing keys=.
+                # GH#25413
                 raise ValueError(
                     "Cannot concat indices that do not have the same number "
                     f"of levels: got levels {sorted(nlevels_set)}. When passing "

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -899,6 +899,26 @@ def pivot(
     """
     columns_listlike = com.convert_to_list_like(columns)
 
+    # GH#35785 Validate up front that index/columns/values reference actual
+    # columns of the frame. Otherwise passing e.g. an Index object for ``index``
+    # raises a cryptic error from downstream label arithmetic instead of a clear
+    # message naming the offending labels.
+    labels_to_check: list[tuple[str, list]] = [("columns", list(columns_listlike))]
+    if index is not lib.no_default:
+        labels_to_check.append(("index", list(com.convert_to_list_like(index))))
+    if values is not lib.no_default and not isinstance(values, tuple):
+        # a tuple ``values`` is treated as a single (MultiIndex) column label;
+        #  leave it to the existing lookup, which raises a KeyError naming the
+        #  tuple (GH#17160). Any other value must reference columns of the frame.
+        labels_to_check.append(("values", list(com.convert_to_list_like(values))))
+    for param_name, labels in labels_to_check:
+        missing = [label for label in labels if label not in data.columns]
+        if missing:
+            raise KeyError(
+                f"The following '{param_name}' labels are not columns of the "
+                f"DataFrame: {missing}"
+            )
+
     # If columns is None we will create a MultiIndex level with None as name
     # which might cause duplicated names because None is the default for
     # level names

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -899,17 +899,13 @@ def pivot(
     """
     columns_listlike = com.convert_to_list_like(columns)
 
-    # GH#35785 Validate up front that index/columns/values reference actual
-    # columns of the frame. Otherwise passing e.g. an Index object for ``index``
-    # raises a cryptic error from downstream label arithmetic instead of a clear
-    # message naming the offending labels.
+    # GH#35785 without this, downstream label arithmetic raises cryptically.
     labels_to_check: list[tuple[str, list]] = [("columns", list(columns_listlike))]
     if index is not lib.no_default:
         labels_to_check.append(("index", list(com.convert_to_list_like(index))))
     if values is not lib.no_default and not isinstance(values, tuple):
-        # a tuple ``values`` is treated as a single (MultiIndex) column label;
-        #  leave it to the existing lookup, which raises a KeyError naming the
-        #  tuple (GH#17160). Any other value must reference columns of the frame.
+        # GH#17160 a tuple ``values`` is a single (MultiIndex) label; the
+        #  existing lookup already raises a KeyError naming it.
         labels_to_check.append(("values", list(com.convert_to_list_like(values))))
     for param_name, labels in labels_to_check:
         missing = [label for label in labels if label not in data.columns]

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -522,9 +522,8 @@ class ExponentialMovingWindow(BaseWindow):
         2  2.428571  5.428571  8.428571
         """
         if callable(func):
-            # GH#41700 ExponentialMovingWindow has no ``apply`` method, so the
-            # BaseWindow.aggregate fallback to ``self.apply(...)`` raises a
-            # confusing AttributeError. Give a clear message instead.
+            # GH#41700 BaseWindow.aggregate falls back to ``self.apply(...)``,
+            #  which ExponentialMovingWindow does not implement.
             raise NotImplementedError(
                 f"{type(self).__name__}.aggregate does not support arbitrary "
                 "callables; supported aggregations are mean, sum, std, var, "

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -521,6 +521,15 @@ class ExponentialMovingWindow(BaseWindow):
         1  1.666667  4.666667  7.666667
         2  2.428571  5.428571  8.428571
         """
+        if callable(func):
+            # GH#41700 ExponentialMovingWindow has no ``apply`` method, so the
+            # BaseWindow.aggregate fallback to ``self.apply(...)`` raises a
+            # confusing AttributeError. Give a clear message instead.
+            raise NotImplementedError(
+                f"{type(self).__name__}.aggregate does not support arbitrary "
+                "callables; supported aggregations are mean, sum, std, var, "
+                "cov, corr."
+            )
         return super().aggregate(func, *args, **kwargs)
 
     agg = aggregate

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -289,16 +289,28 @@ class Writer(ABC):
 
     def write(self) -> str:
         iso_dates = self.date_format == "iso"
-        return ujson_dumps(
-            self.obj_to_write,
-            orient=self.orient,
-            double_precision=self.double_precision,
-            ensure_ascii=self.ensure_ascii,
-            date_unit=self.date_unit,
-            iso_dates=iso_dates,
-            default_handler=self.default_handler,
-            indent=self.indent,
-        )
+        try:
+            return ujson_dumps(
+                self.obj_to_write,
+                orient=self.orient,
+                double_precision=self.double_precision,
+                ensure_ascii=self.ensure_ascii,
+                date_unit=self.date_unit,
+                iso_dates=iso_dates,
+                default_handler=self.default_handler,
+                indent=self.indent,
+            )
+        except OverflowError as err:
+            # GH#36211 the C ujson encoder recurses without bound on object
+            # types it does not understand, surfacing as a cryptic
+            # "Maximum recursion level reached" OverflowError.
+            if "Maximum recursion level reached" not in str(err):
+                raise
+            raise ValueError(
+                "Unable to serialize object to JSON: encountered an "
+                "unsupported object type; convert the column to a supported "
+                "type (e.g. str) before calling to_json."
+            ) from err
 
     @property
     @abstractmethod

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -301,9 +301,8 @@ class Writer(ABC):
                 indent=self.indent,
             )
         except OverflowError as err:
-            # GH#36211 the C ujson encoder recurses without bound on object
-            # types it does not understand, surfacing as a cryptic
-            # "Maximum recursion level reached" OverflowError.
+            # GH#36211 the C encoder recurses without bound on object types it
+            #  does not understand.
             if "Maximum recursion level reached" not in str(err):
                 raise
             raise ValueError(

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2781,6 +2781,18 @@ class SQLiteDatabase(PandasSQL):
                 )
                 raise ex from inner_exc
 
+            if re.fullmatch(r"[A-Za-z_]\w*", sql.strip()):
+                # GH#54233 a bare identifier is almost certainly an attempt to
+                # read a table by name, which is only supported with a
+                # SQLAlchemy connection, not a DBAPI one.
+                ex = DatabaseError(
+                    f"Execution failed on sql '{sql}': {exc}\n\n"
+                    "Reading a table by name is only supported when using a "
+                    "SQLAlchemy connection. With a DBAPI connection, pass a SQL "
+                    f"query instead, e.g. 'SELECT * FROM {sql.strip()}'."
+                )
+                raise ex from exc
+
             ex = DatabaseError(f"Execution failed on sql '{sql}': {exc}")
             raise ex from exc
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2783,8 +2783,7 @@ class SQLiteDatabase(PandasSQL):
 
             if re.fullmatch(r"[A-Za-z_]\w*", sql.strip()):
                 # GH#54233 a bare identifier is almost certainly an attempt to
-                # read a table by name, which is only supported with a
-                # SQLAlchemy connection, not a DBAPI one.
+                #  read a table by name.
                 ex = DatabaseError(
                     f"Execution failed on sql '{sql}': {exc}\n\n"
                     "Reading a table by name is only supported when using a "

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -8,7 +8,11 @@ import pytest
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 from pandas.errors import Pandas4Warning
 
-from pandas.core.dtypes.base import _registry as registry
+from pandas.core.dtypes.base import (
+    ExtensionDtype,
+    _registry as registry,
+    register_extension_dtype,
+)
 from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_categorical_dtype,
@@ -1128,6 +1132,32 @@ def test_registry(dtype):
 )
 def test_registry_find(dtype, expected):
     assert registry.find(dtype) == expected
+
+
+def test_construct_from_string_no_name_gh46093():
+    # GH#46093 an ExtensionDtype subclass without a string `name` should give a
+    #  clear TypeError instead of a bare AssertionError.
+    class FooType(ExtensionDtype):
+        pass
+
+    msg = (
+        "Cannot construct a 'FooType' from a string because it does not define "
+        "a string 'name' attribute"
+    )
+    with pytest.raises(TypeError, match=msg):
+        FooType.construct_from_string("foo")
+
+
+def test_register_extension_dtype_no_name_gh46093():
+    # GH#46093 registering an ExtensionDtype subclass that never overrides the
+    #  abstract `name` property fails fast with a clear message rather than a
+    #  bare AssertionError (or an opaque "data type not understood") on use.
+    msg = "Cannot register 'NamelessType' because it does not define a string"
+    with pytest.raises(TypeError, match=msg):
+
+        @register_extension_dtype
+        class NamelessType(ExtensionDtype):
+            pass
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -1135,8 +1135,7 @@ def test_registry_find(dtype, expected):
 
 
 def test_construct_from_string_no_name_gh46093():
-    # GH#46093 an ExtensionDtype subclass without a string `name` should give a
-    #  clear TypeError instead of a bare AssertionError.
+    # GH#46093
     class FooType(ExtensionDtype):
         pass
 
@@ -1149,9 +1148,7 @@ def test_construct_from_string_no_name_gh46093():
 
 
 def test_register_extension_dtype_no_name_gh46093():
-    # GH#46093 registering an ExtensionDtype subclass that never overrides the
-    #  abstract `name` property fails fast with a clear message rather than a
-    #  bare AssertionError (or an opaque "data type not understood") on use.
+    # GH#46093 registration fails fast rather than erroring later on use
     msg = "Cannot register 'NamelessType' because it does not define a string"
     with pytest.raises(TypeError, match=msg):
 

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -120,7 +120,7 @@ class TestPeriodArray(base.ExtensionTests):
         super().test_values_for_json(data)
 
     @pytest.mark.xfail(
-        raises=OverflowError, reason="PeriodArray cannot be serialized to JSON"
+        raises=ValueError, reason="PeriodArray cannot be serialized to JSON"
     )
     def test_json_roundtrip(self, data):
         # GH 65127

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1536,3 +1536,19 @@ def test_loc_setitem_tz_aware_column_expansion():
     _time = datetime.fromtimestamp(1695887042, timezone.utc)
     df.loc[df.id >= 2, "time"] = _time
     assert df["time"].dtype == DatetimeTZDtype(tz="UTC", unit="us")
+
+
+def test_setitem_boolean_mask_length_mismatch_message_gh45593():
+    # GH#45593 setting with a boolean-DataFrame mask and a value whose length
+    # does not match the number of True entries should give an actionable
+    # message, not the cryptic "cannot assign mismatch length to masked array"
+    df = DataFrame({"a": [1], "b": [1]})
+    # split the columns into separate blocks so the value mismatch surfaces
+    df[["a", "b"]] = [[2, 2]]
+    select_df = DataFrame({"a": [True], "b": [False]})
+    msg = (
+        r"Cannot set with a boolean DataFrame mask: the number of values \(2\) "
+        r"does not match the number of True entries in the mask \(1\)\."
+    )
+    with pytest.raises(ValueError, match=msg):
+        df[select_df] = [3, 3]

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -1539,9 +1539,7 @@ def test_loc_setitem_tz_aware_column_expansion():
 
 
 def test_setitem_boolean_mask_length_mismatch_message_gh45593():
-    # GH#45593 setting with a boolean-DataFrame mask and a value whose length
-    # does not match the number of True entries should give an actionable
-    # message, not the cryptic "cannot assign mismatch length to masked array"
+    # GH#45593
     df = DataFrame({"a": [1], "b": [1]})
     # split the columns into separate blocks so the value mismatch surfaces
     df[["a", "b"]] = [[2, 2]]

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -233,15 +233,15 @@ def test_indices_concatenation_order():
 
     # should fail (not the same number of levels)
     msg = "Cannot concat indices that do not have the same number of levels"
-    with pytest.raises(AssertionError, match=msg):
+    with pytest.raises(ValueError, match=msg):
         df.groupby("a").apply(f2)
-    with pytest.raises(AssertionError, match=msg):
+    with pytest.raises(ValueError, match=msg):
         df2.groupby("a").apply(f2)
 
     # should fail (incorrect shape)
-    with pytest.raises(AssertionError, match=msg):
+    with pytest.raises(ValueError, match=msg):
         df.groupby("a").apply(f3)
-    with pytest.raises(AssertionError, match=msg):
+    with pytest.raises(ValueError, match=msg):
         df2.groupby("a").apply(f3)
 
 

--- a/pandas/tests/indexes/multi/test_isin.py
+++ b/pandas/tests/indexes/multi/test_isin.py
@@ -102,3 +102,39 @@ def test_isin_generator():
     result = midx.isin(x for x in [(1, 2)])
     expected = np.array([True])
     tm.assert_numpy_array_equal(result, expected)
+
+
+def test_isin_scalar_values_raises_gh20252():
+    # GH#20252 passing scalars (non-tuples) should raise a clear error, not
+    #  a cryptic "object of type 'int' has no len()" TypeError
+    midx = MultiIndex.from_arrays([[1, 2, 3], ["a", "b", "c"]])
+    msg = (
+        "MultiIndex.isin expects an iterable of tuples of length 2 "
+        r"\(the number of levels\); got a scalar \(1\) at position 0\. "
+        "To match on a single level, pass the level= argument\\."
+    )
+    with pytest.raises(ValueError, match=msg):
+        midx.isin([1, 2])
+
+
+@pytest.mark.parametrize(
+    "values, bad_len, position",
+    [
+        ([("foo", "one", "B"), ("bar",)], 1, 1),
+        ([("foo", "one")], 2, 0),
+        ([("foo", "one", "B"), ("bar", "two", "A", "x")], 4, 1),
+    ],
+)
+def test_isin_wrong_length_tuples_raises_gh26622(values, bad_len, position):
+    # GH#26622 tuples whose length does not match nlevels used to silently
+    #  give wrong results (partial/short tuples) or raise an AssertionError
+    #  (too-long tuples); now they raise a clear ValueError
+    midx = MultiIndex.from_product([["foo", "bar"], ["one", "two"], ["A", "B"]])
+    msg = (
+        "MultiIndex.isin expects an iterable of tuples of length 3 "
+        rf"\(the number of levels\); got an element of length {bad_len} at "
+        rf"position {position}\. To match on a single level, pass the "
+        "level= argument\\."
+    )
+    with pytest.raises(ValueError, match=msg):
+        midx.isin(values)

--- a/pandas/tests/indexes/multi/test_isin.py
+++ b/pandas/tests/indexes/multi/test_isin.py
@@ -105,8 +105,7 @@ def test_isin_generator():
 
 
 def test_isin_scalar_values_raises_gh20252():
-    # GH#20252 passing scalars (non-tuples) should raise a clear error, not
-    #  a cryptic "object of type 'int' has no len()" TypeError
+    # GH#20252
     midx = MultiIndex.from_arrays([[1, 2, 3], ["a", "b", "c"]])
     msg = (
         "MultiIndex.isin expects an iterable of tuples of length 2 "
@@ -126,9 +125,7 @@ def test_isin_scalar_values_raises_gh20252():
     ],
 )
 def test_isin_wrong_length_tuples_raises_gh26622(values, bad_len, position):
-    # GH#26622 tuples whose length does not match nlevels used to silently
-    #  give wrong results (partial/short tuples) or raise an AssertionError
-    #  (too-long tuples); now they raise a clear ValueError
+    # GH#26622 short tuples used to silently give wrong results
     midx = MultiIndex.from_product([["foo", "bar"], ["one", "two"], ["A", "B"]])
     msg = (
         "MultiIndex.isin expects an iterable of tuples of length 3 "

--- a/pandas/tests/indexes/multi/test_reindex.py
+++ b/pandas/tests/indexes/multi/test_reindex.py
@@ -135,8 +135,7 @@ def test_reindex_not_all_tuples():
 
 
 def test_reindex_flat_integer_target_raises_gh26460():
-    # GH#26460 reindexing a unique integer MultiIndex onto a flat integer
-    #  target used to raise a cryptic Cython "Buffer dtype mismatch" error
+    # GH#26460
     mi = MultiIndex.from_arrays([[4, 4, 8], [8, 10, 12]])
     msg = (
         "cannot reindex a MultiIndex with a flat 'int64' index; the reindex "

--- a/pandas/tests/indexes/multi/test_reindex.py
+++ b/pandas/tests/indexes/multi/test_reindex.py
@@ -134,6 +134,18 @@ def test_reindex_not_all_tuples():
     tm.assert_numpy_array_equal(indexer, expected)
 
 
+def test_reindex_flat_integer_target_raises_gh26460():
+    # GH#26460 reindexing a unique integer MultiIndex onto a flat integer
+    #  target used to raise a cryptic Cython "Buffer dtype mismatch" error
+    mi = MultiIndex.from_arrays([[4, 4, 8], [8, 10, 12]])
+    msg = (
+        "cannot reindex a MultiIndex with a flat 'int64' index; the reindex "
+        r"target must contain tuples of length 2 \(the number of levels\)"
+    )
+    with pytest.raises(ValueError, match=msg):
+        mi.reindex([8, 10])
+
+
 def test_reindex_limit_arg_with_multiindex():
     # GH21247
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2576,8 +2576,7 @@ def test_large_number_string_column():
 
 
 def test_to_json_unsupported_object_gh36211():
-    # GH#36211 to_json on an object type the encoder cannot serialize should
-    # raise a clear ValueError instead of a cryptic recursion OverflowError
+    # GH#36211
     df = DataFrame({"a": [Path("m1")]})
     msg = "Unable to serialize object to JSON: encountered an unsupported object type"
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -6,6 +6,7 @@ from io import (
 )
 import json
 import os
+from pathlib import Path
 import sys
 import uuid
 
@@ -2572,3 +2573,12 @@ def test_large_number_string_column():
         }
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_to_json_unsupported_object_gh36211():
+    # GH#36211 to_json on an object type the encoder cannot serialize should
+    # raise a clear ValueError instead of a cryptic recursion OverflowError
+    df = DataFrame({"a": [Path("m1")]})
+    msg = "Unable to serialize object to JSON: encountered an unsupported object type"
+    with pytest.raises(ValueError, match=msg):
+        df.to_json()

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1530,9 +1530,7 @@ SELECT * FROM groups;
 
 
 def test_read_sql_bare_table_name_dbapi_message_gh54233(sqlite_buildin):
-    # GH#54233 a bare table name on a DBAPI connection cannot be reflected, so
-    # give a clear message pointing to SQLAlchemy / a SQL query instead of a
-    # cryptic SQL syntax error.
+    # GH#54233 a bare table name on a DBAPI connection cannot be reflected
     DataFrame({"a": [1], "b": [2]}).to_sql("demo", sqlite_buildin, index=False)
 
     msg = "Reading a table by name is only supported when using a SQLAlchemy"

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1529,6 +1529,22 @@ SELECT * FROM groups;
     tm.assert_frame_equal(result, expected)
 
 
+def test_read_sql_bare_table_name_dbapi_message_gh54233(sqlite_buildin):
+    # GH#54233 a bare table name on a DBAPI connection cannot be reflected, so
+    # give a clear message pointing to SQLAlchemy / a SQL query instead of a
+    # cryptic SQL syntax error.
+    DataFrame({"a": [1], "b": [2]}).to_sql("demo", sqlite_buildin, index=False)
+
+    msg = "Reading a table by name is only supported when using a SQLAlchemy"
+    with pytest.raises(sql.DatabaseError, match=msg):
+        pd.read_sql("demo", sqlite_buildin)
+
+    # a genuine SQL query still works
+    result = pd.read_sql("SELECT * FROM demo", sqlite_buildin)
+    expected = DataFrame({"a": [1], "b": [2]})
+    tm.assert_frame_equal(result, expected)
+
+
 def flavor(conn_name):
     if "postgresql" in conn_name:
         return "postgresql"

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -1029,6 +1029,20 @@ def test_concat_keys_overlapping_intervalindex_level():
     tm.assert_series_equal(result, expected)
 
 
+def test_concat_mismatched_nlevels_with_keys_gh25413():
+    # GH#25413 concatenating a mix of single-level and MultiIndex objects while
+    #  passing keys= should raise a clear ValueError, not an AssertionError
+    df1 = DataFrame(np.arange(12).reshape(4, 3), columns=["A", "B", "C"])
+    df2 = DataFrame(
+        np.arange(12).reshape(4, 3),
+        columns=["A", "B", "C"],
+        index=MultiIndex.from_product([["a", "b"], [1, 2]]),
+    )
+    msg = "Cannot concat indices that do not have the same number of levels"
+    with pytest.raises(ValueError, match=msg):
+        concat([df1, df2], keys=[1, 2])
+
+
 def test_concat_keys_overlapping_intervalindex_value_index():
     # GH#64825 the per-Series index is itself an overlapping IntervalIndex
     value_index = IntervalIndex.from_tuples([(0.0, 10.0), (0.0, 20.0)], name="foo")

--- a/pandas/tests/reshape/concat/test_concat.py
+++ b/pandas/tests/reshape/concat/test_concat.py
@@ -1030,8 +1030,7 @@ def test_concat_keys_overlapping_intervalindex_level():
 
 
 def test_concat_mismatched_nlevels_with_keys_gh25413():
-    # GH#25413 concatenating a mix of single-level and MultiIndex objects while
-    #  passing keys= should raise a clear ValueError, not an AssertionError
+    # GH#25413
     df1 = DataFrame(np.arange(12).reshape(4, 3), columns=["A", "B", "C"])
     df2 = DataFrame(
         np.arange(12).reshape(4, 3),

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -3189,5 +3189,40 @@ class TestPivot:
         expected = DataFrame(
             index=expected_index, columns=expected_columns, dtype=dtype
         )
-
         tm.assert_frame_equal(result, expected)
+
+
+def test_pivot_non_column_label_raises_gh35785():
+    # GH#35785 passing a non-column label (e.g. an Index object) for
+    # index/columns/values should raise a clear error naming the offending
+    # labels instead of a cryptic downstream TypeError.
+    df = DataFrame.from_records(
+        [{"date": datetime(2016, 3, 2), "col1": 1, "col2": 2}], index=["date"]
+    )
+
+    # passing the frame's Index object as ``index`` (its values are not columns)
+    msg = "The following 'index' labels are not columns of the DataFrame"
+    with pytest.raises(KeyError, match=msg):
+        df.pivot(index=df.index, columns="col1")
+    with pytest.raises(KeyError, match=msg):
+        df.pivot(index=df.index, columns="col1", values="col2")
+
+    # a bare missing scalar label for each parameter
+    with pytest.raises(KeyError, match="'index' labels are not columns"):
+        df.pivot(index="missing", columns="col1")
+    with pytest.raises(KeyError, match="'columns' labels are not columns"):
+        df.pivot(index="col2", columns="missing")
+    with pytest.raises(KeyError, match="'values' labels are not columns"):
+        df.pivot(index="col2", columns="col1", values="missing")
+
+    # valid usage with real column labels is unaffected
+    valid = DataFrame(
+        {"foo": ["one", "one", "two"], "bar": ["A", "B", "A"], "baz": [1, 2, 3]}
+    )
+    result = valid.pivot(index="foo", columns="bar", values="baz")
+    expected = DataFrame(
+        {"A": [1.0, 3.0], "B": [2.0, np.nan]},
+        index=Index(["one", "two"], name="foo"),
+    )
+    expected.columns.name = "bar"
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -3189,18 +3189,17 @@ class TestPivot:
         expected = DataFrame(
             index=expected_index, columns=expected_columns, dtype=dtype
         )
+
         tm.assert_frame_equal(result, expected)
 
 
 def test_pivot_non_column_label_raises_gh35785():
-    # GH#35785 passing a non-column label (e.g. an Index object) for
-    # index/columns/values should raise a clear error naming the offending
-    # labels instead of a cryptic downstream TypeError.
+    # GH#35785
     df = DataFrame.from_records(
         [{"date": datetime(2016, 3, 2), "col1": 1, "col2": 2}], index=["date"]
     )
 
-    # passing the frame's Index object as ``index`` (its values are not columns)
+    # the frame's Index object; its values are not columns
     msg = "The following 'index' labels are not columns of the DataFrame"
     with pytest.raises(KeyError, match=msg):
         df.pivot(index=df.index, columns="col1")

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -221,8 +221,7 @@ def test_ewm_sum_adjust_false_notimplemented():
 
 
 def test_ewm_aggregate_callable_gh41700(frame_or_series):
-    # GH#41700 arbitrary callables raise a clear NotImplementedError instead of
-    # a confusing "no attribute 'apply'" AttributeError
+    # GH#41700
     obj = frame_or_series(range(5)).ewm(alpha=0.1)
     msg = "aggregate does not support arbitrary callables"
     with pytest.raises(NotImplementedError, match=msg):

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -220,6 +220,19 @@ def test_ewm_sum_adjust_false_notimplemented():
         data.sum()
 
 
+def test_ewm_aggregate_callable_gh41700(frame_or_series):
+    # GH#41700 arbitrary callables raise a clear NotImplementedError instead of
+    # a confusing "no attribute 'apply'" AttributeError
+    obj = frame_or_series(range(5)).ewm(alpha=0.1)
+    msg = "aggregate does not support arbitrary callables"
+    with pytest.raises(NotImplementedError, match=msg):
+        obj.agg(lambda x: x)
+    with pytest.raises(NotImplementedError, match=msg):
+        obj.agg(np.sum)
+    # supported string aggregations still work
+    tm.assert_equal(obj.agg("mean"), obj.mean())
+
+
 @pytest.mark.parametrize("method", ["sum", "std", "var", "cov", "corr"])
 def test_times_only_mean_implemented(frame_or_series, method):
     # GH 51695


### PR DESCRIPTION
closes #20252
closes #26622
closes #26460
closes #25413
closes #35785
closes #36211
closes #41700
closes #46093
closes #45593
closes #54233
closes #65770

Batch of error-reporting improvements from triaging the "Error Reporting" label. Each of these raised a cryptic `AssertionError`/`AttributeError`, an internal message, or silently returned a wrong result; this replaces them with clear, actionable errors. Message-only — no public API/behavior change beyond the error text, except where the previous behavior was silently wrong.

- `MultiIndex.isin` (GH-20252, GH-26622): validate that values are tuples of length `nlevels`; clear `ValueError` instead of `TypeError`/`AssertionError`/silent wrong result.
- `DataFrame` constructor reindexing an integer `MultiIndex` onto a flat integer index (GH-26460): clear `ValueError` instead of `Buffer dtype mismatch`.
- `concat(keys=...)` with mismatched index nlevels (GH-25413): `ValueError` instead of `AssertionError`.
- `DataFrame.pivot` / `pivot` (GH-35785): `KeyError` naming the non-column labels instead of a cryptic `radd` `TypeError`.
- `to_json` with an unsupported object type such as `pathlib.Path` (GH-36211): `ValueError` instead of `OverflowError: Maximum recursion level reached`.
- `ewm().agg(<callable>)` (GH-41700): `NotImplementedError` instead of `AttributeError: 'ExponentialMovingWindow' object has no attribute 'apply'`.
- `register_extension_dtype` on a dtype without a string `name` (GH-46093): `TypeError` at registration instead of a bare `AssertionError` on later use.
- boolean-`DataFrame`-mask setitem (GH-45593): `ValueError` describing the length mismatch instead of "cannot assign mismatch length to masked array".
- `read_sql` with a bare table name on a DBAPI connection (GH-54233): `DatabaseError` explaining that reading a table by name requires a SQLAlchemy connection, instead of a raw SQL syntax error.
- `assert_series_equal` (GH-65770): honor `check_series_type=False` for the backing array's subclass, and stop mislabeling backing-array class differences as "Series classes are different".

Each fix has a regression test and a whatsnew entry. Opening as draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
