### PR TITLE
DOC clarify single-column list selection

### DIFF
--- a/doc/source/user_guide/10min.rst
+++ b/doc/source/user_guide/10min.rst
@@ -197,6 +197,13 @@ for getting a subset/rearranging:
 
    df[["B", "A"]]
 
+A list containing a single label still selects a :class:`DataFrame`, not a
+:class:`Series`:
+
+.. ipython:: python
+
+   df[["A"]]
+
 For a :class:`DataFrame`, passing a slice ``:`` selects matching rows:
 
 .. ipython:: python


### PR DESCRIPTION
- [x] closes #66616
- [ ] tests added / passed
- [ ] passes `pre-commit run --all-files`

This updates the "10 minutes to pandas" Getitem section to show that passing a list with one column label, such as `df[["A"]]`, returns a DataFrame rather than a Series.

Validation performed:

- `git diff --check`
- `Select-String -Path doc\source\user_guide\10min.rst -Pattern 'df\[\["A"\]\]|A list containing a single label'`

I could not run the single-page docs build locally because `python doc\make.py html --single user_guide/10min.rst` failed before building with `ModuleNotFoundError: No module named 'docutils'` in this environment.
