### PR TITLE
BUG: query/eval string & MultiIndex-level ==/!= fail with python parser (GH#57812)

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1506,6 +1506,7 @@ Other
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which caused an exception when using NumPy attributes via ``@`` notation, e.g., ``df.eval("@np.floor(a)")``. (:issue:`58041`)
 - Bug in :meth:`DataFrame.eval` and :meth:`DataFrame.query` which did not allow to use ``tan`` function. (:issue:`55091`)
 - Bug in :meth:`DataFrame.groupby` with ``None`` values with filter (:issue:`62501`)
+- Bug in :meth:`DataFrame.query` and :meth:`DataFrame.eval` where string or list ``==``/``!=`` comparisons (including on :class:`MultiIndex` level names) raised ``NotImplementedError: 'In' nodes are not implemented`` when using ``parser="python"``. (:issue:`57812`)
 - Bug in :meth:`DataFrame.query` where using duplicate column names led to a ``TypeError``. (:issue:`59950`)
 - Bug in :meth:`DataFrame.query` which raised an exception or produced incorrect results when expressions contained backtick-quoted column names containing the hash character ``#``, backticks, or characters that fall outside the ASCII range (U+0001..U+007F). (:issue:`59285`) (:issue:`49633`)
 - Bug in :meth:`DataFrame.query` which raised an exception when querying integer column names using backticks. (:issue:`60494`)

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -184,6 +184,10 @@ def _is_type(t):
 _is_list = _is_type(list)
 _is_str = _is_type(str)
 
+# symbols for the membership ops we synthesize when rewriting ==/!= into in/not
+# in (see BaseExprVisitor._rewrite_membership_op)
+_cmp_op_to_sym = {ast.In: "in", ast.NotIn: "not in"}
+
 
 # partition all AST nodes
 _all_nodes = frozenset(
@@ -433,6 +437,9 @@ class BaseExprVisitor(ast.NodeVisitor):
         op_instance = node.op
         op_type = type(op_instance)
 
+        # whether we internally rewrote ==/!= into an in/not in membership op
+        rewritten = False
+
         # must be two terms and the comparison operator must be ==/!=/in/not in
         if is_term(left) and is_term(right) and op_type in self.rewrite_map:
             left_list, right_list = map(_is_list, (left, right))
@@ -440,7 +447,12 @@ class BaseExprVisitor(ast.NodeVisitor):
 
             # if there are any strings or lists in the expression
             if left_list or right_list or left_str or right_str:
-                op_instance = self.rewrite_map[op_type]()
+                new_op_type = self.rewrite_map[op_type]
+                # only ==/!= are rewritten here; an explicit in/not in keeps its
+                # original op_type and is still routed through ``self.visit`` so
+                # that parsers which disallow those nodes reject them (GH#57812)
+                rewritten = new_op_type is not op_type
+                op_instance = new_op_type()
 
             # pop the string variable out of locals and replace it with a list
             # of one string, kind of a hack
@@ -452,7 +464,14 @@ class BaseExprVisitor(ast.NodeVisitor):
                 name = self.env.add_tmp([left.value])
                 left = self.term_type(name, self.env)
 
-        op = self.visit(op_instance)
+        if rewritten:
+            # The membership op we synthesized from ==/!= may be disallowed by
+            # this parser (e.g. the python parser rejects In/NotIn). Build the
+            # BinOp directly instead of dispatching through the (possibly
+            # disallowed) ``visit_*`` handler.
+            op = partial(BinOp, _cmp_op_to_sym[type(op_instance)])
+        else:
+            op = self.visit(op_instance)
         return op, op_instance, left, right
 
     def _maybe_transform_eq_ne(self, node, left=None, right=None):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -456,6 +456,54 @@ class TestDataFrameQueryWithMultiIndex:
         exp = df[ind != "red"]
         tm.assert_frame_equal(res, exp)
 
+    def test_query_multiindex_level_python_parser(self, parser, engine):
+        # GH#57812 querying a MultiIndex level with ==/!= (which is internally
+        # rewritten to a membership op) must resolve the level name for the
+        # python parser too, not only the pandas parser / numexpr engine.
+        a = np.random.default_rng(2).choice(["red", "green"], size=10)
+        b = np.arange(10)
+        index = MultiIndex.from_arrays([a, b], names=["color", "rating"])
+        df = DataFrame(np.random.default_rng(2).standard_normal((10, 2)), index=index)
+
+        color = Series(
+            df.index.get_level_values("color").values, index=index, name="color"
+        )
+        rating = Series(
+            df.index.get_level_values("rating").values, index=index, name="rating"
+        )
+
+        # string level
+        tm.assert_frame_equal(
+            df.query('color == "red"', parser=parser, engine=engine),
+            df[color == "red"],
+        )
+        tm.assert_frame_equal(
+            df.query('color != "red"', parser=parser, engine=engine),
+            df[color != "red"],
+        )
+        tm.assert_frame_equal(
+            df.query('color == ["red"]', parser=parser, engine=engine),
+            df[color.isin(["red"])],
+        )
+
+        # numeric level
+        tm.assert_frame_equal(
+            df.query("rating == 1", parser=parser, engine=engine),
+            df[rating == 1],
+        )
+
+        # unnamed levels via the ilevel_* aliases
+        unnamed = DataFrame(
+            df.to_numpy(), index=MultiIndex.from_arrays([a, b])
+        )
+        ind0 = Series(
+            unnamed.index.get_level_values(0).values, index=unnamed.index
+        )
+        tm.assert_frame_equal(
+            unnamed.query('ilevel_0 == "red"', parser=parser, engine=engine),
+            unnamed[ind0 == "red"],
+        )
+
     def test_query_multiindex_get_index_resolvers(self):
         df = DataFrame(
             np.ones((10, 3)),
@@ -1044,80 +1092,47 @@ class TestDataFrameQueryStrings:
         tm.assert_frame_equal(result, expected)
 
     def test_str_query_method(self, parser, engine):
+        # GH#57812 string ==/!= is rewritten to a membership (isin) op and must
+        # work for both the pandas and python parsers.
         df = DataFrame(np.random.default_rng(2).standard_normal((10, 1)), columns=["b"])
         df["strings"] = Series(list("aabbccddee"))
         expect = df[df.strings == "a"]
 
-        if parser != "pandas":
-            col = "strings"
-            lst = '"a"'
+        res = df.query('"a" == strings', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, expect)
 
-            lhs = [col] * 2 + [lst] * 2
-            rhs = lhs[::-1]
+        res = df.query('strings == "a"', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, expect)
+        tm.assert_frame_equal(res, df[df.strings.isin(["a"])])
 
-            eq, ne = "==", "!="
-            ops = 2 * ([eq, ne])
-            msg = r"'(Not)?In' nodes are not implemented"
+        expect = df[df.strings != "a"]
+        res = df.query('strings != "a"', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, expect)
 
-            for lh, op_, rh in zip(lhs, ops, rhs, strict=True):
-                ex = f"{lh} {op_} {rh}"
-                with pytest.raises(NotImplementedError, match=msg):
-                    df.query(
-                        ex,
-                        engine=engine,
-                        parser=parser,
-                        local_dict={"strings": df.strings},
-                    )
-        else:
-            res = df.query('"a" == strings', engine=engine, parser=parser)
-            tm.assert_frame_equal(res, expect)
-
-            res = df.query('strings == "a"', engine=engine, parser=parser)
-            tm.assert_frame_equal(res, expect)
-            tm.assert_frame_equal(res, df[df.strings.isin(["a"])])
-
-            expect = df[df.strings != "a"]
-            res = df.query('strings != "a"', engine=engine, parser=parser)
-            tm.assert_frame_equal(res, expect)
-
-            res = df.query('"a" != strings', engine=engine, parser=parser)
-            tm.assert_frame_equal(res, expect)
-            tm.assert_frame_equal(res, df[~df.strings.isin(["a"])])
+        res = df.query('"a" != strings', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, expect)
+        tm.assert_frame_equal(res, df[~df.strings.isin(["a"])])
 
     def test_str_list_query_method(self, parser, engine):
+        # GH#57812 list ==/!= is rewritten to a membership (isin) op and must
+        # work for both the pandas and python parsers.
         df = DataFrame(np.random.default_rng(2).standard_normal((10, 1)), columns=["b"])
         df["strings"] = Series(list("aabbccddee"))
         expect = df[df.strings.isin(["a", "b"])]
 
-        if parser != "pandas":
-            col = "strings"
-            lst = '["a", "b"]'
+        res = df.query('strings == ["a", "b"]', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, expect)
 
-            lhs = [col] * 2 + [lst] * 2
-            rhs = lhs[::-1]
+        res = df.query('["a", "b"] == strings', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, expect)
 
-            eq, ne = "==", "!="
-            ops = 2 * ([eq, ne])
-            msg = r"'(Not)?In' nodes are not implemented"
+        expect = df[~df.strings.isin(["a", "b"])]
 
-            for lh, ops_, rh in zip(lhs, ops, rhs, strict=True):
-                ex = f"{lh} {ops_} {rh}"
-                with pytest.raises(NotImplementedError, match=msg):
-                    df.query(ex, engine=engine, parser=parser)
-        else:
-            res = df.query('strings == ["a", "b"]', engine=engine, parser=parser)
-            tm.assert_frame_equal(res, expect)
+        res = df.query('strings != ["a", "b"]', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, expect)
 
-            res = df.query('["a", "b"] == strings', engine=engine, parser=parser)
-            tm.assert_frame_equal(res, expect)
-
-            expect = df[~df.strings.isin(["a", "b"])]
-
-            res = df.query('strings != ["a", "b"]', engine=engine, parser=parser)
-            tm.assert_frame_equal(res, expect)
-
-            res = df.query('["a", "b"] != strings', engine=engine, parser=parser)
-            tm.assert_frame_equal(res, expect)
+        res = df.query('["a", "b"] != strings', engine=engine, parser=parser)
+        tm.assert_frame_equal(res, expect)
 
     def test_query_with_string_columns(self, parser, engine):
         df = DataFrame(


### PR DESCRIPTION
- [x] closes #57812
- [x] Tests added and passing
- [x] All code checks passed
- [x] Added an entry in the latest `doc/source/whatsnew/v3.0.0.rst` file

## Summary

`df.query('col == "x"', parser='python')` — and MultiIndex level names such as
`df.query('color == "red"', parser='python')` — raised
`NotImplementedError: 'In' nodes are not implemented`, while the pandas parser /
numexpr engine handled the same expression correctly. This worked in 2.3.x and
regressed on `main`.

## Root cause

`BaseExprVisitor._rewrite_membership_op` rewrites `==`/`!=` into an `in`/`not in`
(isin) membership op whenever an operand is a string or list, then dispatched the
synthesized op through `self.visit(op_instance)`. The python parser
(`PythonExprVisitor`) intentionally disallows `In`/`NotIn` nodes so that
*explicit* `in`/`not in` typed in a query string are rejected — but that also
rejected the *internally generated* membership op.

## Fix

When the op has been internally rewritten from `==`/`!=`, build the `BinOp`
directly instead of dispatching through the possibly-disallowed `visit_*`
handler. Explicit `in`/`not in` keep their original op type and continue to flow
through `self.visit`, so the python parser still rejects them (behavior
unchanged; `test_simple_in_ops` still passes).

## Tests

- Updated `test_str_query_method` / `test_str_list_query_method` (both parsers now
  behave identically for string/list `==`/`!=`).
- Added `test_query_multiindex_level_python_parser` covering named string/numeric
  levels and unnamed `ilevel_*` levels across all parser/engine combos.
- `pandas/tests/computation/`, `pandas/tests/frame/test_query_eval.py`, and
  `pandas/tests/series/` all pass (24,745 passed locally).
