### PR TITLE
BUG: DatetimeIndex/TimedeltaIndex union(sort=False) dropped values past self

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -290,6 +290,7 @@ Datetimelike
 - Bug in :meth:`DataFrame.to_string` and :meth:`Series.to_string` where ``na_rep`` was ignored for datetime and timedelta columns, always displaying ``NaT`` (:issue:`55426`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
 - Bug in :meth:`DatetimeIndex.intersection` returning incorrect results when the two indexes had matching ``freq`` but did not lie on the same grid, e.g. ranges with the same business-day frequency but different time-of-day components (:issue:`44025`)
+- Bug in :meth:`DatetimeIndex.union` and :meth:`TimedeltaIndex.union` with ``sort=False`` silently dropping values from the other index that fell after the end of ``self`` (:issue:`66322`)
 - Bug in :meth:`Series.dt.isocalendar` with a pyarrow-backed datetime or date dtype not preserving the original index, resetting it to a default :class:`RangeIndex` (:issue:`65894`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
 - Bug in subtracting :class:`BusinessHour` (or :class:`CustomBusinessHour`) from a :class:`Timestamp` giving incorrect results when the subtraction would land exactly on the business-hour opening time (:issue:`33682`)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -1334,24 +1334,13 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         # Only need to "adjoin", not overlap
         return (right_start == left_end + freq) or right_start in left
 
-    def _fast_union(self, other: Self, sort=None) -> Self:
+    def _fast_union(self, other: Self) -> Self:
         # Caller is responsible for ensuring self and other are non-empty
+        #  and that the result is monotonic, so that it retains self.freq.
 
         # to make our life easier, "sort" the two ranges
         if self[0] <= other[0]:
             left, right = self, other
-        elif sort is False:
-            # TDIs are not in the "correct" order and we don't want
-            #  to sort but want to remove overlaps
-            left, right = self, other
-            left_start = left[0]
-            loc = right.searchsorted(left_start, side="left")
-            right_chunk = right._values[:loc]
-            dates = concat_compat((left._values, right_chunk))
-            result = type(self)._simple_new(dates, name=self.name)
-            # The sort=False result is non-monotonic (self's values followed
-            #  by earlier values from other), so it cannot carry a freq.
-            return result
         else:
             left, right = other, self
 
@@ -1380,10 +1369,12 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, ABC):
         if self._can_range_setop(other):
             return self._range_union(other, sort=sort)
 
-        if self._can_fast_union(other):
-            # in the case with sort=None, the _can_fast_union check ensures
-            #  that result.freq == self.freq
-            return self._fast_union(other, sort=sort)
+        if self._can_fast_union(other) and (sort is not False or self[0] <= other[0]):
+            # the _can_fast_union check ensures that result.freq == self.freq.
+            #  With sort=False and self starting after other, the result would
+            #  instead be non-monotonic and carry no freq, so we leave that case
+            #  to the generic path below.  GH#66322
+            return self._fast_union(other)
         else:
             # super()._union can return an ArrayLike; wrap into an Index first
             result = self._wrap_setop_result(other, super()._union(other, sort))

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -190,6 +190,27 @@ class TestDatetimeIndexSetOps:
         assert not result.is_monotonic_increasing
         assert result.freq is None
 
+    def test_union_sort_false_other_extends_past_self(self):
+        # GH#66322 with sort=False and self starting after other, the result
+        #  is non-monotonic, so the fast path does not apply; previously it
+        #  appended only other[:self[0]] and silently dropped the tail.
+        dti = date_range("2016-01-01", periods=6, freq="MS")
+        left = dti[2:4]
+
+        result = left.union(dti, sort=False)
+        expected = DatetimeIndex(
+            [
+                "2016-03-01",
+                "2016-04-01",
+                "2016-01-01",
+                "2016-02-01",
+                "2016-05-01",
+                "2016-06-01",
+            ]
+        )
+        tm.assert_index_equal(result, expected)
+        assert result.freq is None
+
     def test_union_dataframe_index(self):
         rng1 = date_range("1/1/1999", "1/1/2012", freq="MS")
         s1 = Series(np.random.default_rng(2).standard_normal(len(rng1)), rng1)

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -46,6 +46,20 @@ class TestTimedeltaIndex:
         #  retain a freq; otherwise e.g. shift silently returns an empty index.
         assert result.freq is None
 
+    def test_union_sort_false_other_extends_past_self(self):
+        # GH#66322 with sort=False and self starting after other, the result
+        #  is non-monotonic, so the fast path does not apply; previously the
+        #  tail past self[-1] was silently dropped.
+        tdi = timedelta_range("1day", periods=6)
+        left = tdi[2:4]
+
+        result = left.union(tdi, sort=False)
+        expected = TimedeltaIndex(
+            ["3 Days", "4 Days", "1 Days", "2 Days", "5 Days", "6 Days"]
+        )
+        tm.assert_index_equal(result, expected)
+        assert result.freq is None
+
     def test_union_coverage(self):
         # GH#59051
         msg = "'d' is deprecated and will be removed in a future version."


### PR DESCRIPTION
The `sort=False` path in `DatetimeTimedeltaMixin._fast_union` appended only `other`'s values falling *before* `self[0]`, silently dropping those falling *after* `self[-1]`:

```python
>>> dti = pd.date_range("2016-01-01", periods=6, freq="MS")
>>> dti[2:4].union(dti, sort=False)   # 2016-05 and 2016-06 are gone
DatetimeIndex(['2016-03-01', '2016-04-01', '2016-01-01', '2016-02-01'],
              dtype='datetime64[us]', freq=None)
```

This is a pre-existing bug, not a regression: the faulty value selection dates to GH-30704 (2020) and is present verbatim in 3.0.4. GH-65191 and its follow-up GH-66171 only ever touched the `freq` assignment on this branch, never the value selection. There is no issue on file, so the whatsnew cites this PR.

Rather than teach the branch to also append the tail, this removes it. `_can_fast_union` documents that fast-union-ability implies `freq` is retained on the result — `_get_join_freq` leans on the same contract — and this branch was the sole case where that didn't hold. When `sort=False` and `self` starts after `other`, `other[0]` always lands ahead of `self[0]` in the result, so the result is *always* non-monotonic with `freq=None`; the generic `Index._union` path already handles it correctly. `_range_union` likewise has no `sort=False` special case, deferring to `RangeIndex.union`. With the branch gone `sort` is unused in `_fast_union`, so it is dropped from the signature.

Verified the generic path matches the corrected fast path — identical values and `freq` — across every reachable slice pair for `MS`/`D`/`W`/`ME`/`QS`/`B`. Tick freqs such as `h` are unaffected: they short-circuit into `_range_union` before `_can_fast_union` is consulted, and already returned the correct values.
