### PR TITLE
BUG: read_csv parallel path takes the corrupting path for falsy non-False low_memory (GH#66259)

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -440,8 +440,8 @@ def _can_parallelize_csv(filepath_or_buffer, kwds: dict) -> bool:
       literal newline would be split mid-field.
     * ``parse_dates`` is unset - datetime format inference is per-chunk and may
       disagree with the serial whole-column inference.
-    * ``low_memory`` is not ``False`` - ``low_memory=False`` guarantees
-      whole-file type inference, which per-chunk parallel reading cannot honour
+    * ``low_memory`` is truthy - a falsy ``low_memory`` guarantees whole-file
+      type inference, which per-chunk parallel reading cannot honour
       (``low_memory=True`` already documents per-chunk inference divergence).
     * ``storage_options`` is ``None`` - it raises for local paths in the serial
       path, and that error must not be masked.
@@ -544,9 +544,12 @@ def _can_parallelize_csv(filepath_or_buffer, kwds: dict) -> bool:
     if kwds.get("parse_dates"):
         return False
 
-    # low_memory=False guarantees whole-file type inference, which per-chunk
-    # parallel reading cannot honour (GH#64347).
-    if kwds.get("low_memory") is False:
+    # A falsy low_memory guarantees whole-file type inference, which per-chunk
+    # parallel reading cannot honour (GH#64347).  Test truthiness, not identity:
+    # low_memory is not coerced to bool, and the serial path in
+    # CParserWrapper.read also branches on truthiness, so low_memory=0 /
+    # np.False_ must take the serial path too (GH#66327).
+    if not kwds.get("low_memory", True):
         return False
 
     # on_bad_lines="warn" includes line numbers in its warnings; chunk workers

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -231,15 +231,17 @@ class TestCanParallelizeCsv:
         assert _can_parallelize_csv(path, self._kwds(parse_dates=None))
         assert _can_parallelize_csv(path, self._kwds(parse_dates=False))
 
-    def test_rejects_low_memory_false(self, tmp_path, monkeypatch):
-        # low_memory=False guarantees whole-file type inference, which the
+    @pytest.mark.parametrize("low_memory", [False, 0, np.False_])
+    def test_rejects_low_memory_false(self, tmp_path, monkeypatch, low_memory):
+        # A falsy low_memory guarantees whole-file type inference, which the
         # per-chunk parallel path cannot honour; low_memory=True (and the unset
         # default) document per-chunk divergence, so they stay eligible
-        # (GH#64347).
+        # (GH#64347).  low_memory is not coerced to bool, so falsy non-False
+        # values must be rejected too (GH#66327).
         path = tmp_path / "data.csv"
         path.write_text("a,b\n1,2\n", encoding="utf-8")
         monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
-        assert not _can_parallelize_csv(path, self._kwds(low_memory=False))
+        assert not _can_parallelize_csv(path, self._kwds(low_memory=low_memory))
         assert _can_parallelize_csv(path, self._kwds(low_memory=True))
         assert _can_parallelize_csv(path, self._kwds())
 
@@ -1054,19 +1056,22 @@ def test_parallel_deferred_strings_mixed_chunk_dtypes(tmp_path, monkeypatch):
     tm.assert_frame_equal(parallel, serial)
 
 
-def test_parallel_low_memory_false_matches_serial(tmp_path, monkeypatch):
-    # low_memory=False promises whole-file type inference.  A chunk holding only
-    # NA tokens and a uint64-range int hits the C parser's na_filter=0
+@pytest.mark.parametrize("low_memory", [False, 0, np.False_])
+def test_parallel_low_memory_false_matches_serial(tmp_path, monkeypatch, low_memory):
+    # A falsy low_memory promises whole-file type inference.  A chunk holding
+    # only NA tokens and a uint64-range int hits the C parser's na_filter=0
     # uint64-conflict path (gh-14983) and keeps "nan" as a literal string, while
     # the serial whole-file pass masks it to NaN.  Both chunk results are object
     # dtype, so the per-column dtype-consistency check cannot catch it - the
-    # parallel path must step aside for low_memory=False (GH#64347).
+    # parallel path must step aside (GH#64347).  low_memory is not coerced to
+    # bool and the serial path branches on truthiness, so falsy non-False values
+    # must step aside too (GH#66327).
     raw = b"col\n" + b"hello\n" * 500 + (b"nan\n" + b"9223372036854775808\n") * 3000
     path = tmp_path / "uint64.csv"
     path.write_bytes(raw)
 
-    result = _read_forced_parallel(path, monkeypatch, low_memory=False)
-    expected = read_csv(io.BytesIO(raw), low_memory=False)
+    result = _read_forced_parallel(path, monkeypatch, low_memory=low_memory)
+    expected = read_csv(io.BytesIO(raw), low_memory=low_memory)
     tm.assert_frame_equal(result, expected)
     # serial semantics: every "nan" token is masked to NaN, none survive as text
     assert (result["col"] == "nan").sum() == 0


### PR DESCRIPTION
The `low_memory` gate in `_can_parallelize_csv` added by GH-66327 (addressing Bug 3 of GH-66259) tested identity:

```python
if kwds.get("low_memory") is False:
    return False
```

But `low_memory` is never coerced to `bool`, and the serial path branches on truthiness (`if self.low_memory:` in `CParserWrapper.read`). So `low_memory=0` and `np.False_` promised whole-file type inference to the serial reader while slipping past the parallel guard — reintroducing exactly the silent corruption that gate exists to prevent.

Verified on a 6MB uint64-conflict CSV (200k `hello` rows, then alternating `nan` / `9223372036854775808`) with `mode.max_threads=4`:

| `low_memory` | NA count | literal `"nan"` |
|---|---|---|
| `False` | 200000 | 0 |
| `0` | **12501** | **187499** |
| `np.False_` | **12501** | **187499** |

Silent — no exception, no warning. All three agree at `max_threads=1`. Both columns are `str` dtype, so the gather's per-column dtype reconciliation cannot see the divergence.

The fix tests truthiness instead, defaulting to `True` to match `_c_parser_defaults`, so an unset `low_memory` stays eligible for the parallel path:

```python
if not kwds.get("low_memory", True):
    return False
```

Tests: parametrized the two existing `low_memory` tests over `[False, 0, np.False_]` — the `_can_parallelize_csv` guard check and the end-to-end uint64-conflict serial-comparison test. Reverting the one-line fix fails all four new cases and passes the two `False` ones.

No whatsnew entry: parallel `read_csv` is itself new in unreleased 3.1.0, so this never shipped.

Note on GH-66259: deliberately no closing keyword. That issue bundles six divergences and several are still live — Bug 1 (`EmptyDataError` on a headerless file with a leading blank line, open PR GH-66344), Bug 5 (per-chunk duplicated `ParserWarning`), Bug 6 (deferred mmap unmap on the error path). This PR only closes the leak in the Bug 3 gate. No overlap with GH-66344, which touches `readers.py` elsewhere.