### PR TITLE
BUG: month and quarter offsets truncated n to 32 bits (GH#66549)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -335,6 +335,7 @@ Categorical
 
 Datetimelike
 ^^^^^^^^^^^^
+- Bug in :attr:`Timestamp.days_in_month`, and in month-end and business-day offsets, using a wrapped year to decide whether the year is a leap year, for second-resolution datetimes with a year beyond ``2**31`` (:issue:`66549`)
 - Bug in :class:`ArrowExtensionArray` where adding a :class:`DateOffset` to a ``date32[pyarrow]`` or ``date64[pyarrow]`` Series raised an ``ArrowTypeError`` (:issue:`57168`)
 - Bug in :class:`DatetimeIndex` constructor raising ``ValueError`` when passing equivalent but not equal frequencies (e.g. ``QS-FEB`` vs ``QS-MAY``) (:issue:`61086`)
 - Bug in :class:`DatetimeIndex` raising ``AttributeError`` when comparing against Arrow date types (date32, date64) (:issue:`62051`)
@@ -366,6 +367,7 @@ Datetimelike
 - Bug in :meth:`Series.dt.isocalendar` with a pyarrow-backed datetime or date dtype not preserving the original index, resetting it to a default :class:`RangeIndex` (:issue:`65894`)
 - Bug in ``day_of_week``, :meth:`Timestamp.weekday` and :meth:`Timestamp.day_name` returning a wrong weekday, or raising ``OverflowError``, for second-resolution datetimes with a year beyond ``2**31`` (:issue:`66549`)
 - Bug in adding a :class:`DateOffset` with a ``milliseconds`` component to a :class:`Timestamp` returning a microsecond-resolution result, inconsistent with the millisecond-resolution result of the equivalent :class:`DatetimeIndex` and :class:`Series` operations (:issue:`64806`)
+- Bug in adding a month-, quarter-, half-year-, year- or semi-month-based offset (e.g. :class:`MonthEnd`, :class:`QuarterEnd`, :class:`YearEnd`, :class:`SemiMonthEnd`) with ``n`` of magnitude ``2**31`` or more silently shifting by a wrapped number of periods, e.g. ``n=2**32`` behaving like ``n=0`` (:issue:`66549`)
 - Bug in adding non-nano :class:`DatetimeIndex` with non-vectorized offsets (e.g. :class:`CustomBusinessDay`, :class:`CustomBusinessMonthEnd`) having a sub-unit ``offset`` parameter incorrectly truncating the result or raising ``AttributeError`` (:issue:`56586`)
 - Bug in adding or subtracting a ``timedelta64`` NumPy array and a timezone-naive :class:`Timestamp` where the promotion to the finer of the two resolutions, or the addition itself, silently wrapped to an unrelated date instead of raising :class:`OutOfBoundsDatetime`, unlike the timezone-aware and scalar equivalents (:issue:`66552`)
 - Bug in subtracting :class:`BusinessHour` (or :class:`CustomBusinessHour`) from a :class:`Timestamp` giving incorrect results when the subtraction would land exactly on the business-hour opening time (:issue:`33682`)

--- a/pandas/_libs/tslibs/ccalendar.pxd
+++ b/pandas/_libs/tslibs/ccalendar.pxd
@@ -8,12 +8,12 @@ ctypedef (int32_t, int32_t, int32_t) iso_calendar_t
 
 cdef int dayofweek(int64_t y, int m, int d) noexcept nogil
 cdef bint is_leapyear(int64_t year) noexcept nogil
-cpdef int32_t get_days_in_month(int year, Py_ssize_t month) noexcept nogil
+cpdef int32_t get_days_in_month(int64_t year, Py_ssize_t month) noexcept nogil
 cpdef int32_t get_week_of_year(int year, int month, int day) noexcept nogil
 cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) noexcept nogil
 cpdef int32_t get_day_of_year(int year, int month, int day) noexcept nogil
-cpdef int get_lastbday(int year, int month) noexcept nogil
-cpdef int get_firstbday(int year, int month) noexcept nogil
+cpdef int get_lastbday(int64_t year, int month) noexcept nogil
+cpdef int get_firstbday(int64_t year, int month) noexcept nogil
 
 cdef dict c_MONTH_NUMBERS, MONTH_TO_CAL_NUM
 

--- a/pandas/_libs/tslibs/ccalendar.pyx
+++ b/pandas/_libs/tslibs/ccalendar.pyx
@@ -52,13 +52,13 @@ weekday_to_int = {int_to_weekday[key]: key for key in int_to_weekday}
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef int32_t get_days_in_month(int year, Py_ssize_t month) noexcept nogil:
+cpdef int32_t get_days_in_month(int64_t year, Py_ssize_t month) noexcept nogil:
     """
     Return the number of days in the given month of the given year.
 
     Parameters
     ----------
-    year : int
+    year : int64_t
     month : int
 
     Returns
@@ -264,13 +264,13 @@ cpdef int32_t get_day_of_year(int year, int month, int day) noexcept nogil:
 # ---------------------------------------------------------------------
 # Business Helpers
 
-cpdef int get_lastbday(int year, int month) noexcept nogil:
+cpdef int get_lastbday(int64_t year, int month) noexcept nogil:
     """
     Find the last day of the month that is a business day.
 
     Parameters
     ----------
-    year : int
+    year : int64_t
     month : int
 
     Returns
@@ -285,13 +285,13 @@ cpdef int get_lastbday(int year, int month) noexcept nogil:
     return days_in_month - max(((wkday + days_in_month - 1) % 7) - 4, 0)
 
 
-cpdef int get_firstbday(int year, int month) noexcept nogil:
+cpdef int get_firstbday(int64_t year, int month) noexcept nogil:
     """
     Find the first day of the month that is a business day.
 
     Parameters
     ----------
-    year : int
+    year : int64_t
     month : int
 
     Returns

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -4850,7 +4850,8 @@ cdef class SemiMonthOffset(SingleConstructorOffset):
                 i8other.ndim, i8other.shape, cnp.NPY_INT64, 0
             )
             npy_datetimestruct dts
-            int months, to_day, nadj, n = self._n
+            int64_t months, nadj, n = self._n
+            int to_day
             int days_in_month, day, anchor_dom = self._day_of_month
             bint is_start = isinstance(self, SemiMonthBegin)
             NPY_DATETIMEUNIT reso = get_unit_from_dtype(dtarr.dtype)
@@ -7602,28 +7603,28 @@ cdef datetime _shift_day(datetime other, int days):
     return localize_pydatetime(shifted, tz)
 
 
-cdef int year_add_months(npy_datetimestruct dts, int months) noexcept nogil:
+cdef int64_t year_add_months(npy_datetimestruct dts, int64_t months) noexcept nogil:
     """
     New year number after shifting npy_datetimestruct number of months.
     """
     return dts.year + (dts.month + months - 1) // 12
 
 
-cdef int month_add_months(npy_datetimestruct dts, int months) noexcept nogil:
+cdef int month_add_months(npy_datetimestruct dts, int64_t months) noexcept nogil:
     """
     New month number after shifting npy_datetimestruct
     number of months.
     """
     cdef:
-        int new_month = (dts.month + months) % 12
-    return 12 if new_month == 0 else new_month
+        int64_t new_month = (dts.month + months) % 12
+    return 12 if new_month == 0 else <int>new_month
 
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef ndarray shift_quarters(
     ndarray dtindex,
-    int quarters,
+    int64_t quarters,
     int q1start_month,
     str day_opt,
     int modby=3,
@@ -7636,7 +7637,7 @@ cdef ndarray shift_quarters(
     Parameters
     ----------
     dtindex : int64_t[:] timestamps for input dates
-    quarters : int number of quarters to shift
+    quarters : int64_t number of quarters to shift
     q1start_month : int month in which Q1 begins by convention
     day_opt : {'start', 'end', 'business_start', 'business_end'}
     modby : int (3 for quarters, 12 for years)
@@ -7651,7 +7652,8 @@ cdef ndarray shift_quarters(
         ndarray out = cnp.PyArray_EMPTY(dtindex.ndim, dtindex.shape, cnp.NPY_INT64, 0)
         Py_ssize_t _
         int64_t val, res_val
-        int months_since, n
+        int months_since
+        int64_t n
         npy_datetimestruct dts
         cnp.broadcast mi = cnp.PyArray_MultiIterNew2(out, dtindex)
         _DayOpt day_opt_enum = _str_to_day_opt(day_opt)
@@ -7688,7 +7690,7 @@ cdef ndarray shift_quarters(
 @cython.boundscheck(False)
 def shift_months(
     ndarray dtindex,  # int64_t, arbitrary ndim
-    int months,
+    int64_t months,
     str day_opt=None,
     NPY_DATETIMEUNIT reso=NPY_DATETIMEUNIT.NPY_FR_ns,
 ):
@@ -7706,7 +7708,7 @@ def shift_months(
         npy_datetimestruct dts
         int count = dtindex.size
         ndarray out = cnp.PyArray_EMPTY(dtindex.ndim, dtindex.shape, cnp.NPY_INT64, 0)
-        int months_to_roll
+        int64_t months_to_roll
         int64_t val, res_val
         _DayOpt day_opt_enum
 
@@ -7794,8 +7796,9 @@ def shift_month(stamp: datetime, months: int, day_opt: object = None) -> datetim
     shifted : datetime or Timestamp (same as input `stamp`)
     """
     cdef:
-        int year, month, day
-        int days_in_month, dy
+        int month, day
+        int days_in_month
+        int64_t year, dy
         npy_datetimestruct dts
 
     if isinstance(stamp, _Timestamp):
@@ -7860,7 +7863,7 @@ cdef int get_day_of_month(npy_datetimestruct* dts, _DayOpt day_opt) noexcept nog
         return get_lastbday(dts.year, dts.month)
 
 
-cpdef int roll_convention(int other, int n, int compare) noexcept nogil:
+cpdef int64_t roll_convention(int other, int64_t n, int compare) noexcept nogil:
     """
     Possibly increment or decrement the number of periods to shift
     based on rollforward/rollbackward conventions.
@@ -7874,7 +7877,7 @@ cpdef int roll_convention(int other, int n, int compare) noexcept nogil:
 
     Returns
     -------
-    n : int number of periods to increment
+    n : int64_t number of periods to increment
     """
     if n > 0 and other < compare:
         n -= 1
@@ -7924,10 +7927,10 @@ def roll_qtrday(other: datetime, n: int, month: int,
     return _roll_qtrday(&dts, n, months_since, day_opt_enum)
 
 
-cdef int _roll_qtrday(npy_datetimestruct* dts,
-                      int n,
-                      int months_since,
-                      _DayOpt day_opt) noexcept nogil:
+cdef int64_t _roll_qtrday(npy_datetimestruct* dts,
+                          int64_t n,
+                          int months_since,
+                          _DayOpt day_opt) noexcept nogil:
     """
     See roll_qtrday.__doc__
     """

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -1314,6 +1314,60 @@ def test_dateoffset_n_vectorized_near_dst_transition(box, n):
     assert result[0] == scalar
 
 
+@pytest.mark.parametrize("box", [DatetimeIndex, Series])
+@pytest.mark.parametrize(
+    "offset",
+    [
+        offsets.MonthEnd(2**32),
+        offsets.MonthBegin(2**32),
+        offsets.SemiMonthEnd(2**32),
+        offsets.SemiMonthBegin(2**32),
+        offsets.QuarterEnd(2**32),
+        offsets.QuarterBegin(2**32),
+        offsets.HalfYearEnd(2**32),
+        offsets.YearEnd(2**32),
+        offsets.YearBegin(2**32),
+        offsets.BYearEnd(2**32),
+    ],
+)
+def test_offset_n_above_int32(box, offset):
+    # GH#66549 n was held in a C int, so a multiple of 2**32 silently truncated
+    #  to zero and the shift became a no-op
+    ts = Timestamp("2000-01-03").as_unit("s")
+    obj = box([ts])
+
+    result = box(obj + offset)
+    # 2**32 months is on the order of 3.6e8 years; a truncated n leaves us in 2000
+    assert result[0].year > 10**7
+
+    # the scalar path is a separate implementation, and truncated to zero too
+    assert result[0] == ts + offset
+
+
+def test_month_end_n_above_int32_exact():
+    # GH#66549 MonthEnd(n) shifts by n - 1 whole months when the starting day
+    #  is before the end of the month, then rolls to the end of that month
+    ts = Timestamp("2000-01-03").as_unit("s")
+
+    result = ts + offsets.MonthEnd(2**32)
+
+    months = (result.year - ts.year) * 12 + (result.month - ts.month)
+    assert months == 2**32 - 1
+    assert result.day == 30  # April
+
+
+def test_month_end_year_above_int32():
+    # GH#66549 get_days_in_month truncated the year to 32 bits, so the leap-year
+    #  determination used a wrapped year. 2147483700 is not a leap year, but
+    #  2147483700 - 2**32 is.
+    dti = DatetimeIndex(np.array(["2147483700-02-05"], dtype="M8[s]"))
+
+    assert dti[0].days_in_month == 28
+    expected = DatetimeIndex(np.array(["2147483700-02-28"], dtype="M8[s]"))
+    tm.assert_index_equal(dti + offsets.MonthEnd(1), expected)
+    assert dti[0] + offsets.MonthEnd(1) == expected[0]
+
+
 @pytest.mark.parametrize("n", [1, 2])
 @pytest.mark.parametrize(
     "unit",


### PR DESCRIPTION
Addresses item 3 (and the remainder of item 4) of GH-66549. Not a full fix for that issue, so no closing keyword — items 1, 2 and 5 are still open, and item 1 is covered by GH-66567.

`n` was carried through the month-arithmetic layer in a C `int`, so an `n` that is a multiple of `2**32` silently became a no-op and `n >= 2**31` wrapped negative, on both the scalar and the vectorized paths:

```python
>>> dr = pd.date_range("2000-01-03", periods=1, unit="s")
>>> dr + pd.offsets.SemiMonthEnd(2**32)
DatetimeIndex(['2000-01-15'], dtype='datetime64[s]', freq=None)   # == SemiMonthEnd(0)
>>> dr + pd.offsets.QuarterEnd(2**32)
DatetimeIndex(['2000-03-31'], dtype='datetime64[s]', freq=None)   # == QuarterEnd(0)
```

Widened the period count to `int64_t` in `year_add_months`, `month_add_months`, `shift_months`, `shift_quarters`, `shift_month`, `roll_convention`, `_roll_qtrday` and `SemiMonthOffset._apply_array`. All ten affected offset classes now agree between the scalar and vectorized paths; `MonthEnd(2**32)` from `2000-01-03` gives `357915941-04-30`, i.e. `2**32 - 1` whole months.

Also widened the year argument of `get_days_in_month`, `get_lastbday` and `get_firstbday` from `int` to `int64_t` (the `dayofweek` half of that landed in GH-66589). This is required here rather than separable: without it those years are decided from a wrapped value, which is reachable at second resolution today —

```python
>>> dti = pd.DatetimeIndex(np.array(["2147483700-02-05"], dtype="M8[s]"))
>>> dti[0].days_in_month
29                                       # 2147483700 is not a leap year
>>> dti + pd.offsets.MonthEnd(1)
DatetimeIndex(['2147483700-02-29'], ...) # a day that does not exist
>>> dti[0] + pd.offsets.MonthEnd(1)
ValueError: day is out of range for month
```

Type widenings only; no behavior change for `n` within `int32`. Left for the other items: the bare `OverflowError` from the vendored C on out-of-bounds month shifts, `Week`/`BusinessDay` (a different mechanism — day-count adds rather than month arithmetic), and the duplicated `checked_*` externs.