### PR TITLE
CI: restore actions:write for cache cleanup workflow

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -16,6 +16,8 @@ defaults:
 jobs:
   cleanup:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
     if: github.repository_owner == 'pandas-dev'
     steps:
       - name: Clean closed pull request caches


### PR DESCRIPTION
The daily `Clean closed branch caches` run has failed every day since GH-64909, which folded the daily purge in from `cache-cleanup-daily.yml` and dropped the job-level `permissions: actions: write` that the deleted workflow had. With only the workflow-level `permissions: {}`, `gh cache delete` gets:

```
X Failed to delete cache: HTTP 403: Resource not accessible by integration
```

The `pull_request: closed` path mostly reports success only because there is usually nothing to delete for that ref — it hits the same 403 whenever a closed PR actually has caches.

Restoring the two lines the old daily workflow had.
