### PR TITLE
WEB: remove not-working list of people from Code of Conduct page

### DIFF
--- a/web/pandas/community/coc.md
+++ b/web/pandas/community/coc.md
@@ -42,13 +42,8 @@ reported issues. The working group is made up of pandas contributors and users.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the working group by e-mail (coc@pandas.pydata.org).
 Messages sent to this e-mail address will not be publicly visible but only to
-the working group members. The working group currently includes
-
-<ul>
-    {% for person in maintainers.coc %}
-    <li>{{ person }}</li>
-    {% endfor %}
-</ul>
+the working group members. The current working group composition can be found
+at the [pandas team page](https://pandas.pydata.org/about/team.html#workgroups).
 
 All complaints will be reviewed and investigated and will result in a response
 that is deemed necessary and appropriate to the circumstances. Maintainers are


### PR DESCRIPTION
Another follow-up on https://github.com/pandas-dev/pandas/pull/65896, as I also noticed that the text seems to indicate it is listing the working group members, but this jinja template is not actually working, resulting in an empty list. 
Since that list tends to get out of date in the various places we have this text, I just removed the non-working list instead of fixing it, and replaced it with a link to the team page where the working group members are listed.