### PR TITLE
DOC: Clarify limit keyword behavior in interpolate

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8064,6 +8064,9 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         limit : int, optional
             Maximum number of consecutive NaNs to fill. Must be greater than
             0.
+
+            In other words, if there is a gap with more than this number of
+            consecutive NaNs, it will only be partially filled.
         inplace : bool, default False
             Update the data in place if possible.
         limit_direction : {'forward', 'backward', 'both'}, optional, default 'forward'

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12314,7 +12314,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         halflife : float, str, timedelta, optional
             Specify decay in terms of half-life
 
-            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\right)`,
+            :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\\right)`,
             for :math:`halflife > 0`.
 
             If ``times`` is specified, a timedelta convertible unit over which an

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -898,6 +898,9 @@ class Resampler(BaseGroupBy, PandasObject):
         limit : int, optional
             Maximum number of consecutive NaNs to fill. Must be greater than
             0.
+
+            In other words, if there is a gap with more than this number of
+            consecutive NaNs, it will only be partially filled.
         limit_direction : {'forward', 'backward', 'both'}, Optional
             Consecutive NaNs will be filled in this direction.
 

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -149,7 +149,7 @@ class ExponentialMovingWindow(BaseWindow):
     halflife : float, str, timedelta, optional
         Specify decay in terms of half-life
 
-        :math:`\alpha = 1 - \exp\left(-\ln(2) / halflife\right)`, for
+        :math:`\alpha = 1 - \\exp\\left(-\\ln(2) / halflife\\right)`, for
         :math:`halflife > 0`.
 
         If ``times`` is specified, a timedelta convertible unit over which an


### PR DESCRIPTION
- [x] closes #36352

The `interpolate` docstring now clarifies that if a gap of NaNs is larger than `limit`, the gap will only be partially filled (rather than left completely untouched). This matches the clarification currently present in the `fillna` docstring.