### PR TITLE
DOC: Fix plural mistakes in 10 minutes to pandas guide

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -250,7 +250,7 @@ Select via the position of the passed integers:
 
    df.iloc[3]
 
-Integer slices acts similar to NumPy/Python:
+Integer slices act similar to NumPy/Python:
 
 .. ipython:: python
 
@@ -641,7 +641,7 @@ financial applications. See the :ref:`Time Series section <timeseries>`.
    ts_utc = ts.tz_localize("UTC")
    ts_utc
 
-:meth:`Series.tz_convert` converts a timezones aware time series to another time zone:
+:meth:`Series.tz_convert` converts a timezone aware time series to another time zone:
 
 .. ipython:: python
 


### PR DESCRIPTION
Fixes:
Line 253: change "acts" to "act."
Line 644: change "timezones aware" to "timezone aware," to match how pandas refers to this elsewhere (tz_localize, tz_aware).

- [x] closes #66413
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
