### PR TITLE
TST: check data file existence instead of directory in parser fixtures (GH#39321)

### DIFF
--- a/pandas/tests/io/parser/common/test_common_basic.py
+++ b/pandas/tests/io/parser/common/test_common_basic.py
@@ -658,9 +658,9 @@ def test_whitespace_regex_separator(all_parsers, data, expected):
     tm.assert_frame_equal(result, expected)
 
 
-def test_sub_character(all_parsers, csv_dir_path):
+def test_sub_character(all_parsers, datapath):
     # see gh-16893
-    filename = os.path.join(csv_dir_path, "sub_char.csv")
+    filename = datapath("io", "parser", "data", "sub_char.csv")
     expected = DataFrame([[1, 2, 3]], columns=["a", "\x1ab", "c"])
 
     parser = all_parsers

--- a/pandas/tests/io/parser/common/test_file_buffer_url.py
+++ b/pandas/tests/io/parser/common/test_file_buffer_url.py
@@ -38,11 +38,11 @@ skip_pyarrow = pytest.mark.usefixtures("pyarrow_skip")
 
 @pytest.mark.network
 @pytest.mark.single_cpu
-def test_url(all_parsers, csv_dir_path, httpserver):
+def test_url(all_parsers, datapath, httpserver):
     parser = all_parsers
     kwargs = {"sep": "\t"}
 
-    local_path = os.path.join(csv_dir_path, "salaries.csv")
+    local_path = datapath("io", "parser", "data", "salaries.csv")
     with open(local_path, encoding="utf-8") as f:
         httpserver.serve_content(content=f.read())
 
@@ -53,11 +53,11 @@ def test_url(all_parsers, csv_dir_path, httpserver):
 
 
 @pytest.mark.slow
-def test_local_file(all_parsers, csv_dir_path):
+def test_local_file(all_parsers, datapath):
     parser = all_parsers
     kwargs = {"sep": "\t"}
 
-    local_path = os.path.join(csv_dir_path, "salaries.csv")
+    local_path = datapath("io", "parser", "data", "salaries.csv")
     local_result = parser.read_csv(local_path, **kwargs)
     url = "file://localhost/" + local_path
 
@@ -451,8 +451,8 @@ def test_file_descriptor_leak(all_parsers, temp_file):
         parser.read_csv(path)
 
 
-def test_memory_map(all_parsers, csv_dir_path):
-    mmap_file = os.path.join(csv_dir_path, "test_mmap.csv")
+def test_memory_map(all_parsers, datapath):
+    mmap_file = datapath("io", "parser", "data", "test_mmap.csv")
     parser = all_parsers
 
     expected = DataFrame(

--- a/pandas/tests/io/parser/common/test_index.py
+++ b/pandas/tests/io/parser/common/test_index.py
@@ -5,7 +5,6 @@ specific classification into the other test modules.
 
 from datetime import datetime
 from io import StringIO
-import os
 
 import pytest
 
@@ -251,9 +250,9 @@ bar,12,13,14,15
 
 
 @skip_pyarrow
-def test_read_csv_no_index_name(all_parsers, csv_dir_path):
+def test_read_csv_no_index_name(all_parsers, datapath):
     parser = all_parsers
-    csv2 = os.path.join(csv_dir_path, "test2.csv")
+    csv2 = datapath("io", "parser", "data", "test2.csv")
     result = parser.read_csv(csv2, index_col=0, parse_dates=True)
 
     expected = DataFrame(

--- a/pandas/tests/io/parser/common/test_read_errors.py
+++ b/pandas/tests/io/parser/common/test_read_errors.py
@@ -6,7 +6,6 @@ specific classification into the other test modules.
 import codecs
 import csv
 from io import StringIO
-import os
 from pathlib import Path
 
 import numpy as np
@@ -68,13 +67,13 @@ def test_empty_sep(pyarrow_parser_only):
         parser.read_csv(StringIO(data), sep="")
 
 
-def test_bad_stream_exception(all_parsers, csv_dir_path):
+def test_bad_stream_exception(all_parsers, datapath):
     # see gh-13652
     #
     # This test validates that both the Python engine and C engine will
     # raise UnicodeDecodeError instead of C engine raising ParserError
     # and swallowing the exception that caused read to fail.
-    path = os.path.join(csv_dir_path, "sauron.SHIFT_JIS.csv")
+    path = datapath("io", "parser", "data", "sauron.SHIFT_JIS.csv")
     codec = codecs.lookup("utf-8")
     utf8 = codecs.lookup("utf-8")
     parser = all_parsers

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -96,14 +96,6 @@ class PyArrowParser(BaseParser):
 
 
 @pytest.fixture
-def csv_dir_path(datapath):
-    """
-    The directory path to the data files needed for parser tests.
-    """
-    return datapath("io", "parser", "data")
-
-
-@pytest.fixture
 def csv1(datapath):
     """
     The path to the data file "test1.csv" needed for parser tests.

--- a/pandas/tests/io/parser/dtypes/test_categorical.py
+++ b/pandas/tests/io/parser/dtypes/test_categorical.py
@@ -4,7 +4,6 @@ for all of the parsers defined in parsers.py
 """
 
 from io import StringIO
-import os
 
 import numpy as np
 import pytest
@@ -133,9 +132,9 @@ def test_categorical_dtype_high_cardinality_numeric(all_parsers, monkeypatch):
     tm.assert_frame_equal(actual, expected)
 
 
-def test_categorical_dtype_utf16(all_parsers, csv_dir_path):
+def test_categorical_dtype_utf16(all_parsers, datapath):
     # see gh-10153
-    pth = os.path.join(csv_dir_path, "utf16_ex.txt")
+    pth = datapath("io", "parser", "data", "utf16_ex.txt")
     parser = all_parsers
     encoding = "utf-16"
     sep = "\t"
@@ -202,9 +201,9 @@ def test_categorical_dtype_chunksize_explicit_categories(all_parsers):
             tm.assert_frame_equal(actual, expected)
 
 
-def test_categorical_dtype_latin1(all_parsers, csv_dir_path):
+def test_categorical_dtype_latin1(all_parsers, datapath):
     # see gh-10153
-    pth = os.path.join(csv_dir_path, "unicode_series.csv")
+    pth = datapath("io", "parser", "data", "unicode_series.csv")
     parser = all_parsers
     encoding = "latin-1"
 

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -12,7 +12,6 @@ from io import (
     TextIOWrapper,
 )
 import mmap
-import os
 import tarfile
 
 import numpy as np
@@ -549,14 +548,14 @@ def test_buffer_rd_bytes_bad_unicode(c_parser_only):
 
 
 @pytest.mark.parametrize("tar_suffix", [".tar", ".tar.gz"])
-def test_read_tarfile(c_parser_only, csv_dir_path, tar_suffix):
+def test_read_tarfile(c_parser_only, datapath, tar_suffix):
     # see gh-16530
     #
     # Unfortunately, Python's CSV library can't handle
     # tarfile objects (expects string, not bytes when
     # iterating through a file-like).
     parser = c_parser_only
-    tar_path = os.path.join(csv_dir_path, "tar_csv" + tar_suffix)
+    tar_path = datapath("io", "parser", "data", "tar_csv" + tar_suffix)
 
     with tarfile.open(tar_path, "r") as tar:
         data_file = tar.extractfile("tar_data.csv")

--- a/pandas/tests/io/parser/test_compression.py
+++ b/pandas/tests/io/parser/test_compression.py
@@ -3,7 +3,6 @@ Tests compressed data parsing functionality for all
 of the parsers defined in parsers.py
 """
 
-import os
 from pathlib import Path
 import tarfile
 import zipfile
@@ -142,11 +141,11 @@ def test_infer_compression(all_parsers, csv1, buffer, ext):
     tm.assert_frame_equal(result, expected)
 
 
-def test_compression_utf_encoding(all_parsers, csv_dir_path, utf_value, encoding_fmt):
+def test_compression_utf_encoding(all_parsers, datapath, utf_value, encoding_fmt):
     # see gh-18071, gh-24130
     parser = all_parsers
     encoding = encoding_fmt.format(utf_value)
-    path = os.path.join(csv_dir_path, f"utf{utf_value}_ex_small.zip")
+    path = datapath("io", "parser", "data", f"utf{utf_value}_ex_small.zip")
 
     result = parser.read_csv(path, encoding=encoding, compression="zip", sep="\t")
     expected = DataFrame(
@@ -170,9 +169,9 @@ def test_invalid_compression(all_parsers, invalid_compression):
         parser.read_csv("test_file.zip", **compress_kwargs)
 
 
-def test_compression_tar_archive(all_parsers, csv_dir_path):
+def test_compression_tar_archive(all_parsers, datapath):
     parser = all_parsers
-    path = os.path.join(csv_dir_path, "tar_csv.tar.gz")
+    path = datapath("io", "parser", "data", "tar_csv.tar.gz")
     df = parser.read_csv(path)
     assert list(df.columns) == ["a"]
 

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -7,7 +7,6 @@ from io import (
     BytesIO,
     TextIOWrapper,
 )
-import os
 import tempfile
 
 import numpy as np
@@ -74,15 +73,15 @@ A,B,C
     tm.assert_frame_equal(result, expected)
 
 
-def test_utf16_example(all_parsers, csv_dir_path):
-    path = os.path.join(csv_dir_path, "utf16_ex.txt")
+def test_utf16_example(all_parsers, datapath):
+    path = datapath("io", "parser", "data", "utf16_ex.txt")
     parser = all_parsers
     result = parser.read_csv(path, encoding="utf-16", sep="\t")
     assert len(result) == 50
 
 
-def test_unicode_encoding(all_parsers, csv_dir_path):
-    path = os.path.join(csv_dir_path, "unicode_series.csv")
+def test_unicode_encoding(all_parsers, datapath):
+    path = datapath("io", "parser", "data", "unicode_series.csv")
     parser = all_parsers
 
     result = parser.read_csv(path, header=None, encoding="latin-1")


### PR DESCRIPTION
closes #39321

Parser test data is intentionally excluded from the sdist. The `csv_dir_path` fixture returned the *directory* (which ships, empty), so `datapath`'s existence check passed and tests then failed confusingly deep inside on the missing file.

Convert the callers to `datapath("io", "parser", "data", <file>)`, which checks the file itself — raising a clear error under the default strict mode and skipping under `--no-strict-data-files`. The now-unused `csv_dir_path` fixture and six stale `import os` lines are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
