### PR TITLE
BUG: Index.get_indexer now treats pd.NA consistently for list and ndarray targets

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -393,6 +393,7 @@ Indexing
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
 - Bug in :meth:`DataFrame.xs` where ``drop_level=False`` was ignored for fully specified :class:`MultiIndex` keys when ``level`` was not explicitly provided (:issue:`6507`)
 - Bug in :meth:`Index.get_indexer_non_unique` raising ``ZeroDivisionError`` instead of returning an all-missing result when called on an empty index with a non-empty target (:issue:`54746`)
+- Bug in :meth:`Index.get_indexer` matching ``pd.NA`` against ``NaN`` for list targets but not for ndarray or :class:`Index` targets, leading to inconsistent results between :meth:`Index.get_loc`, ``get_indexer`` and :meth:`Index.drop` (:issue:`65419`)
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)
 - Bug in :meth:`Index.get_loc` raising ``KeyError`` when looking up a tuple in an object-dtype :class:`Index` with duplicates (:issue:`37800`)
 - Bug in :meth:`Index.insert` silently casting booleans to numeric when used with nullable numeric dtypes like ``Float64`` or ``Int64`` (:issue:`61709`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7098,13 +7098,11 @@ class Index(IndexOpsMixin, PandasObject):
             isinstance(self.dtype, StringDtype)
             and self.dtype.na_value is np.nan
             and using_string_dtype()
+            and target_index.dtype == object
             and not isinstance(target_index, ABCMultiIndex)
         ):
-            # Fill missing values to ensure consistent missing value representation
-            # across list, ndarray, and Index targets; otherwise ``pd.NA`` in an
-            # object-dtype target would not match ``np.nan`` in ``self`` while the
-            # list path would (GH#65419).  MultiIndex is excluded because it does
-            # not implement ``fillna``.
+            # Normalize pd.NA -> np.nan so object-dtype targets match self (GH#65419).
+            # MultiIndex is excluded (no fillna).
             target_index = target_index.fillna(np.nan)
         return target_index
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7095,12 +7095,16 @@ class Index(IndexOpsMixin, PandasObject):
             # is object dtype (coercing to string dtype will alter the missing values)
             target_index = Index(target, dtype=self.dtype)
         elif (
-            not hasattr(target, "dtype")
-            and isinstance(self.dtype, StringDtype)
+            isinstance(self.dtype, StringDtype)
             and self.dtype.na_value is np.nan
             and using_string_dtype()
+            and not isinstance(target_index, ABCMultiIndex)
         ):
             # Fill missing values to ensure consistent missing value representation
+            # across list, ndarray, and Index targets; otherwise ``pd.NA`` in an
+            # object-dtype target would not match ``np.nan`` in ``self`` while the
+            # list path would (GH#65419).  MultiIndex is excluded because it does
+            # not implement ``fillna``.
             target_index = target_index.fillna(np.nan)
         return target_index
 

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -18,7 +18,7 @@ contain tests for the corresponding methods specific to those Index subclasses.
 import numpy as np
 import pytest
 
-from pandas._config import using_string_dtype
+from pandas._config import option_context
 
 from pandas.compat import PY314
 from pandas.errors import InvalidIndexError
@@ -396,29 +396,26 @@ def test_get_indexer_non_unique_empty_index(dtype, target_values):
     tm.assert_numpy_array_equal(result_missing, np.array([0, 1], dtype=np.intp))
 
 
-@pytest.mark.skipif(
-    not using_string_dtype(),
-    reason="NA->NaN normalization in _maybe_cast_listlike_indexer only applies "
-    "under the infer_string future; under infer_string=0 the index is object "
-    "dtype and pd.NA does not match np.nan on any path (GH#65419)",
-)
 def test_get_indexer_na_matches_nan_consistently_for_list_and_ndarray():
     # GH#65419: ``Index.get_indexer`` matched ``pd.NA`` against ``np.nan`` for
     # list targets but not for ndarray / Index targets, because the
     # ``pd.NA -> np.nan`` normalization in ``_maybe_cast_listlike_indexer``
     # only applied to list-like inputs.  ``get_loc`` and ``Index.drop`` were
     # similarly inconsistent.
-    idx = Index([np.nan, "b"])
+    with option_context("future.infer_string", True):
+        idx = Index([np.nan, "b"], dtype="str")
 
-    expected = np.array([0], dtype=np.intp)
+        expected = np.array([0], dtype=np.intp)
 
-    # list path already matched pd.NA against NaN before the fix
-    tm.assert_numpy_array_equal(idx.get_indexer([NA]), expected)
-    # ndarray and Index paths now match as well
-    tm.assert_numpy_array_equal(idx.get_indexer(np.array([NA], dtype=object)), expected)
-    tm.assert_numpy_array_equal(idx.get_indexer(Index([NA])), expected)
+        # list path already matched pd.NA against NaN before the fix
+        tm.assert_numpy_array_equal(idx.get_indexer([NA]), expected)
+        # ndarray and Index paths now match as well
+        tm.assert_numpy_array_equal(
+            idx.get_indexer(np.array([NA], dtype=object)), expected
+        )
+        tm.assert_numpy_array_equal(idx.get_indexer(Index([NA])), expected)
 
-    # ``Index.drop`` routes through ``get_indexer_for`` with an ndarray, so it
-    # should also drop the NaN entry given ``pd.NA``.
-    tm.assert_index_equal(idx.drop([NA]), Index(["b"], dtype=idx.dtype))
-    tm.assert_index_equal(idx.drop([np.nan]), Index(["b"], dtype=idx.dtype))
+        # ``Index.drop`` routes through ``get_indexer_for`` with an ndarray, so it
+        # should also drop the NaN entry given ``pd.NA``.
+        tm.assert_index_equal(idx.drop([NA]), Index(["b"], dtype=idx.dtype))
+        tm.assert_index_equal(idx.drop([np.nan]), Index(["b"], dtype=idx.dtype))

--- a/pandas/tests/indexes/test_indexing.py
+++ b/pandas/tests/indexes/test_indexing.py
@@ -18,6 +18,8 @@ contain tests for the corresponding methods specific to those Index subclasses.
 import numpy as np
 import pytest
 
+from pandas._config import using_string_dtype
+
 from pandas.compat import PY314
 from pandas.errors import InvalidIndexError
 
@@ -392,3 +394,31 @@ def test_get_indexer_non_unique_empty_index(dtype, target_values):
 
     tm.assert_numpy_array_equal(result_idx, np.array([-1, -1], dtype=np.intp))
     tm.assert_numpy_array_equal(result_missing, np.array([0, 1], dtype=np.intp))
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="NA->NaN normalization in _maybe_cast_listlike_indexer only applies "
+    "under the infer_string future; under infer_string=0 the index is object "
+    "dtype and pd.NA does not match np.nan on any path (GH#65419)",
+)
+def test_get_indexer_na_matches_nan_consistently_for_list_and_ndarray():
+    # GH#65419: ``Index.get_indexer`` matched ``pd.NA`` against ``np.nan`` for
+    # list targets but not for ndarray / Index targets, because the
+    # ``pd.NA -> np.nan`` normalization in ``_maybe_cast_listlike_indexer``
+    # only applied to list-like inputs.  ``get_loc`` and ``Index.drop`` were
+    # similarly inconsistent.
+    idx = Index([np.nan, "b"])
+
+    expected = np.array([0], dtype=np.intp)
+
+    # list path already matched pd.NA against NaN before the fix
+    tm.assert_numpy_array_equal(idx.get_indexer([NA]), expected)
+    # ndarray and Index paths now match as well
+    tm.assert_numpy_array_equal(idx.get_indexer(np.array([NA], dtype=object)), expected)
+    tm.assert_numpy_array_equal(idx.get_indexer(Index([NA])), expected)
+
+    # ``Index.drop`` routes through ``get_indexer_for`` with an ndarray, so it
+    # should also drop the NaN entry given ``pd.NA``.
+    tm.assert_index_equal(idx.drop([NA]), Index(["b"], dtype=idx.dtype))
+    tm.assert_index_equal(idx.drop([np.nan]), Index(["b"], dtype=idx.dtype))


### PR DESCRIPTION
Fixes #65419.

## What

`Index.get_indexer` matched `pd.NA` against `np.nan` for list targets but not for ndarray or `Index` targets, so the same lookup gave different answers depending on the input shape.  `Index.get_loc` (scalar), the list form of `get_indexer`, and `Index.drop` (which routes through `get_indexer_for` with an ndarray) disagreed on whether `pd.NA` matches a `NaN` label.

## Why

The `pd.NA -> np.nan` normalization in `Index._maybe_cast_listlike_indexer` was gated by `not hasattr(target, "dtype")`, so it only fired for list-like inputs.  ndarray and `Index` inputs kept their original `pd.NA`, which then failed to match the index's `np.nan` NA value for `StringDtype` indexes (the default for `Index([np.nan, "b"])` in pandas 3.x).

## Before / after

```python
import numpy as np
import pandas as pd

idx = pd.Index([np.nan, "b"])

idx.get_indexer([pd.NA])                          # array([0])
idx.get_indexer(np.array([pd.NA], dtype=object))  # array([-1])  <-  before
idx.get_indexer(pd.Index([pd.NA]))                # array([-1])  <-  before
idx.drop([pd.NA])                                 # KeyError    <-  before
```

After the fix all four paths agree: `array([0])` for the three `get_indexer` calls and `Index(["b"], dtype="str")` for `drop([pd.NA])`.

## Approach

Drop the `not hasattr(target, "dtype")` condition from the `StringDtype` branch of `_maybe_cast_listlike_indexer` so ndarray and `Index` targets go through the same `fillna(np.nan)` normalization as list targets.  `MultiIndex` is excluded because it does not implement `fillna`.  The fix is one conditional; the rest of the diff is the regression test and the whatsnew entry.

Two prior PRs (#65442, #65477) targeted `self.dtype == object`, which does not match the default `StringDtype` of `Index([np.nan, "b"])` in pandas 3.x and so left the reproducer unfixed; this PR targets `StringDtype` directly.  Commenters `Ella-horizon` and `sayantancodex` noted they would work on this issue but no PR has been opened in 7 weeks.

## Testing

- New regression test `test_get_indexer_na_matches_nan_consistently_for_list_and_ndarray` in `pandas/tests/indexes/test_indexing.py` (red on the unpatched tree, green after the fix).
- `pandas/tests/indexes/test_indexing.py` and `pandas/tests/indexes/test_base.py`: all non-pyarrow tests pass locally.  The only local failures are `ImportError: pyarrow requires pandas 1.0.0 or above` from running an editable dev build with a `0+untagged...` version string, which is an environment artifact unrelated to this change.
- `pandas/tests/indexing/test_indexers.py`, `pandas/tests/reshape/merge/test_merge.py`, `pandas/tests/reshape/merge/test_join.py`, `pandas/tests/series/methods/test_drop.py`, `pandas/tests/frame/methods/test_drop.py`, `pandas/tests/series/methods/test_reindex.py`, `pandas/tests/frame/methods/test_reindex.py`, `pandas/tests/indexes/test_setops.py`: all non-pyarrow tests pass.