### PR TITLE
BUG: PeriodIndex.from_fields rejects non-December quarterly freqs (#55784)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -652,8 +652,8 @@ Period
 - Bug in :meth:`Period.strftime` where unknown format directives (e.g. ``"%Q"``) silently produced platform-dependent output and crashed the Python process on Windows; an ``Invalid format string`` ``ValueError`` is now raised on all platforms (:issue:`53562`)
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` returning incorrect timestamps when the target frequency normalized to nanoseconds (e.g. ``"1ns"``) or when converting a nanosecond ``Period`` to a coarser target frequency (:issue:`63760`)
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` with ``how="end"`` losing nanosecond precision when the target frequency normalized to nanoseconds (e.g. ``"1ns"``); the target frequency is now also validated when ``how="end"`` (:issue:`63760`)
+- Bug in :meth:`PeriodIndex.from_fields` incorrectly rejecting quarterly ``freq`` values not anchored on December (e.g. ``QuarterEnd(startingMonth=2)``), even though the equivalent scalar :class:`Period` works, has been fixed (:issue:`55784`)
 - Bug in adding an integer, timedelta or offset to a :class:`Period` returning ``NaT`` when the result was one step past the lower bound, instead of raising ``OverflowError`` as it already did further out (:issue:`66552`)
-- Bug in :meth:`PeriodIndex.from_fields` raising ``ValueError`` (previously ``AssertionError``) for a quarterly ``freq`` not anchored on December (e.g. ``QuarterEnd(startingMonth=2)``), even though the equivalent scalar :class:`Period` works (:issue:`55784`)
 -
 
 Plotting

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -653,6 +653,7 @@ Period
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` returning incorrect timestamps when the target frequency normalized to nanoseconds (e.g. ``"1ns"``) or when converting a nanosecond ``Period`` to a coarser target frequency (:issue:`63760`)
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` with ``how="end"`` losing nanosecond precision when the target frequency normalized to nanoseconds (e.g. ``"1ns"``); the target frequency is now also validated when ``how="end"`` (:issue:`63760`)
 - Bug in adding an integer, timedelta or offset to a :class:`Period` returning ``NaT`` when the result was one step past the lower bound, instead of raising ``OverflowError`` as it already did further out (:issue:`66552`)
+- Bug in :meth:`PeriodIndex.from_fields` raising ``ValueError`` (previously ``AssertionError``) for a quarterly ``freq`` not anchored on December (e.g. ``QuarterEnd(startingMonth=2)``), even though the equivalent scalar :class:`Period` works (:issue:`55784`)
 -
 
 Plotting

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1586,8 +1586,8 @@ def _range_from_fields(
         else:
             freq = to_offset(freq, is_period=True)
             base = libperiod.freq_to_dtype_code(freq)
-            if base != FreqGroup.FR_QTR.value:
-                raise AssertionError("base must equal FR_QTR")
+            if FreqGroup.from_period_dtype_code(base) != FreqGroup.FR_QTR:
+                raise ValueError("freq must be a quarterly frequency")
 
         freqstr = freq.freqstr
         year, quarter = _make_field_arrays(year, quarter)

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -213,7 +213,7 @@ class TestPeriodIndex:
         tm.assert_index_equal(idx, exp)
 
     @pytest.mark.parametrize("starting_month", range(1, 13))
-    def test_from_fields_quarterly_non_december_anchor(self, starting_month):
+    def test_from_fields_quarterly_anchors(self, starting_month):
         # GH#55784 from_fields rejected any quarterly freq not anchored on
         # December, even though the equivalent scalar Period works.
         freq = offsets.QuarterEnd(startingMonth=starting_month)
@@ -221,6 +221,13 @@ class TestPeriodIndex:
         expected = Period(year=2014, quarter=3, freq=freq)
         assert result[0] == expected
         assert result.dtype == PeriodDtype(freq)
+
+    def test_from_fields_quarterly_rejects_non_quarterly_freq(self):
+        # GH#55784 from_fields should reject non-quarterly frequencies
+        # when the ``quarter`` field is supplied.
+        msg = "freq must be a quarterly frequency"
+        with pytest.raises(ValueError, match=msg):
+            PeriodIndex.from_fields(year=[2014], quarter=[3], freq=offsets.MonthEnd())
 
     def test_constructor_nano(self):
         idx = period_range(

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -212,6 +212,16 @@ class TestPeriodIndex:
         exp = period_range("2007-01", periods=3, freq="M")
         tm.assert_index_equal(idx, exp)
 
+    @pytest.mark.parametrize("starting_month", range(1, 13))
+    def test_from_fields_quarterly_non_december_anchor(self, starting_month):
+        # GH#55784 from_fields rejected any quarterly freq not anchored on
+        # December, even though the equivalent scalar Period works.
+        freq = offsets.QuarterEnd(startingMonth=starting_month)
+        result = PeriodIndex.from_fields(year=[2014], quarter=[3], freq=freq)
+        expected = Period(year=2014, quarter=3, freq=freq)
+        assert result[0] == expected
+        assert result.dtype == PeriodDtype(freq)
+
     def test_constructor_nano(self):
         idx = period_range(
             start=Period(ordinal=1, freq="ns"),


### PR DESCRIPTION
- [x] closes #55784
- [x] Tests added and passed
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html)
- [x] Added an entry in the latest ``doc/source/whatsnew/vX.X.X.rst`` file

`_range_from_fields` validated a quarterly `freq` with an exact-equality check
`base != FreqGroup.FR_QTR.value`. Quarterly period dtype codes are `FR_QTR`
plus the anchor-month offset (`Q-DEC`=2000, `Q-JAN`=2001, ..., `Q-FEB`=2002), so
the check only accepted `Q-DEC` and raised `AssertionError: base must equal
FR_QTR` for every other quarterly anchor -- even though the equivalent scalar
`Period(year=2014, quarter=3, freq=QuarterEnd(startingMonth=2))` works fine.

```python
>>> import pandas as pd
>>> pd.Period(year=2014, quarter=3, freq=pd.offsets.QuarterEnd(startingMonth=2))
Period('2014Q3', 'Q-FEB')
>>> pd.PeriodIndex.from_fields(year=[2014], quarter=[3],
...                            freq=pd.offsets.QuarterEnd(startingMonth=2))
AssertionError: base must equal FR_QTR
```

The fix uses a frequency-group membership test instead of exact equality:

```python
if FreqGroup.from_period_dtype_code(base) != FreqGroup.FR_QTR:
```

`base` itself is unchanged (it is still passed to `libperiod.period_ordinal`),
so the anchored quarterly frequency is preserved; only the guard is corrected to
accept any code in the `FR_QTR` group. Added a regression test parametrized over
all twelve quarterly anchors, asserting the result matches the scalar `Period`
path. Non-quarterly frequencies are still rejected, and the existing `Q-DEC`
behavior is unchanged.
