### PR TITLE
DOC: update Series and DataFrame comparison fill_value docs to include str (#66349)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10825,7 +10825,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -10942,7 +10942,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11058,7 +11058,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11176,7 +11176,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11294,7 +11294,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11414,7 +11414,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11514,7 +11514,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11631,7 +11631,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11726,7 +11726,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11819,7 +11819,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -11911,7 +11911,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -12005,7 +12005,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -12098,7 +12098,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing
@@ -12191,7 +12191,7 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
+        fill_value : float, str, or None, default None
             Fill existing missing (NaN) values, and any new element needed for
             successful DataFrame alignment, with this value before computation.
             If data in both corresponding DataFrame locations is missing

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -7354,7 +7354,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         self,
         other,
         level: Level | None = None,
-        fill_value: float | None = None,
+        fill_value: Hashable | None = None,
         axis: Axis = 0,
     ) -> Series:
         """
@@ -7372,7 +7372,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7436,7 +7436,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7501,7 +7501,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7568,7 +7568,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7636,7 +7636,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7704,7 +7704,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7769,7 +7769,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7833,7 +7833,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7897,7 +7897,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -7963,7 +7963,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8015,7 +8015,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         self,
         other,
         level: Level | None = None,
-        fill_value: float | None = None,
+        fill_value: Hashable | None = None,
         axis: Axis = 0,
     ) -> Series:
         """
@@ -8031,7 +8031,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8104,7 +8104,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8167,7 +8167,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8235,7 +8235,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8302,7 +8302,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8367,7 +8367,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8429,7 +8429,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8494,7 +8494,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8559,7 +8559,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8624,7 +8624,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8689,7 +8689,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing
@@ -8760,7 +8760,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
+        fill_value : float, str, or None, default None (NaN)
             Fill existing missing (NaN) values, and any new element needed for
             successful Series alignment, with this value before computation.
             If data in both corresponding Series locations is missing


### PR DESCRIPTION
Closes #66349.

The `fill_value` parameter description for comparison methods (`eq`, `ne`, `lt`, `gt`, `le`, `ge`) in both `Series` and `DataFrame` previously specified `float or None`. This PR updates the docstrings and type hints to explicitly include `str` (and update type hints to `Hashable`) since passing a string `fill_value` works correctly at runtime for string dtypes.