### PR TITLE
DOC: clarify Series.map elementwise usage

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4882,9 +4882,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         """
         Map values of Series according to an input mapping or function.
 
-        Used for substituting each value in a Series with another value,
-        that may be derived from a function, a ``dict`` or
-        a :class:`Series`.
+        This is the preferred method for elementwise operations on a Series.
+        It can also substitute each value with another value derived from a
+        function, a ``dict`` or a :class:`Series`.
 
         Parameters
         ----------
@@ -5005,6 +5005,15 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         3    None
         4    None
         dtype: object
+
+        For example, use ``map`` with a lambda function to increment each value:
+
+        >>> ser = pd.Series([1, 2, 3])
+        >>> ser.map(lambda x: x + 1)
+        0    2
+        1    3
+        2    4
+        dtype: int64
         """
         if func is None:
             if "arg" in kwargs:


### PR DESCRIPTION
Clarifies `Series.map` as the preferred method for elementwise Series operations and adds a numeric lambda example after the existing examples.

- [x] closes #58184
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature (not applicable; documentation-only change)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions (not applicable; no new API)
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature (not applicable; documentation-only change)
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
