### PR TITLE
TST: Use assert_almost_equal in test_autocorr

### DIFF
--- a/pandas/tests/series/methods/test_autocorr.py
+++ b/pandas/tests/series/methods/test_autocorr.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+import pandas._testing as tm
+
 
 class TestAutoCorr:
     def test_autocorr(self, datetime_series):
@@ -14,7 +16,7 @@ class TestAutoCorr:
             assert np.isnan(corr1)
             assert np.isnan(corr2)
         else:
-            assert corr1 == corr2
+            assert tm.assert_almost_equal(corr1, corr2)
 
         # Choose a random lag between 1 and length of Series - 2
         # and compare the result with the Series corr() function
@@ -27,4 +29,4 @@ class TestAutoCorr:
             assert np.isnan(corr1)
             assert np.isnan(corr2)
         else:
-            assert corr1 == corr2
+            assert tm.assert_almost_equal(corr1, corr2)


### PR DESCRIPTION
Possibly recent failure in wheel tests e.g. https://github.com/pandas-dev/pandas/actions/runs/29952937309/job/89035066455

```python
  =================================== FAILURES ===================================
  __________________________ TestAutoCorr.test_autocorr __________________________
  [gw1] darwin -- Python 3.11.9 /private/var/folders/8j/3c4g2vh16vgc8j40cj25qfqh0000gn/T/cibw-run-qrs0f47p/cp311-macosx_x86_64/venv-test-x86_64/bin/python
  
  self = <pandas.tests.series.methods.test_autocorr.TestAutoCorr object at 0x12c65f450>
  datetime_series = 2000-01-03    0.189053
  2000-01-04   -0.522748
  2000-01-05   -0.413064
  2000-01-06   -2.441467
  2000-01-07    1.799707
  200...2-08    2.056703
  2000-02-09   -1.638443
  2000-02-10   -1.729411
  2000-02-11   -1.504831
  Freq: B, Name: ts, dtype: float64
  
      def test_autocorr(self, datetime_series):
          # Just run the function
          corr1 = datetime_series.autocorr()
      
          # Now run it with the lag parameter
          corr2 = datetime_series.autocorr(lag=1)
      
          # corr() with lag needs Series of at least length 2
          if len(datetime_series) <= 2:
              assert np.isnan(corr1)
              assert np.isnan(corr2)
          else:
  >           assert corr1 == corr2
  E           assert np.float64(-0.04203874243403255) == np.float64(-0.04203874243403256)
  
  ../venv-test-x86_64/lib/python3.11/site-packages/pandas/tests/series/methods/test_autocorr.py:17: AssertionError
```