### PR TITLE
DOC: Fix unescaped \right in DataFrame.ewm halflife docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12314,7 +12314,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         halflife : float, str, timedelta, optional
             Specify decay in terms of half-life
 
-            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\right)`,
+            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\\right)`,
             for :math:`halflife > 0`.
 
             If ``times`` is specified, a timedelta convertible unit over which an

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -149,7 +149,7 @@ class ExponentialMovingWindow(BaseWindow):
     halflife : float, str, timedelta, optional
         Specify decay in terms of half-life
 
-        :math:`\alpha = 1 - \exp\left(-\ln(2) / halflife\right)`, for
+        :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\\right)`, for
         :math:`halflife > 0`.
 
         If ``times`` is specified, a timedelta convertible unit over which an


### PR DESCRIPTION
- [x] closes #66379

The `\right` inside the `halflife` docstring for `ewm` was being interpreted as a carriage return because it lacked a double backslash in the raw docstring, causing a sphinx warning. This PR correctly escapes `\right` and the other math directives to ensure it renders correctly.