### PR TITLE
BUG: Timestamp subtraction landing on the NaT sentinel (GH#66552)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -366,6 +366,7 @@ Datetimelike
 - Bug in adding a :class:`DateOffset` with a ``milliseconds`` component to a :class:`Timestamp` returning a microsecond-resolution result, inconsistent with the millisecond-resolution result of the equivalent :class:`DatetimeIndex` and :class:`Series` operations (:issue:`64806`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
 - Bug in subtracting :class:`BusinessHour` (or :class:`CustomBusinessHour`) from a :class:`Timestamp` giving incorrect results when the subtraction would land exactly on the business-hour opening time (:issue:`33682`)
+- Bug in subtracting two :class:`Timestamp` objects whose difference lands exactly on the ``NaT`` sentinel raising ``AssertionError``, or with ``python -O`` returning a corrupt :class:`Timedelta` for which :func:`isna` was ``False``, instead of raising :class:`OutOfBoundsDatetime` (:issue:`66552`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -693,6 +693,14 @@ cdef class _Timestamp(ABCTimestamp):
             # Timedelta
             try:
                 res_value = self._value - other._value
+                if res_value == NPY_NAT:
+                    # GH#66552 int64 can hold this difference, but the value is
+                    #  the NaT sentinel, so it is not representable as a
+                    #  Timedelta. Raise like the neighbouring difference one
+                    #  step further out of bounds does.
+                    raise OutOfBoundsTimedelta(
+                        "Result is not representable as a pandas.Timedelta."
+                    )
                 return Timedelta._from_value_and_reso(res_value, self._creso)
             except (OverflowError, OutOfBoundsDatetime, OutOfBoundsTimedelta) as err:
                 if both_timestamps:

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -14,6 +14,7 @@ from pandas._libs.tslibs import (
     OutOfBoundsTimedelta,
     Timedelta,
     Timestamp,
+    iNaT,
     offsets,
     to_offset,
 )
@@ -82,6 +83,26 @@ class TestTimestampArithmetic:
 
         # but we're OK for timestamp and datetime.datetime
         assert (a - b.to_pydatetime()) == (a.to_pydatetime() - b)
+
+    @pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+    def test_sub_lands_on_nat_sentinel_raises(self, unit):
+        # GH#66552 the difference fits in int64 but equals iNaT, which cannot be
+        #  stored as a Timedelta; previously this tripped a bare assert, and with
+        #  `python -O` produced a Timedelta whose _value was iNaT
+        left = Timestamp(np.datetime64(iNaT + 1, unit))
+        right = Timestamp(np.datetime64(1, unit))
+        assert left._value - right._value == iNaT
+
+        msg = "Result is too large"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            left - right
+
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            left.to_datetime64() - right
+
+        # the neighbor one step further out already raised
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            left - Timestamp(np.datetime64(2, unit))
 
     def test_delta_preserve_nanos(self):
         val = Timestamp(1337299200000000123)


### PR DESCRIPTION
Addresses one item from GH-66552 (the `Timestamp - Timestamp` path); the rest of that issue stays open.

`NaT` is stored as `INT64_MIN`, so a difference of two `Timestamp` objects that lands exactly there fits in int64 but is not representable as a `Timedelta`. It reached the bare `assert value != NPY_NAT` in `_timedelta_from_value_and_reso`:

```python
>>> Timestamp(iNaT + 1) - Timestamp(1)
AssertionError
>>> Timestamp(iNaT + 1) - Timestamp(2)   # one step further out, on main
OutOfBoundsDatetime: Result is too large for pandas.Timedelta. ...
```

Under `python -O` the assert vanishes and you get a live `Timedelta` whose `_value` is `iNaT`, which is not `NaT` and for which `isna()` returns `False`:

```
$ python -O
>>> res = Timestamp(iNaT + 1) - Timestamp(1)
>>> res, res._value, pd.isna(res), res is pd.NaT
(Timedelta('-106752 days +00:12:43.145224192'), -9223372036854775808, False, False)
```

The sentinel result now raises the same `OutOfBoundsDatetime` the neighbouring difference one step further out of bounds already raises, so the operation is self-consistent at its lower bound. `res_value` is an untyped Cython local, so the subtraction itself is Python-int arithmetic and never wraps — the only hole was landing exactly on the sentinel, hence a single equality check rather than a `checked_sub`.

Scoped deliberately: the `assert` in `_timedelta_from_value_and_reso` is left in place, since it is still reachable from `Timedelta.__mul__`/`__truediv__`, which GH-66552 lists separately and which need an exception-type decision (bare `OverflowError` on the scalar vs `OutOfBoundsTimedelta` on `TimedeltaIndex`).