### PR TITLE
BUG: read_csv c-engine truncated strings at an embedded NUL byte

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -479,6 +479,7 @@ I/O
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where a ``defaultdict`` passed as ``dtype`` did not apply its default to columns not explicitly listed (:issue:`41574`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where an empty ``usecols`` (e.g. ``usecols=[]``) was ignored and returned all columns instead of an empty frame, unlike the other engines (:issue:`66056`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where passing tuples in ``names`` produced flat columns instead of :class:`MultiIndex` columns as with the other engines (:issue:`65862`)
+- Fixed bug in :func:`read_csv` with the ``c`` engine where a quoted field containing an embedded NUL byte was silently truncated at the NUL under the default string dtype or ``dtype_backend="pyarrow"`` (:issue:`66415`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug in :func:`read_excel` with the ``openpyxl`` engine where reading a sheet set its ``max_row`` and ``max_column`` to ``None`` on the workbook exposed through ``ExcelFile.book`` (:issue:`63010`)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -2514,6 +2514,7 @@ cdef _string_pyarrow_utf8(parser_t *parser, int64_t col,
         Py_ssize_t i, lines
         Py_ssize_t total_bytes = 0
         int64_t wlen, seg
+        c_int64_t token_idx = 0
         coliter_t it
         const char *word = NULL
         ndarray[int32_t, ndim=1] offsets32
@@ -2558,7 +2559,7 @@ cdef _string_pyarrow_utf8(parser_t *parser, int64_t col,
     coliter_setup(&it, parser, col, line_start)
     with nogil:
         for i in range(lines):
-            word = coliter_next(&it)
+            word = coliter_next_with_idx(&it, &token_idx)
 
             if na_filter and kh_get_str_starts_item(na_hashset, word):
                 na_count += 1
@@ -2569,7 +2570,9 @@ cdef _string_pyarrow_utf8(parser_t *parser, int64_t col,
                     offsets32_ptr[i + 1] = <int32_t>total_bytes
                 continue
 
-            wlen = strlen(word)
+            # _token_len, not strlen: an embedded NUL is a data byte here, so
+            # strlen would truncate the field at it (GH#66277).
+            wlen = _token_len(parser, token_idx)
 
             if not large and total_bytes + wlen > <Py_ssize_t>INT32_MAX:
                 overflow = True

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -775,3 +775,16 @@ def test_string_storage_python_consistent(c_parser_only):
         assert isinstance(arr.dtype, StringDtype)
         assert arr.dtype.storage == "python"
         assert type(arr) is arr.dtype.construct_array_type()
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"dtype_backend": "pyarrow"}])
+def test_embedded_nul_byte_roundtrip(c_parser_only, kwargs):
+    # GH#66277: the pyarrow string fast path computed token lengths with
+    # strlen, so a quoted field with an embedded NUL byte was truncated at the
+    # NUL instead of matching the object path
+    pytest.importorskip("pyarrow")
+    parser = c_parser_only
+    result = parser.read_csv(BytesIO(b'a\n"x\x00y"\n'), **kwargs)
+    expected = parser.read_csv(BytesIO(b'a\n"x\x00y"\n'), dtype=object)
+    assert result["a"][0] == "x\x00y"
+    assert expected["a"][0] == "x\x00y"


### PR DESCRIPTION
Discovered while reviewing GH-66277. The ``c``-engine pyarrow string fast path (`_string_pyarrow_utf8`) computed each field's length with `strlen`, which stops at the first NUL byte. A quoted field containing an embedded NUL was therefore truncated at the NUL under the default string dtype or `dtype_backend="pyarrow"`, silently disagreeing with the object path:

```python
>>> pd.read_csv(BytesIO(b'a\n"x\x00y"\n'))["a"][0]
'x'                     # should be 'x\x00y'
>>> pd.read_csv(BytesIO(b'a\n"x\x00y"\n'), dtype=object)["a"][0]
'x\x00y'
```

The fix uses `_token_len`, which derives the length from the tokenizer's word offsets, matching the integer and datetime fast paths (the datetime path already carries a `_token_len, not strlen` comment for exactly this reason). No separate issue was filed; splitting this out of GH-66277 so the data-correctness fix can land on its own.
