### PR TITLE
PERF: keep the read_csv chunk split when one line is very long

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -199,7 +199,6 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when an extension dtype is requested (e.g. ``dtype="Int64"``, ``dtype="boolean"``, or ``dtype="int64[pyarrow]"``) (:issue:`66279`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing integer columns (:issue:`65347`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` when reading a large file containing an unusually long line in parallel, which previously used far fewer threads than requested (:issue:`66392`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading from binary file-like objects (e.g. PyArrow S3 file handles) by avoiding unnecessary ``TextIOWrapper`` wrapping (:issue:`46823`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading in parallel: closing a parser no longer blocks the other parser threads while its buffers are freed (:issue:`66272`)
 - Performance improvement in :func:`read_csv` with ``engine="c"``, especially for large files and parallel reads (:issue:`66271`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -199,6 +199,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when an extension dtype is requested (e.g. ``dtype="Int64"``, ``dtype="boolean"``, or ``dtype="int64[pyarrow]"``) (:issue:`66279`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing integer columns (:issue:`65347`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` when reading a large file containing an unusually long line in parallel, which previously used far fewer threads than requested (:issue:`66392`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading from binary file-like objects (e.g. PyArrow S3 file handles) by avoiding unnecessary ``TextIOWrapper`` wrapping (:issue:`46823`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading in parallel: closing a parser no longer blocks the other parser threads while its buffers are freed (:issue:`66272`)
 - Performance improvement in :func:`read_csv` with ``engine="c"``, especially for large files and parallel reads (:issue:`66271`)

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -620,8 +620,13 @@ def _find_chunk_byte_offsets(
             fd.seek(target)
             fd.readline()  # advance past the partial line at the split point
             pos = fd.tell()
-            if pos >= file_size or pos == offsets[-1]:
+            if pos >= file_size:
                 break
+            if pos == offsets[-1]:
+                # This target fell inside the line the previous boundary
+                # already ended; skip it rather than abandoning the boundaries
+                # after it, so one long line cannot collapse the whole split.
+                continue
             offsets.append(pos)
 
     offsets.append(file_size)

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
+from pandas.compat import WASM
 from pandas.errors import (
     ParserError,
     ParserWarning,
@@ -899,6 +900,7 @@ def test_parallel_single_long_line(tmp_path, monkeypatch):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.skipif(WASM, reason="WASM cannot spawn threads, so no split happens")
 def test_parallel_long_line_keeps_the_split(tmp_path, monkeypatch):
     # A line covering the middle of the file swallows the interior split
     # targets.  The boundaries after it must survive: the results are correct
@@ -927,6 +929,7 @@ def test_parallel_long_line_keeps_the_split(tmp_path, monkeypatch):
     tm.assert_frame_equal(result, expected)
     # Two of the interior targets land inside the long line; giving up at the
     # first leaves 2 chunks no matter how many workers were asked for.
+    assert chunk_counts, "the parallel path did not run"
     assert chunk_counts[0] >= 3
 
 

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -439,20 +439,6 @@ class TestFindChunkByteOffsets:
         assert len(offsets) - 1 >= 20
         assert all(offsets[i] < offsets[i + 1] for i in range(len(offsets) - 1))
 
-    def test_long_line_keeps_later_boundaries_at_low_chunk_counts(self, tmp_path):
-        # The reader asks for a chunk per worker, so a single line covering
-        # the middle of the file can swallow every interior target but the
-        # last one.  That last one must still produce a boundary.
-        path = tmp_path / "data.csv"
-        blob = b'1,"' + b"x" * 39_995 + b'"\n'  # 40_000 bytes, spanning 20-60%
-        path.write_bytes(b"a,b\n" + b"1,2\n" * 5_000 + blob + b"1,2\n" * 10_000)
-
-        offsets = _find_chunk_byte_offsets(str(path), 4, data_start=4)
-        # The 25% and 50% targets land inside the long line; the 75% one does
-        # not, so the split keeps 3 chunks rather than collapsing to 2.
-        assert len(offsets) - 1 == 3
-        assert all(offsets[i] < offsets[i + 1] for i in range(len(offsets) - 1))
-
 
 # ---------------------------------------------------------------------------
 # _read_csv_parallel  (correctness: parallel == serial)
@@ -911,6 +897,37 @@ def test_parallel_single_long_line(tmp_path, monkeypatch):
     result = _read_forced_parallel(path, monkeypatch)
     expected = read_csv(io.BytesIO(raw))
     tm.assert_frame_equal(result, expected)
+
+
+def test_parallel_long_line_keeps_the_split(tmp_path, monkeypatch):
+    # A line covering the middle of the file swallows the interior split
+    # targets.  The boundaries after it must survive: the results are correct
+    # either way, so a collapse is invisible except as lost parallelism, which
+    # is what this asserts (GH#66392).
+    path = tmp_path / "data.csv"
+    blob = "1," + "9" * 39_995 + "\n"  # 40 KB, covering 20-60% of the data
+    path.write_text(
+        "a,b\n" + "1,2\n" * 5_000 + blob + "1,2\n" * 10_000, encoding="utf-8"
+    )
+
+    chunk_counts = []
+
+    def spy(filepath, n_chunks, data_start):
+        offsets = _find_chunk_byte_offsets(filepath, n_chunks, data_start)
+        chunk_counts.append(len(offsets) - 1)
+        return offsets
+
+    monkeypatch.setattr("pandas.io.parsers.readers._PARALLEL_READ_MIN_BYTES", 1)
+    monkeypatch.setattr("pandas.io.parsers.readers._find_chunk_byte_offsets", spy)
+
+    with option_context("mode.max_threads", 1):
+        expected = read_csv(path)
+    with option_context("mode.max_threads", 4):
+        result = read_csv(path)
+    tm.assert_frame_equal(result, expected)
+    # Two of the interior targets land inside the long line; giving up at the
+    # first leaves 2 chunks no matter how many workers were asked for.
+    assert chunk_counts[0] >= 3
 
 
 def test_parallel_mixed_dtype_column_matches_serial(tmp_path, monkeypatch):

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -424,6 +424,35 @@ class TestFindChunkByteOffsets:
         # Can't produce 8 distinct split points in 4 bytes.
         assert len(offsets) >= 2
 
+    def test_one_long_line_does_not_collapse_the_split(self, tmp_path):
+        # A line long enough to swallow several split targets must only cost
+        # those targets, not every boundary after it.
+        path = tmp_path / "data.csv"
+        lines = [b"a,b\n"] + [b"1,2\n"] * 20_000
+        lines.insert(10, b'1,"' + b"x" * 40_000 + b'"\n')
+        path.write_bytes(b"".join(lines))
+
+        offsets = _find_chunk_byte_offsets(str(path), 32, data_start=4)
+        # Skipping only the swallowed targets keeps most of the split; giving
+        # up at the first one degenerates to 2 chunks.  The long line covers
+        # roughly a third of the 32 targets.
+        assert len(offsets) - 1 >= 20
+        assert all(offsets[i] < offsets[i + 1] for i in range(len(offsets) - 1))
+
+    def test_long_line_keeps_later_boundaries_at_low_chunk_counts(self, tmp_path):
+        # The reader asks for a chunk per worker, so a single line covering
+        # the middle of the file can swallow every interior target but the
+        # last one.  That last one must still produce a boundary.
+        path = tmp_path / "data.csv"
+        blob = b'1,"' + b"x" * 39_995 + b'"\n'  # 40_000 bytes, spanning 20-60%
+        path.write_bytes(b"a,b\n" + b"1,2\n" * 5_000 + blob + b"1,2\n" * 10_000)
+
+        offsets = _find_chunk_byte_offsets(str(path), 4, data_start=4)
+        # The 25% and 50% targets land inside the long line; the 75% one does
+        # not, so the split keeps 3 chunks rather than collapsing to 2.
+        assert len(offsets) - 1 == 3
+        assert all(offsets[i] < offsets[i + 1] for i in range(len(offsets) - 1))
+
 
 # ---------------------------------------------------------------------------
 # _read_csv_parallel  (correctness: parallel == serial)


### PR DESCRIPTION
`_find_chunk_byte_offsets` picks parallel-read split targets at even byte intervals and advances each one past the partial line it lands in. If a target fell inside a line that an earlier boundary had already passed, the loop `break`ed — discarding every remaining boundary — so a single long line collapsed the split to two chunks regardless of how many were requested.

Skip the swallowed target instead of giving up on the ones after it.

This costs parallelism only: a collapsed split still produces the correct frame, which is why the end-to-end test asserts the resulting chunk count alongside `assert_frame_equal`. Both tests fail on main — `read_csv` uses 2 chunks where it should use 3, and the unit test's 32-chunk split degenerates to 2.

The trigger is narrow on main today (with one chunk per worker, a line has to cover ~a quarter of the file to swallow two targets) and about three times easier to hit under the finer split in GH-66275, which is where this was found. No whatsnew entry: parallel reading is itself new in 3.1.0, so there is no released behaviour this improves on.
