### PR TITLE
BUG: to_datetime ignoring dayfirst/yearfirst with unit (GH#63472)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -341,6 +341,7 @@ Datetimelike
 - Bug in :func:`to_datetime` when passed a :class:`DataFrame` of date/time field columns raising for years outside the range 1000-9999 (:issue:`65195`)
 - Bug in :func:`to_datetime` when passed a :class:`DataFrame` of date/time field columns with ``errors="coerce"`` returning ``datetime64[s]`` dtype instead of ``datetime64[us]`` when all rows were invalid (:issue:`65195`)
 - Bug in :func:`to_datetime` when using a low time resolution ``unit``, higher resolution in ``origin`` is now preserved instead of silently dropped (e.g. ``unit="D"`` with microsecond precision origin) (:issue:`63419`)
+- Bug in :func:`to_datetime` with string input silently ignoring ``dayfirst`` and ``yearfirst`` when ``unit`` was also passed (:issue:`63472`)
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``AssertionError`` instead of :class:`OutOfBoundsDatetime` when replacing with a ``datetime`` value outside the ``datetime64[ns]`` range (:issue:`61671`)
 - Bug in :meth:`DataFrame.to_string` and :meth:`Series.to_string` where ``na_rep`` was ignored for datetime and timedelta columns, always displaying ``NaT`` (:issue:`55426`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -527,8 +527,8 @@ def _to_datetime_with_unit(
     name,
     utc: bool,
     errors: str,
-    dayfirst=None,
-    yearfirst=None,
+    dayfirst,
+    yearfirst,
 ) -> Index:
     """
     to_datetime specalized to the case where a 'unit' is passed.

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -444,7 +444,9 @@ def _convert_listlike_datetimes(
     elif unit is not None:
         if format is not None:
             raise ValueError("cannot specify both format and unit")
-        return _to_datetime_with_unit(arg, unit, name, utc, errors)
+        return _to_datetime_with_unit(
+            arg, unit, name, utc, errors, dayfirst=dayfirst, yearfirst=yearfirst
+        )
     elif getattr(arg, "ndim", 1) > 1:
         raise TypeError(
             "arg must be a string, datetime, list, tuple, 1-d array, or Series"
@@ -519,7 +521,15 @@ def _array_strptime_with_fallback(
     return Index(result, dtype=result.dtype, name=name, copy=False)
 
 
-def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
+def _to_datetime_with_unit(
+    arg,
+    unit,
+    name,
+    utc: bool,
+    errors: str,
+    dayfirst=None,
+    yearfirst=None,
+) -> Index:
     """
     to_datetime specalized to the case where a 'unit' is passed.
     """
@@ -548,7 +558,9 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
                         )
 
                     arg = arg.astype(object)
-                    return _to_datetime_with_unit(arg, unit, name, utc, errors)
+                    return _to_datetime_with_unit(
+                        arg, unit, name, utc, errors, dayfirst, yearfirst
+                    )
             arr = arg.astype(f"datetime64[{unit}]", copy=False)
             dtype = get_supported_dtype(arr.dtype)
             try:
@@ -557,7 +569,9 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
                 if errors == "raise":
                     raise
                 arg = arg.astype(object)
-                return _to_datetime_with_unit(arg, unit, name, utc, errors)
+                return _to_datetime_with_unit(
+                    arg, unit, name, utc, errors, dayfirst, yearfirst
+                )
             tz_parsed = None
 
         elif arg.dtype.kind == "f":
@@ -574,7 +588,13 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
                 # With all-round-or-NaN entries, we give the requested unit
                 #  back like with integers
                 result = _to_datetime_with_unit(
-                    int_values, unit=unit, name=name, utc=utc, errors=errors
+                    int_values,
+                    unit=unit,
+                    name=name,
+                    utc=utc,
+                    errors=errors,
+                    dayfirst=dayfirst,
+                    yearfirst=yearfirst,
                 )
                 result._data[mask] = NaT
                 return result
@@ -586,7 +606,13 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
                 except OutOfBoundsDatetime as err:
                     if errors != "raise":
                         return _to_datetime_with_unit(
-                            arg.astype(object), unit, name, utc, errors
+                            arg.astype(object),
+                            unit,
+                            name,
+                            utc,
+                            errors,
+                            dayfirst,
+                            yearfirst,
                         )
                     raise OutOfBoundsDatetime(
                         f"cannot convert input with unit '{unit}'"
@@ -600,6 +626,8 @@ def _to_datetime_with_unit(arg, unit, name, utc: bool, errors: str) -> Index:
                 arg,
                 utc=utc,
                 errors=errors,
+                dayfirst=dayfirst,
+                yearfirst=yearfirst,
                 unit_for_numerics=unit,
             )
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3977,6 +3977,7 @@ def test_empty_string_datetime_coerce__unit():
 @pytest.mark.parametrize(
     "kwargs, expected",
     [
+        ({}, "2012-10-11"),
         ({"dayfirst": True}, "2012-11-10"),
         ({"yearfirst": True}, "2010-11-12"),
         ({"dayfirst": True, "yearfirst": True}, "2010-12-11"),
@@ -3994,17 +3995,17 @@ def test_to_datetime_unit_dayfirst_yearfirst(kwargs, expected, cache):
 
 
 @pytest.mark.parametrize(
-    "kwargs, expected",
+    "kwargs, parsed",
     [
         ({"dayfirst": True}, "2012-11-10"),
         ({"yearfirst": True}, "2010-11-12"),
     ],
 )
-def test_to_datetime_unit_dayfirst_yearfirst_mixed_numeric(kwargs, expected, cache):
+def test_to_datetime_unit_dayfirst_yearfirst_mixed_numeric(kwargs, parsed, cache):
     # GH#63472 the unit still applies to the numeric entries
     result = to_datetime(["10/11/12", 1], unit="s", cache=cache, **kwargs)
 
-    expected = DatetimeIndex([expected, "1970-01-01 00:00:01"], dtype="datetime64[us]")
+    expected = DatetimeIndex([parsed, "1970-01-01 00:00:01"], dtype="datetime64[us]")
     tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -3974,6 +3974,40 @@ def test_empty_string_datetime_coerce__unit():
     tm.assert_index_equal(expected, result)
 
 
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({"dayfirst": True}, "2012-11-10"),
+        ({"yearfirst": True}, "2010-11-12"),
+        ({"dayfirst": True, "yearfirst": True}, "2010-12-11"),
+    ],
+)
+def test_to_datetime_unit_dayfirst_yearfirst(kwargs, expected, cache):
+    # GH#63472 dayfirst/yearfirst were silently ignored for string entries
+    #  when 'unit' was passed
+    arg = ["10/11/12"]
+    result = to_datetime(arg, unit="s", cache=cache, **kwargs)
+
+    tm.assert_index_equal(result, DatetimeIndex([expected], dtype="datetime64[us]"))
+    # passing a unit gives the same result as not passing one
+    tm.assert_index_equal(result, to_datetime(arg, cache=cache, **kwargs))
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({"dayfirst": True}, "2012-11-10"),
+        ({"yearfirst": True}, "2010-11-12"),
+    ],
+)
+def test_to_datetime_unit_dayfirst_yearfirst_mixed_numeric(kwargs, expected, cache):
+    # GH#63472 the unit still applies to the numeric entries
+    result = to_datetime(["10/11/12", 1], unit="s", cache=cache, **kwargs)
+
+    expected = DatetimeIndex([expected, "1970-01-01 00:00:01"], dtype="datetime64[us]")
+    tm.assert_index_equal(result, expected)
+
+
 def test_to_datetime_monotonic_increasing_index(cache):
     # GH28238
     cstart = start_caching_at


### PR DESCRIPTION
A facet of GH-63472 — deliberately *not* the whole issue, so no closing keyword.

`to_datetime` silently ignored `dayfirst`/`yearfirst` for string input when `unit` was also passed:

```python
>>> pd.to_datetime(["10/11/12"], dayfirst=True)
DatetimeIndex(['2012-11-10'], dtype='datetime64[us]', freq=None)
>>> pd.to_datetime(["10/11/12"], dayfirst=True, unit="s")
DatetimeIndex(['2012-10-11'], dtype='datetime64[us]', freq=None)   # dayfirst ignored
```

Strings reach this code path at all because GH-58407 enforced that strings passed with a `unit` are parsed as datetime strings, matching the behavior without a unit — so ignoring `dayfirst`/`yearfirst` there contradicted that. This is pure plumbing: `_to_datetime_with_unit` never forwarded the two keywords down to `tslib.array_to_datetime`, which has accepted them all along.

The recursive `_to_datetime_with_unit` calls (uint64 overflow, `astype_overflowsafe`, float OOB) get the args threaded through too. None of them can actually reach the string branch — they all originate inside the numeric-dtype branches — but this leaves no path that silently drops the keywords.

The two params are required rather than defaulted, so a call site added later can't silently drop them the way the original bug did, and they're left unannotated — both matching `objects_to_datetime64`, which takes them the same way and handles the identical `bool | None` → `bint` situation on the no-unit path.

The remaining GH-63472 divergence — the `unit` path skips `_guess_datetime_format_for_array`, so mixed-format ISO strings parse fine with `unit` but raise without it — is blocked on enforcing the GH-55663 deprecation in GH-65181, so this PR stays scoped to the `dayfirst`/`yearfirst` plumbing.

