### PR TITLE
BUG: online ewm ignoring decay for single-column frames

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -567,6 +567,7 @@ Plotting
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - :meth:`DataFrame.ewm` and :meth:`Series.ewm` now raise an informative ``NotImplementedError`` instead of a confusing ``AttributeError`` when ``agg``/``aggregate`` is passed an arbitrary callable (:issue:`41700`)
+- Bug in :class:`.ExponentialMovingWindow` with ``online`` ignoring the decay for a single-column :class:`DataFrame`, returning the unweighted cumulative mean (:issue:`66522`)
 - Bug in :class:`PeriodIndex` resampling to a finer frequency where aggregation methods returned the original values instead of aggregating, e.g. ``count`` returned the data values rather than the number of observations per bin; empty bins now contain the method's identity value (e.g. ``0`` for ``sum`` instead of ``NaN``), consistent with :class:`DatetimeIndex` resampling (:issue:`42763`)
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -1166,9 +1166,6 @@ class OnlineExponentialMovingWindow(ExponentialMovingWindow):
         is_frame = self._selected_obj.ndim == 2
         if update_times is not None:
             raise NotImplementedError("update_times is not implemented.")
-        update_deltas = np.ones(
-            max(self._selected_obj.shape[-1] - 1, 0), dtype=np.float64
-        )
         if update is not None:
             if self._mean.last_ewm is None:
                 raise ValueError(
@@ -1191,6 +1188,7 @@ class OnlineExponentialMovingWindow(ExponentialMovingWindow):
             else:
                 result_kwargs["name"] = self._selected_obj.name
             np_array = self._selected_obj.astype(np.float64).to_numpy()
+        update_deltas = np.ones(max(len(np_array) - 1, 0), dtype=np.float64)
         ewma_func = generate_online_numba_ewma_func(
             **get_jit_arguments(self.engine_kwargs)
         )

--- a/pandas/core/window/online.py
+++ b/pandas/core/window/online.py
@@ -68,7 +68,7 @@ def generate_online_numba_ewma_func(
                     if is_observations[j] or not ignore_na:
                         # note that len(deltas) = len(vals) - 1 and deltas[i] is to be
                         # used in conjunction with vals[i+1]
-                        old_wt[j] *= old_wt_factor ** deltas[j - 1]
+                        old_wt[j] *= old_wt_factor ** deltas[i - 1]
                         if is_observations[j]:
                             # avoid numerical errors on constant series
                             if weighted_avg[j] != cur[j]:

--- a/pandas/tests/window/test_online.py
+++ b/pandas/tests/window/test_online.py
@@ -35,7 +35,13 @@ class TestEWM:
 
     @pytest.mark.slow
     @pytest.mark.parametrize(
-        "obj", [DataFrame({"a": range(5), "b": range(5)}), Series(range(5), name="foo")]
+        "obj",
+        [
+            DataFrame({"a": range(5), "b": range(5)}),
+            # GH#66522 single-column DataFrame
+            DataFrame({"a": range(5)}),
+            Series(range(5), name="foo"),
+        ],
     )
     def test_online_vs_non_online_mean(self, obj, nogil, parallel, adjust, ignore_na):
         expected = obj.ewm(0.5, adjust=adjust, ignore_na=ignore_na).mean()


### PR DESCRIPTION
Fixes #66522

`online_ewma` indexed `deltas` with the column index `j` instead of the row index `i`,
and `OnlineExponentialMovingWindow.mean` sized `update_deltas` from the column count
rather than the number of rows it passes to the kernel. For a single-column frame that
array is empty, so `deltas[j - 1]` is an out-of-bounds read that numba turns into
`0.0`, `old_wt_factor ** 0` is 1, and the weight never decays.

Changes:

- `online.py`: use `deltas[i - 1]`, which is the contract the comment right above the
  line already describes.
- `ewm.py`: build `update_deltas` from `len(np_array)` after `np_array` is assembled.
  The old expression was wrong on the `update=` path too, since it never accounted for
  the length of `update`; that only mattered once the kernel indexed by row.
- Added a single-column `DataFrame` to the `obj` parametrization of
  `test_online_vs_non_online_mean`. It covers both the initial `mean()` and the
  `mean(update=...)` call, and fails on main.

Verified on x86-64 Linux, CPU only, python 3.12 with numpy 2.4.6 and numba 0.66.0.
The new parametrization fails before the change and passes after; the full
`pandas/tests/window/` suite passes (9525 passed, 330 skipped, 49 xfailed). Not
verified: other numba versions, ARM or Windows, and whether the `parallel=True`
parametrizations actually ran parallelized here (numba warns it cannot parallelize
this function, and the test class filters that warning). The docs build was not run.

Thanks to @jbrockmendel for the report, which already pinned both wrong lines.