### PR TITLE
BUG: Timestamp silently ignored by-component keyword arguments (GH#31930)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -104,12 +104,12 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 
 Other API changes
 ^^^^^^^^^^^^^^^^^
+- :class:`Timestamp` now raises ``ValueError`` when a date attribute keyword argument (``year``, ``month``, ``day``, ``hour``, ``minute``, ``second``, or ``microsecond``) is passed together with a datetime-like positional argument. Previously the keyword was silently ignored. Build the :class:`Timestamp` from components or from the datetime-like input, but not both (:issue:`31930`)
 - :meth:`.DataFrameGroupBy.sum` and :meth:`.DataFrameGroupBy.mean` on float dtypes with sorted grouping keys may differ from prior versions in the last few floating-point digits, due to a faster summation algorithm that does not use Kahan compensation (:issue:`65103`)
 - :meth:`DataFrame.select_dtypes` now selects only columns with exactly the given dtype when a dtype instance is passed to ``include`` or ``exclude``. Previously an instance selected all columns with a matching ``dtype.type``, e.g. ``pd.DatetimeTZDtype(tz="UTC")`` also selected other timezones, ``np.dtype("int64")`` also selected ``Int64`` and Arrow ``int64`` columns, and ``pd.CategoricalDtype(["a", "b"])`` selected every categorical column (:issue:`40234`)
 - :meth:`DataFrame.to_hdf` no longer writes a ``pandas_version`` attribute into the HDF5 file; the value was hardcoded to ``"0.15.2"`` and never reflected the pandas version. As a consequence, ``format="table"`` files written with pandas 3.1 or later cannot be read by pandas 3.0 or earlier (:issue:`62792`)
 - APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`64483`).
 - Removed the ``freq`` and ``freqstr`` attributes from :class:`.DatetimeArray` and :class:`.TimedeltaArray`. Frequency is now stored only on :class:`DatetimeIndex` and :class:`TimedeltaIndex`; access ``Series.dt.freq`` or wrap the array in an Index to retrieve a frequency. The ``check_freq`` keyword on :func:`testing.assert_extension_array_equal` for these array types has also been removed (:issue:`24566`).
--
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.deprecations:

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -2938,13 +2938,28 @@ class Timestamp(_Timestamp):
 
             ts_input = datetime(**datetime_kwargs)
 
-        elif is_integer_object(year):
+        elif is_integer_object(year) and is_integer_object(ts_input):
             # User passed positional arguments:
             # Timestamp(year, month, day[, hour[, minute[, second[,
             # microsecond[, tzinfo]]]]])
             ts_input = datetime(ts_input, year, month, day or 0,
                                 hour or 0, minute or 0, second or 0, fold=fold or 0)
             unit = None
+
+        elif (year is not None or month is not None or day is not None or
+                hour is not None or minute is not None or second is not None or
+                microsecond is not None):
+            # GH#31930 A datetime-like ts_input was passed together with
+            # by-component keyword arguments (year, month, day, hour, minute,
+            # second, or microsecond), which would otherwise be silently
+            # ignored. (nanosecond is excluded: it is also accepted alongside
+            # a datetime-like ts_input, GH#18898.)
+            raise ValueError(
+                "Cannot pass a date attribute keyword argument (year, month, "
+                "day, hour, minute, second, or microsecond) when passing a "
+                "datetime-like positional argument; build the Timestamp from "
+                "components or from the datetime-like input, but not both."
+            )
 
         if getattr(ts_input, "tzinfo", None) is not None and tz is not None:
             raise ValueError("Cannot pass a datetime or Timestamp with tzinfo with "

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -317,6 +317,37 @@ class TestTimestampConstructorPositionalAndKeywordSupport:
         with pytest.raises(ValueError, match=msg):
             Timestamp("2010-10-10 12:59:59.999999999", **kwarg)
 
+    @pytest.mark.parametrize(
+        "ts_input",
+        [
+            datetime(2020, 12, 31),
+            Timestamp("2020-12-31"),
+            np.datetime64("2020-12-31"),
+            date(2020, 12, 31),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "arg", ["year", "month", "day", "hour", "minute", "second", "microsecond"]
+    )
+    def test_date_kwarg_with_datetime_input_raises(self, ts_input, arg):
+        # GH#31930 passing a by-component keyword together with a datetime-like
+        # ts_input previously silently ignored the keyword; now raises
+        msg = "Cannot pass a date attribute keyword argument"
+        with pytest.raises(ValueError, match=msg):
+            Timestamp(ts_input, **{arg: 5})
+
+    def test_date_kwarg_with_int_unit_input_raises(self):
+        # GH#31930 same for the int + unit value form
+        msg = "Cannot pass a date attribute keyword argument"
+        with pytest.raises(ValueError, match=msg):
+            Timestamp(1_600_000_000, unit="s", hour=5)
+
+    def test_nanosecond_kwarg_with_datetime_input_allowed(self):
+        # GH#18898 nanosecond is a genuine extension of datetime and remains
+        # allowed alongside a datetime-like ts_input (GH#31930)
+        result = Timestamp(datetime(2020, 12, 31), nanosecond=5)
+        assert result.nanosecond == 5
+
     @pytest.mark.parametrize("kwargs", [{}, {"year": 2020}, {"year": 2020, "month": 1}])
     def test_constructor_missing_keyword(self, kwargs):
         # GH#31200


### PR DESCRIPTION
closes #31930

`Timestamp` accepts two construction forms: a value-form first argument (a datetime-like, string, or int/float epoch value) and a by-component form (`year`, `month`, `day`, ...). Mixing them silently dropped the by-component keyword:

```python
>>> pd.Timestamp(datetime(2020, 12, 31), hour=23)
Timestamp('2020-12-31 00:00:00')   # hour ignored
```

This now raises `ValueError`. The string-input form already raised for this, so this brings the datetime/int forms in line. The `nanosecond` keyword — which `datetime` has no field for — remains accepted alongside a datetime-like input (GH-18898). As a side effect, the previously cryptic `Timestamp(datetime(...), year=1)` -> `TypeError: 'datetime.datetime' object cannot be interpreted as an integer` now gives the same clear `ValueError`.

The check is allocation-free (an inline chained `is not None` rather than a list + `any(...)`), so `Timestamp.__new__` construction cost is unchanged.