### PR TITLE
BUG: loc setitem 2D list of lists/tuples on object-dtype frame (GH#37629)

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1152,12 +1152,15 @@ class Block(PandasObject, libinternals.Block):
                 casted = setitem_datetimelike_compat(values, num_set, casted)
 
                 if (
-                    isinstance(casted, list)
+                    self.ndim == 1
+                    and isinstance(casted, list)
                     and len(casted) > 0
                     and isinstance(casted[0], (tuple, list, np.ndarray))
                 ):
                     # Prevent numpy from unpacking nested containers
-                    # (e.g. tuples) during boolean-indexed assignment. GH#37629
+                    # (e.g. tuples) into a scalar cell during assignment. GH#37629
+                    # Only for 1D blocks: on a 2D block a list of lists/tuples is
+                    # a genuine 2D value whose rows must not be wrapped. GH#65264
                     casted = construct_1d_object_array_from_listlike(casted)
 
             self = self._maybe_copy(inplace=True)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1171,6 +1171,16 @@ def test_loc_setitem_list_of_tuples_on_object_column():
     tm.assert_frame_equal(df2, expected)
 
 
+@pytest.mark.parametrize("value", [[[1, 2], [3, 4], [5, 6]], [(1, 2), (3, 4), (5, 6)]])
+def test_loc_setitem_2d_list_on_object_frame(value):
+    # GH#65264 - a list of lists/tuples assigned to a 2D object block is a
+    # genuine 2D value; its rows must not be wrapped into single object cells
+    df = DataFrame({"a": [10, 20, 30], "b": [40, 50, 60]}, dtype=object)
+    df.loc[:, :] = value
+    expected = DataFrame({"a": [1, 3, 5], "b": [2, 4, 6]}, dtype=object)
+    tm.assert_frame_equal(df, expected)
+
+
 def test_object_dtype_series_set_series_element():
     # GH 48933
     s1 = Series(dtype="O", index=["a", "b"])


### PR DESCRIPTION
The GH-37629 fix in GH-65264 unconditionally wrapped a `list` whose first element is a tuple/list/ndarray with `construct_1d_object_array_from_listlike`. That is correct for a **1D block** (single object column), where a list of tuples is a sequence of scalar cells — but on a **2D object block** a list of lists/tuples is a genuine 2D value whose *rows* must not be collapsed into single object cells.

As a result `df.loc[:, :] = [[1, 2], [1, 2]]` on an all-object frame wrapped each row-list into one cell and broadcast it to every row (so every cell held `[1, 2]`); larger shapes raised `ValueError`. The ndarray form was unaffected.

Fix: gate the wrapping on `self.ndim == 1`. On a 2D block numpy already interprets the list of lists/tuples as a 2D value correctly; on a 1D block the GH-37629 behavior (tuples preserved as scalar cells) is retained.

PR GH-65264 is unreleased, so no whatsnew entry is added for this within-release regression.