### PR TITLE
PERF: fix performance regression in string construction from GH-65831

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -962,6 +962,7 @@ cpdef ndarray[object] ensure_string_array(
     cdef:
         Py_ssize_t i = 0, n = len(arr)
         bint already_copied = True
+        ndarray[object] newarr
 
     if hasattr(arr, "to_numpy"):
 
@@ -1025,8 +1026,12 @@ cpdef ndarray[object] ensure_string_array(
 
         return result
 
+    newarr = np.asarray(arr, dtype=object)
+    if not newarr.flags.aligned:
+        newarr = newarr.copy()
+
     for i in range(n):
-        val = arr[i]
+        val = newarr[i]
 
         if isinstance(val, str):
             continue

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -964,21 +964,26 @@ cpdef ndarray[object] ensure_string_array(
         bint already_copied = True
         ndarray[object] newarr
 
-    if hasattr(arr, "to_numpy"):
+    if (
+        hasattr(arr, "dtype")
+        and arr.dtype.kind in "mM"
+        # TODO: we should add a custom ArrowExtensionArray.astype implementation
+        # that handles astype(str) specifically, avoiding ending up here and
+        # then we can remove the below check for `_pa_array` (for ArrowEA)
+        and not hasattr(arr, "_pa_array")
+    ):
+        # dtype check to exclude DataFrame
+        # GH#41409 TODO: not a great place for this
+        out = np.asarray(arr.astype(str), dtype=object)
+        if convert_na_value and skipna:
+            if hasattr(arr, "isna"):
+                nans = arr.isna()
+            else:
+                nans = np.isnat(arr)
+            out[nans] = na_value
+        return out
 
-        if (
-            hasattr(arr, "dtype")
-            and arr.dtype.kind in "mM"
-            # TODO: we should add a custom ArrowExtensionArray.astype implementation
-            # that handles astype(str) specifically, avoiding ending up here and
-            # then we can remove the below check for `_pa_array` (for ArrowEA)
-            and not hasattr(arr, "_pa_array")
-        ):
-            # dtype check to exclude DataFrame
-            # GH#41409 TODO: not a great place for this
-            out = arr.astype(str).astype(object)
-            out[arr.isna()] = na_value
-            return out
+    if hasattr(arr, "to_numpy"):
         arr = arr.to_numpy(dtype=object)
     elif not util.is_array(arr):
         # GH#61155: Guarantee a 1-d result when array is a list of lists

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -708,3 +708,30 @@ def test_pd_array_structured_masked_array_raises():
     msg = "Cannot construct an array from an ndarray with compound dtype"
     with pytest.raises(ValueError, match=msg):
         pd.array(ma_arr)
+
+
+@pytest.mark.parametrize(
+    "data, dtype, expected_data",
+    [
+        (
+            ["1970-01-01T00:00:00.000000001"],
+            "datetime64[ns]",
+            ["1970-01-01T00:00:00.000000001"],
+        ),
+        (
+            [1],
+            "timedelta64[ns]",
+            ["1 nanoseconds"],
+        ),
+    ],
+)
+def test_numpy_datetime_like_to_string(data, dtype, expected_data):
+    arr = np.array(data, dtype=dtype)
+    result = pd.array(arr, dtype="string")
+    expected = (
+        pd.StringDtype()
+        .construct_array_type()
+        ._from_sequence(expected_data, dtype=pd.StringDtype())
+    )
+
+    tm.assert_equal(result, expected)


### PR DESCRIPTION
- [x] closes #pandas-dev/asv-runner#155 (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

---

Output of `asv compare --only-changed 800872~ HEAD`:

| Change   | Before [e51a5ef9] <perf-read_csv-block-lane^2~24>   | After [9c4ad2b5] <perf/string-construction>   |   Ratio | Benchmark (Parameter)                                                           |
|----------|-----------------------------------------------------|-----------------------------------------------|---------|---------------------------------------------------------------------------------|
| -        | 17.6±2ms                                            | 14.5±0.3ms                                    |    0.82 | strings.Construction.time_construction('categorical_series', 'string[pyarrow]') |

The performance increase for the pyarrow case seems unrelated.