### PR TITLE
BUG: min/max on object dtype with skipna=False not propagating NA (GH-4147)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -373,6 +373,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`Series.min`, and :meth:`Series.max` on object-dtype data raising ``TypeError`` when missing values were present alongside values that do not support comparison with ``float`` (e.g. strings, :class:`datetime.date` objects, or mixed-timezone :class:`Timestamp` objects) (:issue:`4147`, :issue:`18588`, :issue:`24109`, :issue:`58707`, :issue:`61204`, :issue:`65500`)
+- Bug in :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`Series.min`, and :meth:`Series.max` on object-dtype data with ``skipna=False`` failing to propagate missing values, either raising ``TypeError`` or returning a value computed as though the missing values were absent; they now return a missing value like other dtypes do (:issue:`4147`)
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` returning incorrect row labels for nullable ``UInt64`` columns containing missing values alongside values above ``2**53`` (:issue:`64478`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` with ``axis=1`` and ``skipna=False`` returning incorrect column labels for extension array dtypes (e.g. :class:`BooleanDtype`, nullable integer/float, :class:`ArrowDtype`) (:issue:`56903`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -372,7 +372,7 @@ Timezones
 
 Numeric
 ^^^^^^^
-- Bug in :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`Series.min`, and :meth:`Series.max` on object-dtype data raising ``TypeError`` when missing values were present alongside values that do not support comparison with ``float`` (e.g. strings or mixed-timezone :class:`Timestamp` objects) (:issue:`65500`)
+- Bug in :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`Series.min`, and :meth:`Series.max` on object-dtype data raising ``TypeError`` when missing values were present alongside values that do not support comparison with ``float`` (e.g. strings, :class:`datetime.date` objects, or mixed-timezone :class:`Timestamp` objects) (:issue:`4147`, :issue:`18588`, :issue:`24109`, :issue:`58707`, :issue:`61204`, :issue:`65500`)
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` returning incorrect row labels for nullable ``UInt64`` columns containing missing values alongside values above ``2**53`` (:issue:`64478`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` with ``axis=1`` and ``skipna=False`` returning incorrect column labels for extension array dtypes (e.g. :class:`BooleanDtype`, nullable integer/float, :class:`ArrowDtype`) (:issue:`56903`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1145,13 +1145,21 @@ def _nanminmax(meth, fill_value_typ):
             return _na_for_min_count(values, axis)
 
         dtype = values.dtype
-        if dtype == object and skipna:
+        min_count = 1
+        if dtype == object:
             # GH#65500: _get_values' +/-inf fill isn't comparable with arbitrary
             # objects (Timestamps, strings) and raises.  Fill NAs from the same
             # slice instead (leaves min/max unchanged); all-NA slices keep the
             # +/-inf fill since _maybe_null_out discards them anyway.
-            mask = _maybe_get_mask(values, skipna, mask)
-            if mask is not None and mask.any():
+            if mask is None:
+                mask = isna(values)
+            if not skipna:
+                # GH#4147: a float NaN propagates through the comparison on its
+                # own, but an object NA does not, so it used to be compared
+                # as-is.  Fill it like the skipna case so nothing raises, then
+                # null out every slice that held one to match float64/str/dt64.
+                min_count = values.size if axis is None else values.shape[axis]
+            if mask.any():
                 fill_value = _get_fill_value(dtype, fill_value_typ=fill_value_typ)
                 if mask.all():
                     values = np.full(values.shape, fill_value, dtype=object)
@@ -1175,7 +1183,12 @@ def _nanminmax(meth, fill_value_typ):
             )
         result = getattr(values, meth)(axis)
         result = _maybe_null_out(
-            result, axis, mask, values.shape, datetimelike=dtype.kind in "mM"
+            result,
+            axis,
+            mask,
+            values.shape,
+            min_count=min_count,
+            datetimelike=dtype.kind in "mM",
         )
         return result
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1,4 +1,7 @@
-from datetime import timedelta
+from datetime import (
+    date,
+    timedelta,
+)
 from decimal import Decimal
 import re
 
@@ -2576,6 +2579,68 @@ def test_minmax_extensionarray(method, numeric_only):
         index=Index(["Int64"]),
     )
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", [object, "str"])
+def test_minmax_axis0_string_columns_with_na(dtype):
+    # GH#18588: the string columns were silently dropped as nuisance columns,
+    # and once numeric_only stopped dropping them the +/-inf NA fill raised
+    df = DataFrame(
+        {
+            "col1": [0, 1, 2, 3],
+            "col2": Series(["a", "b", None, "d"], dtype=dtype),
+            "col3": Series(["e", "f", None, "h"], dtype=dtype),
+        }
+    )
+    index = Index(["col1", "col2", "col3"])
+
+    result = df.min(axis=0)
+    tm.assert_series_equal(result, Series([0, "a", "e"], index=index, dtype=object))
+
+    result = df.max(axis=0)
+    tm.assert_series_equal(result, Series([3, "d", "h"], index=index, dtype=object))
+
+
+def test_minmax_axis0_object_date_with_na():
+    # GH#61204
+    df = DataFrame(
+        {"dates": [np.nan, np.nan, date(2025, 1, 3), date(2025, 1, 4)]}, dtype=object
+    )
+    index = Index(["dates"])
+
+    result = df.min(axis=0)
+    tm.assert_series_equal(
+        result, Series([date(2025, 1, 3)], index=index, dtype=object)
+    )
+
+    result = df.max(axis=0)
+    tm.assert_series_equal(
+        result, Series([date(2025, 1, 4)], index=index, dtype=object)
+    )
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+def test_minmax_object_na_positions_differ_per_slice(axis):
+    # GH#18588: the NA fill is taken per reduction slice, so slices whose NAs
+    # sit in different positions do not borrow each other's values, and an
+    # all-NA slice reduces to NA rather than poisoning its neighbours
+    df = DataFrame(
+        {
+            "a": ["x", None, "b"],
+            "b": [None, "q", "p"],
+            "c": [None, None, None],
+        },
+        dtype=object,
+    )
+    if axis == 0:
+        exp_min = Series(["b", "p", None], index=Index(["a", "b", "c"]), dtype=object)
+        exp_max = Series(["x", "q", None], index=Index(["a", "b", "c"]), dtype=object)
+    else:
+        exp_min = Series(["x", "q", "b"], dtype=object)
+        exp_max = Series(["x", "q", "p"], dtype=object)
+
+    tm.assert_series_equal(df.min(axis=axis), exp_min)
+    tm.assert_series_equal(df.max(axis=axis), exp_max)
 
 
 @pytest.mark.parametrize("ts_value", [Timestamp("2000-01-01"), pd.NaT])

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -2199,8 +2199,10 @@ class TestDataFrameReductions:
         expected = Series([winner, ts1], dtype=object)
         tm.assert_series_equal(result, expected)
 
+        # GH#4147: the NaT row holds an NA, so skipna=False propagates it.
+        # object-dtype reductions use None as the NA sentinel.
         result = getattr(df, method)(axis=1, skipna=False)
-        expected = Series([winner, pd.NaT], dtype=object)
+        expected = Series([winner, None], dtype=object)
         tm.assert_series_equal(result, expected)
 
     def test_frame_any_with_timedelta(self):
@@ -2641,6 +2643,27 @@ def test_minmax_object_na_positions_differ_per_slice(axis):
 
     tm.assert_series_equal(df.min(axis=axis), exp_min)
     tm.assert_series_equal(df.max(axis=axis), exp_max)
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+def test_minmax_object_skipna_false_propagates_per_slice(axis):
+    # GH#4147: only the slices that actually hold an NA reduce to NA
+    df = DataFrame(
+        {
+            "a": ["x", None, "b"],
+            "b": ["r", "q", "p"],
+        },
+        dtype=object,
+    )
+    if axis == 0:
+        exp_min = Series([None, "p"], index=Index(["a", "b"]), dtype=object)
+        exp_max = Series([None, "r"], index=Index(["a", "b"]), dtype=object)
+    else:
+        exp_min = Series(["r", None, "b"], dtype=object)
+        exp_max = Series(["x", None, "p"], dtype=object)
+
+    tm.assert_series_equal(df.min(axis=axis, skipna=False), exp_min)
+    tm.assert_series_equal(df.max(axis=axis, skipna=False), exp_max)
 
 
 @pytest.mark.parametrize("ts_value", [Timestamp("2000-01-01"), pd.NaT])

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1278,6 +1278,31 @@ class TestSeriesReductions:
         assert isna(ser.min())
         assert isna(ser.max())
 
+    @pytest.mark.parametrize(
+        "data",
+        [
+            ["a", None, "d"],
+            # pre-3.1 this silently returned 1.0/3.0 rather than propagating
+            [1.0, np.nan, 3.0],
+            [date(2018, 1, 1), None, date(2018, 1, 3)],
+            [Timestamp("2024-05-13", tz="America/New_York"), NaT],
+            [np.nan, np.nan],
+        ],
+    )
+    def test_minmax_object_with_na_skipna_false(self, data):
+        # GH#4147: object dtype used to compare NAs as-is under skipna=False,
+        # raising or returning a wrong answer instead of propagating the NA
+        ser = Series(data, dtype=object)
+        assert isna(ser.min(skipna=False))
+        assert isna(ser.max(skipna=False))
+
+    @pytest.mark.parametrize("data", [["a", "d"], [(1, 3), (2, 2)]])
+    def test_minmax_object_skipna_false_no_na(self, data):
+        # GH#4147: without NAs, skipna=False still reduces normally
+        ser = Series(data, dtype=object)
+        assert ser.min(skipna=False) == data[0]
+        assert ser.max(skipna=False) == data[1]
+
     def test_idxminmax_object_dtype(self, using_infer_string):
         # pre-2.1 object-dtype was disallowed for argmin/max
         ser = Series(["foo", "bar", "baz"])

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1,4 +1,5 @@
 from datetime import (
+    date,
     datetime,
     timedelta,
 )
@@ -23,6 +24,7 @@ from pandas import (
     Timedelta,
     TimedeltaIndex,
     Timestamp,
+    concat,
     date_range,
     isna,
     period_range,
@@ -1230,7 +1232,20 @@ class TestSeriesReductions:
         [
             (["a", "b", np.nan], "a", "b"),
             (["a", "b", None], "a", "b"),
+            # GH#4147
+            (["alpha", np.nan, "charlie", "delta"], "alpha", "delta"),
             ([(1, 3), (2, 2), np.nan], (1, 3), (2, 2)),
+            # GH#24109, including the NaT sentinel left behind by .dt.date
+            (
+                [date(2018, 1, 1), None, date(2018, 1, 3)],
+                date(2018, 1, 1),
+                date(2018, 1, 3),
+            ),
+            (
+                [date(2018, 1, 1), NaT, date(2018, 1, 3)],
+                date(2018, 1, 1),
+                date(2018, 1, 3),
+            ),
         ],
     )
     def test_minmax_object_with_na(self, data, exp_min, exp_max):
@@ -1248,6 +1263,14 @@ class TestSeriesReductions:
         ser = Series([ts1, ts2, NaT], dtype=object)
         assert ser.max() == ts1
         assert ser.min() == ts2
+
+    def test_minmax_object_tzaware_with_nat(self):
+        # GH#58707: concatenating tz-aware with tz-naive NaT gives object dtype
+        ts = Timestamp("2024-05-13 12:00:00", tz="America/New_York")
+        ser = concat([Series([ts]), Series([NaT])])
+        assert ser.dtype == object
+        assert ser.max() == ts
+        assert ser.min() == ts
 
     def test_minmax_object_all_na(self):
         # GH#65500


### PR DESCRIPTION
closes #4147
closes #18588
closes #24109
closes #58707
closes #61204

All five report the same underlying bug in object-dtype `min`/`max` with missing
values. The `skipna=True` half was already fixed on main by GH-65526, which stopped
`nanops._nanminmax` filling NA entries with float `±inf` (not comparable with
strings, `datetime.date`, or `Timestamp`). This PR adds the missing regression
coverage for that half and fixes the `skipna=False` half, which was still broken.

### Bug fix: `skipna=False` on object dtype

`_nanminmax` gated the NA fill on `dtype == object and skipna`. With `skipna=False`
the `_get_values` fallback never builds a mask for object dtype, so NAs were fed
into the comparison as-is. A float NaN propagates through a comparison on its own;
an object NA does not. The result was either a raise or a silently wrong answer:

```python
>>> pd.Series(["a", None, "d"], dtype=object).min(skipna=False)
TypeError: '<=' not supported between instances of 'str' and 'float'
>>> pd.Series([1.0, np.nan, 3.0], dtype=object).max(skipna=False)   # wrong
3.0
```

Both now return a missing value, matching `float64`, `str` and `datetime64`. The
object branch is de-gated to all object dtypes: the NA fill runs regardless of
`skipna` so the comparison cannot raise, and for `skipna=False` the result is then
discarded by `_maybe_null_out` with `min_count` set to the slice length, so any
slice holding an NA reduces to NA.

This changes one assertion in `test_reduce_axis1_dt64tz_mixed_tz_with_nat`, added by
GH-65526 earlier in this same unreleased cycle: the `skipna=False` row containing
`NaT` previously reduced to `NaT` and now reduces to `None`. The old `NaT` was an
artifact of numpy reducing the raw object array; `None` is the object-dtype NA
sentinel `_maybe_null_out` already uses. No released behavior changes.

### Test coverage

Prior coverage was Series-only, so the 2D `take_along_axis` branch of `_nanminmax` —
exactly what GH-18588 and GH-61204 report — was untested. New in
`frame/test_reductions.py`:

- `test_minmax_axis0_string_columns_with_na` — GH-18588's repro. Parametrized over
  `object` and `str`, since the issue's literal code now infers `str` dtype and
  takes the Arrow path rather than the object one.
- `test_minmax_axis0_object_date_with_na` — GH-61204's repro.
- `test_minmax_object_na_positions_differ_per_slice` — NAs in different positions
  per column plus an all-NA column, over both axes. This is where the per-slice fill
  and the all-NA `±inf` override actually matter.
- `test_minmax_object_skipna_false_propagates_per_slice` — only the slices that hold
  an NA reduce to NA.

In `reductions/test_reductions.py`, GH-4147's and GH-24109's exact data was added to
`test_minmax_object_with_na` (including the `NaT` sentinel `.dt.date` leaves behind,
which GH-24109 hits), plus `test_minmax_object_tzaware_with_nat` for GH-58707's
single-tz concat and `test_minmax_object_with_na_skipna_false` /
`test_minmax_object_skipna_false_no_na` for the fix above.

Each new object-dtype assertion for the `skipna=True` half was confirmed to fail
with GH-65526 reverted; the `str` parametrization passes either way, as expected.

### Not addressed here

`idxmin`/`idxmax` on object-with-NA still raise — `nanargmin`/`nanargmax` keep the
`±inf` fill, and `_maybe_fix_arg_at_na` assumes that fill is a sentinel extremum, so
they cannot simply reuse the same-slice fill. `test_idxminmax_object_dtype` codifies
the current raise and GH-4279 was closed, so that one wants a decision rather than
just a patch.
