### PR TITLE
DOC: Fix halflife math rendering in DataFrame.ewm

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12303,7 +12303,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         halflife : float, str, timedelta, optional
             Specify decay in terms of half-life
 
-            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\\right)`,
+            :math:`\alpha = 1 - \exp\left(-\ln(2) / halflife\right)`,
             for :math:`halflife > 0`.
 
             If ``times`` is specified, a timedelta convertible unit over which an

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12303,7 +12303,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         halflife : float, str, timedelta, optional
             Specify decay in terms of half-life
 
-            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\right)`,
+            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\\right)`,
             for :math:`halflife > 0`.
 
             If ``times`` is specified, a timedelta convertible unit over which an

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12293,12 +12293,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         com : float, optional
             Specify decay in terms of center of mass
 
-            :math:`\alpha = 1 / (1 + com)`, for :math:`com \\geq 0`.
+            :math:`\alpha = 1 / (1 + com)`, for :math:`com \geq 0`.
 
         span : float, optional
             Specify decay in terms of span
 
-            :math:`\alpha = 2 / (span + 1)`, for :math:`span \\geq 1`.
+            :math:`\alpha = 2 / (span + 1)`, for :math:`span \geq 1`.
 
         halflife : float, str, timedelta, optional
             Specify decay in terms of half-life
@@ -12313,7 +12313,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         alpha : float, optional
             Specify smoothing factor :math:`\alpha` directly
 
-            :math:`0 < \alpha \\leq 1`.
+            :math:`0 < \alpha \leq 1`.
 
         min_periods : int, default 0
             Minimum number of observations in window required to have a value;
@@ -12340,7 +12340,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 \begin{split}
                     y_0 &= x_0\\
                     y_t &= (1 - \alpha) y_{t-1} + \alpha x_t,
-                \\end{split}
+                \end{split}
 
         ignore_na : bool, default False
             Ignore missing values when calculating weights.


### PR DESCRIPTION
## Summary

Fix the escaping in the `halflife` math expression in `pandas/core/generic.py` by adding the missing backslash before `\right`. This resolves the KaTeX rendering issue ("Missing \left or extra \right") in the development documentation.

- [x] closes #66379
- [ ] Tests added and passed (na - documentation only change)
- [X] All code checks passed (not run locally)
- [ ] Added type annotations to new arguments/methods/functions (not applicable)
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file (na - documentation only change)
- [x] I have reviewed and followed all the contribution guidelines.
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`. (not used)
