### PR TITLE
BUG: Timestamp.isoformat splicing nanoseconds into a sub-minute UTC offset

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -379,6 +379,7 @@ Timezones
 - Bug in :class:`DatetimeIndex` addition with a :class:`DateOffset` that has only timedelta components (e.g. ``DateOffset(hours=-2)``) raising ``ValueError`` near DST transitions, while scalar :class:`Timestamp` addition worked correctly (:issue:`28610`)
 - Bug in :meth:`DatetimeIndex.tz_convert` and :meth:`DatetimeIndex.tz_localize` returning incorrect offsets for far-future dates (roughly 2088 to 2100) with ``zoneinfo`` timezones whose DST rule follows Ramadan, such as ``Africa/Casablanca`` and ``Africa/El_Aaiun`` (:issue:`65712`)
 - Bug in :meth:`Series.dt.tz_localize` and :meth:`Series.dt.tz_convert` (and their :class:`DatetimeIndex` counterparts) returning incorrect results for non-nanosecond resolutions (e.g. ``"s"``, ``"ms"``, ``"us"``) on timestamps before roughly 1677 (:issue:`66252`)
+- Bug in :meth:`Timestamp.isoformat`, ``str(Timestamp)``, and the rendering of :class:`Series` and :class:`DatetimeIndex` (including ``repr``, ``astype(str)``, and :meth:`DataFrame.to_csv`) splicing the fractional seconds into the middle of the UTC offset for timestamps in a timezone whose offset is not a whole number of minutes, such as any zone in its pre-standardization era (e.g. ``Asia/Tokyo`` before 1888) (:issue:`66547`)
 - Bug in :meth:`Timestamp.to_julian_date` and :meth:`DatetimeIndex.to_julian_date` returning the Julian date of the local wall clock for timezone-aware inputs instead of the underlying UTC instant (:issue:`54763`)
 
 Numeric

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1493,8 +1493,10 @@ cdef class _Timestamp(ABCTimestamp):
         By default, the fractional part is omitted if self.microsecond == 0
         and self._nanosecond == 0.
 
-        If self.tzinfo is not None, the UTC offset is also attached,
-        giving a full format of 'YYYY-MM-DD HH:MM:SS.mmmmmmnnn+HH:MM'.
+        If self.tzinfo is not None, the UTC offset is also attached, giving a
+        full format of 'YYYY-MM-DD HH:MM:SS.mmmmmmnnn+HH:MM[:SS[.ffffff]]'.
+        The ':SS' is present only if the offset is not a whole number of
+        minutes, as for a timezone in its pre-standardization era.
 
         Parameters
         ----------
@@ -1527,15 +1529,23 @@ cdef class _Timestamp(ABCTimestamp):
         base_ts = "microseconds" if timespec == "nanoseconds" else timespec
         base = super(_Timestamp, self).isoformat(sep=sep, timespec=base_ts)
         # We need to replace the fake year 1970 with our real year
-        base = f"{self._year:04d}-" + base.split("-", 1)[1]
+        year_str = f"{self._year:04d}"
+        base = year_str + "-" + base.split("-", 1)[1]
 
         if self._nanosecond == 0 and timespec != "nanoseconds":
             return base
 
-        if self.tzinfo is not None:
-            base1, base2 = base[:-6], base[-6:]
-        else:
+        # The UTC offset is usually "+HH:MM", but grows a ":SS[.ffffff]" suffix when
+        # it is not a whole number of minutes, so find where it starts instead of
+        # assuming a fixed width.  Search past "YYYY-MM-DD" and the separator -- the
+        # year is not always 4 digits, and may be negative -- so that a date dash is
+        # never mistaken for the offset's sign.  No sign there means no offset.
+        time_start = len(year_str) + 7
+        tz_pos = max(base.rfind("+", time_start), base.rfind("-", time_start))
+        if tz_pos == -1:
             base1, base2 = base, ""
+        else:
+            base1, base2 = base[:tz_pos], base[tz_pos:]
 
         if timespec == "nanoseconds" or (timespec == "auto" and self._nanosecond):
             if self.microsecond or timespec == "nanoseconds":

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -16,6 +16,19 @@ from pandas import (
 import pandas._testing as tm
 
 
+def test_get_values_for_csv_sub_minute_utc_offset():
+    # GH#66547 array formatting routes through Timestamp.isoformat, so a UTC
+    #  offset carrying seconds used to have the fraction spliced into it
+    dti = DatetimeIndex(["1800-01-01 00:00:00.000000001"], tz="UTC").tz_convert(
+        "Asia/Tokyo"
+    )
+    expected = np.array(["1800-01-01 09:18:59.000000001+09:18:59"], dtype=object)
+
+    tm.assert_numpy_array_equal(dti._get_values_for_csv(), expected)
+    tm.assert_numpy_array_equal(Series(dti).astype(str).to_numpy(), expected)
+    assert expected[0] in repr(dti)
+
+
 def test_get_values_for_csv():
     index = pd.date_range(freq="1D", periods=3, start="2017-01-01")
 

--- a/pandas/tests/scalar/timestamp/test_formats.py
+++ b/pandas/tests/scalar/timestamp/test_formats.py
@@ -1,10 +1,13 @@
 from datetime import (
     UTC,
     datetime,
+    timedelta,
+    timezone,
 )
 import pprint
 
 import dateutil.tz
+import numpy as np
 import pytest
 
 from pandas.compat import WASM
@@ -89,6 +92,94 @@ ts_no_us = Timestamp(
 )
 def test_isoformat(ts, timespec, expected_iso):
     assert ts.isoformat(timespec=timespec) == expected_iso
+
+
+@pytest.mark.parametrize(
+    "tz, expected_offset",
+    [
+        (timezone(timedelta(seconds=33539)), "+09:18:59"),
+        (timezone(timedelta(seconds=-28378)), "-07:52:58"),
+        (timezone(timedelta(seconds=33539, microseconds=7)), "+09:18:59.000007"),
+        (timezone(timedelta(hours=9)), "+09:00"),
+        (timezone(timedelta(hours=-8)), "-08:00"),
+        ("UTC", "+00:00"),
+    ],
+)
+@pytest.mark.parametrize(
+    "microsecond, nanosecond, timespec, frac",
+    [
+        (0, 123, "auto", ".000000123"),
+        (132263, 123, "auto", ".132263123"),
+        (0, 0, "nanoseconds", ".000000000"),
+        (132263, 0, "nanoseconds", ".132263000"),
+    ],
+)
+def test_isoformat_sub_minute_utc_offset(
+    tz, expected_offset, microsecond, nanosecond, timespec, frac
+):
+    # GH#66547 an offset that is not a whole number of minutes is rendered as
+    #  "+HH:MM:SS", so the nanoseconds must not be spliced into it
+    ts = Timestamp(
+        year=2019,
+        month=5,
+        day=18,
+        hour=15,
+        minute=17,
+        second=8,
+        microsecond=microsecond,
+        nanosecond=nanosecond,
+        tz=tz,
+    )
+    assert (
+        ts.isoformat(timespec=timespec) == f"2019-05-18T15:17:08{frac}{expected_offset}"
+    )
+
+
+@pytest.mark.parametrize(
+    "dt64, expected",
+    [
+        # years wider than 4 digits, and negative years, reachable at
+        #  resolutions coarser than nanosecond
+        (np.datetime64(2**63 - 1, "s"), "292277026596-12-04T15:30:07.000000000"),
+        (np.datetime64(-(2**63) + 1, "s"), "-292277022657-01-27T08:29:53.000000000"),
+        (np.datetime64(2**63 - 1, "ms"), "292278994-08-17T07:12:55.807000000"),
+        (
+            np.datetime64("10000-01-01T00:00:00.132263", "us"),
+            "10000-01-01T00:00:00.132263000",
+        ),
+        (
+            np.datetime64("-1000-01-01T00:00:00.132263", "us"),
+            "-1000-01-01T00:00:00.132263000",
+        ),
+    ],
+)
+@pytest.mark.parametrize("sep", ["T", "-", "+"])
+def test_isoformat_wide_year_no_date_splice(dt64, expected, sep):
+    # GH#66547 locating the UTC offset must not mistake a date dash -- or an
+    #  unusual separator -- for the offset's sign when the year is not 4 digits
+    ts = Timestamp(dt64)
+    result = ts.isoformat(sep=sep, timespec="nanoseconds")
+    assert result == expected.replace("T", sep)
+
+
+@pytest.mark.parametrize(
+    "tz, expected",
+    [
+        ("Asia/Tokyo", "1800-01-01T09:18:59.000000001+09:18:59"),
+        ("US/Pacific", "1799-12-31T16:07:02.000000001-07:52:58"),
+    ],
+)
+def test_isoformat_pre_standardization_offset(tz, expected):
+    # GH#66547 zones carry a seconds component in their pre-standardization
+    #  local-mean-time era
+    ts = Timestamp("1800-01-01 00:00:00.000000001", tz="UTC").tz_convert(tz)
+    result = ts.isoformat()
+    assert result == expected
+    assert str(ts) == expected.replace("T", " ")
+    # the offset must be rendered exactly as the stdlib renders it
+    assert ts.to_pydatetime(warn=False).isoformat() == expected.replace(
+        ".000000001", ""
+    )
 
 
 class TestTimestampRendering:


### PR DESCRIPTION
Not linked to an existing issue; found while working on GH-66510.

`datetime.isoformat` renders the UTC offset as `+HH:MM:SS[.ffffff]` whenever the offset is not a whole number of minutes, but `Timestamp.isoformat` assumed a fixed 6-character `+HH:MM` and appended the nanosecond fraction between the two halves of the slice. Any zone in its pre-standardization (local mean time) era hits this — `Asia/Tokyo` is +09:18:59 before 1888, `US/Pacific` is −07:52:58 before 1883 — as does any fixed offset carrying seconds.

```python
>>> str(pd.Timestamp("1800-01-01 00:00:00.000000001", tz="UTC").tz_convert("Asia/Tokyo"))
'1800-01-01 09:18:59+09.000000001:18:59'   # fraction spliced into the offset
```

This is not just the scalar: `format_array_from_datetime` routes all tz-aware array rendering through `Timestamp.isoformat`, so `repr`, `astype(str)` and `to_csv` were corrupted identically — `to_csv` emitted `1800-01-01 09:18:59.000000+09001:18:59`.

The fix locates the offset rather than assuming its width. The search deliberately starts past `YYYY-MM-DD` and the separator, computed from the rendered year instead of a hardcoded index: `f"{year:04d}"` is a *minimum* width, and resolutions coarser than nanosecond reach years up to 292277026596 and down to −292277022657, so a fixed start index would mistake a date dash (or a `-`/`+` `sep`) for the offset sign and splice the nanoseconds into the date.

`__repr__` is unaffected — it goes through `strftime("%z")`, which emits `+091859` and places the fraction correctly.

Two adjacent pre-existing bugs are left out of scope: `Timestamp.fromisoformat` drops nanoseconds unconditionally, and the parse side (`strptime.pyx` `%z`, `np_datetime_strings.c`) truncates or rejects `±HH:MM:SS` offsets, so pandas now emits a string its own parser cannot read back (`datetime.fromisoformat` handles it fine).