### PR TITLE
DOC: clarify sort_index determinism to fix #63154

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8762,9 +8762,10 @@ class DataFrame(NDFrame, OpsMixin):
             Whether to modify the DataFrame rather than creating a new one.
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
-            information. `mergesort` and `stable` are the only stable algorithms. For
-            DataFrames, this option is only applied when sorting on a single
-            column or label.
+            information. The sort order is deterministic for a given input.
+            `mergesort` and `stable` are the only stable algorithms, which preserve
+            the relative order of equal keys. For DataFrames, this option is only
+            applied when sorting on a single column or label.
         na_position : {'first', 'last'}, default 'last'
             Puts NaNs at the beginning if `first`; `last` puts NaNs at the end.
             Not implemented for MultiIndex.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8763,9 +8763,9 @@ class DataFrame(NDFrame, OpsMixin):
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
             information. The sort order is deterministic for a given input.
-            `mergesort` and `stable` are the only stable algorithms, which preserve
-            the relative order of equal keys. For DataFrames, this option is only
-            applied when sorting on a single column or label.
+            'mergesort' and 'stable' are the only stable algorithms, which preserve
+            the relative order of equal keys. This option is ignored when sorting on a
+            MultiIndex or when a `level` is specified.
         na_position : {'first', 'last'}, default 'last'
             Puts NaNs at the beginning if `first`; `last` puts NaNs at the end.
             Not implemented for MultiIndex.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8763,7 +8763,7 @@ class DataFrame(NDFrame, OpsMixin):
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
             information. The sort order is deterministic for a given input.
-            ``mergesort`` and ``stable`` are the only stable algorithms, which preserve
+            'mergesort' and 'stable' are the only stable algorithms, which preserve
             the relative order of equal keys. This option is ignored when sorting on a
             MultiIndex or when a `level` is specified.
         na_position : {'first', 'last'}, default 'last'

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8763,7 +8763,7 @@ class DataFrame(NDFrame, OpsMixin):
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
             information. The sort order is deterministic for a given input.
-            'mergesort' and 'stable' are the only stable algorithms, which preserve
+            ``mergesort`` and ``stable`` are the only stable algorithms, which preserve
             the relative order of equal keys. This option is ignored when sorting on a
             MultiIndex or when a `level` is specified.
         na_position : {'first', 'last'}, default 'last'

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4203,9 +4203,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             If True, perform operation in-place.
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
-            information. 'mergesort' and 'stable' are the only stable algorithms. For
-            DataFrames, this option is only applied when sorting on a single
-            column or label.
+            information. The sort order is deterministic for a given input.
+            `mergesort` and `stable` are the only stable algorithms, which preserve
+            the relative order of equal keys. For DataFrames, this option is only
+            applied when sorting on a single column or label.
         na_position : {'first', 'last'}, default 'last'
             If 'first' puts NaNs at the beginning, 'last' puts NaNs at the end.
             Not implemented for MultiIndex.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4204,7 +4204,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
             information. The sort order is deterministic for a given input.
-            'mergesort' and 'stable' are the only stable algorithms, which preserve
+            ``mergesort`` and ``stable`` are the only stable algorithms, which preserve
             the relative order of equal keys. This option is ignored when sorting on a
             MultiIndex or when a `level` is specified.
         na_position : {'first', 'last'}, default 'last'

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4204,9 +4204,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
             information. The sort order is deterministic for a given input.
-            `mergesort` and `stable` are the only stable algorithms, which preserve
-            the relative order of equal keys. For DataFrames, this option is only
-            applied when sorting on a single column or label.
+            'mergesort' and 'stable' are the only stable algorithms, which preserve
+            the relative order of equal keys. This option is ignored when sorting on a
+            MultiIndex or when a `level` is specified.
         na_position : {'first', 'last'}, default 'last'
             If 'first' puts NaNs at the beginning, 'last' puts NaNs at the end.
             Not implemented for MultiIndex.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4204,7 +4204,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, default 'quicksort'
             Choice of sorting algorithm. See also :func:`numpy.sort` for more
             information. The sort order is deterministic for a given input.
-            ``mergesort`` and ``stable`` are the only stable algorithms, which preserve
+            'mergesort' and 'stable' are the only stable algorithms, which preserve
             the relative order of equal keys. This option is ignored when sorting on a
             MultiIndex or when a `level` is specified.
         na_position : {'first', 'last'}, default 'last'


### PR DESCRIPTION
This PR updates the docstring for sort_index on both DataFrame and Series to explicitly state that the sorting algorithm is deterministic for a given input.

This mirrors the changes recently made to sort_values in #65986, which missed updating the sort_index docstrings to clarify this behavior.

Checklist:
[x] I have read the CONTRIBUTING.md file.