### PR TITLE
BUG handle remaining ujson encoder API failures

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -556,6 +556,7 @@ MultiIndex
 
 I/O
 ^^^
+- Fixed segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when object iteration, dictionary-key conversion, or label encoding raises an exception (:issue:`66356`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``EmptyDataError`` (matching the ``c`` and ``python`` engines) instead of a cryptic ``ParserError`` reporting ``Empty CSV file or block`` when no columns can be parsed from the input (:issue:`66065`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``ValueError`` for the unsupported ``na_filter=False`` instead of silently ignoring it (:issue:`66053`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises an informative ``TypeError`` when passed a text-mode file handle (the engine requires a binary buffer) instead of a cryptic ``a bytes-like object is required`` error (:issue:`66065`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -911,6 +911,9 @@ static const char *Tuple_iterGetName(JSOBJ Py_UNUSED(obj),
 static void Set_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->itemValue = NULL;
   GET_TC(tc)->iterator = PyObject_GetIter(obj);
+  if (GET_TC(tc)->iterator == NULL) {
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+  }
 }
 
 static int Set_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
@@ -919,9 +922,15 @@ static int Set_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     GET_TC(tc)->itemValue = NULL;
   }
 
-  PyObject *item = PyIter_Next(GET_TC(tc)->iterator);
+  if (GET_TC(tc)->iterator == NULL) {
+    return 0;
+  }
 
+  PyObject *item = PyIter_Next(GET_TC(tc)->iterator);
   if (item == NULL) {
+    if (PyErr_Occurred()) {
+      ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    }
     return 0;
   }
 
@@ -959,6 +968,11 @@ static const char *Set_iterGetName(JSOBJ Py_UNUSED(obj),
 static void Dir_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->attrList = PyObject_Dir(obj);
   GET_TC(tc)->index = 0;
+  if (GET_TC(tc)->attrList == NULL) {
+    GET_TC(tc)->size = 0;
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return;
+  }
   GET_TC(tc)->size = PyList_GET_SIZE(GET_TC(tc)->attrList);
 }
 
@@ -973,7 +987,8 @@ static void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     GET_TC(tc)->itemName = NULL;
   }
 
-  Py_DECREF((PyObject *)GET_TC(tc)->attrList);
+  Py_XDECREF((PyObject *)GET_TC(tc)->attrList);
+  GET_TC(tc)->attrList = NULL;
 }
 
 static int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
@@ -982,6 +997,10 @@ static int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
   PyObject *itemName = GET_TC(tc)->itemName;
 
   if (PyErr_Occurred() || ((JSONObjectEncoder *)tc->encoder)->errorMsg) {
+    return 0;
+  }
+
+  if (GET_TC(tc)->attrList == NULL) {
     return 0;
   }
 
@@ -999,6 +1018,10 @@ static int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
     PyObject *attrName =
         PyList_GET_ITEM(GET_TC(tc)->attrList, GET_TC(tc)->index);
     PyObject *attr = PyUnicode_AsUTF8String(attrName);
+    if (attr == NULL) {
+      ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+      return 0;
+    }
     const char *attrStr = PyBytes_AS_STRING(attr);
 
     if (attrStr[0] == '_') {
@@ -1267,11 +1290,19 @@ static int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String(GET_TC(tc)->itemName);
   } else if (!PyBytes_Check(GET_TC(tc)->itemName)) {
     GET_TC(tc)->itemName = PyObject_Str(GET_TC(tc)->itemName);
+    if (GET_TC(tc)->itemName == NULL) {
+      ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+      return 0;
+    }
     PyObject *itemNameTmp = GET_TC(tc)->itemName;
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String(GET_TC(tc)->itemName);
     Py_DECREF(itemNameTmp);
   } else {
     Py_INCREF(GET_TC(tc)->itemName);
+  }
+  if (GET_TC(tc)->itemName == NULL) {
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    return 0;
   }
   return 1;
 }
@@ -1455,6 +1486,12 @@ static char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
       }
 
       cLabel = (char *)PyUnicode_AsUTF8(item);
+      if (cLabel == NULL) {
+        Py_DECREF(item);
+        NpyArr_freeLabels(ret, num);
+        ret = 0;
+        break;
+      }
       len = strlen(cLabel);
     }
 
@@ -1895,6 +1932,9 @@ ISITERABLE:
       pc->rowLabels = NpyArr_encodeLabels((PyArrayObject *)values, enc,
                                           pc->rowLabelsLen, values_is_utc);
       Py_DECREF(tmpObj);
+      if (!pc->rowLabels) {
+        goto INVALID;
+      }
       tmpObj =
           (enc->outputFormat == INDEX ? PyObject_GetAttrString(obj, "columns")
                                       : PyObject_GetAttrString(obj, "index"));

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -676,6 +676,53 @@ class TestUltraJSONTests:
             "d": 4,
         }
 
+    def test_encode_object_bad_dir(self):
+        class _TestObject:
+            def __dir__(self):
+                raise TypeError("I raise you one exception")
+
+        with pytest.raises(TypeError, match="I raise you one exception"):
+            ujson.ujson_dumps(_TestObject())
+
+    def test_encode_object_dir_surrogate(self):
+        class _TestObject:
+            def __dir__(self):
+                return ["\ud800"]
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps(_TestObject())
+
+    def test_encode_bad_set(self):
+        class MySet(set):
+            def __iter__(self):
+                raise TypeError("I raise you one exception")
+
+        with pytest.raises(TypeError, match="I raise you one exception"):
+            ujson.ujson_dumps(MySet([1, 2, 3]))
+
+    def test_encode_bad_set_iterator_next(self):
+        class MySet(set):
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise TypeError("I raise you one exception")
+
+        with pytest.raises(TypeError, match="I raise you one exception"):
+            ujson.ujson_dumps(MySet([1, 2, 3]))
+
+    def test_encode_dict_with_lone_surrogate_key(self):
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps({"\ud800": "value"})
+
+    def test_encode_dict_with_lone_surrogate_object_key(self):
+        class LoneSurrogateProxy:
+            def __str__(self):
+                return "\ud800"
+
+        with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+            ujson.ujson_dumps({LoneSurrogateProxy(): "value"})
+
     def test_ujson__name__(self):
         # GH 52898
         assert ujson.__name__ == "pandas._libs._ujson"
@@ -854,6 +901,27 @@ class TestPandasJSONTests:
             "df2": ujson.ujson_loads(ujson.ujson_dumps(df, **kwargs)),
         }
         assert ujson.ujson_loads(ujson.ujson_dumps(nested, **kwargs)) == exp
+
+    def test_encode_labels_invalid_str(self):
+        class LoneSurrogateProxy:
+            def __str__(self):
+                return "\ud800"
+
+        for obj in [
+            DataFrame({LoneSurrogateProxy(): [1, 2, 3]}),
+            DataFrame({"a": [1, 2, 3]}, index=[LoneSurrogateProxy()] * 3),
+            Series([1, 2, 3], index=[LoneSurrogateProxy()] * 3),
+        ]:
+            with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+                ujson.ujson_dumps(obj)
+
+    def test_encode_labels_custom_str(self):
+        class Proxy:
+            def __str__(self):
+                return "proxy"
+
+        result = ujson.ujson_loads(ujson.ujson_dumps(DataFrame({Proxy(): [1]})))
+        assert result == {"proxy": {"0": 1}}
 
     def test_series(self, orient):
         dtype = np.int64


### PR DESCRIPTION
xref #66356

This complements #66357 and intentionally does not duplicate its fixes for large integer values, `Decimal` subclasses, or `datetime.time`.

## What changed

- Preserve exceptions raised while creating or advancing set iterators.
- Handle failures from `PyObject_Dir` and UTF-8 conversion of attribute names.
- Handle dict-key string and UTF-8 conversion failures.
- Propagate UTF-8 conversion failures for pandas labels.
- Add focused regression tests and a whatsnew entry.

Unchecked Python C API failures in these remaining paths could leave a pending exception and then dereference a NULL pointer, producing a process crash instead of a Python exception.

## Validation

Validated from a fresh Meson/Ninja build based on `ac9ca5033fdd5357c0a8d8b13b28a8195912b905`:

- 8 new regression tests passed.
- `pandas/tests/io/json/test_ujson.py`: 228 passed, 1 skipped (optional `pytz` unavailable).
- The compiled `_ujson` extension was loaded from the fresh build directory.

## Checklist

- [x] Tests added and passed.
- [x] Added an entry in the latest whatsnew file.
- [x] Reviewed and followed the contribution guidelines.
- [x] AI assistance was prompted to follow `AGENTS.md`.

AI assistance was used to discover, stress-test, review, and validate these failure paths. The final diff was deliberately narrowed to the cases not covered by #66357.