### PR TITLE
BUG: get_dummies stopped encoding object-fallback ArrowDtype columns (GH#66091)

### DIFF
--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -161,8 +161,9 @@ def get_dummies(
 
     def _is_encodable(arr) -> bool:
         # The columns get_dummies encodes by default: object, string (any
-        # storage), categorical, and the Arrow-backed string/dictionary
-        # equivalents (GH#56273).
+        # storage), categorical, the Arrow-backed string/dictionary
+        # equivalents (GH#56273), and other Arrow types whose numpy fallback
+        # is object (binary, decimal, time32/time64, ...).
         dtype = arr.dtype
         if isinstance(dtype, (StringDtype, CategoricalDtype)):
             return True
@@ -170,21 +171,28 @@ def get_dummies(
             import pyarrow as pa
 
             pa_type = dtype.pyarrow_dtype
-            return (
+            if (
                 pa.types.is_string(pa_type)
                 or pa.types.is_large_string(pa_type)
                 or pa.types.is_string_view(pa_type)
                 or pa.types.is_dictionary(pa_type)
-            )
+            ):
+                return True
+            # Arrow types whose numpy fallback is object (e.g. binary,
+            # decimal, time32/time64) were encoded before GH#66091 decoupled
+            # this from select_dtypes(include="object"); keep encoding them.
+            return dtype.numpy_dtype == np.dtype(object)
         # is_object_dtype last: it raises for ArrowDtypes whose `.type` is
-        # not implemented (e.g. string_view)
+        # not implemented (handled above)
         return is_object_dtype(dtype)
 
     if isinstance(data, DataFrame):
         # determine columns being encoded
         if columns is None:
             mgr = data._mgr._get_data_subset(_is_encodable).copy(deep=False)
-            data_to_encode = data._constructor_from_mgr(mgr, axes=mgr.axes)
+            data_to_encode = data._constructor_from_mgr(
+                mgr, axes=mgr.axes
+            ).__finalize__(data)
         elif not is_list_like(columns):
             raise TypeError("Input must be a list-like for parameter `columns`")
         else:
@@ -232,7 +240,11 @@ def get_dummies(
             rest_mgr = data._mgr._get_data_subset(
                 lambda arr: not _is_encodable(arr)
             ).copy(deep=False)
-            with_dummies = [data._constructor_from_mgr(rest_mgr, axes=rest_mgr.axes)]
+            with_dummies = [
+                data._constructor_from_mgr(rest_mgr, axes=rest_mgr.axes).__finalize__(
+                    data
+                )
+            ]
 
         for col, pre, sep in zip(
             data_to_encode.items(), prefix, prefix_sep, strict=True

--- a/pandas/core/reshape/encoding.py
+++ b/pandas/core/reshape/encoding.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from pandas._libs import missing as libmissing
 from pandas._libs.sparse import IntIndex
+from pandas.compat import pa_version_under16p0
 from pandas.util._decorators import set_module
 
 from pandas.core.dtypes.common import (
@@ -174,8 +175,9 @@ def get_dummies(
             if (
                 pa.types.is_string(pa_type)
                 or pa.types.is_large_string(pa_type)
-                or pa.types.is_string_view(pa_type)
                 or pa.types.is_dictionary(pa_type)
+                # is_string_view is only available in pyarrow>=16
+                or (not pa_version_under16p0 and pa.types.is_string_view(pa_type))
             ):
                 return True
             # Arrow types whose numpy fallback is object (e.g. binary,

--- a/pandas/tests/reshape/test_get_dummies.py
+++ b/pandas/tests/reshape/test_get_dummies.py
@@ -739,3 +739,49 @@ class TestGetDummies:
         )
         result = get_dummies(df)
         tm.assert_frame_equal(result, expected)
+
+    @td.skip_if_no("pyarrow")
+    def test_get_dummies_arrow_object_fallback_dtype(self):
+        # GH#66091: Arrow types whose numpy fallback is object (binary,
+        # decimal, time32/time64, ...) are encoded by default, matching the
+        # pre-decoupling select_dtypes(include="object") behavior.
+        df = DataFrame(
+            {"name": Series([b"a", b"b", b"a"], dtype=ArrowDtype(pa.binary())), "x": 1}
+        )
+        result = get_dummies(df)
+        expected = DataFrame(
+            {
+                "x": 1,
+                "name_b'a'": Series([True, False, True], dtype="bool[pyarrow]"),
+                "name_b'b'": Series([False, True, False], dtype="bool[pyarrow]"),
+            }
+        )
+        tm.assert_frame_equal(result, expected)
+
+    @td.skip_if_no("pyarrow")
+    def test_get_dummies_arrow_object_fallback_encoded(self):
+        # GH#66091: further Arrow subtypes with an object numpy fallback are
+        # also encoded rather than silently passed through.
+        pa_types = [
+            pa.large_binary(),
+            pa.binary(3),
+            pa.decimal128(5, 2),
+            pa.time32("s"),
+            pa.time64("us"),
+        ]
+        for pa_type in pa_types:
+            values = pa.array([None, None, None], type=pa_type)
+            df = DataFrame({"name": Series(values, dtype=ArrowDtype(pa_type)), "x": 1})
+            result = get_dummies(df, dummy_na=True)
+            # the object-fallback column is encoded, not passed through
+            assert "name" not in result.columns
+            dummy_cols = [col for col in result.columns if str(col).startswith("name_")]
+            assert dummy_cols
+            assert all(result[col].dtype == "bool[pyarrow]" for col in dummy_cols)
+
+    def test_get_dummies_preserves_attrs_no_encodable_columns(self):
+        # GH#66091: attrs must be preserved when there are no columns to encode
+        df = DataFrame({"C": [1, 2, 3], "D": [4.0, 5.0, 6.0]})
+        df.attrs = {"hello": "world"}
+        result = get_dummies(df)
+        assert result.attrs == {"hello": "world"}


### PR DESCRIPTION
GH-66091 decoupled `get_dummies` column selection from `select_dtypes` by replacing `select_dtypes(include=["object", "string", "category"])` with a local `_is_encodable` predicate. That predicate only matched Arrow `string`/`large_string`/`string_view`/`dictionary`, so it silently stopped encoding `ArrowDtype` columns whose numpy fallback is object but that aren't string/dictionary — `binary`, `large_binary`, `decimal128`, `time32`/`time64`, etc. The old `select_dtypes(include="object")` matched these because it normalizes `ArrowDtype` to `numpy_dtype` (→ object) before matching.

```python
df = pd.DataFrame({"c": pd.Series([b"a", b"b", b"a"], dtype=pd.ArrowDtype(pa.binary()))})
pd.get_dummies(df).columns
# was: Index(['c'], ...)  (unencoded)
# now: Index(["c_b'a'", "c_b'b'"], ...)
```

Fix: `_is_encodable` now also returns `True` for any `ArrowDtype` whose `numpy_dtype` is object, mirroring the pre-decoupling `select_dtypes` behavior.

Also restores `DataFrame.attrs` propagation: the new `_get_data_subset` + `_constructor_from_mgr` path skipped the `__finalize__(data)` that `select_dtypes` performed, dropping `attrs` when no column was encodable. Added `.__finalize__(data)` to both constructor calls.

The regression is unreleased (introduced this dev cycle), so no whatsnew entry.