### PR TITLE
DOC: fix docstring parameter names that do not match the signature

### DIFF
--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -34,7 +34,7 @@ def round_trip_pickle(obj: Any, tmp_path: Path) -> DataFrame | Series:
     ----------
     obj : any object
         The object to pickle and then re-read.
-    path : str, path object or file-like object, default None
+    tmp_path : str, path object or file-like object, default None
         The path where the pickled object is written and then read.
 
     Returns
@@ -58,7 +58,7 @@ def round_trip_pathlib(
         IO writing function (e.g. DataFrame.to_csv )
     reader : callable
         IO reading function (e.g. pd.read_csv )
-    path : str, default None
+    tmp_path : str, default None
         The path where the object is written and then read.
 
     Returns

--- a/pandas/_testing/_io.py
+++ b/pandas/_testing/_io.py
@@ -34,7 +34,7 @@ def round_trip_pickle(obj: Any, tmp_path: Path) -> DataFrame | Series:
     ----------
     obj : any object
         The object to pickle and then re-read.
-    tmp_path : str, path object or file-like object, default None
+    tmp_path : Path
         The path where the pickled object is written and then read.
 
     Returns
@@ -58,7 +58,7 @@ def round_trip_pathlib(
         IO writing function (e.g. DataFrame.to_csv )
     reader : callable
         IO reading function (e.g. pd.read_csv )
-    tmp_path : str, default None
+    tmp_path : Path
         The path where the object is written and then read.
 
     Returns

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1506,8 +1506,6 @@ def diff(arr, n: int | float | np.integer | np.floating, axis: AxisInt = 0):
         number of periods
     axis : {0, 1}
         axis to shift on
-    stacklevel : int, default 3
-        The stacklevel for the lost dtype warning.
 
     Returns
     -------

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -2100,7 +2100,6 @@ def _make_sparse(
     kind : {'block', 'integer'}
     fill_value : NaN or another value
     dtype : np.dtype, optional
-    copy : bool, default False
 
     Returns
     -------

--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -100,12 +100,6 @@ class AbstractEngine(metaclass=abc.ABCMeta):
         """
         Return an evaluated expression.
 
-        Parameters
-        ----------
-        env : Scope
-            The local and global environment in which to evaluate an
-            expression.
-
         Notes
         -----
         Must be implemented by subclasses.

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -5865,14 +5865,6 @@ def get_groupby(
     Parameters
     ----------
     obj : pandas object
-    level : int, default None
-        Level of MultiIndex
-    groupings : list of Grouping objects
-        Most users should ignore this
-    exclusions : array-like, optional
-        List of columns to exclude
-    name : str
-        Most users should ignore this
 
     Returns
     -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -8195,7 +8195,6 @@ def maybe_sequence_to_range(sequence: Axes) -> Axes:
     Parameters
     ----------
     sequence : 1D sequence
-    names : sequence of str
 
     Returns
     -------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -382,7 +382,7 @@ class MultiIndex(Index):
             Codes to check for validity. Defaults to current codes.
         levels : optional list
             Levels to check for validity. Defaults to current levels.
-        levels_to_validate: optional list
+        levels_to_verify: optional list
             Specifies the levels to verify.
 
         Raises
@@ -1707,7 +1707,7 @@ class MultiIndex(Index):
 
         Parameters
         ----------
-        values : str or sequence
+        names : str or sequence
             name(s) to set
         level : int, level name, or sequence of int/level names (default None)
             If the index is a MultiIndex (hierarchical), level(s) to set (None

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -382,7 +382,7 @@ class MultiIndex(Index):
             Codes to check for validity. Defaults to current codes.
         levels : optional list
             Levels to check for validity. Defaults to current levels.
-        levels_to_verify: optional list
+        levels_to_verify : optional list
             Specifies the levels to verify.
 
         Raises

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -114,7 +114,7 @@ def interleaved_dtype(dtypes: list[DtypeObj]) -> DtypeObj | None:
 
     Parameters
     ----------
-    blocks : List[DtypeObj]
+    dtypes : List[DtypeObj]
 
     Returns
     -------

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -110,7 +110,7 @@ if TYPE_CHECKING:
 
 def interleaved_dtype(dtypes: list[DtypeObj]) -> DtypeObj | None:
     """
-    Find the common dtype for `blocks`.
+    Find the common dtype for `dtypes`.
 
     Parameters
     ----------
@@ -119,7 +119,7 @@ def interleaved_dtype(dtypes: list[DtypeObj]) -> DtypeObj | None:
     Returns
     -------
     dtype : np.dtype, ExtensionDtype, or None
-        None is returned when `blocks` is empty.
+        None is returned when `dtypes` is empty.
     """
     if not len(dtypes):
         return None

--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -26,7 +26,7 @@ def _side_expander(prop_fmt: str) -> Callable:
 
     Parameters
     ----------
-    side : str
+    prop_fmt : str
         The border side to expand into properties
 
     Returns
@@ -256,7 +256,7 @@ class CSSResolver:
 
         Parameters
         ----------
-        declarations_str : str | Iterable[tuple[str, str]]
+        declarations : str | Iterable[tuple[str, str]]
             A CSS string or set of CSS declaration tuples
             e.g. "font-weight: bold; background: blue" or
             {("font-weight", "bold"), ("background", "blue")}

--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -263,7 +263,7 @@ class CSSResolver:
             {("font-weight", "bold"), ("background", "blue")}
         inherited : dict, optional
             Atomic properties indicating the inherited style context in which
-            declarations_str is to be resolved. ``inherited`` should already
+            declarations is to be resolved. ``inherited`` should already
             be resolved, i.e. valid output of this method.
 
         Returns

--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -27,7 +27,8 @@ def _side_expander(prop_fmt: str) -> Callable:
     Parameters
     ----------
     prop_fmt : str
-        The border side to expand into properties
+        Format string for the expanded property, with a placeholder for the
+        side, e.g. ``"margin-{:s}"``.
 
     Returns
     -------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -4304,7 +4304,7 @@ def _background_gradient(
 
         Parameters
         ----------
-        color : rgb or rgba tuple
+        rgba : rgb or rgba tuple
 
         Returns
         -------

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -636,11 +636,6 @@ class StylerRenderer:
         Also add elements to the cellstyle_map for more efficient grouped elements in
         <style></style> block
 
-        Parameters
-        ----------
-        sparsify_index : bool
-            Whether index_headers section will add rowspan attributes (>1) to elements.
-
         Returns
         -------
         body : list
@@ -2266,10 +2261,8 @@ class Tooltips:
 
         Parameters
         ----------
-        styler_data : DataFrame
+        styler : DataFrame
             Underlying ``Styler`` DataFrame used for reindexing.
-        uuid : str
-            The underlying ``Styler`` uuid for CSS id.
         d : dict
             The dictionary prior to final render
 

--- a/pandas/io/formats/style_render.py
+++ b/pandas/io/formats/style_render.py
@@ -2261,8 +2261,8 @@ class Tooltips:
 
         Parameters
         ----------
-        styler : DataFrame
-            Underlying ``Styler`` DataFrame used for reindexing.
+        styler : StylerRenderer
+            The renderer whose ``data`` the tooltips are reindexed against.
         d : dict
             The dictionary prior to final render
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -637,7 +637,7 @@ def _maybe_coerce_freq(code) -> str:
 
     Parameters
     ----------
-    source : str or DateOffset
+    code : str or DateOffset
         Frequency converting from
 
     Returns

--- a/scripts/validate_unwanted_patterns.py
+++ b/scripts/validate_unwanted_patterns.py
@@ -514,10 +514,6 @@ def main(
         Source path representing path to a file/directory.
     output_format : str
         Output format of the error message.
-    file_extensions_to_check : str
-        Comma separated values of what file extensions to check.
-    excluded_file_paths : str
-        Comma separated values of what file paths to exclude during the check.
 
     Returns
     -------


### PR DESCRIPTION
Twenty-two `Parameters` entries name something the function does not take. Documentation only, no behaviour change.

Two kinds. Renamed in the code, not in the docstring:

| Where | Says | Takes |
|---|---|---|
| `_testing/_io.py` `round_trip_pickle`, `round_trip_pathlib` | `path` | `tmp_path` |
| `core/indexes/multi.py` `_set_names` | `values` | `names` |
| `core/indexes/multi.py` `_verify_integrity` | `levels_to_validate` | `levels_to_verify` |
| `core/internals/managers.py` `interleaved_dtype` | `blocks` | `dtypes` |
| `io/formats/css.py` `_side_expander` | `side` | `prop_fmt` |
| `io/formats/css.py` `CSSResolver.__call__` | `declarations_str` | `declarations` |
| `io/formats/style.py` `relative_luminance` | `color` | `rgba` |
| `io/formats/style_render.py` `_translate` | `styler_data` | `styler` |
| `tseries/frequencies.py` `_maybe_coerce_freq` | `source` | `code` |

Gone from the signature, still documented: `stacklevel` in `algorithms.diff`, `copy` in `_make_sparse`, `env` in `AbstractEngine._evaluate`, `names` in `maybe_sequence_to_range`, `uuid` in `_translate`, `sparsify_index` in `_translate_body`, `file_extensions_to_check` and `excluded_file_paths` in `scripts/validate_unwanted_patterns.py`, and four in `get_groupby` (`level`, `groupings`, `exclusions`, `name`) where only `obj` still exists.

Two of the removals left an empty `Parameters` section, so the section went with them: `_evaluate` takes no arguments at all, and `_translate_body` takes three that were never documented. If you want those three written up properly I can send that separately, it seemed like a different change from this one.

`interleaved_dtype` is worth a second look: the summary line and the `Returns` text also say `blocks`, so the rename left three mentions behind. I changed the parameter entry and left the prose, since rewording it goes past what this is about.

Found with a checker I wrote that compares numpydoc `Parameters` against the real signature; each of these was read by hand before touching it.
