### PR TITLE
BUG: Avoid NumPy 2.5 DeprecationWarning in Timedelta.view

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1877,7 +1877,7 @@ cdef class _Timedelta(timedelta):
         >>> td.view(int)
         np.int64(259200000000)
         """
-        return np.timedelta64(self._value).view(dtype)
+        return np.timedelta64(self._value, "ns").view(dtype)
 
     @property
     def components(self):

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1877,7 +1877,7 @@ cdef class _Timedelta(timedelta):
         >>> td.view(int)
         np.int64(259200000000)
         """
-        return np.timedelta64(self._value, "ns").view(dtype)
+        return np.timedelta64(self._value, self.unit).view(dtype)
 
     @property
     def components(self):

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -105,8 +105,9 @@ class TestNonNano:
                 assert res.dtype == "m8[ms]"
             elif unit == NpyDatetimeUnit.NPY_FR_us.value:
                 assert res.dtype == "m8[us]"
-                
+
     def test_view(self):
+        # GH#66608
         td = Timedelta(seconds=1)
         with tm.assert_produces_warning(None):
             res = td.view(np.int64)

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -105,6 +105,12 @@ class TestNonNano:
                 assert res.dtype == "m8[ms]"
             elif unit == NpyDatetimeUnit.NPY_FR_us.value:
                 assert res.dtype == "m8[us]"
+                
+    def test_view(self):
+        td = Timedelta(seconds=1)
+        with tm.assert_produces_warning(None):
+            res = td.view(np.int64)
+        assert res == td._value
 
     def test_truediv_timedeltalike(self, td):
         assert td / td == 1


### PR DESCRIPTION
- [x] closes #66608 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.


I havent added any entries to `doc/source/whatsnew/vX.X.X.rst` as it seemed like a pretty easy fix, let me know if it is required though, would be happy to add it promptly!