### PR TITLE
BUG: Period arithmetic landing on the NaT sentinel (GH#66552)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -579,6 +579,7 @@ Period
 - Bug in :meth:`Period.strftime` where unknown format directives (e.g. ``"%Q"``) silently produced platform-dependent output and crashed the Python process on Windows; an ``Invalid format string`` ``ValueError`` is now raised on all platforms (:issue:`53562`)
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` returning incorrect timestamps when the target frequency normalized to nanoseconds (e.g. ``"1ns"``) or when converting a nanosecond ``Period`` to a coarser target frequency (:issue:`63760`)
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` with ``how="end"`` losing nanosecond precision when the target frequency normalized to nanoseconds (e.g. ``"1ns"``); the target frequency is now also validated when ``how="end"`` (:issue:`63760`)
+- Bug in adding an integer, timedelta or offset to a :class:`Period` returning ``NaT`` when the result was one step past the lower bound, instead of raising ``OverflowError`` as it already did further out (:issue:`66552`)
 -
 
 Plotting

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2056,6 +2056,19 @@ cdef class _Period(PeriodMixin):
     def __hash__(self):
         return hash((self.ordinal, self.freqstr))
 
+    cdef _period_from_computed_ordinal(self, int64_t ordinal):
+        """
+        Build a Period from an ordinal produced by arithmetic on this one.
+
+        NPY_NAT is INT64_MIN, so an ordinal that lands on it is not NaT but is
+        indistinguishable from it once stored; the Period constructor renders it
+        as NaT.  The neighbouring result one step further out already raises
+        OverflowError, as does the vectorized path. (GH#66552)
+        """
+        if ordinal == NPY_NAT:
+            raise OverflowError("Period ordinal is out of bounds")
+        return Period(ordinal=ordinal, freq=self._freq)
+
     def _add_timedeltalike_scalar(self, other) -> "Period":
         cdef:
             int64_t inc, ordinal
@@ -2082,7 +2095,7 @@ cdef class _Period(PeriodMixin):
                                         f"Period(freq={self.freqstr})") from err
         with cython.overflowcheck(True):
             ordinal = self._ordinal + inc
-        return Period(ordinal=ordinal, freq=self._freq)
+        return self._period_from_computed_ordinal(ordinal)
 
     def _add_offset(self, other) -> "Period":
         # Non-Tick DateOffset other
@@ -2092,7 +2105,7 @@ cdef class _Period(PeriodMixin):
         self._require_matching_unit(other._period_unit, base=True)
 
         ordinal = self._ordinal + other.n
-        return Period(ordinal=ordinal, freq=self._freq)
+        return self._period_from_computed_ordinal(ordinal)
 
     @cython.overflowcheck(True)
     def __add__(self, other):
@@ -2104,7 +2117,7 @@ cdef class _Period(PeriodMixin):
             return NaT
         elif util.is_integer_object(other):
             ordinal = self._ordinal + other * self._dtype._n
-            return Period(ordinal=ordinal, freq=self._freq)
+            return self._period_from_computed_ordinal(ordinal)
 
         elif is_period_object(other):
             # can't add datetime-like

--- a/pandas/tests/scalar/period/test_arithmetic.py
+++ b/pandas/tests/scalar/period/test_arithmetic.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import numpy as np
 import pytest
 
+from pandas._libs.tslibs import iNaT
 from pandas._libs.tslibs.period import IncompatibleFrequency
 
 from pandas import (
@@ -34,6 +35,28 @@ class TestPeriodArithmetic:
             per + Timedelta(1)
         with pytest.raises(OverflowError, match=msg):
             per + offsets.Nano(1)
+
+    def test_add_sub_nat_sentinel_raises(self):
+        # GH#66552: an ordinal that lands exactly on the NaT sentinel is not
+        #  NaT, but was rendered as NaT instead of raising like the step one
+        #  further out already does
+        msg = "Period ordinal is out of bounds"
+        per = Timestamp.min.to_period("ns")
+
+        with pytest.raises(OverflowError, match=msg):
+            per - 1
+        with pytest.raises(OverflowError, match=msg):
+            per - Timedelta(1)
+        with pytest.raises(OverflowError, match=msg):
+            per + offsets.Nano(-1)
+
+        # non-tick offsets take a separate branch
+        per = Period(ordinal=iNaT + 1, freq="M")
+
+        with pytest.raises(OverflowError, match=msg):
+            per - 1
+        with pytest.raises(OverflowError, match=msg):
+            per + offsets.MonthEnd(-1)
 
     def test_period_add_integer(self):
         per1 = Period(freq="D", year=2008, month=1, day=1)


### PR DESCRIPTION
One item from GH-66552: the scalar `Period` paths where an ordinal computed by arithmetic lands exactly on `NPY_NAT`.

`NPY_NAT` is `int64.min`, so such an ordinal is perfectly representable, but it is indistinguishable from `NaT` once stored and the `Period` constructor renders it as `NaT` — while the result one step further out raises:

```python
>>> per = pd.Timestamp.min.to_period("ns")   # ordinal == iNaT + 1
>>> per - 1
NaT
>>> per - 2
OverflowError: Python int too large to convert to C long
```

Three sites hand a computed ordinal to the constructor — `_add_timedeltalike_scalar`, `_add_offset` and the integer branch of `__add__` — and they now go through one helper that rejects the sentinel. `__sub__` delegates to `self + (-other)`, so subtraction is covered by the same three.

`OverflowError` because that is what the neighbour one step further out already raises on all three, and what the vectorized `PeriodIndex - 2` raises as well, so the scalar and array paths agree on the type.

Not covered here: the array path, where `pd.PeriodIndex([per]) - 1` still returns `NaT`. That is `add_overflowsafe`, which is shared with datetime64/timedelta64 and needs the `_sub_periodlike` opt-out described in the issue. This is the same split as GH-66580, which fixed the scalar `Timestamp - Timestamp` sentinel and left its array counterpart alone.

The new test sits next to `test_add_overflow_raises` (GH-55503), which covers the identical three sites at the top of the range.