### PR TITLE
BUG: DataFrame constructor raises AttributeError on Sequences other than list/tuple/range (GH#27539)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -396,6 +396,7 @@ Numeric
 
 Conversion
 ^^^^^^^^^^
+- Bug in :class:`DataFrame` constructor raising ``AttributeError`` when given a one-dimensional :class:`collections.abc.Sequence` that is not a ``list``, ``tuple`` or ``range`` (e.g. :class:`collections.deque`, ``array.array``, ``numba.typed.List``) (:issue:`27539`)
 - Bug in :class:`DataFrame` constructor raising ``TypeError`` when given a list whose first element is a list-like dataclass (e.g. a :class:`collections.UserList` subclass); such elements are now treated as list-like rows (:issue:`41682`)
 - Bug in :class:`DataFrame` constructor where ``NaT`` in a :class:`TimedeltaIndex` row was incorrectly inferred as ``datetime64`` instead of ``timedelta64`` (:issue:`23985`)
 - Bug in :class:`DataFrame` constructor where constructing from a list of uniform-dtype arrays (e.g. pyarrow, :class:`CategoricalDtype`, nullable dtypes) lost the dtype (:issue:`49593`)

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -518,7 +518,9 @@ def _prep_ndarraylike(values, copy: bool = True) -> np.ndarray:
             return v
 
         v = extract_array(v, extract_numpy=True)
-        if isinstance(v, (list, tuple, range)):
+        if isinstance(v, abc.Sequence) and not isinstance(v, (str, bytes)):
+            # GH#27539 not just list/tuple/range but any Sequence, e.g. deque,
+            #  array.array, numba.typed.List. str/bytes are Sequences but scalar.
             v = construct_1d_object_array_from_listlike(v)
         if isinstance(v, np.ndarray) and v.dtype == object:
             v = lib.maybe_convert_objects(v)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -4,6 +4,7 @@ from collections import (
     UserList,
     abc,
     defaultdict,
+    deque,
     namedtuple,
 )
 from collections.abc import Iterator
@@ -76,6 +77,18 @@ MIXED_INT_DTYPES = [
     "int32",
     "int64",
 ]
+
+
+class DummySequence(abc.Sequence):
+    # stand-in for third-party Sequence implementations such as numba.typed.List
+    def __init__(self, lst) -> None:
+        self._lst = lst
+
+    def __getitem__(self, n):
+        return self._lst[n]
+
+    def __len__(self) -> int:
+        return len(self._lst)
 
 
 class TestDataFrameConstructors:
@@ -1423,6 +1436,58 @@ class TestDataFrameConstructors:
         columns = ["num", "str"]
         result = DataFrame(lst_containers, columns=columns)
         expected = DataFrame([[1, "a"], [2, "b"]], columns=columns)
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "box",
+        [
+            deque,
+            UserList,
+            functools.partial(array.array, "i"),
+            lambda lst: memoryview(np.array(lst)),
+            DummySequence,
+        ],
+    )
+    def test_constructor_1d_sequence(self, box):
+        # GH#27539 a 1D Sequence that is not a list/tuple/range used to raise
+        #  AttributeError in the DataFrame constructor
+        result = DataFrame(box([1, 2, 3]))
+        expected = DataFrame([1, 2, 3])
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            [1, 2, 3],
+            [1.0, 2.0, 3.0],
+            ["a", "b"],
+            [1, "a", True],
+            [Timestamp("2020-01-01"), Timestamp("2020-01-02")],
+            [pd.NaT, pd.NaT],
+            [],
+        ],
+    )
+    def test_constructor_1d_sequence_dtype_inference(self, data):
+        # GH#27539 dtype inference for a generic Sequence must match both the
+        #  equivalent list and what the Series constructor would infer
+        result = DataFrame(deque(data))
+        expected = DataFrame(data)
+        tm.assert_frame_equal(result, expected)
+        if data:
+            assert result.dtypes.iloc[0] == Series(deque(data)).dtype
+
+    @td.skip_if_no("numba")
+    def test_constructor_numba_typed_list(self):
+        # GH#27539
+        import numba
+
+        data = [1.0, 2.0]
+        typed_list = numba.typed.List()
+        for item in data:
+            typed_list.append(item)
+
+        result = DataFrame(typed_list)
+        expected = DataFrame(data)
         tm.assert_frame_equal(result, expected)
 
     def test_constructor_stdlib_array(self):


### PR DESCRIPTION
- [x] closes #27539
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
