### PR TITLE
ENH: Add limit_distance parameter to Series/DataFrame.interpolate

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -35,6 +35,7 @@ Other enhancements
 - :meth:`Series.to_json` now supports serializing custom ExtensionArrays (by correctly using the ``_values_for_json`` method of an ExtensionArray) (:issue:`65047`)
 - :meth:`Timestamp.round`, :meth:`Timestamp.floor`, and :meth:`Timestamp.ceil` now officially accept :class:`Timedelta` arguments (:issue:`63687`)
 - Added :class:`NamedFunc`, an alias to :class:`NamedAgg` for a more semantically accurate name when used with non-aggregation functions; either can accept arbitrary functions (:issue:`65164`)
+- Added ``limit_distance`` parameter to :meth:`Series.interpolate` and :meth:`DataFrame.interpolate`, allowing users to restrict interpolation to gaps smaller than a specified maximum physical or temporal distance (including support for duration strings and :class:`Timedelta` objects) (:issue:`66545`)
 - :meth:`ExtensionArray.map` now calls :meth:`ExtensionArray._cast_pointwise_result` to retain the dtype backend, e.g. Arrow-backed arrays now preserve their Arrow dtype through ``map`` (:issue:`57189`, :issue:`62164`)
 - :func:`read_csv` now supports ``dtype="complex64"`` and ``dtype="complex128"`` with the C engine, enabling round-tripping of complex-number columns written by :meth:`DataFrame.to_csv` (:issue:`9379`)
 - :func:`to_datetime` and ``strptime`` parsing now support the ``%N`` directive for matching exactly 9 digits representing nanoseconds, providing symmetry with ``strftime`` formatting (:issue:`65863`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8048,6 +8048,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace: bool = False,
         limit_direction: Literal["forward", "backward", "both"] | None = None,
         limit_area: Literal["inside", "outside"] | None = None,
+        limit_distance: float | None = None,
         **kwargs,
     ) -> Self:
         """
@@ -8104,6 +8105,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             * 'inside': Only fill NaNs surrounded by valid values
               (interpolate).
             * 'outside': Only fill NaNs outside valid values (extrapolate).
+
+        limit_distance : float, optional
+            Maximum x-axis distance between consecutive valid points to interpolate.
+            Only supported when method is 'index' or 'values'.
 
         **kwargs : optional
             Keyword arguments to pass on to the interpolating function. Not
@@ -8247,6 +8252,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             limit=limit,
             limit_direction=limit_direction,
             limit_area=limit_area,
+            limit_distance=limit_distance,
             inplace=inplace,
             **kwargs,
         )

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8107,9 +8107,20 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
               (interpolate).
             * 'outside': Only fill NaNs outside valid values (extrapolate).
 
-        limit_distance : float, optional
-            Maximum x-axis distance between consecutive valid points to interpolate.
-            Only supported when method is 'index' or 'values'.
+        limit_distance : float, int, str, or Timedelta, optional
+            Maximum allowed x-axis distance between consecutive valid points to
+            interpolate. Must be greater than 0.
+
+            * For numerical indexes, should be a numeric scalar (`float` or `int`).
+            * For :class:`DatetimeIndex` or :class:`TimedeltaIndex`, can be a
+              time duration string (e.g., ``'5s'``, ``'2h'``) or a
+              :class:`Timedelta` object.
+            * Only supported when ``method`` is ``'index'``, ``'values'``, or
+              ``'time'``.
+
+            .. versionchanged:: 3.1.0
+               Added support for time duration strings and ``Timedelta`` objects
+               when interpolating over temporal indexes.
 
         **kwargs : optional
             Keyword arguments to pass on to the interpolating function. Not

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8243,8 +8243,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         axis = self._get_axis_number(axis)
 
         if limit_distance is not None:
-            is_invalid_numeric = isinstance(limit_distance, (int, float)) and limit_distance <= 0
-            is_invalid_timedelta = isinstance(limit_distance, Timedelta) and limit_distance <= Timedelta(0)
+            is_invalid_numeric = (
+                isinstance(limit_distance, (int, float))
+                and limit_distance <= 0
+            )
+            is_invalid_timedelta = (
+                isinstance(limit_distance, Timedelta)
+                and limit_distance <= Timedelta(0)
+            )
 
             if is_invalid_numeric or is_invalid_timedelta:
                 raise ValueError("limit_distance must be greater than 0")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8242,6 +8242,13 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         axis = self._get_axis_number(axis)
 
+        if limit_distance is not None:
+            is_invalid_numeric = isinstance(limit_distance, (int, float)) and limit_distance <= 0
+            is_invalid_timedelta = isinstance(limit_distance, Timedelta) and limit_distance <= Timedelta(0)
+
+            if is_invalid_numeric or is_invalid_timedelta:
+                raise ValueError("limit_distance must be greater than 0")
+
         if self.empty:
             return self if inplace else self.copy()
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -33,6 +33,7 @@ from pandas._libs import lib
 from pandas._libs.lib import is_range_indexer
 from pandas._libs.tslibs import (
     Period,
+    Timedelta,
     Timestamp,
     to_offset,
 )
@@ -8048,7 +8049,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         inplace: bool = False,
         limit_direction: Literal["forward", "backward", "both"] | None = None,
         limit_area: Literal["inside", "outside"] | None = None,
-        limit_distance: float | None = None,
+        limit_distance: float | int | str | Timedelta | None = None,
         **kwargs,
     ) -> Self:
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8243,17 +8243,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         axis = self._get_axis_number(axis)
 
         if limit_distance is not None:
-            is_invalid_numeric = (
-                isinstance(limit_distance, (int, float))
-                and limit_distance <= 0
+            target_index = self._get_axis(axis)
+            unit = getattr(target_index, "unit", None) or getattr(
+                target_index.dtype, "unit", None
             )
-            is_invalid_timedelta = (
-                isinstance(limit_distance, Timedelta)
-                and limit_distance <= Timedelta(0)
-            )
-
-            if is_invalid_numeric or is_invalid_timedelta:
-                raise ValueError("limit_distance must be greater than 0")
+            missing.validate_limit_distance(limit_distance, unit=unit)
 
         if self.empty:
             return self if inplace else self.copy()

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -20,6 +20,8 @@ from pandas._libs import (
     internals as libinternals,
     lib,
 )
+from pandas._libs.tslibs import Timedelta
+
 from pandas._libs.internals import (
     BlockPlacement,
     BlockValuesRefs,
@@ -1478,7 +1480,7 @@ class Block(PandasObject, libinternals.Block):
         limit: int | None = None,
         limit_direction: Literal["forward", "backward", "both"] = "forward",
         limit_area: Literal["inside", "outside"] | None = None,
-        limit_distance: float | None = None,
+        limit_distance: float | int | str | Timedelta | None = None,
         **kwargs,
     ) -> list[Block]:
         inplace = validate_bool_kwarg(inplace, "inplace")

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -20,8 +20,6 @@ from pandas._libs import (
     internals as libinternals,
     lib,
 )
-from pandas._libs.tslibs import Timedelta
-
 from pandas._libs.internals import (
     BlockPlacement,
     BlockValuesRefs,
@@ -123,6 +121,7 @@ if TYPE_CHECKING:
         Sequence,
     )
 
+    from pandas._libs.tslibs import Timedelta
     from pandas._typing import (
         ArrayLike,
         AxisInt,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1478,6 +1478,7 @@ class Block(PandasObject, libinternals.Block):
         limit: int | None = None,
         limit_direction: Literal["forward", "backward", "both"] = "forward",
         limit_area: Literal["inside", "outside"] | None = None,
+        limit_distance: float | None = None,
         **kwargs,
     ) -> list[Block]:
         inplace = validate_bool_kwarg(inplace, "inplace")
@@ -1501,6 +1502,7 @@ class Block(PandasObject, libinternals.Block):
             limit=limit,
             limit_direction=limit_direction,
             limit_area=limit_area,
+            limit_distance=limit_distance,
             copy=copy,
             **kwargs,
         )

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -22,6 +22,7 @@ from pandas._libs import (
     algos,
     lib,
 )
+from pandas._libs.tslibs import Timedelta
 from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.dtypes.cast import infer_dtype_from
@@ -42,9 +43,6 @@ from pandas.core.dtypes.missing import (
     isna,
     na_value_for_dtype,
 )
-
-from pandas._libs.tslibs import Timedelta
-from pandas.core.tools.timedeltas import to_timedelta
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -414,6 +412,8 @@ def interpolate_2d_inplace(
     # default limit is unlimited GH #16282
     limit = algos.validate_limit(nobs=None, limit=limit)
 
+    # Check index.unit first so microsecond/millisecond DatetimeIndexes are caught!
+    unit = getattr(index, "unit", None) or getattr(index.dtype, "unit", None)
     indices = _index_to_interp_indices(index, method)
 
     def func(yvalues: np.ndarray) -> None:
@@ -430,6 +430,7 @@ def interpolate_2d_inplace(
             fill_value=fill_value,
             bounds_error=False,
             mask=mask,
+            unit=unit,
             **kwargs,
         )
 
@@ -522,6 +523,7 @@ def _interpolate_1d(
     bounds_error: bool = False,
     order: int | None = None,
     mask=None,
+    unit: str | None = None,
     **kwargs,
 ) -> None:
     """
@@ -590,7 +592,9 @@ def _interpolate_1d(
         preserve_nans = np.union1d(preserve_nans, mid_nans)
 
     if limit_distance is not None:
-        distance_nans = _interp_limit_distance(indices, invalid, limit_distance)
+        distance_nans = _interp_limit_distance(
+            indices, invalid, limit_distance, unit=unit
+        )
         preserve_nans = np.union1d(preserve_nans, distance_nans)
 
     is_datetimelike = yvalues.dtype.kind in "mM"
@@ -1171,10 +1175,12 @@ def _interp_limit(
 
     return np.intersect1d(f_idx, b_idx, assume_unique=assume_unique)
 
+
 def _interp_limit_distance(
     indices: np.ndarray,
     invalid: npt.NDArray[np.bool_],
     limit_distance: float | int | str | Timedelta,
+    unit: str | None = None,
 ) -> np.ndarray:
     """
     Return index positions of invalid values that should not be filled
@@ -1202,7 +1208,14 @@ def _interp_limit_distance(
     """
     # Normalize and validate limit_distance
     if isinstance(limit_distance, (str, Timedelta)):
-        threshold = to_timedelta(limit_distance).value
+        from pandas.core.tools.timedeltas import to_timedelta
+
+        td = to_timedelta(limit_distance)
+        if unit is not None:
+            # Cast to matching NumPy timedelta unit then to int64
+            threshold = td.to_numpy().astype(f"m8[{unit}]").astype(np.int64)
+        else:
+            threshold = td.value
     else:
         threshold = limit_distance
 
@@ -1234,6 +1247,9 @@ def _interp_limit_distance(
 
     # Calculate the physical x-axis gap across each NaN
     gap_sizes = np.abs(indices[right_valid_pos] - indices[left_valid_pos])
+
+    if gap_sizes.dtype.kind in "mM":
+        gap_sizes = gap_sizes.view("i8")
 
     # Return only the NaN positions where the gap exceeds the threshold
     return invalid_inside[gap_sizes > threshold]

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -1206,6 +1206,20 @@ def _interp_limit_distance(
         1D array of integer positions corresponding to invalid values that
         should be preserved as NaN (excluded from interpolation).
     """
+    is_temporal = unit is not None
+    is_td_or_str = isinstance(limit_distance, (str, Timedelta))
+
+    if not is_temporal and is_td_or_str:
+        raise ValueError(
+            "Cannot use a time duration string or Timedelta limit_distance "
+            "with a non-temporal index."
+        )
+    if is_temporal and not is_td_or_str:
+        raise ValueError(
+            "Cannot use a numeric limit_distance with a temporal index; "
+            "pass a Timedelta or time duration string instead."
+        )
+
     # Normalize and validate limit_distance
     if isinstance(limit_distance, (str, Timedelta)):
         from pandas.core.tools.timedeltas import to_timedelta

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -43,6 +43,9 @@ from pandas.core.dtypes.missing import (
     na_value_for_dtype,
 )
 
+from pandas._libs.tslibs import Timedelta
+from pandas.core.tools.timedeltas import to_timedelta
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import TypeAlias
@@ -375,7 +378,7 @@ def interpolate_2d_inplace(
     limit: int | None = None,
     limit_direction: str = "forward",
     limit_area: str | None = None,
-    limit_distance: float | None = None,
+    limit_distance: float | int | str | Timedelta | None = None,
     fill_value: Any | None = None,
     mask=None,
     **kwargs,
@@ -514,7 +517,7 @@ def _interpolate_1d(
     limit: int | None = None,
     limit_direction: str = "forward",
     limit_area: Literal["inside", "outside"] | None = None,
-    limit_distance: float | None = None,
+    limit_distance: float | int | str | Timedelta | None = None,
     fill_value: Any | None = None,
     bounds_error: bool = False,
     order: int | None = None,
@@ -1171,27 +1174,50 @@ def _interp_limit(
 def _interp_limit_distance(
     indices: np.ndarray,
     invalid: npt.NDArray[np.bool_],
-    limit_distance: float,
+    limit_distance: float | int | str | Timedelta,
 ) -> np.ndarray:
     """
     Return index positions of invalid values that should not be filled
     because the x-axis distance between the surrounding valid points
     exceeds limit_distance.
+
+    Parameters
+    ----------
+    indices : np.ndarray
+        1D array of numeric x-axis values (e.g., index labels, timestamps,
+        or positional coordinates) used to measure physical distance.
+    invalid : npt.NDArray[np.bool_]
+        Boolean mask representing NA/NaN values where True indicates a
+        missing or invalid value.
+    limit_distance : float, int, str, or Timedelta
+        Maximum allowed x-axis distance between consecutive valid points
+        for interior NaN values to be interpolated. For DatetimeIndex or
+        TimedeltaIndex, can be a time duration string (e.g., '5s').
+
+    Returns
+    -------
+    np.ndarray
+        1D array of integer positions corresponding to invalid values that
+        should be preserved as NaN (excluded from interpolation).
     """
     valid_pos = np.flatnonzero(~invalid)
     invalid_pos = np.flatnonzero(invalid)
 
+    # everything is valid if there are no NaNs
+    # or if there are less than 2 valid points (impossible to interpolate)
     if len(valid_pos) < 2 or len(invalid_pos) == 0:
         return np.array([], dtype=np.int64)
 
     # For every NaN position, find the valid index immediately next to it
     right_idx = np.searchsorted(valid_pos, invalid_pos, side="left")
 
-    # Only inspect NaNs that sit BETWEEN two valid points (not leading/trailing NaNs)
+    # Only inspect NaNs that sit between two valid points (not leading/trailing NaNs)
     inside_mask = (right_idx > 0) & (right_idx < len(valid_pos))
     if not inside_mask.any():
         return np.array([], dtype=np.int64)
 
+    # Map each interior NaN to its own array index and the array indexes
+    # of the valid anchor points immediately to its left and right
     invalid_inside = invalid_pos[inside_mask]
     right_valid_pos = valid_pos[right_idx[inside_mask]]
     left_valid_pos = valid_pos[right_idx[inside_mask] - 1]
@@ -1199,5 +1225,11 @@ def _interp_limit_distance(
     # Calculate the physical x-axis gap across each NaN
     gap_sizes = indices[right_valid_pos] - indices[left_valid_pos]
 
-    # Return only the NaN positions where the gap exceeds our threshold
-    return invalid_inside[gap_sizes > limit_distance]
+    # Normalize limit_distance to match indices units
+    if isinstance(limit_distance, (str, Timedelta)):
+        threshold = to_timedelta(limit_distance).value
+    else:
+        threshold = limit_distance
+
+    # Return only the NaN positions where the gap exceeds the threshold
+    return invalid_inside[gap_sizes > threshold]

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -375,6 +375,7 @@ def interpolate_2d_inplace(
     limit: int | None = None,
     limit_direction: str = "forward",
     limit_area: str | None = None,
+    limit_distance: float | None = None,
     fill_value: Any | None = None,
     mask=None,
     **kwargs,
@@ -422,6 +423,7 @@ def interpolate_2d_inplace(
             limit=limit,
             limit_direction=limit_direction,
             limit_area=limit_area_validated,
+            limit_distance=limit_distance,
             fill_value=fill_value,
             bounds_error=False,
             mask=mask,
@@ -512,6 +514,7 @@ def _interpolate_1d(
     limit: int | None = None,
     limit_direction: str = "forward",
     limit_area: Literal["inside", "outside"] | None = None,
+    limit_distance: float | None = None,
     fill_value: Any | None = None,
     bounds_error: bool = False,
     order: int | None = None,
@@ -582,6 +585,10 @@ def _interpolate_1d(
         mid_nans = np.setdiff1d(all_nans, start_nans, assume_unique=True)
         mid_nans = np.setdiff1d(mid_nans, end_nans, assume_unique=True)
         preserve_nans = np.union1d(preserve_nans, mid_nans)
+
+    if limit_distance is not None:
+        distance_nans = _interp_limit_distance(indices, invalid, limit_distance)
+        preserve_nans = np.union1d(preserve_nans, distance_nans)
 
     is_datetimelike = yvalues.dtype.kind in "mM"
 
@@ -1160,3 +1167,37 @@ def _interp_limit(
                 return b_idx
 
     return np.intersect1d(f_idx, b_idx, assume_unique=assume_unique)
+
+def _interp_limit_distance(
+    indices: np.ndarray,
+    invalid: npt.NDArray[np.bool_],
+    limit_distance: float,
+) -> np.ndarray:
+    """
+    Return index positions of invalid values that should not be filled
+    because the x-axis distance between the surrounding valid points
+    exceeds limit_distance.
+    """
+    valid_pos = np.flatnonzero(~invalid)
+    invalid_pos = np.flatnonzero(invalid)
+
+    if len(valid_pos) < 2 or len(invalid_pos) == 0:
+        return np.array([], dtype=np.int64)
+
+    # For every NaN position, find the valid index immediately next to it
+    right_idx = np.searchsorted(valid_pos, invalid_pos, side="left")
+
+    # Only inspect NaNs that sit BETWEEN two valid points (not leading/trailing NaNs)
+    inside_mask = (right_idx > 0) & (right_idx < len(valid_pos))
+    if not inside_mask.any():
+        return np.array([], dtype=np.int64)
+
+    invalid_inside = invalid_pos[inside_mask]
+    right_valid_pos = valid_pos[right_idx[inside_mask]]
+    left_valid_pos = valid_pos[right_idx[inside_mask] - 1]
+
+    # Calculate the physical x-axis gap across each NaN
+    gap_sizes = indices[right_valid_pos] - indices[left_valid_pos]
+
+    # Return only the NaN positions where the gap exceeds our threshold
+    return invalid_inside[gap_sizes > limit_distance]

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -1176,6 +1176,45 @@ def _interp_limit(
     return np.intersect1d(f_idx, b_idx, assume_unique=assume_unique)
 
 
+def validate_limit_distance(
+    limit_distance: float | int | str | Timedelta,
+    unit: str | None = None,
+) -> None:
+    """
+    Validate that limit_distance is positive, non-NA, and matches the index type.
+    """
+    is_temporal = unit is not None
+    is_td_or_str = isinstance(limit_distance, (str, Timedelta))
+
+    if not is_temporal and is_td_or_str:
+        raise ValueError(
+            "Cannot use a time duration string or Timedelta limit_distance "
+            "with a non-temporal index."
+        )
+    if is_temporal and not is_td_or_str:
+        raise ValueError(
+            "Cannot use a numeric limit_distance with a temporal index; "
+            "pass a Timedelta or time duration string instead."
+        )
+
+    is_invalid_na = isna(limit_distance)
+    is_invalid_numeric = (
+        isinstance(limit_distance, (int, float, np.number))
+        and not is_invalid_na
+        and limit_distance <= 0
+    )
+
+    is_invalid_timedelta = False
+    if is_td_or_str and not is_invalid_na:
+        from pandas.core.tools.timedeltas import to_timedelta
+
+        td = to_timedelta(limit_distance)
+        is_invalid_timedelta = isna(td) or td <= Timedelta(0)
+
+    if is_invalid_na or is_invalid_numeric or is_invalid_timedelta:
+        raise ValueError("limit_distance must be greater than 0")
+
+
 def _interp_limit_distance(
     indices: np.ndarray,
     invalid: npt.NDArray[np.bool_],
@@ -1206,19 +1245,7 @@ def _interp_limit_distance(
         1D array of integer positions corresponding to invalid values that
         should be preserved as NaN (excluded from interpolation).
     """
-    is_temporal = unit is not None
-    is_td_or_str = isinstance(limit_distance, (str, Timedelta))
-
-    if not is_temporal and is_td_or_str:
-        raise ValueError(
-            "Cannot use a time duration string or Timedelta limit_distance "
-            "with a non-temporal index."
-        )
-    if is_temporal and not is_td_or_str:
-        raise ValueError(
-            "Cannot use a numeric limit_distance with a temporal index; "
-            "pass a Timedelta or time duration string instead."
-        )
+    validate_limit_distance(limit_distance, unit=unit)
 
     # Normalize and validate limit_distance
     if isinstance(limit_distance, (str, Timedelta)):

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -1286,11 +1286,23 @@ def _interp_limit_distance(
     right_valid_pos = valid_pos[right_idx[inside_mask]]
     left_valid_pos = valid_pos[right_idx[inside_mask] - 1]
 
-    # Calculate the physical x-axis gap across each NaN
-    gap_sizes = np.abs(indices[right_valid_pos] - indices[left_valid_pos])
+    right_vals = indices[right_valid_pos]
+    left_vals = indices[left_valid_pos]
 
-    if gap_sizes.dtype.kind in "mM":
-        gap_sizes = gap_sizes.view("i8")
+    if right_vals.dtype.kind in "mM":
+        right_vals = right_vals.view("i8")
+        left_vals = left_vals.view("i8")
+
+    if right_vals.dtype.kind in "iu":
+        # Overflow-safe unsigned subtraction for extreme endpoints
+        # (e.g. Timestamp.max - Timestamp.min > 292 years in nanoseconds)
+        larger = np.maximum(right_vals, left_vals)
+        smaller = np.minimum(right_vals, left_vals)
+        gap_sizes = larger.view(np.uint64) - smaller.view(np.uint64)
+        if isinstance(threshold, (int, np.integer)):
+            threshold = np.uint64(threshold)
+    else:
+        gap_sizes = np.abs(right_vals - left_vals)
 
     # Return only the NaN positions where the gap exceeds the threshold
     return invalid_inside[gap_sizes > threshold]

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -1200,11 +1200,21 @@ def _interp_limit_distance(
         1D array of integer positions corresponding to invalid values that
         should be preserved as NaN (excluded from interpolation).
     """
+    # Normalize and validate limit_distance
+    if isinstance(limit_distance, (str, Timedelta)):
+        threshold = to_timedelta(limit_distance).value
+    else:
+        threshold = limit_distance
+
+    if threshold <= 0:
+        raise ValueError("limit_distance must be greater than 0")
+
+    # Identify valid and invalid positions
     valid_pos = np.flatnonzero(~invalid)
     invalid_pos = np.flatnonzero(invalid)
 
-    # everything is valid if there are no NaNs
-    # or if there are less than 2 valid points (impossible to interpolate)
+    # everything is valid if thereare less than 2 valid points
+    # or if there are no NaNs (impossible/no need to interpolate)
     if len(valid_pos) < 2 or len(invalid_pos) == 0:
         return np.array([], dtype=np.int64)
 
@@ -1223,13 +1233,7 @@ def _interp_limit_distance(
     left_valid_pos = valid_pos[right_idx[inside_mask] - 1]
 
     # Calculate the physical x-axis gap across each NaN
-    gap_sizes = indices[right_valid_pos] - indices[left_valid_pos]
-
-    # Normalize limit_distance to match indices units
-    if isinstance(limit_distance, (str, Timedelta)):
-        threshold = to_timedelta(limit_distance).value
-    else:
-        threshold = limit_distance
+    gap_sizes = np.abs(indices[right_valid_pos] - indices[left_valid_pos])
 
     # Return only the NaN positions where the gap exceeds the threshold
     return invalid_inside[gap_sizes > threshold]

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -545,20 +545,31 @@ class TestSeriesInterpolateData:
         res2 = ser.interpolate(method="index", limit_distance=7.0)
         assert np.isnan(res2.iloc[1])  # 8.0 > 7.0 -> Stays NaN
 
-    @pytest.mark.parametrize("limit_dist", [0, -5.0])
+    @pytest.mark.parametrize("limit_dist", [0, -5.0, np.nan])
     def test_interpolate_limit_distance_invalid_threshold(self, limit_dist):
         ser = Series([1.0, np.nan, 2.0])
         msg = "limit_distance must be greater than 0"
         with pytest.raises(ValueError, match=msg):
             ser.interpolate(method="index", limit_distance=limit_dist)
 
-    @pytest.mark.parametrize("limit_dist", [0, -5.0])
+    @pytest.mark.parametrize("limit_dist", [0, -5.0, np.nan])
     def test_interpolate_limit_distance_empty_series_raises(self, limit_dist):
         # Ensure empty Series validates limit_distance consistently with non-empty
         ser = Series([], dtype=float)
         msg = "limit_distance must be greater than 0"
         with pytest.raises(ValueError, match=msg):
             ser.interpolate(method="index", limit_distance=limit_dist)
+
+    @pytest.mark.parametrize(
+        "limit_dist", ["0s", "-5s", pd.Timedelta(seconds=-5), pd.Timedelta(0)]
+    )
+    def test_interpolate_limit_distance_empty_temporal_raises(self, limit_dist):
+        # Ensure empty temporal Series rejects invalid duration strings/Timedeltas
+        msg = "limit_distance must be greater than 0"
+        for idx in [pd.DatetimeIndex([]), pd.TimedeltaIndex([])]:
+            ser = Series([], index=idx, dtype=float)
+            with pytest.raises(ValueError, match=msg):
+                ser.interpolate(method="time", limit_distance=limit_dist)
 
     def test_interpolate_limit_distance_type_mismatch_raises(self):
         # 1. Passing time string/Timedelta to a non-temporal index
@@ -618,12 +629,14 @@ class TestSeriesInterpolateData:
                 "2026-01-01 00:00:15",  # Gap 2: 11 seconds
             ]
         )
-        ser = Series([10.0, np.nan, 20.0, np.nan, 30.0], index=times)
+        tds = pd.to_timedelta([0, 2, 4, 14, 15], unit="s")
 
-        result = ser.interpolate(method="time", limit_distance=limit_dist)
+        for idx in [times, tds]:
+            ser = Series([10.0, np.nan, 20.0, np.nan, 30.0], index=idx)
+            result = ser.interpolate(method="time", limit_distance=limit_dist)
 
-        assert not np.isnan(result.iloc[1])  # Gap 4s <= 5s -> Filled
-        assert np.isnan(result.iloc[3])  # Gap 11s > 5s -> Stays NaN
+            assert not np.isnan(result.iloc[1])  # Gap 4s <= 5s -> Filled
+            assert np.isnan(result.iloc[3])  # Gap 11s > 5s -> Stays NaN
 
     def test_interpolate_limit_distance_consecutive_nans(self):
         # Gap 1 (index 0 to 3, distance = 3.0 <= 4.0): Both NaNs should be filled

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -675,6 +675,18 @@ class TestSeriesInterpolateData:
         assert np.isnan(res_nan.loc[2.0, "A"])
         assert np.isnan(res_nan.loc[2.0, "B"])
 
+    def test_interpolate_limit_distance_extreme_endpoints(self):
+        # GH#66548: Ensure gap calculation does not overflow on extreme timestamps
+        idx = pd.DatetimeIndex(
+            [pd.Timestamp.min, pd.Timestamp("2000-01-01"), pd.Timestamp.max]
+        )
+        ser = Series([1.0, np.nan, 2.0], index=idx)
+
+        # Gap between Timestamp.min and Timestamp.max is ~584 years (> int64 max nanos)
+        # Should not overflow and should correctly remain NaN for a 10-day limit
+        result = ser.interpolate(method="time", limit_distance="10D")
+        assert np.isnan(result.iloc[1])
+
     def test_interp_limit_direction(self):
         # These tests are for issue #9218 -- fill NaNs in both directions.
         s = Series([1, 3, np.nan, np.nan, np.nan, 11])

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -552,6 +552,28 @@ class TestSeriesInterpolateData:
         with pytest.raises(ValueError, match=msg):
             ser.interpolate(method="index", limit_distance=limit_dist)
 
+    @pytest.mark.parametrize("limit_dist", [0, -5.0])
+    def test_interpolate_limit_distance_empty_series_raises(self, limit_dist):
+        # Ensure empty Series validates limit_distance consistently with non-empty
+        ser = Series([], dtype=float)
+        msg = "limit_distance must be greater than 0"
+        with pytest.raises(ValueError, match=msg):
+            ser.interpolate(method="index", limit_distance=limit_dist)
+
+    def test_interpolate_limit_distance_type_mismatch_raises(self):
+        # 1. Passing time string/Timedelta to a non-temporal index
+        ser_int = Series([1.0, np.nan, 3.0], index=[0, 1, 2])
+        msg_int = "Cannot use a time duration string or Timedelta"
+        with pytest.raises(ValueError, match=msg_int):
+            ser_int.interpolate(method="index", limit_distance="5s")
+
+        # 2. Passing numeric integer/float to a temporal DatetimeIndex
+        times = pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"])
+        ser_time = Series([10.0, np.nan, 30.0], index=times)
+        msg_time = "Cannot use a numeric limit_distance with a temporal index"
+        with pytest.raises(ValueError, match=msg_time):
+            ser_time.interpolate(method="time", limit_distance=5)
+
     def test_interpolate_limit_distance_too_few_points(self):
         # 1. No NaNs
         ser_all_valid = Series([10.0, 20.0, 30.0], index=[1.0, 2.0, 3.0])

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -517,6 +517,129 @@ class TestSeriesInterpolateData:
         with pytest.raises(ValueError, match=msg):
             s.interpolate(**kwargs)
 
+    def test_interpolate_limit_distance_exact_boundaries(self):
+        # limit_distance = 5.0:
+        # Gap 1 (between 0.0 and 4.9) = 4.9 <= 5.0 -> Should be filled
+        # Gap 2 (between 10.0 and 15.0) = 5.0 <= 5.0 -> Should be filled
+        # Gap 3 (between 20.0 and 25.1) = 5.1 > 5.0 -> Too large, stays NaN
+        index = [0.0, 2.0, 4.9, 10.0, 12.0, 15.0, 20.0, 22.0, 25.1]
+        ser = Series(
+            [1.0, np.nan, 2.0, 3.0, np.nan, 4.0, 5.0, np.nan, 6.0], index=index
+        )
+
+        result = ser.interpolate(method="index", limit_distance=5.0)
+
+        assert not np.isnan(result.iloc[1])  # Gap 4.9 is filled
+        assert not np.isnan(result.iloc[4])  # Gap 5.0 is filled
+        assert np.isnan(result.iloc[7])  # Gap 5.1 is NOT filled
+
+    def test_interpolate_limit_distance_decreasing_index(self):
+        # limit_distance = 9.0:
+        # Gap is abs(2.0 - 10.0) = 8.0. Tests the np.abs() fix.
+        index = [10.0, 5.0, 2.0]
+        ser = Series([100.0, np.nan, 200.0], index=index)
+
+        res1 = ser.interpolate(method="index", limit_distance=9.0)
+        assert not np.isnan(res1.iloc[1])  # 8.0 <= 9.0 -> Filled
+
+        res2 = ser.interpolate(method="index", limit_distance=7.0)
+        assert np.isnan(res2.iloc[1])  # 8.0 > 7.0 -> Stays NaN
+
+    @pytest.mark.parametrize("limit_dist", [0, -5.0])
+    def test_interpolate_limit_distance_invalid_threshold(self, limit_dist):
+        ser = Series([1.0, np.nan, 2.0])
+        msg = "limit_distance must be greater than 0"
+        with pytest.raises(ValueError, match=msg):
+            ser.interpolate(method="index", limit_distance=limit_dist)
+
+    def test_interpolate_limit_distance_too_few_points(self):
+        # 1. No NaNs
+        ser_all_valid = Series([10.0, 20.0, 30.0], index=[1.0, 2.0, 3.0])
+        tm.assert_series_equal(
+            ser_all_valid.interpolate(method="index", limit_distance=5.0),
+            ser_all_valid,
+        )
+
+        # 2. All NaNs (0 valid points)
+        ser_all_nan = Series([np.nan, np.nan, np.nan], index=[1.0, 2.0, 3.0])
+        tm.assert_series_equal(
+            ser_all_nan.interpolate(method="index", limit_distance=5.0),
+            ser_all_nan,
+        )
+
+        # 3. Only 1 valid point -> trailing NaN is forward-filled to 10.0 by default
+        ser_one_valid = Series([np.nan, 10.0, np.nan], index=[1.0, 2.0, 3.0])
+        expected_one = Series([np.nan, 10.0, 10.0], index=[1.0, 2.0, 3.0])
+        tm.assert_series_equal(
+            ser_one_valid.interpolate(method="index", limit_distance=5.0),
+            expected_one,
+        )
+
+    def test_interpolate_limit_distance_boundary_nans(self):
+        # NaNs on the very edge should safely bypass the limit_distance logic
+        index = [1.0, 2.0, 3.0, 4.0]
+        ser = Series([np.nan, 10.0, 20.0, np.nan], index=index)
+
+        result = ser.interpolate(method="index", limit_distance=0.1)
+        # Default limit_direction='forward' forward-fills trailing NaNs to 20.0
+        expected = Series([np.nan, 10.0, 20.0, 20.0], index=index)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("limit_dist", ["5s", pd.Timedelta(seconds=5)])
+    def test_interpolate_limit_distance_datetime_and_timedelta(self, limit_dist):
+        times = pd.to_datetime(
+            [
+                "2026-01-01 00:00:00",
+                "2026-01-01 00:00:02",
+                "2026-01-01 00:00:04",  # Gap 1: 4 seconds
+                "2026-01-01 00:00:14",
+                "2026-01-01 00:00:15",  # Gap 2: 11 seconds
+            ]
+        )
+        ser = Series([10.0, np.nan, 20.0, np.nan, 30.0], index=times)
+
+        result = ser.interpolate(method="time", limit_distance=limit_dist)
+
+        assert not np.isnan(result.iloc[1])  # Gap 4s <= 5s -> Filled
+        assert np.isnan(result.iloc[3])  # Gap 11s > 5s -> Stays NaN
+
+    def test_interpolate_limit_distance_consecutive_nans(self):
+        # Gap 1 (index 0 to 3, distance = 3.0 <= 4.0): Both NaNs should be filled
+        # Gap 2 (index 3 to 10, distance = 7.0 > 4.0): Both NaNs should stay NaN
+        index = [0.0, 1.0, 2.0, 3.0, 5.0, 8.0, 10.0]
+        ser = Series([100.0, np.nan, np.nan, 200.0, np.nan, np.nan, 300.0], index=index)
+
+        result = ser.interpolate(method="index", limit_distance=4.0)
+
+        # First gap (distance 3.0) -> Interpolated
+        assert not np.isnan(result.iloc[1])
+        assert not np.isnan(result.iloc[2])
+
+        # Second gap (distance 7.0) -> Preserved as NaN
+        assert np.isnan(result.iloc[4])
+        assert np.isnan(result.iloc[5])
+
+    def test_interpolate_limit_distance_dataframe(self):
+        # Ensure limit_distance works cleanly across DataFrame columns
+        index = [0.0, 2.0, 10.0]
+        df = pd.DataFrame(
+            {
+                "A": [1.0, np.nan, 3.0],  # Gap = 10.0
+                "B": [10.0, np.nan, 30.0],  # Gap = 10.0
+            },
+            index=index,
+        )
+
+        # Threshold 15.0 -> Both columns should interpolate
+        res_filled = df.interpolate(method="index", limit_distance=15.0)
+        assert not np.isnan(res_filled.loc[2.0, "A"])
+        assert not np.isnan(res_filled.loc[2.0, "B"])
+
+        # Threshold 5.0 -> Both columns should preserve NaN
+        res_nan = df.interpolate(method="index", limit_distance=5.0)
+        assert np.isnan(res_nan.loc[2.0, "A"])
+        assert np.isnan(res_nan.loc[2.0, "B"])
+
     def test_interp_limit_direction(self):
         # These tests are for issue #9218 -- fill NaNs in both directions.
         s = Series([1, 3, np.nan, np.nan, np.nan, 11])


### PR DESCRIPTION
Closes #66545

Adds a `limit_distance` parameter to `Series.interpolate()` and `DataFrame.interpolate()`. This allows users to restrict interpolation across numerical or time-based gaps that exceed a specified threshold (supporting numeric scalars, duration strings like `"5s"`, and `pd.Timedelta` objects).

- [x] closes #66545
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md` (I used some AI in writing the code).