### PR TITLE
BUG: unique/factorize returning wrong results for non-UTF-8 strings (GH#34550)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -395,6 +395,7 @@ Strings
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
+- Bug in :meth:`Series.unique`, :meth:`Index.unique` and :func:`factorize` on object dtype returning incorrect results when the values were not UTF-8 encodable, e.g. lone surrogates (:issue:`34550`)
 
 Interval
 ^^^^^^^^

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -1179,6 +1179,7 @@ cdef class StringHashTable(HashTable):
             khiter_t k
             bint use_na_value
             bint non_null_na_value
+            list refs = []
 
         if return_inverse:
             labels = np.zeros(n, dtype=np.intp)
@@ -1210,7 +1211,12 @@ cdef class StringHashTable(HashTable):
                 try:
                     v = PyUnicode_AsUTF8(<str>val)
                 except UnicodeEncodeError:
-                    v = PyUnicode_AsUTF8(<str>repr(val))
+                    # GH#34550 val is not utf-8 encodable (e.g. a lone
+                    #  surrogate). Retain the repr in `refs` so the buffer
+                    #  `v` points to outlives the nogil loop below.
+                    val = repr(val)
+                    refs.append(val)
+                    v = PyUnicode_AsUTF8(<str>val)
                 vecs[i] = v
 
         # compute

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -121,6 +121,25 @@ def test_unique_bad_unicode(index_or_series):
         tm.assert_numpy_array_equal(result, expected)
 
 
+@pytest.mark.single_cpu
+def test_unique_distinct_bad_unicode(index_or_series):
+    # GH#34550 distinct non-utf8-encodable values must not collapse together.
+    #  Repeated values can pass even when the underlying buffers dangle.
+    uvals = [chr(0xD800 + i) for i in range(50)]
+    arr = np.empty(len(uvals), dtype=object)
+    arr[:] = uvals
+
+    obj = index_or_series(arr, dtype=object)
+    result = obj.unique()
+
+    assert len(result) == len(uvals)
+    assert set(result) == set(uvals)
+
+    codes, uniques = pd.factorize(arr)
+    tm.assert_numpy_array_equal(codes, np.arange(len(uvals), dtype=np.intp))
+    assert set(uniques) == set(uvals)
+
+
 def test_nunique_dropna(dropna):
     # GH37566
     ser = pd.Series(["yes", "yes", pd.NA, np.nan, None, pd.NaT])


### PR DESCRIPTION
Noticed as an intermittent `test_unique_bad_unicode` failure across a number of unrelated PRs.

`StringHashTable._unique` falls back to `PyUnicode_AsUTF8(<str>repr(val))` for values that are not utf-8 encodable — the GH-34550 path, e.g. lone surrogates. `repr(val)` is a temporary that is freed at the end of the loop iteration, so `vecs[i]` retains a dangling pointer that the subsequent `nogil` khash loop dereferences.

The outcome depends on heap layout, so it surfaces and hides with completely unrelated changes; it showed up on py314 CI at 1cda7d9f (GH-66275, a `read_csv` perf PR that only perturbed allocation patterns).

The existing test uses the *same* surrogate twice, so it can only miss by one — and it passes on some platforms even with the bug present. With *distinct* surrogates the damage is much larger:

```python
vals = [chr(0xD800 + i) for i in range(50)]
arr = np.empty(50, dtype=object); arr[:] = vals

pd.Series(arr, dtype=object).unique()   # -> 1 element, expected 50
pd.factorize(arr)                       # -> 1 unique, all codes 0
```

Silent wrong results rather than a crash, so a green test suite is not evidence of absence. `pd.factorize` is affected identically.

Fix keeps each fallback repr alive for the duration of the function so the UTF-8 buffer outlives the khash loop, and adds a regression test using distinct surrogates. The two neighbouring sites (`lookup`, `map_locations`) are unaffected: there `val` is kept alive by `values` and `na_string_sentinel` is an instance attribute — only the `repr` path creates an unowned temporary.

Same bug family as GH-65244.