### PR TITLE
DOC: document pd.col Expression objects

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -230,6 +230,8 @@ numpydoc_validation_exclude = {
     r"pandas\.errors\.IncompatibilityWarning$",
     r"pandas\.errors\.PyperclipException$",
     r"pandas\.errors\.PyperclipWindowsException$",
+    # Typing classes with no numpydoc-style docstrings
+    r"pandas\.api\.typing\.Expression$",
     # Offset .base properties
     r"pandas\.tseries\.offsets\.DateOffset\.base$",
     r"pandas\.tseries\.offsets\.BusinessDay\.base$",

--- a/doc/source/reference/general_functions.rst
+++ b/doc/source/reference/general_functions.rst
@@ -76,6 +76,7 @@ Top-level evaluation
 
    col
    eval
+   api.typing.Expression
 
 Datetime formats
 ~~~~~~~~~~~~~~~~

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -80,9 +80,13 @@ def _pretty_print_args_kwargs(*args: Any, **kwargs: Any) -> str:
 @set_module("pandas.api.typing")
 class Expression:
     """
-    Class representing a deferred column.
+    Class representing a deferred column or expression.
 
     This is not meant to be instantiated directly. Instead, use :meth:`pandas.col`.
+
+    The attributes and methods available on an ``Expression`` depend on the
+    context where it is evaluated (e.g., within a DataFrame or Series).
+    Therefore, they are not exhaustively documented here.
     """
 
     def __init__(


### PR DESCRIPTION
Provides an API documentation page for `pandas.api.typing.Expression` (returned by `pd.col`) per maintainer discussion.

- Adds `Expression` to `numpydoc_validation_exclude` because it follows relaxed rules (no constructor, no examples).
- Adds `api.typing.Expression` to the Top-level evaluation section in `general_functions.rst`.
- Explains in the docstring that available attributes depend on the evaluation context.

- [x] closes #63084
- [ ] Tests added and passed
- [x] All code checks passed
- [ ] Added type annotations
- [ ] Added an entry in the latest whatsnew
- [x] I have reviewed and followed all the contribution guidelines
- [ ] If I used AI to develop this pull request, I prompted it to follow AGENTS.md.