### PR TITLE
BUG: loc/iloc setitem transposing nested values on single-block frames (GH#65241)

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2489,7 +2489,9 @@ class _iLocIndexer(_LocationIndexer):
 
         # GH#44103 - setting a scalar row across columns with a list-like
         # value must go through the split path so each column gets its
-        # corresponding scalar value.
+        # corresponding scalar value.  Restricted to ExtensionArray blocks:
+        # the non-split path already handles the others correctly, and forcing
+        # the split path there transposes rectangular nested values (GH#65241).
         if (
             not take_split_path
             and isinstance(indexer, tuple)
@@ -2498,6 +2500,8 @@ class _iLocIndexer(_LocationIndexer):
             and not is_integer(indexer[1])
             and is_list_like(value)
             and not isinstance(value, (ABCSeries, ABCDataFrame))
+            # not take_split_path guarantees exactly one block
+            and self.obj._mgr.blocks[0].is_extension
         ):
             take_split_path = True
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -3248,6 +3248,65 @@ class TestLocListlike:
 
 
 @pytest.mark.parametrize(
+    "indexer_name, col_key",
+    [
+        ("loc", ["a", "b"]),
+        ("iloc", [0, 1]),
+        ("loc", [True, True]),
+        ("loc", slice("a", "b")),
+        ("iloc", slice(0, 2)),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        [[1, 2], [3, 4]],
+        [(1, 2), (3, 4)],
+        [[1, 2], [3, 4, 5]],
+        ([1, 2], [3, 4]),
+        ([1, 2], [3, 4, 5]),
+    ],
+)
+def test_setitem_int_row_listlike_cols_nested_value(indexer_name, col_key, value):
+    # GH#65241 the GH#44103 fix forced the split path for a scalar row plus
+    #  list-like columns on any single-block frame; on non-extension blocks
+    #  that transposed nested values and raised on ragged ones
+    df = DataFrame({"a": [1, "x"], "b": [2, "y"]}, dtype=object)
+    assert df._mgr.is_single_block and not df._mgr.blocks[0].is_extension
+
+    getattr(df, indexer_name)[0, col_key] = value
+
+    expected = DataFrame({"a": [value[0], "x"], "b": [value[1], "y"]}, dtype=object)
+    tm.assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize("indexer_name, col_key", [("loc", ["a"]), ("iloc", [0])])
+def test_setitem_int_row_single_col_nested_value(indexer_name, col_key):
+    # GH#65241 the split path raised ValueError for a length-1 list of lists
+    df = DataFrame({"a": [1, "x"], "b": [2, "y"]}, dtype=object)
+
+    getattr(df, indexer_name)[0, col_key] = [[1, 2]]
+
+    expected = DataFrame({"a": [[1, 2], "x"], "b": [2, "y"]}, dtype=object)
+    tm.assert_frame_equal(df, expected)
+
+
+def test_loc_setitem_int_row_length_mismatch_message():
+    # GH#65241 a numpy-dtype single-block frame takes the non-split path, where
+    #  numpy raises; frames that take the split path get pandas' message
+    df = DataFrame({"a": [1, 2], "b": [3, 4]})
+    assert df._mgr.is_single_block
+    with pytest.raises(ValueError, match="setting an array element with a sequence"):
+        df.loc[0, ["a", "b"]] = [7, 8, 9]
+
+    df2 = DataFrame({"a": [1, 2], "b": [3, 4], "c": ["u", "v"]})
+    assert not df2._mgr.is_single_block
+    msg = "Must have equal len keys and value when setting with an iterable"
+    with pytest.raises(ValueError, match=msg):
+        df2.loc[0, ["a", "b"]] = [7, 8, 9]
+
+
+@pytest.mark.parametrize(
     "columns, column_key, expected_columns",
     [
         ([2011, 2012, 2013], [2011, 2012], [0, 1]),


### PR DESCRIPTION
GH-65241 fixed GH-44103 (`df.loc[0, ["a"]] = ["one"]` raising on a single-column ExtensionArray frame) by forcing the split path for a scalar row plus list-like columns on any single-block frame. But the non-split path only mishandles list-like values on ExtensionArray blocks; on ndarray blocks the split path reads a rectangular nested value as rows x columns, so on an object-dtype frame:

```python
df = DataFrame({"a": [1, "x"], "b": [2, "y"]}, dtype=object)
df.loc[0, ["a", "b"]] = [[1, 2], [3, 4]]
# a=[1, 3], b=[2, 4]  -- transposed; was a=[1, 2], b=[3, 4]
```

A list of tuples was transposed and retyped to lists, and single-column (`[[1, 2]]`) or ragged (`[[1, 2], [3, 4, 5]]`) values raised `ValueError`.

Gate the branch on `Block.is_extension` so it applies only where the GH-44103 bug actually occurs. Since EA blocks are 1D, that is the single-column EA case the original fix targeted. Note `is_extension` is narrower than "not an ndarray": `datetime64`/`timedelta64` blocks hold a `DatetimeArray`/`TimedeltaArray` but are not extension blocks, and the non-split path handles them correctly.

No whatsnew entry: GH-65241 landed in the unreleased 3.1.0, so the regression never shipped.

The tests parametrize over `loc`/`iloc` and over list, boolean-mask, and slice column keys, since the gate's `not is_integer(indexer[1])` clause admits all of them.