### PR TITLE
BUG: parallel read_csv raised EmptyDataError on a blank first data line (GH#66259)

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -42,6 +42,7 @@ from pandas._libs.parsers import STR_NA_VALUES
 from pandas.compat._cpu import available_cpu_count
 from pandas.errors import (
     AbstractMethodError,
+    EmptyDataError,
     Pandas4Warning,
     ParserError,
     ParserWarning,
@@ -694,8 +695,9 @@ def _read_csv_parallel(
 
     Returns ``None`` when parallel reading turns out not to be applicable
     after all (the data section cannot be split, the engine falls back to
-    python, or per-chunk dtype inference disagrees in a way that would not
-    match the serial result); the caller then reads serially.  Splitting is
+    python, the one-line sample used to infer column names has no columns, or
+    per-chunk dtype inference disagrees in a way that would not match the
+    serial result); the caller then reads serially.  Splitting is
     done at raw ``\\n`` boundaries, so a boundary inside a quoted field raises
     ``ParserError`` from the affected worker - the caller treats that as a
     serial-fallback signal too.
@@ -757,7 +759,14 @@ def _read_csv_parallel(
         first_line = fd.readline()
 
     name_buf = io.BytesIO(preamble + first_line)
-    name_reader = TextFileReader(name_buf, **base_kwds)
+    try:
+        name_reader = TextFileReader(name_buf, **base_kwds)
+    except EmptyDataError:
+        # The one data line we sliced off is blank (e.g. header=None on a file
+        # whose first physical line is empty), so the name-inference read sees
+        # no columns.  The serial path skips the blank line and reads the file
+        # fine, so fall back rather than propagate.  GH#66259
+        return None
     if not isinstance(name_reader._engine, CParserWrapper):
         # TextFileReader fell back to the python engine for a reason the
         # eligibility checks did not anticipate; load_buffer needs the C engine.

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -995,6 +995,7 @@ def test_parallel_blank_first_data_line_matches_serial(
     assert result.shape == (500, 2)
 
 
+@pytest.mark.skipif(WASM, reason="WASM stays serial, so the spy sees no call")
 def test_parallel_all_blank_lines_raises(tmp_path, monkeypatch):
     # The fallback for a blank first data line must not mask a file that has
     # no columns at all: serial raises, so the parallel path must too

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -22,6 +22,7 @@ import pytest
 
 from pandas.compat import WASM
 from pandas.errors import (
+    EmptyDataError,
     ParserError,
     ParserWarning,
 )
@@ -612,6 +613,17 @@ class TestReadCsvParallel:
         kwds = self._base_kwds(path)
         assert _read_csv_parallel(str(path), kwds, 4) is None
 
+    def test_blank_first_data_line_returns_none(self, tmp_path):
+        # header=None with a blank first data line: name inference parses a
+        # single blank line and raises EmptyDataError, which must be turned
+        # into a serial fallback rather than propagate (GH#66259).
+        path = tmp_path / "blank_first.csv"
+        path.write_text(
+            "\n" + "".join(f"{i},{i * 2}\n" for i in range(5_000)), encoding="utf-8"
+        )
+        kwds = self._base_kwds(path, header=None)
+        assert _read_csv_parallel(str(path), kwds, 4) is None
+
     def test_quoted_newline_in_header_returns_none(self, tmp_path):
         # A quoted embedded newline in the header makes the physical line
         # count disagree with the logical row count, so data_start would land
@@ -955,6 +967,56 @@ def test_parallel_blank_line_before_header_matches_serial(tmp_path, monkeypatch)
     expected = read_csv(io.BytesIO(raw))
     tm.assert_frame_equal(result, expected)
     assert result["col1"].dtype == np.int64
+
+
+@pytest.mark.parametrize(
+    "preamble,skiprows",
+    [
+        (b"\n", 0),
+        (b"   \n", 0),
+        (b"junk1\njunk2\n\n", 2),
+    ],
+)
+def test_parallel_blank_first_data_line_matches_serial(
+    tmp_path, monkeypatch, preamble, skiprows
+):
+    # header=None puts no header line in the preamble, so a blank first data
+    # line ends up as the single line name inference parses, and that raises
+    # EmptyDataError where the serial path just skips it (GH#66259).  A
+    # whitespace-only line must not tokenize as a single field either: that
+    # would infer one column and silently read the rest as an implicit index.
+    raw = preamble + b"".join(f"{i},{i * 2}\n".encode() for i in range(500))
+    path = tmp_path / "blank_first.csv"
+    path.write_bytes(raw)
+
+    result = _read_forced_parallel(path, monkeypatch, header=None, skiprows=skiprows)
+    expected = read_csv(io.BytesIO(raw), header=None, skiprows=skiprows)
+    tm.assert_frame_equal(result, expected)
+    assert result.shape == (500, 2)
+
+
+def test_parallel_all_blank_lines_raises(tmp_path, monkeypatch):
+    # The fallback for a blank first data line must not mask a file that has
+    # no columns at all: serial raises, so the parallel path must too
+    # (GH#66259).
+    path = tmp_path / "blank_only.csv"
+    path.write_bytes(b"\n" * 500)
+
+    returned = []
+
+    def spy(filepath, kwds, n_workers):
+        result = _read_csv_parallel(filepath, kwds, n_workers)
+        returned.append(result)
+        return result
+
+    monkeypatch.setattr("pandas.io.parsers.readers._read_csv_parallel", spy)
+
+    msg = "No columns to parse from file"
+    with pytest.raises(EmptyDataError, match=msg):
+        _read_forced_parallel(path, monkeypatch, header=None)
+    # The serial read raises the same error, so without this the test would
+    # pass even if the parallel path propagated it directly.
+    assert returned == [None], "the parallel path did not fall back"
 
 
 def test_parallel_single_long_line(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes **Bug 1** of GH-66259 only. That issue bundles six separate parallel-vs-serial divergences and some are still live, so no closing keyword here.

With `header=None` on a large local file whose first physical data line is blank or whitespace-only, the parallel path's column-name inference parses that single blank line and raises `EmptyDataError`. That is not a `ParserError` subclass, so the serial fallback in `_read` does not catch it and the read fails — where a serial read (`mode.max_threads=1`) skips the blank line and succeeds. The same happens when an integer `skiprows` lands the data start on a blank line.

```python
with open("f1.csv", "wb") as fh:
    fh.write(b"\n")  # leading blank line
    fh.write(b"".join(f"{i},{i*2},x{i}\n".encode() for i in range(2_600_000)))  # ~59 MB

pd.read_csv("f1.csv", header=None)
# -> EmptyDataError: No columns to parse from file

with pd.option_context("mode.max_threads", 1):
    pd.read_csv("f1.csv", header=None)   # OK, (2600000, 3)
```

The parallel path now falls back to serial in that case. A file that genuinely has no columns still raises, because the serial read raises it too.

No whatsnew entry: the parallel path (GH-64347) is itself unreleased, matching the two earlier fixes to it, GH-66327 and GH-66613.