### PR TITLE
BUG: setitem-with-expansion saturating or raising for integer EA dtypes (GH#65094)

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -52,11 +52,14 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.dtypes import (
+    ArrowDtype,
+    BaseMaskedDtype,
     DatetimeTZDtype,
     ExtensionDtype,
     IntervalDtype,
     NumpyEADtype,
     PeriodDtype,
+    SparseDtype,
 )
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
@@ -3757,6 +3760,15 @@ def maybe_warn_multiindex_expansion(index: Index, key, target: str, hint: str) -
         )
 
 
+def _as_float64(arr: ArrayLike) -> np.ndarray:
+    """
+    Numpy float64 representation of a numeric array, with NA as NaN.
+    """
+    if isinstance(arr, np.ndarray):
+        return arr.astype(np.float64, copy=False)
+    return arr.to_numpy(dtype=np.float64, na_value=np.nan)
+
+
 def infer_and_maybe_downcast(
     orig: ExtensionArray,
     new_arr,
@@ -3787,13 +3799,29 @@ def infer_and_maybe_downcast(
         and new_arr.dtype.kind == "f"
     ):
         try:
-            converted = new_arr.astype(orig.dtype)
+            floats = _as_float64(new_arr)
+            # GH#66394 an out-of-range float->int cast saturates or wraps
+            #  instead of raising, which the roundtrip check below cannot
+            #  detect, since e.g. 2**63 and 2**63 - 1 are the same float64.
+            if isinstance(dtype, (ArrowDtype, BaseMaskedDtype)):
+                np_dtype = dtype.numpy_dtype
+            elif isinstance(dtype, SparseDtype):
+                np_dtype = dtype.subtype
+            else:
+                # a third-party ExtensionDtype we have no bounds for
+                np_dtype = None
+            if np_dtype is None or floats_fit_integer_dtype(
+                floats[~np.isnan(floats)], np_dtype
+            ):
+                converted = new_arr.astype(orig.dtype)
+                # Only accept the conversion if no values were truncated.  The
+                #  comparison is done in numpy float space because pyarrow
+                #  refuses its own int64->double cast above 2**53, even for
+                #  values that survive it intact.
+                if array_equivalent(_as_float64(converted), floats):
+                    new_arr = converted
         except (ValueError, TypeError):
             pass
-        else:
-            # Only accept the conversion if no values were truncated
-            if (converted.astype(new_arr.dtype) == new_arr).all():
-                new_arr = converted
     elif dtype.kind in "mM" and new_arr.dtype != dtype:
         # GH#66402 inference re-derives the unit from the scalars, which for a
         #  freshly-constructed Timestamp/Timedelta is us.  Restore the original

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -3990,3 +3990,29 @@ def test_loc_setitem_multi_element_list_into_cell():
     df = DataFrame([{"foo": None, "bar": None}], index=["a"])
     df.loc["a", "foo"] = ["123", "456"]
     assert df.loc["a", "foo"] == ["123", "456"]
+
+
+@td.skip_if_no("pyarrow")
+def test_loc_setitem_row_expansion_int_ea_float_value():
+    # GH#65094 row expansion casts each column back to its original dtype; an
+    #  integral float above 2**53 used to raise ArrowInvalid for ArrowDtype and
+    #  saturate to the dtype's max for masked dtypes
+    df = DataFrame(
+        {
+            "arrow": pd.array([1, 2], dtype="int64[pyarrow]"),
+            "masked": pd.array([1, 2], dtype="Int64"),
+            "numpy": [1, 2],
+        }
+    )
+
+    with tm.assert_produces_warning(Pandas4Warning, match="incompatible dtype"):
+        df.loc[2] = [1.7e18, 2.0**63, 3.0]
+
+    expected = DataFrame(
+        {
+            "arrow": pd.array([1, 2, 1700000000000000000], dtype="int64[pyarrow]"),
+            "masked": pd.array([1.0, 2.0, 2.0**63], dtype="Float64"),
+            "numpy": [1, 2, 3],
+        }
+    )
+    tm.assert_frame_equal(df, expected)

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -2035,3 +2035,63 @@ def test_setitem_enlarge_within_int64_range():
 
     expected = Series([1, 2, 2**62], dtype="int64")
     tm.assert_series_equal(ser, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype, expected_dtype",
+    [
+        ("Int64", "Float64"),
+        ("UInt64", "Float64"),
+        ("int64[pyarrow]", "double[pyarrow]"),
+        ("uint64[pyarrow]", "double[pyarrow]"),
+    ],
+)
+def test_setitem_enlarge_out_of_int_ea_range(dtype, expected_dtype):
+    # GH#65094 the out-of-range float->int cast saturates instead of raising,
+    #  and the roundtrip check could not see it, since e.g. 2**63 and 2**63 - 1
+    #  are the same float64, so the value was silently stored as the dtype max
+    if "pyarrow" in dtype:
+        pytest.importorskip("pyarrow")
+    value = 2.0**64 if dtype.lower().startswith("uint") else 2.0**63
+    ser = Series([1, 2], dtype=dtype)
+
+    with tm.assert_produces_warning(Pandas4Warning, match="incompatible dtype"):
+        ser.loc[2] = value
+
+    expected = Series([1.0, 2.0, value], dtype=expected_dtype)
+    tm.assert_series_equal(ser, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype, value", [("Sparse[int64]", 2.0**63), ("Sparse[uint64]", 2.0**64)]
+)
+def test_setitem_enlarge_out_of_sparse_int_range(dtype, value):
+    # GH#65094 SparseDtype reaches the same cast, but spells its backing numpy
+    #  dtype `subtype`, so it was skipping the range check and storing the
+    #  saturated value
+    ser = Series([1, 2], dtype=dtype)
+
+    with tm.assert_produces_warning(
+        Pandas4Warning, match="incompatible dtype", raise_on_extra_warnings=False
+    ):
+        ser.loc[2] = value
+
+    expected = Series([1.0, 2.0, value], dtype="Sparse[float64]")
+    tm.assert_series_equal(ser, expected)
+
+
+@pytest.mark.parametrize("dtype", ["Int64", "int64[pyarrow]", "Sparse[int64]"])
+def test_setitem_enlarge_int_ea_above_2_53(dtype):
+    # GH#65094 an in-range integral float above 2**53 is exact, so the dtype is
+    #  retained.  For ArrowDtype the check used to roundtrip through pyarrow,
+    #  whose int64->double cast rejects anything above 2**53, raising
+    #  ArrowInvalid out of .loc
+    if "pyarrow" in dtype:
+        pytest.importorskip("pyarrow")
+    ser = Series([1, 2], dtype=dtype)
+
+    with tm.assert_produces_warning(None):
+        ser.loc[2] = 1.7e18
+
+    expected = Series([1, 2, 1700000000000000000], dtype=dtype)
+    tm.assert_series_equal(ser, expected)


### PR DESCRIPTION
Follow-up to GH-65094, which added an integer-ExtensionArray branch to `infer_and_maybe_downcast`. That branch verified a float->int cast by roundtripping the result back through the ExtensionArray, which has two problems:

- The roundtrip is blind to saturation, since e.g. `2**63` and `int64max` are the same `float64`. `Series([1, 2], dtype="Int64").loc[2] = 2.0**63` silently stored `int64max` and kept `Int64`. Same for `UInt64` + `2.0**64` and for `Sparse[int64]`.
- For `ArrowDtype` the reverse leg raises: pyarrow refuses its own `int64->double` cast above `2**53`. `Series([1, 2], dtype="int64[pyarrow]").loc[2] = 1.7e18` raised `pyarrow.lib.ArrowInvalid` out of `.loc`, even though the value converts exactly.

Both now go through `floats_fit_integer_dtype` (the helper the numpy path already uses, from GH-66394), and the truncation check is done in numpy float space instead of roundtripping through the EA. The three backends agree afterwards:

| value into | `int64` (numpy) | `Int64` | `int64[pyarrow]` |
|---|---|---|---|
| `1.7e18` | `int64` | `Int64` | `int64[pyarrow]` (was `ArrowInvalid`) |
| `2.0**63` | `float64` | `Float64` (was silently `int64max`) | `double[pyarrow]` (was `ArrowInvalid`) |

No whatsnew entry: GH-65094 has not appeared in a release, so this is dev-only.
