### PR TITLE
BLD: build window extensions against strict C++ standard libraries (GH#51047)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -50,6 +50,7 @@ Other enhancements
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
 - Improved type inference of comparison and arithmetic operators on :class:`Series` and :class:`DataFrame` for static type checkers (e.g. ``ser == "a"`` is now inferred as :class:`Series` instead of ``Any``) (:issue:`40762`)
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)
+- Building from source no longer fails when compiling the windowing extensions against C++ standard libraries that provide only ``std::signbit`` (:issue:`50979`, :issue:`51047`)
 - Setting values with :meth:`DataFrame.at` or :meth:`Series.at` using a non-scalar indexer (e.g. a boolean mask, list, or array) now raises a clearer ``InvalidIndexError`` directing users to ``.loc`` (:issue:`51866`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -1,9 +1,7 @@
 # cython: boundscheck=False, wraparound=False, cdivision=True
 
-from libc.math cimport (
-    fabs,
-    signbit,
-)
+from libc.math cimport fabs
+from libcpp.cmath cimport signbit
 from libcpp.deque cimport deque
 from libcpp.stack cimport stack
 from libcpp.unordered_map cimport unordered_map


### PR DESCRIPTION
closes #51047
closes #50979

`aggregations.pyx` is compiled as C++. Pulling in `<complex>` includes `<cmath>`, which per the standard undefines the C99 `signbit` macro — leaving no global `::signbit` on conforming standard libraries and breaking the build. Import `signbit` from `libcpp.cmath` so `std::signbit` is used explicitly. `fabs` stays on `libc.math`; it is an ordinary function, not a macro, so `<cmath>` does not affect it.

This also resolves GH-50979: PR GH-45008 deleted the vendored `cmath` shim whose non-MSVC `#else` branch did `#include <cmath>`, and `std::signbit` covers that path's intent (including the z/OS branch) without restoring the header.

Verified: the module compiles as C++ and the full window `var`/`std`/`mean` test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
