### PR TITLE
BUG: preserve embedded NUL fields in read_csv inference

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -499,6 +499,7 @@ I/O
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where a ``defaultdict`` passed as ``dtype`` did not apply its default to columns not explicitly listed (:issue:`41574`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where an empty ``usecols`` (e.g. ``usecols=[]``) was ignored and returned all columns instead of an empty frame, unlike the other engines (:issue:`66056`)
 - Fixed bug in :func:`read_csv` with ``engine="pyarrow"`` where passing tuples in ``names`` produced flat columns instead of :class:`MultiIndex` columns as with the other engines (:issue:`65862`)
+- Fixed bug in :func:`read_csv` with the ``c`` engine silently truncating integer- and boolean-shaped fields containing an embedded NUL byte instead of preserving the full field (:issue:`66524`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where a quoted field containing an embedded NUL byte was silently truncated at the NUL under the default string dtype or ``dtype_backend="pyarrow"`` (:issue:`66415`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -68,6 +68,7 @@ from libc.stdlib cimport (
     malloc,
 )
 from libc.string cimport (
+    memchr,
     memcpy,
     memset,
     strcasecmp,
@@ -1259,6 +1260,12 @@ cdef class TextReader:
                     if str(e) == "Number is not int":
                         maybe_int = False
                         continue
+                    elif str(e) == _NUL_NOT_NUMERIC:
+                        # GH#66524: an embedded NUL disqualifies the column from
+                        # numeric inference; float would truncate and accept it.
+                        col_res, na_count = self._string_convert(
+                            i, start, end, na_filter, na_hashset,
+                            allow_pyarrow=col_dtype is None)
                     else:
                         # This error is raised from trying to convert to uint64,
                         # and we discover that we cannot convert to any numerical
@@ -1271,9 +1278,14 @@ cdef class TextReader:
                     try:
                         col_res, na_count = _try_pylong(self.parser, i, start,
                                                         end, na_filter, na_hashset)
-                    except ValueError:
+                    except ValueError as e:
+                        # GH#66524: the embedded-NUL rejection must keep
+                        # filtering NA; ordinary PyLong failures keep their
+                        # existing na_filter=0 fallback.
                         col_res, na_count = self._string_convert(
-                            i, start, end, 0, na_hashset,
+                            i, start, end,
+                            na_filter if str(e) == _NUL_NOT_NUMERIC else 0,
+                            na_hashset,
                             allow_pyarrow=col_dtype is None)
 
                 if col_res is not None:
@@ -1944,6 +1956,7 @@ cdef _string_box_utf8(parser_t *parser, int64_t col,
         coliter_t it
         const char *word = NULL
         c_int64_t token_idx = 0
+        int64_t word_len
         ndarray[object] result
 
         int ret = 0
@@ -1969,6 +1982,16 @@ cdef _string_box_utf8(parser_t *parser, int64_t col,
                 result[i] = NA
                 continue
 
+        word_len = _token_len(parser, token_idx)
+
+        if _has_embedded_nul(word, word_len):
+            # GH#66524: the intern table's keys are NUL-terminated, so such a
+            # token would collide with its own truncated prefix and whichever
+            # was decoded first would win for both. Decode directly instead;
+            # these tokens are simply not deduplicated.
+            result[i] = PyUnicode_DecodeUTF8(word, word_len, encoding_errors)
+            continue
+
         # no deletions from this table, so ret == 0 means already present
         k = kh_put_strbox(table, word, &ret)
 
@@ -1977,8 +2000,7 @@ cdef _string_box_utf8(parser_t *parser, int64_t col,
             # this increments the refcount, but need to test
             pyval = <object>table.vals[k]
         else:
-            pyval = PyUnicode_DecodeUTF8(
-                word, _token_len(parser, token_idx), encoding_errors)
+            pyval = PyUnicode_DecodeUTF8(word, word_len, encoding_errors)
 
             table.vals[k] = <PyObject *>pyval
 
@@ -2814,14 +2836,18 @@ cdef int _probe_int64(parser_t *parser, int64_t col,
         coliter_t it
         const char *word = NULL
         c_int64_t token_idx = 0
+        int64_t word_len
 
     coliter_setup(&it, parser, col, line_start)
     for _ in range(lines):
         word = coliter_next_with_idx(&it, &token_idx)
         if na_filter and kh_get_str_starts_item(na_hashset, word):
             continue
-        str_to_int64(word, _token_len(parser, token_idx),
-                     &error, parser.thousands)
+        word_len = _token_len(parser, token_idx)
+        str_to_int64(word, word_len, &error, parser.thousands)
+        if error != 0 and _nul_truncated_number(word, word_len,
+                                                parser.thousands):
+            return _NUL_TRUNCATED
         return error
     return 0
 
@@ -2871,13 +2897,16 @@ cdef int _probe_bool_flex(parser_t *parser, int64_t col,
         Py_ssize_t lines = line_end - line_start
         coliter_t it
         const char *word = NULL
+        c_int64_t token_idx = 0
         uint8_t tmp
 
     coliter_setup(&it, parser, col, line_start)
     for _ in range(lines):
-        word = coliter_next(&it)
+        word = coliter_next_with_idx(&it, &token_idx)
         if na_filter and kh_get_str_starts_item(na_hashset, word):
             continue
+        if _has_embedded_nul(word, _token_len(parser, token_idx)):
+            return -1
         if kh_get_str_starts_item(true_hashset, word):
             return 0
         if kh_get_str_starts_item(false_hashset, word):
@@ -3036,6 +3065,9 @@ cdef _try_uint64(parser_t *parser, int64_t col,
         error = _try_uint64_nogil(parser, col, line_start, line_end,
                                   na_filter, na_hashset, data, &state)
     if error != 0:
+        if raise_on_invalid and error == _NUL_TRUNCATED:
+            # GH#66524: as in _try_int64.
+            raise ValueError(_NUL_NOT_NUMERIC)
         if error == ERROR_OVERFLOW:
             # Can't get the word variable
             raise OverflowError("Overflow")
@@ -3050,6 +3082,42 @@ cdef _try_uint64(parser_t *parser, int64_t col,
         raise OverflowError("Overflow")
 
     return result
+
+
+# GH#66524: hands the embedded-NUL rejection up to _convert_tokens' cast-order
+# loop, following the "Number is not int" convention already used there.
+cdef str _NUL_NOT_NUMERIC = "Embedded NUL is not numeric"
+
+
+cdef enum:
+    # Not one of the ERROR_* codes: those are public through the pd_parser
+    # capsule, so their meaning must stay fixed. Never leaves this module.
+    _NUL_TRUNCATED = -2
+
+
+cdef inline bint _nul_truncated_number(const char *word, int64_t length,
+                                       char tsep) noexcept nogil:
+    # True when the token's NUL-terminated prefix is by itself a complete
+    # integer, i.e. only the embedded NUL ended the parse. engine="python"
+    # rejects those outright, so the caller must not fall through to the float
+    # stage. "1.5\0xyz" is not of this shape, so it still reaches float, where
+    # both engines agree on 1.5.
+    cdef:
+        int64_t prefix_len = <int64_t>strlen(word)
+        int err = 0
+    if prefix_len >= length:
+        return False
+    str_to_int64(word, prefix_len, &err, tsep)
+    # OVERFLOW still means the prefix was entirely digits.
+    return err == 0 or err == ERROR_OVERFLOW
+
+
+cdef inline bint _has_embedded_nul(const char *word,
+                                   int64_t length) noexcept nogil:
+    # True when the token carries a NUL before its real end. Every gate that
+    # compares NUL-terminated C strings needs this, or it accepts the prefix
+    # and silently drops the rest.
+    return length > 0 and memchr(word, 0, length) != NULL
 
 
 cdef inline int64_t _token_len(parser_t *parser, int64_t token_idx) noexcept nogil:
@@ -3074,6 +3142,7 @@ cdef int _try_uint64_nogil(parser_t *parser, int64_t col,
         coliter_t it
         const char *word = NULL
         c_int64_t token_idx = 0
+        int64_t word_len
         char thousands = parser.thousands
 
     coliter_setup(&it, parser, col, line_start)
@@ -3087,16 +3156,20 @@ cdef int _try_uint64_nogil(parser_t *parser, int64_t col,
                 data[i] = 0
                 continue
 
-            data[i] = str_to_uint64(state, word, _token_len(parser, token_idx),
-                                    &error, thousands)
+            word_len = _token_len(parser, token_idx)
+            data[i] = str_to_uint64(state, word, word_len, &error, thousands)
             if error != 0:
+                if _nul_truncated_number(word, word_len, thousands):
+                    return _NUL_TRUNCATED
                 return error
     else:
         for i in range(lines):
             word = coliter_next_with_idx(&it, &token_idx)
-            data[i] = str_to_uint64(state, word, _token_len(parser, token_idx),
-                                    &error, thousands)
+            word_len = _token_len(parser, token_idx)
+            data[i] = str_to_uint64(state, word, word_len, &error, thousands)
             if error != 0:
+                if _nul_truncated_number(word, word_len, thousands):
+                    return _NUL_TRUNCATED
                 return error
 
     return 0
@@ -3128,6 +3201,10 @@ cdef _try_int64(parser_t *parser, int64_t col,
                                      na_filter, na_hashset, NA, data,
                                      &na_count)
     if error != 0:
+        if raise_on_invalid and error == _NUL_TRUNCATED:
+            # GH#66524: not numeric at all -- skip the rest of the cast order
+            # rather than retrying this column as float.
+            raise ValueError(_NUL_NOT_NUMERIC)
         if error == ERROR_OVERFLOW:
             # Can't get the word variable
             raise OverflowError("Overflow")
@@ -3149,6 +3226,7 @@ cdef int _try_int64_nogil(parser_t *parser, int64_t col,
         coliter_t it
         const char *word = NULL
         c_int64_t token_idx = 0
+        int64_t word_len
         char thousands = parser.thousands
 
     na_count[0] = 0
@@ -3163,16 +3241,20 @@ cdef int _try_int64_nogil(parser_t *parser, int64_t col,
                 data[i] = NA
                 continue
 
-            data[i] = str_to_int64(word, _token_len(parser, token_idx),
-                                   &error, thousands)
+            word_len = _token_len(parser, token_idx)
+            data[i] = str_to_int64(word, word_len, &error, thousands)
             if error != 0:
+                if _nul_truncated_number(word, word_len, thousands):
+                    return _NUL_TRUNCATED
                 return error
     else:
         for i in range(lines):
             word = coliter_next_with_idx(&it, &token_idx)
-            data[i] = str_to_int64(word, _token_len(parser, token_idx),
-                                   &error, thousands)
+            word_len = _token_len(parser, token_idx)
+            data[i] = str_to_int64(word, word_len, &error, thousands)
             if error != 0:
+                if _nul_truncated_number(word, word_len, thousands):
+                    return _NUL_TRUNCATED
                 return error
 
     return 0
@@ -3188,6 +3270,7 @@ cdef _try_pylong(parser_t *parser, Py_ssize_t col,
         Py_ssize_t lines
         coliter_t it
         const char *word = NULL
+        c_int64_t token_idx = 0
         ndarray[object] result
         object NA = na_values[np.object_]
 
@@ -3196,12 +3279,18 @@ cdef _try_pylong(parser_t *parser, Py_ssize_t col,
     coliter_setup(&it, parser, col, line_start)
 
     for i in range(lines):
-        word = coliter_next(&it)
+        word = coliter_next_with_idx(&it, &token_idx)
         if na_filter and kh_get_str_starts_item(na_hashset, word):
             # in the hash table
             na_count += 1
             result[i] = NA
             continue
+
+        if _has_embedded_nul(word, _token_len(parser, token_idx)):
+            # GH#66524: PyLong_FromString would stop at the NUL and accept the
+            # prefix. Signalled distinctly from the "Invalid integer" failure
+            # below so the caller can keep filtering NA for just this case.
+            raise ValueError(_NUL_NOT_NUMERIC)
 
         py_int = PyLong_FromString(word, NULL, 10)
         if py_int is None:
@@ -3258,13 +3347,14 @@ cdef int _try_bool_flex_nogil(parser_t *parser, int64_t col,
         Py_ssize_t _, lines = line_end - line_start
         coliter_t it
         const char *word = NULL
+        c_int64_t token_idx = 0
 
     na_count[0] = 0
     coliter_setup(&it, parser, col, line_start)
 
     if na_filter:
         for _ in range(lines):
-            word = coliter_next(&it)
+            word = coliter_next_with_idx(&it, &token_idx)
 
             if kh_get_str_starts_item(na_hashset, word):
                 # in the hash table
@@ -3272,6 +3362,9 @@ cdef int _try_bool_flex_nogil(parser_t *parser, int64_t col,
                 data[0] = NA
                 data += 1
                 continue
+
+            if _has_embedded_nul(word, _token_len(parser, token_idx)):
+                return -1
 
             if kh_get_str_starts_item(true_hashset, word):
                 data[0] = 1
@@ -3288,7 +3381,10 @@ cdef int _try_bool_flex_nogil(parser_t *parser, int64_t col,
             data += 1
     else:
         for _ in range(lines):
-            word = coliter_next(&it)
+            word = coliter_next_with_idx(&it, &token_idx)
+
+            if _has_embedded_nul(word, _token_len(parser, token_idx)):
+                return -1
 
             if kh_get_str_starts_item(true_hashset, word):
                 data[0] = 1
@@ -3308,18 +3404,21 @@ cdef int _try_bool_flex_nogil(parser_t *parser, int64_t col,
     return 0
 
 
-cdef inline int _bool_numeric_literal(const char *word) noexcept nogil:
+cdef inline int _bool_numeric_literal(const char *word,
+                                      int64_t length) noexcept nogil:
     # The numeric boolean spellings BooleanArray accepts by default:
     # "1"/"1.0" -> 1, "0"/"0.0" -> 0, anything else -> -1.
-    if word[0] == ord("1"):
-        if word[1] == 0:
+    # GH#66524: driven by the token's real length rather than by a NUL
+    # terminator, so "1\0x" is not mistaken for the literal "1".
+    if length == 1:
+        if word[0] == ord("1"):
             return 1
-        if word[1] == ord(".") and word[2] == ord("0") and word[3] == 0:
-            return 1
-    elif word[0] == ord("0"):
-        if word[1] == 0:
+        if word[0] == ord("0"):
             return 0
-        if word[1] == ord(".") and word[2] == ord("0") and word[3] == 0:
+    elif length == 3 and word[1] == ord(".") and word[2] == ord("0"):
+        if word[0] == ord("1"):
+            return 1
+        if word[0] == ord("0"):
             return 0
     return -1
 
@@ -3341,18 +3440,24 @@ cdef int _try_boolean_masked_nogil(parser_t *parser, int64_t col,
         Py_ssize_t i, lines = line_end - line_start
         coliter_t it
         const char *word = NULL
+        c_int64_t token_idx = 0
+        int64_t word_len
         int numeric
 
     coliter_setup(&it, parser, col, line_start)
     for i in range(lines):
-        word = coliter_next(&it)
+        word = coliter_next_with_idx(&it, &token_idx)
 
         if na_filter and kh_get_str_starts_item(na_hashset, word):
             mask[i] = 1
             data[i] = 0
             continue
 
-        numeric = _bool_numeric_literal(word)
+        word_len = _token_len(parser, token_idx)
+        if _has_embedded_nul(word, word_len):
+            return -1
+
+        numeric = _bool_numeric_literal(word, word_len)
         if kh_get_str_starts_item(true_hashset, word) or numeric == 1:
             data[i] = 1
         elif kh_get_str_starts_item(false_hashset, word) or numeric == 0:

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -2343,6 +2343,9 @@ int64_t str_to_int64(const char *p_item, int64_t length, int *error,
   // lets from_chars get its end pointer without a strlen scan.
   size_t str_len =
       length < 0 ? strlen(p) : (size_t)length - (size_t)(p - p_item);
+  // GH#66524: token end in the original input, captured before the tsep branch
+  // below reassigns p/str_len to the scratch buffer.
+  const char *const token_end = p + str_len;
   const char *number_end = NULL;
   if (tsep != '\0' && memchr(p, tsep, str_len) != NULL) {
     const int written =
@@ -2359,16 +2362,19 @@ int64_t str_to_int64(const char *p_item, int64_t length, int *error,
   int64_t number;
   const char *endptr;
   const pd_strtoi_status status = pd_strtoll(p, p + str_len, &number, &endptr);
+  // Compared against endptr, in whichever buffer endptr refers to.
+  const char *end = p + str_len;
   if (number_end != NULL) {
     // GH#64631: detect trailing junk in the original input that
     // copy_number_without_tsep stopped at (e.g. "1 ," with tsep=',').
     endptr = number_end;
+    end = token_end;
   }
   if (status == PD_STRTOI_OVERFLOW) {
     // Overflow with trailing junk → INVALID_CHARS (so caller can fall through
-    // to float parsing, e.g. "18446744073709551616.0"). Pure overflow (endptr
-    // at NUL) → OVERFLOW (caller retries as uint64).
-    *error = *endptr ? ERROR_INVALID_CHARS : ERROR_OVERFLOW;
+    // to float parsing, e.g. "18446744073709551616.0"). Pure overflow (whole
+    // token consumed) → OVERFLOW (caller retries as uint64).
+    *error = endptr != end ? ERROR_INVALID_CHARS : ERROR_OVERFLOW;
     return 0;
   }
   if (status == PD_STRTOI_INVALID) {
@@ -2377,12 +2383,13 @@ int64_t str_to_int64(const char *p_item, int64_t length, int *error,
   }
 
   // Skip trailing spaces.
-  while (isspace_ascii(*endptr)) {
+  while (endptr < end && isspace_ascii(*endptr)) {
     ++endptr;
   }
 
-  // Did we use up all the characters?
-  if (*endptr) {
+  // Did we use up all the characters? GH#66524: against the token end, not a
+  // *endptr NUL test, so "1\0xyz" is rejected instead of parsing as "1".
+  if (endptr != end) {
     *error = ERROR_INVALID_CHARS;
     return 0;
   }
@@ -2419,6 +2426,8 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int64_t length,
   // lets from_chars get its end pointer without a strlen scan.
   size_t str_len =
       length < 0 ? strlen(p) : (size_t)length - (size_t)(p - p_item);
+  // GH#66524: see str_to_int64.
+  const char *const token_end = p + str_len;
   const char *number_end = NULL;
   if (tsep != '\0' && memchr(p, tsep, str_len) != NULL) {
     const int written =
@@ -2435,12 +2444,14 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int64_t length,
   uint64_t number;
   const char *endptr;
   const pd_strtoi_status status = pd_strtoull(p, p + str_len, &number, &endptr);
+  const char *end = p + str_len;
   if (number_end != NULL) {
     // GH#64631: detect trailing junk in the original input.
     endptr = number_end;
+    end = token_end;
   }
   if (status == PD_STRTOI_OVERFLOW) {
-    *error = *endptr ? ERROR_INVALID_CHARS : ERROR_OVERFLOW;
+    *error = endptr != end ? ERROR_INVALID_CHARS : ERROR_OVERFLOW;
     return 0;
   }
   if (status == PD_STRTOI_INVALID) {
@@ -2449,12 +2460,12 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int64_t length,
   }
 
   // Skip trailing spaces.
-  while (isspace_ascii(*endptr)) {
+  while (endptr < end && isspace_ascii(*endptr)) {
     ++endptr;
   }
 
-  // Did we use up all the characters?
-  if (*endptr) {
+  // Did we use up all the characters? GH#66524: see str_to_int64.
+  if (endptr != end) {
     *error = ERROR_INVALID_CHARS;
     return 0;
   }

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -866,3 +866,123 @@ def test_embedded_nul_byte_roundtrip(c_parser_only, kwargs):
     expected = parser.read_csv(BytesIO(b'a\n"x\x00y"\n'), dtype=object)
     assert result["a"][0] == "x\x00y"
     assert expected["a"][0] == "x\x00y"
+
+
+def test_embedded_nul_not_parsed_as_int(c_parser_only):
+    # GH#66524: str_to_int64 checked *endptr rather than whether the parse
+    # consumed the whole token, so "1\x00xyz" was accepted as the integer 1
+    # and the trailing bytes were silently dropped.
+    parser = c_parser_only
+    data = b"a\n1\n1\x00xyz\n3\n"
+    result = parser.read_csv(BytesIO(data))
+    assert result["a"].tolist() == ["1", "1\x00xyz", "3"]
+    tm.assert_frame_equal(result, read_csv(BytesIO(data), engine="python"))
+
+
+def test_embedded_nul_not_parsed_as_bool(c_parser_only):
+    # GH#66524: the inferred-bool path treats the token as NUL-terminated, so
+    # "True\x00xyz" was accepted as True instead of leaving the column as
+    # strings the way engine="python" does. Quoted, to cover the tokenizer's
+    # quoted-field branch as well.
+    parser = c_parser_only
+    data = b'a\nTrue\n"True\x00xyz"\nFalse\n'
+    result = parser.read_csv(BytesIO(data))
+    assert result["a"].tolist() == ["True", "True\x00xyz", "False"]
+    tm.assert_frame_equal(result, read_csv(BytesIO(data), engine="python"))
+
+
+def test_embedded_nul_boolean_dtype(c_parser_only):
+    # GH#66524: _bool_numeric_literal treated word[1] == 0 as end-of-token, so
+    # "1\x00x" was accepted as the numeric literal "1" and never fell through
+    # to the generic path that raises.
+    parser = c_parser_only
+    with pytest.raises(ValueError, match="cannot be cast to bool"):
+        parser.read_csv(BytesIO(b"a\n1\x00x\nTrue\n"), dtype="boolean")
+
+
+def test_embedded_nul_bool_guards_both_gates(c_parser_only):
+    # GH#66524: the inferred-bool path has two independent gates that each
+    # assume a NUL-terminated token -- the true/false hash sets
+    # (kh_get_str_starts_item) and to_boolean's strcasecmp -- so a fix has to
+    # guard both. Each gate is exercised in isolation:
+    #   "tRuE" is not in the seeded hash sets, so only to_boolean can accept it
+    #   "yes" is rejected by to_boolean, so only the hash set can accept it
+    parser = c_parser_only
+
+    # to_boolean gate. That the c engine accepts the mixed-case spelling at all
+    # while engine="python" does not is a separate, pre-existing divergence;
+    # it is asserted here to pin it down as deliberately unchanged.
+    result = parser.read_csv(BytesIO(b"a\nTrue\ntRuE\nFalse\n"))
+    assert result["a"].tolist() == [True, True, False]
+
+    result = parser.read_csv(BytesIO(b"a\nTrue\ntRuE\x00xyz\nFalse\n"))
+    assert result["a"].tolist() == ["True", "tRuE\x00xyz", "False"]
+
+    # Hash-set gate, reached via a user-supplied true_values entry that
+    # to_boolean rejects outright.
+    kwds = {"true_values": ["yes"], "false_values": ["no"]}
+    result = parser.read_csv(BytesIO(b"a\nyes\nno\n"), **kwds)
+    assert result["a"].tolist() == [True, False]
+
+    result = parser.read_csv(BytesIO(b"a\nyes\nyes\x00xyz\nno\n"), **kwds)
+    assert result["a"].tolist() == ["yes", "yes\x00xyz", "no"]
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (b"a\nzzz\nzzz\x00xyz\n", ["zzz", "zzz\x00xyz"]),
+        (b"a\nzzz\x00xyz\nzzz\n", ["zzz\x00xyz", "zzz"]),
+    ],
+)
+def test_embedded_nul_string_intern_collision(c_parser_only, data, expected):
+    # GH#66524: _string_box_utf8 decoded with _token_len but keyed its intern
+    # table on the NUL-terminated word, so two tokens sharing a NUL-truncated
+    # prefix collided and whichever was decoded first won for both. In the
+    # second ordering that replaced the clean value with the NUL-bearing one.
+    # Reached without any numeric or boolean conversion being involved.
+    parser = c_parser_only
+    result = parser.read_csv(BytesIO(data))
+    assert result["a"].tolist() == expected
+    tm.assert_frame_equal(result, read_csv(BytesIO(data), engine="python"))
+
+
+def test_embedded_nul_not_parsed_as_uint64(c_parser_only):
+    # GH#66524: values above INT64_MAX take the str_to_uint64 retry path, which
+    # carried the same NUL-terminated completeness check as str_to_int64.
+    parser = c_parser_only
+    data = b"a\n18446744073709551615\n18446744073709551614\x00xyz\n"
+    result = parser.read_csv(BytesIO(data))
+    assert result["a"].tolist() == [
+        "18446744073709551615",
+        "18446744073709551614\x00xyz",
+    ]
+    tm.assert_frame_equal(result, read_csv(BytesIO(data), engine="python"))
+
+
+def test_embedded_nul_pylong_fallback_keeps_na(c_parser_only):
+    # GH#66524: values that overflow int64 take the _try_pylong path, whose
+    # PyLong_FromString stops at a NUL. Its rejection lands in a different
+    # fallback branch than the int64 one, which must also filter NA rather than
+    # turning the blank row into a literal empty string.
+    parser = c_parser_only
+    data = b"a,b\n99999999999999999999999,x\n99999999999999999999998\x00y,y\n,z\n"
+    result = parser.read_csv(BytesIO(data))
+    assert result["a"].tolist()[:2] == [
+        "99999999999999999999999",
+        "99999999999999999999998\x00y",
+    ]
+    assert result["a"].isna().tolist() == [False, False, True]
+    tm.assert_frame_equal(result, read_csv(BytesIO(data), engine="python"))
+
+
+def test_embedded_nul_fallback_keeps_na(c_parser_only):
+    # GH#66524: the embedded-NUL rejection routes the column to the string
+    # fallback through its own branch in the cast-order loop, which must pass
+    # the real na_filter/na_hashset through -- the neighbouring branch passes
+    # na_filter=0, which would turn the NA row into a literal empty string.
+    parser = c_parser_only
+    data = b"a,b\n1,x\n1\x00xyz,y\n,z\n3,w\n"
+    result = parser.read_csv(BytesIO(data))
+    assert result["a"].isna().tolist() == [False, False, True, False]
+    tm.assert_frame_equal(result, read_csv(BytesIO(data), engine="python"))

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -879,6 +879,27 @@ def test_embedded_nul_not_parsed_as_int(c_parser_only):
     tm.assert_frame_equal(result, read_csv(BytesIO(data), engine="python"))
 
 
+def test_embedded_nul_nullable_backend(c_parser_only):
+    # GH#66524: the nullable backend accepted "1\x00xyz" as the integer 1, so
+    # the column came back as Int64 [1, 1, 3] instead of the strings
+    # engine="python" returns.
+    parser = c_parser_only
+    data = b"a\n1\n1\x00xyz\n3\n"
+    result = parser.read_csv(BytesIO(data), dtype_backend="numpy_nullable")
+    tm.assert_frame_equal(
+        result,
+        read_csv(BytesIO(data), engine="python", dtype_backend="numpy_nullable"),
+    )
+
+
+def test_embedded_nul_explicit_int_dtype(c_parser_only):
+    # GH#66524: with an explicit int dtype the c engine accepted "1\x00xyz" as
+    # the integer 1 and returned [1, 1, 3]; engine="python" rejects the column.
+    parser = c_parser_only
+    with pytest.raises(ValueError, match="invalid literal"):
+        parser.read_csv(BytesIO(b"a\n1\n1\x00xyz\n3\n"), dtype="int64")
+
+
 def test_embedded_nul_not_parsed_as_bool(c_parser_only):
     # GH#66524: the inferred-bool path treats the token as NUL-terminated, so
     # "True\x00xyz" was accepted as True instead of leaving the column as

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -1069,8 +1069,6 @@ def test_parse_dates_low_memory_embedded_nul_chunks(position):
     # before converting anything ("first") or rebuilds earlier chunks from
     # receipts ("last")
     date_strings = [f"2020-01-{(i % 28) + 1:02d}" for i in range(19_999)]
-    # unique date prefix: avoids the NUL-terminated intern-table collision
-    # in _string_box_utf8, which is not under test here
     nul_value = "2021-06-15\x00X"
     if position == "first":
         date_strings.insert(0, nul_value)


### PR DESCRIPTION
- [x] closes #66524
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (No Python API was added.)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

The C parser's integer, unsigned-integer, and boolean paths treated an embedded NUL as the end of a field even though the tokenizer supplied the field's full length. The string intern table could then collide with the truncated prefix and lose the suffix during fallback.

This checks bounded integer parses against the real token end, rejects embedded NULs before NUL-terminated boolean comparisons, and decodes NUL-containing strings without using the NUL-terminated intern key. Regression tests cover signed and unsigned inference, an explicit integer dtype, the `numpy_nullable` backend, both boolean gates, nullable booleans, large Python integers, NA handling, and both string-collision orderings.

Checks run:

- `python -m pytest pandas/tests/io/parser/test_c_parser_only.py -q -p no:cacheprovider` (220 passed, 6 skipped)
- `python -m pytest pandas/tests/io/parser -q -p no:cacheprovider` (4159 passed, 1014 skipped, 52 xfailed)
- `python -m pytest pandas/tests/io/parser/test_parse_dates.py::test_parse_dates_low_memory_embedded_nul_chunks -q -p no:cacheprovider` (2 passed)
- `pre-commit run --files doc/source/whatsnew/v3.1.0.rst pandas/_libs/parsers.pyx pandas/_libs/src/parser/tokenizer.c pandas/tests/io/parser/test_c_parser_only.py pandas/tests/io/parser/test_parse_dates.py`

Development disclosure: I used Claude Code (Opus 5) for implementation and debugging, supervised with Codex. I reviewed the final diff and reran the checks above before opening this draft.

