### PR TITLE
PERF: cascade Series.dt.components for ArrowDtype durations

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -358,7 +358,7 @@ Performance improvements
 - Performance improvement in :meth:`Series.isin` and :meth:`DataFrame.isin`
   when checking a numeric :class:`Series` or :class:`Index` against a
   list-like of integers of a different numeric dtype (:issue:`46485`).
-- Performance improvement in the :attr:`Series.dt` duration component accessors (``days``, ``seconds``, ``microseconds``, ``nanoseconds``, ``components``, etc.) for :class:`ArrowDtype` durations by using PyArrow compute instead of converting to :class:`TimedeltaArray` (:issue:`63470`)
+- Performance improvement in the :attr:`Series.dt` duration component accessors (``days``, ``seconds``, ``microseconds``, ``nanoseconds``, ``components``, etc.) for :class:`ArrowDtype` durations by using PyArrow compute instead of converting to :class:`TimedeltaArray` (:issue:`63470`, :issue:`66635`)
 - Performance improvement in tab completion and :meth:`DataFrame.__dir__`
   for :class:`DataFrame` and :class:`Series` with a large string-valued
   index or large number of columns (:issue:`18587`).

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3803,21 +3803,25 @@ class ArrowExtensionArray(
         return pa_type.unit
 
     @cache_readonly
-    def _dt_day_remainder(self) -> pa.ChunkedArray:
+    def _dt_day_and_remainder(self) -> tuple[pa.ChunkedArray, pa.ChunkedArray]:
         """
-        Return the remainder after removing full days, always non-negative.
+        Return ``(days, sub-day remainder)`` for a duration array.
 
-        For negative durations like -22h 57m 57s (= -1 day + 1h 2m 3s),
-        this returns the positive offset from the day boundary.
-
-        This is cached because it's used by all sub-day component accessors.
+        The remainder is always non-negative (e.g. -22h57m57s = -1 day + 1h2m3s
+        gives the positive offset from the day boundary). Deriving the remainder
+        already requires the day count, so both are cached together to avoid
+        recomputing the floor division in ``_dt_days``.
         """
         unit = self._duration_unit
         divisor = _DURATION_DIVISORS["day"][unit]
         arr = self._pa_array.cast(pa.int64())
         days = floor_div_int64(arr, divisor)
-        # remainder = arr - days * divisor (always non-negative)
-        return pc.subtract(arr, pc.multiply(days, divisor))
+        remainder = pc.subtract(arr, pc.multiply(days, divisor))
+        return days, remainder
+
+    @property
+    def _dt_day_remainder(self) -> pa.ChunkedArray:
+        return self._dt_day_and_remainder[1]
 
     def _dt_subday_component(self, component: str, modulo: int) -> Self:
         """
@@ -3837,10 +3841,8 @@ class ArrowExtensionArray(
 
     @property
     def _dt_days(self) -> Self:
-        unit = self._duration_unit
-        arr = self._pa_array.cast(pa.int64())
-        result = floor_div_int64(arr, _DURATION_DIVISORS["day"][unit])
-        return self._from_pyarrow_array(result.cast(pa.int32()))
+        days = self._dt_day_and_remainder[0]
+        return self._from_pyarrow_array(days.cast(pa.int32()))
 
     @property
     def _dt_hours(self) -> Self:
@@ -3894,21 +3896,37 @@ class ArrowExtensionArray(
         """
         Return all duration components.
 
-        The day remainder is computed once (and cached on ``_dt_day_remainder``),
-        so every sub-day component below reuses it. Note that the per-field
-        semantics differ from the like-named accessors: ``seconds`` here is the
-        0-59 seconds field (not the 0-86399 total) and ``microseconds`` is the
-        0-999 field (not the 0-999999 total).
+        Sub-day fields are peeled off a running remainder from the coarsest unit
+        down, so each is ``remainder // divisor`` with no modulo needed.
+        ``seconds``/``microseconds`` here are the 0-59 / 0-999 fields.
         """
-        return {
-            "days": self._dt_days,
-            "hours": self._dt_hours,
-            "minutes": self._dt_minutes,
-            "seconds": self._dt_subday_component("second", modulo=60),
-            "milliseconds": self._dt_milliseconds,
-            "microseconds": self._dt_subday_component("microsecond", modulo=1000),
-            "nanoseconds": self._dt_nanoseconds,
-        }
+        unit = self._duration_unit
+        components: dict[str, ArrowExtensionArray] = {"days": self._dt_days}
+        remainder = self._dt_day_remainder
+        subday = (
+            ("hours", "hour"),
+            ("minutes", "minute"),
+            ("seconds", "second"),
+            ("milliseconds", "millisecond"),
+            ("microseconds", "microsecond"),
+            ("nanoseconds", "nanosecond"),
+        )
+        # index of the finest field present at this resolution; its remainder
+        # update is redundant since no finer field follows
+        last = max(
+            i for i, (_, c) in enumerate(subday) if unit in _DURATION_DIVISORS[c]
+        )
+        for i, (name, component) in enumerate(subday):
+            divisor = _DURATION_DIVISORS[component].get(unit)
+            if divisor is None:
+                # array resolution is coarser than this component -> always 0
+                components[name] = self._dt_zero_or_null_int32()
+                continue
+            value = pc.divide(remainder, divisor)
+            components[name] = self._from_pyarrow_array(value.cast(pa.int32()))
+            if i != last:
+                remainder = pc.subtract(remainder, pc.multiply(value, divisor))
+        return components
 
     def _dt_to_pytimedelta(self) -> np.ndarray:
         data = self._pa_array.to_pylist()

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3425,13 +3425,13 @@ def test_dt_day_remainder_cache_invalidation():
         [1 * 3600 + 2 * 60 + 3, 4 * 3600 + 5 * 60 + 6], dtype="int32[pyarrow]"
     )
     tm.assert_series_equal(result_before, expected_before)
-    assert "_dt_day_remainder" in arr._cache
+    assert "_dt_day_and_remainder" in arr._cache
 
     # Modify the array
     arr[0] = pd.Timedelta("3 days 7:08:09")
 
     # Cache should be invalidated
-    assert "_dt_day_remainder" not in arr._cache
+    assert "_dt_day_and_remainder" not in arr._cache
 
     # Accessing again should give correct (recomputed) values, not stale cached values
     result_after = pd.Series(arr._dt_seconds, dtype="int32[pyarrow]")
@@ -3453,7 +3453,7 @@ def test_dt_day_remainder_cache_not_pickled(tmp_path):
     )
     arr = ser.array
     arr._dt_day_remainder  # populate the cache
-    assert "_dt_day_remainder" in arr._cache
+    assert "_dt_day_and_remainder" in arr._cache
 
     result = tm.round_trip_pickle(arr, tmp_path / "cache.pkl")
     assert result._cache == {}
@@ -3468,7 +3468,7 @@ def test_dt_day_remainder_cache_invalidated_on_sort():
         dtype=ArrowDtype(pa.duration("ns")),
     )
     arr._dt_day_remainder  # populate the cache
-    assert "_dt_day_remainder" in arr._cache
+    assert "_dt_day_and_remainder" in arr._cache
 
     arr.sort()
     assert arr._cache == {}


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file.
- [x] I have reviewed and followed all the contribution guidelines.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Speeds up `Series.dt.components` for `ArrowDtype` durations with two changes:

1. Sub-day fields are peeled off a running remainder from the coarsest unit down, so each is a single division with no modulo (PyArrow has no modulo kernel, so each `%` was emulated with divide/multiply/subtract).
2. The day floor-division is cached once and shared by `_dt_days` and `_dt_day_remainder`, instead of being recomputed on every `.dt.components` call.

No behavior change, covered by the existing `test_arrow` duration-component tests.

Benchmark of `TimedeltaComponents.time_components` (`duration[ns][pyarrow]`, best of 60, before = main / after = branch): `Series.dt.components` 34.5 ms -> 18.0 ms (~1.9x) at N=100k all-positive, and 320 ms -> 173 ms (~1.85x) at N=1M mixed-sign. Single-field accessors unchanged.

xref #63283, #63470
