### PR TITLE
DOC: describe rows and columns skipped by header and index_col

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -93,9 +93,9 @@ header : int or list of ints, default ``'infer'``
   skipped). Note that this parameter ignores commented lines and empty
   lines if ``skip_blank_lines=True``, so header=0 denotes the first
   line of data rather than the first line of the file.
-  When a list is passed to ``header``, rows before the first specified
-  header row are skipped. Likewise, when a list is passed to ``index_col``,
-  columns before the first specified index column are skipped.
+  When a list is passed to ``header``, rows above the row at ``min(header)``
+  are skipped. Likewise, when a list is passed to ``index_col``, columns before
+  the column at ``min(index_col)`` are skipped.
 
 names : array-like, default ``None``
   List of column names to use. If file contains no header row, then you should
@@ -3490,8 +3490,9 @@ and a ``MultiIndex`` column by passing a list of rows to ``header``.  If either 
 or ``columns`` have serialized level names those will be read in as well by specifying
 the rows/columns that make up the levels.
 
-When reading an Excel file, rows before the first row specified by a list passed to ``header`` are skipped.
-Columns before the first column specified by a list passed to ``index_col`` are skipped as well.
+When reading an Excel file, rows above the row at ``min(header)`` are skipped when
+``header`` is a list. Columns before the column at ``min(index_col)`` are skipped
+when ``index_col`` is a list as well.
 
 For example, to read in a ``MultiIndex`` index without names:
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -93,6 +93,8 @@ header : int or list of ints, default ``'infer'``
   skipped). Note that this parameter ignores commented lines and empty
   lines if ``skip_blank_lines=True``, so header=0 denotes the first
   line of data rather than the first line of the file.
+When a list is passed to ``header``, rows before the first specified header row are skipped. Likewise, when a list is passed to ``index_col``, columns before the first specified index column are skipped.
+
 names : array-like, default ``None``
   List of column names to use. If file contains no header row, then you should
   explicitly pass ``header=None``. Duplicates in this list are not allowed.
@@ -3485,6 +3487,8 @@ Reading a ``MultiIndex``
 and a ``MultiIndex`` column by passing a list of rows to ``header``.  If either the ``index``
 or ``columns`` have serialized level names those will be read in as well by specifying
 the rows/columns that make up the levels.
+
+When reading an Excel file, rows before the first row specified by a list passed to ``header`` are skipped. Columns before the first column specified by a list passed to ``index_col`` are skipped as well.
 
 For example, to read in a ``MultiIndex`` index without names:
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -93,7 +93,9 @@ header : int or list of ints, default ``'infer'``
   skipped). Note that this parameter ignores commented lines and empty
   lines if ``skip_blank_lines=True``, so header=0 denotes the first
   line of data rather than the first line of the file.
-When a list is passed to ``header``, rows before the first specified header row are skipped. Likewise, when a list is passed to ``index_col``, columns before the first specified index column are skipped.
+  When a list is passed to ``header``, rows before the first specified
+  header row are skipped. Likewise, when a list is passed to ``index_col``,
+  columns before the first specified index column are skipped.
 
 names : array-like, default ``None``
   List of column names to use. If file contains no header row, then you should

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3490,7 +3490,8 @@ and a ``MultiIndex`` column by passing a list of rows to ``header``.  If either 
 or ``columns`` have serialized level names those will be read in as well by specifying
 the rows/columns that make up the levels.
 
-When reading an Excel file, rows before the first row specified by a list passed to ``header`` are skipped. Columns before the first column specified by a list passed to ``index_col`` are skipped as well.
+When reading an Excel file, rows before the first row specified by a list passed to ``header`` are skipped.
+Columns before the first column specified by a list passed to ``index_col`` are skipped as well.
 
 For example, to read in a ``MultiIndex`` index without names:
 


### PR DESCRIPTION
Fixes #66378

Document that list-valued `header` and `index_col` arguments skip preceding rows and columns when reading CSV and Excel files.