### PR TITLE
BUG: DataFrame.from_dict scalar-values error message pointed to a nonexistent index parameter (GH#25515)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -518,6 +518,7 @@ Other
 
 - Bug in :class:`DataFrame` constructor where passing the same :class:`Index` object as both ``index`` and ``columns`` shared a single object between the two axes, so mutating metadata such as ``names`` on one would also change the other (:issue:`42934`)
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
+- Bug in :meth:`DataFrame.from_dict` where passing a dict of only scalar values raised a :class:`ValueError` telling users to pass an ``index``, even though :meth:`DataFrame.from_dict` has no ``index`` parameter; the message now points to ``orient='index'`` or the :class:`DataFrame` constructor (:issue:`25515`)
 - Bug in :meth:`DataFrame.select_dtypes` with an :class:`~pandas.api.extensions.ExtensionDtype` subclass such as :class:`ArrowDtype` or :class:`DatetimeTZDtype` raising ``TypeError``, emitting a spurious ``UserWarning``, or selecting the wrong columns; passing such a class now selects every column whose dtype is an instance of that class (:issue:`65366`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1775,6 +1775,17 @@ class DataFrame(NDFrame, OpsMixin):
         elif orient in ("columns", "tight"):
             if columns is not None:
                 raise ValueError(f"cannot use columns parameter with orient='{orient}'")
+            if (
+                orient == "columns"
+                and isinstance(data, dict)
+                and len(data) > 0
+                and all(is_scalar(value) for value in data.values())
+            ):
+                # GH#25515
+                raise ValueError(
+                    "If using all scalar values, pass orient='index' to use "
+                    "the keys as the index, or use the DataFrame constructor."
+                )
         else:  # pragma: no cover
             raise ValueError(
                 f"Expected 'index', 'columns' or 'tight' for orient parameter. "

--- a/pandas/tests/frame/constructors/test_from_dict.py
+++ b/pandas/tests/frame/constructors/test_from_dict.py
@@ -207,9 +207,14 @@ class TestFromDict:
         DataFrame.from_dict({"foo": s1, "baz": s3, "bar": s2})
 
     def test_from_dict_scalars_requires_index(self):
-        msg = "If using all scalar values, you must pass an index"
+        # GH#25515 the message must be actionable: from_dict has no index
+        #  parameter, so it points to orient="index" / the DataFrame constructor
+        msg = "If using all scalar values, pass orient='index'"
         with pytest.raises(ValueError, match=msg):
-            DataFrame.from_dict(OrderedDict([("b", 8), ("a", 5), ("a", 6)]))
+            DataFrame.from_dict({"a": 0.7})
+
+        with pytest.raises(ValueError, match=msg):
+            DataFrame.from_dict({"b": 8, "a": 6})
 
     def test_from_dict_orient_invalid(self):
         msg = (


### PR DESCRIPTION
closes #25515

``DataFrame.from_dict`` with a dict of only scalar values raised the ``DataFrame`` constructor's message *"If using all scalar values, you must pass an index"* — but ``from_dict`` has no ``index`` parameter, so that advice is not actionable via the API the user called.

This detects the all-scalar case in ``from_dict`` and raises a message that points to the two remedies that actually work: ``orient='index'`` (dict keys become the index) or the ``DataFrame`` constructor (which does take ``index``). The plain ``DataFrame(...)`` constructor is unchanged.

The ``OrderedDict`` in the original report (and the older GH-22705 ``from_items`` migration discussion) is incidental — plain dicts are ordered, and the error fires on all-scalar values, not on duplicate keys — so the reworked test uses plain dicts.

Behavior is otherwise unchanged: the new branch raises on exactly the same inputs that already raised ``ValueError``, only the message text differs.