### PR TITLE
BUG: SparseArray groupby mis-materialized the fill value (GH#64758)

### DIFF
--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -28,7 +28,11 @@ from pandas._libs.sparse import (
     IntIndex,
     SparseIndex,
 )
-from pandas._libs.tslibs import NaT
+from pandas._libs.tslibs import (
+    NaT,
+    Timedelta,
+    Timestamp,
+)
 from pandas.compat.numpy import function as nv
 from pandas.errors import (
     Pandas4Warning,
@@ -47,6 +51,7 @@ from pandas.core.dtypes.cast import (
     construct_1d_object_array_from_listlike,
     find_common_type,
     maybe_box_datetimelike,
+    maybe_promote,
 )
 from pandas.core.dtypes.common import (
     is_bool_dtype,
@@ -1497,14 +1502,43 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 skipna=kwargs.get("skipna", True),
             )
 
+        # Densify, keeping the dense dtype the subtype would have.  self.to_dense()
+        #  is no good here because it casts the fill_value to the subtype, turning
+        #  the NaNs of a Sparse[int64, nan] into 0s; np.asarray is no good either
+        #  because it promotes on type(fill_value) and so widens e.g.
+        #  Sparse[uint64] to float64.
+        if self.sp_index.ngaps == 0:
+            npvalues = self.sp_values
+        else:
+            npdtype = self.sp_values.dtype
+            fill_value = self.fill_value
+            if isna(fill_value):
+                # SparseDtype._check_fill_value guarantees that a non-NA
+                #  fill_value fits in the subtype, so only an NA needs promoting.
+                npdtype, fill_value = maybe_promote(npdtype, fill_value)
+            elif isinstance(fill_value, (Timestamp, Timedelta)):
+                # np.full would route these through the stdlib datetime protocol
+                #  and so truncate to microseconds
+                fill_value = fill_value.asm8
+            npvalues = np.full(self.shape, fill_value, dtype=npdtype)
+            npvalues[self.sp_index.indices] = self.sp_values
+
+        if npvalues.dtype.kind in "mM":
+            # Defer to DatetimeArray/TimedeltaArray, which reject the
+            #  operations that are invalid for their dtype.
+            return ensure_wrapped_if_datetimelike(npvalues)._groupby_op(
+                how=how,
+                has_dropped_na=has_dropped_na,
+                min_count=min_count,
+                ngroups=ngroups,
+                ids=ids,
+                **kwargs,
+            )
+
         from pandas.core.groupby.ops import WrappedCythonOp
 
         kind = WrappedCythonOp.get_kind_from_how(how)
         op = WrappedCythonOp(how=how, kind=kind, has_dropped_na=has_dropped_na)
-
-        # Convert to dense for the cython operation.
-        # The cython code handles NaN detection on dense float arrays natively.
-        npvalues = self.to_dense()
 
         res_values = op._cython_op_ndim_compat(
             npvalues,

--- a/pandas/tests/groupby/test_sparse.py
+++ b/pandas/tests/groupby/test_sparse.py
@@ -6,6 +6,8 @@ from pandas import (
     DataFrame,
     Series,
     SparseDtype,
+    Timedelta,
+    Timestamp,
 )
 import pandas._testing as tm
 
@@ -107,3 +109,150 @@ class TestSparseGroupby:
         result = sparse_ser.groupby(keys).mean()
         expected = dense_ser.groupby(keys).mean()
         tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("op", ["min", "max", "sum", "mean", "cumsum", "any"])
+    def test_sparse_groupby_nan_fill_value_gaps(self, op):
+        # GH#64758 the NaN fill_value must be materialized rather than
+        #  unsafely cast to the int64 subtype
+        keys = ["a", "a", "b", "b"]
+        sparse_ser = Series([1, 0, 1, 0]).astype("Sparse[int64]")
+        sparse_ser = sparse_ser.astype(SparseDtype(np.int64, np.nan))
+        assert sparse_ser.array.sp_index.ngaps == 2
+
+        dense_ser = Series([1.0, np.nan, 1.0, np.nan])
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("op", ["sum", "any", "all"])
+    def test_sparse_groupby_bool_nan_fill_value(self, op):
+        # GH#64758 a NaN fill_value on a bool subtype was cast to True; the gaps
+        #  are missing values, so the dense equivalent is object dtype
+        keys = ["a", "a", "b", "b"]
+        sparse_ser = Series([True, False, True, False]).astype(SparseDtype(bool, False))
+        sparse_ser = sparse_ser.astype(SparseDtype(bool, np.nan))
+        assert sparse_ser.array.sp_index.ngaps == 2
+
+        dense_ser = Series([True, np.nan, True, np.nan])
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "subtype", ["int8", "int32", "uint16", "uint64", "float32"]
+    )
+    @pytest.mark.parametrize("op", ["min", "max", "sum", "cumsum"])
+    def test_sparse_groupby_preserves_subtype(self, subtype, op):
+        # GH#64758 densifying must give the subtype's own dense dtype; widening
+        #  uint64 to float64 would round values above 2**53
+        keys = ["a", "a", "b", "b"]
+        big = 2**63 + 12345 if subtype == "uint64" else 3
+        dense_ser = Series(np.array([1, 0, big, 0], dtype=subtype))
+        sparse_ser = dense_ser.astype(SparseDtype(subtype, 0))
+        assert sparse_ser.array.sp_index.ngaps == 2
+
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("op", ["min", "max", "sum", "cumsum"])
+    def test_sparse_groupby_wider_fill_value(self, op):
+        # GH#64758 SparseDtype allows a fill_value whose type is wider than the
+        #  subtype as long as it round-trips; the result still follows the subtype
+        keys = ["a", "a", "b", "b"]
+        dense_ser = Series(np.array([1, 0, 3, 0], dtype="int64"))
+        sparse_ser = dense_ser.astype(SparseDtype("int64", 0.0))
+        assert sparse_ser.array.sp_index.ngaps == 2
+
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("nat_fill", [None, pd.NaT])
+    @pytest.mark.parametrize(
+        "unit",
+        ["datetime64[ns]", "datetime64[s]", "timedelta64[ns]", "timedelta64[us]"],
+    )
+    @pytest.mark.parametrize("op", ["min", "max", "mean", "median", "cummax", "rank"])
+    def test_sparse_groupby_datetimelike(self, unit, op, nat_fill):
+        # GH#64758 datetimelike subtypes must not be treated as raw integers,
+        #  and the result must keep the subtype's unit
+        keys = ["a", "a", "b", "b"]
+        dense_ser = Series(np.array([1, 2, 3, "NaT"], dtype=unit))
+        sparse_ser = dense_ser.astype(SparseDtype(unit, nat_fill))
+        assert sparse_ser.array.sp_index.ngaps == 1
+
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("op", ["min", "max", "mean", "cummax"])
+    def test_sparse_groupby_datetimelike_subsecond_fill_value(self, op):
+        # GH#64758 a sub-microsecond Timestamp fill_value must not be truncated
+        #  when the gaps are materialized
+        keys = ["a", "a", "b", "b"]
+        dense_ser = Series(np.array([1, 2, 3, 4], dtype="M8[ns]"))
+        sparse_ser = dense_ser.astype(SparseDtype("M8[ns]", Timestamp(3)))
+        assert sparse_ser.array.sp_index.ngaps == 1
+
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("op", ["min", "sum", "cumsum"])
+    def test_sparse_groupby_timedelta_subsecond_fill_value(self, op):
+        # GH#64758 same for a sub-microsecond Timedelta fill_value
+        keys = ["a", "a", "b", "b"]
+        dense_ser = Series(np.array([1, 2, 3, 4], dtype="m8[ns]"))
+        sparse_ser = dense_ser.astype(SparseDtype("m8[ns]", Timedelta(3)))
+        assert sparse_ser.array.sp_index.ngaps == 1
+
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("nat_fill", [None, pd.NaT])
+    @pytest.mark.parametrize("op", ["sum", "cumsum"])
+    def test_sparse_groupby_timedelta_sum(self, op, nat_fill):
+        # GH#64758 adding timedeltas is valid, unlike adding datetimes
+        keys = ["a", "a", "b", "b"]
+        dense_ser = Series(np.array([1, 2, 3, "NaT"], dtype="m8[ns]"))
+        sparse_ser = dense_ser.astype(SparseDtype("m8[ns]", nat_fill))
+
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("nat_fill", [None, pd.NaT])
+    @pytest.mark.parametrize(
+        "unit, op",
+        [
+            ("datetime64[ns]", "sum"),
+            ("datetime64[ns]", "prod"),
+            ("datetime64[ns]", "var"),
+            ("datetime64[ns]", "skew"),
+            ("datetime64[ns]", "kurt"),
+            ("datetime64[ns]", "cumsum"),
+            ("datetime64[ns]", "cumprod"),
+            # any/all raise with a different message than the arithmetic ops
+            ("datetime64[ns]", "any"),
+            ("datetime64[ns]", "all"),
+            ("timedelta64[ns]", "prod"),
+            ("timedelta64[ns]", "var"),
+            ("timedelta64[ns]", "skew"),
+            ("timedelta64[ns]", "kurt"),
+            ("timedelta64[ns]", "cumprod"),
+        ],
+    )
+    def test_sparse_groupby_datetimelike_invalid(self, unit, op, nat_fill):
+        # GH#64758 operations that are invalid for the subtype must raise
+        #  instead of silently returning garbage
+        keys = ["a", "a", "b", "b"]
+        dense_ser = Series(np.array([1, 2, 3, "NaT"], dtype=unit))
+        sparse_ser = dense_ser.astype(SparseDtype(unit, nat_fill))
+
+        with pytest.raises(TypeError) as sparse_err:
+            getattr(sparse_ser.groupby(keys), op)()
+        with pytest.raises(TypeError) as dense_err:
+            getattr(dense_ser.groupby(keys), op)()
+        assert str(sparse_err.value) == str(dense_err.value)


### PR DESCRIPTION
GH-64758 implemented `SparseArray._groupby_op` by densifying with `to_dense()`, which is `np.asarray(self, dtype=self.sp_values.dtype)`. Pinning the dense dtype to the subtype means a fill value that does not fit the subtype gets cast instead of materialized, and it hands datetimelike subtypes to the cython op with none of their subtype guards.

Reductions and transformations on the following silently returned wrong values on `main`:

| input | `main` | dense |
|---|---|---|
| `Sparse[int64, nan]` `.min()` | `0` | `1.0` |
| `Sparse[bool, nan]` `.sum()` | `[2, 2]` int64 | `[True, True]` object |
| `Sparse[M8[ns], Timestamp(3)]` `.min()` | `[1ns, 0ns]` | `[1ns, 3ns]` |
| `Sparse[m8[ns], Timedelta(3)]` `.sum()` | `[3ns, 4ns]` | `[3ns, 7ns]` |
| `Sparse[M8[ns]]` `.sum()` | `Timestamp("2070-01-01")` | `TypeError` |

The last row generalizes: `sum`/`prod`/`var`/`skew`/`kurt`/`cumsum`/`cumprod`/`any`/`all` on a `datetime64` subtype, and `prod`/`var`/`skew`/`kurt`/`cumprod` on a `timedelta64` subtype, all returned garbage where dense raises.

Build the dense array explicitly instead. The subtype is promoted via `maybe_promote` only for an NA fill value — `SparseDtype._check_fill_value` already guarantees a non-NA fill value fits the subtype, so promoting there would widen `Sparse[int64, 0.0]` to float64 and `Sparse[M8[s], Timestamp(...)]` to `M8[ns]`. A `Timestamp`/`Timedelta` fill value is unboxed with `.asm8` because `np.full` would otherwise route it through the stdlib datetime protocol and truncate to microseconds. Datetime64/timedelta64 then delegate to `DatetimeArray`/`TimedeltaArray._groupby_op`, which own the subtype guards.

The `ngaps == 0` fastpath keeps returning `sp_values` un-promoted: with no gaps the fill value never materializes, so the dense equivalent is the subtype itself.

No whatsnew entry — GH-64758 landed in the unreleased 3.1.0, so none of this shipped.