### PR TITLE
BUG: merge on NaN-labeled join key produced duplicate columns or raised TypeError for pd.NA (#65899)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -570,6 +570,7 @@ Reshaping
 - :meth:`DataFrame.pivot` and :func:`pivot` now raise an informative ``KeyError`` naming the offending labels when ``index``, ``columns``, or ``values`` are not columns of the frame, instead of a cryptic ``TypeError`` (:issue:`35785`)
 - Bug in :func:`concat` raising ``InvalidIndexError`` when ``keys`` or the concatenated objects' index was an overlapping :class:`IntervalIndex` (:issue:`64825`)
 - Bug in :func:`merge` where merging on a :class:`MultiIndex` containing ``NaN`` values mapped ``NaN`` keys to the last level value instead of ``NaN`` (:issue:`64492`)
+- Bug in :func:`merge` where merging on a NaN-labeled join key (e.g. ``np.nan``, ``pd.NA``, ``pd.NaT``) produced duplicate columns (e.g. ``nan_x`` / ``nan_y``) or raised ``TypeError`` for ``pd.NA`` (:issue:`65899`)
 - Bug in :meth:`DataFrame.combine` raising ``OverflowError`` when the combining function returned a value too large for the columns' common integer dtype (e.g. ``2**64``) instead of keeping the result (:issue:`66394`)
 - Bug in :meth:`DataFrame.melt` where ``var_name`` colliding with an ``id_vars`` column or ``value_name`` silently overwrote the affected column data instead of raising (:issue:`65654`)
 - Bug in :meth:`DataFrame.pivot_table` with ``margins=True`` raising ``TypeError`` when ``values`` has an :class:`ExtensionDtype` that cannot hold ``NA`` (e.g. :class:`IntervalDtype` with an integer subtype) and no ``columns`` were specified (:issue:`55484`)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -24,6 +24,7 @@ from pandas._libs import (
     lib,
 )
 from pandas._libs.lib import is_range_indexer
+from pandas._libs.missing import is_matching_na
 from pandas.errors import MergeError
 from pandas.util._decorators import (
     cache_readonly,
@@ -1252,7 +1253,7 @@ class _MergeOperation:
                 and self.orig_right._is_level_reference(
                     right_key  # type: ignore[arg-type]
                 )
-                and left_key == right_key
+                and (is_matching_na(left_key, right_key) or left_key == right_key)
                 and name not in result.index.names
             ):
                 names_to_restore.append(name)
@@ -1608,7 +1609,9 @@ class _MergeOperation:
                         else:
                             # work-around for merge_asof(right_index=True)
                             right_keys.append(right.index._values)
-                        if lk is not None and lk == rk:  # FIXME: what about other NAs?
+                        if lk is not None and (
+                            is_matching_na(lk, rk) or lk == rk
+                        ):
                             right_drop.append(rk)
                     else:
                         rk = cast("ArrayLike", rk)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1609,9 +1609,7 @@ class _MergeOperation:
                         else:
                             # work-around for merge_asof(right_index=True)
                             right_keys.append(right.index._values)
-                        if lk is not None and (
-                            is_matching_na(lk, rk) or lk == rk
-                        ):
+                        if lk is not None and (is_matching_na(lk, rk) or lk == rk):
                             # Use the actual label stored on ``right`` rather
                             # than ``rk``: the DataFrame constructor normalizes
                             # most NA-like column labels (``pd.NA``, ``None``)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1612,7 +1612,16 @@ class _MergeOperation:
                         if lk is not None and (
                             is_matching_na(lk, rk) or lk == rk
                         ):
-                            right_drop.append(rk)
+                            # Use the actual label stored on ``right`` rather
+                            # than ``rk``: the DataFrame constructor normalizes
+                            # most NA-like column labels (``pd.NA``, ``None``)
+                            # to ``np.nan``, so dropping via ``rk`` would raise
+                            # ``KeyError``. ``get_indexer_for`` accepts any
+                            # NA-like value and returns the matching position.
+                            loc = right.columns.get_indexer_for([rk])
+                            right_drop.append(
+                                right.columns[loc[0]] if loc[0] != -1 else rk
+                            )
                     else:
                         rk = cast("ArrayLike", rk)
                         right_keys.append(rk)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1513,6 +1513,47 @@ class TestMerge:
         with pytest.raises(ValueError, match=re.escape(msg)):
             data1.merge(data2, how="full")
 
+    @pytest.mark.parametrize(
+        "na_value",
+        [np.nan, pd.NA, pd.NaT],
+    )
+    def test_merge_on_na_label(self, na_value):
+        # GH#65899: merging on a NaN/NA-labeled join key produced duplicate
+        # columns (e.g. ``nan_x`` / ``nan_y``) because ``lk == rk`` returned
+        # False for NaN, and raised ``TypeError`` for ``pd.NA`` (whose
+        # ``__eq__`` returns ``pd.NA``, ambiguous in a boolean context).
+        left = DataFrame({na_value: [1, 2, 3], "a": [10, 20, 30]})
+        right = DataFrame({na_value: [1, 2, 3], "b": [40, 50, 60]})
+        result = merge(left, right, left_on=na_value, right_on=na_value)
+
+        # ``pd.NA`` and ``pd.NaT`` get normalized to ``np.nan`` / ``NaT`` when
+        # used as DataFrame column labels; compare on the normalized value.
+        expected_key = left.columns[0]
+        expected = DataFrame(
+            {expected_key: [1, 2, 3], "a": [10, 20, 30], "b": [40, 50, 60]}
+        )
+        tm.assert_frame_equal(result, expected)
+
+    def test_merge_on_na_label_restores_index_level(self):
+        # GH#65899: when the NA-labeled key is an index level in both frames,
+        # ``_maybe_restore_index_levels`` must still recognize the matching NA
+        # labels and restore the index (previously ``left_key == right_key``
+        # returned False for NaN, so the level was dropped instead of restored).
+        left = DataFrame(
+            {"a": [10, 20, 30]},
+            index=Index([1, 2, 3], name=np.nan),
+        )
+        right = DataFrame(
+            {"b": [40, 50, 60]},
+            index=Index([1, 2, 3], name=np.nan),
+        )
+        result = merge(left, right, left_on=np.nan, right_on=np.nan)
+        expected = DataFrame(
+            {"a": [10, 20, 30], "b": [40, 50, 60]},
+            index=Index([1, 2, 3], name=np.nan),
+        )
+        tm.assert_frame_equal(result, expected)
+
 
 def _check_merge(x, y):
     for how in ["inner", "left", "outer"]:


### PR DESCRIPTION
- [x] Closes #65899
- [x] Tests added / passed
- [x] Whatsnew entry added

## Problem

Merging on a NaN-labeled join key (e.g. ``np.nan``, ``pd.NA``, ``pd.NaT`` used as a column label) produced duplicate columns (``nan_x`` / ``nan_y``) or raised ``TypeError: boolean value of NA is ambiguous`` for ``pd.NA``.

Two places in ``merge.py`` used ``==`` to compare key labels, which is unsafe for NA values:

1. ``_get_merge_keys`` (the ``lk == rk`` check guarding ``right_drop.append(rk)``): for ``np.nan``, ``nan == nan`` is ``False``, so the right key was not dropped — producing ``nan_x`` / ``nan_y`` suffixes. For ``pd.NA``, ``pd.NA == pd.NA`` returns ``pd.NA``, which raises ``TypeError`` in a boolean context.

2. ``_maybe_restore_index_levels`` (the ``left_key == right_key`` check): for ``np.nan``-named index levels, the level was not restored even when both frames had the matching NaN label.

The original code already had a ``# FIXME: what about other NAs?`` comment flagging this gap.

## Fix

Replace the bare ``==`` comparisons with ``is_matching_na(a, b) or a == b``. ``is_matching_na`` (from ``pandas._libs.missing``) is the existing pandas helper that compares two scalars for matching NA-ness, treating same-type NAs as equal (e.g. ``np.nan``/``np.nan``, ``pd.NA``/``pd.NA``, ``NaT``/``NaT``) while returning ``False`` for mixed NA types or non-NA values. The ``or a == b`` fallback handles the non-NA case (e.g. string labels) so the normal path is unchanged.

## Behavior after fix

\`\`\`python
>>> left = pd.DataFrame({np.nan: [1, 2, 3], "a": [10, 20, 30]})
>>> right = pd.DataFrame({np.nan: [1, 2, 3], "b": [40, 50, 60]})
>>> pd.merge(left, right, left_on=np.nan, right_on=np.nan)
   NaN   a   b
0    1  10  40
1    2  20  50
2    3  30  60
\`\`\`

Previously this returned columns ``[nan, nan_x, a, nan_y, b]`` (np.nan case) or raised ``TypeError`` (pd.NA case).

## Tests

- ``test_merge_on_na_label``: parametrized over ``[np.nan, pd.NA, pd.NaT]`` covering both the duplicate-columns (np.nan) and TypeError (pd.NA) regressions.
- ``test_merge_on_na_label_restores_index_level``: covers the ``_maybe_restore_index_levels`` path where the NA-named key is an index level in both frames.