### PR TITLE
PERF: use pyarrow kernel for Series.str.zfill with ArrowStringArray

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -267,6 +267,7 @@ Performance improvements
 - Performance improvement in :meth:`Series.corr` with ``method="pearson"`` by avoiding an unnecessary correlation matrix calculation for 1D inputs (:issue:`65502`)
 - Performance improvement in :meth:`Series.skew`, :meth:`Series.kurt`, and their :class:`DataFrame` counterparts when axis is ``None`` or ``0`` (:issue:`64884`)
 - Performance improvement in :meth:`Series.str.isascii` for :class:`StringDtype` with storage ``"pyarrow"``, which fell back to an object-dtype implementation instead of using PyArrow's ``string_is_ascii`` kernel (:issue:`66335`)
+- Performance improvement in :meth:`Series.str.zfill` for :class:`StringDtype` with storage ``"pyarrow"``, which fell back to an object-dtype implementation instead of using PyArrow's ``utf8_zfill`` kernel (:issue:`66339`)
 - Performance improvement in :meth:`Series.to_json` and :meth:`DataFrame.to_json` with ``date_format="iso"`` for a timezone-aware datetime :class:`Series` and for a timezone-aware :class:`DatetimeIndex` (:issue:`66007`)
 - Performance improvement in :meth:`Timedelta.total_seconds` (:issue:`65388`)
 - Performance improvement in :meth:`arrays.SparseArray.isna` by avoiding a dense-then-resparsify round-trip (:issue:`41023`)

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -169,6 +169,13 @@ class ArrowStringArrayMixin:
             pa_pad(self._pa_array, width=width, padding=fillchar)
         )
 
+    def _str_zfill(self, width: int) -> Self:
+        if pa_version_under21p0:
+            predicate = lambda val: val.zfill(width)
+            result = self._apply_elementwise(predicate)
+            return self._from_pyarrow_array(pa.chunked_array(result))
+        return self._from_pyarrow_array(pc.utf8_zfill(self._pa_array, width))
+
     def _str_get(self, i: int) -> Self:
         lengths = pc.utf8_length(self._pa_array)
         if i >= 0:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -35,7 +35,6 @@ from pandas.compat import (
     HAS_PYARROW,
     PYARROW_MIN_VERSION,
     pa_version_under14p0,
-    pa_version_under21p0,
     pa_version_under25p0,
 )
 from pandas.compat.numpy import function as nv
@@ -3585,13 +3584,6 @@ class ArrowExtensionArray(
         predicate = lambda val: "\n".join(tw.wrap(val))
         result = self._apply_elementwise(predicate)
         return self._from_pyarrow_array(pa.chunked_array(result))
-
-    def _str_zfill(self, width: int) -> Self:
-        if pa_version_under21p0:
-            predicate = lambda val: val.zfill(width)
-            result = self._apply_elementwise(predicate)
-            return type(self)(pa.chunked_array(result))
-        return type(self)(pc.utf8_zfill(self._pa_array, width))
 
     def _dt_zero_or_null_int32(self) -> Self:
         """

--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -418,6 +418,7 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
     _str_slice_replace = ArrowStringArrayMixin._str_slice_replace
     _str_len = ArrowStringArrayMixin._str_len
     _str_slice = ArrowStringArrayMixin._str_slice
+    _str_zfill = ArrowStringArrayMixin._str_zfill
 
     @staticmethod
     def _is_re_pattern_with_flags(pat: str | re.Pattern) -> bool:

--- a/pandas/tests/strings/test_case_justify.py
+++ b/pandas/tests/strings/test_case_justify.py
@@ -371,6 +371,20 @@ def test_zfill(any_string_dtype):
     tm.assert_series_equal(result, expected)
 
 
+def test_zfill_signed(any_string_dtype):
+    s = Series(["-3", "+7", "-", "0"], dtype=any_string_dtype)
+    result = s.str.zfill(5)
+    expected = Series(["-0003", "+0007", "-0000", "00000"], dtype=any_string_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+def test_zfill_all_null(any_string_dtype):
+    s = Series([None, None], dtype=any_string_dtype)
+    result = s.str.zfill(5)
+    expected = Series([None, None], dtype=any_string_dtype)
+    tm.assert_series_equal(result, expected)
+
+
 def test_wrap(any_string_dtype):
     # test values are: two words less than width, two words equal to width,
     # two words greater than width, one word less than width, one word


### PR DESCRIPTION
ArrowStringArray lists ObjectStringArrayMixin ahead of ArrowExtensionArray in its MRO, so any _str_* method missing from the alias block silently gets the object-dtype implementation. _str_zfill already had a correctly version-gated Arrow implementation that was unreachable for StringDtype with storage "pyarrow".

Alias it to ArrowExtensionArray. At 500k elements this is 62.7ms -> 10.8ms (5.8x). Output is unchanged: pc.utf8_zfill is sign-aware and matches str.zfill on "-3" -> "-0003", "+7", "-" and "-0".

Also use _from_pyarrow_array instead of type(self)(...), which matters now that ArrowStringArray reaches this method: the subclass overrides _from_pyarrow_array specifically to skip __init__'s type check and pc.cast.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
