### PR TITLE
TST: cover divmod/rdivmod on NA (GH#66493)

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1119,8 +1119,8 @@ def all_arithmetic_functions(request):
 
     Notes
     -----
-    This includes divmod and rdivmod, whereas all_arithmetic_operators
-    does not.
+    This does not include divmod and rdivmod, which return a tuple and so
+    cannot be used interchangeably with the other operators.
     """
     return request.param
 

--- a/pandas/tests/scalar/test_na_scalar.py
+++ b/pandas/tests/scalar/test_na_scalar.py
@@ -14,6 +14,7 @@ from pandas.core.dtypes.common import is_scalar
 
 import pandas as pd
 import pandas._testing as tm
+from pandas.core import roperator
 
 
 def test_singleton():
@@ -62,13 +63,22 @@ def test_arithmetic_ops(all_arithmetic_functions, other):
 
     if op.__name__ in ("pow", "rpow", "rmod") and isinstance(other, (str, bytes)):
         pytest.skip(reason=f"{op.__name__} with NA and {other} not defined.")
-    if op.__name__ in ("divmod", "rdivmod"):
-        assert op(NA, other) is (NA, NA)
-    else:
-        if op.__name__ == "rpow":
-            # avoid special case
-            other += 1
-        assert op(NA, other) is NA
+    if op.__name__ == "rpow":
+        # avoid special case
+        other += 1
+    assert op(NA, other) is NA
+
+
+@pytest.mark.parametrize("op", [divmod, roperator.rdivmod])
+@pytest.mark.parametrize(
+    "other", [NA, 1, 1.0, "a", b"a", np.int64(1), np.nan], ids=repr
+)
+def test_divmod_ops(op, other):
+    # GH#66493 divmod is not part of the all_arithmetic_functions fixture,
+    # so it needs its own test.
+    div, mod = op(NA, other)
+    assert div is NA
+    assert mod is NA
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #66493

`test_arithmetic_ops` contained `assert op(NA, other) is (NA, NA)`, which
compares against a freshly constructed tuple and so can never be true. It never
failed because the branch is dead: `all_arithmetic_functions` does not include
`divmod`/`rdivmod`, despite its docstring saying it does.

Changes:

- Drop the unreachable divmod branch from `test_arithmetic_ops`.
- Add `test_divmod_ops`, which exercises `divmod` and `roperator.rdivmod`
  against `NA` over the same `other` values and asserts each element of the
  returned tuple `is NA`.
- Correct the `all_arithmetic_functions` docstring, which had the divmod note
  backwards.

I did not add `divmod`/`rdivmod` to the fixture as the reporter suggested.
Four other modules use that fixture and assume a non-tuple result, so adding
the two ops fails 136 tests in `tests/arrays/sparse/test_arithmetics.py`,
`tests/arithmetic/test_numeric.py` and `tests/frame/test_arithmetic.py`. The
docstring now says why divmod is excluded. Happy to go the other way if you
would rather fix those call sites too.

Verified on Linux x86_64, CPU only, Python 3.12, numpy 2.4, pandas built from
this branch. With the old assertion the new test fails 14/14, with the new one
it passes 14/14. `pandas/tests/scalar/`, `pandas/tests/arithmetic/`,
`pandas/tests/frame/test_arithmetic.py` and
`pandas/tests/arrays/sparse/test_arithmetics.py` pass (25858 passed, 475
skipped, 19 xfailed). ruff 0.15.20 check/format and isort 6.1.0 are clean on
both files. I did not run the full test suite or the full pre-commit set.

Thanks to @Andrej730 for spotting this.