### PR TITLE
TST: min/max on object-dtype data with missing values (GH-18588)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -380,7 +380,7 @@ Timezones
 
 Numeric
 ^^^^^^^
-- Bug in :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`Series.min`, and :meth:`Series.max` on object-dtype data raising ``TypeError`` when missing values were present alongside values that do not support comparison with ``float`` (e.g. strings or mixed-timezone :class:`Timestamp` objects) (:issue:`65500`)
+- Bug in :meth:`DataFrame.min`, :meth:`DataFrame.max`, :meth:`Series.min`, and :meth:`Series.max` on object-dtype data raising ``TypeError`` when missing values were present alongside values that do not support comparison with ``float`` (e.g. strings, :class:`datetime.date` objects, or mixed-timezone :class:`Timestamp` objects) (:issue:`4147`, :issue:`18588`, :issue:`24109`, :issue:`58707`, :issue:`61204`, :issue:`65500`)
 - Fixed bug in :func:`read_excel` where having a column with mixture of numeric and boolean values will typecast the values based on the first appearance data type since 1==True and 0==False (:issue:`60088`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` returning incorrect row labels for nullable ``UInt64`` columns containing missing values alongside values above ``2**53`` (:issue:`64478`)
 - Fixed bug in :meth:`DataFrame.idxmax` and :meth:`DataFrame.idxmin` with ``axis=1`` and ``skipna=False`` returning incorrect column labels for extension array dtypes (e.g. :class:`BooleanDtype`, nullable integer/float, :class:`ArrowDtype`) (:issue:`56903`)

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -1,4 +1,7 @@
-from datetime import timedelta
+from datetime import (
+    date,
+    timedelta,
+)
 from decimal import Decimal
 import re
 
@@ -2576,6 +2579,68 @@ def test_minmax_extensionarray(method, numeric_only):
         index=Index(["Int64"]),
     )
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", [object, "str"])
+def test_minmax_axis0_string_columns_with_na(dtype):
+    # GH#18588: the string columns were silently dropped as nuisance columns,
+    # and once numeric_only stopped dropping them the +/-inf NA fill raised
+    df = DataFrame(
+        {
+            "col1": [0, 1, 2, 3],
+            "col2": Series(["a", "b", None, "d"], dtype=dtype),
+            "col3": Series(["e", "f", None, "h"], dtype=dtype),
+        }
+    )
+    index = Index(["col1", "col2", "col3"])
+
+    result = df.min(axis=0)
+    tm.assert_series_equal(result, Series([0, "a", "e"], index=index, dtype=object))
+
+    result = df.max(axis=0)
+    tm.assert_series_equal(result, Series([3, "d", "h"], index=index, dtype=object))
+
+
+def test_minmax_axis0_object_date_with_na():
+    # GH#61204
+    df = DataFrame(
+        {"dates": [np.nan, np.nan, date(2025, 1, 3), date(2025, 1, 4)]}, dtype=object
+    )
+    index = Index(["dates"])
+
+    result = df.min(axis=0)
+    tm.assert_series_equal(
+        result, Series([date(2025, 1, 3)], index=index, dtype=object)
+    )
+
+    result = df.max(axis=0)
+    tm.assert_series_equal(
+        result, Series([date(2025, 1, 4)], index=index, dtype=object)
+    )
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+def test_minmax_object_na_positions_differ_per_slice(axis):
+    # GH#18588: the NA fill is taken per reduction slice, so slices whose NAs
+    # sit in different positions do not borrow each other's values, and an
+    # all-NA slice reduces to NA rather than poisoning its neighbours
+    df = DataFrame(
+        {
+            "a": ["x", None, "b"],
+            "b": [None, "q", "p"],
+            "c": [None, None, None],
+        },
+        dtype=object,
+    )
+    if axis == 0:
+        exp_min = Series(["b", "p", None], index=Index(["a", "b", "c"]), dtype=object)
+        exp_max = Series(["x", "q", None], index=Index(["a", "b", "c"]), dtype=object)
+    else:
+        exp_min = Series(["x", "q", "b"], dtype=object)
+        exp_max = Series(["x", "q", "p"], dtype=object)
+
+    tm.assert_series_equal(df.min(axis=axis), exp_min)
+    tm.assert_series_equal(df.max(axis=axis), exp_max)
 
 
 @pytest.mark.parametrize("ts_value", [Timestamp("2000-01-01"), pd.NaT])

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1,4 +1,5 @@
 from datetime import (
+    date,
     datetime,
     timedelta,
 )
@@ -23,6 +24,7 @@ from pandas import (
     Timedelta,
     TimedeltaIndex,
     Timestamp,
+    concat,
     date_range,
     isna,
     period_range,
@@ -1230,7 +1232,20 @@ class TestSeriesReductions:
         [
             (["a", "b", np.nan], "a", "b"),
             (["a", "b", None], "a", "b"),
+            # GH#4147
+            (["alpha", np.nan, "charlie", "delta"], "alpha", "delta"),
             ([(1, 3), (2, 2), np.nan], (1, 3), (2, 2)),
+            # GH#24109, including the NaT sentinel left behind by .dt.date
+            (
+                [date(2018, 1, 1), None, date(2018, 1, 3)],
+                date(2018, 1, 1),
+                date(2018, 1, 3),
+            ),
+            (
+                [date(2018, 1, 1), NaT, date(2018, 1, 3)],
+                date(2018, 1, 1),
+                date(2018, 1, 3),
+            ),
         ],
     )
     def test_minmax_object_with_na(self, data, exp_min, exp_max):
@@ -1248,6 +1263,14 @@ class TestSeriesReductions:
         ser = Series([ts1, ts2, NaT], dtype=object)
         assert ser.max() == ts1
         assert ser.min() == ts2
+
+    def test_minmax_object_tzaware_with_nat(self):
+        # GH#58707: concatenating tz-aware with tz-naive NaT gives object dtype
+        ts = Timestamp("2024-05-13 12:00:00", tz="America/New_York")
+        ser = concat([Series([ts]), Series([NaT])])
+        assert ser.dtype == object
+        assert ser.max() == ts
+        assert ser.min() == ts
 
     def test_minmax_object_all_na(self):
         # GH#65500


### PR DESCRIPTION
closes #4147
closes #18588
closes #24109
closes #58707
closes #61204

All five report the same bug: object-dtype `min`/`max` raising `TypeError` when missing
values are present alongside values that do not support comparison with `float` —
strings, `datetime.date`, or mixed-timezone `Timestamp` objects.

It was fixed on main by GH-65526, which stopped `nanops._nanminmax` filling NA entries
with float `±inf`. This PR is **test-only** — it adds the missing regression coverage
and closes the five reports out.

### Coverage

Existing coverage was Series-only, so the 2D `take_along_axis` branch of `_nanminmax`
— which is exactly what GH-18588 and GH-61204 report — was untested. New in
`frame/test_reductions.py`:

- `test_minmax_axis0_string_columns_with_na` — GH-18588's repro. Parametrized over
  `object` and `str`, since the issue's literal code now infers `str` dtype and takes
  the Arrow path rather than the object one.
- `test_minmax_axis0_object_date_with_na` — GH-61204's repro.
- `test_minmax_object_na_positions_differ_per_slice` — NAs in different positions per
  column plus an all-NA column, over both axes. This is where the per-slice fill and
  the all-NA `±inf` override actually matter.

In `reductions/test_reductions.py`, GH-4147's and GH-24109's exact data was added to
`test_minmax_object_with_na` (including the `NaT` sentinel `.dt.date` leaves behind,
which GH-24109 hits), plus `test_minmax_object_tzaware_with_nat` for GH-58707's
single-tz concat.

Each new assertion was confirmed to fail with GH-65526 reverted; the `str`
parametrization passes either way, as expected.

### Follow-up

While writing these I found that the same code path still mishandles `skipna=False`,
and that `idxmin`/`idxmax`, `sum`/`prod` and the groupby fallback have related defects.
Those are behaviour changes rather than tests, so they are in a separate PR stacked on
this one rather than mixed in here.
