### PR TITLE
BUG: select_dtypes with a subtype-only interval spec matched no columns (GH#40234)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -493,6 +493,7 @@ Reshaping
 - Bug in :meth:`DataFrame.melt` where ``var_name`` colliding with an ``id_vars`` column or ``value_name`` silently overwrote the affected column data instead of raising (:issue:`65654`)
 - Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)
 - Bug in :meth:`DataFrame.select_dtypes` where a nullable extension dtype name such as ``"Int64"`` or ``"boolean"`` also selected numpy columns sharing the same scalar type; it now selects only columns of that extension dtype (:issue:`40234`)
+- Bug in :meth:`DataFrame.select_dtypes` where an interval spec giving a subtype but no ``closed`` keyword, such as ``"interval[int64]"`` or ``pd.IntervalDtype("int64")``, selected no columns; it now selects every interval column with that subtype, for any ``closed`` value (:issue:`40234`)
 - Bug in :meth:`DataFrame.select_dtypes` where the string form of an Arrow dtype such as ``"int64[pyarrow]"`` selected no columns and ``"float64[pyarrow]"`` selected numpy float columns; an Arrow dtype string now selects only columns of that exact dtype (:issue:`59888`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -106,6 +106,7 @@ from pandas.core.dtypes.dtypes import (
     CategoricalDtype,
     DatetimeTZDtype,
     ExtensionDtype,
+    IntervalDtype,
 )
 from pandas.core.dtypes.generic import (
     ABCIndex,
@@ -5488,6 +5489,22 @@ class DataFrame(NDFrame, OpsMixin):
 
                 return func
 
+            def matches_interval_subtype(
+                target: IntervalDtype,
+            ) -> Callable[[DtypeObj], bool]:
+                # GH#66119, GH#66120: an interval spec with a subtype but no
+                # ``closed`` (e.g. the string "interval[int64]" or the instance
+                # IntervalDtype("int64")) has closed=None, which ``==`` never
+                # matches since no column has closed=None. Treat it as naming
+                # the subtype family, matching that subtype for any closed.
+                def func(dtype_obj: DtypeObj) -> bool:
+                    return (
+                        isinstance(dtype_obj, IntervalDtype)
+                        and dtype_obj.subtype == target.subtype
+                    )
+
+                return func
+
             def matches_np_dtype(
                 np_dtype: np.dtype,
             ) -> Callable[[DtypeObj], bool]:
@@ -5542,6 +5559,17 @@ class DataFrame(NDFrame, OpsMixin):
                         # "category" string
                         resolved.add(dtype.type)
                         funcs.append(matches_type(dtype.type))
+                        continue
+                    elif (
+                        isinstance(dtype, IntervalDtype)
+                        and dtype.subtype is not None
+                        and dtype.closed is None
+                    ):
+                        # GH#66119: a partially-specified IntervalDtype instance
+                        # (subtype but no closed, e.g. IntervalDtype("int64"))
+                        # names the subtype family, matching any closed value
+                        resolved.add(dtype)
+                        ea_funcs.append(matches_interval_subtype(dtype))
                         continue
                     resolved.add(dtype)
                     instances.append(dtype)
@@ -5622,8 +5650,19 @@ class DataFrame(NDFrame, OpsMixin):
                                 # a bare name (e.g. "Int64", "category") names
                                 # the dtype's class and matches any instance.
                                 if "[" in dtype:
-                                    resolved.add(pdtype)
-                                    ea_funcs.append(matches_ea_instance(pdtype))
+                                    if (
+                                        isinstance(pdtype, IntervalDtype)
+                                        and pdtype.closed is None
+                                    ):
+                                        # GH#66120: "interval[int64]" resolves to
+                                        # closed=None; match the subtype family
+                                        resolved.add(pdtype)
+                                        ea_funcs.append(
+                                            matches_interval_subtype(pdtype)
+                                        )
+                                    else:
+                                        resolved.add(pdtype)
+                                        ea_funcs.append(matches_ea_instance(pdtype))
                                 else:
                                     resolved.add(type(pdtype))
                                     ea_funcs.append(matches_ea_class(type(pdtype)))

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -911,3 +911,62 @@ def test_select_dtypes_arrow_timestamp_string_matches_only_arrow():
     )
     result = df.select_dtypes(include=["timestamp[ns][pyarrow]"])
     tm.assert_frame_equal(result, df[["arrow"]])
+
+
+@pytest.mark.parametrize("spec", ["interval[int64]", pd.IntervalDtype("int64")])
+def test_select_dtypes_interval_subtype_matches_any_closed(spec):
+    # GH#66119, GH#66120: an interval spec with a subtype but no ``closed``
+    # (the string "interval[int64]" or the instance IntervalDtype("int64"),
+    # both of which have closed=None) selects interval columns of that
+    # subtype for any closed value. Previously these matched nothing because
+    # no column ever has closed=None.
+    df = DataFrame(
+        {
+            "int_right": pd.arrays.IntervalArray.from_breaks([0, 1, 2, 3]),
+            "int_left": pd.arrays.IntervalArray.from_breaks(
+                [0, 1, 2, 3], closed="left"
+            ),
+            "float_right": pd.arrays.IntervalArray.from_breaks([0.0, 1.0, 2.0, 3.0]),
+            "other": [1, 2, 3],
+        }
+    )
+    result = df.select_dtypes(include=spec)
+    tm.assert_frame_equal(result, df[["int_right", "int_left"]])
+
+    result = df.select_dtypes(exclude=spec)
+    tm.assert_frame_equal(result, df[["float_right", "other"]])
+
+
+@pytest.mark.parametrize(
+    "spec", ["interval[int64, right]", pd.IntervalDtype("int64", "right")]
+)
+def test_select_dtypes_interval_closed_matches_exact(spec):
+    # GH#66119, GH#66120: a fully specified interval spec (subtype and closed)
+    # still matches only that exact closed value
+    df = DataFrame(
+        {
+            "int_right": pd.arrays.IntervalArray.from_breaks([0, 1, 2, 3]),
+            "int_left": pd.arrays.IntervalArray.from_breaks(
+                [0, 1, 2, 3], closed="left"
+            ),
+        }
+    )
+    result = df.select_dtypes(include=spec)
+    tm.assert_frame_equal(result, df[["int_right"]])
+
+
+def test_select_dtypes_interval_family_string_and_bare_instance():
+    # GH#66120: the bare "interval" string and a bare IntervalDtype() instance
+    # both select every interval column regardless of subtype or closed
+    df = DataFrame(
+        {
+            "int_right": pd.arrays.IntervalArray.from_breaks([0, 1, 2, 3]),
+            "float_left": pd.arrays.IntervalArray.from_breaks(
+                [0.0, 1.0, 2.0, 3.0], closed="left"
+            ),
+            "other": [1, 2, 3],
+        }
+    )
+    expected = df[["int_right", "float_left"]]
+    tm.assert_frame_equal(df.select_dtypes(include="interval"), expected)
+    tm.assert_frame_equal(df.select_dtypes(include=pd.IntervalDtype()), expected)


### PR DESCRIPTION
Fixes a regression from the select_dtypes exact-match rework (GH-66119, GH-66120), part of GH-40234 / GH-59888.

A `select_dtypes` interval spec that gives a subtype but no `closed` keyword — the string `"interval[int64]"` or the instance `pd.IntervalDtype("int64")` — resolves to `closed=None`. The exact-`==` matching those PRs introduced never matched, because no column ever has `closed=None`, so both forms selected **no columns** (and `exclude` removed nothing). Pre-rework, the string matched the whole `Interval` type family.

Such a spec is now treated as naming the subtype family: it selects every interval column with that subtype, for any `closed` value. Fully specified specs (`"interval[int64, right]"`, `IntervalDtype("int64", "right")`) still match exactly, and bare `"interval"` / `IntervalDtype()` still match all interval columns. Subtype matching stays resolution-sensitive, consistent with the datetime64/timedelta64-unit behavior.