### PR TITLE
DOC: batch of documentation clarifications

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -168,7 +168,7 @@ Selection
 
    While standard Python / NumPy expressions for selecting and setting are
    intuitive and come in handy for interactive work, for production code, we
-   recommend the optimized pandas data access methods, :meth:`DataFrame.at`, :meth:`DataFrame.iat`,
+   recommend the optimized pandas data access methods, :attr:`DataFrame.at`, :attr:`DataFrame.iat`,
    :meth:`DataFrame.loc` and :meth:`DataFrame.iloc`.
 
 See the indexing documentation :ref:`Indexing and Selecting Data <indexing>` and :ref:`MultiIndex / Advanced Indexing <advanced>`.
@@ -207,7 +207,7 @@ For a :class:`DataFrame`, passing a slice ``:`` selects matching rows:
 Selection by label
 ~~~~~~~~~~~~~~~~~~
 
-See more in :ref:`Selection by Label <indexing.label>` using :meth:`DataFrame.loc` or :meth:`DataFrame.at`.
+See more in :ref:`Selection by Label <indexing.label>` using :meth:`DataFrame.loc` or :attr:`DataFrame.at`.
 
 Selecting a row matching a label:
 
@@ -242,7 +242,7 @@ For getting fast access to a scalar (equivalent to the prior method):
 Selection by position
 ~~~~~~~~~~~~~~~~~~~~~
 
-See more in :ref:`Selection by Position <indexing.integer>` using :meth:`DataFrame.iloc` or :meth:`DataFrame.iat`.
+See more in :ref:`Selection by Position <indexing.integer>` using :meth:`DataFrame.iloc` or :attr:`DataFrame.iat`.
 
 Select via the position of the passed integers:
 

--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -977,8 +977,9 @@ with optional filling of missing data with ``fill_method``.
 
 :func:`merge_asof` is similar to an ordered left-join except that matches are on the
 nearest key rather than equal keys. For each row in the ``left`` :class:`DataFrame`,
-the last row in the ``right`` :class:`DataFrame` is selected where the ``on`` key is less
-than the left's key. Both :class:`DataFrame` must be sorted by the key.
+the last row in the ``right`` :class:`DataFrame` is selected where the ``on`` key is
+less than or equal to the left's key. Both :class:`DataFrame` must be sorted by the
+key.
 
 Optionally :func:`merge_asof` can perform a group-wise merge by matching the
 ``by`` key in addition to the nearest match on the ``on`` key.

--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -1794,8 +1794,8 @@ This would be more or less equivalent to:
     >>> backend.module.plot(pd.Series([1, 2, 3]))
 
 The backend module can then use other visualization tools (Bokeh, Altair, hvplot,...)
-to generate the plots. Some libraries implementing a backend for pandas are listed
-on `the ecosystem page <https://pandas.pydata.org/community/ecosystem.html>`_.
+to generate the plots. Some libraries implementing a backend for pandas are
+listed on `the ecosystem page <https://pandas.pydata.org/community/ecosystem.html#plotting-backends>`_.
 
 Developers guide can be found at
 https://pandas.pydata.org/docs/dev/development/extending.html#plotting-backends

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -895,6 +895,9 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         DatetimeIndex.tz : A timezone that has a variable offset from UTC.
         DatetimeIndex.tz_localize : Localize tz-naive DatetimeIndex to a
             given time zone, or remove timezone from a tz-aware DatetimeIndex.
+        Series.dt.tz : A timezone that has a variable offset from UTC.
+        Series.dt.tz_localize : Localize tz-naive Series datetimes to a given
+            time zone, or remove timezone from tz-aware Series datetimes.
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8205,6 +8205,7 @@ class DataFrame(NDFrame, OpsMixin):
         See Also
         --------
         DataFrame.value_counts: Count unique combinations of columns.
+        Index.duplicated : Indicate duplicate index values.
 
         Notes
         -----
@@ -8253,6 +8254,17 @@ class DataFrame(NDFrame, OpsMixin):
         1  Yum Yum   cup     4.0
         2  Indomie   cup     3.5
         4  Indomie  pack     5.0
+
+        Duplicates in the index are not considered. To drop rows with a
+        duplicate index label, use :meth:`Index.duplicated` with boolean
+        indexing.
+
+        >>> indexed = df.set_index("brand")
+        >>> indexed[~indexed.index.duplicated(keep="first")]
+                style  rating
+        brand
+        Yum Yum   cup     4.0
+        Indomie   cup     3.5
         """
         if self.empty:
             return self.copy(deep=False)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7650,6 +7650,19 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         * When dict is used as the `to_replace` value, it is like
           key(s) in the dict are the to_replace part and
           value(s) in the dict are the value parameter.
+        * Unless `regex` is True, a key matches only if it equals the entire
+          value, not a substring of it: ``{"b": "z"}`` replaces the value ``"b"``
+          but leaves ``"a b c"`` unchanged.
+        * Dict entries are applied one after another, in insertion order. Which
+          entries apply to an element is decided up front by matching every key
+          against the original value, but each substitution is made into the
+          result of the previous ones. An entry can therefore end up a no-op if
+          an earlier one already rewrote the text it targeted: with
+          ``regex=True``, ``{"x": "1", "x y": "2"}`` turns ``"x y"`` into
+          ``"1 y"``, while ``{"x y": "2", "x": "1"}`` turns it into ``"2"``.
+          Conversely, a later entry can rewrite what an earlier one produced:
+          ``{"ab": "ba", "ba": "zz"}`` turns ``"ab ba"`` into ``"zz zz"``.
+          With overlapping keys, order the dict most-specific-first.
         * Replacement is based on equality, not identity. Since Python treats
           ``True == 1`` and ``False == 0``, replacing one will also affect
           the other when they share a dtype (e.g. ``object``).

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -324,6 +324,24 @@ class IndexingMixin:
         0     1     3
         1   100   300
         2  1000  3000
+
+        **Selecting along an explicit axis**
+
+        ``.iloc`` can be called with an ``axis`` argument to apply a single
+        indexer to that axis.
+
+        >>> df.iloc(axis=0)[1]
+        a    100
+        b    200
+        c    300
+        d    400
+        Name: 1, dtype: int64
+
+        >>> df.iloc(axis=1)[1]
+        0       2
+        1     200
+        2    2000
+        Name: b, dtype: int64
         """
         return _iLocIndexer("iloc", self)
 
@@ -467,6 +485,22 @@ class IndexingMixin:
         >>> df.loc[lambda df: df["shield"] == 8]
                     max_speed  shield
         sidewinder          7       8
+
+        **Selecting along an explicit axis**
+
+        ``.loc`` can be called with an ``axis`` argument to apply a single
+        indexer to that axis.
+
+        >>> df.loc(axis=0)["viper"]
+        max_speed    4
+        shield       5
+        Name: viper, dtype: int64
+
+        >>> df.loc(axis=1)["shield"]
+        cobra         2
+        viper         5
+        sidewinder    8
+        Name: shield, dtype: int64
 
         **Setting values**
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -730,7 +730,9 @@ def merge_asof(
     -------
     DataFrame
         A DataFrame of the two merged objects, containing all rows from the
-        left DataFrame and the nearest matches from the right DataFrame.
+        left DataFrame and the nearest matches from the right DataFrame. The
+        key column holds the left DataFrame's values; the right DataFrame's
+        key column is retained only if it has a different name.
 
     See Also
     --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2514,6 +2514,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         Series.duplicated : Related method on Series, indicating duplicate
             Series values.
         Series.unique : Return unique values as an array.
+        Index.duplicated : Indicate duplicate index values.
 
         Examples
         --------
@@ -2559,6 +2560,18 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         1       cow
         3    beetle
         5     hippo
+        Name: animal, dtype: str
+
+        Only the values are considered, not the index. To drop entries with a
+        duplicate index label, use :meth:`Index.duplicated` with boolean
+        indexing.
+
+        >>> s.index = ["a", "b", "b", "c", "c", "d"]
+        >>> s[~s.index.duplicated(keep="first")]
+        a     llama
+        b       cow
+        c    beetle
+        d     hippo
         Name: animal, dtype: str
         """
         inplace = validate_bool_kwarg(inplace, "inplace")

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -511,6 +511,11 @@ class StringMethods(NoNewAttributesMixin):
             Series/Index/DataFrame in `others` (objects without an index need
             to match the length of the calling Series/Index). To disable
             alignment, use `.values` on any Series/Index/DataFrame in `others`.
+            Note: when the caller is an :class:`Index`, its *values* are used
+            as the index for alignment, so a ``Series`` or ``DataFrame`` in
+            `others` is aligned against those values rather than positionally.
+            An ``Index`` or ``np.ndarray`` in `others` has no index of its own
+            and is always used positionally.
 
         Returns
         -------
@@ -599,6 +604,19 @@ class StringMethods(NoNewAttributesMixin):
         4    -e
         2    -c
         dtype: str
+
+        When the caller is an :class:`Index`, alignment uses the values of that
+        ``Index``, so concatenating with a ``Series`` whose index is unrelated
+        gives missing values:
+
+        >>> idx = pd.Index(["a", "b", "c"])
+        >>> idx.str.cat(pd.Series(["x", "y", "z"]))
+        Index([nan, nan, nan], dtype='object')
+
+        Use ``.to_numpy()`` (or ``.values``) to concatenate positionally:
+
+        >>> idx.str.cat(pd.Series(["x", "y", "z"]).to_numpy())
+        Index(['ax', 'by', 'cz'], dtype='str')
 
         For more examples, see :ref:`here <text.concatenate>`.
         """


### PR DESCRIPTION
closes #53279
closes #46414
closes #35556
closes #47813
closes #49254

A batch of targeted documentation fixes for long-standing issues. No behavior changes.

- **merge_asof** (GH-53279): the user guide said the match is the last right row whose key is "less than" the left's, but the default `allow_exact_matches=True` includes exact matches. Also documents that the result's key column holds the *left* frame's values and the right key column survives only under a different name — which is what the reporter was actually seeing. Note the retention rule is purely name-based, not a difference between `on` and `left_on`/`right_on` as suggested later in that thread, and it matches `pd.merge`'s convention, so it appears intended rather than a bug.
- **replace** (GH-46414): documents that a dict key matches the whole value unless `regex=True`, and how overlapping entries interact — which entries fire is decided up front against the original value, but each substitution applies to the running result, so a later entry can rewrite what an earlier one produced.
- **str.cat** (GH-35556): documents that an `Index` caller aligns on its own values, so a `Series`/`DataFrame` in `others` aligns by label while an `Index`/`ndarray` is used positionally — the asymmetry in the original report.
- **drop_duplicates** (GH-47813): notes the index is ignored, with an `Index.duplicated` example on both `Series` and `DataFrame`, per the maintainer's "put the example right in drop_duplicates".
- **loc/iloc** (GH-49254): adds examples of the `(axis=...)` calling convention, as suggested in the thread instead of changing the 10min references. Separately, `at`/`iat` are properties rather than methods, so 10min now uses `:attr:` for them — they were rendering with misleading trailing parens, which was the original complaint.
- **Series.dt.tz_convert** (GH-49297, reference only): adds `Series.dt.*` See Also entries next to the existing `DatetimeIndex` ones. Leaving the issue open, since the maintainer-preferred fix is dynamic docstring editing or inlining, and this only alleviates the symptom.
- **visualization** (GH-58251, reference only): links to the `#plotting-backends` section rather than the whole ecosystem page. The broader asks there are still under discussion.