### PR TITLE
doc: update fill_value parameter documentation for Series comparison methods

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -7372,7 +7372,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7436,7 +7436,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7501,7 +7501,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7568,7 +7568,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7636,7 +7636,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7704,7 +7704,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing


### PR DESCRIPTION
# doc: update fill_value parameter documentation for Series comparison methods

## Summary

This PR updates the documentation for the fill_value parameter in Series comparison methods (eq, ne, lt, gt, le, ge) to correctly reflect that string values are supported for string dtype. Previously, the docstrings stated that fill_value was "None or float value", which was incomplete and misleading for users working with string data.

## Changes

- Updated the docstring for fill_value parameter in Series.eq() method
- Updated the docstring for fill_value parameter in Series.ne() method  
- Updated the docstring for fill_value parameter in Series.lt() method
- Updated the docstring for fill_value parameter in Series.gt() method
- Updated the docstring for fill_value parameter in Series.le() method
- Updated the docstring for fill_value parameter in Series.ge() method
- Changed description from "None or float value, default None (NaN)" to "float, str, or None, default None (NaN)"

Fixes #66349

## Testing

The changes are documentation-only, so no functional tests were required. I verified that:
1. The changes only affect docstrings and not function signatures or implementation
2. All six comparison methods (eq, ne, lt, gt, le, ge) were updated consistently
3. The documentation builds successfully (verified syntax and formatting)

The changes are minimal and focused, addressing exactly the issue described in #66349 without introducing any functional changes or breaking changes.

---
### AI disclosure (keep this line as is)

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
