### PR TITLE
BUG: Fix misleading ValueError in str.match with compiled regex flags (#66138)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -426,7 +426,7 @@ Strings
 ^^^^^^^
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
-- Bug in :meth:`Series.str.match` and :meth:`Series.str.fullmatch` raising a misleading ``ValueError`` when passed a compiled regex pattern with standard flags like ``re.MULTILINE`` (:issue:`66138`)
+- Bug in :meth:`Series.str.match` raising a misleading ``ValueError`` when passed a compiled regex pattern with standard flags like ``re.MULTILINE``, and in :meth:`Series.str.fullmatch` raising ``ValueError`` when ``case`` or ``flags`` were compatible with the compiled pattern (:issue:`66138`)
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
 - Bug in :meth:`Series.str.split` with :class:`ArrowDtype` ``string`` not inferring regex for multi-character patterns when ``regex=None``, causing the pattern to be treated as a literal instead of a regular expression (:issue:`58321`)
 - Bug in :meth:`Series.unique`, :meth:`Index.unique` and :func:`factorize` on object dtype returning incorrect results when the values were not UTF-8 encodable, e.g. lone surrogates (:issue:`34550`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -426,6 +426,7 @@ Strings
 ^^^^^^^
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
+- Bug in :meth:`Series.str.match` and :meth:`Series.str.fullmatch` raising a misleading ``ValueError`` when passed a compiled regex pattern with standard flags like ``re.MULTILINE`` (:issue:`66138`)
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
 - Bug in :meth:`Series.str.split` with :class:`ArrowDtype` ``string`` not inferring regex for multi-character patterns when ``regex=None``, causing the pattern to be treated as a literal instead of a regular expression (:issue:`58321`)
 - Bug in :meth:`Series.unique`, :meth:`Index.unique` and :func:`factorize` on object dtype returning incorrect results when the values were not UTF-8 encodable, e.g. lone surrogates (:issue:`34550`)

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -240,12 +240,7 @@ class ObjectStringArrayMixin:
             flags |= re.IGNORECASE
 
         if isinstance(pat, re.Pattern):
-            # We need to check that flags matches pat.flags.
-            # pat.flags will have re.U regardless, so we need to add it here
-            # before checking for a match
-            flags = flags | re.U
-
-            if flags != pat.flags:
+            if flags & ~pat.flags:
                 raise ValueError("Cannot pass flags that do not match pat.flags")
             regex = pat
         else:
@@ -264,7 +259,12 @@ class ObjectStringArrayMixin:
         if not case:
             flags |= re.IGNORECASE
 
-        regex = re.compile(pat, flags=flags)
+        if isinstance(pat, re.Pattern):
+            if flags & ~pat.flags:
+                raise ValueError("Cannot pass flags that do not match pat.flags")
+            regex = pat
+        else:
+            regex = re.compile(pat, flags=flags)
 
         f = lambda x: regex.fullmatch(x) is not None
         return self._str_map(f, na_value=na, dtype=np.dtype(bool))

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1185,6 +1185,11 @@ def test_match_compiled_regex(any_string_dtype):
     expected = Series([True, True, True, True], dtype=expected_dtype)
     tm.assert_series_equal(result, expected)
 
+    # GH#66138
+    result = values.str.match(re.compile("ab", flags=re.MULTILINE))
+    expected = Series([True, False, True, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
     msg = (
         "Cannot both specify 'flags' and pass a compiled "
         "regexp object with conflicting flags"

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1377,6 +1377,17 @@ def test_fullmatch_compiled_regex(any_string_dtype):
     expected = Series([True, True, False, False], dtype=expected_dtype)
     tm.assert_series_equal(result, expected)
 
+    # GH#66138 compatible case/flags should not raise
+    result = values.str.fullmatch(re.compile("ab", flags=re.IGNORECASE), case=False)
+    expected = Series([True, True, False, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+    result = values.str.fullmatch(
+        re.compile("ab", flags=re.IGNORECASE), flags=re.IGNORECASE
+    )
+    expected = Series([True, True, False, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
     with pytest.raises(
         ValueError, match="Cannot pass flags that do not match pat.flags"
     ):

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1364,7 +1364,7 @@ def test_fullmatch_compiled_regex(any_string_dtype):
         tm.assert_series_equal(result, expected)
     else:
         with pytest.raises(
-            ValueError, match="cannot process flags argument with a compiled pattern"
+            ValueError, match="Cannot pass flags that do not match pat.flags"
         ):
             values.str.fullmatch(re.compile("ab"), case=False)
 
@@ -1373,7 +1373,7 @@ def test_fullmatch_compiled_regex(any_string_dtype):
     tm.assert_series_equal(result, expected)
 
     with pytest.raises(
-        ValueError, match="cannot process flags argument with a compiled pattern"
+        ValueError, match="Cannot pass flags that do not match pat.flags"
     ):
         values.str.fullmatch(re.compile("ab"), flags=re.IGNORECASE)
 


### PR DESCRIPTION
`Series.str.match(pat=re.compile(r"A", re.MULTILINE))` raised
`ValueError: Cannot pass flags that do not match pat.flags` even when no
explicit `flags=` argument was passed. The check was a duplicate of
the validation in `accessor.py` that already handles user-passed flags.

Removed the broken flag comparison from `_str_match` in
`object_array.py`, making it consistent with `_str_fullmatch` which
already uses `re.compile(pat, flags=flags)` without the check.

- Closes #66138