### PR TITLE
BUG: Period minus Period raised OverflowError for a count of INT64_MIN (GH#66552)

### DIFF
--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -135,5 +135,7 @@ cdef int64_t convert_reso(
     bint round_ok,
 ) except? -1
 
-cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right)
+cpdef cnp.ndarray add_overflowsafe(
+    cnp.ndarray left, cnp.ndarray right, bint sentinel_ok=*
+)
 cpdef cnp.ndarray mul_overflowsafe(cnp.ndarray left, cnp.ndarray right)

--- a/pandas/_libs/tslibs/np_datetime.pyi
+++ b/pandas/_libs/tslibs/np_datetime.pyi
@@ -27,6 +27,7 @@ def compare_mismatched_resolutions(
 def add_overflowsafe(
     left: npt.NDArray[np.int64],
     right: npt.NDArray[np.int64],
+    sentinel_ok: bool = ...,
 ) -> npt.NDArray[np.int64]: ...
 def mul_overflowsafe(
     left: npt.NDArray[np.int64],

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -841,11 +841,18 @@ cdef int64_t _convert_reso_with_dtstruct(
 
 
 @cython.overflowcheck(True)
-cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right):
+cpdef cnp.ndarray add_overflowsafe(
+    cnp.ndarray left, cnp.ndarray right, bint sentinel_ok=False
+):
     """
     Overflow-safe addition for datetime64/timedelta64 dtypes.
 
     `right` may either be zero-dim or of the same shape as `left`.
+
+    A sum landing exactly on NPY_DATETIME_NAT is rejected, since as a datetime64
+    or timedelta64 value it would be indistinguishable from a missing one. Pass
+    ``sentinel_ok=True`` where the result is a count rather than such a value,
+    so that NPY_DATETIME_NAT is a legitimate answer (GH#66552).
 
     TODO(numpy>=2.5): numpy raises OverflowError natively for datetime64/
     timedelta64 add and subtract (numpy GH-31378); remove this once the numpy
@@ -873,7 +880,7 @@ cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right):
                 res_value = NPY_DATETIME_NAT
             else:
                 res_value = lval + rval
-                if res_value == NPY_DATETIME_NAT:
+                if res_value == NPY_DATETIME_NAT and not sentinel_ok:
                     # GH#66549 int64 can hold this sum, but the value is the
                     #  NaT sentinel, so it would be indistinguishable from a
                     #  missing value downstream. Treat it as an overflow.

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1251,7 +1251,12 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         new_i8_data = add_overflowsafe(
             self.asi8, np.asarray(-other_i8, dtype="i8"), sentinel_ok=True
         )
-        new_data = np.array([self.freq.base * x for x in new_i8_data])
+        # multiply by python ints: numpy's scalar multiply spuriously reports
+        #  overflow for a np.int64 count of INT64_MIN on Windows
+        counts = new_i8_data.ravel().tolist()
+        new_data = np.array([self.freq.base * count for count in counts]).reshape(
+            new_i8_data.shape
+        )
 
         if o_mask is None:
             # i.e. Period scalar

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1246,7 +1246,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         self._check_compatible_with(other)
 
         other_i8, o_mask = self._get_i8_values_and_mask(other)
-        new_i8_data = add_overflowsafe(self.asi8, np.asarray(-other_i8, dtype="i8"))
+        # GH#66552 the difference is a count of periods, not an ordinal, so
+        #  INT64_MIN is a legitimate answer here and not the NaT sentinel.
+        new_i8_data = add_overflowsafe(
+            self.asi8, np.asarray(-other_i8, dtype="i8"), sentinel_ok=True
+        )
         new_data = np.array([self.freq.base * x for x in new_i8_data])
 
         if o_mask is None:

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -1537,3 +1537,57 @@ class TestPeriodIndexSeriesMethods:
         )
         tm.assert_index_equal(idx - Period("NaT", freq="M"), exp)
         tm.assert_index_equal(Period("NaT", freq="M") - idx, exp)
+
+
+def test_pi_sub_pi_count_on_nat_sentinel():
+    # GH#66552 the difference of two Periods is a count of periods, not an
+    #  ordinal, so INT64_MIN is a legitimate answer rather than the NaT sentinel
+    left = PeriodIndex([Period(ordinal=-(2**62), freq="D")])
+    right = PeriodIndex([Period(ordinal=2**62, freq="D")])
+    expected_offset = pd.offsets.Day(-(2**63))
+
+    # the scalar path has always given back the count; the array paths agree
+    assert left[0] - right[0] == expected_offset
+
+    tm.assert_numpy_array_equal(
+        left._data - right._data, np.array([expected_offset], dtype=object)
+    )
+    tm.assert_index_equal(left - right, pd.Index([expected_offset]))
+    tm.assert_series_equal(
+        Series(left) - Series(right), Series([expected_offset], dtype=object)
+    )
+
+
+def test_pi_sub_period_count_on_nat_sentinel():
+    # GH#66552 same, with a Period scalar on the right
+    pi = PeriodIndex([Period(ordinal=-(2**62), freq="D")])
+    result = pi - Period(ordinal=2**62, freq="D")
+    expected = pd.Index([pd.offsets.Day(-(2**63))])
+    tm.assert_index_equal(result, expected)
+
+
+def test_pi_sub_pi_still_raises_on_overflow():
+    # GH#66552 the sentinel opt-out must not disable the int64 overflow check
+    left = PeriodIndex([Period(ordinal=2**62, freq="D")])
+    right = PeriodIndex([Period(ordinal=-(2**62), freq="D")])
+    msg = "Overflow in int64 addition"
+    with pytest.raises(OverflowError, match=msg):
+        left - right
+
+
+def test_pi_sub_pi_nat_still_propagates():
+    # GH#66552 the opt-out is about the result, not about NaT operands
+    left = PeriodIndex([Period(ordinal=-(2**62), freq="D"), pd.NaT])
+    right = PeriodIndex([pd.NaT, Period(ordinal=2**62, freq="D")])
+    result = left - right
+    expected = pd.Index([pd.NaT, pd.NaT], dtype=object)
+    tm.assert_index_equal(result, expected)
+
+
+def test_pi_add_int_still_raises_on_nat_sentinel():
+    # GH#66552 an ordinal landing on the sentinel is still an overflow; only
+    #  the Period-minus-Period count path opts out
+    pi = PeriodIndex([Period(ordinal=-(2**63) + 1, freq="D")])
+    msg = "Overflow in int64 addition"
+    with pytest.raises(OverflowError, match=msg):
+        pi - 1


### PR DESCRIPTION
Addresses the "Where `INT64_MIN` is legitimate" item of GH-66552.

`add_overflowsafe` rejects a sum landing exactly on `NPY_NAT`, since as a datetime64 or timedelta64 value it would be indistinguishable from a missing one. That guard landed in GH-66602 without the opt-out GH-66552 calls for, so `Period` minus `Period` — which returns a *count* of periods rather than an ordinal — started raising for a result the scalar path still gives:

```python
>>> left = pd.PeriodIndex([pd.Period(ordinal=-(2**62), freq="D")])
>>> right = pd.PeriodIndex([pd.Period(ordinal=2**62, freq="D")])

>>> left[0] - right[0]        # scalar, correct
<-9223372036854775808 * Days>

>>> left - right              # on main
OverflowError: Overflow in int64 addition
```

Gate the result check behind a `sentinel_ok` flag and pass it from `_sub_periodlike`, the one caller whose result is a count. NaT operands still short-circuit to NaT, and genuine int64 overflow still raises.

`_sub_periodlike` now also builds its offsets from python ints rather than iterating the int64 array directly. Feeding a `np.int64` of `INT64_MIN` to `BaseOffset.__mul__` trips a spurious `RuntimeWarning: overflow encountered in scalar multiply` on Windows, where numpy's scalar-multiply overflow check falls back off `__builtin_mul_overflow` and misfires on `INT64_MIN`. The `ravel()`/`reshape()` is load-bearing: `PeriodArray` can be 2D, and `tolist()` on a 2D array would hand `__mul__` nested lists.

No whatsnew: the regression was introduced and fixed within the unreleased 3.1.0 dev cycle, and the existing entry describes the ordinal-producing paths, which are unaffected.

As GH-66552 notes, nothing covered this — a full `pandas/tests` run passes with `PeriodArray - PeriodArray` regressed — so the tests here pin down both the count (array/Index/Series, against the scalar) and that the opt-out does not leak: a genuine `2**63` overflow still raises, an ordinal landing on the sentinel still raises, and NaT operands still propagate.
