### PR TITLE
BUG: Fix query() IndexError when columns.name is numeric (#66501)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -553,7 +553,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         for i, name in enumerate(axis_index.names):
             if name is not None:
-                key = level = name
+                key = name
+                level = i
             else:
                 # prefix with 'i' or 'c' depending on the input axis
                 # e.g., you must do ilevel_0 for the 0th level of an unnamed


### PR DESCRIPTION
When `DataFrame.columns.name` is an integer, `query()` raises
`IndexError: Too many levels: Index has only 1 level, not <int>`.

Root cause: `_get_axis_resolvers` assigned `level = name`, conflating
the level label (which can be any hashable) with the level position
(0-based integer). When `name` was an integer, it was passed to
`get_level_values()` as a level number instead of a level name.

Fix: separate `key` (the label) from `level` (the position index `i`).

Closes #66501