### PR TITLE
BUG: array_equivalent wrong on native complex with NaN component (GH#66160)

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -484,20 +484,15 @@ def array_equivalent(
 
 
 def _array_equivalent_float(left: np.ndarray, right: np.ndarray) -> bool:
-    # lib.array_equivalent_float only accepts native float32/float64; complex
-    # is viewed to float pairs below. Everything else (float16, longdouble,
-    # byte-swapped) uses numpy -- the native check also stops a byte-swapped
-    # complex .view() from silently reinterpreting its bytes (GH#65192).
-    supported_itemsize = (8, 16) if left.dtype.kind == "c" else (4, 8)
-    if not (left.dtype.isnative and left.dtype.itemsize in supported_itemsize):
+    # lib.array_equivalent_float only accepts native float32/float64. Complex is
+    # compared with numpy: viewing it to float pairs would test the real and
+    # imaginary parts independently, breaking whole-element NA semantics -- a
+    # complex value is NA if either part is NaN (GH#66160). float16, longdouble,
+    # and byte-swapped floats also fall back to numpy (GH#65192).
+    if left.dtype.kind == "c" or not (
+        left.dtype.isnative and left.dtype.itemsize in (4, 8)
+    ):
         return bool(((left == right) | (np.isnan(left) & np.isnan(right))).all())
-    if left.dtype.kind == "c":
-        if not (left.flags.c_contiguous and right.flags.c_contiguous):
-            return bool(((left == right) | (np.isnan(left) & np.isnan(right))).all())
-        # View complex as float pairs (complex128 -> float64, complex64 -> float32)
-        float_dtype = np.finfo(left.dtype).dtype
-        left = left.view(float_dtype)
-        right = right.view(float_dtype)
     if left.ndim > 1:
         if left.flags.f_contiguous and right.flags.f_contiguous:
             # .T is a C-contiguous view of an F-contiguous array

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -434,6 +434,33 @@ def test_array_equivalent_nonnative_complex_bytes():
 
 
 @pytest.mark.parametrize("dtype_equal", [True, False])
+@pytest.mark.parametrize("dtype", ["c16", "c8", ">c16", ">c8"])
+def test_array_equivalent_complex_nan_component(dtype, dtype_equal):
+    # GH#66160 a complex value is NA if either part is NaN, so two elements that
+    # are both NA are equivalent even when their non-NaN parts differ. The
+    # fastpath viewed complex as float pairs and compared parts independently,
+    # returning the wrong answer (and disagreeing with the dtype_equal=False
+    # path) for native complex.
+    left = np.array([complex(1, np.nan)], dtype=dtype)
+    right = np.array([complex(2, np.nan)], dtype=dtype)
+    assert array_equivalent(left, right, dtype_equal=dtype_equal)
+
+    # NaN in the real part, differing imaginary parts -- still both NA
+    left = np.array([complex(np.nan, 1)], dtype=dtype)
+    right = np.array([complex(np.nan, 2)], dtype=dtype)
+    assert array_equivalent(left, right, dtype_equal=dtype_equal)
+
+    # a genuine NA element mixed with an equal finite element
+    left = np.array([1 + 2j, complex(3, np.nan)], dtype=dtype)
+    right = np.array([1 + 2j, complex(9, np.nan)], dtype=dtype)
+    assert array_equivalent(left, right, dtype_equal=dtype_equal)
+
+    # differing finite elements are not equivalent
+    right = np.array([5 + 2j, complex(9, np.nan)], dtype=dtype)
+    assert not array_equivalent(left, right, dtype_equal=dtype_equal)
+
+
+@pytest.mark.parametrize("dtype_equal", [True, False])
 def test_array_equivalent_tdi(dtype_equal):
     assert array_equivalent(
         TimedeltaIndex([0, np.nan]),


### PR DESCRIPTION
Followup to GH-65192 / GH-66160. Those fixed `float16`/byte-swapped and
non-native complex, but native complex was still on the fastpath, which
viewed complex arrays as float pairs (`complex128` -> two `float64`) and
compared the real and imaginary parts *independently*.

That breaks whole-element NA semantics: a complex value is NA if *either*
part is NaN, so two elements that are both NA are equivalent even when their
non-NaN parts differ. For example `array_equivalent(np.array([1+nanj]),
np.array([2+nanj]))` gave `dtype_equal=True -> False` but
`dtype_equal=False -> True` — self-inconsistent for identical dtypes, and
`Series.equals` returned `False` where it should return `True` (both
elements are NA). 3.0.x, which used `np.isnan` on the complex array, returned
`True`.

Fix: drop the complex pair-view entirely and route all complex through the
numpy comparison `((left == right) | (np.isnan(left) & np.isnan(right))).all()`,
where `np.isnan` on complex reports whole-element NA. This matches the
`dtype_equal=False` path exactly.

No whatsnew: GH-65192 and GH-66160 are both unreleased (3.1.0.dev), so this
is a same-cycle regression fix.