### PR TITLE
DOC: don't execute the read_xml remote-URL example

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -2836,10 +2836,16 @@ Read an XML string:
 
 Read a URL with no options:
 
-.. ipython:: python
+.. code-block:: ipython
 
-   df = pd.read_xml("https://www.w3schools.com/xml/books.xml")
-   df
+   In [362]: df = pd.read_xml("https://www.w3schools.com/xml/books.xml")
+
+   In [363]: df
+   Out[363]:
+      category             title               author  year  price
+   0   cooking  Everyday Italian  Giada De Laurentiis  2005  30.00
+   1  children      Harry Potter         J K. Rowling  2005  29.99
+   2       web      Learning XML          Erik T. Ray  2003  39.95
 
 Read in the content of the "books.xml" file and pass it to ``read_xml``
 as a string:


### PR DESCRIPTION
The "Read a URL with no options" example in the `read_xml` section ran

```python
df = pd.read_xml("https://www.w3schools.com/xml/books.xml")
```

inside an executed `.. ipython:: python` directive. w3schools started returning `403 Access Denied` today, so the block raises and takes down the doc build on `main` and on every open PR branch:

```
sphinx.errors.SphinxParallelError: RuntimeError: Unexpected exception in
`doc/source/user_guide/io.rst` line 2843
```

(The reported line is the *closing* line of the directive, not the failing call, which made it look unrelated to the network fetch.)

This converts it to a non-executed ``.. code-block:: ipython`` with hard-coded `In`/`Out`, matching the `read_html` fdic.gov example a few hundred lines earlier in the same file. The output stays visible to readers and the `In []` numbering picks up from the preceding executed block.

The only other remote-URL example in the docs (the `read_csv` bls.gov one) was already a plain non-executed `code-block`, so after this there are no executed network fetches left in the documentation.

Verified locally: `python doc/make.py html --single user_guide/io.rst` builds with zero warnings and the section renders as intended.