### PR TITLE
DOC: fix tutorial data card text in dark mode

### DIFF
--- a/doc/source/_static/css/getting_started.css
+++ b/doc/source/_static/css/getting_started.css
@@ -7,6 +7,7 @@
 
 .gs-data-title {
   align-items: center;
+  color: var(--pst-color-text-base);
   font-size: 0.9rem;
 }
 


### PR DESCRIPTION
This sets the tutorial data-card title to the theme text color, keeping it readable when the documentation is viewed in dark mode.

Fixes #66437