### PR TITLE
PERF: bump vendored fast_float to 8.2.10

### DIFF
--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -411,6 +411,32 @@ class ReadCSVFloatPrecision(StringIORewind):
         )
 
 
+class ReadCSVFloats(StringIORewind):
+    # Float columns at default settings, over significant-digit counts that
+    # bracket the C parser's fast path: up to 19 significant digits are read
+    # straight from the digits, longer mantissas need a second pass.
+    params = [5, 10, 19, 25]
+    param_names = ["num_digits"]
+
+    def setup(self, num_digits):
+        int_digits = num_digits // 2
+        floats = [
+            random.choice(string.digits[1:])
+            + "".join(random.choice(string.digits) for _ in range(int_digits - 1))
+            + "."
+            + "".join(
+                random.choice(string.digits) for _ in range(num_digits - int_digits)
+            )
+            for _ in range(15)
+        ]
+        rows = ",".join(["{}"] * 3) + "\n"
+        data = (rows * 5).format(*floats) * 2000  # 10000 x 3 floats csv
+        self.StringIO_input = StringIO(data)
+
+    def time_read_csv(self, num_digits):
+        read_csv(self.data(self.StringIO_input), header=None, names=list("abc"))
+
+
 class ReadCSVEngine(StringIORewind):
     params = ["c", "python", "pyarrow"]
     param_names = ["engine"]

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -411,32 +411,6 @@ class ReadCSVFloatPrecision(StringIORewind):
         )
 
 
-class ReadCSVFloats(StringIORewind):
-    # Float columns at default settings, over significant-digit counts that
-    # bracket the C parser's fast path: up to 19 significant digits are read
-    # straight from the digits, longer mantissas need a second pass.
-    params = [5, 10, 19, 25]
-    param_names = ["num_digits"]
-
-    def setup(self, num_digits):
-        int_digits = num_digits // 2
-        floats = [
-            random.choice(string.digits[1:])
-            + "".join(random.choice(string.digits) for _ in range(int_digits - 1))
-            + "."
-            + "".join(
-                random.choice(string.digits) for _ in range(num_digits - int_digits)
-            )
-            for _ in range(15)
-        ]
-        rows = ",".join(["{}"] * 3) + "\n"
-        data = (rows * 5).format(*floats) * 2000  # 10000 x 3 floats csv
-        self.StringIO_input = StringIO(data)
-
-    def time_read_csv(self, num_digits):
-        read_csv(self.data(self.StringIO_input), header=None, names=list("abc"))
-
-
 class ReadCSVEngine(StringIORewind):
     params = ["c", "python", "pyarrow"]
     param_names = ["engine"]

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -213,6 +213,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for large uncompressed local files, which are now read in parallel across multiple CPU cores; this is enabled by default except on Windows and can be controlled with the ``mode.max_threads`` option (:issue:`64347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when an extension dtype is requested (e.g. ``dtype="Int64"``, ``dtype="boolean"``, or ``dtype="int64[pyarrow]"``) (:issue:`66279`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing float columns (:issue:`66456`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing integer columns (:issue:`65347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading from binary file-like objects (e.g. PyArrow S3 file handles) by avoiding unnecessary ``TextIOWrapper`` wrapping (:issue:`46823`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading in parallel: closing a parser no longer blocks the other parser threads while its buffers are freed (:issue:`66272`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -213,7 +213,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for large uncompressed local files, which are now read in parallel across multiple CPU cores; this is enabled by default except on Windows and can be controlled with the ``mode.max_threads`` option (:issue:`64347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when an extension dtype is requested (e.g. ``dtype="Int64"``, ``dtype="boolean"``, or ``dtype="int64[pyarrow]"``) (:issue:`66279`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing float columns (:issue:`66456`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing float columns (:issue:`66457`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing integer columns (:issue:`65347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading from binary file-like objects (e.g. PyArrow S3 file handles) by avoiding unnecessary ``TextIOWrapper`` wrapping (:issue:`46823`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading in parallel: closing a parser no longer blocks the other parser threads while its buffers are freed (:issue:`66272`)

--- a/pandas/tests/io/parser/common/test_float.py
+++ b/pandas/tests/io/parser/common/test_float.py
@@ -161,7 +161,7 @@ def test_precise_xstrtod_large_mantissa(c_parser_only, value):
     ],
 )
 def test_float_correctly_rounded(all_parsers, value):
-    # GH#66456
+    # GH#66457
     parser = all_parsers
     result = parser.read_csv(StringIO(f"data\n{value}"))
 

--- a/pandas/tests/io/parser/common/test_float.py
+++ b/pandas/tests/io/parser/common/test_float.py
@@ -141,6 +141,35 @@ def test_precise_xstrtod_large_mantissa(c_parser_only, value):
 
 
 @pytest.mark.parametrize(
+    "value",
+    [
+        # up to 19 significant digits, parsed straight from the digits
+        "1.7976931348623157e308",  # largest finite double
+        "2.2250738585072014e-308",  # smallest normal double
+        "9007199254740993.0",  # 2**53 + 1, not representable; rounds to 2**53
+        "12345.678901234567",
+        # more than 19 significant digits, so the mantissa has to be truncated
+        # before it can be rounded
+        "2.22507385850720113605740979670913197593481954635164565e-308",
+        "1.00000000000000000000000000000000000000000000000000001",
+        "123456789012345678901234567890.5",
+        # subnormals, where picking the last bit requires comparing against the
+        # full decimal expansion rather than a truncated mantissa
+        "4.9406564584124654e-324",  # smallest positive subnormal
+        "2.4703282292062327e-324",  # just under the halfway point -> 0.0
+        "2.4703282292062328e-324",  # just over it -> smallest subnormal
+    ],
+)
+def test_float_correctly_rounded(all_parsers, value):
+    # GH#66456
+    parser = all_parsers
+    result = parser.read_csv(StringIO(f"data\n{value}"))
+
+    expected = DataFrame({"data": [float(value)]})
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
     "value", ["81e31d04049863b72", "d81e31d04049863b72", "81e3104049863b72"]
 )
 def test_invalid_float_number(all_parsers_all_precisions, value):

--- a/pandas/tests/io/parser/common/test_ints.py
+++ b/pandas/tests/io/parser/common/test_ints.py
@@ -195,7 +195,16 @@ def test_int64_uint64_range(all_parsers, val):
 
 @skip_pyarrow  # CSV parse error: Empty CSV file or block
 @pytest.mark.parametrize(
-    "val", [np.iinfo(np.uint64).max + 1, np.iinfo(np.int64).min - 1]
+    "val",
+    [
+        np.iinfo(np.uint64).max + 1,
+        np.iinfo(np.int64).min - 1,
+        # 20-digit values that exceed uint64 by more than 2**64, so a parser
+        # accumulating into a 64-bit register wraps back into the range of
+        # valid 20-digit values and can miss the overflow (GH#66456)
+        30000000000000000000,
+        47386862472818278521,
+    ],
 )
 def test_outside_int64_uint64_range(all_parsers, val, request):
     # These numbers fall just outside the int64-uint64

--- a/pandas/tests/io/parser/common/test_ints.py
+++ b/pandas/tests/io/parser/common/test_ints.py
@@ -201,7 +201,7 @@ def test_int64_uint64_range(all_parsers, val):
         np.iinfo(np.int64).min - 1,
         # 20-digit values that exceed uint64 by more than 2**64, so a parser
         # accumulating into a 64-bit register wraps back into the range of
-        # valid 20-digit values and can miss the overflow (GH#66456)
+        # valid 20-digit values and can miss the overflow (GH#66457)
         30000000000000000000,
         47386862472818278521,
     ],

--- a/subprojects/fast_float.wrap
+++ b/subprojects/fast_float.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = fast_float-8.2.3
+directory = fast_float-8.2.10
 
-source_url = https://github.com/fastfloat/fast_float/archive/refs/tags/v8.2.3.tar.gz
-source_filename = fast_float-8.2.3.tar.gz
-source_hash = fa811076bad7b7151ce826005a7213971c879b192ee4505a7016c8413038c2d0
+source_url = https://github.com/fastfloat/fast_float/archive/refs/tags/v8.2.10.tar.gz
+source_filename = fast_float-8.2.10.tar.gz
+source_hash = 76f958dd97b1cf4d8862d1f0986a47d4bdfa8845252bae15ef0f40de3b95961f
 patch_directory = fast_float
 
 [provide]

--- a/subprojects/packagefiles/fast_float/meson.build
+++ b/subprojects/packagefiles/fast_float/meson.build
@@ -2,7 +2,7 @@ project(
     'fast_float',
     'cpp',
     license: 'Apache-2.0',
-    version: '8.2.3',
+    version: '8.2.10',
 )
 
 fast_float_inc = include_directories('include')


### PR DESCRIPTION
Bumps the vendored fast_float from 8.2.3 to 8.2.10. Split out of GH-66238 so the dependency bump can land on its own.

pandas' only fast_float consumer is `fast_float_wrappers.cpp`, which is `double`-only, so the win is in float parsing: 8.2.4 inlines `from_chars_advanced` and its dispatch callers, 8.2.6 unrolls the integer-part digit scan and adds a 4-digit SWAR follow-up, and 8.2.7 keeps the integer/fraction spans off the hot path — they are read only by the rare `too_many_digits` and `digit_comp` slow paths, which now re-parse in a cold helper.

### Benchmarks

Measured on the shared read_csv benchmark suite (123 cases, M3 Pro) against a build of **the identical commit** with 8.2.3, so the fast_float version is the only difference: baseline and branch measured back-to-back per case with alternating order, adaptive rounds to a ±0.8% target, 99% CIs. **56 significant wins, 0 real regressions.**

| float case | speedup | 99% CI |
|---|---|---|
| float, decimal comma | 1.16x | [1.16, 1.17] |
| float (6-decimal) | 1.16x | [1.15, 1.17] |
| float, 1-decimal | 1.15x | [1.15, 1.16] |
| float, mixed widths | 1.13x | [1.12, 1.14] |
| float, 17 significant digits | 1.09x | [1.08, 1.10] |
| float, scientific notation | 1.07x | [1.07, 1.08] |

Frames that merely contain float columns benefit too:

| case | speedup | 99% CI |
|---|---|---|
| tall-narrow (1 col × 5M) | 1.15x | [1.14, 1.15] |
| NA 1% | 1.14x | [1.14, 1.15] |
| wide (100 cols) | 1.08x | [1.07, 1.09] |
| mixed dtypes | 1.04x | [1.04, 1.05] |

Integer, string, quoting and datetime paths are neutral, as expected. One case, `int` at 12 threads, flagged 0.98x [0.961, 0.9998]: the interval only just excludes 1.0, integer parsing never reaches fast_float here, and the null control was clean, so this reads as code layout (`fast_float_wrappers.cpp.o` shifting alignment of its neighbours in `libpandas_tokenizer.a`) rather than a real effect. Two commits landed mid-run, so the driver flagged a moved HEAD; the measured build artifacts are byte-identical before and after, so the numbers stand.

### The 20-digit overflow fix

8.2.10 also reworks `parse_int_string`'s overflow check ([fastfloat/fast_float#394](https://github.com/fastfloat/fast_float/pull/394)): the old `i < min_safe_u64(base)` test misses 20-digit values that wrap a whole multiple of 2^64 and land back above `min_safe`. Over 4M random 20-digit strings, 8.2.3 wrongly accepted 1,478,428 of them (`47386862472818278521` came back as `10493374325399175289`); 8.2.10 accepted none.

This is **not** a user-visible fix on main — `pd_strtoll`/`pd_strtoull` use `std::from_chars`, which was correct on all 4M cases, so pandas never reaches fast_float's integer path today. It goes live in GH-66238, which switches integer parsing to `fast_float::from_chars`, so landing this first removes that hazard. The two 20-digit values added to `test_outside_int64_uint64_range` are a forward guard: the existing parameters have a residue below `min_safe` and so would not have caught the upstream bug.

Also adds `test_float_correctly_rounded`, covering the three float paths 8.2.7 restructured (mantissas within 19 significant digits, longer ones that must be truncated before rounding, and subnormals at the rounding boundary).

The `ReadCSVFloats` asv benchmark has been dropped from this PR and will come back in its own, alongside the removal of `ReadCSVFloatPrecision` — `float_precision` no longer selects a converter, so that benchmark measures nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

