### PR TITLE
DOC: fix no-op dict rename_categories example in categorical.rst

### DIFF
--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -349,7 +349,7 @@ Renaming categories is done by using the
     s = s.cat.rename_categories(new_categories)
     s
     # You can also pass a dict-like object to map the renaming
-    s = s.cat.rename_categories({1: "x", 2: "y", 3: "z"})
+    s = s.cat.rename_categories({"Group a": "x", "Group b": "y", "Group c": "z"})
     s
 
 .. note::


### PR DESCRIPTION
## Description
The dict-based rename_categories example was a no-op; its keys (1, 2, 3)
never matched the actual categories at that point ("Group a", "Group b",
"Group c"). Fixed by matching the dict keys to the real categories.

- [x] closes #66574
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

