### PR TITLE
DOC fix dark mode text in tutorial data cards

### DIFF
--- a/doc/source/_static/css/getting_started.css
+++ b/doc/source/_static/css/getting_started.css
@@ -38,6 +38,10 @@
  border: none;
 }
 
+.gs-data .card-body {
+  color: var(--pst-color-text-base);
+}
+
 /* note/alert properties */
 
 .alert-heading {


### PR DESCRIPTION
- [x] closes #65062.

This continues the work started in #65076, which was closed as stale. I asked whether I could pick up the work on that PR and received approval from a pandas maintainer.

The tutorial data callout text is difficult to read in dark mode because Bootstrap's .card-body text color does not follow the documentation theme.

This PR incorporates the review feedback from #65076 by:

limiting the color override to .gs-data .card-body;
leaving the existing btn-dark button classes unchanged.

The change uses --pst-color-text-base, which adapts to the active documentation theme.

Built the affected Getting Started tutorial pages locally and verified that the data callout text is readable in both light and dark mode.  See screenshot below:
<img width="854" height="795" alt="Screenshot 2026-07-30 at 2 39 15 PM" src="https://github.com/user-attachments/assets/5a746858-e90b-449a-8038-0f015fbc1579" />


- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
