### PR TITLE
BUG: Do not force re.UNICODE if re.ASCII flag is passed

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1552,7 +1552,8 @@ class StringMethods(NoNewAttributesMixin):
         if flags is not lib.no_default:
             # pat.flags will have re.U regardless, so we need to add it here
             # before checking for a match
-            flags = flags | re.U
+            if not (flags & re.ASCII):
+                flags = flags | re.U
             if is_re(pat):
                 if pat.flags != flags:
                     raise ValueError(


### PR DESCRIPTION
- [x] closes #66348
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Summary of Changes
This PR prevents pandas from blindly applying the `re.U` flag in `pandas/core/strings/accessor.py` if the user explicitly passes the `re.ASCII` flag. 

By wrapping the default Unicode assignment in a bitwise check (`if not (flags & re.ASCII):`), this resolves the fatal `ValueError: ASCII and UNICODE flags are incompatible` crash when passing `flags=re.ASCII` to string accessor methods like `.str.match()`.