### PR TITLE
BUG: avoid float64 precision loss in isin for uint64 vs int64 (#59609)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -372,6 +372,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`Series.min`, and :meth:`Series.max` on object-dtype data raising ``TypeError`` when missing values were present alongside values that do not support comparison with ``float`` (e.g. strings or mixed-timezone :class:`Timestamp` objects) (:issue:`65500`)
+- Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` returning incorrect ``True`` matches when comparing signed and unsigned 64-bit integers via a NumPy array for magnitudes above ``2**53``, due to a lossy ``float64`` cast (:issue:`59609`)
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` returning incorrect row labels for nullable ``UInt64`` columns containing missing values alongside values above ``2**53`` (:issue:`64478`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` with ``axis=1`` and ``skipna=False`` returning incorrect column labels for extension array dtypes (e.g. :class:`BooleanDtype`, nullable integer/float, :class:`ArrowDtype`) (:issue:`56903`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -507,6 +507,21 @@ _MINIMUM_COMP_ARR_LEN = 1_000_000
 _FLOAT64_INT_EXACT_MAX = 2**53
 
 
+def _may_lose_int_precision_as_float64(arr: np.ndarray) -> bool:
+    """
+    Return True if casting ``arr`` to float64 could change an integer's identity.
+
+    Used by :func:`isin` to decide when a common float/complex dtype is unsafe
+    (e.g. uint64 vs int64 promoting to float64 for magnitudes > 2**53).
+    """
+    if arr.dtype.kind not in "iu" or arr.dtype.itemsize < 8 or arr.size == 0:
+        return False
+    return (
+        int(arr.min()) < -_FLOAT64_INT_EXACT_MAX
+        or int(arr.max()) > _FLOAT64_INT_EXACT_MAX
+    )
+
+
 def isin(comps: ListLike, values: ListLike) -> npt.NDArray[np.bool_]:
     """
     Compute the isin boolean array.
@@ -683,6 +698,14 @@ def isin(comps: ListLike, values: ListLike) -> npt.NDArray[np.bool_]:
 
     else:
         common = np_find_common_type(values.dtype, comps_array.dtype)
+        if common.kind in "fc" and (
+            _may_lose_int_precision_as_float64(values)
+            or _may_lose_int_precision_as_float64(comps_array)
+        ):
+            # GH#59609 / GH#46485: mismatched signed/unsigned 64-bit integers
+            # (and similar) promote to float64, which is not exact above 2**53.
+            # Compare as Python ints via object dtype instead.
+            common = np.dtype(object)
         values = values.astype(common, copy=False)
         comps_array = comps_array.astype(common, copy=False)
         f = htable.ismember

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1207,6 +1207,44 @@ class TestIsin:
         expected = Series(False)
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "comps_dtype,values_dtype",
+        [
+            (np.uint64, np.int64),
+            (np.int64, np.uint64),
+            ("UInt64", np.int64),
+            ("Int64", np.uint64),
+        ],
+    )
+    def test_isin_uint64_vs_int64_ndarray_no_precision_loss(
+        self, comps_dtype, values_dtype
+    ):
+        # GH#59609: signed/unsigned 64-bit integers promote to float64 as a
+        # common type. Values above 2**53 must not match via that lossy cast
+        # when ``values`` is already an ndarray (the list-like path already
+        # had protection from GH#46485).
+        a = 635554097106142143
+        b = 635554097106142079
+        assert float(a) == float(b)
+
+        ser = Series([a], dtype=comps_dtype)
+        result = ser.isin(np.array([b], dtype=values_dtype))
+        expected_dtype = "boolean" if isinstance(comps_dtype, str) else bool
+        expected = Series([False], dtype=expected_dtype)
+        tm.assert_series_equal(result, expected)
+
+        # Matching values still succeed.
+        result_match = ser.isin(np.array([a], dtype=values_dtype))
+        expected_match = Series([True], dtype=expected_dtype)
+        tm.assert_series_equal(result_match, expected_match)
+
+    def test_isin_uint64_vs_int64_ndarray_small_values(self):
+        # GH#59609: values within float64's exact-int range remain correct
+        # (and may use the numeric common-type path).
+        ser = Series([1, 2, 3], dtype=np.uint64)
+        result = ser.isin(np.array([2, 4], dtype=np.int64))
+        tm.assert_series_equal(result, Series([False, True, False]))
+
     def test_isin_uint64_vs_float_no_precision_loss(self):
         # GH#46485: a uint64 magnitude > 2**53 must not be down-cast to float64
         # when checking membership against float targets.


### PR DESCRIPTION
- [x] closes #59609
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

``Series.isin`` / ``algorithms.isin`` compared signed and unsigned 64-bit integer ndarrays by casting both to ``float64``, which is not exact above ``2**53`` and produced false matches (e.g. ``UInt64`` vs an ``int64`` NumPy array). Extend the existing GH#46485 object-dtype fallback to that ndarray common-type path when either side may lose integer precision.