### PR TITLE
BUG: MultiIndex.isin raising TypeError on iterator elements

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4831,6 +4831,10 @@ class MultiIndex(Index):
             if not isinstance(values, MultiIndex):
                 # GH#20252, GH#26622 from_tuples silently gives wrong results
                 #  for elements that aren't tuple-likes of length nlevels.
+                # GH#66514 iterators have no len, so materialize them first.
+                values = [
+                    tuple(value) if is_iterator(value) else value for value in values
+                ]
                 for position, value in enumerate(values):
                     if is_list_like(value) and len(value) == self.nlevels:
                         continue

--- a/pandas/tests/indexes/multi/test_isin.py
+++ b/pandas/tests/indexes/multi/test_isin.py
@@ -104,6 +104,27 @@ def test_isin_generator():
     tm.assert_numpy_array_equal(result, expected)
 
 
+@pytest.mark.parametrize("box", [list, set])
+def test_isin_iterator_values(box):
+    # GH#66514 elements that are iterators have no len
+    midx = MultiIndex.from_arrays([[1, 2, 3], ["a", "b", "c"]])
+    result = midx.isin(box([iter([1, "a"])]))
+    expected = np.array([True, False, False])
+    tm.assert_numpy_array_equal(result, expected)
+
+
+def test_isin_iterator_values_wrong_length_raises():
+    # GH#66514 iterators are length-checked like any other element
+    midx = MultiIndex.from_arrays([[1, 2, 3], ["a", "b", "c"]])
+    msg = (
+        "MultiIndex.isin expects an iterable of tuples of length 2 "
+        r"\(the number of levels\); got an element of length 3 at position 0\. "
+        "To match on a single level, pass the level= argument\\."
+    )
+    with pytest.raises(ValueError, match=msg):
+        midx.isin([iter([1, "a", "x"])])
+
+
 def test_isin_scalar_values_raises_gh20252():
     # GH#20252
     midx = MultiIndex.from_arrays([[1, 2, 3], ["a", "b", "c"]])


### PR DESCRIPTION
Fixes #66514

The `MultiIndex.isin` validation loop added for GH#20252 / GH#26622 calls `len(value)`
on anything `is_list_like` accepts, but that includes iterators, which have no
`__len__`. Elements that are iterators used to reach `MultiIndex.from_tuples`, which
handled them; now they raise `TypeError: object of type 'list_iterator' has no len()`
first.

Fix: materialize iterator elements with `tuple(...)` before the loop, so they can be
length-checked and are still intact when `from_tuples` consumes them. `is_iterator`
was already imported in the module.

Verified on Linux, CPython 3.13, numpy 2.4, built from this branch with meson-python:

- Reproduced first on the nightly named in the issue (`3.1.0.dev0+1420.g7986b42596`),
  whose `multi.py` is byte-identical to current main.
- `mi.isin({iter([3])})` now returns `[False False True]`, the same as released 3.0.3.
- New tests fail on main with the reported `TypeError` and pass with the patch.
- `pandas/tests/indexes/` (16517 passed), every `-k isin` test in the repo (471
  passed), and the `multi.py` doctests all pass. ruff check and ruff format clean.

One side effect worth flagging. Replacing `values` with a list changes which branch of
`from_tuples` handles an ndarray argument, so `mi.isin(np.array([[1, "a"], [3, "c"]]))`
now behaves like the equivalent list of rows instead of raising `ValueError: Buffer has
wrong number of dimensions`. Only inputs that previously raised are affected, nothing
that returned a result changes. Happy to add an `if any(is_iterator(v) for v in
values):` guard if you would rather keep that error path.

No whatsnew entry: the regression is unreleased, it arrived with the 3.1.0 entry for
GH#20252 / GH#26622.

Not verified: full test suite, mypy/pyright, non-ruff pre-commit hooks.

Thanks to @loicdiridollou for the report and the minimal reproducer.