### PR TITLE
CI: align codeql-action pins so CodeQL analysis runs again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     labels:
       - "CI"
       - "Dependencies"
+    groups:
+      # init/autobuild/analyze must stay on the same version or CodeQL errors out
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,8 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4
-      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      - uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      - uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4
       - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4


### PR DESCRIPTION
Dependabot treats each `github/codeql-action` sub-action as its own dependency, so GH-66386 and GH-66387 bumped `analyze` and `init` to 4.37.1 while `autobuild` stayed at 4.37.0. The versions have to match — every CodeQL run since then fails for *all three* languages with:

```
We were unable to automatically build your code. [...]
Loaded a configuration file for version '4.37.1', but running version '4.37.0'
```

Pinning `autobuild` to the same SHA, and grouping the sub-actions in `dependabot.yml` so they get bumped together and this cannot recur.

Note this only restores the `python` and `actions` analyses. `c-cpp` fails separately — `autobuild` has never been able to build pandas — which is worth its own issue.
