### PR TITLE
BUG: read_hdf did not round-trip missing values in a string Index on table append or in a MultiIndex level (GH#9604)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -440,7 +440,7 @@ I/O
 - Fixed ``MemoryError`` in :meth:`HDFStore.select` when iterating large tables with ``chunksize`` and no ``where`` filter (:issue:`15937`)
 - Fixed bug in :func:`read_hdf` raising on files written by older pandas versions whose ``freq`` index attribute could not be decoded; the ``freq`` is now dropped with a warning instead of corrupting the index (:issue:`35917`)
 - Fixed bug in :func:`read_hdf` where a categorical column containing a category equal to the ``nan_rep`` string (e.g. the default ``"nan"``) raised ``ValueError: operands could not be broadcast together`` instead of reading that category back as ``NaN`` (:issue:`21741`)
-- Fixed bug in :func:`read_hdf` where a string :class:`Index` did not round-trip missing values and the literal string ``"nan"``: a missing value was read back as ``"nan"`` and a literal ``"nan"`` was read back as ``NaN`` (:issue:`9604`)
+- Fixed bug in :func:`read_hdf` where a string :class:`Index` or :class:`MultiIndex` level did not round-trip missing values and the literal string ``"nan"``: a missing value was read back as ``"nan"`` and a literal ``"nan"`` was read back as ``NaN`` (:issue:`9604`)
 - Fixed bug in :meth:`DataFrame.to_hdf` and :meth:`HDFStore.put` where writing an object to a key silently deleted any nested keys stored beneath it (:issue:`17267`)
 - Fixed bug in :meth:`DataFrame.to_hdf` raising ``TypeError`` when the index had a non-tick :class:`DateOffset` ``freq`` (e.g. ``DateOffset(years=1)``) (:issue:`45790`)
 - Fixed bug in :meth:`DataFrame.to_hdf` with ``format="table"`` where a :class:`TimedeltaIndex` was reconstructed as a :class:`PeriodIndex` (when ``freq`` was set) or an integer :class:`Index` (otherwise) on read-back (:issue:`21466`)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2619,6 +2619,10 @@ class IndexCol:
 
     is_an_indexable: bool = True
     is_data_indexable: bool = True
+    # GH#9604: True for a data column that stores a string MultiIndex level, so
+    # it round-trips missing values like a string Index rather than via the
+    # global data-column nan_rep default.
+    is_mi_level: bool = False
     _info_fields = ["freq", "tz", "index_name", "ordered"]
 
     def __init__(
@@ -3312,11 +3316,19 @@ class DataCol(IndexCol):
 
         # convert nans / decode
         if kind == "string":
-            # Old files may have been written without nan_rep persisted; the
-            # writer (write_data) defaulted None to "nan", so do the same here.
+            if self.is_mi_level:
+                # GH#9604: a string MultiIndex level round-trips like a string
+                # Index. self.nan_rep is the per-level sentinel (None when the
+                # level had no missing value), and a literal "nan" is left
+                # untouched instead of being read back as a missing value.
+                col_nan_rep = self.nan_rep
+            else:
+                # Old files may have been written without nan_rep persisted; the
+                # writer (write_data) defaulted None to "nan", so do the same.
+                col_nan_rep = nan_rep if nan_rep is not None else "nan"
             converted = _unconvert_string_array(
                 converted,
-                nan_rep=nan_rep if nan_rep is not None else "nan",
+                nan_rep=col_nan_rep,
                 encoding=encoding,
                 errors=errors,
             )
@@ -3329,6 +3341,9 @@ class DataCol(IndexCol):
         _set_attr_if_changed(self.attrs, self.meta_attr, self.meta)
         assert self.dtype is not None
         _set_attr_if_changed(self.attrs, self.dtype_attr, self.dtype)
+        if self.nan_rep is not None:
+            # GH#9604: per-level string MultiIndex NaN sentinel (see convert).
+            _set_attr_if_changed(self.attrs, self.nan_rep_attr, self.nan_rep)
 
 
 class DataIndexableCol(DataCol):
@@ -4428,6 +4443,10 @@ class Table(Fixed):
         self.attrs.encoding = self.encoding
         self.attrs.errors = self.errors
         self.attrs.levels = self.levels
+        # GH#9604: marks that string MultiIndex levels are stored with a
+        # per-level NaN sentinel (older files lack it and read back as before).
+        # self.levels is the int default 1 for non-MI tables, a list for MI.
+        self.attrs.mi_level_nan_rep = isinstance(self.levels, list)
         self.attrs.info = self.info
 
     def get_attrs(self) -> None:
@@ -4470,6 +4489,11 @@ class Table(Fixed):
 
         desc = self.description
         table_attrs = self.table.attrs
+        # GH#9604: levels / the MultiIndex-level marker live on the group attrs
+        # (self.attrs), not the table-node attrs used for per-column metadata.
+        levels_attr = getattr(self.attrs, "levels", None)
+        levels = levels_attr if isinstance(levels_attr, list) else []
+        mi_level_marker = getattr(self.attrs, "mi_level_nan_rep", False)
 
         # Note: each of the `name` kwargs below are str, ensured
         #  by the definition in index_cols.
@@ -4527,6 +4551,14 @@ class Table(Fixed):
             #  meta = "category" if md is not None else None
             meta = getattr(table_attrs, f"{c}_meta", None)
 
+            # GH#9604: a string MultiIndex level stored as a data column carries
+            # a per-level NaN sentinel and round-trips missing values like a
+            # string Index; older files lack the marker and read back as before.
+            is_mi_level = c in levels and mi_level_marker
+            nan_rep = (
+                getattr(table_attrs, f"{c}_nan_rep", None) if is_mi_level else None
+            )
+
             obj = klass(
                 name=c,
                 cname=c,
@@ -4539,6 +4571,8 @@ class Table(Fixed):
                 metadata=md,
                 dtype=dtype,
             )
+            obj.is_mi_level = is_mi_level
+            obj.nan_rep = nan_rep
             return obj
 
         # Note: the definition of `values_cols` ensures that each
@@ -4835,7 +4869,31 @@ class Table(Fixed):
         idx = axes[0]
         a = obj.axes[idx]
         axis_name = obj._get_axis_name(idx)
-        new_index = _convert_index(axis_name, a, self.encoding, self.errors)
+        # GH#9604: reuse the string-Index NaN sentinel persisted by an earlier
+        # append so it is stable across chunks; if none has been persisted yet
+        # but this chunk introduces a missing value, choose the sentinel against
+        # the values already stored so it cannot collide with them.
+        existing_nan_rep = None
+        existing_values = None
+        if table_exists:
+            existing_index_col = self.index_axes[0]
+            existing_nan_rep = existing_index_col.nan_rep
+            if (
+                existing_nan_rep is None
+                and existing_index_col.kind == "string"
+                and np.asarray(a.isna()).any()
+            ):
+                existing_values = _read_stored_index_values(
+                    self.table, existing_index_col.cname, self.encoding, self.errors
+                )
+        new_index = _convert_index(
+            axis_name,
+            a,
+            self.encoding,
+            self.errors,
+            existing_nan_rep=existing_nan_rep,
+            existing_values=existing_values,
+        )
         new_index.axis = idx
 
         # Because we are always 2D, there is only one new_index, so
@@ -4907,12 +4965,32 @@ class Table(Fixed):
                 existing_col = None
 
             new_name = name or f"values_block_{i}"
+
+            # GH#9604: a string MultiIndex level (stored as a data column)
+            # encodes its missing values with a per-level sentinel rather than
+            # the global nan_rep, so a literal "nan" in a level survives the
+            # round-trip like it does for a string Index.
+            level_names = self.levels if isinstance(self.levels, list) else []
+            is_level = name is not None and name in level_names
+            level_nan_rep = None
+            if is_level:
+                assert name is not None  # for mypy, implied by is_level
+                level_nan_rep = _make_level_nan_rep(
+                    blk.values,
+                    name,
+                    existing_col,
+                    self.table,
+                    self.encoding,
+                    self.errors,
+                )
+            block_nan_rep = level_nan_rep if level_nan_rep is not None else nan_rep
+
             data_converted = _maybe_convert_for_string_atom(
                 new_name,
                 blk.values,
                 existing_col=existing_col,
                 min_itemsize=min_itemsize,
-                nan_rep=nan_rep,
+                nan_rep=block_nan_rep,
                 encoding=self.encoding,
                 errors=self.errors,
                 columns=b_items,
@@ -4948,6 +5026,8 @@ class Table(Fixed):
                 dtype=dtype_name,
                 data=data,
             )
+            col.is_mi_level = is_level
+            col.nan_rep = level_nan_rep
             col.update_info(new_info)
 
             vaxes.append(col)
@@ -5820,20 +5900,87 @@ def _set_tz(
     return dta
 
 
-def _make_index_nan_rep(values: np.ndarray, mask: np.ndarray) -> str:
+def _make_index_nan_rep(
+    values: np.ndarray, mask: np.ndarray, existing: set | None = None
+) -> str:
     """
     Choose a string NaN sentinel for a string Index that does not collide with
     any non-missing value, so genuine missing values round-trip without being
     confused with a literal string such as ``"nan"`` (GH#9604).
+
+    ``existing`` holds values already stored for this column in a prior
+    ``table``-format append; the sentinel must avoid those too, since a single
+    sentinel is persisted for the whole column.
     """
-    existing = set(values[~mask])
+    seen = set(values[~mask])
+    if existing is not None:
+        seen |= existing
     nan_rep = "nan"
-    while nan_rep in existing:
+    while nan_rep in seen:
         nan_rep = f"_{nan_rep}_"
     return nan_rep
 
 
-def _convert_index(name: str, index: Index, encoding: str, errors: str) -> IndexCol:
+def _read_stored_index_values(table, cname: str, encoding: str, errors: str) -> set:
+    """
+    Read the values already stored for a string Index column (GH#9604), so a
+    NaN sentinel chosen for a later append cannot collide with them.
+    """
+    raw = getattr(table.cols, cname)[:]
+    decoded = _unconvert_string_array(
+        raw, nan_rep=None, encoding=encoding, errors=errors
+    )
+    return set(decoded)
+
+
+def _make_level_nan_rep(
+    blk_values,
+    name: str,
+    existing_col,
+    table,
+    encoding: str,
+    errors: str,
+) -> str | None:
+    """
+    Choose the NaN sentinel for a string MultiIndex level stored as a data
+    column, mirroring the string-Index handling (GH#9604): reuse the sentinel
+    already persisted for the column, otherwise mint a collision-free one only
+    when the level actually has a missing value. Returns None when no sentinel
+    is needed (a literal "nan" then round-trips because the level read path
+    skips substitution when the sentinel is absent).
+    """
+    if isinstance(blk_values.dtype, StringDtype):
+        blk_values = blk_values.to_numpy()
+    if blk_values.dtype != object:
+        return None
+
+    flat = np.asarray(blk_values).reshape(-1)
+    mask = isna(flat)
+    nan_rep = existing_col.nan_rep if existing_col is not None else None
+    if mask.any() and nan_rep is None:
+        existing_values = None
+        if existing_col is not None and existing_col.kind == "string":
+            existing_values = _read_stored_index_values(
+                table, existing_col.cname, encoding, errors
+            )
+        nan_rep = _make_index_nan_rep(flat, mask, existing_values)
+    if nan_rep is not None and (flat[~mask] == nan_rep).any():
+        raise ValueError(
+            f"Cannot store the string {str(nan_rep)!r} in MultiIndex level "
+            f"[{name}]: it collides with the sentinel used to encode missing "
+            "values in this column"
+        )
+    return nan_rep
+
+
+def _convert_index(
+    name: str,
+    index: Index,
+    encoding: str,
+    errors: str,
+    existing_nan_rep: str | None = None,
+    existing_values: set | None = None,
+) -> IndexCol:
     assert isinstance(name, str)
 
     index_name = index.name
@@ -5921,11 +6068,25 @@ def _convert_index(name: str, index: Index, encoding: str, errors: str) -> Index
         # write_index / IndexCol.set_attr) so the reader can restore the NAs
         # while leaving a literal "nan" untouched.
         mask = np.asarray(index.isna())
-        nan_rep = None
-        if mask.any():
-            nan_rep = _make_index_nan_rep(values, mask)
-            values = values.copy()
-            values[mask] = nan_rep
+        # Reuse the sentinel already persisted for this column (a ``table``
+        # append) so it stays stable across chunks; only mint a fresh one when
+        # none exists yet, avoiding every value already stored (existing_values)
+        # as well as the ones in this chunk.
+        nan_rep = existing_nan_rep
+        if mask.any() and nan_rep is None:
+            nan_rep = _make_index_nan_rep(values, mask, existing_values)
+        if nan_rep is not None:
+            if (values[~mask] == nan_rep).any():
+                # A real value equal to the sentinel is indistinguishable from a
+                # missing value on read; refuse rather than silently corrupt it.
+                raise ValueError(
+                    f"Cannot store the string {str(nan_rep)!r} in Index column "
+                    f"[{name}]: it collides with the sentinel used to encode "
+                    "missing values in this column"
+                )
+            if mask.any():
+                values = values.copy()
+                values[mask] = nan_rep
         converted = _convert_string_array(values, encoding, errors)
         itemsize = converted.dtype.itemsize
         return IndexCol(

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -14,6 +14,7 @@ from pandas import (
     DatetimeIndex,
     HDFStore,
     Index,
+    MultiIndex,
     Series,
     _testing as tm,
     bdate_range,
@@ -172,6 +173,151 @@ def test_string_index_all_na_roundtrips(temp_h5_path):
     result = read_hdf(temp_h5_path, "s")
     tm.assert_series_equal(result, ser, check_index_type=False)
     assert result.index.isna().all()
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_index_real_na_multichunk_append(temp_hdfstore):
+    # GH#9604 — a string Index with genuine missing values written across
+    # several table-format appends keeps a single, stable NaN sentinel, so
+    # every chunk's missing values round-trip (the sentinel used to be
+    # recomputed per chunk and could silently reinterpret earlier rows).
+    ser1 = Series(range(2), index=Index([np.nan, "x"], dtype=str))
+    ser2 = Series(range(2, 4), index=Index(["y", np.nan], dtype=str))
+
+    temp_hdfstore.append("s", ser1)
+    temp_hdfstore.append("s", ser2)
+
+    expected = Series(range(4), index=Index([np.nan, "x", "y", np.nan], dtype=str))
+    tm.assert_series_equal(temp_hdfstore.select("s"), expected)
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_index_literal_nan_then_real_na_append(temp_hdfstore):
+    # GH#9604 — a literal "nan" written first and a genuine missing value
+    # appended later both round-trip: the sentinel minted for the second chunk
+    # dodges the "nan" already stored (min_itemsize reserves room for it).
+    ser1 = Series(range(2), index=Index(["nan", "x"], dtype=str))
+    ser2 = Series(range(2, 4), index=Index([np.nan, "y"], dtype=str))
+
+    temp_hdfstore.append("s", ser1, min_itemsize={"index": 5})
+    temp_hdfstore.append("s", ser2)
+
+    expected = Series(range(4), index=Index(["nan", "x", np.nan, "y"], dtype=str))
+    tm.assert_series_equal(temp_hdfstore.select("s"), expected)
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_index_append_value_colliding_with_sentinel_raises(temp_hdfstore):
+    # GH#9604 — appending a real value equal to the NaN sentinel already in use
+    # is refused loudly rather than silently corrupting the stored missing
+    # values (the sentinel here is "nan", chosen for the first chunk).
+    temp_hdfstore.append(
+        "s", Series([0, 1], index=Index([np.nan, "aaaaaaa"], dtype=str))
+    )
+
+    ser2 = Series([2, 3], index=Index([np.nan, "nan"], dtype=str))
+    with pytest.raises(ValueError, match="collides with the sentinel"):
+        temp_hdfstore.append("s", ser2)
+
+
+def test_string_index_literal_nan_multichunk_append_no_na(temp_hdfstore):
+    # GH#9604 — a string Index that never has a missing value keeps no sentinel,
+    # so a literal "nan" can be appended freely across chunks.
+    ser1 = Series(range(2), index=Index(["nan", "x"], dtype=str))
+    ser2 = Series(range(2, 4), index=Index(["nan", "z"], dtype=str))
+
+    temp_hdfstore.append("s", ser1)
+    temp_hdfstore.append("s", ser2)
+
+    expected = Series(range(4), index=Index(["nan", "x", "nan", "z"], dtype=str))
+    tm.assert_series_equal(temp_hdfstore.select("s"), expected)
+
+
+def test_string_multiindex_level_literal_nan(temp_h5_path):
+    # GH#9604 — a literal "nan" string in a MultiIndex level round-trips in the
+    # table format. Levels are stored as data columns, which previously read a
+    # literal "nan" back as a missing value via the global NaN sentinel.
+    mi = MultiIndex.from_arrays(
+        [Index(["nan", "a", "b"], dtype=str), [1, 2, 3]], names=["s", "i"]
+    )
+    ser = Series(range(3), index=mi)
+
+    ser.to_hdf(temp_h5_path, key="t", format="table")
+    tm.assert_series_equal(read_hdf(temp_h5_path, "t"), ser)
+
+
+def test_string_multiindex_level_query_literal_nan(temp_hdfstore):
+    # GH#9604 — a literal "nan" is stored as itself (not a sentinel), so it
+    # remains queryable through a where clause on the level.
+    mi = MultiIndex.from_arrays(
+        [Index(["nan", "a", "b"], dtype=str), [1, 2, 3]], names=["s", "i"]
+    )
+    temp_hdfstore.append("t", Series(range(3), index=mi))
+
+    result = temp_hdfstore.select("t", where="s == 'nan'")
+    assert len(result) == 1
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_multiindex_level_real_na(temp_h5_path):
+    # GH#9604 — a genuine missing value in a MultiIndex level round-trips.
+    mi = MultiIndex.from_arrays(
+        [Index(["a", np.nan, "b"], dtype=str), [1, 2, 3]], names=["s", "i"]
+    )
+    ser = Series(range(3), index=mi)
+
+    ser.to_hdf(temp_h5_path, key="t", format="table")
+    tm.assert_series_equal(read_hdf(temp_h5_path, "t"), ser)
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_multiindex_level_literal_and_real_na(temp_h5_path):
+    # GH#9604 — a literal "nan" and a genuine missing value coexist in one
+    # MultiIndex level and both round-trip (the per-level sentinel dodges "nan").
+    mi = MultiIndex.from_arrays(
+        [Index(["nan", np.nan, "b", "c"], dtype=str), [1, 2, 3, 4]], names=["s", "i"]
+    )
+    ser = Series(range(4), index=mi)
+
+    ser.to_hdf(temp_h5_path, key="t", format="table")
+    tm.assert_series_equal(read_hdf(temp_h5_path, "t"), ser)
+
+
+def test_string_multiindex_level_literal_nan_append(temp_hdfstore):
+    # GH#9604 — a literal "nan" in a MultiIndex level survives across appends.
+    s1 = Series(
+        range(2),
+        index=MultiIndex.from_arrays(
+            [Index(["nan", "a"], dtype=str), [1, 2]], names=["s", "i"]
+        ),
+    )
+    s2 = Series(
+        range(2, 4),
+        index=MultiIndex.from_arrays(
+            [Index(["b", "nan"], dtype=str), [3, 4]], names=["s", "i"]
+        ),
+    )
+
+    temp_hdfstore.append("t", s1)
+    temp_hdfstore.append("t", s2)
+
+    result = temp_hdfstore.select("t")
+    assert list(result.index.get_level_values("s")) == ["nan", "a", "b", "nan"]
 
 
 def test_api(temp_h5_path):


### PR DESCRIPTION
closes #9604

Follow-up to GH-66225, which added a per-index NaN sentinel so a string `Index` could round-trip both a genuine missing value and the literal string `"nan"`. That sentinel was chosen from a single write and persisted as one attribute for the whole column, which left two defects:

- **Table-format append (regression, silent data loss).** The sentinel was recomputed per chunk and its attribute overwritten each time, with no cross-chunk validation. Appending `["nan", "x"]` then `[NA, "y"]` read the literal `"nan"` back as `NaN`, and a later chunk could switch the sentinel and reinterpret earlier chunks' missing values. The append path now **reuses** the persisted sentinel so it is stable across chunks, mints a collision-free one only when the first missing value appears (avoiding the values already stored), and **raises** instead of silently corrupting when a real value equals the sentinel in use.

- **String MultiIndex level (gap).** Levels are stored as data columns, which used the global `nan_rep` and so lost a literal `"nan"` (it came back as `NaN`), inconsistent with the fixed/single-index paths. Each string level now gets its own sentinel and round-trips a literal `"nan"` and a genuine missing value in both the `fixed` and `table` formats. A literal `"nan"` is stored as itself, so it stays queryable via a `where` clause. Files written by older pandas lack the marker and read back exactly as before.