### PR TITLE
BUG: str.find raised ArrowInvalid for pyarrow strings with null-only chunks (GH#64123)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -520,6 +520,7 @@ Strings
 ^^^^^^^
 - Bug in :meth:`DataFrame.replace` with ``regex=True`` mutating the underlying :class:`StringArray` when the replacement value was not a string (:issue:`57733`)
 - Bug in :meth:`Series.memory_usage` with ``deep=True`` raising ``TypeError`` on PyPy for ``str`` dtype with Python storage (:issue:`46176`)
+- Bug in :meth:`Series.str.find` and :meth:`Index.str.find` with PyArrow-backed string dtypes raising ``ArrowInvalid`` when the values contained non-ASCII characters alongside a stretch of missing values, and returning a null dtype instead of an integer one when the values were all missing or the object was empty (:issue:`64123`)
 - Bug in :meth:`Series.str.partition` and :meth:`Series.str.split` with ``expand=True`` raising for :class:`ArrowDtype` when the :class:`Series` was empty or held only null values; an empty :class:`Series` now expands to no columns and an all-null one to a single all-NA column, matching object dtype (:issue:`63602`)
 - Bug in :meth:`Series.str.rsplit` and :meth:`Index.str.rsplit` silently accepting a compiled regex and returning incorrect results (:issue:`29633`)
 - Bug in :meth:`Series.str.split` with :class:`ArrowDtype` ``string`` not inferring regex for multi-character patterns when ``regex=None``, causing the pattern to be treated as a literal instead of a regular expression (:issue:`58321`)

--- a/pandas/core/arrays/_arrow_string_mixins.py
+++ b/pandas/core/arrays/_arrow_string_mixins.py
@@ -443,12 +443,14 @@ class ArrowStringArrayMixin:
         return ArrowStringArrayMixin._str_match(self, pat, case, flags, na)
 
     def _str_find(self, sub: str, start: int = 0, end: int | None = None):
-        if not pc.all(pc.string_is_ascii(self._pa_array)).as_py():
+        # min_count=0 so that an empty or all-null array reports True instead of
+        #  null, keeping it on the pyarrow path below
+        if not pc.all(pc.string_is_ascii(self._pa_array), min_count=0).as_py():
             # GH#64123 - pc.find_substring returns byte offsets instead of
             # character offsets for multi-byte UTF-8 characters, so we fall back
             # to Python str.find which correctly returns character offsets.
             res_list = self._apply_elementwise(lambda val: val.find(sub, start, end))
-            return self._convert_int_result(pa.chunked_array(res_list))
+            return self._convert_int_result(pa.chunked_array(res_list, type=pa.int64()))
 
         if (start == 0 or start is None) and end is None:
             result = pc.find_substring(self._pa_array, sub)
@@ -458,7 +460,9 @@ class ArrowStringArrayMixin:
                 res_list = self._apply_elementwise(
                     lambda val: val.find(sub, start, end)
                 )
-                return self._convert_int_result(pa.chunked_array(res_list))
+                return self._convert_int_result(
+                    pa.chunked_array(res_list, type=pa.int64())
+                )
             if start is None:
                 start_offset = 0
                 start = 0

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -1666,6 +1666,76 @@ def test_find_multibyte_chars(any_string_dtype):
     tm.assert_series_equal(result, expected)
 
 
+def test_find_multibyte_chars_all_na_chunk(any_string_dtype):
+    # GH#64123 - the non-ascii fallback must keep an integer result type even
+    #  when a chunk holds nothing but nulls
+    ser = pd.concat(
+        [
+            Series([None, None], dtype=any_string_dtype),
+            Series(["永a", "ba"], dtype=any_string_dtype),
+        ],
+        ignore_index=True,
+    )
+    if is_object_or_nan_string_dtype(any_string_dtype):
+        expected_dtype = np.float64
+        item = np.nan
+    else:
+        expected_dtype = "Int64"
+        item = pd.NA
+
+    result = ser.str.find("a")
+    expected = Series([item, item, 1, 1], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+def test_find_all_na(any_string_dtype):
+    # GH#64123
+    ser = Series([None, None], dtype=any_string_dtype)
+    if any_string_dtype == object:
+        # an all-NA object result is never inferred to a numeric dtype
+        expected_dtype = object
+        item = None
+    elif is_object_or_nan_string_dtype(any_string_dtype):
+        expected_dtype = np.float64
+        item = np.nan
+    else:
+        expected_dtype = "Int64"
+        item = pd.NA
+
+    result = ser.str.find("a")
+    expected = Series([item, item], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+    result = ser.str.find("", 1, 2)
+    tm.assert_series_equal(result, expected)
+
+
+def test_find_empty(any_string_dtype):
+    # GH#64123
+    ser = Series([], dtype=any_string_dtype)
+    expected_dtype = (
+        np.int64 if is_object_or_nan_string_dtype(any_string_dtype) else "Int64"
+    )
+
+    result = ser.str.find("a")
+    expected = Series([], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+@td.skip_if_no("pyarrow")
+@pytest.mark.parametrize("pa_type", ["string", "large_string"])
+def test_find_all_na_arrow_dtype(pa_type):
+    # GH#64123 - the result stayed null-typed instead of becoming integer
+    import pyarrow as pa
+
+    dtype = pd.ArrowDtype(getattr(pa, pa_type)())
+    ser = Series([None, None], dtype=dtype)
+
+    result = ser.str.find("a")
+    expected = Series([None, None], dtype="int64[pyarrow]")
+    tm.assert_series_equal(result, expected)
+
+
 # --------------------------------------------------------------------------------------
 # str.translate
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to GH-64133, which fixed the byte-offset bug in GH-64123 but introduced a new failure for the PyArrow-backed string dtypes.

That fix added a Python fallback for non-ASCII values which builds `pa.chunked_array(res_list)` with no `type`. `_apply_elementwise` returns one Python list per chunk, so a chunk holding only nulls infers `null` type and a zero-chunk array has no type at all:

```python
ser = pd.concat([pd.Series([None, None], dtype="string[pyarrow]"),
                 pd.Series(["永a", "ba"], dtype="string[pyarrow]")])
ser.str.find("a")          # ArrowInvalid: Invalid null value

tbl = pa.Table.from_batches([], schema=pa.schema([("a", pa.string())]))
tbl.to_pandas(types_mapper=pd.ArrowDtype)["a"].str.find("a")
# ArrowInvalid: cannot construct ChunkedArray from empty vector and omitted type

ser = pd.Series([None, None], dtype=pd.ArrowDtype(pa.string()))
ser.str.find("a").dtype    # null[pyarrow], so .fillna(-1) then raises
```

Two changes:

- `type=pa.int64()` on both `pa.chunked_array` calls in `_str_find` (the non-ASCII fallback and the pre-existing `sub == ""` branch). This is what fixes the mixed-chunk crash — that array has valid non-ASCII values, so it legitimately takes the fallback.
- `min_count=0` on the ASCII gate. `pc.all` returns null when there are no valid values and `not None` is truthy, so empty and all-null arrays were being routed into the Python fallback in the first place; they now stay on the `pc.find_substring` path.

Verified `str.find` matches object dtype elementwise across `("a",)`, `("a", 1)`, `("a", 1, 3)`, `("a", -2)`, `("",)`, `("", 1)`, `("", 1, 2)`, `("z",)` for `string[pyarrow]`, `ArrowDtype(string)` and `ArrowDtype(large_string)`.

`ArrowExtensionArray._str_rfind`, `_str_index` and `_str_rindex` have the same untyped-`chunked_array` defect, but it predates GH-64133 and lives in a different class, so it is not touched here.