### PR TITLE
BUG: fix str.split/partition/rpartition returning string on categorical (GH#66341)

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -891,7 +891,10 @@ class StringMethods(NoNewAttributesMixin):
             regex = True
         result = self._data.array._str_split(pat, n, expand, regex)
         if self._data.dtype == "category":
-            dtype = self._data.dtype.categories.dtype
+            if expand:
+                dtype = self._data.dtype.categories.dtype
+            else:
+                dtype = object
         else:
             dtype = object if self._data.dtype == object else None
         return self._wrap_result(
@@ -1112,7 +1115,10 @@ class StringMethods(NoNewAttributesMixin):
         """
         result = self._data.array._str_partition(sep, expand)
         if self._data.dtype == "category":
-            dtype = self._data.dtype.categories.dtype
+            if expand:
+                dtype = self._data.dtype.categories.dtype
+            else:
+                dtype = object
         else:
             dtype = object if self._data.dtype == object else None
         return self._wrap_result(
@@ -1204,7 +1210,10 @@ class StringMethods(NoNewAttributesMixin):
         """
         result = self._data.array._str_rpartition(sep, expand)
         if self._data.dtype == "category":
-            dtype = self._data.dtype.categories.dtype
+            if expand:
+                dtype = self._data.dtype.categories.dtype
+            else:
+                dtype = object
         else:
             dtype = object if self._data.dtype == object else None
         return self._wrap_result(

--- a/pandas/tests/strings/test_split_partition.py
+++ b/pandas/tests/strings/test_split_partition.py
@@ -834,3 +834,35 @@ def test_split_arrow_dtype_regex_false_multichar():
     )
     expected.columns = RangeIndex(3)
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("method", ["split", "rsplit"])
+def test_split_categorical(method):
+    # GH#66341 - str.split/rsplit on categorical should return lists, not strings
+    values = Series(["a_b_c", "c_d_e", np.nan, "f_g_h"], dtype="category")
+    result = getattr(values.str, method)("_")
+    exp = Series([["a", "b", "c"], ["c", "d", "e"], np.nan, ["f", "g", "h"]])
+    tm.assert_series_equal(result, exp)
+    assert result.dtype == object
+
+
+def test_split_categorical_expand():
+    # GH#66341 - str.split on categorical with expand=True
+    values = Series(["a_b_c", "c_d_e", np.nan, "f_g_h"], dtype="category")
+    result = values.str.split("_", expand=True)
+    exp = DataFrame(
+        [["a", "b", "c"], ["c", "d", "e"], [np.nan] * 3, ["f", "g", "h"]],
+    )
+    tm.assert_frame_equal(result, exp)
+
+
+@pytest.mark.parametrize("method", ["partition", "rpartition"])
+def test_partition_categorical(method):
+    # GH#66341 - str.partition/rpartition on categorical should return tuples
+    values = Series(["a_b_c", "c_d_e", np.nan, "f_g_h"], dtype="category")
+    result = getattr(values.str, method)("_", expand=False)
+    exp = Series(
+        [("a", "_", "b_c"), ("c", "_", "d_e"), np.nan, ("f", "_", "g_h")]
+    )
+    tm.assert_series_equal(result, exp)
+    assert result.dtype == object


### PR DESCRIPTION
## Description
Fixes #66341

## Problem
When calling `str.split()`, `str.partition()`, or `str.rpartition()` on a categorical Series with `expand=False` (the default), the result contains Python lists or tuples. However, the dtype was being set to the categories' dtype (e.g. `StringDtype`), causing the list/tuple to be cast to its string representation.

**Before (bug):**
```python
s = pd.Series(["a_b_c", "c_d_e"], dtype="category")
result = s.str.split("_")
# result.iloc[0] == "['a', 'b', 'c']"  # string, not list!
# result.dtype == string
```

**After (fix):**
```python
# result.iloc[0] == ['a', 'b', 'c']  # actual list
# result.dtype == object
```

## Root Cause
In `StringMethods.split()` (and `partition`/`rpartition`), the dtype for `_wrap_result` was unconditionally set to `self._data.dtype.categories.dtype` for categorical input. When `expand=False`, the result contains list/tuple elements that need `object` dtype, not the string dtype of the categories.

## Fix
Only use the categories' dtype when `expand=True` (where the result is a DataFrame and individual string columns are correctly typed). When `expand=False`, use `object` dtype.

Also fixes the same issue in `partition()` and `rpartition()` which had the identical bug pattern.

## Tests
Added 4 tests in `test_split_partition.py`:
- `test_split_categorical` - split/rsplit on category returns lists
- `test_split_categorical_expand` - split with expand=True on category
- `test_partition_categorical` - partition/rpartition on category returns tuples
