### PR TITLE
BUG: unstack(sort=False) placed values under wrong row labels (GH#62816)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -723,6 +723,7 @@ Reshaping
 - Bug in :meth:`DataFrame.select_dtypes` where an interval spec giving a subtype but no ``closed`` keyword, such as ``"interval[int64]"`` or ``pd.IntervalDtype("int64")``, selected no columns; it now selects every interval column with that subtype, for any ``closed`` value (:issue:`40234`)
 - Bug in :meth:`DataFrame.select_dtypes` where the string form of an Arrow dtype such as ``"int64[pyarrow]"`` selected no columns and ``"float64[pyarrow]"`` selected numpy float columns; an Arrow dtype string now selects only columns of that exact dtype (:issue:`59888`)
 - Bug in :meth:`DataFrame.stack` raising a bare ``AssertionError`` or an ``IndexError`` when ``level`` contained duplicate entries, including duplicates produced by resolving level names or negative level numbers; it now raises an informative ``ValueError`` (:issue:`66588`)
+- Bug in :meth:`DataFrame.unstack` and :meth:`Series.unstack` with ``sort=False`` placing values under the wrong row labels, or collapsing distinct index combinations into a single row (:issue:`62816`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -13912,7 +13912,9 @@ class DataFrame(NDFrame, OpsMixin):
         fill_value : scalar
             Replace NaN with this value if the unstack produces missing values.
         sort : bool, default True
-            Sort the level(s) in the resulting MultiIndex columns.
+            Sort the level(s) in the resulting MultiIndex columns. This also
+            orders the rows of the result: sorted by the remaining levels if
+            ``True``, in order of first appearance if ``False``.
 
         Returns
         -------

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -56,7 +56,6 @@ from pandas.core.series import Series
 from pandas.core.sorting import (
     compress_group_index,
     decons_obs_group_ids,
-    get_compressed_ids,
     get_group_index,
     get_group_index_sorter,
 )
@@ -181,76 +180,90 @@ class _Unstacker:
         self._make_selectors()
 
     @cache_readonly
-    def _indexer_and_to_sort(
-        self,
-    ) -> tuple[
-        npt.NDArray[np.intp],
-        list[np.ndarray],  # each has _some_ signed integer dtype
-    ]:
-        v = self.level
+    def _comp_index_and_ngroups(self) -> tuple[npt.NDArray[np.intp], int]:
+        """
+        For each entry of self.index, the row of the result it belongs to.
 
-        codes = list(self.index.codes)
-        if not self.sort:
-            # Create new codes considering that labels are already sorted
-            codes = [factorize(code)[0] for code in codes]
-        levs = list(self.index.levels)
-        to_sort = codes[:v] + codes[v + 1 :] + [codes[v]]
-        sizes = tuple(len(x) for x in levs[:v] + levs[v + 1 :] + [levs[v]])
+        With sort=True the rows are numbered lexicographically; with sort=False
+        they are numbered by first appearance. Either way the number is the
+        position the row occupies in the result, which the rest of the class
+        relies on: the values land in row `comp_index` (see _make_selectors) and
+        `compressor` reads the labels back out in that same order.
+        """
+        level_num = self.level
+        levs = self.index.levels
+        codes = self.index.codes
+        remaining_labels = list(codes[:level_num] + codes[level_num + 1 :])
+        remaining_levels = levs[:level_num] + levs[level_num + 1 :]
+        sizes = tuple(len(lev) for lev in remaining_levels)
 
-        comp_index, obs_ids = get_compressed_ids(to_sort, sizes)
-        ngroups = len(obs_ids)
-
-        indexer = get_group_index_sorter(comp_index, ngroups)
-        return indexer, to_sort
+        ids = get_group_index(remaining_labels, sizes, sort=True, xnull=False)
+        comp_index, obs_ids = compress_group_index(ids, sort=self.sort)
+        return ensure_platform_int(comp_index), len(obs_ids)
 
     @cache_readonly
-    def sorted_labels(self) -> list[np.ndarray]:
-        indexer, to_sort = self._indexer_and_to_sort
+    def _unstacked_level_codes(self) -> np.ndarray:
+        """
+        For each entry of self.index, the column of the result it belongs to.
+
+        Note this is not a position within self.removed_level: with sort=False
+        NaN gets a column of its own but is absent from removed_level.
+        """
+        level_codes = self.index.codes[self.level]
         if self.sort:
-            return [line.take(indexer) for line in to_sort]
-        return to_sort
+            # -1 for NaN; self.lift shifts those into position 0.
+            return level_codes
+        # removed_level is in order of first appearance, and so is this, with
+        #  NaN numbered wherever it first appeared (see unique_nan_index).
+        return factorize(level_codes)[0]
+
+    @cache_readonly
+    def _indexer(self) -> npt.NDArray[np.intp]:
+        # libreshape.unstack walks the values in the order they occupy in the
+        #  result, so sort the rows by (result row, result column).
+        comp_index, ngroups = self._comp_index_and_ngroups
+        stride = self.index.levshape[self.level] + self.has_nan
+        keys = [comp_index, self._unstacked_level_codes]
+
+        # xnull=False shifts a -1 code to 0, which is where _make_selectors puts
+        #  it too via self.lift, so the two orderings stay in step.
+        ids = get_group_index(keys, (ngroups, stride), sort=True, xnull=False)
+        comp_ids, obs_ids = compress_group_index(ids, sort=True)
+        return get_group_index_sorter(ensure_platform_int(comp_ids), len(obs_ids))
 
     @cache_readonly
     def _indexer_is_identity(self) -> bool:
         # Note: index.is_monotonic_increasing would be wrong here: it reflects
         #  tuple values, which can be monotonic while the codes are not (GH#65107).
-        indexer, _ = self._indexer_and_to_sort
-        return lib.is_range_indexer(indexer, len(self.index))
+        return lib.is_range_indexer(self._indexer, len(self.index))
 
     def _make_sorted_values(self, values: np.ndarray) -> np.ndarray:
         if self._indexer_is_identity:
             return values
-        indexer, _ = self._indexer_and_to_sort
-        sorted_values = algos.take_nd(values, indexer, axis=0, allow_fill=False)
+        sorted_values = algos.take_nd(values, self._indexer, axis=0, allow_fill=False)
         return sorted_values
 
     def _make_selectors(self) -> None:
-        new_levels = self.new_index_levels
+        comp_index, ngroups = self._comp_index_and_ngroups
 
-        # make the mask
-        remaining_labels = self.sorted_labels[:-1]
-        level_sizes = tuple(len(x) for x in new_levels)
-
-        comp_index, obs_ids = get_compressed_ids(remaining_labels, level_sizes)
-        ngroups = len(obs_ids)
-
-        comp_index = ensure_platform_int(comp_index)
         stride = self.index.levshape[self.level] + self.has_nan
         self.full_shape = ngroups, stride
 
-        selector = self.sorted_labels[-1] + stride * comp_index + self.lift
+        # make the mask
+        selector = self._unstacked_level_codes + stride * comp_index + self.lift
         mask = np.zeros(np.prod(self.full_shape), dtype=bool)
         mask.put(selector, True)
 
         if mask.sum() < len(self.index):
             raise ValueError("Index contains duplicate entries, cannot reshape")
 
-        self.group_index = comp_index
         self.mask = mask
-        if self.sort:
-            self.compressor = comp_index.searchsorted(np.arange(ngroups))
-        else:
-            self.compressor = np.sort(np.unique(comp_index, return_index=True)[1])
+        # For each row of the result, the position of an entry of self.index
+        #  belonging to it. All such entries agree on the remaining levels, so
+        #  which one we keep does not matter.
+        compressor = np.empty(ngroups, dtype=np.intp)
+        compressor[comp_index] = np.arange(len(comp_index))
+        self.compressor = compressor
 
     @cache_readonly
     def mask_all(self) -> bool:
@@ -443,12 +456,9 @@ class _Unstacker:
     @cache_readonly
     def new_index(self) -> MultiIndex | Index:
         # Does not depend on values or value_columns
-        if self.sort:
-            labels = self.sorted_labels[:-1]
-        else:
-            v = self.level
-            codes = list(self.index.codes)
-            labels = codes[:v] + codes[v + 1 :]
+        level_num = self.level
+        codes = self.index.codes
+        labels = codes[:level_num] + codes[level_num + 1 :]
         result_codes = [lab.take(self.compressor) for lab in labels]
 
         # construct the new index

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4841,7 +4841,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         fill_value : scalar value, default None
             Value to use when replacing NaN values.
         sort : bool, default True
-            Sort the level(s) in the resulting MultiIndex columns.
+            Sort the level(s) in the resulting MultiIndex columns. This also
+            orders the rows of the result: sorted by the remaining levels if
+            ``True``, in order of first appearance if ``False``.
 
         Returns
         -------

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1440,6 +1440,114 @@ def test_unstack_sort_false_unsorted_with_gaps():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("frame", [False, True])
+@pytest.mark.parametrize("dtype", ["int64", "Int64", "int64[pyarrow]"])
+def test_unstack_sort_false_multiple_remaining_levels(frame, dtype):
+    # GH#62816 With two or more levels left over, the result rows
+    #  follow first appearance, but the values were laid out in lexicographic
+    #  order of the remaining codes, so they landed under the wrong labels.
+    #  The extension dtypes go through BlockManager.unstack instead of
+    #  _Unstacker.get_result, which consumes the same machinery differently.
+    if dtype == "int64[pyarrow]":
+        pytest.importorskip("pyarrow")
+    index = MultiIndex.from_tuples(
+        [(2, "a", 9), (1, "c", 9), (2, "c", 9)], names=["x", "y", "z"]
+    )
+    obj = Series([10, 20, 30], index=index, dtype=dtype)
+    expected_index = MultiIndex.from_tuples(
+        [(2, "a"), (1, "c"), (2, "c")], names=["x", "y"]
+    )
+    if frame:
+        obj = obj.to_frame("val")
+        expected_columns = MultiIndex.from_tuples([("val", 9)], names=[None, "z"])
+    else:
+        expected_columns = Index([9], name="z")
+
+    result = obj.unstack(level=2, sort=False)
+
+    expected = DataFrame(
+        [[10], [20], [30]],
+        index=expected_index,
+        columns=expected_columns,
+        dtype=dtype,
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_unstack_sort_false_multiple_remaining_levels_with_gaps():
+    # GH#62816 As above, but with missing combinations so the values go through
+    #  the masked fill path rather than the plain reshape.
+    index = MultiIndex.from_tuples(
+        [(2, "a", 9), (1, "c", 8), (2, "c", 9), (1, "c", 9)], names=["x", "y", "z"]
+    )
+    ser = Series([10.0, 20.0, 30.0, 40.0], index=index)
+
+    result = ser.unstack(level=2, sort=False)
+
+    expected = DataFrame(
+        [[10.0, np.nan], [40.0, 20.0], [30.0, np.nan]],
+        index=MultiIndex.from_tuples([(2, "a"), (1, "c"), (2, "c")], names=["x", "y"]),
+        columns=Index([9, 8], name="z"),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_unstack_sort_false_nan_in_unstacked_level_one_remaining_level():
+    # GH#62816 A single remaining level is enough to misplace values once the
+    #  unstacked level holds NaN: the sort indexer sized that level from its
+    #  length while renumbering its codes, so the NaN column collided with the
+    #  next row. Distinct mechanism from the >=2-remaining-levels case.
+    index = MultiIndex.from_tuples(
+        [("r0", np.nan), ("r1", np.nan), ("r0", "u0")], names=["r", "u"]
+    )
+    ser = Series([1.0, 2.0, 3.0], index=index)
+
+    result = ser.unstack(sort=False)
+
+    expected = DataFrame(
+        [[1.0, 3.0], [2.0, np.nan]],
+        index=Index(["r0", "r1"], name="r"),
+        columns=Index([np.nan, "u0"], name="u"),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_unstack_sort_false_does_not_collapse_rows():
+    # GH#62816 Distinct index combinations were merged into a single result
+    #  row, silently dropping data rather than only mislabelling it.
+    index = MultiIndex.from_tuples([(np.nan, np.nan, np.nan), ("a0", "b0", np.nan)])
+    ser = Series([1.0, 2.0], index=index)
+
+    result = ser.unstack(0, sort=False)
+
+    expected = DataFrame(
+        [[1.0, np.nan], [np.nan, 2.0]],
+        index=MultiIndex.from_tuples([(np.nan, np.nan), ("b0", np.nan)]),
+        columns=Index([np.nan, "a0"]),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_unstack_multiple_sort_false_multiple_remaining_levels():
+    # GH#62816 _unstack_multiple routes through the same _Unstacker, so
+    #  unstacking several levels at once and leaving two or more behind hit
+    #  the same misplacement.
+    index = MultiIndex.from_tuples(
+        [(2, "a", 9, "p"), (1, "c", 9, "p"), (2, "c", 9, "p")],
+        names=["x", "y", "z", "w"],
+    )
+    ser = Series([10.0, 20.0, 30.0], index=index)
+
+    result = ser.unstack(["z", "w"], sort=False)
+
+    expected = DataFrame(
+        [[10.0], [20.0], [30.0]],
+        index=MultiIndex.from_tuples([(2, "a"), (1, "c"), (2, "c")], names=["x", "y"]),
+        columns=MultiIndex.from_tuples([(9, "p")], names=["z", "w"]),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_unstack_monotonic_values_unsorted_codes():
     # GH#65107 An MI whose tuple *values* are monotonic but whose codes are
     #  unsorted (here level 0 has unsorted levels ['b', 'a']) must still be


### PR DESCRIPTION
closes #62816

`_Unstacker` numbered the result rows in two different ways, and the two only agreed when at most one level was left after the unstack. Values were placed in row `comp_index`, which `get_compressed_ids` numbers lexicographically by the remaining levels' codes, while the row labels came from `compressor`, which numbered them by first appearance. With `sort=False` those orders diverge, so values landed under the wrong labels — silently, with no error or warning.

The issue's own example:

```python
df.value_counts(subset=["Department", "Gender", "Location"]).unstack(fill_value=0, sort=False)
```

Two further shapes of the same defect, both fixed here:

* One remaining level is enough once the unstacked level contains NaN — a different mechanism (the sort indexer rather than the `compressor`/`comp_index` disagreement).
* With two or more remaining levels it could do worse than mislabel: distinct index combinations were collapsed into a single row, dropping data.

The fix compresses the remaining levels once, with `sort=self.sort`, so the group number *is* the row's position in the result; the sort indexer and `compressor` are then derived from that single numbering. `new_index` no longer needs a `sort` branch.

`sort=True` behaviour is unchanged — the indexer, ngroups, result codes and selector set are identical to before over a large randomized comparison — and `sort=False` gets faster (~1.75x on 400k rows), since the old code re-factorized every level separately; the rewrite also drops the `sorted_labels` materialization.

The `sort` docstrings for both methods said the flag only sorts the resulting MultiIndex columns; it also determines the row order, which is what this PR is about, so they are corrected too.

Two neighbouring `unstack(sort=False)` label bugs turned up while testing this. Both are independent of the numbering fix and are left for follow-ups: GH-66672 (`Series.unstack` puts the NaN column first while its values stay in place) and GH-66673 (columns mislabelled when the unstacked level has unused entries).
