### PR TITLE
BUG preserve non-string columns in JSON table roundtrip

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -554,6 +554,7 @@ MultiIndex
 
 I/O
 ^^^
+- Fixed bug in :func:`read_json` with ``orient="table"`` returning missing values when table schema column names were non-string scalars (:issue:`46392`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``EmptyDataError`` (matching the ``c`` and ``python`` engines) instead of a cryptic ``ParserError`` reporting ``Empty CSV file or block`` when no columns can be parsed from the input (:issue:`66065`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``ValueError`` for the unsupported ``na_filter=False`` instead of silently ignoring it (:issue:`66053`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises an informative ``TypeError`` when passed a text-mode file handle (the engine requires a binary buffer) instead of a cryptic ``a bytes-like object is required`` error (:issue:`66065`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -554,7 +554,6 @@ MultiIndex
 
 I/O
 ^^^
-- Fixed bug in :func:`read_json` with ``orient="table"`` returning missing values when table schema column names were non-string scalars (:issue:`46392`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``EmptyDataError`` (matching the ``c`` and ``python`` engines) instead of a cryptic ``ParserError`` reporting ``Empty CSV file or block`` when no columns can be parsed from the input (:issue:`66065`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``ValueError`` for the unsupported ``na_filter=False`` instead of silently ignoring it (:issue:`66053`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises an informative ``TypeError`` when passed a text-mode file handle (the engine requires a binary buffer) instead of a cryptic ``a bytes-like object is required`` error (:issue:`66065`)
@@ -583,6 +582,7 @@ I/O
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with an explicit string-like ``dtype`` (``object``, ``"str"``, ``"string"`` or ``"category"``) (:issue:`66525`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug in :func:`read_excel` with the ``openpyxl`` engine where reading a sheet set its ``max_row`` and ``max_column`` to ``None`` on the workbook exposed through ``ExcelFile.book`` (:issue:`63010`)
+- Fixed bug in :func:`read_json` with ``orient="table"`` returning missing values when table schema column names were non-string scalars (:issue:`46392`)
 - Fixed bug in :func:`read_sas` where ``encoding="infer"`` raised ``LookupError: unknown encoding: infer`` instead of falling back to latin-1, for SAS7BDAT files recording an encoding pandas does not recognize and for XPORT files, which record no encoding at all (:issue:`66470`)
 - Fixed bug where :func:`read_html` parsed nested tables incorrectly when using ``html5lib`` or ``bs4`` flavors (:issue:`64524`)
 - Fixed bugs in :func:`read_csv` with ``engine="pyarrow"`` where column names were handled inconsistently with the other engines: duplicated names were not de-duplicated to ``"x.1"``-style names, empty header fields did not get ``"Unnamed: {i}"`` placeholder names, and an unnamed ``index_col`` produced an index named ``""`` instead of an unnamed index (:issue:`13017`, :issue:`35211`)

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -422,6 +422,12 @@ class JSONTableWriter(FrameWriter):
             msg = "Overlapping names between the index and columns"
             raise ValueError(msg)
 
+        field_names = [str(field["name"]) for field in self.schema["fields"]]
+        if len(field_names) != len(set(field_names)):
+            raise ValueError(
+                "Table schema field names must be unique after conversion to string"
+            )
+
         timedeltas = obj.select_dtypes(include=["timedelta"]).columns
         copied = False
         if len(timedeltas):

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -13,6 +13,7 @@ from typing import (
     Literal,
     Self,
     TypeVar,
+    cast,
     final,
     overload,
 )
@@ -422,7 +423,8 @@ class JSONTableWriter(FrameWriter):
             msg = "Overlapping names between the index and columns"
             raise ValueError(msg)
 
-        field_names = [str(field["name"]) for field in self.schema["fields"]]
+        fields = cast("list[dict[str, Any]]", self.schema["fields"])
+        field_names = [str(field["name"]) for field in fields]
         if len(field_names) != len(set(field_names)):
             raise ValueError(
                 "Table schema field names must be unique after conversion to string"

--- a/pandas/io/json/_table_schema.py
+++ b/pandas/io/json/_table_schema.py
@@ -35,7 +35,10 @@ from pandas.core.dtypes.dtypes import (
     PeriodDtype,
 )
 
-from pandas import DataFrame
+from pandas import (
+    DataFrame,
+    Index,
+)
 import pandas.core.common as com
 
 from pandas.tseries.frequencies import to_offset
@@ -378,7 +381,13 @@ def parse_table_schema(json, precise_float: bool) -> DataFrame:
     """
     table = ujson_loads(json, precise_float=precise_float)
     col_order = [field["name"] for field in table["schema"]["fields"]]
-    df = DataFrame(table["data"], columns=col_order)[col_order]
+    stringified_col_order = [str(column) for column in col_order]
+    if len(stringified_col_order) != len(set(stringified_col_order)):
+        raise ValueError(
+            "Table schema field names must be unique after conversion to string"
+        )
+    df = DataFrame(table["data"], columns=stringified_col_order)
+    df.columns = col_order
 
     dtypes = {
         field["name"]: convert_json_field_to_pandas_type(field)
@@ -394,8 +403,11 @@ def parse_table_schema(json, precise_float: bool) -> DataFrame:
     with option_context("future.distinguish_nan_and_na", False):
         df = df.astype(dtypes)
 
+    data_columns = col_order
     if "primaryKey" in table["schema"]:
-        df = df.set_index(table["schema"]["primaryKey"])
+        primary_key = table["schema"]["primaryKey"]
+        df = df.set_index(primary_key)
+        data_columns = [column for column in col_order if column not in primary_key]
         if len(df.index.names) == 1:
             if df.index.name == "index":
                 df.index.name = None
@@ -404,4 +416,5 @@ def parse_table_schema(json, precise_float: bool) -> DataFrame:
                 None if x.startswith("level_") else x for x in df.index.names
             ]
 
+    df.columns = Index(data_columns)
     return df

--- a/pandas/io/json/_table_schema.py
+++ b/pandas/io/json/_table_schema.py
@@ -380,7 +380,25 @@ def parse_table_schema(json, precise_float: bool) -> DataFrame:
     pandas.read_json
     """
     table = ujson_loads(json, precise_float=precise_float)
-    col_order = [field["name"] for field in table["schema"]["fields"]]
+    fields = table["schema"]["fields"]
+    schema_col_order = [field["name"] for field in fields]
+    col_order = schema_col_order.copy()
+
+    if table["data"]:
+        data_col_order = list(table["data"][0])
+        for i, column in enumerate(col_order):
+            # Object keys keep the full float representation, while numeric
+            # schema field names are limited by to_json's double_precision.
+            if (
+                isinstance(column, float)
+                and str(column) not in data_col_order
+                and i < len(data_col_order)
+            ):
+                try:
+                    col_order[i] = float(data_col_order[i])
+                except ValueError:
+                    pass
+
     stringified_col_order = [str(column) for column in col_order]
     if len(stringified_col_order) != len(set(stringified_col_order)):
         raise ValueError(
@@ -390,8 +408,8 @@ def parse_table_schema(json, precise_float: bool) -> DataFrame:
     df.columns = col_order
 
     dtypes = {
-        field["name"]: convert_json_field_to_pandas_type(field)
-        for field in table["schema"]["fields"]
+        column: convert_json_field_to_pandas_type(field)
+        for column, field in zip(col_order, fields, strict=True)
     }
 
     # No ISO constructor for Timedelta as of yet, so need to raise
@@ -406,6 +424,11 @@ def parse_table_schema(json, precise_float: bool) -> DataFrame:
     data_columns = col_order
     if "primaryKey" in table["schema"]:
         primary_key = table["schema"]["primaryKey"]
+        if not isinstance(primary_key, list):
+            primary_key = [primary_key]
+        primary_key = [
+            col_order[schema_col_order.index(column)] for column in primary_key
+        ]
         df = df.set_index(primary_key)
         data_columns = [column for column in col_order if column not in primary_key]
         if len(df.index.names) == 1:

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -746,6 +746,24 @@ class TestTableOrientReader:
         result = pd.read_json(out, orient="table")
         tm.assert_frame_equal(df, result)
 
+    @pytest.mark.parametrize("columns", [[1, 2], [1.5, 2.5], [True, False]])
+    def test_read_json_table_orient_non_string_columns(self, columns):
+        # GH 46392
+        expected = DataFrame([[1, 2], [3, 4]], columns=columns)
+
+        result = pd.read_json(
+            StringIO(expected.to_json(orient="table")), orient="table"
+        )
+
+        tm.assert_frame_equal(result, expected)
+
+    def test_json_table_orient_stringified_column_collision(self):
+        df = DataFrame([[1, 2]], columns=[1, "1"])
+
+        msg = "field names must be unique after conversion to string"
+        with pytest.raises(ValueError, match=msg):
+            df.to_json(orient="table")
+
     @pytest.mark.parametrize(
         "index_nm",
         [

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -746,7 +746,7 @@ class TestTableOrientReader:
         result = pd.read_json(out, orient="table")
         tm.assert_frame_equal(df, result)
 
-    @pytest.mark.parametrize("columns", [[1, 2], [1.5, 2.5], [True, False]])
+    @pytest.mark.parametrize("columns", [[1, 2], [np.pi, 2.5], [True, False]])
     def test_read_json_table_orient_non_string_columns(self, columns):
         # GH 46392
         expected = DataFrame([[1, 2], [3, 4]], columns=columns)
@@ -754,6 +754,23 @@ class TestTableOrientReader:
         result = pd.read_json(
             StringIO(expected.to_json(orient="table")), orient="table"
         )
+
+        tm.assert_frame_equal(result, expected)
+
+    def test_read_json_table_orient_scalar_primary_key(self):
+        data = """{
+            "schema": {
+                "fields": [
+                    {"name": "index", "type": "integer"},
+                    {"name": "e", "type": "integer"}
+                ],
+                "primaryKey": "index"
+            },
+            "data": [{"index": 0, "e": 1}]
+        }"""
+        expected = DataFrame({"e": [1]})
+
+        result = pd.read_json(StringIO(data), orient="table")
 
         tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
JSON object keys are always strings, while the table schema retains scalar column labels such as integers. `parse_table_schema` previously passed the original labels directly to the `DataFrame` constructor, so those labels did not match the decoded string keys and the resulting columns were filled with missing values.

This change reads records using stringified field names, restores the schema labels, and rebuilds the final column `Index` after extracting the primary key so both label values and label dtype round-trip. It covers integer, float, and boolean labels.

Labels such as `1` and `"1"` collapse to the same JSON object key. The table writer and reader now reject that collision explicitly instead of silently losing data.

Tests:

- `python -m pytest pandas/tests/io/json/test_json_table_schema.py -q` (`186 passed`)
- `python -m pytest pandas/tests/io/json -m "not network" -q` (`1037 passed`)
- Ruff check and format checks on changed Python files
- codespell on all changed files

AI disclosure: I used Codex to help investigate, implement, and test this change. I reviewed the resulting diff and test coverage before submission, and prompted it to follow `AGENTS.md`.

- [x] closes #46392
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions (not applicable; no new API)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
