### PR TITLE
BUG: convert_dtypes(dtype_backend="numpy_nullable") returns pyarrow-storage StringDtype

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -394,6 +394,7 @@ Conversion
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``TypeError`` when ``to_replace`` was ``Ellipsis`` (``...``) (:issue:`50373`)
 - Fixed bug in :meth:`DataFrame.to_dict` with ``orient="index"`` did not respect the ``into`` argument in nested mappings (:issue:`65778`)
+- Fixed bug in :meth:`Series.convert_dtypes` and :meth:`DataFrame.convert_dtypes` where ``dtype_backend="numpy_nullable"`` could return a :class:`StringDtype` with ``storage="pyarrow"`` instead of ``storage="python"`` when pyarrow was installed (:issue:`64238`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1062,9 +1062,19 @@ def convert_dtypes(
                 pa_type = to_pyarrow_type(base_dtype)
             if pa_type is not None:
                 inferred_dtype = ArrowDtype(pa_type)
-    elif dtype_backend == "numpy_nullable" and isinstance(inferred_dtype, ArrowDtype):
-        # GH 53648
-        inferred_dtype = _arrow_dtype_mapping()[inferred_dtype.pyarrow_dtype]
+    elif dtype_backend == "numpy_nullable":
+        if isinstance(inferred_dtype, ArrowDtype):
+            # GH 53648
+            inferred_dtype = _arrow_dtype_mapping()[inferred_dtype.pyarrow_dtype]
+        elif (
+            isinstance(inferred_dtype, StringDtype)
+            and inferred_dtype.storage == "pyarrow"
+        ):
+            # GH#64238 respect dtype_backend="numpy_nullable" even when
+            # pd.options.mode.string_storage resolves to "pyarrow"
+            inferred_dtype = StringDtype(
+                storage="python", na_value=inferred_dtype.na_value
+            )
 
     assert not isinstance(inferred_dtype, str)
     return inferred_dtype

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -305,6 +305,17 @@ class TestSeriesConvertDtypes:
         expected = pd.Series(range(2), dtype="Int32")
         tm.assert_series_equal(result, expected)
 
+    def test_convert_dtypes_numpy_nullable_string_storage(self):
+        # GH#64238 dtype_backend="numpy_nullable" should always give
+        # StringDtype(storage="python"), even when pyarrow is installed and
+        # pd.options.mode.string_storage resolves to "pyarrow"
+        pytest.importorskip("pyarrow")
+        ser = pd.Series(["a", "b", None])
+        result = ser.convert_dtypes(dtype_backend="numpy_nullable")
+        expected = pd.Series(["a", "b", None], dtype=pd.StringDtype(storage="python"))
+        tm.assert_series_equal(result, expected)
+        assert result.dtype.storage == "python"
+
     def test_convert_dtypes_pyarrow_null(self):
         # GH#55346
         pa = pytest.importorskip("pyarrow")

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -33,7 +33,7 @@ class TestSeriesConvertDtypes:
             (
                 ["x", "y", "z"],
                 np.dtype("O"),
-                pd.StringDtype(),
+                pd.StringDtype(storage="python"),
                 {("convert_string", False): np.dtype("O")},
             ),
             (
@@ -45,7 +45,7 @@ class TestSeriesConvertDtypes:
             (
                 ["h", "i", np.nan],
                 np.dtype("O"),
-                pd.StringDtype(),
+                pd.StringDtype(storage="python"),
                 {("convert_string", False): np.dtype("O")},
             ),
             (  # GH32117


### PR DESCRIPTION
yeah this one's just wrong. `convert_dtypes(dtype_backend="numpy_nullable")` is supposed to hand you numpy-backed nullable dtypes, but for string columns it doesn't actually force that - it just calls `pandas_dtype_func("string")`, which resolves whatever `mode.string_storage` currently is. That option defaults to `"auto"`, which picks `"pyarrow"` storage the moment pyarrow is importable. So on pretty much any modern env with pyarrow installed, asking for `numpy_nullable` silently gives you back a `StringDtype(storage="pyarrow")` instead.

The `dtype_backend="pyarrow"` branch right below already does the right thing and forces everything to `ArrowDtype` regardless of the global option. The `numpy_nullable` branch only ever special-cased converting an existing `ArrowDtype` back down (GH 53648) - it never touched string storage at all. See `pandas/core/dtypes/cast.py` around line 1065.

Fix: when `dtype_backend="numpy_nullable"` and we land on a pyarrow-storage `StringDtype`, force it to `storage="python"`, keeping the same na_value.

Repro'd against released 3.0.5 with pyarrow installed:
```python
pd.Series(['a','b',None]).convert_dtypes(dtype_backend="numpy_nullable").dtype.storage
# 'pyarrow', should be 'python'
```
Patched the same code in that install to confirm the fix works and doesn't touch the pyarrow-backend path or break the existing GH#53648 numpy_nullable-from-ArrowDtype test.

Honest caveat: I didn't have a compiled dev build (meson/cython toolchain) on hand, so the new test hasn't run through the actual pandas test runner on this branch - I verified the same logic against an installed release build instead. Diff's small enough to review directly either way.

Fixes #64238