### PR TITLE
TST: relax exact-equality asserts in test_autocorr (GH#65502)

### DIFF
--- a/pandas/tests/series/methods/test_autocorr.py
+++ b/pandas/tests/series/methods/test_autocorr.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+import pandas._testing as tm
+
 
 class TestAutoCorr:
     def test_autocorr(self, datetime_series):
@@ -14,7 +16,10 @@ class TestAutoCorr:
             assert np.isnan(corr1)
             assert np.isnan(corr2)
         else:
-            assert corr1 == corr2
+            # Not exact equality: the dot-product Pearson kernel (GH#65502) is not
+            # bit-reproducible across calls on threaded BLAS (e.g. Accelerate), so
+            # compare with a tolerance rather than ``==``.
+            tm.assert_almost_equal(corr1, corr2)
 
         # Choose a random lag between 1 and length of Series - 2
         # and compare the result with the Series corr() function
@@ -27,4 +32,4 @@ class TestAutoCorr:
             assert np.isnan(corr1)
             assert np.isnan(corr2)
         else:
-            assert corr1 == corr2
+            tm.assert_almost_equal(corr1, corr2)


### PR DESCRIPTION
Since GH-65502 (merged 2026-07-17), `Series.corr(method="pearson")` computes the correlation from three separate `np.dot` reductions instead of `np.corrcoef`. On threaded BLAS — notably macOS Accelerate, which numpy 2.x links — those reductions are not bit-reproducible across calls, so two identical `Series.autocorr()` invocations can differ by ~1 ULP.

`test_autocorr` asserted exact `corr1 == corr2` between two such computations, so it fails on the macOS x86_64 wheel builds — reddening the wheel job on every build-touching PR (and the scheduled `wheels.yml` on `main`). It is the sole failure in those runs (`1 failed, 171080 passed`).

This relaxes both asserts to `tm.assert_almost_equal`. The test's intent — that the default `lag` matches `lag=1`, and that `autocorr(lag=n)` matches `corr(shift(n))` — is unchanged; only the spurious bit-exact comparison is dropped.

Note: this makes explicit that GH-65502 traded bit-reproducibility of `Series.corr` for speed (an unremarked side effect at the time). The result remains correct to full double precision; only the last bit varies run-to-run on non-deterministic BLAS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
