### PR TITLE
CI: restore pip installs dropped by setup-python v7

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -140,8 +140,10 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          pip-install: '-r requirements-dev.txt'
           cache-dependency-path: 'requirements-dev.txt'
 
       - name: Check Pip Cache Hit
         run: echo ${{ steps.setup_python.outputs.cache-hit }}
+
+      - name: Install requirements-dev.txt
+        run: python -m pip install -r requirements-dev.txt

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -517,7 +517,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
-          pip-install: pyodide-build
+
+      - name: Install pyodide-build
+        run: python -m pip install pyodide-build
 
       - name: Save Emscripten version
         run: echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,9 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
-          pip-install: build
+
+      - name: Install build
+        run: python -m pip install build
 
       - name: Build sdist
         run: python -m build --sdist
@@ -139,8 +141,10 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
-          # cryptography pin due to https://github.com/pyca/cryptography/pull/14216
-          pip-install: wheel cryptography==46.0.3
+
+      - name: Install wheel
+        # cryptography pin due to https://github.com/pyca/cryptography/pull/14216
+        run: python -m pip install wheel cryptography==46.0.3
 
       - name: Validate wheel RECORD
         run: for whl in $(ls wheelhouse); do wheel unpack wheelhouse/$whl -d /tmp; done


### PR DESCRIPTION
`actions/setup-python` v7.0.0 removed the `pip-install` input, which GH-66384 bumped us onto. The action only warns on unknown inputs, so all four steps using it silently stopped installing anything:

```
##[warning]Unexpected input(s) 'pip-install', valid inputs are [... 'pip-version']
```

The visible breakage is the **Pyodide build** job, red on `main` since GH-66384 merged: `pyodide-build` is never installed, so `pyodide config get emscripten_version` writes an empty `EMSCRIPTEN_VERSION`, and `setup-emsdk` then 404s asking for version `""`. (`pipefail` doesn't catch it because `echo EMSCRIPTEN_VERSION=$(...)` still exits 0.)

Three more sites were affected but not yet visibly red:

- `code-checks.yml` — the "Test install requirements-dev.txt" job has been passing without installing `requirements-dev.txt` at all, i.e. testing nothing.
- `wheels.yml` (sdist) — `build` missing; `python -m build --sdist` would fail on the next scheduled/tag run.
- `wheels.yml` (validation) — `wheel` missing; `wheel unpack` would fail.

Replaced each with an explicit `python -m pip install` step, which is robust across future action versions.
