### PR TITLE
PERF: vectorize datetimelike array addition when the bounds allow it (GH#66552)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -252,6 +252,7 @@ Performance improvements
 - Performance improvement in :attr:`Series.is_monotonic_increasing` and :attr:`Series.is_monotonic_decreasing` for :class:`ArrowDtype` and masked dtypes by dispatching to the :class:`ExtensionArray` (:issue:`56619`)
 - Performance improvement in :class:`DataFrame` repr by avoiding redundant formatting when columns exceed terminal width (:issue:`64863`)
 - Performance improvement in :class:`DatetimeIndex` and :class:`Series` construction with a timezone-aware ``datetime64`` dtype from a sequence of strings (:issue:`66123`)
+- Performance improvement in :class:`DatetimeIndex`, :class:`TimedeltaIndex`, :class:`PeriodIndex`, and :class:`Series` arithmetic with a datetimelike scalar or array (:issue:`66552`)
 - Performance improvement in :class:`GroupBy` reductions and transformations for :class:`SparseDtype` columns (:issue:`36123`)
 - Performance improvement in :func:`bdate_range` and :func:`date_range` with ``freq="B"`` or ``freq="C"`` (business day frequencies) (:issue:`16463`)
 - Performance improvement in :func:`concat` and :meth:`DataFrame.astype` to extension dtypes (:issue:`65672`)

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -840,6 +840,13 @@ cdef int64_t _convert_reso_with_dtstruct(
     return result
 
 
+# The reductions in add_overflowsafe's fast path cost a fixed ~1us that the
+#  per-element loop does not pay, putting the measured crossover at a few
+#  hundred elements.  Round up so that small inputs, the common case for
+#  scalar-broadcast arithmetic, stay on the loop.
+cdef Py_ssize_t _ADD_VECTORIZED_MIN_SIZE = 1000
+
+
 @cython.overflowcheck(True)
 cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right):
     """
@@ -854,6 +861,26 @@ cpdef cnp.ndarray add_overflowsafe(cnp.ndarray left, cnp.ndarray right):
     cdef:
         Py_ssize_t _, N = left.size
         int64_t lval, rval, res_value
+        int64_t lmin, lmax, rmin, rmax
+
+    # Fast path: bound the result from the operands' min/max, and when every
+    #  sum provably stays inside (NPY_DATETIME_NAT, INT64_MAX] hand the whole
+    #  thing to numpy.  NPY_DATETIME_NAT is INT64_MIN, so a minimum above it
+    #  also rules out NaT operands.
+    if N >= _ADD_VECTORIZED_MIN_SIZE and right.size > 0:
+        lmin = left.min()
+        rmin = right.min()
+        if lmin > NPY_DATETIME_NAT and rmin > NPY_DATETIME_NAT:
+            lmax = left.max()
+            rmax = right.max()
+            # Each bound is phrased to keep the subtraction itself in range.
+            if (
+                (rmin >= 0 or lmin > NPY_DATETIME_NAT - rmin)
+                and (rmax <= 0 or lmax <= INT64_MAX - rmax)
+            ):
+                return left + right
+
+    cdef:
         ndarray iresult = cnp.PyArray_EMPTY(
             left.ndim, left.shape, cnp.NPY_INT64, 0
         )

--- a/pandas/tests/tslibs/test_np_datetime.py
+++ b/pandas/tests/tslibs/test_np_datetime.py
@@ -1,10 +1,12 @@
 import numpy as np
 import pytest
 
+from pandas._libs.tslibs import iNaT
 from pandas._libs.tslibs.dtypes import NpyDatetimeUnit
 from pandas._libs.tslibs.np_datetime import (
     OutOfBoundsDatetime,
     OutOfBoundsTimedelta,
+    add_overflowsafe,
     astype_overflowsafe,
     is_unitless,
     py_get_unit_from_dtype,
@@ -138,6 +140,65 @@ def test_td64_to_tdstruct():
         "nanoseconds": 0,
     }
     assert res4 == exp4
+
+
+# add_overflowsafe switches to a vectorized path once the input is large
+#  enough, so these use an array well past that threshold; the guards have to
+#  hold on both routes.
+LARGE = 5000
+
+
+@pytest.mark.parametrize("size", [1, LARGE])
+def test_add_overflowsafe_rejects_int64_overflow(size):
+    left = np.full(size, np.iinfo(np.int64).max, dtype="i8")
+    right = np.array(1, dtype="i8")
+
+    with pytest.raises(OverflowError, match="Overflow in int64 addition"):
+        add_overflowsafe(left, right)
+
+
+@pytest.mark.parametrize("size", [1, LARGE])
+def test_add_overflowsafe_rejects_nat_sentinel_result(size):
+    # GH#66552 a sum landing on iNaT is indistinguishable from a missing value
+    left = np.full(size, iNaT + 1, dtype="i8")
+    right = np.array(-1, dtype="i8")
+
+    with pytest.raises(OverflowError, match="Overflow in int64 addition"):
+        add_overflowsafe(left, right)
+
+
+@pytest.mark.parametrize("size", [1, LARGE])
+def test_add_overflowsafe_allows_bounds(size):
+    # one step inside the range on either end is fine
+    left = np.full(size, iNaT + 2, dtype="i8")
+    result = add_overflowsafe(left, np.array(-1, dtype="i8"))
+    tm.assert_numpy_array_equal(result, np.full(size, iNaT + 1, dtype="i8"))
+
+    left = np.full(size, np.iinfo(np.int64).max - 1, dtype="i8")
+    result = add_overflowsafe(left, np.array(1, dtype="i8"))
+    expected = np.full(size, np.iinfo(np.int64).max, dtype="i8")
+    tm.assert_numpy_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("size", [1, LARGE])
+def test_add_overflowsafe_propagates_nat(size):
+    left = np.full(size, iNaT, dtype="i8")
+    result = add_overflowsafe(left, np.array(1, dtype="i8"))
+    tm.assert_numpy_array_equal(result, np.full(size, iNaT, dtype="i8"))
+
+    left = np.arange(size, dtype="i8")
+    result = add_overflowsafe(left, np.array(iNaT, dtype="i8"))
+    tm.assert_numpy_array_equal(result, np.full(size, iNaT, dtype="i8"))
+
+
+def test_add_overflowsafe_elementwise_right():
+    # a bounds check on the operands has to hold for every pairing, and the
+    #  result keeps the shape of `left`
+    left = np.arange(LARGE, dtype="i8").reshape(50, -1)
+    right = np.full(left.shape, 7, dtype="i8")
+
+    result = add_overflowsafe(left, right)
+    tm.assert_numpy_array_equal(result, left + 7)
 
 
 class TestAstypeOverflowSafe:


### PR DESCRIPTION
Addresses the "Performance" section of GH-66552.

`add_overflowsafe` backs add/subtract for `DatetimeArray`, `TimedeltaArray` and `PeriodArray`, and so for the corresponding Index and Series. It loops per element to check both for int64 overflow and for a result landing on the `NaT` sentinel, which costs about 12x a plain numpy add.

Take min/max of both operands first. If the bounds prove every sum stays inside `(iNaT, INT64_MAX]`, then no element can overflow or land on the sentinel, and the addition can go to numpy in one vectorized pass. The bounds are conservative in the safe direction — a batch that could overflow falls back to the loop — so no result can skip a guard. This is the same shape as the existing fast path in `astype_overflowsafe` a few hundred lines up, which the issue points at as the model.

The two reductions cost a fixed ~1us that the loop does not pay, putting the crossover at a few hundred elements, so small inputs stay on the loop rather than regressing.

1M elements, macOS arm64:

| | main | this PR |
|---|---|---|
| `DatetimeIndex + Timedelta` | 5.04 ms | 0.41 ms |
| `DatetimeIndex - DatetimeIndex` | 6.91 ms | 1.31 ms |
| `TimedeltaIndex + Timedelta` | 4.41 ms | 0.39 ms |
| `PeriodIndex + 1` | 6.14 ms | 0.40 ms |
| `DatetimeIndex + Day(1)` | 6.13 ms | 0.43 ms |

`add_overflowsafe` had no direct tests, and no existing test used an array large enough to reach the new path, so the added tests are parametrized over a size on each side of the threshold. I checked they are not vacuous by mutating each bound to be one off; both mutations fail, and only at the large size.