### PR TITLE
BUG preserve tuple names in rename_axis

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -377,6 +377,8 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
+
+- Fixed :meth:`DataFrame.rename_axis` treating a tuple name as multiple names for a non-:class:`MultiIndex`. (:issue:`66656`)
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :class:`Series` where empty frozensets were formatted incorrectly (:issue:`66192`)
 - Fixed bug in :func:`testing.assert_series_equal` showing a misleading class mismatch message when Series values were backed by different :class:`numpy.ndarray` subclasses (:issue:`65770`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2118,7 +2118,10 @@ class Index(IndexOpsMixin, PandasObject):
             level = level_list
             names = names_adjusted
 
-        if not is_list_like(names):
+        if (
+            not is_list_like(names)
+            or (isinstance(names, tuple) and not isinstance(self, ABCMultiIndex))
+        ):
             names = [names]  # type: ignore[assignment]
         if level is not None and not is_list_like(level):
             level = [level]

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -56,9 +56,7 @@ class TestDataFrame:
         assert result.index.name == name
 
     def test_rename_axis_tuple_name_multiindex(self):
-        df = DataFrame(
-            [1], index=MultiIndex.from_tuples([("a", "b")])
-        )
+        df = DataFrame([1], index=MultiIndex.from_tuples([("a", "b")]))
 
         result = df.rename_axis(("level1", "level2"))
 

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -46,6 +46,24 @@ class TestDataFrame:
         assert result.columns.names == ["L1", "L2"]
         assert result.index.names == [None, None]
 
+    def test_rename_axis_tuple_name(self):
+        # GH#66656
+        name = (1, 2, 3)
+        df = DataFrame([1], index=pd.Index([1], name=name))
+
+        result = df.reset_index().rename_axis(name)
+
+        assert result.index.name == name
+
+    def test_rename_axis_tuple_name_multiindex(self):
+        df = DataFrame(
+            [1], index=MultiIndex.from_tuples([("a", "b")])
+        )
+
+        result = df.rename_axis(("level1", "level2"))
+
+        assert result.index.names == ["level1", "level2"]
+
     def test_nonzero_single_element(self):
         df = DataFrame([[False, False]])
         msg_err = "The truth value of a DataFrame is ambiguous"


### PR DESCRIPTION
Fixes #66656

Treat tuple names as a scalar name for non-MultiIndex objects in rename_axis, while preserving tuple-as-level-names behavior for MultiIndex. Adds regression coverage for both cases and a whatsnew entry.

Validation: git diff --check and py_compile passed. Focused pytest was unavailable locally because pytest is not installed.