### PR TITLE
BUG: Timestamp +/- timedelta64 ndarray silently wrapping (GH#66552)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -365,6 +365,7 @@ Datetimelike
 - Bug in :meth:`Series.dt.isocalendar` with a pyarrow-backed datetime or date dtype not preserving the original index, resetting it to a default :class:`RangeIndex` (:issue:`65894`)
 - Bug in adding a :class:`DateOffset` with a ``milliseconds`` component to a :class:`Timestamp` returning a microsecond-resolution result, inconsistent with the millisecond-resolution result of the equivalent :class:`DatetimeIndex` and :class:`Series` operations (:issue:`64806`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
+- Bug in adding or subtracting a ``timedelta64`` NumPy array and a timezone-naive :class:`Timestamp` where the promotion to the finer of the two resolutions, or the addition itself, silently wrapped to an unrelated date instead of raising :class:`OutOfBoundsDatetime`, unlike the timezone-aware and scalar equivalents (:issue:`66552`)
 - Bug in subtracting :class:`BusinessHour` (or :class:`CustomBusinessHour`) from a :class:`Timestamp` giving incorrect results when the subtraction would land exactly on the business-hour opening time (:issue:`33682`)
 
 Timedelta

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -84,7 +84,11 @@ from pandas._libs.tslibs.nattype cimport (
 )
 from pandas._libs.tslibs.np_datetime cimport (
     NPY_DATETIMEUNIT,
+    NPY_FR_GENERIC,
+    NPY_FR_W,
     NPY_FR_ns,
+    add_overflowsafe,
+    astype_overflowsafe,
     check_nat_sentinel,
     cmp_dtstructs,
     cmp_scalar,
@@ -192,6 +196,58 @@ def integer_op_not_supported(obj):
         "use `n * obj.freq`"
     )
     return TypeError(int_addsub_msg)
+
+
+cdef _addsub_timedelta64_array(_Timestamp ts, ndarray other, bint subtract):
+    """
+    Add or subtract a timedelta64 ndarray to/from a tz-naive Timestamp.
+
+    Matching numpy, the operands are cast to the finer of the two units. Unlike
+    numpy, both that cast and the addition itself raise instead of wrapping,
+    matching what the scalar and tz-aware paths already do (GH#66552).
+    """
+    cdef:
+        NPY_DATETIMEUNIT other_reso = get_unit_from_dtype(other.dtype)
+        NPY_DATETIMEUNIT reso = ts._creso
+        ndarray i8other, i8result
+
+    if other_reso == NPY_FR_GENERIC:
+        # numpy reads a generic timedelta64 in the other operand's unit
+        other_reso = reso
+    elif other_reso < NPY_FR_W or other_reso > NPY_FR_ns:
+        # year/month, which numpy itself refuses to add to a time unit, and
+        #  sub-nanosecond units, which we have no reso for; leave both to numpy
+        return (ts.asm8 - other) if subtract else (ts.asm8 + other)
+
+    if reso < other_reso:
+        ts = ts._as_creso(other_reso, round_ok=True)
+        reso = other_reso
+    elif reso > other_reso:
+        other = astype_overflowsafe(
+            other, np.dtype(f"m8[{npy_unit_to_abbrev(reso)}]")
+        )
+
+    if not other.dtype.isnative:
+        # the view below would misread a byte-swapped buffer
+        other = other.astype(other.dtype.newbyteorder("="))
+
+    i8other = other.view("i8")
+    if subtract:
+        # NPY_NAT negates to itself, so NaT still propagates
+        i8other = np.negative(i8other)
+
+    try:
+        i8result = add_overflowsafe(i8other, np.array(ts._value, dtype="i8"))
+    except OverflowError as err:
+        raise OutOfBoundsDatetime(
+            f"Out of bounds {npy_unit_to_attrname[reso]} timestamp"
+        ) from err
+
+    result = i8result.view(f"M8[{npy_unit_to_abbrev(reso)}]")
+    if result.ndim == 0:
+        # match numpy, which gives back a scalar rather than a 0-dim array
+        return result[()]
+    return result
 
 
 class MinMaxReso:
@@ -636,7 +692,7 @@ cdef class _Timestamp(ABCTimestamp):
                 raise integer_op_not_supported(self)
             if other.dtype.kind == "m":
                 if self.tz is None:
-                    return self.asm8 + other
+                    return _addsub_timedelta64_array(self, other, subtract=False)
                 return np.asarray(
                     [self + other[n] for n in range(len(other))],
                     dtype=object,
@@ -663,7 +719,7 @@ cdef class _Timestamp(ABCTimestamp):
                 raise integer_op_not_supported(self)
             if other.dtype.kind == "m":
                 if self.tz is None:
-                    return self.asm8 - other
+                    return _addsub_timedelta64_array(self, other, subtract=True)
                 return np.asarray(
                     [self - other[n] for n in range(len(other))],
                     dtype=object,

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -257,6 +257,59 @@ class TestTimestampArithmetic:
         with pytest.raises(TypeError, match=msg):
             other - ts
 
+    @pytest.mark.parametrize("subtract", [False, True])
+    def test_addsub_m8ndarray_overflow_in_cast(self, subtract):
+        # GH#66552 the promotion to the finer of the two units used to wrap
+        ts = Timestamp("2500-01-01").as_unit("s")
+        other = np.array([1], dtype="m8[ns]")
+
+        msg = "Cannot cast 2500-01-01 00:00:00 to unit='ns' without overflow"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            ts - other if subtract else ts + other
+
+        # the coarser operand is the one cast when the Timestamp is finer
+        ts = Timestamp("2000-01-01").as_unit("ns")
+        other = np.array([2**62], dtype="m8[s]")
+
+        msg = "Cannot convert 4611686018427387904 seconds to timedelta64"
+        with pytest.raises(OutOfBoundsTimedelta, match=msg):
+            ts - other if subtract else ts + other
+
+    @pytest.mark.parametrize("subtract", [False, True])
+    def test_addsub_m8ndarray_overflow(self, subtract):
+        # GH#66552 the addition itself used to wrap
+        ts = Timestamp("2000-01-01").as_unit("ns")
+        other = np.array([9 * 10**18], dtype="m8[ns]")
+        if subtract:
+            other = -other
+
+        msg = "Out of bounds nanosecond timestamp"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            ts - other if subtract else ts + other
+
+    @pytest.mark.parametrize("unit", ["s", "ns"])
+    def test_addsub_m8ndarray_byteswapped(self, unit):
+        # GH#66552 the overflow check reads the values as int64
+        ts = Timestamp("2000-01-01").as_unit("s")
+        other = np.array([1], dtype=f">m8[{unit}]")
+
+        expected = ts.as_unit(unit).asm8 + np.array([1], dtype=f"m8[{unit}]")
+        tm.assert_numpy_array_equal(ts + other, expected)
+
+        expected = ts.as_unit(unit).asm8 - np.array([1], dtype=f"m8[{unit}]")
+        tm.assert_numpy_array_equal(ts - other, expected)
+
+    def test_addsub_m8ndarray_nat_operand(self):
+        # GH#66552 a NaT operand still propagates rather than raising
+        ts = Timestamp("2000-01-01").as_unit("s")
+        other = np.array([np.timedelta64("NaT", "s"), np.timedelta64(1, "s")])
+
+        expected = np.array(["NaT", "2000-01-01 00:00:01"], dtype="M8[s]")
+        tm.assert_numpy_array_equal(ts + other, expected)
+
+        expected = np.array(["NaT", "1999-12-31 23:59:59"], dtype="M8[s]")
+        tm.assert_numpy_array_equal(ts - other, expected)
+
     @pytest.mark.parametrize("shape", [(6,), (2, 3)])
     def test_addsub_m8ndarray_tzaware(self, shape):
         # GH#33296


### PR DESCRIPTION
Addresses item 3 of GH-66552.

The tz-naive `is_array` branch of `_Timestamp.__add__`/`__sub__` was a raw `self.asm8 +/- other`, which wraps in two places: on numpy's promotion to the finer of the two units, and in the addition itself.

```python
>>> Timestamp("2500-01-01").as_unit("s") + np.array([1], "m8[ns]")
array(["1915-06-14T00:25:26.290448385"], dtype="datetime64[ns]")
>>> Timestamp("2000-01-01") + np.array([9 * 10**18], "m8[ns]")
array(["1700-08-23T16:25:26.290448384"], dtype="datetime64[ns]")
```

Both now raise. The exception type is pinned by the tz-aware branch of the same method, which loops through the scalar path and so already gives `OutOfBoundsDatetime` for the first case and `OutOfBoundsTimedelta` when it is the coarser operand that has to be cast.

Scope is deliberately just this one item: no sentinel check is added here, since the scalar `Timestamp + Timedelta` half of GH-66552 item 1 is still open and guarding only the array side would introduce the scalar/array disagreement the issue warns about.

Four behaviors preserved rather than "fixed", each verified by probing:

- `m8[Y]`/`m8[M]` and sub-nanosecond units fall through to numpy. `astype_overflowsafe` would otherwise convert a year as 365 days and truncate 1 ps to 0 us, and numpy itself raises `UFuncTypeError` for the former.
- A generic `m8` array is read in the other operand's unit, matching numpy.
- 0-dim input returns a numpy scalar, not a 0-dim array.
- NaT still propagates (`NPY_NAT` negates to itself, so the subtract direction is safe).

One adjacent bug surfaced while writing this: viewing as `int64` misreads a non-native-byteorder buffer, so `ts.as_unit("s") + np.array([1], ">m8[s]")` came back as year 2283416254. No existing test covers big-endian `m8`; one is added.

Verified with an exact Python-int oracle over 4 Timestamp resolutions x 8 timedelta64 units x 400 magnitudes x add/sub: 0 mismatches, 0 spurious raises, 0 missed raises.

One cost worth flagging: 1M-element `Timestamp + m8[us]` goes 1.3 ms -> 14.9 ms, the known per-element `add_overflowsafe` price. No internal path does `Timestamp + ndarray`, and `DatetimeArray + Timedelta` already pays the same. The min/max fast path GH-66552 proposes belongs inside `add_overflowsafe`, where it would speed up the existing callers too, and is not trivial: a NaT in the array *is* the int64 minimum, which defeats a naive min/max guard.