### PR TITLE
PERF:  Improve performance in DataFrame.{skew,kurt} with axis=1 for integer datatype

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1650,9 +1650,10 @@ def diff_2d(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef void accumulate_moments_scalar(
-    const float64_t[::1] values,
+    const float64_t* values,
+    size_t n,
     bint skipna,
-    const uint8_t[::1] mask,
+    const uint8_t* mask,
     int64_t* nobs,
     float64_t* mean,
     float64_t* m2,
@@ -1661,12 +1662,8 @@ cdef void accumulate_moments_scalar(
     int max_moment,
 ) noexcept nogil:
     cdef:
-        Moments moments
-        const float64_t* values_ptr = &values[0]
-        const uint8_t* mask_ptr = &mask[0] if mask is not None else NULL
-        size_t n = <size_t>values.shape[0]
+        Moments moments = moments_reduce(values, n, skipna, mask, max_moment)
 
-    moments = moments_reduce(values_ptr, n, skipna, mask_ptr, max_moment)
     if max_moment >= 4:
         m4[0] = moments.m4
     if max_moment >= 3:
@@ -1675,6 +1672,51 @@ cdef void accumulate_moments_scalar(
     m2[0] = moments.m2
     mean[0] = moments.mean
     nobs[0] = <int64_t>moments.n
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef void accumulate_moments_axis_contiguous(
+    const float64_t[:, :] values,
+    bint skipna,
+    const uint8_t[:, :] mask,
+    bint uses_mask,
+    int64_t[:] nobs,
+    float64_t[:] mean,
+    float64_t[:] m2,
+    float64_t[:] m3,
+    float64_t[:] m4,
+    Py_ssize_t nouter,
+    Py_ssize_t ninner,
+    int axis,
+    int max_moment,
+) noexcept nogil:
+    cdef:
+        Py_ssize_t i
+        const float64_t* val_ptr = NULL
+        const uint8_t* mask_ptr = NULL
+        float64_t* m3_ptr = NULL
+        float64_t* m4_ptr = NULL
+
+    for i in range(nouter):
+        if max_moment >= 3:
+            m3_ptr = &m3[i]
+        if max_moment >= 4:
+            m4_ptr = &m4[i]
+
+        if axis == 0:
+            val_ptr = &values[0, i]
+            if uses_mask:
+                mask_ptr = &mask[0, i]
+        else:
+            val_ptr = &values[i, 0]
+            if uses_mask:
+                mask_ptr = &mask[i, 0]
+
+        accumulate_moments_scalar(
+            val_ptr, ninner, skipna, mask_ptr, &nobs[i], &mean[i], &m2[i],
+            m3_ptr, m4_ptr, max_moment
+        )
 
 
 @cython.boundscheck(False)
@@ -1695,18 +1737,31 @@ cdef void accumulate_moments_axis(
         Py_ssize_t i, j, nrows = values.shape[0], ncols = values.shape[1]
         Py_ssize_t nouter, ninner
         bint is_na_entry, uses_mask = mask is not None
+        bint is_contiguous
         float64_t val
         float64_t* m3_ptr = NULL
         float64_t* m4_ptr = NULL
 
     if axis == 0:
-        # Assumes F-contiguous
         nouter = ncols
         ninner = nrows
+        # https://docs.cython.org/en/latest/src/userguide/memoryviews.html#memoryview-objects-and-cython-arrays
+        # strides is the stride along each dimension, in bytes.
+        is_contiguous = values.strides[0] == sizeof(float64_t)
+        if uses_mask:
+            is_contiguous = is_contiguous and mask.strides[0] == sizeof(uint8_t)
     else:
-        # Assumes C-contiguous
         nouter = nrows
         ninner = ncols
+        is_contiguous = values.strides[1] == sizeof(float64_t)
+        if uses_mask:
+            is_contiguous = is_contiguous and mask.strides[1] == sizeof(uint8_t)
+
+    if is_contiguous:
+        accumulate_moments_axis_contiguous(values, skipna, mask, uses_mask,
+                                           nobs, mean, m2, m3, m4,
+                                           nouter, ninner, axis, max_moment)
+        return
 
     for i in range(nouter):
         if max_moment >= 3:
@@ -1745,9 +1800,13 @@ def scalar_skew(
     cdef:
         int64_t nobs = 0
         float64_t mean = 0.0, m2 = 0.0, m3 = 0.0
+        const float64_t* val_ptr = &values[0]
+        const uint8_t* mask_ptr = &mask[0] if mask is not None else NULL
+        size_t n = <size_t>values.shape[0]
 
     with nogil:
-        accumulate_moments_scalar(values, skipna, mask, &nobs, &mean, &m2, &m3, NULL, 3)
+        accumulate_moments_scalar(val_ptr, n, skipna, mask_ptr,
+                                  &nobs, &mean, &m2, &m3, NULL, 3)
 
     return calc_skew(nobs, m2, m3)
 
@@ -1762,9 +1821,13 @@ def scalar_kurt(
     cdef:
         int64_t nobs = 0
         float64_t mean = 0.0, m2 = 0.0, m3 = 0.0, m4 = 0.0
+        const float64_t* val_ptr = &values[0]
+        const uint8_t* mask_ptr = &mask[0] if mask is not None else NULL
+        size_t n = <size_t>values.shape[0]
 
     with nogil:
-        accumulate_moments_scalar(values, skipna, mask, &nobs, &mean, &m2, &m3, &m4, 4)
+        accumulate_moments_scalar(val_ptr, n, skipna, mask_ptr,
+                                  &nobs, &mean, &m2, &m3, &m4, 4)
 
     return calc_kurt(nobs, m2, m4)
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -25,7 +25,6 @@ from pandas._libs.tslibs import OutOfBoundsTimedelta
 from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.dtypes.common import (
-    ensure_float64,
     is_float,
     is_float_dtype,
     is_integer,
@@ -1674,8 +1673,10 @@ def nanskew(
     >>> round(nanops.nanskew(s.values), 6)
     np.float64(1.732051)
     """
+    preferred_order: Literal["F", "C"] = "F" if axis == 0 else "C"
     dtype = values.dtype
-    values = ensure_float64(values)
+    if values.dtype != np.float64:
+        values = values.astype(np.float64, order=preferred_order)
 
     result: npt.NDArray[np.floating] | np.floating
     if axis is None or (values.ndim == 1 and axis == 0):
@@ -1733,8 +1734,10 @@ def nankurt(
     >>> round(nanops.nankurt(s.values), 6)
     np.float64(-1.289256)
     """
+    preferred_order: Literal["F", "C"] = "F" if axis == 0 else "C"
     dtype = values.dtype
-    values = ensure_float64(values)
+    if values.dtype != np.float64:
+        values = values.astype(np.float64, order=preferred_order)
 
     result: npt.NDArray[np.floating] | np.floating
     if axis is None or (values.ndim == 1 and axis == 0):


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This PR optimizes skew and kurt DataFrame reductions over axis=1 when it needs to convert the array datatype to `np.float64`. It uses the contiguity detection from #66302.

## Benchmark

The benchmark suite only evaluates DataFrames with dimensions 100k x 4. Because this PR's performance improvements scale with the number of columns, I have included custom benchmark below with varying nrows, ncols and uses only integers. The benchmark script is available in the details below.

| Change   | Before [3381aec6] <main>   | After [917c378d] <perf/axis1-contiguous-skew-kurt>   |   Ratio | Benchmark (Parameter)                                  |
|----------|----------------------------|------------------------------------------------------|---------|--------------------------------------------------------|
| +        | 4.07±0.03ms                | 5.94±0.02ms                                          |    1.46 | stat_ops.FrameOps.time_op('skew', 'int', 1)            |
| +        | 3.70±0.02ms                | 4.28±0.03ms                                          |    1.16 | stat_ops.FrameOps.time_op('skew', 'float', 1)          |
| +        | 57.3±0.9μs                 | 65.3±2μs                                             |    1.14 | series_methods.NanOps.time_func('skew', 1000, 'int8')  |
| +        | 57.8±0.9μs                 | 65.5±6μs                                             |    1.13 | series_methods.NanOps.time_func('kurt', 1000, 'int32') |
| +        | 56.5±0.5μs                 | 63.5±0.5μs                                           |    1.12 | series_methods.NanOps.time_func('kurt', 1000, 'int64') |
| +        | 64.1±1μs                   | 71.5±0.6μs                                           |    1.12 | series_methods.NanOps.time_func('skew', 1000, 'Int64') |
| +        | 58.5±2μs                   | 65.0±1μs                                             |    1.11 | series_methods.NanOps.time_func('skew', 1000, 'int32') |
| -        | 4.66±0.4ms                 | 4.11±0.07ms                                          |    0.88 | gil.ParallelRolling.time_rolling('kurt')               |
| -        | 1.02±0.02ms                | 891±20μs                                             |    0.87 | stat_ops.FrameOps.time_op('kurt', 'float', None)       |
| -        | 1.31±0.05ms                | 1.12±0.02ms                                          |    0.85 | stat_ops.FrameOps.time_op('kurt', 'int', 0)            |
| -        | 4.70±0.05ms                | 3.92±0.1ms                                           |    0.83 | stat_ops.FrameOps.time_op('kurt', 'float', 1)          |



| method | nrows | ncols | PR (ms) | main (ms) | Speedup |
|--------|-------|-------|---------|-----------|---------|
| skew | 1000 | 4 | 0.091 | 0.071 | 0.78x |
| skew | 1000 | 8 | 0.095 | 0.098 | 1.03x |
| skew | 1000 | 20 | 0.116 | 0.202 | 1.74x |
| skew | 1000 | 100 | 0.290 | 1.198 | 4.13x |
| skew | 100000 | 4 | 8.221 | 7.175 | 0.87x |
| skew | 100000 | 8 | 5.823 | 6.473 | 1.11x |
| skew | 100000 | 20 | 9.593 | 22.096 | 2.30x |
| skew | 100000 | 100 | 67.774 | 168.234 | 2.48x |
| kurt | 1000 | 4 | 0.094 | 0.078 | 0.83x |
| kurt | 1000 | 8 | 0.097 | 0.148 | 1.52x |
| kurt | 1000 | 20 | 0.118 | 0.220 | 1.87x |
| kurt | 1000 | 100 | 0.275 | 1.085 | 3.94x |
| kurt | 100000 | 4 | 6.292 | 3.997 | 0.64x |
| kurt | 100000 | 8 | 5.809 | 7.914 | 1.36x |
| kurt | 100000 | 20 | 10.712 | 24.540 | 2.29x |
| kurt | 100000 | 100 | 66.767 | 116.058 | 1.74x |


<details>
<summary>Benchmark Script</summary>

```python
import pandas as pd
import numpy as np
import itertools
import timeit


def run_bench():
    nrows = [1000, 100000]
    ncols = [4, 8, 20, 100]
    methods = ["skew", "kurt"]
    results = {}

    for method, nrow, ncol in itertools.product(methods, nrows, ncols):
        values = np.random.randn(nrow, ncol)
        df = pd.DataFrame(values).astype(int)

        stmt = f"df.{method}(axis=1)"
        timer = timeit.Timer(stmt, globals={"df": df})

        number, _ = timer.autorange()
        repeats = timer.repeat(number=number)

        results[f"{method}_{nrow}_{ncol}"] = (min(repeats) / number) * 1000
    return results
```

</details>