### PR TITLE
BUG: read_csv(engine="pyarrow") cryptic errors for invalid single-character options

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -410,6 +410,7 @@ I/O
 - Fixed bug in :func:`read_excel` with the ``openpyxl`` engine where reading a sheet set its ``max_row`` and ``max_column`` to ``None`` on the workbook exposed through ``ExcelFile.book`` (:issue:`63010`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed bugs in :func:`read_csv` with ``engine="pyarrow"`` where column names were handled inconsistently with the other engines: duplicated names were not de-duplicated to ``"x.1"``-style names, empty header fields did not get ``"Unnamed: {i}"`` placeholder names, and an unnamed ``index_col`` produced an index named ``""`` instead of an unnamed index (:issue:`13017`, :issue:`35211`)
+- Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where invalid ``sep``, ``quotechar``, ``escapechar``, and ``decimal`` arguments raised cryptic errors, or in the case of ``quotechar=None`` were silently ignored, instead of raising the same informative errors as the other engines (:issue:`66317`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
 - Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -53,6 +53,37 @@ class ArrowParserWrapper(ParserBase):
         encoding: str | None = self.kwds.get("encoding")
         self.encoding = "utf-8" if encoding is None else encoding
 
+        # GH#66317 validate the single-character options up front so the user
+        #  gets the same informative errors as with the other engines instead
+        #  of cryptic errors from pyarrow option conversion.
+        delimiter = self.kwds.get("delimiter")
+        if delimiter is not None and len(delimiter) != 1:
+            # longer separators already raise in _clean_options; this catches
+            #  e.g. sep=""
+            raise ValueError("Only length-1 delimiters supported")
+
+        quotechar = self.kwds.get("quotechar", '"')
+        if quotechar is not None and not isinstance(quotechar, (str, bytes)):
+            raise TypeError(
+                f'"quotechar" must be string, not {type(quotechar).__name__}'
+            )
+        if not quotechar:
+            # None or zero-length; pyarrow only supports quoting=QUOTE_MINIMAL,
+            #  so quoting is always enabled
+            raise TypeError("quotechar must be set if quoting enabled")
+        if len(quotechar) > 1:
+            raise TypeError('"quotechar" must be a 1-character string')
+
+        escapechar = self.kwds.get("escapechar")
+        if escapechar is not None and (
+            not isinstance(escapechar, (str, bytes)) or len(escapechar) != 1
+        ):
+            raise ValueError("Only length-1 escapes supported")
+
+        decimal = self.kwds.get("decimal", ".")
+        if not isinstance(decimal, (str, bytes)) or len(decimal) != 1:
+            raise ValueError("Only length-1 decimal markers supported")
+
         na_values = self.kwds["na_values"]
         if isinstance(na_values, dict):
             raise ValueError(

--- a/pandas/tests/io/parser/common/test_read_errors.py
+++ b/pandas/tests/io/parser/common/test_read_errors.py
@@ -34,14 +34,38 @@ def test_empty_decimal_marker(all_parsers):
     msg = "Only length-1 decimal markers supported"
     parser = all_parsers
 
-    if parser.engine == "pyarrow":
-        msg = (
-            "only single character unicode strings can be "
-            "converted to Py_UCS4, got length 0"
-        )
-
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), decimal="")
+
+
+@pytest.mark.parametrize("escapechar", ["", "xx"])
+def test_bad_escapechar(all_parsers, escapechar):
+    # GH#66317
+    data = "a,b\n1,2"
+    parser = all_parsers
+
+    if parser.engine == "python":
+        # message and exception type come from the csv module
+        err = TypeError
+        msg = '"escapechar" must be'
+    else:
+        err = ValueError
+        msg = "Only length-1 escapes supported"
+
+    with pytest.raises(err, match=msg):
+        parser.read_csv(StringIO(data), escapechar=escapechar)
+
+
+def test_empty_sep(pyarrow_parser_only):
+    # GH#66317 previously leaked a cryptic error from pyarrow option
+    #  conversion; the C engine has a similarly-cryptic error here and the
+    #  python engine treats sep="" as a regex, so pyarrow-only.
+    data = "a,b\n1,2"
+    parser = pyarrow_parser_only
+
+    msg = "Only length-1 delimiters supported"
+    with pytest.raises(ValueError, match=msg):
+        parser.read_csv(StringIO(data), sep="")
 
 
 def test_bad_stream_exception(all_parsers, csv_dir_path):

--- a/pandas/tests/io/parser/test_quoting.py
+++ b/pandas/tests/io/parser/test_quoting.py
@@ -17,7 +17,6 @@ import pandas._testing as tm
 pytestmark = pytest.mark.filterwarnings(
     "ignore:Passing a BlockManager to DataFrame:DeprecationWarning"
 )
-skip_pyarrow = pytest.mark.usefixtures("pyarrow_skip")
 
 
 if PY314:
@@ -40,7 +39,6 @@ else:
         ({"quotechar": 2}, f'"quotechar" must be {MSG2}, not int'),
     ],
 )
-@skip_pyarrow  # ParserError: CSV parse error: Empty CSV file or block
 def test_bad_quote_char(all_parsers, kwargs, msg):
     data = "1,2,3"
     parser = all_parsers
@@ -93,20 +91,17 @@ def test_quote_char_various(all_parsers, quote_char):
 
 @pytest.mark.parametrize("quoting", [csv.QUOTE_MINIMAL, csv.QUOTE_NONE])
 @pytest.mark.parametrize("quote_char", ["", None])
-def test_null_quote_char(all_parsers, quoting, quote_char, request):
+def test_null_quote_char(all_parsers, quoting, quote_char):
     kwargs = {"quotechar": quote_char, "quoting": quoting}
     data = "a,b,c\n1,2,3"
     parser = all_parsers
 
-    if parser.engine == "pyarrow":
-        if quoting != csv.QUOTE_MINIMAL:
-            # any non-default value of ``quoting`` is rejected outright
-            msg = "The 'quoting' option is not supported with the 'pyarrow' engine"
-            with pytest.raises(ValueError, match=msg):
-                parser.read_csv(StringIO(data), **kwargs)
-            return
-        mark = pytest.mark.xfail(reason="pyarrow mishandles null/blank quote chars")
-        request.applymarker(mark)
+    if parser.engine == "pyarrow" and quoting != csv.QUOTE_MINIMAL:
+        # any non-default value of ``quoting`` is rejected outright
+        msg = "The 'quoting' option is not supported with the 'pyarrow' engine"
+        with pytest.raises(ValueError, match=msg):
+            parser.read_csv(StringIO(data), **kwargs)
+        return
 
     if quoting != csv.QUOTE_NONE:
         # Sanity checking.


### PR DESCRIPTION
Split out from GH-66064.

`read_csv(engine="pyarrow")` passed the single-character options straight to pyarrow, so invalid values raised cryptic errors leaking implementation internals:

- `quotechar=""`, `quotechar="foo"`, `escapechar="xx"`, `decimal=""`, `sep=""` → `only single character unicode strings can be converted to Py_UCS4`
- `quotechar=2`, `escapechar=2` → `ord() expected string of length 1, but int found`
- `quotechar=None` was silently ignored (the other engines raise)

This validates `sep`, `quotechar`, `escapechar`, and `decimal` up front in the arrow wrapper, raising the same informative errors as the C engine. `quotechar=None` now raises `quotechar must be set if quoting enabled` like the other engines (pyarrow only supports the default `quoting=QUOTE_MINIMAL`, so quoting is always enabled).

### `ValueError` vs `TypeError`

Each check reuses the exact exception type and message the C engine (`parsers.pyx`) already raises for that option, so the pyarrow errors match byte-for-byte:

- **`quotechar`** → `TypeError` (`'"quotechar" must be a 1-character string'`, `quotechar must be set if quoting enabled`, `'"quotechar" must be string, not ...'`) — mirrors `_set_quoting`, which is the C engine's one `TypeError` case.
- **`escapechar`** → `ValueError("Only length-1 escapes supported")`
- **`decimal`** → `ValueError("Only length-1 decimal markers supported")`
- **`sep`/`delimiter`** → `ValueError("Only length-1 delimiters supported")`

The C engine's own convention is inconsistent (only `quotechar`/`quoting` raise `TypeError`; every other "length-1" option raises `ValueError`), but matching it per-option keeps the engines interchangeable. `sep` is the one option with no clean C-engine analog to copy — the C engine leaks a `Py_UCS4` error there — so it's grouped with the other "length-1" `ValueError` checks rather than with `quotechar`.

The C engine's `sep=""` `Py_UCS4` leak in `parsers.pyx` is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
