### PR TITLE
BUG: raise on datetimelike arithmetic landing on NaT sentinel (#66552)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -360,6 +360,7 @@ Datetimelike
 - Bug in :meth:`Series.dt.isocalendar` with a pyarrow-backed datetime or date dtype not preserving the original index, resetting it to a default :class:`RangeIndex` (:issue:`65894`)
 - Bug in adding a :class:`DateOffset` with a ``milliseconds`` component to a :class:`Timestamp` returning a microsecond-resolution result, inconsistent with the millisecond-resolution result of the equivalent :class:`DatetimeIndex` and :class:`Series` operations (:issue:`64806`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
+- Bug in datetimelike arithmetic where a result landing exactly on ``INT64_MIN`` (the ``NaT`` sentinel) silently returned ``NaT`` instead of raising; both the vectorized ``add_overflowsafe`` path and the scalar :class:`Timedelta` binary operations are now guarded (:issue:`66552`)
 - Bug in subtracting :class:`BusinessHour` (or :class:`CustomBusinessHour`) from a :class:`Timestamp` giving incorrect results when the subtraction would land exactly on the business-hour opening time (:issue:`33682`)
 
 Timedelta

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -873,6 +873,10 @@ cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right):
                 res_value = NPY_DATETIME_NAT
             else:
                 res_value = lval + rval
+                if res_value == NPY_DATETIME_NAT:
+                    # a sum of exactly int64.min is representable, but
+                    #  would be misinterpreted as NaT
+                    raise OverflowError
 
             # Analogous to: result[i] = res_value
             (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = res_value

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -985,9 +985,10 @@ def _binary_op_method_timedeltalike(op, name):
 
         res = op(self._value, other._value)
         if res == NPY_NAT:
-            # e.g. test_implementation_limits
-            # TODO: more generally could do an overflowcheck in op?
-            return NaT
+            raise OutOfBoundsTimedelta(
+                f"Outside the range of representable timedeltas: "
+                f"{self} {name} {other}"
+            )
 
         return _timedelta_from_value_and_reso(Timedelta, res, reso=self._creso)
 

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -779,6 +779,18 @@ class TestAddSubNaTMasking:
         )
         tm.assert_index_equal(result, exp)
 
+    def test_tdi_add_overflow_nat_sentinel(self):
+        # GH#66552 result landing exactly on INT64_MIN (NaT sentinel)
+        #  must raise instead of silently returning NaT
+        tdi = pd.to_timedelta([Timedelta.min]).as_unit("ns")
+        msg = "Overflow in int64 addition"
+        with pytest.raises(OverflowError, match=msg):
+            tdi - Timedelta(1, "ns")
+
+        dti = pd.to_datetime([Timestamp.min]).as_unit("ns")
+        with pytest.raises(OverflowError, match=msg):
+            dti - Timedelta(1, "ns")
+
 
 class TestTimedeltaArraylikeAddSubOps:
     # Tests for timedelta64[ns] __add__, __sub__, __radd__, __rsub__

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -621,8 +621,10 @@ class TestTimedeltas:
         assert min_td._value == iNaT + 1
         assert max_td._value == lib.i8max
 
-        # Beyond lower limit, a NAT before the Overflow
-        assert (min_td - Timedelta(1, "ns")) is NaT
+        # GH#66552 - result landing on INT64_MIN must raise, not return NaT
+        msg = "Outside the range of representable timedeltas"
+        with pytest.raises(OutOfBoundsTimedelta, match=msg):
+            min_td - Timedelta(1, "ns")
 
         msg = "int too (large|big) to convert"
         with pytest.raises(OverflowError, match=msg):


### PR DESCRIPTION
  - [x] closes #66552
  - [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
  - [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
  - [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
  - [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
  - [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
  - [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
