### PR TITLE
ENH: add DataFrame._from_arrow for pandas-side arrow to DataFrame con…

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -768,6 +768,22 @@ class DataFrame(NDFrame, OpsMixin):
         table = pa.Table.from_pandas(self, schema=requested_schema)
         return table.__arrow_c_stream__()
 
+    @classmethod
+    def _from_pyarrow(cls, table) -> DataFrame:
+        """
+        Construct a DataFrame from a ``pyarrow.Table``.
+
+        Private, pandas-controlled entry point for the arrow -> pandas
+        conversion (GH#59780). Exposed as a method (rather than a module-level
+        function) so the API pyarrow calls is stable across internal refactors.
+        The pandas-specific metadata/index handling lives in
+        :mod:`pandas.core.interchange.from_arrow`; the array-level conversion is
+        delegated to pyarrow.
+        """
+        from pandas.core.interchange.from_arrow import table_to_dataframe
+
+        return table_to_dataframe(table)
+
     # ----------------------------------------------------------------------
 
     @property

--- a/pandas/core/interchange/from_arrow.py
+++ b/pandas/core/interchange/from_arrow.py
@@ -1,0 +1,136 @@
+"""
+Reconstruct a pandas :class:`DataFrame` from a ``pyarrow.Table``.
+
+This is the pandas-side home for the "pandas metadata" handling that has
+historically lived in pyarrow's ``pandas_compat.py`` (GH#59780). The low-level
+conversion of each column's memory is still delegated to pyarrow; what lives
+here is the pandas-specific reconstruction of the index, the column labels and
+(eventually) the dtypes from the ``b"pandas"`` schema metadata, so that pandas
+controls the arrow -> pandas conversion.
+
+This is an initial, deliberately small implementation: it covers the common
+cases (a default/serialized :class:`Index`, a :class:`RangeIndex` stored as
+metadata, and string column labels) and leaves the more involved cases
+(``MultiIndex`` columns, full ``numpy_type`` dtype restoration, ``attrs``) as
+follow-ups, see the ``TODO`` markers below.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+    from pandas import (
+        DataFrame,
+        Index,
+    )
+
+_INDEX_LEVEL_PATTERN = re.compile(r"^__index_level_\d+__$")
+
+
+def _index_name(field_name: str) -> str | None:
+    """
+    User-facing name for a serialized index level.
+
+    Auto-generated ``__index_level_N__`` names correspond to an unnamed index,
+    so they map back to ``None``.
+    """
+    if _INDEX_LEVEL_PATTERN.match(field_name):
+        return None
+    return field_name
+
+
+def _reconstruct_index(
+    table: pa.Table,
+    index_descriptors: list,
+    columns: dict[str, pa.ChunkedArray],
+) -> tuple[Index, set[str]]:
+    """
+    Build the row :class:`Index` from the pandas metadata index descriptors.
+
+    Returns the reconstructed index and the set of field names that were
+    consumed as index levels (so the caller can drop them from the data).
+    """
+    from pandas import (
+        Index,
+        MultiIndex,
+        RangeIndex,
+    )
+
+    arrays: list = []
+    names: list[str | None] = []
+    consumed: set[str] = set()
+
+    for descriptor in index_descriptors:
+        if isinstance(descriptor, str):
+            # a serialized index level stored as an actual column in the table
+            level = columns[descriptor].to_pandas()
+            # clear the arrow field name so it does not leak into the index name
+            # (the user-facing name is derived from the descriptor below)
+            level.name = None
+            arrays.append(level)
+            names.append(_index_name(descriptor))
+            consumed.add(descriptor)
+        elif isinstance(descriptor, dict) and descriptor.get("kind") == "range":
+            # a RangeIndex stored purely as metadata (no backing column)
+            return (
+                RangeIndex(
+                    start=descriptor["start"],
+                    stop=descriptor["stop"],
+                    step=descriptor["step"],
+                    name=descriptor["name"],
+                ),
+                consumed,
+            )
+
+    if not arrays:
+        return RangeIndex(table.num_rows), consumed
+    if len(arrays) == 1:
+        return Index(arrays[0], name=names[0]), consumed
+    return MultiIndex.from_arrays(arrays, names=names), consumed
+
+
+def table_to_dataframe(table: pa.Table) -> DataFrame:
+    """
+    Convert a ``pyarrow.Table`` to a pandas :class:`DataFrame`.
+
+    Parameters
+    ----------
+    table : pyarrow.Table
+
+    Returns
+    -------
+    DataFrame
+    """
+    from pandas import DataFrame
+
+    columns = {name: table.column(i) for i, name in enumerate(table.column_names)}
+    metadata = table.schema.pandas_metadata
+
+    if metadata is None:
+        # No pandas metadata: straight column-wise conversion with a default index.
+        data = {name: col.to_pandas() for name, col in columns.items()}
+        return DataFrame(data)
+
+    index_descriptors = metadata.get("index_columns", [])
+    index, index_fields = _reconstruct_index(table, index_descriptors, columns)
+
+    # data columns are everything that was not consumed as an index level
+    data = {
+        name: col.to_pandas()
+        for name, col in columns.items()
+        if name not in index_fields
+    }
+    # to_pandas() yields Series on a default RangeIndex; assemble then attach the
+    # reconstructed index (all columns share that same default index, so this is
+    # an alignment-free assignment).
+    result = DataFrame(data)
+    result.index = index
+
+    # TODO(GH#59780): restore original (possibly non-string / MultiIndex) column
+    # labels and dtypes from ``metadata["columns"]`` / ``metadata["column_indexes"]``,
+    # and restore ``DataFrame.attrs`` from ``metadata["attributes"]``.
+    return result

--- a/pandas/tests/interchange/test_from_arrow.py
+++ b/pandas/tests/interchange/test_from_arrow.py
@@ -1,0 +1,50 @@
+import pytest
+
+import pandas as pd
+import pandas._testing as tm
+
+pa = pytest.importorskip("pyarrow")
+
+
+@pytest.mark.parametrize(
+    "df",
+    [
+        # default RangeIndex
+        pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}),
+        # named non-range index
+        pd.DataFrame({"a": [1, 2, 3]}, index=pd.Index([10, 20, 30], name="idx")),
+        # unnamed non-range index
+        pd.DataFrame({"a": [1, 2, 3]}, index=[7, 8, 9]),
+        # MultiIndex rows
+        pd.DataFrame(
+            {"a": [1, 2, 3, 4]},
+            index=pd.MultiIndex.from_tuples(
+                [("x", 1), ("x", 2), ("y", 1), ("y", 2)], names=["l1", "l2"]
+            ),
+        ),
+        # mixed dtypes
+        pd.DataFrame(
+            {
+                "i": [1, 2, 3],
+                "f": [1.5, 2.5, 3.5],
+                "b": [True, False, True],
+                "dt": pd.to_datetime(["2024-01-01", "2024-06-15", "2024-12-31"]),
+            }
+        ),
+    ],
+)
+def test_from_arrow_roundtrip(df):
+    # GH#59780 pandas-side arrow -> DataFrame conversion round-trips through the
+    # pandas metadata that pa.Table.from_pandas writes.
+    table = pa.Table.from_pandas(df)
+    result = pd.DataFrame._from_pyarrow(table)
+    tm.assert_frame_equal(result, df)
+
+
+def test_from_arrow_no_pandas_metadata():
+    # a table without the b"pandas" schema metadata converts with a default index
+    table = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    assert table.schema.pandas_metadata is None
+    result = pd.DataFrame._from_pyarrow(table)
+    expected = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
First step toward #59780: moving pyarrow's pandas-specific conversion into pandas.

Adds a private `DataFrame._from_arrow(table)` classmethod (a method rather than a module
function, per Joris's note, so the surface pyarrow calls stays stable across internal
`pandas.core` refactors) that delegates to
`pandas.core.interchange.from_arrow._table_to_dataframe`. The index and column-label
reconstruction from the pandas metadata lives in pandas; array-level conversion stays in
pyarrow.

Covers default/named/unnamed `Index`, `MultiIndex`, metadata-only `RangeIndex`, and mixed
dtypes. Left as TODOs for follow-up: MultiIndex columns, full `numpy_type` dtype restoration,
and `attrs`.

Open for discussion (per the issue): the module location and the method name/API surface.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] Tests added and passed
- [x] All code checks passed.
- [x] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file (private API, no user-facing change)
- [x] I have reviewed and followed all the contribution guidelines.
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

xref apache/arrow#44068