### PR TITLE
DOC: batch of user guide and docstring fixes

### DIFF
--- a/doc/source/user_guide/advanced.rst
+++ b/doc/source/user_guide/advanced.rst
@@ -165,6 +165,22 @@ completely analogous way to selecting a column in a regular DataFrame:
    df["bar"]["one"]
    s["qux"]
 
+For a ``Series``, ``[]`` selects on the index, so ``s["qux"]`` above performs
+partial selection on the row labels. For a ``DataFrame``, however, ``[]``
+selects *columns*: ``df["bar"]`` works above only because this ``df`` has a
+``MultiIndex`` on its columns. If the ``MultiIndex`` is on the rows instead,
+selecting a partial label with ``[]`` raises a ``KeyError`` — use ``.loc``
+for partial selection on the rows:
+
+.. ipython:: python
+   :okexcept:
+
+   df.T["bar"]
+
+.. ipython:: python
+
+   df.T.loc["bar"]
+
 See :ref:`Cross-section with hierarchical index <advanced.xs>` for how to select
 on a deeper level.
 

--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -706,6 +706,55 @@ We can also pass infinite values to define the bins:
    factor = pd.cut(arr, [-np.inf, 0, np.inf])
    factor
 
+.. _basics.float_precision:
+
+Floating-point precision
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+pandas stores real-valued data using 64-bit floating point by default.
+Floating-point numbers can represent only a finite set of values: a decimal
+number like ``0.03`` is stored as the nearest representable binary fraction,
+and the result of every arithmetic operation is rounded to the nearest
+representable value. As a consequence, computations that would give identical
+results in exact arithmetic can differ, typically around the 16th significant
+digit, depending on how they are carried out:
+
+.. ipython:: python
+
+   ser = pd.Series(0.03, index=range(60))
+   ser.head(20).mean() == ser.mean()
+
+Both means display as ``0.03`` by default, but they are not identical:
+
+.. ipython:: python
+
+   means = pd.Series([ser.head(20).mean(), ser.mean()])
+   with pd.option_context("display.precision", 20):
+       print(means)
+
+This is not specific to pandas: it is inherent to `IEEE 754
+<https://en.wikipedia.org/wiki/IEEE_754>`__ floating-point arithmetic, which
+is used by virtually all modern hardware and software. See the `Python
+tutorial <https://docs.python.org/3/tutorial/floatingpoint.html>`__ for an
+accessible introduction.
+
+For this reason, avoid relying on exact equality of *computed* floating-point
+values. In particular, using computed floats as labels — for example grouping
+on a column produced by a ``mean`` — can split what displays as a single
+value into multiple groups:
+
+.. ipython:: python
+
+   means.nunique()
+
+If you need to compare or group on computed floats, round them first with
+:meth:`~Series.round`, compare with :func:`numpy.isclose`, or bin the values
+with :func:`~pandas.cut`:
+
+.. ipython:: python
+
+   means.round(10).nunique()
+
 .. _basics.apply:
 
 Function application
@@ -852,6 +901,36 @@ statistics methods, takes an optional ``axis`` argument:
    df.apply(np.cumsum)
    df.apply(np.exp)
 
+.. warning::
+
+   For a general Python callable, :meth:`~DataFrame.apply` invokes it once per
+   column (or once per row with ``axis=1``) in a Python-level loop. It is a
+   tool for flexibility, not speed: when a vectorized equivalent exists, it
+   will generally be much faster. Every example above can be written more
+   directly without ``apply``:
+
+   .. ipython:: python
+
+      df.mean()            # df.apply(lambda x: np.mean(x))
+      df.mean(axis=1)      # df.apply(lambda x: np.mean(x), axis=1)
+      df.max() - df.min()  # df.apply(lambda x: x.max() - x.min())
+      df.cumsum()          # df.apply(np.cumsum)
+      np.exp(df)           # df.apply(np.exp)
+
+   The first four avoid the per-column loop and are several times faster on a
+   wide frame. The last is a NumPy ufunc, which ``apply`` recognizes and
+   applies to the whole frame at once, so the two are equally fast; the
+   direct spelling is simply clearer.
+
+   Before reaching for ``apply``, look for a vectorized alternative: a
+   DataFrame or Series method, an arithmetic or comparison operation
+   (see :ref:`basics.binop`), or an accessor method such as the
+   :ref:`vectorized string methods <text.string_methods>` under ``.str`` or
+   the :ref:`datetime properties <basics.dt_accessors>` under ``.dt``.
+   Reserve ``apply`` for logic with no vectorized equivalent, such as a
+   function from a third-party library that operates on one row or column
+   at a time.
+
 The :meth:`~DataFrame.apply` method will also dispatch on a string method name.
 
 .. ipython:: python
@@ -883,6 +962,9 @@ maximum value for each column occurred:
    )
    tsdf.apply(lambda x: x.idxmax())
 
+(In this case the built-in ``tsdf.idxmax()`` gives the same result more
+simply; ``apply`` is shown for illustration.)
+
 You may also pass additional arguments and keyword arguments to the :meth:`~DataFrame.apply`
 method.
 
@@ -908,6 +990,7 @@ Series operation on each column or row:
    tsdf
    tsdf.apply(pd.Series.interpolate)
 
+(Here too, ``tsdf.interpolate()`` is the idiomatic spelling.)
 
 Finally, :meth:`~DataFrame.apply` takes an argument ``raw`` which is False by default, which
 converts each row or column into a Series before applying the function. When

--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -168,6 +168,44 @@ One could hard code:
 
    df[AllCrit]
 
+Repeating rows or columns
+*************************
+
+Unlike :meth:`Series.repeat`, ``DataFrame`` has no ``repeat`` method. The same result can be
+achieved by repeating the row (or column) labels and passing them to :meth:`DataFrame.reindex`.
+This requires the labels on the repeated axis to be unique :issue:`42943`
+
+.. ipython:: python
+
+   df = pd.DataFrame({"AAA": [1, 2], "BBB": [3, 4]})
+   df.reindex(df.index.repeat(2))
+   df.reindex(df.index.repeat(2)).reset_index(drop=True)
+   df.reindex(columns=df.columns.repeat([1, 2]))
+
+Repeating positions with :meth:`DataFrame.iloc` instead works whether or not the labels are
+unique:
+
+.. ipython:: python
+
+   df.iloc[np.repeat(np.arange(len(df)), 2)]
+
+Expanding ranges into rows
+**************************
+
+Given columns of ``start`` and ``stop`` values, expand each row into one row per value in
+``range(start, stop)``. Applying ``range`` row-wise and calling :meth:`Series.explode` is
+simple but slow for large inputs; a vectorized construction with :func:`numpy.repeat` is
+much faster, especially when there are many rows to expand :issue:`39630`
+
+.. ipython:: python
+
+   df = pd.DataFrame({"start": [10, 27, 30], "stop": [15, 31, 31]})
+   start = df["start"].to_numpy()
+   stop = df["stop"].to_numpy()
+   counts = stop - start
+   offsets = np.arange(counts.sum()) - np.repeat(counts.cumsum() - counts, counts)
+   pd.Series(np.repeat(start, counts) + offsets, index=df.index.repeat(counts))
+
 .. _cookbook.selection:
 
 Selection
@@ -946,6 +984,32 @@ Calculate the first day of the month for each entry in a DatetimeIndex
    dates = pd.date_range("2000-01-01", periods=5)
    dates.to_period(freq="M").to_timestamp()
 
+Split rows describing events with a start and stop time into multiple rows, so that each row
+falls within a single interval of a fixed frequency. Extra columns are replicated for each
+piece, and the original row label identifies which event each piece came from :issue:`34836`
+
+.. ipython:: python
+
+   df = pd.DataFrame(
+       {
+           "start": pd.to_datetime(["2020-06-01 08:06", "2020-06-01 21:10"]),
+           "stop": pd.to_datetime(["2020-06-01 09:14", "2020-06-02 01:30"]),
+           "foo": ["bar", "baz"],
+       }
+   )
+   freq = "30min"
+
+   def split_event(start, stop, freq):
+       edges = pd.date_range(start.floor(freq), stop.ceil(freq), freq=freq)
+       cuts = [start, *edges[(edges > start) & (edges < stop)], stop]
+       return list(zip(cuts[:-1], cuts[1:]))
+
+   result = df.assign(
+       pieces=[split_event(start, stop, freq) for start, stop in zip(df["start"], df["stop"])]
+   ).explode("pieces")
+   result[["start", "stop"]] = pd.DataFrame(result["pieces"].tolist(), index=result.index)
+   result.drop(columns="pieces")
+
 .. _cookbook.resample:
 
 Resampling
@@ -1107,8 +1171,18 @@ The :ref:`CSV <io.read_csv_table>` docs
 `Reading a csv chunk-by-chunk
 <https://stackoverflow.com/questions/11622652/large-persistent-dataframe-in-pandas/12193309#12193309>`__
 
-`Reading only certain rows of a csv chunk-by-chunk
-<https://stackoverflow.com/questions/19674212/pandas-data-frame-select-rows-and-clear-memory>`__
+Reading only rows matching a condition, chunk-by-chunk, so that only ``chunksize`` rows of
+the file are read at a time rather than the whole file :issue:`32072`
+
+.. ipython:: python
+
+   from io import StringIO
+
+   data = "col_1,col_2\n940,45\n1040,52\n1530,46\n753,43\n890,32\n"
+   pd.concat(
+       (chunk.query("col_1 >= 1000") for chunk in pd.read_csv(StringIO(data), chunksize=2)),
+       ignore_index=True,
+   )
 
 `Reading the first few lines of a frame
 <https://stackoverflow.com/questions/15008970/way-to-read-first-few-lines-for-pandas-dataframe>`__
@@ -1123,6 +1197,21 @@ using that handle to read.
 <https://stackoverflow.com/questions/15555005/get-inferred-dataframe-types-iteratively-using-chunksize>`__
 
 Dealing with bad lines :issue:`2886`
+
+Fields containing the ``read_csv`` comment character are truncated when read back unless they
+are quoted; write with ``quoting=csv.QUOTE_NONNUMERIC`` to quote all strings. Note that only
+the default C engine honors the quoting when reading; ``engine="python"`` strips the comment
+regardless :issue:`27637`
+
+.. ipython:: python
+
+   import csv
+   from io import StringIO
+
+   df = pd.DataFrame({"strings": ["a#b", "plain"], "value": [1, 2]})
+   out = df.to_csv(index=False, quoting=csv.QUOTE_NONNUMERIC)
+   print(out)
+   pd.read_csv(StringIO(out), comment="#")
 
 `Write a multi-row index CSV without writing duplicates
 <https://stackoverflow.com/questions/17349574/pandas-write-multiindex-rows-with-to-csv>`__
@@ -1442,6 +1531,14 @@ Often it's useful to obtain the lower (or upper) triangular form of a correlatio
     mask = np.tril(np.ones_like(corr_mat, dtype=np.bool_), k=-1)
 
     corr_mat.where(mask)
+
+To list each pair only once, sorted by correlation strength, stack the masked matrix into a
+Series and sort by absolute value :issue:`24728`
+
+.. ipython:: python
+
+    pairs = corr_mat.where(mask).stack().dropna()
+    pairs.sort_values(key=abs, ascending=False)
 
 The ``method`` argument within ``DataFrame.corr`` can accept a callable in addition to the named correlation types.  Here we compute the `distance correlation <https://en.wikipedia.org/wiki/Distance_correlation>`__ matrix for a ``DataFrame`` object.
 

--- a/doc/source/user_guide/gotchas.rst
+++ b/doc/source/user_guide/gotchas.rst
@@ -426,3 +426,57 @@ constructors using something similar to the following:
 See `the NumPy documentation on byte order
 <https://numpy.org/doc/stable/user/byteswapping.html>`__ for more
 details.
+
+.. _gotchas.nested-lists:
+
+Storing lists inside a ``DataFrame`` or ``Series``
+--------------------------------------------------
+
+It is possible to store Python lists (or other collections) in the cells of
+a ``DataFrame`` or ``Series``, but it is best avoided. A column containing
+lists has ``object`` dtype: each cell holds a reference to a separate Python
+object, so the column uses far more memory than a native-dtype column and no
+operation on it can use pandas' vectorized code paths. Because lists are not
+hashable, such a column also cannot be used as a group or merge key, and
+methods that need to hash the values, like :meth:`~DataFrame.drop_duplicates`,
+raise a ``TypeError``.
+
+.. ipython:: python
+
+   df = pd.DataFrame(
+       {
+           "name": ["A.J. Price"] * 3,
+           "opponent": ["76ers", "blazers", "bobcats"],
+       }
+   )
+   df["nearest_neighbors"] = [["Zach LaVine", "Jeremy Lin", "Nate Robinson"]] * 3
+   df
+   df.dtypes
+
+Instead, prefer a "long" format, with one row per list element. Existing
+list-valued cells can be converted with :meth:`~DataFrame.explode`:
+
+.. ipython:: python
+
+   exploded = df.explode("nearest_neighbors")
+   exploded
+   exploded.dtypes
+
+Each element now occupies its own row in a natively-typed column, and the
+usual vectorized operations, grouping, and joining all apply. If a nested
+presentation is needed at the end of a computation, the lists can be
+rebuilt with ``agg(list)``:
+
+.. ipython:: python
+
+   exploded.groupby(["name", "opponent"], sort=False)["nearest_neighbors"].agg(list)
+
+For columns of delimited strings, split directly into columns or indicator
+variables with ``.str`` methods rather than creating lists as an
+intermediate step:
+
+.. ipython:: python
+
+   ser = pd.Series(["a|b", "b", "a|c"])
+   ser.str.split("|", expand=True)
+   ser.str.get_dummies(sep="|")

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -65,12 +65,12 @@ filepath_or_buffer : various
   locations), or any object with a ``read()`` method (such as an open file or
   :class:`~python:io.StringIO`).
 sep : str, defaults to ``','`` for :func:`read_csv`, ``\t`` for :func:`read_table`
-  Delimiter to use. If sep is ``None``, the C engine cannot automatically detect
-  the separator, but the Python parsing engine can, meaning the latter will be
-  used and automatically detect the separator by Python's builtin sniffer tool,
-  :class:`python:csv.Sniffer`. In addition, separators longer than 1 character and
-  different from ``'\s+'`` will be interpreted as regular expressions and
-  will also force the use of the Python parsing engine. Note that regex
+  Delimiter to use. ``sep=None`` detects the separator from the first valid row
+  of the file with Python's builtin sniffer tool, :class:`python:csv.Sniffer`; it
+  is supported only by the Python parsing engine and must be combined with
+  ``engine='python'`` explicitly. In addition, separators longer than 1 character
+  and different from ``'\s+'`` will be interpreted as regular expressions and
+  will force the use of the Python parsing engine. Note that regex
   delimiters are prone to ignoring quoted data. Regex example: ``'\\r\\t'``.
 delimiter : str, default ``None``
   Alternative argument name for sep.
@@ -172,12 +172,15 @@ dtype_backend : {"numpy_nullable", "pyarrow"}, defaults to NumPy backed DataFram
 
 engine : {``'c'``, ``'python'``, ``'pyarrow'``}
   Parser engine to use. The C and pyarrow engines are faster, while the python engine
-  is currently more feature-complete. Multithreading is currently only supported by
-  the pyarrow engine. Some features of the "pyarrow" engine
-  are unsupported or may not work correctly.
+  is currently more feature-complete. The pyarrow engine is multithreaded, and the C
+  engine reads :ref:`sufficiently large files <io.csv.parallel>` in parallel. Some
+  features of the "pyarrow" engine are unsupported or may not work correctly.
 converters : dict, default ``None``
   Dict of functions for converting values in certain columns. Keys can either be
-  integers or column labels.
+  integers or column labels. The function is applied to the raw text read from the
+  file, before any missing-value detection: an empty field is passed as an empty
+  string ``''``, and ``na_values`` and ``keep_default_na`` have no effect on a
+  column that has a converter.
 true_values : list, default ``None``
   Values to consider as ``True``.
 false_values : list, default ``None``
@@ -1419,7 +1422,8 @@ Automatically "sniffing" the delimiter
 
 ``read_csv`` is capable of inferring delimited (not necessarily
 comma-separated) files, as pandas uses the :class:`python:csv.Sniffer`
-class of the csv module. For this, you have to specify ``sep=None``.
+class of the csv module. For this, you have to specify ``sep=None`` together
+with ``engine='python'``.
 
 .. ipython:: python
 
@@ -1482,45 +1486,46 @@ Specifying ``iterator=True`` will also return the ``TextFileReader`` object:
 Specifying the parser engine
 ''''''''''''''''''''''''''''
 
-pandas currently supports three engines, the C engine, the python engine, and a
-pyarrow engine (requires the ``pyarrow`` package). In general, the pyarrow engine is fastest
-on larger workloads and is equivalent in speed to the C engine on most other workloads.
-The python engine tends to be slower than the pyarrow and C engines on most workloads. However,
-the pyarrow engine is much less robust than the C engine, which lacks a few features compared to the
-Python engine.
+pandas supports three parser engines, selected with the ``engine`` keyword:
+the C engine (``engine='c'``, the default), the python engine
+(``engine='python'``), and the pyarrow engine (``engine='pyarrow'``, which
+requires the ``pyarrow`` package). In general, the pyarrow engine is fastest
+on larger workloads and is equivalent in speed to the C engine on most other
+workloads; the python engine is the slowest, but it is the only one that
+supports regex separators and ``skipfooter``. The table below compares the
+three engines:
 
-Where possible, pandas uses the C parser (specified as ``engine='c'``), but it may fall
-back to Python if C-unsupported options are specified.
+.. csv-table::
+   :header: "", "``'c'``", "``'python'``", "``'pyarrow'``"
+   :widths: 40, 18, 18, 18
 
-Currently, options unsupported by the C and pyarrow engines include:
+   "Default engine","yes","",""
+   "Relative speed","fast","slowest","fastest on large workloads"
+   "Multithreaded",":ref:`for large files <io.csv.parallel>`","no","yes"
+   "Regex or multi-character ``sep``","no","yes","no"
+   "``sep=None`` (auto-detect the separator)","no","yes","no"
+   "``skipfooter``","no","yes","no"
+   "``low_memory``","yes","no","no"
+   "``lineterminator``","yes","no","no"
+   "``memory_map``","yes","yes","no"
+   "``iterator`` / ``chunksize`` / ``nrows``","yes","yes","no"
+   "``comment``, ``thousands``, ``skipinitialspace``","yes","yes","no"
+   "``dayfirst``","yes","yes","no"
+   "``converters``","yes","yes","no"
+   "``quoting``, ``dialect``","yes","yes","no"
+   "``na_filter``","yes","yes","no"
 
-* ``sep`` other than a single character (e.g. regex separators)
-* ``skipfooter``
+Where possible, pandas uses the C parser (specified as ``engine='c'``), but
+it may fall back to Python if C-unsupported options are specified: passing an
+option only the python engine supports produces a ``ParserWarning`` unless
+the python engine is selected explicitly with ``engine='python'``. Selecting
+the C engine explicitly instead raises a ``ValueError``, as does passing an
+option unsupported by the pyarrow engine together with ``engine='pyarrow'``.
 
-Specifying any of the above options will produce a ``ParserWarning`` unless the
-python engine is selected explicitly using ``engine='python'``.
-
-Options that are unsupported by the pyarrow engine which are not covered by the list above include:
-
-* ``float_precision``
-* ``chunksize``
-* ``comment``
-* ``nrows``
-* ``thousands``
-* ``memory_map``
-* ``dialect``
-* ``on_bad_lines``
-* ``quoting``
-* ``lineterminator``
-* ``converters``
-* ``decimal``
-* ``iterator``
-* ``dayfirst``
-* ``verbose``
-* ``skipinitialspace``
-* ``low_memory``
-
-Specifying these options with ``engine='pyarrow'`` will raise a ``ValueError``.
+``sep=None``, which sniffs the separator, is an exception to this fallback and
+must be combined with ``engine='python'`` explicitly. The other engines do not
+fall back to Python for it: the C engine raises a ``TypeError``, and the
+pyarrow engine silently parses each line as a single column.
 
 .. _io.csv.parallel:
 
@@ -3150,6 +3155,14 @@ of reading in Wikipedia's very large (12 GB+) latest article data dump.
 
     [3578765 rows x 3 columns]
 
+.. note::
+
+   ``iterparse`` cannot be combined with ``stylesheet``. XSLT transformation
+   requires the entire tree in memory, which is exactly what ``iterparse``
+   avoids, so a ``stylesheet`` passed alongside ``iterparse`` is ignored
+   without warning. To transform a document with XSLT, use ``xpath`` parsing
+   instead.
+
 .. _io.xml:
 
 Writing XML
@@ -3528,6 +3541,23 @@ should be passed to ``index_col`` and ``header``:
    :suppress:
 
    os.remove("path_to_file.xlsx")
+
+.. note::
+
+   When a ``DataFrame`` with ``MultiIndex`` columns is written by
+   :meth:`~DataFrame.to_excel`, a row containing the index name(s) — blank
+   when the index is unnamed — is always inserted between the header rows and
+   the data. This makes the format unambiguous, and
+   ``read_excel`` assumes this layout when ``header`` is a list of two or more
+   rows and ``index_col`` is given: if the cells outside the ``index_col``
+   in the row following the last header row are all empty, that row is
+   interpreted as the index name(s) rather than as data. A spreadsheet not
+   written by pandas that lacks this separator row will therefore lose its
+   first data row to the index name(s) if that row has values only in the
+   index column(s); there is no way for the parser to distinguish the two
+   layouts. If your file does not contain the separator row, read it without
+   ``index_col`` and call :meth:`~DataFrame.set_index` on the resulting
+   column(s) instead.
 
 Missing values in columns specified in ``index_col`` will be forward filled to
 allow roundtripping with ``to_excel`` for ``merged_cells=True``. To avoid forward
@@ -6062,6 +6092,24 @@ Specifying this will return an iterator through chunks of the query result:
 
     for chunk in pd.read_sql_query("SELECT * FROM data_chunks", engine, chunksize=5):
         print(chunk)
+
+.. _io.sql.chunksize:
+
+.. note::
+
+   ``chunksize`` controls only how many rows pandas converts into a
+   ``DataFrame`` at a time; by itself it usually does not reduce peak memory
+   usage. Most database drivers fetch the complete result set into client
+   memory before the first chunk is produced. Actually streaming the result
+   requires a server-side cursor, which with SQLAlchemy is requested with the
+   ``stream_results`` execution option (supported by, e.g., the psycopg2 and
+   pymysql drivers; drivers without server-side cursor support ignore it):
+
+   .. code-block:: python
+
+      with engine.connect().execution_options(stream_results=True) as conn:
+          for chunk in pd.read_sql_query("SELECT * FROM data_chunks", conn, chunksize=5):
+              print(chunk)
 
 
 Engine connection examples

--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -238,6 +238,26 @@ described above.
 A similar situation occurs when using :class:`Series` or :class:`DataFrame` objects in ``if``
 statements, see :ref:`gotchas.truth`.
 
+Converting a nullable array to NumPy keeps :class:`NA` in the resulting
+object-dtype array, so NumPy operations that must produce a boolean result hit
+the same ``TypeError``. Elementwise comparison is the common case: NumPy
+compares each pair of elements, gets :class:`NA` back for the missing entries,
+and then fails when casting the result to bool dtype.
+
+.. ipython:: python
+   :okexcept:
+
+   arr = pd.array(["a", "b", None], dtype="string")
+   np.asarray(arr)
+   np.asarray(arr) == np.array(["a", "z"])[:, None]
+
+Pass an explicit ``na_value`` to :meth:`~api.extensions.ExtensionArray.to_numpy`
+to substitute a value NumPy can compare, such as ``None`` or ``np.nan``:
+
+.. ipython:: python
+
+   arr.to_numpy(dtype=object, na_value=None) == np.array(["a", "z"])[:, None]
+
 NumPy ufuncs
 ------------
 

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -854,6 +854,40 @@ Here, ``side="right"`` returns the position just past ``"2000-01-02"``, and
 ``side="left"`` returns the position of ``"2000-01-04"`` itself. Since ``.iloc``
 uses standard Python half-open slicing, the result excludes both endpoints.
 
+.. _timeseries.at_time:
+
+Selecting a time of day
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Like :ref:`partial string indexing <timeseries.partialindexing>`, the methods
+:meth:`~DataFrame.at_time` and :meth:`~DataFrame.between_time` operate on the
+object's index, selecting rows by their time of day regardless of the date.
+:meth:`~DataFrame.at_time` selects all timestamps at a particular time:
+
+.. ipython:: python
+
+   rng_time = pd.date_range("2018-01-01", periods=10, freq="6h")
+   ts_time = pd.Series(range(10), index=rng_time)
+   ts_time
+   ts_time.at_time("12:00")
+
+:meth:`~DataFrame.between_time` selects the rows whose time of day falls
+between two times, including both endpoints by default; the ``inclusive``
+argument controls whether each endpoint is included:
+
+.. ipython:: python
+
+   ts_time.between_time("00:00", "12:00")
+   ts_time.between_time("00:00", "12:00", inclusive="left")
+
+Both methods also accept ``datetime.time`` objects:
+
+.. ipython:: python
+
+   import datetime
+
+   ts_time.at_time(datetime.time(12, 0))
+
 Truncating & fancy indexing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1590,8 +1624,8 @@ or some other non-observed day.  Defined observance rules are:
     :header: "Rule", "Description"
     :widths: 15, 70
 
-    "next_workday", "move Saturday and Sunday to Monday"
-    "previous_workday", "move Saturday and Sunday to Friday"
+    "next_workday", "move to the next weekday, always advancing by at least one day"
+    "previous_workday", "move to the previous weekday, always moving back by at least one day"
     "nearest_workday", "move Saturday to Friday and Sunday to Monday"
     "before_nearest_workday", "apply ``nearest_workday`` and then move to previous workday before that day"
     "after_nearest_workday", "apply ``nearest_workday`` and then move to next workday after that day"

--- a/doc/source/user_guide/window.rst
+++ b/doc/source/user_guide/window.rst
@@ -612,6 +612,35 @@ Whereas if ``ignore_na=True``, the weighted average would be calculated as
 
         \frac{(1-\alpha) \cdot 3 + 1 \cdot 5}{(1-\alpha) + 1}.
 
+The same applies when ``adjust=False``, using the ``adjust=False`` weights given
+above. Assuming ``adjust=False``, if ``ignore_na=False``, the weighted average of
+``3, NaN, 5`` would be calculated as
+
+.. math::
+
+        \frac{(1-\alpha)^2 \cdot 3 + \alpha \cdot 5}{(1-\alpha)^2 + \alpha},
+
+whereas if ``ignore_na=True`` it would be calculated as
+
+.. math::
+
+        \frac{(1-\alpha) \cdot 3 + \alpha \cdot 5}{(1-\alpha) + \alpha}.
+
+.. note::
+
+   The recursion :math:`y_t = (1 - \alpha) y_{t-1} + \alpha x_t` given above for
+   ``adjust=False`` assumes that no values are missing; it holds because those
+   weights sum to exactly 1. When a value is missing, the weights of the
+   remaining observations no longer sum to 1 and are renormalized, so applying
+   that recursion directly to the values on either side of a missing entry does
+   not reproduce the result.
+
+.. ipython:: python
+
+   ser = pd.Series([3, np.nan, 5])
+   ser.ewm(alpha=2 / 3, adjust=False, ignore_na=False).mean()
+   ser.ewm(alpha=2 / 3, adjust=False, ignore_na=True).mean()
+
 The :meth:`~ExponentialMovingWindow.var`, :meth:`~ExponentialMovingWindow.std`, and :meth:`~ExponentialMovingWindow.cov` functions have a ``bias`` argument,
 specifying whether the result should contain biased or unbiased statistics.
 For example, if ``bias=True``, ``ewmvar(x)`` is calculated as

--- a/pandas/_config/dates.py
+++ b/pandas/_config/dates.py
@@ -8,12 +8,20 @@ from pandas._config import config as cf
 
 pc_date_dayfirst_doc = """
 : boolean
-    When True, prints and parses dates with the day first, eg 20/01/2005
+    When True, parses ambiguous dates with the day first, eg 20/01/2005.
+    This affects parsing only, not how dates are displayed, and applies to
+    the Period constructor and partial-string indexing on a DatetimeIndex.
+    Timestamp, to_datetime and read_csv take their own dayfirst keyword and
+    are unaffected.
 """
 
 pc_date_yearfirst_doc = """
 : boolean
-    When True, prints and parses dates with the year first, eg 2005/01/20
+    When True, parses ambiguous dates with the year first, eg 2005/01/20.
+    This affects parsing only, not how dates are displayed, and applies to
+    the Period constructor and partial-string indexing on a DatetimeIndex.
+    Timestamp, to_datetime and read_csv take their own yearfirst keyword and
+    are unaffected.
 """
 
 with cf.config_prefix("display"):

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1218,9 +1218,9 @@ default 'raise'
 
         Parameters
         ----------
-        freq : str or Period, optional
-            One of pandas' :ref:`period aliases <timeseries.period_aliases>`
-            or a Period object. Will be inferred by default.
+        freq : str, optional
+            One of pandas' :ref:`period aliases <timeseries.period_aliases>`.
+            Will be inferred by default.
 
         Returns
         -------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10902,11 +10902,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11019,11 +11019,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11135,11 +11135,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11253,11 +11253,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11371,11 +11371,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11491,11 +11491,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11591,11 +11591,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11708,11 +11708,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11803,11 +11803,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11896,11 +11896,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -11988,11 +11988,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -12082,11 +12082,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -12175,11 +12175,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------
@@ -12268,11 +12268,11 @@ class DataFrame(NDFrame, OpsMixin):
         level : int or label
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : float or None, default None
-            Fill existing missing (NaN) values, and any new element needed for
-            successful DataFrame alignment, with this value before computation.
-            If data in both corresponding DataFrame locations is missing
-            the result will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
 
         Returns
         -------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -750,9 +750,9 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
         Parameters
         ----------
-        freq : str or Period, optional
-            One of pandas' :ref:`period aliases <timeseries.period_aliases>`
-            or a Period object. Will be inferred by default.
+        freq : str, optional
+            One of pandas' :ref:`period aliases <timeseries.period_aliases>`.
+            Will be inferred by default.
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -7403,11 +7403,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7467,11 +7467,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7532,11 +7532,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7599,11 +7599,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7667,11 +7667,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7735,11 +7735,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7800,11 +7800,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7864,11 +7864,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7928,11 +7928,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -7994,11 +7994,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8062,11 +8062,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8135,11 +8135,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8198,11 +8198,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8266,11 +8266,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8333,11 +8333,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8398,11 +8398,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8460,11 +8460,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8525,11 +8525,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8590,11 +8590,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8655,11 +8655,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8720,11 +8720,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 
@@ -8791,11 +8791,11 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level.
-        fill_value : None or float value, default None (NaN)
-            Fill existing missing (NaN) values, and any new element needed for
-            successful Series alignment, with this value before computation.
-            If data in both corresponding Series locations is missing
-            the result of filling (at that location) will be missing.
+        fill_value : scalar or None, default None
+            Fill NA values, whether present in the original data or introduced
+            by alignment, with this value before computation. Positions where
+            both inputs are NA are left unfilled and behave as NA does for the
+            operation.
         axis : {0 or 'index'}
             Unused. Parameter needed for compatibility with DataFrame.
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1793,12 +1793,13 @@ class ExcelFile:
               column if the callable returns ``True``.
 
             Returns a subset of the columns according to behavior above.
-        Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``.
-        To instantiate a :class:`~pandas.DataFrame` with element order preserved
-        use ``pd.read_excel(path, usecols=['foo', 'bar'])[['foo', 'bar']]`` for
-        columns in ``['foo', 'bar']`` order or
-        ``pd.read_excel(path, usecols=['foo', 'bar'])[['bar', 'foo']]`` for
-        ``['bar', 'foo']`` order.
+            Element order is ignored, so ``usecols=[0, 1]`` is the same as
+            ``[1, 0]``. To instantiate a :class:`~pandas.DataFrame` with element
+            order preserved use
+            ``pd.read_excel(path, usecols=['foo', 'bar'])[['foo', 'bar']]`` for
+            columns in ``['foo', 'bar']`` order or
+            ``pd.read_excel(path, usecols=['foo', 'bar'])[['bar', 'foo']]`` for
+            ``['bar', 'foo']`` order.
         converters : dict, default None
             Dict of functions for converting values in certain columns. Keys can
             either be integers or column labels, values are functions that take one

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -258,6 +258,13 @@ def read_excel(
         ``to_excel`` for ``merged_cells=True``. To avoid forward filling the
         missing values use ``set_index`` after reading the data instead of
         ``index_col``.
+
+        When ``header`` is a list of two or more rows (``MultiIndex``
+        columns), the row after the last header row is expected to hold the
+        index name(s) — blank if the index is unnamed — as written by
+        ``to_excel``. A file lacking this separator row can lose its first
+        data row to the index name(s); see :ref:`the user guide
+        <io.excel.reading_multiindex>` for details.
     usecols : str, list-like, or callable, default None
         * If None, then parse all columns.
         * If str, then indicates comma separated list of Excel column letters
@@ -270,6 +277,12 @@ def read_excel(
           column if the callable returns ``True``.
 
         Returns a subset of the columns according to behavior above.
+        Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``.
+        To instantiate a :class:`~pandas.DataFrame` with element order preserved
+        use ``pd.read_excel(path, usecols=['foo', 'bar'])[['foo', 'bar']]`` for
+        columns in ``['foo', 'bar']`` order or
+        ``pd.read_excel(path, usecols=['foo', 'bar'])[['bar', 'foo']]`` for
+        ``['bar', 'foo']`` order.
     dtype : Type name or dict of column -> type, default None
         Data type for data or columns. E.g. {'a': np.float64, 'b': np.int32}
         Use ``object`` to preserve data as stored in Excel and not interpret dtype,
@@ -1761,6 +1774,13 @@ class ExcelFile:
             ``to_excel`` for ``merged_cells=True``. To avoid forward filling the
             missing values use ``set_index`` after reading the data instead of
             ``index_col``.
+
+            When ``header`` is a list of two or more rows (``MultiIndex``
+            columns), the row after the last header row is expected to hold
+            the index name(s) — blank if the index is unnamed — as written by
+            ``to_excel``. A file lacking this separator row can lose its first
+            data row to the index name(s); see :ref:`the user guide
+            <io.excel.reading_multiindex>` for details.
         usecols : str, list-like, or callable, default None
             * If None, then parse all columns.
             * If str, then indicates comma separated list of Excel column letters
@@ -1773,6 +1793,12 @@ class ExcelFile:
               column if the callable returns ``True``.
 
             Returns a subset of the columns according to behavior above.
+        Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``.
+        To instantiate a :class:`~pandas.DataFrame` with element order preserved
+        use ``pd.read_excel(path, usecols=['foo', 'bar'])[['foo', 'bar']]`` for
+        columns in ``['foo', 'bar']`` order or
+        ``pd.read_excel(path, usecols=['foo', 'bar'])[['bar', 'foo']]`` for
+        ``['bar', 'foo']`` order.
         converters : dict, default None
             Dict of functions for converting values in certain columns. Keys can
             either be integers or column labels, values are functions that take one

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -1165,13 +1165,12 @@ def read_csv(
         accepts an optional size argument, such as a file handle (e.g. via
         builtin ``open`` function) or ``StringIO``.
     sep : str, default ','
-        Character or regex pattern to treat as the delimiter. If ``sep=None``, the
-        C engine cannot automatically detect
-        the separator, but the Python parsing engine can, meaning the latter will
-        be used and automatically detect the separator from only the first valid
-        row of the file by Python's builtin sniffer tool, ``csv.Sniffer``.
+        Character or regex pattern to treat as the delimiter. ``sep=None`` detects
+        the separator from the first valid row of the file with Python's builtin
+        sniffer tool, ``csv.Sniffer``; it is supported only by the Python parsing
+        engine and must be combined with ``engine='python'`` explicitly.
         In addition, separators longer than 1 character and different from
-        ``'\\s+'`` will be interpreted as regular expressions and will also force
+        ``'\\s+'`` will be interpreted as regular expressions and will force
         the use of the Python parsing engine. Note that regex delimiters are prone
         to ignoring quoted data. Regex example: ``'\\r\\t'``.
     delimiter : str, optional
@@ -1254,13 +1253,16 @@ def read_csv(
     engine : {'c', 'python', 'pyarrow'}, optional
         Parser engine to use. The C and pyarrow engines are faster,
         while the python engine
-        is currently more feature-complete. Multithreading
-        is currently only supported by
-        the pyarrow engine. Some features of the "pyarrow" engine
+        is currently more feature-complete. The pyarrow engine is
+        multithreaded, and the C engine reads sufficiently large files in
+        parallel. Some features of the "pyarrow" engine
         are unsupported or may not work correctly.
     converters : dict of {Hashable : Callable}, optional
         Functions for converting values in specified columns. Keys can either
-        be column labels or column indices.
+        be column labels or column indices. The function is applied to the raw
+        text read from the file, before any missing-value detection: an empty
+        field is passed as an empty string ``''``, and ``na_values`` and
+        ``keep_default_na`` have no effect on a column that has a converter.
     true_values : list, optional
         Values to consider as ``True`` in addition
         to case-insensitive variants of 'True'.
@@ -1763,13 +1765,12 @@ def read_table(
         accepts an optional size argument, such as a file handle (e.g. via
         builtin ``open`` function) or ``StringIO``.
     sep : str, default '\\t' (tab-stop)
-        Character or regex pattern to treat as the delimiter. If ``sep=None``, the
-        C engine cannot automatically detect
-        the separator, but the Python parsing engine can, meaning the latter will
-        be used and automatically detect the separator from only the first valid
-        row of the file by Python's builtin sniffer tool, ``csv.Sniffer``.
+        Character or regex pattern to treat as the delimiter. ``sep=None`` detects
+        the separator from the first valid row of the file with Python's builtin
+        sniffer tool, ``csv.Sniffer``; it is supported only by the Python parsing
+        engine and must be combined with ``engine='python'`` explicitly.
         In addition, separators longer than 1 character and different from
-        ``'\\s+'`` will be interpreted as regular expressions and will also force
+        ``'\\s+'`` will be interpreted as regular expressions and will force
         the use of the Python parsing engine. Note that regex delimiters are prone
         to ignoring quoted data. Regex example: ``'\\r\\t'``.
     delimiter : str, optional
@@ -1849,13 +1850,16 @@ def read_table(
     engine : {'c', 'python', 'pyarrow'}, optional
         Parser engine to use. The C and pyarrow engines are faster,
         while the python engine
-        is currently more feature-complete. Multithreading is
-        currently only supported by
-        the pyarrow engine. The 'pyarrow' engine is an *experimental* engine,
+        is currently more feature-complete. The pyarrow engine is
+        multithreaded, and the C engine reads sufficiently large files in
+        parallel. The 'pyarrow' engine is an *experimental* engine,
         and some features are unsupported, or may not work correctly, with this engine.
     converters : dict of {Hashable : Callable}, optional
         Functions for converting values in specified columns. Keys can either
-        be column labels or column indices.
+        be column labels or column indices. The function is applied to the raw
+        text read from the file, before any missing-value detection: an empty
+        field is passed as an empty string ``''``, and ``na_values`` and
+        ``keep_default_na`` have no effect on a column that has a converter.
     true_values : list, optional
         Values to consider as ``True`` in addition to
         case-insensitive variants of 'True'.

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -336,7 +336,10 @@ def read_sql_table(
         List of column names to select from SQL table.
     chunksize : int, default None
         If specified, returns an iterator where `chunksize` is the number of
-        rows to include in each chunk.
+        rows to include in each chunk. By itself this typically does not
+        reduce peak memory usage, as most drivers buffer the full result set
+        unless a server-side cursor is used; see the :ref:`user guide
+        <io.sql.chunksize>` on streaming results.
     dtype_backend : {'numpy_nullable', 'pyarrow'}
         Back-end data type applied to the resultant :class:`DataFrame`
         (still experimental). If not specified, the default behavior
@@ -452,7 +455,11 @@ def read_sql_query(
         Column(s) to set as index(MultiIndex).
     coerce_float : bool, default True
         Attempts to convert values of non-string, non-numeric objects (like
-        decimal.Decimal) to floating point. Useful for SQL result sets.
+        decimal.Decimal) to floating point. Useful for SQL result sets. This
+        can lose precision: an integral ``decimal.Decimal`` larger than ``2**53``
+        has no exact ``float64`` representation, so a long identifier can be
+        silently rounded. Pass ``False`` to leave such values as Python objects
+        in an ``object``-dtype column.
     params : list, tuple or mapping, optional, default: None
         List of parameters to pass to execute method.  The syntax used
         to pass parameters is database driver dependent. Check your
@@ -470,7 +477,10 @@ def read_sql_query(
           such as SQLite.
     chunksize : int, default None
         If specified, return an iterator where `chunksize` is the number of
-        rows to include in each chunk.
+        rows to include in each chunk. By itself this typically does not
+        reduce peak memory usage, as most drivers buffer the full result set
+        unless a server-side cursor is used; see the :ref:`user guide
+        <io.sql.chunksize>` on streaming results.
     dtype : Type name or dict of columns
         Data type for data or columns. E.g. np.float64 or
         {'a': np.float64, 'b': np.int32, 'c': 'Int64'}.
@@ -600,7 +610,11 @@ def read_sql(
         Column(s) to set as index(MultiIndex).
     coerce_float : bool, default True
         Attempts to convert values of non-string, non-numeric objects (like
-        decimal.Decimal) to floating point, useful for SQL result sets.
+        decimal.Decimal) to floating point, useful for SQL result sets. This
+        can lose precision: an integral ``decimal.Decimal`` larger than ``2**53``
+        has no exact ``float64`` representation, so a long identifier can be
+        silently rounded. Pass ``False`` to leave such values as Python objects
+        in an ``object``-dtype column.
     params : list, tuple or dict, optional, default: None
         List of parameters to pass to execute method.  The syntax used
         to pass parameters is database driver dependent. Check your
@@ -621,7 +635,10 @@ def read_sql(
         a table).
     chunksize : int, default None
         If specified, return an iterator where `chunksize` is the
-        number of rows to include in each chunk.
+        number of rows to include in each chunk. By itself this typically
+        does not reduce peak memory usage, as most drivers buffer the full
+        result set unless a server-side cursor is used; see the
+        :ref:`user guide <io.sql.chunksize>` on streaming results.
     dtype_backend : {'numpy_nullable', 'pyarrow'}
         Back-end data type applied to the resultant :class:`DataFrame`
         (still experimental). If not specified, the default behavior

--- a/pandas/io/xml.py
+++ b/pandas/io/xml.py
@@ -963,15 +963,18 @@ def read_xml(
         installed and specify 'lxml' as ``parser``. The ``xpath`` must
         reference nodes of transformed XML document generated after XSLT
         transformation and not the original XML document. Only XSLT 1.0
-        scripts and not later versions is currently supported.
+        scripts and not later versions is currently supported. This option
+        cannot be combined with ``iterparse`` and is ignored if ``iterparse``
+        is used.
 
     iterparse : dict, optional
         The nodes or attributes to retrieve in iterparsing of XML document
         as a dict with key being the name of repeating element and value being
         list of elements or attribute names that are descendants of the repeated
         element. Note: If this option is used, it will replace ``xpath`` parsing
-        and unlike ``xpath``, descendants do not need to relate to each other but can
-        exist anywhere in document under the repeating element. This memory-
+        and any ``stylesheet`` is ignored, since XSLT requires the whole tree in
+        memory. Unlike ``xpath``, descendants do not need to relate to each other
+        but can exist anywhere in document under the repeating element. This memory-
         efficient method should be used for very large XML files (500MB, 1GB, or 5GB+).
         For example, ``{"row_element": ["child_elem", "attr", "grandchild_elem"]}``.
 

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -118,6 +118,10 @@ def nearest_workday(dt: datetime) -> datetime:
 def next_workday(dt: datetime) -> datetime:
     """
     returns next workday used for observances
+
+    The date is always advanced by at least one day, even when ``dt`` already
+    falls on a weekday. To leave weekdays unchanged and move only weekend
+    dates forward, use ``next_monday`` or ``weekend_to_monday``.
     """
     dt += timedelta(days=1)
     while dt.weekday() > 4:
@@ -129,6 +133,10 @@ def next_workday(dt: datetime) -> datetime:
 def previous_workday(dt: datetime) -> datetime:
     """
     returns previous workday used for observances
+
+    The date is always moved back by at least one day, even when ``dt``
+    already falls on a weekday. To leave weekdays unchanged and move only
+    weekend dates back, use ``previous_friday``.
     """
     dt -= timedelta(days=1)
     while dt.weekday() > 4:


### PR DESCRIPTION
closes #42943
closes #39630
closes #34836
closes #32072
closes #27637
closes #24728
closes #50893
closes #17972
closes #38863
closes #34188
closes #10693
closes #39683
closes #17027
closes #21766
closes #55542
closes #58553
closes #59026
closes #58538
closes #66349

A batch of long-open docs issues, grouped into one branch since each is a
few lines. Every code example and behavioral claim below was run against
this build; the docstring changes pass numpydoc validation, and the edited
user guide pages build clean.

**Docs that were factually wrong**

- `display.date_dayfirst` / `date_yearfirst` said they "print and parse"
  dates. They only affect parsing, and only in `Period` construction and
  partial-string `DatetimeIndex` indexing — the two `get_option` calls in
  `parsing.pyx` are the only consumers, and `Timestamp` / `to_datetime` /
  `read_csv` take their own keyword.
- `DatetimeIndex.to_period` / `DatetimeArray.to_period` documented
  `freq : str or Period`, but a `Period` is rejected by the signature
  itself (`TypeError: expected str`). `Timestamp.to_period` was already
  correct. This does not settle the `MonthBegin` question in GH-60671.
- The holiday observance table said `next_workday` "move[s] Saturday and
  Sunday to Monday"; it always advances at least one day, so a Monday
  moves to Tuesday. Fixed both rows and the two docstrings.
- The parser-engine section listed `on_bad_lines` and `decimal` as
  pyarrow-unsupported (they are supported), listed `verbose` (removed in
  3.0), and omitted `na_filter`. Replaced with a table regenerated from
  `_pyarrow_unsupported` / `_python_unsupported` and checked cell by cell
  against all three engines. `float_precision` is left out as deprecated,
  and `lineterminator` is python-unsupported.
- The `sep` and `engine` entries in the `read_csv` / `read_table`
  docstrings and in io.rst promised a `sep=None` fallback to the python
  engine that no longer happens, and claimed only pyarrow is
  multithreaded. The missing fallback is a 3.0 regression, reported
  separately as GH-66639; the docs here describe what actually happens.
- The crosstab-style `fill_value` type on the flex ops was `float or
  None`, though any scalar works. Applied @rhshadrach's suggested type
  and description to all 36 blocks (22 in `series.py`, 14 in `frame.py`).
  Note `DataFrame.eq`/`ne`/`lt`/`gt`/`le`/`ge` do not take `fill_value`,
  so they are untouched. This supersedes #66371 and #66634.

**Behavior that was correct but undocumented**

- `converters` are applied to the raw text before missing-value
  detection, so an empty field arrives as `''` and `na_values` is ignored
  for that column.
- `read_excel` silently loses a data row when a `MultiIndex`-column file
  lacks the separator row that `to_excel` always writes; mirrored into
  the `read_excel` and `ExcelFile.parse` docstrings.
- `read_sql` `chunksize` does not reduce peak memory without a
  server-side cursor; documented with a `stream_results` example.
- `ewm(adjust=False)` renormalizes weights across a missing value, so the
  documented recursion does not reproduce the result across a gap.
- Converting a nullable array to NumPy keeps `pd.NA`, so elementwise
  comparison raises; `to_numpy(na_value=...)` is the fix (GH-62802).
- `read_xml` silently ignores `stylesheet` when `iterparse` is used,
  since XSLT needs the whole tree in memory (GH-58857).
- `coerce_float` can silently round an integral `Decimal` above `2**53`.
  `read_sql_table` already warned about this; `read_sql` and
  `read_sql_query` now match (GH-61667).
- `read_excel` `usecols` ignores element order, matching what `read_csv`
  already documents (GH-61386).

**New cookbook recipes**, each the approach a maintainer endorsed in the
thread in place of an API addition: repeating rows/columns via
`Index.repeat`, vectorized start/stop range expansion, splitting events on
interval boundaries, chunk-wise filtered reads (replacing a stale link
whose accepted answer used `.ix`), quoting fields containing the
`read_csv` comment character, and correlation pairs listed once and
sorted by strength.

Also adds a floating-point precision section and a `DataFrame.apply`
warning box to basics.rst, a note that `[]` selects columns on a
`DataFrame`, a gotchas section on storing lists in cells, and an
`at_time`/`between_time` section.
