### PR TITLE
Update doc styler na rep

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -749,7 +749,10 @@ styler_thousands = """
 
 styler_na_rep = """
 : str, optional
-    The string representation for values identified as missing.
+    The string representation for values identified as missing, used as the
+    default in :meth:`.Styler.format`. This option does not affect the
+    string representation of missing values when a Series or DataFrame is
+    printed.
 """
 
 styler_escape = """


### PR DESCRIPTION
Closes #66407

Clarifies that the `styler.format.na_rep` option only affects Styler
rendering (`.style` output) and does not affect the string representation
used when printing a Series or DataFrame, per @rhshadrach's comment on
the issue.

- [x] No functional change; docstring update only