### PR TITLE
BUG: `str.split()`/`rsplit()` with no separator on `ArrowDtype` keeps empty whitespace tokens

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -364,6 +364,7 @@ Strings
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
+- Bug in :meth:`Series.str.split` and :meth:`Series.str.rsplit` with :class:`ArrowDtype` and no separator keeping empty whitespace tokens (:issue:`66368`)
 
 Interval
 ^^^^^^^^

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -488,6 +488,7 @@ Strings
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
+- Bug in :meth:`Series.str.split` and :meth:`Series.str.rsplit` with :class:`ArrowDtype` and no separator keeping empty whitespace tokens (:issue:`66368`)
 - Bug in :meth:`Series.str.split` with :class:`ArrowDtype` ``string`` not inferring regex for multi-character patterns when ``regex=None``, causing the pattern to be treated as a literal instead of a regular expression (:issue:`58321`)
 - Bug in :meth:`Series.unique`, :meth:`Index.unique` and :func:`factorize` on object dtype returning incorrect results when the values were not UTF-8 encodable, e.g. lone surrogates (:issue:`34550`)
 - Bug in :meth:`Series.unique`, :meth:`Index.unique`, :meth:`Series.nunique`, :func:`factorize` and ``groupby`` on object dtype, and on ``str``/``string`` dtype backed by python storage, collapsing distinct strings that are identical up to an embedded NUL byte, e.g. ``""`` and ``"\x00"``, into a single value (:issue:`34551`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3543,11 +3543,11 @@ class ArrowExtensionArray(
         expand: bool = False,
         regex: bool | None = None,
     ) -> Self:
+        if pat is None:
+            return self._str_split_whitespace(n, reverse=False)
         if n in {-1, 0}:
             n = None
-        if pat is None:
-            split_func = pc.utf8_split_whitespace
-        elif regex:
+        if regex:
             split_func = functools.partial(pc.split_pattern_regex, pattern=pat)
         else:
             split_func = functools.partial(pc.split_pattern, pattern=pat)
@@ -3557,14 +3557,24 @@ class ArrowExtensionArray(
         if pat is not None and not isinstance(pat, str):
             msg = f"expected a string object, not {type(pat).__name__}"
             raise TypeError(msg)
+        if pat is None:
+            return self._str_split_whitespace(n, reverse=True)
         if n in {-1, 0}:
             n = None
-        if pat is None:
-            return self._from_pyarrow_array(
-                pc.utf8_split_whitespace(self._pa_array, max_splits=n, reverse=True)
-            )
         return self._from_pyarrow_array(
             pc.split_pattern(self._pa_array, pat, max_splits=n, reverse=True)
+        )
+
+    def _str_split_whitespace(self, n: int | None, *, reverse: bool) -> Self:
+        if n is None or n == 0:
+            n = -1
+        if reverse:
+            predicate = lambda val: val.rsplit(None, n)
+        else:
+            predicate = lambda val: val.split(None, n)
+        result = self._apply_elementwise(predicate)
+        return self._from_pyarrow_array(
+            pa.chunked_array(result, type=pa.list_(self._pa_array.type))
         )
 
     def _str_translate(self, table: dict[int, str]) -> Self:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3546,11 +3546,11 @@ class ArrowExtensionArray(
         expand: bool = False,
         regex: bool | None = None,
     ) -> Self:
+        if pat is None:
+            return self._str_split_whitespace(n, reverse=False)
         if n in {-1, 0}:
             n = None
-        if pat is None:
-            split_func = pc.utf8_split_whitespace
-        elif regex is True:
+        if regex is True:
             split_func = functools.partial(pc.split_pattern_regex, pattern=pat)
         elif regex is False:
             split_func = functools.partial(pc.split_pattern, pattern=pat)
@@ -3565,14 +3565,24 @@ class ArrowExtensionArray(
         if pat is not None and not isinstance(pat, str):
             msg = f"expected a string object, not {type(pat).__name__}"
             raise TypeError(msg)
+        if pat is None:
+            return self._str_split_whitespace(n, reverse=True)
         if n in {-1, 0}:
             n = None
-        if pat is None:
-            return self._from_pyarrow_array(
-                pc.utf8_split_whitespace(self._pa_array, max_splits=n, reverse=True)
-            )
         return self._from_pyarrow_array(
             pc.split_pattern(self._pa_array, pat, max_splits=n, reverse=True)
+        )
+
+    def _str_split_whitespace(self, n: int | None, *, reverse: bool) -> Self:
+        if n is None or n == 0:
+            n = -1
+        if reverse:
+            predicate = lambda val: val.rsplit(None, n)
+        else:
+            predicate = lambda val: val.split(None, n)
+        result = self._apply_elementwise(predicate)
+        return self._from_pyarrow_array(
+            pa.chunked_array(result, type=pa.list_(self._pa_array.type))
         )
 
     def _str_translate(self, table: dict[int, str]) -> Self:

--- a/pandas/tests/strings/test_split_partition.py
+++ b/pandas/tests/strings/test_split_partition.py
@@ -41,6 +41,25 @@ def test_split_more_than_one_char(any_string_dtype, method):
     tm.assert_series_equal(result, exp)
 
 
+def test_split_whitespace_arrow_dtype():
+    # GH#66368
+    pa = pytest.importorskip("pyarrow")
+    list_dtype = pd.ArrowDtype(pa.list_(pa.string()))
+
+    ser = Series(["  hi  there ", "", "   ", "a b c"], dtype=pd.ArrowDtype(pa.string()))
+    exp = Series([["hi", "there"], [], [], ["a", "b", "c"]], dtype=list_dtype)
+    tm.assert_series_equal(ser.str.split(), exp)
+    tm.assert_series_equal(ser.str.rsplit(), exp)
+
+    ser = Series(["  a  b  c "], dtype=pd.ArrowDtype(pa.string()))
+    tm.assert_series_equal(
+        ser.str.split(n=1), Series([["a", "b  c "]], dtype=list_dtype)
+    )
+    tm.assert_series_equal(
+        ser.str.rsplit(n=1), Series([["  a  b", "c"]], dtype=list_dtype)
+    )
+
+
 def test_split_more_regex_split(any_string_dtype):
     # regex split
     values = Series(["a,b_c", "c_d,e", np.nan, "f,g,h"], dtype=any_string_dtype)

--- a/pandas/tests/strings/test_split_partition.py
+++ b/pandas/tests/strings/test_split_partition.py
@@ -43,6 +43,25 @@ def test_split_more_than_one_char(any_string_dtype, method):
     tm.assert_series_equal(result, exp)
 
 
+def test_split_whitespace_arrow_dtype():
+    # GH#66368
+    pa = pytest.importorskip("pyarrow")
+    list_dtype = ArrowDtype(pa.list_(pa.string()))
+
+    ser = Series(["  hi  there ", "", "   ", "a b c"], dtype=ArrowDtype(pa.string()))
+    exp = Series([["hi", "there"], [], [], ["a", "b", "c"]], dtype=list_dtype)
+    tm.assert_series_equal(ser.str.split(), exp)
+    tm.assert_series_equal(ser.str.rsplit(), exp)
+
+    ser = Series(["  a  b  c "], dtype=ArrowDtype(pa.string()))
+    tm.assert_series_equal(
+        ser.str.split(n=1), Series([["a", "b  c "]], dtype=list_dtype)
+    )
+    tm.assert_series_equal(
+        ser.str.rsplit(n=1), Series([["  a  b", "c"]], dtype=list_dtype)
+    )
+
+
 def test_split_more_regex_split(any_string_dtype):
     # regex split
     values = Series(["a,b_c", "c_d,e", np.nan, "f,g,h"], dtype=any_string_dtype)


### PR DESCRIPTION
Routes the no-separator case of `str.split`/`rsplit` on `ArrowDtype` through Python's `str.split` instead of pyarrow's `utf8_split_whitespace`, so it drops empty whitespace tokens and matches the other backends. Explicit-separator splits keep the fast pyarrow path.

- [X] closes #66368 
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [X] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
