### PR TITLE
fix: respect use_na_sentinel for pre-encoded Arrow DictionaryArrays

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1865,13 +1865,10 @@ class ArrowExtensionArray(
 
         data = self._pa_array
 
+        # GH 66490
         if pa.types.is_dictionary(data.type):
-            if null_encoding == "encode":
-                # dictionary encode does nothing if an already encoded array is given
-                data = data.cast(data.type.value_type)
-                encoded = data.dictionary_encode(null_encoding=null_encoding)
-            else:
-                encoded = data
+            data = data.cast(data.type.value_type)
+            encoded = data.dictionary_encode(null_encoding=null_encoding)
         else:
             encoded = data.dictionary_encode(null_encoding=null_encoding)
         if encoded.length() == 0:

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1866,9 +1866,7 @@ class ArrowExtensionArray(
         data = self._pa_array
         if data.length() == 0:
             indices = np.array([], dtype=np.intp)
-            uniques = self._from_pyarrow_array(
-                pa.chunked_array([], type=data.type.value_type)
-            )
+            uniques = self._from_pyarrow_array(pa.chunked_array([], type=data.type))
             return indices, uniques
 
         if not pa.types.is_dictionary(data.type):

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1864,27 +1864,57 @@ class ArrowExtensionArray(
         null_encoding = "mask" if use_na_sentinel else "encode"
 
         data = self._pa_array
-
-        # GH 66490
-        if pa.types.is_dictionary(data.type):
-            data = data.cast(data.type.value_type)
-        encoded = data.dictionary_encode(null_encoding=null_encoding)
-        if encoded.length() == 0:
+        if data.length() == 0:
             indices = np.array([], dtype=np.intp)
             uniques = self._from_pyarrow_array(
-                pa.chunked_array([], type=encoded.type.value_type)
+                pa.chunked_array([], type=data.type.value_type)
             )
-        else:
-            # GH 54844
-            combined = encoded.combine_chunks()
-            pa_indices = combined.indices
-            if pa_indices.null_count > 0:
-                pa_indices = _safe_fill_null(pa_indices, -1)
-            indices = pa_indices.to_numpy(zero_copy_only=False, writable=True).astype(
-                np.intp, copy=False
-            )
-            uniques = self._from_pyarrow_array(combined.dictionary)
+            return indices, uniques
 
+        if not pa.types.is_dictionary(data.type):
+            encoded = data.dictionary_encode(null_encoding=null_encoding)
+        else:
+            encoded = data
+
+        encoded = encoded.combine_chunks()  # GH 54844
+
+        # GH 66490
+        dictionary_has_nulls = encoded.dictionary.null_count > 0
+        indices_has_nulls = encoded.indices.null_count > 0
+        if (null_encoding == "mask") and dictionary_has_nulls:
+            null_index = pc.indices_nonzero(encoded.dictionary.is_null())[0]
+            is_null = pc.equal(encoded.indices, null_index)
+            needs_shift = pc.greater(encoded.indices, null_index)
+            pa_indices = pc.if_else(
+                is_null,
+                pa.scalar(None, type=encoded.indices.type),
+                pc.subtract(
+                    encoded.indices,
+                    pc.cast(needs_shift, encoded.indices.type),
+                ),
+            )
+            pa_uniques = encoded.dictionary.drop_null()
+
+        elif (null_encoding == "encode") and indices_has_nulls:
+            if dictionary_has_nulls:
+                null_index = pc.indices_nonzero(encoded.dictionary.is_null())[0]
+                pa_uniques = encoded.dictionary
+            else:
+                null_index = len(encoded.dictionary)
+                pa_uniques = pa.concat_arrays(
+                    [encoded.dictionary, pa.array([None], type=encoded.dictionary.type)]
+                )
+            pa_indices = pc.fill_null(encoded.indices, null_index)
+
+        else:
+            pa_indices, pa_uniques = encoded.indices, encoded.dictionary
+
+        if pa_indices.null_count > 0:
+            pa_indices = _safe_fill_null(pa_indices, -1)
+        indices = pa_indices.to_numpy(zero_copy_only=False, writable=True).astype(
+            np.intp, copy=False
+        )
+        uniques = self._from_pyarrow_array(pa_uniques)
         return indices, uniques
 
     def reshape(self, *args, **kwargs):

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -1868,9 +1868,7 @@ class ArrowExtensionArray(
         # GH 66490
         if pa.types.is_dictionary(data.type):
             data = data.cast(data.type.value_type)
-            encoded = data.dictionary_encode(null_encoding=null_encoding)
-        else:
-            encoded = data.dictionary_encode(null_encoding=null_encoding)
+        encoded = data.dictionary_encode(null_encoding=null_encoding)
         if encoded.length() == 0:
             indices = np.array([], dtype=np.intp)
             uniques = self._from_pyarrow_array(

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3939,34 +3939,67 @@ def test_factorize_chunked_dictionary():
 
 
 @pytest.mark.parametrize(
-    ("codes", "uniques"),
+    ("codes", "uniques", "use_na_sentinel", "expected_indices", "expected_uniques"),
     [
-        pytest.param([0, None], ["a1"], id="null_in_codes"),
-        pytest.param([0, 1], ["a1", None], id="null_in_uniques"),
+        pytest.param(
+            [0, None], ["a1"], True, [0, -1], ["a1"], id="null_in_indices_w_na_sentinel"
+        ),
+        pytest.param(
+            [0, None],
+            ["a1"],
+            False,
+            [0, 1],
+            ["a1", None],
+            id="null_in_indices_wo_na_sentinel",
+        ),
+        pytest.param(
+            [0, 1],
+            ["a1", None],
+            True,
+            [0, -1],
+            ["a1"],
+            id="null_in_uniques_w_na_sentinel",
+        ),
+        pytest.param(
+            [0, 1],
+            ["a1", None],
+            False,
+            [0, 1],
+            ["a1", None],
+            id="null_in_uniques_wo_na_sentinel",
+        ),
+        pytest.param(
+            [None, 0, 1, 1, 2, None],
+            ["a1", None, "a2"],
+            True,
+            [-1, 0, -1, -1, 1, -1],
+            ["a1", "a2"],
+            id="null_in_both_w_na_sentinel",
+        ),
+        pytest.param(
+            [None, 0, 1, 1, 2, None],
+            ["a1", None, "a2"],
+            False,
+            [1, 0, 1, 1, 2, 1],
+            ["a1", None, "a2"],
+            id="null_in_both_w_na_sentinel",
+        ),
     ],
 )
-def test_factorize_dictionary_with_na(codes, uniques):
-    # GH#60567
+def test_factorize_dictionary_with_na(
+    codes, uniques, use_na_sentinel, expected_indices, expected_uniques
+):
+    # GH#60567 & GH#66490
     pa_arr = pa.DictionaryArray.from_arrays(
         pa.array(codes, type=pa.int32()),
         pa.array(uniques, type=pa.utf8()),
     )
     arr = pd.array(pa_arr, dtype=ArrowDtype(pa_arr.type))
-
-    # use_na_sentinel=False should produce valid integer codes for Null values
-    indices, uniques = arr.factorize(use_na_sentinel=False)
-    expected_indices = np.array([0, 1], dtype=np.intp)
-    expected_uniques = pd.array(["a1", None], dtype=ArrowDtype(pa.string()))
-    tm.assert_numpy_array_equal(indices, expected_indices)
-    tm.assert_extension_array_equal(uniques, expected_uniques)
-
-    # GH#66490
-    # use_na_sentinel=True should produce -1 codes for Null values
-    indices, uniques = arr.factorize(use_na_sentinel=True)
-    expected_indices = np.array([0, -1], dtype=np.intp)
-    expected_uniques = pd.array(["a1"], dtype=ArrowDtype(pa.string()))
-    tm.assert_numpy_array_equal(indices, expected_indices)
-    tm.assert_extension_array_equal(uniques, expected_uniques)
+    indices, uniques = arr.factorize(use_na_sentinel=use_na_sentinel)
+    tm.assert_numpy_array_equal(indices, np.array(expected_indices, dtype=np.intp))
+    tm.assert_extension_array_equal(
+        uniques, pd.array(expected_uniques, dtype=ArrowDtype(pa.string()))
+    )
 
 
 def test_dictionary_astype_categorical():

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3938,14 +3938,33 @@ def test_factorize_chunked_dictionary():
     tm.assert_index_equal(res_uniques, exp_uniques)
 
 
-def test_factorize_dictionary_with_na():
+@pytest.mark.parametrize(
+    ("codes", "uniques"),
+    [
+        pytest.param([0, None], ["a1"], id="null_in_codes"),
+        pytest.param([0, 1], ["a1", None], id="null_in_uniques"),
+    ],
+)
+def test_factorize_dictionary_with_na(codes, uniques):
     # GH#60567
-    arr = pd.array(
-        ["a1", pd.NA], dtype=ArrowDtype(pa.dictionary(pa.int32(), pa.utf8()))
+    pa_arr = pa.DictionaryArray.from_arrays(
+        pa.array(codes, type=pa.int32()),
+        pa.array(uniques, type=pa.utf8()),
     )
+    arr = pd.array(pa_arr, dtype=ArrowDtype(pa_arr.type))
+
+    # use_na_sentinel=False should produce valid integer codes for Null values
     indices, uniques = arr.factorize(use_na_sentinel=False)
     expected_indices = np.array([0, 1], dtype=np.intp)
     expected_uniques = pd.array(["a1", None], dtype=ArrowDtype(pa.string()))
+    tm.assert_numpy_array_equal(indices, expected_indices)
+    tm.assert_extension_array_equal(uniques, expected_uniques)
+
+    # GH#66490
+    # use_na_sentinel=True should produce -1 codes for Null values
+    indices, uniques = arr.factorize(use_na_sentinel=True)
+    expected_indices = np.array([0, -1], dtype=np.intp)
+    expected_uniques = pd.array(["a1"], dtype=ArrowDtype(pa.string()))
     tm.assert_numpy_array_equal(indices, expected_indices)
     tm.assert_extension_array_equal(uniques, expected_uniques)
 


### PR DESCRIPTION
When calling `pandas.factorize` on a PyArrow backed Series, re-encode pre-encoded DictionaryArrays to match the requested null encoding before factorization. This ensures use_na_sentinel=True consistently produces sentinel codes regardless of how the input DictionaryArray was originally constructed.

- [x] closes #66490
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
