### PR TITLE
BUG: fix mask order mismatch with values for nanskew and nankurt

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -5,6 +5,7 @@ import itertools
 from typing import (
     TYPE_CHECKING,
     Any,
+    Literal,
     cast,
 )
 import warnings
@@ -1321,8 +1322,9 @@ def nanskew(
 
     result: npt.NDArray[np.floating] | np.floating
     if axis is None or (values.ndim == 1 and axis == 0):
+        order: Literal["F", "C"] = "F" if values.flags.f_contiguous else "C"
         result_float = libalgos.scalar_skew(
-            values.ravel("K"), skipna, mask.ravel("K") if mask is not None else None
+            values.ravel(order), skipna, mask.ravel(order) if mask is not None else None
         )
         result = np.float64(result_float)
     elif axis in {0, 1}:
@@ -1378,8 +1380,9 @@ def nankurt(
 
     result: npt.NDArray[np.floating] | np.floating
     if axis is None or (values.ndim == 1 and axis == 0):
+        order: Literal["F", "C"] = "F" if values.flags.f_contiguous else "C"
         result_float = libalgos.scalar_kurt(
-            values.ravel("K"), skipna, mask.ravel("K") if mask is not None else None
+            values.ravel(order), skipna, mask.ravel(order) if mask is not None else None
         )
         result = np.float64(result_float)
     elif axis in {0, 1}:

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -182,6 +182,29 @@ def arr_nan_float1_1d(arr_nan_float1):
     return arr_nan_float1[:, 0]
 
 
+@pytest.fixture(
+    params=[
+        "nanany",
+        "nanall",
+        "nansum",
+        "nanmean",
+        "nanmedian",
+        "nanstd",
+        "nanvar",
+        "nansem",
+        "nanargmax",
+        "nanargmin",
+        "nanmax",
+        "nanmin",
+        "nanskew",
+        "nankurt",
+        "nanprod",
+    ]
+)
+def nanops_univariate_methods(request):
+    return request.param
+
+
 class TestnanopsDataFrame:
     def setup_method(self):
         nanops._USE_BOTTLENECK = False
@@ -1301,28 +1324,9 @@ def test_numpy_ops(numpy_op, expected):
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    "operation",
-    [
-        nanops.nanany,
-        nanops.nanall,
-        nanops.nansum,
-        nanops.nanmean,
-        nanops.nanmedian,
-        nanops.nanstd,
-        nanops.nanvar,
-        nanops.nansem,
-        nanops.nanargmax,
-        nanops.nanargmin,
-        nanops.nanmax,
-        nanops.nanmin,
-        nanops.nanskew,
-        nanops.nankurt,
-        nanops.nanprod,
-    ],
-)
-def test_nanops_independent_of_mask_param(operation):
+def test_nanops_independent_of_mask_param(nanops_univariate_methods):
     # GH22764
+    operation = getattr(nanops, nanops_univariate_methods)
     ser = Series([1, 2, np.nan, 3, np.nan, 4])
     mask = ser.isna()
     median_expected = operation(ser._values)
@@ -1538,3 +1542,43 @@ def test_idxminmax_float_inf_tie():
     assert df.idxmin().tolist() == [1, 0]
     assert df["a"].idxmax() == 1
     assert df["a"].idxmin() == 1
+
+
+@pytest.mark.parametrize("axis", [0, 1, None])
+def test_nanops_fortran_layout_mask_mismatch(
+    disable_bottleneck, nanops_univariate_methods, axis
+):
+    func = getattr(nanops, nanops_univariate_methods)
+    arr_f = np.array(
+        [[1.0, np.nan, 2.0, 5.0], [3.0, 4.0, 5.0, 6.0]],
+        dtype=np.float32,
+        order="F",
+    )
+    mask_f = np.isnan(arr_f)
+
+    arr_c = arr_f.copy(order="C")
+    mask_c = mask_f.copy(order="C")
+
+    res_f = func(arr_f, axis=axis, mask=mask_f)
+    res_c = func(arr_c, axis=axis, mask=mask_c)
+
+    tm.assert_almost_equal(res_f, res_c)
+
+
+@pytest.mark.parametrize("axis", [0, 1, None])
+def test_nanops_mismatched_mask_layout(
+    disable_bottleneck, nanops_univariate_methods, axis
+):
+    func = getattr(nanops, nanops_univariate_methods)
+    arr_f = np.array(
+        [[1.0, np.nan, 2.0, 5.0], [3.0, 4.0, 5.0, 6.0]],
+        dtype=np.float64,
+        order="F",
+    )
+    mask_c = np.isnan(arr_f).copy(order="C")
+    mask_f = np.isnan(arr_f).copy(order="F")
+
+    res_mismatched = func(arr_f, axis=axis, mask=mask_c)
+    res_matched = func(arr_f, axis=axis, mask=mask_f)
+
+    tm.assert_almost_equal(res_mismatched, res_matched)

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1544,41 +1544,32 @@ def test_idxminmax_float_inf_tie():
     assert df["a"].idxmin() == 1
 
 
-@pytest.mark.parametrize("axis", [0, 1, None])
-def test_nanops_fortran_layout_mask_mismatch(
-    disable_bottleneck, nanops_univariate_methods, axis
-):
-    func = getattr(nanops, nanops_univariate_methods)
-    arr_f = np.array(
-        [[1.0, np.nan, 2.0, 5.0], [3.0, 4.0, 5.0, 6.0]],
-        dtype=np.float32,
-        order="F",
-    )
-    mask_f = np.isnan(arr_f)
+def _copy_array_with_layout(arr, layout):
+    if layout == "strided":
+        base = np.zeros((arr.shape[0], arr.shape[1] * 2), dtype=arr.dtype)
+        base[:, ::2] = arr
+        return base[:, ::2]
 
-    arr_c = arr_f.copy(order="C")
-    mask_c = mask_f.copy(order="C")
-
-    res_f = func(arr_f, axis=axis, mask=mask_f)
-    res_c = func(arr_c, axis=axis, mask=mask_c)
-
-    tm.assert_almost_equal(res_f, res_c)
+    return arr.copy(order=layout)
 
 
 @pytest.mark.parametrize("axis", [0, 1, None])
-def test_nanops_mismatched_mask_layout(
-    disable_bottleneck, nanops_univariate_methods, axis
+@pytest.mark.parametrize("arr_layout", ["C", "F", "strided"])
+@pytest.mark.parametrize("mask_layout", ["C", "F", "strided"])
+def test_mask_memory_layout_mismatch(
+    disable_bottleneck, nanops_univariate_methods, axis, arr_layout, mask_layout
 ):
     func = getattr(nanops, nanops_univariate_methods)
-    arr_f = np.array(
-        [[1.0, np.nan, 2.0, 5.0], [3.0, 4.0, 5.0, 6.0]],
-        dtype=np.float64,
-        order="F",
-    )
-    mask_c = np.isnan(arr_f).copy(order="C")
-    mask_f = np.isnan(arr_f).copy(order="F")
 
-    res_mismatched = func(arr_f, axis=axis, mask=mask_c)
-    res_matched = func(arr_f, axis=axis, mask=mask_f)
+    rng = np.random.default_rng(2)
+    base_arr = rng.random((6, 5))
+    base_arr[0, 1] = np.nan
+    base_mask = np.isnan(base_arr)
 
-    tm.assert_almost_equal(res_mismatched, res_matched)
+    arr = _copy_array_with_layout(base_arr, arr_layout)
+    mask = _copy_array_with_layout(base_mask, mask_layout)
+
+    expected = func(base_arr, axis=axis, mask=base_mask)
+    result = func(arr, axis=axis, mask=mask)
+
+    tm.assert_almost_equal(result, expected)


### PR DESCRIPTION
Problem identified by @jbrockmendel in https://github.com/pandas-dev/pandas/pull/66302#discussion_r3618790447.

It's possible that row order between `values` and `mask` for `nanskew` and `nankurt` is different, making `np.ravel("K")` mismatch the indices.

---

- [ ] xref #66302 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`. 