### PR TITLE
ENH: Consistent name property for the iterates in DataFrameGroupBy #6…

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -289,7 +289,7 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
          Timestamp('2023-02-01 00:00:00'): np.int64(4)}
         """
         groups_dict = self._grouper.groups
-        if isinstance(self.keys, list) and len(self.keys) ==1:
+        if isinstance(self.keys, list) and len(self.keys) == 1:
             return {(k,): v for k, v in groups_dict.items()}
         return groups_dict
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -288,17 +288,10 @@ class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
         {Timestamp('2023-01-01 00:00:00'): np.int64(2),
          Timestamp('2023-02-01 00:00:00'): np.int64(4)}
         """
-        if isinstance(self.keys, list) and len(self.keys) == 1:
-            warnings.warn(
-                "In a future version, the keys of `groups` will be a "
-                f"tuple with a single element, e.g. ({self.keys[0]},) , "
-                f"instead of a scalar, e.g. {self.keys[0]}, when grouping "
-                "by a list with a single element. Use ``df.groupby(by='a').groups`` "
-                "instead of ``df.groupby(by=['a']).groups`` to avoid this warning",
-                Pandas4Warning,
-                stacklevel=find_stack_level(),
-            )
-        return self._grouper.groups
+        groups_dict = self._grouper.groups
+        if isinstance(self.keys, list) and len(self.keys) ==1:
+            return {(k,): v for k, v in groups_dict.items()}
+        return groups_dict
 
     @final
     @property

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -561,34 +561,42 @@ class TestGrouping:
 
         df = DataFrame([[1, "A"]], columns=midx)
 
-        msg = "In a future version, the keys"
         grouped = df.groupby("to filter").groups
         assert grouped["A"] == [0]
 
-        with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            grouped = df.groupby([("to filter", "")]).groups
-        assert grouped["A"] == [0]
+        grouped_tuple = df.groupby([("to filter", "")]).groups
+        assert grouped_tuple[("A",)] == [0]
 
         df = DataFrame([[1, "A"], [2, "B"]], columns=midx)
 
         expected = df.groupby("to filter").groups
-        with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            result = df.groupby([("to filter", "")]).groups
+
+        expected = {(k,): v for k, v in expected.items()}
+
+        result = df.groupby([("to filter", "")]).groups
         assert result == expected
 
         df = DataFrame([[1, "A"], [2, "A"]], columns=midx)
 
         expected = df.groupby("to filter").groups
-        with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            result = df.groupby([("to filter", "")]).groups
+
+        expected = {(k,): v for k, v in expected.items()}
+
+        result = df.groupby([("to filter", "")]).groups
         tm.assert_dict_equal(result, expected)
 
     def test_groupby_multiindex_tuple(self):
-        # GH 17979, GH#59179
+        # GH 17979, GH#59179, GH#62141
         df = DataFrame(
             [[1, 2, 3, 4], [3, 4, 5, 6], [1, 4, 2, 3]],
             columns=MultiIndex.from_arrays([["a", "b", "b", "c"], [1, 1, 2, 2]]),
         )
+
+        expected = df.groupby([("b", 1)]).groups
+        result = df.groupby(("b", 1)).groups
+
+        result = {(k,): v for k, v in result.items()}
+        tm.assert_dict_equal(expected, result)
 
         msg = "In a future version, the keys"
         with tm.assert_produces_warning(Pandas4Warning, match=msg):
@@ -603,20 +611,22 @@ class TestGrouping:
             ),
         )
 
-        with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            expected = df2.groupby([("b", "d")]).groups
+        expected = df2.groupby([("b", "d")]).groups
         result = df.groupby(("b", 1)).groups
+
+        result = {(k,): v for k, v in result.items()}
         tm.assert_dict_equal(expected, result)
 
         df3 = DataFrame(df.values, columns=[("a", "d"), ("b", "d"), ("b", "e"), "c"])
 
-        with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            expected = df3.groupby([("b", "d")]).groups
+        expected = df3.groupby([("b", "d")]).groups
         result = df.groupby(("b", 1)).groups
+
+        result = {(k,): v for k, v in result.items()}
         tm.assert_dict_equal(expected, result)
 
     def test_groupby_multiindex_partial_indexing_equivalence(self):
-        # GH 17977, GH#59179
+        # GH 17977, GH#59179, GH#62141
         df = DataFrame(
             [[1, 2, 3, 4], [3, 4, 5, 6], [1, 4, 2, 3]],
             columns=MultiIndex.from_arrays([["a", "b", "b", "c"], [1, 1, 2, 2]]),
@@ -642,10 +652,8 @@ class TestGrouping:
         result_max = df.groupby([("a", 1)])["b"].max()
         tm.assert_frame_equal(expected_max, result_max)
 
-        msg = "In a future version, the keys"
-        with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            expected_groups = df.groupby([("a", 1)])[[("b", 1), ("b", 2)]].groups
-            result_groups = df.groupby([("a", 1)])["b"].groups
+        expected_groups = df.groupby([("a", 1)])[[("b", 1), ("b", 2)]].groups
+        result_groups = df.groupby([("a", 1)])["b"].groups
         tm.assert_dict_equal(expected_groups, result_groups)
 
     def test_groupby_level(self, sort, multiindex_dataframe_random_data, df):

--- a/pandas/tests/groupby/test_indexing.py
+++ b/pandas/tests/groupby/test_indexing.py
@@ -309,15 +309,12 @@ def test_groupby_get_nonexisting_groups():
     with pytest.raises(KeyError, match=msg):
         grps.get_group(("a2", "b1"))
 
+
 def test_groupby_groups_single_element_list_tuple_key():
     # GH 62141
-    df = pd.DataFrame(
-        {
-            "a": [1, 2, 7],
-            "b": [2, 5, 8]
-        })
+    df = pd.DataFrame({"a": [1, 2, 7], "b": [2, 5, 8]})
     grouped = df.groupby(["a"])
 
-    #list group keys should be tuples 
+    # list group keys should be tuples
     expected_keys = [(1,), (2,), (7,)]
     assert list(grouped.groups.keys()) == expected_keys

--- a/pandas/tests/groupby/test_indexing.py
+++ b/pandas/tests/groupby/test_indexing.py
@@ -308,3 +308,16 @@ def test_groupby_get_nonexisting_groups():
     msg = "('a2', 'b1')"
     with pytest.raises(KeyError, match=msg):
         grps.get_group(("a2", "b1"))
+
+def test_groupby_groups_single_element_list_tuple_key():
+    # GH 62141
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 7],
+            "b": [2, 5, 8]
+        })
+    grouped = df.groupby(["a"])
+
+    #list group keys should be tuples 
+    expected_keys = [(1,), (2,), (7,)]
+    assert list(grouped.groups.keys()) == expected_keys


### PR DESCRIPTION
- [x] closes #62141
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### Description

This PR addresses #62141 by updating `DataFrameGroupBy.groups` when grouping by a single-element list (e.g., `df.groupby(['a'])`). 

Previously, accessing `.groups` when grouping by a single-element list returned scalar keys while raising a deprecation warning. This PR changes `.groups` to return single-element tuple keys directly (e.g., `{(1,): [0, 1]}`), resolving the inconsistency with `DataFrameGroupBy.__iter__` and grouping by multi-element lists.

### Changes Made
1. Updated `DataFrameGroupBy.groups` property in `pandas/core/groupby/groupby.py` to return single-element tuple keys when `self.keys` is a single-element list.
2. Added regression test `test_groupby_groups_single_element_list_tuple_key` in `pandas/tests/groupby/test_indexing.py`.