### PR TITLE
BLD: invoke generate_version.py through the interpreter (GH#64272)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -45,6 +45,7 @@ Other enhancements
 - Added :meth:`ExtensionArray.sort` for in-place sorting of :class:`ExtensionArray` (:issue:`64977`)
 - Added :meth:`Index.replace` method to support value replacement functionality similar to :meth:`Series.replace` (:issue:`19495`)
 - Added reduction methods as public API on pandas-implemented extension arrays where applicable (:issue:`63512`)
+- Building from source no longer fails on a checkout with CRLF line endings, such as under WSL (:issue:`64272`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,12 @@ project(
     'c',
     'cpp',
     'cython',
-    version: run_command(['generate_version.py', '--print'], check: true).stdout().strip(),
+    version: run_command(
+        find_program('python3', 'python'),
+        'generate_version.py',
+        '--print',
+        check: true,
+    ).stdout().strip(),
     license: 'BSD-3',
     meson_version: '>=1.2.3',
     default_options: [


### PR DESCRIPTION
closes #64272

`meson.build` computed the project version by running `generate_version.py` and relying on its shebang. On a checkout with CRLF line endings (e.g. under WSL), `/usr/bin/env` sees `python3\r` and the build fails with exit 127. Invoke the interpreter explicitly via `find_program('python3', 'python')`, matching the other eight script invocations in the build.

Supersedes the stale-closed PR GH-64275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
