### PR TITLE
BUG prevent C parser reuse after conversion errors

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -589,6 +589,7 @@ I/O
 - Fixed bug in :func:`read_csv` with the ``c`` engine where a value in ``na_values``, ``true_values`` or ``false_values`` containing an embedded NUL byte was truncated at the NUL, so it also matched unrelated fields sharing the prefix before it (:issue:`19886`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where a value passed to a ``converters`` callable was truncated at an embedded NUL byte (:issue:`19886`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
+- Fixed bug in :func:`read_csv` with the ``c`` engine where requesting another chunk after a dtype conversion or ``converters`` callable raised could segfault; the reader now raises ``ValueError`` because it cannot continue after a conversion error (:issue:`66622`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with ``dtype="S"`` (:issue:`19886`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with an explicit string-like ``dtype`` (``object``, ``"str"``, ``"string"`` or ``"category"``) (:issue:`66525`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -388,6 +388,7 @@ cdef class TextReader:
         object orig_header
         bint na_filter, keep_default_na, has_usecols, has_mi_columns
         bint allow_leading_cols
+        bint conversion_error
         # Trim the parser's buffers after a whole-file read.  The parallel
         # reader turns this off on its workers, whose buffers are reused
         # across chunks and freed at close.
@@ -564,6 +565,7 @@ cdef class TextReader:
         self.na_filter = na_filter
         self._pa_target = None
         self.trim_after_read = True
+        self.conversion_error = False
 
         if float_precision in ("round_trip", "legacy", "high", None):
             self.parser.double_converter = precise_xstrtod_wrapper
@@ -1044,6 +1046,9 @@ cdef class TextReader:
             int64_t buffered_lines
             int64_t irows
 
+        if self.conversion_error:
+            raise ValueError("C parser cannot continue after a conversion error")
+
         if rows is not None:
             irows = rows
             buffered_lines = self.parser.lines - self.parser_start
@@ -1062,7 +1067,11 @@ cdef class TextReader:
         if self.parser_start >= self.parser.lines:
             raise StopIteration
 
-        columns = self._convert_column_data(rows)
+        try:
+            columns = self._convert_column_data(rows)
+        except BaseException:
+            self.conversion_error = True
+            raise
         if len(columns) > 0:
             rows_read = len(list(columns.values())[0])
             # trim

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -819,6 +819,23 @@ def test_block_lane_chunked_reads_match(c_parser_only):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "conversion", [{"dtype": {"a": int}}, {"converters": {"a": int}}]
+)
+def test_chunk_conversion_error_makes_reader_unusable(c_parser_only, conversion):
+    parser = c_parser_only
+    values = [*range(5), "oops", *range(6, 15)]
+    data = "a\n" + "\n".join(map(str, values))
+    with parser.read_csv(StringIO(data), chunksize=10, **conversion) as reader:
+        msg = "invalid literal for int\\(\\) with base 10: 'oops'"
+        with pytest.raises(ValueError, match=msg):
+            next(reader)
+        with pytest.raises(
+            ValueError, match="C parser cannot continue after a conversion error"
+        ):
+            next(reader)
+
+
 def test_block_lane_crlf_pairs_at_block_edges(c_parser_only):
     # \r\n pairs are consumed in-lane; pairs split across a 16-byte block
     # boundary or bare \r must defer to the state machine.  Vary field


### PR DESCRIPTION
- [x] closes #66622
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added an entry in `doc/source/whatsnew/v3.1.0.rst`
- [x] I have reviewed and followed all contribution guidelines
- [x] I used AI and prompted it to follow `AGENTS.md`

Mark the C parser as unusable when conversion of a chunk raises. Subsequent reads now raise a deterministic `ValueError` instead of accessing inconsistent parser buffers and potentially segfaulting.

Regression tests cover failures from both an explicit dtype and a converter callable.