### PR TITLE
BUG: segfault reading from a closed read_csv reader (GH#66622)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -592,6 +592,7 @@ I/O
 - Fixed bug in :func:`read_csv` with the ``c`` engine where a value in ``na_values``, ``true_values`` or ``false_values`` containing an embedded NUL byte was truncated at the NUL, so it also matched unrelated fields sharing the prefix before it (:issue:`19886`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where a value passed to a ``converters`` callable was truncated at an embedded NUL byte (:issue:`19886`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where an embedded ``\r`` followed by a space in an unquoted field could cause an infinite re-parsing loop, producing spurious rows or a buffer overflow (:issue:`51141`)
+- Fixed bug in :func:`read_csv` with the ``c`` engine where reading from a chunked or iterator reader after it had been closed -- explicitly, by leaving its ``with`` block, or automatically after a chunk raised -- crashed the interpreter instead of raising ``ValueError`` (:issue:`66622`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with ``dtype="S"`` (:issue:`19886`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with an explicit string-like ``dtype`` (``object``, ``"str"``, ``"string"`` or ``"category"``) (:issue:`66525`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -407,6 +407,9 @@ cdef class TextReader:
         int64_t lm_chunk_idx
         object _buffer_ref  # keeps pre-loaded bytes alive during parse
         str _pa_target  # cached _string_convert target; None = unresolved
+        # Set by _close, which frees the tokenizer's buffers.  Reading from a
+        # closed reader would dereference those freed pointers (GH#66622).
+        bint is_closed
 
     cdef public:
         int64_t leading_cols, table_width
@@ -650,6 +653,10 @@ cdef class TextReader:
 
     def close(self):
         _close(self)
+
+    cdef _check_not_closed(self):
+        if self.is_closed:
+            raise ValueError("I/O operation on closed file.")
 
     def load_buffer(self, const unsigned char[::1] data, bint strip_bom=False):
         """Pre-load all chunk bytes into the parser's internal buffer.
@@ -931,6 +938,7 @@ cdef class TextReader:
         """
         rows=None --> read all rows
         """
+        self._check_not_closed()
         # Don't care about memory usage
         columns = self._read_rows(rows, self.trim_after_read)
 
@@ -946,6 +954,8 @@ cdef class TextReader:
         cdef:
             size_t rows_read = 0
             list chunks = []
+
+        self._check_not_closed()
 
         if self.datetime_cols:
             # Per-chunk fastpath state keyed by column; see _DatetimeChunkState.
@@ -1800,6 +1810,7 @@ cdef class TextReader:
 # which causes a class attribute lookup and violates best practices
 # https://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#finalization-method-dealloc
 cdef _close(TextReader reader):
+    reader.is_closed = True
     # Drop the pre-loaded buffer reference deterministically so the caller
     # can close the backing mmap (free-threaded builds may otherwise delay
     # the release past pool shutdown).

--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
 class CParserWrapper(ParserBase):
     low_memory: bool
     _reader: parsers.TextReader
+    _exhausted: bool
 
     def __init__(self, src: ReadCsvBuffer[str], **kwds) -> None:
         super().__init__(kwds)
@@ -68,6 +69,7 @@ class CParserWrapper(ParserBase):
         kwds = kwds.copy()
 
         self.low_memory = kwds.pop("low_memory", False)
+        self._exhausted = False
 
         # #2442
         kwds["allow_leading_cols"] = self.index_col is not False
@@ -250,6 +252,10 @@ class CParserWrapper(ParserBase):
     ]:
         index: Index | MultiIndex | None
         column_names: Sequence[Hashable] | MultiIndex
+        if self._exhausted:
+            # Exhausting the reader closed it, so calling into the C reader
+            # again would raise instead of signalling the end of the data.
+            raise StopIteration
         try:
             if self.low_memory:
                 chunks = self._reader.read_low_memory(nrows)
@@ -285,6 +291,7 @@ class CParserWrapper(ParserBase):
                 return index, columns, col_dict
 
             else:
+                self._exhausted = True
                 self.close()
                 raise
 

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -20,6 +20,7 @@ import pytest
 from pandas.compat import WASM
 from pandas.errors import (
     Pandas4Warning,
+    ParserError,
     ParserWarning,
 )
 import pandas.util._test_decorators as td
@@ -1252,3 +1253,75 @@ def test_na_values_leading_nul(c_parser_only):
     assert result["a"].isna().tolist() == [True, False, False]
     assert result["a"][1] == "\x00z"
     assert result["a"][2] == ""
+
+
+def _raise_on_five(value):
+    if value == "5":
+        raise RuntimeError("boom")
+    return value
+
+
+@pytest.mark.parametrize(
+    "data,kwargs,error,match",
+    [
+        (
+            "a,b\n" + "".join(f"{i},{'oops' if i == 5 else i}\n" for i in range(20)),
+            {"dtype": {"b": "int64"}},
+            ValueError,
+            "invalid literal for int",
+        ),
+        (
+            "a,b\n" + "".join(f"{i},{i}\n" for i in range(20)),
+            {"converters": {"b": _raise_on_five}},
+            RuntimeError,
+            "boom",
+        ),
+        (
+            "a,b\n"
+            + "".join(
+                (f"{i},{i},{i}\n" if i == 15 else f"{i},{i}\n") for i in range(20)
+            ),
+            {},
+            ParserError,
+            "Expected 2 fields",
+        ),
+    ],
+)
+def test_read_after_chunk_raised(c_parser_only, data, kwargs, error, match):
+    # GH#66622: a chunk that raised closed the reader, and reading again then
+    # dereferenced the freed tokenizer buffers instead of raising.
+    parser = c_parser_only
+
+    with parser.read_csv(StringIO(data), chunksize=10, **kwargs) as reader:
+        with pytest.raises(error, match=match):
+            for _ in reader:
+                pass
+
+        with pytest.raises(ValueError, match="I/O operation on closed file"):
+            next(reader)
+
+
+def test_read_after_close(c_parser_only):
+    # GH#66622: reading from a closed reader crashed the interpreter.
+    parser = c_parser_only
+    data = "a,b\n" + "".join(f"{i},{i}\n" for i in range(20))
+
+    with parser.read_csv(StringIO(data), chunksize=10) as reader:
+        assert len(next(reader)) == 10
+
+    with pytest.raises(ValueError, match="I/O operation on closed file"):
+        next(reader)
+
+
+def test_exhausted_reader_keeps_raising_stop_iteration(c_parser_only):
+    # GH#66622: exhausting a reader closes it, but it must keep behaving like a
+    # spent iterator rather than reporting a closed file.
+    parser = c_parser_only
+    data = "a,b\n" + "".join(f"{i},{i}\n" for i in range(20))
+
+    reader = parser.read_csv(StringIO(data), chunksize=10)
+    assert len(list(reader)) == 2
+
+    for _ in range(2):
+        with pytest.raises(StopIteration):
+            next(reader)


### PR DESCRIPTION
closes #66622

`TextFileReader.read` closes the reader whenever the engine raises, and `close` frees the C tokenizer's buffers (`stream`, `word_ends`, `line_start`, `line_fields`) while leaving `parser->lines` and friends intact. The next read therefore believed it still had buffered rows, skipped re-tokenizing, and dereferenced the freed pointers in `_convert_column_data`.

The failing `dtype=` conversion in the issue is only one way in — a raising `converters=` callable, a mid-file `ParserError`, an explicit `reader.close()`, or just leaving the reader's `with` block all crashed the same way, with no error involved in the last two.

`TextReader.read` / `read_low_memory` now raise `ValueError: I/O operation on closed file.` when the reader is closed, matching what `engine="python"` already does. Exhausting a reader also closes it, so `CParserWrapper` tracks that case separately and keeps raising `StopIteration` there — that also stops the post-exhaustion path from calling `_tokenize_rows` on the freed parser, which was reading through a dangling `source` pointer.