### PR TITLE
ENH: register pyarrow extension types on pandas import

### DIFF
--- a/ci/import_pandas_check.py
+++ b/ci/import_pandas_check.py
@@ -29,3 +29,12 @@ import_mods = {m.split(".")[0] for m in sys.modules} | set(sys.modules)
 mods = blocklist & import_mods
 if mods:
     raise Exception(f"pandas should not import {', '.join(mods)}")
+
+# GH#41432 importing this module registers the pyarrow extension types for
+# Period and Interval, so pyarrow recognizes them when reading pandas data
+# directly rather than only after a parquet or feather round-trip.
+if (
+    "pyarrow" in sys.modules
+    and "pandas.core.arrays.arrow.extension_types" not in sys.modules
+):
+    raise Exception("pandas should register its pyarrow extension types on import")

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -51,6 +51,7 @@ Other enhancements
 - Improved type inference of comparison and arithmetic operators on :class:`Series` and :class:`DataFrame` for static type checkers (e.g. ``ser == "a"`` is now inferred as :class:`Series` instead of ``Any``) (:issue:`40762`)
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)
 - Setting values with :meth:`DataFrame.at` or :meth:`Series.at` using a non-scalar indexer (e.g. a boolean mask, list, or array) now raises a clearer ``InvalidIndexError`` directing users to ``.loc`` (:issue:`51866`)
+- pandas now registers its :class:`Period` and :class:`Interval` pyarrow extension types when it is imported, so pyarrow recognizes them when reading pandas data directly (e.g. via ``pyarrow.parquet.read_table``) without a prior pandas conversion in the same process (:issue:`41432`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.notable_bug_fixes:

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -137,6 +137,18 @@ from pandas import api, arrays, errors, io, plotting, tseries
 from pandas import testing
 from pandas.util._print_versions import show_versions
 
+# GH#41432: importing this module registers the pyarrow extension types for
+# Period and Interval, so pyarrow recognizes them when reading pandas data
+# directly instead of only after a parquet or feather round-trip has triggered
+# the lazy registration. Imported for that side effect only.
+from pandas.compat.pyarrow import HAS_PYARROW as _HAS_PYARROW
+
+if _HAS_PYARROW:
+    from pandas.core.arrays.arrow import extension_types as _extension_types
+
+    del _extension_types
+del _HAS_PYARROW
+
 from pandas.io.api import (
     # excel
     ExcelFile,

--- a/pandas/tests/arrays/period/test_arrow_compat.py
+++ b/pandas/tests/arrays/period/test_arrow_compat.py
@@ -30,27 +30,6 @@ def test_arrow_extension_type():
     assert hash(p1) != hash(p3)
 
 
-@pytest.mark.single_cpu
-def test_arrow_extension_type_registered_on_import(tmp_path):
-    # GH#41432 the extension types are registered when pandas is imported, so
-    # pyarrow reads them back correctly even without a prior pandas round-trip in
-    # the reading process. Uses a subprocess for a clean import state, since
-    # registration is a process-wide side effect other tests already trigger.
-    import subprocess
-    import sys
-
-    path = tmp_path / "period.parquet"
-    pd.DataFrame({"a": pd.period_range("2012", freq="Y", periods=3)}).to_parquet(path)
-
-    code = (
-        "import pandas  # noqa: F401  # registers the extension types on import\n"
-        "import pyarrow.parquet as pq\n"
-        f"typ = pq.read_table({str(path)!r}).schema.field('a').type\n"
-        "assert str(typ).startswith('extension<pandas.period'), typ\n"
-    )
-    subprocess.check_call([sys.executable, "-c", code])
-
-
 @pytest.mark.parametrize(
     "data, freq",
     [

--- a/pandas/tests/arrays/period/test_arrow_compat.py
+++ b/pandas/tests/arrays/period/test_arrow_compat.py
@@ -30,6 +30,27 @@ def test_arrow_extension_type():
     assert hash(p1) != hash(p3)
 
 
+@pytest.mark.single_cpu
+def test_arrow_extension_type_registered_on_import(tmp_path):
+    # GH#41432 the extension types are registered when pandas is imported, so
+    # pyarrow reads them back correctly even without a prior pandas round-trip in
+    # the reading process. Uses a subprocess for a clean import state, since
+    # registration is a process-wide side effect other tests already trigger.
+    import subprocess
+    import sys
+
+    path = tmp_path / "period.parquet"
+    pd.DataFrame({"a": pd.period_range("2012", freq="Y", periods=3)}).to_parquet(path)
+
+    code = (
+        "import pandas  # noqa: F401  # registers the extension types on import\n"
+        "import pyarrow.parquet as pq\n"
+        f"typ = pq.read_table({str(path)!r}).schema.field('a').type\n"
+        "assert str(typ).startswith('extension<pandas.period'), typ\n"
+    )
+    subprocess.check_call([sys.executable, "-c", code])
+
+
 @pytest.mark.parametrize(
     "data, freq",
     [


### PR DESCRIPTION
- [x] closes #41432
- [x] Tests added and passed
- [x] All code checks passed
- [ ] Added type annotations to new arguments/methods/functions
- [x] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file
- [x] I have reviewed and followed all the contribution guidelines
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

The Period and Interval pyarrow extension types are only registered when something triggers the import of `pandas.core.arrays.arrow.extension_types`, so pyarrow reading pandas data directly gets the raw storage type back:

```python
# process 1
import pandas as pd
pd.DataFrame({"a": pd.period_range("2012", freq="Y", periods=3)}).to_parquet("p.parquet")
```

```python
# process 2, only imports pandas
import pandas
import pyarrow.parquet as pq
print(pq.read_table("p.parquet").schema.field("a").type)
# int64      <- expected extension<pandas.period<ArrowPeriodType>>
```

Reading via `pd.read_parquet` is unaffected, since `io/parquet.py` imports the module on the way. This registers the types at import time instead, behind `HAS_PYARROW`.

The two concerns raised when this was last discussed no longer apply: the circular import is gone, and pandas already imports pyarrow eagerly through `pandas.compat.pyarrow`, so registering on top of it measured ~3ms locally.

The test runs in a subprocess because registration is a process-wide side effect that other tests already trigger, so an in-process test would pass regardless of the change.