### PR TITLE
DOC: fix copy-paste bug in PyArrow storage example in text.rst

### DIFF
--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -830,7 +830,7 @@ represented and behave as ``pd.NA``.
 
    pd.Series(
        ["a", "b", None, np.nan, pd.NA],
-       dtype=pd.StringDtype(storage="python", na_value=pd.NA)
+       dtype=pd.StringDtype(storage="pyarrow", na_value=pd.NA)
    )
 
 Notice that the last three values are all inferred by pandas as being NA


### PR DESCRIPTION
## Description
The "PyArrow storage with `pd.NA` values" example in `text.rst` used
`storage="python"`; identical to the preceding "Python storage" example
and contradicting the section heading/text, which claims a PyArrow-backed
array. Fixed to `storage="pyarrow"`.
No issue filed; this is a trivial one-word typo fix, which the
contributing guide exempts from requiring an associated issue.


- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

