### PR TITLE
BUG: read_hdf returned a sentinel string for missing values appended to a MultiIndex level in an older file (GH#9604)

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -4966,8 +4966,16 @@ class Table(Fixed):
             # encodes its missing values with a per-level sentinel rather than
             # the global nan_rep, so a literal "nan" in a level survives the
             # round-trip like it does for a string Index.
+            # The read path honors the per-level sentinel only when the table
+            # carries the marker attribute, which set_attrs writes when the
+            # table is created and an append cannot add retroactively. So when
+            # appending to a table written before the marker existed, keep
+            # encoding missing values with the global nan_rep, otherwise the
+            # sentinel would be read back as a literal string.
             level_names = self.levels if isinstance(self.levels, list) else []
             is_level = name is not None and name in level_names
+            if is_level and table_exists:
+                is_level = bool(getattr(self.attrs, "mi_level_nan_rep", False))
             level_nan_rep = None
             if is_level:
                 assert name is not None  # for mypy, implied by is_level

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -320,6 +320,48 @@ def test_string_multiindex_level_literal_nan_append(temp_hdfstore):
     assert list(result.index.get_level_values("s")) == ["nan", "a", "b", "nan"]
 
 
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_multiindex_level_append_to_file_without_marker(temp_hdfstore):
+    # GH#9604 — the per-level sentinel is honored on read only when the table
+    # carries the marker attribute, which is written when the table is created.
+    # Appending a missing value to a file written before the marker existed must
+    # keep using the global nan_rep, otherwise the sentinel is read back as a
+    # literal string.
+    s1 = Series(
+        range(2),
+        index=MultiIndex.from_arrays(
+            [Index(["nan", "wide_value"], dtype=str), [1, 2]], names=["s", "i"]
+        ),
+    )
+    temp_hdfstore.append("t", s1)
+    del temp_hdfstore.get_storer("t").attrs.mi_level_nan_rep
+
+    s2 = Series(
+        range(2, 4),
+        index=MultiIndex.from_arrays(
+            [Index([np.nan, "y"], dtype=str), [3, 4]], names=["s", "i"]
+        ),
+    )
+    temp_hdfstore.append("t", s2)
+
+    # the stored "nan" reads back as missing, as it did before the sentinel was
+    # introduced, and so does the appended missing value
+    expected = Series(
+        range(4),
+        index=MultiIndex.from_arrays(
+            [
+                Index([np.nan, "wide_value", np.nan, "y"], dtype=str),
+                [1, 2, 3, 4],
+            ],
+            names=["s", "i"],
+        ),
+    )
+    tm.assert_series_equal(temp_hdfstore.select("t"), expected)
+
+
 def test_api(temp_h5_path):
     # GH4584
     # API issue when to_hdf doesn't accept append AND format args


### PR DESCRIPTION
Follow-up to GH-66330 (GH-9604), which gave each string `MultiIndex` level its own NaN sentinel so a literal `"nan"` and a genuine missing value could both round-trip.

The writer mints that sentinel unconditionally, but the reader honors it only when the table carries the `mi_level_nan_rep` marker attribute. `set_attrs` writes the marker when the table is created and an append cannot add it retroactively, so appending a missing value to a `MultiIndex` file written by an older pandas stored the sentinel while the reader still used the global `nan_rep`:

```python
# level already holding "nan", in a file written before the marker existed
mi1 = MultiIndex.from_arrays([Index(["nan", "wide_value"], dtype=str), [1, 2]])
Series(range(2), index=mi1).to_hdf(path, key="t", format="table", append=True)

mi2 = MultiIndex.from_arrays([Index([np.nan, "y"], dtype=str), [3, 4]])
Series(range(2, 4), index=mi2).to_hdf(path, key="t", format="table", append=True)

list(read_hdf(path, "t").index.get_level_values(0))
# [nan, 'wide_value', '_nan_', 'y']   <- the appended missing value
```

The appended `NaN` came back as the literal string `'_nan_'`, silently and with no warning.

Appending to a table without the marker now keeps encoding missing values with the global `nan_rep`, which is what the reader applies to such a file — restoring the pre-GH-66330 behavior for it exactly. Files created since GH-66330 carry the marker and keep the full per-level round-trip.

The plain string `Index` path is unaffected: its sentinel is read back unconditionally from the per-column attribute, and a missing value in a legacy file already read back as the string `"nan"` both before and after an append, so minting a sentinel there does not reinterpret existing rows.

No whatsnew entry — GH-66330 is unreleased, so the existing 3.1.0 note still describes the shipped behavior.
