### PR TITLE
BUG: read_pickle dropping Timestamp tz for pandas<=1.2 pickles (GH#61792)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -504,6 +504,7 @@ I/O
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where ``parse_dates`` did not parse numeric-looking date columns or index columns, leaving them as integers or strings instead of datetimes (:issue:`34066`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where invalid ``sep``, ``quotechar``, ``escapechar``, and ``decimal`` arguments raised cryptic errors, or in the case of ``quotechar=None`` were silently ignored, instead of raising the same informative errors as the other engines (:issue:`66317`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where passing a scalar (non-dict) ``dtype`` together with ``index_col`` raised ``AttributeError``; the scalar ``dtype`` is now also applied to the index column, matching the default ``c`` engine (:issue:`45801`)
+- Fixed bug in :func:`read_pickle` where the timezone of a :class:`Timestamp` was silently dropped when reading a pickle written by pandas 1.2 or earlier, so the timestamp came back tz-naive at its UTC wall time (:issue:`61792`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
 - Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -5,6 +5,7 @@ Pickle compatibility to pandas version 1.0
 from __future__ import annotations
 
 import contextlib
+import datetime
 import io
 import pickle
 from typing import (
@@ -15,7 +16,10 @@ from typing import (
 import numpy as np
 
 from pandas._libs.arrays import NDArrayBacked
-from pandas._libs.tslibs import BaseOffset
+from pandas._libs.tslibs import (
+    BaseOffset,
+    Timestamp,
+)
 
 from pandas.core.arrays import (
     DatetimeArray,
@@ -75,6 +79,22 @@ class Unpickler(pickle._Unpickler):
         stack = self.stack  # type: ignore[attr-defined]
         args = stack.pop()
         func = stack[-1]
+
+        if (
+            func is Timestamp
+            and len(args) == 3
+            and (args[1] is None or isinstance(args[1], (str, BaseOffset)))
+            and (args[2] is None or isinstance(args[2], datetime.tzinfo))
+        ):
+            # GH#61792 pandas <= 1.2 pickled Timestamp as (value, freq, tz).
+            #  `freq` is gone, so those slots now mean year/month and passing
+            #  args positionally silently drops the tz. The isinstance checks
+            #  keep a genuine by-component reduce, e.g. (Timestamp, (2020, 1, 2)),
+            #  out of this branch.
+            value, _freq, tz = args
+            # An explicit tz=None rejects a tz-aware value, so only pass it when set.
+            stack[-1] = Timestamp(value) if tz is None else Timestamp(value, tz=tz)
+            return
 
         try:
             stack[-1] = func(*args)

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -27,11 +27,15 @@ import tarfile
 from typing import Any
 import uuid
 import zipfile
+import zoneinfo
 
 import numpy as np
 import pytest
 
-from pandas.compat import is_platform_little_endian
+from pandas.compat import (
+    is_platform_little_endian,
+    pickle_compat,
+)
 from pandas.compat._optional import import_optional_dependency
 
 import pandas as pd
@@ -94,15 +98,6 @@ def test_pickles(datapath):
         for typ, dv in data.items():
             for dt, result in dv.items():
                 expected = current_data[typ][dt]
-
-                if (
-                    typ == "timestamp"
-                    and dt in ("tz", "both")
-                    and legacy_version < Version("1.3.0")
-                ):
-                    # convert to wall time
-                    # (bug since pandas 2.0 that tz gets dropped for older pickle files)
-                    expected = expected.tz_convert(None)
 
                 if legacy_version < Version("3.0.0.dev0"):
                     # before 3.0, we had:
@@ -588,3 +583,59 @@ def test_pickle_frame_v124_unpickle_130(datapath):
 
     expected = DataFrame(index=[], columns=[])
     tm.assert_frame_equal(df, expected)
+
+
+def _legacy_timestamp_pickle(args: tuple) -> bytes:
+    # Emulate pandas<=1.2, whose Timestamp.__reduce__ returned
+    #  (Timestamp, (value, freq, tz)).
+    inner = pickle.dumps(args, protocol=0)
+    return (
+        b"cpandas._libs.tslibs.timestamps\nTimestamp\n"
+        + inner.removesuffix(pickle.STOP)
+        + pickle.REDUCE
+        + pickle.STOP
+    )
+
+
+@pytest.mark.parametrize("freq", [None, "D", Day()])
+def test_unpickle_legacy_timestamp_keeps_tz(freq):
+    # GH#61792 the removal of Timestamp.freq turned the legacy (value, freq, tz)
+    #  reduce args into (ts_input, year, month), silently dropping the tz
+    tz = zoneinfo.ZoneInfo("US/Eastern")
+    expected = pd.Timestamp("2011-01-01", tz=tz)
+
+    data = _legacy_timestamp_pickle((expected.as_unit("ns")._value, freq, tz))
+    result = pickle_compat.loads(data)
+
+    assert result == expected
+    assert result.tz == tz
+
+
+@pytest.mark.parametrize("freq", [None, "D", Day()])
+def test_unpickle_legacy_timestamp_naive(freq):
+    # GH#61792
+    expected = pd.Timestamp("2011-01-01")
+
+    data = _legacy_timestamp_pickle((expected.as_unit("ns")._value, freq, None))
+    result = pickle_compat.loads(data)
+
+    assert result == expected
+    assert result.tz is None
+
+
+def test_unpickle_legacy_timestamp_aware_input():
+    # GH#61792 forwarding an explicit tz=None would reject a tz-aware ts_input
+    dt = datetime.datetime(2011, 1, 1, tzinfo=zoneinfo.ZoneInfo("US/Eastern"))
+    data = _legacy_timestamp_pickle((dt, None, None))
+    result = pickle_compat.loads(data)
+
+    assert result == pd.Timestamp(dt)
+
+
+def test_unpickle_timestamp_by_component():
+    # GH#61792 a genuine by-component reduce must not be mistaken for the
+    #  legacy (value, freq, tz) form
+    data = _legacy_timestamp_pickle((2020, 1, 2))
+    result = pickle_compat.loads(data)
+
+    assert result == pd.Timestamp(2020, 1, 2)


### PR DESCRIPTION
pandas <= 1.2 pickled `Timestamp` as `(value, freq, tz)`. `freq` was removed in 3.0, so those slots are now interpreted as `year`/`month` and the tz was silently dropped — legacy timestamps loaded tz-naive at their UTC wall time.

This was already known and encoded in `test_pickles`, which converted the expected value to wall time with the comment *"bug since pandas 2.0 that tz gets dropped for older pickle files"* (noted in GH-61792). That workaround is removed here, so the shipped 1.1.0 legacy pickle now asserts the tz is preserved.

Handled in `Unpickler.load_reduce`, gated on the `freq` and `tz` slots having plausible types so a genuine by-component reduce such as `(Timestamp, (2020, 1, 2))` isn't mangled into a bogus tz-aware value. The tz is only forwarded when non-None — an explicit `tz=None` rejects a tz-aware `ts_input`.

Added tests cover both of those guards directly, and use `pickle_compat.loads` rather than `read_pickle`: a by-component reduce succeeds on the stdlib pass and never reaches the shim.