### PR TITLE
TST: define all_reductions fixture in the EA tests

### DIFF
--- a/pandas/tests/extension/conftest.py
+++ b/pandas/tests/extension/conftest.py
@@ -212,3 +212,30 @@ def invalid_scalar(data):
     If the array can hold any item (i.e. object dtype), then use pytest.skip.
     """
     return object.__new__(object)
+
+
+@pytest.fixture(
+    params=[
+        # numeric reductions
+        "count",
+        "sum",
+        "max",
+        "min",
+        "mean",
+        "prod",
+        "std",
+        "var",
+        "median",
+        "kurt",
+        "skew",
+        "sem",
+        # boolean reductions
+        "all",
+        "any",
+    ]
+)
+def all_reductions(request):
+    """
+    Fixture for all (boolean + numeric) reduction names.
+    """
+    return request.param


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/63512, ensuring the EA base tests only use fixtures defined locally in its conftest.py (otherwise downstream users have to redefine those fixtures)