### PR TITLE
BUG: check Python API return values in ujson encoder (GH#66489)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -507,6 +507,7 @@ I/O
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
 - Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)
+- Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when the JSON encoder failed to convert a value to text -- for example an integer whose decimal form exceeds ``sys.get_int_max_str_digits()``, a label or ``dict`` key containing a lone surrogate, or a ``__dir__``/``__iter__``/``isoformat`` override that raises; the underlying exception is now propagated (:issue:`66489`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -1472,6 +1472,8 @@ static char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
             // numpy arrays are already scaled to the correct unit
             // only need to scale if coming from a datetime/timedelta object
             if (scaleNanosecToUnit(&i8date, targetUnit) == -1) {
+              PyObject_Free(cLabel);
+              Py_DECREF(item);
               NpyArr_freeLabels(ret, num);
               ret = 0;
               break;

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -442,6 +442,15 @@ static const char *PyTimeToJSON(JSOBJ _obj, JSONTypeContext *tc,
     PyObject *tmp = str;
     str = PyUnicode_AsUTF8String(str);
     Py_DECREF(tmp);
+  } else if (!PyBytes_Check(str)) {
+    Py_DECREF(str);
+    PyErr_SetString(PyExc_ValueError, "Failed to convert time");
+    str = NULL;
+  }
+  if (str == NULL) {
+    *outLen = 0;
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return NULL;
   }
 
   GET_TC(tc)->newObj = str;
@@ -467,6 +476,11 @@ static const char *PyDecimalToUTF8Callback(JSOBJ _obj, JSONTypeContext *tc,
 
   Py_ssize_t s_len;
   char *outValue = (char *)PyUnicode_AsUTF8AndSize(str, &s_len);
+  if (outValue == NULL) {
+    *len = 0;
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return NULL;
+  }
   *len = s_len;
 
   return outValue;
@@ -914,6 +928,11 @@ static void Set_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
 }
 
 static int Set_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+  if (GET_TC(tc)->iterator == NULL) {
+    // PyObject_GetIter failed in Set_iterBegin, let the exception propagate
+    return 0;
+  }
+
   if (GET_TC(tc)->itemValue) {
     Py_DECREF(GET_TC(tc)->itemValue);
     GET_TC(tc)->itemValue = NULL;
@@ -959,7 +978,10 @@ static const char *Set_iterGetName(JSOBJ Py_UNUSED(obj),
 static void Dir_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->attrList = PyObject_Dir(obj);
   GET_TC(tc)->index = 0;
-  GET_TC(tc)->size = PyList_GET_SIZE(GET_TC(tc)->attrList);
+  // PyObject_Dir can fail, in which case the exception is propagated by
+  // Dir_iterNext, which stops immediately when an error is set
+  GET_TC(tc)->size =
+      GET_TC(tc)->attrList ? PyList_GET_SIZE(GET_TC(tc)->attrList) : 0;
 }
 
 static void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
@@ -973,7 +995,7 @@ static void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     GET_TC(tc)->itemName = NULL;
   }
 
-  Py_DECREF((PyObject *)GET_TC(tc)->attrList);
+  Py_XDECREF((PyObject *)GET_TC(tc)->attrList);
 }
 
 static int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
@@ -999,6 +1021,10 @@ static int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
     PyObject *attrName =
         PyList_GET_ITEM(GET_TC(tc)->attrList, GET_TC(tc)->index);
     PyObject *attr = PyUnicode_AsUTF8String(attrName);
+    if (attr == NULL) {
+      ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+      return 0;
+    }
     const char *attrStr = PyBytes_AS_STRING(attr);
 
     if (attrStr[0] == '_') {
@@ -1266,12 +1292,22 @@ static int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (PyUnicode_Check(GET_TC(tc)->itemName)) {
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String(GET_TC(tc)->itemName);
   } else if (!PyBytes_Check(GET_TC(tc)->itemName)) {
-    GET_TC(tc)->itemName = PyObject_Str(GET_TC(tc)->itemName);
-    PyObject *itemNameTmp = GET_TC(tc)->itemName;
-    GET_TC(tc)->itemName = PyUnicode_AsUTF8String(GET_TC(tc)->itemName);
-    Py_DECREF(itemNameTmp);
+    PyObject *itemNameTmp = PyObject_Str(GET_TC(tc)->itemName);
+    GET_TC(tc)->itemName = NULL;
+    if (itemNameTmp != NULL) {
+      GET_TC(tc)->itemName = PyUnicode_AsUTF8String(itemNameTmp);
+      Py_DECREF(itemNameTmp);
+    }
   } else {
     Py_INCREF(GET_TC(tc)->itemName);
+  }
+
+  if (GET_TC(tc)->itemName == NULL) {
+    /* Converting the key failed.
+      Set errorMsg(to tell encoder to stop),
+      and let Python exception propagate. */
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return 0;
   }
   return 1;
 }
@@ -1455,6 +1491,12 @@ static char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
       }
 
       cLabel = (char *)PyUnicode_AsUTF8(item);
+      if (cLabel == NULL) {
+        Py_DECREF(item);
+        NpyArr_freeLabels(ret, num);
+        ret = 0;
+        break;
+      }
       len = strlen(cLabel);
     }
 
@@ -1895,6 +1937,9 @@ ISITERABLE:
       pc->rowLabels = NpyArr_encodeLabels((PyArrayObject *)values, enc,
                                           pc->rowLabelsLen, values_is_utc);
       Py_DECREF(tmpObj);
+      if (!pc->rowLabels) {
+        goto INVALID;
+      }
       tmpObj =
           (enc->outputFormat == INDEX ? PyObject_GetAttrString(obj, "columns")
                                       : PyObject_GetAttrString(obj, "index"));
@@ -2047,7 +2092,18 @@ static double Object_getDoubleValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
 static const char *Object_getBigNumStringValue(JSOBJ obj, JSONTypeContext *tc,
                                                size_t *_outLen) {
   PyObject *repr = PyObject_Str(obj);
+  if (repr == NULL) {
+    *_outLen = 0;
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return NULL;
+  }
   const char *str = PyUnicode_AsUTF8AndSize(repr, (Py_ssize_t *)_outLen);
+  if (str == NULL) {
+    *_outLen = 0;
+    Py_DECREF(repr);
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return NULL;
+  }
   char *bytes = PyObject_Malloc(*_outLen + 1);
   memcpy(bytes, str, *_outLen + 1);
   GET_TC(tc)->cStr = bytes;

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -28,6 +28,9 @@ from pandas import (
 import pandas._testing as tm
 
 
+LONE_SURROGATE = "\ud800"
+
+
 def _clean_dict(d):
     """
     Sanitize dictionary for JSON by converting all keys to strings.
@@ -675,6 +678,94 @@ class TestUltraJSONTests:
             "b": 2,
             "d": 4,
         }
+
+    def test_encode_object_dir_raises(self):
+        # GH#66489
+        class _TestObject:
+            def __dir__(self):
+                raise TypeError("I raise you one exception")
+
+        with pytest.raises(TypeError, match="I raise you one exception"):
+            ujson.ujson_dumps(_TestObject())
+
+    def test_encode_object_dir_lone_surrogate(self):
+        # GH#66489
+        class _TestObject:
+            def __dir__(self):
+                return [LONE_SURROGATE]
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(_TestObject())
+
+    def test_encode_set_iter_raises(self):
+        # GH#66489
+        class _TestSet(set):
+            def __iter__(self):
+                raise TypeError("I raise you one exception")
+
+        with pytest.raises(TypeError, match="I raise you one exception"):
+            ujson.ujson_dumps(_TestSet([1, 2, 3]))
+
+    def test_encode_decimal_lone_surrogate(self):
+        # GH#66489
+        class _TestDecimal(decimal.Decimal):
+            def __format__(self, *args, **kwargs):
+                return LONE_SURROGATE
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(_TestDecimal(1))
+
+    def test_encode_time_non_str_isoformat(self):
+        # GH#66489
+        class _TestTime(datetime.time):
+            def isoformat(self, *args, **kwargs):
+                return 1
+
+        with pytest.raises(ValueError, match="Failed to convert time"):
+            ujson.ujson_dumps(_TestTime())
+
+    def test_encode_time_lone_surrogate_isoformat(self):
+        # GH#66489
+        class _TestTime(datetime.time):
+            def isoformat(self, *args, **kwargs):
+                return LONE_SURROGATE
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(_TestTime())
+
+    def test_encode_huge_int(self):
+        # GH#66489
+        with pytest.raises(ValueError, match="Exceeds the limit"):
+            ujson.ujson_dumps(1 << 1_000_000)
+
+    def test_encode_huge_int_key(self):
+        # GH#66489
+        with pytest.raises(ValueError, match="Exceeds the limit"):
+            ujson.ujson_dumps({1 << 1_000_000: "value"})
+
+    def test_encode_lone_surrogate_key(self):
+        # GH#66489
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps({LONE_SURROGATE: "value"})
+
+    def test_encode_lone_surrogate_str_key(self):
+        # GH#66489
+        class _TestKey:
+            def __str__(self) -> str:
+                return LONE_SURROGATE
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps({_TestKey(): "value"})
+
+    def test_encode_lone_surrogate_labels(self):
+        # GH#66489
+        class _TestKey:
+            def __str__(self) -> str:
+                return LONE_SURROGATE
+
+        df = DataFrame({_TestKey(): [1, 2, 3]})
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(df)
 
     def test_ujson__name__(self):
         # GH 52898

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -27,7 +27,6 @@ from pandas import (
 )
 import pandas._testing as tm
 
-
 LONE_SURROGATE = "\ud800"
 
 


### PR DESCRIPTION
Fixes #66489

## Root cause

`objToJSON.c` calls Python C-API functions that can fail - `PyObject_Str`,
`PyUnicode_AsUTF8String`, `PyUnicode_AsUTF8AndSize`, `PyUnicode_AsUTF8`, `PyObject_Dir`,
`PyObject_GetIter` - and then dereferences the result without checking it for `NULL`.
Any input that makes one of those raise (an integer whose decimal form exceeds
`sys.get_int_max_str_digits()`, a lone surrogate that cannot be UTF-8 encoded, or a user
`__dir__`/`__iter__`/`isoformat`/`__format__` override that raises or returns the wrong
type) segfaults instead of propagating the Python exception.

## Fix

Each of those return values is now checked. On failure the encoder sets
`enc->errorMsg = ""` - the idiom already used by `PyUnicodeToUTF8` and
`PyDateTimeToIsoCallback` in this file - so encoding stops and the exception Python
already raised propagates out of `objToJSON`, which ends with
`if (PyErr_Occurred()) return NULL;`. No new error text is invented, except for
`datetime.time` subclasses whose `isoformat()` returns a non-string, which now raise
`ValueError: Failed to convert time` (matching the existing message on the adjacent
failure path) instead of reading a bogus length off a non-`bytes` object.

One additional missing check: `pc->rowLabels = NpyArr_encodeLabels(...)` was the only one
of the four `NpyArr_encodeLabels` call sites that did not test its result. Without it the
encoder kept calling back into Python with an exception already pending, and a
`DataFrame` with a lone-surrogate label surfaced a misleading
`ValueError: Error retrieving .array from Index/Series object` rather than the real
`UnicodeEncodeError`.

## Verification

Built from source on Linux x86_64, CPython 3.11.15, NumPy 2.4.6, gcc 15.2.0. No special
hardware involved - this is a pure C-extension bug.

11 tests were added to `pandas/tests/io/json/test_ujson.py`, one per case listed in the
issue. Each was run in its own process (a segfault kills pytest). Before the change 10 of
the 11 exit with SIGSEGV (139) and the eleventh fails; after the change all 11 pass and
raise the appropriate `ValueError` / `UnicodeEncodeError` / `TypeError`. The public API
is affected too: `pd.Series([1 << 1_000_000], dtype=object).to_json()` segfaulted before
and now raises `ValueError: Exceeds the limit (4300 digits) for integer string
conversion`.

`pandas/tests/io/json/` passes: 1044 passed, 119 skipped, 48 xfailed
(`test_pandas.py::TestPandasContainer::test_url` deselected - no `pytest-localserver` in
this environment, and it errors on an unmodified checkout too). `ruff`, `ruff format`,
`clang-format` (at the versions pinned in `.pre-commit-config.yaml`) and `sphinx-lint` are
clean.

## Not verified

- No refcount/leak measurement: I did not build a `--with-pydebug` CPython or run
  valgrind. The new early-return paths look balanced by inspection, but that is reasoning,
  not measurement.
- Only Linux x86_64 / CPython 3.11 / gcc 15.2. Not tested on macOS, Windows, or 32-bit.
- Only `pandas/tests/io/json/` was run, not the full suite.
- Not fuzzed. This covers the 11 cases enumerated in the issue; I did not exhaustively
  audit every C-API call in the file.

Thanks to @fastbyte19 for the fuzzing work and for enumerating every crashing input -
the reproducers in the issue made this straightforward to trace.