### PR TITLE
BUG: Fix issue #66552

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -360,6 +360,7 @@ Datetimelike
 - Bug in :meth:`Series.dt.isocalendar` with a pyarrow-backed datetime or date dtype not preserving the original index, resetting it to a default :class:`RangeIndex` (:issue:`65894`)
 - Bug in adding a :class:`DateOffset` with a ``milliseconds`` component to a :class:`Timestamp` returning a microsecond-resolution result, inconsistent with the millisecond-resolution result of the equivalent :class:`DatetimeIndex` and :class:`Series` operations (:issue:`64806`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
+- Bug in datetimelike arithmetic (scalar :class:`Timestamp`/:class:`Timedelta`, :class:`DatetimeIndex`/:class:`TimedeltaIndex`, :class:`Series`, and :class:`DateOffset` addition) where a result landing exactly on the ``NaT`` sentinel (``int64`` minimum) was silently returned as ``NaT`` or wrapped around instead of raising (:issue:`66552`)
 - Bug in subtracting :class:`BusinessHour` (or :class:`CustomBusinessHour`) from a :class:`Timestamp` giving incorrect results when the subtraction would land exactly on the business-hour opening time (:issue:`33682`)
 
 Timedelta

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -135,5 +135,9 @@ cdef int64_t convert_reso(
     bint round_ok,
 ) except? -1
 
-cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right)
+cpdef cnp.ndarray add_overflowsafe(
+    cnp.ndarray left,
+    cnp.ndarray right,
+    bint raise_on_sentinel=*,
+)
 cpdef cnp.ndarray mul_overflowsafe(cnp.ndarray left, cnp.ndarray right)

--- a/pandas/_libs/tslibs/np_datetime.pyi
+++ b/pandas/_libs/tslibs/np_datetime.pyi
@@ -27,6 +27,7 @@ def compare_mismatched_resolutions(
 def add_overflowsafe(
     left: npt.NDArray[np.int64],
     right: npt.NDArray[np.int64],
+    raise_on_sentinel: bool = ...,
 ) -> npt.NDArray[np.int64]: ...
 def mul_overflowsafe(
     left: npt.NDArray[np.int64],

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -841,11 +841,22 @@ cdef int64_t _convert_reso_with_dtstruct(
 
 
 @cython.overflowcheck(True)
-cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right):
+cpdef cnp.ndarray add_overflowsafe(
+    cnp.ndarray left,
+    cnp.ndarray right,
+    bint raise_on_sentinel=True,
+):
     """
     Overflow-safe addition for datetime64/timedelta64 dtypes.
 
     `right` may either be zero-dim or of the same shape as `left`.
+
+    NaT values in `left` or `right` are propagated.  A result that lands
+    exactly on the NaT sentinel (INT64_MIN) is indistinguishable from a
+    missing value once stored, so by default we raise OverflowError for it
+    (GH-66552).  ``raise_on_sentinel=False`` allows such results through; it
+    is only used for Period count subtraction, where INT64_MIN is a valid
+    answer rather than the sentinel.
 
     TODO(numpy>=2.5): numpy raises OverflowError natively for datetime64/
     timedelta64 add and subtract (numpy GH-31378); remove this once the numpy
@@ -858,6 +869,31 @@ cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right):
             left.ndim, left.shape, cnp.NPY_INT64, 0
         )
         cnp.broadcast mi = cnp.PyArray_MultiIterNew3(iresult, left, right)
+        object lmin, lmax, rmin, rmax
+
+    if raise_on_sentinel and left.ndim >= 1 and right.ndim >= 1:
+        # Fast path: if min/max of both operands are within the overflow-safe
+        #  range, there are no NATs (NAT == INT64_MIN) and no risk of a sum
+        #  landing on the sentinel or overflowing, so we can use numpy's
+        #  vectorized add.  Restricted to ndim >= 1 since 0-d .view(dtype)
+        #  has edge cases; the slow path handles 0-d fine.
+        if left.size > 0 and right.size > 0:
+            lmin = left.min()
+            lmax = left.max()
+            rmin = right.min()
+            rmax = right.max()
+            # The bound has to exclude INT64_MIN itself rather than merely
+            #  staying inside int64: a sum landing on the sentinel must still
+            #  be detected.
+            if (
+                int(lmin) > NPY_DATETIME_NAT
+                and int(lmax) < INT64_MAX
+                and int(rmin) > NPY_DATETIME_NAT
+                and int(rmax) < INT64_MAX
+                and int(lmin) + int(rmin) > NPY_DATETIME_NAT
+                and int(lmax) + int(rmax) < INT64_MAX
+            ):
+                return left + right
 
     # Note: doing this try/except outside the loop improves performance over
     #  doing it inside the loop.
@@ -873,6 +909,10 @@ cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right):
                 res_value = NPY_DATETIME_NAT
             else:
                 res_value = lval + rval
+                if res_value == NPY_DATETIME_NAT and raise_on_sentinel:
+                    # a sum of exactly int64.min is representable, but would be
+                    #  misinterpreted as NaT
+                    raise OverflowError
 
             # Analogous to: result[i] = res_value
             (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = res_value

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -65,6 +65,7 @@ from pandas._libs.tslibs.dtypes cimport (
     c_OFFSET_TO_PERIOD_FREQSTR,
     c_PERIOD_AND_OFFSET_DEPR_FREQSTR,
     c_PERIOD_TO_OFFSET_FREQSTR,
+    npy_unit_to_abbrev,
     periods_per_day,
 )
 from pandas._libs.tslibs.nattype cimport (
@@ -73,6 +74,8 @@ from pandas._libs.tslibs.nattype cimport (
 )
 from pandas._libs.tslibs.np_datetime cimport (
     NPY_DATETIMEUNIT,
+    add_overflowsafe,
+    astype_overflowsafe,
     get_unit_from_dtype,
     import_pandas_datetime,
     npy_datetimestruct,
@@ -95,6 +98,51 @@ from .timedeltas import Timedelta
 from .timestamps cimport _Timestamp
 
 from .timestamps import Timestamp
+
+
+cdef extern from "pandas/portable.h":
+    int checked_add(int64_t a, int64_t b, int64_t *res) nogil
+
+
+cdef ndarray _add_timedelta_overflowsafe(
+    ndarray dtarr, int64_t delta_i8, NPY_DATETIMEUNIT delta_reso
+):
+    """
+    Add a fixed timedelta to a datetime64 ndarray in an overflow-safe way,
+    matching numpy's promotion to the finer resolution unit.
+
+    A result landing exactly on the NaT sentinel (INT64_MIN) is
+    indistinguishable from a missing value, so we raise OverflowError for it
+    (GH-66552).
+    """
+    cdef:
+        NPY_DATETIMEUNIT arr_reso = get_unit_from_dtype(dtarr.dtype)
+        object unit_name = npy_unit_to_abbrev(arr_reso)
+        int64_t arr_ppd, delta_ppd
+        object rescaled
+
+    if delta_reso > arr_reso:
+        # numpy would promote dtarr up to the finer unit, which can silently
+        #  wrap and land on the sentinel; raise instead
+        unit_name = npy_unit_to_abbrev(delta_reso)
+        dtarr = astype_overflowsafe(dtarr, np.dtype(f"M8[{unit_name}]"))
+    elif delta_reso < arr_reso:
+        # numpy converts the timedelta up to the array's unit (exact).  Do the
+        #  rescale with Python ints so the intermediate product cannot wrap
+        #  past int64 (GH-66552).
+        arr_ppd = periods_per_day(arr_reso)
+        delta_ppd = periods_per_day(delta_reso)
+        rescaled = (<object>delta_i8) * arr_ppd // delta_ppd
+        if rescaled < -2 ** 63 or rescaled > 2 ** 63 - 1:
+            raise OverflowError("Overflow in int64 addition")
+        delta_i8 = rescaled
+
+    return add_overflowsafe(
+        dtarr.view("i8"),
+        np.broadcast_to(
+            np.array([delta_i8], dtype="i8"), (<object>dtarr).shape
+        ),
+    ).view(np.dtype(f"M8[{unit_name}]"))
 
 # ---------------------------------------------------------------------
 # day_opt enum: avoids repeated string comparisons in nogil loops
@@ -1559,7 +1607,12 @@ cdef class Day(SingleConstructorOffset):
         return other + np.timedelta64(self._n, "D")
 
     def _apply_array(self, dtarr):
-        return dtarr + np.timedelta64(self._n, "D")
+        # We cannot simply defer to numpy here, which silently wraps on
+        #  overflow and treats a result landing on the NaT sentinel as NaT
+        #  (GH-66552).
+        return _add_timedelta_overflowsafe(
+            dtarr, self._n, NPY_DATETIMEUNIT.NPY_FR_D
+        )
 
     @cache_readonly
     def freqstr(self) -> str:
@@ -2068,7 +2121,14 @@ cdef class RelativeDeltaOffset(BaseOffset):
         if months:
             shifted = shift_months(dt64other.view("i8"), months, reso=reso)
             dt64other = shifted.view(dtarr.dtype)
-        return dt64other + delta
+        # We cannot simply defer to numpy here, which silently wraps on
+        #  overflow and treats a result landing on the NaT sentinel as NaT
+        #  (GH-66552).
+        return _add_timedelta_overflowsafe(
+            dt64other,
+            (<_Timedelta>delta)._value,
+            (<_Timedelta>delta)._creso,
+        )
 
     def is_on_offset(self, dt: datetime) -> bool:
         """
@@ -2677,10 +2737,11 @@ cdef class BusinessDay(BusinessMixin):
             ndarray result = cnp.PyArray_EMPTY(
                 i8other.ndim, i8other.shape, cnp.NPY_INT64, 0
             )
-            int64_t val, res_val
+            int64_t val, res_val, delta
             int wday, days, weeks
             npy_datetimestruct dts
             int64_t DAY_PERIODS = periods_per_day(reso)
+            bint overflowed = False
             cnp.broadcast mi = cnp.PyArray_MultiIterNew2(result, i8other)
 
         weeks = periods // 5
@@ -2697,12 +2758,24 @@ cdef class BusinessDay(BusinessMixin):
                     wday = dayofweek(dts.year, dts.month, dts.day)
 
                     days = self._adjust_ndays(wday, weeks)
-                    res_val = val + (7 * weeks + days) * DAY_PERIODS
+                    delta = (7 * <int64_t>weeks + days) * DAY_PERIODS
+                    if checked_add(val, delta, &res_val):
+                        # overflow in the shift itself (GH-66552)
+                        overflowed = True
+                        res_val = NPY_NAT
+                    elif res_val == NPY_NAT:
+                        # a shift of exactly int64.min is representable, but
+                        #  would be misinterpreted as NaT (GH-66552)
+                        overflowed = True
+                        res_val = NPY_NAT
 
                 # Analogous to: out[i] = res_val
                 (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = res_val
 
                 cnp.PyArray_MultiIter_NEXT(mi)
+
+        if overflowed:
+            raise OverflowError("Overflow in int64 addition")
 
         return result
 
@@ -2737,7 +2810,13 @@ cdef class BusinessDay(BusinessMixin):
         reso = get_unit_from_dtype(dtarr.dtype)
         res = self._shift_bdays(i8other, reso=reso)
         if self._offset:
-            res = res.view(dtarr.dtype) + Timedelta(self._offset)
+            # We cannot simply defer to numpy here, which silently wraps on
+            #  overflow and treats a result landing on the NaT sentinel as NaT
+            #  (GH-66552).
+            td = Timedelta(self._offset)
+            res = _add_timedelta_overflowsafe(
+                res.view(dtarr.dtype), td._value, td._creso
+            )
         return res
 
     @property
@@ -5204,7 +5283,14 @@ cdef class Week(SingleConstructorOffset):
             td = timedelta(days=7 * self._n)
             unit = np.datetime_data(dtarr.dtype)[0]
             td64 = np.timedelta64(td, unit)
-            return dtarr + td64
+            # We cannot simply defer to numpy here, which silently wraps on
+            #  overflow and treats a result landing on the NaT sentinel as NaT
+            #  (GH-66552).
+            return _add_timedelta_overflowsafe(
+                dtarr,
+                td64.astype("i8"),
+                get_unit_from_dtype(td64.dtype),
+            )
         else:
             reso = get_unit_from_dtype(dtarr.dtype)
             i8other = dtarr.view("i8")
@@ -5228,7 +5314,7 @@ cdef class Week(SingleConstructorOffset):
         """
         cdef:
             Py_ssize_t _, count = i8other.size
-            int64_t val, res_val
+            int64_t val, res_val, delta
             ndarray out = cnp.PyArray_EMPTY(
                 i8other.ndim, i8other.shape, cnp.NPY_INT64, 0
             )
@@ -5236,6 +5322,7 @@ cdef class Week(SingleConstructorOffset):
             int wday, days, weeks, n = self._n
             int anchor_weekday = self.weekday
             int64_t DAY_PERIODS = periods_per_day(reso)
+            bint overflowed = False
             cnp.broadcast mi = cnp.PyArray_MultiIterNew2(out, i8other)
 
         with nogil:
@@ -5256,12 +5343,24 @@ cdef class Week(SingleConstructorOffset):
                         if weeks > 0:
                             weeks -= 1
 
-                    res_val = val + (7 * weeks + days) * DAY_PERIODS
+                    delta = (7 * <int64_t>weeks + days) * DAY_PERIODS
+                    if checked_add(val, delta, &res_val):
+                        # overflow in the shift itself (GH-66552)
+                        overflowed = True
+                        res_val = NPY_NAT
+                    elif res_val == NPY_NAT:
+                        # a shift of exactly int64.min is representable, but
+                        #  would be misinterpreted as NaT (GH-66552)
+                        overflowed = True
+                        res_val = NPY_NAT
 
                 # Analogous to: out[i] = res_val
                 (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = res_val
 
                 cnp.PyArray_MultiIter_NEXT(mi)
+
+        if overflowed:
+            raise OverflowError("Overflow in int64 addition")
 
         return out
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2082,6 +2082,10 @@ cdef class _Period(PeriodMixin):
                                         f"Period(freq={self.freqstr})") from err
         with cython.overflowcheck(True):
             ordinal = self._ordinal + inc
+        if ordinal == NPY_NAT:
+            # a sum of exactly int64.min is representable, but would be
+            #  indistinguishable from NaT once stored (GH-66552)
+            raise OverflowError
         return Period(ordinal=ordinal, freq=self._freq)
 
     def _add_offset(self, other) -> "Period":
@@ -2092,6 +2096,10 @@ cdef class _Period(PeriodMixin):
         self._require_matching_unit(other._period_unit, base=True)
 
         ordinal = self._ordinal + other.n
+        if ordinal == NPY_NAT:
+            # a sum of exactly int64.min is representable, but would be
+            #  indistinguishable from NaT once stored (GH-66552)
+            raise OverflowError
         return Period(ordinal=ordinal, freq=self._freq)
 
     @cython.overflowcheck(True)
@@ -2104,6 +2112,10 @@ cdef class _Period(PeriodMixin):
             return NaT
         elif util.is_integer_object(other):
             ordinal = self._ordinal + other * self._dtype._n
+            if ordinal == NPY_NAT:
+                # a sum of exactly int64.min is representable, but would be
+                #  indistinguishable from NaT once stored (GH-66552)
+                raise OverflowError
             return Period(ordinal=ordinal, freq=self._freq)
 
         elif is_period_object(other):

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -65,12 +65,15 @@ from pandas._libs.tslibs.nattype cimport (
 from pandas._libs.tslibs.np_datetime cimport (
     NPY_DATETIMEUNIT,
     NPY_FR_ns,
+    add_overflowsafe,
+    astype_overflowsafe,
     cmp_dtstructs,
     cmp_scalar,
     convert_reso,
     get_datetime64_unit,
     get_unit_from_dtype,
     import_pandas_datetime,
+    mul_overflowsafe,
     npy_datetimestruct,
     pandas_datetime_to_datetimestruct,
     pandas_timedelta_to_timedeltastruct,
@@ -955,7 +958,29 @@ def _binary_op_method_timedeltalike(op, name):
                 item = cnp.PyArray_ToScalar(cnp.PyArray_DATA(other), other)
                 return f(self, item)
 
-            elif other.dtype.kind in "mM":
+            elif other.dtype.kind == "m":
+                # We cannot simply defer to numpy here, which silently wraps
+                #  on overflow and on promotion to the finer unit (GH-66552).
+                other_creso = get_unit_from_dtype(other.dtype)
+                reso = max(self._creso, other_creso)
+                if self._creso < reso:
+                    self = (<_Timedelta>self)._as_creso(reso, round_ok=True)
+                if other_creso < reso:
+                    other = astype_overflowsafe(
+                        other, np.dtype(f"m8[{npy_unit_to_abbrev(reso)}]")
+                    )
+                self_i8 = np.broadcast_to(
+                    np.array([self._value], dtype="i8"), other.shape
+                )
+                if name == "__sub__":
+                    new_values = add_overflowsafe(self_i8, -other.view("i8"))
+                elif name == "__rsub__":
+                    new_values = add_overflowsafe(-self_i8, other.view("i8"))
+                else:
+                    new_values = add_overflowsafe(self_i8, other.view("i8"))
+                return new_values.view(f"m8[{npy_unit_to_abbrev(reso)}]")
+
+            elif other.dtype.kind == "M":
                 return op(self.to_timedelta64(), other)
             elif other.dtype.kind == "O":
                 return np.array([op(self, x) for x in other])
@@ -986,8 +1011,10 @@ def _binary_op_method_timedeltalike(op, name):
         res = op(self._value, other._value)
         if res == NPY_NAT:
             # e.g. test_implementation_limits
-            # TODO: more generally could do an overflowcheck in op?
-            return NaT
+            # A result landing exactly on the sentinel (int64.min) is
+            #  representable but indistinguishable from NaT once stored, so we
+            #  raise just like the step further out of bounds (GH-66552).
+            raise OverflowError("Overflow in int64 addition")
 
         return _timedelta_from_value_and_reso(Timedelta, res, reso=self._creso)
 
@@ -1198,7 +1225,11 @@ cdef _timedelta_from_value_and_reso(cls, int64_t value, NPY_DATETIMEUNIT reso):
     cdef:
         _Timedelta td_base
 
-    assert value != NPY_NAT
+    if value == NPY_NAT:
+        # The NaT sentinel cannot be stored as a real value: under `python -O`
+        #  a bare assert would let a live object with _value == iNaT through,
+        #  one that is not NaT and for which isna() is False (GH-66552).
+        raise OverflowError
     # For millisecond and second resos, we cannot actually pass int(value) because
     #  many cases would fall outside of the pytimedelta implementation bounds.
     #  We pass 0 instead, and override seconds, microseconds, days.
@@ -2734,6 +2765,16 @@ class Timedelta(_Timedelta):
                 # see also: item_from_zerodim
                 item = cnp.PyArray_ToScalar(cnp.PyArray_DATA(other), other)
                 return self.__mul__(item)
+            if other.dtype.kind in "iu":
+                # We cannot simply defer to numpy here, which silently wraps
+                #  on overflow and on products landing on the sentinel
+                #  (GH-66552).
+                return mul_overflowsafe(
+                    np.broadcast_to(
+                        np.array([self._value], dtype="i8"), other.shape
+                    ),
+                    other.astype("i8", copy=False),
+                ).view(f"m8[{npy_unit_to_abbrev(self._creso)}]")
             return other * self.to_timedelta64()
 
         elif is_bool_object(other):

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -83,8 +83,11 @@ from pandas._libs.tslibs.nattype cimport (
     c_NaT as NaT,
 )
 from pandas._libs.tslibs.np_datetime cimport (
+    NPY_DATETIME_NAT,
     NPY_DATETIMEUNIT,
     NPY_FR_ns,
+    add_overflowsafe,
+    astype_overflowsafe,
     check_nat_sentinel,
     cmp_dtstructs,
     cmp_scalar,
@@ -616,6 +619,10 @@ cdef class _Timestamp(ABCTimestamp):
 
             try:
                 new_value = self._value + nanos
+                if new_value == NPY_DATETIME_NAT:
+                    # a sum of exactly int64.min is representable, but would be
+                    #  indistinguishable from NaT once stored (GH-66552)
+                    raise OverflowError
                 result = type(self)._from_value_and_reso(
                     new_value, reso=self._creso, tz=self.tzinfo
                 )
@@ -636,7 +643,30 @@ cdef class _Timestamp(ABCTimestamp):
                 raise integer_op_not_supported(self)
             if other.dtype.kind == "m":
                 if self.tz is None:
-                    return self.asm8 + other
+                    # We cannot simply defer to numpy here, which silently
+                    #  wraps on overflow and on promotion to the finer unit
+                    #  (GH-66552).
+                    other_creso = get_unit_from_dtype(other.dtype)
+                    if other_creso > self._creso:
+                        # numpy would promote self to the finer unit, which
+                        #  can silently wrap; raise instead.
+                        self = (<_Timestamp>self)._as_creso(
+                            other_creso, round_ok=True
+                        )
+                    elif other_creso < self._creso:
+                        other = astype_overflowsafe(
+                            other,
+                            np.dtype(f"m8[{npy_unit_to_abbrev(self._creso)}]"),
+                        )
+                    new_values = add_overflowsafe(
+                        np.broadcast_to(
+                            np.array([self._value], dtype="i8"), other.shape
+                        ),
+                        other.view("i8"),
+                    )
+                    return new_values.view(
+                        f"M8[{npy_unit_to_abbrev(self._creso)}]"
+                    )
                 return np.asarray(
                     [self + other[n] for n in range(len(other))],
                     dtype=object,
@@ -663,7 +693,30 @@ cdef class _Timestamp(ABCTimestamp):
                 raise integer_op_not_supported(self)
             if other.dtype.kind == "m":
                 if self.tz is None:
-                    return self.asm8 - other
+                    # We cannot simply defer to numpy here, which silently
+                    #  wraps on overflow and on promotion to the finer unit
+                    #  (GH-66552).
+                    other_creso = get_unit_from_dtype(other.dtype)
+                    if other_creso > self._creso:
+                        # numpy would promote self to the finer unit, which
+                        #  can silently wrap; raise instead.
+                        self = (<_Timestamp>self)._as_creso(
+                            other_creso, round_ok=True
+                        )
+                    elif other_creso < self._creso:
+                        other = astype_overflowsafe(
+                            other,
+                            np.dtype(f"m8[{npy_unit_to_abbrev(self._creso)}]"),
+                        )
+                    new_values = add_overflowsafe(
+                        np.broadcast_to(
+                            np.array([self._value], dtype="i8"), other.shape
+                        ),
+                        -other.view("i8"),
+                    )
+                    return new_values.view(
+                        f"M8[{npy_unit_to_abbrev(self._creso)}]"
+                    )
                 return np.asarray(
                     [self - other[n] for n in range(len(other))],
                     dtype=object,

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1265,7 +1265,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         self._check_compatible_with(other)
 
         other_i8, o_mask = self._get_i8_values_and_mask(other)
-        new_i8_data = add_overflowsafe(self.asi8, np.asarray(-other_i8, dtype="i8"))
+        # raise_on_sentinel=False because this is a count of periods, not an
+        #  ordinal: INT64_MIN is a legitimate answer here (GH-66552)
+        new_i8_data = add_overflowsafe(
+            self.asi8, np.asarray(-other_i8, dtype="i8"), raise_on_sentinel=False
+        )
         new_data = np.array([self.freq.base * x for x in new_i8_data])
 
         if o_mask is None:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -31,6 +31,7 @@ from pandas._libs.tslibs import (
     OutOfBoundsTimedelta,
     Timedelta,
     Timestamp,
+    add_overflowsafe,
     astype_overflowsafe,
     fields,
     get_supported_dtype,
@@ -801,12 +802,15 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             and isinstance(offset, RelativeDeltaOffset)
             and not offset._use_relativedelta
         ):
-            res_values = self._ndarray + offset._pd_timedelta
-            # GH#64806 offset._pd_timedelta may have finer resolution than
-            # self, promoting res_values to a finer unit; derive the dtype
-            # from the promoted values rather than assuming self.dtype's unit.
-            res_unit = cast("TimeUnit", np.datetime_data(res_values.dtype)[0])
-            res_dtype = tz_to_dtype(self.tz, res_unit)
+            # We cannot simply defer to numpy here, which silently wraps on
+            #  overflow and treats a result landing on the NaT sentinel as NaT
+            #  (GH-66552).
+            self_matched, other = self._ensure_matching_resos(offset._pd_timedelta)
+            other_i8, o_mask = self._get_i8_values_and_mask(other)
+            res_values = add_overflowsafe(
+                self_matched.asi8, np.asarray(other_i8, dtype="i8")
+            ).view(f"M8[{self_matched.unit}]")
+            res_dtype = tz_to_dtype(self.tz, self_matched.unit)
             result = type(self)._simple_new(res_values, dtype=res_dtype)
             if offset.normalize:
                 result = result.normalize()

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1794,6 +1794,34 @@ class TestDatetime64OverflowHandling:
         with pytest.raises(OverflowError, match=msg):
             tmax - t2
 
+    def test_dti_add_dateoffset_landing_on_nat_sentinel_raises(self):
+        # GH-66552
+        # Operations whose result lands exactly on the NaT sentinel (int64
+        #  min) are indistinguishable from NaT once stored, so they raise
+        #  instead of silently returning NaT or wrapping.
+        dti_min = DatetimeIndex([Timestamp.min])
+        dti_max = DatetimeIndex([Timestamp.max])
+        msg = "Overflow in int64 addition"
+
+        with pytest.raises(OverflowError, match=msg):
+            dti_min + DateOffset(nanoseconds=-1)
+        with pytest.raises(OverflowError, match=msg):
+            dti_max + pd.offsets.BusinessDay()
+
+        # a few days past the sentinel, Week(-1)/Week(1) shifts onto it
+        dti_iatn_7d = DatetimeIndex(
+            [Timestamp(Timestamp.min._value - 1 + 7 * 86400 * 10**9)]
+        )
+        with pytest.raises(OverflowError, match=msg):
+            dti_iatn_7d + pd.offsets.Week(-1)
+        with pytest.raises(OverflowError, match=msg):
+            dti_iatn_7d - pd.offsets.Week(1)
+
+        # one unit away from the sentinel still works (no silent wrap)
+        result = dti_min + Timedelta(1, "ns")
+        expected = DatetimeIndex([Timestamp("1677-09-21 00:12:43.145224194")])
+        tm.assert_index_equal(result, expected)
+
 
 class TestTimestampSeriesArithmetic:
     def test_empty_series_add_sub(self, box_with_array):

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -779,6 +779,21 @@ class TestAddSubNaTMasking:
         )
         tm.assert_index_equal(result, exp)
 
+    def test_tdi_sub_landing_on_nat_sentinel_raises(self):
+        # GH-66552
+        # Operations whose result lands exactly on the NaT sentinel (int64
+        #  min) are indistinguishable from NaT once stored, so they raise
+        #  instead of silently returning NaT or wrapping.
+        tdi_min = pd.to_timedelta([Timedelta.min])
+        msg = "Overflow in int64 addition"
+        with pytest.raises(OverflowError, match=msg):
+            tdi_min - Timedelta(1, "ns")
+
+        # one unit away from the sentinel still works
+        result = tdi_min + Timedelta(1, "ns")
+        expected = TimedeltaIndex([Timedelta(Timedelta.min._value + 1, "ns")])
+        tm.assert_index_equal(result, expected)
+
 
 class TestTimedeltaArraylikeAddSubOps:
     # Tests for timedelta64[ns] __add__, __sub__, __radd__, __rsub__

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -359,6 +359,25 @@ class TestTimedeltaAdditionSubtraction:
         assert isinstance(result, Timedelta)
         assert result == 0 * td
 
+    def test_td_add_sub_landing_on_nat_sentinel_raises(self):
+        # GH-66552
+        # Operations whose result lands exactly on the NaT sentinel (int64
+        #  min) are indistinguishable from NaT once stored, so they raise
+        #  instead of silently returning NaT or wrapping.
+        td_min = Timedelta.min
+        td_max = Timedelta.max
+        td_ns1 = Timedelta(1, "ns")
+
+        msg = "Overflow in int64 addition"
+        with pytest.raises(OverflowError, match=msg):
+            td_min - td_ns1
+        with pytest.raises(OverflowError, match="int too big to convert"):
+            td_max + td_ns1
+
+        # one unit away from the sentinel is still representable
+        assert td_min + td_ns1 == Timedelta(Timedelta.min._value + 1, "ns")
+        assert td_max - td_ns1 == Timedelta(Timedelta.max._value - 1, "ns")
+
 
 class TestTimedeltaMultiplicationDivision:
     """
@@ -371,6 +390,29 @@ class TestTimedeltaMultiplicationDivision:
         __mod__, __rmod__,
         __divmod__, __rdivmod__
     """
+
+    def test_td_mul_div_landing_on_nat_sentinel_raises(self):
+        # GH-66552
+        # Operations whose result lands exactly on the NaT sentinel (int64
+        #  min) are indistinguishable from NaT once stored, so they raise
+        #  instead of silently returning NaT or wrapping.
+        msg = "int too big to convert"
+        with pytest.raises(OverflowError, match=msg):
+            Timedelta.min * 2
+        with pytest.raises(OverflowError, match=msg):
+            Timedelta.max * 2
+        with pytest.raises(OverflowError, match=msg):
+            Timedelta.max / 0.5
+        with pytest.raises(OverflowError, match=msg):
+            Timedelta.max // 0.5
+
+        # vectorized multiplication also raises rather than wrapping
+        msg = "Overflow in int64 multiplication"
+        other = np.array([2], dtype="i8")
+        with pytest.raises(OverflowError, match=msg):
+            Timedelta.min * other
+        with pytest.raises(OverflowError, match=msg):
+            other * Timedelta.min
 
     # ---------------------------------------------------------------
     # Timedelta.__mul__, __rmul__

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -621,8 +621,12 @@ class TestTimedeltas:
         assert min_td._value == iNaT + 1
         assert max_td._value == lib.i8max
 
-        # Beyond lower limit, a NAT before the Overflow
-        assert (min_td - Timedelta(1, "ns")) is NaT
+        # Beyond lower limit, a NAT before the Overflow.  A result landing
+        # exactly on the NaT sentinel is representable but indistinguishable
+        # from NaT once stored, so it raises instead (GH-66552).
+        msg = "Overflow in int64 addition"
+        with pytest.raises(OverflowError, match=msg):
+            min_td - Timedelta(1, "ns")
 
         msg = "int too (large|big) to convert"
         with pytest.raises(OverflowError, match=msg):

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -14,6 +14,7 @@ from pandas._libs.tslibs import (
     OutOfBoundsTimedelta,
     Timedelta,
     Timestamp,
+    iNaT,
     offsets,
     to_offset,
 )
@@ -325,6 +326,37 @@ class TestTimestampArithmetic:
 
         assert ts1 == ts2
         assert hash(ts1) == hash(ts2)
+
+    def test_arithmetic_landing_on_nat_sentinel_raises(self):
+        # GH-66552
+        # Operations whose result lands exactly on the NaT sentinel (int64
+        #  min) are indistinguishable from NaT once stored, so they raise
+        #  instead of silently returning NaT or wrapping.
+        ts_min = Timestamp.min
+        ts_max = Timestamp.max
+        td_ns1 = Timedelta(1, "ns")
+        td_neg1 = Timedelta(-1, "ns")
+
+        msg = "Out of bounds nanosecond timestamp"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            ts_min - td_ns1
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            ts_max + td_ns1
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            ts_min + td_neg1
+
+        # one unit away from the sentinel is still representable
+        assert ts_min + td_ns1 == Timestamp("1677-09-21 00:12:43.145224194")
+        assert ts_max - td_ns1 == Timestamp("2262-04-11 23:47:16.854775806")
+
+        # Timestamp - Timestamp landing on the sentinel
+        with pytest.raises(OutOfBoundsDatetime, match="Result is too large"):
+            ts_min - Timestamp(1)
+
+        # Timestamp + Week(-1) from a few days past the sentinel
+        ts_iatn_7d = Timestamp(iNaT + 7 * 86400 * 10**9)
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            ts_iatn_7d + offsets.Week(-1)
 
 
 class SubDatetime(datetime):


### PR DESCRIPTION
- [x] closes #66552
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
      - `test_arithmetic_landing_on_nat_sentinel_raises` (pandas/tests/scalar/timestamp/test_arithmetic.py)
      - `test_td_add_sub_landing_on_nat_sentinel_raises`, `test_td_mul_div_landing_on_nat_sentinel_raises` (pandas/tests/scalar/timedelta/test_arithmetic.py)
      - `test_dti_add_dateoffset_landing_on_nat_sentinel_raises` (pandas/tests/arithmetic/test_datetime64.py)
      - `test_tdi_sub_landing_on_nat_sentinel_raises` (pandas/tests/arithmetic/test_timedelta64.py)
      - `test_implementation_limits` updated (pandas/tests/scalar/timedelta/test_timedelta.py)
      - Verified: all 6 fail on un-fixed source, pass with fix; full gate 21524 passed / 724 skipped / 47 xfailed / 0 failed
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
      - `pre-commit run --files <15 changed files>`: all hooks pass (ruff, isort, cython-lint, vulture, codespell, whatsnew sort, etc.)
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
      - `add_overflowsafe(left, right, raise_on_sentinel: bool = ...)` annotated in `pandas/_libs/tslibs/np_datetime.pyi`; internal Cython cdef helpers (`_add_timedelta_overflowsafe`) are module-private and need no stubs.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
      - `doc/source/whatsnew/v3.1.0.rst` (Datetimelike section, line 363, sorted): datetimelike arithmetic landing exactly on the NaT sentinel now raises instead of returning NaT/wrapping (:issue:`66552`)
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
      - AI (opencode, model `big-pickle`) developed the fix and ran the full 9-step validation checklist; pandas `AGENTS.md` was loaded and followed throughout.