### PR TITLE
BUG: add isinstance check for datetime index

### DIFF
--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -296,6 +296,15 @@ def use_dynamic_x(ax: Axes, index: Index) -> bool:
     if freq_str is None:
         return False
 
+    # GH#65915: create a check for the DateTimeIndex containing tz-info
+    # this fixes the cited issue for regular dataframes
+    # however, the issue persists when non-regular dataframes are used:
+    #   i.e., when dataframes have indexes of non-equal lengths
+    #   this suggests that the issue could potentially lie with the
+    #   PeriodConverter class in plotting/_matplotlib
+    if isinstance(index, ABCDatetimeIndex) and index.tz is not None:
+        return False
+
     # GH#2571: for DatetimeIndex, fall back to non-dynamic plotting if the
     # timestamps don't align with the inferred period frequency. We only
     # inspect the first element because the index has a (possibly inferred)
@@ -352,6 +361,14 @@ def maybe_convert_index(ax: Axes, data: NDFrameT) -> tuple[NDFrameT, str | None]
                     dtype=np.int64,
                 )
             else:
+                # GH#65915: create a check for the DateTimeIndex containing tz-info
+                # this fixes the cited issue for regular dataframes
+                # however, the issue persists when non-regular dataframes are used:
+                #   i.e., when dataframes have indexes of non-equal lengths
+                #   this suggests that the issue could potentially lie with the
+                #   PeriodConverter class in plotting/_matplotlib
+                if data.index.tz is not None:
+                    return data, None
                 data = data.tz_localize(None).to_period(freq=freq_str)
         elif isinstance(data.index, ABCPeriodIndex):
             if freq_str == "B":

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -23,6 +23,7 @@ from pandas import (
     Index,
     NaT,
     Series,
+    Timestamp,
     concat,
     isna,
     to_datetime,
@@ -60,9 +61,15 @@ class TestTSPlot:
         _check_plot_works(ts.plot)
         ax = ts.plot()
         xdata = next(iter(ax.get_lines())).get_xdata()
-        # xdata are raw Period ordinals (int64); reconstruct to check labels
-        first = Period(ordinal=int(xdata[0]), freq=ax.freq)
-        last = Period(ordinal=int(xdata[-1]), freq=ax.freq)
+        # xdata are may be Period ordinals (int64) or TimeStamps for timezone aware data
+        # check if xdata are timestamps
+        if isinstance(xdata[0], Timestamp):
+            first = xdata[0]
+            last = xdata[-1]
+        else:
+            # xdata are Period intervals (int64)
+            first = Period(ordinal=int(xdata[0]), freq=ax.freq)
+            last = Period(ordinal=int(xdata[-1]), freq=ax.freq)
         assert (first.hour, first.minute) == (0, 0)
         assert (last.hour, last.minute) == (1, 0)
 


### PR DESCRIPTION
- [partially ✅] closes #65915 for regular dataframes. The error still persists with non-regular dataframes, suggesting a potential issue with the `PeriodConverter`.
- [✅] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [✅] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [not needed for diffs: ⛔] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [✅] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [✅] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
- [✅] I wrote this code myself, just using MistralAI LeChat for guidance on understanding the codebase. The git diffs are my own after reviewing the problem statement in #65915, my own understanding of the codebase and the LeChat output summaries.
- [🐈] I just like emojis!