### PR TITLE
BUG: memory_usage missing the engine's object copy (GH#66593)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -429,6 +429,7 @@ Conversion
 Strings
 ^^^^^^^
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
+- Bug in :meth:`Index.memory_usage` under-reporting for arrow-backed string dtypes by not counting the object-dtype copy of the values that the index engine holds once it has been built (:issue:`66593`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
 - Bug in :meth:`Series.str.split` with :class:`ArrowDtype` ``string`` not inferring regex for multi-character patterns when ``regex=None``, causing the pattern to be treated as a literal instead of a regular expression (:issue:`58321`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -46,6 +46,7 @@ from pandas._libs.tslibs import (
     Timestamp,
     tz_compare,
 )
+from pandas.compat import PYPY
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
     DuplicateLabelError,
@@ -5468,6 +5469,21 @@ class Index(IndexOpsMixin, PandasObject):
         # include our engine hashtable, only if it's already cached
         if "_engine" in self._cache:
             result += self._engine.sizeof(deep=deep)
+
+            # GH#66593 the engine also holds the array it was built from. That is
+            #  our own array except when _get_engine_target had to cast to object,
+            #  e.g. for arrow-backed strings, where it is a copy that
+            #  _memory_usage did not see.
+            engine_values = getattr(self._engine, "values", None)
+            own_values = getattr(self._values, "_ndarray", self._values)
+            if (
+                isinstance(engine_values, np.ndarray)
+                and engine_values.dtype == object
+                and engine_values is not own_values
+            ):
+                result += engine_values.nbytes
+                if deep and not PYPY:
+                    result += lib.memory_usage_of_objects(engine_values)
         return result
 
     @final

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -98,7 +98,9 @@ def test_memory_usage(index_or_series_memory_obj):
         elif isinstance(obj.dtype, pd.CategoricalDtype):
             return _is_object_dtype(obj.dtype.categories)
         elif isinstance(obj.dtype, pd.StringDtype):
-            return obj.dtype.storage == "python"
+            # python storage boxes the values itself; for the other storages the
+            #  index engine holds an object-dtype copy of them (GH#66593)
+            return True
         return is_object_dtype(obj)
 
     has_objects = _is_object_dtype(obj) or (is_ser and _is_object_dtype(obj.index))

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -102,6 +102,12 @@ class TestCategorical(base.ExtensionTests):
             if not using_string_dtype():
                 assert na_value_obj in data_missing
 
+    def test_memory_usage(self, data):
+        # GH#66593 the categories Index caches an engine that holds an
+        #  object-dtype copy of the categories, which nbytes does not include
+        data.categories._cache.pop("_engine", None)
+        super().test_memory_usage(data)
+
     def test_empty(self, dtype):
         cls = dtype.construct_array_type()
         result = cls._empty((4,), dtype=dtype)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -4,6 +4,7 @@ from functools import partial
 import math
 import operator
 import re
+import sys
 
 import numpy as np
 import pytest
@@ -1817,6 +1818,22 @@ def test_index_comparison_different_string_dtype(string_dtype_no_object):
     result = s_str > s_obj
     expected.index = idx.astype(string_dtype_no_object)
     assert_series_equal(result, expected)
+
+
+def test_memory_usage_counts_engine_object_copy():
+    # GH#66593 for arrow-backed strings the engine holds an object-dtype copy
+    #  of the whole Index that memory_usage did not account for
+    pytest.importorskip("pyarrow")
+    dtype = pd.StringDtype(storage="pyarrow", na_value=np.nan)
+    idx = Index([f"{i:040d}" for i in range(100)], dtype=dtype)
+
+    before = idx.memory_usage(deep=True)
+    idx.get_loc(idx[0])  # builds and caches the engine
+    growth = idx.memory_usage(deep=True) - before
+
+    held = idx._engine.values
+    boxed = held.nbytes + sum(sys.getsizeof(s) for s in held)
+    assert growth == idx._engine.sizeof(deep=True) + boxed
 
 
 def test_get_level_values_boolean_names():

--- a/pandas/tests/indexes/test_old_base.py
+++ b/pandas/tests/indexes/test_old_base.py
@@ -353,9 +353,10 @@ class TestBase:
 
         res_with_engine = index.memory_usage()
 
-        # the empty engine doesn't affect the result even when initialized with values,
-        # because engine.sizeof() doesn't consider the content of engine.values
-        assert res_with_engine == res_without_engine
+        # engine.sizeof() doesn't consider the content of engine.values, so the
+        # empty engine only adds the array it holds, and only when that array is a
+        # copy made by _get_engine_target rather than our own (GH#66593)
+        assert res_with_engine >= res_without_engine
 
         if len(index) == 0:
             assert res_without_engine == 0


### PR DESCRIPTION
Fixes #66593

`Index.memory_usage` adds `self._engine.sizeof(deep=deep)`, which reports the
hashtable and nothing else. For arrow-backed string dtypes `_get_engine_target`
hands the engine `vals.astype(object)`, so the engine also retains a distinct
pointer array and a full set of freshly boxed `PyUnicode` objects that
`_memory_usage` never saw. For object dtype that array *is* the Index's own
array, which is why the bug only shows up on the string dtypes.

The fix, in `Index.memory_usage`: when the cached engine's array is an
object-dtype ndarray that is not the array backing `self._values`, add its
`nbytes`, and at `deep=True` also `lib.memory_usage_of_objects` on it. The
identity check is what keeps object dtype and `string[python]`, where the engine
shares our array, from being double counted; the `dtype == object` check keeps
the masked and datetime engines, which hold an i8/M8 view of our own buffer, out
of it.

I left `HashTable.sizeof` alone. Making it honour `deep` would double count for
object dtype, where the strings are shared with the Index and already counted,
and the hashtable cannot tell which case it is in. The Index is the only layer
that knows.

Three existing tests encoded the old accounting and are updated:

- `base/test_misc.py::test_memory_usage`: its local `_is_object_dtype` claimed
  only `storage == "python"` strings have a deep component. That is now false for
  any string Index with a cached engine, which this test always has.
- `indexes/test_old_base.py::test_memory_usage_doesnt_trigger_engine`: the
  engine's copy is allocated when the engine is constructed, not when its mapping
  is populated, so the `==` becomes `>=`. What the test is actually about, that
  `memory_usage()` does not build the engine, is untouched.
- `extension/test_categorical.py`: constructing a `Categorical` leaves a cached
  engine on the categories Index, so `memory_usage(index=False) == nbytes` no
  longer holds. Overridden locally to drop that engine rather than weakening the
  shared assertion for every EA. That assertion is already only conditionally
  true on main: `pd.Categorical(list("abcdefghij")).categories.get_loc("a")` makes
  `Series(c).memory_usage(index=False)` return 402 against `nbytes` of 102.

## Verified

x86-64 Linux, CPython 3.11.15, numpy 2.4.6, pyarrow 25.0.0, built from this
branch. CPU only.

The issue's reproducer goes from a reported growth of 16908 kB to 65408 kB, which
is 16908 (hashtable) + 4000 (pointer array) + 44500 (boxed strings). Against RSS,
500k keys x 40 chars, engine build only:

| dtype | reported before | reported after | RSS delta |
|---|---|---|---|
| `object` | 16.9 MB | 16.9 MB | 17.0 MB |
| `str` | 16.9 MB | 65.4 MB | 70.3 MB |
| `string[python]` | 16.9 MB | 16.9 MB | 16.8 MB |

`object` and `string[python]` are unchanged, which is the point of the identity
check. The residual 65.4 vs 70.3 MB on `str` is pymalloc arena overhead from
allocating 500k `PyUnicode` objects.

New test `test_memory_usage_counts_engine_object_copy` fails on the parent commit
and passes here. Full suite: 217415 passed, 0 failed (the 383 errors are missing
`qapp` and `httpserver` fixtures in my container, all in `pandas/tests/io`).
pre-commit and `mypy 2.1.0` clean on the changed files.

## Not verified

PyPy (the `not PYPY` guard mirrors `_memory_usage` but is untested here) and
32-bit. My `PyUnicode` totals differ from the issue's because I am on CPython 3.11
rather than 3.13; the ratio matches. I did not separately measure the frame-level
example in the issue, though it routes through the same code path.

A `bool[pyarrow]` Index also gets an object copy, and `memory_usage_of_objects`
will over-count its boxed singletons. That over-count is pre-existing for any
object array of shared objects, so I left it alone. GH-58529's `MultiIndex` case
is also untouched.

Thanks to @jbrockmendel for the report, which pinned both mechanisms and the
exact line in `_get_engine_target`.