### PR TITLE
BUG allow zero merge_asof tolerance

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2604,20 +2604,20 @@ class _AsOfMerge(_OrderedMerge):
                 if not isinstance(self.tolerance, datetime.timedelta):
                     raise MergeError(msg)
                 if self.tolerance < Timedelta(0):
-                    raise MergeError("tolerance must be positive")
+                    raise MergeError("tolerance must be non-negative")
 
             elif is_integer_dtype(lt.dtype):
                 if not is_integer(self.tolerance):
                     raise MergeError(msg)
                 if self.tolerance < 0:
-                    raise MergeError("tolerance must be positive")
+                    raise MergeError("tolerance must be non-negative")
 
             elif is_float_dtype(lt.dtype):
                 if not is_number(self.tolerance):
                     raise MergeError(msg)
                 # error: Unsupported operand types for > ("int" and "Number")
                 if self.tolerance < 0:  # type: ignore[operator]
-                    raise MergeError("tolerance must be positive")
+                    raise MergeError("tolerance must be non-negative")
 
             else:
                 raise MergeError("key must be integer, timestamp or float")

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -1965,6 +1965,26 @@ class TestAsOfMerge:
             by="ticker",
             tolerance=1,
         )
+        left = pd.DataFrame({"key": [1]})
+        right = pd.DataFrame({"key": [1], "value": [2]})
+        result = merge_asof(left, right, on="key", tolerance=0)
+        expected = pd.DataFrame({"key": [1], "value": [2]})
+        tm.assert_frame_equal(result, expected)
+
+        datetime_left = pd.DataFrame({"key": to_datetime(["2020-01-01"])})
+        datetime_right = pd.DataFrame(
+            {"key": to_datetime(["2020-01-01"]), "value": [2]}
+        )
+        result = merge_asof(
+            datetime_left, datetime_right, on="key", tolerance=Timedelta(0)
+        )
+        expected = datetime_right
+        tm.assert_frame_equal(result, expected)
+
+        float_left = pd.DataFrame({"key": [1.0]})
+        float_right = pd.DataFrame({"key": [1.0], "value": [2]})
+        result = merge_asof(float_left, float_right, on="key", tolerance=0.0)
+        tm.assert_frame_equal(result, float_right)
 
         msg = r"incompatible tolerance .*, must be compat with type .*"
 
@@ -1982,7 +2002,7 @@ class TestAsOfMerge:
                 tolerance=1.0,
             )
 
-        msg = "tolerance must be positive"
+        msg = "tolerance must be non-negative"
 
         # invalid negative
         with pytest.raises(MergeError, match=msg):


### PR DESCRIPTION
Allows zero tolerance for datetime, integer, and float merge_asof keys as an exact-match tolerance. Adds result assertions for all three key types.\n\nValidation: git diff --check and py_compile passed. Focused pytest was unavailable locally because pytest is not installed.