### PR TITLE
BUG: #66356 - Fix 4 segfaults from ujson_dumps values that are abnormal

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -436,7 +436,7 @@ I/O
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
 - Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
-- Fixed several segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing python objects that are very abnormal, including massive ``int`` values, and strings that cannot be encoded as utf-8 (:issue:`66356`)
+- Fixed several segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing python objects that are very abnormal, including massive :class:`int` values, and strings that cannot be encoded as utf-8 (:issue:`66356`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - :meth:`HDFStore.put` and :meth:`HDFStore.append` now support storing :class:`Series` and :class:`DataFrame` columns with :class:`PeriodDtype` in both ``"fixed"`` and ``"table"`` formats (:issue:`41978`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -436,7 +436,7 @@ I/O
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
 - Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
-- Fixed several segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing python objects that are very abnormal (:issue:`66356`)
+- Fixed several segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing python objects that are very abnormal, including massive ``int`` values, and strings that cannot be encoded as utf-8 (:issue:`66356`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - :meth:`HDFStore.put` and :meth:`HDFStore.append` now support storing :class:`Series` and :class:`DataFrame` columns with :class:`PeriodDtype` in both ``"fixed"`` and ``"table"`` formats (:issue:`41978`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -436,6 +436,7 @@ I/O
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
 - Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
+- Fixed several segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing python objects that are very abnormal (:issue:`66356`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - :meth:`HDFStore.put` and :meth:`HDFStore.append` now support storing :class:`Series` and :class:`DataFrame` columns with :class:`PeriodDtype` in both ``"fixed"`` and ``"table"`` formats (:issue:`41978`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -430,6 +430,7 @@ static const char *PyDecimalToUTF8Callback(JSOBJ _obj, JSONTypeContext *tc,
   Py_ssize_t s_len;
   char *outValue = (char *)PyUnicode_AsUTF8AndSize(str, &s_len);
   if (outValue == NULL) {
+    *len = 0;
     ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
     return NULL;
   }

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -387,6 +387,23 @@ static const char *PyTimeToJSON(JSOBJ _obj, JSONTypeContext *tc,
     PyObject *tmp = str;
     str = PyUnicode_AsUTF8String(str);
     Py_DECREF(tmp);
+    if (str == NULL) {
+      *outLen = 0;
+      if (!PyErr_Occurred()) {
+        PyErr_SetString(PyExc_ValueError, "Failed to convert time");
+      }
+      ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+      return NULL;
+    }
+  }
+  if (!PyBytes_Check(str)) {
+    *outLen = 0;
+    Py_DECREF(str);
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_ValueError, "Failed to convert time");
+    }
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return NULL;
   }
 
   GET_TC(tc)->newObj = str;
@@ -412,6 +429,10 @@ static const char *PyDecimalToUTF8Callback(JSOBJ _obj, JSONTypeContext *tc,
 
   Py_ssize_t s_len;
   char *outValue = (char *)PyUnicode_AsUTF8AndSize(str, &s_len);
+  if (outValue == NULL) {
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return NULL;
+  }
   *len = s_len;
 
   return outValue;
@@ -1975,7 +1996,18 @@ static double Object_getDoubleValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
 static const char *Object_getBigNumStringValue(JSOBJ obj, JSONTypeContext *tc,
                                                size_t *_outLen) {
   PyObject *repr = PyObject_Str(obj);
+  if (repr == NULL) {
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    *_outLen = 0;
+    return NULL;
+  }
   const char *str = PyUnicode_AsUTF8AndSize(repr, (Py_ssize_t *)_outLen);
+  if (str == NULL) {
+    Py_DECREF(repr);
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    *_outLen = 0;
+    return NULL;
+  }
   char *bytes = PyObject_Malloc(*_outLen + 1);
   memcpy(bytes, str, *_outLen + 1);
   GET_TC(tc)->cStr = bytes;

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -400,7 +400,7 @@ static const char *PyTimeToJSON(JSOBJ _obj, JSONTypeContext *tc,
     *outLen = 0;
     Py_DECREF(str);
     if (!PyErr_Occurred()) {
-      PyErr_SetString(PyExc_ValueError, "Failed to convert time");
+      PyErr_SetString(PyExc_TypeError, "isoformat() must return str");
     }
     ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
     return NULL;

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -5,6 +5,7 @@ import json
 import locale
 import math
 import re
+import sys
 import time
 
 import dateutil
@@ -26,6 +27,8 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
+
+LONE_SURROGATE = "\ud800"
 
 
 def _clean_dict(d):
@@ -374,6 +377,22 @@ class TestUltraJSONTests:
         with pytest.raises(ValueError, match=msg):
             ujson.ujson_dumps(val, date_unit="foo")
 
+    def test_encode_time_invalid_subclass_surrogate(self):
+        class InvalidTime(datetime.time):
+            def isoformat(self):
+                return LONE_SURROGATE
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(InvalidTime())
+
+    def test_encode_time_invalid_subclass_non_str(self):
+        class InvalidTime(datetime.time):
+            def isoformat(self):
+                return 1
+
+        with pytest.raises(ValueError, match="Failed to convert time"):
+            ujson.ujson_dumps(InvalidTime())
+
     def test_encode_to_utf8(self):
         unencoded = "\xe6\x97\xa5\xd1\x88"
 
@@ -676,6 +695,14 @@ class TestUltraJSONTests:
             "d": 4,
         }
 
+    def test_encode_invalid_decimal_subclass(self):
+        class InvalidDecimal(decimal.Decimal):
+            def __format__(self, *a, **kw):
+                return LONE_SURROGATE
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(InvalidDecimal(1))
+
     def test_ujson__name__(self):
         # GH 52898
         assert ujson.__name__ == "pandas._libs._ujson"
@@ -804,6 +831,15 @@ class TestNumpyJSONTests:
         )
         with pytest.raises(TypeError, match=msg):
             ujson.ujson_dumps(np.longdouble(1234.5))
+
+    def test_encode_large_int_object(self):
+        cur_limit = sys.get_int_max_str_digits()
+        sys.set_int_max_str_digits(1000)
+        try:
+            with pytest.raises(ValueError, match="Exceeds the limit"):
+                ujson.ujson_dumps(1 << 1_000_000)
+        finally:
+            sys.set_int_max_str_digits(cur_limit)
 
 
 class TestPandasJSONTests:

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -701,6 +701,23 @@ class TestUltraJSONTests:
         with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
             ujson.ujson_dumps(InvalidDecimal(1))
 
+    def test_encode_large_int_object(self):
+        cur_limit = sys.get_int_max_str_digits()
+        sys.set_int_max_str_digits(1000)
+        try:
+            with pytest.raises(ValueError, match="Exceeds the limit"):
+                ujson.ujson_dumps(1 << 1_000_000)
+        finally:
+            sys.set_int_max_str_digits(cur_limit)
+
+    def test_encode_invalid_int_subclass(self):
+        class InvalidInt(int):
+            def __str__(self):
+                return "\ud800"
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(InvalidInt(1 << 1_000_000))
+
     def test_ujson__name__(self):
         # GH 52898
         assert ujson.__name__ == "pandas._libs._ujson"
@@ -829,23 +846,6 @@ class TestNumpyJSONTests:
         )
         with pytest.raises(TypeError, match=msg):
             ujson.ujson_dumps(np.longdouble(1234.5))
-
-    def test_encode_large_int_object(self):
-        cur_limit = sys.get_int_max_str_digits()
-        sys.set_int_max_str_digits(1000)
-        try:
-            with pytest.raises(ValueError, match="Exceeds the limit"):
-                ujson.ujson_dumps(1 << 1_000_000)
-        finally:
-            sys.set_int_max_str_digits(cur_limit)
-
-    def test_encode_invalid_int_subclass(self):
-        class InvalidInt(int):
-            def __str__(self):
-                return "\ud800"
-
-        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
-            ujson.ujson_dumps(InvalidInt(1 << 1_000_000))
 
 
 class TestPandasJSONTests:

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -28,8 +28,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-LONE_SURROGATE = "\ud800"
-
 
 def _clean_dict(d):
     """
@@ -380,7 +378,7 @@ class TestUltraJSONTests:
     def test_encode_time_invalid_subclass_surrogate(self):
         class InvalidTime(datetime.time):
             def isoformat(self):
-                return LONE_SURROGATE
+                return "\ud800"
 
         with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
             ujson.ujson_dumps(InvalidTime())
@@ -698,7 +696,7 @@ class TestUltraJSONTests:
     def test_encode_invalid_decimal_subclass(self):
         class InvalidDecimal(decimal.Decimal):
             def __format__(self, *a, **kw):
-                return LONE_SURROGATE
+                return "\ud800"
 
         with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
             ujson.ujson_dumps(InvalidDecimal(1))
@@ -840,6 +838,14 @@ class TestNumpyJSONTests:
                 ujson.ujson_dumps(1 << 1_000_000)
         finally:
             sys.set_int_max_str_digits(cur_limit)
+
+    def test_encode_invalid_int_subclass(self):
+        class InvalidInt(int):
+            def __str__(self):
+                return "\ud800"
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(InvalidInt(1 << 1_000_000))
 
 
 class TestPandasJSONTests:

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -388,7 +388,7 @@ class TestUltraJSONTests:
             def isoformat(self):
                 return 1
 
-        with pytest.raises(ValueError, match="Failed to convert time"):
+        with pytest.raises(TypeError, match=re.escape("isoformat() must return str")):
             ujson.ujson_dumps(InvalidTime())
 
     def test_encode_to_utf8(self):


### PR DESCRIPTION
Cases handled here:
 - Very large integer values (>int_max_str_digits)
 - Decimal subclasses that return valid unicode that can't be encoded as utf-8
 - datetime.time subclasses with .isoformat() methods that don't return a string
 - .. .. .. .. return a non-utf8able string

**Note**: This change doesn't code all of the issues identified by #66356, but these are the ones where the fix is localized and doesn't have wider lifecycle changes (either iterators etc, or object cleanups up the stack)

- [ ] closes #66356.
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](t
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

AI: I used claude and codex to: assist with diagnosing the root cause, analysis to find related issues, pre-commit code reviews and help analysing object lifetimes etc.

All actual code changes were made by me 