### PR TITLE
BUG: fix str.split/rsplit with pat=None on ArrowDtype leaving empty whitespace tokens (#66368)

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3547,7 +3547,11 @@ class ArrowExtensionArray(
         if n in {-1, 0}:
             n = None
         if pat is None:
-            split_func = pc.utf8_split_whitespace
+            result = self._apply_elementwise(
+                lambda val: val.split() if n is None else val.split(None, n)
+            )
+            chunks = [pa.array(chunk, type=pa.list_(pa.string())) for chunk in result]
+            return self._from_pyarrow_array(pa.chunked_array(chunks))
         elif regex is True:
             split_func = functools.partial(pc.split_pattern_regex, pattern=pat)
         elif regex is False:
@@ -3566,9 +3570,11 @@ class ArrowExtensionArray(
         if n in {-1, 0}:
             n = None
         if pat is None:
-            return self._from_pyarrow_array(
-                pc.utf8_split_whitespace(self._pa_array, max_splits=n, reverse=True)
+            result = self._apply_elementwise(
+                lambda val: val.rsplit() if n is None else val.rsplit(None, n)
             )
+            chunks = [pa.array(chunk, type=pa.list_(pa.string())) for chunk in result]
+            return self._from_pyarrow_array(pa.chunked_array(chunks))
         return self._from_pyarrow_array(
             pc.split_pattern(self._pa_array, pat, max_splits=n, reverse=True)
         )

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -2429,6 +2429,47 @@ def test_str_split_pat_none(method):
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("method", ["rsplit", "split"])
+def test_str_split_pat_none_whitespace(method):
+    # GH 66368 — str.split() on ArrowDtype must match Python str.split()
+    # behavior: strip leading/trailing empty strings from whitespace split
+    ser = pd.Series(
+        ["  hi  there ", "", " ", "a b c", None],
+        dtype=ArrowDtype(pa.string()),
+    )
+    result = getattr(ser.str, method)()
+    expected = pd.Series(
+        ArrowExtensionArray(pa.array([["hi", "there"], [], [], ["a", "b", "c"], None]))
+    )
+    tm.assert_series_equal(result, expected)
+
+
+def test_str_split_pat_none_n():
+    # GH 66368 — max_splits (n) with pat=None on ArrowDtype
+    ser = pd.Series(
+        ["a b c d", "  hi  there  "],
+        dtype=ArrowDtype(pa.string()),
+    )
+    result = ser.str.split(n=1)
+    expected = pd.Series(
+        ArrowExtensionArray(pa.array([["a", "b c d"], ["hi", "there  "]]))
+    )
+    tm.assert_series_equal(result, expected)
+
+
+def test_str_rsplit_pat_none_n():
+    # GH 66368 — max_splits (n) with pat=None on ArrowDtype (right split)
+    ser = pd.Series(
+        ["a b c d", "  hi  there  "],
+        dtype=ArrowDtype(pa.string()),
+    )
+    result = ser.str.rsplit(n=1)
+    expected = pd.Series(
+        ArrowExtensionArray(pa.array([["a b c", "d"], ["  hi", "there"]]))
+    )
+    tm.assert_series_equal(result, expected)
+
+
 def test_str_split():
     # GH 52401
     ser = pd.Series(["a1cbcb", "a2cbcb", None], dtype=ArrowDtype(pa.string()))


### PR DESCRIPTION
Fixes str.split()/rsplit() with pat=None on ArrowDtype producing empty-string tokens from leading/trailing/consecutive whitespace instead of matching Python `str.split()` behavior.

**WHY**

`pc.utf8_split_whitespace` splits on *individual* whitespace characters, not on *runs* of whitespace like Python `str.split()`. For `"  hi  there "` it produces `['', 'hi', 'there', '']` instead of `['hi', 'there']`. PyArrow has no compute function that mirrors `str.split()` exactly — `pc.utf8_split_whitespace` collapses consecutive whitespace but leaves boundary empties, while approaches like `utf8_trim_whitespace` + `replace_substring_regex` + `split_pattern` break when `max_splits=n` because the remaining substring must keep its original whitespace.

**HOW**

Delegates the `pat=None` branch to `_apply_elementwise` with Python's `str.split()`/`str.rsplit()`, matching the object-dtype backend's exact behavior. This is the same pattern already used by `_str_rfind`, `_str_translate`, and `_str_wrap` in this file.

**Verify**
```
python -m pytest pandas/tests/extension/test_arrow.py -k "test_str_split_pat_none" -v
```

Fixes #66368
