### PR TITLE
DOC: note under-specified IntervalDtype in select_dtypes Notes (GH#40234)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5368,8 +5368,9 @@ class DataFrame(NDFrame, OpsMixin):
           ``pd.CategoricalDtype(["a", "b"])``) selects only columns with
           exactly that dtype, whereas a class or string selects a family
           of dtypes. Under-specified instances like a unitless
-          ``np.dtype("datetime64")`` or a bare ``pd.CategoricalDtype()``
-          select their whole family
+          ``np.dtype("datetime64")``, a bare ``pd.CategoricalDtype()``, or a
+          ``pd.IntervalDtype("int64")`` without a ``closed`` select their
+          whole family
         * To select datetimes, use ``np.datetime64``, ``'datetime'`` or
           ``'datetime64'``
         * To select timedeltas, use ``np.timedelta64``, ``'timedelta'`` or


### PR DESCRIPTION
The `DataFrame.select_dtypes` Notes list a unitless `np.dtype("datetime64")` and a bare `pd.CategoricalDtype()` as under-specified instances that select their whole family. GH-66325 gave a subtype-only `pd.IntervalDtype("int64")` (and its string form `"interval[int64]"`) the same behavior, so mention it alongside them.

Docstring only, no behavior change. GH-40234 is already closed by GH-66325; this is just the doc follow-up.