### PR TITLE
BUG: str.contains/count on pyarrow strings mishandled regex \Z (GH#63705)

### DIFF
--- a/pandas/core/arrays/string_arrow.py
+++ b/pandas/core/arrays/string_arrow.py
@@ -80,6 +80,12 @@ def _is_string_view(typ):
     return not pa_version_under16p0 and pa.types.is_string_view(typ)
 
 
+# Matches a `\Z` that is an end-of-string assertion rather than an escaped
+# backslash followed by a literal "Z"; the captured group keeps any preceding
+# pairs of escaped backslashes intact.
+_unescaped_end_anchor = re.compile(r"(?<!\\)((?:\\\\)*)\\Z")
+
+
 # TODO: Inherit directly from BaseStringArrayMethods. Currently we inherit from
 # ObjectStringArrayMixin because we want to have the object-dtype based methods as
 # fallback for the ones that pyarrow doesn't yet support
@@ -448,13 +454,9 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
         else:
             pattern = pat
 
-        if (
-            pattern.endswith("\\Z")
-            # Second condition counts the number of `\` that patterns ends with
-            # prior to Z -> needs to be odd to end with an unescaped \Z
-            and (len(pattern) - len(pattern[:-1].rstrip("\\")) + 1) % 2 == 1
-        ):
-            pattern = pattern[:-2] + "\\z"
+        # RE2 spells the end-of-string anchor `\z`; Python's `\Z` is the same
+        # assertion and may appear anywhere in the pattern, not just at the end.
+        pattern = _unescaped_end_anchor.sub(r"\1\\z", pattern)
 
         return pattern, case, flags
 
@@ -470,10 +472,14 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
             flags
             or self._is_re_pattern_with_flags(pat)
             or (regex and self._has_unsupported_regex(pat))
+            # a compiled pattern is not a valid literal; defer to the object path
+            or (not regex and isinstance(pat, re.Pattern))
         ):
             return super()._str_contains(pat, case, flags, na, regex)
 
-        pat, case, flags = self._preprocess_re_pattern(pat, case, flags)
+        # with regex=False `pat` is matched literally, so must not be rewritten
+        if regex:
+            pat, case, flags = self._preprocess_re_pattern(pat, case, flags)
         return ArrowStringArrayMixin._str_contains(self, pat, case, flags, na, regex)
 
     def _str_match(
@@ -546,11 +552,15 @@ class ArrowStringArray(ObjectStringArrayMixin, ArrowExtensionArray, BaseStringAr
             return ArrowExtensionArray._str_repeat(self, repeats=repeats)
 
     def _str_count(self, pat: str, flags: int = 0):
-        if flags or self._has_unsupported_regex(pat):
+        if (
+            flags
+            or self._is_re_pattern_with_flags(pat)
+            or self._has_unsupported_regex(pat)
+        ):
             return super()._str_count(pat, flags)
 
-        pat, _, _ = self._preprocess_re_pattern(pat, True, 0)
-        result = pc.count_substring_regex(self._pa_array, pat)
+        pat, case, _ = self._preprocess_re_pattern(pat, True, 0)
+        result = pc.count_substring_regex(self._pa_array, pat, ignore_case=not case)
         return self._convert_int_result(result)
 
     def _str_partition(self, sep: str, expand: bool):

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -414,6 +414,38 @@ def test_contains_end_of_string(any_string_dtype):
     tm.assert_series_equal(result, expected)
 
 
+def test_contains_end_of_string_not_at_end_of_pattern(any_string_dtype):
+    # GH#63705 `\Z` is an end-of-string assertion wherever it appears in the
+    # pattern, not only when it is the last thing in it
+    expected_dtype = (
+        np.bool_ if is_object_or_nan_string_dtype(any_string_dtype) else "boolean"
+    )
+
+    ser = Series(["foo", "bar", "foobar"], dtype=any_string_dtype)
+
+    result = ser.str.contains(r"foo\Z|bar")
+    expected = Series([True, True, True], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+    result = ser.str.contains(r"(?:foo\Z)")
+    expected = Series([True, False, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+def test_contains_end_of_string_not_regex(any_string_dtype):
+    # GH#63705 with regex=False the pattern is matched literally, so `\Z` must
+    # not be rewritten to `\z`
+    expected_dtype = (
+        np.bool_ if is_object_or_nan_string_dtype(any_string_dtype) else "boolean"
+    )
+
+    ser = Series(["foo", r"bar\Z", r"bar\z", "baz"], dtype=any_string_dtype)
+
+    result = ser.str.contains(r"bar\Z", regex=False)
+    expected = Series([False, True, False, False], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
 # --------------------------------------------------------------------------------------
 # str.startswith
 # --------------------------------------------------------------------------------------

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -2,6 +2,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+import re
 
 import numpy as np
 import pytest
@@ -116,6 +117,23 @@ def test_count_end_of_string(any_string_dtype):
     ser = Series([r"bar\Z", "bar", "bars", "bar\n"], dtype=any_string_dtype)
     result = ser.str.count(r"bar\\Z")
     expected = Series([1, 0, 0, 0], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+
+def test_count_compiled_pattern_with_flags(any_string_dtype):
+    # GH#63705 flags on a compiled pattern must not be dropped
+    expected_dtype = (
+        "int64" if is_object_or_nan_string_dtype(any_string_dtype) else "Int64"
+    )
+
+    ser = Series(["Apple pie apple", "apple", "APPLE"], dtype=any_string_dtype)
+    result = ser.str.count(re.compile("apple", re.IGNORECASE))
+    expected = Series([2, 1, 1], dtype=expected_dtype)
+    tm.assert_series_equal(result, expected)
+
+    ser = Series(["a\nb", "ab", "axb"], dtype=any_string_dtype)
+    result = ser.str.count(re.compile("a.b", re.DOTALL))
+    expected = Series([1, 0, 1], dtype=expected_dtype)
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
Follow-up to GH-63705 (original report GH-63385), which taught the pyarrow string
path to translate Python's `\Z` end-of-string anchor into RE2's `\z`. Three gaps
in that translation:

- `_str_contains` ran the rewrite unconditionally, including for `regex=False`.
  With `regex=False` the pattern is matched *literally*, so `contains("bar\Z",
  regex=False)` was rewritten to the literal `"bar\z"` and silently matched the
  wrong string.
- `_str_count` discarded the `case`/`flags` that `_preprocess_re_pattern`
  extracts from a compiled pattern, so `count(re.compile("apple",
  re.IGNORECASE))` silently ignored the flag. It also lacked the
  `_is_re_pattern_with_flags` gate the other methods have, so a pattern compiled
  with e.g. `re.DOTALL` took the pyarrow path and lost it.
- The rewrite only fired when `\Z` was the *last* thing in the pattern, but `\Z`
  is a valid assertion anywhere. `contains(r"foo\Z|bar")` reached pyarrow
  verbatim and raised `ArrowInvalid: invalid escape sequence: \Z`.

The trailing-only `endswith("\\Z")` + backslash-parity check is replaced with a
single substitution that rewrites every *unescaped* `\Z`, so escaped runs
(`bar\\Z`, `bar\\\Z`, `bar\\\\Z`) are still left alone — the existing tests for
those cover the parity behavior.

Verified with a differential sweep of 24 `\Z`-adversarial patterns (nested
groups, alternations, character classes, inline-flag prefixes, compiled
patterns) across `contains`/`match`/`fullmatch`/`count`/`findall`/`replace` plus
the `regex=False` variants, comparing pyarrow-backed results against object
dtype: 0 mismatches.

No whatsnew entry: GH-63705 is not in any 3.0.x release, so none of this
behavior has shipped.

One thing found while sweeping but deliberately **not** fixed here, as it is a
different bug with a different cause: `pc.count_substring_regex` counts
zero-width *anchor* matches at positions Python's `re` does not, so
`Series.str.count` over-counts anchored patterns on pyarrow strings:

```python
ser = pd.Series(["foo bar"], dtype="str")
ser.str.count("^")    # arrow 8, object 1
ser.str.count("$")    # arrow 2, object 1
ser.str.count(r"\b")  # arrow 7, object 4
```

`^`/`$` never went through the `\Z` rewrite at all and diverge on `main` today,
so this predates GH-63705. Happy to file it separately.
