### PR TITLE
BUG: skew/kurt on ArrowDtype returned the biased statistic; kurt raised

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -323,6 +323,7 @@ Numeric
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` with ``axis=1`` and ``skipna=False`` returning incorrect column labels for extension array dtypes (e.g. :class:`BooleanDtype`, nullable integer/float, :class:`ArrowDtype`) (:issue:`56903`)
 - Fixed bug in :meth:`Series.clip` where passing a scalar numpy array (e.g. ``np.array(0)``) would raise a ``TypeError`` (:issue:`59053`)
 - Fixed bug in :meth:`Series.mean` and :meth:`Series.sum` (and their :class:`DataFrame` counterparts) overflowing for ``float16`` dtypes instead of upcasting to ``float64`` (:issue:`43929`)
+- Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) for :class:`ArrowDtype` returning the biased (population) statistic instead of the bias-corrected sample statistic returned by other dtypes; :meth:`Series.kurt` also raised ``TypeError`` instead of computing a result (:issue:`66336`)
 - Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) returning ``0.0`` for degenerate distributions; these now return ``NaN`` (:issue:`62864`)
 - Fixed bug in complex-dtype :meth:`Series.duplicated` and :meth:`Series.unique` (and related hashtable-backed methods) raising ``TypeError`` when backed by a :class:`NumpyExtensionArray` (:issue:`54761`)
 - Fixed bug where :class:`DataFrame` arithmetic operations with :class:`Series` did not support the fill_value parameter(:issue:`61581`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -2548,6 +2548,7 @@ class ArrowExtensionArray(
                 "prod": "product",
                 "std": "stddev",
                 "var": "variance",
+                "kurt": "kurtosis",
             }.get(name, name)
             # error: Incompatible types in assignment
             # (expression has type "Optional[Any]", variable has type
@@ -2568,6 +2569,8 @@ class ArrowExtensionArray(
         elif name in ["std", "var", "sem"] and "ddof" not in kwargs:
             # pyarrow defaults to ddof=0, pandas behavior is ddof=1
             kwargs["ddof"] = 1
+        elif name in ["skew", "kurt"] and "biased" not in kwargs:
+            kwargs["biased"] = False
 
         try:
             result = pyarrow_meth(data_to_reduce, skip_nulls=skipna, **kwargs)
@@ -2738,6 +2741,16 @@ class ArrowExtensionArray(
     ):
         nv.validate_stat_ddof_func((), kwargs, fname="skew")
         return self._reduce("skew", skipna=skipna, axis=axis, **kwargs)
+
+    def kurt(
+        self,
+        *,
+        skipna: bool = True,
+        axis: AxisInt | None = 0,
+        **kwargs,
+    ):
+        nv.validate_stat_ddof_func((), kwargs, fname="kurt")
+        return self._reduce("kurt", skipna=skipna, axis=axis, **kwargs)
 
     def median(
         self,

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -439,20 +439,32 @@ class TestArrowArray(base.ExtensionTests):
         self.check_accumulate(ser, op_name, skipna)
 
     def _supports_reduction(self, ser: pd.Series, op_name: str) -> bool:
-        if op_name == "kurt" or (pa_version_under20p0 and op_name == "skew"):
+        if pa_version_under20p0 and op_name in ("skew", "kurt"):
             return False
 
         dtype = ser.dtype
         # error: Item "dtype[Any]" of "dtype[Any] | ExtensionDtype" has
         # no attribute "pyarrow_dtype"
         pa_dtype = dtype.pyarrow_dtype  # type: ignore[union-attr]
-        if pa.types.is_temporal(pa_dtype) and op_name in ["sum", "var", "prod", "skew"]:
+        if pa.types.is_temporal(pa_dtype) and op_name in [
+            "sum",
+            "var",
+            "prod",
+            "skew",
+            "kurt",
+        ]:
             if pa.types.is_duration(pa_dtype) and op_name in ["sum"]:
                 # summing timedeltas is one case that *is* well-defined
                 pass
             else:
                 return False
-        elif pa.types.is_binary(pa_dtype) and op_name in ["sum", "skew", "any", "all"]:
+        elif pa.types.is_binary(pa_dtype) and op_name in [
+            "sum",
+            "skew",
+            "kurt",
+            "any",
+            "all",
+        ]:
             return False
         elif (
             pa.types.is_string(pa_dtype) or pa.types.is_binary(pa_dtype)
@@ -464,6 +476,7 @@ class TestArrowArray(base.ExtensionTests):
             "sem",
             "var",
             "skew",
+            "kurt",
             "any",
             "all",
         ]:
@@ -533,11 +546,11 @@ class TestArrowArray(base.ExtensionTests):
             if op_name == "sum" and not pa_version_under21p0:
                 # https://github.com/apache/arrow/pull/44184
                 cmp_dtype = ArrowDtype(pa.decimal128(38, 3))
-            elif op_name not in ["median", "var", "std", "sem", "skew"]:
+            elif op_name not in ["median", "var", "std", "sem", "skew", "kurt"]:
                 cmp_dtype = arr.dtype
             else:
                 cmp_dtype = "float64[pyarrow]"
-        elif op_name in ["median", "var", "std", "mean", "skew", "sem"]:
+        elif op_name in ["median", "var", "std", "mean", "skew", "kurt", "sem"]:
             cmp_dtype = "float64[pyarrow]"
         elif op_name in ["sum", "prod"] and pa.types.is_boolean(pa_type):
             cmp_dtype = "uint64[pyarrow]"
@@ -553,29 +566,15 @@ class TestArrowArray(base.ExtensionTests):
 
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     @pytest.mark.parametrize("skipna", [True, False])
-    def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna, request):
-        if (
-            not pa_version_under20p0
-            and skipna
-            and all_numeric_reductions == "skew"
-            and (
-                pa.types.is_integer(data.dtype.pyarrow_dtype)
-                or pa.types.is_floating(data.dtype.pyarrow_dtype)
-            )
-        ):
-            request.applymarker(
-                pytest.mark.xfail(
-                    reason="https://github.com/apache/arrow/issues/45733",
-                )
-            )
+    def test_reduce_series_numeric(self, data, all_numeric_reductions, skipna):
         return super().test_reduce_series_numeric(data, all_numeric_reductions, skipna)
 
     @pytest.mark.parametrize("skipna", [True, False])
     def test_reduce_frame(self, data, all_numeric_reductions, skipna, request):
         op_name = all_numeric_reductions
-        if op_name == "skew" and pa_version_under20p0:
+        if op_name in ("skew", "kurt") and pa_version_under20p0:
             if data.dtype._is_numeric:
-                mark = pytest.mark.xfail(reason="skew not implemented")
+                mark = pytest.mark.xfail(reason=f"{op_name} not implemented")
                 request.applymarker(mark)
         return super().test_reduce_frame(data, all_numeric_reductions, skipna)
 


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.


Series.skew on ArrowDtype returned pyarrow's default biased (population) statistic, while numpy- and masked-backed Series return the bias-corrected sample statistic:

    pd.Series([1., 2., 3., 4., 10.]).skew()                          # 1.6970562748
    pd.Series([1., 2., 3., 4., 10.], dtype="double[pyarrow]").skew() # 1.1384199577

_reduce_pyarrow already corrects pandas-vs-pyarrow default mismatches (min_count for sum/prod, q for median, ddof for std/var/sem) but never passed `biased`. pyarrow added the biased/unbiased toggle in 20.0.0, the same release that added `pc.skew/pc.kurtosis` (apache/arrow#45733), so this was never blocked upstream. No version gate is needed: on pyarrow < 20, the kernels are absent and _reduce_pyarrow raises before the kwargs block.

Series.kurt additionally raised TypeError because the pyarrow name map had no "kurt" -> "kurtosis" entry, so getattr(pc, "kurt") returned None. Also adds ArrowExtensionArray.kurt for parity with skew and with masked arrays.

The test_reduce_series_numeric xfail cited apache/arrow#45733 as if pandas were blocked; that issue is closed (fixed in 20.0.0), and the xfail was masking this bug, so it is removed. `pc.skew`and `pc.kurtosis` were verified to have identical type support, so kurt is now treated like skew across the reduction support matrix.