### PR TITLE
BUG: respect re.ASCII flag in str.match/fullmatch (GH#66348)

### DIFF
--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1551,8 +1551,9 @@ class StringMethods(NoNewAttributesMixin):
         """
         if flags is not lib.no_default:
             # pat.flags will have re.U regardless, so we need to add it here
-            # before checking for a match
-            flags = flags | re.U
+            # before checking for a match. But don't override re.ASCII (GH#66348).
+            if not (flags & re.ASCII):
+                flags = flags | re.U
             if is_re(pat):
                 if pat.flags != flags:
                     raise ValueError(

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -242,8 +242,9 @@ class ObjectStringArrayMixin:
         if isinstance(pat, re.Pattern):
             # We need to check that flags matches pat.flags.
             # pat.flags will have re.U regardless, so we need to add it here
-            # before checking for a match
-            flags = flags | re.U
+            # before checking for a match. But don't override re.ASCII (GH#66348).
+            if not (flags & re.ASCII):
+                flags = flags | re.U
 
             if flags != pat.flags:
                 raise ValueError("Cannot pass flags that do not match pat.flags")

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1728,3 +1728,34 @@ def test_flags_kwarg(any_string_dtype):
     with tm.assert_produces_warning(UserWarning, match=msg):
         result = data.str.contains(pat, flags=re.IGNORECASE)
     assert result.iloc[0]
+
+
+def test_match_ascii_flag(any_string_dtype):
+    # GH#66348 - re.ASCII flag should not be overridden by re.U
+    values = Series(["abc", "123", "ñ"], dtype=any_string_dtype)
+
+    # \w matches unicode letters by default, so ñ matches
+    result = values.str.match(r"\w+", flags=0)
+    expected = Series([True, True, True], dtype=bool)
+    tm.assert_series_equal(result, expected)
+
+    # With re.ASCII, \w only matches [a-zA-Z0-9_], so ñ should NOT match
+    result = values.str.match(r"\w+", flags=re.ASCII)
+    expected = Series([True, True, False], dtype=bool)
+    tm.assert_series_equal(result, expected)
+
+    # Compiled pattern with re.ASCII
+    pat = re.compile(r"\w+", flags=re.ASCII)
+    result = values.str.match(pat)
+    expected = Series([True, True, False], dtype=bool)
+    tm.assert_series_equal(result, expected)
+
+
+def test_fullmatch_ascii_flag(any_string_dtype):
+    # GH#66348 - re.ASCII flag should not be overridden by re.U
+    values = Series(["abc", "123", "ñ"], dtype=any_string_dtype)
+
+    # With re.ASCII, \w+ should not match standalone ñ
+    result = values.str.fullmatch(r"\w+", flags=re.ASCII)
+    expected = Series([True, True, False], dtype=bool)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
## Description
Fixes #66348

## Problem
When passing `re.ASCII` flag to `str.match()` or `str.fullmatch()`, the flag was silently overridden by `re.U`. In Python 3, `re.U` and `re.ASCII` are mutually exclusive, so the `re.ASCII` flag had no effect.

**Before (bug):**
```python
s = pd.Series(["abc", "123", u"\u00f1"])
s.str.match(r"\w+", flags=re.ASCII)
# [True, True, True]  -- wrong! ñ should NOT match \w+ in ASCII mode
```

**After (fix):**
```python
# [True, True, False]  -- correct! ñ doesn't match [a-zA-Z0-9_]
```

## Root Cause
In `StringMethods.match()` (accessor.py line 1555), the code unconditionally OR'd `re.U` into the flags: `flags = flags | re.U`. This overwrote `re.ASCII` since they are mutually exclusive in Python 3's `re` module.

The same pattern existed in `ObjectStringArrayMixin._str_match()` (object_array.py line 246) for compiled regex patterns.

## Fix
Only add `re.U` when `re.ASCII` is NOT already set:
```python
if not (flags & re.ASCII):
    flags = flags | re.U
```

Applied in both `accessor.py` (StringMethods.match) and `object_array.py` (ObjectStringArrayMixin._str_match).

## Tests
Added `test_match_ascii_flag` and `test_fullmatch_ascii_flag` in `test_find_replace.py` verifying that `re.ASCII` correctly restricts `\w+` to ASCII-only characters.
