### PR TITLE
DOC: document Series-specific to_json orient formats

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2407,26 +2407,31 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
                 - default is 'index'
                 - allowed values are: {'split', 'records', 'index', 'table'}.
-                - with 'records', the result is a JSON array of the Series
-                  values only; the index labels are not included.
+                - the format of the JSON string:
+
+                  - 'split' : dict like {'name' -> name, 'index' -> [index],
+                    'data' -> [values]}
+                  - 'records' : list like [value, ... , value]; the index
+                    labels and the Series name are not included
+                  - 'index' : dict like {index -> value}
+                  - 'table' : dict like {'schema': {schema}, 'data': {data}}
 
             * DataFrame:
 
                 - default is 'columns'
                 - allowed values are: {'split', 'records', 'index', 'columns',
                   'values', 'table'}.
+                - the format of the JSON string:
 
-            * The format of the JSON string:
+                  - 'split' : dict like {'index' -> [index], 'columns' -> [columns],
+                    'data' -> [values]}
+                  - 'records' : list like [{column -> value}, ... , {column -> value}]
+                  - 'index' : dict like {index -> {column -> value}}
+                  - 'columns' : dict like {column -> {index -> value}}
+                  - 'values' : just the values array
+                  - 'table' : dict like {'schema': {schema}, 'data': {data}}
 
-                - 'split' : dict like {'index' -> [index], 'columns' -> [columns],
-                  'data' -> [values]}
-                - 'records' : list like [{column -> value}, ... , {column -> value}]
-                - 'index' : dict like {index -> {column -> value}}
-                - 'columns' : dict like {column -> {index -> value}}
-                - 'values' : just the values array
-                - 'table' : dict like {'schema': {schema}, 'data': {data}}
-
-                Describing the data, where data component is like ``orient='records'``.
+            For ``orient='table'``, the data component is like ``orient='records'``.
 
         date_format : {None, 'epoch', 'iso'}
             Type of date conversion. 'epoch' = epoch milliseconds,
@@ -2578,6 +2583,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         '[1,2,3]'
         >>> ser.to_json(orient="records", lines=True)
         '1\\n2\\n3\\n'
+
+        For a Series, the default ``orient="index"`` maps index labels to
+        values, and ``orient="split"`` has a 'name' entry in place of a
+        DataFrame's 'columns':
+
+        >>> ser.to_json()
+        '{"0":1,"1":2,"2":3}'
+        >>> ser.to_json(orient="split")
+        '{"name":null,"index":[0,1,2],"data":[1,2,3]}'
 
         Encoding/decoding a Dataframe using ``'index'`` formatted JSON:
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -670,7 +670,7 @@ def read_json(
         Indication of expected JSON string format.
         Compatible JSON strings can be produced by ``to_json()`` with a
         corresponding orient value.
-        The set of possible orients is:
+        When ``typ == 'frame'``, the set of possible orients is:
 
         - ``'split'`` : dict like
           ``{index -> [index], columns -> [columns], data -> [values]}``
@@ -680,6 +680,14 @@ def read_json(
         - ``'columns'`` : dict like ``{column -> {index -> value}}``
         - ``'values'`` : just the values array
         - ``'table'`` : dict like ``{'schema': {schema}, 'data': {data}}``
+
+        When ``typ == 'series'``, the shapes differ, since a Series has no
+        columns:
+
+        - ``'split'`` : dict like
+          ``{name -> name, index -> [index], data -> [values]}``
+        - ``'records'`` : list like ``[value, ... , value]``
+        - ``'index'`` : dict like ``{index -> value}``
 
         The allowed and default values depend on the value
         of the `typ` parameter.


### PR DESCRIPTION
- [x] closes #23584 (Replace xxxx with the GitHub issue number)
- [x] All code checks passed.

`to_json`'s docstring documented the JSON formats only in their DataFrame shapes. For a Series the shapes differ: `orient='split'` has a `name` entry and no `columns`, `orient='index'` is a flat `{index -> value}` mapping, and `orient='records'` is an array of values without index labels or name — the confusion reported in #23584.

This restructures the `orient` parameter description into per-type format lists and adds two doctested Series examples (default orient and `split`).

Verification: all outputs checked against a source build; doctests pass for both `Series.to_json` and `DataFrame.to_json` (19/19 each); `numpydoc.validate("pandas.Series.to_json")` reports no errors.

Disclosure per the automated-contributions policy: this change was prepared with the assistance of an AI coding tool; all documented behavior was verified by execution and the text was fully reviewed.
