### PR TITLE
BUG: Fix DataFrame.unstack(sort=False) labels with unused levels (GH#66673)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -729,6 +729,7 @@ Reshaping
 - Bug in :meth:`DataFrame.select_dtypes` where an interval spec giving a subtype but no ``closed`` keyword, such as ``"interval[int64]"`` or ``pd.IntervalDtype("int64")``, selected no columns; it now selects every interval column with that subtype, for any ``closed`` value (:issue:`40234`)
 - Bug in :meth:`DataFrame.select_dtypes` where the string form of an Arrow dtype such as ``"int64[pyarrow]"`` selected no columns and ``"float64[pyarrow]"`` selected numpy float columns; an Arrow dtype string now selects only columns of that exact dtype (:issue:`59888`)
 - Bug in :meth:`DataFrame.stack` raising a bare ``AssertionError`` or an ``IndexError`` when ``level`` contained duplicate entries, including duplicates produced by resolving level names or negative level numbers; it now raises an informative ``ValueError`` (:issue:`66588`)
+- Bug in :meth:`DataFrame.unstack` with ``sort=False`` labeling columns incorrectly when the unstacked level contained unused entries (:issue:`66673`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -157,7 +157,9 @@ class _Unstacker:
                 self.unique_nan_index = np.flatnonzero(nan_mask)[0]
 
             self.removed_level = self.removed_level.take(unique_codes)
-            self.removed_level_full = self.removed_level_full.take(unique_codes)
+            self.removed_level_full = self.removed_level_full.take(
+                self.removed_level_full.get_indexer(self.removed_level)
+            )
 
         if config["mode"]["performance_warnings"]:
             # Bug fix GH 20601

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1388,6 +1388,36 @@ def test_unstack_sort_false(frame_or_series, dtype):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("dtype", ["float64", "Int64"])
+def test_unstack_sort_false_unused_levels(dtype):
+    # GH 66673
+    index = MultiIndex(
+        levels=[["a", "b"], ["x", "y", "z"]],
+        codes=[[0, 0, 1, 1], [2, 0, 2, 0]],
+        names=["r", "c"],
+    )
+    df = DataFrame({"v": [1.0, 2, 3, 4]}, index=index)
+    obj = df if dtype == "float64" else df["v"].astype(dtype)
+
+    result = obj.unstack(sort=False)
+
+    if dtype == "float64":
+        columns = MultiIndex(
+            levels=[["v"], ["z", "x"]],
+            codes=[[0, 0], [0, 1]],
+            names=[None, "c"],
+        )
+    else:
+        columns = Index(["z", "x"], name="c")
+    expected = DataFrame(
+        [[1, 2], [3, 4]],
+        index=Index(["a", "b"], name="r"),
+        columns=columns,
+        dtype=dtype,
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "levels2, expected_columns",
     [


### PR DESCRIPTION
- [x] closes #66673
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an [entry](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#whatsnew) in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Fix `DataFrame.unstack(sort=False)` when the unstacked level contains unused entries. The selected labels are now matched by value after unused levels are removed, so the output columns remain aligned with the values. The regression test covers both a DataFrame and an `Int64` Series path.

Codex was used to inspect the implementation and draft the code, regression tests, release note, and PR description. I reviewed and modified the changes locally against `AGENTS.md` and the pandas contribution guides.
