### PR TITLE
BUG: Preserve parent index in Series.dt.to_pydatetime() (#66443)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -618,6 +618,7 @@ Styler
 
 Other
 ^^^^^
+- Fixed bug in :meth:Series.dt.to_pydatetime dropping the parent index (:issue:66443)
 
 - Bug in :class:`DataFrame` constructor where passing the same :class:`Index` object as both ``index`` and ``columns`` shared a single object between the two axes, so mutating metadata such as ``names`` on one would also change the other (:issue:`42934`)
 - Bug in :func:`eval` and :meth:`DataFrame.eval` where passing a :class:`Series` or :class:`DataFrame` as ``expr`` silently parsed its (possibly truncated) repr instead of raising, producing a confusing error (:issue:`16289`)

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -361,7 +361,7 @@ class DatetimeProperties(Properties):
         # GH#20306
         from pandas import Series
 
-        return Series(self._get_values().to_pydatetime(), dtype=object)
+        return Series(self._get_values().to_pydatetime(), index=self._parent.index, dtype=object)
 
     @property
     def freq(self):

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -361,7 +361,11 @@ class DatetimeProperties(Properties):
         # GH#20306
         from pandas import Series
 
-        return Series(self._get_values().to_pydatetime(), index=self._parent.index, dtype=object)
+        return Series(
+            self._get_values().to_pydatetime(),
+            index=self._parent.index,
+            dtype=object,
+        )
 
     @property
     def freq(self):

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -226,7 +226,16 @@ class ArrowTemporalProperties(PandasDelegate, PandasObject, NoNewAttributesMixin
 
     def to_pydatetime(self) -> Series:
         # GH#20306
-        return cast("ArrowExtensionArray", self._parent.array)._dt_to_pydatetime()
+        if self._orig is not None:
+            index = self._orig.index
+        else:
+            index = self._parent.index
+        result = cast("ArrowExtensionArray", self._parent.array)._dt_to_pydatetime()
+        return type(self._parent)(
+            result._values,
+            index=index,
+            name=self._parent.name,
+        ).__finalize__(self._parent)
 
     def isocalendar(self) -> DataFrame:
         from pandas import DataFrame

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -960,3 +960,18 @@ def test_day_attribute_non_nano_beyond_int32():
     result = ser.dt.days
     expected = Series([1579371003, 1559453522, 2839645203, 2586, 27, 42066, 0])
     tm.assert_series_equal(result, expected)
+
+
+def test_to_pydatetime_index_preservation():
+    # GH#66443
+    from datetime import datetime
+
+    idx = Index([10, 11, 12])
+    ser = Series(pd.to_datetime(['2026-01-01', '2026-02-01', '2026-03-01']), index=idx)
+    result = ser.dt.to_pydatetime()
+    expected = Series(
+        [datetime(2026, 1, 1), datetime(2026, 2, 1), datetime(2026, 3, 1)],
+        index=idx,
+        dtype=object,
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] Closes #66443

### Description
In pandas/core/indexes/accessors.py, calling Series.dt.to_pydatetime() was returning a Series constructed without index=self._parent.index, causing it to reset to a fresh RangeIndex.

This PR passes index=self._parent.index when building the returned Series, bringing .dt.to_pydatetime() in line with all other .dt accessors.