### PR TITLE
DOC: Add query() example for string filtering

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1289,6 +1289,17 @@ Pretty close to how you might write it on paper:
 
    df.query('a < b < c')
 
+The ``query()`` method can also be useful when filtering rows based on string values.
+
+.. ipython:: python
+
+   employees = pd.DataFrame({
+       "Name": ["Alice", "Bob", "Charlie"],
+       "Department": ["HR", "IT", "HR"]
+   })
+
+   employees.query('Department == "HR"')
+
 The ``in`` and ``not in`` operators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -2,9 +2,9 @@
 
 {{ header }}
 
-***************************
+******************************
 Indexing and selecting data
-***************************
+******************************
 
 The axis labeling information in pandas objects serves many purposes:
 


### PR DESCRIPTION
## Summary

Added a simple example demonstrating how `DataFrame.query()` can filter rows based on string values.

Example added:

```python
employees = pd.DataFrame({
    "Name": ["Alice", "Bob", "Charlie"],
    "Department": ["HR", "IT", "HR"]
})

employees.query('Department == "HR"')