### PR TITLE
Backport PR #66090 on branch 3.0.x (BLD: exclude numpy 2.5.0 when building wheels (py3.14 segfault))

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -16,6 +16,7 @@ Version 3.0
 .. toctree::
    :maxdepth: 2
 
+   v3.0.5
    v3.0.4
    v3.0.3
    v3.0.2

--- a/doc/source/whatsnew/v3.0.5.rst
+++ b/doc/source/whatsnew/v3.0.5.rst
@@ -1,0 +1,33 @@
+.. _whatsnew_305:
+
+What's new in 3.0.5 (Month XX, 2026)
+------------------------------------
+
+These are the changes in pandas 3.0.5. See :ref:`release` for a full changelog
+including other versions of pandas.
+
+{{ header }}
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_305.regressions:
+
+Fixed regressions
+~~~~~~~~~~~~~~~~~
+
+- Fixed a regression where the pandas 3.0.4 wheels could crash with a segmentation fault on Python 3.14 (and other datetime code paths), because they were built against an incompatible numpy version (:issue:`66086`)
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_305.bug_fixes:
+
+Bug fixes
+~~~~~~~~~
+
+-
+
+.. ---------------------------------------------------------------------------
+.. _whatsnew_305.contributors:
+
+Contributors
+~~~~~~~~~~~~
+
+.. contributors:: v3.0.4..v3.0.5|HEAD

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 
   # build dependencies
   - versioneer
-  - cython>=3.1.0,<4.0.0a0
+  - cython>=3.1.0,<4
   - meson>=1.2.1,<2
   - meson-python>=0.17.1,<1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,13 @@ requires = [
     "meson-python>=0.17.1,<1",
     "meson>=1.2.1,<2",
     "wheel",
-    "Cython>3.1.0,<4.0.0a0",  # Note: sync with setup.py, environment.yml and asv.conf.json
-    # Force numpy higher than 2.0, so that built wheels are compatible
-    # with both numpy 1 and 2
-    "numpy>=2.0.0",
+    # "<4", not "<4.0.0a0": a pre-release in the bound makes pip eligible to
+    # install Cython pre-releases (that pulled the 3.3.0a1 alpha into 3.0.4).
+    "Cython>3.1.0,<4",  # Note: sync with setup.py, environment.yml and asv.conf.json
+    # numpy >= 2.0 keeps wheels compatible with numpy 1 and 2. Exclude 2.5.0:
+    # wheels built against it segfault on older numpy (GH#66086; numpy GH#31804,
+    # fixed in 2.5.1).
+    "numpy>=2.0.0,!=2.5.0",
     "versioneer[toml]"
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 
 pip
 versioneer[toml]
-cython>=3.1.0,<4.0.0a0
+cython>=3.1.0,<4
 meson[ninja]>=1.2.1,<2
 meson-python>=0.17.1,<1
 pytest>=8.3.4


### PR DESCRIPTION
Manual backport of GH-66090 to `3.0.x` for a 3.0.5 release (3.0.4 is the broken release).

The 3.0.4 wheels segfault on datetime paths (e.g. constructing a `Timedelta`) on Python 3.14 + older numpy, because they were built against numpy 2.5.0, which is not backward-compatible with older numpy at the ABI level. The fix excludes numpy 2.5.0 from the build requirement and tightens the Cython upper bound so pip won't pull in a pre-release.

Changes vs. the original PR:
- `pyproject.toml`: `numpy>=2.0.0` → `numpy>=2.0.0,!=2.5.0`; Cython `<4.0.0a0` → `<4`.
- `environment.yml` / `requirements-dev.txt`: Cython `<4.0.0a0` → `<4`.
- Added a `v3.0.5` whatsnew entry (release date placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
