### PR TITLE
BUG: plot.scatter raised for datetime columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -692,6 +692,7 @@ Period
 Plotting
 ^^^^^^^^
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
+- Bug in :meth:`DataFrame.plot.scatter` with timezone-aware data labelling the axis in UTC instead of in the data's own timezone (:issue:`64613`)
 -
 
 Groupby/resample/rolling

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -1390,8 +1390,11 @@ class ScatterPlot(PlanePlot):
             )
 
         scatter = ax.scatter(
-            x_data._values,
-            data[y]._values,
+            # matplotlib cannot consume ExtensionArrays directly; np.asarray
+            #  gives it either a plain ndarray or objects (e.g. Timestamp,
+            #  Period) that its unit converters understand.
+            np.asarray(x_data._values),
+            np.asarray(data[y]._values),
             c=c_values,
             label=label,
             cmap=cmap,
@@ -1421,7 +1424,12 @@ class ScatterPlot(PlanePlot):
         if len(errors_x) > 0 or len(errors_y) > 0:
             err_kwds = dict(errors_x, **errors_y)
             err_kwds["ecolor"] = scatter.get_facecolor()[0]
-            ax.errorbar(data[x]._values, data[y]._values, linestyle="none", **err_kwds)
+            ax.errorbar(
+                np.asarray(data[x]._values),
+                np.asarray(data[y]._values),
+                linestyle="none",
+                **err_kwds,
+            )
 
     def _get_c_values(self, color, color_by_categorical: bool, c_is_column: bool):
         c = self.c
@@ -1527,9 +1535,15 @@ class HexBinPlot(PlanePlot):
         if C is None:
             c_values = None
         else:
-            c_values = data[C]._values
+            c_values = np.asarray(data[C]._values)
 
-        ax.hexbin(data[x]._values, data[y]._values, C=c_values, cmap=cmap, **self.kwds)
+        ax.hexbin(
+            np.asarray(data[x]._values),
+            np.asarray(data[y]._values),
+            C=c_values,
+            cmap=cmap,
+            **self.kwds,
+        )
         if cb:
             self._plot_colorbar(ax, fig=fig)
 

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -892,6 +892,19 @@ class TestDataFramePlots:
 
         _check_plot_works(df.plot.scatter, x=x, y=y)
 
+    @pytest.mark.parametrize("tz", [None, "US/Pacific"])
+    def test_scatterplot_datetime_y_data(self, tz):
+        # GH#64613 datetime y-column raised instead of plotting; the y axis
+        #  should get the same datetime scaling a line plot gets
+        dates = date_range(start=date(2019, 1, 1), periods=12, freq="W", tz=tz)
+        vals = np.random.default_rng(2).normal(0, 1, len(dates))
+        df = DataFrame({"vals": vals, "dates": dates})
+
+        _, ax = plt.subplots(2)
+        df.plot.scatter(x="vals", y="dates", ax=ax[0])
+        df.plot(x="vals", y="dates", ax=ax[1])
+        assert ax[0].get_yticks() == pytest.approx(ax[1].get_yticks())
+
     @pytest.mark.parametrize(
         "infer_string", [False, pytest.param(True, marks=td.skip_if_no("pyarrow"))]
     )


### PR DESCRIPTION
GH-64613 switched the matplotlib call sites in `ScatterPlot._make_plot` from `.values` to `._values`, which hands matplotlib a raw `DatetimeArray` it cannot consume. On main:

```python
df = pd.DataFrame({"x": [1.0, 2.0, 3.0], "dt": pd.date_range("2020", periods=3)})
df.plot.scatter(x="x", y="dt")
# DTypePromotionError: The DType <class 'numpy.dtypes.Float64DType'> could not be
# promoted by <class 'numpy.dtypes.DateTime64DType'>

df["dttz"] = pd.date_range("2020", periods=3, tz="US/Pacific")
df.plot.scatter(x="x", y="dttz")
# TypeError: float() argument must be a string or a real number, not 'Timestamp'
```

Both plotted fine before that PR. Only datetime-as-`x` was covered by tests, which is how it escaped.

`np.asarray` on the matplotlib-facing arguments restores this: matplotlib gets a plain ndarray for numpy-backed dtypes and objects its unit converters understand for the rest. Those are the same arrays `MPLPlot._iter_data` already yields, so a timezone-aware column now lands on the same axis whether it is drawn with `plot.scatter` or `plot` — the regression test asserts exactly that.

Against released 3.0 there is one visible change, hence the whatsnew entry: `.values` returned UTC-normalized `M8`, so a timezone-aware axis was labelled in UTC. It is now labelled in the data's own timezone. The points themselves are unmoved — `date2num` of the UTC `M8` and of the tz-aware `Timestamp` are equal.

The `errorbar` and `hexbin` calls get the same wrap for consistency. Neither is a reachable failure today (`_convert_to_ndarray` floats masked dtypes first, and hexbin rejects non-numeric `x`/`y`), but matplotlib's tolerance for ExtensionArrays is uneven — `ax.errorbar` with an `Int64` array holding `pd.NA` raises directly — so normalizing at the boundary is deliberate.

Note `_get_c_values` is left passing `._values`: wrapping it would break `c=<datetime column>`, since matplotlib's colour parser does `np.asanyarray(c, dtype=float)`.