### PR TITLE
BUG: length-aware string hashtable keys, fixing embedded-NUL collapse in unique/factorize/groupby

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -410,6 +410,7 @@ Strings
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
 - Bug in :meth:`Series.str.split` with :class:`ArrowDtype` ``string`` not inferring regex for multi-character patterns when ``regex=None``, causing the pattern to be treated as a literal instead of a regular expression (:issue:`58321`)
 - Bug in :meth:`Series.unique`, :meth:`Index.unique` and :func:`factorize` on object dtype returning incorrect results when the values were not UTF-8 encodable, e.g. lone surrogates (:issue:`34550`)
+- Bug in :meth:`Series.unique`, :meth:`Index.unique`, :func:`factorize` and ``groupby`` on object dtype collapsing distinct strings that are identical up to an embedded NUL byte, e.g. ``""`` and ``"\x00"``, into a single value (:issue:`34551`)
 
 Interval
 ^^^^^^^^
@@ -496,6 +497,7 @@ I/O
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where passing tuples in ``names`` produced flat columns instead of :class:`MultiIndex` columns as with the other engines (:issue:`65862`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where a quoted field containing an embedded NUL byte was silently truncated at the NUL under the default string dtype or ``dtype_backend="pyarrow"`` (:issue:`66415`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
+- Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with ``dtype=object`` or ``dtype="category"`` (:issue:`19886`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug in :func:`read_excel` with the ``openpyxl`` engine where reading a sheet set its ``max_row`` and ``max_column`` to ``None`` on the workbook exposed through ``ExcelFile.book`` (:issue:`63010`)
 - Fixed bug in :func:`read_sas` where ``encoding="infer"`` raised ``LookupError: unknown encoding: infer`` instead of falling back to latin-1, for SAS7BDAT files recording an encoding pandas does not recognize and for XPORT files, which record no encoding at all (:issue:`66470`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -410,7 +410,7 @@ Strings
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
 - Bug in :meth:`Series.str.split` with :class:`ArrowDtype` ``string`` not inferring regex for multi-character patterns when ``regex=None``, causing the pattern to be treated as a literal instead of a regular expression (:issue:`58321`)
 - Bug in :meth:`Series.unique`, :meth:`Index.unique` and :func:`factorize` on object dtype returning incorrect results when the values were not UTF-8 encodable, e.g. lone surrogates (:issue:`34550`)
-- Bug in :meth:`Series.unique`, :meth:`Index.unique`, :func:`factorize` and ``groupby`` on object dtype collapsing distinct strings that are identical up to an embedded NUL byte, e.g. ``""`` and ``"\x00"``, into a single value (:issue:`34551`)
+- Bug in :meth:`Series.unique`, :meth:`Index.unique`, :meth:`Series.nunique`, :func:`factorize` and ``groupby`` on object dtype, and on ``str``/``string`` dtype backed by python storage, collapsing distinct strings that are identical up to an embedded NUL byte, e.g. ``""`` and ``"\x00"``, into a single value (:issue:`34551`)
 
 Interval
 ^^^^^^^^
@@ -495,9 +495,10 @@ I/O
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where a ``defaultdict`` passed as ``dtype`` did not apply its default to columns not explicitly listed (:issue:`41574`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where an empty ``usecols`` (e.g. ``usecols=[]``) was ignored and returned all columns instead of an empty frame, unlike the other engines (:issue:`66056`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where passing tuples in ``names`` produced flat columns instead of :class:`MultiIndex` columns as with the other engines (:issue:`65862`)
+- Fixed bug in :func:`read_csv` with the ``c`` engine and ``dtype="category"`` where ``encoding_errors`` was ignored, so an undecodable byte raised ``UnicodeDecodeError`` even with ``encoding_errors="replace"`` (:issue:`66525`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where a quoted field containing an embedded NUL byte was silently truncated at the NUL under the default string dtype or ``dtype_backend="pyarrow"`` (:issue:`66415`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
-- Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with ``dtype=object`` or ``dtype="category"`` (:issue:`19886`)
+- Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with an explicit string-like ``dtype`` (``object``, ``"str"``, ``"string"`` or ``"category"``) (:issue:`66525`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug in :func:`read_excel` with the ``openpyxl`` engine where reading a sheet set its ``max_row`` and ``max_column`` to ``None`` on the workbook exposed through ``ExcelFile.book`` (:issue:`63010`)
 - Fixed bug in :func:`read_sas` where ``encoding="infer"`` raised ``LookupError: unknown encoding: infer`` instead of falling back to latin-1, for SAS7BDAT files recording an encoding pandas does not recognize and for XPORT files, which record no encoding at all (:issue:`66470`)

--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -22,6 +22,7 @@ from pandas._libs.khash cimport (
     kh_int64_t,
     kh_pymap_t,
     kh_str_t,
+    kh_strview_t,
     kh_uint8_t,
     kh_uint16_t,
     kh_uint32_t,

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -29,6 +29,7 @@ from pandas._libs.khash cimport (
     kh_needed_n_buckets,
     kh_python_hash_equal,
     kh_python_hash_func,
+    kh_strview,
     khiter_t,
 )
 from pandas._libs.missing cimport (

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -3,7 +3,7 @@ Template for each `dtype` helper function for hashtable
 
 WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 """
-from cpython.unicode cimport PyUnicode_AsUTF8
+from cpython.unicode cimport PyUnicode_AsUTF8AndSize
 
 {{py:
 
@@ -964,6 +964,11 @@ cdef class {{name}}Factorizer(Factorizer):
 
 
 cdef class StringHashTable(HashTable):
+    # Keys borrow each str's cached UTF-8 buffer via PyUnicode_AsUTF8AndSize,
+    # which yields the length alongside the pointer, so keying on an explicit
+    # length costs no extra pass. The buffer lives exactly as long as the str
+    # does, so callers must keep the str alive while the key is in the table.
+
     # these by-definition *must* be strings
     # or a sentinel np.nan / None missing value
     na_string_sentinel = '__nan__'
@@ -984,8 +989,8 @@ cdef class StringHashTable(HashTable):
     def sizeof(self, deep: bool = False) -> int:
         overhead = 4 * sizeof(uint32_t) + 3 * sizeof(uint32_t*)
         for_flags = max(1, self.table.n_buckets >> 5) * sizeof(uint32_t)
-        for_pairs =  self.table.n_buckets * (sizeof(char *) +      # keys
-                                             sizeof(Py_ssize_t))   # vals
+        for_pairs =  self.table.n_buckets * (sizeof(kh_strview_t) +  # keys
+                                             sizeof(Py_ssize_t))     # vals
         return overhead + for_flags + for_pairs
 
     def get_state(self) -> dict[str, int]:
@@ -1000,8 +1005,11 @@ cdef class StringHashTable(HashTable):
     cpdef get_item(self, str val):
         cdef:
             khiter_t k
-            const char *v
-        v = PyUnicode_AsUTF8(val)
+            kh_strview_t v
+            Py_ssize_t length
+            const char *ptr
+        ptr = PyUnicode_AsUTF8AndSize(val, &length)
+        v = kh_strview(ptr, length)
 
         k = kh_get_str(self.table, v)
         if k != self.table.n_buckets:
@@ -1013,9 +1021,12 @@ cdef class StringHashTable(HashTable):
         cdef:
             khiter_t k
             int ret = 0
-            const char *v
+            kh_strview_t v
+            Py_ssize_t length
+            const char *ptr
 
-        v = PyUnicode_AsUTF8(key)
+        ptr = PyUnicode_AsUTF8AndSize(key, &length)
+        v = kh_strview(ptr, length)
 
         k = kh_put_str(self.table, v, &ret)
         if kh_exist_str(self.table, k):
@@ -1033,16 +1044,17 @@ cdef class StringHashTable(HashTable):
             intp_t *resbuf = <intp_t*>labels.data
             khiter_t k
             kh_str_t *table = self.table
-            const char *v
-            const char **vecs
+            kh_strview_t *vecs
+            Py_ssize_t length
+            const char *ptr
 
-        vecs = <const char **>malloc(n * sizeof(char *))
+        vecs = <kh_strview_t *>malloc(n * sizeof(kh_strview_t))
         if vecs is NULL:
             raise MemoryError()
         for i in range(n):
             val = values[i]
-            v = PyUnicode_AsUTF8(val)
-            vecs[i] = v
+            ptr = PyUnicode_AsUTF8AndSize(val, &length)
+            vecs[i] = kh_strview(ptr, length)
 
         with nogil:
             for i in range(n):
@@ -1064,24 +1076,27 @@ cdef class StringHashTable(HashTable):
             Py_ssize_t i, n = len(values)
             int ret = 0
             object val
-            const char *v
+            kh_strview_t v
+            kh_strview_t *vecs
+            Py_ssize_t length
+            const char *ptr
             khiter_t k
             intp_t[::1] locs = np.empty(n, dtype=np.intp)
 
         # these by-definition *must* be strings
-        vecs = <const char **>malloc(n * sizeof(char *))
+        vecs = <kh_strview_t *>malloc(n * sizeof(kh_strview_t))
         if vecs is NULL:
             raise MemoryError()
         for i in range(n):
             val = values[i]
 
             if isinstance(val, str):
-                # GH#31499 if we have an np.str_ PyUnicode_AsUTF8 won't recognize
-                #  it as a str, even though isinstance does.
-                v = PyUnicode_AsUTF8(<str>val)
+                # GH#31499 if we have an np.str_ PyUnicode_AsUTF8AndSize won't
+                #  recognize it as a str, even though isinstance does.
+                ptr = PyUnicode_AsUTF8AndSize(<str>val, &length)
             else:
-                v = PyUnicode_AsUTF8(self.na_string_sentinel)
-            vecs[i] = v
+                ptr = PyUnicode_AsUTF8AndSize(self.na_string_sentinel, &length)
+            vecs[i] = kh_strview(ptr, length)
 
         with nogil:
             for i in range(n):
@@ -1103,24 +1118,26 @@ cdef class StringHashTable(HashTable):
             Py_ssize_t i, n = len(values)
             int ret = 0
             object val
-            const char *v
-            const char **vecs
+            kh_strview_t v
+            kh_strview_t *vecs
+            Py_ssize_t length
+            const char *ptr
             khiter_t k
 
         # these by-definition *must* be strings
-        vecs = <const char **>malloc(n * sizeof(char *))
+        vecs = <kh_strview_t *>malloc(n * sizeof(kh_strview_t))
         if vecs is NULL:
             raise MemoryError()
         for i in range(n):
             val = values[i]
 
             if isinstance(val, str):
-                # GH#31499 if we have an np.str_ PyUnicode_AsUTF8 won't recognize
-                #  it as a str, even though isinstance does.
-                v = PyUnicode_AsUTF8(<str>val)
+                # GH#31499 if we have an np.str_ PyUnicode_AsUTF8AndSize won't
+                #  recognize it as a str, even though isinstance does.
+                ptr = PyUnicode_AsUTF8AndSize(<str>val, &length)
             else:
-                v = PyUnicode_AsUTF8(self.na_string_sentinel)
-            vecs[i] = v
+                ptr = PyUnicode_AsUTF8AndSize(self.na_string_sentinel, &length)
+            vecs[i] = kh_strview(ptr, length)
 
         with nogil:
             for i in range(n):
@@ -1174,8 +1191,10 @@ cdef class StringHashTable(HashTable):
             int64_t[::1] uindexer
             int ret = 0
             object val
-            const char *v
-            const char **vecs
+            kh_strview_t v
+            kh_strview_t *vecs
+            Py_ssize_t length
+            const char *ptr
             khiter_t k
             bint use_na_value
             bint non_null_na_value
@@ -1188,7 +1207,7 @@ cdef class StringHashTable(HashTable):
         non_null_na_value = not checknull(na_value)
 
         # assign pointers and pre-filter out missing (if ignore_na)
-        vecs = <const char **>malloc(n * sizeof(char *))
+        vecs = <kh_strview_t *>malloc(n * sizeof(kh_strview_t))
         if vecs is NULL:
             raise MemoryError()
         for i in range(n):
@@ -1209,15 +1228,15 @@ cdef class StringHashTable(HashTable):
             else:
                 # if ignore_na is False, we also stringify NaN/None/etc.
                 try:
-                    v = PyUnicode_AsUTF8(<str>val)
+                    ptr = PyUnicode_AsUTF8AndSize(<str>val, &length)
                 except UnicodeEncodeError:
                     # GH#34550 val is not utf-8 encodable (e.g. a lone
                     #  surrogate). Retain the repr in `refs` so the buffer
-                    #  `v` points to outlives the nogil loop below.
+                    #  `ptr` points to outlives the nogil loop below.
                     val = repr(val)
                     refs.append(val)
-                    v = PyUnicode_AsUTF8(<str>val)
-                vecs[i] = v
+                    ptr = PyUnicode_AsUTF8AndSize(<str>val, &length)
+                vecs[i] = kh_strview(ptr, length)
 
         # compute
         with nogil:

--- a/pandas/_libs/include/pandas/vendored/klib/khash.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash.h
@@ -749,7 +749,10 @@ typedef const char *kh_cstr_t;
 #define kh_exist_set_int8(h, k) (kh_exist(h, k))
 #define kh_exist_set_uint8(h, k) (kh_exist(h, k))
 
-KHASH_MAP_INIT_STR(str, size_t)
+// kh_str_t is deliberately *not* instantiated here. pandas keys its string
+// tables on an explicit (pointer, length) pair so that values containing
+// embedded NUL bytes are not truncated; see KHASH_MAP_INIT_STRVIEW in
+// khash_python.h.
 KHASH_MAP_INIT_INT(int32, size_t)
 KHASH_MAP_INIT_UINT(uint32, size_t)
 KHASH_MAP_INIT_INT64(int64, size_t)

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -380,11 +380,71 @@ KHASH_SET_INIT_PYOBJECT(pyset)
 #define kh_exist_pymap(h, k) (kh_exist(h, k))
 #define kh_exist_pyset(h, k) (kh_exist(h, k))
 
-KHASH_MAP_INIT_STR(strbox, kh_pyobject_t)
+// Length-aware string key.
+//
+// A bare `const char *` key (klib's kh_cstr_t) hashes and compares only up to
+// the first NUL byte, so distinct values that share a NUL-terminated prefix
+// collapse into a single entry. Python strings, CSV fields and Arrow string
+// buffers can all contain embedded NULs, which made that silently return wrong
+// results (GH#34551, GH#19886). Keying on an explicit (pointer, length) pair
+// fixes it, and additionally lets a key point at a slice of a larger buffer
+// without copying or NUL-terminating it.
+//
+// The pointed-to bytes are borrowed, exactly as for kh_cstr_t: the caller must
+// keep them alive for as long as the entry is in the table.
+typedef struct {
+  const char *ptr;
+  size_t len;
+} kh_strview_t;
+
+static inline kh_strview_t kh_strview(const char *ptr, size_t len) {
+  kh_strview_t result;
+  result.ptr = ptr;
+  result.len = len;
+  return result;
+}
+
+// X31 over exactly `len` bytes. Bit-identical to __ac_X31_hash_string for
+// NUL-free input, so bucket distribution -- and hence performance -- is
+// unchanged for the data that used to work.
+static inline khuint_t kh_strview_hash_func(kh_strview_t key) {
+  khuint_t h = 0;
+  if (key.len) {
+    h = (khuint_t)key.ptr[0];
+    for (size_t i = 1; i < key.len; ++i)
+      h = (h << 5) - h + (khuint_t)key.ptr[i];
+  }
+  return h;
+}
+
+// The length check alone settles most probes, and the byte loop is deliberate:
+// memcmp with a runtime length does not inline, and one libc call per token
+// costs ~9% on a bool column, where a hashset lookup hits on nearly every
+// token and there is little other per-token work to absorb it.
+static inline int kh_strview_hash_equal(kh_strview_t a, kh_strview_t b) {
+  if (a.len != b.len)
+    return 0;
+  for (size_t i = 0; i < a.len; ++i)
+    if (a.ptr[i] != b.ptr[i])
+      return 0;
+  return 1;
+}
+
+#define KHASH_SET_INIT_STRVIEW(name)                                           \
+  KHASH_INIT(name, kh_strview_t, char, 0, kh_strview_hash_func,                \
+             kh_strview_hash_equal)
+
+#define KHASH_MAP_INIT_STRVIEW(name, khval_t)                                  \
+  KHASH_INIT(name, kh_strview_t, khval_t, 1, kh_strview_hash_func,             \
+             kh_strview_hash_equal)
+
+KHASH_MAP_INIT_STRVIEW(str, size_t)
+KHASH_MAP_INIT_STRVIEW(strbox, kh_pyobject_t)
 
 typedef struct {
   kh_str_t *table;
   int starts[256];
+  int has_empty;
 } kh_str_starts_t;
 
 typedef kh_str_starts_t *p_kh_str_starts_t;
@@ -396,22 +456,35 @@ static inline p_kh_str_starts_t kh_init_str_starts(void) {
   return result;
 }
 
-static inline khuint_t kh_put_str_starts_item(kh_str_starts_t *table, char *key,
-                                              int *ret) {
-  khuint_t result = kh_put_str(table->table, key, ret);
+// NOTE: these two derive the length with strlen, so an na_value or a field
+// containing an embedded NUL is still compared only up to that NUL -- exactly
+// the pre-existing behavior. Giving them an explicit length is what fixes
+// GH#19886, and is deliberately left to a follow-up because it changes
+// user-visible NA semantics (and hence dtype inference).
+static inline khuint_t kh_put_str_starts_item(kh_str_starts_t *table,
+                                              const char *key, int *ret) {
+  size_t len = strlen(key);
+  khuint_t result = kh_put_str(table->table, kh_strview(key, len), ret);
   if (*ret != 0) {
-    table->starts[(unsigned char)key[0]] = 1;
+    // The empty key gets its own flag rather than a slot in starts[]. Sharing
+    // starts['\0'] with it would make every token that merely *begins* with an
+    // embedded NUL look like a candidate.
+    if (len == 0)
+      table->has_empty = 1;
+    else
+      table->starts[(unsigned char)key[0]] = 1;
   }
   return result;
 }
 
 static inline khuint_t kh_get_str_starts_item(const kh_str_starts_t *table,
                                               const char *key) {
-  unsigned char ch = *key;
-  if (table->starts[ch]) {
-    if (ch == '\0' || kh_get_str(table->table, key) != table->table->n_buckets)
-      return 1;
-  }
+  size_t len = strlen(key);
+  if (len == 0)
+    return (khuint_t)table->has_empty;
+  if (table->starts[(unsigned char)key[0]] &&
+      kh_get_str(table->table, kh_strview(key, len)) != table->table->n_buckets)
+    return 1;
   return 0;
 }
 

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -386,7 +386,7 @@ KHASH_SET_INIT_PYOBJECT(pyset)
 // the first NUL byte, so distinct values that share a NUL-terminated prefix
 // collapse into a single entry. Python strings, CSV fields and Arrow string
 // buffers can all contain embedded NULs, which made that silently return wrong
-// results (GH#34551, GH#19886). Keying on an explicit (pointer, length) pair
+// results (GH#34551, GH#66525). Keying on an explicit (pointer, length) pair
 // fixes it, and additionally lets a key point at a slice of a larger buffer
 // without copying or NUL-terminating it.
 //
@@ -430,10 +430,6 @@ static inline int kh_strview_hash_equal(kh_strview_t a, kh_strview_t b) {
   return 1;
 }
 
-#define KHASH_SET_INIT_STRVIEW(name)                                           \
-  KHASH_INIT(name, kh_strview_t, char, 0, kh_strview_hash_func,                \
-             kh_strview_hash_equal)
-
 #define KHASH_MAP_INIT_STRVIEW(name, khval_t)                                  \
   KHASH_INIT(name, kh_strview_t, khval_t, 1, kh_strview_hash_func,             \
              kh_strview_hash_equal)
@@ -441,10 +437,19 @@ static inline int kh_strview_hash_equal(kh_strview_t a, kh_strview_t b) {
 KHASH_MAP_INIT_STRVIEW(str, size_t)
 KHASH_MAP_INIT_STRVIEW(strbox, kh_pyobject_t)
 
+// NUL-terminated keys for kh_str_starts_t only. The na/true/false-values
+// tables still hash and compare up to the first NUL -- the pre-existing
+// behavior. Giving them a length-aware key is what fixes GH#19886, and is
+// deliberately left to a follow-up because it changes user-visible NA
+// semantics (and hence dtype inference). Do not "fix" it here by deriving the
+// length with strlen: kh_get_str_starts_item runs per token per column on the
+// read_csv hot path, and that strlen alone measured 4-21% on every csvbench
+// core case.
+KHASH_MAP_INIT_STR(strz, size_t)
+
 typedef struct {
-  kh_str_t *table;
+  kh_strz_t *table;
   int starts[256];
-  int has_empty;
 } kh_str_starts_t;
 
 typedef kh_str_starts_t *p_kh_str_starts_t;
@@ -452,49 +457,36 @@ typedef kh_str_starts_t *p_kh_str_starts_t;
 static inline p_kh_str_starts_t kh_init_str_starts(void) {
   kh_str_starts_t *result =
       (kh_str_starts_t *)KHASH_CALLOC(1, sizeof(kh_str_starts_t));
-  result->table = kh_init_str();
+  result->table = kh_init_strz();
   return result;
 }
 
-// NOTE: these two derive the length with strlen, so an na_value or a field
-// containing an embedded NUL is still compared only up to that NUL -- exactly
-// the pre-existing behavior. Giving them an explicit length is what fixes
-// GH#19886, and is deliberately left to a follow-up because it changes
-// user-visible NA semantics (and hence dtype inference).
 static inline khuint_t kh_put_str_starts_item(kh_str_starts_t *table,
                                               const char *key, int *ret) {
-  size_t len = strlen(key);
-  khuint_t result = kh_put_str(table->table, kh_strview(key, len), ret);
+  khuint_t result = kh_put_strz(table->table, key, ret);
   if (*ret != 0) {
-    // The empty key gets its own flag rather than a slot in starts[]. Sharing
-    // starts['\0'] with it would make every token that merely *begins* with an
-    // embedded NUL look like a candidate.
-    if (len == 0)
-      table->has_empty = 1;
-    else
-      table->starts[(unsigned char)key[0]] = 1;
+    table->starts[(unsigned char)key[0]] = 1;
   }
   return result;
 }
 
 static inline khuint_t kh_get_str_starts_item(const kh_str_starts_t *table,
                                               const char *key) {
-  size_t len = strlen(key);
-  if (len == 0)
-    return (khuint_t)table->has_empty;
-  if (table->starts[(unsigned char)key[0]] &&
-      kh_get_str(table->table, kh_strview(key, len)) != table->table->n_buckets)
-    return 1;
+  unsigned char ch = *key;
+  if (table->starts[ch]) {
+    if (ch == '\0' || kh_get_strz(table->table, key) != table->table->n_buckets)
+      return 1;
+  }
   return 0;
 }
 
 static inline void kh_destroy_str_starts(kh_str_starts_t *table) {
-  kh_destroy_str(table->table);
+  kh_destroy_strz(table->table);
   KHASH_FREE(table);
 }
 
 static inline void kh_resize_str_starts(kh_str_starts_t *table, khuint_t val) {
-  kh_resize_str(table->table, val);
+  kh_resize_strz(table->table, val);
 }
 
 // utility function: given the number of elements

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -76,8 +76,6 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
 
     bint kh_exist_pyset(kh_pyset_t*, khiter_t)
 
-    ctypedef char* kh_cstr_t
-
     # Borrowed (pointer, length) pair; see khash_python.h. Keying on an
     # explicit length is what keeps values with embedded NUL bytes distinct.
     ctypedef struct kh_strview_t:
@@ -102,10 +100,15 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
 
     bint kh_exist_str(kh_str_t*, khiter_t) nogil
 
+    # NUL-terminated keys, deliberately: the na/true/false-values tables keep
+    # the pre-existing truncate-at-first-NUL semantics until a follow-up
+    # changes them (GH#19886); see khash_python.h.
+    ctypedef struct kh_strz_t:
+        khuint_t n_buckets, size, n_occupied, upper_bound
+
     ctypedef struct kh_str_starts_t:
-        kh_str_t *table
+        kh_strz_t *table
         int starts[256]
-        int has_empty
 
     kh_str_starts_t* kh_init_str_starts() nogil
     khuint_t kh_put_str_starts_item(kh_str_starts_t* table, const char* key,

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -78,18 +78,26 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
 
     ctypedef char* kh_cstr_t
 
+    # Borrowed (pointer, length) pair; see khash_python.h. Keying on an
+    # explicit length is what keeps values with embedded NUL bytes distinct.
+    ctypedef struct kh_strview_t:
+        const char *ptr
+        size_t len
+
+    kh_strview_t kh_strview(const char *ptr, size_t length) noexcept nogil
+
     ctypedef struct kh_str_t:
         khuint_t n_buckets, size, n_occupied, upper_bound
         uint32_t *flags
-        kh_cstr_t *keys
+        kh_strview_t *keys
         size_t *vals
 
     kh_str_t* kh_init_str() nogil
     void kh_destroy_str(kh_str_t*) nogil
     void kh_clear_str(kh_str_t*) nogil
-    khuint_t kh_get_str(kh_str_t*, kh_cstr_t) nogil
+    khuint_t kh_get_str(kh_str_t*, kh_strview_t) nogil
     void kh_resize_str(kh_str_t*, khuint_t) nogil
-    khuint_t kh_put_str(kh_str_t*, kh_cstr_t, int*) nogil
+    khuint_t kh_put_str(kh_str_t*, kh_strview_t, int*) nogil
     void kh_del_str(kh_str_t*, khuint_t) nogil
 
     bint kh_exist_str(kh_str_t*, khiter_t) nogil
@@ -97,11 +105,13 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
     ctypedef struct kh_str_starts_t:
         kh_str_t *table
         int starts[256]
+        int has_empty
 
     kh_str_starts_t* kh_init_str_starts() nogil
-    khuint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key,
+    khuint_t kh_put_str_starts_item(kh_str_starts_t* table, const char* key,
                                     int* ret) nogil
-    khuint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) nogil
+    khuint_t kh_get_str_starts_item(const kh_str_starts_t* table,
+                                    const char* key) nogil
     void kh_destroy_str_starts(kh_str_starts_t*) nogil
     void kh_resize_str_starts(kh_str_starts_t*, khuint_t) nogil
 
@@ -110,15 +120,15 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
     ctypedef struct kh_strbox_t:
         khuint_t n_buckets, size, n_occupied, upper_bound
         uint32_t *flags
-        kh_cstr_t *keys
+        kh_strview_t *keys
         PyObject **vals
 
     kh_strbox_t* kh_init_strbox() nogil
     void kh_destroy_strbox(kh_strbox_t*) nogil
     void kh_clear_strbox(kh_strbox_t*) nogil
-    khuint_t kh_get_strbox(kh_strbox_t*, kh_cstr_t) nogil
+    khuint_t kh_get_strbox(kh_strbox_t*, kh_strview_t) nogil
     void kh_resize_strbox(kh_strbox_t*, khuint_t) nogil
-    khuint_t kh_put_strbox(kh_strbox_t*, kh_cstr_t, int*) nogil
+    khuint_t kh_put_strbox(kh_strbox_t*, kh_strview_t, int*) nogil
     void kh_del_strbox(kh_strbox_t*, khuint_t) nogil
 
     bint kh_exist_strbox(kh_strbox_t*, khiter_t) nogil

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1329,7 +1329,8 @@ cdef class TextReader:
             # TODO: I suspect that _categorical_convert could be
             # optimized when dtype is an instance of CategoricalDtype
             codes, cats, na_count = _categorical_convert(
-                self.parser, i, start, end, na_filter, na_hashset)
+                self.parser, i, start, end, na_filter, na_hashset,
+                self.encoding_errors)
 
             # Method accepts list of strings, not encoded ones.
             true_values = [x.decode() for x in self.true_values]
@@ -2679,7 +2680,8 @@ cdef _string_pyarrow_utf8(parser_t *parser, int64_t col,
 @cython.boundscheck(False)
 cdef _categorical_convert(parser_t *parser, int64_t col,
                           int64_t line_start, int64_t line_end,
-                          bint na_filter, kh_str_starts_t *na_hashset):
+                          bint na_filter, kh_str_starts_t *na_hashset,
+                          const char *encoding_errors):
     "Convert column data into codes, categories"
     cdef:
         int na_count = 0
@@ -2697,6 +2699,11 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
         kh_str_t *table
         kh_strview_t key
         khiter_t k
+
+        dict seen
+        int64_t[::1] remap_view
+        ndarray[object] result
+        Py_ssize_t n_cats
 
     lines = line_end - line_start
     codes = np.empty(lines, dtype=np.int64)
@@ -2729,13 +2736,36 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
             codes[i] = table.vals[k]
 
     # parse and box categories to python strings
-    result = np.empty(table.n_occupied, dtype=np.object_)
+    n_cats = table.n_occupied
+    result = np.empty(n_cats, dtype=np.object_)
     for k in range(table.n_buckets):
         if kh_exist_str(table, k):
             result[table.vals[k]] = PyUnicode_DecodeUTF8(
-                table.keys[k].ptr, table.keys[k].len, NULL)
+                table.keys[k].ptr, table.keys[k].len, encoding_errors)
 
     kh_destroy_str(table)
+
+    # The table dedupes on raw bytes, but a lossy encoding_errors can decode two
+    # distinct keys to the same label (b"q\xff" and b"q\xfe" both -> "q�").
+    # Merge those codes; leaving them split would build a Categorical with
+    # duplicate categories, which raises.  Strict UTF-8 decoding is injective, so
+    # the default path can never collide and must not pay for this scan.
+    if encoding_errors != b"strict":
+        seen = {}
+        remap = np.empty(n_cats, dtype=np.int64)
+        remap_view = remap
+        for i in range(n_cats):
+            remap_view[i] = seen.setdefault(result[i], len(seen))
+
+        if len(seen) != n_cats:
+            merged = np.empty(len(seen), dtype=np.object_)
+            for label, code in seen.items():
+                merged[code] = label
+            result = merged
+            for i in range(lines):
+                if codes[i] != NA:
+                    codes[i] = remap_view[codes[i]]
+
     return np.asarray(codes), result, na_count
 
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -117,6 +117,8 @@ from pandas._libs.khash cimport (
     kh_str_starts_t,
     kh_str_t,
     kh_strbox_t,
+    kh_strview,
+    kh_strview_t,
     khiter_t,
 )
 
@@ -1944,6 +1946,7 @@ cdef _string_box_utf8(parser_t *parser, int64_t col,
         coliter_t it
         const char *word = NULL
         c_int64_t token_idx = 0
+        int64_t word_len
         ndarray[object] result
 
         int ret = 0
@@ -1961,6 +1964,7 @@ cdef _string_box_utf8(parser_t *parser, int64_t col,
 
     for i in range(lines):
         word = coliter_next_with_idx(&it, &token_idx)
+        word_len = _token_len(parser, token_idx)
 
         if na_filter:
             if kh_get_str_starts_item(na_hashset, word):
@@ -1969,16 +1973,17 @@ cdef _string_box_utf8(parser_t *parser, int64_t col,
                 result[i] = NA
                 continue
 
-        # no deletions from this table, so ret == 0 means already present
-        k = kh_put_strbox(table, word, &ret)
+        # no deletions from this table, so ret == 0 means already present.
+        # The key carries its length, so two fields that differ only past an
+        # embedded NUL no longer intern to the same object.
+        k = kh_put_strbox(table, kh_strview(word, <size_t>word_len), &ret)
 
         # in the hash table
         if ret == 0:
             # this increments the refcount, but need to test
             pyval = <object>table.vals[k]
         else:
-            pyval = PyUnicode_DecodeUTF8(
-                word, _token_len(parser, token_idx), encoding_errors)
+            pyval = PyUnicode_DecodeUTF8(word, word_len, encoding_errors)
 
             table.vals[k] = <PyObject *>pyval
 
@@ -2200,7 +2205,7 @@ cdef _box_arena_utf8(bytes arena, const int64_t[::1] offsets,
     from an arena captured by `_collect_arena`.
     """
     cdef:
-        Py_ssize_t i, lines = offsets.shape[0]
+        Py_ssize_t i, lines = offsets.shape[0], word_len
         const char *buf = PyBytes_AsString(arena)
         const char *word
         ndarray[object] result = np.empty(lines, dtype=np.object_)
@@ -2216,13 +2221,14 @@ cdef _box_arena_utf8(bytes arena, const int64_t[::1] offsets,
             result[i] = NA
             continue
         word = buf + offsets[i]
+        word_len = strlen(word)
 
-        k = kh_get_strbox(table, word)
+        k = kh_get_strbox(table, kh_strview(word, <size_t>word_len))
         if k != table.n_buckets:
             pyval = <object>table.vals[k]
         else:
-            pyval = PyUnicode_DecodeUTF8(word, strlen(word), encoding_errors)
-            k = kh_put_strbox(table, word, &ret)
+            pyval = PyUnicode_DecodeUTF8(word, word_len, encoding_errors)
+            k = kh_put_strbox(table, kh_strview(word, <size_t>word_len), &ret)
             table.vals[k] = <PyObject *>pyval
 
         result[i] = pyval
@@ -2680,6 +2686,8 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
         Py_ssize_t i, lines
         coliter_t it
         const char *word = NULL
+        c_int64_t token_idx = 0
+        int64_t word_len
 
         int64_t NA = -1
         int64_t[::1] codes
@@ -2687,6 +2695,7 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
 
         int ret = 0
         kh_str_t *table
+        kh_strview_t key
         khiter_t k
 
     lines = line_end - line_start
@@ -2699,7 +2708,8 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
         coliter_setup(&it, parser, col, line_start)
 
         for i in range(lines):
-            word = coliter_next(&it)
+            word = coliter_next_with_idx(&it, &token_idx)
+            word_len = _token_len(parser, token_idx)
 
             if na_filter:
                 if kh_get_str_starts_item(na_hashset, word):
@@ -2708,10 +2718,11 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
                     codes[i] = NA
                     continue
 
-            k = kh_get_str(table, word)
+            key = kh_strview(word, <size_t>word_len)
+            k = kh_get_str(table, key)
             # not in the hash table
             if k == table.n_buckets:
-                k = kh_put_str(table, word, &ret)
+                k = kh_put_str(table, key, &ret)
                 table.vals[k] = current_category
                 current_category += 1
 
@@ -2721,7 +2732,8 @@ cdef _categorical_convert(parser_t *parser, int64_t col,
     result = np.empty(table.n_occupied, dtype=np.object_)
     for k in range(table.n_buckets):
         if kh_exist_str(table, k):
-            result[table.vals[k]] = PyUnicode_FromString(table.keys[k])
+            result[table.vals[k]] = PyUnicode_DecodeUTF8(
+                table.keys[k].ptr, table.keys[k].len, NULL)
 
     kh_destroy_str(table)
     return np.asarray(codes), result, na_count

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -140,6 +140,38 @@ def test_unique_distinct_bad_unicode(index_or_series):
     assert set(uniques) == set(uvals)
 
 
+@pytest.mark.parametrize(
+    "uvals",
+    [
+        ["", "\x00"],
+        ["x\x00y", "x\x00z"],
+        ["a", "a\x00", "a\x00\x00", "\x00a"],
+    ],
+)
+def test_unique_embedded_null(index_or_series, uvals):
+    # GH#34551 object-dtype strings route through StringHashTable, which used
+    #  to key on a NUL-terminated C string and so collapsed distinct values
+    #  sharing a prefix up to their first NUL.
+    #  The values are repeated deliberately: Index.unique short-circuits on
+    #  is_unique for an all-distinct input, so only a duplicated input reaches
+    #  StringHashTable at all.
+    vals = uvals * 2
+    arr = np.empty(len(vals), dtype=object)
+    arr[:] = vals
+
+    result = index_or_series(arr, dtype=object).unique()
+    assert list(result) == uvals
+
+    codes, uniques = pd.factorize(arr)
+    expected = np.tile(np.arange(len(uvals), dtype=np.intp), 2)
+    tm.assert_numpy_array_equal(codes, expected)
+    assert list(uniques) == uvals
+
+    # groupby factorizes through the same table
+    grouped = pd.DataFrame({"key": pd.Series(arr, dtype=object)}).groupby("key")
+    assert grouped.ngroups == len(uvals)
+
+
 def test_nunique_dropna(dropna):
     # GH37566
     ser = pd.Series(["yes", "yes", pd.NA, np.nan, None, pd.NaT])

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -167,8 +167,11 @@ def test_unique_embedded_null(index_or_series, uvals):
     tm.assert_numpy_array_equal(codes, expected)
     assert list(uniques) == uvals
 
+    ser = pd.Series(arr, dtype=object)
+    assert ser.nunique() == len(uvals)
+
     # groupby factorizes through the same table
-    grouped = pd.DataFrame({"key": pd.Series(arr, dtype=object)}).groupby("key")
+    grouped = pd.DataFrame({"key": ser}).groupby("key")
     assert grouped.ngroups == len(uvals)
 
 

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -866,3 +866,15 @@ def test_embedded_nul_byte_roundtrip(c_parser_only, kwargs):
     expected = parser.read_csv(BytesIO(b'a\n"x\x00y"\n'), dtype=object)
     assert result["a"][0] == "x\x00y"
     assert expected["a"][0] == "x\x00y"
+
+
+@pytest.mark.parametrize("dtype", [object, "category", None])
+def test_embedded_nul_distinct_values(c_parser_only, dtype):
+    # GH#19886: the object path interned fields in a hash table keyed on the
+    # NUL-terminated word, so two fields differing only past an embedded NUL
+    # were silently boxed to the same value.
+    parser = c_parser_only
+    data = b'a\n"x\x00y"\n"x\x00z"\n"x"\n'
+
+    result = parser.read_csv(BytesIO(data), dtype=dtype, keep_default_na=False)
+    assert list(result["a"]) == ["x\x00y", "x\x00z", "x"]

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -868,13 +868,60 @@ def test_embedded_nul_byte_roundtrip(c_parser_only, kwargs):
     assert expected["a"][0] == "x\x00y"
 
 
-@pytest.mark.parametrize("dtype", [object, "category", None])
-def test_embedded_nul_distinct_values(c_parser_only, dtype):
-    # GH#19886: the object path interned fields in a hash table keyed on the
+@pytest.mark.parametrize("dtype", [object, "str", "string", "category", None])
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (b'a\n"x\x00y"\n"x\x00z"\n"x"\n', ["x\x00y", "x\x00z", "x"]),
+        (b'a\n"x\x00y"\n"x\x00z"\n"x\x00w"\n', ["x\x00y", "x\x00z", "x\x00w"]),
+    ],
+)
+def test_embedded_nul_distinct_values(c_parser_only, dtype, data, expected):
+    # GH#66525: the object path interned fields in a hash table keyed on the
     # NUL-terminated word, so two fields differing only past an embedded NUL
-    # were silently boxed to the same value.
+    # were silently boxed to the same value.  The second fixture is all
+    # equal-length, so distinguishing it needs a comparison that reads past
+    # the NUL rather than just a key-length check.
     parser = c_parser_only
-    data = b'a\n"x\x00y"\n"x\x00z"\n"x"\n'
 
     result = parser.read_csv(BytesIO(data), dtype=dtype, keep_default_na=False)
-    assert list(result["a"]) == ["x\x00y", "x\x00z", "x"]
+    assert list(result["a"]) == expected
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b'a\n"q\x00\xff"\n',
+        b'a\n"q\xff"\n',
+        # two *distinct* undecodable fields: the table dedupes on raw bytes, so
+        # these stay separate keys but decode to one label
+        b'a\n"q\xff"\n"q\xfe"\n',
+        b'a\n"q\xff"\n"q\xfe"\n"z"\n"q\xff"\n',
+    ],
+)
+@pytest.mark.parametrize("encoding_errors", ["replace", "ignore"])
+def test_categorical_honors_encoding_errors(c_parser_only, data, encoding_errors):
+    # GH#66525: _categorical_convert decoded its category labels with strict
+    # errors regardless of encoding_errors, so an undecodable byte raised where
+    # dtype=object honored the argument.  Two keys that decode to the same label
+    # must merge, or the Categorical is built with duplicate categories.
+    parser = c_parser_only
+    kwargs = {"keep_default_na": False, "encoding_errors": encoding_errors}
+
+    result = parser.read_csv(BytesIO(data), dtype="category", **kwargs)
+    expected = parser.read_csv(BytesIO(data), dtype=object, **kwargs)
+    assert list(result["a"]) == list(expected["a"])
+
+
+def test_categorical_encoding_errors_merge_with_na(c_parser_only):
+    # GH#66525: a merged column that also contains NA exercises the sentinel
+    # guard in the code remap -- a -1 code must not be looked up in the map.
+    parser = c_parser_only
+    data = b'a,b\n"q\xff",1\n,2\n"q\xfe",3\n"z",4\n'
+
+    result = parser.read_csv(
+        BytesIO(data), dtype={"a": "category"}, encoding_errors="replace"
+    )["a"]
+
+    assert list(result.cat.categories) == ["q�", "z"]
+    assert list(result.cat.codes) == [0, -1, 0, 1]

--- a/pandas/tests/libs/test_hashtable.py
+++ b/pandas/tests/libs/test_hashtable.py
@@ -600,6 +600,33 @@ def test_no_reallocation_StringHashTable(N):
 
 
 @pytest.mark.parametrize(
+    "keys",
+    [
+        ["", "\x00"],
+        ["x\x00y", "x\x00z"],
+        ["a", "a\x00", "a\x00\x00", "\x00a"],
+        ["\x00" * 3, "\x00" * 4],
+    ],
+)
+def test_StringHashTable_embedded_null(keys):
+    # GH#34551 the table used to key on a NUL-terminated C string, so distinct
+    #  values sharing a prefix up to their first NUL collapsed into one entry.
+    arr = np.empty(len(keys), dtype=np.object_)
+    arr[:] = keys
+
+    table = ht.StringHashTable()
+    table.map_locations(arr)
+    assert len(table) == len(keys)
+    for i, key in enumerate(keys):
+        assert table.get_item(key) == i
+
+    tm.assert_numpy_array_equal(
+        table.get_indexer(arr), np.arange(len(keys), dtype=np.intp)
+    )
+    assert list(ht.StringHashTable().unique(arr)) == keys
+
+
+@pytest.mark.parametrize(
     "table_type, dtype",
     [
         (ht.Float64HashTable, np.float64),


### PR DESCRIPTION
- [x] closes #34551
- [x] closes #66525
- [x] Tests added and passing
- [x] All code checks passed
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file

pandas keys several khash tables on `kh_cstr_t`, a bare `const char *`, hashed with `__ac_X31_hash_string` (which stops at the first NUL) and compared with `strcmp`. Any value containing an embedded NUL is therefore truncated for both hashing and comparison, so distinct values sharing a prefix up to their first NUL collapse into one.

```python
arr = np.array(["", "\x00"], dtype=object)
pd.unique(arr)        # before: ['']            after: ['', '\x00']
pd.factorize(arr)[0]  # before: [0, 0]          after: [0, 1]

df = pd.DataFrame({"c": pd.Series(np.array(["", "\x00", "", "\x00"], dtype=object))})
df.groupby("c").ngroups   # before: 1           after: 2
```

Keyed on an explicit `{const char *ptr; size_t len}` pair instead. The hash is X31 over exactly `len` bytes -- **bit-identical to `__ac_X31_hash_string` for NUL-free input**, so bucket distribution is unchanged -- and equality is a length check plus a byte comparison. `PyUnicode_AsUTF8AndSize` and `_token_len` supply the length, so no path pays an extra `strlen`.

Fixes `unique`, `factorize`, `Series.unique`, `Index.unique` and `groupby` on object dtype, plus `read_csv`'s `dtype=object` interning and `dtype="category"` conversion (both of which silently boxed two distinct fields to one value). Boxing the category labels with an explicit length also surfaced that `_categorical_convert` ignored `encoding_errors`; it now honors it, merging any labels a lossy handler decodes to the same string.

### Note on the issue's snippet

GH-34551 is titled for `DataFrame.drop_duplicates`, but that method routes through `PyObjectHashTable` and already returns the right answer -- the issue's own snippet passes on `main`. The confusion it reports is real, but it lives in `unique`/`factorize`/`groupby`. Worth knowing before comparing this diff against the issue title.

### Performance

The `na_values`/`true_values`/`false_values` hashsets are deliberately **not** converted: they keep NUL-terminated keys via their own `kh_strz` instantiation. Preserving their truncate-at-NUL matching on top of length-aware keys would require a per-token `strlen` on the `read_csv` hot path, which measured 4-21% slower on every case of the 19-case `read_csv` benchmark core suite. With those tables untouched, all 19 cases are at parity with this branch's merge-base (ratios 0.994-1.011; the only two cases clearing the significance bar are ~1% wins).

For the tables that do change key type, the byte-by-byte equality is deliberate: `memcmp` with a runtime length does not inline, and on the combined branch the libc call cost -9.2% on a bool column. The `a.len != b.len` check settles most probes, so long keys did not need a threshold (`long fields (~150B)` +3.6%).

### Scope

One of three PRs splitting the embedded-NUL work apart so the piece needing a semantics discussion doesn't block the rest:

- GH-66511 -- fixed-width / converters / column names. Independent of this PR.
- **this PR** -- the key type for `StringHashTable`, the `dtype=object` interning table and the `dtype="category"` table. The `na_values`/`true_values`/`false_values` hashsets are untouched, so **NA handling and `read_csv` performance are unchanged by this PR**.
- GH-66513 -- converts those hashsets to length-aware keys, which **changes user-visible NA semantics and dtype inference**. Stacked on this PR.

Draft until the set can be reviewed together.
