### PR TITLE
BUG: read_csv parallel default ignored CPU affinity and cgroup limits

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1535,7 +1535,7 @@ considerably. This happens automatically when all of the following hold:
 
 * ``filepath_or_buffer`` is a local, uncompressed file path
 * the C engine is used (the default)
-* the file is at least 50 MB
+* the file is at least 5 MB
 * no options are passed that require parsing the file as a whole, such as
   ``iterator``, ``chunksize``, ``nrows``, ``usecols``, ``index_col``,
   ``parse_dates``, list/callable ``skiprows``, multi-row headers, or
@@ -1544,11 +1544,14 @@ considerably. This happens automatically when all of the following hold:
 Calls that are not eligible fall back to the serial path, and the result is
 always identical to a serial read.
 
-The number of threads is controlled with the ``mode.max_threads`` option,
-which defaults to the number of CPU cores, capped at ``4``. On Windows the
-default is ``1`` (serial), as parallel reading currently does not improve
-performance there. Set the option to ``1`` to disable parallel reading, e.g.
-when pandas runs inside an application that already parallelizes work:
+The number of threads is controlled with the ``mode.max_threads`` option, which
+defaults to the number of CPU cores, capped at ``4`` and limited to the CPUs
+available to the process -- CPU affinity, and the cgroup CPU quota when the
+process runs in its own cgroup namespace, as it does under Docker and
+Kubernetes. On Windows the default is ``1`` (serial), as parallel reading
+currently does not improve performance there. Set the option to ``1`` to
+disable parallel reading, e.g. when pandas runs inside an application that
+already parallelizes work:
 
 .. code-block:: python
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1535,7 +1535,9 @@ considerably. This happens automatically when all of the following hold:
 
 * ``filepath_or_buffer`` is a local, uncompressed file path
 * the C engine is used (the default)
-* the file is at least 5 MB
+* the file's data rows total at least 5 MB, excluding any header preamble
+* more than one thread is in use -- see ``mode.max_threads`` below, which
+  defaults to ``1`` on Windows and when the process is limited to a single CPU
 * no options are passed that require parsing the file as a whole, such as
   ``iterator``, ``chunksize``, ``nrows``, ``usecols``, ``index_col``,
   ``parse_dates``, list/callable ``skiprows``, multi-row headers, or

--- a/pandas/compat/_cpu.py
+++ b/pandas/compat/_cpu.py
@@ -86,9 +86,10 @@ def available_cpu_count() -> int | None:
     On Linux ``sched_getaffinity`` always succeeds, so an unconstrained box
     reports its full logical CPU count rather than ``None``.
 
-    Cached for the process lifetime: the CPU allocation is effectively static
-    (cgroup limits do not change at runtime and affinity is normally set once at
-    startup), and this is on the ``read_csv`` hot path.
+    Cached for the process lifetime: the CPU allocation is static in practice
+    (affinity is normally set once at startup, and a live quota change via
+    ``docker update`` or an in-place pod resize is rare), and this is on the
+    ``read_csv`` hot path.
     """
     limits = []
     if hasattr(os, "sched_getaffinity"):

--- a/pandas/compat/_cpu.py
+++ b/pandas/compat/_cpu.py
@@ -1,7 +1,4 @@
 """
-_cpu
-====
-
 Detection of the CPU allocation actually available to this process.
 
 Used to bound the default worker count for parallel I/O, so that a default

--- a/pandas/compat/_cpu.py
+++ b/pandas/compat/_cpu.py
@@ -1,0 +1,102 @@
+"""
+_cpu
+====
+
+Detection of the CPU allocation actually available to this process.
+
+Used to bound the default worker count for parallel I/O, so that a default
+:func:`~pandas.read_csv` does not oversubscribe a machine on which the process
+has been given only a slice of the CPUs -- a CPU affinity mask, or a cgroup CPU
+quota as set by ``docker --cpus`` and Kubernetes CPU limits.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+
+
+def _read_sysfs_int(path: str) -> int | None:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return int(fh.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _read_sysfs_str(path: str) -> str | None:
+    # ValueError as well as OSError, matching _read_sysfs_int: a non-UTF-8 byte
+    # raises UnicodeDecodeError, and this feeds available_cpu_count(), which
+    # _default_n_workers calls unguarded -- so it would surface out of read_csv
+    # rather than falling back.
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read().strip()
+    except (OSError, ValueError):
+        return None
+
+
+def _parse_cgroup_v2_quota(text: str) -> float | None:
+    """
+    CPU count from a cgroup v2 ``cpu.max`` value.
+
+    The format is ``"<quota> <period>"`` (both in microseconds) or ``"max"`` when
+    the CPU time is unlimited; returns ``None`` when unlimited or malformed.
+    """
+    parts = text.split()
+    if not parts or parts[0] == "max":
+        return None
+    try:
+        quota = int(parts[0])
+        period = int(parts[1]) if len(parts) > 1 else 100000
+    except ValueError:
+        return None
+    if quota > 0 and period > 0:
+        return quota / period
+    return None
+
+
+def _cgroup_cpu_quota() -> float | None:
+    """CPUs allowed by the process's cgroup CFS quota, or None if unlimited."""
+    # cgroup v2; under a cgroup namespace (the common container case) this is the
+    # limit the container itself sees.
+    text = _read_sysfs_str("/sys/fs/cgroup/cpu.max")
+    if text is not None:
+        return _parse_cgroup_v2_quota(text)
+    # cgroup v1
+    quota = _read_sysfs_int("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    period = _read_sysfs_int("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    if quota and quota > 0 and period and period > 0:
+        return quota / period
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def available_cpu_count() -> int | None:
+    """
+    Number of CPUs the process may actually use, or None if unconstrained.
+
+    Takes the tighter of the CPU affinity mask (``taskset``, SLURM cpusets) and
+    the cgroup CFS quota (Docker ``--cpus``, Kubernetes CPU limits), so a default
+    worker count does not oversubscribe a restricted environment.  Returns
+    ``None`` only where neither limit is probed -- in practice macOS and
+    Windows.  macOS exposes no affinity mask at all; Windows does (via
+    ``GetProcessAffinityMask`` and job-object rate limits) but it is not
+    implemented here, since parallel reading is off by default there anyway.
+    On Linux ``sched_getaffinity`` always succeeds, so an unconstrained box
+    reports its full logical CPU count rather than ``None``.
+
+    Cached for the process lifetime: the CPU allocation is effectively static
+    (cgroup limits do not change at runtime and affinity is normally set once at
+    startup), and this is on the ``read_csv`` hot path.
+    """
+    limits = []
+    if hasattr(os, "sched_getaffinity"):
+        try:
+            limits.append(len(os.sched_getaffinity(0)))
+        except OSError:
+            pass
+    quota = _cgroup_cpu_quota()
+    if quota is not None:
+        limits.append(max(1, int(quota)))
+    return min(limits) if limits else None

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -461,10 +461,12 @@ with cf.config_prefix("mode"):
 max_threads_doc = """
 : int or None
     Maximum number of worker threads for parallel operations (e.g. ``read_csv``
-    for large files).  ``None`` (the default) means use ``min(os.cpu_count(), 4)``.
-    Set to ``1`` to disable parallel execution, or to a fixed number to raise the
-    cap or to limit thread usage when pandas is embedded in a larger parallel
-    workflow.
+    for large files).  ``None`` (the default) means use ``min(os.cpu_count(), 4)``,
+    further limited to the CPUs available to the process (CPU affinity and cgroup
+    limits); on Windows and WASM the default is ``1``, as parallel reading is
+    disabled there.  Set to ``1`` to disable parallel execution, or to a fixed
+    number to raise the cap or to limit thread usage when pandas is embedded in a
+    larger parallel workflow.
 """
 
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -463,10 +463,10 @@ max_threads_doc = """
     Maximum number of worker threads for parallel operations (e.g. ``read_csv``
     for large files).  ``None`` (the default) means use ``min(os.cpu_count(), 4)``,
     further limited to the CPUs available to the process (CPU affinity and cgroup
-    limits); on Windows and WASM the default is ``1``, as parallel reading is
-    disabled there.  Set to ``1`` to disable parallel execution, or to a fixed
-    number to raise the cap or to limit thread usage when pandas is embedded in a
-    larger parallel workflow.
+    limits); on Windows the default is ``1``, as parallel reading is not faster
+    there.  Set to ``1`` to disable parallel execution, or to a fixed number to
+    raise the cap or to limit thread usage when pandas is embedded in a larger
+    parallel workflow.  Ignored on Emscripten/Pyodide, which cannot spawn threads.
 """
 
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -39,6 +39,7 @@ from pandas._config import get_option
 
 from pandas._libs import lib
 from pandas._libs.parsers import STR_NA_VALUES
+from pandas.compat._cpu import available_cpu_count
 from pandas.errors import (
     AbstractMethodError,
     Pandas4Warning,
@@ -199,6 +200,12 @@ _python_unsupported = {"low_memory", "float_precision"}
 _PARALLEL_READ_MIN_BYTES = 5 * 1024 * 1024  # 5 MB
 # Minimum rows per parallel chunk, bounding how finely a file is split.
 _PARALLEL_MIN_CHUNK_ROWS = 2000
+
+# Ceiling on the *default* parallel-read worker count: parallel CSV reading
+# sees diminishing returns beyond a handful of workers, and a low default
+# avoids oversubscribing the machine.  mode.max_threads overrides it in either
+# direction.
+_MAX_DEFAULT_WORKERS = 4
 _pyarrow_unsupported = {
     "skipfooter",
     "float_precision",
@@ -340,26 +347,7 @@ def _read(
     # Each worker gets its own file handle and TextReader so the GIL-free tokenisation
     # and type-conversion code in parsers.pyx runs truly in parallel.
     if not iterator and chunksize is None and nrows is None:
-        _max = get_option("mode.max_threads")
-        if sys.platform == "emscripten":
-            # WASM cannot spawn threads, regardless of mode.max_threads.
-            _n_workers = 1
-        elif _max is not None:
-            _n_workers = _max
-        elif sys.platform == "win32":
-            # Parallel CSV reading does not currently speed up on Windows: even
-            # with the file warm in the OS cache, using more than one thread is
-            # no faster (and slower at two threads).  Default to serial there;
-            # users can still opt in explicitly via mode.max_threads.  See the
-            # benchmark numbers in the GH#64347 discussion:
-            # https://github.com/pandas-dev/pandas/pull/64347#issuecomment-4468820601
-            _n_workers = 1
-        else:
-            # Cap the default at 4 threads: parallel CSV reading sees
-            # diminishing returns beyond a handful of workers, and a lower
-            # default avoids oversubscribing the machine.  Users who want more
-            # can opt in explicitly via mode.max_threads.
-            _n_workers = min(os.cpu_count() or 1, 4)
+        _n_workers = _default_n_workers()
         if _n_workers > 1 and _can_parallelize_csv(filepath_or_buffer, kwds):
             _filepath = stringify_path(filepath_or_buffer)
             assert isinstance(_filepath, str)  # guaranteed by _can_parallelize_csv
@@ -382,6 +370,41 @@ def _read(
 
     with parser:
         return parser.read(nrows)
+
+
+def _default_n_workers() -> int:
+    """
+    Default worker count for a parallel ``read_csv``.
+
+    ``mode.max_threads`` wins whenever it is set (except on WASM, which cannot
+    spawn threads at all).  Otherwise parallel reading is off by default on
+    Windows, and elsewhere defaults to ``_MAX_DEFAULT_WORKERS`` logical CPUs,
+    clamped to the CPUs actually available to the process (CPU affinity /
+    cgroup limits) so that an embedded or containerised pandas does not
+    oversubscribe its allocation.
+    """
+    max_threads = get_option("mode.max_threads")
+    if sys.platform == "emscripten":
+        # WASM cannot spawn threads, regardless of mode.max_threads.
+        return 1
+    if max_threads is not None:
+        return max_threads
+    if sys.platform == "win32":
+        # Parallel CSV reading does not currently speed up on Windows: even
+        # with the file warm in the OS cache, using more than one thread is
+        # no faster (and slower at two threads).  Default to serial there;
+        # users can still opt in explicitly via mode.max_threads.  See the
+        # benchmark numbers in the GH#64347 discussion:
+        # https://github.com/pandas-dev/pandas/pull/64347#issuecomment-4468820601
+        return 1
+    n_workers = min(os.cpu_count() or 1, _MAX_DEFAULT_WORKERS)
+    # os.cpu_count() counts the machine's CPUs, not the ones this process may
+    # use, so it alone would put _MAX_DEFAULT_WORKERS parse threads on a
+    # single-CPU container.
+    available = available_cpu_count()
+    if available is not None:
+        n_workers = min(n_workers, available)
+    return n_workers
 
 
 def _can_parallelize_csv(filepath_or_buffer, kwds: dict) -> bool:

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -376,12 +376,12 @@ def _default_n_workers() -> int:
     """
     Default worker count for a parallel ``read_csv``.
 
-    ``mode.max_threads`` wins whenever it is set (except on WASM, which cannot
-    spawn threads at all).  Otherwise parallel reading is off by default on
-    Windows, and elsewhere defaults to ``_MAX_DEFAULT_WORKERS`` logical CPUs,
-    clamped to the CPUs actually available to the process (CPU affinity /
-    cgroup limits) so that an embedded or containerised pandas does not
-    oversubscribe its allocation.
+    ``mode.max_threads`` wins whenever it is set (except on Emscripten, which
+    cannot spawn threads at all).  Otherwise parallel reading is off by default
+    on Windows, and elsewhere is the smallest of the machine's logical CPU
+    count, ``_MAX_DEFAULT_WORKERS``, and the CPUs actually available to the
+    process (CPU affinity / cgroup limits) -- so that an embedded or
+    containerised pandas does not oversubscribe its allocation.
     """
     max_threads = get_option("mode.max_threads")
     if sys.platform == "emscripten":
@@ -447,7 +447,8 @@ def _can_parallelize_csv(filepath_or_buffer, kwds: dict) -> bool:
       path, and that error must not be masked.
     * ``on_bad_lines`` is not ``"warn"`` - chunk workers would report
       chunk-relative (i.e. wrong) line numbers.
-    * The file is at least ``_PARALLEL_READ_MIN_BYTES`` bytes large.
+    * Both the file and its data section (i.e. excluding the header preamble)
+      are at least ``_PARALLEL_READ_MIN_BYTES`` bytes large.
 
     Note that a chunk boundary landing on a newline embedded inside a quoted
     field leaves that chunk's parser inside an open quote at EOF, which raises

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -20,7 +20,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
-from pandas.compat import WASM
+from pandas.compat import (
+    WASM,
+    _cpu,
+)
+from pandas.compat._cpu import (
+    _parse_cgroup_v2_quota,
+    available_cpu_count,
+)
 from pandas.errors import (
     ParserError,
     ParserWarning,
@@ -36,9 +43,11 @@ from pandas import (
 )
 import pandas._testing as tm
 
+from pandas.io.parsers import readers as _readers
 from pandas.io.parsers.base_parser import ParserBase
 from pandas.io.parsers.readers import (
     _can_parallelize_csv,
+    _default_n_workers,
     _find_chunk_byte_offsets,
     _find_data_start_offset,
     _read_csv_parallel,
@@ -807,14 +816,15 @@ def test_parallel_default_off_on_windows(tmp_path, monkeypatch):
 
 def test_parallel_default_thread_cap(tmp_path, monkeypatch):
     """The default worker count is capped at 4, regardless of core count."""
-    import pandas.io.parsers.readers as _readers
-
     path = tmp_path / "big.csv"
     _make_large_csv(path)
     monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
     monkeypatch.setattr(_readers.sys, "platform", "linux")
     # More cores than the cap: the default should clamp down to 4.
     monkeypatch.setattr(_readers.os, "cpu_count", lambda: 16)
+    # Otherwise a CI runner with fewer than 4 usable CPUs clamps below the cap
+    # and this test measures the runner, not the cap.
+    monkeypatch.setattr(_readers, "available_cpu_count", lambda: None)
 
     workers = []
 
@@ -832,6 +842,170 @@ def test_parallel_default_thread_cap(tmp_path, monkeypatch):
     with option_context("mode.max_threads", 8):
         read_csv(path)
     assert workers == [8]
+
+
+# ---------------------------------------------------------------------------
+# Default worker count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cpu_count, available, expected",
+    [
+        (2, None, 2),  # unconstrained, below the cap -> logical CPU count
+        (16, None, 4),  # cap binds
+        (16, 1, 1),  # single-CPU container
+        (16, 2, 2),  # cgroup/affinity tighter than the cap
+        (16, 8, 4),  # allocation looser than the cap -> cap still binds
+        (2, 8, 2),  # allocation looser than the machine
+    ],
+)
+def test_default_n_workers_combines_cap_and_allocation(
+    monkeypatch, cpu_count, available, expected
+):
+    # Default = min(logical CPUs, available CPUs, _MAX_DEFAULT_WORKERS).
+    assert _readers._MAX_DEFAULT_WORKERS == 4
+    monkeypatch.setattr(_readers.sys, "platform", "linux")
+    monkeypatch.setattr(_readers.os, "cpu_count", lambda: cpu_count)
+    monkeypatch.setattr(_readers, "available_cpu_count", lambda: available)
+    with option_context("mode.max_threads", None):
+        assert _default_n_workers() == expected
+
+
+def test_default_n_workers_windows_is_serial(monkeypatch):
+    monkeypatch.setattr(_readers.sys, "platform", "win32")
+    with option_context("mode.max_threads", None):
+        assert _default_n_workers() == 1
+
+
+def test_default_n_workers_wasm_is_serial(monkeypatch):
+    monkeypatch.setattr(_readers.sys, "platform", "emscripten")
+    # WASM stays serial even if a worker count is requested explicitly.
+    with option_context("mode.max_threads", 8):
+        assert _default_n_workers() == 1
+
+
+def test_default_n_workers_max_threads_exceeds_cap(monkeypatch):
+    # _MAX_DEFAULT_WORKERS and the availability clamp bound the *default* only.
+    # The mode.max_threads docs promise an explicit setting still wins.
+    monkeypatch.setattr(_readers.sys, "platform", "linux")
+    monkeypatch.setattr(_readers.os, "cpu_count", lambda: 2)
+    monkeypatch.setattr(_readers, "available_cpu_count", lambda: 1)
+    with option_context("mode.max_threads", 32):
+        assert _default_n_workers() == 32
+
+
+@pytest.mark.parametrize("platform_name", ["linux", "win32"])
+def test_default_n_workers_max_threads_wins(monkeypatch, platform_name):
+    monkeypatch.setattr(_readers.sys, "platform", platform_name)
+    with option_context("mode.max_threads", 3):
+        assert _default_n_workers() == 3
+
+
+# ---------------------------------------------------------------------------
+# CPU allocation detection (pandas.compat._cpu)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("max 100000", None),  # unlimited
+        ("max", None),
+        ("400000 100000", 4.0),
+        ("150000 100000", 1.5),
+        ("100000", 1.0),  # period defaults to 100000us
+        ("0 100000", None),  # zero quota -> ignored
+        ("garbage", None),
+        ("", None),
+    ],
+)
+def test_parse_cgroup_v2_quota(text, expected):
+    assert _parse_cgroup_v2_quota(text) == expected
+
+
+@pytest.mark.parametrize(
+    "affinity, quota, expected",
+    [
+        ({0, 1, 2, 3, 4, 5, 6, 7}, None, 8),  # affinity only
+        ({0, 1, 2, 3, 4, 5, 6, 7}, 4.0, 4),  # cgroup quota tighter
+        ({0, 1, 2, 3}, 8.0, 4),  # affinity tighter
+        ({0, 1}, 1.5, 1),  # fractional quota floors, min 1
+    ],
+)
+def test_available_cpu_count(monkeypatch, affinity, quota, expected):
+    monkeypatch.setattr(
+        os, "sched_getaffinity", lambda pid: set(affinity), raising=False
+    )
+    monkeypatch.setattr(_cpu, "_cgroup_cpu_quota", lambda: quota)
+    available_cpu_count.cache_clear()
+    try:
+        assert available_cpu_count() == expected
+    finally:
+        available_cpu_count.cache_clear()
+
+
+def test_available_cpu_count_unconstrained(monkeypatch):
+    # No affinity limit and no cgroup quota -> None (do not clamp).
+
+    def raise_oserror(pid):
+        raise OSError
+
+    monkeypatch.setattr(os, "sched_getaffinity", raise_oserror, raising=False)
+    monkeypatch.setattr(_cpu, "_cgroup_cpu_quota", lambda: None)
+    available_cpu_count.cache_clear()
+    try:
+        assert available_cpu_count() is None
+    finally:
+        available_cpu_count.cache_clear()
+
+
+def test_available_cpu_count_does_not_raise():
+    # _default_n_workers calls available_cpu_count() bare, so anything escaping
+    # it escapes read_csv.  Every other test mocks both the affinity call and
+    # the cgroup reads; this one runs it against the host.
+    available_cpu_count.cache_clear()
+    try:
+        result = available_cpu_count()
+    finally:
+        available_cpu_count.cache_clear()
+    assert result is None or (isinstance(result, int) and result >= 1)
+
+
+def test_cgroup_cpu_quota_v2(monkeypatch):
+    monkeypatch.setattr(
+        _cpu,
+        "_read_sysfs_str",
+        lambda path: "400000 100000" if path == "/sys/fs/cgroup/cpu.max" else None,
+    )
+    assert _cpu._cgroup_cpu_quota() == 4.0
+
+
+def test_cgroup_cpu_quota_v1_fallback(monkeypatch):
+    ints = {
+        "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": 300000,
+        "/sys/fs/cgroup/cpu/cpu.cfs_period_us": 100000,
+    }
+    monkeypatch.setattr(_cpu, "_read_sysfs_str", lambda path: None)  # no cgroup v2
+    monkeypatch.setattr(_cpu, "_read_sysfs_int", lambda path: ints.get(path))
+    assert _cpu._cgroup_cpu_quota() == 3.0
+
+
+def test_cgroup_cpu_quota_unlimited(monkeypatch):
+    monkeypatch.setattr(
+        _cpu,
+        "_read_sysfs_str",
+        lambda path: "max 100000" if path == "/sys/fs/cgroup/cpu.max" else None,
+    )
+    monkeypatch.setattr(_cpu, "_read_sysfs_int", lambda path: None)
+    assert _cpu._cgroup_cpu_quota() is None
+
+
+def test_read_sysfs_str_non_utf8(tmp_path):
+    # A non-UTF-8 byte must read as "unknown", not raise out of read_csv.
+    path = tmp_path / "cpu.max"
+    path.write_bytes(b"\xff\xfe")
+    assert _cpu._read_sysfs_str(str(path)) is None
 
 
 # ---------------------------------------------------------------------------

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -20,14 +20,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
-from pandas.compat import (
-    WASM,
-    _cpu,
-)
-from pandas.compat._cpu import (
-    _parse_cgroup_v2_quota,
-    available_cpu_count,
-)
+from pandas.compat import WASM
 from pandas.errors import (
     ParserError,
     ParserWarning,
@@ -97,8 +90,6 @@ class TestCanParallelizeCsv:
         return base
 
     def test_eligible_large_file(self, tmp_path, monkeypatch):
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "big.csv"
         _make_large_csv(path)
         # Lower the threshold so the test file qualifies regardless of its size.
@@ -107,8 +98,6 @@ class TestCanParallelizeCsv:
 
     def test_accepts_default_engine(self, tmp_path, monkeypatch):
         """engine=None (the default) should be treated the same as engine='c'."""
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -165,8 +154,6 @@ class TestCanParallelizeCsv:
         assert not _can_parallelize_csv(path, self._kwds(engine="pyarrow"))
 
     def test_rejects_custom_lineterminator(self, tmp_path, monkeypatch):
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         # The chunk splitter always scans for \n; a different lineterminator
@@ -185,8 +172,6 @@ class TestCanParallelizeCsv:
         # UTF-16/32 encode \n as a multi-byte sequence (e.g. b"\x0a\x00" in
         # UTF-16LE).  Splitting on raw \n bytes would misalign chunks and
         # silently corrupt data.
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -198,8 +183,6 @@ class TestCanParallelizeCsv:
         # words as UTF-8; only UTF-8-compatible encodings are byte-safe.  "ascii"
         # is excluded too: the workers would decode a non-ASCII byte as UTF-8 and
         # succeed, masking the UnicodeDecodeError serial raises (GH#64347).
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -211,8 +194,6 @@ class TestCanParallelizeCsv:
     def test_rejects_python_engine_seps(self, tmp_path, monkeypatch):
         # Multi-char/regex seps (other than r"\s+") and sep=None force the
         # python engine inside TextFileReader (GH#64347).
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -221,16 +202,12 @@ class TestCanParallelizeCsv:
         assert _can_parallelize_csv(path, self._kwds(delimiter=r"\s+"))
 
     def test_rejects_comment(self, tmp_path, monkeypatch):
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
         assert not _can_parallelize_csv(path, self._kwds(comment="#"))
 
     def test_rejects_escapechar(self, tmp_path, monkeypatch):
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -240,16 +217,12 @@ class TestCanParallelizeCsv:
         # dialect is merged into the kwds inside TextFileReader, i.e. after
         # this check runs; a dialect-specified escapechar would otherwise
         # bypass the escapechar check above (GH#64347).
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
         assert not _can_parallelize_csv(path, self._kwds(dialect="excel"))
 
     def test_rejects_parse_dates(self, tmp_path, monkeypatch):
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -263,8 +236,6 @@ class TestCanParallelizeCsv:
         # per-chunk parallel path cannot honour; low_memory=True (and the unset
         # default) document per-chunk divergence, so they stay eligible
         # (GH#64347).
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -284,8 +255,6 @@ class TestCanParallelizeCsv:
     def test_rejects_on_bad_lines_warn(self, tmp_path, monkeypatch):
         # "warn" includes line numbers in its warnings; chunk workers would
         # report chunk-relative (i.e. wrong) ones (GH#64347).
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -297,8 +266,6 @@ class TestCanParallelizeCsv:
     def test_rejects_blank_line_in_preamble(self, tmp_path, monkeypatch):
         # A blank line before the header shifts where pandas locates the
         # header relative to the physical line count (GH#64347).
-        import pandas.io.parsers.readers as _readers
-
         path = tmp_path / "data.csv"
         path.write_text("\na,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
@@ -743,8 +710,6 @@ def test_read_csv_auto_parallel(tmp_path, monkeypatch):
     read_csv() transparently uses the parallel path for large local files.
     Result must match the serial read obtained via engine='python'.
     """
-    import pandas.io.parsers.readers as _readers
-
     path = tmp_path / "big.csv"
     _make_large_csv(path)
     # Lower the threshold so any file triggers the parallel path.
@@ -763,8 +728,6 @@ def test_read_csv_parallel_vs_serial_large_file(tmp_path, monkeypatch):
     For a file that exceeds the threshold, the parallel result equals the
     result from a direct serial C-engine read (with parallelism forced off).
     """
-    import pandas.io.parsers.readers as _readers
-
     path = tmp_path / "big.csv"
     _make_large_csv(path)
     # Lower the threshold so any file triggers the parallel path.
@@ -785,14 +748,14 @@ def test_parallel_default_off_on_windows(tmp_path, monkeypatch):
     warm in the OS cache, so the default is serial there; users opt in via
     ``mode.max_threads`` (which is honoured on every platform).
     """
-    import pandas.io.parsers.readers as _readers
-
     path = tmp_path / "big.csv"
     _make_large_csv(path)
     monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
     # Pin the non-Windows default so the test does not depend on the host's
-    # actual core count.
+    # actual core count, or on how many CPUs a container/affinity mask leaves
+    # the runner -- one usable CPU would make the default serial everywhere.
     monkeypatch.setattr(_readers.os, "cpu_count", lambda: 4)
+    monkeypatch.setattr(_readers, "available_cpu_count", lambda: None)
 
     # Stub the parallel reader so this exercises only the platform-gating
     # decision.  Calling the real one would start threads, which fails on
@@ -900,112 +863,6 @@ def test_default_n_workers_max_threads_wins(monkeypatch, platform_name):
     monkeypatch.setattr(_readers.sys, "platform", platform_name)
     with option_context("mode.max_threads", 3):
         assert _default_n_workers() == 3
-
-
-# ---------------------------------------------------------------------------
-# CPU allocation detection (pandas.compat._cpu)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "text, expected",
-    [
-        ("max 100000", None),  # unlimited
-        ("max", None),
-        ("400000 100000", 4.0),
-        ("150000 100000", 1.5),
-        ("100000", 1.0),  # period defaults to 100000us
-        ("0 100000", None),  # zero quota -> ignored
-        ("garbage", None),
-        ("", None),
-    ],
-)
-def test_parse_cgroup_v2_quota(text, expected):
-    assert _parse_cgroup_v2_quota(text) == expected
-
-
-@pytest.mark.parametrize(
-    "affinity, quota, expected",
-    [
-        ({0, 1, 2, 3, 4, 5, 6, 7}, None, 8),  # affinity only
-        ({0, 1, 2, 3, 4, 5, 6, 7}, 4.0, 4),  # cgroup quota tighter
-        ({0, 1, 2, 3}, 8.0, 4),  # affinity tighter
-        ({0, 1}, 1.5, 1),  # fractional quota floors, min 1
-    ],
-)
-def test_available_cpu_count(monkeypatch, affinity, quota, expected):
-    monkeypatch.setattr(
-        os, "sched_getaffinity", lambda pid: set(affinity), raising=False
-    )
-    monkeypatch.setattr(_cpu, "_cgroup_cpu_quota", lambda: quota)
-    available_cpu_count.cache_clear()
-    try:
-        assert available_cpu_count() == expected
-    finally:
-        available_cpu_count.cache_clear()
-
-
-def test_available_cpu_count_unconstrained(monkeypatch):
-    # No affinity limit and no cgroup quota -> None (do not clamp).
-
-    def raise_oserror(pid):
-        raise OSError
-
-    monkeypatch.setattr(os, "sched_getaffinity", raise_oserror, raising=False)
-    monkeypatch.setattr(_cpu, "_cgroup_cpu_quota", lambda: None)
-    available_cpu_count.cache_clear()
-    try:
-        assert available_cpu_count() is None
-    finally:
-        available_cpu_count.cache_clear()
-
-
-def test_available_cpu_count_does_not_raise():
-    # _default_n_workers calls available_cpu_count() bare, so anything escaping
-    # it escapes read_csv.  Every other test mocks both the affinity call and
-    # the cgroup reads; this one runs it against the host.
-    available_cpu_count.cache_clear()
-    try:
-        result = available_cpu_count()
-    finally:
-        available_cpu_count.cache_clear()
-    assert result is None or (isinstance(result, int) and result >= 1)
-
-
-def test_cgroup_cpu_quota_v2(monkeypatch):
-    monkeypatch.setattr(
-        _cpu,
-        "_read_sysfs_str",
-        lambda path: "400000 100000" if path == "/sys/fs/cgroup/cpu.max" else None,
-    )
-    assert _cpu._cgroup_cpu_quota() == 4.0
-
-
-def test_cgroup_cpu_quota_v1_fallback(monkeypatch):
-    ints = {
-        "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": 300000,
-        "/sys/fs/cgroup/cpu/cpu.cfs_period_us": 100000,
-    }
-    monkeypatch.setattr(_cpu, "_read_sysfs_str", lambda path: None)  # no cgroup v2
-    monkeypatch.setattr(_cpu, "_read_sysfs_int", lambda path: ints.get(path))
-    assert _cpu._cgroup_cpu_quota() == 3.0
-
-
-def test_cgroup_cpu_quota_unlimited(monkeypatch):
-    monkeypatch.setattr(
-        _cpu,
-        "_read_sysfs_str",
-        lambda path: "max 100000" if path == "/sys/fs/cgroup/cpu.max" else None,
-    )
-    monkeypatch.setattr(_cpu, "_read_sysfs_int", lambda path: None)
-    assert _cpu._cgroup_cpu_quota() is None
-
-
-def test_read_sysfs_str_non_utf8(tmp_path):
-    # A non-UTF-8 byte must read as "unknown", not raise out of read_csv.
-    path = tmp_path / "cpu.max"
-    path.write_bytes(b"\xff\xfe")
-    assert _cpu._read_sysfs_str(str(path)) is None
 
 
 # ---------------------------------------------------------------------------

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -808,61 +808,61 @@ def test_parallel_default_thread_cap(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Default worker count
+# _default_n_workers
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "cpu_count, available, expected",
-    [
-        (2, None, 2),  # unconstrained, below the cap -> logical CPU count
-        (16, None, 4),  # cap binds
-        (16, 1, 1),  # single-CPU container
-        (16, 2, 2),  # cgroup/affinity tighter than the cap
-        (16, 8, 4),  # allocation looser than the cap -> cap still binds
-        (2, 8, 2),  # allocation looser than the machine
-    ],
-)
-def test_default_n_workers_combines_cap_and_allocation(
-    monkeypatch, cpu_count, available, expected
-):
-    # Default = min(logical CPUs, available CPUs, _MAX_DEFAULT_WORKERS).
-    assert _readers._MAX_DEFAULT_WORKERS == 4
-    monkeypatch.setattr(_readers.sys, "platform", "linux")
-    monkeypatch.setattr(_readers.os, "cpu_count", lambda: cpu_count)
-    monkeypatch.setattr(_readers, "available_cpu_count", lambda: available)
-    with option_context("mode.max_threads", None):
-        assert _default_n_workers() == expected
+class TestDefaultNWorkers:
+    """Unit tests for the default worker count."""
 
+    @pytest.mark.parametrize(
+        "cpu_count, available, expected",
+        [
+            (2, None, 2),  # unconstrained, below the cap -> logical CPU count
+            (16, None, 4),  # cap binds
+            (16, 1, 1),  # single-CPU container
+            (16, 2, 2),  # cgroup/affinity tighter than the cap
+            (16, 8, 4),  # allocation looser than the cap -> cap still binds
+            (2, 8, 2),  # allocation looser than the machine
+        ],
+    )
+    def test_combines_cap_and_allocation(
+        self, monkeypatch, cpu_count, available, expected
+    ):
+        # Default = min(logical CPUs, available CPUs, _MAX_DEFAULT_WORKERS).
+        assert _readers._MAX_DEFAULT_WORKERS == 4
+        monkeypatch.setattr(_readers.sys, "platform", "linux")
+        monkeypatch.setattr(_readers.os, "cpu_count", lambda: cpu_count)
+        monkeypatch.setattr(_readers, "available_cpu_count", lambda: available)
+        with option_context("mode.max_threads", None):
+            assert _default_n_workers() == expected
 
-def test_default_n_workers_windows_is_serial(monkeypatch):
-    monkeypatch.setattr(_readers.sys, "platform", "win32")
-    with option_context("mode.max_threads", None):
-        assert _default_n_workers() == 1
+    def test_windows_is_serial(self, monkeypatch):
+        monkeypatch.setattr(_readers.sys, "platform", "win32")
+        with option_context("mode.max_threads", None):
+            assert _default_n_workers() == 1
 
+    def test_wasm_is_serial(self, monkeypatch):
+        monkeypatch.setattr(_readers.sys, "platform", "emscripten")
+        # WASM stays serial even if a worker count is requested explicitly.
+        with option_context("mode.max_threads", 8):
+            assert _default_n_workers() == 1
 
-def test_default_n_workers_wasm_is_serial(monkeypatch):
-    monkeypatch.setattr(_readers.sys, "platform", "emscripten")
-    # WASM stays serial even if a worker count is requested explicitly.
-    with option_context("mode.max_threads", 8):
-        assert _default_n_workers() == 1
+    def test_max_threads_exceeds_cap(self, monkeypatch):
+        # _MAX_DEFAULT_WORKERS and the availability clamp bound the *default*
+        # only.  The mode.max_threads docs promise an explicit setting still
+        # wins.
+        monkeypatch.setattr(_readers.sys, "platform", "linux")
+        monkeypatch.setattr(_readers.os, "cpu_count", lambda: 2)
+        monkeypatch.setattr(_readers, "available_cpu_count", lambda: 1)
+        with option_context("mode.max_threads", 32):
+            assert _default_n_workers() == 32
 
-
-def test_default_n_workers_max_threads_exceeds_cap(monkeypatch):
-    # _MAX_DEFAULT_WORKERS and the availability clamp bound the *default* only.
-    # The mode.max_threads docs promise an explicit setting still wins.
-    monkeypatch.setattr(_readers.sys, "platform", "linux")
-    monkeypatch.setattr(_readers.os, "cpu_count", lambda: 2)
-    monkeypatch.setattr(_readers, "available_cpu_count", lambda: 1)
-    with option_context("mode.max_threads", 32):
-        assert _default_n_workers() == 32
-
-
-@pytest.mark.parametrize("platform_name", ["linux", "win32"])
-def test_default_n_workers_max_threads_wins(monkeypatch, platform_name):
-    monkeypatch.setattr(_readers.sys, "platform", platform_name)
-    with option_context("mode.max_threads", 3):
-        assert _default_n_workers() == 3
+    @pytest.mark.parametrize("platform_name", ["linux", "win32"])
+    def test_max_threads_wins(self, monkeypatch, platform_name):
+        monkeypatch.setattr(_readers.sys, "platform", platform_name)
+        with option_context("mode.max_threads", 3):
+            assert _default_n_workers() == 3
 
 
 # ---------------------------------------------------------------------------

--- a/pandas/tests/test_cpu.py
+++ b/pandas/tests/test_cpu.py
@@ -1,0 +1,128 @@
+"""
+Tests for pandas.compat._cpu: detection of the CPU allocation available to
+this process (affinity mask and cgroup CFS quota).
+"""
+
+import os
+
+import pytest
+
+from pandas.compat import _cpu
+from pandas.compat._cpu import (
+    _parse_cgroup_v2_quota,
+    available_cpu_count,
+)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("max 100000", None),  # unlimited
+        ("max", None),
+        ("400000 100000", 4.0),
+        ("150000 100000", 1.5),
+        ("50000 100000", 0.5),  # docker --cpus=0.5, Kubernetes cpu: 500m
+        ("100000", 1.0),  # period defaults to 100000us
+        ("0 100000", None),  # zero quota -> ignored
+        ("garbage", None),
+        ("", None),
+    ],
+)
+def test_parse_cgroup_v2_quota(text, expected):
+    assert _parse_cgroup_v2_quota(text) == expected
+
+
+@pytest.mark.parametrize(
+    "affinity, quota, expected",
+    [
+        ({0, 1, 2, 3, 4, 5, 6, 7}, None, 8),  # affinity only
+        ({0, 1, 2, 3, 4, 5, 6, 7}, 4.0, 4),  # cgroup quota tighter
+        ({0, 1, 2, 3}, 8.0, 4),  # affinity tighter
+        ({0, 1}, 1.5, 1),  # fractional quota floors, min 1
+        ({0, 1, 2, 3}, 0.5, 1),  # sub-1-CPU quota still leaves one worker
+    ],
+)
+def test_available_cpu_count(monkeypatch, affinity, quota, expected):
+    monkeypatch.setattr(
+        os, "sched_getaffinity", lambda pid: set(affinity), raising=False
+    )
+    monkeypatch.setattr(_cpu, "_cgroup_cpu_quota", lambda: quota)
+    available_cpu_count.cache_clear()
+    try:
+        assert available_cpu_count() == expected
+    finally:
+        available_cpu_count.cache_clear()
+
+
+def test_available_cpu_count_unconstrained(monkeypatch):
+    # No affinity limit and no cgroup quota -> None (do not clamp).
+
+    def raise_oserror(pid):
+        raise OSError
+
+    monkeypatch.setattr(os, "sched_getaffinity", raise_oserror, raising=False)
+    monkeypatch.setattr(_cpu, "_cgroup_cpu_quota", lambda: None)
+    available_cpu_count.cache_clear()
+    try:
+        assert available_cpu_count() is None
+    finally:
+        available_cpu_count.cache_clear()
+
+
+def test_available_cpu_count_does_not_raise():
+    # _default_n_workers calls available_cpu_count() bare, so anything escaping
+    # it escapes read_csv.  Every other test mocks both the affinity call and
+    # the cgroup reads; this one runs it against the host.
+    available_cpu_count.cache_clear()
+    try:
+        result = available_cpu_count()
+    finally:
+        available_cpu_count.cache_clear()
+    assert result is None or (isinstance(result, int) and result >= 1)
+
+
+def test_cgroup_cpu_quota_v2(monkeypatch):
+    monkeypatch.setattr(
+        _cpu,
+        "_read_sysfs_str",
+        lambda path: "400000 100000" if path == "/sys/fs/cgroup/cpu.max" else None,
+    )
+    assert _cpu._cgroup_cpu_quota() == 4.0
+
+
+@pytest.mark.parametrize("quota, expected", [(300000, 3.0), (-1, None)])
+def test_cgroup_cpu_quota_v1_fallback(monkeypatch, quota, expected):
+    # -1 is the unlimited sentinel cpu.cfs_quota_us holds on an unconstrained
+    # cgroup v1 host; reading it as a quota would force every read_csv serial.
+    ints = {
+        "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": quota,
+        "/sys/fs/cgroup/cpu/cpu.cfs_period_us": 100000,
+    }
+    monkeypatch.setattr(_cpu, "_read_sysfs_str", lambda path: None)  # no cgroup v2
+    monkeypatch.setattr(_cpu, "_read_sysfs_int", lambda path: ints.get(path))
+    assert _cpu._cgroup_cpu_quota() == expected
+
+
+def test_cgroup_cpu_quota_unlimited(monkeypatch):
+    monkeypatch.setattr(
+        _cpu,
+        "_read_sysfs_str",
+        lambda path: "max 100000" if path == "/sys/fs/cgroup/cpu.max" else None,
+    )
+    monkeypatch.setattr(_cpu, "_read_sysfs_int", lambda path: None)
+    assert _cpu._cgroup_cpu_quota() is None
+
+
+def test_read_sysfs_str_non_utf8(tmp_path):
+    # A non-UTF-8 byte must read as "unknown", not raise out of read_csv.
+    path = tmp_path / "cpu.max"
+    path.write_bytes(b"\xff\xfe")
+    assert _cpu._read_sysfs_str(str(path)) is None
+
+
+def test_read_sysfs_int_non_numeric(tmp_path):
+    # Same for a non-numeric value; every other test replaces _read_sysfs_int
+    # with a stub, so this is the only check that it swallows ValueError.
+    path = tmp_path / "cpu.cfs_quota_us"
+    path.write_text("max", encoding="utf-8")
+    assert _cpu._read_sysfs_int(str(path)) is None


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. (see below -- the feature this refines is unreleased)

> Split out of GH-66152, which is now stacked on top of this PR. That one raises the default worker count to the physical core count and needs a policy discussion; this one does not.

The parallel `read_csv` path added in GH-64347 picks its default worker count as `min(os.cpu_count(), 4)`. `os.cpu_count()` reports the machine's CPUs, not the ones this process may actually use, so a default `read_csv` inside a container limited to one CPU (`docker --cpus=1`, a Kubernetes CPU limit) or under an affinity mask (`taskset`, a SLURM cpuset) spawns up to 4 parse threads onto that allocation.

This clamps the default to the tighter of the CPU affinity mask and the cgroup CFS quota (v2 `cpu.max`, falling back to v1 `cpu.cfs_quota_us`/`cpu.cfs_period_us`). The cap stays at 4, so the change can only ever *lower* the worker count relative to what is on main — nobody gets more threads than today. An explicit `mode.max_threads` still wins in either direction.

The detection lives in a new `pandas/compat/_cpu.py`. The inline worker-count block in `_read` moves to `_default_n_workers()` unchanged apart from the clamp, which makes it directly testable.

Its unit tests live in a new `pandas/tests/test_cpu.py`, mirroring `pandas/tests/test_optional_dependency.py` for `pandas/compat/_optional.py`; the `_default_n_workers` tests stay with the rest of the parallel-read tests in `pandas/tests/io/parser/test_parallel_read.py`.

No whatsnew entry: `v3.1.0` is unreleased, so the parallel path this refines has never shipped. The existing GH-64347 performance entry still describes the behaviour accurately.

Doc fixes ride along:
- `io.rst` said the parallel path needs a file "at least 50 MB"; `_PARALLEL_READ_MIN_BYTES` is 5 MB. This is wrong on main today, independent of the rest of the PR.
- `io.rst` presents its eligibility conditions as sufficient ("happens automatically when all of the following hold"). This PR makes that false — a process limited to a single CPU satisfies every bullet and still reads serially — so the list gains a worker-count bullet.
- That 5 MB threshold applies to the data section, not the whole file: `_can_parallelize_csv` checks `file_size` *and* `file_size - data_start`, so a 5 MB + 1 byte file with a header line is over the threshold and still ineligible. Corrected in `io.rst` and in `_can_parallelize_csv`'s own docstring.
- `io.rst` and the `mode.max_threads` option docstring now mention the availability clamp. The option docstring also no longer lumps Windows together with Emscripten: an explicit `mode.max_threads` re-enables parallel reading on Windows, but is ignored under Emscripten, which cannot spawn threads at all.

Two existing tests needed a fix rather than a port. `test_parallel_default_thread_cap` and `test_parallel_default_off_on_windows` both pin `os.cpu_count` but not the new availability clamp, so each would fail on a runner with fewer usable CPUs than it assumes — exactly the environment this PR targets. Both now stub `available_cpu_count`, so they measure the cap and the platform gate rather than the runner.
