### PR TITLE
BUG: convert_dtypes raises OverflowError for integers outside the int64 range

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -425,6 +425,7 @@ Conversion
 - Bug in dtype inference from ``object``-dtype data (e.g. :class:`Series` construction, :meth:`Series.map`, :meth:`DataFrame.infer_objects`) returning ``float64`` instead of ``object`` when a ``None`` came before an integer outside the ``int64``/``uint64`` range, or before a mix of signed and unsigned integers; these now infer the same dtype as the equivalent data without the ``None`` (:issue:`66519`)
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`)
 - Fixed bug in :class:`DataFrame` constructor where mutating the result could corrupt the source :class:`Series` or :class:`Index` when built with ``dtype="str"`` and ``infer_string=False`` (:issue:`63936`)
+- Fixed bug in :meth:`DataFrame.convert_dtypes` and :meth:`Series.convert_dtypes` raising ``OverflowError`` instead of retaining ``object`` dtype when given an integer outside the ``int64`` range (:issue:`66517`)
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``TypeError`` when ``to_replace`` was ``Ellipsis`` (``...``) (:issue:`50373`)
 - Fixed bug in :meth:`DataFrame.to_dict` with ``orient="index"`` did not respect the ``into`` argument in nested mappings (:issue:`65778`)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -972,7 +972,10 @@ def convert_dtypes(
                 and input_array.dtype == object
                 and (isinstance(inferred_dtype, str) and inferred_dtype == "integer")
             ):
-                inferred_dtype = target_int_dtype
+                arr = input_array[notna(input_array)]
+                if len(arr) == 0 or (arr.min() >= np.iinfo(np.int64).min
+                                     and arr.max() <= np.iinfo(np.int64).max):
+                    inferred_dtype = target_int_dtype
 
         if convert_floating:
             if input_array.dtype.kind in "fb":

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -334,7 +334,14 @@ class TestSeriesConvertDtypes:
         tm.assert_series_equal(result, expected)
 
     def test_convert_dtypes_complex(self):
-        # GH 60129
+        # GH 66517
         ser = pd.Series([1.5 + 3.0j, 1.5 - 3.0j])
         result = ser.convert_dtypes()
         tm.assert_series_equal(result, ser)
+
+    def test_convert_dtypes_overflow_stays_object(self):
+       result = pd.Series([2**64], dtype=object).convert_dtypes()
+       assert result.dtype == object
+
+       result = pd.Series([-(2**63) - 1], dtype=object).convert_dtypes()
+       assert result.dtype == object

--- a/test_overflow.py
+++ b/test_overflow.py
@@ -1,0 +1,7 @@
+import pandas as pd
+
+pd.Series([2**64], dtype=object).convert_dtypes()
+# OverflowError: Python int too large to convert to C long
+
+pd.Series([-(2**63) - 1], dtype=object).convert_dtypes()
+# OverflowError: Python int too large to convert to C long


### PR DESCRIPTION
- [x] closes #66517
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
