### PR TITLE
TST: fix test_rdc_overlapping_back_reference under the read_sas encoding deprecation

### DIFF
--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -518,11 +518,11 @@ def test_rdc_overlapping_back_reference(datapath):
     # rewritten to expand 8 bytes from 4 back.
     with open(datapath("io", "sas", "data", "test11.sas7bdat"), "rb") as fd:
         data = bytearray(fd.read())
-    original = pd.read_sas(io.BytesIO(bytes(data)), format="sas7bdat")
+    original = pd.read_sas(io.BytesIO(bytes(data)), format="sas7bdat", encoding=None)
 
     assert data[120922:120924] == b"\x8d\x00"
     data[120922:120924] = b"\x81\x00"
-    result = pd.read_sas(io.BytesIO(bytes(data)), format="sas7bdat")
+    result = pd.read_sas(io.BytesIO(bytes(data)), format="sas7bdat", encoding=None)
 
     # Column11 is bytes 56-63 of the row and is now copied from byte 52, so it
     # repeats the second half of Column9 (bytes 48-55) twice. The fixture is


### PR DESCRIPTION
Test-only fix for a failure on main.

GH-66462 added `test_rdc_overlapping_back_reference` with bare `read_sas` calls; GH-66470 (merged the same day) deprecated the `read_sas` default of `encoding=None` and updated every call site that existed at the time. `test11.sas7bdat` has text columns, so the new test emits `Pandas4Warning` and errors. Both PRs were green in isolation.

Passing `encoding=None` explicitly keeps the behavior the test was written against; it only asserts on numeric columns, so decoding is irrelevant to what it checks.