### PR TITLE
BUG: DatetimeIndex/Timestamp + DateOffset sub-unit resolution (GH#64806)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -291,6 +291,7 @@ Datetimelike
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
 - Bug in :meth:`DatetimeIndex.intersection` returning incorrect results when the two indexes had matching ``freq`` but did not lie on the same grid, e.g. ranges with the same business-day frequency but different time-of-day components (:issue:`44025`)
 - Bug in :meth:`Series.dt.isocalendar` with a pyarrow-backed datetime or date dtype not preserving the original index, resetting it to a default :class:`RangeIndex` (:issue:`65894`)
+- Bug in adding a :class:`DateOffset` with a ``milliseconds`` component to a :class:`Timestamp` returning a microsecond-resolution result, inconsistent with the millisecond-resolution result of the equivalent :class:`DatetimeIndex` and :class:`Series` operations (:issue:`64806`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
 - Bug in subtracting :class:`BusinessHour` (or :class:`CustomBusinessHour`) from a :class:`Timestamp` giving incorrect results when the subtraction would land exactly on the business-hour opening time (:issue:`33682`)
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1961,7 +1961,21 @@ cdef class RelativeDeltaOffset(BaseOffset):
                 # bring tz back from UTC calculation
                 other = localize_pydatetime(other, tzinfo)
 
-            return Timestamp(other)
+            result = Timestamp(other)
+            # GH#64806 The computation above uses Python timedelta /
+            # relativedelta, which floor sub-second components to microseconds
+            # and lose the offset's declared resolution (e.g. milliseconds).
+            # Coerce to that resolution when lossless so the scalar result
+            # matches the vectorized DatetimeIndex/Series path; apply_wraps
+            # then narrows back to ``other``'s unit where that is also lossless.
+            try:
+                offset_unit = self._pd_timedelta.unit
+            except NotImplementedError:
+                return result
+            result2 = result.as_unit(offset_unit)
+            if result == result2:
+                result = result2
+            return result
         else:
             return other + timedelta(self._n)
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -802,7 +802,12 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             and not offset._use_relativedelta
         ):
             res_values = self._ndarray + offset._pd_timedelta
-            result = type(self)._simple_new(res_values, dtype=self.dtype)
+            # GH#64806 offset._pd_timedelta may have finer resolution than
+            # self, promoting res_values to a finer unit; derive the dtype
+            # from the promoted values rather than assuming self.dtype's unit.
+            res_unit = cast("TimeUnit", np.datetime_data(res_values.dtype)[0])
+            res_dtype = tz_to_dtype(self.tz, res_unit)
+            result = type(self)._simple_new(res_values, dtype=res_dtype)
             if offset.normalize:
                 result = result.normalize()
             return result

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1640,6 +1640,38 @@ class TestDatetime64DateOffsetArithmetic:
         pointwise2 = DatetimeIndex([x + offset2 for x in dti2])
         tm.assert_index_equal(result2, pointwise2)
 
+    def test_dt64arr_add_dateoffset_finer_reso(self):
+        # GH#64806 - a pure-timedelta DateOffset with finer resolution than a
+        # tz-aware DatetimeIndex must promote the result unit like the tz-naive
+        # path instead of raising AssertionError, and must match the scalar
+        # Timestamp + DateOffset result (value and unit).
+        dti = DatetimeIndex(["2020-01-01 00:00:00"], tz="US/Eastern").as_unit("s")
+        offset = DateOffset(milliseconds=5)
+
+        result = dti + offset
+        expected = DatetimeIndex(
+            ["2020-01-01 00:00:00.005000-05:00"],
+            dtype="datetime64[ms, US/Eastern]",
+        )
+        tm.assert_index_equal(result, expected)
+        # the tz-aware fast path matches the tz-naive path's unit promotion
+        naive = dti.tz_localize(None) + offset
+        tm.assert_index_equal(result.tz_localize(None), naive)
+        # and it matches the scalar Timestamp + DateOffset path
+        pointwise = DatetimeIndex([ts + offset for ts in dti])
+        tm.assert_index_equal(result, pointwise)
+
+        # promotion still holds when the addition crosses a DST transition
+        dti2 = DatetimeIndex(["2018-03-11 01:59:59"], tz="US/Eastern").as_unit("s")
+        result2 = dti2 + DateOffset(milliseconds=1500)
+        expected2 = DatetimeIndex(
+            ["2018-03-11 03:00:00.500000-04:00"],
+            dtype="datetime64[ms, US/Eastern]",
+        )
+        tm.assert_index_equal(result2, expected2)
+        pointwise2 = DatetimeIndex([ts + DateOffset(milliseconds=1500) for ts in dti2])
+        tm.assert_index_equal(result2, pointwise2)
+
 
 class TestDatetime64OverflowHandling:
     # TODO: box + de-duplicate

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -807,6 +807,22 @@ class TestDateOffset:
 
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "offset_kwargs", [{"milliseconds": 5}, {"months": 1, "milliseconds": 5}]
+    )
+    def test_dateoffset_milliseconds_reso_matches_vectorized(self, offset_kwargs, unit):
+        # GH#64806 scalar Timestamp + DateOffset with a milliseconds component
+        # must preserve the offset's declared resolution (matching the
+        # vectorized DatetimeIndex path) instead of flooring to microseconds.
+        offset = DateOffset(**offset_kwargs)
+        ts = Timestamp("2022-01-01").as_unit(unit)
+
+        result = ts + offset
+        expected = (DatetimeIndex([ts]) + offset)[0]
+
+        assert result == expected
+        assert result.unit == expected.unit
+
     def test_offset_invalid_arguments(self):
         msg = "^Invalid argument/s or bad combination of arguments"
         with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
Follow-up to GH-64806, which fixed vectorized `DatetimeIndex + DateOffset` near DST transitions but left two defects:

1. The tz-aware fast path hardcoded `dtype=self.dtype`, so a finer-resolution offset (e.g. `DateOffset(milliseconds=5)` on a second-unit index) raised a bare `AssertionError` when the values were promoted to a finer unit. The result dtype is now derived from the promoted values, matching the tz-naive path. (Introduced in GH-64806, unreleased.)

2. Scalar `Timestamp + DateOffset(milliseconds=...)` returned a microsecond-resolution result, disagreeing with the millisecond-resolution result of the equivalent `DatetimeIndex`/`Series` operation. `RelativeDeltaOffset._apply` now coerces the result to the offset's declared resolution when lossless (`apply_wraps` then narrows back to the operand's unit where that is also lossless), so scalar and vectorized paths agree. This also covers the relativedelta+sub-second case (e.g. `DateOffset(months=1, milliseconds=5)`).

Only defect 2 changes released behavior; whatsnew added accordingly.